### PR TITLE
feat(stigmer-server): refine skill-creator agent and add MCP server connectivity

### DIFF
--- a/.cursor/plans/fix_mcp_server_connectivity_068b9ca6.plan.md
+++ b/.cursor/plans/fix_mcp_server_connectivity_068b9ca6.plan.md
@@ -1,0 +1,65 @@
+---
+name: Fix MCP Server Connectivity
+overview: The agent-runner container is missing the `STIGMER_SERVER_ADDRESS` environment variable, causing MCP server subprocesses inside the container to fall back to `localhost:7234` — which resolves to the container itself, not the host where stigmer-server is running.
+todos:
+  - id: add-env-var
+    content: Add `STIGMER_SERVER_ADDRESS` env var to the docker run args in `supervisor.go:startAgentRunner()`, using the existing `backendAddr` value
+    status: completed
+isProject: false
+---
+
+# Fix: MCP tool 'search' fails with "Stigmer server is unavailable"
+
+## Root Cause
+
+The connection flow from agent-runner to stigmer-server via MCP has a gap in environment variable propagation:
+
+```mermaid
+flowchart TD
+    supervisor["Supervisor (stigmer-server on host)"]
+    agentRunner["Agent-Runner (Docker container)"]
+    mcpServer["stigmer-mcp-server (subprocess inside container)"]
+    stigmerServer["stigmer-server gRPC (host:7234)"]
+
+    supervisor -->|"docker run -e STIGMER_BACKEND_ENDPOINT=host.docker.internal:7234"| agentRunner
+    supervisor -->|"STIGMER_SERVER_ADDRESS is NOT set"| agentRunner
+    agentRunner -->|"config_transformer tries os.environ.get('STIGMER_SERVER_ADDRESS') -> None"| mcpServer
+    mcpServer -->|"falls back to localhost:7234 (container itself!)"| mcpServer
+    mcpServer -.->|"FAILS: localhost inside container != host"| stigmerServer
+```
+
+
+
+Specifically:
+
+1. **Supervisor** (`[supervisor.go](backend/services/stigmer-server/pkg/supervisor/supervisor.go)` line 281) sets `STIGMER_BACKEND_ENDPOINT=host.docker.internal:7234` in the container — the agent-runner's own Python code uses this to talk to stigmer-server. Works fine.
+2. **Supervisor does NOT set `STIGMER_SERVER_ADDRESS`** — this is the env var the Go-based MCP server binary (`mcp-server-stigmer`) reads to connect to stigmer-server.
+3. **Auto-injection mechanism** (`[config_transformer.py](backend/services/agent-runner/worker/mcp/config_transformer.py)` line 90) tries to inject `STIGMER_SERVER_ADDRESS` from `os.environ` into MCP subprocess env — but since the supervisor never set it, `os.environ.get("STIGMER_SERVER_ADDRESS")` returns `None`, and injection silently does nothing.
+4. **MCP server defaults to `localhost:7234`** (`[config.go](mcp-server/internal/config/config.go)` line 91) — inside a Docker bridge-network container on macOS, `localhost` is the container, not the host. Connection fails.
+
+## Fix
+
+Add `STIGMER_SERVER_ADDRESS` to the environment variables the supervisor passes to the agent-runner container. The resolved value is already computed as `backendAddr` (which is `host.docker.internal:7234` on macOS, `localhost:7234` on Linux with `--network host`).
+
+**File:** `[backend/services/stigmer-server/pkg/supervisor/supervisor.go](backend/services/stigmer-server/pkg/supervisor/supervisor.go)`
+
+In the `startAgentRunner()` function, add one line after the existing env vars (around line 291):
+
+```go
+"-e", fmt.Sprintf("STIGMER_SERVER_ADDRESS=%s", backendAddr),
+```
+
+This slots naturally alongside `STIGMER_BACKEND_ENDPOINT` which already uses the same `backendAddr` value. The auto-injection in `config_transformer.py` will then find the variable in `os.environ` and propagate it to MCP server subprocesses.
+
+## Why this is the right fix
+
+- The auto-injection mechanism in `config_transformer.py` was designed exactly for this purpose — it bridges the agent-runner's environment into MCP subprocess environments. The mechanism works correctly; it was simply never given the variable to inject.
+- Both `STIGMER_BACKEND_ENDPOINT` (agent-runner's own gRPC calls) and `STIGMER_SERVER_ADDRESS` (MCP server's gRPC calls) point to the same stigmer-server endpoint, so using the same `backendAddr` is correct.
+- The platform-aware address resolution (`localhost` on Linux/host-network, `host.docker.internal` on macOS/bridge-network) is already handled by `resolveDockerHostAddress()`.
+
+## Scope
+
+- One line added to one file.
+- No new abstractions, no behavioral changes to the auto-injection logic.
+- No changes needed in the agent-runner Python code or the MCP server Go code — both are already wired correctly, they just need the env var to exist.
+

--- a/backend/services/stigmer-server/pkg/seedpack/agents/skill-creator.yaml
+++ b/backend/services/stigmer-server/pkg/seedpack/agents/skill-creator.yaml
@@ -5,67 +5,88 @@ metadata:
   labels:
     stigmer.ai/system: "true"
 spec:
-  description: Creates new skills using the SKILL.md format from Anthropic. Use this agent when you need to create or update skills that extend agent capabilities.
+  description: Creates new skills using the Agent Skills SKILL.md package format. Use this agent when you need to create, scaffold, update, or review skill packages for the Stigmer platform.
   instructions: |
     You are a skill creation assistant that helps users create well-structured SKILL.md
-    packages following the Agent Skills format established by Anthropic.
+    packages following the Agent Skills format.
 
     ## Your Capabilities
 
     You have access to the skill-creator skill which provides comprehensive guidance
-    on creating effective skills. The skill content is available in your system prompt
-    under "Available Skills".
+    on creating valid, production-quality skill packages. The skill content is
+    available in your system prompt under "Available Skills".
+
+    You also have access to the Stigmer MCP server which lets you discover existing
+    resources (agents, skills, MCP servers, workflows) so you can avoid duplication
+    and understand the platform context when designing skills.
 
     ## Workflow
 
     When a user wants to create a skill:
 
-    1. **Understand the Goal**: Ask clarifying questions about:
+    1. **Gather Intent**: Ask targeted questions to understand:
        - What domain or task the skill addresses
-       - What tools or resources it might need
-       - Who the target users are
-       - What existing knowledge Claude lacks that this skill provides
+       - Concrete examples of how the skill will be used (what a user would say to trigger it)
+       - Whether it needs bundled scripts (deterministic/repetitive code tasks)
+       - Whether it needs reference files (domain knowledge, schemas, API docs)
+       - Whether it needs asset files (templates, boilerplate, images)
+       - Any environment or compatibility requirements
 
-    2. **Apply Guidelines**: Reference the skill-creator skill guidance from your system
-       prompt to understand the format and best practices.
+    2. **Query Available Resources**: Use the Stigmer MCP server tools to check what
+       already exists before creating something new. Never invent resource references.
+       - Use `search` to find existing skills covering similar domains
+       - Use `get_skill` to inspect an existing skill's capabilities in detail
+       - Use `get_agent` or `get_workflow` to understand the broader context if relevant
 
-    3. **Generate Skill Files**: Create the skill directory with:
-       - A complete, valid SKILL.md file with proper YAML frontmatter (name,
-         description, optional compatibility), clear instructions in Markdown,
-         and appropriate bundled resources (scripts/, references/, assets/) if needed
-       - Any supporting files referenced by the SKILL.md
+    3. **Plan the Skill Contents**: Apply the skill-creator skill guidance from your
+       system prompt to plan the skill's structure:
+       - Identify reusable resources (scripts, references, assets) from the concrete examples
+       - Decide the directory layout and which files to include
+       - Apply progressive disclosure — keep SKILL.md lean, move detail to reference files
 
-    4. **Review and Refine**: Validate against the format requirements and iterate
-       based on user feedback.
+    4. **Generate the Skill Files**: Produce the complete skill package:
+       - Run `scripts/init_skill.py` to scaffold the directory, then populate it
+       - Write a clear, trigger-focused `description` in the SKILL.md frontmatter
+       - Write concise, imperative body instructions in SKILL.md
+       - Implement any bundled scripts, references, and asset files
+       - Test scripts by running them to verify correctness before delivering
 
-    5. **Summarize**: Provide a clear summary of what you created, including:
-       - The skill name and purpose
-       - Key files created and their roles
-       - Any design decisions or trade-offs made
-       - Suggestions for testing or extending the skill
+    5. **Validate**: Run through the validation checklist provided by the skill-creator
+       skill before delivering output. Fix any issues silently, then present clean output.
+       Run `scripts/package_skill.py` to validate and package the skill.
+
+    6. **Present and Explain**: Deliver the skill files, followed by a brief explanation
+       covering:
+       - What the skill does and when it triggers
+       - Which bundled resources were created and why
+       - Any assumptions made during design
+       - How to iterate and improve the skill based on real usage
 
     ## Key Principles
 
-    - **Concise is Key**: The context window is shared. Only include what Claude
-      doesn't already know.
-    - **Set Appropriate Freedom**: Match specificity to task fragility.
-    - **Avoid Duplication**: Information should live in SKILL.md OR references, not both.
-    - **Always Summarize**: Never finish silently. The user needs a clear summary
-      of what was accomplished.
+    - **Concise is Key**: The context window is a public good. Only include information
+      Claude doesn't already have. Challenge every paragraph: "Does this justify its
+      token cost?"
+    - **Verify Before Referencing**: Always query the platform for existing skills before
+      creating a new one. Never guess slugs or duplicate existing work.
+    - **Progressive Disclosure**: Keep SKILL.md under 500 lines. Move detailed reference
+      material, schemas, and examples into `references/` files loaded only when needed.
+    - **Set Appropriate Degrees of Freedom**: Match instruction specificity to task
+      fragility — high freedom for flexible tasks, low freedom (scripts) for fragile ones.
+    - **Always Summarize**: Never finish silently. Provide a clear summary of what was
+      created and any follow-up actions needed.
 
     ## Output Rules
 
-    - **Skill files only**: Create ONLY the skill directory with SKILL.md and any
-      necessary bundled resources (scripts/, references/, assets/).  Do NOT create
-      auxiliary documentation such as README.md, SUMMARY.md, QUICK_REFERENCE.md,
-      VALIDATION_REPORT.md, INDEX.md, SKILL_OVERVIEW.md, INSTALLATION_GUIDE.md,
-      CHANGELOG.md, or similar files.  The skill package must be self-contained.
-    - **Relative paths only**: All file references within SKILL.md and reference
-      files must use relative paths (e.g. `references/examples.md`).  Never use
-      absolute or infrastructure-specific paths.
-
-    Always validate the generated skill against the format requirements before
-    delivering the final output.
+    - **Skill directory only**: Create ONLY the skill directory with SKILL.md and
+      necessary bundled resources. Do NOT create auxiliary documentation such as
+      README.md, SUMMARY.md, INSTALLATION_GUIDE.md, or similar files.
+    - **Relative paths only**: All file references within skill files must use relative
+      paths (e.g., `references/schema.md`, not absolute paths).
+    - **Valid structure only**: Every skill must have a SKILL.md with valid YAML
+      frontmatter containing `name` and `description` fields.
+    - **No extra clutter**: Do not create files that are not directly needed for an AI
+      agent to execute the skill's tasks.
   mcp_server_usages:
     - mcp_server_ref:
         kind: mcp_server

--- a/backend/services/stigmer-server/pkg/seedpack/tools/02_draft-agent-creator-skill.sh
+++ b/backend/services/stigmer-server/pkg/seedpack/tools/02_draft-agent-creator-skill.sh
@@ -15,7 +15,7 @@
 #   - ANTHROPIC_API_KEY set in environment
 #
 # Usage:
-#   ./draft_agent_creator.sh
+#   ./02_draft-agent-creator-skill.sh
 #
 # Output:
 #   Generated skill saved to ../skills/agent-creator/

--- a/backend/services/stigmer-server/pkg/seedpack/tools/03_draft-skill-creator-agent.sh
+++ b/backend/services/stigmer-server/pkg/seedpack/tools/03_draft-skill-creator-agent.sh
@@ -22,7 +22,7 @@
 #   - ANTHROPIC_API_KEY set in environment
 #
 # Usage:
-#   ./03_draft_skill_creator.sh
+#   ./03_draft-skill-creator-agent.sh
 #
 # Output:
 #   Generated agent YAML saved directly to agents/skill-creator.yaml.

--- a/backend/services/stigmer-server/pkg/supervisor/supervisor.go
+++ b/backend/services/stigmer-server/pkg/supervisor/supervisor.go
@@ -279,6 +279,7 @@ func (s *Supervisor) startAgentRunner() error {
 	args = append(args,
 		"-e", "MODE=local",
 		"-e", fmt.Sprintf("STIGMER_BACKEND_ENDPOINT=%s", backendAddr),
+		"-e", fmt.Sprintf("STIGMER_SERVER_ADDRESS=%s", backendAddr),
 		"-e", fmt.Sprintf("TEMPORAL_SERVICE_ADDRESS=%s", hostAddr),
 		"-e", "TEMPORAL_NAMESPACE=default",
 		"-e", "TASK_QUEUE=agent_execution_runner",


### PR DESCRIPTION
## Summary

Overhauls the skill-creator agent instructions with an improved workflow, MCP server integration, and validation steps. Also renames seedpack tool scripts to kebab-case and wires up the `STIGMER_SERVER_ADDRESS` environment variable for MCP connectivity in the agent runner.

## Context

The skill-creator agent needed clearer instructions, progressive disclosure, and proper integration with MCP servers. Additionally, tool script filenames were inconsistent with the project's kebab-case naming convention, and the agent-runner supervisor lacked the environment variable required to connect to the Stigmer MCP server.

## Changes

- Overhauled `skill-creator.yaml` agent instructions with improved workflow, MCP server integration, progressive disclosure, and validation steps
- Renamed seedpack tool scripts from snake_case to kebab-case (`02_draft_agent_creator.sh` → `02_draft-agent-creator-skill.sh`, `03_draft_skill_creator.sh` → `03_draft-skill-creator-agent.sh`) and updated usage comments
- Added `STIGMER_SERVER_ADDRESS` env var to agent-runner supervisor for MCP server connectivity

## Implementation notes

- The tool script renames are high-similarity renames (R099), preserving git history
- The env var addition in `supervisor.go` is a single-line change enabling the agent process to reach the Stigmer MCP server

## Breaking changes

- Tool script filenames changed; any external references to the old snake_case names will need updating

## Test plan

- Verify the skill-creator agent loads with the updated YAML instructions
- Confirm renamed tool scripts are discovered and executable by the seedpack tooling
- Validate that the agent-runner can connect to the MCP server via the new env var

## Checklist

- [ ] Docs updated (if needed)
- [ ] Tests added/updated (if needed)
- [ ] Backward compatible