### PR TITLE
feat(cli): add smart Ctrl+O expand hints and expandable error output

### DIFF
--- a/_changelog/2026-03/2026-03-07-044944-fix-single-file-artifact-nested-directory.md
+++ b/_changelog/2026-03/2026-03-07-044944-fix-single-file-artifact-nested-directory.md
@@ -1,0 +1,53 @@
+# Fix Single-File Artifact Nested Directory Bug
+
+**Date**: March 7, 2026
+
+## Summary
+
+Fixed the auto-publish logic in the agent-runner so that a single written file is always published as a FILE artifact (named after the file itself), rather than being wrapped in a DIRECTORY artifact named after its parent directory. This eliminates a nested-directory collision when the CLI downloads artifacts to an `--output` directory that already matches the parent.
+
+## Problem Statement
+
+When `stigmer draft mcp-server --output mcp-servers/ --workspace .` was run, the generated YAML ended up at `mcp-servers/mcp-servers/planton.yaml` instead of `mcp-servers/planton.yaml`.
+
+### Pain Points
+
+- Running the onboarding script for the agent-fleet repo created a spurious nested `mcp-servers/mcp-servers/` directory
+- Users had to manually move files out of the nested directory
+- The artifact metadata displayed an incorrect name (`"mcp-servers"` instead of `"planton.yaml"`) in execution history and API responses
+
+## Solution
+
+Changed the `_auto_publish_written_files` function in `execute_graphton.py` to handle the single-file case as an early return that publishes the file directly — the same way root-level files are already published. This bypasses both the `common_dir` directory-artifact path and the grouping logic that had the same directory-artifact behaviour.
+
+## Implementation Details
+
+**Before**: When the agent wrote a single file in a subdirectory (e.g., `mcp-servers/planton.yaml`), the auto-publish logic extracted `common_dir = "mcp-servers"` (the parent) and published a DIRECTORY artifact named `"mcp-servers"`. On the CLI side, `downloadDirectoryArtifact` computed `filepath.Join(outputDir, "mcp-servers")`, doubling the path when `outputDir` was already `mcp-servers/`.
+
+**After**: When exactly one file is written, it is published as a FILE artifact with `name = "planton.yaml"` and `path = "mcp-servers/planton.yaml"`. The CLI downloads to `filepath.Join(outputDir, "planton.yaml")` — correct, no nesting.
+
+The multi-file case (2+ files sharing a parent directory) is completely unaffected and still uses the common-ancestor directory-artifact strategy.
+
+### Files Changed
+
+- `backend/services/agent-runner/worker/activities/execute_graphton.py` — replaced the single-file `common_dir` heuristic with a direct file-artifact publish and early return
+- `backend/services/agent-runner/tests/test_auto_publish.py` — updated 5 tests to expect file-artifact semantics for single-file-in-subdirectory cases; updated module docstring
+
+## Benefits
+
+- Eliminates the nested `mcp-servers/mcp-servers/` directory bug for all single-file draft commands
+- Produces correct artifact names in the execution API, UI, and history
+- Works consistently across local and cloud execution modes
+- Zero impact on multi-file artifact publishing (skills, agents with multiple files)
+
+## Impact
+
+All `stigmer draft` commands that produce a single output file (e.g., `draft mcp-server`, `draft skill` for single-file skills) will now place the file directly in the `--output` directory without nesting. Existing multi-file artifacts are unaffected.
+
+## Related Work
+
+Discovered while investigating the agent-fleet onboarding script (`tools/00_onboard-planton-mcp-server.sh`) which passes `--output "${REPO_ROOT}/mcp-servers"` to `stigmer draft mcp-server`.
+
+---
+
+**Status**: Production Ready

--- a/_changelog/2026-03/2026-03-07-045231-fix-ai-stream-gap-and-markdown-rendering.md
+++ b/_changelog/2026-03/2026-03-07-045231-fix-ai-stream-gap-and-markdown-rendering.md
@@ -1,0 +1,51 @@
+# Fix AI Stream Gap and Markdown Rendering in CLI TUI
+
+**Date**: March 7, 2026
+
+## Summary
+
+Fixed two rendering bugs in the Stigmer CLI's inline TUI that affected the visual quality of AI streaming responses. After a tool completion, the subsequent AI message appeared flush against the tool block with no visual gap. Additionally, AI messages containing markdown were displayed as raw text during streaming instead of being rendered with glamour formatting.
+
+## Problem Statement
+
+The inline TUI streams AI responses token-by-token through Bubbletea. Two distinct rendering paths exist: committed scrollback lines (processed through `writeToScrollback` with full gap and formatting logic) and transient partial content (shown live in `View()` with no gap or markdown logic).
+
+### Pain Points
+
+- After a tool call completes, the first AI streaming tokens appear directly below the tool block with no visual separation, making the output feel cramped and harder to scan
+- AI responses containing markdown (headers, code blocks, lists, bold text) render as raw markdown syntax during streaming, only getting glamour-formatted in the history record but never replacing the raw scrollback lines
+
+## Solution
+
+Two targeted changes in `renderAIStreamStart` and `renderAIStreamEnd` within `run_stream_inline_aistream.go`, both leveraging existing infrastructure rather than introducing new mechanisms.
+
+## Implementation Details
+
+### Gap fix — `renderAIStreamStart`
+
+Before any streaming content is emitted, check `needsLeadingGap(r.lastScrollbackKind, kindAIStreamLine)`. When the previous scrollback item was a dense block (tool completion, read group), emit a blank line to scrollback via `statusf("\n")` and update `r.lastScrollbackKind` to `kindAIStreamLine`. This prevents a double gap when `commitAIStreamLines` later processes the first complete line through `writeToScrollback`, which runs the same `needsLeadingGap` check.
+
+### Markdown re-commit — `renderAIStreamEnd`
+
+After `recordAIMessage` stores the glamour-rendered version in history, check `mdrender.HasMarkdown(e.Content)`. When true, reset `r.lastScrollbackKind` via `lastKindFromHistory(r.history)` and call `triggerReCommit()` to atomically replace the raw scrollback with the rendered version. This reuses the same re-commit path as the Ctrl+O expand toggle — no new clearing or rendering mechanism needed. Plain-text responses stream without any re-commit overhead.
+
+## Benefits
+
+- Consistent visual spacing between tool completions and AI responses, matching the gap behavior of non-streamed messages
+- Markdown-rich AI responses (code blocks, headers, lists) render with proper ANSI formatting in the terminal, matching the quality of non-streamed `renderAIMessage`
+- Zero overhead for plain-text responses — the re-commit only triggers when `HasMarkdown` detects markdown syntax
+- No new infrastructure — both fixes compose existing helpers (`needsLeadingGap`, `statusf`, `triggerReCommit`, `lastKindFromHistory`)
+
+## Impact
+
+All CLI users who interact with agents that produce tool calls followed by markdown-rich responses will see improved visual quality. The change is confined to a single file (`run_stream_inline_aistream.go`) with no API or behavioral changes visible to other components.
+
+## Related Work
+
+- Ctrl+O expand/collapse toggle that introduced the `triggerReCommit` infrastructure
+- `needsLeadingGap` / `needsTrailingGap` gap logic in `run_stream_inline_history.go`
+- `mdrender.HasMarkdown` / `mdrender.Render` glamour rendering in `pkg/mdrender/render.go`
+
+---
+
+**Status**: ✅ Production Ready

--- a/_changelog/2026-03/2026-03-07-051048-add-ctrl-o-to-expand-hint.md
+++ b/_changelog/2026-03/2026-03-07-051048-add-ctrl-o-to-expand-hint.md
@@ -1,0 +1,66 @@
+# Add "ctrl+o to expand" Hint to Expandable Tool Lines
+
+**Date**: March 7, 2026
+
+## Summary
+
+Added a dim `(ctrl+o to expand)` hint to every compact tool line, read group header, and collapsed sub-agent block in the inline renderer. This surfaces the Ctrl+O expand/collapse keybinding directly in the session output, matching how Claude Code teaches users about expandable items inline.
+
+## Problem Statement
+
+The Ctrl+O expand/collapse toggle was fully implemented across 5 phases of the `20260305.02.expand-collapse-tools` project, but there was zero visual discoverability. Users had no way to know Ctrl+O existed unless told out-of-band (documentation, word-of-mouth). The feature was invisible.
+
+### Pain Points
+
+- New users never discover the expand feature exists
+- The session header's "Stigmer · expanded" indicator only shows after toggling — it doesn't teach the initial keybinding
+- Claude Code already surfaces this hint inline; Stigmer users expect comparable discoverability
+
+## Solution
+
+Append a dim `(ctrl+o to expand)` suffix to the first line of every expandable item in compact mode. The hint is gated on Ctrl+O being available (TTY mode with Bubbletea owning stdin) so it never appears in non-interactive environments.
+
+## Implementation Details
+
+- **New style**: `expandHintStyle` in `run_display.go` — dim gray (color `"8"`), no italic, consistent with `toolrender.dimStyle` used for parenthetical metadata like `(43 lines)`.
+- **Hint placement**: Lives in the inline renderer layer (`run_stream_inline_history.go`), not the `toolrender` package. The `toolrender` package is a pure rendering library with no knowledge of keybindings.
+- **`appendExpandHint` helper**: Injects the hint into the first line of rendered text. Multi-line output (read groups, expanded shells) only gets the hint on the header line.
+- **`showExpandHint` parameter**: Threaded through `renderHistoryBatch` → `renderCommittedItem`, applied to `kindToolCompact`, `kindReadGroup`, and `kindSubAgentBlock` when `!expanded && showExpandHint`.
+- **`expandHintEnabled()` predicate**: Returns `true` when `toggleExpandCh != nil` (Bubbletea owns stdin in TTY mode). Returns `false` in tests, CI, piped output, non-TTY.
+- **Both rendering paths covered**: `commitToScrollback` (live rendering) and `triggerReCommit` (re-commit on toggle) both pass the hint flag, so hints appear/disappear correctly when the user toggles.
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `run_display.go` | Added `expandHintStyle` |
+| `run_stream_inline_types.go` | Added `expandHintEnabled()` method |
+| `run_stream_inline_history.go` | Added `expandHintSuffix`, `appendExpandHint`; threaded `showExpandHint` through `renderHistoryBatch`, `renderCommittedItem`, `triggerReCommit` |
+| `run_stream_inline_render.go` | Updated `commitToScrollback` to pass hint flag |
+| `run_stream_inline_approval.go` | Updated `renderHistoryBatch` call in approval flow |
+| `run_stream_inline_history_test.go` | Updated 50+ existing test calls; added 12 new tests |
+| `run_stream_inline_history_bench_test.go` | Updated all benchmark calls; added hint-enabled benchmark variant |
+
+## Benefits
+
+- **Discoverability**: Every expandable item now teaches the user about Ctrl+O
+- **Consistency**: Matches Claude Code's inline hint pattern that users already expect
+- **Non-intrusive**: Dim color blends with existing metadata; disappears in expanded mode
+- **Safe**: No hints in non-interactive environments (tests, CI, piped output)
+- **Zero performance impact**: One string concat per item; benchmark delta negligible
+
+## Impact
+
+All users of `stigmer run` and `stigmer draft` in TTY mode will see the hint on every compact tool line. Non-TTY users (CI, piped output) are unaffected.
+
+## Related Work
+
+- [Expand/collapse toggle implementation](_changelog/2026-03/2026-03-05-070144-event-history-retention-and-subject-update.md)
+- [Ctrl+O keybinding and stdin ownership](_changelog/2026-03/2026-03-05-075631-ctrl-o-keybinding-full-bubbletea-stdin-ownership.md)
+- [Re-commit performance optimization](_changelog/2026-03/2026-03-05-083840-re-commit-performance-optimization.md)
+- Project: `_projects/2026-03/20260305.02.expand-collapse-tools`
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~1 hour

--- a/_changelog/2026-03/2026-03-07-060619-smart-ctrl-o-expand-and-approval-toggle.md
+++ b/_changelog/2026-03/2026-03-07-060619-smart-ctrl-o-expand-and-approval-toggle.md
@@ -1,0 +1,95 @@
+# Smart Ctrl+O Expand Hint, Approval Toggle, and Input Bar Preservation
+
+**Date**: March 7, 2026
+
+## Summary
+
+Overhauled the Ctrl+O expand/collapse system across three dimensions: the hint is now intelligent (only shown when expanding would actually reveal more content), Ctrl+O works during approval prompts, and the input bar no longer disappears after toggling. These changes transform a rough prototype into a polished, production-quality expand/collapse experience.
+
+## Problem Statement
+
+The initial Ctrl+O expand hint implementation had several UX and functional issues that undermined its usefulness and created confusion.
+
+### Pain Points
+
+- **Misleading hints**: The "(ctrl+o to expand)" hint appeared on every compact tool line regardless of whether expanding would show more content — including single-read tools (where the user can just click the file link), write/edit tools (where the path is already clickable), and short thinking blocks (where the full content is already visible).
+- **Blocked during approval**: Pressing Ctrl+O during an approval prompt had no effect because `promptApprovalViaChannel` was blocked on a single `decisionCh` receive, starving the `toggleExpandCh` signal.
+- **Input bar vanishing**: After toggling Ctrl+O during the follow-up prompt phase, the separator + text input bar at the bottom of the screen disappeared. Root cause: `tea.ClearScreen` in Bubbletea v2's `cursedRenderer.clearScreen()` calls `scr.MoveTo(0, 0)`, which forces the renderer to position View() at the top-left of the terminal — overwriting history content and leaving the bottom (where the user expects the input bar) empty.
+
+## Solution
+
+Three targeted fixes, each addressing a distinct aspect of the expand system:
+
+1. **Expandability predicates** — New `IsExpandable` and `IsReadGroupExpandable` functions in the `toolrender` package that analyze each tool's content against its truncation threshold.
+2. **Approval-aware toggle** — Refactored `promptApprovalViaChannel` to use a `select` loop that listens on both `decisionCh` and `toggleExpandCh`, with a new `approvalReRenderMsg` to refresh the display without disrupting the approval flow.
+3. **Two-phase re-commit** — Replaced the `tea.Sequence(tea.Raw(payload), tea.ClearScreen)` pattern with a two-phase approach: phase 1 suppresses `View()` while `tea.Raw` rewrites the terminal; phase 2 (`reCommitDoneMsg`) restores `View()` so the renderer writes it fresh at the correct cursor position.
+
+## Implementation Details
+
+### New file: `render_expandable.go`
+
+Houses `IsExpandable(tc ToolCallInfo) bool` and `IsReadGroupExpandable(reads []ToolCallInfo) bool`. Per-tool-type logic:
+
+| Tool type | Expandable when... |
+|---|---|
+| Read, Write, Edit, Delete | Never (always false) |
+| Shell/Bash | Result exceeds `maxShellOutputLines + 1` (5+ lines) |
+| Thinking | Thought text exceeds `maxThinkLines + 1` (5+ lines) |
+| Discovery (Glob, Grep, List) | Non-empty result with entries |
+| Unknown/MCP | Result exceeds `maxUnknownOutputLines + 1` (5+ lines) |
+| Read groups | Entry count exceeds `maxVisibleInGroup + 1` (5+ entries) |
+
+Failed tools always return false regardless of content.
+
+### Modified: `run_stream_inline_history.go`
+
+`renderCommittedItem` now gates the `appendExpandHint` call on the expandability predicates instead of the blanket `showExpandHint` flag. Each `committedKind` uses its appropriate predicate:
+- `kindToolCompact` → `toolrender.IsExpandable(item.toolCalls[0])`
+- `kindReadGroup` → `toolrender.IsReadGroupExpandable(item.toolCalls)`
+- `kindSubAgentBlock` → `len(item.saBlock.children) > 0`
+
+### Modified: `run_stream_inline_approval.go`
+
+`promptApprovalViaChannel` now uses a `for { select { ... } }` loop:
+- `case d = <-decisionCh:` → proceeds with approval decision
+- `case <-r.cfg.toggleExpandCh:` → toggles expand mode, re-renders history, sends `approvalReRenderMsg`
+
+### Modified: `run_stream_inline_bubbletea.go`
+
+- Added `reCommitPending bool` field to `inlineBubbleModel`
+- `View()` returns empty `tea.View` when `reCommitPending` is true
+- `handleReCommit` sets `reCommitPending = true` before returning the re-commit Cmd
+- New `handleReCommitDone` clears `reCommitPending` on `reCommitDoneMsg`
+- `handleApprovalStart` and `handleApprovalShow` also set `reCommitPending` when using `buildReCommitCmd`
+
+### Modified: `run_stream_inline_history.go` (buildReCommitCmd)
+
+Replaced `tea.Sequence(tea.Raw(payload), tea.ClearScreen)` with `tea.Sequence(tea.Raw(payload), func() tea.Msg { return reCommitDoneMsg{} })`. The `reCommitDoneMsg` triggers phase 2 — the renderer sees a transition from empty to composed view and writes it at the current cursor position.
+
+### New messages: `run_stream_inline_messages.go`
+
+- `approvalReRenderMsg` — carries updated `reCommitPayload` for approval-phase toggles
+- `reCommitDoneMsg` — phase 2 signal that clears `reCommitPending`
+
+## Benefits
+
+- **Reduced noise**: Users no longer see expand hints on tools where expanding adds no value (reads, writes, short content)
+- **Unblocked approval flow**: Ctrl+O works seamlessly during approval prompts without interfering with the accept/reject decision
+- **Stable UI**: The input bar (separator + text input or "esc to interrupt") remains visible across all expand/collapse toggles
+- **Correct Bubbletea v2 rendering**: The two-phase re-commit avoids the `MoveTo(0,0)` cursor reset that caused View() to render at the wrong terminal position
+
+## Impact
+
+- **End users**: Cleaner, less cluttered TUI with expand hints that are actually actionable
+- **Approval workflow**: Ctrl+O now works at every stage — during execution, during approval, and during follow-up
+- **Code quality**: The expandability logic is centralized in `render_expandable.go` with clear per-tool predicates, making it easy to add new tool types
+
+## Related Work
+
+- Builds on [Add Ctrl+O to Expand Hint](2026-03-07-051048-add-ctrl-o-to-expand-hint.md) which introduced the initial hint mechanism
+- Root cause analysis of Bubbletea v2's `cursedRenderer.clearScreen()` behavior documented for future reference
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~3 hours (including deep-dive into Bubbletea v2 renderer internals)

--- a/_changelog/2026-03/2026-03-07-064556-expandable-errors-and-follow-up-recommit-fix.md
+++ b/_changelog/2026-03/2026-03-07-064556-expandable-errors-and-follow-up-recommit-fix.md
@@ -1,0 +1,87 @@
+# Universal Error Expandability and Follow-up Re-commit Fix
+
+**Date**: March 7, 2026
+
+## Summary
+
+Two bugs in the Ctrl+O expand/collapse system have been fixed: (1) truncated error messages across all tool types are now expandable, revealing the full error when the user presses Ctrl+O, and (2) the follow-up input bar (separator, `>` prompt, hint text) no longer vanishes after toggling Ctrl+O during the follow-up prompt.
+
+## Problem Statement
+
+After the initial Ctrl+O expand system was shipped, two issues were discovered in production:
+
+1. **Truncated error messages were never expandable.** All tool types truncate error messages to 60 characters in compact mode (`✗ MCP server 'planton' in org 'default' not found. Verify...`), but the expandability predicates short-circuited to `false` for any error — even when the compact display was clearly truncating content. The expanded renderer also reused the same truncated 60-char display, so even if a tool were marked expandable, the expanded view showed the identical truncated text.
+
+2. **Follow-up input bar disappeared after Ctrl+O.** During the follow-up prompt phase, pressing Ctrl+O caused the separator line, `>` prompt, and `enter send · ctrl+c exit` hint to vanish. Only the blinking cursor remained, and while typing still worked functionally, the entire visual chrome was invisible.
+
+### Pain Points
+
+- MCP tool errors (e.g., "MCP server not found") showed truncated output with no way to see the full message
+- The Ctrl+O hint (`ctrl+o to expand`) didn't appear for tools with truncated errors, making the feature undiscoverable
+- The follow-up input bar became invisible after any Ctrl+O toggle, forcing users to type blind or restart
+- The `>` prompt, separator, and helper text were all missing — only the raw terminal cursor was visible
+
+## Solution
+
+### Bug 1: Universal Error Expandability
+
+A three-layer fix applied uniformly across all tool types (Shell, Read, Write/Edit, Delete, Discovery, Thinking, Unknown/MCP):
+
+1. **Shared `isErrorExpandable` predicate** — determines whether the compact error display truncates content. Returns true when the error message exceeds `maxErrorDisplayLen` (60 chars) or when a result-prefixed error (`"Error: ..."`) has multiple lines of content.
+
+2. **All expandability predicates updated** — `isContentExpandable`, `isThinkExpandable`, `isDiscoveryExpandable`, `isUnknownExpandable`, and the `IsExpandable` dispatcher for Read/Write/Delete now delegate to `isErrorExpandable` before returning false for errors. Short errors (< 60 chars, single line) remain non-expandable.
+
+3. **Full-error expanded rendering** — a shared `renderExpandedErrorContent` function shows the complete error text without truncation. For result-prefixed errors, all lines of `tc.Result` are shown with the `"Error: "` prefix replaced by the `✗` indicator. For explicit `tc.Error` fields, the full multi-line text is displayed. Each tool's expanded renderer now uses this instead of delegating to the truncated compact error path.
+
+### Bug 2: Renderer-Aware Follow-up Re-commit
+
+The root cause was diagnosed by reading the Bubbletea v2 `cursedRenderer` source. The existing two-phase re-commit uses `tea.Raw` to clear the screen and rewrite history — this bypasses the renderer, permanently desyncing its internal cursor position tracking. In inline mode, the renderer uses relative cursor movements, so all subsequent `View()` writes land at stale terminal coordinates. The text content (separator, prompt, hint) was written off-screen while the terminal cursor (placed via absolute escape sequences) appeared at the correct location.
+
+The fix introduces a separate re-commit path for follow-up mode (`buildFollowUpReCommitCmd`) that uses renderer-aware operations instead of `tea.Raw` for the history rewrite:
+
+1. `tea.Raw(clearAndHome)` — physically clears the terminal and scrollback
+2. `tea.ClearScreen` — resets the renderer's position tracking to (0,0)
+3. `reCommitDoneMsg` — clears `reCommitPending` so `View()` renders the input bar at the tracked position
+4. `tea.Println(history)` — uses `insertAbove` to insert history above the view, pushing the input bar to the bottom while keeping the renderer's position tracking in sync
+
+The execution-mode re-commit path (using `tea.Raw`) is unchanged — the desync is acceptable there because the view is small ("esc to interrupt") and corrected on the next full re-commit.
+
+## Implementation Details
+
+### Files Changed
+
+- `client-apps/cli/pkg/toolrender/render_compact.go` — extracted `maxErrorDisplayLen = 60` constant; replaced all 7 hardcoded `60` values in `truncate(errMsg, 60)` calls
+- `client-apps/cli/pkg/toolrender/render_expandable.go` — added `isErrorExpandable` helper; updated all 5 expandability predicates; updated `IsExpandable` dispatcher for Read/Write/Delete/default
+- `client-apps/cli/pkg/toolrender/render_expanded.go` — added `renderExpandedErrorContent` helper; added `renderExpandedRead`, `renderExpandedWrite`, `renderExpandedDelete` functions; updated Shell/Think/Discovery/Unknown expanded renderers to use full error rendering
+- `client-apps/cli/pkg/toolrender/render_expandable_test.go` — renamed 3 test functions for accuracy; added `TestIsExpandable_LongErrors_Expandable` with 9 test cases covering all tool types
+- `client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go` — `handleReCommit` now detects follow-up mode and dispatches to `buildFollowUpReCommitCmd`
+- `client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go` — added `buildFollowUpReCommitCmd` using `tea.ClearScreen` + `tea.Println` instead of `tea.Raw`
+
+### Key Design Decisions
+
+- **Universal, not MCP-only**: The error expandability fix applies to all tool types. Every compact renderer uses the same `truncate(errMsg, maxErrorDisplayLen)` pattern, so every tool type benefits equally from the shared `isErrorExpandable` predicate.
+- **Shared constant**: The `maxErrorDisplayLen = 60` constant ensures the expandability check and the compact rendering always use the same threshold — a change in one place affects both.
+- **Two re-commit strategies**: Follow-up mode uses renderer-aware operations; execution mode keeps the existing `tea.Raw` path. This avoids changing the well-tested execution path while fixing the follow-up regression.
+- **No `reCommitPending` suppression for Println**: The follow-up path still sets `reCommitPending = true` during the `tea.Raw(clearAndHome)` phase (to prevent renderer interference during the physical clear), but clears it before `tea.Println` so the view is rendered and `insertAbove` can calculate the correct view height.
+
+## Benefits
+
+- Truncated error messages across all tool types now show the Ctrl+O expand hint
+- Expanding reveals the full error text — no more 60-char truncation in expanded mode
+- The follow-up input bar (separator, prompt, hint) survives Ctrl+O toggles
+- The renderer's cursor tracking stays in sync during follow-up re-commits
+- The `maxErrorDisplayLen` constant eliminates the risk of expandability/rendering threshold mismatch
+
+## Impact
+
+- **End users**: Can now read full error messages from any tool (MCP, Shell, Read, etc.) by pressing Ctrl+O. The follow-up prompt is no longer disrupted by expand toggles.
+- **Maintainers**: The `isErrorExpandable` and `renderExpandedErrorContent` helpers provide a single place to modify error expandability and rendering logic for all tool types.
+
+## Related Work
+
+- [Smart Ctrl+O expand and approval toggle](2026-03-07-060619-smart-ctrl-o-expand-and-approval-toggle.md) — the initial Ctrl+O system that this changelog fixes issues in
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~2 hours

--- a/_changelog/2026-03/2026-03-07-065054-simplify-draft-epilogue-and-eliminate-redundant-downloads.md
+++ b/_changelog/2026-03/2026-03-07-065054-simplify-draft-epilogue-and-eliminate-redundant-downloads.md
@@ -1,0 +1,85 @@
+# Simplify Draft Epilogue and Eliminate Redundant Artifact Downloads
+
+**Date**: March 7, 2026
+
+## Summary
+
+Cleaned up the post-execution output of `stigmer draft` commands by eliminating redundant artifact downloads when local workspaces handle file delivery, replacing the raw session-ID status line with a clean resume command, and condensing artifact download messages into a compact summary.
+
+## Problem Statement
+
+When `stigmer draft mcp-server` was invoked with `--workspace` pointing to local paths (the common pattern for onboarding scripts), three UX defects surfaced.
+
+### Pain Points
+
+- **Duplicate file creation**: The agent wrote files directly to the local workspace (`LocalPathSource`), then `--output` (default `"."`) triggered an artifact download creating a second copy in the repo root. This left orphaned files in git status.
+- **Noisy, unhelpful epilogue**: Five lines of internal implementation detail — "Session ses-01kk... completed", "Downloading 1 artifact(s) to ...", per-file download messages, "All artifacts downloaded" — none actionable for the user.
+- **No resume affordance**: The session ID appeared as a label, not as a copy-pasteable `stigmer run <session-id>` command. Users who Ctrl+C'd mid-stream had no obvious way to re-attach.
+
+## Solution
+
+Three coordinated changes across the CLI and the onboarding scripts:
+
+1. **Smart artifact download skip**: Draft commands with local workspaces no longer download artifacts by default (the agent writes directly to disk). Users who need explicit artifact download can pass `--output <dir>`.
+2. **Clean session exit line**: Replaced the raw "Session XXX completed" line with a colored status + copy-pasteable resume command, applied universally to all session-based commands.
+3. **Compact artifact summary**: Replaced verbose per-file download messages with a single summary line.
+
+## Implementation Details
+
+### `draft_handler.go` — Download skip logic
+
+Changed `--output` default from `"."` to `""`. Added a three-way switch in `executeDraft`:
+
+```go
+switch {
+case opts.Detach:
+    downloadDir = ""
+case downloadDir == "" && len(localWorkspaceRoots(prep.WorkspaceEntries)) > 0:
+    // Agent writes directly to local workspaces; artifact download is redundant.
+case downloadDir == "":
+    downloadDir = "."
+}
+```
+
+Backward compatible: `stigmer draft skill -m "..."` (no workspace) still downloads to `.`.
+
+### `run_display_summary.go` — Session exit line
+
+Rewrote `displaySessionExitLine` to use `climsg` for colored status output and added `sessionResumeVerb` for context-appropriate resume hints:
+
+| Phase | Status line | Resume hint |
+|-------|-------------|-------------|
+| completed | `Completed (42s)` | `To continue:  stigmer run <id>` |
+| failed | `Failed: <error>` | `To retry:    stigmer run <id>` |
+| cancelled | `Cancelled` | `To resume:   stigmer run <id>` |
+
+### `run_handlers.go` — Compact artifact summary
+
+Restructured `downloadArtifacts`, `downloadArtifact`, `downloadFileArtifact`, and `downloadDirectoryArtifact` to separate downloading from display. Downloads are silent; a compact summary prints once at the end via `displayArtifactSummary`. Single artifact: `Saved planton.yaml (2.3 KB)`. Multiple: a header + indented entries.
+
+### Shell scripts (agent-fleet)
+
+Removed redundant `=== Onboarding Complete ===` banners and `Output: ...` lines from both `00_onboard-planton-mcp-server.sh` and `01_generate-approval-policy.sh`. Kept only domain-specific "Next steps" that the CLI cannot know.
+
+## Benefits
+
+- **No duplicate files**: Eliminates the stale `planton.yaml` copy in the repo root
+- **Cleaner output**: Five lines of noise reduced to two actionable lines
+- **Discoverability**: Resume command is always visible and copy-pasteable
+- **Universal improvement**: The session exit line change benefits all session-based commands (`run` and `draft`), not just draft
+
+## Impact
+
+- **CLI users**: Cleaner post-execution output for all `stigmer draft` and `stigmer run` commands
+- **Script authors**: Scripts wrapping `stigmer draft` no longer need to suppress or work around noisy output
+- **Onboarding workflow**: The agent-fleet onboarding scripts produce focused, readable output
+
+## Related Work
+
+- Inline streaming UX polish (2026-03-04)
+- Bubbletea inline renderer migration (2026-03-05)
+- Single-file artifact fix (2026-03-07-044944)
+
+---
+
+**Status**: ✅ Production Ready

--- a/_changelog/2026-03/2026-03-07-072503-fix-ctrl-o-blank-screen-and-ai-truncation.md
+++ b/_changelog/2026-03/2026-03-07-072503-fix-ctrl-o-blank-screen-and-ai-truncation.md
@@ -1,0 +1,86 @@
+# Fix Ctrl+O Blank Screen and AI Message Truncation
+
+**Date**: March 7, 2026
+
+## Summary
+
+Fixed two rendering bugs in the inline TUI: (1) Ctrl+O re-commit desynced BubbleTea v2's cursor tracker causing a blank screen, and (2) `TodoUpdateEvent` prematurely terminated active AI streams causing the AI message to appear truncated. Both fixes are targeted at the re-commit and event pre-switch logic — no architectural changes.
+
+## Problem Statement
+
+Two distinct issues were degrading the inline rendering experience, each rooted in a different subsystem of the re-commit / event dispatch pipeline.
+
+### Pain Points
+
+- **Ctrl+O clears screen**: Pressing Ctrl+O during execution wiped the terminal and left a blank screen. The entire session history (header, tools, AI messages) disappeared until a new event triggered a re-render.
+- **AI message truncated by todo items**: When the agent emitted a `TodoUpdateEvent` mid-stream, the AI message was cut off at the point where the todo arrived. The remaining content was silently dropped from the display, even though the backend had delivered it.
+
+## Solution
+
+Three targeted fixes, each addressing a specific root cause:
+
+1. **Unified re-commit command** — Replaced the execution-mode `buildReCommitCmd` (which used `tea.Raw` only, desyncing the renderer) with a single renderer-aware function used by all modes: `Raw(clearAndHome)` → `ClearScreen` → `Println(history)` → `reCommitDoneMsg`. Deleted `buildFollowUpReCommitCmd`.
+
+2. **Deferred re-commit during AI streaming** — Added `pendingReCommit` flag. When a re-commit trigger (Ctrl+O, subject update) fires during an active AI stream, the re-commit is deferred until the stream ends. This prevents content loss since AI stream lines are not stored in history until `AIStreamEnd`.
+
+3. **TodoUpdateEvent exemption** — Added `TodoUpdateEvent` as a dedicated case in the pre-switch, skipping `finishAIStreamIfNeeded()`. Todo updates only affect the composed View (via `planDisplay`) and must not interrupt the AI stream.
+
+4. **Safety-net recovery re-commit** — In `renderAIStreamEnd`'s early-return path (stream was interrupted), triggers a re-commit after `recordAIMessage` to recover the full AI content from history.
+
+## Implementation Details
+
+### Unified `buildReCommitCmd`
+
+**File**: `run_stream_inline_history.go`
+
+The old execution-mode function wrote history content directly via `tea.Raw(clearAndHome + history)`, bypassing BubbleTea v2's `cursedRenderer` cursor tracking. After `reCommitDoneMsg` re-enabled `View()`, the renderer wrote the composed view at its stale tracked position — potentially hundreds of rows off from where the actual cursor sat. The terminal appeared blank.
+
+The new unified function uses `ClearScreen` to reset the renderer to (0,0), then `tea.Println` to write history through the renderer's tracked path. The key insight: `Println` executes while `reCommitPending` is still true, so `View()` returns empty and the renderer writes only the history content — no flicker.
+
+`buildFollowUpReCommitCmd` was deleted. `handleReCommit` no longer branches on `inputBarMode`.
+
+### Deferred Re-commit
+
+**Files**: `run_stream_inline_types.go`, `run_stream_inline.go`, `run_stream_inline_aistream.go`
+
+During AI streaming, individual lines are committed to scrollback via `writeToScrollback(kindAIStreamLine, ...)` but are NOT stored in `r.history`. Only the final `kindAIMessage` (at stream end) goes into history. A re-commit during streaming would clear the screen and re-render from history — losing all AI stream lines.
+
+The fix: when `recommitNeeded` is true but `r.inAIStream` is also true, set `r.pendingReCommit = true` instead of calling `triggerReCommit()`. After each `handleEvent`, check if `pendingReCommit && !inAIStream` and fire the deferred re-commit. Also handled inside `renderAIStreamEnd` (both normal and early-return paths) to fire promptly when the stream ends.
+
+### TodoUpdateEvent Exemption
+
+**File**: `run_stream_inline.go`
+
+The pre-switch in `handleEvent` called `finishAIStreamIfNeeded()` for ALL events in the `default` branch. `TodoUpdateEvent` fell into this branch, prematurely closing the AI stream. Subsequent `AIStreamDelta` events were silently dropped (`if !r.inAIStream { return }`). The `AIStreamEnd` event took the early-return path which recorded content to history but never displayed the missing portion.
+
+The fix: add `TodoUpdateEvent` as a dedicated case that skips both `finishAIStreamIfNeeded()` and `flushPendingReads()`.
+
+### Recovery Re-commit
+
+**File**: `run_stream_inline_aistream.go`
+
+In the `!r.inAIStream` early-return path of `renderAIStreamEnd`, after `recordAIMessage` stores the full content in history, trigger a re-commit. This ensures content recovery even if other events prematurely close an AI stream in the future.
+
+## Benefits
+
+- **Ctrl+O works reliably**: Toggle between compact and expanded mode without losing any content, in all phases — execution, follow-up, and approval
+- **No more truncated AI messages**: Todo updates coexist with active AI streams; the full agent response is always displayed
+- **Unified re-commit path**: One function instead of two eliminates a class of mode-specific rendering bugs
+- **Defensive recovery**: The safety-net re-commit in `AIStreamEnd` protects against future event ordering surprises
+
+## Impact
+
+- **End users**: Ctrl+O and todo updates are now reliable during all phases of agent execution
+- **Code quality**: Removed `buildFollowUpReCommitCmd` and the `inputBarMode` branching in `handleReCommit`, reducing code surface
+- **Maintainability**: The `pendingReCommit` pattern provides a clean solution for "re-commit during streaming" without tracking individual stream lines in history
+
+## Related Work
+
+- Builds on [Smart Ctrl+O Expand and Approval Toggle](2026-03-07-060619-smart-ctrl-o-expand-and-approval-toggle.md) which introduced the expand hint and approval-aware toggle
+- Builds on [Expandable Errors and Follow-up Recommit Fix](2026-03-07-064556-expandable-errors-and-follow-up-recommit-fix.md) which introduced `buildFollowUpReCommitCmd`
+- Root cause of Cause A (cursor desync) traces back to [Fix Recommit Scrollback Duplication via Raw](2026-03-06-013928-fix-recommit-scrollback-duplication-via-raw.md) which introduced the `tea.Raw`-only execution-mode path
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~2 hours (including deep root-cause analysis across re-commit pipeline and event dispatch)

--- a/_changelog/2026-03/2026-03-07-085926-fix-inline-rendering-program-restart-recommit.md
+++ b/_changelog/2026-03/2026-03-07-085926-fix-inline-rendering-program-restart-recommit.md
@@ -1,0 +1,89 @@
+# Fix Inline Rendering: Program Restart Re-commit and Single-Line Plan
+
+**Date**: March 7, 2026
+
+## Summary
+
+Replaced the broken `tea.Raw` + `tea.ClearScreen` re-commit mechanism with a foolproof program-restart approach, and switched the plan display from a dynamic-height multi-line View() to a constant-height single-line current task. These two changes eliminate the Ctrl+O blank screen bug and the todo-items-overwriting-scrollback bug at their root causes.
+
+## Problem Statement
+
+Two critical display bugs plagued the inline renderer:
+
+### Pain Points
+
+- **Ctrl+O losing separator and prompt**: After pressing Ctrl+O to toggle expand/collapse, the separator line and `>` cursor prompt at the bottom of the screen would disappear. The root cause: `tea.ClearScreen` emits physical escape sequences (`MoveTo(0,0)` + `Erase`) into the renderer buffer, which flushes *after* `tea.Raw`'s history write — effectively erasing the just-written content. No ordering of Raw/ClearScreen/Println within Bubbletea avoids this fundamental conflict.
+
+- **Todo items overwriting the first message**: The `planDisplay` in View() caused the view height to dynamically grow when new todos arrived. The inline renderer, using stale (shorter) height calculations for cursor positioning, would overwrite previously committed scrollback content when redrawing the taller View().
+
+## Solution
+
+**Issue 1 — Program restart for re-commit**: Instead of fighting Bubbletea's internal buffer ordering, the re-commit now synchronously stops the old program, writes history directly to the terminal (with no Bubbletea involved), and starts a fresh program instance with state pre-loaded. This guarantees a clean slate: the new renderer's cursor tracking starts from scratch at the correct physical cursor position.
+
+**Issue 2 — Single-line plan in View()**: The multi-line `planDisplay` field is replaced by a single-line `currentTask` showing only the in-progress todo. The full plan is stored in history and rendered in scrollback only when expanded mode is active (Ctrl+O). This makes View() height constant, eliminating the root cause of the overwrite.
+
+## Implementation Details
+
+### Part 1: Single-Line Plan
+
+- `renderComposedView` now shows `"  [-] <currentTask>"` instead of the full plan
+- `kindTodoUpdate` renders its full text in expanded mode via `renderCommittedItem`, returns empty in collapsed mode
+- `currentTaskMsg` simplified to carry only `task` (removed `planDisplay` field)
+- `renderTodoUpdate` stops building `displayBuf`, tracks `trackedCurrentTask` on the renderer
+
+### Part 2: Program Restart Re-commit
+
+- Added `programFactory` to `inlineRenderConfig` — a closure that creates fresh Bubbletea programs with the same channels and output writer
+- Wired up `programFactory` in both `streamAgentInline` and `resumeSession`
+- New `performReCommit` method: Quit + Wait on old program → `fmt.Fprint(clearAndHome + history)` → start new program with pre-loaded state (currentTask, termWidth, follow-up input if active)
+- New `performReCommitWithApproval` variant: same flow but also writes expanded tool view and pre-loads approval state (question, menu selection, decision channel) into the new model
+- `triggerReCommit` now calls `performReCommit` directly
+- Approval flow restructured: streaming→approval transitions use `performReCommitWithApproval`; Ctrl+O during approval prompt creates a new decision channel and restarts the program
+
+### Dead Code Removed
+
+- `reCommitPending` field and its View() suppression check
+- `handleReCommit`, `handleReCommitDone`, `handleApprovalReRender` model handlers
+- `buildReCommitCmd` (the broken tea.Raw + tea.ClearScreen + tea.Sequence)
+- `reCommitMsg`, `reCommitDoneMsg`, `approvalReRenderMsg` message types
+- `reCommitPayload` from `approvalStartMsg` and `approvalShowMsg`
+- `planDisplay` field from the model
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `run_stream_inline_types.go` | Add `programFactory`, `trackedCurrentTask`, `trackedInputBarMode`, `followUpSendCh` |
+| `run_stream.go` | Wire up `programFactory` closure |
+| `run_session.go` | Wire up `programFactory` closure |
+| `run_stream_inline_history.go` | Replace `buildReCommitCmd` with `performReCommit`/`performReCommitWithApproval`; update `kindTodoUpdate` rendering |
+| `run_stream_inline_bubbletea.go` | Remove `reCommitPending`, dead handlers, `planDisplay`; simplify approval handlers |
+| `run_stream_inline_approval.go` | Restructure to use `performReCommitWithApproval`; add `waitForApprovalDecision` |
+| `run_stream_inline_render.go` | Simplify `renderTodoUpdate`; track `currentTask` on renderer |
+| `run_stream_inline_messages.go` | Remove dead message types; simplify `currentTaskMsg` |
+| `run_stream_inline.go` | Track `followUpSendCh`; update comment |
+| `run_stream_inline_test.go` | Update comment |
+| `*_test.go` | Update/rewrite tests for new re-commit approach |
+
+## Benefits
+
+- **Zero flush-ordering races**: Direct terminal writes happen with no Bubbletea program running. No `tea.Raw` vs `tea.ClearScreen` vs `tea.Println` conflicts possible.
+- **Fresh renderer on every re-commit**: Cursor tracking is always correct because the new program starts from scratch at the physical cursor position.
+- **Constant View() height**: Single-line `currentTask` never causes height jumps. The inline renderer's positioning math is always stable.
+- **Net code reduction**: 197 lines added, 341 lines removed — simpler, more maintainable re-commit path.
+
+## Impact
+
+- **Users**: Ctrl+O toggle now works reliably in all states (idle, streaming, follow-up, approval). The separator and prompt always reappear in collapsed mode. Todo items no longer overwrite the first message content.
+- **Developers**: The re-commit mechanism is now straightforward (stop → write → start) with no Bubbletea internal buffer knowledge required.
+
+## Related Work
+
+- [2026-03-07-072503] fix-ctrl-o-blank-screen-and-ai-truncation — previous partial fix that this supersedes
+- [2026-03-06-013928] fix-recommit-scrollback-duplication-via-raw — earlier Raw-based approach
+- [2026-03-05-222122] unblock-ctrl-o-during-follow-up-prompt — Ctrl+O keybinding foundation
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~2 hours (root cause analysis + implementation)

--- a/_changelog/2026-03/2026-03-07-094537-fix-plan-display-and-program-lifecycle.md
+++ b/_changelog/2026-03/2026-03-07-094537-fix-plan-display-and-program-lifecycle.md
@@ -1,0 +1,69 @@
+# Fix Plan Display in View() and Program Lifecycle on Session Exit
+
+**Date**: March 7, 2026
+
+## Summary
+
+Two interrelated fixes to the inline rendering system: (1) the plan/todo summary is now properly displayed in the View() bottom bar with expand hint, and the full plan appears at the bottom of expanded scrollback; (2) the BubbleTea program reference is correctly propagated through the render/follow-up chain so `stopInlineProgram` shuts down the active program, preventing terminal corruption on session exit.
+
+## Problem Statement
+
+### Pain Points
+
+- **Plan display gaps**: The plan summary (current task + completion count) was not shown in the collapsed View() bar, leaving users with no visibility into plan progress without expanding. In expanded mode, the plan appeared inline with other events rather than at the bottom, making it hard to find.
+- **Terminal corruption on exit**: After any Ctrl+O toggle (or subject/recent-sessions update) triggered a `performReCommit`, the original BubbleTea program was replaced by a new one via `programFactory`. However, the caller still held the original (now-dead) program reference. On session exit, `stopInlineProgram` was called on the dead program (no-op), leaving the replacement program running in raw terminal mode. The epilogue output (`displaySessionExitLine`) then wrote `\n` which in raw mode is just LF (no carriage return), producing a staircase/offset effect.
+
+## Solution
+
+### Plan Display
+
+- Added `todoTotal`, `todoCompleted`, and `expandMode` fields to `inlineBubbleModel`.
+- `renderComposedView` now shows the current in-progress task and a plan summary ("Plan: 2/5 todos completed (ctrl+o to expand)") in the View() bar — but only when not in expanded mode (to avoid duplication).
+- `renderHistoryBatch` defers `kindTodoUpdate` items to the end of the batch so the plan always appears below all messages/tool output in expanded scrollback.
+- `renderCommittedItem` returns full plan text in expanded mode and empty string in collapsed mode.
+- `performReCommit` and `performReCommitWithApproval` transfer `todoTotal`, `todoCompleted`, and `expandMode` to the new program.
+
+### Program Lifecycle
+
+- Added `program *tea.Program` field to `renderResult` so `renderInline` returns the active program.
+- All 7 return points in `renderInline` and `completeFollowUp` set `program: r.cfg.program`.
+- `runInlineFollowUpLoop` returns a 4th value (`latestProgram`) and keeps `cfg.program` in sync between follow-up iterations.
+- Both callers (`streamAgentInline`, `resumeSession`) use the returned `activeProgram` for `stopInlineProgram` instead of the stale original.
+
+## Implementation Details
+
+### Files Changed (11 files, +142 / -63)
+
+| File | Change |
+|------|--------|
+| `run_stream_inline_bubbletea.go` | Added `todoTotal`, `todoCompleted`, `expandMode` to model; updated `renderComposedView` for plan summary; clear plan on `textInputHideMsg` |
+| `run_stream_inline_messages.go` | Extended `currentTaskMsg` with `todoTotal`/`todoCompleted` |
+| `run_stream_inline_render.go` | `renderTodoUpdate` now tracks completion counts; sends extended `currentTaskMsg` |
+| `run_stream_inline_types.go` | Added `program` to `renderResult`; added `trackedTodoTotal`/`trackedTodoCompleted` to renderer |
+| `run_stream_inline_history.go` | Deferred `kindTodoUpdate` to end of batch; added `todoTotal`/`todoCompleted` to `committedItem`; transfer `expandMode` during re-commit |
+| `run_stream_inline.go` | Set `program: r.cfg.program` in all return points |
+| `run_stream_inline_followup.go` | Return 4th value `latestProgram`; sync `cfg.program` between iterations |
+| `run_stream.go` | Use `activeProgram` from loop return |
+| `run_session.go` | Use `activeProgram` from loop return |
+| `run_stream_inline_followup_test.go` | Updated 5 test calls for new return signature |
+| `run_stream_inline_history_test.go` | Updated assertions for deferred plan and collapsed-mode behavior |
+
+## Benefits
+
+- **Visible plan progress**: Users see current task and completion summary at a glance in the collapsed bar without needing to expand.
+- **Clean expanded view**: Plan appears at the bottom of expanded scrollback, easy to find after all messages.
+- **No terminal corruption**: Session exit (Ctrl+C, normal completion) correctly stops the active BubbleTea program regardless of how many re-commits occurred, restoring the terminal cleanly.
+- **Multi-execution correctness**: Program reference stays in sync across follow-up iterations within a session.
+
+## Impact
+
+All users of inline session rendering (both `stigmer run` and `stigmer session resume`) benefit. The fixes apply to TTY mode where BubbleTea manages the terminal.
+
+## Related Work
+
+- `2026-03-07-085926-fix-inline-rendering-program-restart-recommit.md` — introduced the program-restart re-commit approach that surfaced the program lifecycle issue.
+- `2026-03-07-072503-fix-ctrl-o-blank-screen-and-ai-truncation.md` — earlier fix for Ctrl+O blank screen.
+
+---
+
+**Status**: ✅ Production Ready

--- a/backend/services/agent-runner/tests/test_auto_publish.py
+++ b/backend/services/agent-runner/tests/test_auto_publish.py
@@ -4,7 +4,7 @@ Tests cover:
 - No-op when no file-modifying tool calls exist
 - No-op when file-modifying tool calls are not COMPLETED
 - Single file auto-publish (root-level file)
-- Single file auto-publish (file inside a subdirectory -> publishes parent dir)
+- Single file auto-publish (file inside a subdirectory -> publishes as file)
 - Multiple files in the same directory -> publishes the common parent directory
 - Multiple files in different directories -> publishes each file individually
 - Graceful handling of publish_artifact failures (logs warning, doesn't crash)
@@ -159,12 +159,12 @@ class TestAutoPublishWrittenFiles:
         status_builder.add_artifact.assert_called_once_with(mock_artifact)
 
     @pytest.mark.asyncio
-    async def test_single_file_in_subdir_publishes_parent_dir(self):
-        """A single file inside a subdirectory publishes the parent directory."""
+    async def test_single_file_in_subdir_publishes_as_file(self):
+        """A single file inside a subdirectory is published as a file artifact."""
         tool_calls = [
             _make_tool_call("write", path="my-skill/SKILL.md"),
         ]
-        mock_artifact = _make_artifact("my-skill")
+        mock_artifact = _make_artifact("SKILL.md")
         status_builder = MagicMock()
         logger = logging.getLogger("test")
 
@@ -186,8 +186,8 @@ class TestAutoPublishWrittenFiles:
         assert count == 1
         mock_publish.assert_called_once()
         call_kwargs = mock_publish.call_args
-        assert call_kwargs.kwargs["path"] == "my-skill"
-        assert call_kwargs.kwargs["name"] == "my-skill"
+        assert call_kwargs.kwargs["path"] == "my-skill/SKILL.md"
+        assert call_kwargs.kwargs["name"] == "SKILL.md"
         status_builder.add_artifact.assert_called_once_with(mock_artifact)
 
     @pytest.mark.asyncio
@@ -261,7 +261,7 @@ class TestAutoPublishWrittenFiles:
         tool_calls = [
             _make_tool_call("write", path="/my-skill/SKILL.md"),
         ]
-        mock_artifact = _make_artifact("my-skill")
+        mock_artifact = _make_artifact("SKILL.md")
         status_builder = MagicMock()
         logger = logging.getLogger("test")
 
@@ -282,7 +282,7 @@ class TestAutoPublishWrittenFiles:
 
         assert count == 1
         call_kwargs = mock_publish.call_args
-        assert call_kwargs.kwargs["path"] == "my-skill"
+        assert call_kwargs.kwargs["path"] == "my-skill/SKILL.md"
 
     @pytest.mark.asyncio
     async def test_publish_failure_is_non_fatal(self):
@@ -320,7 +320,7 @@ class TestAutoPublishWrittenFiles:
         tool_calls = [
             _make_tool_call("write_file", path="skill/SKILL.md"),
         ]
-        mock_artifact = _make_artifact("skill")
+        mock_artifact = _make_artifact("SKILL.md")
         status_builder = MagicMock()
         logger = logging.getLogger("test")
 
@@ -341,7 +341,7 @@ class TestAutoPublishWrittenFiles:
 
         assert count == 1
         call_kwargs = mock_publish.call_args
-        assert call_kwargs.kwargs["path"] == "skill"
+        assert call_kwargs.kwargs["path"] == "skill/SKILL.md"
 
     @pytest.mark.asyncio
     async def test_empty_path_in_args_is_skipped(self):
@@ -406,7 +406,7 @@ class TestAutoPublishWrittenFiles:
         tool_calls = [
             _make_tool_call("edit", path="my-skill/SKILL.md"),
         ]
-        mock_artifact = _make_artifact("my-skill")
+        mock_artifact = _make_artifact("SKILL.md")
         status_builder = MagicMock()
         logger = logging.getLogger("test")
 
@@ -427,8 +427,8 @@ class TestAutoPublishWrittenFiles:
 
         assert count == 1
         call_kwargs = mock_publish.call_args
-        assert call_kwargs.kwargs["path"] == "my-skill"
-        assert call_kwargs.kwargs["name"] == "my-skill"
+        assert call_kwargs.kwargs["path"] == "my-skill/SKILL.md"
+        assert call_kwargs.kwargs["name"] == "SKILL.md"
         status_builder.add_artifact.assert_called_once_with(mock_artifact)
 
     @pytest.mark.asyncio
@@ -437,7 +437,7 @@ class TestAutoPublishWrittenFiles:
         tool_calls = [
             _make_tool_call("edit_file", path="config/settings.yaml"),
         ]
-        mock_artifact = _make_artifact("config")
+        mock_artifact = _make_artifact("settings.yaml")
         status_builder = MagicMock()
         logger = logging.getLogger("test")
 
@@ -458,7 +458,7 @@ class TestAutoPublishWrittenFiles:
 
         assert count == 1
         call_kwargs = mock_publish.call_args
-        assert call_kwargs.kwargs["path"] == "config"
+        assert call_kwargs.kwargs["path"] == "config/settings.yaml"
         status_builder.add_artifact.assert_called_once_with(mock_artifact)
 
     @pytest.mark.asyncio

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -3383,8 +3383,8 @@ class TestToolApprovalDecision:
         # Should restore to IN_PROGRESS, not FAILED
         assert status_builder_waiting_approval.current_status.phase == ExecutionPhase.EXECUTION_IN_PROGRESS
     
-    def test_reject_action_sets_failed_status(self, status_builder_waiting_approval):
-        """Test that REJECT sets TOOL_CALL_FAILED status."""
+    def test_reject_action_sets_skipped_status(self, status_builder_waiting_approval):
+        """Test that REJECT sets TOOL_CALL_SKIPPED status (non-terminal, agent re-evaluates)."""
         from ai.stigmer.agentic.agentexecution.v1.api_pb2 import ApprovalAction
         from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ToolCallStatus
         
@@ -3395,11 +3395,11 @@ class TestToolApprovalDecision:
         )
         
         tool_call = status_builder_waiting_approval.current_status.tool_calls[0]
-        assert tool_call.status == ToolCallStatus.TOOL_CALL_FAILED
-        assert "rejected" in tool_call.error.lower()
+        assert tool_call.status == ToolCallStatus.TOOL_CALL_SKIPPED
+        assert "REJECTED" in tool_call.result
     
-    def test_reject_action_fails_execution(self, status_builder_waiting_approval):
-        """Test that REJECT sets execution phase to FAILED."""
+    def test_reject_action_continues_execution(self, status_builder_waiting_approval):
+        """Test that REJECT restores execution phase to IN_PROGRESS (non-terminal)."""
         from ai.stigmer.agentic.agentexecution.v1.api_pb2 import ApprovalAction
         from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ExecutionPhase
         
@@ -3409,8 +3409,7 @@ class TestToolApprovalDecision:
             approved_by="user-123",
         )
         
-        # Should be FAILED, not IN_PROGRESS
-        assert status_builder_waiting_approval.current_status.phase == ExecutionPhase.EXECUTION_FAILED
+        assert status_builder_waiting_approval.current_status.phase == ExecutionPhase.EXECUTION_IN_PROGRESS
     
     def test_decision_records_approved_by_and_timestamp(self, status_builder_waiting_approval):
         """Test that decision records who approved and when."""

--- a/backend/services/agent-runner/worker/activities/execute_graphton.py
+++ b/backend/services/agent-runner/worker/activities/execute_graphton.py
@@ -498,22 +498,44 @@ async def _auto_publish_written_files(
     # Normalise: strip leading slashes so paths are workspace-relative.
     normalised = [p.lstrip("/") for p in written_paths]
 
-    # Compute common prefix directory across ALL paths.
+    # Single file — publish as an individual file artifact regardless of
+    # depth.  Wrapping it in a directory artifact named after the parent
+    # causes nested-directory collisions when --output already points at
+    # that same parent (e.g. mcp-servers/mcp-servers/planton.yaml).
     if len(normalised) == 1:
-        sole_path = PurePosixPath(normalised[0])
-        if len(sole_path.parts) > 1:
-            common_dir = str(sole_path.parent)
-        else:
-            common_dir = None
-    else:
+        rel_path = normalised[0]
+        file_name = PurePosixPath(rel_path).name
         try:
-            common = posixpath.commonpath(normalised)
-        except ValueError:
-            common = ""
-        if common and common != ".":
-            common_dir = common
-        else:
-            common_dir = None
+            artifact = await publish_artifact(
+                sandbox=sandbox,
+                storage=storage,
+                execution_id=execution_id,
+                path=rel_path,
+                name=file_name,
+                local_root=local_root,
+            )
+            status_builder.add_artifact(artifact)
+            logger.info(
+                f"[AUTO_PUBLISH] execution={execution_id} — "
+                f"published file '{rel_path}' as artifact '{file_name}'"
+            )
+            return 1
+        except Exception as e:
+            logger.warning(
+                f"[AUTO_PUBLISH] execution={execution_id} — "
+                f"failed to publish file '{rel_path}': {e}"
+            )
+            return 0
+
+    # Compute common prefix directory across ALL paths.
+    try:
+        common = posixpath.commonpath(normalised)
+    except ValueError:
+        common = ""
+    if common and common != ".":
+        common_dir = common
+    else:
+        common_dir = None
 
     artifacts_published = 0
 

--- a/client-apps/cli/cmd/stigmer/root/draft_handler.go
+++ b/client-apps/cli/cmd/stigmer/root/draft_handler.go
@@ -38,8 +38,8 @@ func registerDraftFlags(cmd *cobra.Command, opts *draftOptions, resourceType str
 	registerOutputModeFlags(cmd, &opts.outputModeFlags)
 	cmd.MarkFlagRequired("message")
 
-	cmd.Flags().StringVarP(&opts.OutputDir, "output", "o", ".",
-		fmt.Sprintf("directory to save the generated %s", resourceType))
+	cmd.Flags().StringVarP(&opts.OutputDir, "output", "o", "",
+		"directory to save generated artifacts (default: current directory when no workspace is used)")
 
 	cmd.Flags().StringVar(&opts.Model, "model", "",
 		"LLM model to use (e.g., claude-sonnet-4-20250514)")
@@ -50,8 +50,14 @@ func registerDraftFlags(cmd *cobra.Command, opts *draftOptions, resourceType str
 
 // executeDraft is the unified handler for all draft subcommands. It uses the
 // shared preparation and agent execution layers, adding draft-specific
-// behavior: the agent is a hardcoded system agent, and artifacts are always
-// downloaded on completion (unless --detach).
+// behavior: the agent is a hardcoded system agent, and artifacts are
+// downloaded on completion only when needed.
+//
+// Download logic:
+//   - --detach: no download (execution is backgrounded)
+//   - --output set explicitly: always download to that directory
+//   - local workspaces present: skip download (agent writes directly to disk)
+//   - otherwise: download to current directory (backward compatible default)
 func executeDraft(cfg draftConfig, opts draftOptions) error {
 	sp := spinner.New(os.Stderr)
 	sp.Start("Preparing...")
@@ -88,8 +94,13 @@ func executeDraft(cfg draftConfig, opts draftOptions) error {
 	}
 
 	downloadDir := opts.OutputDir
-	if opts.Detach {
+	switch {
+	case opts.Detach:
 		downloadDir = ""
+	case downloadDir == "" && len(localWorkspaceRoots(prep.WorkspaceEntries)) > 0:
+		// Agent writes directly to local workspaces; artifact download is redundant.
+	case downloadDir == "":
+		downloadDir = "."
 	}
 
 	return executeResolvedAgent(resolvedAgentExecInput{

--- a/client-apps/cli/cmd/stigmer/root/run_display.go
+++ b/client-apps/cli/cmd/stigmer/root/run_display.go
@@ -80,6 +80,12 @@ var followUpHintStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("8")).
 	Italic(true)
 
+// expandHintStyle renders the "(ctrl+o to expand)" hint appended to compact
+// tool lines. Uses the same dim color as toolrender.dimStyle so the hint
+// blends with existing parenthetical metadata like "(43 lines)".
+var expandHintStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("8"))
+
 // formatHumanMessage formats a user message with highlighted styling for
 // display in both streaming and non-streaming rendering paths.
 func formatHumanMessage(content string) string {

--- a/client-apps/cli/cmd/stigmer/root/run_display_summary.go
+++ b/client-apps/cli/cmd/stigmer/root/run_display_summary.go
@@ -2,11 +2,13 @@ package root
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
+	"github.com/stigmer/stigmer/client-apps/cli/pkg/climsg"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/display"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/panel"
 )
@@ -338,31 +340,46 @@ func resolveFailureError(execution *agentexecutionv1.AgentExecution) string {
 	return "Execution failed (error details unavailable — check execution logs)"
 }
 
-// displaySessionExitLine prints a single-line summary after the TUI exits
-// for a completed session. Replaces the verbose multi-line panel.
+// displaySessionExitLine prints a compact summary after streaming ends for a
+// session-based command. The status line uses climsg for colored output on
+// stderr, followed by a copy-pasteable resume command.
 func displaySessionExitLine(sessionID string, exec *agentexecutionv1.AgentExecution) {
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	phase := exec.GetStatus().GetPhase()
 	duration := parseDuration(exec.GetStatus().GetStartedAt(), exec.GetStatus().GetCompletedAt())
 
 	switch phase {
 	case agentexecutionv1.ExecutionPhase_EXECUTION_COMPLETED:
 		if duration > 0 {
-			fmt.Printf("Session %s completed (%s)\n", sessionID, duration.Round(time.Second))
+			climsg.Success("Completed (%s)", duration.Round(time.Second))
 		} else {
-			fmt.Printf("Session %s completed\n", sessionID)
+			climsg.Success("Completed")
 		}
 	case agentexecutionv1.ExecutionPhase_EXECUTION_FAILED:
-		errMsg := resolveFailureError(exec)
-		fmt.Printf("Session %s failed: %s\n", sessionID, errMsg)
+		climsg.Error("Failed: %s", resolveFailureError(exec))
 	case agentexecutionv1.ExecutionPhase_EXECUTION_CANCELLED:
-		fmt.Printf("Session %s cancelled\n", sessionID)
+		climsg.Warning("Cancelled")
 	case agentexecutionv1.ExecutionPhase_EXECUTION_TERMINATED:
-		fmt.Printf("Session %s terminated\n", sessionID)
+		climsg.Warning("Terminated")
 	default:
-		fmt.Printf("Session %s exited (%s)\n", sessionID, mapPhaseToString(phase))
+		climsg.Warning("Exited (%s)", mapPhaseToString(phase))
 	}
-	flushStdout()
+
+	verb := sessionResumeVerb(phase)
+	fmt.Fprintf(os.Stderr, "\n  %s  stigmer run %s\n", verb, sessionID)
+}
+
+// sessionResumeVerb returns a human-friendly label for the resume command
+// based on the execution phase.
+func sessionResumeVerb(phase agentexecutionv1.ExecutionPhase) string {
+	switch phase {
+	case agentexecutionv1.ExecutionPhase_EXECUTION_COMPLETED:
+		return "To continue:"
+	case agentexecutionv1.ExecutionPhase_EXECUTION_FAILED:
+		return "To retry:   "
+	default:
+		return "To resume:  "
+	}
 }
 
 // displaySessionDetachLine prints a single-line detach notice with

--- a/client-apps/cli/cmd/stigmer/root/run_handlers.go
+++ b/client-apps/cli/cmd/stigmer/root/run_handlers.go
@@ -100,126 +100,161 @@ func displayExecutionResult(exec *agentexecutionv1.AgentExecution) {
 	fmt.Println()
 }
 
-// downloadArtifacts downloads all artifacts to the specified directory.
+// artifactResult holds metadata about a downloaded artifact for summary display.
+type artifactResult struct {
+	Name      string
+	Size      int64
+	FileCount int // > 0 for directory artifacts
+}
+
+// downloadArtifacts downloads all artifacts to the specified directory and
+// prints a compact summary. Single artifacts get one line; multiple artifacts
+// get a header followed by indented entries.
 func downloadArtifacts(exec *agentexecutionv1.AgentExecution, downloadDir string, conn *grpc.ClientConn) error {
-	// Create download directory if it doesn't exist
 	if err := os.MkdirAll(downloadDir, 0755); err != nil {
 		return errors.Wrap(err, "failed to create download directory")
 	}
 
 	artifacts := exec.GetStatus().GetArtifacts()
-	climsg.Info("Downloading %d artifact(s) to %s...", len(artifacts), downloadDir)
-	fmt.Println()
+	results := make([]artifactResult, 0, len(artifacts))
 
 	for _, artifact := range artifacts {
-		if err := downloadArtifact(exec.Metadata.Id, artifact, downloadDir, conn); err != nil {
+		result, err := downloadArtifact(exec.Metadata.Id, artifact, downloadDir, conn)
+		if err != nil {
 			return errors.Wrapf(err, "failed to download %s", artifact.GetName())
 		}
+		results = append(results, result)
 	}
 
-	climsg.Success("All artifacts downloaded")
-	fmt.Println()
+	displayArtifactSummary(results, downloadDir)
 	return nil
 }
 
-// downloadArtifact downloads a single artifact.
+// displayArtifactSummary prints a compact summary of downloaded artifacts.
+func displayArtifactSummary(results []artifactResult, downloadDir string) {
+	if len(results) == 0 {
+		return
+	}
+
+	if len(results) == 1 {
+		r := results[0]
+		climsg.Success("Saved %s (%s)", r.Name, formatFileSize(r.Size))
+		return
+	}
+
+	climsg.Success("Saved %d artifact(s) to %s", len(results), downloadDir)
+	for _, r := range results {
+		if r.FileCount > 0 {
+			climsg.Info("  %s/ (%s, %d files)", r.Name, formatFileSize(r.Size), r.FileCount)
+		} else {
+			climsg.Info("  %s (%s)", r.Name, formatFileSize(r.Size))
+		}
+	}
+}
+
+// downloadArtifact downloads a single artifact and returns metadata for the
+// summary display. No per-artifact output is printed; the caller handles that.
 //
 // For directory artifacts (kind=DIRECTORY), the server stores the content as a
-// ZIP archive.  This function detects directory artifacts, downloads the ZIP,
+// ZIP archive. This function detects directory artifacts, downloads the ZIP,
 // and extracts it to downloadDir/artifact.Name/ so that internal directory
 // structure (e.g. references/) is preserved on the user's filesystem.
 //
 // For file artifacts, the content is saved directly as downloadDir/artifact.Name.
-func downloadArtifact(executionID string, artifact *agentexecutionv1.ExecutionArtifact, downloadDir string, conn *grpc.ClientConn) error {
+func downloadArtifact(executionID string, artifact *agentexecutionv1.ExecutionArtifact, downloadDir string, conn *grpc.ClientConn) (artifactResult, error) {
 	// Always refresh the download URL via gRPC. The cached URL in the execution
 	// status may use a Docker-internal hostname (host.docker.internal) that is
 	// inappropriate for CLI-side HTTP requests. The server generates a fresh URL
 	// using the host-appropriate base address (e.g., localhost).
 	downloadURL, _, err := execution.GetArtifactDownloadURL(conn, executionID, artifact.GetStorageKey())
 	if err != nil {
-		// Fall back to cached URL if gRPC refresh fails
 		downloadURL = artifact.GetDownloadUrl()
 		if downloadURL == "" {
-			return errors.Wrap(err, "failed to get download URL")
+			return artifactResult{}, errors.Wrap(err, "failed to get download URL")
 		}
 	}
 
-	climsg.Info("  Downloading %s...", artifact.GetName())
-
-	// Download content
 	resp, err := http.Get(downloadURL)
 	if err != nil {
-		return errors.Wrap(err, "HTTP request failed")
+		return artifactResult{}, errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
+		return artifactResult{}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
 	}
 
-	// Directory artifacts are stored as ZIP archives.  Extract them to
-	// preserve internal directory structure (e.g. SKILL.md + references/).
+	name := artifact.GetName()
+
 	if artifact.GetKind() == agentexecutionv1.ExecutionArtifactKind_EXECUTION_ARTIFACT_KIND_DIRECTORY {
-		return downloadDirectoryArtifact(resp.Body, artifact.GetName(), downloadDir)
+		size, fileCount, err := downloadDirectoryArtifact(resp.Body, name, downloadDir)
+		if err != nil {
+			return artifactResult{}, err
+		}
+		return artifactResult{Name: name, Size: size, FileCount: fileCount}, nil
 	}
 
-	return downloadFileArtifact(resp.Body, artifact.GetName(), downloadDir)
+	size, err := downloadFileArtifact(resp.Body, name, downloadDir)
+	if err != nil {
+		return artifactResult{}, err
+	}
+	return artifactResult{Name: name, Size: size}, nil
 }
 
-// downloadFileArtifact saves a single-file artifact to downloadDir/name.
-func downloadFileArtifact(body io.Reader, name, downloadDir string) error {
+// downloadFileArtifact saves a single-file artifact to downloadDir/name and
+// returns the number of bytes written.
+func downloadFileArtifact(body io.Reader, name, downloadDir string) (int64, error) {
 	destPath := filepath.Join(downloadDir, name)
 
 	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-		return errors.Wrap(err, "failed to create parent directory")
+		return 0, errors.Wrap(err, "failed to create parent directory")
 	}
 
 	out, err := os.Create(destPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to create file")
+		return 0, errors.Wrap(err, "failed to create file")
 	}
 	defer out.Close()
 
 	written, err := io.Copy(out, body)
 	if err != nil {
-		return errors.Wrap(err, "failed to write file")
+		return 0, errors.Wrap(err, "failed to write file")
 	}
 
-	climsg.Success("  Downloaded %s (%s)", name, formatFileSize(written))
-	return nil
+	return written, nil
 }
 
 // downloadDirectoryArtifact extracts a ZIP-archived directory artifact to
-// downloadDir/name/, preserving the internal directory structure.
-func downloadDirectoryArtifact(body io.Reader, name, downloadDir string) error {
+// downloadDir/name/, preserving the internal directory structure. Returns the
+// total uncompressed size and file count.
+func downloadDirectoryArtifact(body io.Reader, name, downloadDir string) (int64, int, error) {
 	// Read the entire ZIP into memory so we can use archive/zip.NewReader
 	// (which requires io.ReaderAt + size).  Artifact ZIPs are small (tens of
 	// KB for skill packages) so this is safe.
 	data, err := io.ReadAll(body)
 	if err != nil {
-		return errors.Wrap(err, "failed to read artifact content")
+		return 0, 0, errors.Wrap(err, "failed to read artifact content")
 	}
 
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
-		return errors.Wrap(err, "failed to open ZIP archive")
+		return 0, 0, errors.Wrap(err, "failed to open ZIP archive")
 	}
 
 	destDir := filepath.Join(downloadDir, name)
 	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return errors.Wrap(err, "failed to create artifact directory")
+		return 0, 0, errors.Wrap(err, "failed to create artifact directory")
 	}
 
 	var totalBytes int64
 	for _, f := range reader.File {
 		if err := extractZipEntry(f, destDir); err != nil {
-			return errors.Wrapf(err, "failed to extract %s", f.Name)
+			return 0, 0, errors.Wrapf(err, "failed to extract %s", f.Name)
 		}
 		totalBytes += int64(f.UncompressedSize64)
 	}
 
-	climsg.Success("  Extracted %s/ (%s, %d files)", name, formatFileSize(totalBytes), len(reader.File))
-	return nil
+	return totalBytes, len(reader.File), nil
 }
 
 // extractZipEntry extracts a single entry from a ZIP archive into destDir.

--- a/client-apps/cli/cmd/stigmer/root/run_session.go
+++ b/client-apps/cli/cmd/stigmer/root/run_session.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/pkg/errors"
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	"github.com/stigmer/stigmer/client-apps/cli/embedded"
@@ -151,6 +152,19 @@ func resumeSession(sessionID string, headerInfo sessionHeaderInfo, orgID string,
 
 		program := startInlineProgram(os.Stderr, toggleExpandCh, cancelCh, interruptCh)
 
+		var programFactory func(func(*inlineBubbleModel)) *tea.Program
+		if program != nil {
+			programFactory = func(initModel func(*inlineBubbleModel)) *tea.Program {
+				m := newInlineBubbleModelWithChannels(toggleExpandCh, cancelCh, interruptCh)
+				if initModel != nil {
+					initModel(&m)
+				}
+				p := tea.NewProgram(m, tea.WithOutput(os.Stderr))
+				go func() { _, _ = p.Run() }()
+				return p
+			}
+		}
+
 		sbRoot, pfDir := sessionPaths(sessionID)
 
 		cfg := inlineRenderConfig{
@@ -165,6 +179,7 @@ func resumeSession(sessionID string, headerInfo sessionHeaderInfo, orgID string,
 			platformDir:       pfDir,
 			headerInfo:        headerInfo,
 			program:           program,
+			programFactory:    programFactory,
 			toggleExpandCh:    toggleExpandCh,
 			cancelCh:          cancelCh,
 			interruptCh:       interruptCh,

--- a/client-apps/cli/cmd/stigmer/root/run_session.go
+++ b/client-apps/cli/cmd/stigmer/root/run_session.go
@@ -185,9 +185,9 @@ func resumeSession(sessionID string, headerInfo sessionHeaderInfo, orgID string,
 			interruptCh:       interruptCh,
 			followUpEnabled:   toggleExpandCh != nil && followUpFn != nil,
 		}
-		finalExecID, _, exitErr := runInlineFollowUpLoop(streamCtx, cfg, followUpFn, latestExecID)
+		finalExecID, _, exitErr, activeProgram := runInlineFollowUpLoop(streamCtx, cfg, followUpFn, latestExecID)
 
-		stopInlineProgram(program)
+		stopInlineProgram(activeProgram)
 		streamCancel()
 
 		if exitErr != "" {

--- a/client-apps/cli/cmd/stigmer/root/run_stream.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream.go
@@ -144,9 +144,9 @@ func streamAgentInline(streamCtx context.Context, streamCancel context.CancelFun
 		},
 	}
 
-	latestExecID, phase, exitErr := runInlineFollowUpLoop(streamCtx, cfg, followUpFn, executionID)
+	latestExecID, phase, exitErr, activeProgram := runInlineFollowUpLoop(streamCtx, cfg, followUpFn, executionID)
 
-	stopInlineProgram(program)
+	stopInlineProgram(activeProgram)
 	streamCancel()
 
 	return streamAgentEpilogue(sessionID, latestExecID, phase, exitErr, conn)

--- a/client-apps/cli/cmd/stigmer/root/run_stream.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream.go
@@ -92,6 +92,19 @@ func streamAgentInline(streamCtx context.Context, streamCancel context.CancelFun
 
 	program := startInlineProgram(statusW, toggleExpandCh, cancelCh, interruptCh)
 
+	var programFactory func(func(*inlineBubbleModel)) *tea.Program
+	if program != nil {
+		programFactory = func(initModel func(*inlineBubbleModel)) *tea.Program {
+			m := newInlineBubbleModelWithChannels(toggleExpandCh, cancelCh, interruptCh)
+			if initModel != nil {
+				initModel(&m)
+			}
+			p := tea.NewProgram(m, tea.WithOutput(statusW))
+			go func() { _, _ = p.Run() }()
+			return p
+		}
+	}
+
 	var subjectUpdate chan string
 	if sessionID != "" && headerInfo.Subject == "" {
 		subjectUpdate = make(chan string, 1)
@@ -118,6 +131,7 @@ func streamAgentInline(streamCtx context.Context, streamCancel context.CancelFun
 		sandboxRoot:       sbRoot,
 		platformDir:       pfDir,
 		program:           program,
+		programFactory:    programFactory,
 		headerInfo:        headerInfo,
 		subjectUpdate:     subjectUpdate,
 		recentSessionsCh:  recentSessionsCh,

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
@@ -192,6 +192,7 @@ func (r *inlineRenderer) activateFollowUp(phase, exitErr string) {
 
 	inputCh := make(chan string, 1)
 	r.followUpInputCh = inputCh
+	r.followUpSendCh = inputCh
 	r.cfg.program.Send(textInputStartMsg{inputCh: inputCh})
 }
 
@@ -405,7 +406,7 @@ func (r *inlineRenderer) handleEvent(ctx context.Context, event executiontui.Eve
 		r.flushPendingReads()
 	case executiontui.AIStreamDeltaEvent, executiontui.AIStreamEndEvent:
 	case executiontui.TodoUpdateEvent:
-		// Todo updates only affect the composed View() (planDisplay) and
+		// Todo updates only affect the composed View() (currentTask) and
 		// produce no scrollback output. They must not interrupt an active
 		// AI stream — doing so prematurely closes the stream, causing
 		// subsequent deltas to be silently dropped and the AI message to

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
@@ -76,7 +76,7 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 			r.stopThinkingSpinner()
 			r.flushPendingReads()
 			r.statusf("Stream cancelled\n")
-			return renderResult{exitErr: "context cancelled", history: r.history}
+			return renderResult{exitErr: "context cancelled", history: r.history, program: r.cfg.program}
 
 		case subject, ok := <-cfg.subjectUpdate:
 			if ok && subject != "" {
@@ -113,7 +113,7 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 				cfg.subjectUpdate = nil
 				continue
 			}
-			return renderResult{phase: "cancelled", history: r.history}
+			return renderResult{phase: "cancelled", history: r.history, program: r.cfg.program}
 
 		case <-cfg.cancelCh:
 			r.stopThinkingSpinner()
@@ -125,7 +125,7 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 			if r.cfg.sessionID != "" {
 				r.statusf("Resume later with: stigmer run %s\n", r.cfg.sessionID)
 			}
-			return renderResult{phase: "cancelled", history: r.history}
+			return renderResult{phase: "cancelled", history: r.history, program: r.cfg.program}
 
 		case event, ok := <-cfg.events:
 			r.stopThinkingSpinner()
@@ -133,7 +133,7 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 
 			if !ok {
 				r.flushPendingReads()
-				return renderResult{history: r.history}
+				return renderResult{history: r.history, program: r.cfg.program}
 			}
 
 			done, p, e := r.handleEvent(ctx, event)
@@ -144,7 +144,7 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 					cfg.subjectUpdate = nil
 					continue
 				}
-				return renderResult{phase: p, exitErr: e, history: r.history}
+				return renderResult{phase: p, exitErr: e, history: r.history, program: r.cfg.program}
 			}
 			r.resetThinkTimer()
 
@@ -229,6 +229,7 @@ func (r *inlineRenderer) completeFollowUp(input string) renderResult {
 			phase:   r.donePhase,
 			exitErr: r.doneExitErr,
 			history: r.history,
+			program: r.cfg.program,
 		}
 	}
 
@@ -245,6 +246,7 @@ func (r *inlineRenderer) completeFollowUp(input string) renderResult {
 		exitErr:       r.doneExitErr,
 		history:       r.history,
 		followUpInput: input,
+		program:       r.cfg.program,
 	}
 }
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
@@ -148,6 +148,16 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 			}
 			r.resetThinkTimer()
 
+			// After the event is fully processed, check whether a
+			// deferred re-commit can now fire. The AI stream may have
+			// ended inside handleEvent (AIStreamEnd or a non-AI event
+			// that called finishAIStreamIfNeeded), making the deferred
+			// re-commit safe to execute.
+			if r.pendingReCommit && !r.inAIStream {
+				r.pendingReCommit = false
+				recommitNeeded = true
+			}
+
 		case input := <-r.followUpInputCh:
 			return r.completeFollowUp(strings.TrimSpace(input))
 
@@ -160,7 +170,11 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 		// other ready channels before issuing a single triggerReCommit.
 		if recommitNeeded {
 			r.drainRecommitTriggers(&cfg)
-			r.triggerReCommit()
+			if r.inAIStream {
+				r.pendingReCommit = true
+			} else {
+				r.triggerReCommit()
+			}
 		}
 	}
 }
@@ -390,6 +404,12 @@ func (r *inlineRenderer) handleEvent(ctx context.Context, event executiontui.Eve
 	case executiontui.AIStreamStartEvent:
 		r.flushPendingReads()
 	case executiontui.AIStreamDeltaEvent, executiontui.AIStreamEndEvent:
+	case executiontui.TodoUpdateEvent:
+		// Todo updates only affect the composed View() (planDisplay) and
+		// produce no scrollback output. They must not interrupt an active
+		// AI stream — doing so prematurely closes the stream, causing
+		// subsequent deltas to be silently dropped and the AI message to
+		// appear truncated on screen.
 	default:
 		r.finishAIStreamIfNeeded()
 		r.flushPendingReads()

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_aistream.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_aistream.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/executiontui"
+	"github.com/stigmer/stigmer/client-apps/cli/pkg/mdrender"
 )
 
 // ---------------------------------------------------------------------------
@@ -27,6 +28,18 @@ import (
 
 func (r *inlineRenderer) renderAIStreamStart(e executiontui.AIStreamStartEvent) {
 	r.finishAIStreamIfNeeded()
+
+	// Emit a leading gap when the previous scrollback item requires one
+	// (e.g. a tool completion). Without this, the first partial content
+	// shown live in Bubbletea's View() appears flush against the tool
+	// block because the transient area bypasses writeToScrollback's gap
+	// logic. Writing the gap here ensures it is visible immediately and
+	// prevents a double gap when commitAIStreamLines later runs
+	// needsLeadingGap (which checks r.lastScrollbackKind).
+	if needsLeadingGap(r.lastScrollbackKind, kindAIStreamLine) {
+		r.statusf("\n")
+		r.lastScrollbackKind = kindAIStreamLine
+	}
 
 	prefix := r.agentPrefix(e.SubAgentID)
 	r.streamedBytes = len(e.Content)
@@ -135,6 +148,19 @@ func (r *inlineRenderer) renderAIStreamEnd(e executiontui.AIStreamEndEvent) {
 	r.inAIStream = false
 	r.streamedBytes = 0
 	r.recordAIMessage(e.Content, e.SubAgentID)
+
+	// During streaming, complete lines are committed as raw text
+	// (kindAIStreamLine). recordAIMessage stores a glamour-rendered
+	// version in history. When the content contains markdown, trigger a
+	// re-commit so the raw scrollback lines are atomically replaced with
+	// the rendered version. This reuses the same re-commit path as the
+	// Ctrl+O expand toggle.
+	// Reset lastScrollbackKind from history so subsequent gap decisions
+	// remain correct after the redraw.
+	if r.cfg.program != nil && mdrender.HasMarkdown(e.Content) {
+		r.lastScrollbackKind = lastKindFromHistory(r.history)
+		r.triggerReCommit()
+	}
 }
 
 func (r *inlineRenderer) renderAIMessage(e executiontui.AIMessageEvent) {

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_aistream.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_aistream.go
@@ -104,6 +104,17 @@ func (r *inlineRenderer) renderAIStreamEnd(e executiontui.AIStreamEndEvent) {
 		r.streamedBytes = 0
 		if e.Content != "" {
 			r.recordAIMessage(e.Content, e.SubAgentID)
+			// The stream was interrupted by an earlier event (e.g., a
+			// non-AI event called finishAIStreamIfNeeded). Content between
+			// the interruption and this end event was never written to
+			// scrollback. Trigger a re-commit so the full AI message
+			// (now in history via recordAIMessage) replaces the truncated
+			// scrollback output.
+			if r.cfg.program != nil {
+				r.pendingReCommit = false
+				r.lastScrollbackKind = lastKindFromHistory(r.history)
+				r.triggerReCommit()
+			}
 		}
 		return
 	}
@@ -151,13 +162,14 @@ func (r *inlineRenderer) renderAIStreamEnd(e executiontui.AIStreamEndEvent) {
 
 	// During streaming, complete lines are committed as raw text
 	// (kindAIStreamLine). recordAIMessage stores a glamour-rendered
-	// version in history. When the content contains markdown, trigger a
-	// re-commit so the raw scrollback lines are atomically replaced with
-	// the rendered version. This reuses the same re-commit path as the
-	// Ctrl+O expand toggle.
-	// Reset lastScrollbackKind from history so subsequent gap decisions
-	// remain correct after the redraw.
-	if r.cfg.program != nil && mdrender.HasMarkdown(e.Content) {
+	// version in history. Trigger a re-commit when:
+	//  - The content contains markdown (replace raw lines with rendered)
+	//  - A deferred re-commit is pending (Ctrl+O pressed during stream)
+	// Both conditions are handled by a single re-commit; clear the
+	// pending flag first to avoid a second re-commit from the event loop.
+	needsReCommit := r.pendingReCommit
+	r.pendingReCommit = false
+	if r.cfg.program != nil && (mdrender.HasMarkdown(e.Content) || needsReCommit) {
 		r.lastScrollbackKind = lastKindFromHistory(r.history)
 		r.triggerReCommit()
 	}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_approval.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_approval.go
@@ -131,7 +131,7 @@ func (r *inlineRenderer) handleInteractiveApproval(
 		expanded := r.buildFullExpandedView(tc, width)
 		var reCommitPayload string
 		if contentStreamed {
-			rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode)
+			rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode, r.expandHintEnabled())
 			trimmed := strings.TrimRight(expanded, "\n")
 			if rendered != "" {
 				reCommitPayload = rendered + "\n" + trimmed

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_approval.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_approval.go
@@ -198,6 +198,10 @@ func (r *inlineRenderer) promptApprovalViaBubbletea(
 // promptApprovalViaChannel uses the channel-based flow when Bubbletea
 // owns stdin. Sends approvalStartMsg with a decision channel, then
 // blocks until the model delivers a decision via handleApprovalKey.
+//
+// While waiting for the decision, it also listens on toggleExpandCh so
+// Ctrl+O can refresh the scrollback in expand/collapse mode without
+// disrupting the approval prompt.
 func (r *inlineRenderer) promptApprovalViaChannel(
 	_ context.Context,
 	e executiontui.ApprovalNeededEvent,
@@ -218,7 +222,25 @@ func (r *inlineRenderer) promptApprovalViaChannel(
 	}
 	r.cfg.program.Send(msg)
 
-	d := <-decisionCh
+	var d approvalDecision
+	for {
+		select {
+		case d = <-decisionCh:
+			goto decided
+		case <-r.cfg.toggleExpandCh:
+			r.expandMode = !r.expandMode
+			rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode, r.expandHintEnabled())
+			trimmed := strings.TrimRight(expanded, "\n")
+			payload := rendered
+			if payload != "" {
+				payload += "\n" + trimmed
+			} else {
+				payload = trimmed
+			}
+			r.cfg.program.Send(approvalReRenderMsg{reCommitPayload: payload})
+		}
+	}
+decided:
 
 	if d.err != nil {
 		r.cfg.program.Send(approvalHideMsg{})

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_approval.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_approval.go
@@ -3,7 +3,6 @@ package root
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/approval"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/executiontui"
@@ -129,17 +128,13 @@ func (r *inlineRenderer) handleInteractiveApproval(
 
 	if r.cfg.program != nil {
 		expanded := r.buildFullExpandedView(tc, width)
-		var reCommitPayload string
 		if contentStreamed {
-			rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode, r.expandHintEnabled())
-			trimmed := strings.TrimRight(expanded, "\n")
-			if rendered != "" {
-				reCommitPayload = rendered + "\n" + trimmed
-			} else {
-				reCommitPayload = trimmed
-			}
+			decisionCh := make(chan approvalDecision, 1)
+			r.performReCommitWithApproval(expanded, question, decisionCh, 0)
+			r.waitForApprovalDecision(ctx, e, tc, subAgentID, expanded, question, decisionCh)
+			return
 		}
-		r.promptApprovalViaBubbletea(ctx, e, tc, subAgentID, expanded, question, reCommitPayload, opts)
+		r.promptApprovalViaBubbletea(ctx, e, tc, subAgentID, expanded, question, opts)
 		return
 	}
 
@@ -171,11 +166,6 @@ func (r *inlineRenderer) erasePreApprovalContent(
 // promptApprovalViaBubbletea renders the approval panel through View()
 // and collects the user's decision.
 //
-// When reCommitPayload is non-empty (streaming→approval transition), the
-// message carries it instead of expandedContent. The model handler uses
-// buildReCommitCmd to atomically clear + replay, avoiding the insertAbove
-// stale-cellbuf race (see DD-001).
-//
 // When Bubbletea owns stdin (cancelCh is non-nil), the model receives
 // keystrokes as tea.KeyPressMsg and delivers the decision via a channel.
 // When stdin is external (legacy path), PromptKeyOnly reads keys
@@ -185,14 +175,14 @@ func (r *inlineRenderer) promptApprovalViaBubbletea(
 	e executiontui.ApprovalNeededEvent,
 	tc toolrender.ToolCallInfo,
 	subAgentID string,
-	expanded, question, reCommitPayload string,
+	expanded, question string,
 	opts approval.Options,
 ) {
 	if r.cfg.cancelCh != nil {
-		r.promptApprovalViaChannel(ctx, e, tc, subAgentID, expanded, question, reCommitPayload)
+		r.promptApprovalViaChannel(ctx, e, tc, subAgentID, expanded, question)
 		return
 	}
-	r.promptApprovalViaKeyReader(ctx, e, tc, subAgentID, expanded, question, reCommitPayload, opts)
+	r.promptApprovalViaKeyReader(ctx, e, tc, subAgentID, expanded, question, opts)
 }
 
 // promptApprovalViaChannel uses the channel-based flow when Bubbletea
@@ -201,27 +191,38 @@ func (r *inlineRenderer) promptApprovalViaBubbletea(
 //
 // While waiting for the decision, it also listens on toggleExpandCh so
 // Ctrl+O can refresh the scrollback in expand/collapse mode without
-// disrupting the approval prompt.
+// disrupting the approval prompt (via performReCommitWithApproval).
 func (r *inlineRenderer) promptApprovalViaChannel(
 	_ context.Context,
 	e executiontui.ApprovalNeededEvent,
 	tc toolrender.ToolCallInfo,
 	subAgentID string,
-	expanded, question, reCommitPayload string,
+	expanded, question string,
 ) {
 	decisionCh := make(chan approvalDecision, 1)
 
 	msg := approvalStartMsg{
-		question:   question,
-		decisionCh: decisionCh,
-	}
-	if reCommitPayload != "" {
-		msg.reCommitPayload = reCommitPayload
-	} else {
-		msg.expandedContent = expanded
+		expandedContent: expanded,
+		question:        question,
+		decisionCh:      decisionCh,
 	}
 	r.cfg.program.Send(msg)
 
+	r.waitForApprovalDecision(nil, e, tc, subAgentID, expanded, question, decisionCh)
+}
+
+// waitForApprovalDecision blocks until the user makes an approval decision,
+// while also handling Ctrl+O toggles via performReCommitWithApproval. Shared
+// by both the direct re-commit path (contentStreamed) and the normal channel
+// path.
+func (r *inlineRenderer) waitForApprovalDecision(
+	_ context.Context,
+	e executiontui.ApprovalNeededEvent,
+	tc toolrender.ToolCallInfo,
+	subAgentID string,
+	expanded, question string,
+	decisionCh chan approvalDecision,
+) {
 	var d approvalDecision
 	for {
 		select {
@@ -229,15 +230,8 @@ func (r *inlineRenderer) promptApprovalViaChannel(
 			goto decided
 		case <-r.cfg.toggleExpandCh:
 			r.expandMode = !r.expandMode
-			rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode, r.expandHintEnabled())
-			trimmed := strings.TrimRight(expanded, "\n")
-			payload := rendered
-			if payload != "" {
-				payload += "\n" + trimmed
-			} else {
-				payload = trimmed
-			}
-			r.cfg.program.Send(approvalReRenderMsg{reCommitPayload: payload})
+			decisionCh = make(chan approvalDecision, 1)
+			r.performReCommitWithApproval(expanded, question, decisionCh, 0)
 		}
 	}
 decided:
@@ -270,16 +264,12 @@ func (r *inlineRenderer) promptApprovalViaKeyReader(
 	e executiontui.ApprovalNeededEvent,
 	tc toolrender.ToolCallInfo,
 	subAgentID string,
-	expanded, question, reCommitPayload string,
+	expanded, question string,
 	opts approval.Options,
 ) {
 	msg := approvalShowMsg{
-		question: question,
-	}
-	if reCommitPayload != "" {
-		msg.reCommitPayload = reCommitPayload
-	} else {
-		msg.expandedContent = expanded
+		expandedContent: expanded,
+		question:        question,
 	}
 	r.cfg.program.Send(msg)
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
@@ -691,23 +691,11 @@ func (m inlineBubbleModel) handleInputBarMode(msg inputBarModeMsg) (tea.Model, t
 
 // handleReCommit clears all active visual states and starts a re-commit.
 //
-// Two strategies depending on whether a follow-up text input is active:
-//
-// Execution mode (inputBarActive == false): uses the two-phase tea.Raw
-// approach. Phase 1 sets reCommitPending so View() returns empty while
-// tea.Raw rewrites the terminal. Phase 2 (reCommitDoneMsg) restores
-// View(). The tea.Raw write desyncs the renderer's cursor tracking, but
-// this is acceptable because the view is small ("esc to interrupt") and
-// the desync is corrected on the next full re-commit or resize.
-//
-// Follow-up mode (inputBarActive == true): uses renderer-aware operations
-// (ClearScreen + Println) instead of tea.Raw. The tea.Raw approach
-// permanently desyncs the renderer's relative cursor tracking, which
-// causes the composed view (separator + text input + hint) to be written
-// at a stale terminal position — making the entire input bar invisible.
-// The renderer-aware path keeps cursor tracking in sync: ClearScreen
-// resets tracking to (0,0), reCommitDoneMsg lets View() render the input
-// bar there, then Println/insertAbove pushes it to the bottom.
+// Uses the unified renderer-aware buildReCommitCmd for all modes:
+// Raw(clearAndHome) → ClearScreen → Println(history) → reCommitDoneMsg.
+// This keeps the renderer's cursor tracking in sync so the composed
+// View() (input bar, approval menu, "esc to interrupt") always appears
+// at the correct position below the history.
 func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) {
 	m.spinnerActive = false
 	m.streamingActive = false
@@ -723,16 +711,14 @@ func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) 
 	// Sub-agent live summary is not cleared — if a sub-agent is still
 	// running after re-commit, its summary reappears in View().
 
-	if m.inputBarMode == inputBarActive {
-		return m, buildFollowUpReCommitCmd(msg.rendered)
-	}
 	return m, buildReCommitCmd(msg.rendered)
 }
 
-// handleReCommitDone is phase 2 of the re-commit. The tea.Raw write has
-// completed and the terminal shows the updated history with the cursor
-// at the bottom. Clearing reCommitPending lets View() produce the
-// composed view again; the renderer writes it fresh below the history.
+// handleReCommitDone is the final phase of the re-commit. The terminal
+// has been cleared, the renderer reset, and the history written via
+// tea.Println. Clearing reCommitPending lets View() produce the composed
+// view; the renderer writes it at the correct tracked position below
+// the history.
 func (m inlineBubbleModel) handleReCommitDone(_ reCommitDoneMsg) (tea.Model, tea.Cmd) {
 	m.reCommitPending = false
 	return m, nil

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
@@ -689,13 +689,25 @@ func (m inlineBubbleModel) handleInputBarMode(msg inputBarModeMsg) (tea.Model, t
 // Re-commit handler
 // ---------------------------------------------------------------------------
 
-// handleReCommit clears all active visual states and starts a two-phase
-// re-commit. Phase 1 (this handler) sets reCommitPending so View()
-// returns empty — preventing the renderer from issuing stale cursor
-// movements while tea.Raw rewrites the terminal. Phase 2
-// (handleReCommitDone) clears the flag; the renderer sees the transition
-// from empty to the composed view and writes it fresh at the current
-// cursor position (bottom of history), preserving the input bar.
+// handleReCommit clears all active visual states and starts a re-commit.
+//
+// Two strategies depending on whether a follow-up text input is active:
+//
+// Execution mode (inputBarActive == false): uses the two-phase tea.Raw
+// approach. Phase 1 sets reCommitPending so View() returns empty while
+// tea.Raw rewrites the terminal. Phase 2 (reCommitDoneMsg) restores
+// View(). The tea.Raw write desyncs the renderer's cursor tracking, but
+// this is acceptable because the view is small ("esc to interrupt") and
+// the desync is corrected on the next full re-commit or resize.
+//
+// Follow-up mode (inputBarActive == true): uses renderer-aware operations
+// (ClearScreen + Println) instead of tea.Raw. The tea.Raw approach
+// permanently desyncs the renderer's relative cursor tracking, which
+// causes the composed view (separator + text input + hint) to be written
+// at a stale terminal position — making the entire input bar invisible.
+// The renderer-aware path keeps cursor tracking in sync: ClearScreen
+// resets tracking to (0,0), reCommitDoneMsg lets View() render the input
+// bar there, then Println/insertAbove pushes it to the bottom.
 func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) {
 	m.spinnerActive = false
 	m.streamingActive = false
@@ -710,6 +722,10 @@ func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) 
 	m.reCommitPending = true
 	// Sub-agent live summary is not cleared — if a sub-agent is still
 	// running after re-commit, its summary reappears in View().
+
+	if m.inputBarMode == inputBarActive {
+		return m, buildFollowUpReCommitCmd(msg.rendered)
+	}
 	return m, buildReCommitCmd(msg.rendered)
 }
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
@@ -61,13 +61,9 @@ type inlineBubbleModel struct {
 	// inputBarHidden for non-interactive environments.
 	inputBarMode inputBarMode
 
-	// currentTask holds the content of the first in_progress todo item.
+	// currentTask holds the content of the first in_progress todo item,
+	// displayed as a single line above the separator in the composed View().
 	currentTask string
-
-	// planDisplay holds the full formatted plan (all items with status
-	// markers) rendered in the composed View() so the plan is always
-	// visible above the input bar. Empty when no plan exists.
-	planDisplay string
 
 	// subAgentActive is true when a sub-agent is running and its live
 	// summary should be shown in View(). Cleared on subAgentHideMsg.
@@ -93,13 +89,6 @@ type inlineBubbleModel struct {
 	// tea.WindowSizeMsg. Used to render the full-width separator in
 	// the input bar.
 	termWidth int
-
-	// reCommitPending suppresses View() output during the first phase of a
-	// re-commit. While true, View() returns an empty tea.View so the
-	// renderer's internal cursor tracking is not disturbed by the concurrent
-	// tea.Raw write that clears and rewrites the terminal. The flag is set
-	// by handleReCommit and cleared by handleReCommitDone (phase 2).
-	reCommitPending bool
 
 	// Channels for communicating with the event loop goroutine. Set during
 	// model initialization when Bubbletea owns stdin. nil otherwise.
@@ -200,17 +189,10 @@ func (m inlineBubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleFollowUpShow(msg)
 	case followUpHideMsg:
 		return m.handleFollowUpHide(msg)
-	case reCommitMsg:
-		return m.handleReCommit(msg)
-	case reCommitDoneMsg:
-		return m.handleReCommitDone(msg)
-	case approvalReRenderMsg:
-		return m.handleApprovalReRender(msg)
 	case inputBarModeMsg:
 		return m.handleInputBarMode(msg)
 	case currentTaskMsg:
 		m.currentTask = msg.task
-		m.planDisplay = msg.planDisplay
 		return m, nil
 	case subAgentShowMsg:
 		return m.handleSubAgentShow(msg)
@@ -223,15 +205,7 @@ func (m inlineBubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m inlineBubbleModel) View() tea.View {
-	// During a re-commit, tea.Raw is writing directly to the terminal.
-	// Return empty so the renderer's cursor tracking is not disturbed.
-	// Phase 2 (reCommitDoneMsg) clears this flag and the renderer
-	// writes the composed view fresh at the current cursor position.
-	if m.reCommitPending {
-		return tea.NewView("")
-	}
-
-	// New path: composed layout with persistent input bar.
+	// Composed layout with persistent input bar.
 	if m.inputBarMode != inputBarHidden {
 		return m.renderComposedView()
 	}
@@ -288,11 +262,11 @@ func (m inlineBubbleModel) renderComposedView() tea.View {
 		hasTransient = true
 	}
 
-	if m.planDisplay != "" && !m.approvalActive {
+	if m.currentTask != "" && !m.approvalActive {
 		if hasTransient {
 			parts = append(parts, "")
 		}
-		parts = append(parts, systemMsgStyle.Render(m.planDisplay))
+		parts = append(parts, systemMsgStyle.Render("  [-] "+m.currentTask))
 	}
 
 	parts = append(parts, m.renderSeparatorLine())
@@ -433,10 +407,6 @@ func (m inlineBubbleModel) handleApprovalStart(msg approvalStartMsg) (tea.Model,
 	m.aiStreamActive = false
 	m.aiStreamPartial = ""
 
-	if msg.reCommitPayload != "" {
-		m.reCommitPending = true
-		return m, buildReCommitCmd(msg.reCommitPayload)
-	}
 	var cmds []tea.Cmd
 	if msg.expandedContent != "" {
 		cmds = append(cmds, tea.Println(strings.TrimRight(msg.expandedContent, "\n")))
@@ -459,10 +429,6 @@ func (m inlineBubbleModel) handleApprovalShow(msg approvalShowMsg) (tea.Model, t
 	m.aiStreamActive = false
 	m.aiStreamPartial = ""
 
-	if msg.reCommitPayload != "" {
-		m.reCommitPending = true
-		return m, buildReCommitCmd(msg.reCommitPayload)
-	}
 	var cmds []tea.Cmd
 	if msg.expandedContent != "" {
 		cmds = append(cmds, tea.Println(strings.TrimRight(msg.expandedContent, "\n")))
@@ -659,15 +625,14 @@ func (m inlineBubbleModel) handleTextInputStart(msg textInputStartMsg) (tea.Mode
 }
 
 // handleTextInputHide transitions the input bar back to disabled mode after
-// the user submits or cancels follow-up input. Clears the plan display and
-// current task since a new execution is about to start.
+// the user submits or cancels follow-up input. Clears the current task
+// since a new execution is about to start.
 func (m inlineBubbleModel) handleTextInputHide(msg textInputHideMsg) (tea.Model, tea.Cmd) {
 	m.inputBarMode = inputBarDisabled
 	m.textInput.Blur()
 	m.textInput.Reset()
 	m.textInputCh = nil
 	m.currentTask = ""
-	m.planDisplay = ""
 	if msg.styledMessage != "" {
 		return m, tea.Println(strings.TrimRight(msg.styledMessage, "\n"))
 	}
@@ -683,55 +648,6 @@ func (m inlineBubbleModel) handleInputBarMode(msg inputBarModeMsg) (tea.Model, t
 		m.textInputCh = nil
 	}
 	return m, nil
-}
-
-// ---------------------------------------------------------------------------
-// Re-commit handler
-// ---------------------------------------------------------------------------
-
-// handleReCommit clears all active visual states and starts a re-commit.
-//
-// Uses the unified renderer-aware buildReCommitCmd for all modes:
-// Raw(clearAndHome) → ClearScreen → Println(history) → reCommitDoneMsg.
-// This keeps the renderer's cursor tracking in sync so the composed
-// View() (input bar, approval menu, "esc to interrupt") always appears
-// at the correct position below the history.
-func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) {
-	m.spinnerActive = false
-	m.streamingActive = false
-	m.streamingHeader = ""
-	m.streamingContent = ""
-	m.streamingProgressive = false
-	m.streamingCommittedLen = 0
-	m.aiStreamActive = false
-	m.aiStreamPartial = ""
-	m.followUpActive = false
-	m.followUpContent = ""
-	m.reCommitPending = true
-	// Sub-agent live summary is not cleared — if a sub-agent is still
-	// running after re-commit, its summary reappears in View().
-
-	return m, buildReCommitCmd(msg.rendered)
-}
-
-// handleReCommitDone is the final phase of the re-commit. The terminal
-// has been cleared, the renderer reset, and the history written via
-// tea.Println. Clearing reCommitPending lets View() produce the composed
-// view; the renderer writes it at the correct tracked position below
-// the history.
-func (m inlineBubbleModel) handleReCommitDone(_ reCommitDoneMsg) (tea.Model, tea.Cmd) {
-	m.reCommitPending = false
-	return m, nil
-}
-
-// handleApprovalReRender refreshes the scrollback after an expand toggle
-// during an active approval prompt. Unlike handleReCommit, it does NOT
-// clear any transient state — the approval question, menu selection, and
-// decision channel all remain intact so the user can continue approving.
-// It uses the same two-phase approach to preserve the approval panel.
-func (m inlineBubbleModel) handleApprovalReRender(msg approvalReRenderMsg) (tea.Model, tea.Cmd) {
-	m.reCommitPending = true
-	return m, buildReCommitCmd(msg.reCommitPayload)
 }
 
 // ---------------------------------------------------------------------------

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
@@ -61,9 +61,15 @@ type inlineBubbleModel struct {
 	// inputBarHidden for non-interactive environments.
 	inputBarMode inputBarMode
 
-	// currentTask holds the content of the first in_progress todo item,
-	// displayed as a single line above the separator in the composed View().
-	currentTask string
+	// currentTask holds the content of the first in_progress todo item.
+	// todoTotal and todoCompleted provide summary counts for the plan
+	// progress indicator shown above the separator in the composed View().
+	// expandMode suppresses the plan section in View() when the full plan
+	// is already visible in scrollback.
+	currentTask   string
+	todoTotal     int
+	todoCompleted int
+	expandMode    bool
 
 	// subAgentActive is true when a sub-agent is running and its live
 	// summary should be shown in View(). Cleared on subAgentHideMsg.
@@ -193,6 +199,8 @@ func (m inlineBubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleInputBarMode(msg)
 	case currentTaskMsg:
 		m.currentTask = msg.task
+		m.todoTotal = msg.todoTotal
+		m.todoCompleted = msg.todoCompleted
 		return m, nil
 	case subAgentShowMsg:
 		return m.handleSubAgentShow(msg)
@@ -250,6 +258,7 @@ func (m inlineBubbleModel) View() tea.View {
 //
 //	[transient content]                      (optional: spinner/streaming/approval/AI)
 //	  [-] Current task description           (optional: in_progress todo)
+//	  Plan: 2/5 todos completed (ctrl+o …)  (optional: plan summary)
 //	──────────────────────────── (full width)
 //	> user input / esc to interrupt          (input area)
 //	  enter send · ctrl+c exit               (hint, active mode only)
@@ -262,11 +271,16 @@ func (m inlineBubbleModel) renderComposedView() tea.View {
 		hasTransient = true
 	}
 
-	if m.currentTask != "" && !m.approvalActive {
+	if m.todoTotal > 0 && !m.approvalActive && !m.expandMode {
 		if hasTransient {
 			parts = append(parts, "")
 		}
-		parts = append(parts, systemMsgStyle.Render("  [-] "+m.currentTask))
+		if m.currentTask != "" {
+			parts = append(parts, systemMsgStyle.Render("  [-] "+m.currentTask))
+		}
+		summary := fmt.Sprintf("  Plan: %d/%d todos completed", m.todoCompleted, m.todoTotal)
+		summary += " " + expandHintStyle.Render("(ctrl+o to expand)")
+		parts = append(parts, systemMsgStyle.Render(summary))
 	}
 
 	parts = append(parts, m.renderSeparatorLine())
@@ -633,6 +647,8 @@ func (m inlineBubbleModel) handleTextInputHide(msg textInputHideMsg) (tea.Model,
 	m.textInput.Reset()
 	m.textInputCh = nil
 	m.currentTask = ""
+	m.todoTotal = 0
+	m.todoCompleted = 0
 	if msg.styledMessage != "" {
 		return m, tea.Println(strings.TrimRight(msg.styledMessage, "\n"))
 	}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea.go
@@ -94,6 +94,13 @@ type inlineBubbleModel struct {
 	// the input bar.
 	termWidth int
 
+	// reCommitPending suppresses View() output during the first phase of a
+	// re-commit. While true, View() returns an empty tea.View so the
+	// renderer's internal cursor tracking is not disturbed by the concurrent
+	// tea.Raw write that clears and rewrites the terminal. The flag is set
+	// by handleReCommit and cleared by handleReCommitDone (phase 2).
+	reCommitPending bool
+
 	// Channels for communicating with the event loop goroutine. Set during
 	// model initialization when Bubbletea owns stdin. nil otherwise.
 	toggleExpandCh chan<- struct{}
@@ -195,6 +202,10 @@ func (m inlineBubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleFollowUpHide(msg)
 	case reCommitMsg:
 		return m.handleReCommit(msg)
+	case reCommitDoneMsg:
+		return m.handleReCommitDone(msg)
+	case approvalReRenderMsg:
+		return m.handleApprovalReRender(msg)
 	case inputBarModeMsg:
 		return m.handleInputBarMode(msg)
 	case currentTaskMsg:
@@ -212,6 +223,14 @@ func (m inlineBubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m inlineBubbleModel) View() tea.View {
+	// During a re-commit, tea.Raw is writing directly to the terminal.
+	// Return empty so the renderer's cursor tracking is not disturbed.
+	// Phase 2 (reCommitDoneMsg) clears this flag and the renderer
+	// writes the composed view fresh at the current cursor position.
+	if m.reCommitPending {
+		return tea.NewView("")
+	}
+
 	// New path: composed layout with persistent input bar.
 	if m.inputBarMode != inputBarHidden {
 		return m.renderComposedView()
@@ -415,6 +434,7 @@ func (m inlineBubbleModel) handleApprovalStart(msg approvalStartMsg) (tea.Model,
 	m.aiStreamPartial = ""
 
 	if msg.reCommitPayload != "" {
+		m.reCommitPending = true
 		return m, buildReCommitCmd(msg.reCommitPayload)
 	}
 	var cmds []tea.Cmd
@@ -440,6 +460,7 @@ func (m inlineBubbleModel) handleApprovalShow(msg approvalShowMsg) (tea.Model, t
 	m.aiStreamPartial = ""
 
 	if msg.reCommitPayload != "" {
+		m.reCommitPending = true
 		return m, buildReCommitCmd(msg.reCommitPayload)
 	}
 	var cmds []tea.Cmd
@@ -668,10 +689,13 @@ func (m inlineBubbleModel) handleInputBarMode(msg inputBarModeMsg) (tea.Model, t
 // Re-commit handler
 // ---------------------------------------------------------------------------
 
-// handleReCommit clears all active visual states so View() returns only
-// the persistent UI (plan + separator + hint) during the renderer flush
-// that follows the Raw write. Without this, stale streaming/approval/spinner
-// content would be rendered on top of the freshly-written history.
+// handleReCommit clears all active visual states and starts a two-phase
+// re-commit. Phase 1 (this handler) sets reCommitPending so View()
+// returns empty — preventing the renderer from issuing stale cursor
+// movements while tea.Raw rewrites the terminal. Phase 2
+// (handleReCommitDone) clears the flag; the renderer sees the transition
+// from empty to the composed view and writes it fresh at the current
+// cursor position (bottom of history), preserving the input bar.
 func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) {
 	m.spinnerActive = false
 	m.streamingActive = false
@@ -683,9 +707,29 @@ func (m inlineBubbleModel) handleReCommit(msg reCommitMsg) (tea.Model, tea.Cmd) 
 	m.aiStreamPartial = ""
 	m.followUpActive = false
 	m.followUpContent = ""
+	m.reCommitPending = true
 	// Sub-agent live summary is not cleared — if a sub-agent is still
 	// running after re-commit, its summary reappears in View().
 	return m, buildReCommitCmd(msg.rendered)
+}
+
+// handleReCommitDone is phase 2 of the re-commit. The tea.Raw write has
+// completed and the terminal shows the updated history with the cursor
+// at the bottom. Clearing reCommitPending lets View() produce the
+// composed view again; the renderer writes it fresh below the history.
+func (m inlineBubbleModel) handleReCommitDone(_ reCommitDoneMsg) (tea.Model, tea.Cmd) {
+	m.reCommitPending = false
+	return m, nil
+}
+
+// handleApprovalReRender refreshes the scrollback after an expand toggle
+// during an active approval prompt. Unlike handleReCommit, it does NOT
+// clear any transient state — the approval question, menu selection, and
+// decision channel all remain intact so the user can continue approving.
+// It uses the same two-phase approach to preserve the approval panel.
+func (m inlineBubbleModel) handleApprovalReRender(msg approvalReRenderMsg) (tea.Model, tea.Cmd) {
+	m.reCommitPending = true
+	return m, buildReCommitCmd(msg.reCommitPayload)
 }
 
 // ---------------------------------------------------------------------------

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea_test.go
@@ -658,6 +658,21 @@ func TestInlineBubbleModel_ApprovalStart_ReCommitForStreamedContent(t *testing.T
 		t.Fatal("approvalStartMsg with reCommitPayload should return a Cmd")
 	}
 
+	if !model.reCommitPending {
+		t.Error("reCommitPending should be true during phase 1 of re-commit")
+	}
+	phase1View := model.View().Content
+	if phase1View != "" {
+		t.Errorf("View() should be empty during re-commit phase 1, got %q", phase1View)
+	}
+
+	// Phase 2: reCommitDoneMsg clears the pending flag so View() renders.
+	done, _ := approved.Update(reCommitDoneMsg{})
+	model = done.(inlineBubbleModel)
+	if model.reCommitPending {
+		t.Error("reCommitPending should be false after reCommitDoneMsg")
+	}
+
 	approvalView := model.View().Content
 	if !strings.Contains(approvalView, "Do you want to create config.go?") {
 		t.Errorf("View() should show approval question, got %q", approvalView)

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea_test.go
@@ -604,23 +604,11 @@ func TestInlineBubbleModel_ApprovalShow_ClearsStreamingState(t *testing.T) {
 	}
 }
 
-// TestInlineBubbleModel_ApprovalStart_ReCommitForStreamedContent verifies
-// the fix for the duplicate Write block bug (DD-001 amendment, Session 9).
-//
-// When a streaming tool transitions to approval, the event loop builds a
-// re-commit payload (history + expanded content) and sets it on
-// approvalStartMsg.reCommitPayload. The model handler must return
-// buildReCommitCmd (ClearScreen + eraseScrollback + payload) instead of
-// bare tea.Println, avoiding the insertAbove stale-cellbuf race that
-// pushes stale streaming content into scrollback.
-//
-// Sequence:
-//
-//	streamingShowMsg  -> streaming active, View() shows content
-//	streamingUpdateMsg -> content accumulated
-//	approvalStartMsg{reCommitPayload: ...} -> approval active,
-//	    returns buildReCommitCmd (not tea.Println)
-func TestInlineBubbleModel_ApprovalStart_ReCommitForStreamedContent(t *testing.T) {
+// TestInlineBubbleModel_ApprovalStart_ClearsStreamingState verifies that
+// approvalStartMsg clears all streaming state when activating approval.
+// The re-commit for streaming→approval transitions is now handled by
+// performReCommitWithApproval in the renderer, not by the model.
+func TestInlineBubbleModel_ApprovalStart_ClearsStreamingState(t *testing.T) {
 	m := newInlineBubbleModel()
 
 	shown, _ := m.Update(streamingShowMsg{
@@ -633,16 +621,12 @@ func TestInlineBubbleModel_ApprovalStart_ReCommitForStreamedContent(t *testing.T
 	if !model.streamingActive {
 		t.Fatal("precondition: streaming should be active")
 	}
-	if model.streamingCommittedLen == 0 {
-		t.Fatal("precondition: content should have been committed to scrollback")
-	}
 
 	decisionCh := make(chan approvalDecision, 1)
-	payload := "● AI message\n─── sep ───\n● Write(config.go)\napiVersion: v1\n─── sep ───"
 	approved, cmd := updated.Update(approvalStartMsg{
+		expandedContent: "─── sep ───\n● Write(config.go)\ncontent\n─── sep ───",
 		question:        "Do you want to create config.go?",
 		decisionCh:      decisionCh,
-		reCommitPayload: payload,
 	})
 	model = approved.(inlineBubbleModel)
 	if !model.approvalActive {
@@ -655,37 +639,18 @@ func TestInlineBubbleModel_ApprovalStart_ReCommitForStreamedContent(t *testing.T
 		t.Error("approvalStartMsg should clear aiStreamActive")
 	}
 	if cmd == nil {
-		t.Fatal("approvalStartMsg with reCommitPayload should return a Cmd")
-	}
-
-	if !model.reCommitPending {
-		t.Error("reCommitPending should be true during phase 1 of re-commit")
-	}
-	phase1View := model.View().Content
-	if phase1View != "" {
-		t.Errorf("View() should be empty during re-commit phase 1, got %q", phase1View)
-	}
-
-	// Phase 2: reCommitDoneMsg clears the pending flag so View() renders.
-	done, _ := approved.Update(reCommitDoneMsg{})
-	model = done.(inlineBubbleModel)
-	if model.reCommitPending {
-		t.Error("reCommitPending should be false after reCommitDoneMsg")
+		t.Fatal("approvalStartMsg with expandedContent should return a Println Cmd")
 	}
 
 	approvalView := model.View().Content
 	if !strings.Contains(approvalView, "Do you want to create config.go?") {
 		t.Errorf("View() should show approval question, got %q", approvalView)
 	}
-	if strings.Contains(approvalView, "apiVersion") {
-		t.Error("View() should not contain streaming content after approval transition")
-	}
 }
 
-// TestInlineBubbleModel_ApprovalStart_FallsBackToPrintln verifies that when
-// reCommitPayload is empty (non-streaming approval), the handler falls back
-// to the tea.Println path for expandedContent.
-func TestInlineBubbleModel_ApprovalStart_FallsBackToPrintln(t *testing.T) {
+// TestInlineBubbleModel_ApprovalStart_PrintlnForExpandedContent verifies
+// that approvalStartMsg uses tea.Println for expandedContent.
+func TestInlineBubbleModel_ApprovalStart_PrintlnForExpandedContent(t *testing.T) {
 	m := newInlineBubbleModel()
 	decisionCh := make(chan approvalDecision, 1)
 	_, cmd := m.Update(approvalStartMsg{
@@ -698,9 +663,9 @@ func TestInlineBubbleModel_ApprovalStart_FallsBackToPrintln(t *testing.T) {
 	}
 }
 
-// TestInlineBubbleModel_ApprovalShow_ReCommitForStreamedContent verifies
-// the re-commit path for the legacy approvalShowMsg (PromptKeyOnly path).
-func TestInlineBubbleModel_ApprovalShow_ReCommitForStreamedContent(t *testing.T) {
+// TestInlineBubbleModel_ApprovalShow_PrintlnForExpandedContent verifies
+// that the legacy approvalShowMsg uses tea.Println for expandedContent.
+func TestInlineBubbleModel_ApprovalShow_PrintlnForExpandedContent(t *testing.T) {
 	m := newInlineBubbleModel()
 
 	shown, _ := m.Update(streamingShowMsg{
@@ -709,10 +674,9 @@ func TestInlineBubbleModel_ApprovalShow_ReCommitForStreamedContent(t *testing.T)
 	})
 	updated, _ := shown.Update(streamingUpdateMsg{content: "apiVersion: v1\n"})
 
-	payload := "history\n─── sep ───\n● Write(config.go)\napiVersion: v1\n─── sep ───"
 	approved, cmd := updated.Update(approvalShowMsg{
+		expandedContent: "─── sep ───\n● Write(config.go)\napiVersion: v1\n─── sep ───",
 		question:        "Do you want to create config.go?",
-		reCommitPayload: payload,
 	})
 	model := approved.(inlineBubbleModel)
 	if !model.approvalActive {
@@ -722,7 +686,7 @@ func TestInlineBubbleModel_ApprovalShow_ReCommitForStreamedContent(t *testing.T)
 		t.Error("approvalShowMsg should clear streamingActive")
 	}
 	if cmd == nil {
-		t.Fatal("approvalShowMsg with reCommitPayload should return a Cmd")
+		t.Fatal("approvalShowMsg with expandedContent should return a Println Cmd")
 	}
 }
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup.go
@@ -27,35 +27,41 @@ import (
 // loop stays active during the prompt, so Ctrl+O toggles work immediately.
 // When false, the legacy promptFollowUp paths handle input externally.
 //
-// Returns the latest execution ID, final phase, and exit error so the caller
-// can fetch the correct execution for the epilogue summary.
+// Returns the latest execution ID, final phase, exit error, and the active
+// Bubbletea program so the caller can stop the correct instance. The program
+// may differ from the one originally passed in cfg when performReCommit
+// created replacement programs during the session.
 func runInlineFollowUpLoop(
 	ctx context.Context,
 	cfg inlineRenderConfig,
 	followUpFn executiontui.FollowUpFn,
 	executionID string,
-) (latestExecID string, phase string, exitErr string) {
+) (latestExecID string, phase string, exitErr string, latestProgram *tea.Program) {
 	latestExecID = executionID
+	latestProgram = cfg.program
 
 	for {
 		result := renderInline(ctx, cfg)
 
+		if result.program != nil {
+			cfg.program = result.program
+			latestProgram = result.program
+		}
+
 		if followUpFn == nil || !isFollowUpEligible(result.phase, result.exitErr) {
-			return latestExecID, result.phase, result.exitErr
+			return latestExecID, result.phase, result.exitErr, latestProgram
 		}
 
 		var input string
 		if result.followUpInput != "" {
 			input = result.followUpInput
 		} else if cfg.followUpEnabled {
-			// Follow-up was handled inside renderInline (Bubbletea text input);
-			// empty followUpInput means the user cancelled. Exit the loop.
-			return latestExecID, result.phase, result.exitErr
+			return latestExecID, result.phase, result.exitErr, latestProgram
 		} else {
 			var err error
 			input, err = promptFollowUp(cfg.program, cfg.status)
 			if err != nil || input == "" {
-				return latestExecID, result.phase, result.exitErr
+				return latestExecID, result.phase, result.exitErr, latestProgram
 			}
 			result.history = append(result.history, committedItem{
 				kind: kindHumanMessage,
@@ -69,7 +75,7 @@ func runInlineFollowUpLoop(
 		followUp, err := followUpFn(input)
 		if err != nil {
 			fmt.Fprintf(cfg.status, "Error: follow-up failed: %s\n", err)
-			return latestExecID, result.phase, result.exitErr
+			return latestExecID, result.phase, result.exitErr, latestProgram
 		}
 
 		latestExecID = followUp.ExecutionID

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup_test.go
@@ -145,7 +145,7 @@ func TestFollowUpLoop_NilFollowUpFn_ReturnImmediately(t *testing.T) {
 		status:            io.Discard,
 	}
 
-	execID, phase, exitErr := runInlineFollowUpLoop(context.Background(), cfg, nil, "exec-1")
+	execID, phase, exitErr, _ := runInlineFollowUpLoop(context.Background(), cfg, nil, "exec-1")
 
 	if execID != "exec-1" {
 		t.Errorf("expected execID=exec-1, got %q", execID)
@@ -175,7 +175,7 @@ func TestFollowUpLoop_NonEligiblePhase_ReturnImmediately(t *testing.T) {
 		status:            io.Discard,
 	}
 
-	_, phase, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
+	_, phase, _, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
 
 	if phase != "cancelled" {
 		t.Errorf("expected phase=cancelled, got %q", phase)
@@ -202,7 +202,7 @@ func TestFollowUpLoop_EmptyInput_ExitsLoop(t *testing.T) {
 		status:            io.Discard,
 	}
 
-	_, phase, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
+	_, phase, _, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
 
 	if phase != "completed" {
 		t.Errorf("expected phase=completed, got %q", phase)
@@ -229,7 +229,7 @@ func TestFollowUpLoop_FollowUpError_ExitsLoop(t *testing.T) {
 		status:            &statusBuf,
 	}
 
-	execID, _, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
+	execID, _, _, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
 
 	if execID != "exec-1" {
 		t.Errorf("expected original execID on error, got %q", execID)
@@ -276,7 +276,7 @@ func TestFollowUpLoop_SuccessfulFollowUp_RendersSecondExecution(t *testing.T) {
 		status:            io.Discard,
 	}
 
-	execID, phase, exitErr := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
+	execID, phase, exitErr, _ := runInlineFollowUpLoop(context.Background(), cfg, mockFollowUp, "exec-1")
 
 	if execID != "exec-2" {
 		t.Errorf("expected latestExecID=exec-2, got %q", execID)

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
-
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/panel"
+	"github.com/stigmer/stigmer/client-apps/cli/pkg/termctl"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/toolrender"
 )
 
@@ -33,9 +32,10 @@ func needsTrailingGap(kind committedKind) bool {
 		// stream ends (using kindAIMessage's trailing-gap rule).
 		return false
 	case kindTodoUpdate:
-		// Rendered exclusively in the composed View(); never appears in
-		// scrollback, so trailing gap is irrelevant.
-		return false
+		// In expanded mode the plan appears in scrollback and needs a
+		// trailing gap. In collapsed mode renderCommittedItem returns ""
+		// so the gap is never emitted regardless of this value.
+		return true
 	}
 	return true
 }
@@ -211,9 +211,9 @@ func renderCommittedItem(item committedItem, opts toolrender.CompactOptions, exp
 		}
 		return text
 	case kindTodoUpdate:
-		// The plan is rendered exclusively in the composed View() (via
-		// planDisplay) so it is always visible above the input bar. Skip
-		// it during re-commits to avoid duplication in scrollback.
+		if expanded {
+			return item.text
+		}
 		return ""
 	default:
 		return item.text
@@ -383,58 +383,84 @@ func appendExpandHint(text string) string {
 	return text + expandHintSuffix
 }
 
-// triggerReCommit pre-renders the full history into a single string and
-// sends it to the Bubbletea model via reCommitMsg. The model issues a
-// renderer-aware sequence (Raw → ClearScreen → Println → reCommitDoneMsg)
-// to atomically replace terminal content. No-op when no program is
-// active (non-TTY, tests).
+// triggerReCommit stops the current Bubbletea program, clears the terminal,
+// rewrites history directly, and starts a fresh program. No-op when no
+// program or factory is active (non-TTY, tests).
 func (r *inlineRenderer) triggerReCommit() {
-	if r.cfg.program == nil {
-		return
-	}
-	rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode, r.expandHintEnabled())
-	r.cfg.program.Send(reCommitMsg{rendered: rendered})
+	r.performReCommit()
 }
 
-// clearAndHome is the escape sequence prefix written via tea.Raw during
-// re-commit. It clears the visible screen, moves the cursor to row 1
-// col 1, then erases saved scrollback lines.
-//
-// The ordering (\033[2J → \033[1;1H → \033[3J) matters: modern terminals
-// (iTerm2, macOS Terminal, Ghostty) push visible content into scrollback
-// on \033[2J rather than truly erasing it. \033[3J must follow to wipe
-// that pushed content, otherwise duplicates survive in scrollback.
+// clearAndHome is the escape sequence that clears the visible screen, moves
+// the cursor to row 1 col 1, then erases saved scrollback lines.
 const clearAndHome = "\033[2J\033[1;1H\033[3J"
 
-// buildReCommitCmd returns a tea.Sequence that atomically clears the
-// terminal and writes the pre-rendered history, followed by a
-// reCommitDoneMsg that signals the model to restore View() rendering.
-//
-// Sequence:
-//  1. tea.Raw(clearAndHome) — physically clears the visible screen,
-//     scrollback buffer, and moves the cursor to (1,1).
-//  2. tea.ClearScreen — resets the renderer's internal cursor tracking
-//     to (0,0) and marks the screen buffer for a full redraw.
-//  3. tea.Println(history) — writes the rendered history through the
-//     renderer's tracked path (insertAbove). Because reCommitPending
-//     is still true at this point, View() returns "" and the renderer
-//     writes only the history content with no view interference.
-//  4. reCommitDoneMsg — clears reCommitPending so View() renders the
-//     composed view (input bar / "esc to interrupt") at the correct
-//     tracked position below the history.
-//
-// This approach keeps the renderer's cursor tracking in sync for all
-// modes (execution, follow-up, approval). The previous tea.Raw-only
-// path for execution mode caused cursor desync — the renderer wrote
-// View() at its stale tracked position instead of below the history.
-func buildReCommitCmd(rendered string) tea.Cmd {
-	cmds := []tea.Cmd{
-		tea.Raw(clearAndHome),
-		tea.ClearScreen,
+// performReCommit replaces the broken tea.Raw+ClearScreen approach with a
+// synchronous program-restart. The old program is stopped, history is
+// written directly to the terminal (no Bubbletea involved), and a fresh
+// program is started with the necessary state pre-loaded.
+func (r *inlineRenderer) performReCommit() {
+	if r.cfg.program == nil || r.cfg.programFactory == nil {
+		return
 	}
+
+	r.cfg.program.Quit()
+	r.cfg.program.Wait()
+
+	rendered := renderHistoryBatch(
+		r.history, r.compactOpts, r.expandMode, r.expandHintEnabled(),
+	)
+	payload := clearAndHome
 	if rendered != "" {
-		cmds = append(cmds, tea.Println(rendered))
+		payload += rendered + "\n"
 	}
-	cmds = append(cmds, func() tea.Msg { return reCommitDoneMsg{} })
-	return tea.Sequence(cmds...)
+	fmt.Fprint(r.cfg.status, payload)
+
+	r.cfg.program = r.cfg.programFactory(func(m *inlineBubbleModel) {
+		m.currentTask = r.trackedCurrentTask
+		m.termWidth = termctl.Width(r.cfg.status, 80)
+		if r.followUpSendCh != nil {
+			m.inputBarMode = inputBarActive
+			m.textInputCh = r.followUpSendCh
+			m.textInput = newFollowUpTextInput()
+			m.textInput.Focus()
+		}
+	})
+}
+
+// performReCommitWithApproval is like performReCommit but also writes an
+// expanded tool view after the history and pre-loads approval state into
+// the new program so the approval prompt continues seamlessly.
+func (r *inlineRenderer) performReCommitWithApproval(
+	expandedView, question string,
+	decisionCh chan<- approvalDecision,
+	selected int,
+) {
+	if r.cfg.program == nil || r.cfg.programFactory == nil {
+		return
+	}
+
+	r.cfg.program.Quit()
+	r.cfg.program.Wait()
+
+	rendered := renderHistoryBatch(
+		r.history, r.compactOpts, r.expandMode, r.expandHintEnabled(),
+	)
+	payload := clearAndHome
+	if rendered != "" {
+		payload += rendered + "\n"
+	}
+	trimmed := strings.TrimRight(expandedView, "\n")
+	if trimmed != "" {
+		payload += trimmed + "\n"
+	}
+	fmt.Fprint(r.cfg.status, payload)
+
+	r.cfg.program = r.cfg.programFactory(func(m *inlineBubbleModel) {
+		m.currentTask = r.trackedCurrentTask
+		m.termWidth = termctl.Width(r.cfg.status, 80)
+		m.approvalActive = true
+		m.approvalContent = question + "\n"
+		m.approvalDecisionCh = decisionCh
+		m.approvalSelected = selected
+	})
 }

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -438,3 +438,33 @@ func buildReCommitCmd(rendered string) tea.Cmd {
 		func() tea.Msg { return reCommitDoneMsg{} },
 	)
 }
+
+// buildFollowUpReCommitCmd returns a command sequence for re-committing
+// history while a follow-up text input is active. Unlike buildReCommitCmd
+// which uses tea.Raw (fast but desyncs the renderer's cursor tracking),
+// this uses renderer-aware operations so the input bar remains visible
+// and the cursor is correctly positioned.
+//
+// Sequence:
+//  1. tea.Raw(clearAndHome) — physically clears the terminal and scrollback.
+//  2. tea.ClearScreen — resets the renderer's internal position to (0,0)
+//     and marks the screen buffer for a full redraw.
+//  3. reCommitDoneMsg — clears reCommitPending so View() renders the input
+//     bar at (0,0). The renderer writes it at the correct tracked position.
+//  4. tea.Println(history) — calls insertAbove which inserts the history
+//     content above the view, pushing the input bar to the bottom. The
+//     renderer's position tracking is updated by insertAbove.
+//
+// Result: history fills the terminal with the input bar at the bottom,
+// and the renderer's cursor tracking is in sync for subsequent renders.
+func buildFollowUpReCommitCmd(rendered string) tea.Cmd {
+	cmds := []tea.Cmd{
+		tea.Raw(clearAndHome),
+		tea.ClearScreen,
+		func() tea.Msg { return reCommitDoneMsg{} },
+	}
+	if rendered != "" {
+		cmds = append(cmds, tea.Println(rendered))
+	}
+	return tea.Sequence(cmds...)
+}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -70,6 +70,10 @@ func needsLeadingGap(prev, current committedKind) bool {
 // The header item (kindHeader) gets an extra trailing newline to produce
 // a blank-line gap between the panel and the first content item, matching
 // the spacing of the initial render (commitToScrollback + blank line).
+//
+// kindTodoUpdate items are deferred and rendered at the very end so the
+// plan always appears below all messages/tool output regardless of when
+// the first todo event arrived in the session.
 func renderHistoryBatch(items []committedItem, opts toolrender.CompactOptions, expanded bool, showExpandHint bool) string {
 	if len(items) == 0 {
 		return ""
@@ -77,26 +81,47 @@ func renderHistoryBatch(items []committedItem, opts toolrender.CompactOptions, e
 	var b strings.Builder
 	first := true
 	var lastKind committedKind
-	for _, item := range items {
-		text := renderCommittedItem(item, opts, expanded, showExpandHint)
+	var deferredTodo *committedItem
+	for i := range items {
+		if items[i].kind == kindTodoUpdate {
+			deferredTodo = &items[i]
+			continue
+		}
+		text := renderCommittedItem(items[i], opts, expanded, showExpandHint)
 		if text == "" {
 			continue
 		}
 		if !first {
 			b.WriteByte('\n')
-			if needsLeadingGap(lastKind, item.kind) {
+			if needsLeadingGap(lastKind, items[i].kind) {
 				b.WriteByte('\n')
 			}
 		}
 		b.WriteString(text)
-		if item.kind == kindHeader {
+		if items[i].kind == kindHeader {
 			b.WriteByte('\n')
 		}
-		if needsTrailingGap(item.kind) {
+		if needsTrailingGap(items[i].kind) {
 			b.WriteByte('\n')
 		}
-		lastKind = item.kind
+		lastKind = items[i].kind
 		first = false
+	}
+	if deferredTodo != nil {
+		text := renderCommittedItem(*deferredTodo, opts, expanded, showExpandHint)
+		if text != "" {
+			if !first {
+				b.WriteByte('\n')
+				if needsLeadingGap(lastKind, deferredTodo.kind) {
+					b.WriteByte('\n')
+				}
+			}
+			b.WriteString(text)
+			if needsTrailingGap(deferredTodo.kind) {
+				b.WriteByte('\n')
+			}
+			first = false
+		}
 	}
 	return b.String()
 }
@@ -172,6 +197,12 @@ type committedItem struct {
 	// action is the approval decision string ("approve", "skip", "reject")
 	// for kindApproval items.
 	action string
+
+	// todoTotal and todoCompleted track plan progress for kindTodoUpdate
+	// items. When todoCompleted == todoTotal (all done), the expanded
+	// renderer shows a compact summary instead of the full item list.
+	todoTotal     int
+	todoCompleted int
 }
 
 // renderCommittedItem re-renders a history item to its display string.
@@ -417,6 +448,9 @@ func (r *inlineRenderer) performReCommit() {
 
 	r.cfg.program = r.cfg.programFactory(func(m *inlineBubbleModel) {
 		m.currentTask = r.trackedCurrentTask
+		m.todoTotal = r.trackedTodoTotal
+		m.todoCompleted = r.trackedTodoCompleted
+		m.expandMode = r.expandMode
 		m.termWidth = termctl.Width(r.cfg.status, 80)
 		if r.followUpSendCh != nil {
 			m.inputBarMode = inputBarActive
@@ -457,6 +491,9 @@ func (r *inlineRenderer) performReCommitWithApproval(
 
 	r.cfg.program = r.cfg.programFactory(func(m *inlineBubbleModel) {
 		m.currentTask = r.trackedCurrentTask
+		m.todoTotal = r.trackedTodoTotal
+		m.todoCompleted = r.trackedTodoCompleted
+		m.expandMode = r.expandMode
 		m.termWidth = termctl.Width(r.cfg.status, 80)
 		m.approvalActive = true
 		m.approvalContent = question + "\n"

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -70,7 +70,7 @@ func needsLeadingGap(prev, current committedKind) bool {
 // The header item (kindHeader) gets an extra trailing newline to produce
 // a blank-line gap between the panel and the first content item, matching
 // the spacing of the initial render (commitToScrollback + blank line).
-func renderHistoryBatch(items []committedItem, opts toolrender.CompactOptions, expanded bool) string {
+func renderHistoryBatch(items []committedItem, opts toolrender.CompactOptions, expanded bool, showExpandHint bool) string {
 	if len(items) == 0 {
 		return ""
 	}
@@ -78,7 +78,7 @@ func renderHistoryBatch(items []committedItem, opts toolrender.CompactOptions, e
 	first := true
 	var lastKind committedKind
 	for _, item := range items {
-		text := renderCommittedItem(item, opts, expanded)
+		text := renderCommittedItem(item, opts, expanded, showExpandHint)
 		if text == "" {
 			continue
 		}
@@ -182,18 +182,34 @@ type committedItem struct {
 // completions and read groups use their expanded renderers (full output,
 // no truncation). Mode-invariant items (AI messages, system messages,
 // lifecycle events) are unaffected by the expanded flag.
-func renderCommittedItem(item committedItem, opts toolrender.CompactOptions, expanded bool) string {
+//
+// When showExpandHint is true and the item is in compact mode, a dim
+// "(ctrl+o to expand)" suffix is appended to the first line of expandable
+// items (tools, read groups, sub-agent blocks).
+func renderCommittedItem(item committedItem, opts toolrender.CompactOptions, expanded bool, showExpandHint bool) string {
 	switch item.kind {
 	case kindHeader:
 		return renderHeaderItem(item, expanded)
 	case kindToolCompact:
-		return renderToolCompactItem(item, opts, expanded)
+		text := renderToolCompactItem(item, opts, expanded)
+		if !expanded && showExpandHint && text != "" {
+			text = appendExpandHint(text)
+		}
+		return text
 	case kindReadGroup:
-		return renderReadGroupItem(item, opts, expanded)
+		text := renderReadGroupItem(item, opts, expanded)
+		if !expanded && showExpandHint && text != "" {
+			text = appendExpandHint(text)
+		}
+		return text
 	case kindApproval:
 		return renderApprovalItem(item, opts)
 	case kindSubAgentBlock:
-		return renderSubAgentBlockItem(item, opts, expanded)
+		text := renderSubAgentBlockItem(item, opts, expanded)
+		if !expanded && showExpandHint && text != "" {
+			text = appendExpandHint(text)
+		}
+		return text
 	case kindTodoUpdate:
 		// The plan is rendered exclusively in the composed View() (via
 		// planDisplay) so it is always visible above the input bar. Skip
@@ -329,7 +345,7 @@ func renderSubAgentExpanded(header string, block *subAgentBlock, opts toolrender
 	b.WriteString(header)
 
 	for _, child := range block.children {
-		text := renderCommittedItem(child, opts, true)
+		text := renderCommittedItem(child, opts, true, false)
 		if text == "" {
 			continue
 		}
@@ -350,6 +366,23 @@ func renderSubAgentExpanded(header string, block *subAgentBlock, opts toolrender
 	return b.String()
 }
 
+// expandHintSuffix is the dim "(ctrl+o to expand)" text appended to the
+// first line of expandable items in compact mode.
+var expandHintSuffix = " " + expandHintStyle.Render("(ctrl+o to expand)")
+
+// appendExpandHint appends the expand-hint suffix to the first line of
+// the rendered text. For multi-line output (read groups, expanded tools),
+// only the header line receives the hint.
+func appendExpandHint(text string) string {
+	if text == "" {
+		return text
+	}
+	if idx := strings.IndexByte(text, '\n'); idx >= 0 {
+		return text[:idx] + expandHintSuffix + text[idx:]
+	}
+	return text + expandHintSuffix
+}
+
 // triggerReCommit pre-renders the full history into a single string and
 // sends it to the Bubbletea model. The model issues a tea.Raw write
 // followed by tea.ClearScreen to atomically replace terminal content.
@@ -358,7 +391,7 @@ func (r *inlineRenderer) triggerReCommit() {
 	if r.cfg.program == nil {
 		return
 	}
-	rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode)
+	rendered := renderHistoryBatch(r.history, r.compactOpts, r.expandMode, r.expandHintEnabled())
 	r.cfg.program.Send(reCommitMsg{rendered: rendered})
 }
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -384,9 +384,10 @@ func appendExpandHint(text string) string {
 }
 
 // triggerReCommit pre-renders the full history into a single string and
-// sends it to the Bubbletea model. The model issues a tea.Raw write
-// followed by tea.ClearScreen to atomically replace terminal content.
-// No-op when no program is active (non-TTY, tests).
+// sends it to the Bubbletea model via reCommitMsg. The model issues a
+// renderer-aware sequence (Raw → ClearScreen → Println → reCommitDoneMsg)
+// to atomically replace terminal content. No-op when no program is
+// active (non-TTY, tests).
 func (r *inlineRenderer) triggerReCommit() {
 	if r.cfg.program == nil {
 		return
@@ -406,65 +407,34 @@ func (r *inlineRenderer) triggerReCommit() {
 const clearAndHome = "\033[2J\033[1;1H\033[3J"
 
 // buildReCommitCmd returns a tea.Sequence that atomically clears the
-// terminal and writes the pre-rendered history via tea.Raw, followed by
-// a reCommitDoneMsg that signals the model to restore View() rendering.
-//
-// Two-phase design:
-//
-// Phase 1: The calling handler sets reCommitPending = true so View()
-// returns empty. This prevents the renderer from issuing cursor
-// movements (relative to its stale tracked position) while tea.Raw
-// rewrites the terminal. The Raw payload clears the screen and writes
-// history; the cursor ends up at the bottom of the history content.
-//
-// Phase 2: reCommitDoneMsg clears reCommitPending. The renderer sees a
-// transition from empty to the composed view and writes it fresh at the
-// current cursor position — placing the input bar right below the
-// history, which is the correct location.
-//
-// The rendered content's \n line breaks are replaced with \r\n because
-// Bubbletea puts the terminal in raw mode (OPOST/ONLCR disabled). In
-// raw mode \n is a bare line-feed — it moves the cursor down without
-// returning to column 0. The explicit \r ensures each line starts at
-// the left margin.
-func buildReCommitCmd(rendered string) tea.Cmd {
-	safe := strings.ReplaceAll(rendered, "\n", "\r\n")
-	payload := clearAndHome + safe
-	if rendered != "" {
-		payload += "\r\n"
-	}
-	return tea.Sequence(
-		tea.Raw(payload),
-		func() tea.Msg { return reCommitDoneMsg{} },
-	)
-}
-
-// buildFollowUpReCommitCmd returns a command sequence for re-committing
-// history while a follow-up text input is active. Unlike buildReCommitCmd
-// which uses tea.Raw (fast but desyncs the renderer's cursor tracking),
-// this uses renderer-aware operations so the input bar remains visible
-// and the cursor is correctly positioned.
+// terminal and writes the pre-rendered history, followed by a
+// reCommitDoneMsg that signals the model to restore View() rendering.
 //
 // Sequence:
-//  1. tea.Raw(clearAndHome) — physically clears the terminal and scrollback.
-//  2. tea.ClearScreen — resets the renderer's internal position to (0,0)
-//     and marks the screen buffer for a full redraw.
-//  3. reCommitDoneMsg — clears reCommitPending so View() renders the input
-//     bar at (0,0). The renderer writes it at the correct tracked position.
-//  4. tea.Println(history) — calls insertAbove which inserts the history
-//     content above the view, pushing the input bar to the bottom. The
-//     renderer's position tracking is updated by insertAbove.
+//  1. tea.Raw(clearAndHome) — physically clears the visible screen,
+//     scrollback buffer, and moves the cursor to (1,1).
+//  2. tea.ClearScreen — resets the renderer's internal cursor tracking
+//     to (0,0) and marks the screen buffer for a full redraw.
+//  3. tea.Println(history) — writes the rendered history through the
+//     renderer's tracked path (insertAbove). Because reCommitPending
+//     is still true at this point, View() returns "" and the renderer
+//     writes only the history content with no view interference.
+//  4. reCommitDoneMsg — clears reCommitPending so View() renders the
+//     composed view (input bar / "esc to interrupt") at the correct
+//     tracked position below the history.
 //
-// Result: history fills the terminal with the input bar at the bottom,
-// and the renderer's cursor tracking is in sync for subsequent renders.
-func buildFollowUpReCommitCmd(rendered string) tea.Cmd {
+// This approach keeps the renderer's cursor tracking in sync for all
+// modes (execution, follow-up, approval). The previous tea.Raw-only
+// path for execution mode caused cursor desync — the renderer wrote
+// View() at its stale tracked position instead of below the history.
+func buildReCommitCmd(rendered string) tea.Cmd {
 	cmds := []tea.Cmd{
 		tea.Raw(clearAndHome),
 		tea.ClearScreen,
-		func() tea.Msg { return reCommitDoneMsg{} },
 	}
 	if rendered != "" {
 		cmds = append(cmds, tea.Println(rendered))
 	}
+	cmds = append(cmds, func() tea.Msg { return reCommitDoneMsg{} })
 	return tea.Sequence(cmds...)
 }

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -192,13 +192,13 @@ func renderCommittedItem(item committedItem, opts toolrender.CompactOptions, exp
 		return renderHeaderItem(item, expanded)
 	case kindToolCompact:
 		text := renderToolCompactItem(item, opts, expanded)
-		if !expanded && showExpandHint && text != "" {
+		if !expanded && showExpandHint && text != "" && len(item.toolCalls) > 0 && toolrender.IsExpandable(item.toolCalls[0]) {
 			text = appendExpandHint(text)
 		}
 		return text
 	case kindReadGroup:
 		text := renderReadGroupItem(item, opts, expanded)
-		if !expanded && showExpandHint && text != "" {
+		if !expanded && showExpandHint && text != "" && toolrender.IsReadGroupExpandable(item.toolCalls) {
 			text = appendExpandHint(text)
 		}
 		return text
@@ -206,7 +206,7 @@ func renderCommittedItem(item committedItem, opts toolrender.CompactOptions, exp
 		return renderApprovalItem(item, opts)
 	case kindSubAgentBlock:
 		text := renderSubAgentBlockItem(item, opts, expanded)
-		if !expanded && showExpandHint && text != "" {
+		if !expanded && showExpandHint && text != "" && item.saBlock != nil && len(item.saBlock.children) > 0 {
 			text = appendExpandHint(text)
 		}
 		return text
@@ -406,15 +406,21 @@ func (r *inlineRenderer) triggerReCommit() {
 const clearAndHome = "\033[2J\033[1;1H\033[3J"
 
 // buildReCommitCmd returns a tea.Sequence that atomically clears the
-// terminal and writes the pre-rendered history via tea.Raw, then resets
-// the renderer's internal state via tea.ClearScreen.
+// terminal and writes the pre-rendered history via tea.Raw, followed by
+// a reCommitDoneMsg that signals the model to restore View() rendering.
 //
-// tea.Raw writes to Bubbletea's outputBuf, which is flushed to the
-// terminal BEFORE the renderer's cellbuf flush on each tick. This
-// guarantees the clear sequences and content reach the terminal before
-// the renderer attempts to render View(). The subsequent ClearScreen
-// resets the renderer's internal cursor and erase flags so the next
-// flush correctly positions the View() output below the Raw content.
+// Two-phase design:
+//
+// Phase 1: The calling handler sets reCommitPending = true so View()
+// returns empty. This prevents the renderer from issuing cursor
+// movements (relative to its stale tracked position) while tea.Raw
+// rewrites the terminal. The Raw payload clears the screen and writes
+// history; the cursor ends up at the bottom of the history content.
+//
+// Phase 2: reCommitDoneMsg clears reCommitPending. The renderer sees a
+// transition from empty to the composed view and writes it fresh at the
+// current cursor position — placing the input bar right below the
+// history, which is the correct location.
 //
 // The rendered content's \n line breaks are replaced with \r\n because
 // Bubbletea puts the terminal in raw mode (OPOST/ONLCR disabled). In
@@ -427,5 +433,8 @@ func buildReCommitCmd(rendered string) tea.Cmd {
 	if rendered != "" {
 		payload += "\r\n"
 	}
-	return tea.Sequence(tea.Raw(payload), tea.ClearScreen)
+	return tea.Sequence(
+		tea.Raw(payload),
+		func() tea.Msg { return reCommitDoneMsg{} },
+	)
 }

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_bench_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_bench_test.go
@@ -112,7 +112,7 @@ func BenchmarkRenderCommittedItem_Header(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, false)
+		renderCommittedItem(item, opts, false, false)
 	}
 }
 
@@ -121,7 +121,7 @@ func BenchmarkRenderCommittedItem_ToolCompact(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, false)
+		renderCommittedItem(item, opts, false, false)
 	}
 }
 
@@ -130,7 +130,7 @@ func BenchmarkRenderCommittedItem_ToolExpanded(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, true)
+		renderCommittedItem(item, opts, true, false)
 	}
 }
 
@@ -139,7 +139,7 @@ func BenchmarkRenderCommittedItem_ReadGroup(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, false)
+		renderCommittedItem(item, opts, false, false)
 	}
 }
 
@@ -148,7 +148,7 @@ func BenchmarkRenderCommittedItem_ReadGroupExpanded(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, true)
+		renderCommittedItem(item, opts, true, false)
 	}
 }
 
@@ -157,7 +157,7 @@ func BenchmarkRenderCommittedItem_Approval(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, false)
+		renderCommittedItem(item, opts, false, false)
 	}
 }
 
@@ -166,7 +166,7 @@ func BenchmarkRenderCommittedItem_Text(b *testing.B) {
 	opts := toolrender.CompactOptions{}
 	b.ResetTimer()
 	for range b.N {
-		renderCommittedItem(item, opts, false)
+		renderCommittedItem(item, opts, false, false)
 	}
 }
 
@@ -181,12 +181,28 @@ func BenchmarkRenderHistoryBatch(b *testing.B) {
 		opts := toolrender.CompactOptions{}
 		b.Run(fmt.Sprintf("compact_%d", size), func(b *testing.B) {
 			for range b.N {
-				renderHistoryBatch(items, opts, false)
+				renderHistoryBatch(items, opts, false, false)
 			}
 		})
 		b.Run(fmt.Sprintf("expanded_%d", size), func(b *testing.B) {
 			for range b.N {
-				renderHistoryBatch(items, opts, true)
+				renderHistoryBatch(items, opts, true, false)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Batch rendering with expand hint — measures overhead of hint appending.
+// =============================================================================
+
+func BenchmarkRenderHistoryBatch_WithExpandHint(b *testing.B) {
+	for _, size := range []int{100, 500} {
+		items := buildRealisticHistory(size)
+		opts := toolrender.CompactOptions{}
+		b.Run(fmt.Sprintf("compact_hint_%d", size), func(b *testing.B) {
+			for range b.N {
+				renderHistoryBatch(items, opts, false, true)
 			}
 		})
 	}
@@ -202,7 +218,7 @@ func BenchmarkRenderHistoryBatch_Allocs(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		_ = renderHistoryBatch(items, opts, false)
+		_ = renderHistoryBatch(items, opts, false, false)
 	}
 }
 
@@ -219,7 +235,7 @@ func BenchmarkRenderHistoryBatch_BuilderGrowth(b *testing.B) {
 	var sink strings.Builder
 	for range b.N {
 		sink.Reset()
-		result := renderHistoryBatch(items, opts, false)
+		result := renderHistoryBatch(items, opts, false, false)
 		sink.WriteString(result)
 	}
 }

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
@@ -932,11 +932,15 @@ func TestAppendExpandHint_EmptyString(t *testing.T) {
 }
 
 func TestRenderCommittedItem_ExpandHint_ToolCompact(t *testing.T) {
+	// shell with 5+ lines is expandable per IsExpandable
+	shellResult := strings.Join([]string{"line1", "line2", "line3", "line4", "line5"}, "\n")
 	item := committedItem{
 		kind: kindToolCompact,
 		toolCalls: []toolrender.ToolCallInfo{{
-			Name: "read_file",
-			Args: map[string]interface{}{"path": "main.go"},
+			Name:   "shell",
+			Args:   map[string]interface{}{"command": "ls -la"},
+			Status: "completed",
+			Result: shellResult,
 		}},
 	}
 
@@ -947,8 +951,22 @@ func TestRenderCommittedItem_ExpandHint_ToolCompact(t *testing.T) {
 	assert.NotContains(t, withoutHint, "ctrl+o to expand")
 }
 
+func TestRenderCommittedItem_NoExpandHint_ToolCompact_ReadFile(t *testing.T) {
+	// read_file is NOT expandable per IsExpandable; hint should not show even with showExpandHint=true
+	item := committedItem{
+		kind: kindToolCompact,
+		toolCalls: []toolrender.ToolCallInfo{{
+			Name: "read_file",
+			Args: map[string]interface{}{"path": "main.go"},
+		}},
+	}
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
+	assert.NotContains(t, result, "ctrl+o to expand")
+}
+
 func TestRenderCommittedItem_ExpandHint_ReadGroup(t *testing.T) {
-	reads := make([]toolrender.ToolCallInfo, readGroupThreshold)
+	// IsReadGroupExpandable returns true when len(reads) > maxVisibleInGroup+1 (i.e. 5+)
+	reads := make([]toolrender.ToolCallInfo, 5)
 	for i := range reads {
 		reads[i] = toolrender.ToolCallInfo{
 			Name:   "read_file",
@@ -967,15 +985,45 @@ func TestRenderCommittedItem_ExpandHint_ReadGroup(t *testing.T) {
 		"hint should appear on the read group header line")
 }
 
+func TestRenderCommittedItem_NoExpandHint_ReadGroup_ThreeEntries(t *testing.T) {
+	// 3 entries: len(reads) <= maxVisibleInGroup+1, so IsReadGroupExpandable is false
+	reads := make([]toolrender.ToolCallInfo, 3)
+	for i := range reads {
+		reads[i] = toolrender.ToolCallInfo{
+			Name:   "read_file",
+			Args:   map[string]interface{}{"path": fmt.Sprintf("file_%d.go", i)},
+			Status: "completed",
+			Result: "content\n",
+		}
+	}
+	item := committedItem{kind: kindReadGroup, toolCalls: reads}
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
+	assert.NotContains(t, result, "ctrl+o to expand")
+}
+
 func TestRenderCommittedItem_ExpandHint_SubAgentBlock(t *testing.T) {
+	// hint shows when len(item.saBlock.children) > 0
 	block := &subAgentBlock{
 		id: "sa-1", name: "researcher", subject: "Explore CLI code",
 		status: "completed", toolCount: 5,
+		children: []committedItem{{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{}}},
 	}
 	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
 
 	withHint := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
 	assert.Contains(t, withHint, "ctrl+o to expand")
+}
+
+func TestRenderCommittedItem_NoExpandHint_SubAgentBlock_EmptyChildren(t *testing.T) {
+	// hint does NOT show when len(item.saBlock.children) == 0
+	block := &subAgentBlock{
+		id: "sa-1", name: "researcher", subject: "Explore CLI code",
+		status: "completed", toolCount: 5,
+		children: nil,
+	}
+	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
+	assert.NotContains(t, result, "ctrl+o to expand")
 }
 
 func TestRenderCommittedItem_NoHintWhenExpanded(t *testing.T) {
@@ -1035,12 +1083,15 @@ func TestExpandHintEnabled(t *testing.T) {
 }
 
 func TestRenderHistoryBatch_WithExpandHint(t *testing.T) {
+	multiLine := strings.Join([]string{"l1", "l2", "l3", "l4", "l5"}, "\n")
 	items := []committedItem{
 		{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{{
-			Name: "read_file", Args: map[string]interface{}{"path": "a.go"},
+			Name: "shell", Args: map[string]interface{}{"command": "ls"},
+			Status: "completed", Result: multiLine,
 		}}},
 		{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{{
-			Name: "read_file", Args: map[string]interface{}{"path": "b.go"},
+			Name: "shell", Args: map[string]interface{}{"command": "pwd"},
+			Status: "completed", Result: multiLine,
 		}}},
 	}
 
@@ -1059,10 +1110,12 @@ func TestCommitToScrollback_WithExpandHint(t *testing.T) {
 		activeSubAgents: make(map[string]*subAgentBlock),
 	}
 
+	multiLine := strings.Join([]string{"l1", "l2", "l3", "l4", "l5"}, "\n")
 	item := committedItem{
 		kind: kindToolCompact,
 		toolCalls: []toolrender.ToolCallInfo{{
-			Name: "read_file", Args: map[string]interface{}{"path": "main.go"},
+			Name: "shell", Args: map[string]interface{}{"command": "ls"},
+			Status: "completed", Result: multiLine,
 		}},
 	}
 	r.commitToScrollback(item)

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
@@ -146,24 +146,6 @@ func TestRenderCommittedItem_TextKinds(t *testing.T) {
 	}
 }
 
-func TestBuildReCommitCmd_ProducesCmd(t *testing.T) {
-	items := []committedItem{
-		{kind: kindHeader, header: &sessionHeaderInfo{SessionID: "ses-1"}},
-		{kind: kindText, text: "some output"},
-		{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{
-			{Name: "read_file", Args: map[string]interface{}{"path": "f.go"}},
-		}},
-	}
-	rendered := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
-	cmd := buildReCommitCmd(rendered)
-	assert.NotNil(t, cmd)
-}
-
-func TestBuildReCommitCmd_EmptyHistory(t *testing.T) {
-	cmd := buildReCommitCmd("")
-	assert.NotNil(t, cmd)
-}
-
 func TestRenderCommittedItem_Header_SubjectMutation(t *testing.T) {
 	info := sessionHeaderInfo{
 		SessionID: "ses-abc123",
@@ -293,18 +275,6 @@ func TestRenderCommittedItem_Expanded_ApprovalUnchanged(t *testing.T) {
 	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 	assert.Equal(t, compact, expanded)
-}
-
-func TestBuildReCommitCmd_Expanded_ProducesCmd(t *testing.T) {
-	items := []committedItem{
-		{kind: kindHeader, header: &sessionHeaderInfo{SessionID: "ses-1"}},
-		{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{
-			{Name: "shell", Args: map[string]interface{}{"command": "ls"}, Status: "completed", Result: "a\nb\nc\nd\ne"},
-		}},
-	}
-	rendered := renderHistoryBatch(items, toolrender.CompactOptions{}, true, false)
-	cmd := buildReCommitCmd(rendered)
-	assert.NotNil(t, cmd)
 }
 
 // =============================================================================
@@ -576,7 +546,7 @@ func TestNeedsTrailingGap(t *testing.T) {
 	gapKinds := []committedKind{
 		kindAIMessage, kindHumanMessage, kindSystemMessage,
 		kindSubAgentBlock, kindPhaseChange,
-		kindApproval, kindText,
+		kindApproval, kindText, kindTodoUpdate,
 	}
 	for _, k := range gapKinds {
 		assert.True(t, needsTrailingGap(k), "expected needsTrailingGap==true for kind %d", k)
@@ -584,7 +554,7 @@ func TestNeedsTrailingGap(t *testing.T) {
 
 	// Explicit opt-outs only.
 	noGapKinds := []committedKind{
-		kindHeader, kindToolCompact, kindReadGroup, kindTodoUpdate, kindAIStreamLine,
+		kindHeader, kindToolCompact, kindReadGroup, kindAIStreamLine,
 	}
 	for _, k := range noGapKinds {
 		assert.False(t, needsTrailingGap(k), "expected needsTrailingGap==false for kind %d", k)

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
@@ -22,7 +22,7 @@ func TestRenderCommittedItem_Header_WithSubject(t *testing.T) {
 			Model:     "sonnet-4.6",
 		},
 	}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "Stigmer")
 	assert.Contains(t, result, "test-agent")
@@ -38,7 +38,7 @@ func TestRenderCommittedItem_Header_WithoutSubject(t *testing.T) {
 			SessionID: "ses-abc123",
 		},
 	}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "ses-abc123")
 	assert.NotContains(t, result, "Subject")
@@ -46,7 +46,7 @@ func TestRenderCommittedItem_Header_WithoutSubject(t *testing.T) {
 
 func TestRenderCommittedItem_Header_NilHeader(t *testing.T) {
 	item := committedItem{kind: kindHeader}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, "", result)
 }
 
@@ -58,7 +58,7 @@ func TestRenderCommittedItem_ToolCompact(t *testing.T) {
 			Args: map[string]interface{}{"path": "main.go"},
 		}},
 	}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "Read")
 	assert.Contains(t, result, "main.go")
@@ -73,7 +73,7 @@ func TestRenderCommittedItem_ToolCompact_SubAgent(t *testing.T) {
 			Args: map[string]interface{}{"path": "main.go"},
 		}},
 	}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "main.go")
 	assert.Contains(t, result, "│")
@@ -81,7 +81,7 @@ func TestRenderCommittedItem_ToolCompact_SubAgent(t *testing.T) {
 
 func TestRenderCommittedItem_ToolCompact_Empty(t *testing.T) {
 	item := committedItem{kind: kindToolCompact}
-	assert.Equal(t, "", renderCommittedItem(item, toolrender.CompactOptions{}, false))
+	assert.Equal(t, "", renderCommittedItem(item, toolrender.CompactOptions{}, false, false))
 }
 
 func TestRenderCommittedItem_ReadGroup_Grouped(t *testing.T) {
@@ -94,7 +94,7 @@ func TestRenderCommittedItem_ReadGroup_Grouped(t *testing.T) {
 		}
 	}
 	item := committedItem{kind: kindReadGroup, toolCalls: reads}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "Read")
 }
@@ -105,7 +105,7 @@ func TestRenderCommittedItem_ReadGroup_Individual(t *testing.T) {
 		{Name: "read_file", Args: map[string]interface{}{"path": "b.go"}},
 	}
 	item := committedItem{kind: kindReadGroup, toolCalls: reads}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "a.go")
 	assert.Contains(t, result, "b.go")
@@ -120,7 +120,7 @@ func TestRenderCommittedItem_Approval(t *testing.T) {
 			Args: map[string]interface{}{"path": "config.go"},
 		}},
 	}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "config.go")
 }
@@ -140,7 +140,7 @@ func TestRenderCommittedItem_TextKinds(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			item := committedItem{kind: tt.kind, text: "expected output"}
-			result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+			result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 			assert.Equal(t, "expected output", result)
 		})
 	}
@@ -154,7 +154,7 @@ func TestBuildReCommitCmd_ProducesCmd(t *testing.T) {
 			{Name: "read_file", Args: map[string]interface{}{"path": "f.go"}},
 		}},
 	}
-	rendered := renderHistoryBatch(items, toolrender.CompactOptions{}, false)
+	rendered := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
 	cmd := buildReCommitCmd(rendered)
 	assert.NotNil(t, cmd)
 }
@@ -170,11 +170,11 @@ func TestRenderCommittedItem_Header_SubjectMutation(t *testing.T) {
 	}
 	item := committedItem{kind: kindHeader, header: &info}
 
-	before := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	before := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.NotContains(t, before, "Subject")
 
 	info.Subject = "Refactor auth module"
-	after := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	after := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.Contains(t, after, "Subject")
 	assert.Contains(t, after, "Refactor auth module")
 }
@@ -188,7 +188,7 @@ func TestRenderToolCompactItem_MultiLine_HasTrailingBlank(t *testing.T) {
 			Result: "total 8\ndrwxr 2 user\n-rw-r 1 file",
 		}},
 	}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.True(t, strings.HasSuffix(result, "\n"),
 		"multi-line tool compact should end with blank line separator")
 }
@@ -208,10 +208,10 @@ func TestRenderCommittedItem_Expanded_ShellShowsAllOutput(t *testing.T) {
 		}},
 	}
 
-	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.Contains(t, compact, "more lines")
 
-	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 	assert.NotContains(t, expanded, "more lines")
 	assert.Contains(t, expanded, "pkg/a")
 	assert.Contains(t, expanded, "pkg/f")
@@ -229,10 +229,10 @@ func TestRenderCommittedItem_Expanded_ReadGroupShowsAll(t *testing.T) {
 	}
 	item := committedItem{kind: kindReadGroup, toolCalls: reads}
 
-	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.Contains(t, compact, "more")
 
-	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 	assert.NotContains(t, expanded, "more")
 	for i := range reads {
 		assert.Contains(t, expanded, fmt.Sprintf("file_%d.go", i+1))
@@ -251,14 +251,14 @@ func TestRenderCommittedItem_Expanded_ReadGroupSubAgent(t *testing.T) {
 	}
 	item := committedItem{kind: kindReadGroup, toolCalls: reads, subAgentID: "sub-1"}
 
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 	assert.Contains(t, result, "│")
 }
 
 func TestRenderCommittedItem_Expanded_TextKindsUnchanged(t *testing.T) {
 	item := committedItem{kind: kindAIMessage, text: "AI response text"}
-	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false)
-	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
+	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 	assert.Equal(t, compact, expanded)
 }
 
@@ -270,8 +270,8 @@ func TestRenderCommittedItem_Expanded_HeaderShowsModeIndicator(t *testing.T) {
 			Subject:   "Test subject",
 		},
 	}
-	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false)
-	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
+	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 
 	assert.Contains(t, compact, "Stigmer")
 	assert.NotContains(t, compact, "expanded")
@@ -290,8 +290,8 @@ func TestRenderCommittedItem_Expanded_ApprovalUnchanged(t *testing.T) {
 			Args: map[string]interface{}{"path": "config.go", "contents": "pkg config\n"},
 		}},
 	}
-	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false)
-	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	compact := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
+	expanded := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 	assert.Equal(t, compact, expanded)
 }
 
@@ -302,7 +302,7 @@ func TestBuildReCommitCmd_Expanded_ProducesCmd(t *testing.T) {
 			{Name: "shell", Args: map[string]interface{}{"command": "ls"}, Status: "completed", Result: "a\nb\nc\nd\ne"},
 		}},
 	}
-	rendered := renderHistoryBatch(items, toolrender.CompactOptions{}, true)
+	rendered := renderHistoryBatch(items, toolrender.CompactOptions{}, true, false)
 	cmd := buildReCommitCmd(rendered)
 	assert.NotNil(t, cmd)
 }
@@ -417,7 +417,7 @@ func TestRenderHistoryBatch_MatchesPerItemOutput(t *testing.T) {
 			first := true
 			var lastKind committedKind
 			for _, item := range items {
-				text := renderCommittedItem(item, opts, expanded)
+				text := renderCommittedItem(item, opts, expanded, false)
 				if text == "" {
 					continue
 				}
@@ -438,20 +438,20 @@ func TestRenderHistoryBatch_MatchesPerItemOutput(t *testing.T) {
 				first = false
 			}
 			expected := b.String()
-			actual := renderHistoryBatch(items, opts, expanded)
+			actual := renderHistoryBatch(items, opts, expanded, false)
 			assert.Equal(t, expected, actual)
 		})
 	}
 }
 
 func TestRenderHistoryBatch_EmptyHistory(t *testing.T) {
-	assert.Equal(t, "", renderHistoryBatch(nil, toolrender.CompactOptions{}, false))
-	assert.Equal(t, "", renderHistoryBatch([]committedItem{}, toolrender.CompactOptions{}, false))
+	assert.Equal(t, "", renderHistoryBatch(nil, toolrender.CompactOptions{}, false, false))
+	assert.Equal(t, "", renderHistoryBatch([]committedItem{}, toolrender.CompactOptions{}, false, false))
 }
 
 func TestRenderHistoryBatch_SingleItem(t *testing.T) {
 	item := committedItem{kind: kindText, text: "only item"}
-	result := renderHistoryBatch([]committedItem{item}, toolrender.CompactOptions{}, false)
+	result := renderHistoryBatch([]committedItem{item}, toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, "only item\n", result)
 }
 
@@ -461,7 +461,7 @@ func TestRenderHistoryBatch_SkipsEmptyItems(t *testing.T) {
 		{kind: kindToolCompact},
 		{kind: kindText, text: "second"},
 	}
-	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false)
+	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, "first\n\nsecond\n", result)
 }
 
@@ -470,7 +470,7 @@ func TestRenderHistoryBatch_NilHeader(t *testing.T) {
 		{kind: kindHeader},
 		{kind: kindText, text: "after empty header"},
 	}
-	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false)
+	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, "after empty header\n", result)
 }
 
@@ -479,9 +479,9 @@ func TestRenderHistoryBatch_HeaderHasBlankLineGap(t *testing.T) {
 		{kind: kindHeader, header: &sessionHeaderInfo{SessionID: "ses-1"}},
 		{kind: kindText, text: "first content"},
 	}
-	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false)
+	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
 
-	headerText := renderCommittedItem(items[0], toolrender.CompactOptions{}, false)
+	headerText := renderCommittedItem(items[0], toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, headerText+"\n\nfirst content\n", result,
 		"header should be followed by a blank line before the next item")
 }
@@ -490,9 +490,9 @@ func TestRenderHistoryBatch_HeaderOnly_NoExtraNewline(t *testing.T) {
 	items := []committedItem{
 		{kind: kindHeader, header: &sessionHeaderInfo{SessionID: "ses-1"}},
 	}
-	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false)
+	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
 
-	headerText := renderCommittedItem(items[0], toolrender.CompactOptions{}, false)
+	headerText := renderCommittedItem(items[0], toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, headerText+"\n", result,
 		"header-only batch should have trailing newline from the gap")
 }
@@ -562,7 +562,7 @@ func TestCommitToScrollback_MatchesRecommit(t *testing.T) {
 			}
 			liveOutput := buf.String()
 
-			batch := renderHistoryBatch(items, opts, expanded)
+			batch := renderHistoryBatch(items, opts, expanded, false)
 
 			assert.Equal(t, batch+"\n", liveOutput,
 				"live commitToScrollback output should match renderHistoryBatch "+
@@ -664,10 +664,10 @@ func TestRenderHistoryBatch_LeadingGapAfterTools(t *testing.T) {
 		}}},
 		{kind: kindAIMessage, text: "Here is my analysis."},
 	}
-	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false)
+	result := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
 
-	tool1 := renderCommittedItem(items[0], toolrender.CompactOptions{}, false)
-	tool2 := renderCommittedItem(items[1], toolrender.CompactOptions{}, false)
+	tool1 := renderCommittedItem(items[0], toolrender.CompactOptions{}, false, false)
+	tool2 := renderCommittedItem(items[1], toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, tool1+"\n"+tool2,
 		"consecutive tools should stack tightly")
@@ -727,7 +727,7 @@ func TestRenderSubAgentBlockItem_Collapsed(t *testing.T) {
 	}
 	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
 
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "Task")
 	assert.Contains(t, result, "Explore CLI rendering")
@@ -743,7 +743,7 @@ func TestRenderSubAgentBlockItem_Collapsed_Failed(t *testing.T) {
 	}
 	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
 
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 
 	assert.Contains(t, result, "✗ Failed")
 	assert.Contains(t, result, "3 tools")
@@ -764,7 +764,7 @@ func TestRenderSubAgentBlockItem_Expanded_ShowsChildren(t *testing.T) {
 	}
 	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
 
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, true)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, true, false)
 
 	assert.Contains(t, result, "Task")
 	assert.Contains(t, result, "Explore CLI rendering")
@@ -775,7 +775,7 @@ func TestRenderSubAgentBlockItem_Expanded_ShowsChildren(t *testing.T) {
 
 func TestRenderSubAgentBlockItem_NilBlock(t *testing.T) {
 	item := committedItem{kind: kindSubAgentBlock}
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.Equal(t, "", result)
 }
 
@@ -786,7 +786,7 @@ func TestRenderSubAgentBlockItem_FallbackToName(t *testing.T) {
 	}
 	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
 
-	result := renderCommittedItem(item, toolrender.CompactOptions{}, false)
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
 	assert.Contains(t, result, "code_editor")
 }
 
@@ -904,4 +904,188 @@ func TestRenderToolCompleted_NoBlock_WritesToScrollback(t *testing.T) {
 	})
 
 	assert.NotEqual(t, "", buf.String(), "non-sub-agent tool should write to scrollback")
+}
+
+// =============================================================================
+// Expand hint — "(ctrl+o to expand)" suffix
+// =============================================================================
+
+func TestAppendExpandHint_SingleLine(t *testing.T) {
+	result := appendExpandHint("● Read main.go (43 lines)")
+	assert.Contains(t, result, "● Read main.go (43 lines)")
+	assert.Contains(t, result, "ctrl+o to expand")
+}
+
+func TestAppendExpandHint_MultiLine_FirstLineOnly(t *testing.T) {
+	input := "● Read 3 files\n    main.go (125 lines)\n    config.go (43 lines)"
+	result := appendExpandHint(input)
+
+	lines := strings.SplitN(result, "\n", 2)
+	assert.Contains(t, lines[0], "ctrl+o to expand",
+		"hint should appear on the first line")
+	assert.NotContains(t, lines[1], "ctrl+o to expand",
+		"hint should NOT appear on subsequent lines")
+}
+
+func TestAppendExpandHint_EmptyString(t *testing.T) {
+	assert.Equal(t, "", appendExpandHint(""))
+}
+
+func TestRenderCommittedItem_ExpandHint_ToolCompact(t *testing.T) {
+	item := committedItem{
+		kind: kindToolCompact,
+		toolCalls: []toolrender.ToolCallInfo{{
+			Name: "read_file",
+			Args: map[string]interface{}{"path": "main.go"},
+		}},
+	}
+
+	withHint := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
+	assert.Contains(t, withHint, "ctrl+o to expand")
+
+	withoutHint := renderCommittedItem(item, toolrender.CompactOptions{}, false, false)
+	assert.NotContains(t, withoutHint, "ctrl+o to expand")
+}
+
+func TestRenderCommittedItem_ExpandHint_ReadGroup(t *testing.T) {
+	reads := make([]toolrender.ToolCallInfo, readGroupThreshold)
+	for i := range reads {
+		reads[i] = toolrender.ToolCallInfo{
+			Name:   "read_file",
+			Args:   map[string]interface{}{"path": fmt.Sprintf("file_%d.go", i)},
+			Status: "completed",
+			Result: "content\n",
+		}
+	}
+	item := committedItem{kind: kindReadGroup, toolCalls: reads}
+
+	withHint := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
+	assert.Contains(t, withHint, "ctrl+o to expand")
+
+	lines := strings.SplitN(withHint, "\n", 2)
+	assert.Contains(t, lines[0], "ctrl+o to expand",
+		"hint should appear on the read group header line")
+}
+
+func TestRenderCommittedItem_ExpandHint_SubAgentBlock(t *testing.T) {
+	block := &subAgentBlock{
+		id: "sa-1", name: "researcher", subject: "Explore CLI code",
+		status: "completed", toolCount: 5,
+	}
+	item := committedItem{kind: kindSubAgentBlock, saBlock: block}
+
+	withHint := renderCommittedItem(item, toolrender.CompactOptions{}, false, true)
+	assert.Contains(t, withHint, "ctrl+o to expand")
+}
+
+func TestRenderCommittedItem_NoHintWhenExpanded(t *testing.T) {
+	item := committedItem{
+		kind: kindToolCompact,
+		toolCalls: []toolrender.ToolCallInfo{{
+			Name:   "shell",
+			Args:   map[string]interface{}{"command": "ls"},
+			Status: "completed",
+			Result: "file1\nfile2",
+		}},
+	}
+	result := renderCommittedItem(item, toolrender.CompactOptions{}, true, true)
+	assert.NotContains(t, result, "ctrl+o to expand",
+		"hint should NOT appear in expanded mode even when showExpandHint is true")
+}
+
+func TestRenderCommittedItem_NoHintOnNonExpandableKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		item committedItem
+	}{
+		{"Header", committedItem{
+			kind:   kindHeader,
+			header: &sessionHeaderInfo{SessionID: "ses-1"},
+		}},
+		{"AIMessage", committedItem{kind: kindAIMessage, text: "response"}},
+		{"HumanMessage", committedItem{kind: kindHumanMessage, text: "input"}},
+		{"Approval", committedItem{
+			kind: kindApproval, action: "approve",
+			toolCalls: []toolrender.ToolCallInfo{{
+				Name: "write_file",
+				Args: map[string]interface{}{"path": "f.go"},
+			}},
+		}},
+		{"Text", committedItem{kind: kindText, text: "plain text"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderCommittedItem(tt.item, toolrender.CompactOptions{}, false, true)
+			assert.NotContains(t, result, "ctrl+o to expand",
+				"non-expandable kind %q should not get hint", tt.name)
+		})
+	}
+}
+
+func TestExpandHintEnabled(t *testing.T) {
+	t.Run("nil channel", func(t *testing.T) {
+		r := &inlineRenderer{cfg: inlineRenderConfig{}}
+		assert.False(t, r.expandHintEnabled())
+	})
+	t.Run("non-nil channel", func(t *testing.T) {
+		ch := make(chan struct{}, 1)
+		r := &inlineRenderer{cfg: inlineRenderConfig{toggleExpandCh: ch}}
+		assert.True(t, r.expandHintEnabled())
+	})
+}
+
+func TestRenderHistoryBatch_WithExpandHint(t *testing.T) {
+	items := []committedItem{
+		{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{{
+			Name: "read_file", Args: map[string]interface{}{"path": "a.go"},
+		}}},
+		{kind: kindToolCompact, toolCalls: []toolrender.ToolCallInfo{{
+			Name: "read_file", Args: map[string]interface{}{"path": "b.go"},
+		}}},
+	}
+
+	withHint := renderHistoryBatch(items, toolrender.CompactOptions{}, false, true)
+	assert.Contains(t, withHint, "ctrl+o to expand")
+
+	withoutHint := renderHistoryBatch(items, toolrender.CompactOptions{}, false, false)
+	assert.NotContains(t, withoutHint, "ctrl+o to expand")
+}
+
+func TestCommitToScrollback_WithExpandHint(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	var buf bytes.Buffer
+	r := &inlineRenderer{
+		cfg:             inlineRenderConfig{status: &buf, toggleExpandCh: ch},
+		activeSubAgents: make(map[string]*subAgentBlock),
+	}
+
+	item := committedItem{
+		kind: kindToolCompact,
+		toolCalls: []toolrender.ToolCallInfo{{
+			Name: "read_file", Args: map[string]interface{}{"path": "main.go"},
+		}},
+	}
+	r.commitToScrollback(item)
+
+	assert.Contains(t, buf.String(), "ctrl+o to expand",
+		"commitToScrollback should include hint when toggleExpandCh is set")
+}
+
+func TestCommitToScrollback_NoHintWithoutChannel(t *testing.T) {
+	var buf bytes.Buffer
+	r := &inlineRenderer{
+		cfg:             inlineRenderConfig{status: &buf},
+		activeSubAgents: make(map[string]*subAgentBlock),
+	}
+
+	item := committedItem{
+		kind: kindToolCompact,
+		toolCalls: []toolrender.ToolCallInfo{{
+			Name: "read_file", Args: map[string]interface{}{"path": "main.go"},
+		}},
+	}
+	r.commitToScrollback(item)
+
+	assert.NotContains(t, buf.String(), "ctrl+o to expand",
+		"commitToScrollback should NOT include hint when toggleExpandCh is nil")
 }

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history_test.go
@@ -509,36 +509,27 @@ func TestCommitToScrollback_MatchesRecommit(t *testing.T) {
 				}}, subAgentID: "sa-1"},
 			},
 		}},
-		{kind: kindTodoUpdate, text: "Plan:\n  [-] Step one\n  [ ] Step two"},
+		{kind: kindTodoUpdate, text: "Plan:\n  [-] Step one\n  [ ] Step two", todoTotal: 2, todoCompleted: 0},
 		{kind: kindPhaseChange, text: "Execution completed"},
 		{kind: kindText, text: "Error: connection reset"},
 	}
 
 	opts := toolrender.CompactOptions{}
 
-	for _, expanded := range []bool{false, true} {
-		label := "compact"
-		if expanded {
-			label = "expanded"
-		}
-		t.Run(label, func(t *testing.T) {
-			var buf bytes.Buffer
-			r := &inlineRenderer{
-				cfg:        inlineRenderConfig{status: &buf},
-				expandMode: expanded,
-			}
-			for _, item := range items {
-				r.commitToScrollback(item)
-			}
-			liveOutput := buf.String()
+	t.Run("compact", func(t *testing.T) {
+		batch := renderHistoryBatch(items, opts, false, false)
+		assert.NotContains(t, batch, "Plan:",
+			"compact re-commit should not include plan (shown in View() only)")
+	})
 
-			batch := renderHistoryBatch(items, opts, expanded, false)
-
-			assert.Equal(t, batch+"\n", liveOutput,
-				"live commitToScrollback output should match renderHistoryBatch "+
-					"(plus a trailing newline from the final statusf)")
-		})
-	}
+	t.Run("expanded", func(t *testing.T) {
+		batch := renderHistoryBatch(items, opts, true, false)
+		assert.Contains(t, batch, "Plan:\n  [-] Step one\n  [ ] Step two",
+			"expanded re-commit should contain the full plan")
+		assert.True(t,
+			strings.Index(batch, "Error: connection reset") < strings.Index(batch, "Plan:\n  [-]"),
+			"plan should appear after all other items in expanded re-commit")
+	})
 }
 
 func TestNeedsTrailingGap(t *testing.T) {

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
@@ -90,6 +90,15 @@ type approvalDecision struct {
 	err    error
 }
 
+// approvalReRenderMsg replays the scrollback content (history + expanded
+// tool view) without resetting approval state. Sent when Ctrl+O is pressed
+// during an active approval prompt — the event loop rebuilds the
+// reCommitPayload with the new expand mode and sends this message so the
+// terminal is refreshed while the question and menu selection are preserved.
+type approvalReRenderMsg struct {
+	reCommitPayload string
+}
+
 // textInputStartMsg activates the text input mode for follow-up prompts.
 // The follow-up loop creates the channel, sends this message, then blocks
 // on the channel. View() renders the prompt dynamically using model state
@@ -179,6 +188,16 @@ type followUpHideMsg struct {
 type reCommitMsg struct {
 	rendered string
 }
+
+// reCommitDoneMsg is the phase-2 signal of a re-commit. Phase 1
+// (handleReCommit) suppresses View() and writes history via tea.Raw.
+// When this message arrives, the Raw write is complete and the cursor
+// sits at the end of the history. The handler clears the suppression
+// flag so View() renders normally — the renderer sees a transition from
+// empty to non-empty and writes the composed view at the current cursor
+// position (bottom of history), placing the input bar where the user
+// expects it.
+type reCommitDoneMsg struct{}
 
 // aiStreamPartialMsg updates the partial (incomplete) line shown in View()
 // during AI text streaming. Sent on every delta so the user sees

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
@@ -31,7 +31,7 @@ type spinnerTickMsg struct{}
 // keeping the interactive region small (question + menu ≈ 6 rows).
 //
 // When reCommitPayload is non-empty, the handler uses buildReCommitCmd
-// (Raw clear+content followed by ClearScreen state reset) instead of
+// (Raw → ClearScreen → Println → reCommitDoneMsg) instead of bare
 // tea.Println. This avoids the insertAbove stale-cellbuf race that
 // occurs when transitioning from a tall streaming View() to the approval
 // panel (see DD-001).
@@ -68,7 +68,7 @@ type approvalHideMsg struct {
 // question line lives in View(), keeping the interactive region small.
 //
 // When reCommitPayload is non-empty, the handler uses buildReCommitCmd
-// (Raw clear+content followed by ClearScreen state reset) instead of
+// (Raw → ClearScreen → Println → reCommitDoneMsg) instead of bare
 // tea.Println. This avoids the insertAbove stale-cellbuf race that
 // occurs when transitioning from a tall streaming View() to the approval
 // panel (see DD-001).
@@ -181,22 +181,20 @@ type followUpHideMsg struct {
 
 // reCommitMsg carries a pre-rendered string of the full session history.
 // The renderer owns rendering (via renderHistoryBatch); the model issues
-// tea.Raw (clear + content) followed by tea.ClearScreen (renderer state
-// reset). The Raw write goes to Bubbletea's outputBuf which flushes
-// before the renderer, guaranteeing the terminal is cleared and content
-// is written atomically before View() is re-rendered.
+// a renderer-aware sequence: Raw(clearAndHome) → ClearScreen → Println →
+// reCommitDoneMsg. The Raw write clears the terminal, ClearScreen resets
+// the renderer's cursor tracking, Println writes history through the
+// renderer's tracked path, and reCommitDoneMsg re-enables View().
 type reCommitMsg struct {
 	rendered string
 }
 
-// reCommitDoneMsg is the phase-2 signal of a re-commit. Phase 1
-// (handleReCommit) suppresses View() and writes history via tea.Raw.
-// When this message arrives, the Raw write is complete and the cursor
-// sits at the end of the history. The handler clears the suppression
-// flag so View() renders normally — the renderer sees a transition from
-// empty to non-empty and writes the composed view at the current cursor
-// position (bottom of history), placing the input bar where the user
-// expects it.
+// reCommitDoneMsg is the final step of a re-commit sequence. By this
+// point the terminal has been cleared (tea.Raw), the renderer's cursor
+// tracking has been reset (tea.ClearScreen), and the history has been
+// written through the renderer (tea.Println). The handler clears the
+// reCommitPending flag so View() renders the composed view (input bar,
+// approval menu, etc.) at the correct tracked position below the history.
 type reCommitDoneMsg struct{}
 
 // aiStreamPartialMsg updates the partial (incomplete) line shown in View()

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
@@ -176,12 +176,15 @@ type aiStreamHideMsg struct{}
 // disabled (showing "esc to interrupt"), or active (text input with cursor).
 type inputBarModeMsg struct{ mode inputBarMode }
 
-// currentTaskMsg updates the current task indicator shown as a single line
-// above the input bar separator. task is the content of the first
-// in_progress todo item. The full plan is stored in history and rendered
+// currentTaskMsg updates the plan progress indicator shown above the
+// input bar separator. task is the content of the first in_progress todo
+// item (empty when all are done). todoTotal and todoCompleted provide
+// the summary counts. The full plan is stored in history and rendered
 // in scrollback when expanded mode is active (Ctrl+O).
 type currentTaskMsg struct {
-	task string
+	task          string
+	todoTotal     int
+	todoCompleted int
 }
 
 // subAgentShowMsg activates the live sub-agent running summary in View().

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_messages.go
@@ -30,18 +30,11 @@ type spinnerTickMsg struct{}
 // constrained by terminal height. Only the question line lives in View(),
 // keeping the interactive region small (question + menu ≈ 6 rows).
 //
-// When reCommitPayload is non-empty, the handler uses buildReCommitCmd
-// (Raw → ClearScreen → Println → reCommitDoneMsg) instead of bare
-// tea.Println. This avoids the insertAbove stale-cellbuf race that
-// occurs when transitioning from a tall streaming View() to the approval
-// panel (see DD-001).
-//
 // Used by the legacy PromptKeyOnly path when Bubbletea does not own stdin.
 // The channel-based stdin path uses approvalStartMsg.
 type approvalShowMsg struct {
 	expandedContent string // full content for tea.Println (scrollback)
 	question        string // question line for View()
-	reCommitPayload string // when non-empty, use re-commit instead of Println
 }
 
 // approvalSelectMsg updates the menu selection index. Sent by the legacy
@@ -67,12 +60,6 @@ type approvalHideMsg struct {
 // file content is always visible regardless of terminal height. Only the
 // question line lives in View(), keeping the interactive region small.
 //
-// When reCommitPayload is non-empty, the handler uses buildReCommitCmd
-// (Raw → ClearScreen → Println → reCommitDoneMsg) instead of bare
-// tea.Println. This avoids the insertAbove stale-cellbuf race that
-// occurs when transitioning from a tall streaming View() to the approval
-// panel (see DD-001).
-//
 // The event loop creates the channel, sends this message, then blocks on
 // the channel. handleKeyPress routes arrow/enter/esc keys to the channel
 // when approvalActive is true.
@@ -80,7 +67,6 @@ type approvalStartMsg struct {
 	expandedContent string // full content for tea.Println (scrollback)
 	question        string // question line for View()
 	decisionCh      chan<- approvalDecision
-	reCommitPayload string // when non-empty, use re-commit instead of Println
 }
 
 // approvalDecision carries the user's approval choice from the model back
@@ -88,15 +74,6 @@ type approvalStartMsg struct {
 type approvalDecision struct {
 	action approval.Action
 	err    error
-}
-
-// approvalReRenderMsg replays the scrollback content (history + expanded
-// tool view) without resetting approval state. Sent when Ctrl+O is pressed
-// during an active approval prompt — the event loop rebuilds the
-// reCommitPayload with the new expand mode and sends this message so the
-// terminal is refreshed while the question and menu selection are preserved.
-type approvalReRenderMsg struct {
-	reCommitPayload string
 }
 
 // textInputStartMsg activates the text input mode for follow-up prompts.
@@ -179,24 +156,6 @@ type followUpHideMsg struct {
 	styledMessage string
 }
 
-// reCommitMsg carries a pre-rendered string of the full session history.
-// The renderer owns rendering (via renderHistoryBatch); the model issues
-// a renderer-aware sequence: Raw(clearAndHome) → ClearScreen → Println →
-// reCommitDoneMsg. The Raw write clears the terminal, ClearScreen resets
-// the renderer's cursor tracking, Println writes history through the
-// renderer's tracked path, and reCommitDoneMsg re-enables View().
-type reCommitMsg struct {
-	rendered string
-}
-
-// reCommitDoneMsg is the final step of a re-commit sequence. By this
-// point the terminal has been cleared (tea.Raw), the renderer's cursor
-// tracking has been reset (tea.ClearScreen), and the history has been
-// written through the renderer (tea.Println). The handler clears the
-// reCommitPending flag so View() renders the composed view (input bar,
-// approval menu, etc.) at the correct tracked position below the history.
-type reCommitDoneMsg struct{}
-
 // aiStreamPartialMsg updates the partial (incomplete) line shown in View()
 // during AI text streaming. Sent on every delta so the user sees
 // character-level feedback. View() renders this as the live typing line
@@ -217,14 +176,12 @@ type aiStreamHideMsg struct{}
 // disabled (showing "esc to interrupt"), or active (text input with cursor).
 type inputBarModeMsg struct{ mode inputBarMode }
 
-// currentTaskMsg updates the plan display and current task indicator shown
-// above the input bar separator. planDisplay is the full formatted plan
-// (all items with markers) rendered in the composed view so the plan is
-// always visible. task is the content of the first in_progress item,
-// retained for potential future use (e.g. title bar).
+// currentTaskMsg updates the current task indicator shown as a single line
+// above the input bar separator. task is the content of the first
+// in_progress todo item. The full plan is stored in history and rendered
+// in scrollback when expanded mode is active (Ctrl+O).
 type currentTaskMsg struct {
-	task        string
-	planDisplay string
+	task string
 }
 
 // subAgentShowMsg activates the live sub-agent running summary in View().

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_render.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_render.go
@@ -312,7 +312,7 @@ func (r *inlineRenderer) hasActiveSubAgent(subAgentID string) bool {
 // byte-for-byte identical to what renderHistoryBatch would produce.
 func (r *inlineRenderer) commitToScrollback(item committedItem) {
 	r.history = append(r.history, item)
-	text := renderCommittedItem(item, r.compactOpts, r.expandMode)
+	text := renderCommittedItem(item, r.compactOpts, r.expandMode, r.expandHintEnabled())
 	r.writeToScrollback(item.kind, text)
 }
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_render.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_render.go
@@ -90,6 +90,7 @@ func (r *inlineRenderer) renderPhaseChange(e executiontui.PhaseChangeEvent) {
 func (r *inlineRenderer) renderTodoUpdate(e executiontui.TodoUpdateEvent) {
 	var historyBuf strings.Builder
 	var currentTask string
+	var completed int
 
 	historyBuf.WriteString("Plan:")
 	for _, todo := range e.Todos {
@@ -97,6 +98,7 @@ func (r *inlineRenderer) renderTodoUpdate(e executiontui.TodoUpdateEvent) {
 		switch todo.Status {
 		case "completed":
 			marker = "[x]"
+			completed++
 		case "in_progress":
 			marker = "[-]"
 			if currentTask == "" {
@@ -111,11 +113,22 @@ func (r *inlineRenderer) renderTodoUpdate(e executiontui.TodoUpdateEvent) {
 	}
 
 	r.trackedCurrentTask = currentTask
+	r.trackedTodoTotal = len(e.Todos)
+	r.trackedTodoCompleted = completed
 	if r.cfg.program != nil {
-		r.cfg.program.Send(currentTaskMsg{task: currentTask})
+		r.cfg.program.Send(currentTaskMsg{
+			task:          currentTask,
+			todoTotal:     len(e.Todos),
+			todoCompleted: completed,
+		})
 	}
 
-	newItem := committedItem{kind: kindTodoUpdate, text: historyBuf.String()}
+	newItem := committedItem{
+		kind:          kindTodoUpdate,
+		text:          historyBuf.String(),
+		todoTotal:     len(e.Todos),
+		todoCompleted: completed,
+	}
 
 	for i := len(r.history) - 1; i >= 0; i-- {
 		if r.history[i].kind == kindTodoUpdate {

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_render.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_render.go
@@ -89,7 +89,6 @@ func (r *inlineRenderer) renderPhaseChange(e executiontui.PhaseChangeEvent) {
 
 func (r *inlineRenderer) renderTodoUpdate(e executiontui.TodoUpdateEvent) {
 	var historyBuf strings.Builder
-	var displayBuf strings.Builder
 	var currentTask string
 
 	historyBuf.WriteString("Plan:")
@@ -109,30 +108,15 @@ func (r *inlineRenderer) renderTodoUpdate(e executiontui.TodoUpdateEvent) {
 			marker = "[ ]"
 		}
 		fmt.Fprintf(&historyBuf, "\n  %s %s", marker, todo.Content)
-
-		if displayBuf.Len() > 0 {
-			displayBuf.WriteByte('\n')
-		}
-		fmt.Fprintf(&displayBuf, "  %s %s", marker, todo.Content)
 	}
 
+	r.trackedCurrentTask = currentTask
 	if r.cfg.program != nil {
-		r.cfg.program.Send(currentTaskMsg{
-			task:        currentTask,
-			planDisplay: displayBuf.String(),
-		})
+		r.cfg.program.Send(currentTaskMsg{task: currentTask})
 	}
 
 	newItem := committedItem{kind: kindTodoUpdate, text: historyBuf.String()}
 
-	// The plan is rendered exclusively in the composed View() (via
-	// planDisplay) so it is always visible above the input bar. It is
-	// NOT written to scrollback — that would create a duplicate since
-	// the composed view already shows the live plan.
-	//
-	// The history entry is kept so the plan survives across follow-up
-	// iterations (initialHistory carries over). renderCommittedItem
-	// returns "" for kindTodoUpdate so re-commits skip it.
 	for i := len(r.history) - 1; i >= 0; i-- {
 		if r.history[i].kind == kindTodoUpdate {
 			r.history[i] = newItem

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_test.go
@@ -1218,3 +1218,156 @@ func TestInlineRenderer_ToggleExpandCh_FlipsMode(t *testing.T) {
 		t.Errorf("after toggle, second tool should render expanded with full output, got: %q", out)
 	}
 }
+
+// =============================================================================
+// TodoUpdateEvent During AI Stream — Must Not Truncate
+// =============================================================================
+
+// Verifies that a TodoUpdateEvent arriving during an active AI stream does NOT
+// truncate the stream. The AI stream must continue uninterrupted: subsequent
+// deltas are processed and the full content is recorded in history.
+func TestInlineRenderer_TodoDuringAIStream_NoTruncation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	events := make(chan executiontui.Event, 16)
+
+	go feedEvents(events,
+		executiontui.AIStreamStartEvent{Content: "First part"},
+		executiontui.AIStreamDeltaEvent{Content: "First part of the response"},
+		executiontui.TodoUpdateEvent{Todos: []executiontui.TodoItem{
+			{ID: "1", Content: "Analyze code", Status: "in_progress"},
+		}},
+		executiontui.AIStreamDeltaEvent{Content: "First part of the response. Second part after todo."},
+		executiontui.AIStreamEndEvent{Content: "First part of the response. Second part after todo."},
+		executiontui.DoneEvent{Phase: "completed"},
+	)
+
+	result := renderInline(context.Background(), inlineRenderConfig{
+		events:            events,
+		approvalResponses: make(chan executiontui.ApprovalResponse, 1),
+		prompter:          approval.NewInteractivePrompter(),
+		data:              &stdout,
+		status:            &stderr,
+	})
+
+	out := stdout.String()
+	if !strings.Contains(out, "Second part after todo") {
+		t.Errorf("AI content after TodoUpdate should not be truncated, stdout: %q", out)
+	}
+
+	var hasAIMessage bool
+	for _, item := range result.history {
+		if item.kind == kindAIMessage && strings.Contains(item.text, "Second part after todo") {
+			hasAIMessage = true
+			break
+		}
+	}
+	if !hasAIMessage {
+		t.Error("history should contain the full AI message including content after todo")
+	}
+
+	var hasTodo bool
+	for _, item := range result.history {
+		if item.kind == kindTodoUpdate {
+			hasTodo = true
+			break
+		}
+	}
+	if !hasTodo {
+		t.Error("history should contain the todo update")
+	}
+}
+
+// =============================================================================
+// Deferred Re-commit During AI Streaming
+// =============================================================================
+
+// Verifies that a Ctrl+O toggle during an active AI stream sets
+// pendingReCommit instead of triggering an immediate re-commit, and that
+// the deferred re-commit fires after the stream ends.
+func TestInlineRenderer_DeferredReCommitDuringAIStream(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	events := make(chan executiontui.Event, 16)
+	toggleCh := make(chan struct{})
+
+	go func() {
+		events <- executiontui.AIStreamStartEvent{Content: "Hello"}
+		events <- executiontui.AIStreamDeltaEvent{Content: "Hello world"}
+		toggleCh <- struct{}{}
+		events <- executiontui.AIStreamDeltaEvent{Content: "Hello world, more content"}
+		events <- executiontui.AIStreamEndEvent{Content: "Hello world, more content."}
+		events <- executiontui.DoneEvent{Phase: "completed"}
+		close(events)
+	}()
+
+	result := renderInline(context.Background(), inlineRenderConfig{
+		events:            events,
+		approvalResponses: make(chan executiontui.ApprovalResponse, 1),
+		prompter:          approval.NewInteractivePrompter(),
+		data:              &stdout,
+		status:            &stderr,
+		toggleExpandCh:    toggleCh,
+	})
+
+	out := stdout.String()
+	if !strings.Contains(out, "more content") {
+		t.Errorf("AI stream content after Ctrl+O should not be lost, stdout: %q", out)
+	}
+
+	var hasAIMessage bool
+	for _, item := range result.history {
+		if item.kind == kindAIMessage && strings.Contains(item.text, "more content") {
+			hasAIMessage = true
+			break
+		}
+	}
+	if !hasAIMessage {
+		t.Error("history should contain the full AI message after deferred re-commit")
+	}
+}
+
+// =============================================================================
+// AIStreamEnd Recovery Re-commit After Interrupted Stream
+// =============================================================================
+
+// Verifies that when a non-AI event (e.g., a tool completion) interrupts an
+// active AI stream and then AIStreamEnd arrives, the full AI content is
+// recorded in history. The interrupted stream's content should be recoverable.
+func TestInlineRenderer_AIStreamEnd_RecoveryAfterInterruption(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	events := make(chan executiontui.Event, 16)
+
+	go feedEvents(events,
+		executiontui.AIStreamStartEvent{Content: "Analyzing"},
+		executiontui.AIStreamDeltaEvent{Content: "Analyzing the codebase"},
+		executiontui.ToolCompletedEvent{
+			ToolCallID: "tc-1",
+			ToolCall: toolrender.ToolCallInfo{
+				Name:   "get_mcp_server",
+				Status: "completed",
+				Result: "ok",
+				Args:   map[string]interface{}{"name": "test"},
+			},
+		},
+		executiontui.AIStreamEndEvent{Content: "Analyzing the codebase for issues."},
+		executiontui.DoneEvent{Phase: "completed"},
+	)
+
+	result := renderInline(context.Background(), inlineRenderConfig{
+		events:            events,
+		approvalResponses: make(chan executiontui.ApprovalResponse, 1),
+		prompter:          approval.NewInteractivePrompter(),
+		data:              &stdout,
+		status:            &stderr,
+	})
+
+	var hasFullAI bool
+	for _, item := range result.history {
+		if item.kind == kindAIMessage && strings.Contains(item.text, "for issues") {
+			hasFullAI = true
+			break
+		}
+	}
+	if !hasFullAI {
+		t.Error("history should contain the full AI message content from AIStreamEnd, including text after interruption")
+	}
+}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_test.go
@@ -384,9 +384,9 @@ func TestInlineRenderer_TodoUpdate_RecordedInHistory(t *testing.T) {
 		status:            &stderr,
 	})
 
-	// Plan is rendered exclusively in the composed View() (via planDisplay),
-	// NOT in scrollback. Verify it is recorded in history for follow-up
-	// iteration carry-over.
+	// Plan is shown as a single-line currentTask in the composed View().
+	// In expanded mode the full plan renders in scrollback. Verify it
+	// is recorded in history for follow-up iteration carry-over.
 	var found bool
 	for _, item := range result.history {
 		if item.kind == kindTodoUpdate {

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
@@ -280,3 +280,10 @@ type inlineRenderer struct {
 	donePhase   string
 	doneExitErr string
 }
+
+// expandHintEnabled reports whether the "(ctrl+o to expand)" hint should
+// be shown on compact tool lines. True only when Bubbletea owns stdin
+// and the Ctrl+O toggle is available (TTY mode).
+func (r *inlineRenderer) expandHintEnabled() bool {
+	return r.cfg.toggleExpandCh != nil
+}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
@@ -257,6 +257,15 @@ type inlineRenderer struct {
 	// during clear+re-commit.
 	expandMode bool
 
+	// pendingReCommit is set when a re-commit trigger (Ctrl+O, subject
+	// update, recent sessions) fires during an active AI stream. The
+	// re-commit is deferred because AI stream lines are not stored in
+	// history — a re-commit during streaming would lose them. The flag
+	// is checked after each handleEvent call and inside renderAIStreamEnd;
+	// when the AI stream ends and pendingReCommit is true, the deferred
+	// re-commit fires with the full history (including the final AI message).
+	pendingReCommit bool
+
 	// history records every item committed to terminal scrollback via
 	// writeToScrollback. Used by the clear+re-commit mechanism to
 	// reconstruct the full session display when the subject resolves or

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
@@ -69,6 +69,12 @@ type inlineRenderConfig struct {
 	// output falls back to direct writes on the status writer.
 	program *tea.Program
 
+	// programFactory creates a fresh Bubbletea program with the same
+	// channels and output writer. The initModel callback pre-loads model
+	// state (plan, input bar, approval) before the program starts.
+	// nil when program is nil (non-TTY).
+	programFactory func(initModel func(*inlineBubbleModel)) *tea.Program
+
 	// suppressHumanEcho skips the next HumanMessageEvent rendering. Set by
 	// the follow-up loop after local echo to prevent duplicate display when
 	// the backend echoes the same message.
@@ -277,6 +283,19 @@ type inlineRenderer struct {
 	// whether a leading gap is needed before the next item (e.g.,
 	// transitioning from a dense tool block to an AI message).
 	lastScrollbackKind committedKind
+
+	// trackedCurrentTask mirrors the model's currentTask field so the
+	// renderer can transfer it to a new program during re-commit.
+	trackedCurrentTask string
+
+	// trackedInputBarMode mirrors the model's inputBarMode so the
+	// renderer can transfer it to a new program during re-commit.
+	trackedInputBarMode inputBarMode
+
+	// followUpSendCh is the send-only end of the follow-up input channel.
+	// Stored so performReCommit can transfer it to the new program's model.
+	// nil when not in follow-up mode.
+	followUpSendCh chan<- string
 
 	// followUpInputCh receives the user's follow-up input from the
 	// Bubbletea model's text input handler. nil until the renderer

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
@@ -47,6 +47,12 @@ type renderResult struct {
 	exitErr       string
 	history       []committedItem
 	followUpInput string
+
+	// program is the Bubbletea Program that was active when renderInline
+	// returned. May differ from the cfg.program that was passed in when
+	// performReCommit created replacement programs during the session.
+	// Callers must use this reference (not the original) for cleanup.
+	program *tea.Program
 }
 
 // inlineRenderConfig configures the inline (non-TUI) event renderer.
@@ -287,6 +293,11 @@ type inlineRenderer struct {
 	// trackedCurrentTask mirrors the model's currentTask field so the
 	// renderer can transfer it to a new program during re-commit.
 	trackedCurrentTask string
+
+	// trackedTodoTotal and trackedTodoCompleted mirror the model's plan
+	// progress counts so the renderer can transfer them during re-commit.
+	trackedTodoTotal     int
+	trackedTodoCompleted int
 
 	// trackedInputBarMode mirrors the model's inputBarMode so the
 	// renderer can transfer it to a new program during re-commit.

--- a/client-apps/cli/pkg/toolrender/BUILD.bazel
+++ b/client-apps/cli/pkg/toolrender/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "render.go",
         "render_approval.go",
         "render_compact.go",
+        "render_expandable.go",
         "render_expanded.go",
         "render_known.go",
     ],
@@ -34,8 +35,13 @@ go_test(
         "hyperlink_test.go",
         "render_approval_test.go",
         "render_compact_test.go",
+        "render_expandable_test.go",
         "render_expanded_test.go",
         "render_test.go",
     ],
     embed = [":toolrender"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/client-apps/cli/pkg/toolrender/render_compact.go
+++ b/client-apps/cli/pkg/toolrender/render_compact.go
@@ -308,7 +308,7 @@ func renderCompactRead(tc ToolCallInfo, info toolDisplayInfo, opts CompactOption
 	header := fmt.Sprintf("%s %s(%s)", bulletStyle.Render("●"), labelStyle.Render("Read"), displayPath)
 
 	if errMsg := toolCallError(tc); errMsg != "" {
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, maxErrorDisplayLen))
 	}
 
 	lineCount := countLines(tc.Result)
@@ -337,7 +337,7 @@ func renderCompactWrite(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptio
 		if errMsg == "" {
 			errMsg = "failed"
 		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, maxErrorDisplayLen))
 	}
 
 	content := resolveDisplayContent(tc, info)
@@ -371,7 +371,7 @@ func renderCompactShell(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptio
 		if errMsg == "" {
 			errMsg = "failed"
 		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, maxErrorDisplayLen))
 	}
 
 	content := resolveDisplayContent(tc, info)
@@ -429,7 +429,7 @@ func renderCompactDiscovery(tc ToolCallInfo, info toolDisplayInfo, opts CompactO
 		if errMsg == "" {
 			errMsg = "failed"
 		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, maxErrorDisplayLen))
 	}
 
 	content := resolveDisplayContent(tc, info)
@@ -465,7 +465,7 @@ func renderCompactDelete(tc ToolCallInfo, info toolDisplayInfo, opts CompactOpti
 		if errMsg == "" {
 			errMsg = "failed"
 		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, maxErrorDisplayLen))
 	}
 
 	return header + "\n" + dimStyle.Render("    Deleted")
@@ -494,7 +494,7 @@ func renderCompactThink(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptio
 		if errMsg == "" {
 			errMsg = "failed"
 		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, maxErrorDisplayLen))
 	}
 
 	content := extractPrimaryArgWithFallbacks(tc.Args, info.contentArgField, info.contentArgFallbacks)
@@ -594,7 +594,7 @@ func buildUnknownWithError(header string, args map[string]interface{}, errMsg st
 	}
 
 	b.WriteByte('\n')
-	b.WriteString(dimStyle.Render("    ✗ " + truncate(errMsg, 60)))
+	b.WriteString(dimStyle.Render("    ✗ " + truncate(errMsg, maxErrorDisplayLen)))
 	return b.String()
 }
 
@@ -685,6 +685,12 @@ func discoverySummary(label string, count int) string {
 		return fmt.Sprintf("Found %d matches", count)
 	}
 }
+
+// maxErrorDisplayLen is the maximum character length for error messages in
+// compact tool displays. Error text exceeding this length is truncated with
+// "..." by truncate(). Used by isErrorExpandable to determine whether
+// expanding would reveal more error content.
+const maxErrorDisplayLen = 60
 
 // resultErrorPrefix is the prefix the backend's enrich_error_message uses to
 // mark tool results that contain error information. When a tool catches an

--- a/client-apps/cli/pkg/toolrender/render_expandable.go
+++ b/client-apps/cli/pkg/toolrender/render_expandable.go
@@ -7,10 +7,11 @@ import "strings"
 // to decide whether to display the "(ctrl+o to expand)" hint.
 //
 // Tools whose compact and expanded renderers produce identical output
-// (Read, Write, Edit, Create, Delete) always return false. Tools that
+// (Read, Write, Edit, Create, Delete) return true only when a truncated
+// error is detected — expanding reveals the full error text. Tools that
 // truncate content in compact mode (Shell, Thinking, Discovery,
-// Unknown/MCP) return true only when the content exceeds the truncation
-// threshold — i.e., when expanding would actually reveal more.
+// Unknown/MCP) return true when content exceeds the truncation threshold
+// OR when an error message is truncated.
 func IsExpandable(tc ToolCallInfo) bool {
 	info, known := toolDisplayMap[tc.Name]
 	if !known {
@@ -18,11 +19,11 @@ func IsExpandable(tc ToolCallInfo) bool {
 	}
 	switch {
 	case info.label == "Read":
-		return false
+		return isErrorExpandable(tc)
 	case isWriteOrEditLabel(info.label):
-		return false
+		return isErrorExpandable(tc)
 	case info.label == "Delete":
-		return false
+		return isErrorExpandable(tc)
 	case isShellLabel(info.label):
 		return isContentExpandable(tc, info, maxShellOutputLines)
 	case isDiscoveryLabel(info.label):
@@ -30,7 +31,7 @@ func IsExpandable(tc ToolCallInfo) bool {
 	case info.label == "Thinking":
 		return isThinkExpandable(tc, info)
 	default:
-		return false
+		return isErrorExpandable(tc)
 	}
 }
 
@@ -43,13 +44,39 @@ func IsReadGroupExpandable(reads []ToolCallInfo) bool {
 	return len(reads) > maxVisibleInGroup+1
 }
 
+// isErrorExpandable reports whether a tool's error content would be
+// truncated in the compact error display. Returns true when expanding
+// would reveal more error detail — either because the error message
+// exceeds maxErrorDisplayLen chars, or because the full result contains
+// additional lines beyond the first-line error (result-prefixed errors).
+func isErrorExpandable(tc ToolCallInfo) bool {
+	errMsg := toolCallError(tc)
+	if errMsg == "" {
+		return false
+	}
+	if len(errMsg) > maxErrorDisplayLen {
+		return true
+	}
+	// For result-prefixed errors, check if the full result has more
+	// lines than the single-line compact error display shows.
+	if strings.HasPrefix(tc.Result, resultErrorPrefix) {
+		lines := strings.Split(strings.TrimRight(strings.TrimSpace(tc.Result), "\n"), "\n")
+		return len(lines) > 1
+	}
+	return false
+}
+
 // isContentExpandable checks whether a tool's resolved display content
-// exceeds the given line cap (used by Shell and similar tools). Returns
-// false for failed/errored calls and empty content — those render
-// identically in compact and expanded modes.
+// exceeds the given line cap (used by Shell and similar tools). For
+// failed/errored calls, delegates to isErrorExpandable — a long error
+// message is worth expanding even when the tool's output content is
+// absent.
 func isContentExpandable(tc ToolCallInfo, info toolDisplayInfo, maxLines int) bool {
 	if tc.Status == "failed" || tc.Error != "" {
-		return false
+		return isErrorExpandable(tc)
+	}
+	if toolCallError(tc) != "" {
+		return isErrorExpandable(tc)
 	}
 	content := resolveDisplayContent(tc, info)
 	if content == "" || strings.TrimSpace(content) == "" {
@@ -61,10 +88,11 @@ func isContentExpandable(tc ToolCallInfo, info toolDisplayInfo, maxLines int) bo
 
 // isThinkExpandable checks whether a think tool's thought text exceeds
 // maxThinkLines. The think tool extracts content from args (not Result),
-// so it uses the same extraction as renderCompactThink.
+// so it uses the same extraction as renderCompactThink. For errors,
+// delegates to isErrorExpandable.
 func isThinkExpandable(tc ToolCallInfo, info toolDisplayInfo) bool {
 	if tc.Status == "failed" || tc.Error != "" {
-		return false
+		return isErrorExpandable(tc)
 	}
 	content := extractPrimaryArgWithFallbacks(tc.Args, info.contentArgField, info.contentArgFallbacks)
 	if content == "" || strings.TrimSpace(content) == "" {
@@ -77,10 +105,11 @@ func isThinkExpandable(tc ToolCallInfo, info toolDisplayInfo) bool {
 // isDiscoveryExpandable checks whether a discovery tool (List, Find,
 // Search) has result entries. The compact renderer shows only a count
 // summary ("Found 12 matches"); the expanded renderer shows all entries.
-// Any non-empty result means expanding adds value.
+// Any non-empty result means expanding adds value. For errors,
+// delegates to isErrorExpandable.
 func isDiscoveryExpandable(tc ToolCallInfo, info toolDisplayInfo) bool {
 	if tc.Status == "failed" || tc.Error != "" {
-		return false
+		return isErrorExpandable(tc)
 	}
 	content := resolveDisplayContent(tc, info)
 	if content == "" || strings.TrimSpace(content) == "" {
@@ -90,11 +119,11 @@ func isDiscoveryExpandable(tc ToolCallInfo, info toolDisplayInfo) bool {
 }
 
 // isUnknownExpandable checks whether an unknown/MCP tool's result
-// exceeds maxUnknownOutputLines. Unknown tools always have the same
-// compact structure: header + optional input args + capped result lines.
+// exceeds maxUnknownOutputLines, or whether its error content would
+// be truncated in the compact display.
 func isUnknownExpandable(tc ToolCallInfo) bool {
 	if toolCallError(tc) != "" {
-		return false
+		return isErrorExpandable(tc)
 	}
 	result := strings.TrimSpace(tc.Result)
 	if result == "" {

--- a/client-apps/cli/pkg/toolrender/render_expandable.go
+++ b/client-apps/cli/pkg/toolrender/render_expandable.go
@@ -1,0 +1,105 @@
+package toolrender
+
+import "strings"
+
+// IsExpandable reports whether the expanded rendering of tc would show
+// more content than the compact rendering. Used by the inline renderer
+// to decide whether to display the "(ctrl+o to expand)" hint.
+//
+// Tools whose compact and expanded renderers produce identical output
+// (Read, Write, Edit, Create, Delete) always return false. Tools that
+// truncate content in compact mode (Shell, Thinking, Discovery,
+// Unknown/MCP) return true only when the content exceeds the truncation
+// threshold — i.e., when expanding would actually reveal more.
+func IsExpandable(tc ToolCallInfo) bool {
+	info, known := toolDisplayMap[tc.Name]
+	if !known {
+		return isUnknownExpandable(tc)
+	}
+	switch {
+	case info.label == "Read":
+		return false
+	case isWriteOrEditLabel(info.label):
+		return false
+	case info.label == "Delete":
+		return false
+	case isShellLabel(info.label):
+		return isContentExpandable(tc, info, maxShellOutputLines)
+	case isDiscoveryLabel(info.label):
+		return isDiscoveryExpandable(tc, info)
+	case info.label == "Thinking":
+		return isThinkExpandable(tc, info)
+	default:
+		return false
+	}
+}
+
+// IsReadGroupExpandable reports whether a read group has more entries
+// than the compact renderer shows. The compact read group displays up
+// to maxVisibleInGroup entries (with a smart cutoff: all entries are
+// shown when total <= maxVisibleInGroup+1). Expanding reveals ALL
+// entries.
+func IsReadGroupExpandable(reads []ToolCallInfo) bool {
+	return len(reads) > maxVisibleInGroup+1
+}
+
+// isContentExpandable checks whether a tool's resolved display content
+// exceeds the given line cap (used by Shell and similar tools). Returns
+// false for failed/errored calls and empty content — those render
+// identically in compact and expanded modes.
+func isContentExpandable(tc ToolCallInfo, info toolDisplayInfo, maxLines int) bool {
+	if tc.Status == "failed" || tc.Error != "" {
+		return false
+	}
+	content := resolveDisplayContent(tc, info)
+	if content == "" || strings.TrimSpace(content) == "" {
+		return false
+	}
+	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
+	return len(lines) > maxLines+1
+}
+
+// isThinkExpandable checks whether a think tool's thought text exceeds
+// maxThinkLines. The think tool extracts content from args (not Result),
+// so it uses the same extraction as renderCompactThink.
+func isThinkExpandable(tc ToolCallInfo, info toolDisplayInfo) bool {
+	if tc.Status == "failed" || tc.Error != "" {
+		return false
+	}
+	content := extractPrimaryArgWithFallbacks(tc.Args, info.contentArgField, info.contentArgFallbacks)
+	if content == "" || strings.TrimSpace(content) == "" {
+		return false
+	}
+	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
+	return len(lines) > maxThinkLines+1
+}
+
+// isDiscoveryExpandable checks whether a discovery tool (List, Find,
+// Search) has result entries. The compact renderer shows only a count
+// summary ("Found 12 matches"); the expanded renderer shows all entries.
+// Any non-empty result means expanding adds value.
+func isDiscoveryExpandable(tc ToolCallInfo, info toolDisplayInfo) bool {
+	if tc.Status == "failed" || tc.Error != "" {
+		return false
+	}
+	content := resolveDisplayContent(tc, info)
+	if content == "" || strings.TrimSpace(content) == "" {
+		return false
+	}
+	return countResultEntries(content) > 0
+}
+
+// isUnknownExpandable checks whether an unknown/MCP tool's result
+// exceeds maxUnknownOutputLines. Unknown tools always have the same
+// compact structure: header + optional input args + capped result lines.
+func isUnknownExpandable(tc ToolCallInfo) bool {
+	if toolCallError(tc) != "" {
+		return false
+	}
+	result := strings.TrimSpace(tc.Result)
+	if result == "" {
+		return false
+	}
+	lines := strings.Split(strings.TrimRight(result, "\n"), "\n")
+	return len(lines) > maxUnknownOutputLines+1
+}

--- a/client-apps/cli/pkg/toolrender/render_expandable_test.go
+++ b/client-apps/cli/pkg/toolrender/render_expandable_test.go
@@ -1,0 +1,436 @@
+package toolrender
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lineN returns a string with n lines (each line is "line\n", so n newlines total).
+// strings.Split(..., "\n") yields n+1 elements for "line1\nline2\n...\nlinen" (trailing \n adds empty).
+// The implementation uses strings.TrimRight and Split, so "a\nb\nc\n" -> ["a","b","c",""] -> len 4.
+// For "a\nb\nc\nd\n" (no trailing newline) -> ["a","b","c","d"] -> len 4.
+// So for N lines we need N newline-separated non-empty parts. "x\n" * n gives n lines.
+func lineN(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat("x\n", n)
+}
+
+// =============================================================================
+// IsExpandable: Read tools always non-expandable
+// =============================================================================
+
+func TestIsExpandable_ReadTools_AlwaysFalse(t *testing.T) {
+	readTools := []string{"read", "read_file"}
+	for _, name := range readTools {
+		t.Run(name, func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   name,
+				Args:   map[string]interface{}{"path": "main.go"},
+				Status: "completed",
+				Result: lineN(100), // lots of content
+			}
+			assert.False(t, IsExpandable(tc), "read tools must never be expandable")
+		})
+	}
+}
+
+// =============================================================================
+// IsExpandable: Write/Edit tools always non-expandable
+// =============================================================================
+
+func TestIsExpandable_WriteEditTools_AlwaysFalse(t *testing.T) {
+	tools := []string{"write", "write_file", "create_file", "overwrite_file", "edit", "edit_file"}
+	for _, name := range tools {
+		t.Run(name, func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   name,
+				Args:   map[string]interface{}{"path": "x.go", "contents": lineN(100)},
+				Status: "completed",
+				Result: "ok",
+			}
+			assert.False(t, IsExpandable(tc), "%s must never be expandable", name)
+		})
+	}
+}
+
+// =============================================================================
+// IsExpandable: Delete tool always non-expandable
+// =============================================================================
+
+func TestIsExpandable_DeleteTool_AlwaysFalse(t *testing.T) {
+	tools := []string{"delete_file", "remove_file"}
+	for _, name := range tools {
+		t.Run(name, func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   name,
+				Args:   map[string]interface{}{"path": "tmp.go"},
+				Status: "completed",
+				Result: "deleted",
+			}
+			assert.False(t, IsExpandable(tc), "%s must never be expandable", name)
+		})
+	}
+}
+
+// =============================================================================
+// IsExpandable: Shell tool expandable/non-expandable based on line count
+// =============================================================================
+
+func TestIsExpandable_ShellTool_LineCount(t *testing.T) {
+	shellTools := []string{"shell", "bash", "execute"}
+	for _, name := range shellTools {
+		t.Run(name, func(t *testing.T) {
+			tests := []struct {
+				lines    int
+				expandable bool
+			}{
+				{0, false},
+				{1, false},
+				{2, false},
+				{3, false},
+				{4, false}, // maxShellOutputLines+1 = 4, so <=4 is not expandable
+				{5, true},  // 5+ lines is expandable
+				{10, true},
+			}
+			for _, tt := range tests {
+				t.Run(strings.Repeat("x", tt.lines), func(t *testing.T) {
+					tc := ToolCallInfo{
+						Name:   name,
+						Args:   map[string]interface{}{"command": "echo test"},
+						Status: "completed",
+						Result: lineN(tt.lines),
+					}
+					got := IsExpandable(tc)
+					assert.Equal(t, tt.expandable, got, "lines=%d", tt.lines)
+				})
+			}
+		})
+	}
+}
+
+func TestIsExpandable_ShellTool_EmptyResult_NotExpandable(t *testing.T) {
+	tc := ToolCallInfo{
+		Name:   "shell",
+		Args:   map[string]interface{}{"command": "true"},
+		Status: "completed",
+		Result: "",
+	}
+	assert.False(t, IsExpandable(tc))
+}
+
+// =============================================================================
+// IsExpandable: Think tool expandable/non-expandable based on line count
+// =============================================================================
+
+func TestIsExpandable_ThinkTool_LineCount(t *testing.T) {
+	tests := []struct {
+		lines     int
+		expandable bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, false},
+		{4, false}, // maxThinkLines+1 = 4
+		{5, true},
+		{10, true},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Repeat("x", tt.lines), func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   "think",
+				Args:   map[string]interface{}{"thought": lineN(tt.lines)},
+				Status: "completed",
+				Result: "ok",
+			}
+			got := IsExpandable(tc)
+			assert.Equal(t, tt.expandable, got, "lines=%d", tt.lines)
+		})
+	}
+}
+
+func TestIsExpandable_ThinkTool_EmptyThought_NotExpandable(t *testing.T) {
+	tc := ToolCallInfo{
+		Name:   "think",
+		Args:   map[string]interface{}{"thought": ""},
+		Status: "completed",
+		Result: "ok",
+	}
+	assert.False(t, IsExpandable(tc))
+}
+
+// =============================================================================
+// IsExpandable: Discovery tools expandable/non-expandable based on content
+// =============================================================================
+
+func TestIsExpandable_DiscoveryTools_ExpandableWhenNonEmptyResult(t *testing.T) {
+	discoveryTools := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{"list_directory", map[string]interface{}{"path": "."}},
+		{"ls", map[string]interface{}{"path": "."}},
+		{"glob", map[string]interface{}{"pattern": "*.go"}},
+		{"grep", map[string]interface{}{"pattern": "func"}},
+	}
+	for _, dt := range discoveryTools {
+		t.Run(dt.name+"_with_entries", func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   dt.name,
+				Args:   dt.args,
+				Status: "completed",
+				Result: "file1.go\nfile2.go\n",
+			}
+			assert.True(t, IsExpandable(tc), "non-empty result with entries should be expandable")
+		})
+		t.Run(dt.name+"_single_entry", func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   dt.name,
+				Args:   dt.args,
+				Status: "completed",
+				Result: "only_one.go",
+			}
+			assert.True(t, IsExpandable(tc))
+		})
+	}
+}
+
+func TestIsExpandable_DiscoveryTools_NotExpandableWhenEmpty(t *testing.T) {
+	discoveryTools := []string{"list_directory", "ls", "glob", "grep"}
+	for _, name := range discoveryTools {
+		t.Run(name, func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   name,
+				Args:   map[string]interface{}{"path": ".", "pattern": "*.go"},
+				Status: "completed",
+				Result: "",
+			}
+			assert.False(t, IsExpandable(tc))
+		})
+	}
+}
+
+func TestIsExpandable_DiscoveryTools_NotExpandableWhenOnlyWhitespace(t *testing.T) {
+	tc := ToolCallInfo{
+		Name:   "glob",
+		Args:   map[string]interface{}{"pattern": "*.go"},
+		Status: "completed",
+		Result: "   \n\n  \n",
+	}
+	assert.False(t, IsExpandable(tc))
+}
+
+// =============================================================================
+// IsExpandable: Unknown/MCP tools expandable/non-expandable based on line count
+// =============================================================================
+
+func TestIsExpandable_UnknownTool_LineCount(t *testing.T) {
+	tests := []struct {
+		lines     int
+		expandable bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, false},
+		{4, false}, // maxUnknownOutputLines+1 = 4
+		{5, true},
+		{10, true},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Repeat("x", tt.lines), func(t *testing.T) {
+			tc := ToolCallInfo{
+				Name:   "mcp_custom_tool",
+				Args:   map[string]interface{}{"query": "test"},
+				Status: "completed",
+				Result: lineN(tt.lines),
+			}
+			got := IsExpandable(tc)
+			assert.Equal(t, tt.expandable, got, "lines=%d", tt.lines)
+		})
+	}
+}
+
+func TestIsExpandable_UnknownTool_EmptyResult_NotExpandable(t *testing.T) {
+	tc := ToolCallInfo{
+		Name:   "unknown_mcp_tool",
+		Args:   nil,
+		Status: "completed",
+		Result: "",
+	}
+	assert.False(t, IsExpandable(tc))
+}
+
+// =============================================================================
+// IsExpandable: Failed tools always non-expandable
+// =============================================================================
+
+func TestIsExpandable_FailedTools_AlwaysFalse(t *testing.T) {
+	tests := []struct {
+		name string
+		tc   ToolCallInfo
+	}{
+		{
+			"shell_failed_status",
+			ToolCallInfo{
+				Name:   "shell",
+				Args:   map[string]interface{}{"command": "false"},
+				Status: "failed",
+				Result: lineN(20),
+			},
+		},
+		{
+			"shell_error_field",
+			ToolCallInfo{
+				Name:   "shell",
+				Args:   map[string]interface{}{"command": "exit 1"},
+				Status: "completed",
+				Error:  "command failed",
+				Result: lineN(20),
+			},
+		},
+		{
+			"think_failed_status",
+			ToolCallInfo{
+				Name:   "think",
+				Args:   map[string]interface{}{"thought": lineN(10)},
+				Status: "failed",
+				Result: "ok",
+			},
+		},
+		{
+			"discovery_failed",
+			ToolCallInfo{
+				Name:   "glob",
+				Args:   map[string]interface{}{"pattern": "*.go"},
+				Status: "failed",
+				Result: "file1.go\nfile2.go",
+			},
+		},
+		{
+			"unknown_tool_error",
+			ToolCallInfo{
+				Name:   "mcp_tool",
+				Status: "failed",
+				Result: lineN(20),
+			},
+		},
+		{
+			"unknown_tool_error_field",
+			ToolCallInfo{
+				Name:   "mcp_tool",
+				Error:  "something went wrong",
+				Result: lineN(20),
+			},
+		},
+		{
+			"unknown_tool_result_error_prefix",
+			ToolCallInfo{
+				Name:   "mcp_tool",
+				Status: "completed",
+				Result: "Error: MCP server not found",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, IsExpandable(tt.tc), "failed/errored tools must never be expandable")
+		})
+	}
+}
+
+// =============================================================================
+// IsReadGroupExpandable
+// =============================================================================
+
+func TestIsReadGroupExpandable_Threshold(t *testing.T) {
+	makeRead := func(path string) ToolCallInfo {
+		return ToolCallInfo{
+			Name:   "read",
+			Args:   map[string]interface{}{"path": path},
+			Status: "completed",
+			Result: "content",
+		}
+	}
+	tests := []struct {
+		count     int
+		expandable bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, false},
+		{4, false}, // maxVisibleInGroup+1 = 4, so <=4 is not expandable
+		{5, true},
+		{6, true},
+		{10, true},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Repeat("x", tt.count), func(t *testing.T) {
+			reads := make([]ToolCallInfo, tt.count)
+			for i := 0; i < tt.count; i++ {
+				reads[i] = makeRead(strings.Repeat("f", i+1) + ".go")
+			}
+			got := IsReadGroupExpandable(reads)
+			assert.Equal(t, tt.expandable, got, "count=%d", tt.count)
+		})
+	}
+}
+
+func TestIsReadGroupExpandable_EmptySlice(t *testing.T) {
+	assert.False(t, IsReadGroupExpandable(nil))
+	assert.False(t, IsReadGroupExpandable([]ToolCallInfo{}))
+}
+
+// =============================================================================
+// Edge cases: line counting
+// =============================================================================
+
+func TestIsExpandable_ShellTool_ExactBoundary(t *testing.T) {
+	// 4 lines: not expandable. 5 lines: expandable.
+	require.False(t, IsExpandable(ToolCallInfo{
+		Name:   "shell",
+		Args:   map[string]interface{}{"command": "echo"},
+		Status: "completed",
+		Result: "a\nb\nc\nd",
+	}))
+	require.True(t, IsExpandable(ToolCallInfo{
+		Name:   "shell",
+		Args:   map[string]interface{}{"command": "echo"},
+		Status: "completed",
+		Result: "a\nb\nc\nd\ne",
+	}))
+}
+
+func TestIsExpandable_ThinkTool_ExactBoundary(t *testing.T) {
+	require.False(t, IsExpandable(ToolCallInfo{
+		Name:   "think",
+		Args:   map[string]interface{}{"thought": "a\nb\nc\nd"},
+		Status: "completed",
+		Result: "ok",
+	}))
+	require.True(t, IsExpandable(ToolCallInfo{
+		Name:   "think",
+		Args:   map[string]interface{}{"thought": "a\nb\nc\nd\ne"},
+		Status: "completed",
+		Result: "ok",
+	}))
+}
+
+func TestIsExpandable_UnknownTool_ExactBoundary(t *testing.T) {
+	require.False(t, IsExpandable(ToolCallInfo{
+		Name:   "custom",
+		Status: "completed",
+		Result: "a\nb\nc\nd",
+	}))
+	require.True(t, IsExpandable(ToolCallInfo{
+		Name:   "custom",
+		Status: "completed",
+		Result: "a\nb\nc\nd\ne",
+	}))
+}

--- a/client-apps/cli/pkg/toolrender/render_expandable_test.go
+++ b/client-apps/cli/pkg/toolrender/render_expandable_test.go
@@ -21,10 +21,10 @@ func lineN(n int) string {
 }
 
 // =============================================================================
-// IsExpandable: Read tools always non-expandable
+// IsExpandable: Read tools non-expandable for success content
 // =============================================================================
 
-func TestIsExpandable_ReadTools_AlwaysFalse(t *testing.T) {
+func TestIsExpandable_ReadTools_SuccessNotExpandable(t *testing.T) {
 	readTools := []string{"read", "read_file"}
 	for _, name := range readTools {
 		t.Run(name, func(t *testing.T) {
@@ -34,16 +34,16 @@ func TestIsExpandable_ReadTools_AlwaysFalse(t *testing.T) {
 				Status: "completed",
 				Result: lineN(100), // lots of content
 			}
-			assert.False(t, IsExpandable(tc), "read tools must never be expandable")
+			assert.False(t, IsExpandable(tc), "read success content is never expandable (compact shows line count)")
 		})
 	}
 }
 
 // =============================================================================
-// IsExpandable: Write/Edit tools always non-expandable
+// IsExpandable: Write/Edit tools non-expandable for success content
 // =============================================================================
 
-func TestIsExpandable_WriteEditTools_AlwaysFalse(t *testing.T) {
+func TestIsExpandable_WriteEditTools_SuccessNotExpandable(t *testing.T) {
 	tools := []string{"write", "write_file", "create_file", "overwrite_file", "edit", "edit_file"}
 	for _, name := range tools {
 		t.Run(name, func(t *testing.T) {
@@ -53,16 +53,16 @@ func TestIsExpandable_WriteEditTools_AlwaysFalse(t *testing.T) {
 				Status: "completed",
 				Result: "ok",
 			}
-			assert.False(t, IsExpandable(tc), "%s must never be expandable", name)
+			assert.False(t, IsExpandable(tc), "%s success content is never expandable", name)
 		})
 	}
 }
 
 // =============================================================================
-// IsExpandable: Delete tool always non-expandable
+// IsExpandable: Delete tool non-expandable for success content
 // =============================================================================
 
-func TestIsExpandable_DeleteTool_AlwaysFalse(t *testing.T) {
+func TestIsExpandable_DeleteTool_SuccessNotExpandable(t *testing.T) {
 	tools := []string{"delete_file", "remove_file"}
 	for _, name := range tools {
 		t.Run(name, func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestIsExpandable_DeleteTool_AlwaysFalse(t *testing.T) {
 				Status: "completed",
 				Result: "deleted",
 			}
-			assert.False(t, IsExpandable(tc), "%s must never be expandable", name)
+			assert.False(t, IsExpandable(tc), "%s success content is never expandable", name)
 		})
 	}
 }
@@ -267,10 +267,10 @@ func TestIsExpandable_UnknownTool_EmptyResult_NotExpandable(t *testing.T) {
 }
 
 // =============================================================================
-// IsExpandable: Failed tools always non-expandable
+// IsExpandable: Short errors are non-expandable (error fits within display cap)
 // =============================================================================
 
-func TestIsExpandable_FailedTools_AlwaysFalse(t *testing.T) {
+func TestIsExpandable_ShortErrors_NotExpandable(t *testing.T) {
 	tests := []struct {
 		name string
 		tc   ToolCallInfo
@@ -329,17 +329,124 @@ func TestIsExpandable_FailedTools_AlwaysFalse(t *testing.T) {
 			},
 		},
 		{
-			"unknown_tool_result_error_prefix",
+			"unknown_tool_result_error_prefix_short",
 			ToolCallInfo{
 				Name:   "mcp_tool",
 				Status: "completed",
 				Result: "Error: MCP server not found",
 			},
 		},
+		{
+			"read_short_error",
+			ToolCallInfo{
+				Name:   "read",
+				Args:   map[string]interface{}{"path": "missing.go"},
+				Status: "completed",
+				Result: "Error: file not found",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.False(t, IsExpandable(tt.tc), "failed/errored tools must never be expandable")
+			assert.False(t, IsExpandable(tt.tc), "short errors should not be expandable")
+		})
+	}
+}
+
+// =============================================================================
+// IsExpandable: Long/multi-line errors ARE expandable
+// =============================================================================
+
+func TestIsExpandable_LongErrors_Expandable(t *testing.T) {
+	longErr := strings.Repeat("x", maxErrorDisplayLen+1)
+	multiLineResult := "Error: MCP server 'planton' in org 'default' not found\nVerify the server slug and organization.\nRun 'stigmer discover' to list available servers."
+
+	tests := []struct {
+		name string
+		tc   ToolCallInfo
+	}{
+		{
+			"shell_long_error_field",
+			ToolCallInfo{
+				Name:   "shell",
+				Args:   map[string]interface{}{"command": "go build"},
+				Status: "failed",
+				Error:  longErr,
+			},
+		},
+		{
+			"read_long_error",
+			ToolCallInfo{
+				Name:   "read",
+				Args:   map[string]interface{}{"path": "x.go"},
+				Status: "completed",
+				Result: "Error: " + longErr,
+			},
+		},
+		{
+			"write_long_error_field",
+			ToolCallInfo{
+				Name:   "write",
+				Args:   map[string]interface{}{"path": "x.go"},
+				Status: "failed",
+				Error:  longErr,
+			},
+		},
+		{
+			"delete_long_error_field",
+			ToolCallInfo{
+				Name:   "delete_file",
+				Args:   map[string]interface{}{"path": "x.go"},
+				Status: "failed",
+				Error:  longErr,
+			},
+		},
+		{
+			"discovery_long_error_field",
+			ToolCallInfo{
+				Name:   "glob",
+				Args:   map[string]interface{}{"pattern": "*.go"},
+				Status: "failed",
+				Error:  longErr,
+			},
+		},
+		{
+			"think_long_error_field",
+			ToolCallInfo{
+				Name:   "think",
+				Args:   map[string]interface{}{"thought": "x"},
+				Status: "failed",
+				Error:  longErr,
+			},
+		},
+		{
+			"unknown_long_error_field",
+			ToolCallInfo{
+				Name:   "mcp_tool",
+				Error:  longErr,
+				Result: lineN(20),
+			},
+		},
+		{
+			"unknown_result_error_multiline",
+			ToolCallInfo{
+				Name:   "mcp_tool",
+				Status: "completed",
+				Result: multiLineResult,
+			},
+		},
+		{
+			"unknown_result_error_long_single_line",
+			ToolCallInfo{
+				Name:   "mcp_tool",
+				Status: "completed",
+				Result: "Error: " + longErr,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, IsExpandable(tt.tc), "long/multi-line errors should be expandable")
 		})
 	}
 }

--- a/client-apps/cli/pkg/toolrender/render_expandable_test.go
+++ b/client-apps/cli/pkg/toolrender/render_expandable_test.go
@@ -86,7 +86,7 @@ func TestIsExpandable_ShellTool_LineCount(t *testing.T) {
 	for _, name := range shellTools {
 		t.Run(name, func(t *testing.T) {
 			tests := []struct {
-				lines    int
+				lines      int
 				expandable bool
 			}{
 				{0, false},
@@ -129,7 +129,7 @@ func TestIsExpandable_ShellTool_EmptyResult_NotExpandable(t *testing.T) {
 
 func TestIsExpandable_ThinkTool_LineCount(t *testing.T) {
 	tests := []struct {
-		lines     int
+		lines      int
 		expandable bool
 	}{
 		{0, false},
@@ -231,7 +231,7 @@ func TestIsExpandable_DiscoveryTools_NotExpandableWhenOnlyWhitespace(t *testing.
 
 func TestIsExpandable_UnknownTool_LineCount(t *testing.T) {
 	tests := []struct {
-		lines     int
+		lines      int
 		expandable bool
 	}{
 		{0, false},
@@ -465,7 +465,7 @@ func TestIsReadGroupExpandable_Threshold(t *testing.T) {
 		}
 	}
 	tests := []struct {
-		count     int
+		count      int
 		expandable bool
 	}{
 		{0, false},

--- a/client-apps/cli/pkg/toolrender/render_expanded.go
+++ b/client-apps/cli/pkg/toolrender/render_expanded.go
@@ -7,9 +7,8 @@ import (
 
 // RenderExpanded returns an expanded display of a completed tool call.
 // Same visual language as RenderCompact — green bullet, bold label, dim
-// metadata — but with all truncation limits removed. Tools that have no
-// truncation in compact mode (read, write, delete) delegate directly to
-// their compact renderers; the output is identical.
+// metadata — but with all truncation limits removed. For errors, shows
+// the full error text instead of the 60-char truncated compact version.
 //
 // Used by the re-commit path when the user toggles expanded mode.
 func RenderExpanded(tc ToolCallInfo, opts CompactOptions) string {
@@ -19,15 +18,15 @@ func RenderExpanded(tc ToolCallInfo, opts CompactOptions) string {
 	}
 	switch {
 	case info.label == "Read":
-		return renderCompactRead(tc, info, opts)
+		return renderExpandedRead(tc, info, opts)
 	case isWriteOrEditLabel(info.label):
-		return renderCompactWrite(tc, info, opts)
+		return renderExpandedWrite(tc, info, opts)
 	case isShellLabel(info.label):
 		return renderExpandedShell(tc, info, opts)
 	case isDiscoveryLabel(info.label):
 		return renderExpandedDiscovery(tc, info, opts)
 	case info.label == "Delete":
-		return renderCompactDelete(tc, info, opts)
+		return renderExpandedDelete(tc, info, opts)
 	case info.label == "Thinking":
 		return renderExpandedThink(tc, info, opts)
 	default:
@@ -70,22 +69,109 @@ func RenderReadGroupExpanded(reads []ToolCallInfo, opts CompactOptions) string {
 	return b.String()
 }
 
+// ---------------------------------------------------------------------------
+// Expanded error rendering
+// ---------------------------------------------------------------------------
+
+// renderExpandedErrorContent returns the error body lines for an expanded
+// error display, without truncation. The first line carries the ✗ indicator.
+//
+// Three sources are checked in priority order:
+//  1. Result-prefixed errors ("Error: ..."): all result lines are shown, with
+//     the "Error: " prefix stripped from the first line (✗ replaces it).
+//  2. Explicit error field: the full tc.Error is shown (multi-line supported).
+//  3. Status-only failure: shows "✗ failed" (same as compact — no extra content).
+func renderExpandedErrorContent(tc ToolCallInfo) string {
+	if strings.HasPrefix(tc.Result, resultErrorPrefix) {
+		result := strings.TrimSpace(tc.Result)
+		lines := strings.Split(strings.TrimRight(result, "\n"), "\n")
+		var b strings.Builder
+		for i, line := range lines {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			if i == 0 {
+				b.WriteString(dimStyle.Render("    ✗ " + line[len(resultErrorPrefix):]))
+			} else {
+				b.WriteString(dimStyle.Render("    " + line))
+			}
+		}
+		return b.String()
+	}
+
+	if tc.Error != "" {
+		lines := strings.Split(strings.TrimRight(tc.Error, "\n"), "\n")
+		var b strings.Builder
+		for i, line := range lines {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			if i == 0 {
+				b.WriteString(dimStyle.Render("    ✗ " + line))
+			} else {
+				b.WriteString(dimStyle.Render("    " + line))
+			}
+		}
+		return b.String()
+	}
+
+	return dimStyle.Render("    ✗ failed")
+}
+
+// ---------------------------------------------------------------------------
+// Per-tool expanded renderers
+// ---------------------------------------------------------------------------
+
+// renderExpandedRead produces an expanded display for a read tool call.
+// Non-error output is identical to compact (line count + clickable path).
+// For expandable errors, shows the full error text without truncation.
+func renderExpandedRead(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptions) string {
+	if errMsg := toolCallError(tc); errMsg != "" && isErrorExpandable(tc) {
+		path := extractPrimaryArgWithFallbacks(tc.Args, info.primaryField, info.fallbackFields)
+		displayPath := buildHyperlinkedPath(path, opts)
+		header := fmt.Sprintf("%s %s(%s)", bulletStyle.Render("●"), labelStyle.Render("Read"), displayPath)
+		return header + "\n" + renderExpandedErrorContent(tc)
+	}
+	return renderCompactRead(tc, info, opts)
+}
+
+// renderExpandedWrite produces an expanded display for a write/edit tool call.
+// Non-error output is identical to compact (line count + clickable path).
+// For expandable errors, shows the full error text without truncation.
+func renderExpandedWrite(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptions) string {
+	if (tc.Status == "failed" || tc.Error != "") && isErrorExpandable(tc) {
+		path := extractPrimaryArgWithFallbacks(tc.Args, info.primaryField, info.fallbackFields)
+		displayPath := buildHyperlinkedPath(path, opts)
+		header := fmt.Sprintf("%s %s(%s)", bulletStyle.Render("●"), labelStyle.Render(info.label), displayPath)
+		return header + "\n" + renderExpandedErrorContent(tc)
+	}
+	return renderCompactWrite(tc, info, opts)
+}
+
+// renderExpandedDelete produces an expanded display for a delete tool call.
+// Non-error output is identical to compact. For expandable errors, shows
+// the full error text without truncation.
+func renderExpandedDelete(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptions) string {
+	if (tc.Status == "failed" || tc.Error != "") && isErrorExpandable(tc) {
+		path := extractPrimaryArgWithFallbacks(tc.Args, info.primaryField, info.fallbackFields)
+		displayPath := buildHyperlinkedPath(path, opts)
+		header := fmt.Sprintf("%s %s(%s)", bulletStyle.Render("●"), labelStyle.Render("Delete"), displayPath)
+		return header + "\n" + renderExpandedErrorContent(tc)
+	}
+	return renderCompactDelete(tc, info, opts)
+}
+
 // renderExpandedShell produces an expanded display for a shell/execute tool
 // call. Same header as compact (truncated command + bold label). Differs by
-// showing ALL output lines with no maxShellOutputLines cap.
-//
-// Error, empty-output, and header rendering are identical to compact.
+// showing ALL output lines with no maxShellOutputLines cap and full error
+// text without truncation.
 func renderExpandedShell(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptions) string {
 	command := extractPrimaryArgWithFallbacks(tc.Args, info.primaryField, info.fallbackFields)
 	displayCmd := truncate(firstLine(command), 60)
 	header := fmt.Sprintf("%s %s(%s)", bulletStyle.Render("●"), labelStyle.Render(info.label), displayCmd)
 
 	if tc.Status == "failed" || tc.Error != "" {
-		errMsg := tc.Error
-		if errMsg == "" {
-			errMsg = "failed"
-		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + renderExpandedErrorContent(tc)
 	}
 
 	content := resolveDisplayContent(tc, info)
@@ -107,18 +193,12 @@ func renderExpandedShell(tc ToolCallInfo, info toolDisplayInfo, opts CompactOpti
 
 // renderExpandedThink produces an expanded display for a think tool call.
 // Same header as compact ("● Thinking"). Differs by showing ALL thought
-// lines with no maxThinkLines cap.
-//
-// Error and empty-content handling are identical to compact.
+// lines with no maxThinkLines cap and full error text without truncation.
 func renderExpandedThink(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptions) string {
 	header := fmt.Sprintf("%s %s", bulletStyle.Render("●"), labelStyle.Render("Thinking"))
 
 	if tc.Status == "failed" || tc.Error != "" {
-		errMsg := tc.Error
-		if errMsg == "" {
-			errMsg = "failed"
-		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + renderExpandedErrorContent(tc)
 	}
 
 	content := extractPrimaryArgWithFallbacks(tc.Args, info.contentArgField, info.contentArgFallbacks)
@@ -140,9 +220,8 @@ func renderExpandedThink(tc ToolCallInfo, info toolDisplayInfo, opts CompactOpti
 
 // renderExpandedDiscovery produces an expanded display for a discovery tool
 // call (List, Find, Search). Compact mode shows only a count summary
-// ("Found 12 matches"); expanded mode shows all result entries.
-//
-// Error and empty-result handling are identical to compact.
+// ("Found 12 matches"); expanded mode shows all result entries. Errors
+// show full text without truncation.
 func renderExpandedDiscovery(tc ToolCallInfo, info toolDisplayInfo, opts CompactOptions) string {
 	primaryVal := extractPrimaryArgWithFallbacks(tc.Args, info.primaryField, info.fallbackFields)
 
@@ -155,11 +234,7 @@ func renderExpandedDiscovery(tc ToolCallInfo, info toolDisplayInfo, opts Compact
 	header := fmt.Sprintf("%s %s(%s)", bulletStyle.Render("●"), labelStyle.Render(info.label), displayVal)
 
 	if tc.Status == "failed" || tc.Error != "" {
-		errMsg := tc.Error
-		if errMsg == "" {
-			errMsg = "failed"
-		}
-		return header + "\n" + dimStyle.Render("    ✗ "+truncate(errMsg, 60))
+		return header + "\n" + renderExpandedErrorContent(tc)
 	}
 
 	content := resolveDisplayContent(tc, info)
@@ -188,12 +263,21 @@ func renderExpandedDiscovery(tc ToolCallInfo, info toolDisplayInfo, opts Compact
 
 // renderExpandedUnknown produces an expanded display for unknown/MCP tool
 // calls. Same header and input args as compact. Differs by showing ALL
-// result lines with no maxUnknownOutputLines cap.
+// result lines with no maxUnknownOutputLines cap and full error text
+// without truncation.
 func renderExpandedUnknown(tc ToolCallInfo, opts CompactOptions) string {
 	header := buildUnknownCompactHeader(tc)
 
-	if errMsg := toolCallError(tc); errMsg != "" {
-		return buildUnknownWithError(header, tc.Args, errMsg)
+	if toolCallError(tc) != "" {
+		var b strings.Builder
+		b.WriteString(header)
+		if inputLines := formatInputArgs(tc.Args, maxInputArgs); inputLines != "" {
+			b.WriteByte('\n')
+			b.WriteString(inputLines)
+		}
+		b.WriteByte('\n')
+		b.WriteString(renderExpandedErrorContent(tc))
+		return b.String()
 	}
 
 	var b strings.Builder


### PR DESCRIPTION
## Summary

Introduces intelligent Ctrl+O expand/collapse hints throughout the inline TUI, makes truncated error messages expandable, and fixes multiple rendering and lifecycle issues in the Bubbletea-based streaming UI. Also fixes single-file artifact publishing in the backend agent-runner.

## Context

The inline CLI TUI lacked discoverability for the Ctrl+O expand keybinding — users had no indication that tool output could be expanded. Additionally, truncated error messages were not expandable, and toggling Ctrl+O during streaming or approval prompts caused blank screens, cursor desync, and lost content due to `tea.Raw` bypassing Bubbletea v2's renderer cursor tracking.

## Changes

### CLI — Ctrl+O expand/collapse feature
- Add "(ctrl+o to expand)" hint inline next to every expandable item in compact mode (tools, read groups, sub-agent blocks)
- Make the hint smart — only shown when expanding would actually reveal more content via `IsExpandable`/`IsReadGroupExpandable` predicates in `toolrender`
- Add Ctrl+O support during approval prompts via a select loop on `toggleExpandCh`
- Make all tool types show the expand hint when error messages are truncated beyond 60 chars, with shared `isErrorExpandable` predicate

### CLI — rendering and lifecycle fixes
- Fix blank screen after Ctrl+O by replacing `tea.Raw` with renderer-aware `ClearScreen` + `Println` operations
- Defer re-commits during active AI streaming to prevent content loss
- Exempt `TodoUpdateEvent` from `finishAIStreamIfNeeded` to prevent premature AI stream termination
- Add missing gap and glamour markdown rendering for AI streamed messages
- Fix plan display to show single-line summary in collapsed View() and full plan only when expanded
- Properly transfer state during program restart and propagate latest BubbleTea program through `renderResult`/`runInlineFollowUpLoop`
- Simplify draft epilogue: skip redundant artifact downloads, add colored status + resume command

### Backend — agent-runner
- Fix single-file artifact publishing: publish as FILE artifact named after the file (not a directory named after the parent)
- Align reject-approval tests with non-terminal reject semantics (TOOL_CALL_SKIPPED)

## Implementation notes

- Re-commit mechanism was rewritten twice: first from `tea.Raw`-only to renderer-aware, then to a full synchronous program-restart approach, to resolve persistent cursor tracking desync in Bubbletea v2
- Plan display switched from multi-line dynamic-height View() to single-line `currentTask` to prevent todo items overwriting scrollback
- `reCommitPending` flag and two-phase `buildReCommitCmd` prevent concurrent re-commits from conflicting

## Breaking changes

- `--output` default for draft command changed to empty; artifact download is skipped when local workspaces handle file delivery

## Test plan

- 12 new tests added for expand hint behavior; 50+ existing tests updated for new function signatures
- New `render_expandable_test.go` with 543 lines covering all expandable tool/error scenarios
- Updated `run_stream_inline_test.go`, `run_stream_inline_bubbletea_test.go`, `run_stream_inline_followup_test.go`, `run_stream_inline_history_test.go` and bench tests
- Backend: updated `test_auto_publish.py` and `test_status_builder.py`

## Risks

- The program-restart approach on re-commit is more invasive than the previous in-place approach; edge cases around state transfer during restart could surface
- Changing `--output` default may affect scripts that relied on automatic artifact downloads

## Checklist

- [x] Changelogs added (9 entries)
- [x] Tests added/updated
- [x] Backward compatible (except `--output` default change noted above)