### PR TITLE
feat(cli/toolrender): show full content in approval expanded view

### DIFF
--- a/_changelog/2026-03/2026-03-07-101936-show-full-content-in-approval-expanded-view.md
+++ b/_changelog/2026-03/2026-03-07-101936-show-full-content-in-approval-expanded-view.md
@@ -1,0 +1,56 @@
+# Show Full Content in Approval Expanded View
+
+**Date**: March 7, 2026
+
+## Summary
+
+Enhanced the expanded approval view to show full, untruncated content for all tool types before the user makes their approval decision. Previously, shell/execute commands were truncated to 60 characters and MCP tools only showed the single largest argument value. Now the user sees everything they are approving.
+
+## Problem Statement
+
+When a tool call requires approval, the expanded view between the separators is the user's primary window into what they are about to approve. This view was incomplete for two tool categories.
+
+### Pain Points
+
+- **Shell/execute tools**: The command was only visible in the header line, truncated to 60 characters (e.g., `● Shell(cd /Users/.../agent-fleet && ...)`). The content body between the separators was empty because `resolveDisplayContent` returned nothing for shell tools with no Result yet. Long chained commands or complex scripts were impossible to review.
+- **Unknown/MCP tools**: `ExpandedApprovalContent` used `extractLargestArg`, which returned only the raw value of whichever argument was longest. All other arguments — including their key names — were invisible. A tool with `{org: "default", target: "production", config: "<yaml>"}` would only show the YAML, with no indication of the org or target parameters.
+
+## Solution
+
+Targeted changes to `ExpandedApprovalContent` in `render_approval.go` to ensure every approval-gated tool shows its full context. The fix is scoped to the approval flow only — compact/collapsed rendering for completed tools is unchanged.
+
+## Implementation Details
+
+### Shell/Execute Tools
+
+Added a fallback in `ExpandedApprovalContent`: when `resolveDisplayContent` returns empty (no Result yet) and the tool is a shell tool, extract the full command from `args["command"]`. This mirrors how write tools show their file content via `contentArgField`.
+
+The fix is deliberately not in `toolDisplayMap` (adding `contentArgField: "command"`) because that would break completed shell tools with no output — they should show "(no output)", not the command text.
+
+### Unknown/MCP Tools
+
+Replaced `extractLargestArg(tc.Args)` with a new `formatExpandedArgs(tc.Args)` function that formats all arguments as key-value pairs without truncation:
+- Short scalar values are shown inline: `org: "default"`
+- Multi-line or long strings are shown with the key on its own line followed by the full value
+
+### What remains unchanged
+
+- **Write/Edit/Create**: Already showed full file content from args — no change needed
+- **Delete**: Only has a path (shown in header) with no content body — correct as-is
+- **Approval question line**: Still truncated — fine for a single-line prompt
+- **Post-approval collapsed view**: Still truncated — appropriate for the compact display
+
+## Benefits
+
+- Users can review the exact command being executed before approving shell tools
+- Users can see all parameters being passed to MCP/third-party tools
+- Approval decisions are now fully informed across all tool types
+- No change to compact post-approval display — keeps the timeline clean
+
+## Impact
+
+Affects the CLI approval flow for all users. The expanded view (between separators) before the approval prompt now shows complete content for shell and MCP tools. No behavioral changes to non-interactive mode, collapsed views, or post-approval rendering.
+
+---
+
+**Status**: ✅ Production Ready

--- a/client-apps/cli/pkg/toolrender/format.go
+++ b/client-apps/cli/pkg/toolrender/format.go
@@ -148,6 +148,52 @@ func formatInputArgs(args map[string]interface{}, max int) string {
 	return b.String()
 }
 
+// formatExpandedArgs formats all tool arguments for the expanded approval view.
+// Unlike formatInputArgs (which truncates for compact display), this shows
+// every arg in full so the user can see exactly what they are approving.
+//
+// Short scalar values are shown inline:
+//
+//	org: "default"
+//	count: 42
+//
+// Multi-line or long string values are shown with the key on its own line
+// followed by the full value:
+//
+//	content:
+//	apiVersion: v1
+//	kind: ConfigMap
+//	metadata:
+//	  name: my-config
+func formatExpandedArgs(args map[string]interface{}) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		v := args[k]
+		s := formatArgValue(v)
+		if strings.Contains(s, "\n") || len(s) > inputArgPlaceholderLen {
+			b.WriteString(k + ":\n" + s)
+		} else if _, ok := v.(string); ok {
+			b.WriteString(fmt.Sprintf("%s: %q", k, s))
+		} else {
+			b.WriteString(k + ": " + s)
+		}
+	}
+	return b.String()
+}
+
 // formatKeyValue renders a single key-value pair for the compact input arg
 // display. String values are quoted; large strings get a size placeholder.
 func formatKeyValue(key string, val interface{}) string {

--- a/client-apps/cli/pkg/toolrender/render_approval.go
+++ b/client-apps/cli/pkg/toolrender/render_approval.go
@@ -142,13 +142,21 @@ func ExpandedApprovalHeader(tc ToolCallInfo, opts CompactOptions) string {
 	}
 }
 
-// ExpandedApprovalContent extracts the full display content for a tool call.
-// For write/edit tools this is the file content from args; for shell tools
-// this is the command; for read/discovery tools this is the result.
+// ExpandedApprovalContent extracts the full display content for a tool call,
+// designed to give the user complete visibility into what they are approving.
 //
-// For unknown/MCP tools, the largest arg value is returned. This heuristic
-// reliably selects file content over short metadata (paths, names) because
-// the content body is always the largest argument by character count.
+// For write/edit tools this is the file content from args. For shell tools
+// this is the full command (pre-approval) or the result (post-execution).
+// For read/discovery tools this is the result.
+//
+// Shell tools receive special handling: when Result is empty (pre-approval
+// state), the full command text from args is returned so the user can see
+// exactly what will be executed before making an approval decision. This
+// mirrors how write tools show their full file content in the expanded view.
+//
+// For unknown/MCP tools, all arguments are formatted as key-value pairs
+// without truncation so the user can see every parameter being passed. This
+// ensures full transparency for approval decisions on third-party tools.
 //
 // This is the public interface to resolveDisplayContent — the command layer
 // needs it to build the expanded approval view but cannot access the private
@@ -156,9 +164,13 @@ func ExpandedApprovalHeader(tc ToolCallInfo, opts CompactOptions) string {
 func ExpandedApprovalContent(tc ToolCallInfo) string {
 	info, known := toolDisplayMap[tc.Name]
 	if !known {
-		return extractLargestArg(tc.Args)
+		return formatExpandedArgs(tc.Args)
 	}
-	return resolveDisplayContent(tc, info)
+	content := resolveDisplayContent(tc, info)
+	if content == "" && isShellLabel(info.label) {
+		return extractPrimaryArgWithFallbacks(tc.Args, info.primaryField, info.fallbackFields)
+	}
+	return content
 }
 
 // ShouldSuppressCompletion reports whether the ToolCompletedEvent for an

--- a/client-apps/cli/pkg/toolrender/render_approval_test.go
+++ b/client-apps/cli/pkg/toolrender/render_approval_test.go
@@ -689,6 +689,34 @@ func TestExpandedApprovalContent_Shell(t *testing.T) {
 	assertContains(t, result, "ok  pkg/foo")
 }
 
+func TestExpandedApprovalContent_ShellPreApproval(t *testing.T) {
+	longCmd := "cd /Users/suresh/scm/github.com/plantonhq/agent-fleet && bash tools/00_onboard-planton-mcp-server.sh"
+	tc := ToolCallInfo{
+		Name:   "shell",
+		Args:   map[string]interface{}{"command": longCmd},
+		Status: "waiting_approval",
+	}
+	result := ExpandedApprovalContent(tc)
+
+	if result != longCmd {
+		t.Errorf("pre-approval shell should show full command from args, got: %q", result)
+	}
+}
+
+func TestExpandedApprovalContent_ExecutePreApproval(t *testing.T) {
+	cmd := "echo hello && echo world"
+	tc := ToolCallInfo{
+		Name:   "execute",
+		Args:   map[string]interface{}{"command": cmd},
+		Status: "waiting_approval",
+	}
+	result := ExpandedApprovalContent(tc)
+
+	if result != cmd {
+		t.Errorf("pre-approval execute should show full command from args, got: %q", result)
+	}
+}
+
 func TestExpandedApprovalContent_UnknownTool(t *testing.T) {
 	tc := ToolCallInfo{
 		Name: "custom_deploy",
@@ -696,12 +724,11 @@ func TestExpandedApprovalContent_UnknownTool(t *testing.T) {
 	}
 	result := ExpandedApprovalContent(tc)
 
-	if result != "production" {
-		t.Errorf("expected largest arg value, got: %q", result)
-	}
+	assertContains(t, result, "target")
+	assertContains(t, result, "production")
 }
 
-func TestExpandedApprovalContent_MCPToolSelectsLargestArg(t *testing.T) {
+func TestExpandedApprovalContent_MCPToolShowsAllArgs(t *testing.T) {
 	tc := ToolCallInfo{
 		Name: "WriteFile",
 		Args: map[string]interface{}{
@@ -711,11 +738,39 @@ func TestExpandedApprovalContent_MCPToolSelectsLargestArg(t *testing.T) {
 	}
 	result := ExpandedApprovalContent(tc)
 
-	if !strings.Contains(result, "apiVersion") {
-		t.Errorf("expected largest arg (content) to be selected, got: %q", result)
+	assertContains(t, result, "apiVersion")
+	assertContains(t, result, "path")
+	assertContains(t, result, "/tmp/config.yaml")
+	assertContains(t, result, "kind: ConfigMap")
+}
+
+func TestExpandedApprovalContent_MCPToolMultipleShortArgs(t *testing.T) {
+	tc := ToolCallInfo{
+		Name: "planton/deploy_service",
+		Args: map[string]interface{}{
+			"org":    "default",
+			"target": "production",
+			"env":    "us-east-1",
+		},
 	}
-	if result == "/tmp/config.yaml" {
-		t.Error("should not select short path arg over longer content arg")
+	result := ExpandedApprovalContent(tc)
+
+	assertContains(t, result, "org")
+	assertContains(t, result, "default")
+	assertContains(t, result, "target")
+	assertContains(t, result, "production")
+	assertContains(t, result, "env")
+	assertContains(t, result, "us-east-1")
+}
+
+func TestExpandedApprovalContent_MCPToolNoArgs(t *testing.T) {
+	tc := ToolCallInfo{
+		Name: "planton/list_resources",
+	}
+	result := ExpandedApprovalContent(tc)
+
+	if result != "" {
+		t.Errorf("expected empty for no args, got: %q", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

Enhances the expanded approval view to show full, untruncated content for all tool types before the user makes their approval decision. Shell/execute commands now display the complete command text, and unknown/MCP tools show all arguments as labeled key-value pairs.

## Context

When a tool call requires approval, the expanded view between the separators is the user's primary window into what they are about to approve. Shell commands were truncated to 60 characters in the header with an empty content body, making it impossible to review long commands. MCP/unknown tools only showed the single largest argument value, losing all other parameters and their key names.

## Changes

- **Shell/execute tools**: `ExpandedApprovalContent` now falls back to the full command from `args["command"]` when `Result` is empty (pre-approval state), matching how write tools show their file content
- **Unknown/MCP tools**: Replaced `extractLargestArg` with new `formatExpandedArgs` function that formats all arguments as key-value pairs without truncation — short scalars inline, multi-line values with the key on its own line
- Added tests for shell pre-approval content (`ShellPreApproval`, `ExecutePreApproval`) and MCP tool content (`MCPToolShowsAllArgs`, `MCPToolMultipleShortArgs`, `MCPToolNoArgs`)

## Implementation notes

- The shell fix is scoped to `ExpandedApprovalContent` rather than adding `contentArgField: "command"` to `toolDisplayMap`, which would have broken completed shell tools with no output (they should show "(no output)", not the command text)
- Post-approval collapsed views, approval question lines, and non-interactive mode are intentionally unchanged — truncation is appropriate in those contexts

## Breaking changes

- None

## Test plan

- All existing `toolrender` tests pass (129 tests)
- All approval-related tests in `cmd/stigmer/root` pass (24 tests)
- New tests verify shell pre-approval content and MCP tool expanded args

## Checklist

- [ ] Docs updated (if needed)
- [x] Tests added/updated
- [x] Backward compatible