### PR TITLE
fix(cli): add managed program wrapper to prevent silent inline rendering death

### DIFF
--- a/_changelog/2026-03/2026-03-08-061539-fix-inline-rendering-resilience.md
+++ b/_changelog/2026-03/2026-03-08-061539-fix-inline-rendering-resilience.md
@@ -1,0 +1,77 @@
+# Fix Inline Rendering Resilience
+
+**Date**: March 8, 2026
+
+## Summary
+
+Fixes three interrelated bugs in the CLI inline rendering pipeline that caused the terminal to go dark (no output) when the Bubbletea program died silently during terminal resize, a background channel close created a CPU spin loop, or a program restart hung indefinitely. Introduces a thin `managedProgram` lifecycle wrapper that degrades gracefully to direct writes instead of silently dropping all output.
+
+## Problem Statement
+
+After the split-run-resume refactoring, users reported the CLI getting stuck — the server processed events but nothing appeared on screen. Terminal resize during session startup was a reliable trigger. The root cause was three independent bugs that interacted to produce a completely frozen UI.
+
+### Pain Points
+
+- **Silent program death**: `p.Run()` errors were silently discarded (`_, _ = p.Run()`). When Bubbletea's inline program died (e.g., terminal resize edge case in v2), all subsequent `Println`/`Send` calls went to a dead program — no error, no output, no crash
+- **Closed-channel spin loop**: `fetchRecentSessions` used `defer close(ch)`, but the `renderInline` select loop only niled the channel inside the `ok && len(sessions) > 0` guard. A closed channel with no data was never niled, creating a tight CPU spin that starved the event channel
+- **Unbounded `Wait()` in `performReCommit`**: `r.cfg.program.Wait()` had no timeout. If the dying program couldn't process `Quit()`, the entire rendering pipeline froze permanently
+
+## Solution
+
+Rather than scatter defensive checks across 20+ `program.Println`/`program.Send` call sites, the fix introduces a single-responsibility `managedProgram` wrapper that encapsulates exactly one concern: "is the Bubbletea program still alive?" All call sites continue to use the same method signatures; the wrapper handles fallback transparently.
+
+## Implementation Details
+
+### New: `managedProgram` wrapper (`run_stream_inline_program.go`)
+
+A thin struct wrapping `*tea.Program` with an `atomic.Bool` dead flag:
+
+- `runAndMonitor()` — starts `p.Run()` in a goroutine and sets `dead=true` when Run exits (for any reason)
+- `Println()` — delegates to the live program or falls back to `fmt.Fprintln` on the fallback writer
+- `Send()` — delegates or no-ops when dead (transient UI messages are irrelevant in degraded mode)
+- `Wait(timeout)` — waits with a deadline; marks dead if the timeout fires
+- `IsAlive()` — atomic read of the dead flag
+
+### Fix: nil-on-receive for one-shot channels
+
+Moved `cfg.recentSessionsCh = nil` and `cfg.subjectUpdate = nil` before the `ok` check in both the main `renderInline` select loop and `drainRecommitTriggers`. This is the idiomatic Go pattern for one-shot channels in a select loop — regardless of whether data arrived or the channel was closed, the select never re-selects the case.
+
+### Fix: bounded `Wait()` in `performReCommit`
+
+Both `performReCommit` and `performReCommitWithApproval` now call `Wait(2 * time.Second)`. The `stopInlineProgram` cleanup function uses `Wait(5 * time.Second)`. If the timeout fires, the program is marked dead and execution continues.
+
+## Benefits
+
+- **No more dark terminal**: If the Bubbletea program dies, output degrades to direct writes on stderr instead of disappearing entirely
+- **No CPU spin**: Closed one-shot channels are immediately niled, preventing select-loop hot spin
+- **No deadlocks**: All `Wait()` calls have timeouts, preventing indefinite hangs during program restart
+- **Zero call-site changes**: The wrapper's method signatures match the original `*tea.Program`, so the 20+ call sites (statusf, renderTodoUpdate, renderSubAgentStarted, etc.) required no logic changes
+- **Same fallback path**: The dead-program fallback exercises the same code path that already exists for non-TTY environments (`if r.cfg.program == nil`)
+
+## Impact
+
+- **Users**: Terminal resize during session startup no longer freezes the CLI. If Bubbletea encounters any unexpected error, the user sees output (degraded formatting) rather than nothing
+- **Developers**: The `managedProgram` abstraction is the single point of truth for program health — no need to add defensive nil/error checks at each call site
+- **Tests**: 5 new unit tests cover alive/dead transitions, fallback output, and safe no-ops. Existing test suite passes without behavioral changes
+
+## Files Changed
+
+- **New**: `run_stream_inline_program.go` — `managedProgram` wrapper (~100 lines)
+- **New**: `run_stream_inline_program_test.go` — lifecycle unit tests
+- **Modified**: `run_stream_inline_types.go` — `program` field type in `inlineRenderConfig` and `renderResult`
+- **Modified**: `run_stream.go` — `startInlineProgram` and `programFactory` return `*managedProgram`; `stopInlineProgram` accepts `*managedProgram` with timeout
+- **Modified**: `run_stream_inline_followup.go` — function signatures updated for `*managedProgram`
+- **Modified**: `resume_session.go` — `programFactory` signature change
+- **Modified**: `run_stream_inline.go` — nil-on-receive for `recentSessionsCh` and `subjectUpdate`
+- **Modified**: `run_stream_inline_history.go` — bounded `Wait(2s)` in both `performReCommit` variants
+- **Modified**: Test files for type compatibility
+
+## Related Work
+
+- [Split Run and Resume Commands](2026-03-08-021252-split-run-and-resume-commands.md) — the refactoring that exposed the latent bugs
+- [Fix Inline Rendering Program Restart](2026-03-07-085926-fix-inline-rendering-program-restart-recommit.md) — prior re-commit improvements
+- [Bubbletea v2 Migration](2026-03-05-204550-bubbletea-v2-mechanical-api-migration.md) — the v2 upgrade that introduced inline mode
+
+---
+
+**Status**: ✅ Production Ready

--- a/client-apps/cli/cmd/stigmer/root/resume_session.go
+++ b/client-apps/cli/cmd/stigmer/root/resume_session.go
@@ -152,16 +152,17 @@ func resumeSession(sessionID string, headerInfo sessionHeaderInfo, orgID string,
 
 		program := startInlineProgram(os.Stderr, toggleExpandCh, cancelCh, interruptCh)
 
-		var programFactory func(func(*inlineBubbleModel)) *tea.Program
+		var programFactory func(func(*inlineBubbleModel)) *managedProgram
 		if program != nil {
-			programFactory = func(initModel func(*inlineBubbleModel)) *tea.Program {
+			programFactory = func(initModel func(*inlineBubbleModel)) *managedProgram {
 				m := newInlineBubbleModelWithChannels(toggleExpandCh, cancelCh, interruptCh)
 				if initModel != nil {
 					initModel(&m)
 				}
 				p := tea.NewProgram(m, tea.WithOutput(os.Stderr))
-				go func() { _, _ = p.Run() }()
-				return p
+				mp := newManagedProgram(p, os.Stderr)
+				mp.runAndMonitor()
+				return mp
 			}
 		}
 

--- a/client-apps/cli/cmd/stigmer/root/run_stream.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/pkg/errors"
@@ -92,16 +93,17 @@ func streamAgentInline(streamCtx context.Context, streamCancel context.CancelFun
 
 	program := startInlineProgram(statusW, toggleExpandCh, cancelCh, interruptCh)
 
-	var programFactory func(func(*inlineBubbleModel)) *tea.Program
+	var programFactory func(func(*inlineBubbleModel)) *managedProgram
 	if program != nil {
-		programFactory = func(initModel func(*inlineBubbleModel)) *tea.Program {
+		programFactory = func(initModel func(*inlineBubbleModel)) *managedProgram {
 			m := newInlineBubbleModelWithChannels(toggleExpandCh, cancelCh, interruptCh)
 			if initModel != nil {
 				initModel(&m)
 			}
 			p := tea.NewProgram(m, tea.WithOutput(statusW))
-			go func() { _, _ = p.Run() }()
-			return p
+			mp := newManagedProgram(p, statusW)
+			mp.runAndMonitor()
+			return mp
 		}
 	}
 
@@ -152,14 +154,20 @@ func streamAgentInline(streamCtx context.Context, streamCancel context.CancelFun
 	return streamAgentEpilogue(sessionID, latestExecID, phase, exitErr, conn)
 }
 
-// startInlineProgram creates and starts a Bubbletea Program in inline mode
-// for row-tracked stderr rendering. Returns nil when the writer is not a
-// terminal (CI, piped output) — the renderer falls back to direct writes.
+// startInlineProgram creates and starts a managed Bubbletea Program in
+// inline mode for row-tracked stderr rendering. Returns nil when the writer
+// is not a terminal (CI, piped output) — the renderer falls back to direct
+// writes.
 //
 // When the channel arguments are non-nil, the model is wired to the event
 // loop via channels and Bubbletea owns stdin (raw mode). When nil, stdin
 // is not connected and input is handled externally.
-func startInlineProgram(statusW io.Writer, toggleCh, cancelCh, interruptCh chan struct{}) *tea.Program {
+//
+// The returned *managedProgram monitors the underlying tea.Program's Run()
+// goroutine. If Run() exits unexpectedly (e.g., terminal resize edge case),
+// subsequent Println calls degrade to direct writes on statusW and Send
+// calls become no-ops — the rendering pipeline never goes dark.
+func startInlineProgram(statusW io.Writer, toggleCh, cancelCh, interruptCh chan struct{}) *managedProgram {
 	if !termctl.IsSupported(statusW) {
 		return nil
 	}
@@ -175,18 +183,20 @@ func startInlineProgram(statusW io.Writer, toggleCh, cancelCh, interruptCh chan 
 	}
 
 	p := tea.NewProgram(model, opts...)
-	go func() { _, _ = p.Run() }()
-	return p
+	mp := newManagedProgram(p, statusW)
+	mp.runAndMonitor()
+	return mp
 }
 
-// stopInlineProgram sends Quit to the Program and waits for it to exit.
-// Safe to call with nil (non-TTY path).
-func stopInlineProgram(p *tea.Program) {
-	if p == nil {
+// stopInlineProgram sends Quit to the managed program and waits for it
+// to exit. Safe to call with nil (non-TTY path). Uses a generous timeout
+// to avoid blocking indefinitely on a stuck program at session end.
+func stopInlineProgram(mp *managedProgram) {
+	if mp == nil {
 		return
 	}
-	p.Quit()
-	p.Wait()
+	mp.Quit()
+	mp.Wait(5 * time.Second)
 }
 
 // streamAgentJSON renders events as newline-delimited JSON on stdout.

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline.go
@@ -79,16 +79,16 @@ func renderInline(ctx context.Context, cfg inlineRenderConfig) renderResult {
 			return renderResult{exitErr: "context cancelled", history: r.history, program: r.cfg.program}
 
 		case subject, ok := <-cfg.subjectUpdate:
+			cfg.subjectUpdate = nil
 			if ok && subject != "" {
 				r.history[0].header.Subject = subject
-				cfg.subjectUpdate = nil
 				recommitNeeded = true
 			}
 
 		case sessions, ok := <-cfg.recentSessionsCh:
+			cfg.recentSessionsCh = nil
 			if ok && len(sessions) > 0 {
 				r.history[0].header.RecentSessions = sessions
-				cfg.recentSessionsCh = nil
 				recommitNeeded = true
 			}
 
@@ -204,14 +204,14 @@ func (r *inlineRenderer) drainRecommitTriggers(cfg *inlineRenderConfig) {
 	for {
 		select {
 		case subject, ok := <-cfg.subjectUpdate:
+			cfg.subjectUpdate = nil
 			if ok && subject != "" {
 				r.history[0].header.Subject = subject
-				cfg.subjectUpdate = nil
 			}
 		case sessions, ok := <-cfg.recentSessionsCh:
+			cfg.recentSessionsCh = nil
 			if ok && len(sessions) > 0 {
 				r.history[0].header.RecentSessions = sessions
-				cfg.recentSessionsCh = nil
 			}
 		default:
 			return

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_bubbletea_test.go
@@ -952,13 +952,14 @@ func TestStatusf_ProgramPrintln_WhenProgramPresent(t *testing.T) {
 		tea.WithInput(nil),
 	)
 
-	go func() { _, _ = p.Run() }()
+	mp := newManagedProgram(p, &output)
+	mp.runAndMonitor()
 	time.Sleep(50 * time.Millisecond)
 
 	r := &inlineRenderer{
 		cfg: inlineRenderConfig{
 			status:  &output,
-			program: p,
+			program: mp,
 		},
 		suppressedToolIDs: make(map[string]bool),
 	}
@@ -968,8 +969,8 @@ func TestStatusf_ProgramPrintln_WhenProgramPresent(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	p.Quit()
-	p.Wait()
+	mp.Quit()
+	mp.Wait(2 * time.Second)
 
 	got := output.String()
 	if !strings.Contains(got, "hello from println") {

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
-
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/executiontui"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/termctl"
 )
@@ -36,7 +34,7 @@ func runInlineFollowUpLoop(
 	cfg inlineRenderConfig,
 	followUpFn executiontui.FollowUpFn,
 	executionID string,
-) (latestExecID string, phase string, exitErr string, latestProgram *tea.Program) {
+) (latestExecID string, phase string, exitErr string, latestProgram *managedProgram) {
 	latestExecID = executionID
 	latestProgram = cfg.program
 
@@ -96,7 +94,7 @@ func runInlineFollowUpLoop(
 // When Bubbletea owns stdin (cfg.followUpEnabled), the follow-up prompt is
 // handled inside renderInline's event loop instead, so this function is not
 // called on that path.
-func promptFollowUp(program *tea.Program, status io.Writer) (string, error) {
+func promptFollowUp(program *managedProgram, status io.Writer) (string, error) {
 	if program != nil {
 		return promptFollowUpViaKeyReader(program)
 	}
@@ -106,7 +104,7 @@ func promptFollowUp(program *tea.Program, status io.Writer) (string, error) {
 // promptFollowUpViaKeyReader renders the prompt via Bubbletea's View(), reads
 // a line from stdin via readStdinLine, then hides the prompt and commits the
 // styled human message. Legacy path when Bubbletea doesn't own stdin.
-func promptFollowUpViaKeyReader(program *tea.Program) (string, error) {
+func promptFollowUpViaKeyReader(program *managedProgram) (string, error) {
 	program.Send(followUpShowMsg{content: formatFollowUpPrompt()})
 
 	input, err := readStdinLine()

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_followup_test.go
@@ -510,7 +510,8 @@ func newFollowUpTestConfig(
 		tea.WithOutput(io.Discard),
 		tea.WithInput(nil),
 	)
-	go func() { _, _ = p.Run() }()
+	mp := newManagedProgram(p, io.Discard)
+	mp.runAndMonitor()
 
 	if toggleExpandCh == nil {
 		toggleExpandCh = make(chan struct{}, 1)
@@ -522,13 +523,13 @@ func newFollowUpTestConfig(
 		prompter:          approval.NewInteractivePrompter(),
 		data:              io.Discard,
 		status:            io.Discard,
-		program:           p,
+		program:           mp,
 		followUpEnabled:   true,
 		toggleExpandCh:    toggleExpandCh,
 	}
 	cleanup = func() {
-		p.Quit()
-		p.Wait()
+		mp.Quit()
+		mp.Wait(2 * time.Second)
 	}
 	return cfg, capturedCh, cleanup
 }

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_history.go
@@ -3,6 +3,7 @@ package root
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/panel"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/termctl"
@@ -435,7 +436,7 @@ func (r *inlineRenderer) performReCommit() {
 	}
 
 	r.cfg.program.Quit()
-	r.cfg.program.Wait()
+	r.cfg.program.Wait(2 * time.Second)
 
 	rendered := renderHistoryBatch(
 		r.history, r.compactOpts, r.expandMode, r.expandHintEnabled(),
@@ -474,7 +475,7 @@ func (r *inlineRenderer) performReCommitWithApproval(
 	}
 
 	r.cfg.program.Quit()
-	r.cfg.program.Wait()
+	r.cfg.program.Wait(2 * time.Second)
 
 	rendered := renderHistoryBatch(
 		r.history, r.compactOpts, r.expandMode, r.expandHintEnabled(),

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_program.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_program.go
@@ -1,0 +1,106 @@
+package root
+
+import (
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/rs/zerolog/log"
+)
+
+// managedProgram wraps a Bubbletea *tea.Program with lifecycle awareness.
+// When the underlying program exits (cleanly or via error), subsequent
+// Println calls degrade gracefully to direct writes on the fallback writer,
+// and Send calls become no-ops. This prevents the rendering pipeline from
+// going dark when the program dies unexpectedly (e.g., terminal resize
+// edge case in Bubbletea v2 inline mode).
+//
+// The wrapper is transparent to call sites: Println, Send, Quit, and Wait
+// have the same signatures as *tea.Program. The only observable difference
+// is degraded rendering quality when dead — text still appears, but without
+// Bubbletea's row tracking and transient View() region.
+type managedProgram struct {
+	p        *tea.Program
+	dead     atomic.Bool
+	fallback io.Writer
+}
+
+// newManagedProgram creates a managed wrapper around a Bubbletea program.
+// The fallback writer receives direct output when the program dies.
+// The caller must start the program via runAndMonitor.
+func newManagedProgram(p *tea.Program, fallback io.Writer) *managedProgram {
+	return &managedProgram{p: p, fallback: fallback}
+}
+
+// runAndMonitor starts the program in a goroutine and marks the wrapper
+// as dead when Run returns. Errors are logged at warn level — a dead
+// program is non-fatal (rendering degrades to direct writes).
+func (mp *managedProgram) runAndMonitor() {
+	go func() {
+		_, err := mp.p.Run()
+		if err != nil {
+			log.Warn().Err(err).Msg("bubbletea inline program exited with error — degrading to direct writes")
+		}
+		mp.dead.Store(true)
+	}()
+}
+
+// Println commits text to terminal scrollback above the Bubbletea View().
+// When the program is dead, falls back to a direct write on the fallback
+// writer with a trailing newline (matching tea.Program.Println behavior).
+func (mp *managedProgram) Println(args ...interface{}) {
+	if mp.dead.Load() {
+		fmt.Fprintln(mp.fallback, args...)
+		return
+	}
+	mp.p.Println(args...)
+}
+
+// Send delivers a message to the Bubbletea program's message loop.
+// When the program is dead, the message is silently dropped — transient
+// UI updates (spinners, streaming partials, sub-agent badges) are
+// irrelevant in the degraded direct-write mode.
+func (mp *managedProgram) Send(msg tea.Msg) {
+	if mp.dead.Load() {
+		return
+	}
+	mp.p.Send(msg)
+}
+
+// Quit sends a quit command to the program. No-op when already dead.
+func (mp *managedProgram) Quit() {
+	if mp.dead.Load() {
+		return
+	}
+	mp.p.Quit()
+}
+
+// Wait blocks until the program exits or the timeout expires. If the
+// timeout fires before the program exits, the wrapper is marked dead
+// and Wait returns — the caller can continue safely (the orphaned
+// program goroutine will eventually exit on its own).
+func (mp *managedProgram) Wait(timeout time.Duration) {
+	if mp.dead.Load() {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		mp.p.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		log.Warn().Dur("timeout", timeout).Msg("bubbletea program did not exit within timeout — marking dead")
+		mp.dead.Store(true)
+	}
+}
+
+// IsAlive reports whether the underlying program is still running.
+func (mp *managedProgram) IsAlive() bool {
+	return !mp.dead.Load()
+}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_program_test.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_program_test.go
@@ -1,0 +1,108 @@
+package root
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// trivialModel is a minimal Bubbletea model for testing. It exits
+// immediately on any message and renders nothing.
+type trivialModel struct{}
+
+func (trivialModel) Init() tea.Cmd                       { return tea.Quit }
+func (trivialModel) Update(tea.Msg) (tea.Model, tea.Cmd) { return trivialModel{}, tea.Quit }
+func (trivialModel) View() tea.View                      { return tea.NewView("") }
+
+func TestManagedProgram_AliveAfterStart(t *testing.T) {
+	var buf bytes.Buffer
+	p := tea.NewProgram(trivialModel{}, tea.WithOutput(&buf), tea.WithInput(nil))
+	mp := newManagedProgram(p, &buf)
+	mp.runAndMonitor()
+
+	// Give the program time to start and exit (trivialModel quits immediately).
+	time.Sleep(100 * time.Millisecond)
+
+	// After the trivial model exits, the program should be marked dead.
+	if mp.IsAlive() {
+		t.Error("expected managed program to be dead after trivial model exits")
+	}
+}
+
+func TestManagedProgram_PrintlnFallback(t *testing.T) {
+	var fallback bytes.Buffer
+	p := tea.NewProgram(trivialModel{}, tea.WithOutput(&bytes.Buffer{}), tea.WithInput(nil))
+	mp := newManagedProgram(p, &fallback)
+	mp.runAndMonitor()
+
+	// Wait for the program to exit.
+	time.Sleep(100 * time.Millisecond)
+
+	mp.Println("hello from fallback")
+
+	got := fallback.String()
+	if !strings.Contains(got, "hello from fallback") {
+		t.Errorf("expected fallback output to contain 'hello from fallback', got: %q", got)
+	}
+}
+
+func TestManagedProgram_SendNoOpWhenDead(t *testing.T) {
+	var buf bytes.Buffer
+	p := tea.NewProgram(trivialModel{}, tea.WithOutput(&buf), tea.WithInput(nil))
+	mp := newManagedProgram(p, &buf)
+	mp.runAndMonitor()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Should not panic when sending to a dead program.
+	mp.Send(tea.QuitMsg{})
+}
+
+func TestManagedProgram_QuitNoOpWhenDead(t *testing.T) {
+	var buf bytes.Buffer
+	p := tea.NewProgram(trivialModel{}, tea.WithOutput(&buf), tea.WithInput(nil))
+	mp := newManagedProgram(p, &buf)
+	mp.runAndMonitor()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Should not panic when quitting a dead program.
+	mp.Quit()
+}
+
+func TestManagedProgram_WaitReturnsImmediatelyWhenDead(t *testing.T) {
+	var buf bytes.Buffer
+	p := tea.NewProgram(trivialModel{}, tea.WithOutput(&buf), tea.WithInput(nil))
+	mp := newManagedProgram(p, &buf)
+	mp.runAndMonitor()
+
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	mp.Wait(5 * time.Second)
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Wait should return immediately when dead, took %v", elapsed)
+	}
+}
+
+func TestManagedProgram_WaitWithTimeout(t *testing.T) {
+	var buf bytes.Buffer
+	p := tea.NewProgram(trivialModel{}, tea.WithOutput(&buf), tea.WithInput(nil))
+	mp := newManagedProgram(p, &buf)
+	mp.runAndMonitor()
+
+	// Quit and wait — should complete quickly since trivialModel exits fast.
+	mp.Quit()
+	start := time.Now()
+	mp.Wait(2 * time.Second)
+	elapsed := time.Since(start)
+
+	if elapsed > 1*time.Second {
+		t.Errorf("Wait took too long: %v (expected fast completion)", elapsed)
+	}
+}

--- a/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
+++ b/client-apps/cli/cmd/stigmer/root/run_stream_inline_types.go
@@ -4,8 +4,6 @@ import (
 	"io"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
-
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/approval"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/executiontui"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/toolrender"
@@ -48,11 +46,12 @@ type renderResult struct {
 	history       []committedItem
 	followUpInput string
 
-	// program is the Bubbletea Program that was active when renderInline
-	// returned. May differ from the cfg.program that was passed in when
-	// performReCommit created replacement programs during the session.
-	// Callers must use this reference (not the original) for cleanup.
-	program *tea.Program
+	// program is the managed Bubbletea Program that was active when
+	// renderInline returned. May differ from the cfg.program that was
+	// passed in when performReCommit created replacement programs during
+	// the session. Callers must use this reference (not the original)
+	// for cleanup.
+	program *managedProgram
 }
 
 // inlineRenderConfig configures the inline (non-TUI) event renderer.
@@ -69,17 +68,18 @@ type inlineRenderConfig struct {
 	platformDir       string   // session platform dir for .stigmer/ virtual mount
 	cancelExecFn      func()   // cancels the current backend execution; nil-safe
 
-	// program is the Bubbletea Program running alongside the event loop. When
-	// non-nil, status output is routed through program.Println so Bubbletea
-	// tracks stderr row positions accurately. When nil (unit tests, non-TTY),
-	// output falls back to direct writes on the status writer.
-	program *tea.Program
+	// program is the managed Bubbletea Program running alongside the event
+	// loop. When non-nil, status output is routed through program.Println
+	// so Bubbletea tracks stderr row positions accurately. When nil (unit
+	// tests, non-TTY), output falls back to direct writes on the status
+	// writer.
+	program *managedProgram
 
-	// programFactory creates a fresh Bubbletea program with the same
-	// channels and output writer. The initModel callback pre-loads model
-	// state (plan, input bar, approval) before the program starts.
+	// programFactory creates a fresh managed Bubbletea program with the
+	// same channels and output writer. The initModel callback pre-loads
+	// model state (plan, input bar, approval) before the program starts.
 	// nil when program is nil (non-TTY).
-	programFactory func(initModel func(*inlineBubbleModel)) *tea.Program
+	programFactory func(initModel func(*inlineBubbleModel)) *managedProgram
 
 	// suppressHumanEcho skips the next HumanMessageEvent rendering. Set by
 	// the follow-up loop after local echo to prevent duplicate display when


### PR DESCRIPTION
## Summary

Introduces a `managedProgram` lifecycle wrapper around Bubbletea's `*tea.Program` that degrades gracefully to direct stderr writes when the inline program dies unexpectedly. Also fixes a closed-channel spin loop and unbounded `Wait()` calls that contributed to the "stuck terminal" bug.

## Context

After the split-run-resume refactoring, users reported the CLI getting stuck — the server processed events but nothing appeared on screen. Terminal resize during session startup was a reliable trigger. Three independent bugs interacted to produce a completely frozen UI:

1. `p.Run()` errors were silently discarded (`_, _ = p.Run()`), leaving a dead program receiving all output
2. `fetchRecentSessions` closed its channel, but the select loop never niled it when `ok == false`, creating a tight CPU spin
3. `performReCommit` called `Wait()` without a timeout, deadlocking on dying programs

## Changes

- **New `managedProgram` wrapper** (`run_stream_inline_program.go`): Thin struct with `atomic.Bool` dead flag that monitors `Run()` and provides `Println`/`Send`/`Quit`/`Wait(timeout)` methods with transparent fallback
- **Type migration**: Replaced `*tea.Program` with `*managedProgram` in `inlineRenderConfig.program`, `renderResult.program`, `programFactory`, `stopInlineProgram`, `runInlineFollowUpLoop`, and follow-up prompt functions
- **Nil-on-receive for one-shot channels**: Moved `cfg.recentSessionsCh = nil` and `cfg.subjectUpdate = nil` before the `ok` check in both the main select loop and `drainRecommitTriggers`
- **Bounded `Wait()`**: `performReCommit` and `performReCommitWithApproval` use `Wait(2s)`; `stopInlineProgram` uses `Wait(5s)`
- **Tests**: 5 new unit tests for `managedProgram` lifecycle; updated 2 existing test files for type compatibility

## Implementation notes

- The wrapper's method signatures match the original `*tea.Program`, so the 20+ call sites (`statusf`, `renderTodoUpdate`, `renderSubAgentStarted`, etc.) required zero logic changes
- The dead-program fallback exercises the same code path that already exists for non-TTY environments (`if r.cfg.program == nil` branches)
- `startInlineProgram` and both `programFactory` closures now use `newManagedProgram` + `runAndMonitor()`

## Breaking changes

- None

## Test plan

- `go vet ./client-apps/cli/cmd/stigmer/root/` passes clean
- All 5 new `TestManagedProgram_*` tests pass (alive/dead transitions, fallback output, safe no-ops)
- `TestStatusf_ProgramPrintln_WhenProgramPresent` passes with `*managedProgram`
- All 9 `TestRenderInline_FollowUp*` tests pass with updated config type
- Full package test suite passes (only pre-existing flaky `TestJSONOutput_WarningPaths/server_stop_not_running` fails — unrelated daemon state issue)

## Risks

- Low: The wrapper is additive and delegates to the real program when alive
- Medium: Type change from `*tea.Program` to `*managedProgram` touches multiple files, but the compiler catches any missed spots
- Rollback: Revert the single commit to restore original behavior

## Checklist

- [x] Docs updated (changelog added)
- [x] Tests added/updated
- [x] Backward compatible