### PR TITLE
fix(cli): use strict ULID validation in reference parser to prevent slug misidentification

### DIFF
--- a/_changelog/2026-03/2026-03-08-075324-fix-reference-parser-slug-misidentification.md
+++ b/_changelog/2026-03/2026-03-08-075324-fix-reference-parser-slug-misidentification.md
@@ -1,0 +1,60 @@
+# Fix Reference Parser Slug Misidentification as Resource IDs
+
+**Date**: March 8, 2026
+
+## Summary
+
+Fixed a bug in the CLI reference parser where slugs starting with a known resource ID prefix (e.g., `mcp-server-stigmer`) were incorrectly identified as resource IDs, causing `NotFound` errors when discovering or resolving MCP servers and other resources by slug.
+
+## Problem Statement
+
+Running `stigmer discover mcp-server mcp-server-stigmer` returned a `NotFound` error even though the MCP server was listed and available in the current organization.
+
+### Pain Points
+
+- `stigmer discover mcp-server mcp-server-stigmer` failed with `McpServer not found: mcp-server-stigmer` despite the server being visible in `stigmer list mcp-servers`
+- Any resource slug starting with a known ID prefix followed by a hyphen was silently misrouted to the ID-based lookup path
+- The bug affected all resource types whose slugs could collide with ID prefixes: `mcp-*`, `env-*`, `agt-*`, `win-*`, `ses-*`, etc.
+- The error message ("failed to get MCP server by ID") was misleading — the user never intended to look up by ID
+
+## Solution
+
+Replaced the loose prefix-only check (`isResourceID`) in `Parse()` with the strict `ValidateResourceID()` function that requires a complete resource ID: prefix + separator + exactly 26-character ULID body (or a valid UUID). This ensures slugs like `mcp-server-stigmer` correctly fall through to slug-based resolution.
+
+## Implementation Details
+
+The `isResourceIDWithKind` function checked only whether a string started with a known prefix + separator:
+
+```go
+return strings.HasPrefix(ref, prefix+"_") || strings.HasPrefix(ref, prefix+"-")
+```
+
+For the MCP server kind (`id_prefix: "mcp"`), this caused `mcp-server-stigmer` to match `mcp-` and be treated as a resource ID. The `ValidateResourceID` function already existed and enforced ULID body length, but `Parse()` was using the loose check instead.
+
+**Changes**:
+- `reference.go`: Switched `Parse()` from `isResourceID(ref)` to `ValidateResourceID(ref) == nil`
+- `reference_test.go`: Updated all resource ID test cases to use proper 26-char ULIDs; added explicit regression tests for prefix-colliding slugs (`mcp-server-stigmer`, `env-production`, `agt_short`)
+
+The loose `isResourceID` / `HasResourceIDPrefix` functions remain unchanged for intent-detection use cases elsewhere in the codebase.
+
+## Benefits
+
+- `stigmer discover mcp-server mcp-server-stigmer` now resolves correctly via slug-based lookup
+- Eliminates an entire class of bugs where resource slugs collide with ID prefixes
+- No behavioral change for valid resource IDs (prefix + 26-char ULID)
+- Regression tests prevent this from recurring
+
+## Impact
+
+- **CLI users**: Any command that resolves resources by slug (discover, get, run, etc.) is now safe from prefix collisions
+- **Built-in resources**: The seedpack's `mcp-server-stigmer` can be discovered without workarounds
+- **All resource types**: The fix is generic — applies to agents, environments, workflows, sessions, and all other resource kinds
+
+## Related Work
+
+- Seedpack rename: `stigmer-mcp-server` → `mcp-server-stigmer` (which surfaced this bug)
+- Existing `ValidateResourceID` / `ResourceIDKind` strict validation functions that were already correct
+
+---
+
+**Status**: ✅ Production Ready

--- a/client-apps/cli/pkg/reference/reference.go
+++ b/client-apps/cli/pkg/reference/reference.go
@@ -30,20 +30,25 @@ type ParsedReference struct {
 // Parse parses a resource reference string into its components.
 //
 // The function handles multiple reference formats:
-//   - Resource IDs: Detected by prefix from ApiResourceKind enum (e.g., agt_, agt-, mcp_, mcp-)
+//   - Resource IDs: prefix + separator + 26-char ULID (e.g., agt_01ARZ3NDEKTSV4RRFFQ69G5FAV), or UUID
 //   - org/slug: Explicit organization and slug
 //   - org/slug@version: With version suffix
 //   - slug: Slug-only, requires contextOrg to be provided
+//
+// Resource ID detection is strict: the body after the prefix must be exactly 26 characters
+// (ULID length). This prevents slugs like "mcp-server-stigmer" from being misidentified
+// as resource IDs just because they start with a known prefix.
 //
 // The contextOrg parameter provides the default organization for slug-only references.
 // If contextOrg is empty and a slug-only reference is provided, ErrOrgRequired is returned.
 //
 // Examples:
 //
-//	Parse("stigmer/web-search", "")       // org=stigmer, slug=web-search
-//	Parse("web-search", "my-org")         // org=my-org, slug=web-search
-//	Parse("agt_abc123", "")               // IsID=true, ID=agt_abc123
-//	Parse("stigmer/skill@v1.0", "")       // org=stigmer, slug=skill, version=v1.0
+//	Parse("stigmer/web-search", "")                        // org=stigmer, slug=web-search
+//	Parse("web-search", "my-org")                          // org=my-org, slug=web-search
+//	Parse("agt_01ARZ3NDEKTSV4RRFFQ69G5FAV", "")           // IsID=true
+//	Parse("stigmer/skill@v1.0", "")                        // org=stigmer, slug=skill, version=v1.0
+//	Parse("mcp-server-stigmer", "default")                 // org=default, slug=mcp-server-stigmer
 func Parse(ref string, contextOrg string) (*ParsedReference, error) {
 	ref = strings.TrimSpace(ref)
 
@@ -51,8 +56,10 @@ func Parse(ref string, contextOrg string) (*ParsedReference, error) {
 		return nil, newParseError("", "reference string is empty", ErrEmptyReference)
 	}
 
-	// Check if this is a resource ID
-	if isResourceID(ref) {
+	// Check if this is a fully valid resource ID (prefix + separator + 26-char ULID, or UUID).
+	// We use strict validation here to avoid misidentifying slugs that happen to
+	// start with a known prefix (e.g., "mcp-server-stigmer" starts with "mcp-").
+	if ValidateResourceID(ref) == nil {
 		return &ParsedReference{
 			IsID: true,
 			ID:   ref,

--- a/client-apps/cli/pkg/reference/reference_test.go
+++ b/client-apps/cli/pkg/reference/reference_test.go
@@ -57,36 +57,36 @@ func TestParse(t *testing.T) {
 		},
 
 		// Resource IDs - using prefixes from ApiResourceKind enum
-		// Format: prefix + separator (underscore or hyphen) + ULID
+		// Format: prefix + separator (underscore or hyphen) + 26-char ULID
 		{
 			name: "agent ID with underscore",
-			ref:  "agt_abc123",
-			want: &ParsedReference{IsID: true, ID: "agt_abc123"},
+			ref:  "agt_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "agt_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "agent ID with hyphen",
-			ref:  "agt-abc123",
-			want: &ParsedReference{IsID: true, ID: "agt-abc123"},
+			ref:  "agt-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "agt-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "workflow ID with underscore",
-			ref:  "wfl_xyz789",
-			want: &ParsedReference{IsID: true, ID: "wfl_xyz789"},
+			ref:  "wfl_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "wfl_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "workflow ID with hyphen",
-			ref:  "wfl-xyz789",
-			want: &ParsedReference{IsID: true, ID: "wfl-xyz789"},
+			ref:  "wfl-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "wfl-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "mcp server ID with underscore",
-			ref:  "mcp_github-server",
-			want: &ParsedReference{IsID: true, ID: "mcp_github-server"},
+			ref:  "mcp_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "mcp_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "mcp server ID with hyphen",
-			ref:  "mcp-github-server",
-			want: &ParsedReference{IsID: true, ID: "mcp-github-server"},
+			ref:  "mcp-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "mcp-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "UUID format",
@@ -95,63 +95,83 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name: "agent execution ID with underscore",
-			ref:  "aex_run123",
-			want: &ParsedReference{IsID: true, ID: "aex_run123"},
+			ref:  "aex_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "aex_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "agent execution ID with hyphen",
-			ref:  "aex-run123",
-			want: &ParsedReference{IsID: true, ID: "aex-run123"},
+			ref:  "aex-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "aex-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "workflow execution ID with underscore",
-			ref:  "wex_run456",
-			want: &ParsedReference{IsID: true, ID: "wex_run456"},
+			ref:  "wex_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "wex_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "workflow execution ID with hyphen",
-			ref:  "wex-run456",
-			want: &ParsedReference{IsID: true, ID: "wex-run456"},
+			ref:  "wex-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "wex-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "skill ID with underscore",
-			ref:  "skl_abc",
-			want: &ParsedReference{IsID: true, ID: "skl_abc"},
+			ref:  "skl_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "skl_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "skill ID with hyphen",
-			ref:  "skl-abc",
-			want: &ParsedReference{IsID: true, ID: "skl-abc"},
+			ref:  "skl-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "skl-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "agent instance ID with underscore",
-			ref:  "ain_inst1",
-			want: &ParsedReference{IsID: true, ID: "ain_inst1"},
+			ref:  "ain_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "ain_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "agent instance ID with hyphen",
-			ref:  "ain-inst1",
-			want: &ParsedReference{IsID: true, ID: "ain-inst1"},
+			ref:  "ain-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "ain-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "workflow instance ID with underscore",
-			ref:  "win_inst2",
-			want: &ParsedReference{IsID: true, ID: "win_inst2"},
+			ref:  "win_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "win_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "workflow instance ID with hyphen",
-			ref:  "win-inst2",
-			want: &ParsedReference{IsID: true, ID: "win-inst2"},
+			ref:  "win-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "win-01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "session ID with underscore",
-			ref:  "ses_session123",
-			want: &ParsedReference{IsID: true, ID: "ses_session123"},
+			ref:  "ses_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "ses_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
 		},
 		{
 			name: "environment ID with underscore",
-			ref:  "env_myenv",
-			want: &ParsedReference{IsID: true, ID: "env_myenv"},
+			ref:  "env_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			want: &ParsedReference{IsID: true, ID: "env_01ARZ3NDEKTSV4RRFFQ69G5FAV"},
+		},
+
+		// Slugs that happen to start with a known ID prefix should be treated as slugs, not IDs
+		{
+			name:       "mcp-prefixed slug treated as slug",
+			ref:        "mcp-server-stigmer",
+			contextOrg: "default",
+			want:       &ParsedReference{Org: "default", Slug: "mcp-server-stigmer"},
+		},
+		{
+			name:       "env-prefixed slug treated as slug",
+			ref:        "env-production",
+			contextOrg: "my-org",
+			want:       &ParsedReference{Org: "my-org", Slug: "env-production"},
+		},
+		{
+			name:       "incomplete ID prefix treated as slug",
+			ref:        "agt_short",
+			contextOrg: "my-org",
+			want:       &ParsedReference{Org: "my-org", Slug: "agt_short"},
 		},
 
 		// Edge cases


### PR DESCRIPTION
## Summary

Fixes a bug where resource slugs starting with a known ID prefix (e.g., `mcp-server-stigmer` starting with `mcp-`) were incorrectly identified as resource IDs by the reference parser, causing `NotFound` errors when resolving resources by slug.

## Context

After renaming the built-in MCP server from `stigmer-mcp-server` to `mcp-server-stigmer`, `stigmer discover mcp-server mcp-server-stigmer` started failing with a `NotFound` error. The server was listed correctly by `stigmer list mcp-servers`, but the discover command routed the lookup through the ID-based path (`LoadTarget`) instead of the slug-based path (`GetByReference`), because `isResourceID()` only checked for a prefix match without validating the ULID body.

## Changes

- Switch `Parse()` from using the loose `isResourceID()` (prefix-only check) to the strict `ValidateResourceID()` (requires prefix + separator + 26-char ULID or UUID)
- Update all resource ID test cases in `reference_test.go` to use proper 26-char ULIDs
- Add regression tests for slugs that collide with ID prefixes: `mcp-server-stigmer`, `env-production`, `agt_short`
- Add changelog entry documenting the fix

## Implementation notes

- The loose `isResourceID` / `HasResourceIDPrefix` functions are intentionally left unchanged — they serve a different purpose (intent detection) and are not used in the `Parse()` resolution path
- `ValidateResourceID` already existed in the codebase but was not being used by `Parse()`

## Breaking changes

- None. Valid resource IDs (prefix + 26-char ULID) continue to be resolved by ID. Only invalid/incomplete ID-like strings are now correctly treated as slugs.

## Test plan

- All 85 tests in `client-apps/cli/pkg/reference` pass
- New test cases explicitly verify that `mcp-server-stigmer`, `env-production`, and `agt_short` are treated as slugs, not IDs

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Changelog added