### PR TITLE
fix(cli): skip daemon-dependent tests when server is already running

### DIFF
--- a/_changelog/2026-03/2026-03-08-081910-fix-daemon-dependent-test-isolation.md
+++ b/_changelog/2026-03/2026-03-08-081910-fix-daemon-dependent-test-isolation.md
@@ -1,0 +1,49 @@
+# Fix Daemon-Dependent Test Isolation
+
+**Date**: March 8, 2026
+
+## Summary
+
+Fixed a flaky test failure in `make check` caused by daemon-dependent output format tests not being isolated from a running stigmer server. Tests that assume no daemon is running now gracefully skip when a daemon is detected on the default port.
+
+## Problem Statement
+
+Running `make check` on a development machine with an active stigmer daemon caused the `TestJSONOutput_WarningPaths/server_stop_not_running` test to fail.
+
+### Pain Points
+
+- `daemon.IsRunning()` has a gRPC port fallback that detects a real daemon even without a PID file in the test's temp directory
+- The test expected a "warning" / "not running" response but got "success" / "Server stopped successfully"
+- The test actually killed the running daemon as a side effect, making it destructive
+- The failure was environment-dependent: CI (no daemon) passed, local dev (daemon running) failed
+
+## Solution
+
+Added a `skipIfDaemonRunning` test guard that probes the daemon port (`localhost:7234`) via TCP before running subtests that require no daemon to be present. Tests skip gracefully with a clear message when a daemon is detected.
+
+## Implementation Details
+
+- Added `daemonPortInUse()` helper using `net.DialTimeout` with a 500ms timeout to check if the daemon port is occupied
+- Added `skipIfDaemonRunning(t)` helper that calls `t.Skipf` with a descriptive message referencing the port number
+- Added `needsNoDaemon` boolean field to the test table structs in `TestJSONOutput_WarningPaths` and `TestQuietOutput_StdoutIsEmpty`
+- Flagged the four daemon-dependent subtests: `server stop not running` and `server status not running` in both test functions
+
+## Benefits
+
+- `make check` passes reliably regardless of whether a daemon is running
+- No more accidental daemon kills during test runs
+- Clear skip messages explain why tests were skipped
+- Zero impact on CI environments where no daemon runs
+
+## Impact
+
+- **Developers**: Can run `make check` without stopping their local daemon first
+- **CI**: No change — tests still execute fully when no daemon is present
+
+## Related Work
+
+- Previous CI gate fix: `2026-03-07-041145-fix-make-check-lint-and-nil-guard.md`
+
+---
+
+**Status**: ✅ Production Ready

--- a/client-apps/cli/cmd/stigmer/root/output_format_test.go
+++ b/client-apps/cli/cmd/stigmer/root/output_format_test.go
@@ -2,19 +2,39 @@ package root
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stigmer/stigmer/client-apps/cli/internal/cli/daemon"
 	"github.com/stigmer/stigmer/client-apps/cli/pkg/clioutput"
 )
 
 func init() {
 	color.NoColor = true
+}
+
+func daemonPortInUse() bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", daemon.DaemonPort), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+func skipIfDaemonRunning(t *testing.T) {
+	t.Helper()
+	if daemonPortInUse() {
+		t.Skipf("skipping: stigmer daemon is already running on port %d", daemon.DaemonPort)
+	}
 }
 
 // localAnthropicConfig returns a config with a non-Ollama LLM provider,
@@ -199,6 +219,7 @@ func TestJSONOutput_WarningPaths(t *testing.T) {
 		handler        func()
 		wantStatus     string
 		wantMsgContain string
+		needsNoDaemon  bool
 	}{
 		{
 			name:           "server stop not running",
@@ -206,6 +227,7 @@ func TestJSONOutput_WarningPaths(t *testing.T) {
 			handler:        func() { handleServerStop(clioutput.FormatJSON) },
 			wantStatus:     "warning",
 			wantMsgContain: "not running",
+			needsNoDaemon:  true,
 		},
 		{
 			name:           "server status not running",
@@ -213,6 +235,7 @@ func TestJSONOutput_WarningPaths(t *testing.T) {
 			handler:        func() { handleServerStatus(clioutput.FormatJSON) },
 			wantStatus:     "warning",
 			wantMsgContain: "not running",
+			needsNoDaemon:  true,
 		},
 		{
 			name:           "llm list non-ollama provider",
@@ -232,6 +255,9 @@ func TestJSONOutput_WarningPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.needsNoDaemon {
+				skipIfDaemonRunning(t)
+			}
 			setupTestHome(t, tt.config)
 
 			stdout := captureStdout(t, tt.handler)
@@ -254,23 +280,27 @@ func TestJSONOutput_WarningPaths(t *testing.T) {
 
 func TestQuietOutput_StdoutIsEmpty(t *testing.T) {
 	tests := []struct {
-		name    string
-		config  string
-		handler func()
+		name          string
+		config        string
+		handler       func()
+		needsNoDaemon bool
 	}{
-		{"config list", localAnthropicConfig(), func() { handleConfigList(clioutput.FormatQuiet) }},
-		{"config set", localAnthropicConfig(), func() { handleConfigSet("llm.model", "claude-sonnet-4.5", clioutput.FormatQuiet) }},
-		{"backend status", localAnthropicConfig(), func() { handleBackendStatus(clioutput.FormatQuiet) }},
-		{"backend set local", localAnthropicConfig(), func() { handleBackendSet("local", clioutput.FormatQuiet) }},
-		{"llm status", localAnthropicConfig(), func() { handleLLMStatus(clioutput.FormatQuiet) }},
-		{"server stop not running", localAnthropicConfig(), func() { handleServerStop(clioutput.FormatQuiet) }},
-		{"server status not running", localAnthropicConfig(), func() { handleServerStatus(clioutput.FormatQuiet) }},
-		{"llm list non-ollama", localAnthropicConfig(), func() { handleLLMList(clioutput.FormatQuiet) }},
-		{"llm pull non-ollama", localAnthropicConfig(), func() { handleLLMPull("test-model", clioutput.FormatQuiet) }},
+		{"config list", localAnthropicConfig(), func() { handleConfigList(clioutput.FormatQuiet) }, false},
+		{"config set", localAnthropicConfig(), func() { handleConfigSet("llm.model", "claude-sonnet-4.5", clioutput.FormatQuiet) }, false},
+		{"backend status", localAnthropicConfig(), func() { handleBackendStatus(clioutput.FormatQuiet) }, false},
+		{"backend set local", localAnthropicConfig(), func() { handleBackendSet("local", clioutput.FormatQuiet) }, false},
+		{"llm status", localAnthropicConfig(), func() { handleLLMStatus(clioutput.FormatQuiet) }, false},
+		{"server stop not running", localAnthropicConfig(), func() { handleServerStop(clioutput.FormatQuiet) }, true},
+		{"server status not running", localAnthropicConfig(), func() { handleServerStatus(clioutput.FormatQuiet) }, true},
+		{"llm list non-ollama", localAnthropicConfig(), func() { handleLLMList(clioutput.FormatQuiet) }, false},
+		{"llm pull non-ollama", localAnthropicConfig(), func() { handleLLMPull("test-model", clioutput.FormatQuiet) }, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.needsNoDaemon {
+				skipIfDaemonRunning(t)
+			}
 			setupTestHome(t, tt.config)
 
 			stdout := captureStdout(t, tt.handler)


### PR DESCRIPTION
## Summary

Fix a flaky test failure in `make check` where daemon-dependent output format tests broke when a real stigmer server was running on the host machine.

## Context

The `TestJSONOutput_WarningPaths/server_stop_not_running` test assumed no daemon would be listening on port 7234. However, `daemon.IsRunning()` has a gRPC port fallback that detects a running daemon even without a PID file in the test's temp directory. This caused the test to get `"success"` instead of the expected `"warning"`, and as a destructive side effect, it killed the running daemon.

## Changes

- Add `daemonPortInUse()` and `skipIfDaemonRunning(t)` test helpers that probe port 7234 via TCP
- Add `needsNoDaemon` field to the test table structs in `TestJSONOutput_WarningPaths` and `TestQuietOutput_StdoutIsEmpty`
- Flag the four daemon-dependent subtests (`server stop not running`, `server status not running`) to skip gracefully when a daemon is detected

## Implementation notes

- Uses `net.DialTimeout` with a 500ms timeout rather than importing the full `daemon.IsRunning` logic, keeping the guard lightweight and focused on port occupancy
- References `daemon.DaemonPort` directly so the skip message stays in sync if the port constant changes

## Breaking changes

- None

## Test plan

- Ran `make check` with a daemon running — all tests pass (daemon-dependent subtests skip with clear messages)
- Verified the same tests would still execute and pass when no daemon is running (CI-equivalent)

## Checklist

- [ ] Docs updated (if needed)
- [x] Tests added/updated
- [x] Backward compatible