### PR TITLE
feat(seedpack): add approval policy generation script for mcp-server-stigmer

### DIFF
--- a/_changelog/2026-03/2026-03-08-092815-add-mcp-server-stigmer-approval-policy-script.md
+++ b/_changelog/2026-03/2026-03-08-092815-add-mcp-server-stigmer-approval-policy-script.md
@@ -1,0 +1,54 @@
+# Add mcp-server-stigmer Approval Policy Generation Script
+
+**Date**: March 8, 2026
+
+## Summary
+
+Added a new seedpack tool script (`04_generate-approval-policy.sh`) that generates `default_tool_approvals` for the `mcp-server-stigmer` MCP server by querying its discovered capabilities from the Stigmer backend. The script includes strict scoping to prevent the agent from querying or referencing any other MCP server.
+
+## Problem Statement
+
+The `mcp-server-stigmer` seedpack YAML lacked an automated way to generate approval policies for its tools. Without explicit `default_tool_approvals`, destructive or mutating operations (delete, destroy, apply, etc.) could be executed without human review.
+
+### Pain Points
+
+- No scripted workflow to generate approval policies for the built-in Stigmer MCP server
+- Risk of the agent wandering into other MCP servers' data when generating policies
+- No guardrail to prevent the agent from guessing tool names if discovery returns empty results
+
+## Solution
+
+Created `seedpack/tools/04_generate-approval-policy.sh` following the established pattern from the agent-fleet's Planton approval policy script. The agent prompt includes:
+
+1. **Hard scope constraint** — only query `mcp-server-stigmer`, ignore everything else
+2. **Fail-fast instruction** — if discovery returns nothing, stop and report; do not search the workspace or guess tool names
+3. **Step-by-step classification** — retrieve tools, classify safe vs mutating, generate approval entries with `{{args.<field>}}` placeholders, group by domain
+
+## Implementation Details
+
+- New file: `seedpack/tools/04_generate-approval-policy.sh`
+  - Applies the McpServer YAML to trigger auto-discovery
+  - Passes a detailed, scoped prompt to `stigmer draft mcp-server`
+  - Includes the same tempfile + trap pattern as sibling scripts
+- Updated `seedpack/tools/regenerate_all.sh` to include the new script as step 04
+
+## Benefits
+
+- Automated, repeatable approval policy generation for the Stigmer MCP server
+- Strict scoping prevents cross-contamination from other MCP servers
+- Fail-fast behavior avoids hallucinated tool names when discovery data is unavailable
+- Consistent with the agent-fleet pattern, making both repos follow the same conventions
+
+## Impact
+
+- Seedpack maintainers can now run `./tools/04_generate-approval-policy.sh` or `./tools/regenerate_all.sh` to produce approval policies for `mcp-server-stigmer`
+- The `regenerate_all.sh` pipeline now covers all four seedpack generation steps
+
+## Related Work
+
+- Agent-fleet `tools/01_generate-approval-policy.sh` (same pattern for `mcp-server-planton`)
+- Seedpack `tools/03_draft-mcp-server-creator-skill.sh` (sibling script in the pipeline)
+
+---
+
+**Status**: ✅ Production Ready

--- a/seedpack/tools/04_generate-approval-policy.sh
+++ b/seedpack/tools/04_generate-approval-policy.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 04_generate-approval-policy.sh
+# ==============================================================================
+#
+# Applies the mcp-server-stigmer McpServer YAML (triggering auto-discovery of
+# tools and resources), then uses `stigmer draft mcp-server` to generate
+# default_tool_approvals based on the discovered capabilities.
+#
+# Scope: This script operates EXCLUSIVELY on mcp-server-stigmer.
+# It does not query or reference any other MCP server.
+#
+# The mcp-server-creator agent queries the backend for the
+# mcp-server-stigmer discovered tools and determines which operations
+# need human approval based on the nature of each tool. The agent writes
+# the updated YAML directly to seedpack/mcp-servers/mcp-server-stigmer.yaml.
+#
+# Prerequisites:
+#   - stigmer CLI in PATH
+#   - seedpack/mcp-servers/mcp-server-stigmer.yaml exists
+#   - STIGMER_API_KEY configured for discovery to connect to the server
+#
+# Usage:
+#   ./tools/04_generate-approval-policy.sh
+#
+# ==============================================================================
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SEEDPACK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly REPO_ROOT="$(cd "${SEEDPACK_DIR}/.." && pwd)"
+readonly MCP_SERVER_YAML="${SEEDPACK_DIR}/mcp-servers/mcp-server-stigmer.yaml"
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+if ! command -v stigmer &>/dev/null; then
+    echo "ERROR: stigmer CLI not found in PATH"
+    echo "Build it with: make -C client-apps/cli install"
+    exit 1
+fi
+
+if [ ! -f "$MCP_SERVER_YAML" ]; then
+    echo "ERROR: McpServer YAML not found: ${MCP_SERVER_YAML}"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Apply the McpServer (triggers auto-discovery)
+# ---------------------------------------------------------------------------
+
+echo "=== Applying McpServer YAML ==="
+echo "File: ${MCP_SERVER_YAML}"
+echo ""
+
+stigmer apply -f "$MCP_SERVER_YAML"
+
+# ---------------------------------------------------------------------------
+# Generate approval policies from discovered capabilities
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Generating Approval Policies for mcp-server-stigmer ==="
+echo ""
+
+readonly _MSG_FILE="$(mktemp)"
+trap 'rm -f "${_MSG_FILE}"' EXIT
+
+cat > "${_MSG_FILE}" <<'PROMPT'
+Generate an updated mcp-server-stigmer McpServer YAML with default_tool_approvals.
+
+IMPORTANT: Only look at the MCP server named "mcp-server-stigmer".
+Do NOT query, reference, or include details from any other MCP server.
+The only MCP server relevant to this task is mcp-server-stigmer —
+ignore everything else.
+
+If the discovered tools or resources for mcp-server-stigmer cannot be found
+(e.g. the server has not been discovered yet, the backend returns no results,
+or the query fails for any reason), do NOT attempt to find the tools by any
+other means — do not search the workspace, do not guess tool names, do not
+look at other MCP servers' data. Simply reply that you could not find the
+discovered capabilities for mcp-server-stigmer and therefore cannot generate
+the approval policy.
+
+Steps:
+1. Retrieve the discovered tools and resources for the mcp-server-stigmer
+   MCP server from the Stigmer backend.
+2. Classify each tool as read-only (safe) or mutating/destructive (needs approval).
+   Mutating operations include create, update, delete, destroy, apply, lock,
+   unlock, trigger, approve, cancel, upsert, and any action that changes state.
+3. For every mutating or destructive tool, add an entry under
+   spec.default_tool_approvals with:
+     - tool_name: the exact tool name from the discovered capabilities
+     - message: a clear, human-readable sentence describing the action and
+       referencing the relevant arguments using {{args.<field>}} placeholders
+       so reviewers understand what will happen before they approve.
+4. Group the approval entries by domain (e.g. Agent Lifecycle, Skill Management,
+   Workflow Management, MCP Server Configuration, etc.) with YAML comments
+   for readability.
+5. Preserve the existing apiVersion, kind, metadata, and spec fields
+   (description, tags, stdio, env_spec) from the current
+   seedpack/mcp-servers/mcp-server-stigmer.yaml.
+   Replace only the default_tool_approvals section.
+6. Do NOT include the status section in the output.
+
+Write the resulting YAML to seedpack/mcp-servers/mcp-server-stigmer.yaml in the stigmer workspace.
+PROMPT
+
+stigmer draft mcp-server \
+    --workspace "$REPO_ROOT" \
+    -m "$(cat "${_MSG_FILE}")"
+
+echo ""
+echo "=== Generation Complete ==="
+echo "Output: ${MCP_SERVER_YAML}"
+echo ""
+echo "Next steps:"
+echo "  1. Review the updated McpServer YAML with approval policies"
+echo "  2. Apply: stigmer apply -f seedpack/mcp-servers/mcp-server-stigmer.yaml"

--- a/seedpack/tools/regenerate_all.sh
+++ b/seedpack/tools/regenerate_all.sh
@@ -9,6 +9,7 @@
 #   01  Vendor upstream skills (standalone — brings in skill-creator source)
 #   02  Draft agent-creator skill       (uses proto schemas only)
 #   03  Draft mcp-server-creator skill  (uses proto schemas only)
+#   04  Generate mcp-server-stigmer approval policy (uses discovered tools)
 #
 # NOTE: The following agents are hand-maintained and NOT regenerated:
 #   - skill-creator agent        (agents/skill-creator.yaml)
@@ -83,6 +84,7 @@ fi
 
 run_script "${SCRIPT_DIR}/02_draft-agent-creator-skill.sh"
 run_script "${SCRIPT_DIR}/03_draft-mcp-server-creator-skill.sh"
+run_script "${SCRIPT_DIR}/04_generate-approval-policy.sh"
 
 echo ""
 echo "================================================================="


### PR DESCRIPTION
## Summary

Adds a new seedpack tool script (`04_generate-approval-policy.sh`) that generates `default_tool_approvals` for the `mcp-server-stigmer` MCP server by querying its discovered capabilities, and wires it into `regenerate_all.sh`.

## Context

The `mcp-server-stigmer` seedpack YAML had no automated way to produce approval policies for its tools. Without explicit `default_tool_approvals`, destructive or mutating operations could execute without human review. A parallel script already existed in the `agent-fleet` repo for `mcp-server-planton`; this brings the same pattern to the Stigmer seedpack.

## Changes

- Add `seedpack/tools/04_generate-approval-policy.sh` — applies the McpServer YAML, then uses `stigmer draft mcp-server` with a tightly scoped prompt to generate approval entries
- Update `seedpack/tools/regenerate_all.sh` to include step 04 in the pipeline
- Add changelog documenting the new script

## Implementation notes

- The agent prompt is strictly scoped to `mcp-server-stigmer` only — it will not query or reference any other MCP server
- Includes a fail-fast instruction: if discovery returns no results, the agent stops and reports rather than guessing tool names or searching the workspace

## Breaking changes

- None

## Test plan

- Verified script follows the same tempfile + trap pattern as sibling scripts (02, 03)
- Pre-commit checks passed

## Checklist

- [ ] Docs updated (if needed)
- [ ] Tests added/updated (if needed)
- [x] Backward compatible