### PR TITLE
chore(seedpack): update draft scripts model to claude-opus-4.6

### DIFF
--- a/_changelog/2026-03/2026-03-08-101512-update-seedpack-draft-model-to-opus-4-6.md
+++ b/_changelog/2026-03/2026-03-08-101512-update-seedpack-draft-model-to-opus-4-6.md
@@ -1,0 +1,44 @@
+# Update Seedpack Draft Scripts to Claude Opus 4.6
+
+**Date**: March 8, 2026
+
+## Summary
+
+Updated all `stigmer draft` invocations in the seedpack tooling scripts to use `claude-opus-4.6` instead of `claude-sonnet-4.6`. Scripts that were missing the `--model` flag entirely now have it explicitly set.
+
+## Problem Statement
+
+The seedpack draft scripts used `claude-sonnet-4.6` as the model for generating skills and approval policies. With the availability of `claude-opus-4.6`, these scripts needed to be upgraded to use the more capable model for higher quality generation output.
+
+### Pain Points
+
+- Two scripts (`02_draft-agent-creator-skill.sh`, `03_draft-mcp-server-creator-skill.sh`) used `claude-sonnet-4.6` explicitly
+- One script (`04_generate-approval-policy.sh`) had no `--model` flag at all, defaulting to whatever the server chose
+
+## Solution
+
+Updated all three `stigmer draft` invocations in `seedpack/tools/` to use `--model claude-opus-4.6`:
+
+- Changed existing `--model claude-sonnet-4.6` references to `--model claude-opus-4.6`
+- Added `--model claude-opus-4.6` to the approval policy generation script that was missing it
+
+## Implementation Details
+
+Files changed:
+- `seedpack/tools/02_draft-agent-creator-skill.sh` — sonnet → opus
+- `seedpack/tools/03_draft-mcp-server-creator-skill.sh` — sonnet → opus
+- `seedpack/tools/04_generate-approval-policy.sh` — added `--model claude-opus-4.6`
+
+## Benefits
+
+- All seedpack generation scripts now consistently use the same model
+- Every `stigmer draft` call has an explicit `--model` flag, removing reliance on server defaults
+- Higher quality skill and approval policy generation with Opus 4.6
+
+## Impact
+
+Affects seedpack regeneration (`regenerate_all.sh`) — next time skills or approval policies are regenerated, they will use Opus 4.6.
+
+---
+
+**Status**: ✅ Production Ready

--- a/seedpack/mcp-servers/mcp-server-stigmer.yaml
+++ b/seedpack/mcp-servers/mcp-server-stigmer.yaml
@@ -22,3 +22,25 @@ spec:
       STIGMER_API_KEY:
         is_secret: true
         description: "API key for authenticating with stigmer-server (optional for local unauthenticated backends)"
+  default_tool_approvals:
+    # ── Agent Lifecycle ────────────────────────────────────────────────────────
+    - tool_name: apply_agent
+      message: "Create or update agent '{{args.slug}}' in org '{{args.org}}'"
+
+    - tool_name: delete_agent
+      message: "Permanently delete agent '{{args.slug}}' from org '{{args.org}}'"
+
+    # ── Skill Management ───────────────────────────────────────────────────────
+    - tool_name: delete_skill
+      message: "Permanently delete skill '{{args.slug}}' and all its versions from org '{{args.org}}'"
+
+    # ── Workflow Management ────────────────────────────────────────────────────
+    - tool_name: delete_workflow
+      message: "Permanently delete workflow '{{args.slug}}' from org '{{args.org}}'"
+
+    # ── MCP Server Configuration ───────────────────────────────────────────────
+    - tool_name: apply_mcp_server
+      message: "Create or update MCP server '{{args.slug}}' in org '{{args.org}}'"
+
+    - tool_name: delete_mcp_server
+      message: "Permanently delete MCP server '{{args.slug}}' from org '{{args.org}}'"

--- a/seedpack/tools/02_draft-agent-creator-skill.sh
+++ b/seedpack/tools/02_draft-agent-creator-skill.sh
@@ -151,7 +151,7 @@ stigmer draft skill \
   --attach "$WHAT_IS_AGENT_DOC" \
   --output "$SKILLS_DIR" \
   --env "OUTPUT_DIR=seedpack/skills" \
-  --model claude-sonnet-4.6 \
+  --model claude-opus-4.6 \
   -m "$(cat "${_MSG_FILE}")"
 
 readonly GENERATED_DIR="${SKILLS_DIR}/${SKILL_NAME}"

--- a/seedpack/tools/03_draft-mcp-server-creator-skill.sh
+++ b/seedpack/tools/03_draft-mcp-server-creator-skill.sh
@@ -193,7 +193,7 @@ stigmer draft skill \
   --attach "$WHAT_IS_MCP_SERVER_DOC" \
   --output "$SKILLS_DIR" \
   --env "OUTPUT_DIR=seedpack/skills" \
-  --model claude-sonnet-4.6 \
+  --model claude-opus-4.6 \
   -m "$(cat "${_MSG_FILE}")"
 
 readonly GENERATED_DIR="${SKILLS_DIR}/${SKILL_NAME}"

--- a/seedpack/tools/04_generate-approval-policy.sh
+++ b/seedpack/tools/04_generate-approval-policy.sh
@@ -110,6 +110,7 @@ PROMPT
 
 stigmer draft mcp-server \
     --workspace "$REPO_ROOT" \
+    --model claude-opus-4.6 \
     -m "$(cat "${_MSG_FILE}")"
 
 echo ""


### PR DESCRIPTION
## Summary

Updates all `stigmer draft` invocations in the seedpack tooling to use `claude-opus-4.6` and adds default tool approval policies to the mcp-server-stigmer McpServer YAML.

## Context

The seedpack draft scripts were using `claude-sonnet-4.6` or had no explicit `--model` flag. With Opus 4.6 available, all generation scripts should use the more capable model for higher quality output. Additionally, the mcp-server-stigmer YAML was missing `default_tool_approvals` for mutating operations.

## Changes

- Switch `--model claude-sonnet-4.6` → `--model claude-opus-4.6` in `02_draft-agent-creator-skill.sh` and `03_draft-mcp-server-creator-skill.sh`
- Add `--model claude-opus-4.6` to `04_generate-approval-policy.sh` which had no model flag
- Add `default_tool_approvals` section to `mcp-server-stigmer.yaml` covering agent, skill, workflow, and MCP server lifecycle operations

## Breaking changes

None

## Test plan

- Verified all `stigmer draft` calls now have explicit `--model claude-opus-4.6` via grep
- No runtime changes; scripts will use the new model on next execution

## Checklist

- [ ] Docs updated (if needed)
- [ ] Tests added/updated (if needed)
- [x] Backward compatible