### PR TITLE
fix(backend/stigmer-server): extend search index to all searchable resource types

### DIFF
--- a/_changelog/2026-03/2026-03-08-131922-fix-search-index-architecture.md
+++ b/_changelog/2026-03/2026-03-08-131922-fix-search-index-architecture.md
@@ -1,0 +1,87 @@
+# Fix Search Index Architecture: Extend to All Searchable Resource Types
+
+**Date**: March 8, 2026
+
+## Summary
+
+The search index rebuild (`RebuildIndex`) silently aborted when encountering an unhandled resource kind, causing `stigmer list` commands to return empty results after server restart. This change eliminates the brittle `createEmptyProtoForKind` switch statement, extends search indexing to all 13 searchable resource types, and makes the rebuild process resilient to per-kind failures.
+
+## Problem Statement
+
+After running `stigmer server start` followed by `stigmer apply`, the `stigmer list skills` command returned zero results despite skills existing in the database. The root cause was a cascading failure in the search index rebuild pipeline.
+
+### Pain Points
+
+- `RebuildIndex` used a centralized `createEmptyProtoForKind` switch statement that had to be manually kept in sync with new resource types — a parallel mapping that silently drifted.
+- When the `organization` kind was added as searchable (via proto options) but missed from the switch, `RebuildIndex` returned an error and aborted entirely, preventing *all* subsequent kinds (skill, agent, mcp_server, workflow) from being indexed.
+- Only 5 of 13 searchable resource kinds had `SearchableExtractor` implementations, so even with a fix to the switch, the majority of resource types would remain un-indexed.
+- Domain controller pipelines for 8 resource types (project, session, agent_instance, environment, agent_execution, workflow_instance, workflow_execution, execution_context) lacked `IndexSearchStep` / `DeleteSearchIndexStep` wiring, meaning CRUD operations on these resources never updated the search index.
+
+## Solution
+
+A six-phase architectural improvement that eliminates the centralized switch, distributes proto instantiation to each extractor, adds missing extractors, and wires search index maintenance into all CRUD pipelines.
+
+## Implementation Details
+
+### Phase 1 — Eliminate `createEmptyProtoForKind`
+
+Extended the `SearchableExtractor` interface with a `NewEmptyProto() proto.Message` method so each extractor owns its proto instantiation. Updated all 5 existing extractors (agent, skill, mcp_server, workflow, organization) to implement the new method. Removed the `createEmptyProtoForKind` function and its unused proto imports from `sqlite_search_query_store.go`.
+
+### Phase 2 — Resilient `RebuildIndex`
+
+Changed `RebuildIndex` to collect per-kind errors and continue processing remaining kinds instead of aborting entirely. Errors are logged with `zap.Warn` and a summary is returned at the end, ensuring that a failure in one kind (e.g., a corrupt record) doesn't take down the entire index.
+
+### Phase 3 — User-Facing Extractors
+
+Added `SearchableExtractor` implementations for 4 user-facing resource types:
+
+| Kind | Summary Field | Proto |
+|------|--------------|-------|
+| `project` | `spec.description` | `projectv1.Project` |
+| `session` | `spec.subject` | `sessionv1.Session` |
+| `agent_instance` | `spec.description` | `agentinstancev1.AgentInstance` |
+| `environment` | `spec.description` | `environmentv1.Environment` |
+
+### Phase 4 — Operational Extractors
+
+Added `SearchableExtractor` implementations for 4 operational resource types:
+
+| Kind | Summary Field | Proto |
+|------|--------------|-------|
+| `agent_execution` | `metadata.name` | `agentexecutionv1.AgentExecution` |
+| `workflow_instance` | `spec.description` | `workflowinstancev1.WorkflowInstance` |
+| `workflow_execution` | (empty) | `workflowexecutionv1.WorkflowExecution` |
+| `execution_context` | (empty) | `executioncontextv1.ExecutionContext` |
+
+### Phase 5 — Registry Validation
+
+Updated `ValidateExpectedKinds` in `SearchableResourceRegistry` to include all 13 searchable kinds, ensuring the startup-time validation catches any missing extractors in the future.
+
+### Phase 6 — Pipeline Wiring
+
+Wired `IndexSearchStep` into create/update pipelines and `DeleteSearchIndexStep` into delete pipelines for all 8 newly indexed resource types across their respective domain controllers.
+
+## Benefits
+
+- **Correctness**: `stigmer list` commands now return all resources of every searchable kind after server restart.
+- **Resilience**: A bad record in one resource kind no longer prevents indexing of all other kinds.
+- **Maintainability**: Adding a new searchable kind requires only implementing one `SearchableExtractor` — no central switch to update.
+- **Completeness**: All 13 proto-declared searchable kinds are now indexed and maintained through CRUD operations.
+- **Safety net**: `ValidateExpectedKinds` at startup catches missing extractors before they can cause silent data loss.
+
+## Impact
+
+- **All `stigmer list` and `stigmer search` commands** are now backed by a complete, self-healing search index.
+- **Server restart** no longer causes list commands to silently return empty results.
+- **Future resource types** only need to implement the `SearchableExtractor` interface and register via `init()` — no other files need modification.
+- **Files changed**: 41 files (8 new extractor files, 5 modified extractors, 1 interface change, 1 store rewrite, 2 test updates, 24 domain controller pipeline updates).
+
+## Related Work
+
+- Seedpack bootstrap flow relies on the search index being correct after `RebuildIndex` — this fix ensures seedpack resources are discoverable.
+- Organization tenancy migration (2026-03-03) introduced the `organization` kind that triggered the original failure.
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~3 hours (investigation, architecture, implementation, testing)

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/agent"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/agentinstance"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/session"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 	"google.golang.org/grpc/codes"
 )
 
@@ -79,8 +80,9 @@ func (c *AgentExecutionController) buildCreatePipeline() *pipeline.Pipeline[*age
 		AddStep(newSetInitialPhaseStep()).                                                            // 7. Set phase to PENDING
 		AddStep(c.newCreateExecutionContextStep()).                                                   // 8. Create ExecutionContext with merged environment
 		AddStep(c.newProcessAttachmentsStep()).                                                       // 9. Process attachments (upload large files to storage)
-		AddStep(steps.NewPersistStep[*agentexecutionv1.AgentExecution](c.store)).                     // 9. Persist execution
-		AddStep(c.newStartWorkflowStep()).                                                            // 10. Start Temporal workflow
+		AddStep(steps.NewPersistStep[*agentexecutionv1.AgentExecution](c.store)).                                                 // 9. Persist execution
+		AddStep(steps.NewIndexSearchStep[*agentexecutionv1.AgentExecution](c.store, &extractor.AgentExecutionExtractor{})). // 10. Update search index
+		AddStep(c.newStartWorkflowStep()).                                                                                    // 11. Start Temporal workflow
 		Build()
 }
 

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/delete.go
@@ -41,6 +41,7 @@ func (c *AgentExecutionController) buildDeletePipeline() *pipeline.Pipeline[*api
 		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceId]()).                                                  // 1. Validate input
 		AddStep(steps.NewExtractResourceIdStep[*apiresource.ApiResourceId]()).                                              // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*apiresource.ApiResourceId, *agentexecutionv1.AgentExecution](c.store)). // 3. Load existing
-		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceId](c.store)).                                          // 4. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceId](c.store)).        // 4. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*apiresource.ApiResourceId](c.store)). // 5. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/update.go
@@ -6,6 +6,7 @@ import (
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing agent execution using the pipeline framework
@@ -44,6 +45,7 @@ func (c *AgentExecutionController) buildUpdatePipeline() *pipeline.Pipeline[*age
 		AddStep(steps.NewLoadExistingStep[*agentexecutionv1.AgentExecution](c.store)). // 3. Load existing
 		AddStep(steps.NewBuildUpdateStateStep[*agentexecutionv1.AgentExecution]()).    // 4. Build updated state
 		AddStep(steps.NewNormalizeReferencesStep[*agentexecutionv1.AgentExecution]()). // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*agentexecutionv1.AgentExecution](c.store)).      // 6. Persist
+		AddStep(steps.NewPersistStep[*agentexecutionv1.AgentExecution](c.store)).                                                 // 6. Persist
+		AddStep(steps.NewIndexSearchStep[*agentexecutionv1.AgentExecution](c.store, &extractor.AgentExecutionExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/activities/execute_graphton.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/activities/execute_graphton.go
@@ -20,13 +20,17 @@ import (
 //
 // Slim-Payload Pattern (Input + Output):
 // Input:  The activity receives only an executionID (not the full AgentExecution
-//         proto) and hydrates it from the database.
+//
+//	proto) and hydrates it from the database.
+//
 // Output: The activity returns a slim AgentExecutionStatus containing only
-//         workflow-critical fields: phase, pending_approvals, error, usage,
-//         started_at, and completed_at.  Heavy fields (messages, tool_calls,
-//         sub_agent_executions, todos, artifacts, context_info) are omitted
-//         because they are already persisted to the database via progressive
-//         gRPC updates during execution.
+//
+//	workflow-critical fields: phase, pending_approvals, error, usage,
+//	started_at, and completed_at.  Heavy fields (messages, tool_calls,
+//	sub_agent_executions, todos, artifacts, context_info) are omitted
+//	because they are already persisted to the database via progressive
+//	gRPC updates during execution.
+//
 // This keeps both input and output payloads well under Temporal's ~2 MB limit.
 //
 // Polyglot Pattern:

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/controller/create.go
@@ -6,6 +6,7 @@ import (
 	agentinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentinstance/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Create creates a new agent instance using the pipeline framework
@@ -38,6 +39,7 @@ func (c *AgentInstanceController) buildCreatePipeline() *pipeline.Pipeline[*agen
 		AddStep(steps.NewCheckDuplicateStep[*agentinstancev1.AgentInstance](c.store)). // 3. Check duplicate
 		AddStep(steps.NewBuildNewStateStep[*agentinstancev1.AgentInstance]()).         // 4. Build new state
 		AddStep(steps.NewNormalizeReferencesStep[*agentinstancev1.AgentInstance]()).   // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*agentinstancev1.AgentInstance](c.store)).        // 6. Persist agent instance
+		AddStep(steps.NewPersistStep[*agentinstancev1.AgentInstance](c.store)).                                             // 6. Persist agent instance
+		AddStep(steps.NewIndexSearchStep[*agentinstancev1.AgentInstance](c.store, &extractor.AgentInstanceExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/controller/delete.go
@@ -54,6 +54,7 @@ func (c *AgentInstanceController) buildDeletePipeline() *pipeline.Pipeline[*agen
 		AddStep(steps.NewValidateProtoStep[*agentinstancev1.AgentInstanceId]()).                                                // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*agentinstancev1.AgentInstanceId]()).                                            // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*agentinstancev1.AgentInstanceId, *agentinstancev1.AgentInstance](c.store)). // 3. Load instance
-		AddStep(steps.NewDeleteResourceStep[*agentinstancev1.AgentInstanceId](c.store)).                                        // 4. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*agentinstancev1.AgentInstanceId](c.store)).        // 4. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*agentinstancev1.AgentInstanceId](c.store)). // 5. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/controller/update.go
@@ -6,6 +6,7 @@ import (
 	agentinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentinstance/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing agent instance using the pipeline framework
@@ -43,6 +44,7 @@ func (c *AgentInstanceController) buildUpdatePipeline() *pipeline.Pipeline[*agen
 		AddStep(steps.NewLoadExistingStep[*agentinstancev1.AgentInstance](c.store)). // 3. Load existing instance
 		AddStep(steps.NewBuildUpdateStateStep[*agentinstancev1.AgentInstance]()).    // 4. Build updated state
 		AddStep(steps.NewNormalizeReferencesStep[*agentinstancev1.AgentInstance]()). // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*agentinstancev1.AgentInstance](c.store)).      // 6. Persist instance
+		AddStep(steps.NewPersistStep[*agentinstancev1.AgentInstance](c.store)).                                             // 6. Persist instance
+		AddStep(steps.NewIndexSearchStep[*agentinstancev1.AgentInstance](c.store, &extractor.AgentInstanceExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
@@ -6,6 +6,7 @@ import (
 	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Create creates a new environment using the pipeline framework
@@ -43,6 +44,7 @@ func (c *EnvironmentController) buildCreatePipeline() *pipeline.Pipeline[*enviro
 		AddStep(steps.NewResolveSlugStep[*environmentv1.Environment]()).           // 2. Resolve slug
 		AddStep(steps.NewCheckDuplicateStep[*environmentv1.Environment](c.store)). // 3. Check duplicate
 		AddStep(steps.NewBuildNewStateStep[*environmentv1.Environment]()).         // 4. Build new state
-		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).        // 5. Persist environment
+		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                             // 5. Persist environment
+		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 6. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/delete.go
@@ -54,6 +54,7 @@ func (c *EnvironmentController) buildDeletePipeline() *pipeline.Pipeline[*apires
 	return pipeline.NewPipeline[*apiresource.ApiResourceDeleteInput]("environment-delete").
 		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceDeleteInput]()).                                            // 1. Validate field constraints
 		AddStep(steps.NewLoadExistingForDeleteStep[*apiresource.ApiResourceDeleteInput, *environmentv1.Environment](c.store)). // 2. Load environment
-		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceDeleteInput](c.store)).                                    // 3. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceDeleteInput](c.store)).        // 3. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*apiresource.ApiResourceDeleteInput](c.store)). // 4. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/update.go
@@ -6,6 +6,7 @@ import (
 	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing environment using the pipeline framework
@@ -43,6 +44,7 @@ func (c *EnvironmentController) buildUpdatePipeline() *pipeline.Pipeline[*enviro
 		AddStep(steps.NewLoadExistingStep[*environmentv1.Environment](c.store)). // 3. Load existing environment
 		AddStep(steps.NewBuildUpdateStateStep[*environmentv1.Environment]()).    // 4. Build updated state
 		AddStep(steps.NewNormalizeReferencesStep[*environmentv1.Environment]()). // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).      // 6. Persist environment
+		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                             // 6. Persist environment
+		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/executioncontext/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/executioncontext/controller/create.go
@@ -6,6 +6,7 @@ import (
 	executioncontextv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/executioncontext/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Create creates a new execution context using the pipeline framework
@@ -50,6 +51,7 @@ func (c *ExecutionContextController) buildCreatePipeline() *pipeline.Pipeline[*e
 		AddStep(steps.NewCheckDuplicateStep[*executioncontextv1.ExecutionContext](c.store)). // 3. Check duplicate
 		AddStep(steps.NewBuildNewStateStep[*executioncontextv1.ExecutionContext]()).         // 4. Build new state
 		AddStep(steps.NewNormalizeReferencesStep[*executioncontextv1.ExecutionContext]()).   // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*executioncontextv1.ExecutionContext](c.store)).        // 6. Persist
+		AddStep(steps.NewPersistStep[*executioncontextv1.ExecutionContext](c.store)).                                                     // 6. Persist
+		AddStep(steps.NewIndexSearchStep[*executioncontextv1.ExecutionContext](c.store, &extractor.ExecutionContextExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/executioncontext/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/executioncontext/controller/delete.go
@@ -59,6 +59,7 @@ func (c *ExecutionContextController) buildDeletePipeline() *pipeline.Pipeline[*a
 	return pipeline.NewPipeline[*apiresource.ApiResourceDeleteInput]("execution-context-delete").
 		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceDeleteInput]()).                                                      // 1. Validate field constraints
 		AddStep(steps.NewLoadExistingForDeleteStep[*apiresource.ApiResourceDeleteInput, *executioncontextv1.ExecutionContext](c.store)). // 2. Load execution context
-		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceDeleteInput](c.store)).                                              // 3. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceDeleteInput](c.store)).        // 3. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*apiresource.ApiResourceDeleteInput](c.store)). // 4. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/project/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/project/controller/create.go
@@ -6,6 +6,7 @@ import (
 	projectv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/tenancy/project/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Create creates a new project using the pipeline framework.
@@ -56,6 +57,7 @@ func (c *ProjectController) buildCreatePipeline() *pipeline.Pipeline[*projectv1.
 		AddStep(steps.NewCheckDuplicateStep[*projectv1.Project](c.store)). // 3. Check duplicate
 		AddStep(steps.NewBuildNewStateStep[*projectv1.Project]()).         // 4. Build new state
 		AddStep(steps.NewNormalizeReferencesStep[*projectv1.Project]()).   // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*projectv1.Project](c.store)).        // 6. Persist project
+		AddStep(steps.NewPersistStep[*projectv1.Project](c.store)).                                     // 6. Persist project
+		AddStep(steps.NewIndexSearchStep[*projectv1.Project](c.store, &extractor.ProjectExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/project/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/project/controller/delete.go
@@ -61,6 +61,7 @@ func (c *ProjectController) buildDeletePipeline() *pipeline.Pipeline[*projectv1.
 		AddStep(steps.NewValidateProtoStep[*projectv1.ProjectId]()).                                    // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*projectv1.ProjectId]()).                                // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*projectv1.ProjectId, *projectv1.Project](c.store)). // 3. Load project
-		AddStep(steps.NewDeleteResourceStep[*projectv1.ProjectId](c.store)).                            // 4. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*projectv1.ProjectId](c.store)).        // 4. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*projectv1.ProjectId](c.store)). // 5. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/project/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/project/controller/update.go
@@ -6,6 +6,7 @@ import (
 	projectv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/tenancy/project/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing project using the pipeline framework.
@@ -56,6 +57,7 @@ func (c *ProjectController) buildUpdatePipeline() *pipeline.Pipeline[*projectv1.
 		AddStep(steps.NewResolveSlugStep[*projectv1.Project]()).         // 2. Resolve slug
 		AddStep(steps.NewLoadExistingStep[*projectv1.Project](c.store)). // 3. Load existing project
 		AddStep(steps.NewBuildUpdateStateStep[*projectv1.Project]()).    // 4. Build updated state
-		AddStep(steps.NewPersistStep[*projectv1.Project](c.store)).      // 5. Persist project
+		AddStep(steps.NewPersistStep[*projectv1.Project](c.store)).                                     // 5. Persist project
+		AddStep(steps.NewIndexSearchStep[*projectv1.Project](c.store, &extractor.ProjectExtractor{})). // 6. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/session/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/create.go
@@ -6,6 +6,7 @@ import (
 	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Create creates a new session using the pipeline framework
@@ -49,6 +50,7 @@ func (c *SessionController) buildCreatePipeline() *pipeline.Pipeline[*sessionv1.
 		AddStep(steps.NewCheckDuplicateStep[*sessionv1.Session](c.store)). // 3. Check duplicate
 		AddStep(steps.NewBuildNewStateStep[*sessionv1.Session]()).         // 4. Build new state
 		AddStep(steps.NewNormalizeReferencesStep[*sessionv1.Session]()).   // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*sessionv1.Session](c.store)).        // 6. Persist session
+		AddStep(steps.NewPersistStep[*sessionv1.Session](c.store)).                                     // 6. Persist session
+		AddStep(steps.NewIndexSearchStep[*sessionv1.Session](c.store, &extractor.SessionExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/session/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/delete.go
@@ -54,6 +54,7 @@ func (c *SessionController) buildDeletePipeline() *pipeline.Pipeline[*sessionv1.
 		AddStep(steps.NewValidateProtoStep[*sessionv1.SessionId]()).                                    // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*sessionv1.SessionId]()).                                // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*sessionv1.SessionId, *sessionv1.Session](c.store)). // 3. Load session
-		AddStep(steps.NewDeleteResourceStep[*sessionv1.SessionId](c.store)).                            // 4. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*sessionv1.SessionId](c.store)).        // 4. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*sessionv1.SessionId](c.store)). // 5. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/session/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/update.go
@@ -6,6 +6,7 @@ import (
 	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing session using the pipeline framework
@@ -42,6 +43,7 @@ func (c *SessionController) buildUpdatePipeline() *pipeline.Pipeline[*sessionv1.
 		AddStep(steps.NewResolveSlugStep[*sessionv1.Session]()).         // 2. Resolve slug
 		AddStep(steps.NewLoadExistingStep[*sessionv1.Session](c.store)). // 3. Load existing session
 		AddStep(steps.NewBuildUpdateStateStep[*sessionv1.Session]()).    // 4. Build updated state
-		AddStep(steps.NewPersistStep[*sessionv1.Session](c.store)).      // 5. Persist session
+		AddStep(steps.NewPersistStep[*sessionv1.Session](c.store)).                                     // 5. Persist session
+		AddStep(steps.NewIndexSearchStep[*sessionv1.Session](c.store, &extractor.SessionExtractor{})). // 6. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflowinstance"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -74,8 +75,9 @@ func (c *WorkflowExecutionController) buildCreatePipeline() *pipeline.Pipeline[*
 		AddStep(steps.NewNormalizeReferencesStep[*workflowexecutionv1.WorkflowExecution]()).   // 7. Normalize cross-references
 		AddStep(newSetInitialPhaseStep()).                                                     // 8. Set phase to PENDING
 		AddStep(c.newCreateExecutionContextStep()).                                            // 9. Create ExecutionContext with merged environment
-		AddStep(steps.NewPersistStep[*workflowexecutionv1.WorkflowExecution](c.store)).        // 10. Persist execution
-		AddStep(c.newStartWorkflowStep()).                                                     // 9. Start Temporal workflow
+		AddStep(steps.NewPersistStep[*workflowexecutionv1.WorkflowExecution](c.store)).                                                     // 10. Persist execution
+		AddStep(steps.NewIndexSearchStep[*workflowexecutionv1.WorkflowExecution](c.store, &extractor.WorkflowExecutionExtractor{})). // 11. Update search index
+		AddStep(c.newStartWorkflowStep()).                                                                                             // 12. Start Temporal workflow
 		Build()
 }
 

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/delete.go
@@ -55,6 +55,7 @@ func (c *WorkflowExecutionController) buildDeletePipeline() *pipeline.Pipeline[*
 		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceId]()).                                                        // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*apiresource.ApiResourceId]()).                                                    // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*apiresource.ApiResourceId, *workflowexecutionv1.WorkflowExecution](c.store)). // 3. Load execution
-		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceId](c.store)).                                                // 4. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*apiresource.ApiResourceId](c.store)).        // 4. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*apiresource.ApiResourceId](c.store)). // 5. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/update.go
@@ -6,6 +6,7 @@ import (
 	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing workflow execution using the pipeline framework
@@ -46,6 +47,7 @@ func (c *WorkflowExecutionController) buildUpdatePipeline() *pipeline.Pipeline[*
 		AddStep(steps.NewLoadExistingStep[*workflowexecutionv1.WorkflowExecution](c.store)). // 3. Load existing execution
 		AddStep(steps.NewBuildUpdateStateStep[*workflowexecutionv1.WorkflowExecution]()).    // 4. Build updated state
 		AddStep(steps.NewNormalizeReferencesStep[*workflowexecutionv1.WorkflowExecution]()). // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*workflowexecutionv1.WorkflowExecution](c.store)).      // 6. Persist execution
+		AddStep(steps.NewPersistStep[*workflowexecutionv1.WorkflowExecution](c.store)).                                                     // 6. Persist execution
+		AddStep(steps.NewIndexSearchStep[*workflowexecutionv1.WorkflowExecution](c.store, &extractor.WorkflowExecutionExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflow"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Context keys for inter-step communication
@@ -67,7 +68,8 @@ func (c *WorkflowInstanceController) buildCreatePipeline() *pipeline.Pipeline[*w
 		AddStep(steps.NewCheckDuplicateStep[*workflowinstancev1.WorkflowInstance](c.store)). // 5. Check duplicate
 		AddStep(steps.NewBuildNewStateStep[*workflowinstancev1.WorkflowInstance]()).         // 6. Build new state
 		AddStep(steps.NewNormalizeReferencesStep[*workflowinstancev1.WorkflowInstance]()).   // 7. Normalize cross-references
-		AddStep(steps.NewPersistStep[*workflowinstancev1.WorkflowInstance](c.store)).        // 8. Persist workflow instance
+		AddStep(steps.NewPersistStep[*workflowinstancev1.WorkflowInstance](c.store)).                                                 // 8. Persist workflow instance
+		AddStep(steps.NewIndexSearchStep[*workflowinstancev1.WorkflowInstance](c.store, &extractor.WorkflowInstanceExtractor{})). // 9. Update search index
 		Build()
 }
 

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/delete.go
@@ -35,6 +35,7 @@ func (c *WorkflowInstanceController) buildDeletePipeline() *pipeline.Pipeline[*w
 		AddStep(steps.NewValidateProtoStep[*workflowinstancev1.WorkflowInstanceId]()).                                                      // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*workflowinstancev1.WorkflowInstanceId]()).                                                  // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*workflowinstancev1.WorkflowInstanceId, *workflowinstancev1.WorkflowInstance](c.store)). // 3. Load workflow instance
-		AddStep(steps.NewDeleteResourceStep[*workflowinstancev1.WorkflowInstanceId](c.store)).                                              // 4. Delete from database
+		AddStep(steps.NewDeleteResourceStep[*workflowinstancev1.WorkflowInstanceId](c.store)).        // 4. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*workflowinstancev1.WorkflowInstanceId](c.store)). // 5. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/update.go
@@ -6,6 +6,7 @@ import (
 	workflowinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
 
 // Update updates an existing workflow instance using the pipeline framework
@@ -36,6 +37,7 @@ func (c *WorkflowInstanceController) buildUpdatePipeline() *pipeline.Pipeline[*w
 		AddStep(steps.NewLoadExistingStep[*workflowinstancev1.WorkflowInstance](c.store)). // 3. Load existing instance
 		AddStep(steps.NewBuildUpdateStateStep[*workflowinstancev1.WorkflowInstance]()).    // 4. Build updated state (merge spec, preserve status, update audit)
 		AddStep(steps.NewNormalizeReferencesStep[*workflowinstancev1.WorkflowInstance]()). // 5. Normalize cross-references
-		AddStep(steps.NewPersistStep[*workflowinstancev1.WorkflowInstance](c.store)).      // 6. Persist workflow instance
+		AddStep(steps.NewPersistStep[*workflowinstancev1.WorkflowInstance](c.store)).                                                 // 6. Persist workflow instance
+		AddStep(steps.NewIndexSearchStep[*workflowinstancev1.WorkflowInstance](c.store, &extractor.WorkflowInstanceExtractor{})). // 7. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/query/search/extractor/agent_execution_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/agent_execution_extractor.go
@@ -1,0 +1,113 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// AgentExecutionExtractor extracts searchable data from AgentExecution resources.
+//
+// Agent executions are individual invocation records. They have no description
+// field, so the summary is the resource name.
+type AgentExecutionExtractor struct{}
+
+var _ SearchableExtractor = (*AgentExecutionExtractor)(nil)
+
+func init() {
+	Register(&AgentExecutionExtractor{})
+}
+
+func (e *AgentExecutionExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_agent_execution
+}
+
+func (e *AgentExecutionExtractor) NewEmptyProto() proto.Message {
+	return &agentexecutionv1.AgentExecution{}
+}
+
+func (e *AgentExecutionExtractor) GetSearchSummary(resource proto.Message) string {
+	exec, ok := resource.(*agentexecutionv1.AgentExecution)
+	if !ok || exec.GetMetadata() == nil {
+		return ""
+	}
+	return exec.GetMetadata().GetName()
+}
+
+func (e *AgentExecutionExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	exec, ok := resource.(*agentexecutionv1.AgentExecution)
+	if !ok {
+		return nil
+	}
+
+	meta := exec.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_agent_execution,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Description:   "",
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := exec.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *AgentExecutionExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	exec, ok := resource.(*agentexecutionv1.AgentExecution)
+	if !ok {
+		return nil
+	}
+
+	meta := exec.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:       meta.GetName(),
+		Tags:       JoinTags(meta.GetTags()),
+		Org:        meta.GetOrg(),
+		Visibility: meta.GetVisibility().String(),
+	}
+
+	if audit := exec.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/agent_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/agent_extractor.go
@@ -30,6 +30,11 @@ func (e *AgentExtractor) Kind() apiresourcekind.ApiResourceKind {
 	return apiresourcekind.ApiResourceKind_agent
 }
 
+// NewEmptyProto returns a new zero-value Agent proto.
+func (e *AgentExtractor) NewEmptyProto() proto.Message {
+	return &agentv1.Agent{}
+}
+
 // GetSearchSummary extracts the display summary for search results.
 // Returns spec.description if available, otherwise spec.instructions.
 func (e *AgentExtractor) GetSearchSummary(resource proto.Message) string {

--- a/backend/services/stigmer-server/pkg/query/search/extractor/agent_instance_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/agent_instance_extractor.go
@@ -1,0 +1,114 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	agentinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentinstance/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// AgentInstanceExtractor extracts searchable data from AgentInstance resources.
+//
+// Agent instances are running incarnations of an agent definition, bound to a
+// specific configuration and MCP server set. The summary uses spec.description.
+type AgentInstanceExtractor struct{}
+
+var _ SearchableExtractor = (*AgentInstanceExtractor)(nil)
+
+func init() {
+	Register(&AgentInstanceExtractor{})
+}
+
+func (e *AgentInstanceExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_agent_instance
+}
+
+func (e *AgentInstanceExtractor) NewEmptyProto() proto.Message {
+	return &agentinstancev1.AgentInstance{}
+}
+
+func (e *AgentInstanceExtractor) GetSearchSummary(resource proto.Message) string {
+	ai, ok := resource.(*agentinstancev1.AgentInstance)
+	if !ok || ai.GetSpec() == nil {
+		return ""
+	}
+	return ai.GetSpec().GetDescription()
+}
+
+func (e *AgentInstanceExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	ai, ok := resource.(*agentinstancev1.AgentInstance)
+	if !ok {
+		return nil
+	}
+
+	meta := ai.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_agent_instance,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Description:   e.GetSearchSummary(resource),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := ai.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *AgentInstanceExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	ai, ok := resource.(*agentinstancev1.AgentInstance)
+	if !ok {
+		return nil
+	}
+
+	meta := ai.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:        meta.GetName(),
+		Description: e.GetSearchSummary(resource),
+		Tags:        JoinTags(meta.GetTags()),
+		Org:         meta.GetOrg(),
+		Visibility:  meta.GetVisibility().String(),
+	}
+
+	if audit := ai.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/environment_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/environment_extractor.go
@@ -1,0 +1,114 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// EnvironmentExtractor extracts searchable data from Environment resources.
+//
+// Environments provide variable bindings and configuration context for agent
+// executions. The summary uses spec.description.
+type EnvironmentExtractor struct{}
+
+var _ SearchableExtractor = (*EnvironmentExtractor)(nil)
+
+func init() {
+	Register(&EnvironmentExtractor{})
+}
+
+func (e *EnvironmentExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_environment
+}
+
+func (e *EnvironmentExtractor) NewEmptyProto() proto.Message {
+	return &environmentv1.Environment{}
+}
+
+func (e *EnvironmentExtractor) GetSearchSummary(resource proto.Message) string {
+	env, ok := resource.(*environmentv1.Environment)
+	if !ok || env.GetSpec() == nil {
+		return ""
+	}
+	return env.GetSpec().GetDescription()
+}
+
+func (e *EnvironmentExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	env, ok := resource.(*environmentv1.Environment)
+	if !ok {
+		return nil
+	}
+
+	meta := env.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_environment,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Description:   e.GetSearchSummary(resource),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := env.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *EnvironmentExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	env, ok := resource.(*environmentv1.Environment)
+	if !ok {
+		return nil
+	}
+
+	meta := env.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:        meta.GetName(),
+		Description: e.GetSearchSummary(resource),
+		Tags:        JoinTags(meta.GetTags()),
+		Org:         meta.GetOrg(),
+		Visibility:  meta.GetVisibility().String(),
+	}
+
+	if audit := env.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/execution_context_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/execution_context_extractor.go
@@ -1,0 +1,108 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	executioncontextv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/executioncontext/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// ExecutionContextExtractor extracts searchable data from ExecutionContext resources.
+//
+// Execution contexts hold ephemeral state for agent/workflow executions. They
+// have no description field, so the summary is empty.
+type ExecutionContextExtractor struct{}
+
+var _ SearchableExtractor = (*ExecutionContextExtractor)(nil)
+
+func init() {
+	Register(&ExecutionContextExtractor{})
+}
+
+func (e *ExecutionContextExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_execution_context
+}
+
+func (e *ExecutionContextExtractor) NewEmptyProto() proto.Message {
+	return &executioncontextv1.ExecutionContext{}
+}
+
+func (e *ExecutionContextExtractor) GetSearchSummary(resource proto.Message) string {
+	return ""
+}
+
+func (e *ExecutionContextExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	ec, ok := resource.(*executioncontextv1.ExecutionContext)
+	if !ok {
+		return nil
+	}
+
+	meta := ec.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_execution_context,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := ec.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *ExecutionContextExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	ec, ok := resource.(*executioncontextv1.ExecutionContext)
+	if !ok {
+		return nil
+	}
+
+	meta := ec.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:       meta.GetName(),
+		Tags:       JoinTags(meta.GetTags()),
+		Org:        meta.GetOrg(),
+		Visibility: meta.GetVisibility().String(),
+	}
+
+	if audit := ec.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/extractor.go
@@ -39,22 +39,23 @@ import (
 // extractors that know how to extract relevant data from each resource type's
 // specific structure.
 //
-// Each searchable resource kind (agent, skill, mcp_server, workflow) has a
-// corresponding extractor implementation registered with the SearchableResourceRegistry.
+// Each searchable resource kind has a corresponding extractor implementation
+// registered with the SearchableResourceRegistry.
 type SearchableExtractor interface {
 	// Kind returns the API resource kind this extractor handles.
 	// This is used by SearchableResourceRegistry to map resource kinds to extractors.
 	// Each kind should have exactly one extractor.
 	Kind() apiresourcekind.ApiResourceKind
 
+	// NewEmptyProto returns a new zero-value protobuf message of the type this
+	// extractor handles. Used by RebuildIndex to unmarshal resources from the
+	// store without maintaining a separate kind-to-proto mapping.
+	NewEmptyProto() proto.Message
+
 	// GetSearchSummary extracts the display summary for search results.
 	//
 	// This is the description shown in search result listings. The source
-	// field varies by resource type:
-	//   - Agent: spec.description (or spec.instructions as fallback)
-	//   - Skill: spec.description
-	//   - McpServer: spec.description
-	//   - Workflow: spec.description
+	// field varies by resource type (e.g., spec.description, spec.subject).
 	//
 	// Note: Truncation for display is a presentation concern handled by the
 	// CLI or UI, not here. Return the full description.

--- a/backend/services/stigmer-server/pkg/query/search/extractor/mcpserver_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/mcpserver_extractor.go
@@ -29,6 +29,11 @@ func (e *McpServerExtractor) Kind() apiresourcekind.ApiResourceKind {
 	return apiresourcekind.ApiResourceKind_mcp_server
 }
 
+// NewEmptyProto returns a new zero-value McpServer proto.
+func (e *McpServerExtractor) NewEmptyProto() proto.Message {
+	return &mcpserverv1.McpServer{}
+}
+
 // GetSearchSummary extracts the display summary for search results.
 // Returns spec.description.
 func (e *McpServerExtractor) GetSearchSummary(resource proto.Message) string {

--- a/backend/services/stigmer-server/pkg/query/search/extractor/organization_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/organization_extractor.go
@@ -27,6 +27,11 @@ func (e *OrganizationExtractor) Kind() apiresourcekind.ApiResourceKind {
 	return apiresourcekind.ApiResourceKind_organization
 }
 
+// NewEmptyProto returns a new zero-value Organization proto.
+func (e *OrganizationExtractor) NewEmptyProto() proto.Message {
+	return &organizationv1.Organization{}
+}
+
 // GetSearchSummary extracts the display summary for search results.
 // Returns spec.description.
 func (e *OrganizationExtractor) GetSearchSummary(resource proto.Message) string {

--- a/backend/services/stigmer-server/pkg/query/search/extractor/project_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/project_extractor.go
@@ -1,0 +1,114 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	projectv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/tenancy/project/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// ProjectExtractor extracts searchable data from Project resources.
+//
+// Projects are declarative groupings of agents, skills, MCP servers, and
+// workflows. The search summary uses spec.description.
+type ProjectExtractor struct{}
+
+var _ SearchableExtractor = (*ProjectExtractor)(nil)
+
+func init() {
+	Register(&ProjectExtractor{})
+}
+
+func (e *ProjectExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_project
+}
+
+func (e *ProjectExtractor) NewEmptyProto() proto.Message {
+	return &projectv1.Project{}
+}
+
+func (e *ProjectExtractor) GetSearchSummary(resource proto.Message) string {
+	project, ok := resource.(*projectv1.Project)
+	if !ok || project.GetSpec() == nil {
+		return ""
+	}
+	return project.GetSpec().GetDescription()
+}
+
+func (e *ProjectExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	project, ok := resource.(*projectv1.Project)
+	if !ok {
+		return nil
+	}
+
+	meta := project.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_project,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Description:   e.GetSearchSummary(resource),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := project.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *ProjectExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	project, ok := resource.(*projectv1.Project)
+	if !ok {
+		return nil
+	}
+
+	meta := project.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:        meta.GetName(),
+		Description: e.GetSearchSummary(resource),
+		Tags:        JoinTags(meta.GetTags()),
+		Org:         meta.GetOrg(),
+		Visibility:  meta.GetVisibility().String(),
+	}
+
+	if audit := project.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/registry.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/registry.go
@@ -148,11 +148,21 @@ func (r *SearchableResourceRegistry) ValidateExpectedKinds() {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	// All resource kinds with not_search_indexed: false in the proto enum.
 	expectedKinds := []apiresourcekind.ApiResourceKind{
+		apiresourcekind.ApiResourceKind_organization,
 		apiresourcekind.ApiResourceKind_agent,
+		apiresourcekind.ApiResourceKind_agent_execution,
+		apiresourcekind.ApiResourceKind_session,
 		apiresourcekind.ApiResourceKind_skill,
 		apiresourcekind.ApiResourceKind_mcp_server,
+		apiresourcekind.ApiResourceKind_agent_instance,
 		apiresourcekind.ApiResourceKind_workflow,
+		apiresourcekind.ApiResourceKind_workflow_instance,
+		apiresourcekind.ApiResourceKind_workflow_execution,
+		apiresourcekind.ApiResourceKind_environment,
+		apiresourcekind.ApiResourceKind_execution_context,
+		apiresourcekind.ApiResourceKind_project,
 	}
 
 	var missing []string

--- a/backend/services/stigmer-server/pkg/query/search/extractor/registry_test.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/registry_test.go
@@ -19,6 +19,10 @@ func (m *mockExtractor) Kind() apiresourcekind.ApiResourceKind {
 	return m.kind
 }
 
+func (m *mockExtractor) NewEmptyProto() proto.Message {
+	return nil
+}
+
 func (m *mockExtractor) GetSearchSummary(resource proto.Message) string {
 	return "mock summary"
 }
@@ -160,11 +164,24 @@ func TestSearchableResourceRegistry_Size(t *testing.T) {
 func TestSearchableResourceRegistry_ValidateExpectedKinds_AllPresent(t *testing.T) {
 	registry := newTestRegistry()
 
-	// Register all expected kinds
-	registry.extractors[apiresourcekind.ApiResourceKind_agent] = &mockExtractor{kind: apiresourcekind.ApiResourceKind_agent}
-	registry.extractors[apiresourcekind.ApiResourceKind_skill] = &mockExtractor{kind: apiresourcekind.ApiResourceKind_skill}
-	registry.extractors[apiresourcekind.ApiResourceKind_mcp_server] = &mockExtractor{kind: apiresourcekind.ApiResourceKind_mcp_server}
-	registry.extractors[apiresourcekind.ApiResourceKind_workflow] = &mockExtractor{kind: apiresourcekind.ApiResourceKind_workflow}
+	// Register all expected kinds (matching not_search_indexed: false in proto)
+	for _, kind := range []apiresourcekind.ApiResourceKind{
+		apiresourcekind.ApiResourceKind_organization,
+		apiresourcekind.ApiResourceKind_agent,
+		apiresourcekind.ApiResourceKind_agent_execution,
+		apiresourcekind.ApiResourceKind_session,
+		apiresourcekind.ApiResourceKind_skill,
+		apiresourcekind.ApiResourceKind_mcp_server,
+		apiresourcekind.ApiResourceKind_agent_instance,
+		apiresourcekind.ApiResourceKind_workflow,
+		apiresourcekind.ApiResourceKind_workflow_instance,
+		apiresourcekind.ApiResourceKind_workflow_execution,
+		apiresourcekind.ApiResourceKind_environment,
+		apiresourcekind.ApiResourceKind_execution_context,
+		apiresourcekind.ApiResourceKind_project,
+	} {
+		registry.extractors[kind] = &mockExtractor{kind: kind}
+	}
 
 	// Should not panic
 	registry.ValidateExpectedKinds()

--- a/backend/services/stigmer-server/pkg/query/search/extractor/session_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/session_extractor.go
@@ -1,0 +1,114 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// SessionExtractor extracts searchable data from Session resources.
+//
+// Sessions are conversation threads between a user and an agent instance.
+// The search summary uses spec.subject (the conversation topic).
+type SessionExtractor struct{}
+
+var _ SearchableExtractor = (*SessionExtractor)(nil)
+
+func init() {
+	Register(&SessionExtractor{})
+}
+
+func (e *SessionExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_session
+}
+
+func (e *SessionExtractor) NewEmptyProto() proto.Message {
+	return &sessionv1.Session{}
+}
+
+func (e *SessionExtractor) GetSearchSummary(resource proto.Message) string {
+	session, ok := resource.(*sessionv1.Session)
+	if !ok || session.GetSpec() == nil {
+		return ""
+	}
+	return session.GetSpec().GetSubject()
+}
+
+func (e *SessionExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	session, ok := resource.(*sessionv1.Session)
+	if !ok {
+		return nil
+	}
+
+	meta := session.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_session,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Description:   e.GetSearchSummary(resource),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := session.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *SessionExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	session, ok := resource.(*sessionv1.Session)
+	if !ok {
+		return nil
+	}
+
+	meta := session.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:        meta.GetName(),
+		Description: e.GetSearchSummary(resource),
+		Tags:        JoinTags(meta.GetTags()),
+		Org:         meta.GetOrg(),
+		Visibility:  meta.GetVisibility().String(),
+	}
+
+	if audit := session.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/skill_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/skill_extractor.go
@@ -29,6 +29,11 @@ func (e *SkillExtractor) Kind() apiresourcekind.ApiResourceKind {
 	return apiresourcekind.ApiResourceKind_skill
 }
 
+// NewEmptyProto returns a new zero-value Skill proto.
+func (e *SkillExtractor) NewEmptyProto() proto.Message {
+	return &skillv1.Skill{}
+}
+
 // GetSearchSummary extracts the display summary for search results.
 // Returns spec.description.
 func (e *SkillExtractor) GetSearchSummary(resource proto.Message) string {

--- a/backend/services/stigmer-server/pkg/query/search/extractor/workflow_execution_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/workflow_execution_extractor.go
@@ -1,0 +1,108 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// WorkflowExecutionExtractor extracts searchable data from WorkflowExecution resources.
+//
+// Workflow executions are invocation records for workflow instances. They have
+// no description field, so the summary is empty.
+type WorkflowExecutionExtractor struct{}
+
+var _ SearchableExtractor = (*WorkflowExecutionExtractor)(nil)
+
+func init() {
+	Register(&WorkflowExecutionExtractor{})
+}
+
+func (e *WorkflowExecutionExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_workflow_execution
+}
+
+func (e *WorkflowExecutionExtractor) NewEmptyProto() proto.Message {
+	return &workflowexecutionv1.WorkflowExecution{}
+}
+
+func (e *WorkflowExecutionExtractor) GetSearchSummary(resource proto.Message) string {
+	return ""
+}
+
+func (e *WorkflowExecutionExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	we, ok := resource.(*workflowexecutionv1.WorkflowExecution)
+	if !ok {
+		return nil
+	}
+
+	meta := we.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_workflow_execution,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := we.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *WorkflowExecutionExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	we, ok := resource.(*workflowexecutionv1.WorkflowExecution)
+	if !ok {
+		return nil
+	}
+
+	meta := we.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:       meta.GetName(),
+		Tags:       JoinTags(meta.GetTags()),
+		Org:        meta.GetOrg(),
+		Visibility: meta.GetVisibility().String(),
+	}
+
+	if audit := we.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/extractor/workflow_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/workflow_extractor.go
@@ -28,6 +28,11 @@ func (e *WorkflowExtractor) Kind() apiresourcekind.ApiResourceKind {
 	return apiresourcekind.ApiResourceKind_workflow
 }
 
+// NewEmptyProto returns a new zero-value Workflow proto.
+func (e *WorkflowExtractor) NewEmptyProto() proto.Message {
+	return &workflowv1.Workflow{}
+}
+
 // GetSearchSummary extracts the display summary for search results.
 // Returns spec.description.
 func (e *WorkflowExtractor) GetSearchSummary(resource proto.Message) string {

--- a/backend/services/stigmer-server/pkg/query/search/extractor/workflow_instance_extractor.go
+++ b/backend/services/stigmer-server/pkg/query/search/extractor/workflow_instance_extractor.go
@@ -1,0 +1,114 @@
+package extractor
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	workflowinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+)
+
+// WorkflowInstanceExtractor extracts searchable data from WorkflowInstance resources.
+//
+// Workflow instances are running incarnations of a workflow definition.
+// The summary uses spec.description.
+type WorkflowInstanceExtractor struct{}
+
+var _ SearchableExtractor = (*WorkflowInstanceExtractor)(nil)
+
+func init() {
+	Register(&WorkflowInstanceExtractor{})
+}
+
+func (e *WorkflowInstanceExtractor) Kind() apiresourcekind.ApiResourceKind {
+	return apiresourcekind.ApiResourceKind_workflow_instance
+}
+
+func (e *WorkflowInstanceExtractor) NewEmptyProto() proto.Message {
+	return &workflowinstancev1.WorkflowInstance{}
+}
+
+func (e *WorkflowInstanceExtractor) GetSearchSummary(resource proto.Message) string {
+	wi, ok := resource.(*workflowinstancev1.WorkflowInstance)
+	if !ok || wi.GetSpec() == nil {
+		return ""
+	}
+	return wi.GetSpec().GetDescription()
+}
+
+func (e *WorkflowInstanceExtractor) ToSearchResult(resource proto.Message, score float32) *searchv1.SearchResult {
+	wi, ok := resource.(*workflowinstancev1.WorkflowInstance)
+	if !ok {
+		return nil
+	}
+
+	meta := wi.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	result := &searchv1.SearchResult{
+		Kind:          apiresourcekind.ApiResourceKind_workflow_instance,
+		Id:            meta.GetId(),
+		Name:          meta.GetName(),
+		Slug:          meta.GetSlug(),
+		Org:           meta.GetOrg(),
+		QualifiedSlug: buildQualifiedSlug(meta.GetOrg(), meta.GetSlug()),
+		Description:   e.GetSearchSummary(resource),
+		Visibility:    meta.GetVisibility(),
+		Tags:          meta.GetTags(),
+		Score:         score,
+	}
+
+	if audit := wi.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				result.CreatedAt = specAudit.GetCreatedAt()
+			}
+			if specAudit.GetUpdatedAt() != nil {
+				result.UpdatedAt = specAudit.GetUpdatedAt()
+			}
+		}
+	}
+
+	if result.CreatedAt == nil {
+		result.CreatedAt = &timestamppb.Timestamp{}
+	}
+	if result.UpdatedAt == nil {
+		result.UpdatedAt = &timestamppb.Timestamp{}
+	}
+
+	return result
+}
+
+func (e *WorkflowInstanceExtractor) GetSearchIndexEntry(resource proto.Message) *store.SearchIndexEntry {
+	wi, ok := resource.(*workflowinstancev1.WorkflowInstance)
+	if !ok {
+		return nil
+	}
+
+	meta := wi.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+
+	entry := &store.SearchIndexEntry{
+		Name:        meta.GetName(),
+		Description: e.GetSearchSummary(resource),
+		Tags:        JoinTags(meta.GetTags()),
+		Org:         meta.GetOrg(),
+		Visibility:  meta.GetVisibility().String(),
+	}
+
+	if audit := wi.GetStatus().GetAudit(); audit != nil {
+		if specAudit := audit.GetSpecAudit(); specAudit != nil {
+			if specAudit.GetCreatedAt() != nil {
+				entry.CreatedAt = specAudit.GetCreatedAt().GetSeconds()
+			}
+		}
+	}
+
+	return entry
+}

--- a/backend/services/stigmer-server/pkg/query/search/store/sqlite_search_query_store.go
+++ b/backend/services/stigmer-server/pkg/query/search/store/sqlite_search_query_store.go
@@ -9,10 +9,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/proto"
 
-	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
-	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
-	skillv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/skill/v1"
-	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
 	libstore "github.com/stigmer/stigmer/backend/libs/go/store"
@@ -336,16 +332,21 @@ func (s *SQLiteSearchQueryStore) loadAndConvertResource(
 	return ext.ToSearchResult(msg, score), nil
 }
 
-// createProtoForKind creates a new empty proto message for the given kind.
+// createProtoForKind creates a new empty proto message for the given kind
+// by delegating to the extractor registered for that kind.
 func (s *SQLiteSearchQueryStore) createProtoForKind(kind apiresourcekind.ApiResourceKind) (proto.Message, error) {
-	msg := createEmptyProtoForKind(kind)
-	if msg == nil {
+	ext, err := s.registry.GetExtractor(kind)
+	if err != nil {
 		return nil, fmt.Errorf("unsupported kind: %s", kind)
 	}
-	return msg, nil
+	return ext.NewEmptyProto(), nil
 }
 
 // RebuildIndex rebuilds the FTS5 search index from the resources table.
+//
+// This is resilient: if indexing a particular kind fails, it logs a warning
+// and continues with remaining kinds. A combined error is returned at the end
+// so callers can see which kinds failed, but all valid kinds are still indexed.
 func (s *SQLiteSearchQueryStore) RebuildIndex(ctx context.Context) (int, error) {
 	log.Info().Msg("Rebuilding search index...")
 
@@ -355,15 +356,23 @@ func (s *SQLiteSearchQueryStore) RebuildIndex(ctx context.Context) (int, error) 
 	}
 
 	var totalIndexed int
+	var indexErrors []string
 
-	// Index each searchable kind
+	// Index each searchable kind, continuing on per-kind failures
 	for _, kind := range s.registry.SupportedKinds() {
 		count, err := s.indexKind(ctx, kind)
 		if err != nil {
-			return totalIndexed, fmt.Errorf("index %s: %w", kind, err)
+			log.Warn().Err(err).Str("kind", kind.String()).Msg("Failed to index kind (continuing with remaining kinds)")
+			indexErrors = append(indexErrors, fmt.Sprintf("%s: %v", kind, err))
+			continue
 		}
 		totalIndexed += count
 		log.Info().Str("kind", kind.String()).Int("count", count).Msg("Indexed resources")
+	}
+
+	if len(indexErrors) > 0 {
+		log.Warn().Int("total", totalIndexed).Int("failed_kinds", len(indexErrors)).Msg("Search index rebuild completed with errors")
+		return totalIndexed, fmt.Errorf("failed to index %d kind(s): %s", len(indexErrors), strings.Join(indexErrors, "; "))
 	}
 
 	log.Info().Int("total", totalIndexed).Msg("Search index rebuild complete")
@@ -384,11 +393,8 @@ func (s *SQLiteSearchQueryStore) indexKind(ctx context.Context, kind apiresource
 		return 0, fmt.Errorf("list resources: %w", err)
 	}
 
-	// Create proto message for unmarshaling
-	protoMsg := createEmptyProtoForKind(kind)
-	if protoMsg == nil {
-		return 0, fmt.Errorf("cannot create proto for kind: %s", kind)
-	}
+	// Create proto message for unmarshaling via the extractor
+	protoMsg := ext.NewEmptyProto()
 
 	var count int
 	for _, data := range dataList {
@@ -493,19 +499,3 @@ func normalizeScore(bm25Score float64) float32 {
 	return score
 }
 
-// createEmptyProtoForKind creates a new empty proto message for the given kind.
-// This is used during index rebuild to unmarshal resources.
-func createEmptyProtoForKind(kind apiresourcekind.ApiResourceKind) proto.Message {
-	switch kind {
-	case apiresourcekind.ApiResourceKind_agent:
-		return &agentv1.Agent{}
-	case apiresourcekind.ApiResourceKind_skill:
-		return &skillv1.Skill{}
-	case apiresourcekind.ApiResourceKind_mcp_server:
-		return &mcpserverv1.McpServer{}
-	case apiresourcekind.ApiResourceKind_workflow:
-		return &workflowv1.Workflow{}
-	default:
-		return nil
-	}
-}

--- a/backend/services/stigmer-server/pkg/query/search/store/sqlite_search_query_store_test.go
+++ b/backend/services/stigmer-server/pkg/query/search/store/sqlite_search_query_store_test.go
@@ -110,28 +110,3 @@ func TestNormalizeScore(t *testing.T) {
 	}
 }
 
-func TestCreateEmptyProtoForKind(t *testing.T) {
-	tests := []struct {
-		name      string
-		kind      apiresourcekind.ApiResourceKind
-		expectNil bool
-	}{
-		{"agent", apiresourcekind.ApiResourceKind_agent, false},
-		{"skill", apiresourcekind.ApiResourceKind_skill, false},
-		{"mcp_server", apiresourcekind.ApiResourceKind_mcp_server, false},
-		{"workflow", apiresourcekind.ApiResourceKind_workflow, false},
-		{"unsupported", apiresourcekind.ApiResourceKind_session, true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := createEmptyProtoForKind(tc.kind)
-			if tc.expectNil && result != nil {
-				t.Error("expected nil for unsupported kind")
-			}
-			if !tc.expectNil && result == nil {
-				t.Error("expected non-nil proto for supported kind")
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Summary
Fixes a bug where `RebuildIndex` aborted on unhandled resource kinds (e.g. organization), so `stigmer list` commands returned empty results after server restart. This PR removes the brittle `createEmptyProtoForKind` switch, adds `SearchableExtractor` implementations for all 13 searchable kinds, and makes the index rebuild resilient to per-kind failures.

## Context
After `stigmer server start` and `stigmer apply`, `stigmer list skills` showed no skills despite them existing in the DB. Root cause: `RebuildIndex` used a central switch that had no case for `organization`; it returned an error and stopped, so skill (and other) kinds were never indexed. Only five kinds had extractors; the rest were never maintained in the search index.

## Changes
- **SearchableExtractor interface**: Add `NewEmptyProto() proto.Message` so each extractor owns proto instantiation; remove `createEmptyProtoForKind` from the search store.
- **RebuildIndex**: Log per-kind errors and continue indexing remaining kinds instead of aborting.
- **New extractors** (8): project, session, agent_instance, environment, agent_execution, workflow_instance, workflow_execution, execution_context.
- **Existing extractors**: Implement `NewEmptyProto()` on agent, skill, mcpserver, workflow, organization.
- **Registry**: Update `ValidateExpectedKinds` to include all 13 searchable kinds.
- **Pipelines**: Wire `IndexSearchStep` and `DeleteSearchIndexStep` into create/update/delete for project, session, agentinstance, environment, agentexecution, workflowinstance, workflowexecution, executioncontext.
- **Tests**: Adjust registry test for new kinds; remove test for deleted `createEmptyProtoForKind`.
- **Changelog**: Add `_changelog/2026-03/2026-03-08-131922-fix-search-index-architecture.md`.

## Implementation notes
- Best-effort indexing is unchanged: index upsert/delete failures are logged and do not fail the request pipeline.
- ExecutionContext has no update controller; only create and delete pipelines are wired.

## Breaking changes
None.

## Test plan
- Unit: `go test ./backend/services/stigmer-server/...` (registry and search store tests).
- Manual: Fresh server, seedpack bootstrap, `stigmer list skills` / `list mcpservers` / `list projects`; verified `search_index` rows match `resources` for indexed kinds.

## Risks
- Low: New extractors follow the same pattern as existing ones; rebuild continues on per-kind errors, so one bad kind cannot break the whole index. Rollback: revert branch and restart server (next startup will rebuild from current DB state).

## Checklist
- [x] Docs updated (changelog added)
- [x] Tests added/updated (registry test extended; obsolete test removed)
- [x] Backward compatible