### PR TITLE
fix(backend/libs): propagate summarization middleware to sub-agents

### DIFF
--- a/_changelog/2026-03/2026-03-12-051220-propagate-summarization-middleware-to-sub-agents.md
+++ b/_changelog/2026-03/2026-03-12-051220-propagate-summarization-middleware-to-sub-agents.md
@@ -1,0 +1,78 @@
+# Propagate Summarization Middleware to Sub-Agents
+
+**Date**: March 12, 2026
+
+## Summary
+
+Fixed a critical bug where sub-agents ran without context summarization middleware, causing `AnthropicContextOverflowError` when sub-agent conversations exceeded the model's 200K token limit (observed at 249K tokens). The fix propagates `ContextSummarizationMiddleware` from the parent agent into each sub-agent during compilation in `create_deep_agent()`.
+
+## Problem Statement
+
+Agent execution `aex-01kkfkahey3rsp756cefqsvdnv` failed with:
+
+```
+prompt is too long: 249324 tokens > 200000 maximum
+```
+
+Despite having a production-ready context summarization architecture (built in project `20260131.01`), the summarization middleware was only injected into the **parent** agent. Sub-agents were compiled with empty middleware lists, leaving them completely unprotected from context window overflow.
+
+### Pain Points
+
+- Sub-agents could accumulate unbounded context, crashing with `AnthropicContextOverflowError`
+- All 4 sub-agents in the execution were marked `SUB_AGENT_FAILED`, causing the entire execution to fail
+- The status log showed `summarizations=0` despite the parent having summarization configured
+- The existing summarization architecture covered the parent agent but had a gap in sub-agent propagation
+
+## Solution
+
+Inject `ContextSummarizationMiddleware` into each sub-agent's middleware list inside `create_deep_agent()` — the same function that already handles parent agent middleware injection. This required changes only in `agent.py`, with no modifications to the sub-agent transformer, interrupt proxy, or execution wiring.
+
+Each sub-agent gets its own middleware instance (fresh mutable state) with `callback=None` since sub-agent summarization events don't need to be reported through the parent's StatusBuilder.
+
+## Implementation Details
+
+### HITL Path (checkpointer + approval_checker present)
+
+In the sub-agent compilation loop, after building `sa_middleware` from the subagent dict, a fresh `ContextSummarizationMiddleware` is created and inserted at position 0 before passing to `compile_subagent_with_proxy()`:
+
+```python
+if summarization_config is not None and summarization_config.enabled:
+    sa_middleware.insert(0, ContextSummarizationMiddleware(
+        config=summarization_config,
+        callback=None,
+    ))
+```
+
+### Non-HITL Path (no checkpointer or no approval_checker)
+
+Subagent dicts are shallow-copied (to avoid mutating originals) and augmented with a `middleware` key containing the summarization middleware before passing to deepagents.
+
+### Test Coverage
+
+Added 8 unit tests in `TestSubAgentSummarizationPropagation`:
+- HITL path: middleware injected, distinct instances per sub-agent, pre-compiled skipped, disabled config skipped
+- Non-HITL path: middleware injected via dict, originals not mutated, pre-compiled skipped, disabled config skipped
+
+## Benefits
+
+- Sub-agents now have the same context window protection as the parent agent
+- Trigger at 180K tokens, target 160K tokens (for Claude models with 200K context)
+- Prevents `AnthropicContextOverflowError` in long-running sub-agent conversations
+- Each sub-agent manages its own summarization independently
+
+## Impact
+
+- **Agent Executions**: Sub-agents with large tool call histories will now summarize instead of crashing
+- **Reliability**: Eliminates a class of execution failures caused by unbounded sub-agent context growth
+- **Files Changed**: `agent.py` (+41 lines), `test_summarization_middleware.py` (+339 lines)
+- **Files Unchanged**: `subagent_transformer.py`, `interrupt_proxy.py`, `execute_graphton.py`, `summarization_middleware.py`, `summarization_config.py`
+
+## Related Work
+
+- Project `20260131.01.context-summarization-architecture` — the original summarization architecture that this fix completes
+- `2026-03-11-171855-fix-sub-agent-approval-deadlock.md` — prior sub-agent interrupt proxy work
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: 1 session

--- a/backend/libs/python/graphton/src/graphton/core/agent.py
+++ b/backend/libs/python/graphton/src/graphton/core/agent.py
@@ -430,6 +430,20 @@ def create_deep_agent(
                 sa_prompt = sa.get("system_prompt", "")
                 sa_middleware = list(sa.get("middleware", []))
                 
+                if summarization_config is not None and summarization_config.enabled:
+                    from graphton.core.summarization_middleware import ContextSummarizationMiddleware
+                    sa_middleware.insert(0, ContextSummarizationMiddleware(
+                        config=summarization_config,
+                        callback=None,
+                    ))
+                    logger.info(
+                        "Injected summarization middleware into sub-agent '%s' "
+                        "(trigger=%d, target=%d)",
+                        sa_name,
+                        summarization_config.trigger_threshold,
+                        summarization_config.target_tokens,
+                    )
+                
                 compiled_sa = compile_subagent_with_proxy(
                     model=model_instance,
                     tools=sa_tools,
@@ -446,7 +460,32 @@ def create_deep_agent(
                 len(compiled_subagents),
             )
         else:
-            transformed_subagents = subagents
+            if summarization_config is not None and summarization_config.enabled:
+                from graphton.core.summarization_middleware import ContextSummarizationMiddleware
+                
+                augmented_subagents = []
+                for sa in subagents:
+                    if "runnable" in sa:
+                        augmented_subagents.append(sa)
+                        continue
+                    sa_copy = dict(sa)
+                    sa_mw = list(sa_copy.get("middleware", []))
+                    sa_mw.insert(0, ContextSummarizationMiddleware(
+                        config=summarization_config,
+                        callback=None,
+                    ))
+                    sa_copy["middleware"] = sa_mw
+                    augmented_subagents.append(sa_copy)
+                transformed_subagents = augmented_subagents
+                logger.info(
+                    "Injected summarization middleware into %d sub-agent(s) "
+                    "(non-HITL path, trigger=%d, target=%d)",
+                    len(augmented_subagents),
+                    summarization_config.trigger_threshold,
+                    summarization_config.target_tokens,
+                )
+            else:
+                transformed_subagents = subagents
     
     # MCP integration (Universal Authentication Framework)
     if mcp_servers and mcp_tools:

--- a/backend/libs/python/graphton/tests/core/test_summarization_middleware.py
+++ b/backend/libs/python/graphton/tests/core/test_summarization_middleware.py
@@ -487,3 +487,342 @@ class TestInitialization:
         middleware = ContextSummarizationMiddleware(config=disabled_config)
         
         assert middleware.config.enabled is False
+
+
+# =============================================================================
+# Sub-Agent Propagation Tests
+# =============================================================================
+
+
+class TestSubAgentSummarizationPropagation:
+    """Test that create_deep_agent() propagates summarization middleware to sub-agents."""
+
+    @pytest.fixture
+    def summarization_config(self):
+        return SummarizationConfig.for_model("claude-sonnet-4.5")
+
+    @pytest.fixture
+    def subagents(self):
+        return [
+            {
+                "name": "researcher",
+                "description": "Research sub-agent",
+                "system_prompt": "You research things.",
+                "tools": [],
+            },
+            {
+                "name": "writer",
+                "description": "Writer sub-agent",
+                "system_prompt": "You write things.",
+                "tools": [],
+            },
+        ]
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_hitl_path_injects_summarization_middleware(
+        self,
+        mock_parse_model,
+        mock_compile_proxy,
+        mock_deepagents_create,
+        summarization_config,
+        subagents,
+    ):
+        """HITL path: each sub-agent receives ContextSummarizationMiddleware."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_compile_proxy.return_value = {
+            "name": "test",
+            "description": "test",
+            "runnable": MagicMock(),
+        }
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=subagents,
+            checkpointer=MagicMock(),
+            approval_checker=MagicMock(),
+            summarization_config=summarization_config,
+        )
+
+        assert mock_compile_proxy.call_count == 2
+
+        for call in mock_compile_proxy.call_args_list:
+            mw_list = call.kwargs.get("middleware") or call[1].get("middleware", [])
+            summarization_mws = [
+                m for m in mw_list
+                if isinstance(m, ContextSummarizationMiddleware)
+            ]
+            assert len(summarization_mws) == 1
+            assert summarization_mws[0].config == summarization_config
+            assert summarization_mws[0]._callback is None
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_hitl_path_distinct_middleware_instances(
+        self,
+        mock_parse_model,
+        mock_compile_proxy,
+        mock_deepagents_create,
+        summarization_config,
+        subagents,
+    ):
+        """HITL path: each sub-agent gets its own middleware instance (not shared)."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_compile_proxy.return_value = {
+            "name": "test",
+            "description": "test",
+            "runnable": MagicMock(),
+        }
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=subagents,
+            checkpointer=MagicMock(),
+            approval_checker=MagicMock(),
+            summarization_config=summarization_config,
+        )
+
+        instances = []
+        for call in mock_compile_proxy.call_args_list:
+            mw_list = call.kwargs.get("middleware") or call[1].get("middleware", [])
+            for m in mw_list:
+                if isinstance(m, ContextSummarizationMiddleware):
+                    instances.append(m)
+
+        assert len(instances) == 2
+        assert instances[0] is not instances[1]
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_hitl_path_skips_precompiled_subagents(
+        self,
+        mock_parse_model,
+        mock_compile_proxy,
+        mock_deepagents_create,
+        summarization_config,
+    ):
+        """HITL path: pre-compiled sub-agents (with 'runnable' key) are not modified."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        precompiled = {
+            "name": "pre",
+            "description": "pre",
+            "system_prompt": "Pre-compiled prompt",
+            "runnable": MagicMock(),
+        }
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=[precompiled],
+            checkpointer=MagicMock(),
+            approval_checker=MagicMock(),
+            summarization_config=summarization_config,
+        )
+
+        mock_compile_proxy.assert_not_called()
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_hitl_path_no_injection_when_disabled(
+        self,
+        mock_parse_model,
+        mock_compile_proxy,
+        mock_deepagents_create,
+        subagents,
+    ):
+        """HITL path: disabled summarization config does not inject middleware."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_compile_proxy.return_value = {
+            "name": "test",
+            "description": "test",
+            "runnable": MagicMock(),
+        }
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=subagents,
+            checkpointer=MagicMock(),
+            approval_checker=MagicMock(),
+            summarization_config=SummarizationConfig.disabled(),
+        )
+
+        for call in mock_compile_proxy.call_args_list:
+            mw_list = call.kwargs.get("middleware") or call[1].get("middleware", [])
+            summarization_mws = [
+                m for m in mw_list
+                if isinstance(m, ContextSummarizationMiddleware)
+            ]
+            assert len(summarization_mws) == 0
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_non_hitl_path_injects_summarization_middleware(
+        self,
+        mock_parse_model,
+        mock_deepagents_create,
+        summarization_config,
+        subagents,
+    ):
+        """Non-HITL path: sub-agent dicts get middleware key with summarization."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=subagents,
+            checkpointer=None,
+            approval_checker=None,
+            summarization_config=summarization_config,
+        )
+
+        call_kwargs = mock_deepagents_create.call_args
+        passed_subagents = call_kwargs.kwargs.get("subagents") or call_kwargs[1].get("subagents", [])
+
+        assert len(passed_subagents) == 2
+        for sa in passed_subagents:
+            mw_list = sa.get("middleware", [])
+            summarization_mws = [
+                m for m in mw_list
+                if isinstance(m, ContextSummarizationMiddleware)
+            ]
+            assert len(summarization_mws) == 1
+            assert summarization_mws[0].config == summarization_config
+            assert summarization_mws[0]._callback is None
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_non_hitl_path_does_not_mutate_original(
+        self,
+        mock_parse_model,
+        mock_deepagents_create,
+        summarization_config,
+        subagents,
+    ):
+        """Non-HITL path: original subagent dicts are not mutated."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=subagents,
+            checkpointer=None,
+            approval_checker=None,
+            summarization_config=summarization_config,
+        )
+
+        for sa in subagents:
+            assert "middleware" not in sa
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_non_hitl_path_skips_precompiled(
+        self,
+        mock_parse_model,
+        mock_deepagents_create,
+        summarization_config,
+    ):
+        """Non-HITL path: pre-compiled sub-agents are passed through unchanged."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        precompiled = {
+            "name": "pre",
+            "description": "pre",
+            "system_prompt": "Pre-compiled prompt",
+            "runnable": MagicMock(),
+        }
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=[precompiled],
+            checkpointer=None,
+            approval_checker=None,
+            summarization_config=summarization_config,
+        )
+
+        call_kwargs = mock_deepagents_create.call_args
+        passed_subagents = call_kwargs.kwargs.get("subagents") or call_kwargs[1].get("subagents", [])
+
+        assert len(passed_subagents) == 1
+        assert "runnable" in passed_subagents[0]
+        assert "middleware" not in passed_subagents[0]
+
+    @patch("graphton.core.agent.deepagents_create_deep_agent")
+    @patch("graphton.core.agent.parse_model_string")
+    def test_non_hitl_path_no_injection_when_disabled(
+        self,
+        mock_parse_model,
+        mock_deepagents_create,
+        subagents,
+    ):
+        """Non-HITL path: disabled config passes subagents unchanged."""
+        from graphton.core.agent import create_deep_agent
+
+        mock_model = MagicMock()
+        mock_parse_model.return_value = mock_model
+        mock_graph = MagicMock()
+        mock_graph.with_config.return_value = mock_graph
+        mock_deepagents_create.return_value = mock_graph
+
+        create_deep_agent(
+            model="claude-sonnet-4.5",
+            system_prompt="Test prompt",
+            subagents=subagents,
+            checkpointer=None,
+            approval_checker=None,
+            summarization_config=SummarizationConfig.disabled(),
+        )
+
+        call_kwargs = mock_deepagents_create.call_args
+        passed_subagents = call_kwargs.kwargs.get("subagents") or call_kwargs[1].get("subagents", [])
+
+        for sa in passed_subagents:
+            assert "middleware" not in sa


### PR DESCRIPTION
## Summary

Sub-agents were compiled without `ContextSummarizationMiddleware`, allowing their context to grow unbounded past the model's 200K token limit. This fix injects a fresh middleware instance into each sub-agent's middleware list during compilation in `create_deep_agent()`, covering both HITL and non-HITL paths.

## Context

Agent execution `aex-01kkfkahey3rsp756cefqsvdnv` failed with `AnthropicContextOverflowError` (249K tokens > 200K max). The existing summarization architecture (project `20260131.01`) only injected middleware into the parent agent. Sub-agents read their middleware from `sa.get("middleware", [])`, which was always empty because `subagent_transformer.py` never included middleware in the subagent dict. This left sub-agents completely unprotected from context window overflow.

## Changes

- **`agent.py` (HITL path)**: After building `sa_middleware` for each sub-agent, inject `ContextSummarizationMiddleware(config=summarization_config, callback=None)` at position 0 before passing to `compile_subagent_with_proxy()`
- **`agent.py` (non-HITL path)**: Shallow-copy each subagent dict and augment its `middleware` key with a fresh `ContextSummarizationMiddleware` before passing to deepagents
- **`test_summarization_middleware.py`**: Added 8 tests in `TestSubAgentSummarizationPropagation` covering both paths, distinct instances, pre-compiled skip, and disabled config

## Implementation notes

- Each sub-agent gets its own middleware instance with independent mutable state (`_running_summary`, `_summarization_count`, etc.)
- Sub-agent middleware uses `callback=None` to avoid mixing sub-agent summarization events with the parent's StatusBuilder reporting
- Pre-compiled sub-agents (with `runnable` key) are passed through unchanged
- No changes needed in `subagent_transformer.py`, `interrupt_proxy.py`, `execute_graphton.py`, or the summarization middleware/config themselves

## Breaking changes

- None

## Test plan

- 8 new unit tests covering HITL path injection, non-HITL path injection, distinct instances, pre-compiled skip, original dict immutability, and disabled config behavior
- All 8 tests pass; all previously passing tests remain green

## Risks

- Low risk: the change only adds middleware that was already proven in production for the parent agent
- Rollback: revert the single commit to restore previous behavior

## Checklist

- [x] Docs updated (changelog added)
- [x] Tests added/updated (8 new tests)
- [x] Backward compatible