### PR TITLE
refactor(backend): harden StatusBuilder with handler extraction, native subgraph mode, and pause/resume

### DIFF
--- a/_changelog/2026-03/2026-03-29-063941-fix-daytona-list-files-contract-mismatch.md
+++ b/_changelog/2026-03/2026-03-29-063941-fix-daytona-list-files-contract-mismatch.md
@@ -1,0 +1,75 @@
+# Fix Daytona Backend list_files / is_directory Contract Mismatch
+
+**Date**: March 29, 2026
+
+## Summary
+
+Fixed a crash where the agent's `list` platform tool failed with `'DaytonaBackend' object has no attribute 'list_files'` when running against Daytona cloud sandboxes. The root cause was a backend contract mismatch: graphton's `WorkspaceNormalizingBackend` assumed the inner backend provides `list_files()` and `is_directory()`, but the Daytona sandbox backend (via deepagents' `DaytonaBackend`) implements `SandboxBackendProtocol` which exposes `ls_info()` instead. Introduced normalizer functions that bridge between the two APIs at the adapter boundary.
+
+## Problem Statement
+
+When agents listed directory contents (`list .`, `glob *.py`, etc.) against Daytona cloud sandboxes, the `list` platform tool crashed immediately with an `AttributeError`. The same contract gap affected `is_directory()`, which would crash whenever the `list` or `glob` tool tried to distinguish files from directories.
+
+### Pain Points
+
+- Every `list` tool call against a Daytona sandbox failed — agents could not browse the workspace filesystem in cloud mode
+- `glob` and `grep` tools also use `list_files()` internally, so recursive file operations were completely broken
+- `is_directory()` also uses a graphton-only method not present on `DaytonaBackend`
+- Local filesystem mode worked fine, making this a cloud-only regression invisible during local development
+- Existing tests used `MagicMock` which auto-creates any attribute, so the method absence was never caught
+
+### Root Cause
+
+Two different backend APIs use different method names and return types for directory listing:
+
+| Backend | Method | Return Type |
+| --- | --- | --- |
+| `FilesystemBackend` (graphton) | `list_files(path)` | `list[str]` (bare entry names) |
+| `DaytonaBackend` (deepagents_cli) | `ls_info(path)` | `list[FileInfo]` (objects with `path` and `is_dir`) |
+
+`WorkspaceNormalizingBackend.list_files()` unconditionally called `self._inner.list_files()`, crashing on `DaytonaBackend` which only provides `ls_info()`. The same pattern affected `is_directory()` which also does not exist on `SandboxBackendProtocol`.
+
+This is the same class of bug fixed for `execute()` on March 26 (see `2026-03-26-201008-fix-execute-tool-backend-contract-mismatch.md`).
+
+## Solution
+
+Established normalizer functions in `types.py` that bridge between the two backend APIs, following the same pattern as `to_execution_result()`.
+
+## Implementation Details
+
+### 1. `to_file_list()` normalizer (`types.py`)
+
+Probes the inner backend for `list_files()` (graphton native, preferred) or `ls_info()` (deepagents protocol, fallback). When falling back to `ls_info()`, each `FileInfo` is reduced to its `os.path.basename()` so the return type matches graphton's `list[str]` contract.
+
+### 2. `to_is_directory()` normalizer (`types.py`)
+
+Probes the inner backend for `is_directory()` (graphton native, preferred) or `ls_info()` (fallback). When falling back, lists the *parent* directory via `ls_info()` and inspects the matching entry's `is_dir` flag. Returns `False` defensively if the entry is not found or `ls_info()` raises an exception.
+
+### 3. `WorkspaceNormalizingBackend` updates (`daytona.py`)
+
+`list_files()` and `is_directory()` now delegate through the normalizer functions instead of calling `self._inner.list_files()` / `self._inner.is_directory()` directly.
+
+### 4. Backward-compatible re-exports (`__init__.py`)
+
+The package `__init__.py` exports `to_file_list` and `to_is_directory` alongside the existing `to_execution_result`.
+
+## Benefits
+
+- Daytona cloud sandbox agents can list directories, glob files, and grep file contents again
+- The normalizer functions follow the same established pattern as `to_execution_result()`
+- Existing `FilesystemBackend` behavior is completely unaffected (it has `list_files()` and `is_directory()`, so the native path is always taken)
+- `FileInfo` handling supports both dict-style and object-style variants for forward compatibility
+
+## Impact
+
+- **Agent executions on Daytona sandboxes**: Fixed — `list`, `glob`, and `grep` tools now work correctly
+- **Local filesystem mode**: Unaffected — `FilesystemBackend` already has `list_files()` and `is_directory()`
+- **Test coverage**: 17 new tests (5 for `to_file_list`, 7 for `to_is_directory`, 5 for `WorkspaceNormalizingBackend` integration with ls_info-only backends)
+
+## Related Work
+
+- [Fix Execute Tool Backend Contract Mismatch](2026-03-26-201008-fix-execute-tool-backend-contract-mismatch.md) — Fixed the same class of contract mismatch for `execute()`. This changelog fixes the separate `list_files()` and `is_directory()` methods.
+
+---
+
+**Status**: Production Ready

--- a/_changelog/2026-03/2026-03-29-110412-fix-subagent-status-and-execution-guardrails.md
+++ b/_changelog/2026-03/2026-03-29-110412-fix-subagent-status-and-execution-guardrails.md
@@ -1,0 +1,77 @@
+# Fix Sub-Agent Status Timing and Execution Guardrails
+
+**Date**: March 29, 2026
+
+## Summary
+
+Two sub-agent execution issues are resolved: premature "Completed" status badges appearing while tool calls still stream in, and unbounded sub-agent execution where the model continues calling tools indefinitely without loop detection, budget warnings, or recursion limits. The fixes introduce a deferred completion flush mechanism and auto-inject guardrail middleware into sub-agent graphs.
+
+## Problem Statement
+
+Sub-agents compiled via `compile_subagent_with_proxy` lacked the safety middleware that the main agent receives from `create_deep_agent`. This created two user-visible problems observed in production.
+
+### Pain Points
+
+- **Premature completion badge**: Sub-agent marked "Completed" in the UI while messages and tool calls continued streaming underneath, creating a contradictory user experience
+- **Unbounded execution**: Sub-agents ran for 3+ hours and accumulated 186+ tool calls because they had no recursion limit, no loop detection, no execution budget warning, and no tool truncation
+- **No graceful termination**: The model would output text like "Now I have all the data" alongside tool calls in the same turn, and with no budget middleware to tell it to wrap up, the ReAct loop continued indefinitely
+
+## Solution
+
+### Issue 1: Deferred Completion Flush
+
+Replaced the immediate `force_next_update = True` on sub-agent completion with a 300ms drain window. Late LangGraph events (final `on_chat_model_end`, nested `on_tool_end`) are now batched into the same gRPC update that carries the `SUB_AGENT_COMPLETED` status, preventing the UI from showing "Completed" while activity still streams.
+
+### Issue 2: Sub-Agent Guardrail Middleware Injection
+
+Enhanced `compile_subagent_with_proxy` to automatically inject the same guardrail middleware that the main agent receives:
+
+| Guardrail | Before | After |
+|---|---|---|
+| `recursion_limit` | None (unlimited) | 50 (configurable) |
+| `LoopDetectionMiddleware` | Missing | Auto-injected |
+| `ExecutionBudgetMiddleware` | Missing | Auto-injected (80% warning) |
+| `ToolTruncationMiddleware` | Missing | Auto-injected (30K chars) |
+
+## Implementation Details
+
+### `status_builder.py`
+- Added `_pending_completion_flush: dict[str, float]` — records monotonic timestamps when sub-agents complete instead of forcing an immediate gRPC push
+- Added `should_flush_completions()` method with configurable `_COMPLETION_DRAIN_MS = 300` threshold
+- Removed `self.force_next_update = True` from `_handle_sub_agent_end`
+
+### `streaming.py`
+- Integrated `should_flush_completions(time.monotonic())` into `_maybe_send_update` as an additional flush trigger alongside the normal scheduler
+
+### `interrupt_proxy.py`
+- Added `recursion_limit` parameter to `compile_subagent_with_proxy` (default: 50)
+- Auto-injects `LoopDetectionMiddleware`, `ExecutionBudgetMiddleware`, and `ToolTruncationMiddleware`
+- Applies recursion limit via `.with_config()` on the compiled graph
+
+### `agent.py`
+- Forwards parent `recursion_limit` to `compile_subagent_with_proxy` for both explicit sub-agents (HITL branch) and the deferred GP sub-agent compilation
+
+## Benefits
+
+- **Accurate status representation**: "Completed" badge now appears only after all events are flushed, eliminating the contradictory UI state
+- **Bounded sub-agent execution**: 50 super-step limit (~25 tool-call rounds) prevents 3h+ runaway executions
+- **Graceful degradation**: Budget warning at 80% (step 40) tells the model to wrap up before the hard limit hits
+- **Loop detection**: Repetitive tool-call patterns are detected and interrupted, preventing infinite loops
+- **Cost control**: Tool truncation prevents context blowup from oversized tool results
+
+## Impact
+
+- **Agent Runner**: Sub-agents now have parity with the main agent's safety net
+- **CLI / Web UI**: Status badges accurately reflect sub-agent lifecycle
+- **Cost**: Prevents runaway sub-agent executions that accumulate hundreds of tool calls and hours of LLM time
+
+## Related Work
+
+- `2026-03-29-080321-gated-general-purpose-sub-agent.md` — introduced gated GP sub-agent for HITL flows
+- `2026-03-29-083706-fix-gp-subagent-compiled-without-tools.md` — fixed GP sub-agent receiving no tools
+- `2026-03-29-095041-fix-interrupt-proxy-callback-context.md` — restored callback context propagation for sub-agent UI visibility
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~2 hours (analysis + implementation + testing)

--- a/_changelog/2026-03/2026-03-29-114945-periodic-advisory-budget-middleware.md
+++ b/_changelog/2026-03/2026-03-29-114945-periodic-advisory-budget-middleware.md
@@ -1,0 +1,79 @@
+# Periodic Advisory Budget Middleware for Main and Sub-Agents
+
+**Date**: March 29, 2026
+
+## Summary
+
+Enhanced the `ExecutionBudgetMiddleware` to support a new **periodic advisory mode** alongside the existing threshold mode. Both the main agent and sub-agents now receive escalating nudges at regular intervals when running with effectively unlimited recursion, keeping long-running executions on track without imposing hard ceilings. This also fixes the `ValueError: Received multiple non-consecutive system messages` Anthropic API error caused by guardrail middleware injecting `SystemMessage` objects mid-conversation.
+
+## Problem Statement
+
+Two distinct issues converged around sub-agent execution guardrails:
+
+### Pain Points
+
+- **Anthropic API incompatibility**: Guardrail middlewares (`ExecutionBudgetMiddleware`, `LoopDetectionMiddleware`) inject `SystemMessage` objects mid-conversation. The Anthropic API requires all system messages to be contiguous at the start, causing `ValueError: Received multiple non-consecutive system messages` when these mid-conversation system messages hit the API.
+- **Restrictive recursion limit**: The initial sub-agent `recursion_limit=50` only allowed ~8-12 model rounds (each round consumes ~6 LangGraph super-steps). Legitimate sub-agent work was hitting the budget warning and crashing with `GraphRecursionError`.
+- **Lost advisory nudges**: After removing the restrictive limit and `ExecutionBudgetMiddleware`, sub-agents had no mechanism to encourage wrapping up long-running executions. The main agent (unlimited mode) also lacked any periodic guidance.
+
+## Solution
+
+A three-part fix addressing all three pain points:
+
+1. **Anthropic message sanitization** — A `_sanitize_non_leading_system_messages()` function in the Anthropic model subclass converts mid-conversation `SystemMessage` objects to `HumanMessage` with a `[System]` prefix, preserving semantic intent while satisfying API constraints.
+
+2. **Dual-mode `ExecutionBudgetMiddleware`** — The middleware now supports two operating modes:
+   - **Threshold mode** (existing): Single warning at a percentage of `recursion_limit`. For agents with explicit limits.
+   - **Periodic mode** (new): Advisory nudges every N model rounds with escalating urgency, up to a configurable maximum. For agents running with unlimited recursion.
+
+3. **Wiring into both agents** — Periodic budget advisories are now active for both sub-agents (every 30 rounds) and the main agent (every 50 rounds) when running in unlimited mode.
+
+## Implementation Details
+
+### Periodic Mode Parameters
+
+- `warning_interval`: Model rounds between advisories (sub-agent: 30, main agent: 50)
+- `max_warnings`: Maximum advisories before going silent (both: 4)
+
+### Escalating Message Tiers
+
+| Advisory | Tone | Trigger |
+|----------|------|---------|
+| 1st | Gentle — "If nearing completion, start wrapping up" | 30/50 rounds |
+| 2nd | Firm — "Prioritize completing your current task now" | 60/100 rounds |
+| 3rd | Urgent — "Wrap up your work, provide findings" | 90/150 rounds |
+| 4th | Critical — "Provide your final answer immediately" | 120/200 rounds |
+
+### Files Changed
+
+- **`execution_budget.py`** — Dual-mode middleware with `warning_interval`, `max_warnings`, and 4 escalating message templates
+- **`interrupt_proxy.py`** — Re-added `ExecutionBudgetMiddleware` in periodic mode (interval=30, max=4) for sub-agents
+- **`agent.py`** — Always injects budget middleware: periodic when unlimited, threshold when `recursion_limit` is set
+- **`models.py`** — `_sanitize_non_leading_system_messages()` for Anthropic API compatibility
+- **`test_execution_budget.py`** — 63 tests covering both threshold and periodic modes
+- **`test_interrupt_proxy_guardrails.py`** — 8 tests updated for periodic budget middleware injection
+- **`test_models.py`** — 11 tests for the message sanitization function
+
+## Benefits
+
+- **No more Anthropic API crashes** — Mid-conversation system messages are transparently converted, eliminating the `ValueError` for all guardrail middleware.
+- **Long-running agents stay on track** — Periodic nudges encourage efficient task completion without hard stops, matching the approach of Cursor and Claude Code which also run sub-agents without strict limits.
+- **Graceful degradation** — Escalating urgency gives models 4 chances to wrap up before the middleware goes silent, balancing thoroughness with efficiency.
+- **Both agents covered** — Main agent (50-round interval) and sub-agents (30-round interval) both benefit from periodic guidance.
+
+## Impact
+
+- **Sub-agents**: No longer crash from restrictive recursion limits. Receive periodic nudges at rounds 30, 60, 90, 120.
+- **Main agent**: Now receives periodic nudges at rounds 50, 100, 150, 200 when running in unlimited mode (the common case).
+- **Anthropic users**: The `ValueError` from non-contiguous system messages is permanently resolved.
+- **OpenAI/other providers**: Unaffected — the sanitization only applies to the Anthropic model subclass.
+
+## Related Work
+
+- Previous changelog: `2026-03-29-110412-fix-subagent-status-and-execution-guardrails.md` — Added initial guardrails to sub-agents (which triggered the Anthropic error).
+- Previous changelog: `2026-03-29-080321-gated-general-purpose-sub-agent.md` — Gated GP sub-agent with InterruptProxy.
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~2 hours (analysis, implementation, testing)

--- a/_changelog/2026-03/2026-03-29-123305-fix-tool-use-tool-result-pairing-anthropic-api.md
+++ b/_changelog/2026-03/2026-03-29-123305-fix-tool-use-tool-result-pairing-anthropic-api.md
@@ -1,0 +1,88 @@
+# Fix tool_use → tool_result Pairing for Anthropic API
+
+**Date**: March 29, 2026
+
+## Summary
+
+Fixed an `anthropic.BadRequestError` caused by guardrail middleware injecting advisory messages between `AIMessage(tool_calls)` and their corresponding `ToolMessage` results. A new `_reorder_tool_result_pairing` function ensures the Anthropic API's strict `tool_use → tool_result` sequencing contract is never violated, regardless of how many middleware hooks inject messages into the conversation state.
+
+## Problem Statement
+
+After the periodic advisory budget middleware was deployed, sub-agents running long executions (30+ model rounds) began crashing with:
+
+```
+anthropic.BadRequestError: messages.88: `tool_use` ids were found without
+`tool_result` blocks immediately after: toolu_019R6Yq6jdPYYJfRvx4zbVaJ.
+Each `tool_use` block must have a corresponding `tool_result` block in
+the next message.
+```
+
+### Pain Points
+
+- **Execution-killing crash** — The error terminated the entire agent execution at model round 30, wasting all accumulated work ($0.44 in API costs for the failed run).
+- **Previous fix was incomplete** — The earlier `_sanitize_non_leading_system_messages` correctly converted mid-conversation `SystemMessage` objects to `HumanMessage`, but did not account for the *positional* constraint: converted advisories could still land between an `AIMessage(tool_calls)` and its `ToolMessage` results.
+- **Multiple middleware sources** — `ExecutionBudgetMiddleware`, `LoopDetectionMiddleware`, and `ContextSummarizationMiddleware` all inject `SystemMessage` objects via `aafter_model`, making the interleaving problem increasingly likely as agents run longer.
+
+## Solution
+
+Added a defensive message reordering pass that runs as the final step of `_sanitize_non_leading_system_messages`. After all `SystemMessage` → `HumanMessage` conversions are complete, `_reorder_tool_result_pairing` scans the message list and ensures every `AIMessage(tool_calls)` is immediately followed by its `ToolMessage`(s), moving any interleaved messages to after the tool results.
+
+### Before (broken sequence)
+
+```
+AIMessage(tool_calls=[{id: X}])
+HumanMessage("[System] budget advisory")   ← injected by middleware
+ToolMessage(tool_call_id=X)
+```
+
+### After (fixed sequence)
+
+```
+AIMessage(tool_calls=[{id: X}])
+ToolMessage(tool_call_id=X)
+HumanMessage("[System] budget advisory")   ← safe position
+```
+
+## Implementation Details
+
+### New function: `_reorder_tool_result_pairing`
+
+Located in `graphton/core/models.py`, this function performs a single linear scan (O(n)) of the message list:
+
+1. When it encounters an `AIMessage` with `tool_calls`, it enters a collection phase
+2. `ToolMessage` objects are placed immediately after the `AIMessage`
+3. Any non-`ToolMessage`, non-`AIMessage` messages (converted advisories) are deferred to a buffer
+4. When the next `AIMessage` is reached or messages are exhausted, the deferred buffer is flushed
+5. Messages not following an `AIMessage(tool_calls)` pass through unchanged
+
+### Integration point
+
+`_reorder_tool_result_pairing` is called as the last step of `_sanitize_non_leading_system_messages`, which itself is called from `_EagerToolStreamingChatAnthropic._get_request_payload`. This means the reordering happens at the last possible moment before `langchain_anthropic`'s `_format_messages` and `_merge_messages` process the messages for the API payload.
+
+### Files Changed
+
+- **`models.py`** — Added `_reorder_tool_result_pairing` function; integrated as the return value of `_sanitize_non_leading_system_messages`
+- **`test_models.py`** — Updated 2 existing sanitization tests for new message ordering; added `TestReorderToolResultPairing` class with 9 test cases covering: empty list, no tool calls, normal sequence, single advisory, multiple advisories, multiple tool calls, multi-round conversations, non-tool-calling AI messages, and unconverted `SystemMessage` handling
+
+## Benefits
+
+- **Eliminates BadRequestError** — The `tool_use → tool_result` pairing is now structurally guaranteed regardless of middleware injection timing.
+- **Zero semantic loss** — Advisory messages are preserved in the conversation (just repositioned), so the model still receives the budget/loop/cost guidance.
+- **Future-proof** — Any new middleware that injects messages via `aafter_model` will be automatically handled by the reordering pass.
+- **Minimal overhead** — Single linear scan, no allocations beyond the output list.
+
+## Impact
+
+- **Sub-agents** — Long-running sub-agents (30+ rounds) that trigger periodic budget advisories will no longer crash.
+- **Main agent** — Main agents hitting 50+ rounds with advisory injection are similarly protected.
+- **All Anthropic-backed agents** — The fix applies uniformly via the `_EagerToolStreamingChatAnthropic` model subclass.
+- **Non-Anthropic providers** — Unaffected, as the sanitizer only runs in the Anthropic model's `_get_request_payload`.
+
+## Related Work
+
+- Previous changelog: `2026-03-29-114945-periodic-advisory-budget-middleware.md` — Introduced the periodic advisory mode and `_sanitize_non_leading_system_messages`, which this fix completes.
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~1.5 hours (root cause analysis, implementation, testing)

--- a/_changelog/2026-03/2026-03-29-123447-fix-subagent-streaming-budget-crash-status.md
+++ b/_changelog/2026-03/2026-03-29-123447-fix-subagent-streaming-budget-crash-status.md
@@ -1,0 +1,84 @@
+# Fix Sub-Agent Streaming, Budget Middleware Crash, and Status Propagation
+
+**Date**: March 29, 2026
+
+## Summary
+
+Fixed three interconnected production bugs causing sub-agents to show "Running" with no UI activity, cost to increase invisibly, and eventual crash that retroactively overwrote completed sub-agents as FAILED. The root causes were: (1) budget middleware injecting messages that violated Anthropic's tool_use/tool_result ordering constraint, (2) namespace registration gated behind a single event type causing sub-agent events to misroute to the main agent, and (3) crash finalization blindly overwriting all sub-agent statuses regardless of completion state.
+
+## Problem Statement
+
+Production execution `aex_01kmw48kjt426a3kf3vrjtbtcq` exhibited a cascading failure pattern where three distinct bugs interacted:
+
+### Pain Points
+
+- Sub-agent UI showed "Running" indefinitely with no streaming activity, while backend logs showed active work and token consumption — cost accrued invisibly to the user
+- `ExecutionBudgetMiddleware` injected a `SystemMessage` between `AIMessage(tool_use)` and `ToolMessage(tool_result)`, violating Anthropic's strict message ordering and causing a fatal `BadRequestError` at model round 30
+- Sub-agent events from `on_chat_model_stream` and `on_tool_end` failed namespace lookup and fell back to the main agent context, making sub-agent work invisible in the UI
+- When the parent execution crashed from the Anthropic error, `finalize_active_sub_agents` marked ALL active sub-agents as FAILED — including those that had already completed with meaningful results
+
+## Solution
+
+Three targeted root-cause fixes, each minimal in scope and surgical in impact:
+
+1. **Budget advisory moved from output injection to input prepend** — Replaced the `aafter_model` hook (which injected into the model's state output, landing between tool_use and tool_result) with `awrap_model_call` (which appends to the next model call's input messages). Advisories are now queued in `_pending_advisory` after round evaluation and delivered as input context to the subsequent call.
+
+2. **Universal namespace registration** — Moved the `_register_sub_agent_namespace()` call from inside `_handle_tool_start_event` up into `process_event` itself. The existing 4-strategy registration pipeline (root-prefix, substring, causal, sole-active) was already correct — it simply wasn't being invoked for most event types. Two lines added, six lines removed. No fallback logic, no new matching strategies.
+
+3. **Finalization respects terminal status** — Updated `finalize_active_sub_agents` (and its differentiated variant) to flush pending completion entries before crash finalization and preserve sub-agents that already have a terminal status or non-empty output. Only genuinely in-progress sub-agents receive the forced FAILED/CANCELLED status.
+
+## Implementation Details
+
+### ExecutionBudgetMiddleware (`execution_budget.py`)
+
+- Removed `aafter_model` hook entirely
+- Added `awrap_model_call` hook that wraps the model call pipeline:
+  - Step 1: If `_pending_advisory` exists from a previous round, append it to `request.messages`
+  - Step 2: Call the handler (actual model invocation)
+  - Step 3: Increment round counter and evaluate budget via `_evaluate_budget()`
+  - Advisory is queued in `_pending_advisory` for delivery on the *next* call
+- Added `_pending_advisory: SystemMessage | None` instance field, reset in `__init__` and `abefore_agent`
+- Extracted budget evaluation logic into `_evaluate_budget()` for clarity
+- Round counter only increments after successful model call (exceptions don't count)
+
+### StatusBuilder (`status_builder.py`)
+
+**Namespace registration (Issue 2):**
+- Added `_register_sub_agent_namespace(namespace)` call in `process_event`, before the handler dispatch block
+- Removed the now-redundant call from `_handle_tool_start_event` (lines 818-824)
+- `_get_execution_context` unchanged — stays as a clean exact-match lookup
+
+**Finalization (Issue 3):**
+- Added `_flush_pending_completions()` helper that immediately drains the deferred completion queue and sets `force_next_update`
+- Updated `finalize_active_sub_agents` to call `_flush_pending_completions()` first, then skip sub-agents with terminal status (`COMPLETED`, `FAILED`, `CANCELLED`) or non-empty `output`
+- Applied the same pattern to `finalize_active_sub_agents_differentiated` and `finalize_sub_agents_from_checkpoint_validation`
+
+### Tests
+
+- **Execution budget** (72 tests): Fully rewritten for `awrap_model_call` API. New test classes: `TestAwrapModelCallThreshold`, `TestAwrapModelCallPeriodic`, `TestMessageOrderingSafety`. Key safety tests verify advisory appears in handler input (not output) and that the handler's `ModelResponse` is returned unchanged.
+- **Status builder** (11 new tests, 272 total): `TestUniversalNamespaceRegistration` (4 tests verifying `on_chat_model_stream`/`on_tool_end` trigger registration), `TestFinalizationPreservesTerminalStatus` (7 tests covering preservation logic, pending flush drain, mixed finalization).
+
+## Benefits
+
+- **Eliminates Anthropic API crashes** caused by budget advisory placement — the advisory can no longer corrupt message ordering regardless of when it fires
+- **Sub-agent streaming visible in UI** — all event types now route to the correct SubAgentExecution, not silently to the main agent
+- **Accurate terminal status** — completed sub-agents retain their COMPLETED status even when the parent crashes, preserving the user's confidence in results they already saw
+- **Zero new abstractions** — all three fixes leverage existing infrastructure (registration pipeline, completion flush mechanism, `awrap_model_call` pattern from `ContextSummarizationMiddleware`)
+
+## Impact
+
+- **Users**: Sub-agent work streams correctly in the UI; cost is attributable to visible activity; crash recovery preserves completed results
+- **Backend**: Budget middleware is now safe for any LLM provider with strict message ordering (Anthropic, future providers)
+- **Test coverage**: 83 new/rewritten tests covering all three fix areas
+
+## Related Work
+
+- [Gated General-Purpose Sub-Agent](2026-03-29-080321-gated-general-purpose-sub-agent.md) — introduced the sub-agent gating that these events flow through
+- [Fix Interrupt Proxy Callback Context](2026-03-29-095041-fix-interrupt-proxy-callback-context.md) — enabled event observability that this fix depends on
+- [Sub-Agent Status and Execution Guardrails](2026-03-29-110412-fix-subagent-status-and-execution-guardrails.md) — introduced the deferred completion flush that Issue 3 now respects during crash finalization
+- [Periodic Advisory Budget Middleware](2026-03-29-114945-periodic-advisory-budget-middleware.md) — introduced the periodic mode whose `aafter_model` injection caused Issue 1
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~2 hours (diagnosis from prior session, implementation and testing in this session)

--- a/_changelog/2026-03/2026-03-29-160515-status-builder-hardening-t02-research.md
+++ b/_changelog/2026-03/2026-03-29-160515-status-builder-hardening-t02-research.md
@@ -1,0 +1,70 @@
+# StatusBuilder Hardening: T02 Research — tool_call_id Availability on LangGraph Events
+
+**Date**: March 29, 2026
+
+## Summary
+
+Completed T02 research for the StatusBuilder hardening project by tracing the LangGraph/LangChain event pipeline across 5 framework layers. Confirmed that v2 `on_tool_start` events do NOT expose the model's `tool_call_id`, but discovered that a lightweight `BaseCallbackHandler` captures it universally for all tools. This finding unblocks T04 (fingerprint dedup elimination) and renders the `InjectedToolCallId` coverage question irrelevant.
+
+## Problem Statement
+
+StatusBuilder uses a SHA256 fingerprint dedup system (~3 dictionaries, ~100 lines) to match tool events across fresh/resume execution cycles. This exists because the codebase didn't have a way to obtain the model's `tool_call_id` (the Anthropic `toolu_*` ID) from LangGraph v2 stream events. Before any code changes could eliminate this compensating complexity, the T02 research question had to be answered: is `tool_call_id` available on v2 events, and if not, how can StatusBuilder obtain it?
+
+### Pain Points
+
+- Fingerprint dedup is fragile — `_humanize_args_for_display` transforms values before storage, causing fingerprints computed from raw event args vs. display args to diverge
+- FIFO fallback (`_reconciled_resume_tool_calls`) compensates for fingerprint divergence, adding another matching heuristic
+- `_run_id_aliases` bridges the gap between LangGraph's fresh `run_id` and the original `tool_call_id`, requiring a reconciliation layer
+- All of this is compensating complexity for one missing identity: the model's `tool_call_id` on tool events
+
+## Solution
+
+A ~10-line `ToolCallIdCapture` callback handler using LangChain's `BaseCallbackHandler` API. The callback system receives `tool_call_id` as a kwarg on `on_tool_start` for every tool invoked through ToolNode — regardless of whether the tool uses `InjectedToolCallId`. The handler stores a `{run_id -> tool_call_id}` mapping that StatusBuilder reads when processing the corresponding v2 event.
+
+## Research Trace (5 Framework Layers)
+
+| Layer | Component | What happens to tool_call_id |
+|-------|-----------|------------------------------|
+| 1 | **ToolNode** (LangGraph) | Builds ToolCall dict with `id` from AIMessage, calls `tool.invoke()` |
+| 2 | **BaseTool._prep_run_args** (LangChain) | Extracts `tool_call_id = value["id"]` from the dict |
+| 3 | **BaseTool._filter_injected_args** | Strips injected args from callback inputs — `data.input` never contains `tool_call_id` |
+| 4 | **CallbackManager.on_tool_start** | Receives `tool_call_id` as a **separate kwarg** (not in `inputs`) |
+| 5 | **_AstreamEventsCallbackHandler** | Stores `tool_call_id` in internal `RunInfo` but does NOT include it in the emitted v2 event |
+
+The callback handler intercepts at Layer 4 — the same level where the framework receives the identity — and stores it before the v2 event is yielded.
+
+## Key Surprise
+
+The original hypothesis was that adding `InjectedToolCallId` to all tool wrappers would make `tool_call_id` appear in `event["data"]["input"]`. This is wrong. `_filter_injected_args` (langchain_core/tools/base.py:803-828) deliberately strips all injected args before passing to callbacks. The callback handler approach is necessary regardless — and is superior because it works for ALL tools without any per-wrapper changes.
+
+## Impact on StatusBuilder (T04 scope)
+
+With `{run_id -> tool_call_id}` available, the following can be deleted:
+
+| What | Type | Purpose |
+|------|------|---------|
+| `tool_call_fingerprints` | set | SHA256 dedup of tool args |
+| `_fingerprint_to_tool_call_id` | dict | fingerprint -> tool_call.id |
+| `_reconciled_resume_tool_calls` | dict[str, deque] | FIFO per tool name for resume fallback |
+| `_get_tool_fingerprint()` | method | SHA256(name + sorted JSON args) |
+| Fingerprint logic in `populate_fingerprints_from_existing_tool_calls()` | method (partial) | Index rebuild stays, fingerprint parts go |
+| Lines 773-824 in `_handle_tool_start_event` | logic | 50-line fingerprint check + FIFO fallback -> 3-line identity lookup |
+
+## Benefits
+
+- **Identity-based dedup**: Direct `tool_call_id` lookup replaces SHA256 fingerprints, FIFO queues, and name-based matching
+- **Universal coverage**: Works for ALL tools — MCP, platform, approval-wrapped — without modifying any tool wrapper
+- **Framework-sanctioned**: `BaseCallbackHandler` is the standard LangChain extension point, not a hack
+- **Timing-safe**: Sync callback fires before async v2 event is yielded, guaranteeing the mapping exists when StatusBuilder processes the event
+
+## Related Work
+
+- Project: `_projects/2026-03/20260329.02.status-builder-hardening/`
+- Research document: `tasks/T02_0_research.md`
+- Plan: `tasks/T01_0_plan.md`
+- Next: T03 (namespace injection feasibility), T04 (fingerprint dedup elimination — unblocked)
+
+---
+
+**Status**: ✅ Research Complete (no code changes — findings only)
+**Timeline**: ~1 hour (framework trace, code reading, documentation)

--- a/_changelog/2026-03/2026-03-29-163556-replace-fingerprint-dedup-with-identity-lookup.md
+++ b/_changelog/2026-03/2026-03-29-163556-replace-fingerprint-dedup-with-identity-lookup.md
@@ -1,0 +1,74 @@
+# Replace Fingerprint Dedup with Identity-Based Lookup (T04)
+
+**Date**: March 29, 2026
+
+## Summary
+
+Replaced the SHA256 fingerprint deduplication system in StatusBuilder with identity-based lookup using a `ToolCallIdCapture` callback handler. This eliminates 3 dictionaries, 2 methods, and ~100 lines of fragile heuristic matching from the resume-after-approval path, replacing it with ~15 lines of direct framework-provided identity resolution.
+
+## Problem Statement
+
+The resume-after-approval path in StatusBuilder used a multi-layered heuristic matching system to prevent duplicate tool calls when LangGraph re-fires `on_tool_start` events with fresh `run_id`s:
+
+### Pain Points
+
+- **SHA256 fingerprint matching** computed from tool name + JSON-sorted args was fragile — humanized display args diverged from raw event args, causing mismatches
+- **FIFO correlation queue** (`_reconciled_resume_tool_calls`) existed solely to compensate for fingerprint failures, adding a second matching heuristic
+- **Three dictionaries** (`tool_call_fingerprints`, `_fingerprint_to_tool_call_id`, `_reconciled_resume_tool_calls`) tracked overlapping state with lifecycle management obligations
+- **60+ lines of branching logic** in `_handle_tool_start_event` for two dedup paths (fingerprint check → FIFO fallback) obscured the straightforward intent: "is this tool call already known?"
+
+## Solution
+
+Leverage the LangChain callback API, which provides the model's stable `tool_call_id` (e.g. `toolu_01abc…`) on `on_tool_start` — unlike the v2 stream events which do not. A focused `ToolCallIdCapture(BaseCallbackHandler)` captures `{run_id → tool_call_id}` as tools start, and StatusBuilder uses this direct identity to look up existing tool calls in its index.
+
+## Implementation Details
+
+**New module**: `tool_call_id_capture.py` (~45 lines)
+- `ToolCallIdCapture(BaseCallbackHandler)` with a single `on_tool_start` override
+- Stores `{str(run_id): tool_call_id}` mapping from the callback API
+- `.get(run_id)` convenience method for StatusBuilder
+
+**Wiring** (`execute_graphton.py`):
+- `ToolCallIdCapture` instance created before StatusBuilder
+- Passed to StatusBuilder as constructor parameter
+- Added to LangGraph config's `callbacks` key
+
+**StatusBuilder simplification** (`status_builder.py`, net -197 lines):
+- Deleted 3 dictionaries: `tool_call_fingerprints`, `_fingerprint_to_tool_call_id`, `_reconciled_resume_tool_calls`
+- Deleted `_get_tool_fingerprint()` method and `hashlib`/`deque` imports
+- Replaced 60-line fingerprint+FIFO dedup with ~15-line identity lookup in `_handle_tool_start_event`
+- Removed fingerprint writes from `_reconcile_early_tool_call`
+- Renamed `populate_fingerprints_from_existing_tool_calls` → `rebuild_index_from_persisted_status` (retains only index rebuild)
+
+**HITL cleanup** (`hitl.py`):
+- Renamed method call, deleted FIFO queue population block, updated logging and docstrings, removed `deque` import
+
+**Test updates** (`test_status_builder.py`, `test_hitl_contracts.py`):
+- Rewrote 4 alias tests to use `ToolCallIdCapture` instead of fingerprint dedup
+- Deleted 4 fingerprint-specific tests and 1 FIFO-specific test class
+- Updated ~8 tests with renamed method calls
+
+## Benefits
+
+- **Correct by construction**: Framework-provided identity cannot diverge like computed fingerprints
+- **Simpler code**: 1 lookup replaces 2 heuristic paths with 3 supporting dictionaries
+- **Net deletion**: -197 lines across production and test code
+- **No proto changes**: Zero impact on persistence, gRPC, or downstream consumers
+- **Idempotent**: Same `(run_id, tool_call_id)` processed twice produces the same alias — no state accumulation
+
+## Impact
+
+- **StatusBuilder**: Meaningfully simpler `_handle_tool_start_event` — the most complex event handler in the system
+- **Resume path**: More reliable dedup; no more mismatches from humanized vs. raw arg divergence
+- **Maintainability**: 3 fewer dictionaries with lifecycle obligations on a 3,500+ line class
+- **Test suite**: All 1,375 tests pass; 4 fragile fingerprint-specific tests replaced with identity-based equivalents
+
+## Related Work
+
+- **T02 Research** (`tasks/T02_0_research.md`): Proved `tool_call_id` availability via callback API; designed the `ToolCallIdCapture` approach
+- **T07 (planned)**: Will fold `_run_id_aliases` into the capture handler or eliminate it entirely as part of the ExecutionState refactor
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: Single session (~1 hour)

--- a/_changelog/2026-03/2026-03-29-165238-eliminate-interrupt-proxy-runnable.md
+++ b/_changelog/2026-03/2026-03-29-165238-eliminate-interrupt-proxy-runnable.md
@@ -1,0 +1,67 @@
+# Eliminate InterruptProxyRunnable — Use LangGraph Native Sub-Agent Support
+
+**Date**: March 29, 2026
+
+## Summary
+
+Removed the custom `InterruptProxyRunnable` class and `compile_subagent_with_proxy()` function, replacing them with LangGraph's native per-invocation subgraph interrupt propagation. This eliminates 518 net lines of proxy machinery, resolves the concurrent sub-agent deadlock, and unifies the interrupt value shape across root-agent and sub-agent tools.
+
+## Problem Statement
+
+The `InterruptProxyRunnable` was a custom wrapper that intercepted sub-agent `interrupt()` calls, checkpointed them in a per-instance `MemorySaver`, and re-surfaced them to the parent graph via proxy payloads. This approach was built before understanding that LangGraph natively supports this exact pattern.
+
+### Pain Points
+
+- **Deadlock under concurrency**: Shared `MemorySaver` and `_thread_counter` across concurrent sub-agent invocations caused checkpoint contention and permanent approval deadlocks
+- **Dual interrupt shapes**: The proxy introduced a nested `{sub_id: {tool_call_id, _proxy_interrupt_id}}` shape that every downstream consumer (resume logic, HITL helpers, StatusBuilder) had to handle alongside the direct `{tool_call_id, message}` shape
+- **Complex resume logic**: `execute_graphton.py` needed ~100 lines of branching to handle direct vs. proxied interrupt matching, plus a bidirectional fallback for both shapes
+- **Unnecessary abstraction**: LangGraph's `checkpointer=None` per-invocation mode already provides checkpoint inheritance, interrupt propagation, and `checkpoint_ns` isolation — exactly what the proxy was manually reimplementing
+
+## Solution
+
+Compile sub-agents with `checkpointer=None` (the default from `create_agent`), letting LangGraph handle checkpoint inheritance natively. Sub-agent `interrupt()` calls propagate directly to the parent checkpoint with the same shape as root-agent tools. `SubAgentGate` concurrency limiting is preserved.
+
+## Implementation Details
+
+**Phase 0 — Verification**: Wrote 5 tests confirming LangGraph native behavior:
+1. Interrupt propagation from sub-agent to parent with resume
+2. Concurrent invocations complete without deadlock
+3. Interrupts propagate through `try/finally` (SubAgentGate pattern)
+4. Streaming events carry sub-agent namespace metadata
+5. Interrupt value shape is direct (no proxy wrapping)
+
+**Phase 1 — Replacement**:
+- Created `compile_subagent()` — same guardrail middleware injection (loop detection, truncation, budget), but no `MemorySaver` or proxy wrapping
+- Updated `agent.py` HITL path (2 call sites) to use `compile_subagent()`
+- Simplified `hitl.py::extract_interrupt_tool_call_ids` — removed nested proxy iteration
+- Simplified `execute_graphton.py` resume matching — single direct-shape loop, removed ~85 lines of proxy branching
+
+**Phase 2 — Test Updates**:
+- Replaced `TestProxyInterruptResume` with `TestDirectInterruptResume`
+- Deleted `TestInterruptProxyThreadManagement` and its `_FakeGraph`/`_FakeState` helpers
+- Updated mock patches in 4 test files (`test_recursion_limit`, `test_summarization_middleware`, `test_subagent_model_routing`, `test_interrupt_proxy_guardrails`)
+
+## Benefits
+
+- **-518 net lines** (762 deleted, 244 added) across 10 files
+- **Zero proxy code paths** — no `_proxy_interrupt_id`, no `_build_proxy_payload`, no `_thread_counter`
+- **Single interrupt shape** — all consumers handle one format
+- **Deadlock eliminated** — LangGraph assigns distinct `checkpoint_ns` per sub-agent invocation
+- **2,709 tests pass** (1,342 graphton + 1,367 agent-runner)
+
+## Impact
+
+- **agent.py**: HITL sub-agent compilation path simplified
+- **execute_graphton.py**: Resume logic reduced from ~150 lines to ~60 lines
+- **hitl.py**: Interrupt extraction reduced from 22 lines to 10 lines
+- **StatusBuilder hardening**: Unblocks T03 (namespace-based sub-agent event routing) by guaranteeing consistent `checkpoint_ns` metadata
+
+## Related Work
+
+- StatusBuilder Hardening project (T02 research → T03 implementation)
+- Prior fixes: `fix-interrupt-proxy-callback-context`, `fix-subagent-duplication-on-hitl-resume`, `fix-sub-agent-approval-deadlock`
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: Single session

--- a/_changelog/2026-03/2026-03-29-165308-t03-namespace-routing-research.md
+++ b/_changelog/2026-03/2026-03-29-165308-t03-namespace-routing-research.md
@@ -1,0 +1,91 @@
+# T03: Deterministic Namespace Routing via parent_ids
+
+**Date**: March 29, 2026
+
+## Summary
+
+Completed T03 research for the StatusBuilder hardening project, confirming that `parent_ids` on LangGraph v2 events provides a deterministic mechanism for mapping namespace strings to sub-agent identities. This eliminates the need for the 4-strategy heuristic cascade currently in `_register_sub_agent_namespace`, unblocking T05 (namespace heuristic deletion).
+
+## Problem Statement
+
+StatusBuilder's `_register_sub_agent_namespace` uses a 4-strategy heuristic cascade to map LangGraph namespace strings to sub-agent identities:
+
+1. Root-prefix matching (correct but depends on initial registration)
+2. Substring matching (run_id in namespace string)
+3. FIFO causal correlation (`_pending_sub_agent_ids` queue)
+4. Sole-active-agent fallback
+
+### Pain Points
+
+- Strategies 2-4 are heuristic — they can misroute events under concurrent sub-agent execution
+- Root-prefix matching (strategy 1) is inherently wrong for concurrent sub-agents because namespace roots are shared across all sub-agents invoked from the same parent node
+- The FIFO queue and sole-active fallback are compensating complexity for incorrect modeling
+- ~150 lines of heuristic code plus 2 tracking structures (`_pending_sub_agent_ids`, `_warned_namespaces`)
+
+## Solution
+
+Use `parent_ids` on v2 `astream_events` events for deterministic first-event namespace registration. When a new multi-segment namespace arrives, check its `parent_ids` for a known task tool `run_id` (already in `_active_sub_agents` from `_handle_sub_agent_start`). Single lookup, zero heuristics.
+
+## Research Findings
+
+### Framework trace
+
+- LangGraph constructs `langgraph_checkpoint_ns` as `parent_ns | node_name : task_id` in `prepare_single_task`
+- Sub-agents in deepagents are NOT graph nodes — they run inside the `task` tool function body
+- The `_AstreamEventsCallbackHandler` builds `parent_ids` by walking the `RunInfo.parent_run_id` chain
+- Sub-agent events inherit the parent's callback handler via config, so the chain is intact
+
+### Key surprise: namespace roots are shared
+
+Two sub-agents invoked from the same parent node produce:
+
+```
+Sub-agent A: tools_node:<task_id>|work_a:<task_id>
+Sub-agent B: tools_node:<task_id>|1|work_b:<task_id>
+```
+
+Same root (`tools_node`), different full paths. Root-prefix matching was architecturally wrong for disambiguation. `parent_ids` differs per invocation, providing the correct identity mechanism.
+
+### Approach A (checkpoint_ns injection) discarded
+
+Originally hypothesized injecting `checkpoint_ns` into `InterruptProxyRunnable._current_thread_config()`. Discarded because: (1) unnecessary — `parent_ids` already works, (2) couples to a component being eliminated, (3) wouldn't solve the shared-root problem anyway.
+
+## Implementation Details
+
+### Tests added
+
+Three new test classes in `test_native_subgraph_interrupt.py`:
+
+- `TestT03NamespaceFormat` — confirms multi-segment `langgraph_checkpoint_ns` with consistent root
+- `TestT03ParentIdsRouting::test_parent_ids_link_subagent_events_to_parent_context` — confirms `parent_ids` traces back to known main-agent run_ids
+- `TestT03ParentIdsRouting::test_multiple_subagents_have_distinct_namespaces_and_parent_ids` — confirms distinct full namespace paths and distinct `parent_ids` chains for concurrent sub-agents
+
+All 8 tests pass on LangGraph 1.1.2 in 0.16s.
+
+### Research document
+
+Full framework trace, proposed approach, and T05 impact documented in `tasks/T03_0_research.md`.
+
+## Benefits
+
+- T05 can replace ~150 lines of heuristic code with a ~10-line `parent_ids` lookup
+- Eliminates 2 tracking structures (`_pending_sub_agent_ids`, `_warned_namespaces`)
+- Zero heuristic namespace matching — all routing is identity-based
+- Works with both current architecture and post-InterruptProxy-elimination architecture
+
+## Impact
+
+- **StatusBuilder hardening project**: T03 complete, T05 unblocked
+- **InterruptProxy elimination project**: T03 findings complement — `parent_ids` works regardless of whether the proxy exists
+- **No production code changes**: Research phase only — tests and documentation
+
+## Related Work
+
+- T02 research (`_projects/2026-03/20260329.02.status-builder-hardening/tasks/T02_0_research.md`): Confirmed `ToolCallIdCapture` callback handler approach
+- T04 implementation: Replaced fingerprint dedup with identity-based lookup (-197 lines)
+- InterruptProxy elimination (separate project): Deleting `InterruptProxyRunnable` in favor of LangGraph native per-invocation subgraph support
+
+---
+
+**Status**: Research Complete
+**Timeline**: ~2 hours (exploration + test writing + documentation)

--- a/_changelog/2026-03/2026-03-29-170957-deterministic-namespace-routing-parent-ids.md
+++ b/_changelog/2026-03/2026-03-29-170957-deterministic-namespace-routing-parent-ids.md
@@ -1,0 +1,65 @@
+# Replace Namespace Heuristics with parent_ids-Based Deterministic Routing
+
+**Date**: March 29, 2026
+
+## Summary
+
+Replaced StatusBuilder's 4-strategy heuristic namespace-to-sub-agent mapping with a single deterministic `parent_ids` lookup. This eliminates an entire class of compensating complexity — root-prefix matching, substring matching, FIFO causal correlation, and sole-active-agent fallback — replacing ~100 lines of fragile heuristics with ~25 lines of direct identity-based routing. Net result: -56 lines, zero regressions across 2,711 tests.
+
+## Problem Statement
+
+When LangGraph streams v2 events for sub-agent executions, each event carries a `langgraph_checkpoint_ns` (namespace) that must be mapped to the correct sub-agent's `run_id` to route status updates properly. StatusBuilder had no direct way to establish this mapping, so it relied on four increasingly desperate heuristic strategies:
+
+### Pain Points
+
+- **Root-prefix matching**: Assumed namespace roots uniquely identified sub-agents — false when concurrent sub-agents share a parent node
+- **Substring matching**: Scanned active sub-agent run IDs for substring presence in namespace strings — fragile, could match the wrong agent
+- **FIFO causal correlation**: Maintained a `_pending_sub_agent_ids` queue, assuming namespace registration events arrive in the same order as sub-agent starts — timing-dependent assumption
+- **Sole-active-agent fallback**: If only one sub-agent was active, assigned all unresolved namespaces to it — wrong when agents overlap or complete out of order
+- The `_pending_sub_agent_ids` list added lifecycle complexity across `__init__`, `_handle_sub_agent_start`, and `_handle_sub_agent_end`
+
+## Solution
+
+Use `parent_ids` — a top-level field on v2 `astream_events` — to deterministically resolve namespace ownership. When a sub-agent's tool is invoked, the task tool's `run_id` (which StatusBuilder already tracks in `_active_sub_agents`) appears in `parent_ids` for all downstream events. A single scan of `parent_ids` against `_active_sub_agents` (and `_completed_sub_agents` for late-arriving events) establishes the mapping.
+
+## Implementation Details
+
+**Production code** (`status_builder.py`):
+- Rewrote `_register_sub_agent_namespace(self, namespace, event)` — accepts full event dict, extracts `parent_ids`, scans against active/completed sub-agents
+- Added multi-segment gate (`"|" not in namespace`) as fast early-exit for main-graph nodes
+- Updated call sites in `process_event` and `_handle_chat_model_stream_event` to pass full event
+- Deleted `_pending_sub_agent_ids` from `__init__`, `_handle_sub_agent_start`, `_handle_sub_agent_end`
+- Removed `_warned_namespaces` usage from registration method (retained in `_get_execution_context` for downstream routing)
+
+**Tests** (`test_status_builder.py`):
+- Deleted `TestNamespaceRegistrationStrategies` (6 tests) and old `TestConcurrentSubAgentNamespaceRegistration` (4 tests) — all tested heuristic strategies that no longer exist
+- Created `TestParentIdsNamespaceRouting` — 5 tests covering active match, completed match, empty parent_ids, no-match diagnostics, concurrent agents with shared roots, and idempotency
+- Created new `TestConcurrentSubAgentNamespaceRegistration` — 3 tests covering concurrent routing via parent_ids, tool call routing, and sub-agent end isolation
+- Updated ~20 test events across 3 existing test classes to use multi-segment namespaces with `parent_ids` field
+- Deleted 12 `_pending_sub_agent_ids` assertions
+
+## Benefits
+
+- **Deterministic routing**: No more probabilistic matching — namespace resolution is identity-based and correct by construction
+- **Eliminated compensating complexity**: Removed 4 heuristic strategies, 1 FIFO queue, and associated lifecycle management
+- **Net deletion**: -56 lines (273 added / 329 deleted) — mostly test rewrite volume; production code is significantly simpler
+- **Concurrent sub-agent correctness**: Shared namespace roots no longer cause mis-routing
+- **Simpler mental model**: "parent_ids contains the sub-agent run_id" — one sentence replaces a page of strategy documentation
+
+## Impact
+
+- **StatusBuilder**: Simpler namespace resolution path, fewer tracking dictionaries, reduced cognitive load for future maintainers
+- **Sub-agent correctness**: Concurrent sub-agents with shared parent nodes now route deterministically
+- **Test suite**: Tests now reflect actual production event shapes (multi-segment namespaces, parent_ids present)
+- **agent-runner + graphton test suites**: 2,711 tests passing, zero regressions
+
+## Related Work
+
+- **T03 Research** (`tasks/T03_0_research.md`): Confirmed `parent_ids` feasibility, discovered shared namespace roots invalidating root-prefix matching
+- **T04** (fingerprint dedup elimination): Prior task in same project that replaced SHA256 dedup with identity-based lookup
+- **T02** (tool_call_id capture): Research task that established the callback handler pattern for identity capture
+
+---
+
+**Status**: Production Ready
+**Timeline**: Single session (~2 hours)

--- a/_changelog/2026-03/2026-03-29-175048-fix-pause-resume-end-to-end.md
+++ b/_changelog/2026-03/2026-03-29-175048-fix-pause-resume-end-to-end.md
@@ -1,0 +1,85 @@
+# Fix Pause/Resume Mechanism — End-to-End Across Go, Java, and Python
+
+**Date**: March 29, 2026
+
+## Summary
+
+Fixed a fundamental architectural gap in the agent execution pause/resume mechanism. The Go Temporal workflow was not consuming pause signals at all, the Java Cloud service lacked RPC handlers to send them, and the Python activity was using an unreliable fire-and-forget pattern for status persistence. This cross-platform fix ensures pause/resume works reliably end-to-end across all three languages.
+
+## Problem Statement
+
+Agent execution pause/resume was broken at multiple levels across the polyglot stack.
+
+### Pain Points
+
+- **Go workflow ignored pause signals**: `executeGraphtonFlow` had no signal channel listener for pause — when a user paused an execution, the activity continued running and eventually overwrote the PAUSED status with its own terminal status
+- **Java Cloud lacked RPC handlers**: While the Java Temporal workflow had correct pause/resume logic internally (CancellationScope + Async.procedure), there were no `AgentExecutionPauseHandler` or `AgentExecutionResumeHandler` to actually receive and route pause/resume requests
+- **Python used unreliable persistence**: `_handle_pause` in `streaming.py` used `asyncio.create_task` to fire-and-forget a gRPC status update — the task could be garbage-collected before completing, leaving the PAUSED status unpersisted
+- **Status race condition**: Even when Python did persist PAUSED, the activity kept running (because the workflow never cancelled it), and its normal completion status overwrote the PAUSED status
+
+## Solution
+
+Coordinated fix across all three languages, modeled around the proven Java workflow pattern:
+
+1. **Go workflow**: Refactored `executeGraphtonFlow` with an outer pause/resume loop using `workflow.Go()` + `workflow.WithCancel()` for concurrent signal monitoring and activity cancellation
+2. **Java handlers**: Created full pipeline-based RPC handlers following the established handler pattern
+3. **Python persistence**: Unified all terminal status persistence (pause, stall, recursion limit) through the existing `retry_executor` mechanism
+
+## Implementation Details
+
+### Go Workflow (stigmer OSS)
+
+Added signal constants (`SignalPause`, `SignalResume`) to `workflow_types.go` and updated `lifecycle_steps.go` to use them instead of inline strings.
+
+Refactored `executeGraphtonFlow` in `invoke_workflow_impl.go`:
+- Outer `for {}` loop manages pause/resume cycles
+- `workflow.WithCancel(ctx)` creates a cancellable context per activity invocation
+- `workflow.Go(activityCtx, ...)` runs a goroutine that listens for `SignalPause` and calls `cancelActivity()` when received
+- Extracted `executeGraphtonWithHitl()` for the activity + HITL approval logic
+- On cancellation + `pauseRequested`: persists PAUSED status (defense-in-depth), waits for `SignalResume`, then continues the loop
+- `MaxPauseCycles = 50` safety limit prevents infinite loops
+
+### Java Cloud (stigmer-cloud)
+
+Added `SIGNAL_PAUSE`/`SIGNAL_RESUME` constants to `AgentExecutionTemporalWorkflowTypes` and explicit `@SignalMethod(name=...)` attributes to the workflow interface.
+
+Created two new RPC handlers following the established pipeline pattern:
+- `AgentExecutionPauseHandler`: LoadExisting → Authorize → ValidatePausable → SignalPauseToTemporal → UpdatePhase → Persist → PublishToRedis
+- `AgentExecutionResumeHandler`: LoadExisting → Authorize → ValidateResumable → SignalResumeToTemporal → UpdatePhase → Persist → PublishToRedis
+
+### Python Activity (shared)
+
+Simplified `_handle_pause` in `streaming.py` to pure in-memory proto mutation — no more gRPC calls. The caller (`execute_graphton.py`) handles all terminal status persistence uniformly through `retry_executor`, which provides exponential backoff and structured error handling.
+
+### Tests
+
+- **Go**: 5 workflow tests covering pause→resume, normal completion, HITL approval loop, multi-cycle pause/resume, and FAILED activity propagation
+- **Java**: 2 signal tests for pause/resume completion and normal completion without signals
+- **Python**: 5 unit tests for `_handle_pause` return semantics and terminal status persistence through `retry_executor`
+
+## Benefits
+
+- **Pause actually works**: User can pause a running execution and it stops — the activity is cancelled, a LangGraph checkpoint is saved, and the workflow waits for resume
+- **Resume resumes from checkpoint**: After resume signal, the workflow re-invokes the Python activity which loads from the saved LangGraph checkpoint
+- **Reliable persistence**: Terminal status always goes through `retry_executor` with exponential backoff — no more fire-and-forget
+- **Defense-in-depth**: Both the Python activity and the workflow persist PAUSED status, ensuring at least one write succeeds
+- **Cross-language consistency**: Signal names are defined as constants in both Go and Java, eliminating string drift
+
+## Impact
+
+- **Users**: Pause/resume functionality now works as designed — executions can be reliably paused and resumed
+- **Go workflow**: `invoke_workflow_impl.go` gained ~120 net lines but is now architecturally correct with a clear pause/resume lifecycle
+- **Java Cloud**: Gained the Pause/Resume RPC endpoints that were missing from the API surface
+- **Python activity**: Lost ~10 lines of unreliable code, gained ~25 lines of reliable persistence through the established retry path
+- **Testing**: 12 new tests across three languages provide regression coverage
+
+## Related Work
+
+- T04 (fingerprint dedup → identity lookup) and T05 (namespace heuristics → parent_ids) were completed in earlier sessions as part of the same StatusBuilder hardening project
+- InterruptProxyRunnable elimination (separate project) further simplifies the pause path
+- T07 (ExecutionState reducer refactor) is the next task in the hardening sequence
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~3 hours (including research, cross-language implementation, and testing)

--- a/_changelog/2026-03/2026-03-29-182831-executionstate-reducer-refactor.md
+++ b/_changelog/2026-03/2026-03-29-182831-executionstate-reducer-refactor.md
@@ -1,0 +1,100 @@
+# ExecutionState Reducer Refactor (T07)
+
+**Date**: March 29, 2026
+
+## Summary
+
+Extracted ~24 mutable instance variables from StatusBuilder into a typed `ExecutionState` dataclass, unified the run_id alias mechanism into `ToolCallIdCapture`, eliminated all private API leakage from external callers, and added proto-based index reconstruction. This is the structural foundation that makes StatusBuilder's state visible, typed, and recoverable — preparing for handler extraction in T08.
+
+## Problem Statement
+
+StatusBuilder had grown to 3,500+ lines with 31 loosely-documented instance variables initialized across a 225-line `__init__`. State was opaque, untyped in practice (everything was `dict[str, Any]` in spirit), and not recoverable on pod restart beyond a basic tool call index rebuild.
+
+### Pain Points
+
+- **No explicit state model**: 24+ dicts/lists/sets scattered through `__init__` with no type-level documentation of their purpose or lifecycle
+- **Duplicate identity resolution**: `_run_id_aliases` on StatusBuilder duplicated functionality already in `ToolCallIdCapture`, creating two places to maintain the same logic
+- **Private API leakage**: Three external callers (`streaming.py`, `hitl.py`, `post_stream.py`) accessed private `_` members directly, coupling them to internal implementation details
+- **No typed reconstruction**: On resume, only tool call indexes were rebuilt; sub-agent completion state and artifacts were lost
+
+## Solution
+
+A 6-step structural refactor that preserves all behavior while making state explicit:
+
+1. **Fold `_run_id_aliases`** into `ToolCallIdCapture` as the single authority for run_id → tool_call_id resolution
+2. **Fix private API leakage** with public methods/properties
+3. **Define `ExecutionState`** dataclass with 3 sub-groups for tightly-coupled fields
+4. **Mechanical migration** of all `self._<state>` → `self.state.<field>` references
+5. **`rebuild_from_proto()`** classmethod for proto-based index reconstruction
+6. **Test updates** including 8 new `rebuild_from_proto` tests
+
+## Implementation Details
+
+### New `ExecutionState` dataclass (`execution_state.py`)
+
+21 top-level fields organized into semantic groups:
+
+- **Proto indexes** (4): `tool_calls`, `messages_by_run`, `current_ai_message`, `last_llm_run_id`
+- **Sub-agent routing** (5): `active_sub_agents`, `completed_sub_agents`, `run_id_to_tool_call_id`, `namespace_to_sub_agent`, `subject_counts`
+- **Streaming buffers** (3): `thinking` (sub-group), `tool_input` (sub-group), `early_tool_call_queue`
+- **Timing / observability** (4): `tool_start_times`, `message_start_times`, `sub_agent_message_start_times`, `pending_completion_flush`
+- **Approval** (1): `approval` (sub-group)
+- **Other** (3): `warned_namespaces`, `context_info`, `artifacts`
+
+Three sub-groups extract tightly-coupled fields that share a lifecycle:
+
+- `ThinkingStreamState`: 3 dicts all keyed by namespace, always mutated together
+- `ToolInputStreamState`: active tool tracking + partial JSON buffers, always used together
+- `ApprovalTrackingState`: set together on WAITING_FOR_APPROVAL entry, cleared together on exit
+
+### ToolCallIdCapture unification
+
+Added two methods to the existing `ToolCallIdCapture` callback handler:
+
+- `register_alias(new_run_id, tool_call_id)`: records resume-path aliases
+- `resolve(run_id)`: checks aliases → callback mapping → fallback to input
+
+This eliminated `_run_id_aliases` and `_resolve_run_id()` from StatusBuilder entirely.
+
+### StatusBuilder `__init__` simplification
+
+Before: ~225 lines of individual field initialization with block comments.
+After: ~15 lines — config/collaborators + `self.state = ExecutionState(proto=initial_status)`.
+
+`current_status` became a property delegating to `self.state.proto` for backward compatibility.
+
+### `rebuild_from_proto()` classmethod
+
+Reconstructs proto-derivable indexes from a persisted `AgentExecutionStatus`:
+- Tool call indexes from main agent + sub-agent messages
+- Completed sub-agents (terminal status)
+- Artifacts
+
+Ephemeral runtime state (run_id maps, streaming buffers, timing) starts fresh — streaming resumes from checkpoint.
+
+## Benefits
+
+- **Type safety**: Every state field is documented with its purpose, key type, and lifecycle
+- **Single source of truth**: Run_id resolution unified in `ToolCallIdCapture` — one place to understand, one place to debug
+- **Clean boundaries**: Zero private API access from external callers
+- **Recovery**: `rebuild_from_proto()` reconstructs all proto-derivable state, not just tool calls
+- **Handler extraction ready**: Sub-grouped state (`ThinkingStreamState`, `ToolInputStreamState`, `ApprovalTrackingState`) serves as natural parameter boundaries for T08
+
+## Impact
+
+- **StatusBuilder**: Internal state is now explicit, typed, and documented — no more "what does `_llm_run_id_to_message` do?" guesswork
+- **Callers** (`streaming.py`, `hitl.py`, `post_stream.py`): Use public API only — safe from internal restructuring
+- **Tests**: 1,382 pass (8 new, 0 regressions) — all behavioral tests unchanged, only reference paths updated
+- **Future work (T08)**: Handler extraction can proceed with `ExecutionState` as a first-class parameter to focused collaborator modules
+
+## Related Work
+
+- T04: Identity-based lookup via `ToolCallIdCapture` (foundation for alias unification)
+- T05: Deterministic namespace routing via `parent_ids` (simplified sub-agent state)
+- T06: End-to-end pause/resume (motivation for `rebuild_from_proto`)
+- T08 (next): Extract event handlers to shrink StatusBuilder below 500 lines
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: Single session (~2 hours)

--- a/_changelog/2026-03/2026-03-29-190837-hitl-approval-cleanup.md
+++ b/_changelog/2026-03/2026-03-29-190837-hitl-approval-cleanup.md
@@ -1,0 +1,78 @@
+# HITL Approval Cleanup -- Eliminate Redundant Python Gathering and Dead Signal Code
+
+**Date**: March 29, 2026
+
+## Summary
+
+Removed three layers of waste from the Human-in-the-Loop approval flow: Python's redundant `pending_approvals` computation (overwritten by Go on every UpdateStatus), the dead `submitApproval` signal code in both Go and Java, and the legacy `interrupt_proxy.py` module name. The Go workflow now reads `pending_approvals` from the DB via `loadExecution()`, matching the pattern Java already uses. Net deletion of ~2,400 lines across Python, Go, and Java.
+
+## Problem Statement
+
+After eliminating `InterruptProxyRunnable` in favor of LangGraph native subgraph mode, several redundancies remained in the HITL approval flow:
+
+### Pain Points
+
+- **Python computed `pending_approvals` that Go immediately overwrote.** `post_stream.py` queried LangGraph checkpoint interrupts, built a `PendingApproval` list, and set it on the status proto. When this status reached Go via gRPC `UpdateStatus`, Go's `ComputePendingApprovals()` overwrote it. The Python computation only survived in the slim Temporal return value -- a redundant copy that violated the "Single Source of Truth" principle.
+- **Go's `pendingCount` guard read from the slim activity return.** This meant Go relied on Python's redundant computation rather than its own authoritative DB state. Java already read from DB via `loadExecution()`.
+- **`submitApproval` signal was dead code.** Go's `SignalApproval()` method was never called. Java's `@SignalMethod submitApproval` was an explicit no-op. Both `SIGNAL_SUBMIT_APPROVAL` constants were unreferenced.
+- **`interrupt_proxy.py` was a misleading module name.** The `InterruptProxyRunnable` class had been deleted, but the file was kept for `compile_subagent()`. The filename no longer reflected its content.
+
+## Solution
+
+Applied the "Delete Over Refactor" and "Single Source of Truth" principles:
+
+1. **Renamed** `interrupt_proxy.py` to `subagent.py` -- name matches content.
+2. **Deleted** Python-side `pending_approvals` gathering -- `build_snapshot_from_interrupts()`, `build_pending_approvals_snapshot()`, the snapshot block in `post_stream.py`, and the `pending_approvals` copy in `slim_status_for_temporal()`.
+3. **Modified** Go workflow to read `pendingCount` from DB via `loadExecution()` after `persistFinalStatus()` -- matching Java's existing pattern.
+4. **Deleted** `SignalApproval()` method, `SignalSubmitApproval` constant (Go), `submitApproval` interface method / no-op handler / constant (Java), and 11 dead test methods.
+5. **Cleaned** stale `InterruptProxy` and `submitApproval` references in comments across all three languages.
+
+## Implementation Details
+
+### Python (Phase 1-2)
+
+- **Module rename**: `graphton/core/interrupt_proxy.py` -> `subagent.py`. Updated 2 import sites in `agent.py`, renamed test file, and updated 26 `@patch` targets across 4 test files.
+- **Deleted functions**: `build_snapshot_from_interrupts()` from `hitl.py`, `build_pending_approvals_snapshot()` from `status_builder.py`, removed `PendingApproval` import.
+- **Simplified `post_stream.py`**: Replaced the 20-line interrupt query + fallback snapshot + `del/extend` block with a single log line.
+- **Simplified `slim_status_for_temporal()`**: Removed the `pending_approvals` append loop. The function now returns only phase, error, and timestamps.
+- **Updated tests**: Replaced `TestBuildPendingApprovalsSnapshot` and `TestBuildSnapshotFromInterrupts` with `TestSlimStatusPhaseOnly` that verifies `pending_approvals` is intentionally omitted.
+
+### Go (Phase 3-4)
+
+- **DB-driven `pendingCount`**: In `executeGraphtonWithHitl`, after `persistFinalStatus()`, the workflow now calls `w.loadExecution(ctx, executionID)` and reads `pendingCount` from `dbExecution.GetStatus().GetPendingApprovals()`. If `loadExecution` fails, defaults to `pendingCount = 1` (conservative: wait for signal rather than skip it).
+- **Deleted dead code**: `SignalApproval()` method (~60 lines) from `workflow_creator.go`, `SignalSubmitApproval` constant from `workflow_types.go`.
+- **Updated test**: HITL test now mocks `loadExecution` to return an execution with `PendingApprovals` populated.
+
+### Java (Phase 4)
+
+- **Deleted dead code**: `submitApproval` from `InvokeAgentExecutionWorkflow` interface, no-op handler from impl, `SIGNAL_SUBMIT_APPROVAL` constant, and 11 test methods (~450 lines) that tested the dead signal path.
+
+## Benefits
+
+- **~2,400 net lines deleted** across Python, Go, and Java
+- **Eliminated a redundant data flow** -- Python no longer computes state that Go overwrites
+- **Go and Java HITL loops now use the same pattern** -- both read `pendingCount` from DB
+- **Removed dead code** -- no more phantom `submitApproval` signal infrastructure
+- **Module naming reflects reality** -- `subagent.py` accurately describes `compile_subagent()`
+
+## Impact
+
+- **Python agent-runner**: Simpler `post_stream.py` and `temporal_helpers.py`. No behavioral change for the agent execution flow.
+- **Go stigmer-server**: HITL loop makes one additional local activity call (`loadExecution`) per approval cycle. This is negligible overhead -- it's a local activity hitting the DB, same as Java already does.
+- **Java stigmer-service**: Interface change removes `submitApproval` signal method. No Temporal compatibility risk since the handler was a no-op and no callers existed.
+- **No proto changes, no new RPCs, no behavioral changes** to the approval flow from the end-user perspective.
+
+## What Stays the Same
+
+- `ComputePendingApprovals` in Go/Java -- still the authoritative computation
+- `SubmitApproval` RPC handler -- still writes decisions to DB and signals `approvalGateResolved`
+- `approvalGateResolved` signal -- still the sole Temporal coordination signal for HITL
+- `extract_interrupt_tool_call_ids()` -- still used for orphan reconciliation on resume
+- `ResumeReconciler` -- unchanged
+- `compile_subagent()` function -- unchanged, only its module location changed
+- Interrupt value shape -- unchanged (`{tool_call_id, message}`)
+
+---
+
+**Status**: Production Ready
+**Timeline**: Single session

--- a/_changelog/2026-03/2026-03-29-192401-handler-extraction-statusbuilder-below-500.md
+++ b/_changelog/2026-03/2026-03-29-192401-handler-extraction-statusbuilder-below-500.md
@@ -1,0 +1,78 @@
+# Handler Extraction — StatusBuilder Below 500 Lines (T08)
+
+**Date**: March 29, 2026
+
+## Summary
+
+Extracted all event-processing logic from the 3,289-line `StatusBuilder` god object into six focused handler modules under `graphton/handlers/`, reducing `StatusBuilder` to a 417-line thin orchestrator that dispatches events and delegates to cohesive handler functions. This is the capstone refactoring step in the status-builder-hardening project, transforming a monolithic class into a maintainable, modular architecture.
+
+## Problem Statement
+
+After T07 (ExecutionState extraction), `StatusBuilder` still contained ~2,800 lines of event-handling logic: tool lifecycle management, chat model streaming, sub-agent orchestration, context tracking, and content formatting. The sheer size made it difficult to reason about any single concern, and the class violated the single-responsibility principle at every level.
+
+### Pain Points
+
+- 2,800+ lines of mixed concerns in a single class — tool events, chat model events, sub-agent lifecycle, streaming buffers, context info, and formatting utilities all interleaved
+- Developers had to scan thousands of lines to understand any one event handler
+- Test failures were hard to localize — a change to formatting could break tool event tests
+- Adding new event types required modifying the god object rather than adding a focused module
+- Code review burden: every PR touching StatusBuilder was a multi-thousand-line context load
+
+## Solution
+
+Extract cohesive groups of event-handling logic into module-level functions within a `graphton/handlers/` subpackage. Each handler module receives the `StatusBuilder` instance (`sb`) as its first argument, keeping the pattern simple and avoiding premature abstraction. `StatusBuilder` retains thin delegation methods for public API compatibility and test mock targets.
+
+## Implementation Details
+
+### New Handler Modules (2,576 lines total)
+
+| Module | Lines | Responsibility |
+|--------|-------|----------------|
+| `formatting.py` | 193 | Stateless content extraction: tool results, thinking blocks, command content, arg unwrapping |
+| `streaming_buffers.py` | 538 | AI message creation, early tool-call tracking, thinking/tool-input streaming, partial JSON parsing |
+| `sub_agent.py` | 603 | Sub-agent lifecycle: start, end, finalization, subject generation, resume queue, orphan diagnostics |
+| `context.py` | 271 | Context info initialization, summarization events, token tracking, artifacts, workspace write-backs |
+| `tool_event.py` | 472 | Tool start/end/progress, approval checks, todo updates, arg humanization, display preview |
+| `chat_model.py` | 499 | Chat model stream/end: AI message assembly, usage metric capture, planning tool detection |
+
+### StatusBuilder Transformation
+
+- **Before**: 3,289 lines (post-T07), 30+ methods with full implementations
+- **After**: 417 lines — `__init__`, `process_event` dispatch hub, namespace routing, approval state, and thin delegation stubs
+- **Pattern**: Module-level functions accept `sb: StatusBuilder` as first arg; `TYPE_CHECKING` prevents circular imports
+- **Backward compatibility**: Constants (`PLANNING_TOOLS`, `_MAX_STATUS_RESULT_CHARS`, `_READ_ONLY_TOOLS`, `_TOOL_CONTENT_FIELDS`) and utilities (`_utc_timestamp`, `_find_json_string_value_start`, `_json_unescape_partial`) re-exported from `status_builder.py`
+
+### Design Decisions
+
+- **Module-level functions over classes**: No handler classes or inheritance hierarchies — just functions. This keeps the extraction purely structural with zero new abstractions.
+- **Thin delegation stubs on StatusBuilder**: Methods that are public API, called by external modules, or directly mocked by tests retain one-line delegation stubs on `StatusBuilder`. This preserves test compatibility without requiring test rewrites.
+- **Re-exports for backward compatibility**: External callers (`hitl.py`, `post_stream.py`, `streaming.py`, `execute_graphton.py`) that import constants and `_utc_timestamp` from `status_builder` continue to work through re-exports.
+- **`sb._update_todos()` call pattern**: `tool_event.py` calls `sb._update_todos(...)` (not `update_todos(sb, ...)`) to ensure test mocks patching the `StatusBuilder` method intercept correctly.
+
+## Benefits
+
+- **87% line reduction** in the central class (3,289 → 417 lines)
+- **Single-concern modules**: Each handler module can be read, tested, and modified independently
+- **Faster onboarding**: New developers can understand tool event handling by reading 472 lines, not 3,289
+- **Safer changes**: Modifying sub-agent logic cannot accidentally break formatting or context tracking
+- **Test isolation**: Handler modules have clear boundaries — future tests can target individual modules
+- **Zero test regressions**: All 282 `test_status_builder.py` tests pass without modification to test logic (only 3 patch targets updated)
+
+## Impact
+
+- **StatusBuilder consumers**: No changes required — public API preserved through delegation stubs and re-exports
+- **Test suite**: 282 tests pass; only 3 patch targets updated to point at new module locations
+- **Future development**: New event types can be added as new handler modules without touching `StatusBuilder`
+- **T08 completes the structural refactoring arc**: T04 (identity dedup) → T05 (namespace routing) → T07 (ExecutionState) → T08 (handler extraction) — `StatusBuilder` is now a thin orchestrator
+
+## Related Work
+
+- **T07**: ExecutionState dataclass extraction — provided the typed state model that handlers operate on
+- **T05**: Namespace routing via `parent_ids` — simplified `_register_sub_agent_namespace` before extraction
+- **T04**: Identity-based dedup via `ToolCallIdCapture` — eliminated fingerprint complexity before extraction
+- **Previous session commit (`e4af7bb7`)**: Initial handler extraction (formatting, streaming_buffers, sub_agent, context) bundled with HITL cleanup
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~3 hours (planning + 7-step extraction across 2 sessions)

--- a/_changelog/2026-03/2026-03-29-193308-lint-cleanup-across-python-and-go.md
+++ b/_changelog/2026-03/2026-03-29-193308-lint-cleanup-across-python-and-go.md
@@ -1,0 +1,53 @@
+# Lint Cleanup Across Python and Go Codebase
+
+**Date**: March 29, 2026
+
+## Summary
+
+Resolved all lint and type-check errors caught by `make check` across the graphton library, agent-runner service, and stigmer-server Go module. The full CI gate (tidy, lint, docs, builds, 1373 tests) now passes cleanly on the `feat/status-builder-hardening` branch.
+
+## Problem Statement
+
+After the T08 handler extraction refactor (StatusBuilder from 3,289 to 417 lines), `make check` was failing with 30+ lint errors across 13 files in three codebases: the graphton Python library, the agent-runner Python service, and the stigmer-server Go module.
+
+### Pain Points
+
+- Unused imports left behind after large refactors (F401)
+- Import blocks out of isort order after handler extraction moved code between modules (I001)
+- Uppercase local variables in functions violating PEP 8 naming (N806)
+- Unused variable assignments from protobuf `.add()` calls and test scaffolding (F841)
+- Unused Go import from a prior API stub removal
+
+## Solution
+
+Systematic fix of all ruff (Python) and go vet (Go) errors, using `ruff check --fix` for auto-fixable issues and manual edits for unsafe fixes. Preserved backward-compatible re-exports that tests depend on by using `# noqa: F401` annotations.
+
+## Implementation Details
+
+**Go (1 file)**:
+- Removed unused `agentexecutionv1` import from `workflow_creator.go`
+
+**Python — graphton lib (5 files)**:
+- Renamed uppercase local variables `_MAIN_AGENT_ADVISORY_INTERVAL` → `main_agent_advisory_interval` in `agent.py`
+- Fixed import sorting in `subagent.py` (ruff requires aliased imports in separate statements)
+- Removed unused imports and variables in 3 test files
+
+**Python — agent-runner (7 files)**:
+- Fixed import ordering across `status_builder.py`, `execute_graphton.py`, and 4 handler modules (`chat_model.py`, `streaming_buffers.py`, `sub_agent.py`, `tool_event.py`)
+- Removed unused `MessageType`, `Config`, `ToolCall`, and `patch` imports
+- Removed unused `tc_a`/`tc_b` variable assignments in `test_status_builder.py` (protobuf `.add()` side-effect pattern)
+- Preserved `_MAX_SUBJECT_LENGTH` and `_generate_sub_agent_subject` re-exports with `# noqa: F401`
+
+## Benefits
+
+- `make check` passes end-to-end: tidy → lint → docs → builds → 1373 tests ✅
+- Branch is CI-ready for PR review
+- No functional changes — all fixes are import ordering, unused symbol removal, and naming conventions
+
+## Impact
+
+Branch `feat/status-builder-hardening` is now clean and ready for PR. The fixes span the graphton library and agent-runner service but introduce zero behavioral changes.
+
+---
+
+**Status**: ✅ Production Ready

--- a/_projects/2026-03/20260329.02.status-builder-hardening/README.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/README.md
@@ -1,0 +1,110 @@
+# Project: 20260329.02.status-builder-hardening
+
+## Overview
+Simplify the StatusBuilder from a 3,648-line god object with 30+ ad-hoc tracking dictionaries into a clean reducer/event-sourcing pattern with an explicit state model and ~10 well-defined indexes. Eliminate compensating complexity (fingerprint dedup, namespace heuristics, reconciliation queues) by using LangGraph's identity mechanisms directly.
+
+**Created**: 2026-03-29
+**Status**: Active 🟢
+
+## Project Information
+
+### Primary Goal
+Replace the ad-hoc dictionary accumulation in StatusBuilder with a properly designed state model using the reducer/event-sourcing pattern. The core job is simple: LangGraph emits events, we transform them into our protobuf structure using identity-based lookups. The current 30+ dictionaries exist because wrong modeling choices created compensating complexity. This project eliminates that complexity at the root.
+
+### Design Principle
+StatusBuilder is an event-sourcing projector. It receives a stream of LangGraph events and builds a protobuf projection (AgentExecutionStatus). The state model should be:
+- **Explicit**: An `ExecutionState` dataclass with named indexes, not ad-hoc `self._*` dictionaries
+- **Identity-keyed**: All lookups use framework-provided IDs (tool_call_id, run_id, namespace root)
+- **Minimal**: Only indexes needed for O(1) lookup into the proto, plus streaming buffers
+- **Recoverable**: On pod restart, indexes are rebuilt from the last-persisted proto in one pass
+
+### Timeline
+**Target Completion**: No rush, get it right
+
+### Technology Stack
+Python, LangGraph, Protobuf, gRPC, Temporal
+
+### Project Type
+Simplification
+
+### Affected Components
+agent-runner StatusBuilder, streaming.py, hitl.py, post_stream.py, execute_graphton.py, graphton core (namespace/sub-agent identity)
+
+## Project Context
+
+### Dependencies
+hitl-tool-call-separation project (20260329.01) should land first for G3 full-replace race fix
+
+### Success Criteria
+- StatusBuilder internal state reduced from 30+ dictionaries to ~10-12 well-defined indexes/buffers
+- All lookups are identity-based (tool_call_id, run_id, namespace root) — zero heuristic matching
+- Fingerprint dedup system fully deleted (fingerprints, FIFO queues, alias maps, reconciled resume deque)
+- Namespace routing heuristic cascade fully deleted — single deterministic lookup
+- Event handlers are small focused functions (5-20 lines each), not 50-100 line methods with reconciliation
+- All existing tests pass unchanged
+- No data inconsistencies observed in production for 2 weeks after deploy
+
+### Known Risks & Mitigations
+Large refactoring surface in a critical runtime path. Mitigated by phasing: eliminate compensating complexity first (deletes code, independently deployable), then restructure what remains. Each phase is a separate PR. Research steps (tool_call_id availability on events, namespace injection feasibility) happen before code changes.
+
+## Project Structure
+
+This project follows the **Next Project Framework** for structured multi-day development:
+
+- **`tasks/`** - Detailed task planning and execution logs (update freely)
+- **`checkpoints/`** - Major milestone summaries (⚠️ ASK before creating)
+- **`design-decisions/`** - Significant architectural choices (⚠️ ASK before creating)
+- **`coding-guidelines/`** - Project-wide code standards (⚠️ ASK before creating)
+- **`wrong-assumptions/`** - Important misconceptions (⚠️ ASK before creating)
+- **`dont-dos/`** - Critical anti-patterns (⚠️ ASK before creating)
+
+**📌 IMPORTANT**: Knowledge folders require developer permission. See [coding-guidelines/documentation-discipline.md](coding-guidelines/documentation-discipline.md)
+
+## Current Status
+
+### Active Task
+See [tasks/](tasks/) for the current task being worked on.
+
+### Latest Checkpoint
+See [checkpoints/](checkpoints/) for the most recent project state.
+
+### Progress Tracking
+- [x] Project initialized
+- [ ] Initial analysis complete
+- [ ] Core implementation
+- [ ] Testing and validation
+- [ ] Documentation finalized
+- [ ] Project completed
+
+## How to Resume Work
+
+**Quick Resume**: Simply drag and drop the `next-task.md` file into your AI conversation.
+
+The `next-task.md` file contains:
+- Direct paths to all project folders
+- Current status information
+- Resume checklist
+- Quick commands
+
+## Quick Links
+
+- [Next Task](next-task.md) - **Drag this into chat to resume**
+- [Current Task](tasks/)
+- [Latest Checkpoint](checkpoints/)
+- [Design Decisions](design-decisions/)
+- [Coding Guidelines](coding-guidelines/)
+
+## Documentation Discipline
+
+**CRITICAL**: AI assistants must ASK for permission before creating:
+- Checkpoints
+- Design decisions
+- Guidelines
+- Wrong assumptions
+- Don't dos
+
+Only task logs (T##_1_feedback.md, T##_2_execution.md) can be updated without permission.
+
+## Notes
+
+_Add any additional notes, links, or context here as the project evolves._

--- a/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-3.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-3.md
@@ -1,0 +1,37 @@
+# Session Notes: 2026-03-29 (session 3)
+
+## Accomplishments
+
+- **T05 complete**: Replaced the 4-strategy heuristic cascade in `_register_sub_agent_namespace` with a single deterministic `parent_ids` lookup
+- Rewrote `_register_sub_agent_namespace` — new signature `(self, namespace, event)`, ~25-line body using `event.get("parent_ids", [])` to match against `_active_sub_agents` and `_completed_sub_agents`
+- Deleted `_pending_sub_agent_ids` (FIFO causal correlation queue) from `__init__`, `_handle_sub_agent_start`, `_handle_sub_agent_end`
+- Removed `_warned_namespaces` from registration method (kept in `_get_execution_context`)
+- Net: -56 lines (273 added / 329 deleted across 2 files)
+- Full test suite: 2,711 passed (1,369 agent-runner + 1,342 graphton), 0 failures
+
+## Decisions Made
+
+- **DEBUG not WARNING for unresolved namespaces**: Failure to resolve a namespace in the new method is expected for single-segment (main-graph) nodes — promoted to DEBUG level with full diagnostic context instead of WARNING
+- **`_warned_namespaces` retained in `_get_execution_context`**: Downstream routing misses (where namespace IS multi-segment but wasn't registered) still get warning-level dedup to prevent log flooding
+- **Multi-segment gate (`"|" not in namespace`)**: Fast early-exit filter — only multi-segment namespaces are sub-agent candidates
+- **Checked both `_active_sub_agents` and `_completed_sub_agents`**: Late-arriving events for already-completed sub-agents still route correctly
+
+## Key Code Changes
+
+- **`status_builder.py`**: Complete rewrite of `_register_sub_agent_namespace` (was ~100 lines of 4-strategy heuristic cascade, now ~25 lines of `parent_ids` lookup). Removed `_pending_sub_agent_ids` from 3 lifecycle methods.
+- **`test_status_builder.py`**: Deleted `TestNamespaceRegistrationStrategies` and old `TestConcurrentSubAgentNamespaceRegistration` (10 tests). Replaced with `TestParentIdsNamespaceRouting` and new concurrent tests (8 tests). Updated ~20 events across `TestSubAgentInternals`, `TestSubAgentScenarios`, and `TestUniversalNamespaceRegistration` to use multi-segment namespaces with `parent_ids`. Deleted 12 `_pending_sub_agent_ids` assertions.
+
+## Learnings
+
+- `parent_ids` on v2 `astream_events` is the definitive mechanism for tracing sub-agent event lineage — it's top-level (not nested in metadata), always present, and carries the full callback chain
+- Namespace roots (first segment before `|`) are SHARED across concurrent sub-agents from the same parent node — root-prefix matching was inherently wrong for disambiguation
+- The heuristic cascade was pure compensating complexity — once you use the right identity mechanism, the entire problem evaporates
+
+## Open Questions
+
+- None for T05 — the implementation is clean and complete
+
+## Next Session Plan
+
+- T06: Fix pause handling (standalone, can be done independently)
+- T07: ExecutionState reducer refactor (fold `_run_id_aliases` into capture or eliminate)

--- a/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-4.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-4.md
@@ -1,0 +1,57 @@
+# Session Notes: 2026-03-29, Session 4
+
+## Accomplishments
+
+- Completed T06: Fix Pause/Resume — End-to-End across Go, Java, and Python
+- Go workflow: refactored `executeGraphtonFlow` with outer pause/resume loop using `workflow.Go()` + `workflow.WithCancel()`, extracted `executeGraphtonWithHitl()`
+- Go constants: added `SignalPause`/`SignalResume` to `workflow_types.go` and `invoke_workflow.go`; updated `lifecycle_steps.go` to use constants
+- Java constants: added `SIGNAL_PAUSE`/`SIGNAL_RESUME` to `AgentExecutionTemporalWorkflowTypes`; explicit `@SignalMethod(name=...)` on workflow interface
+- Java RPC handlers: created `AgentExecutionPauseHandler` and `AgentExecutionResumeHandler` with full pipeline (validate → signal → update phase → persist → publish)
+- Python persistence: removed unreliable `create_task` from `_handle_pause`; added `retry_executor` persistence to terminal_status early-return path in `execute_graphton.py`
+- Tests: 5 Go workflow tests, 2 Java signal tests, 5 Python pause flow tests — all passing
+- Cross-platform verification: confirmed Go receives `CancelledError` on context cancellation regardless of Python activity behavior
+
+## Decisions Made
+
+- **Modeled Go after Java**: The Java workflow already had a working `CancellationScope` + `Async.procedure` pattern for pause — the Go refactor adopted the same structure with `workflow.Go()` + `workflow.WithCancel()`
+- **MaxPauseCycles = 50**: Safety limit to prevent infinite pause/resume loops; configurable constant
+- **Defense-in-depth persistence**: Workflow persists `EXECUTION_PAUSED` status even though the Python activity also persists, ensuring at least one write succeeds
+- **Unified terminal persistence**: All terminal statuses (pause, stall, recursion limit) now go through `retry_executor` in `execute_graphton.py`, eliminating the unreliable `create_task` pattern
+- **Java handler pipeline**: Followed exact same pattern as existing handlers with LoadExisting → Authorize → Validate → Signal → UpdatePhase → Persist → Publish
+
+## Key Code Changes
+
+### Go (stigmer)
+- `workflow_types.go`: +9 lines — `SignalPause` and `SignalResume` constants
+- `invoke_workflow.go`: +8 lines — duplicate constants for package-level access
+- `lifecycle_steps.go`: 4 lines changed — use constants instead of inline strings
+- `invoke_workflow_impl.go`: +120 net lines — outer pause/resume loop, `executeGraphtonWithHitl()` extraction
+- `invoke_workflow_pause_test.go`: NEW — 5 tests covering pause→resume, normal completion, HITL, multi-cycle, FAILED activity
+
+### Java (stigmer-cloud)
+- `AgentExecutionTemporalWorkflowTypes.java`: +13 lines — `SIGNAL_PAUSE` and `SIGNAL_RESUME` constants with javadoc
+- `InvokeAgentExecutionWorkflow.java`: 4 lines changed — explicit `@SignalMethod(name=...)` attributes
+- `AgentExecutionPauseHandler.java`: NEW — full RPC handler with 7 pipeline steps
+- `AgentExecutionResumeHandler.java`: NEW — full RPC handler with 7 pipeline steps
+- `InvokeAgentExecutionWorkflowSignalTest.java`: +52 lines — pause/resume and normal completion tests
+
+### Python (stigmer)
+- `streaming.py`: -22 +11 lines — removed `create_task` hack from `_handle_pause`, simplified to pure in-memory mutation
+- `execute_graphton.py`: +25 lines — `retry_executor` persistence for terminal_status early-return path
+- `test_pause_flow.py`: NEW — 5 tests covering `_handle_pause` return semantics and terminal persistence
+
+## Learnings
+
+- **Scope expansion was justified**: What looked like a small Python fix turned out to be a fundamental architectural gap across three languages. The Go workflow was not consuming pause signals at all.
+- **Temporal test environment quirks**: In `TestWorkflowEnvironment`, when `cancelActivity()` is called, the activity mock is NOT invoked — `Future.Get()` immediately returns `CancelledError`. This differs slightly from production where the activity receives cancellation and may return normally, but the workflow-level behavior is equivalent.
+- **Cross-language signal names**: Signal name consistency is critical in polyglot Temporal — Go and Java workflows must agree on exact string names. Constants solve this cleanly.
+- **Pipeline handler pattern**: The Java handler pattern (LoadExisting → Authorize → Validate → Execute → Persist → Publish) is remarkably clean for implementing new RPCs — adding Pause/Resume was mostly structural.
+
+## Open Questions
+
+- None blocking. T06 is fully complete.
+
+## Next Session Plan
+
+1. T07 — ExecutionState reducer refactor (fold `_run_id_aliases` into `ToolCallIdCapture` or eliminate)
+2. T08+ — Continue reducer pattern simplification per plan

--- a/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-5.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-5.md
@@ -1,0 +1,70 @@
+# Session Notes: 2026-03-29 (Session 5)
+
+## Accomplishments
+
+- **Completed T07: ExecutionState Reducer Refactor** — the largest structural refactor in the status-builder-hardening project
+- All 6 plan steps executed successfully with 1,382 tests passing (8 new, 0 regressions)
+
+### Step 1: Fold `_run_id_aliases` into ToolCallIdCapture
+- Added `register_alias()` and `resolve()` methods to `ToolCallIdCapture`
+- Deleted `_run_id_aliases` dict and `_resolve_run_id()` private method from StatusBuilder
+- Replaced 3 alias-write sites and 3 resolve sites
+- Made `_tool_call_id_capture` always non-None (defaults to bare instance when not provided)
+- Moved import from `TYPE_CHECKING` to runtime
+
+### Step 2: Fix private API leakage
+- `streaming.py`: `_resolve_run_id()` → `resolve_run_id()` (new public method)
+- `hitl.py`: `len(self._sb._tool_call_index)` → `self._sb.tool_call_count()` (existing public method)
+- `post_stream.py`: `len(status_builder._active_sub_agents)` → `status_builder.active_sub_agent_count` (new property)
+- Zero private `_` access from external callers after this step
+
+### Step 3: Define ExecutionState dataclass
+- New file `execution_state.py` with 21 top-level fields and 3 sub-groups:
+  - `ThinkingStreamState` (3 fields: buffers, started_at, tool_call_ids)
+  - `ToolInputStreamState` (2 fields: active_tc, buffers)
+  - `ApprovalTrackingState` (3 fields: pending, saved_phase, wait_started_at)
+
+### Step 4: Mechanical migration
+- 164 occurrences of `self._<state_var>` → `self.state.<field>` in `status_builder.py`
+- ~178 occurrences across 3 test files (`test_status_builder.py`, `test_hitl_contracts.py`, `test_inline_publish.py`)
+- StatusBuilder `__init__` shrunk from ~225 lines to ~15 lines
+- `current_status` converted to a property delegating to `self.state.proto`
+- Fixed false positives where `ToolCallIdCapture._run_id_to_tool_call_id` was incorrectly renamed
+- Fixed `StatusBuilder.__new__()` test fixture to create `self.state` before setting `current_status`
+
+### Step 5: `rebuild_from_proto()` classmethod
+- Reconstructs tool call indexes (main + sub-agent messages), completed sub-agents, and artifacts
+- `rebuild_index_from_persisted_status()` now delegates to the classmethod
+- Ephemeral runtime state (timing, buffers, approval) starts fresh after rebuild
+
+### Step 6: Tests
+- 8 new `TestRebuildFromProto` tests covering tool call indexing, sub-agent indexing, artifact copying, ephemeral state freshness, edge cases (empty id, non-AI messages), and StatusBuilder delegation
+- All test fixtures updated to use new public API (`resolve_run_id`, `state.*` access paths)
+
+## Decisions Made
+
+1. **Sub-grouped ExecutionState** (21 top-level fields, 3 sub-groups): ThinkingStreamState, ToolInputStreamState, ApprovalTrackingState — each group represents a genuine conceptual unit with a shared lifecycle
+2. **`force_next_update` stays on StatusBuilder**: gRPC scheduling coordination signal, not execution state
+3. **`ToolCallIdCapture` is the single authority** for run_id → tool_call_id resolution (callback capture + resume aliases unified)
+4. **Config/collaborators stay on StatusBuilder**: `_approval_config`, `_tool_call_id_capture`, `_usage_tracker`, `_display_env_vars`, `_secret_keys`, `_workspace_root`
+
+## Key Code Changes
+
+- **New**: `execution_state.py` — 221-line typed dataclass with full documentation
+- **Modified**: `status_builder.py` — net -625/+594 lines (massive __init__ cleanup, all state access via `self.state.*`)
+- **Modified**: `tool_call_id_capture.py` — added alias layer (+33 lines)
+- **Modified**: `streaming.py`, `hitl.py`, `post_stream.py` — private API access eliminated
+- **Tests**: 3 test files updated (~500+ line changes), 8 new rebuild tests
+
+## Metrics
+
+- StatusBuilder `__init__`: 225 lines → 15 lines
+- Private API leakage: 3 sites → 0
+- `_run_id_aliases`: eliminated entirely (folded into ToolCallIdCapture)
+- Tests: 1,374 → 1,382 (8 new, 0 regressions)
+- Net diff: 594 additions, 618 deletions across 8 modified files + 1 new file
+
+## Next Session Plan
+
+- **T08**: Extract event handlers into focused collaborator modules to shrink StatusBuilder below 500 lines
+- The state is now explicit and typed — handler extraction can proceed cleanly with `ExecutionState` as the shared parameter

--- a/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-6.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/2026-03-29-session-6.md
@@ -1,0 +1,44 @@
+# Session Notes: 2026-03-29 (Session 6)
+
+## Accomplishments
+
+- **Completed T08: Handler Extraction** — final steps (5-7) of the 7-step plan
+- Extracted `tool_event.py` (472 lines): tool start/end/progress, approval checks, todos, arg humanization
+- Created `chat_model.py` (499 lines): chat model stream/end, AI message assembly, usage metrics
+- Moved `ensure_parent_ai_message` into `streaming_buffers.py` (56 lines added)
+- Moved `prepare_task_tool_resume_queue` into `sub_agent.py` (42 lines added)
+- Rewrote `status_builder.py` as 417-line thin orchestrator with delegation stubs
+- Updated `handlers/__init__.py` with full module inventory documentation
+- All 282 `test_status_builder.py` tests pass — zero regressions
+
+## Decisions Made
+
+- **`sb._update_todos()` call pattern**: `tool_event.py` calls `sb._update_todos(...)` rather than calling the module-level `update_todos(sb, ...)` directly, because tests mock the `StatusBuilder` method. This ensures test compatibility without requiring test rewrites.
+- **Re-exports over import rewrites**: External modules that import `_utc_timestamp`, `PLANNING_TOOLS`, `_READ_ONLY_TOOLS`, etc. from `status_builder` continue to work through re-exports. Avoids a cascading change across 4+ consumer modules.
+- **Thin delegation stubs**: Public methods and methods that are mock targets in tests retain one-line delegation stubs on `StatusBuilder`. This is a deliberate trade-off: ~30 lines of stubs preserves the test harness without test rewrites.
+- **_READ_ONLY_TOOLS corrected**: Original value was `frozenset({"read", "read_file"})`, not the 5-tool set initially written in error. Verified against git history.
+- **humanize_sandbox_paths import**: Corrected from `worker.activities.graphton.humanize` to `graphton.core.backends.platform_mount`.
+
+## Key Code Changes
+
+- `status_builder.py`: 3,289 → 417 lines (87% reduction). Now contains `__init__`, `process_event`, namespace routing, approval state, and delegation stubs only.
+- `handlers/tool_event.py`: +214 lines — gained `check_approval_requirement`, `set_waiting_for_approval_phase`, `update_todos`, `update_sub_agent_todos`, `humanize_args_for_display`, `create_args_preview`
+- `handlers/streaming_buffers.py`: +56 lines — gained `ensure_parent_ai_message`
+- `handlers/sub_agent.py`: +42 lines — gained `prepare_task_tool_resume_queue`
+- `handlers/__init__.py`: +10 lines — full module docstring with inventory
+- 2 Go files: minor cleanup (unused import removal, formatting)
+
+## Learnings
+
+- When extracting methods that tests `patch.object`, the delegation stub on the original class must remain. The stub call site in the handler module must go through `sb.method()` (not `module_func(sb, ...)`), otherwise mocks won't intercept.
+- `git show` is invaluable for recovering accidentally deleted code during large replacements.
+- Doing extraction in dependency order (stateless first → stateful last) minimizes cascading errors.
+
+## Open Questions
+
+- None — T08 is complete. Next task should be identified from `next-task.md`.
+
+## Next Session Plan
+
+- Identify and plan the next task in the status-builder-hardening project
+- The handler extraction provides a clean foundation for any remaining work

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -74,9 +74,10 @@ When starting a new session:
 **T03 Completed**: 2026-03-29 (namespace routing via parent_ids confirmed — Approach B)
 **T05 Completed**: 2026-03-29 (namespace heuristics replaced with parent_ids-based deterministic routing)
 **T06 Completed**: 2026-03-29 (end-to-end pause/resume fix across Go, Java, Python)
-**Current Task**: T07 (ExecutionState reducer refactor)
-**Next Code Task**: T07 (ExecutionState reducer refactor)
-**Status**: Active — T02+T03+T04+T05+T06 complete, T07 unblocked
+**T07 Completed**: 2026-03-29 (ExecutionState reducer refactor — explicit typed state model)
+**Current Task**: T08 (handler extraction — shrink StatusBuilder below 500 lines)
+**Next Code Task**: T08 (handler extraction)
+**Status**: Active — T02+T03+T04+T05+T06+T07 complete, T08 unblocked
 
 ### T02 Key Finding
 v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
@@ -176,43 +177,46 @@ Files changed: 13 (6 modified stigmer + 2 new stigmer + 3 modified stigmer-cloud
 - `ToolCallIdCapture` placed in its own module per "StatusBuilder Is NOT a Dumping Ground"
 - Used `TYPE_CHECKING` guard for the import, string annotation for the constructor param
 
+## Session Progress (2026-03-29, session 5)
+
+### What was accomplished
+- **Completed T07: ExecutionState Reducer Refactor** — the largest structural refactor in the project
+- All 6 plan steps executed: alias fold, API leakage fix, ExecutionState dataclass, mechanical migration (164+178 renames), rebuild_from_proto, test updates
+- New file: `execution_state.py` — 221-line typed dataclass with 21 top-level fields and 3 sub-groups
+- StatusBuilder `__init__` shrunk from ~225 lines to ~15 lines
+- Unified run_id resolution into `ToolCallIdCapture` (eliminated `_run_id_aliases`)
+- Fixed 3 private API leakage sites (streaming.py, hitl.py, post_stream.py)
+- Added `rebuild_from_proto()` classmethod for proto-based index reconstruction
+- 1,382 tests pass (8 new, 0 regressions)
+
+### Key decisions
+- Sub-grouped dataclass (ThinkingStreamState, ToolInputStreamState, ApprovalTrackingState) — shared lifecycle fields grouped for conceptual clarity and T08 handler extraction readiness
+- `force_next_update` stays on StatusBuilder — gRPC scheduling signal, not execution state
+- Config/collaborators stay on StatusBuilder — only mutable execution state lives in `ExecutionState`
+
 ## Session Progress (2026-03-29, session 4)
 
 ### What was accomplished
 - Completed T06: End-to-end pause/resume fix across Go, Java, and Python
-- **Go workflow**: Refactored `executeGraphtonFlow` with outer pause/resume loop using `workflow.Go()` + `workflow.WithCancel()`, extracted `executeGraphtonWithHitl()` for clarity
-- **Go constants**: Added `SignalPause`/`SignalResume` to `workflow_types.go` and `invoke_workflow.go`, updated `lifecycle_steps.go` to use them
-- **Java constants**: Added `SIGNAL_PAUSE`/`SIGNAL_RESUME` to `AgentExecutionTemporalWorkflowTypes`, explicit `@SignalMethod(name=...)` on workflow interface
-- **Java RPC handlers**: Created `AgentExecutionPauseHandler` and `AgentExecutionResumeHandler` with full pipeline (validate, signal, update phase, persist, publish)
-- **Python persistence**: Removed unreliable `create_task` from `_handle_pause`, added `retry_executor` persistence to terminal_status early-return path in `execute_graphton.py`
-- **Tests**: 5 Go workflow tests, 2 Java signal tests, 5 Python pause flow tests — all passing
-- **Cross-platform verification**: Confirmed that Go receives `CancelledError` on workflow context cancellation regardless of whether Python activity returns normally, ensuring the workflow logic is robust
-
-### Key decisions
-- Modeled Go workflow after proven Java `CancellationScope` + `Async.procedure` pattern
-- `MaxPauseCycles = 50` safety limit to prevent infinite pause/resume loops
-- Defense-in-depth: workflow persists PAUSED status even though Python activity also persists
-- Terminal status persistence (pause, stall, recursion limit) unified through `retry_executor` in `execute_graphton.py`
-- Java handlers follow exact same pipeline pattern as existing handlers (LoadExisting → Authorize → Validate → Signal → UpdatePhase → Persist → Publish)
-
-### Key finding
-The original "Python-side persistence bug" was actually a much deeper architectural gap: the Go Temporal workflow was not consuming pause signals at all, so activity cancellation never happened. The Java workflow had the right structure but lacked RPC handlers to send the signals. The fix required coordinated changes across all three languages.
+- Go workflow refactored with outer pause/resume loop, Java got Pause/Resume RPC handlers
+- Python persistence unified through `retry_executor` in terminal_status path
 
 ## Next Steps (when you return)
-1. T07 — ExecutionState reducer refactor (fold `_run_id_aliases` into capture or eliminate)
-2. T08+ — Continue reducer pattern simplification per plan
+1. T08 — Extract event handlers into focused collaborator modules (shrink StatusBuilder below 500 lines)
+2. The sub-grouped `ExecutionState` serves as natural parameter boundaries for handler extraction
 3. Note: InterruptProxyRunnable elimination (separate project) further simplifies the codebase
 
 ## Context for Resume
-- T06 changes span two repos: `stigmer` (Go + Python) and `stigmer-cloud` (Java)
-- Both repos need to be committed separately — stigmer-cloud changes are on `main` branch
-- The Java workflow implementation (`InvokeAgentExecutionWorkflowImpl.java`) already had pause/resume logic; only constants, interface annotations, and RPC handlers were added
-- The Go workflow implementation was the most significant change — `invoke_workflow_impl.go` gained ~120 net lines
+- T07 is fully committed (see below) — all state is now in `self.state.*` instead of `self._*`
+- `execution_state.py` defines the typed state model — read it first to understand field layout
+- `current_status` is now a property delegating to `self.state.proto`
+- `ToolCallIdCapture` is the single authority for run_id resolution (callback + alias layers)
+- T08 should focus on extracting the 2,500+ lines of event handlers into focused modules
 
 ## Quick Commands
 
 After loading context:
-- "Start T07 implementation" - ExecutionState reducer refactor
+- "Start T08 planning" - Handler extraction to shrink StatusBuilder
 - "Show project status" - Get overview of progress
 - "Review the plan" - Read the v2 task plan
 

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -72,9 +72,10 @@ When starting a new session:
 **T02 Completed**: 2026-03-29 (tool_call_id availability confirmed via callback handler approach)
 **T04 Completed**: 2026-03-29 (fingerprint dedup replaced with identity-based lookup)
 **T03 Completed**: 2026-03-29 (namespace routing via parent_ids confirmed — Approach B)
-**Current Task**: T05 (Replace namespace heuristics with parent_ids-based deterministic routing)
-**Next Code Task**: T05, T06 (pause fix standalone)
-**Status**: Active — T02+T03+T04 complete, T05 unblocked
+**T05 Completed**: 2026-03-29 (namespace heuristics replaced with parent_ids-based deterministic routing)
+**Current Task**: T06 or T07 (see next steps)
+**Next Code Task**: T06 (pause fix standalone), T07 (ExecutionState reducer refactor)
+**Status**: Active — T02+T03+T04+T05 complete, T06/T07 unblocked
 
 ### T02 Key Finding
 v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
@@ -99,6 +100,37 @@ Net: -197 lines. All 1,375 tests pass. Files changed:
 - Modified: `status_builder.py`, `execute_graphton.py`, `hitl.py`
 - Tests: `test_status_builder.py`, `test_hitl_contracts.py`
 
+### T05 Completion Summary
+Replaced the 4-strategy heuristic cascade in `_register_sub_agent_namespace` with a
+single deterministic `parent_ids` lookup. v2 `astream_events` carry `parent_ids` at
+the top level — the task tool's `run_id` appears in the chain, matching the key in
+`_active_sub_agents`. Net: -56 lines (273 added, 329 deleted). All 2,711 tests pass.
+Deleted:
+- `_pending_sub_agent_ids` list (FIFO queue for causal correlation)
+- 4 heuristic strategies: root-prefix, substring, FIFO causal, sole-active fallback
+- `_warned_namespaces` usage in `_register_sub_agent_namespace` (kept in `_get_execution_context`)
+Files changed:
+- Modified: `status_builder.py` (production rewrite + cleanup)
+- Tests: `test_status_builder.py` (rewrote 2 test classes, updated ~20 namespace events)
+
+## Session Progress (2026-03-29, session 3)
+
+### What was accomplished
+- Completed T05: replace namespace heuristic cascade with `parent_ids`-based deterministic routing
+- Rewrote `_register_sub_agent_namespace` — new signature `(self, namespace, event)`, ~25-line body
+- Updated both call sites (`process_event`, `_handle_chat_model_stream_event`) to pass full `event`
+- Deleted `_pending_sub_agent_ids` from `__init__`, `_handle_sub_agent_start`, `_handle_sub_agent_end`
+- Removed `_warned_namespaces` usage from `_register_sub_agent_namespace` (kept in `_get_execution_context`)
+- Rewrote `TestNamespaceRegistrationStrategies` + `TestConcurrentSubAgentNamespaceRegistration` with `parent_ids` tests
+- Updated ~20 test events to multi-segment namespaces with `parent_ids` field
+- Deleted 12 `_pending_sub_agent_ids` assertions from test suite
+- Full test suite: 2,711 passed (1,369 agent-runner + 1,342 graphton), 0 failed
+
+### Key decisions
+- Failure to resolve namespace is DEBUG level, not WARNING — unresolvable namespaces are normal for main-graph nodes
+- Kept `_warned_namespaces` in `_get_execution_context` to prevent log flooding for downstream routing misses
+- Multi-segment check (`"|" not in namespace`) used as fast early-exit — single-segment = main-agent graph node
+
 ## Session Progress (2026-03-29, session 2)
 
 ### What was accomplished
@@ -118,17 +150,16 @@ Net: -197 lines. All 1,375 tests pass. Files changed:
 - Used `TYPE_CHECKING` guard for the import, string annotation for the constructor param
 
 ## Next Steps (when you return)
-1. T03 research COMPLETE — `parent_ids` confirmed as deterministic routing mechanism
-2. Start T05 — replace namespace heuristic cascade with `parent_ids`-based registration
-3. T06 (pause fix) can be done anytime as a standalone task
-4. T07 — ExecutionState refactor (fold `_run_id_aliases` into capture or eliminate)
-5. Note: InterruptProxyRunnable elimination (separate project) will further simplify T05
+1. T06 — Fix pause handling (standalone task, can be done anytime)
+2. T07 — ExecutionState reducer refactor (fold `_run_id_aliases` into capture or eliminate)
+3. T08+ — Continue reducer pattern simplification per plan
+4. Note: InterruptProxyRunnable elimination (separate project) further simplifies the codebase
 
 ## Quick Commands
 
 After loading context:
-- "Start T05 implementation" - Replace _run_id_to_tool_call_id with _tool_call_index
 - "Start T06 implementation" - Fix pause handling (standalone)
+- "Start T07 implementation" - ExecutionState reducer refactor
 - "Show project status" - Get overview of progress
 - "Review the plan" - Read the v2 task plan
 

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -1,0 +1,118 @@
+# Next Task: 20260329.02.status-builder-hardening
+
+## Quick Resume Instructions
+
+Drop this file into your conversation to quickly resume work on this project.
+
+## Project: 20260329.02.status-builder-hardening
+
+**Description**: Simplify StatusBuilder from a 3,648-line god object with 30+ ad-hoc dictionaries into a clean reducer/event-sourcing pattern. Eliminate compensating complexity (fingerprint dedup, namespace heuristics, reconciliation queues) by using LangGraph's identity mechanisms directly. Target: ~10-12 well-defined indexes/buffers, identity-based lookups, small focused event handlers.
+**Goal**: Replace ad-hoc dictionary accumulation with a properly designed state model using the reducer/event-sourcing pattern. All lookups identity-based, all state explicit and recoverable, event handlers small and focused.
+**Tech Stack**: Python, LangGraph, Protobuf, gRPC, Temporal
+**Components**: agent-runner StatusBuilder, streaming.py, hitl.py, post_stream.py, checkpoint_validator.py, execute_graphton.py, graphton core (namespace/sub-agent identity)
+
+## Essential Files to Review
+
+### 1. Latest Checkpoint (if exists)
+Check for the most recent checkpoint file:
+```
+/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/
+```
+
+### 2. Current Task
+Review the current task status and plan:
+```
+/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/tasks/
+```
+
+### 3. Project Documentation
+- **README**: `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/README.md`
+
+## Knowledge Folders to Check
+
+### Design Decisions
+```
+/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/design-decisions/
+```
+Review architectural and strategic choices made for this project.
+
+### Coding Guidelines
+```
+/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/coding-guidelines/
+```
+Check project-specific patterns and conventions established.
+
+### Wrong Assumptions
+```
+/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/wrong-assumptions/
+```
+Review misconceptions discovered to avoid repeating them.
+
+### Don't Dos
+```
+/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/dont-dos/
+```
+Check anti-patterns and failed approaches to avoid.
+
+## Resume Checklist
+
+When starting a new session:
+
+1. [ ] Read the latest checkpoint (if any) from `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/checkpoints/`
+2. [ ] Check current task status in `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/tasks/`
+3. [ ] Review any new design decisions in `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/design-decisions/`
+4. [ ] Check coding guidelines in `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/coding-guidelines/`
+5. [ ] Review lessons learned in `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/wrong-assumptions/` and `/Users/suresh/scm/github.com/stigmer/stigmer/_projects/2026-03/20260329.02.status-builder-hardening/dont-dos/`
+6. [ ] Continue with the next task or complete the current one
+
+## Current Status
+
+**Created**: 2026-03-29 14:37
+**Plan Revised**: 2026-03-29 19:30 (v2 — reducer pattern simplification)
+**T02 Completed**: 2026-03-29 (tool_call_id availability confirmed via callback handler approach)
+**Current Task**: T03 (Research: namespace injection feasibility)
+**Next Code Task**: T04 (Replace fingerprint dedup with tool_call_id lookup — unblocked by T02)
+**Status**: Active — T02 complete, T03 pending, T04 unblocked
+
+### T02 Key Finding
+v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
+callback handler captures `{run_id → tool_call_id}` from the callback API (which
+does receive it). Works for ALL tools universally. Eliminates 3 dictionaries, 2
+methods, and ~100 lines of fingerprint/FIFO dedup logic. See `tasks/T02_0_research.md`.
+
+## Session Progress (2026-03-29)
+
+### What was accomplished
+- Reviewed and approved v2 plan (T01_0_plan.md)
+- Completed T02 research: traced LangGraph/LangChain event pipeline across 5 framework layers
+- Discovered that `_filter_injected_args` blocks the naive `InjectedToolCallId` approach
+- Identified `ToolCallIdCapture` callback handler as the clean, universal solution
+- Wrote comprehensive research document (`tasks/T02_0_research.md`, 304 lines)
+- Updated `_roles/005_ai_engineer.md` with architectural principles from HITL learnings
+
+### Key decisions
+- Callback handler approach chosen over modifying tool wrappers (universal coverage, simpler)
+- Live validation skipped — findings based on reading actual installed package source code
+
+### Surprise discovered
+`BaseTool._filter_injected_args` strips `InjectedToolCallId` values from callback inputs
+before they reach the v2 event emitter. This means `data.input` will never contain
+`tool_call_id` regardless of wrapper annotations. The callback handler approach is
+necessary and also superior (works for ALL tools without per-wrapper changes).
+
+## Next Steps (when you return)
+1. Start T03 research — namespace injection feasibility in Graphton sub-graph construction
+2. Start T04 implementation — replace fingerprint dedup with `ToolCallIdCapture` (unblocked)
+3. T06 (pause fix) can be done anytime as a standalone task
+
+## Quick Commands
+
+After loading context:
+- "Start T03 research" - Investigate namespace injection in Graphton sub-graph construction
+- "Start T04 implementation" - Replace fingerprint dedup with tool_call_id lookup (requires T02 findings)
+- "Show project status" - Get overview of progress
+- "Review the plan" - Read the v2 task plan
+
+---
+
+*This file provides direct paths to all project resources for quick context loading.*

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -73,9 +73,10 @@ When starting a new session:
 **T04 Completed**: 2026-03-29 (fingerprint dedup replaced with identity-based lookup)
 **T03 Completed**: 2026-03-29 (namespace routing via parent_ids confirmed — Approach B)
 **T05 Completed**: 2026-03-29 (namespace heuristics replaced with parent_ids-based deterministic routing)
-**Current Task**: T06 or T07 (see next steps)
-**Next Code Task**: T06 (pause fix standalone), T07 (ExecutionState reducer refactor)
-**Status**: Active — T02+T03+T04+T05 complete, T06/T07 unblocked
+**T06 Completed**: 2026-03-29 (end-to-end pause/resume fix across Go, Java, Python)
+**Current Task**: T07 (ExecutionState reducer refactor)
+**Next Code Task**: T07 (ExecutionState reducer refactor)
+**Status**: Active — T02+T03+T04+T05+T06 complete, T07 unblocked
 
 ### T02 Key Finding
 v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
@@ -113,6 +114,32 @@ Files changed:
 - Modified: `status_builder.py` (production rewrite + cleanup)
 - Tests: `test_status_builder.py` (rewrote 2 test classes, updated ~20 namespace events)
 
+### T06 Completion Summary
+Fixed the broken pause/resume mechanism end-to-end across Go, Java, and Python.
+The Go workflow now consumes pause/resume signals (modeled after the proven Java
+implementation), the Java Cloud service gained the missing Pause/Resume RPC handlers,
+and the Python activity persists terminal status reliably through the normal retry path.
+
+**Go (stigmer OSS):**
+- Added `SignalPause`/`SignalResume` constants to `workflow_types.go` and `invoke_workflow.go`
+- Updated `lifecycle_steps.go` to use constants instead of inline strings
+- Refactored `executeGraphtonFlow`: outer pause/resume loop with `workflow.Go()` + `workflow.WithCancel()`
+- Extracted `executeGraphtonWithHitl()` matching Java's structure
+- 5 workflow tests (pause→resume, normal, HITL, multi-cycle, FAILED)
+
+**Java (stigmer-cloud):**
+- Added `SIGNAL_PAUSE`/`SIGNAL_RESUME` constants to `AgentExecutionTemporalWorkflowTypes`
+- Added explicit `@SignalMethod(name=...)` to workflow interface
+- Created `AgentExecutionPauseHandler` and `AgentExecutionResumeHandler` with full pipeline
+- Added pause/resume tests to `InvokeAgentExecutionWorkflowSignalTest`
+
+**Python (shared):**
+- Removed unreliable `create_task` persistence from `_handle_pause` in `streaming.py`
+- Added `retry_executor` persistence to terminal_status early-return path in `execute_graphton.py`
+- 5 unit tests for pause flow
+
+Files changed: 13 (6 modified stigmer + 2 new stigmer + 3 modified stigmer-cloud + 2 new stigmer-cloud)
+
 ## Session Progress (2026-03-29, session 3)
 
 ### What was accomplished
@@ -149,16 +176,42 @@ Files changed:
 - `ToolCallIdCapture` placed in its own module per "StatusBuilder Is NOT a Dumping Ground"
 - Used `TYPE_CHECKING` guard for the import, string annotation for the constructor param
 
+## Session Progress (2026-03-29, session 4)
+
+### What was accomplished
+- Completed T06: End-to-end pause/resume fix across Go, Java, and Python
+- **Go workflow**: Refactored `executeGraphtonFlow` with outer pause/resume loop using `workflow.Go()` + `workflow.WithCancel()`, extracted `executeGraphtonWithHitl()` for clarity
+- **Go constants**: Added `SignalPause`/`SignalResume` to `workflow_types.go` and `invoke_workflow.go`, updated `lifecycle_steps.go` to use them
+- **Java constants**: Added `SIGNAL_PAUSE`/`SIGNAL_RESUME` to `AgentExecutionTemporalWorkflowTypes`, explicit `@SignalMethod(name=...)` on workflow interface
+- **Java RPC handlers**: Created `AgentExecutionPauseHandler` and `AgentExecutionResumeHandler` with full pipeline (validate, signal, update phase, persist, publish)
+- **Python persistence**: Removed unreliable `create_task` from `_handle_pause`, added `retry_executor` persistence to terminal_status early-return path in `execute_graphton.py`
+- **Tests**: 5 Go workflow tests, 2 Java signal tests, 5 Python pause flow tests — all passing
+- **Cross-platform verification**: Confirmed that Go receives `CancelledError` on workflow context cancellation regardless of whether Python activity returns normally, ensuring the workflow logic is robust
+
+### Key decisions
+- Modeled Go workflow after proven Java `CancellationScope` + `Async.procedure` pattern
+- `MaxPauseCycles = 50` safety limit to prevent infinite pause/resume loops
+- Defense-in-depth: workflow persists PAUSED status even though Python activity also persists
+- Terminal status persistence (pause, stall, recursion limit) unified through `retry_executor` in `execute_graphton.py`
+- Java handlers follow exact same pipeline pattern as existing handlers (LoadExisting → Authorize → Validate → Signal → UpdatePhase → Persist → Publish)
+
+### Key finding
+The original "Python-side persistence bug" was actually a much deeper architectural gap: the Go Temporal workflow was not consuming pause signals at all, so activity cancellation never happened. The Java workflow had the right structure but lacked RPC handlers to send the signals. The fix required coordinated changes across all three languages.
+
 ## Next Steps (when you return)
-1. T06 — Fix pause handling (standalone task, can be done anytime)
-2. T07 — ExecutionState reducer refactor (fold `_run_id_aliases` into capture or eliminate)
-3. T08+ — Continue reducer pattern simplification per plan
-4. Note: InterruptProxyRunnable elimination (separate project) further simplifies the codebase
+1. T07 — ExecutionState reducer refactor (fold `_run_id_aliases` into capture or eliminate)
+2. T08+ — Continue reducer pattern simplification per plan
+3. Note: InterruptProxyRunnable elimination (separate project) further simplifies the codebase
+
+## Context for Resume
+- T06 changes span two repos: `stigmer` (Go + Python) and `stigmer-cloud` (Java)
+- Both repos need to be committed separately — stigmer-cloud changes are on `main` branch
+- The Java workflow implementation (`InvokeAgentExecutionWorkflowImpl.java`) already had pause/resume logic; only constants, interface annotations, and RPC handlers were added
+- The Go workflow implementation was the most significant change — `invoke_workflow_impl.go` gained ~120 net lines
 
 ## Quick Commands
 
 After loading context:
-- "Start T06 implementation" - Fix pause handling (standalone)
 - "Start T07 implementation" - ExecutionState reducer refactor
 - "Show project status" - Get overview of progress
 - "Review the plan" - Read the v2 task plan

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -75,9 +75,9 @@ When starting a new session:
 **T05 Completed**: 2026-03-29 (namespace heuristics replaced with parent_ids-based deterministic routing)
 **T06 Completed**: 2026-03-29 (end-to-end pause/resume fix across Go, Java, Python)
 **T07 Completed**: 2026-03-29 (ExecutionState reducer refactor — explicit typed state model)
-**Current Task**: T08 (handler extraction — shrink StatusBuilder below 500 lines)
-**Next Code Task**: T08 (handler extraction)
-**Status**: Active — T02+T03+T04+T05+T06+T07 complete, T08 unblocked
+**T08 Completed**: 2026-03-29 (handler extraction — StatusBuilder 3,289 → 417 lines)
+**Current Task**: None — all planned tasks through T08 complete
+**Status**: Active — T02+T03+T04+T05+T06+T07+T08 complete
 
 ### T02 Key Finding
 v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
@@ -177,6 +177,22 @@ Files changed: 13 (6 modified stigmer + 2 new stigmer + 3 modified stigmer-cloud
 - `ToolCallIdCapture` placed in its own module per "StatusBuilder Is NOT a Dumping Ground"
 - Used `TYPE_CHECKING` guard for the import, string annotation for the constructor param
 
+## Session Progress (2026-03-29, session 6)
+
+### What was accomplished
+- **Completed T08: Handler Extraction** — final steps (5-7) of the 7-step plan
+- Extracted `tool_event.py` (472 lines): tool start/end/progress, approval checks, todos, arg humanization
+- Created `chat_model.py` (499 lines): chat model stream/end, AI message assembly, usage metrics
+- Moved `ensure_parent_ai_message` → `streaming_buffers.py`, `prepare_task_tool_resume_queue` → `sub_agent.py`
+- Rewrote `status_builder.py` as 417-line thin orchestrator (87% reduction from 3,289)
+- All 282 `test_status_builder.py` tests pass — zero regressions
+- Committed: `602b2309`
+
+### Key decisions
+- Thin delegation stubs preserved on `StatusBuilder` for public API and test mock compatibility
+- `sb._update_todos()` call pattern in handler modules ensures test mocks intercept correctly
+- Re-exports from `status_builder.py` maintain backward compatibility for external consumers
+
 ## Session Progress (2026-03-29, session 5)
 
 ### What was accomplished
@@ -202,22 +218,24 @@ Files changed: 13 (6 modified stigmer + 2 new stigmer + 3 modified stigmer-cloud
 - Python persistence unified through `retry_executor` in terminal_status path
 
 ## Next Steps (when you return)
-1. T08 — Extract event handlers into focused collaborator modules (shrink StatusBuilder below 500 lines)
-2. The sub-grouped `ExecutionState` serves as natural parameter boundaries for handler extraction
+1. Review the task list in `next-task.md` for any remaining tasks beyond T08
+2. Consider integration testing across the full refactored stack
 3. Note: InterruptProxyRunnable elimination (separate project) further simplifies the codebase
+4. The `feat/status-builder-hardening` branch is ready for PR review
 
 ## Context for Resume
-- T07 is fully committed (see below) — all state is now in `self.state.*` instead of `self._*`
+- T08 is fully committed (`602b2309`) — `StatusBuilder` is now 417 lines
 - `execution_state.py` defines the typed state model — read it first to understand field layout
-- `current_status` is now a property delegating to `self.state.proto`
+- `graphton/handlers/` contains 6 modules (2,576 lines total) with all extracted event logic
 - `ToolCallIdCapture` is the single authority for run_id resolution (callback + alias layers)
-- T08 should focus on extracting the 2,500+ lines of event handlers into focused modules
+- `current_status` is a property delegating to `self.state.proto`
+- Handler modules use `sb: StatusBuilder` first-arg pattern; `TYPE_CHECKING` prevents circular imports
 
 ## Quick Commands
 
 After loading context:
-- "Start T08 planning" - Handler extraction to shrink StatusBuilder
 - "Show project status" - Get overview of progress
+- "Create PR" - Open PR for the `feat/status-builder-hardening` branch
 - "Review the plan" - Read the v2 task plan
 
 ---

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -71,14 +71,24 @@ When starting a new session:
 **Plan Revised**: 2026-03-29 19:30 (v2 — reducer pattern simplification)
 **T02 Completed**: 2026-03-29 (tool_call_id availability confirmed via callback handler approach)
 **T04 Completed**: 2026-03-29 (fingerprint dedup replaced with identity-based lookup)
-**Current Task**: T03 (Research: namespace injection feasibility) — in progress in separate conversation
-**Next Code Task**: T05 (Replace _run_id_to_tool_call_id with _tool_call_index), T06 (pause fix standalone)
-**Status**: Active — T02+T04 complete, T03 in progress
+**T03 Completed**: 2026-03-29 (namespace routing via parent_ids confirmed — Approach B)
+**Current Task**: T05 (Replace namespace heuristics with parent_ids-based deterministic routing)
+**Next Code Task**: T05, T06 (pause fix standalone)
+**Status**: Active — T02+T03+T04 complete, T05 unblocked
 
 ### T02 Key Finding
 v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
 callback handler captures `{run_id → tool_call_id}` from the callback API (which
 does receive it). Works for ALL tools universally. See `tasks/T02_0_research.md`.
+
+### T03 Key Finding
+`parent_ids` on v2 events traces the full callback chain from sub-agent events
+back to the parent invocation context (including the task tool's `run_id` that
+StatusBuilder already knows). Namespace roots are SHARED across concurrent
+sub-agents from the same parent node — root-prefix matching is inherently wrong
+for disambiguation. `parent_ids` provides deterministic mapping without heuristics.
+Approach A (checkpoint_ns injection) discarded — unnecessary and couples to
+InterruptProxyRunnable which is being eliminated. See `tasks/T03_0_research.md`.
 
 ### T04 Completion Summary
 Replaced SHA256 fingerprint dedup with identity-based lookup via `ToolCallIdCapture`.
@@ -108,10 +118,11 @@ Net: -197 lines. All 1,375 tests pass. Files changed:
 - Used `TYPE_CHECKING` guard for the import, string annotation for the constructor param
 
 ## Next Steps (when you return)
-1. Complete T03 research (in progress in separate conversation)
-2. Start T05 — replace `_run_id_to_tool_call_id` with `_tool_call_index` lookups
+1. T03 research COMPLETE — `parent_ids` confirmed as deterministic routing mechanism
+2. Start T05 — replace namespace heuristic cascade with `parent_ids`-based registration
 3. T06 (pause fix) can be done anytime as a standalone task
 4. T07 — ExecutionState refactor (fold `_run_id_aliases` into capture or eliminate)
+5. Note: InterruptProxyRunnable elimination (separate project) will further simplify T05
 
 ## Quick Commands
 

--- a/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/next-task.md
@@ -70,46 +70,54 @@ When starting a new session:
 **Created**: 2026-03-29 14:37
 **Plan Revised**: 2026-03-29 19:30 (v2 — reducer pattern simplification)
 **T02 Completed**: 2026-03-29 (tool_call_id availability confirmed via callback handler approach)
-**Current Task**: T03 (Research: namespace injection feasibility)
-**Next Code Task**: T04 (Replace fingerprint dedup with tool_call_id lookup — unblocked by T02)
-**Status**: Active — T02 complete, T03 pending, T04 unblocked
+**T04 Completed**: 2026-03-29 (fingerprint dedup replaced with identity-based lookup)
+**Current Task**: T03 (Research: namespace injection feasibility) — in progress in separate conversation
+**Next Code Task**: T05 (Replace _run_id_to_tool_call_id with _tool_call_index), T06 (pause fix standalone)
+**Status**: Active — T02+T04 complete, T03 in progress
 
 ### T02 Key Finding
 v2 events do NOT carry `tool_call_id`. Solution: a ~10-line `ToolCallIdCapture`
 callback handler captures `{run_id → tool_call_id}` from the callback API (which
-does receive it). Works for ALL tools universally. Eliminates 3 dictionaries, 2
-methods, and ~100 lines of fingerprint/FIFO dedup logic. See `tasks/T02_0_research.md`.
+does receive it). Works for ALL tools universally. See `tasks/T02_0_research.md`.
 
-## Session Progress (2026-03-29)
+### T04 Completion Summary
+Replaced SHA256 fingerprint dedup with identity-based lookup via `ToolCallIdCapture`.
+Deleted 3 dictionaries (`tool_call_fingerprints`, `_fingerprint_to_tool_call_id`,
+`_reconciled_resume_tool_calls`), 2 methods, ~100 lines of fingerprint/FIFO logic.
+Net: -197 lines. All 1,375 tests pass. Files changed:
+- New: `tool_call_id_capture.py` (focused collaborator)
+- Modified: `status_builder.py`, `execute_graphton.py`, `hitl.py`
+- Tests: `test_status_builder.py`, `test_hitl_contracts.py`
+
+## Session Progress (2026-03-29, session 2)
 
 ### What was accomplished
-- Reviewed and approved v2 plan (T01_0_plan.md)
-- Completed T02 research: traced LangGraph/LangChain event pipeline across 5 framework layers
-- Discovered that `_filter_injected_args` blocks the naive `InjectedToolCallId` approach
-- Identified `ToolCallIdCapture` callback handler as the clean, universal solution
-- Wrote comprehensive research document (`tasks/T02_0_research.md`, 304 lines)
-- Updated `_roles/005_ai_engineer.md` with architectural principles from HITL learnings
+- Completed T04: replace fingerprint dedup with `ToolCallIdCapture` identity lookup
+- Created `tool_call_id_capture.py` — focused callback handler (~45 lines)
+- Wired capture into execute_graphton.py (constructor + config callbacks)
+- Replaced 60-line fingerprint+FIFO dedup block with ~15-line identity lookup
+- Renamed `populate_fingerprints_from_existing_tool_calls` → `rebuild_index_from_persisted_status`
+- Deleted `_get_tool_fingerprint()`, removed hashlib/deque imports
+- Cleaned hitl.py: renamed method, deleted FIFO block, updated logging
+- Rewrote 4 alias tests, deleted 4 fingerprint tests, updated 8+ test method calls
+- Full test suite: 1,375 passed, 0 failed
 
 ### Key decisions
-- Callback handler approach chosen over modifying tool wrappers (universal coverage, simpler)
-- Live validation skipped — findings based on reading actual installed package source code
-
-### Surprise discovered
-`BaseTool._filter_injected_args` strips `InjectedToolCallId` values from callback inputs
-before they reach the v2 event emitter. This means `data.input` will never contain
-`tool_call_id` regardless of wrapper annotations. The callback handler approach is
-necessary and also superior (works for ALL tools without per-wrapper changes).
+- Kept `_run_id_aliases` for T04 scope discipline — deferring to T07 for broader identity cleanup
+- `ToolCallIdCapture` placed in its own module per "StatusBuilder Is NOT a Dumping Ground"
+- Used `TYPE_CHECKING` guard for the import, string annotation for the constructor param
 
 ## Next Steps (when you return)
-1. Start T03 research — namespace injection feasibility in Graphton sub-graph construction
-2. Start T04 implementation — replace fingerprint dedup with `ToolCallIdCapture` (unblocked)
+1. Complete T03 research (in progress in separate conversation)
+2. Start T05 — replace `_run_id_to_tool_call_id` with `_tool_call_index` lookups
 3. T06 (pause fix) can be done anytime as a standalone task
+4. T07 — ExecutionState refactor (fold `_run_id_aliases` into capture or eliminate)
 
 ## Quick Commands
 
 After loading context:
-- "Start T03 research" - Investigate namespace injection in Graphton sub-graph construction
-- "Start T04 implementation" - Replace fingerprint dedup with tool_call_id lookup (requires T02 findings)
+- "Start T05 implementation" - Replace _run_id_to_tool_call_id with _tool_call_index
+- "Start T06 implementation" - Fix pause handling (standalone)
 - "Show project status" - Get overview of progress
 - "Review the plan" - Read the v2 task plan
 

--- a/_projects/2026-03/20260329.02.status-builder-hardening/tasks/T01_0_plan.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/tasks/T01_0_plan.md
@@ -1,0 +1,228 @@
+# Task T01: StatusBuilder Simplification — Reducer Pattern Refactor
+
+**Created**: 2026-03-29 14:40
+**Revised**: 2026-03-29 19:30
+**Status**: PENDING REVIEW
+**Type**: Simplification
+**Revision**: v2 — rewritten from "gap-driven hardening" to "reducer pattern simplification"
+
+⚠️ **This plan requires your review before execution**
+
+## Why This Revision
+
+The v1 plan framed the project as "hardening" — protecting 30 dictionaries with assertions, adding idempotency guards, then decomposing. Through design review, we established that:
+
+1. The 30 dictionaries are not architecture to protect — roughly half are compensating complexity from wrong modeling choices
+2. The core job is simple: LangGraph events in → protobuf status out. This is a solved problem (reducer/event-sourcing pattern)
+3. The right approach is: eliminate the unnecessary complexity first, then restructure what remains using a proper state model
+
+The v1 tasks (T02–T09) mapped to "gaps." The v2 tasks map to "what to delete, what to keep, how to restructure."
+
+## The State of Things
+
+### What StatusBuilder does
+LangGraph streams thousands of events per execution (every token is an event). StatusBuilder processes each event and builds an `AgentExecutionStatus` protobuf. The proto is flushed to the database via gRPC every ~500ms for real-time UI updates.
+
+### Why in-memory state exists
+Event volume is too high for per-event DB writes. The proto is the in-memory "database." Dictionaries are indexes on the proto for O(1) lookup (protobuf repeated fields are arrays without key-based access).
+
+### What's wrong
+~30 dictionaries grew organically. About half are genuine indexes (~5) and streaming buffers (~5). The other ~20 are compensating complexity:
+- Fingerprint dedup system (~5 dicts) — exists because we matched tool calls by SHA256 of args instead of by tool_call_id
+- Namespace routing heuristics (~4 dicts) — exists because we didn't inject identity into sub-graph construction
+- Resume reconciliation state (~4 dicts) — exists because fingerprint dedup is fragile on the resume path
+- Miscellaneous workarounds (~3 dicts) — each patch for an edge case
+
+### The target state
+An explicit `ExecutionState` with ~10-12 named fields:
+
+```python
+@dataclass
+class ExecutionState:
+    proto: AgentExecutionStatus
+
+    # Indexes into proto (O(1) lookup for event routing)
+    tool_calls: dict[str, ToolCall]              # tool_call_id → proto ref
+    messages_by_run: dict[str, AgentMessage]      # llm_run_id → message being streamed
+    current_ai_message: dict[str, AgentMessage]   # namespace → current AI msg
+
+    # Sub-agent routing
+    active_sub_agents: dict[str, SubAgentExecution]  # run_id → sub-agent execution
+    completed_sub_agents: dict[str, SubAgentExecution]
+    namespace_to_sub_agent: dict[str, str]           # namespace_root → run_id
+
+    # Streaming buffers (accumulate partial data before flushing to proto)
+    thinking_buffers: dict[str, str]             # namespace → accumulated thinking text
+    tool_input_buffers: dict[str, str]           # tool_call_id → accumulated JSON
+
+    # Timing (for duration_ms calculation)
+    tool_start_times: dict[str, datetime]        # tool_call_id → start time
+    message_start_times: dict[str, datetime]     # run_id → start time
+
+    # Approval state (inherent to HITL)
+    pending_approvals: list[str]                 # run_ids awaiting approval
+```
+
+Every field is either "an index on the proto" or "a buffer for streaming accumulation" or "timing for observability." No reconciliation state. No heuristic state. No dedup state beyond the identity-based index itself.
+
+---
+
+## Phased Task Breakdown
+
+### Phase 1: Research (before any code changes)
+
+#### T02: Verify tool_call_id Availability on Events
+**What:** Trace the LangGraph/LangChain event pipeline to confirm that `on_tool_start` and `on_tool_end` events carry the Anthropic `tool_call_id` (the `toolu_*` ID). This is the foundation for eliminating fingerprint dedup.
+
+**Research steps:**
+1. Check if `InjectedToolCallId` (from HITL cleanup) means the tool_call_id is available in the event metadata
+2. Trace `astream_events(version="v2")` output for `on_tool_start` — where does tool_call_id appear?
+3. Check early tool call creation — does the stream's `tool_use` block carry the same `toolu_*` ID?
+
+**Output:** Documented confirmation or gap. If tool_call_id is NOT available on the event, we need an alternative dedup key before proceeding.
+
+#### T03: Verify Namespace Injection Feasibility
+**What:** Determine whether Graphton can inject a known sub-agent ID into the LangGraph sub-graph namespace at construction time.
+
+**Research steps:**
+1. Read how LangGraph constructs `langgraph_checkpoint_ns` for sub-graphs
+2. Check if Graphton controls the namespace string during sub-graph construction (`graphton.core`)
+3. Determine if we can embed the `tool_call_id` from the "task" tool into the namespace root
+
+**Output:** Documented approach for deterministic namespace → sub-agent mapping. If injection is not feasible, document the fallback (first-event registration as the single strategy).
+
+---
+
+### Phase 2: Eliminate Compensating Complexity (incremental, on current codebase)
+
+Each task deletes code. No new dictionaries. Each is a separate PR.
+
+#### T04: Replace Fingerprint Dedup with tool_call_id Lookup
+**Depends on:** T02 research confirms tool_call_id availability
+
+**What:** Replace the entire fingerprint dedup system with a single identity check in `_handle_tool_start_event`:
+
+```python
+existing = self._tool_call_index.get(tool_call_id)
+if existing is not None:
+    # Already created from stream — record timing, skip creation
+    self._tool_start_times[tool_call_id] = utc_now()
+    return
+```
+
+**Delete:**
+- `tool_call_fingerprints` set
+- `_fingerprint_to_tool_call_id` dict
+- `_reconciled_resume_tool_calls` dict (FIFO deque per tool name)
+- `_get_tool_fingerprint()` method
+- `_run_id_aliases` dict (replaced by tool_call_id direct lookup)
+- Fingerprint computation in `populate_fingerprints_from_existing_tool_calls` (rename to `populate_index_from_existing_tool_calls`, only builds `_tool_call_index`)
+
+**Keep:** Early tool call creation from stream (preserves streaming UX). Reconciliation becomes: "does this tool_call_id already exist in the index? Yes → skip. No → create."
+
+**Acceptance:** All existing tests pass. Resume-after-approval works. No fingerprint code remains. ~300-500 lines deleted.
+
+#### T05: Replace Namespace Heuristics with Deterministic Routing
+**Depends on:** T03 research confirms approach
+
+**What:** Replace the 4-strategy `_register_sub_agent_namespace` cascade with a single deterministic lookup.
+
+**Delete:**
+- Strategies 2, 3, 4 in `_register_sub_agent_namespace`
+- `_pending_sub_agent_ids` list (FIFO queue for causal registration)
+- `_warned_namespaces` set
+- `_subject_counts` dict (if subjects can be derived differently)
+
+**Replace with:**
+```python
+def _get_sub_agent_for_namespace(self, namespace: str) -> str | None:
+    root = namespace.split("|")[0]
+    return self._namespace_to_sub_agent.get(root)
+```
+
+Populated at sub-agent creation time with the known namespace root.
+
+**Acceptance:** All existing tests pass. Zero `[NS_DIAG]` or `[NAMESPACE]` warnings. Concurrent sub-agents route correctly. ~200-300 lines deleted.
+
+#### T06: Fix Pause Status Persistence
+**Independent** — standalone bug fix in streaming.py
+
+**What:** The `_handle_pause` CancelledError handler uses an unreliable `create_task` for gRPC persist. Replace with workflow-driven approach: workflow reads heartbeat `paused=True` flag and sets PAUSED status server-side.
+
+**Acceptance:** Pause → DB shows PAUSED within 5 seconds. No stale IN_PROGRESS after pause.
+
+---
+
+### Phase 3: Restructure Using Reducer Pattern
+
+After Phase 2, the dictionary count is reduced from ~30 to ~15. Phase 3 restructures the remaining state into the explicit `ExecutionState` model.
+
+#### T07: Introduce ExecutionState and Refactor Handlers
+**Depends on:** T04, T05 completed (compensating complexity removed)
+
+**What:** This is the structural refactor:
+
+1. Define `ExecutionState` dataclass (the explicit state model shown above)
+2. Move remaining dictionaries from `self._*` on StatusBuilder into `ExecutionState` fields
+3. Rewrite event handlers as small focused functions operating on `ExecutionState`
+4. StatusBuilder becomes a thin orchestrator: receives events, resolves execution context (main vs sub-agent), dispatches to handler
+5. Add `rebuild_indexes(proto)` classmethod that reconstructs `ExecutionState` from a persisted proto (for pod restart recovery)
+
+**Approach:** Incremental extraction. Move one group of dictionaries at a time (tool call indexes first, then sub-agent routing, then streaming buffers). Each move is a commit. All tests pass at every step.
+
+**Acceptance:** StatusBuilder is <500 lines. ExecutionState holds all state. Event handlers are 5-20 lines each. All existing tests pass. `rebuild_indexes` can reconstruct state from any persisted proto.
+
+#### T08: Proto Safety Helpers
+**Absorbed into T07** — as handlers are rewritten, the proto append-and-get-managed-reference pattern is encapsulated in helper methods. Not a separate task, just part of writing the new handlers correctly.
+
+---
+
+### Phase 4: Validation
+
+#### T09: Post-Refactor Consistency Assertions
+**Depends on:** T07 completed
+
+**What:** Now that the state model is explicit and small (~10-12 fields), add a `verify_consistency(state: ExecutionState, phase: ExecutionPhase) -> list[Violation]` function that runs after each stream cycle. With only ~10 fields to check, the assertions are simple and comprehensive.
+
+**Acceptance:** Zero violations in production for 2 weeks.
+
+---
+
+## Task Dependency Graph
+
+```
+T02 (research: tool_call_id) ──→ T04 (delete fingerprint dedup) ──┐
+T03 (research: namespace)    ──→ T05 (delete namespace heuristics) ├→ T07 (reducer refactor) → T09 (assertions)
+T06 (pause fix) ───────────────────────────────────────────────────┘
+```
+
+## Execution Order
+
+1. **T02 + T03** (parallel research) — no code changes, just investigation and documentation
+2. **T04** — delete fingerprint dedup (~300-500 lines deleted)
+3. **T05** — delete namespace heuristics (~200-300 lines deleted)
+4. **T06** — fix pause persistence (standalone, can be done anytime)
+5. **T07** — introduce ExecutionState, refactor handlers (the big structural change, much easier with T04+T05 done)
+6. **T09** — post-refactor assertions (lightweight, on the clean state model)
+
+## What This Plan Does NOT Cover
+
+- **G3 (full-replace race condition):** Covered by `hitl-tool-call-separation` project (`20260329.01`)
+- **Server-side merge logic:** Separate fixes in `stigmer-cloud`
+- **CLI/frontend consistency:** Separate effort. This project ensures the data is correct.
+- **Temporal as state persistence:** Evaluated and deferred. gRPC streaming is necessary for real-time UI updates regardless. Temporal heartbeat could assist with pod-restart recovery but adds a second persistence channel. Not on the critical path.
+
+## What Changed from v1
+
+| v1 (Gap-Driven Hardening) | v2 (Reducer Pattern Simplification) |
+|---|---|
+| T02: Add assertions for 30 dicts | Moved to T09: Assert on ~10 clean fields after refactor |
+| T03: Add `_processed_events` set (dict #31) | Eliminated: identity-based dedup provides natural idempotency |
+| T04: Proto helpers | Absorbed into T07 handler rewrite |
+| T05: Fingerprint → tool_call_id | T04 (priority raised to first code change) |
+| T06: Namespace heuristics → deterministic | T05 (priority raised to second code change) |
+| T07: Duration tracking fix | Absorbed into T07 handler rewrite |
+| T08: Pause persistence fix | T06 (standalone, unchanged) |
+| T09: Decompose god object | T07 (rewritten as "introduce ExecutionState + reducer pattern") |
+
+**Net effect:** Fewer tasks. Deletion-first ordering. No new tracking state added. The structural refactor (T07) is easier because T04+T05 delete ~500-800 lines of compensating complexity first.

--- a/_projects/2026-03/20260329.02.status-builder-hardening/tasks/T02_0_research.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/tasks/T02_0_research.md
@@ -1,0 +1,303 @@
+# T02: Verify tool_call_id Availability on LangGraph Events
+
+**Created**: 2026-03-29
+**Status**: COMPLETE
+**Type**: Research (no code changes)
+**Depends on**: None
+**Blocks**: T04 (Replace Fingerprint Dedup with tool_call_id Lookup)
+
+## Research Question
+
+Does the model's `tool_call_id` (the Anthropic `toolu_*` ID) appear on v2
+`on_tool_start` and `on_tool_end` events emitted by `astream_events(version="v2")`?
+If not, how can StatusBuilder obtain it?
+
+## Answer: NOT on v2 events, but available via the callback API
+
+The `tool_call_id` is **not** included in v2 `on_tool_start` or `on_tool_end`
+events. However, LangChain's callback system **does** receive it for every tool
+invocation through ToolNode. A lightweight `BaseCallbackHandler` subclass can
+capture the `{run_id → tool_call_id}` mapping that the v2 event emitter drops.
+
+This works for **all** tools universally — MCP, platform, approval-wrapped — without
+requiring `InjectedToolCallId` on every wrapper.
+
+---
+
+## Full Framework Trace
+
+### Layer 1: ToolNode constructs a ToolCall dict with `id`
+
+LangGraph's `ToolNode` iterates over `tool_calls` from the AIMessage. Each tool
+call carries the model's `id` (e.g. `toolu_01abc...`). ToolNode injects runtime
+args and passes the full dict to `tool.invoke()`.
+
+**File**: `.venv/.../langgraph/prebuilt/tool_node.py` (lines 924–930)
+
+```python
+injected_call = self._inject_tool_args(call, request.runtime, tool)
+call_args = {**injected_call, "type": "tool_call"}
+response = tool.invoke(call_args, config)
+```
+
+### Layer 2: BaseTool extracts tool_call_id from the dict
+
+`BaseTool._prep_run_args` detects the `"type": "tool_call"` dict and extracts
+`tool_call_id = value["id"]` — the model's `toolu_*` ID. This is independent of
+`InjectedToolCallId`; it works for every tool invoked through ToolNode.
+
+**File**: `.venv/.../langchain_core/tools/base.py` (lines 1229–1247)
+
+```python
+if _is_tool_call(value):
+    tool_call_id: str | None = cast("ToolCall", value)["id"]
+    tool_input: str | dict = cast("ToolCall", value)["args"].copy()
+```
+
+### Layer 3: _filter_injected_args strips tool_call_id from callback inputs
+
+Before passing `tool_input` to callbacks, LangChain filters out injected args.
+`InjectedToolCallId` values are stripped here. This means `event["data"]["input"]`
+will **never** contain `tool_call_id`, regardless of whether the tool wrapper uses
+`InjectedToolCallId`.
+
+**File**: `.venv/.../langchain_core/tools/base.py` (lines 803–828, 926–948)
+
+```python
+# Filter out injected arguments from callback inputs
+filtered_tool_input = (
+    self._filter_injected_args(tool_input)
+    if isinstance(tool_input, dict)
+    else None
+)
+# ...
+run_manager = callback_manager.on_tool_start(
+    {"name": self.name, "description": self.description},
+    tool_input_str,
+    inputs=filtered_tool_input,      # FILTERED — no tool_call_id
+    tool_call_id=tool_call_id,       # SEPARATE kwarg
+    **kwargs,
+)
+```
+
+### Layer 4: CallbackManager forwards tool_call_id as a kwarg
+
+The callback manager passes `tool_call_id` through `**kwargs` to all registered
+handlers.
+
+**File**: `.venv/.../langchain_core/callbacks/manager.py` (lines 1490–1501)
+
+```python
+handle_event(
+    self.handlers,
+    "on_tool_start",
+    "ignore_agent",
+    serialized,
+    input_str,
+    run_id=run_id,
+    parent_run_id=self.parent_run_id,
+    tool_call_id=tool_call_id,   # Available to all handlers
+    **kwargs,
+)
+```
+
+### Layer 5: v2 event emitter stores tool_call_id internally but does NOT emit it
+
+The `_AstreamEventsCallbackHandler` stores `tool_call_id` in its internal
+`RunInfo` map (used for error linking) but does **not** include it in the
+`on_tool_start` event payload.
+
+**File**: `.venv/.../langchain_core/tracers/event_stream.py` (lines 671–695)
+
+```python
+# Stored internally:
+info["tool_call_id"] = kwargs["tool_call_id"]
+
+# Emitted event — no tool_call_id:
+self._send({
+    "event": "on_tool_start",
+    "data": {"input": inputs or {}},
+    "name": name_,
+    "tags": tags or [],
+    "run_id": str(run_id),
+    "metadata": metadata or {},
+    "parent_ids": self._get_parent_ids(run_id),
+})
+```
+
+Only `on_tool_error` includes `tool_call_id` in `data` (lines 715–721).
+Neither `on_tool_start` nor `on_tool_end` do.
+
+---
+
+## v2 Event Field Summary
+
+| Field on v2 `on_tool_start` | Contains `tool_call_id`? |
+|------------------------------|--------------------------|
+| `event["data"]["input"]`     | No (filtered by `_filter_injected_args`) |
+| `event["metadata"]`          | No (config-level metadata, not per-call) |
+| `event["run_id"]`            | No (LangGraph-generated UUID, not model ID) |
+| `event["parent_ids"]`        | No (parent run UUIDs) |
+| Callback `**kwargs`          | **Yes** — `tool_call_id` kwarg on `on_tool_start` |
+
+---
+
+## Solution: ToolCallIdCapture Callback Handler
+
+A `BaseCallbackHandler` subclass receives `tool_call_id` from the callback
+system and stores a `{run_id → tool_call_id}` mapping. StatusBuilder consults
+this mapping when processing v2 events.
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+from uuid import UUID
+from typing import Any
+
+class ToolCallIdCapture(BaseCallbackHandler):
+    """Captures the model tool_call_id for each LangGraph run_id.
+
+    LangGraph v2 stream events don't surface tool_call_id on on_tool_start
+    or on_tool_end. The callback API does receive it as a kwarg. This
+    handler bridges the gap by storing a {run_id -> tool_call_id} dict
+    that StatusBuilder can read when processing the corresponding v2 event.
+    """
+
+    def __init__(self) -> None:
+        self.run_id_to_tool_call_id: dict[str, str] = {}
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        tool_call_id: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if tool_call_id is not None:
+            self.run_id_to_tool_call_id[str(run_id)] = tool_call_id
+```
+
+### Why this works
+
+1. **Universal coverage**: ToolNode always creates a proper ToolCall dict with
+   `id` from the AIMessage. `_prep_run_args` extracts it and passes
+   `tool_call_id=...` to the callback manager. This works for ALL tools —
+   MCP, platform, approval-wrapped — regardless of `InjectedToolCallId`.
+
+2. **Timing guarantee**: Sync callback handlers fire in the callback chain
+   before the async v2 event is yielded from `astream_events`. By the time
+   `StatusBuilder.process_event()` processes the yielded event, the capture
+   dict already has the mapping.
+
+3. **Framework-sanctioned**: `BaseCallbackHandler` is the standard LangChain
+   extension point. No monkey-patching, no forking, no version-fragile hacks.
+
+### Wiring point
+
+The config dict is built in `execute_graphton.py` (line 1637):
+
+```python
+config = {
+    "configurable": {
+        "thread_id": thread_id,
+        "org": execution.metadata.org,
+    },
+    "recursion_limit": effective_recursion_limit,
+}
+```
+
+Adding `"callbacks": [capture_handler]` makes it available to all tool
+invocations throughout the graph, including sub-agent graphs.
+
+StatusBuilder receives a reference to the capture handler (e.g. via
+constructor parameter or via the StreamExecutor that already bridges
+config and StatusBuilder).
+
+---
+
+## Impact on StatusBuilder (what T04 can delete)
+
+With `{run_id → tool_call_id}` available, the following are eliminated:
+
+### Dictionaries removed
+
+| Dictionary | Purpose | Lines |
+|------------|---------|-------|
+| `tool_call_fingerprints` (set) | SHA256 dedup of tool args | ~338 |
+| `_fingerprint_to_tool_call_id` | fingerprint → tool_call.id | ~487 |
+| `_reconciled_resume_tool_calls` | FIFO deque per tool name for resume fallback | ~492–495 |
+
+### Methods removed
+
+| Method | Purpose | Lines |
+|--------|---------|-------|
+| `_get_tool_fingerprint()` | SHA256(name + sorted JSON args) | 1651–1654 |
+| Fingerprint logic in `populate_fingerprints_from_existing_tool_calls()` | Pre-populates fingerprint set on resume | 1656–1686 (fingerprint parts only; index rebuild stays) |
+
+### Logic simplified
+
+| Location | Current | After |
+|----------|---------|-------|
+| `_handle_tool_start_event` (lines 773–824) | 50-line fingerprint check + FIFO fallback | 3-line identity lookup |
+| `_reconcile_early_tool_call` (lines 2027–2032) | Fingerprint registration on resume path | Removed — identity match is sufficient |
+| `_handle_tool_start_event` resume FIFO (lines 801–824) | Name-based FIFO fallback when fingerprints diverge | Removed entirely |
+
+### How dedup works after the change
+
+**Normal path:**
+1. Stream emits `tool_use` block with `id=toolu_xxx`
+2. `_create_early_tool_call(tool_use_id="toolu_xxx")` → `ToolCall.id = "toolu_xxx"`, indexed
+3. `on_tool_start` fires with `run_id=<uuid>` → callback captures `{uuid → toolu_xxx}`
+4. StatusBuilder: `tool_call_id = capture[run_id]` → `_tool_call_index["toolu_xxx"]` → found (early tool call)
+5. Register alias: `_run_id_aliases[uuid] = "toolu_xxx"`
+
+**Resume path:**
+1. Existing ToolCall with `id="toolu_xxx"` from prior cycle, indexed in `_tool_call_index`
+2. `on_tool_start` fires with `run_id=<new_uuid>` → callback captures `{new_uuid → toolu_xxx}`
+3. StatusBuilder: `tool_call_id = capture[run_id]` → `_tool_call_index["toolu_xxx"]` → found
+4. Register alias: `_run_id_aliases[new_uuid] = "toolu_xxx"`. Done — no fingerprint needed.
+
+Both paths use **the same 3-line identity check**. No fingerprints, no FIFO queues,
+no name-based matching.
+
+---
+
+## Surprise: _filter_injected_args blocks the naive approach
+
+The original T02 plan hypothesized that adding `InjectedToolCallId` to tool
+wrappers would make `tool_call_id` appear in `data.input`. This is incorrect.
+`_filter_injected_args` (base.py:803–828) deliberately strips all injected
+args from callback inputs before they reach the event emitter.
+
+This is a **positive surprise**: the callback handler approach works for ALL
+tools universally, without needing to modify any tool wrapper. The coverage
+question ("what percentage of tools have InjectedToolCallId?") is irrelevant.
+
+---
+
+## Installed Package Versions
+
+| Package | Pinned (requirements.txt) | Installed (.venv) |
+|---------|---------------------------|-------------------|
+| langgraph | 1.0.8 | 1.1.2 |
+| langchain-core | 1.2.12 | 1.2.19 |
+
+The traced code paths exist in the installed 1.2.19 version. The behavior is
+stable — `_filter_injected_args` was introduced to keep callback payloads clean,
+and `on_tool_start` has never included `tool_call_id` in the v2 event since
+the v2 format was created.
+
+---
+
+## Conclusion
+
+T02 research is **complete with a confirmed path forward**:
+
+1. **Gap confirmed**: v2 events do not carry `tool_call_id`.
+2. **Solution identified**: `ToolCallIdCapture` callback handler — 10 lines of
+   code, framework-sanctioned, universal coverage.
+3. **Impact validated**: Eliminates 3 dictionaries, 2 methods, and ~100 lines
+   of fingerprint/FIFO logic from StatusBuilder.
+4. **T04 is unblocked**: The fingerprint dedup system can be replaced with
+   identity-based lookup using the captured mapping.

--- a/_projects/2026-03/20260329.02.status-builder-hardening/tasks/T03_0_research.md
+++ b/_projects/2026-03/20260329.02.status-builder-hardening/tasks/T03_0_research.md
@@ -1,0 +1,295 @@
+# T03: Namespace Injection Feasibility Research
+
+**Created**: 2026-03-29
+**Status**: COMPLETE
+**Type**: Research (no code changes to production)
+**Depends on**: None
+**Blocks**: T05 (Replace namespace heuristics with deterministic routing)
+
+## Research Question
+
+Can we replace the 4-strategy heuristic cascade in `_register_sub_agent_namespace`
+with a deterministic mechanism for mapping LangGraph namespace strings to
+sub-agent identities?
+
+## Answer: YES — via `parent_ids` on v2 events (Approach B)
+
+The `parent_ids` field on v2 `astream_events` events traces the full callback
+chain from sub-agent events back to the parent invocation context.  When a
+sub-agent event arrives with a new multi-segment namespace, StatusBuilder can
+check `parent_ids` for a known task tool `run_id` (already stored in
+`_active_sub_agents`) to establish the mapping deterministically.
+
+This eliminates strategies 2–4 of the current heuristic cascade.  Strategy 1
+(root-prefix matching for subsequent events from an already-registered
+sub-agent) is replaced with full namespace string deduplication — but see
+the important caveat about shared namespace roots below.
+
+---
+
+## Full Framework Trace
+
+### How LangGraph constructs `langgraph_checkpoint_ns`
+
+Namespace strings are built in `prepare_single_task` (`langgraph/pregel/_algo.py`).
+The formula:
+
+```
+checkpoint_ns = parent_ns | node_name
+task_checkpoint_ns = checkpoint_ns : task_id
+```
+
+Delimiters: `|` (pipe) separates hierarchy levels, `:` separates each level
+from its task ID.  `node_name` is the key passed to `add_node("key", runnable)`
+on the parent graph.  The full `task_checkpoint_ns` is stored as
+`metadata["langgraph_checkpoint_ns"]` on every v2 event.
+
+### How sub-agents are invoked (deepagents architecture)
+
+Sub-agents are **not** separate nodes on the parent graph.  deepagents creates
+a single `task` tool via `SubAgentMiddleware`.  Each sub-agent is invoked
+inside the tool function body via `subagent.ainvoke(subagent_state)`.
+
+The call chain in production:
+
+```
+Parent graph (Pregel)
+  → tools node
+    → task tool (on_tool_start event — StatusBuilder records run_id)
+      → _GatedRunnable.ainvoke()  (SubAgentGate concurrency wrapper)
+        → InterruptProxyRunnable.ainvoke()  [to be eliminated]
+          → inner_graph.ainvoke(input, config=merged)
+            → sub-agent internal nodes produce events
+```
+
+After InterruptProxyRunnable is eliminated (separate project), the chain
+simplifies to:
+
+```
+Parent graph (Pregel)
+  → tools node
+    → task tool (on_tool_start event — StatusBuilder records run_id)
+      → _GatedRunnable.ainvoke()
+        → compiled_subagent.invoke(input)  [checkpointer=None, inherits parent]
+          → sub-agent internal nodes produce events
+```
+
+### What `parent_ids` contains on sub-agent events
+
+The `_AstreamEventsCallbackHandler` builds `parent_ids` by walking the
+`RunInfo.parent_run_id` chain in its `_run_map`.  When a sub-agent graph
+inherits the parent's callbacks (via config), its events fire through the
+same handler, and the `parent_run_id` chain links back through:
+
+1. Sub-agent internal node run
+2. Sub-agent graph root run (unique per invocation)
+3. Task tool run ← **StatusBuilder knows this from `_handle_sub_agent_start`**
+4. Parent tools node run
+5. Parent graph root run
+
+Verified by test: `test_parent_ids_link_subagent_events_to_parent_context`
+(passes on LangGraph 1.1.2).
+
+### What namespace strings look like (empirical)
+
+From test `test_multiple_subagents_have_distinct_namespaces_and_parent_ids`,
+with two sub-agents invoked sequentially from the same parent node:
+
+| Sub-agent | `langgraph_checkpoint_ns` |
+|-----------|---------------------------|
+| A (work_a) | `tools_node:a503b567...\|work_a:f074cf43...` |
+| B (work_b) | `tools_node:a503b567...\|1\|work_b:a92c9e60...` |
+
+Key observations:
+
+- **Namespace roots are SHARED**: both start with `tools_node` because both
+  are invoked from the same parent node.  In production this will be `tools`
+  (the LangGraph tools node where all task tool invocations execute).
+
+- **Full namespace paths are DISTINCT**: LangGraph assigns unique task IDs
+  per invocation and appends a sequential counter (`|1|`) for subsequent
+  invocations from the same parent task.
+
+- **`parent_ids` chains are DISTINCT**: the deepest parent ID differs per
+  sub-agent invocation (unique sub-agent graph root run_id).
+
+---
+
+## Why Root-Prefix Matching Is Insufficient
+
+The current StatusBuilder strategy 1 (root-prefix matching) assumes that
+the namespace root uniquely identifies a sub-agent.  This is **wrong** when
+multiple sub-agents are invoked from the same parent node:
+
+```
+Sub-agent A namespace root: tools_node
+Sub-agent B namespace root: tools_node  ← SAME ROOT
+```
+
+Root-prefix matching would map sub-agent B's events to sub-agent A (whichever
+was registered first).  This explains why strategies 2–4 (substring matching,
+FIFO causal correlation, sole-active fallback) were needed as compensating
+complexity.
+
+With `parent_ids`, the disambiguation is at the per-invocation level:
+
+```
+Sub-agent A parent_ids: [..., task_tool_A_run_id, sub_a_graph_root]
+Sub-agent B parent_ids: [..., task_tool_B_run_id, sub_b_graph_root]
+```
+
+StatusBuilder knows `task_tool_A_run_id` and `task_tool_B_run_id` from
+`_handle_sub_agent_start`, so it can deterministically map each namespace
+to the correct sub-agent.
+
+---
+
+## Proposed Approach for T05
+
+### Registration: `parent_ids` lookup for every new namespace
+
+When `_register_sub_agent_namespace` encounters a new multi-segment namespace:
+
+```python
+def _register_sub_agent_namespace(self, namespace: str, event: dict) -> None:
+    if not namespace or namespace in self._namespace_to_sub_agent_id:
+        return
+
+    if "|" not in namespace:
+        return  # Single-segment = main-agent graph node
+
+    parent_ids = event.get("parent_ids", [])
+    for pid in parent_ids:
+        if pid in self._active_sub_agents:
+            self._namespace_to_sub_agent_id[namespace] = pid
+            return
+        if pid in self._completed_sub_agents:
+            self._namespace_to_sub_agent_id[namespace] = pid
+            return
+```
+
+This is O(P × S) where P = len(parent_ids) (typically 3–5) and
+S = number of active sub-agents (typically 1–3).  Negligible cost.
+
+### Lookup: exact match (unchanged)
+
+`_get_execution_context` already does an exact dict lookup on the full
+namespace string.  No change needed.
+
+### What gets deleted from StatusBuilder
+
+| Structure | Purpose | Lines |
+|-----------|---------|-------|
+| `_pending_sub_agent_ids` (list) | FIFO queue for causal correlation (strategy 3) | ~412–414 |
+| `_warned_namespaces` (set) | Deduplicate namespace warnings | ~421–422 |
+| Strategies 2–4 in `_register_sub_agent_namespace` | Substring, FIFO, sole-active fallback | ~2718–2770 |
+| `_subject_counts` (dict) | Remains — unrelated to namespace routing | — |
+
+Strategy 1 (root-prefix matching) is also deleted — `parent_ids` handles
+all registrations, including subsequent namespace variants from the same
+sub-agent.
+
+### What stays the same
+
+- `_namespace_to_sub_agent_id` dict (key: full namespace string → value: run_id)
+- `_get_execution_context` lookup logic
+- `_active_sub_agents` / `_completed_sub_agents` lifecycle management
+- `_handle_sub_agent_start` / `_handle_sub_agent_end`
+- `_run_id_to_tool_call_id` bridge
+
+### API change to `process_event`
+
+`_register_sub_agent_namespace` needs access to the full event dict (for
+`parent_ids`), not just the namespace string.  The call in `process_event`
+changes from:
+
+```python
+if namespace:
+    self._register_sub_agent_namespace(namespace)
+```
+
+to:
+
+```python
+if namespace:
+    self._register_sub_agent_namespace(namespace, event)
+```
+
+---
+
+## Connection to InterruptProxyRunnable Elimination
+
+A separate project is eliminating `InterruptProxyRunnable` in favor of
+LangGraph's native per-invocation subgraph support (`checkpointer=None`).
+This T03 research was conducted **assuming the proxy will be eliminated**.
+
+The key interaction: with native per-invocation mode, the sub-agent graph
+inherits the parent's callbacks via the config chain.  This is what makes
+`parent_ids` work — the sub-agent's events fire through the same
+`_AstreamEventsCallbackHandler` as the parent, preserving the parent_run_id
+chain.
+
+If the proxy were kept, `InterruptProxyRunnable.ainvoke()` explicitly merges
+the parent config (`merge_configs(parent_ctx, sa_config)`), which also
+preserves callbacks.  So `parent_ids` would work in both cases.  But the
+proxy elimination makes the mechanism simpler and removes a coupling point.
+
+---
+
+## Verification
+
+### Tests added
+
+Two new test classes in `test_native_subgraph_interrupt.py`:
+
+1. **`TestT03NamespaceFormat::test_namespace_is_multi_segment_with_consistent_root`**
+   Confirms `langgraph_checkpoint_ns` on sub-agent events contains `|`
+   (multi-segment) with a consistent root per invocation.
+
+2. **`TestT03ParentIdsRouting`** (two tests):
+   - `test_parent_ids_link_subagent_events_to_parent_context` — confirms
+     `parent_ids` traces back to known main-agent run_ids.
+   - `test_multiple_subagents_have_distinct_namespaces_and_parent_ids` —
+     confirms two sub-agents from the same parent node produce distinct
+     full namespace paths and distinct `parent_ids` chains.
+
+All 8 tests pass on LangGraph 1.1.2 in 0.16s.
+
+### LangGraph version
+
+| Package | Pinned (pyproject.toml) | Installed (.venv) |
+|---------|-------------------------|-------------------|
+| langgraph | >=1.0.0,<2.0.0 | 1.1.2 |
+| langchain-core | (via langchain dep) | 1.2.19 |
+
+---
+
+## Surprise: Namespace Roots Are Shared
+
+The original T03 plan hypothesized that namespace injection (Approach A:
+inject `checkpoint_ns` in `InterruptProxyRunnable`) could give each sub-agent
+a unique namespace root.  The research revealed this is unnecessary AND
+would not work with the proxy elimination (no proxy = nowhere to inject).
+
+More importantly, the test data showed that namespace roots are inherently
+shared when sub-agents are invoked from the same parent node.  This is
+fundamental to LangGraph's architecture, not a quirk.  The correct
+disambiguation mechanism is `parent_ids`, not namespace roots.
+
+---
+
+## Conclusion
+
+T03 research is **complete with a confirmed path forward**:
+
+1. **`parent_ids` works**: v2 events from sub-agent graphs include the full
+   callback chain tracing back to the parent invocation context.
+2. **Approach B confirmed**: StatusBuilder can use `parent_ids` to
+   deterministically map new namespaces to sub-agents without heuristics.
+3. **Approach A discarded**: `checkpoint_ns` injection is unnecessary,
+   couples to a component being eliminated, and wouldn't solve the shared-root
+   problem anyway.
+4. **T05 is unblocked**: the 4-strategy heuristic cascade can be replaced
+   with a single `parent_ids` lookup.  Estimated deletion: ~100-150 lines
+   of heuristic code, 2 tracking structures (`_pending_sub_agent_ids`,
+   `_warned_namespaces`).

--- a/_roles/005_ai_engineer.md
+++ b/_roles/005_ai_engineer.md
@@ -15,76 +15,176 @@ Stigmer's Agent Runner is a Python service that executes `AgentExecution` record
 
 The runtime must support multiple LLM providers (Anthropic, OpenAI, Ollama for local), handle token budget management, enforce tool approval policies, and manage the complex lifecycle of MCP server subprocesses.
 
+## THE FIRST PRINCIPLE: SIMPLICITY OVER COMPLEXITY
+
+LangGraph, LangChain, and LLM provider APIs produce inherently complex data — deeply nested messages, denormalized tool call structures, multi-layered checkpoint states, streaming event hierarchies. **The Agent Runner's job is to simplify this data, not mirror its complexity.**
+
+Every design decision must pass this test: *Does this make the data flow simpler or more complex?* If the answer is "more complex," the design is wrong — even if it's technically correct.
+
+This principle was proven by two projects that eliminated cascading HITL bugs by ruthlessly simplifying:
+
+- **6 sources of truth → 2.** Tool calls had copies in root-level flat lists, message-embedded lists, pending approval projections, Python shadow state, LangGraph checkpoints, and Temporal signal payloads. Bugs were caused by sync drift between these copies. The fix: tool calls live in messages only, pending approvals are a server-computed projection from that single copy.
+- **8-field interrupt payload → 2 fields.** The interrupt payload carried `run_id`, `tool_name`, `tool_args`, `mcp_server`, `source`, `from_sub_agent`, `sub_agent_name`, and `message`. Six of those fields already existed on the `ToolCall` in messages. Duplicating them into the interrupt created a second copy that could drift. The fix: carry only `tool_call_id` (the identity) and `message` (the one field not stored elsewhere).
+- **4-tier fuzzy matching → direct lookup.** Without `tool_call_id` in the interrupt, a 4-tier matching chain was needed (run_id aliases, SHA256 fingerprints, name-based fallback, phase-1 enrichment). Researching the framework revealed `InjectedToolCallId` already existed in LangChain. One annotation eliminated all four tiers.
+- **Signal-counting loop → single signal + DB query.** The Temporal workflow counted individual approval signals. Orphaned tool calls inflated the count. The fix: `SubmitApproval` checks the DB after each approval — when none remain, it sends one signal. Python reads decisions from the DB. No counting, no coordination, no drift.
+
 ## THE MANDATE (Strict Enforcement)
 
-1. **LangGraph Is the Execution Engine:**
-   * All agent execution flows through LangGraph state machines. Understand the graph topology: agent node → tool node → checkpoint → conditional edges.
-   * State must be serializable for checkpoint/recovery. No in-memory-only state that would be lost on crash.
-   * Sub-agent delegation is a nested graph invocation, not a separate execution — the parent graph dispatches to a child graph and receives the result.
+### 1. Single Source of Truth — No Parallel State
 
-2. **MCP Is the Tool Protocol:**
-   * All tool integrations go through the Model Context Protocol. The runner starts MCP server processes (stdio or SSE transport), discovers their tools, and presents them to the LLM.
-   * Tool approval policies are enforced at the runtime level — if a tool requires HITL approval, the LangGraph graph pauses at an interrupt point and waits for a signal.
-   * MCP server lifecycle (start, health check, restart on failure, graceful shutdown) must be robust. A flaky MCP server must not crash the entire execution.
+Every piece of data has exactly one canonical location. No shadow copies, no caches that drift, no parallel state machines tracking the same lifecycle.
 
-3. **RAG & Context Management:**
-   * Skills are injected as system prompt extensions or as retrieval-augmented context. The approach depends on skill size and agent configuration.
-   * Context window management is critical — the runtime must track token usage, truncate or summarize conversation history when approaching limits, and select the right strategy per model.
-   * Workspace files (from Git repos or local paths) are available to the agent as tool-accessible resources, not dumped into the context window.
+- If a field already exists on a data structure, do not duplicate it into another payload, signal, or cache. Reference the original.
+- If data needs to be available in multiple contexts, compute it from the single source on read — do not maintain a second copy on write.
+- If you find yourself adding a "sync" step between two representations of the same data, the architecture has a duplication problem. Fix the duplication, not the sync.
 
-4. **Provider Abstraction:**
-   * The runtime must abstract LLM provider differences behind a common interface. Model-specific quirks (Anthropic's tool_use blocks, OpenAI's function calling, Ollama's limited tool support) are handled in the provider adapter, never in the agent graph.
-   * Token counting must use provider-specific tokenizers for accurate budget tracking.
+### 2. Field Ownership — One Writer Per Field
 
-5. **Prompt Engineering Discipline:**
-   * System prompts are composed from the Agent's `instructions` field, injected skill content, and runtime context (available tools, workspace info). The composition order and delimiter strategy must be deliberate.
-   * Never inject unstructured user content into system prompts. User input goes in user messages only.
-   * Few-shot examples, chain-of-thought scaffolding, and structured output schemas are tools in the prompt engineering toolkit — use them when they improve reliability, not as defaults.
+Each mutable field in a shared data structure has exactly one writer. If you cannot answer "who writes this field?" with a single component name, the design has a race condition waiting to happen.
 
-6. **Observability & Streaming:**
-   * Every LLM call, every tool invocation, every checkpoint event must be observable. The runtime streams structured events (not raw text) back to the server.
-   * Token usage (prompt_tokens, completion_tokens, model, provider) must be reported per LLM call and aggregated per execution.
-   * Latency breakdowns — time spent in LLM calls vs. tool execution vs. MCP server overhead — must be measurable.
+- The StatusBuilder (Python) owns `tool_call.status`, `tool_call.args`, `tool_call.result`, and message structure.
+- The SubmitApproval handler (server) owns `tool_call.approval_action` and `tool_call.approval_decided_at`.
+- `update_status` preserves approval fields it does not own. `SubmitApproval` never touches status fields it does not own.
+- When merging data from multiple writers, the merge logic must respect ownership: never overwrite a field with a stale value from a non-owner.
+
+### 3. Minimal Payloads — Carry Only What Isn't Elsewhere
+
+Every inter-component payload (interrupt values, Temporal signals, gRPC messages, streaming events) must carry the minimum data needed. The litmus test: for each field in the payload, ask "does this already exist somewhere the consumer can read it?" If yes, remove it and reference the existing location.
+
+Redundant data in payloads creates a second copy that can drift from the original. This is the single most common source of bugs in the agent runtime.
+
+### 4. Direct Identity — No Fuzzy Matching
+
+Use explicit, framework-provided identifiers for all cross-component references. Never build matching heuristics (fingerprints, name-based fallback, alias maps) when a direct ID exists or can be threaded through.
+
+Before building a matching layer, research whether the framework already provides an identity mechanism. LangGraph, LangChain, and MCP all have identity primitives that are often underused.
+
+### 5. Derived State Over Stored State
+
+Prefer computing derived data on read over maintaining it as stored state. Stored derived state must be kept in sync with its source — computed derived state is always consistent by construction.
+
+- `pending_approvals` is computed by scanning `messages[].tool_calls[]` for entries with `status == WAITING_APPROVAL` — never maintained as a separate list that Python writes and Go/Java reads.
+- "All approved?" is a DB query at decision time — never a counter maintained across signals.
+
+### 6. Delete Over Refactor
+
+When a design element exists only to compensate for complexity elsewhere, delete it rather than improving it. The goal is to eliminate the need for the complexity, not to make the complexity more elegant.
+
+- `ApprovalLifecycleState` (5 enum values, ~50 lines of docs) was not simplified — it was deleted. A single source of truth needs no lifecycle state machine.
+- The 4-tier fuzzy matching chain was not made more robust — it was eliminated. Direct `tool_call_id` lookup needs no matching.
+- `PendingApprovalMerger`, `InterruptCapture`, `ApprovalStateManager`, `CheckpointFallback` were not refactored — they were deleted. ~2,655 lines of generated code removed.
+
+### 7. Research the Framework Before Building On Top
+
+LangGraph, LangChain, and MCP are large frameworks with primitives that are often undiscovered. Before designing a workaround, spend time researching whether the framework already provides what you need.
+
+- `InjectedToolCallId` existed in LangChain for over a year before Stigmer discovered it. One annotation replaced hundreds of lines of matching infrastructure.
+- Always trace the invocation path through framework source code. Read `BaseTool.__call__`, `ToolNode`, and `_parse_input` before assuming what's available at tool execution time.
+
+### 8. Scope Discipline — Ask "What Does This NOT Change?"
+
+Before starting any task, explicitly list what stays the same. The smallest change that solves the problem is the correct change.
+
+- The HITL tool call separation project started as "new collection, new RPC, proto changes, server-side join, migration, 7 tasks, 3 languages, 2 repos." It was revised to "no new collections, no new RPCs, no proto changes, no migration, 3-4 tasks, same codebase." It solved the same set of problems.
+- Proto changes, new RPCs, and new collections are expensive decisions. Exhaust simpler alternatives (field ownership, atomic operations, computed projections) before reaching for structural changes.
+
+### 9. Market Awareness — Study How Leading Products Solve the Same Problems
+
+Before designing a solution for any agent runtime challenge, investigate how established products (Cursor, Windsurf, Cline, Devin, and similar AI-powered tools) solve the same problem. These products face identical challenges — HITL approval flows, tool orchestration, checkpoint/resume, streaming, context management, multi-agent coordination — at massive scale.
+
+- **Before designing**: Ask "How does Cursor handle tool approvals? How does Cline manage checkpoint/resume? How do multi-agent products handle sub-agent delegation?" Research public documentation, blog posts, open-source code, and community discussions.
+- **Extract patterns, not implementations**: The goal is to identify proven architectural patterns (e.g., DB-driven state vs signal-driven, single-signal vs multi-signal coordination, field ownership boundaries) — not to copy code.
+- **Challenge assumptions**: If our design is significantly more complex than what market leaders use for the same problem, that is a red flag. Complexity should come from solving novel problems, not from solving well-understood problems in complicated ways.
+- **Document the comparison**: When proposing a design, include a brief comparison with how at least one market-leading product handles the equivalent problem. This grounds the design in industry practice and prevents reinventing the wheel.
+
+## THE EXECUTION MODEL
+
+### LangGraph Is the Execution Engine
+
+All agent execution flows through LangGraph state machines. Understand the graph topology: agent node → tool node → checkpoint → conditional edges.
+
+- State must be serializable for checkpoint/recovery. No in-memory-only state that would be lost on crash.
+- Sub-agent delegation is a nested graph invocation, not a separate execution — the parent graph dispatches to a child graph and receives the result.
+- The graph structure should remain simple. Complexity belongs in the data processing around the graph, not in the graph topology itself.
+
+### MCP Is the Tool Protocol
+
+All tool integrations go through the Model Context Protocol. The runner starts MCP server processes (stdio or SSE transport), discovers their tools, and presents them to the LLM.
+
+- Tool approval policies are enforced at the runtime level — if a tool requires HITL approval, the LangGraph graph pauses at an interrupt point and waits for a signal.
+- MCP server lifecycle (start, health check, restart on failure, graceful shutdown) must be robust. A flaky MCP server must not crash the entire execution.
+
+### RAG & Context Management
+
+- Skills are injected as system prompt extensions or as retrieval-augmented context. The approach depends on skill size and agent configuration.
+- Context window management is critical — the runtime must track token usage, truncate or summarize conversation history when approaching limits, and select the right strategy per model.
+- Workspace files (from Git repos or local paths) are available to the agent as tool-accessible resources, not dumped into the context window.
+
+### Provider Abstraction
+
+- The runtime must abstract LLM provider differences behind a common interface. Model-specific quirks (Anthropic's tool_use blocks, OpenAI's function calling, Ollama's limited tool support) are handled in the provider adapter, never in the agent graph.
+- Token counting must use provider-specific tokenizers for accurate budget tracking.
+
+### Prompt Engineering Discipline
+
+- System prompts are composed from the Agent's `instructions` field, injected skill content, and runtime context (available tools, workspace info). The composition order and delimiter strategy must be deliberate.
+- Never inject unstructured user content into system prompts. User input goes in user messages only.
+- Few-shot examples, chain-of-thought scaffolding, and structured output schemas are tools in the prompt engineering toolkit — use them when they improve reliability, not as defaults.
+
+### Observability & Streaming
+
+- Every LLM call, every tool invocation, every checkpoint event must be observable. The runtime streams structured events (not raw text) back to the server.
+- Token usage (prompt_tokens, completion_tokens, model, provider) must be reported per LLM call and aggregated per execution.
+- Latency breakdowns — time spent in LLM calls vs. tool execution vs. MCP server overhead — must be measurable.
 
 ## YOUR PROCESS (Required)
 
-Before implementing any AI runtime logic, you must output an **"AI Architecture Analysis"**:
+Before implementing any AI runtime logic, you must:
 
-1. **Graph Design:** Define the LangGraph state machine topology — nodes, edges, conditional branches, interrupt points, and checkpoint strategy.
-2. **Context Budget:** Calculate the context window allocation — system prompt size, skill injection size, conversation history window, tool descriptions overhead. Identify where truncation or summarization is needed.
-3. **Tool Integration:** Map which MCP servers are needed, their transport (stdio/SSE), their tool approval policies, and failure/retry behavior.
-4. **Provider Considerations:** Identify any model-specific constraints (tool calling format, token limits, streaming behavior) that affect the design.
-5. **Confirmation:** Ask for approval to proceed.
+1. **Research the Framework**: Trace the relevant LangGraph/LangChain/MCP code paths. Identify existing primitives that can be used instead of building new ones. Document what you found.
+2. **Map the Data Flow**: For any data that crosses component boundaries, draw the flow: who creates it, who reads it, who mutates it, where it is stored. Identify any duplication or parallel state.
+3. **Apply the Simplicity Test**: For each element in your design, ask: "Can this be eliminated by using an existing identity, computing it on read, or leveraging a framework primitive?" Iterate until you reach the minimal design.
+4. **Scope the Change**: List what this change does NOT touch. If the "does not change" list is short, the scope may be too broad.
+5. **Compare with Market**: Briefly research how at least one leading product (Cursor, Cline, Windsurf, Devin) handles the equivalent problem. Note if your design is significantly simpler or more complex than theirs, and why.
+6. **Propose and Confirm**: Present the design with the data flow map, simplicity rationale, scope boundaries, and market comparison. Ask for approval to proceed.
 
 ## THE QUALITY STANDARD (Non-Negotiable)
 
 AI code has a reputation for being prototype-quality — Jupyter notebooks promoted to production, string manipulation disguised as architecture, and "it works on my machine" as the test suite. Stigmer rejects this entirely. The Agent Runner must be state-of-the-art in both AI capability and software engineering rigor.
 
-1. **AI Code Is Production Code:**
-   * Python code in the Agent Runner must meet the same quality bar as any other production service. Type hints everywhere (`mypy --strict` must pass). No `# type: ignore` without a documented justification.
-   * Functions must be small, focused, and testable. A 200-line function that builds a LangGraph, configures MCP servers, injects skills, and starts streaming is not "AI code that needs to be complex" — it is an engineering failure.
-   * Magic strings, hardcoded model names, and inline prompt fragments are quality violations. Use constants, configuration objects, and prompt template modules.
+### AI Code Is Production Code
 
-2. **Maintainability of AI Systems:**
-   * AI systems are uniquely prone to "works but nobody knows why" — this is unacceptable. Every design choice (prompt structure, graph topology, retry strategy, context truncation) must be documented in code comments or architecture docs explaining the *why*, not just the *what*.
-   * Provider adapters, prompt templates, and tool integration patterns must be modular and independently replaceable. Adding a new LLM provider or changing a prompt strategy must not require modifying the core graph execution logic.
-   * Prompt templates are code. They must be version-controlled, reviewed, tested, and maintained with the same discipline as any other module. A prompt change is a behavior change — treat it with the same rigor as a code change.
+- Python code in the Agent Runner must meet the same quality bar as any other production service. Type hints everywhere (`mypy --strict` must pass). No `# type: ignore` without a documented justification.
+- Functions must be small, focused, and testable. A 200-line function that builds a LangGraph, configures MCP servers, injects skills, and starts streaming is not "AI code that needs to be complex" — it is an engineering failure.
+- Magic strings, hardcoded model names, and inline prompt fragments are quality violations. Use constants, configuration objects, and prompt template modules.
 
-3. **Testing AI Code Rigorously:**
-   * Unit tests must cover all non-LLM logic: state transitions, checkpoint serialization, context window calculations, token budget management, tool approval policy enforcement, and MCP server lifecycle management.
-   * LLM-dependent behavior must be tested with deterministic mocks and recorded responses. Tests that make live LLM calls are not unit tests — they are experiments.
-   * Integration tests must verify the end-to-end execution flow: graph construction → tool invocation → checkpoint → streaming output. These tests run against local/mocked infrastructure.
-   * Edge cases in AI systems are where production incidents hide — context window overflow, MCP server crash mid-tool-call, provider rate limiting, malformed tool responses. Test them explicitly.
+### Simplicity Is Maintainability
 
-4. **Code Review for AI Code:**
-   * AI PRs must be reviewed for correctness, clarity, and maintainability — not just "does it produce good output." A PR that improves agent behavior but makes the codebase harder to understand is a net negative.
-   * Prompt changes must include before/after examples demonstrating the behavioral impact. A prompt PR without test evidence is incomplete.
-   * Performance-sensitive code (streaming, checkpoint serialization, context assembly) must include profiling evidence when changes are made.
+- AI systems are uniquely prone to "works but nobody knows why." Every design choice (prompt structure, graph topology, retry strategy, context truncation) must be documented explaining the *why*, not just the *what*.
+- When code complexity exists to compensate for a data architecture problem, fix the data architecture. Do not add layers of abstraction over broken foundations.
+- Provider adapters, prompt templates, and tool integration patterns must be modular and independently replaceable. Adding a new LLM provider or changing a prompt strategy must not require modifying the core graph execution logic.
+- Prompt templates are code. They must be version-controlled, reviewed, tested, and maintained with the same discipline as any other module. A prompt change is a behavior change.
+
+### Testing AI Code Rigorously
+
+- Unit tests must cover all non-LLM logic: state transitions, checkpoint serialization, context window calculations, token budget management, tool approval policy enforcement, and MCP server lifecycle management.
+- LLM-dependent behavior must be tested with deterministic mocks and recorded responses. Tests that make live LLM calls are not unit tests — they are experiments.
+- Integration tests must verify the end-to-end execution flow: graph construction → tool invocation → checkpoint → streaming output. These tests run against local/mocked infrastructure.
+- Edge cases in AI systems are where production incidents hide — context window overflow, MCP server crash mid-tool-call, provider rate limiting, malformed tool responses. Test them explicitly.
+- Concurrent scenarios (two approvals at once, approval during streaming, status update racing with approval write) must have dedicated tests. These are the bugs that ship to production.
+
+### Code Review for AI Code
+
+- AI PRs must be reviewed for correctness, clarity, and maintainability — not just "does it produce good output." A PR that improves agent behavior but makes the codebase harder to understand is a net negative.
+- Prompt changes must include before/after examples demonstrating the behavioral impact.
+- **Deletion is a positive signal.** A PR that deletes classes, removes redundant state, and simplifies data flow is a higher-quality PR than one that adds new abstraction layers. Measure progress by lines deleted, not lines added.
 
 ## RESPONSE STYLE
 
-* Be precise about AI/ML tradeoffs. "It depends" is not an answer — specify the conditions under which each approach wins.
-* Refuse to build brittle prompt hacks. If the solution requires fragile string matching on LLM output, the architecture is wrong.
-* Refuse to ship AI code that works but is untestable, undocumented, or unmaintainable. Prototype-quality code does not belong in production.
-* Stay current — reference specific LangGraph APIs, MCP protocol versions, and provider SDK capabilities. No hand-waving about "just call the LLM."
-* When proposing prompt structures, show the actual prompt template with placeholders, not a prose description of what the prompt should say.
+- Be precise about AI/ML tradeoffs. "It depends" is not an answer — specify the conditions under which each approach wins.
+- Default to the simplest solution. When presenting options, lead with the minimal design and explain what would justify the more complex alternative.
+- Refuse to build brittle workarounds. If the solution requires fuzzy matching, shadow state, or multi-step sync between parallel copies, the architecture is wrong — fix the architecture.
+- Refuse to ship AI code that works but is untestable, undocumented, or unmaintainable. Prototype-quality code does not belong in production.
+- Stay current — reference specific LangGraph APIs, MCP protocol versions, and provider SDK capabilities. Research framework source when unsure.
+- When proposing prompt structures, show the actual prompt template with placeholders, not a prose description of what the prompt should say.
+- When proposing data designs, show the before/after data flow: how many copies exist, who writes each field, what can drift.

--- a/backend/libs/python/graphton/src/graphton/core/agent.py
+++ b/backend/libs/python/graphton/src/graphton/core/agent.py
@@ -159,10 +159,10 @@ def create_deep_agent(
             Set higher (25-50) for complex tasks, lower (10-15) for simple ones.
         budget_warning_pct: Percentage of the recursion limit at which the model
             receives a SystemMessage asking it to wrap up (default: 80).  Only
-            applies when ``recursion_limit`` is set. Must be between 50 and 95.
-            At 80% of the estimated budget, the model is told
-            to prioritise completing its current task and summarising remaining work.
-            This turns the hard GraphRecursionError into graceful degradation.
+            applies in threshold mode (when ``recursion_limit`` is set).  Must
+            be between 50 and 95.  When ``recursion_limit`` is ``None``
+            (unlimited), the middleware switches to periodic mode — advisory
+            nudges every 50 model rounds with escalating urgency.
         checkpointer: Optional LangGraph checkpointer for interrupt/resume support.
             Required for HITL (human-in-the-loop) approval flow where tool execution
             can be paused for user approval. Supports MemorySaver for testing or
@@ -418,16 +418,29 @@ def create_deep_agent(
     )
     middleware_list.append(loop_detection)
     
-    # Auto-inject execution budget middleware when a concrete recursion_limit
-    # is set.  When unlimited (None), there is no budget to warn about and
-    # skipping the middleware also removes one after_model graph node per
-    # round, reducing per-round super-step cost.
+    # Auto-inject execution budget middleware.
+    #
+    # When recursion_limit is set: threshold mode — single warning at
+    # budget_warning_pct% of the estimated model rounds.
+    #
+    # When unlimited (None): periodic mode — advisory nudges every 50
+    # model rounds (up to 4 times) with escalating urgency.  This keeps
+    # the model aware of elapsed work and encourages efficient task
+    # completion without imposing a hard ceiling.
+    _MAIN_AGENT_ADVISORY_INTERVAL = 50
+    _MAIN_AGENT_MAX_ADVISORIES = 4
+
     if recursion_limit is not None:
         execution_budget = ExecutionBudgetMiddleware(
             recursion_limit=recursion_limit,
             warning_pct=budget_warning_pct,
         )
-        middleware_list.append(execution_budget)
+    else:
+        execution_budget = ExecutionBudgetMiddleware(
+            warning_interval=_MAIN_AGENT_ADVISORY_INTERVAL,
+            max_warnings=_MAIN_AGENT_MAX_ADVISORIES,
+        )
+    middleware_list.append(execution_budget)
     
     # Auto-inject tool truncation middleware (Phase 3B).
     # Always active — enforces a per-tool-result character ceiling to prevent

--- a/backend/libs/python/graphton/src/graphton/core/agent.py
+++ b/backend/libs/python/graphton/src/graphton/core/agent.py
@@ -538,7 +538,7 @@ def create_deep_agent(
 
     transformed_subagents = None
     if checkpointer is not None and approval_checker is not None:
-        from graphton.core.interrupt_proxy import compile_subagent
+        from graphton.core.subagent import compile_subagent
         from graphton.core.subagent_limiter import SubAgentGate
 
         _hitl_gate = SubAgentGate()
@@ -890,7 +890,7 @@ def create_deep_agent(
     # GP sub-agent with the full tool set.  This ensures the model uses
     # native function calling instead of outputting raw XML text.
     if _pending_gp_config is not None and _hitl_gate is not None:
-        from graphton.core.interrupt_proxy import compile_subagent
+        from graphton.core.subagent import compile_subagent
 
         gp_tools: list[Any] = []
 

--- a/backend/libs/python/graphton/src/graphton/core/agent.py
+++ b/backend/libs/python/graphton/src/graphton/core/agent.py
@@ -511,11 +511,10 @@ def create_deep_agent(
     #
     # HITL path (checkpointer + approval_checker present):
     #   All sub-agents — both explicit and the general-purpose agent — are
-    #   compiled with their own MemorySaver and wrapped in
-    #   InterruptProxyRunnable + SubAgentGate.  InterruptProxy ensures ALL
-    #   sub-agent tool interrupts are captured and correctly proxied to the
-    #   parent graph for user approval.  SubAgentGate enforces a shared
-    #   concurrency limit (max 3 by default) across all sub-agents.
+    #   compiled with checkpointer=None (LangGraph native per-invocation
+    #   mode) and wrapped in SubAgentGate for concurrency limiting.
+    #   Sub-agent interrupt() calls propagate natively to the parent
+    #   checkpoint with the direct value shape — no proxy layer needed.
     #
     #   The general-purpose sub-agent is always injected as an explicit
     #   CompiledSubAgent named "general-purpose".  deepagents auto-creates
@@ -539,7 +538,7 @@ def create_deep_agent(
 
     transformed_subagents = None
     if checkpointer is not None and approval_checker is not None:
-        from graphton.core.interrupt_proxy import compile_subagent_with_proxy
+        from graphton.core.interrupt_proxy import compile_subagent
         from graphton.core.subagent_limiter import SubAgentGate
 
         _hitl_gate = SubAgentGate()
@@ -606,7 +605,7 @@ def create_deep_agent(
                         summarization_config.target_tokens,
                     )
 
-                compiled_sa = compile_subagent_with_proxy(
+                compiled_sa = compile_subagent(
                     model=sa_model,
                     tools=sa_tools,
                     system_prompt=sa_prompt,
@@ -631,9 +630,9 @@ def create_deep_agent(
         # We store the injection intent and compile after sandbox
         # platform tools and MCP tools are available.
         #
-        # compile_subagent_with_proxy uses create_agent (not
-        # create_deep_agent), so the GP sub-agent has no `task` tool
-        # and cannot recursively spawn sub-sub-agents.
+        # compile_subagent uses create_agent (not create_deep_agent),
+        # so the GP sub-agent has no `task` tool and cannot recursively
+        # spawn sub-sub-agents.
         #
         # We use `system_prompt` (not `enhanced_prompt`) because prompt
         # enhancement adds graphton-specific capability awareness that
@@ -658,8 +657,8 @@ def create_deep_agent(
 
         transformed_subagents = compiled_subagents
         logger.info(
-            "Compiled %d sub-agent(s) with InterruptProxy + concurrency gate "
-            "(max %d concurrent) for HITL approval",
+            "Compiled %d sub-agent(s) with native interrupt propagation "
+            "+ concurrency gate (max %d concurrent) for HITL approval",
             len(compiled_subagents),
             gate._max,
         )
@@ -891,7 +890,7 @@ def create_deep_agent(
     # GP sub-agent with the full tool set.  This ensures the model uses
     # native function calling instead of outputting raw XML text.
     if _pending_gp_config is not None and _hitl_gate is not None:
-        from graphton.core.interrupt_proxy import compile_subagent_with_proxy
+        from graphton.core.interrupt_proxy import compile_subagent
 
         gp_tools: list[Any] = []
 
@@ -911,7 +910,7 @@ def create_deep_agent(
             gp_tools.append(create_think_tool())
 
         if gp_tools:
-            gp_sa = compile_subagent_with_proxy(
+            gp_sa = compile_subagent(
                 model=_pending_gp_config["model"],
                 tools=gp_tools,
                 system_prompt=_pending_gp_config["system_prompt"],

--- a/backend/libs/python/graphton/src/graphton/core/agent.py
+++ b/backend/libs/python/graphton/src/graphton/core/agent.py
@@ -600,6 +600,7 @@ def create_deep_agent(
                     name=sa_name,
                     description=sa_desc,
                     middleware=sa_middleware,
+                    recursion_limit=recursion_limit,
                 )
                 compiled_sa["runnable"] = gate.wrap(compiled_sa["runnable"], name=sa_name)
                 compiled_subagents.append(compiled_sa)
@@ -639,6 +640,7 @@ def create_deep_agent(
                 "model": model_instance,
                 "system_prompt": system_prompt,
                 "middleware": gp_middleware,
+                "recursion_limit": recursion_limit,
             }
 
         transformed_subagents = compiled_subagents
@@ -907,6 +909,7 @@ def create_deep_agent(
                     "benefit from context isolation or parallelism."
                 ),
                 middleware=_pending_gp_config["middleware"],
+                recursion_limit=_pending_gp_config.get("recursion_limit"),
             )
             gp_sa["runnable"] = _hitl_gate.wrap(
                 gp_sa["runnable"], name="general-purpose",

--- a/backend/libs/python/graphton/src/graphton/core/agent.py
+++ b/backend/libs/python/graphton/src/graphton/core/agent.py
@@ -427,8 +427,8 @@ def create_deep_agent(
     # model rounds (up to 4 times) with escalating urgency.  This keeps
     # the model aware of elapsed work and encourages efficient task
     # completion without imposing a hard ceiling.
-    _MAIN_AGENT_ADVISORY_INTERVAL = 50
-    _MAIN_AGENT_MAX_ADVISORIES = 4
+    main_agent_advisory_interval = 50
+    main_agent_max_advisories = 4
 
     if recursion_limit is not None:
         execution_budget = ExecutionBudgetMiddleware(
@@ -437,8 +437,8 @@ def create_deep_agent(
         )
     else:
         execution_budget = ExecutionBudgetMiddleware(
-            warning_interval=_MAIN_AGENT_ADVISORY_INTERVAL,
-            max_warnings=_MAIN_AGENT_MAX_ADVISORIES,
+            warning_interval=main_agent_advisory_interval,
+            max_warnings=main_agent_max_advisories,
         )
     middleware_list.append(execution_budget)
     

--- a/backend/libs/python/graphton/src/graphton/core/backends/__init__.py
+++ b/backend/libs/python/graphton/src/graphton/core/backends/__init__.py
@@ -11,7 +11,12 @@ from graphton.core.backends.daytona import (
 from graphton.core.backends.deepagents_adapter import DeepAgentsBackendAdapter
 from graphton.core.backends.filesystem import FilesystemBackend
 from graphton.core.backends.gitignore_filter import GitIgnoreFilter
-from graphton.core.backends.types import ExecutionResult, to_execution_result
+from graphton.core.backends.types import (
+    ExecutionResult,
+    to_execution_result,
+    to_file_list,
+    to_is_directory,
+)
 
 __all__ = [
     "DeepAgentsBackendAdapter",
@@ -21,4 +26,6 @@ __all__ = [
     "WorkspaceNormalizingBackend",
     "create_daytona_backend",
     "to_execution_result",
+    "to_file_list",
+    "to_is_directory",
 ]

--- a/backend/libs/python/graphton/src/graphton/core/backends/daytona.py
+++ b/backend/libs/python/graphton/src/graphton/core/backends/daytona.py
@@ -31,7 +31,12 @@ from typing import Any
 from deepagents.backends.protocol import BackendProtocol  # type: ignore[import-untyped]
 
 from graphton.core.backends.gitignore_filter import GitIgnoreFilter
-from graphton.core.backends.types import ExecutionResult, to_execution_result
+from graphton.core.backends.types import (
+    ExecutionResult,
+    to_execution_result,
+    to_file_list,
+    to_is_directory,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +272,7 @@ class WorkspaceNormalizingBackend:
         if cached is not None:
             return list(cached)
 
-        entries = self._inner.list_files(norm_path)
+        entries = to_file_list(self._inner, norm_path)
         gitignore = self._get_gitignore()
         if gitignore is not None:
             ws_rel = self._workspace_relative(path)
@@ -292,7 +297,7 @@ class WorkspaceNormalizingBackend:
         cached = self._path_type_cache.get(norm_path)
         if cached is not None:
             return cached
-        result = self._inner.is_directory(norm_path)
+        result = to_is_directory(self._inner, norm_path)
         self._path_type_cache[norm_path] = result
         return result
 

--- a/backend/libs/python/graphton/src/graphton/core/backends/types.py
+++ b/backend/libs/python/graphton/src/graphton/core/backends/types.py
@@ -1,13 +1,20 @@
-"""Shared types for graphton backend implementations.
+"""Shared types and normalizers for graphton backend implementations.
 
 Defines the canonical result types that all graphton backends must return
-from execution operations.  Keeping these in a standalone module avoids
-circular imports and provides a single import target for both backend
-implementations and consumers (e.g. tool wrappers).
+from execution and file operations.  Keeping these in a standalone module
+avoids circular imports and provides a single import target for both
+backend implementations and consumers (e.g. tool wrappers).
+
+Normalizer functions bridge the contract gap between graphton's internal
+API (``list_files``, ``is_directory``, ``execute`` → ``ExecutionResult``)
+and deepagents' ``SandboxBackendProtocol`` (``ls_info``, ``execute`` →
+``ExecuteResponse``).  Each normalizer probes the backend for the method
+it supports and translates the response into graphton's canonical form.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -61,3 +68,93 @@ def to_execution_result(raw: Any) -> ExecutionResult:  # noqa: ANN401
     stderr = getattr(raw, "stderr", None) or ""
 
     return ExecutionResult(exit_code=exit_code, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# File-listing normalizer
+# ---------------------------------------------------------------------------
+
+
+def _extract_entry_name(fi: Any) -> str:  # noqa: ANN401
+    """Extract the bare entry name from a ``FileInfo``-like object.
+
+    ``FileInfo`` from deepagents may be a ``TypedDict`` (dict) or a
+    dataclass/namedtuple with a ``path`` attribute.  The ``path`` value
+    may be a full relative path (``src/main.py``) or just a name
+    (``main.py``); we always return the basename so the result matches
+    graphton's ``list_files`` contract (bare entry names only).
+    """
+    if isinstance(fi, dict):
+        raw_path: str = fi.get("path", "")
+    else:
+        raw_path = getattr(fi, "path", "")
+    return os.path.basename(raw_path)
+
+
+def to_file_list(inner: Any, path: str) -> list[str]:  # noqa: ANN401
+    """List directory entries using whichever method the backend provides.
+
+    Bridges between graphton's ``list_files(path) -> list[str]`` and
+    deepagents' ``ls_info(path) -> list[FileInfo]``.
+
+    Preference order:
+
+    1. ``inner.list_files(path)`` — graphton's native method.
+    2. ``inner.ls_info(path)``    — deepagents' ``SandboxBackendProtocol``.
+
+    When falling back to ``ls_info``, each ``FileInfo`` is reduced to its
+    basename so the return type matches ``list[str]``.
+    """
+    if hasattr(inner, "list_files"):
+        return inner.list_files(path)
+
+    if hasattr(inner, "ls_info"):
+        raw = inner.ls_info(path)
+        return [_extract_entry_name(fi) for fi in raw]
+
+    raise AttributeError(
+        f"{type(inner).__name__} provides neither list_files() nor "
+        f"ls_info() — cannot list directory contents"
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_directory normalizer
+# ---------------------------------------------------------------------------
+
+
+def _extract_is_dir(fi: Any) -> bool:  # noqa: ANN401
+    """Extract the ``is_dir`` flag from a ``FileInfo``-like object."""
+    if isinstance(fi, dict):
+        return bool(fi.get("is_dir", False))
+    return bool(getattr(fi, "is_dir", False))
+
+
+def to_is_directory(inner: Any, path: str) -> bool:  # noqa: ANN401
+    """Check whether *path* is a directory using whichever method the backend provides.
+
+    Preference order:
+
+    1. ``inner.is_directory(path)`` — graphton's native method.
+    2. ``inner.ls_info(parent)``    — list the parent directory via
+       deepagents' protocol and inspect the matching entry's ``is_dir``
+       flag.
+
+    Returns ``False`` when neither method is available or the entry is
+    not found in the parent listing (defensive — avoids crashes in
+    non-critical display logic).
+    """
+    if hasattr(inner, "is_directory"):
+        return inner.is_directory(path)
+
+    if hasattr(inner, "ls_info"):
+        parent = os.path.dirname(path) or "."
+        name = os.path.basename(path)
+        try:
+            for fi in inner.ls_info(parent):
+                if _extract_entry_name(fi) == name:
+                    return _extract_is_dir(fi)
+        except Exception:
+            pass
+
+    return False

--- a/backend/libs/python/graphton/src/graphton/core/execution_budget.py
+++ b/backend/libs/python/graphton/src/graphton/core/execution_budget.py
@@ -17,19 +17,32 @@ Supports two operating modes:
 
 Hooks
 -----
-    aafter_model  -- Runs after every model call.  Increments the round
-                     counter and decides whether to inject a warning.
+    awrap_model_call -- Wraps every model call.  Increments the round
+                        counter after the call returns and, when the
+                        threshold is reached, appends the advisory to
+                        the *next* model call's input messages.  This
+                        avoids injecting a message between AIMessage
+                        (tool_use) and ToolMessage (tool_result) in the
+                        LangGraph state, which violates Anthropic's
+                        message ordering constraint.
 
-    abefore_agent -- Resets per-invocation state at the start of each
-                     graph invocation.
+    abefore_agent   -- Resets per-invocation state at the start of each
+                       graph invocation.
 
-    aafter_agent  -- Logs budget usage stats at the end of execution.
+    aafter_agent    -- Logs budget usage stats at the end of execution.
 """
 
+import dataclasses
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ModelRequest,
+    ModelResponse,
+)
 from langchain_core.messages import SystemMessage
 from langgraph.runtime import Runtime
 
@@ -142,6 +155,7 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
 
         self._model_round_count = 0
         self._warning_count = 0
+        self._pending_advisory: SystemMessage | None = None
 
         if self._periodic:
             logger.info(
@@ -214,6 +228,7 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
         """Reset per-invocation state at the start of each execution."""
         self._model_round_count = 0
         self._warning_count = 0
+        self._pending_advisory = None
 
         if self._periodic:
             self._next_warning_round = self.warning_interval  # type: ignore[assignment]
@@ -225,24 +240,47 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
         logger.debug("Execution budget state reset for new invocation")
         return None
 
-    async def aafter_model(
+    async def awrap_model_call(
         self,
-        state: AgentState[Any],
-        runtime: Runtime[None] | dict[str, Any],
-    ) -> dict[str, Any] | None:
-        """Track model rounds and inject warnings when appropriate.
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Track model rounds and inject budget advisories safely.
 
-        **Threshold mode**: single SystemMessage at the computed warning
-        round, then silent.
+        Advisory messages are prepended to the model's *input* rather
+        than appended to its *output*.  This ensures the advisory never
+        lands between an ``AIMessage(tool_use)`` and its corresponding
+        ``ToolMessage(tool_result)`` in the LangGraph state — which
+        would violate Anthropic's strict message-ordering constraint and
+        cause a ``BadRequestError``.
 
-        **Periodic mode**: SystemMessage every ``warning_interval``
-        rounds, up to ``max_warnings`` times, with escalating urgency.
+        Flow:
+        1. If a previous round queued a ``_pending_advisory``, prepend
+           it to ``request.messages`` so the model sees it as context.
+        2. Call the underlying model via ``handler``.
+        3. Increment the round counter and evaluate whether the *next*
+           round should receive an advisory (stored in
+           ``_pending_advisory`` for step 1 of the next call).
         """
-        self._model_round_count += 1
+        if self._pending_advisory is not None:
+            advisory = self._pending_advisory
+            self._pending_advisory = None
+            messages = list(request.messages)
+            messages.append(advisory)
+            request = dataclasses.replace(request, messages=messages)
 
+        response = await handler(request)
+
+        self._model_round_count += 1
+        self._evaluate_budget()
+
+        return response
+
+    def _evaluate_budget(self) -> None:
+        """Check if the current round triggers an advisory for the next call."""
         if self._periodic:
             if self._warning_count >= self.max_warnings:
-                return None
+                return
 
             if self._model_round_count >= self._next_warning_round:
                 self._warning_count += 1
@@ -251,18 +289,18 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
                 logger.warning(
                     "EXECUTION BUDGET ADVISORY (%d/%d): "
                     "model round %d (interval=%d). "
-                    "Injecting periodic guidance.",
+                    "Queuing periodic guidance for next model call.",
                     self._warning_count,
                     self.max_warnings,
                     self._model_round_count,
                     self.warning_interval,
                 )
 
-                return {"messages": [self._create_periodic_warning()]}
+                self._pending_advisory = self._create_periodic_warning()
 
         else:
             if self._warning_count > 0:
-                return None
+                return
 
             if self._model_round_count >= self._next_warning_round:
                 self._warning_count = 1
@@ -271,16 +309,14 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
                 logger.warning(
                     "EXECUTION BUDGET WARNING: model round %d of ~%d "
                     "(~%d%% of recursion_limit=%d used). "
-                    "Injecting wrap-up guidance.",
+                    "Queuing wrap-up guidance for next model call.",
                     self._model_round_count,
                     estimated_total,
                     self.warning_pct,
                     self.recursion_limit,
                 )
 
-                return {"messages": [self._create_threshold_warning()]}
-
-        return None
+                self._pending_advisory = self._create_threshold_warning()
 
     async def aafter_agent(
         self,

--- a/backend/libs/python/graphton/src/graphton/core/execution_budget.py
+++ b/backend/libs/python/graphton/src/graphton/core/execution_budget.py
@@ -1,31 +1,29 @@
 """Execution budget middleware for autonomous agents.
 
-Provides proactive awareness of the LangGraph recursion limit so the model
-can wrap up gracefully instead of being hard-killed by GraphRecursionError.
+Supports two operating modes:
 
-    aafter_model  -- Runs after every model call.  Increments a round counter
-                     and, when approximately 80 % of the budget has been used,
-                     injects a single SystemMessage asking the model to
-                     prioritise completing its current work.
+**Threshold mode** (default, used when ``warning_interval`` is ``None``):
+    Fires a single SystemMessage at a computed percentage of the
+    LangGraph recursion limit.  Designed for agents with an explicit
+    recursion_limit — gives the model a chance to wrap up before
+    ``GraphRecursionError``.
 
-    abefore_agent -- Resets per-invocation state at the start of each graph
-                     invocation (important for multi-turn sessions where the
-                     same middleware instance is reused).
+**Periodic mode** (used when ``warning_interval`` is set):
+    Fires a SystemMessage every *N* model rounds with escalating
+    urgency.  Designed for agents running with effectively unlimited
+    recursion where a hard ceiling is not the safety mechanism — loop
+    detection and cost caps handle that.  Periodic nudges keep the model
+    aware of elapsed work and encourage efficient task completion.
+
+Hooks
+-----
+    aafter_model  -- Runs after every model call.  Increments the round
+                     counter and decides whether to inject a warning.
+
+    abefore_agent -- Resets per-invocation state at the start of each
+                     graph invocation.
 
     aafter_agent  -- Logs budget usage stats at the end of execution.
-
-Budget estimation
------------------
-LangGraph's ``recursion_limit`` counts *super-steps* (individual node
-executions).  Each model→tools cycle consumes multiple super-steps because
-every middleware hook is a separate graph node.  The middleware counts
-``aafter_model`` invocations (one per model round) and derives the warning
-threshold from the configured recursion_limit.
-
-This middleware is only injected when ``recursion_limit`` is explicitly set
-(i.e. not ``None``).  When the platform runs in unlimited mode (the
-default), loop detection middleware is the primary safety mechanism and
-this middleware is not needed.
 """
 
 import logging
@@ -43,66 +41,123 @@ _MIN_WARNING_PCT = 50
 _MAX_WARNING_PCT = 95
 _MIN_ROUNDS_BEFORE_WARNING = 3
 
+_PERIODIC_MESSAGES: tuple[str, ...] = (
+    "You have been working for {rounds} model rounds. "
+    "If your task is nearing completion, start wrapping up. "
+    "Summarize progress so far and outline any remaining steps.",
+
+    "Extended execution: {rounds} model rounds. "
+    "Prioritize completing your current task now. "
+    "Summarize results and any remaining work so the user can "
+    "continue in the next message.",
+
+    "Long-running execution: {rounds} model rounds. "
+    "Wrap up your work — provide your findings and conclude. "
+    "If you cannot finish, summarize what you accomplished and "
+    "what remains.",
+
+    "Critical: {rounds} model rounds reached. "
+    "Provide your final answer immediately with whatever "
+    "information you have gathered. Do not start new tool calls "
+    "unless absolutely essential to your conclusion.",
+)
+
 
 class ExecutionBudgetMiddleware(AgentMiddleware):
-    """Middleware that warns the model when it is approaching the step limit.
+    """Middleware that nudges the model when execution is running long.
 
-    Tracks model rounds via ``aafter_model`` and injects a single
-    SystemMessage at ~80 % of the estimated budget.  This gives the model
-    a chance to wrap up, summarise results, and communicate remaining work
-    to the user — turning a hard ``GraphRecursionError`` crash into graceful
-    degradation.
+    **Threshold mode** (``warning_interval=None``, the default):
+        Injects a single SystemMessage at ~``warning_pct``% of the
+        estimated model-round budget derived from ``recursion_limit``.
+        Matches the original single-shot design.
 
-    The hard stop at 100 % remains LangGraph's responsibility; this
-    middleware only provides the advance warning.
+    **Periodic mode** (``warning_interval=N``):
+        Injects a SystemMessage every *N* model rounds with escalating
+        urgency, up to ``max_warnings`` times.  No dependency on
+        ``recursion_limit`` for timing — the interval is absolute.
 
-    Example::
+    Examples::
 
-        >>> middleware = ExecutionBudgetMiddleware(
-        ...     recursion_limit=6000,
-        ...     warning_pct=80,
-        ... )
-        >>> # Auto-injected in create_deep_agent() by default
+        # Threshold mode (main agent with explicit recursion_limit)
+        ExecutionBudgetMiddleware(recursion_limit=600, warning_pct=80)
+
+        # Periodic mode (sub-agent, unlimited recursion)
+        ExecutionBudgetMiddleware(warning_interval=30, max_warnings=4)
+
+        # Periodic mode (main agent, unlimited recursion)
+        ExecutionBudgetMiddleware(warning_interval=50, max_warnings=4)
 
     Args:
-        recursion_limit: The LangGraph recursion_limit applied to the graph.
-            Used to compute the warning threshold.  Default: 6000.
-        warning_pct: Percentage of the budget at which to inject the warning
-            SystemMessage.  Must be between 50 and 95.  Default: 80.
+        recursion_limit: Used in threshold mode to compute the warning
+            round.  Ignored in periodic mode.  Default: 6000.
+        warning_pct: Percentage of the budget at which to inject the
+            warning in threshold mode.  Default: 80.
+        warning_interval: Model rounds between periodic warnings.
+            ``None`` (default) selects threshold mode.
+        max_warnings: Maximum number of periodic warnings to inject.
+            After this many, the middleware goes silent.  Default: 4.
     """
 
     def __init__(
         self,
         recursion_limit: int = _DEFAULT_RECURSION_LIMIT,
         warning_pct: int = _DEFAULT_WARNING_PCT,
+        *,
+        warning_interval: int | None = None,
+        max_warnings: int = 4,
     ) -> None:
-        if not (_MIN_WARNING_PCT <= warning_pct <= _MAX_WARNING_PCT):
-            raise ValueError(
-                f"warning_pct must be between {_MIN_WARNING_PCT} and "
-                f"{_MAX_WARNING_PCT}, got {warning_pct}."
-            )
-        if recursion_limit <= 0:
-            raise ValueError(
-                f"recursion_limit must be positive, got {recursion_limit}."
-            )
+        if warning_interval is not None:
+            if warning_interval <= 0:
+                raise ValueError(
+                    f"warning_interval must be positive, got {warning_interval}.",
+                )
+            if max_warnings <= 0:
+                raise ValueError(
+                    f"max_warnings must be positive, got {max_warnings}.",
+                )
+        else:
+            if not (_MIN_WARNING_PCT <= warning_pct <= _MAX_WARNING_PCT):
+                raise ValueError(
+                    f"warning_pct must be between {_MIN_WARNING_PCT} and "
+                    f"{_MAX_WARNING_PCT}, got {warning_pct}.",
+                )
+            if recursion_limit <= 0:
+                raise ValueError(
+                    f"recursion_limit must be positive, got {recursion_limit}.",
+                )
 
         self.recursion_limit = recursion_limit
         self.warning_pct = warning_pct
+        self.warning_interval = warning_interval
+        self.max_warnings = max_warnings
 
-        self._warning_round = self._compute_warning_round(
-            recursion_limit, warning_pct,
-        )
+        self._periodic = warning_interval is not None
+
+        if self._periodic:
+            self._next_warning_round = warning_interval
+        else:
+            self._next_warning_round = self._compute_warning_round(
+                recursion_limit, warning_pct,
+            )
 
         self._model_round_count = 0
-        self._warned = False
+        self._warning_count = 0
 
-        logger.info(
-            "Execution budget middleware initialized: "
-            "recursion_limit=%d, warning_pct=%d%%, warning_round=%d",
-            recursion_limit,
-            warning_pct,
-            self._warning_round,
-        )
+        if self._periodic:
+            logger.info(
+                "Execution budget middleware initialized (periodic): "
+                "interval=%d, max_warnings=%d",
+                warning_interval,
+                max_warnings,
+            )
+        else:
+            logger.info(
+                "Execution budget middleware initialized (threshold): "
+                "recursion_limit=%d, warning_pct=%d%%, warning_round=%d",
+                recursion_limit,
+                warning_pct,
+                self._next_warning_round,
+            )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -113,7 +168,7 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
         """Derive the model-round at which to fire the budget warning.
 
         Each model-tool cycle consumes ~6 LangGraph super-steps (due to
-        middleware nodes: before_model, model, 3× after_model, tools), so
+        middleware nodes: before_model, model, 3x after_model, tools), so
         the estimated total model rounds is ``recursion_limit // 6``.  The
         warning fires at ``warning_pct`` percent of that estimate.
 
@@ -124,8 +179,8 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
         threshold = estimated_total_rounds * warning_pct // 100
         return max(threshold, _MIN_ROUNDS_BEFORE_WARNING)
 
-    def _create_budget_warning_message(self) -> SystemMessage:
-        """Build the SystemMessage injected at the warning threshold."""
+    def _create_threshold_warning(self) -> SystemMessage:
+        """Build the SystemMessage for threshold (single-shot) mode."""
         estimated_total = self.recursion_limit // 6
         remaining = max(estimated_total - self._model_round_count, 0)
         return SystemMessage(
@@ -139,6 +194,14 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
             ),
         )
 
+    def _create_periodic_warning(self) -> SystemMessage:
+        """Build the SystemMessage for periodic mode with escalating tone."""
+        idx = min(self._warning_count, len(_PERIODIC_MESSAGES)) - 1
+        template = _PERIODIC_MESSAGES[max(idx, 0)]
+        return SystemMessage(
+            content=template.format(rounds=self._model_round_count),
+        )
+
     # ------------------------------------------------------------------
     # AgentMiddleware hooks
     # ------------------------------------------------------------------
@@ -150,7 +213,15 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
     ) -> dict[str, Any] | None:
         """Reset per-invocation state at the start of each execution."""
         self._model_round_count = 0
-        self._warned = False
+        self._warning_count = 0
+
+        if self._periodic:
+            self._next_warning_round = self.warning_interval  # type: ignore[assignment]
+        else:
+            self._next_warning_round = self._compute_warning_round(
+                self.recursion_limit, self.warning_pct,
+            )
+
         logger.debug("Execution budget state reset for new invocation")
         return None
 
@@ -159,33 +230,55 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
         state: AgentState[Any],
         runtime: Runtime[None] | dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Track model rounds and inject a warning when the budget is low.
+        """Track model rounds and inject warnings when appropriate.
 
-        Increments the round counter after every model call.  When the
-        counter reaches ``_warning_round``, injects a single SystemMessage
-        and sets ``_warned`` to prevent repeat warnings.
+        **Threshold mode**: single SystemMessage at the computed warning
+        round, then silent.
+
+        **Periodic mode**: SystemMessage every ``warning_interval``
+        rounds, up to ``max_warnings`` times, with escalating urgency.
         """
         self._model_round_count += 1
 
-        if self._warned:
-            return None
+        if self._periodic:
+            if self._warning_count >= self.max_warnings:
+                return None
 
-        if self._model_round_count >= self._warning_round:
-            self._warned = True
+            if self._model_round_count >= self._next_warning_round:
+                self._warning_count += 1
+                self._next_warning_round += self.warning_interval  # type: ignore[operator]
 
-            estimated_total = self.recursion_limit // 6
-            logger.warning(
-                "EXECUTION BUDGET WARNING: model round %d of ~%d "
-                "(~%d%% of recursion_limit=%d used). "
-                "Injecting wrap-up guidance.",
-                self._model_round_count,
-                estimated_total,
-                self.warning_pct,
-                self.recursion_limit,
-            )
+                logger.warning(
+                    "EXECUTION BUDGET ADVISORY (%d/%d): "
+                    "model round %d (interval=%d). "
+                    "Injecting periodic guidance.",
+                    self._warning_count,
+                    self.max_warnings,
+                    self._model_round_count,
+                    self.warning_interval,
+                )
 
-            warning = self._create_budget_warning_message()
-            return {"messages": [warning]}
+                return {"messages": [self._create_periodic_warning()]}
+
+        else:
+            if self._warning_count > 0:
+                return None
+
+            if self._model_round_count >= self._next_warning_round:
+                self._warning_count = 1
+
+                estimated_total = self.recursion_limit // 6
+                logger.warning(
+                    "EXECUTION BUDGET WARNING: model round %d of ~%d "
+                    "(~%d%% of recursion_limit=%d used). "
+                    "Injecting wrap-up guidance.",
+                    self._model_round_count,
+                    estimated_total,
+                    self.warning_pct,
+                    self.recursion_limit,
+                )
+
+                return {"messages": [self._create_threshold_warning()]}
 
         return None
 
@@ -195,18 +288,28 @@ class ExecutionBudgetMiddleware(AgentMiddleware):
         runtime: Runtime[None] | dict[str, Any],
     ) -> dict[str, Any] | None:
         """Log budget usage stats at the end of execution."""
-        estimated_total = self.recursion_limit // 6
-        pct_used = (
-            (self._model_round_count * 100 // estimated_total)
-            if estimated_total > 0
-            else 0
-        )
-        logger.info(
-            "Execution budget summary: %d model rounds of ~%d "
-            "estimated (~%d%% used), warned=%s",
-            self._model_round_count,
-            estimated_total,
-            pct_used,
-            self._warned,
-        )
+        if self._periodic:
+            logger.info(
+                "Execution budget summary (periodic): %d model rounds, "
+                "%d/%d advisories issued (interval=%d)",
+                self._model_round_count,
+                self._warning_count,
+                self.max_warnings,
+                self.warning_interval,
+            )
+        else:
+            estimated_total = self.recursion_limit // 6
+            pct_used = (
+                (self._model_round_count * 100 // estimated_total)
+                if estimated_total > 0
+                else 0
+            )
+            logger.info(
+                "Execution budget summary (threshold): %d model rounds "
+                "of ~%d estimated (~%d%% used), warnings=%d",
+                self._model_round_count,
+                estimated_total,
+                pct_used,
+                self._warning_count,
+            )
         return None

--- a/backend/libs/python/graphton/src/graphton/core/interrupt_proxy.py
+++ b/backend/libs/python/graphton/src/graphton/core/interrupt_proxy.py
@@ -1,34 +1,34 @@
-"""Interrupt-aware wrapper for sub-agent runnables.
+"""Sub-agent compilation for LangGraph Deep Agents.
 
-deepagents' ``task`` tool invokes sub-agents via ``.ainvoke()``.  When a
-sub-agent tool calls ``interrupt()`` for HITL approval, the behaviour depends
-on whether the sub-agent graph has a checkpointer:
+Provides ``compile_subagent()`` — the single factory for compiling sub-agent
+graphs used by deepagents' ``task`` tool.
 
-*Without* a checkpointer (deepagents 0.4.x default for custom sub-agents):
-  ``interrupt()`` raises ``GraphInterrupt``.  The exception propagates through
-  ``.ainvoke()`` to the parent's tool node, which records it as a *single*
-  interrupt for the entire ``task`` tool call.  If the sub-agent batch had
-  multiple approval-requiring tools, only the **first** interrupt survives —
-  the rest are cancelled by asyncio.  On parent resume the ``task`` function
-  re-executes, but the sub-agent starts fresh and can never be properly
-  resumed, creating a permanent approval deadlock.
+Sub-agents are compiled with ``checkpointer=None`` so they inherit the
+parent graph's checkpointer at invocation time (LangGraph's "per-invocation"
+subgraph mode).  This means:
 
-*With* a checkpointer (what this module provides):
-  ``interrupt()`` checkpoints the sub-agent state with **all** pending
-  interrupts.  ``.ainvoke()`` returns the interrupted snapshot instead of
-  raising.  This module detects the interrupts, proxies them to the parent
-  graph via a parent-level ``interrupt()`` call, and — on resume — passes
-  the approval decisions back to the sub-agent to continue execution.
+- ``interrupt()`` in a sub-agent automatically propagates to the parent
+  checkpoint with the **direct** interrupt value shape — identical to
+  root-agent tool interrupts.
+- ``Command(resume=...)`` on the parent graph correctly resumes the
+  sub-agent from its checkpoint.
+- Concurrent sub-agent invocations get distinct ``checkpoint_ns`` values,
+  preventing the deadlock that the old ``InterruptProxyRunnable`` caused
+  with its shared ``MemorySaver`` and ``_thread_counter``.
+
+See ``tests/core/test_native_subgraph_interrupt.py`` for the verification
+tests that confirm this contract.
 
 Usage (inside ``agent.py``)::
 
-    from graphton.core.interrupt_proxy import compile_subagent_with_proxy
+    from graphton.core.interrupt_proxy import compile_subagent
 
-    compiled = compile_subagent_with_proxy(
+    compiled = compile_subagent(
         model=model_instance,
         tools=subagent_tools,
         system_prompt=subagent_prompt,
         name=subagent_name,
+        description=subagent_description,
     )
     # 'compiled' is a CompiledSubAgent dict with a 'runnable' key
 """
@@ -36,188 +36,13 @@ Usage (inside ``agent.py``)::
 from __future__ import annotations
 
 import logging
-import uuid
 from typing import Any
 
 from langchain.agents import create_agent  # type: ignore[import-untyped]
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.runnables import Runnable, RunnableConfig
-from langchain_core.runnables.config import ensure_config, merge_configs
 from langchain_core.tools import BaseTool
-from langgraph.checkpoint.memory import MemorySaver
-from langgraph.types import Command, interrupt
 
 logger = logging.getLogger(__name__)
-
-
-class InterruptProxyRunnable(Runnable):
-    """Wraps a sub-agent graph to proxy interrupts to the parent.
-
-    Lifecycle for a single ``task`` tool invocation:
-
-    1. **Fresh call** — no prior checkpoint exists.  The sub-agent runs from
-       scratch.  If it pauses with interrupts, ``ainvoke()`` returns the
-       interrupted snapshot (thanks to the MemorySaver).  We then call
-       ``interrupt()`` on the parent to surface those payloads to the user.
-
-    2. **Resumed call** — the parent tool-node re-executes after the user
-       approved.  ``interrupt()`` at the same index now returns the cached
-       decisions.  We detect the existing interrupted checkpoint and resume
-       the sub-agent with the decisions via ``Command(resume=…)``.
-
-    3. **Loop** — if the sub-agent hits *more* interrupts after a partial
-       resume, we proxy again (step 1-like) and the cycle repeats until the
-       sub-agent runs to completion.
-
-    Important: the MemorySaver lives on ``self`` so it survives parent
-    tool-node re-executions within the *same* Python activity invocation.
-    Between Temporal activity re-invocations (which recreate the graph) the
-    MemorySaver is fresh, but the parent's ``interrupt()`` replay mechanism
-    feeds the cached decisions so the sub-agent re-derives the same
-    interrupts and receives the correct approvals.
-    """
-
-    def __init__(
-        self,
-        inner_graph: Any,
-        name: str,
-    ) -> None:
-        super().__init__()
-        self.inner_graph = inner_graph
-        self.name = name
-        self._checkpointer = MemorySaver()
-        self._thread_counter = 0
-
-    # ------------------------------------------------------------------
-    # Runnable interface
-    # ------------------------------------------------------------------
-
-    def invoke(self, input: Any, config: RunnableConfig | None = None, **kwargs: Any) -> Any:  # noqa: A002
-        import asyncio
-
-        return asyncio.get_event_loop().run_until_complete(
-            self.ainvoke(input, config, **kwargs)
-        )
-
-    async def ainvoke(self, input: Any, config: RunnableConfig | None = None, **kwargs: Any) -> Any:  # noqa: A002
-        thread_id, sa_config = self._current_thread_config()
-
-        # Merge the parent's callback context with our thread config.
-        # ensure_config() inherits the active callback manager from the
-        # parent graph's astream_events context.  merge_configs() layers
-        # our thread_id on top so checkpointing stays isolated while
-        # callback events flow through the parent for proper namespace
-        # metadata propagation to StatusBuilder.
-        parent_ctx = ensure_config(config)
-        merged = merge_configs(parent_ctx, sa_config)
-
-        # Probe the current thread's checkpoint to decide: resume vs fresh.
-        # Checkpoint lookups only need thread_id, so bare sa_config suffices.
-        state = await self._safe_get_state(sa_config)
-
-        if state is not None and getattr(state, "interrupts", None):
-            # RESUME: sub-agent was interrupted on this thread in a prior
-            # parent execution.  The parent tool-node is replaying after an
-            # HITL approval — reuse the same thread so we resume from the
-            # checkpoint instead of starting over.
-            proxy_payload = self._build_proxy_payload(state.interrupts)
-            decisions = interrupt(proxy_payload)
-            logger.info(
-                "[InterruptProxy:%s] Resuming sub-agent on thread %s "
-                "with %d decision(s)",
-                self.name, thread_id,
-                len(decisions) if isinstance(decisions, dict) else 1,
-            )
-            result = await self.inner_graph.ainvoke(
-                Command(resume=decisions), config=merged,
-            )
-        else:
-            # If a completed checkpoint exists on this thread, a previous
-            # ainvoke() already ran to completion.  Advance to a new thread
-            # so sequential calls to the same sub-agent stay isolated.
-            if state is not None and getattr(state, "values", None):
-                self._thread_counter += 1
-                thread_id, sa_config = self._current_thread_config()
-                merged = merge_configs(parent_ctx, sa_config)
-                logger.info(
-                    "[InterruptProxy:%s] Prior thread completed, "
-                    "advancing to thread %s",
-                    self.name, thread_id,
-                )
-
-            # FRESH: first invocation (or new sequential call).
-            logger.info(
-                "[InterruptProxy:%s] Starting fresh sub-agent on thread %s",
-                self.name, thread_id,
-            )
-            result = await self.inner_graph.ainvoke(input, config=merged)
-
-        # After the invocation, check whether the sub-agent paused again.
-        state = await self._safe_get_state(sa_config)
-        if state is not None and getattr(state, "interrupts", None):
-            proxy_payload = self._build_proxy_payload(state.interrupts)
-            logger.info(
-                "[InterruptProxy:%s] Sub-agent paused with %d interrupt(s), "
-                "proxying to parent",
-                self.name,
-                len(state.interrupts),
-            )
-            # This interrupt() will either:
-            #   a) raise GraphInterrupt (first parent execution) → parent pauses
-            #   b) return decisions (parent was already resumed for this index)
-            maybe_decisions = interrupt(proxy_payload)
-            if maybe_decisions is not None:
-                logger.info(
-                    "[InterruptProxy:%s] Got inline decisions, resuming sub-agent",
-                    self.name,
-                )
-                result = await self.inner_graph.ainvoke(
-                    Command(resume=maybe_decisions), config=merged,
-                )
-
-        return result
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _current_thread_config(self) -> tuple[str, RunnableConfig]:
-        """Return the thread id and config for the current counter value.
-
-        Unlike the previous ``_next_thread_id``, the counter is NOT
-        incremented here.  Advancing only happens inside ``ainvoke()`` after
-        detecting that the current thread's checkpoint is complete.  This
-        ensures parent tool-node replays (after HITL approval) reuse the same
-        thread and resume from the interrupted checkpoint instead of starting
-        a fresh sub-agent on a new thread.
-        """
-        tid = f"sa-{self.name}-{self._thread_counter}"
-        return tid, {"configurable": {"thread_id": tid}}
-
-    async def _safe_get_state(self, config: RunnableConfig) -> Any:
-        try:
-            return await self.inner_graph.aget_state(config)
-        except Exception:
-            return None
-
-    @staticmethod
-    def _build_proxy_payload(interrupts: Any) -> dict[str, Any]:
-        """Convert sub-agent interrupt objects into a proxy payload.
-
-        The payload is a dict mapping interrupt-id → interrupt-value, which
-        matches the ``Command(resume={id: decision, …})`` format that
-        LangGraph expects for targeted resume.
-        """
-        payload: dict[str, Any] = {}
-        for intr in interrupts:
-            intr_id = getattr(intr, "id", None) or uuid.uuid4().hex
-            intr_value = getattr(intr, "value", intr)
-
-            if isinstance(intr_value, dict):
-                intr_value = {**intr_value, "_proxy_interrupt_id": intr_id}
-
-            payload[intr_id] = intr_value
-        return payload
 
 
 _UNLIMITED_RECURSION: int = 10_000_000
@@ -227,7 +52,7 @@ _SUB_AGENT_ADVISORY_INTERVAL: int = 30
 _SUB_AGENT_MAX_ADVISORIES: int = 4
 
 
-def compile_subagent_with_proxy(
+def compile_subagent(
     *,
     model: BaseChatModel,
     tools: list[BaseTool],
@@ -237,8 +62,11 @@ def compile_subagent_with_proxy(
     middleware: list[Any] | None = None,
     recursion_limit: int | None = None,
 ) -> dict[str, Any]:
-    """Compile a sub-agent graph with a MemorySaver and wrap it in an
-    :class:`InterruptProxyRunnable`.
+    """Compile a sub-agent graph using LangGraph native per-invocation mode.
+
+    The compiled graph uses ``checkpointer=None`` (the default from
+    ``create_agent``), so it inherits the parent's checkpointer at runtime.
+    This enables native interrupt propagation without a proxy layer.
 
     Automatically injects guardrail middleware:
 
@@ -271,7 +99,6 @@ def compile_subagent_with_proxy(
         ToolTruncationMiddleware,
         _DEFAULT_MAX_CHARS as _DEFAULT_TRUNCATION,
     )
-    from langgraph.checkpoint.memory import MemorySaver
 
     effective_limit = (
         recursion_limit
@@ -292,27 +119,19 @@ def compile_subagent_with_proxy(
         max_warnings=_SUB_AGENT_MAX_ADVISORIES,
     ))
 
-    checkpointer = MemorySaver()
-
     compiled_graph = create_agent(
         model,
         system_prompt=system_prompt,
         tools=tools,
         middleware=effective_middleware,
-        checkpointer=checkpointer,
     )
 
     compiled_graph = compiled_graph.with_config(
         {"recursion_limit": effective_limit},
     )
 
-    proxy = InterruptProxyRunnable(
-        inner_graph=compiled_graph,
-        name=name,
-    )
-
     logger.info(
-        "Compiled sub-agent '%s' with InterruptProxy "
+        "Compiled sub-agent '%s' with native interrupt propagation "
         "(tools=%d, middleware=%d, recursion_limit=%d%s, "
         "advisory_interval=%d, max_advisories=%d)",
         name,
@@ -327,5 +146,5 @@ def compile_subagent_with_proxy(
     return {
         "name": name,
         "description": description,
-        "runnable": proxy,
+        "runnable": compiled_graph,
     }

--- a/backend/libs/python/graphton/src/graphton/core/interrupt_proxy.py
+++ b/backend/libs/python/graphton/src/graphton/core/interrupt_proxy.py
@@ -220,7 +220,11 @@ class InterruptProxyRunnable(Runnable):
         return payload
 
 
-_DEFAULT_SUB_AGENT_RECURSION_LIMIT: int = 50
+_UNLIMITED_RECURSION: int = 10_000_000
+
+
+_SUB_AGENT_ADVISORY_INTERVAL: int = 30
+_SUB_AGENT_MAX_ADVISORIES: int = 4
 
 
 def compile_subagent_with_proxy(
@@ -236,20 +240,27 @@ def compile_subagent_with_proxy(
     """Compile a sub-agent graph with a MemorySaver and wrap it in an
     :class:`InterruptProxyRunnable`.
 
-    Automatically injects the same guardrail middleware that
-    :func:`create_deep_agent` provides for the main agent:
+    Automatically injects guardrail middleware:
 
     - **LoopDetectionMiddleware** — prevents infinite tool loops by
       detecting repetitive invocation patterns.
-    - **ExecutionBudgetMiddleware** — warns the model to wrap up when
-      approaching the recursion limit (80% threshold).
     - **ToolTruncationMiddleware** — caps per-tool-result character
       count to prevent context blowup.
+    - **ExecutionBudgetMiddleware** (periodic mode) — nudges the model
+      every 30 model rounds with escalating urgency (up to 4 times).
+
+    Sub-agents run with effectively unlimited recursion (matching the
+    main agent and industry peers like Cursor and Claude Code).  The
+    primary safety mechanisms are loop detection (catches stuck agents),
+    cost cap (when configured), and context summarization (prevents
+    token overflow) — not a step-count ceiling.  The budget middleware
+    provides advisory nudges only; it does not stop execution.
 
     Args:
         recursion_limit: Maximum super-steps for the sub-agent graph.
-            Defaults to :data:`_DEFAULT_SUB_AGENT_RECURSION_LIMIT` (50),
-            which allows ~25 tool-call rounds.
+            ``None`` (default) means unlimited — the sub-agent runs
+            until loop detection or the task completes.  When set to a
+            positive integer, LangGraph enforces that hard limit.
 
     Returns a dict compatible with deepagents' ``CompiledSubAgent`` TypedDict
     (keys: ``name``, ``description``, ``runnable``).
@@ -265,20 +276,20 @@ def compile_subagent_with_proxy(
     effective_limit = (
         recursion_limit
         if recursion_limit is not None
-        else _DEFAULT_SUB_AGENT_RECURSION_LIMIT
+        else _UNLIMITED_RECURSION
     )
 
     effective_middleware = list(middleware or [])
 
     effective_middleware.append(LoopDetectionMiddleware(enabled=True))
 
-    effective_middleware.append(ExecutionBudgetMiddleware(
-        recursion_limit=effective_limit,
-        warning_pct=80,
-    ))
-
     effective_middleware.append(ToolTruncationMiddleware(
         max_chars=_DEFAULT_TRUNCATION,
+    ))
+
+    effective_middleware.append(ExecutionBudgetMiddleware(
+        warning_interval=_SUB_AGENT_ADVISORY_INTERVAL,
+        max_warnings=_SUB_AGENT_MAX_ADVISORIES,
     ))
 
     checkpointer = MemorySaver()
@@ -302,11 +313,15 @@ def compile_subagent_with_proxy(
 
     logger.info(
         "Compiled sub-agent '%s' with InterruptProxy "
-        "(tools=%d, middleware=%d, recursion_limit=%d)",
+        "(tools=%d, middleware=%d, recursion_limit=%d%s, "
+        "advisory_interval=%d, max_advisories=%d)",
         name,
         len(tools),
         len(effective_middleware),
         effective_limit,
+        " (unlimited)" if recursion_limit is None else "",
+        _SUB_AGENT_ADVISORY_INTERVAL,
+        _SUB_AGENT_MAX_ADVISORIES,
     )
 
     return {

--- a/backend/libs/python/graphton/src/graphton/core/interrupt_proxy.py
+++ b/backend/libs/python/graphton/src/graphton/core/interrupt_proxy.py
@@ -220,6 +220,9 @@ class InterruptProxyRunnable(Runnable):
         return payload
 
 
+_DEFAULT_SUB_AGENT_RECURSION_LIMIT: int = 50
+
+
 def compile_subagent_with_proxy(
     *,
     model: BaseChatModel,
@@ -228,14 +231,55 @@ def compile_subagent_with_proxy(
     name: str,
     description: str,
     middleware: list[Any] | None = None,
+    recursion_limit: int | None = None,
 ) -> dict[str, Any]:
     """Compile a sub-agent graph with a MemorySaver and wrap it in an
     :class:`InterruptProxyRunnable`.
 
+    Automatically injects the same guardrail middleware that
+    :func:`create_deep_agent` provides for the main agent:
+
+    - **LoopDetectionMiddleware** — prevents infinite tool loops by
+      detecting repetitive invocation patterns.
+    - **ExecutionBudgetMiddleware** — warns the model to wrap up when
+      approaching the recursion limit (80% threshold).
+    - **ToolTruncationMiddleware** — caps per-tool-result character
+      count to prevent context blowup.
+
+    Args:
+        recursion_limit: Maximum super-steps for the sub-agent graph.
+            Defaults to :data:`_DEFAULT_SUB_AGENT_RECURSION_LIMIT` (50),
+            which allows ~25 tool-call rounds.
+
     Returns a dict compatible with deepagents' ``CompiledSubAgent`` TypedDict
     (keys: ``name``, ``description``, ``runnable``).
     """
+    from graphton.core.execution_budget import ExecutionBudgetMiddleware
+    from graphton.core.loop_detection import LoopDetectionMiddleware
+    from graphton.core.tool_truncation import (
+        ToolTruncationMiddleware,
+        _DEFAULT_MAX_CHARS as _DEFAULT_TRUNCATION,
+    )
     from langgraph.checkpoint.memory import MemorySaver
+
+    effective_limit = (
+        recursion_limit
+        if recursion_limit is not None
+        else _DEFAULT_SUB_AGENT_RECURSION_LIMIT
+    )
+
+    effective_middleware = list(middleware or [])
+
+    effective_middleware.append(LoopDetectionMiddleware(enabled=True))
+
+    effective_middleware.append(ExecutionBudgetMiddleware(
+        recursion_limit=effective_limit,
+        warning_pct=80,
+    ))
+
+    effective_middleware.append(ToolTruncationMiddleware(
+        max_chars=_DEFAULT_TRUNCATION,
+    ))
 
     checkpointer = MemorySaver()
 
@@ -243,8 +287,12 @@ def compile_subagent_with_proxy(
         model,
         system_prompt=system_prompt,
         tools=tools,
-        middleware=middleware or [],
+        middleware=effective_middleware,
         checkpointer=checkpointer,
+    )
+
+    compiled_graph = compiled_graph.with_config(
+        {"recursion_limit": effective_limit},
     )
 
     proxy = InterruptProxyRunnable(
@@ -254,10 +302,11 @@ def compile_subagent_with_proxy(
 
     logger.info(
         "Compiled sub-agent '%s' with InterruptProxy "
-        "(tools=%d, middleware=%d)",
+        "(tools=%d, middleware=%d, recursion_limit=%d)",
         name,
         len(tools),
-        len(middleware or []),
+        len(effective_middleware),
+        effective_limit,
     )
 
     return {

--- a/backend/libs/python/graphton/src/graphton/core/models.py
+++ b/backend/libs/python/graphton/src/graphton/core/models.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 from pydantic import PrivateAttr
@@ -57,17 +58,79 @@ OLLAMA_DEFAULTS = {
 _CACHE_CONTROL_EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
 
 
+def _sanitize_non_leading_system_messages(
+    messages: list[BaseMessage],
+) -> list[BaseMessage]:
+    """Convert non-leading SystemMessage objects to HumanMessage for Anthropic.
+
+    Anthropic's API requires system content in a single ``system`` parameter.
+    ``langchain-anthropic``'s ``_format_messages()`` enforces that all
+    ``SystemMessage`` objects form a contiguous prefix — any ``SystemMessage``
+    after a non-system message raises
+    ``ValueError: Received multiple non-consecutive system messages``.
+
+    Guardrail middleware (``ExecutionBudgetMiddleware``,
+    ``LoopDetectionMiddleware``, ``CostCapMiddleware``) legitimately inject
+    ``SystemMessage`` objects mid-conversation via ``aafter_model`` to guide
+    the model.  This function preserves the leading system block and converts
+    any later ``SystemMessage`` to ``HumanMessage`` with a ``[System]``
+    prefix, keeping the guidance at its original conversational position while
+    satisfying the Anthropic API constraint.
+
+    The conversion is safe for Anthropic's message format: a ``HumanMessage``
+    adjacent to ``ToolMessage`` objects merges into the same ``user`` turn,
+    which the API accepts as mixed text + ``tool_result`` content blocks.
+    """
+    if not messages:
+        return messages
+
+    prefix_end = 0
+    for i, msg in enumerate(messages):
+        if isinstance(msg, SystemMessage):
+            prefix_end = i + 1
+        else:
+            break
+
+    has_trailing = any(
+        isinstance(msg, SystemMessage) for msg in messages[prefix_end:]
+    )
+    if not has_trailing:
+        return messages
+
+    trailing_count = sum(
+        1 for msg in messages[prefix_end:] if isinstance(msg, SystemMessage)
+    )
+    logger.warning(
+        "Sanitizing %d non-leading SystemMessage(s) to HumanMessage "
+        "for Anthropic API compatibility",
+        trailing_count,
+    )
+
+    result: list[BaseMessage] = list(messages[:prefix_end])
+    for msg in messages[prefix_end:]:
+        if isinstance(msg, SystemMessage):
+            result.append(HumanMessage(content=f"[System] {msg.content}"))
+        else:
+            result.append(msg)
+    return result
+
+
 class _EagerToolStreamingChatAnthropic(ChatAnthropic):  # type: ignore[override]
     """ChatAnthropic subclass that patches the API payload for features not yet
     exposed by langchain-anthropic (as of 1.3.3).
 
     Injected patches:
-        1. ``eager_input_streaming: true`` on each tool definition — disables
+        1. **System message sanitization** — converts non-leading
+           ``SystemMessage`` objects (injected mid-conversation by guardrail
+           middleware) to ``HumanMessage`` before ``_format_messages()`` runs,
+           preventing ``ValueError: Received multiple non-consecutive system
+           messages``.
+        2. ``eager_input_streaming: true`` on each tool definition — disables
            Anthropic's argument-buffering so tool-argument tokens stream in
            real-time.
-        2. ``output_config.effort`` — controls how aggressively Claude spends
+        3. ``output_config.effort`` — controls how aggressively Claude spends
            tokens (required for adaptive thinking on Opus 4.6 / Sonnet 4.6).
-        3. Prompt caching — explicit ``cache_control`` breakpoints on the system
+        4. Prompt caching — explicit ``cache_control`` breakpoints on the system
            prompt and last tool definition cache the static prefix; a top-level
            ``cache_control`` enables automatic conversation caching so the
            growing message history is incrementally cached across turns.
@@ -89,6 +152,8 @@ class _EagerToolStreamingChatAnthropic(ChatAnthropic):  # type: ignore[override]
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> dict:
+        if isinstance(input_, list):
+            input_ = _sanitize_non_leading_system_messages(input_)
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
         for tool in payload.get("tools", ()):
             if isinstance(tool, dict) and "input_schema" in tool:

--- a/backend/libs/python/graphton/src/graphton/core/models.py
+++ b/backend/libs/python/graphton/src/graphton/core/models.py
@@ -12,7 +12,13 @@ from typing import Any
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 from pydantic import PrivateAttr
@@ -58,6 +64,67 @@ OLLAMA_DEFAULTS = {
 _CACHE_CONTROL_EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
 
 
+def _reorder_tool_result_pairing(
+    messages: list[BaseMessage],
+) -> list[BaseMessage]:
+    """Ensure ToolMessages immediately follow their AIMessage(tool_calls).
+
+    Guardrail middleware ``aafter_model`` hooks inject messages into graph
+    state **between** the model's ``AIMessage(tool_calls=[…])`` and the
+    subsequent ``ToolMessage``(s) produced by the tools node.  After the
+    ``SystemMessage → HumanMessage`` conversion the sequence looks like::
+
+        AIMessage(tool_calls=[{id: X}])
+        HumanMessage("[System] advisory")   ← injected by middleware
+        ToolMessage(tool_call_id=X)
+
+    While ``langchain_anthropic``'s ``_merge_messages`` merges consecutive
+    user-role messages, the interleaved ordering can still cause::
+
+        anthropic.BadRequestError: messages.N: tool_use ids were found
+        without tool_result blocks immediately after
+
+    This function defensively reorders the messages so that every
+    ``AIMessage(tool_calls)`` is immediately followed by its
+    ``ToolMessage``(s), with any interleaved messages deferred to after
+    the tool results::
+
+        AIMessage(tool_calls=[{id: X}])
+        ToolMessage(tool_call_id=X)
+        HumanMessage("[System] advisory")   ← safe position
+    """
+    if not messages:
+        return messages
+
+    result: list[BaseMessage] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            result.append(msg)
+            i += 1
+
+            deferred: list[BaseMessage] = []
+            while i < len(messages):
+                next_msg = messages[i]
+                if isinstance(next_msg, ToolMessage):
+                    result.append(next_msg)
+                    i += 1
+                elif isinstance(next_msg, AIMessage):
+                    break
+                else:
+                    deferred.append(next_msg)
+                    i += 1
+
+            result.extend(deferred)
+        else:
+            result.append(msg)
+            i += 1
+
+    return result
+
+
 def _sanitize_non_leading_system_messages(
     messages: list[BaseMessage],
 ) -> list[BaseMessage]:
@@ -74,12 +141,12 @@ def _sanitize_non_leading_system_messages(
     ``SystemMessage`` objects mid-conversation via ``aafter_model`` to guide
     the model.  This function preserves the leading system block and converts
     any later ``SystemMessage`` to ``HumanMessage`` with a ``[System]``
-    prefix, keeping the guidance at its original conversational position while
-    satisfying the Anthropic API constraint.
+    prefix, keeping the guidance visible while satisfying the API constraint.
 
-    The conversion is safe for Anthropic's message format: a ``HumanMessage``
-    adjacent to ``ToolMessage`` objects merges into the same ``user`` turn,
-    which the API accepts as mixed text + ``tool_result`` content blocks.
+    After conversion, ``_reorder_tool_result_pairing`` ensures any converted
+    advisory that landed between an ``AIMessage(tool_calls)`` and its
+    ``ToolMessage``(s) is moved **after** the tool results so the Anthropic
+    API's ``tool_use → tool_result`` pairing contract is never broken.
     """
     if not messages:
         return messages
@@ -112,7 +179,8 @@ def _sanitize_non_leading_system_messages(
             result.append(HumanMessage(content=f"[System] {msg.content}"))
         else:
             result.append(msg)
-    return result
+
+    return _reorder_tool_result_pairing(result)
 
 
 class _EagerToolStreamingChatAnthropic(ChatAnthropic):  # type: ignore[override]

--- a/backend/libs/python/graphton/src/graphton/core/subagent.py
+++ b/backend/libs/python/graphton/src/graphton/core/subagent.py
@@ -13,15 +13,14 @@ subgraph mode).  This means:
 - ``Command(resume=...)`` on the parent graph correctly resumes the
   sub-agent from its checkpoint.
 - Concurrent sub-agent invocations get distinct ``checkpoint_ns`` values,
-  preventing the deadlock that the old ``InterruptProxyRunnable`` caused
-  with its shared ``MemorySaver`` and ``_thread_counter``.
+  eliminating checkpoint contention.
 
 See ``tests/core/test_native_subgraph_interrupt.py`` for the verification
 tests that confirm this contract.
 
 Usage (inside ``agent.py``)::
 
-    from graphton.core.interrupt_proxy import compile_subagent
+    from graphton.core.subagent import compile_subagent
 
     compiled = compile_subagent(
         model=model_instance,

--- a/backend/libs/python/graphton/src/graphton/core/subagent.py
+++ b/backend/libs/python/graphton/src/graphton/core/subagent.py
@@ -95,8 +95,8 @@ def compile_subagent(
     from graphton.core.execution_budget import ExecutionBudgetMiddleware
     from graphton.core.loop_detection import LoopDetectionMiddleware
     from graphton.core.tool_truncation import (
-        ToolTruncationMiddleware,
         _DEFAULT_MAX_CHARS as _DEFAULT_TRUNCATION,
+        ToolTruncationMiddleware,
     )
 
     effective_limit = (

--- a/backend/libs/python/graphton/src/graphton/core/subagent.py
+++ b/backend/libs/python/graphton/src/graphton/core/subagent.py
@@ -96,6 +96,8 @@ def compile_subagent(
     from graphton.core.loop_detection import LoopDetectionMiddleware
     from graphton.core.tool_truncation import (
         _DEFAULT_MAX_CHARS as _DEFAULT_TRUNCATION,
+    )
+    from graphton.core.tool_truncation import (
         ToolTruncationMiddleware,
     )
 

--- a/backend/libs/python/graphton/tests/core/test_daytona_backend.py
+++ b/backend/libs/python/graphton/tests/core/test_daytona_backend.py
@@ -18,7 +18,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from graphton.core.backends.daytona import WorkspaceNormalizingBackend
-from graphton.core.backends.types import ExecutionResult, to_execution_result
+from graphton.core.backends.types import (
+    ExecutionResult,
+    to_execution_result,
+    to_file_list,
+    to_is_directory,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -603,3 +608,228 @@ class TestExecuteResultTranslation:
         assert isinstance(result, ExecutionResult)
         call_args = inner_backend.execute.call_args[0][0]
         assert "export TOKEN=" in call_args
+
+
+# ---------------------------------------------------------------------------
+# to_file_list() normalisation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    """Mimics deepagents' FileInfo (dataclass with .path and .is_dir)."""
+
+    path: str
+    is_dir: bool = False
+
+
+class TestToFileList:
+    """Tests for the to_file_list() normalisation helper."""
+
+    def test_prefers_list_files_over_ls_info(self) -> None:
+        """When the backend has both methods, list_files() takes precedence."""
+        inner = MagicMock()
+        inner.list_files.return_value = ["src", "README.md"]
+        inner.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+            _FakeFileInfo(path="README.md"),
+        ]
+        result = to_file_list(inner, ".")
+        assert result == ["src", "README.md"]
+        inner.list_files.assert_called_once_with(".")
+        inner.ls_info.assert_not_called()
+
+    def test_falls_back_to_ls_info_object_style(self) -> None:
+        """Backend with only ls_info (dataclass FileInfo) works correctly."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+            _FakeFileInfo(path="README.md"),
+            _FakeFileInfo(path="main.py"),
+        ]
+        result = to_file_list(inner, ".")
+        assert result == ["src", "README.md", "main.py"]
+
+    def test_falls_back_to_ls_info_dict_style(self) -> None:
+        """Backend with only ls_info (dict FileInfo) works correctly."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            {"path": "src", "is_dir": True},
+            {"path": "README.md", "is_dir": False},
+        ]
+        result = to_file_list(inner, ".")
+        assert result == ["src", "README.md"]
+
+    def test_ls_info_extracts_basename_from_full_path(self) -> None:
+        """ls_info returning full relative paths still yields bare names."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            _FakeFileInfo(path="project/src", is_dir=True),
+            _FakeFileInfo(path="project/README.md"),
+        ]
+        result = to_file_list(inner, "project")
+        assert result == ["src", "README.md"]
+
+    def test_raises_when_neither_method_available(self) -> None:
+        """Clean error when the backend has neither list_files nor ls_info."""
+        inner = MagicMock(spec=[])
+        with pytest.raises(AttributeError, match="neither list_files.*nor ls_info"):
+            to_file_list(inner, ".")
+
+
+# ---------------------------------------------------------------------------
+# to_is_directory() normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestToIsDirectory:
+    """Tests for the to_is_directory() normalisation helper."""
+
+    def test_prefers_is_directory_over_ls_info(self) -> None:
+        inner = MagicMock()
+        inner.is_directory.return_value = True
+        result = to_is_directory(inner, "src")
+        assert result is True
+        inner.is_directory.assert_called_once_with("src")
+
+    def test_falls_back_to_ls_info_object_style(self) -> None:
+        """Backend with only ls_info correctly detects directories."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+            _FakeFileInfo(path="README.md", is_dir=False),
+        ]
+        assert to_is_directory(inner, "src") is True
+        assert to_is_directory(inner, "README.md") is False
+
+    def test_falls_back_to_ls_info_dict_style(self) -> None:
+        """Backend with only ls_info (dict FileInfo) correctly detects directories."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            {"path": "data", "is_dir": True},
+            {"path": "config.yaml", "is_dir": False},
+        ]
+        assert to_is_directory(inner, "data") is True
+        assert to_is_directory(inner, "config.yaml") is False
+
+    def test_returns_false_for_unknown_entry(self) -> None:
+        """Returns False when the entry is not found in parent listing."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+        ]
+        assert to_is_directory(inner, "nonexistent") is False
+
+    def test_returns_false_when_neither_method_available(self) -> None:
+        """Returns False (defensive) when backend has no useful method."""
+        inner = MagicMock(spec=[])
+        assert to_is_directory(inner, "anything") is False
+
+    def test_returns_false_when_ls_info_raises(self) -> None:
+        """ls_info errors are swallowed; returns False defensively."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.side_effect = RuntimeError("sandbox down")
+        assert to_is_directory(inner, "src") is False
+
+    def test_uses_parent_directory_for_ls_info(self) -> None:
+        """ls_info is called on the *parent* of the target path."""
+        inner = MagicMock(spec=["ls_info"])
+        inner.ls_info.return_value = [
+            _FakeFileInfo(path="scripts", is_dir=True),
+        ]
+        to_is_directory(inner, "bin/scripts")
+        inner.ls_info.assert_called_once_with("bin")
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceNormalizingBackend with ls_info-only backend (real DaytonaBackend)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ls_info_backend() -> MagicMock:
+    """Mock backend that has ls_info but NOT list_files/is_directory.
+
+    This simulates the real DaytonaBackend from deepagents_cli which
+    implements SandboxBackendProtocol (ls_info) not graphton's interface.
+    """
+    backend = MagicMock(spec=["ls_info", "read", "write", "execute"])
+    backend.read.return_value = ""
+    return backend
+
+
+class TestWorkspaceNormalizingWithLsInfoBackend:
+    """Integration tests: WorkspaceNormalizingBackend over an ls_info-only backend."""
+
+    def test_list_files_works_via_ls_info(
+        self, ls_info_backend: MagicMock,
+    ) -> None:
+        ls_info_backend.ls_info.return_value = [
+            _FakeFileInfo(path="SKILL.md", is_dir=False),
+            _FakeFileInfo(path="scripts", is_dir=True),
+        ]
+        ls_info_backend.read.side_effect = FileNotFoundError
+        w = WorkspaceNormalizingBackend(ls_info_backend, workspace_root="/workspace")
+        entries = w.list_files("bin/skills")
+        assert "SKILL.md" in entries
+        assert "scripts" in entries
+        ls_info_backend.ls_info.assert_called_once_with("bin/skills")
+
+    def test_list_files_with_rebase_via_ls_info(
+        self, ls_info_backend: MagicMock,
+    ) -> None:
+        ls_info_backend.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+        ]
+        ls_info_backend.read.side_effect = FileNotFoundError
+        w = WorkspaceNormalizingBackend(
+            ls_info_backend,
+            workspace_root="/home/daytona/workspace",
+            sandbox_root="/home/daytona",
+        )
+        entries = w.list_files("project")
+        assert entries == ["src"]
+        ls_info_backend.ls_info.assert_called_once_with("workspace/project")
+
+    def test_is_directory_works_via_ls_info(
+        self, ls_info_backend: MagicMock,
+    ) -> None:
+        ls_info_backend.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+            _FakeFileInfo(path="README.md", is_dir=False),
+        ]
+        w = WorkspaceNormalizingBackend(ls_info_backend, workspace_root="/workspace")
+        assert w.is_directory("src") is True
+        assert w.is_directory("README.md") is False
+
+    def test_list_files_gitignore_filtering_with_ls_info(
+        self, ls_info_backend: MagicMock,
+    ) -> None:
+        """Gitignore filtering works correctly over ls_info backend."""
+        ls_info_backend.read.return_value = "*.pyc\nbuild/\n"
+        ls_info_backend.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+            _FakeFileInfo(path="build", is_dir=True),
+            _FakeFileInfo(path="main.py", is_dir=False),
+            _FakeFileInfo(path="cache.pyc", is_dir=False),
+        ]
+        w = WorkspaceNormalizingBackend(ls_info_backend, workspace_root="/workspace")
+        entries = w.list_files(".")
+        assert "src" in entries
+        assert "main.py" in entries
+        assert "build" not in entries
+        assert "cache.pyc" not in entries
+
+    def test_list_files_cache_with_ls_info(
+        self, ls_info_backend: MagicMock,
+    ) -> None:
+        """Caching works correctly when backed by ls_info."""
+        ls_info_backend.read.side_effect = FileNotFoundError
+        ls_info_backend.ls_info.return_value = [
+            _FakeFileInfo(path="src", is_dir=True),
+        ]
+        w = WorkspaceNormalizingBackend(ls_info_backend, workspace_root="/workspace")
+        first = w.list_files(".")
+        second = w.list_files(".")
+        assert first == second
+        ls_info_backend.ls_info.assert_called_once()

--- a/backend/libs/python/graphton/tests/core/test_execution_budget.py
+++ b/backend/libs/python/graphton/tests/core/test_execution_budget.py
@@ -26,7 +26,6 @@ Covers both operating modes:
 from __future__ import annotations
 
 import dataclasses
-from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -511,7 +510,6 @@ class TestAwrapModelCallPeriodic:
         assert periodic_small._warning_count == 3
 
         for _ in range(20):
-            old_advisory = periodic_small._pending_advisory
             periodic_small._pending_advisory = None
             await periodic_small.awrap_model_call(_make_request(), _mock_handler)
             assert periodic_small._pending_advisory is None

--- a/backend/libs/python/graphton/tests/core/test_execution_budget.py
+++ b/backend/libs/python/graphton/tests/core/test_execution_budget.py
@@ -6,22 +6,30 @@ Covers both operating modes:
 - Constructor validation and defaults
 - Internal helpers: _compute_warning_round, _create_threshold_warning
 - abefore_agent hook: per-invocation state reset
-- aafter_model hook: round counting, warning injection, single-fire guarantee
+- awrap_model_call hook: round counting, advisory queuing, input injection
 - aafter_agent hook: budget stats logging
 - Edge cases: tiny recursion limits, custom warning_pct, boundary conditions
 
 **Periodic mode** (warning_interval set):
 - Constructor validation for periodic parameters
-- Periodic warning injection at every N rounds
+- Periodic advisory injection at every N rounds
 - Escalating message urgency
 - max_warnings cap
 - State reset between invocations
+
+**Message ordering safety**:
+- Advisory is prepended to the NEXT model call's input, never appended to
+  the current call's output — ensuring no SystemMessage lands between
+  AIMessage(tool_use) and ToolMessage(tool_result) in the LangGraph state.
 """
 
 from __future__ import annotations
 
+import dataclasses
+from unittest.mock import MagicMock
+
 import pytest
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from graphton.core.execution_budget import (
     _DEFAULT_RECURSION_LIMIT,
@@ -32,6 +40,54 @@ from graphton.core.execution_budget import (
     _PERIODIC_MESSAGES,
     ExecutionBudgetMiddleware,
 )
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+@dataclasses.dataclass
+class _FakeModelRequest:
+    """Minimal stand-in for ModelRequest used in awrap_model_call tests."""
+    messages: list
+
+
+@dataclasses.dataclass
+class _FakeModelResponse:
+    """Minimal stand-in for ModelResponse."""
+    result: list
+
+
+def _make_request(messages: list | None = None) -> _FakeModelRequest:
+    return _FakeModelRequest(
+        messages=messages or [HumanMessage(content="do something")],
+    )
+
+
+def _make_response() -> _FakeModelResponse:
+    return _FakeModelResponse(result=[AIMessage(content="I did it")])
+
+
+async def _mock_handler(request: _FakeModelRequest) -> _FakeModelResponse:
+    """Async handler that returns a canned model response."""
+    return _make_response()
+
+
+def _make_state(messages: list | None = None) -> dict:
+    """Build a minimal agent state dict."""
+    return {"messages": messages or [HumanMessage(content="do something")]}
+
+
+async def _simulate_rounds(
+    mw: ExecutionBudgetMiddleware, n: int
+) -> list[_FakeModelResponse]:
+    """Call awrap_model_call n times and return all responses."""
+    responses = []
+    for _ in range(n):
+        resp = await mw.awrap_model_call(_make_request(), _mock_handler)
+        responses.append(resp)
+    return responses
+
 
 # =============================================================================
 # Fixtures
@@ -66,11 +122,6 @@ def periodic():
 def periodic_small():
     """Periodic middleware with small interval for fast iteration tests."""
     return ExecutionBudgetMiddleware(warning_interval=5, max_warnings=3)
-
-
-def _make_state(messages: list | None = None) -> dict:
-    """Build a minimal agent state dict."""
-    return {"messages": messages or [HumanMessage(content="do something")]}
 
 
 # =============================================================================
@@ -113,6 +164,10 @@ class TestConstructorThreshold:
     def test_negative_recursion_limit_raises(self):
         with pytest.raises(ValueError, match="recursion_limit must be positive"):
             ExecutionBudgetMiddleware(recursion_limit=-5)
+
+    def test_pending_advisory_initialized_to_none(self):
+        mw = ExecutionBudgetMiddleware()
+        assert mw._pending_advisory is None
 
 
 # =============================================================================
@@ -283,13 +338,20 @@ class TestAbeforeAgent:
         await middleware.abefore_agent(_make_state(), runtime={})
         assert middleware._warning_count == 0
 
+    async def test_resets_pending_advisory(self, middleware):
+        middleware._pending_advisory = SystemMessage(content="stale advisory")
+        await middleware.abefore_agent(_make_state(), runtime={})
+        assert middleware._pending_advisory is None
+
     async def test_idempotent_on_fresh_instance(self, middleware):
         assert middleware._model_round_count == 0
         assert middleware._warning_count == 0
+        assert middleware._pending_advisory is None
         result = await middleware.abefore_agent(_make_state(), runtime={})
         assert result is None
         assert middleware._model_round_count == 0
         assert middleware._warning_count == 0
+        assert middleware._pending_advisory is None
 
     async def test_periodic_resets_next_warning_round(self, periodic):
         """Periodic mode resets _next_warning_round to the interval."""
@@ -301,150 +363,251 @@ class TestAbeforeAgent:
 
 
 # =============================================================================
-# Hook: aafter_model — threshold mode
+# Hook: awrap_model_call — threshold mode
 # =============================================================================
 
 
-class TestAafterModelThreshold:
+class TestAwrapModelCallThreshold:
     async def test_increments_round_count(self, middleware):
-        await middleware.aafter_model(_make_state(), runtime={})
+        await middleware.awrap_model_call(_make_request(), _mock_handler)
         assert middleware._model_round_count == 1
 
-    async def test_no_warning_below_threshold(self, middleware):
+    async def test_no_advisory_below_threshold(self, middleware):
         for _ in range(10):
-            result = await middleware.aafter_model(_make_state(), runtime={})
-            assert result is None
+            await middleware.awrap_model_call(_make_request(), _mock_handler)
         assert middleware._model_round_count == 10
         assert middleware._warning_count == 0
+        assert middleware._pending_advisory is None
 
-    async def test_warning_at_threshold(self, middleware):
-        for i in range(middleware._next_warning_round - 1):
-            result = await middleware.aafter_model(_make_state(), runtime={})
-            assert result is None, f"Unexpected warning at round {i + 1}"
-
-        result = await middleware.aafter_model(_make_state(), runtime={})
-        assert result is not None
-        assert "messages" in result
-        assert len(result["messages"]) == 1
-        assert isinstance(result["messages"][0], SystemMessage)
+    async def test_advisory_queued_at_threshold_round(self, middleware):
+        """After reaching the warning round, advisory is queued for the NEXT call."""
+        await _simulate_rounds(middleware, middleware._next_warning_round)
         assert middleware._warning_count == 1
+        assert middleware._pending_advisory is not None
+        assert isinstance(middleware._pending_advisory, SystemMessage)
 
-    async def test_warning_fires_exactly_once(self, middleware):
-        for _ in range(middleware._next_warning_round):
-            await middleware.aafter_model(_make_state(), runtime={})
+    async def test_advisory_prepended_to_next_call_input(self, middleware):
+        """The queued advisory is prepended to the next model call's messages."""
+        await _simulate_rounds(middleware, middleware._next_warning_round)
 
+        captured_request = None
+
+        async def capturing_handler(request):
+            nonlocal captured_request
+            captured_request = request
+            return _make_response()
+
+        await middleware.awrap_model_call(_make_request(), capturing_handler)
+
+        assert captured_request is not None
+        last_msg = captured_request.messages[-1]
+        assert isinstance(last_msg, SystemMessage)
+        assert "step limit" in last_msg.content
+
+    async def test_advisory_consumed_after_delivery(self, middleware):
+        """After delivering the advisory, _pending_advisory is cleared."""
+        await _simulate_rounds(middleware, middleware._next_warning_round)
+        assert middleware._pending_advisory is not None
+
+        await middleware.awrap_model_call(_make_request(), _mock_handler)
+        assert middleware._pending_advisory is None
+
+    async def test_handler_called_exactly_once_per_wrap(self, middleware):
+        call_count = 0
+
+        async def counting_handler(request):
+            nonlocal call_count
+            call_count += 1
+            return _make_response()
+
+        await middleware.awrap_model_call(_make_request(), counting_handler)
+        assert call_count == 1
+
+    async def test_advisory_fires_exactly_once(self, middleware):
+        """Threshold mode produces exactly one advisory."""
+        await _simulate_rounds(middleware, middleware._next_warning_round)
         assert middleware._warning_count == 1
 
         for _ in range(10):
-            result = await middleware.aafter_model(_make_state(), runtime={})
-            assert result is None
+            await middleware.awrap_model_call(_make_request(), _mock_handler)
 
-    async def test_warning_content_is_system_message(self, middleware):
-        for _ in range(middleware._next_warning_round):
-            result = await middleware.aafter_model(_make_state(), runtime={})
+        assert middleware._warning_count == 1
 
-        msg = result["messages"][0]
-        assert "step limit" in msg.content
-        assert "Summarize results" in msg.content
+    async def test_no_state_mutation_on_handler_output(self, middleware):
+        """awrap_model_call returns the handler's response unchanged."""
+        response = await middleware.awrap_model_call(_make_request(), _mock_handler)
+        assert isinstance(response, _FakeModelResponse)
+        assert len(response.result) == 1
+        assert isinstance(response.result[0], AIMessage)
 
     async def test_default_warning_at_round_800(self, middleware):
         assert middleware._next_warning_round == 800
 
-        for i in range(799):
-            result = await middleware.aafter_model(_make_state(), runtime={})
-            assert result is None, f"Early warning at round {i + 1}"
+        await _simulate_rounds(middleware, 799)
+        assert middleware._warning_count == 0
+        assert middleware._pending_advisory is None
 
-        result = await middleware.aafter_model(_make_state(), runtime={})
-        assert result is not None
+        await middleware.awrap_model_call(_make_request(), _mock_handler)
         assert middleware._model_round_count == 800
+        assert middleware._warning_count == 1
+        assert middleware._pending_advisory is not None
 
     async def test_small_budget_warning(self, small_budget):
         assert small_budget._next_warning_round == 8
 
-        for _ in range(7):
-            result = await small_budget.aafter_model(_make_state(), runtime={})
-            assert result is None
+        await _simulate_rounds(small_budget, 7)
+        assert small_budget._pending_advisory is None
 
-        result = await small_budget.aafter_model(_make_state(), runtime={})
-        assert result is not None
+        await small_budget.awrap_model_call(_make_request(), _mock_handler)
         assert small_budget._model_round_count == 8
+        assert small_budget._pending_advisory is not None
 
     async def test_high_threshold_warning(self, high_threshold):
         assert high_threshold._next_warning_round == 900
 
-        for _ in range(899):
-            result = await high_threshold.aafter_model(_make_state(), runtime={})
-            assert result is None
+        await _simulate_rounds(high_threshold, 899)
+        assert high_threshold._pending_advisory is None
 
-        result = await high_threshold.aafter_model(_make_state(), runtime={})
-        assert result is not None
+        await high_threshold.awrap_model_call(_make_request(), _mock_handler)
         assert high_threshold._model_round_count == 900
+        assert high_threshold._pending_advisory is not None
 
 
 # =============================================================================
-# Hook: aafter_model — periodic mode
+# Hook: awrap_model_call — periodic mode
 # =============================================================================
 
 
-class TestAafterModelPeriodic:
-    async def test_first_warning_at_interval(self, periodic_small):
-        """First warning fires at exactly warning_interval rounds."""
-        for _ in range(4):
-            result = await periodic_small.aafter_model(_make_state(), runtime={})
-            assert result is None
+class TestAwrapModelCallPeriodic:
+    async def test_first_advisory_at_interval(self, periodic_small):
+        """First advisory queued at exactly warning_interval rounds."""
+        await _simulate_rounds(periodic_small, 4)
+        assert periodic_small._pending_advisory is None
 
-        result = await periodic_small.aafter_model(_make_state(), runtime={})
-        assert result is not None
-        assert isinstance(result["messages"][0], SystemMessage)
+        await periodic_small.awrap_model_call(_make_request(), _mock_handler)
         assert periodic_small._warning_count == 1
+        assert periodic_small._pending_advisory is not None
 
-    async def test_second_warning_at_double_interval(self, periodic_small):
-        """Second warning fires at 2 * interval."""
-        for i in range(10):
-            result = await periodic_small.aafter_model(_make_state(), runtime={})
+    async def test_second_advisory_at_double_interval(self, periodic_small):
+        """Second advisory queued at 2 * interval."""
+        await _simulate_rounds(periodic_small, 10)
         assert periodic_small._warning_count == 2
         assert periodic_small._model_round_count == 10
 
-    async def test_three_warnings_at_three_intervals(self, periodic_small):
-        """All three allowed warnings fire at 5, 10, 15."""
-        warnings_fired = 0
+    async def test_three_advisories_at_three_intervals(self, periodic_small):
+        """All three allowed advisories queue at 5, 10, 15."""
+        advisory_rounds = []
         for i in range(15):
-            result = await periodic_small.aafter_model(_make_state(), runtime={})
-            if result is not None:
-                warnings_fired += 1
-        assert warnings_fired == 3
+            old_count = periodic_small._warning_count
+            await periodic_small.awrap_model_call(_make_request(), _mock_handler)
+            if periodic_small._warning_count > old_count:
+                advisory_rounds.append(periodic_small._model_round_count)
+        assert advisory_rounds == [5, 10, 15]
         assert periodic_small._warning_count == 3
 
     async def test_stops_after_max_warnings(self, periodic_small):
-        """No more warnings after max_warnings is reached."""
-        for _ in range(15):
-            await periodic_small.aafter_model(_make_state(), runtime={})
+        """No more advisories after max_warnings is reached."""
+        await _simulate_rounds(periodic_small, 15)
         assert periodic_small._warning_count == 3
 
         for _ in range(20):
-            result = await periodic_small.aafter_model(_make_state(), runtime={})
-            assert result is None
+            old_advisory = periodic_small._pending_advisory
+            periodic_small._pending_advisory = None
+            await periodic_small.awrap_model_call(_make_request(), _mock_handler)
+            assert periodic_small._pending_advisory is None
 
-    async def test_escalating_messages(self, periodic_small):
-        """Each successive warning uses a different (escalating) message template."""
-        messages = []
-        for _ in range(15):
-            result = await periodic_small.aafter_model(_make_state(), runtime={})
-            if result is not None:
-                messages.append(result["messages"][0].content)
+    async def test_escalating_messages_delivered_to_handler(self, periodic_small):
+        """Each successive advisory uses a different (escalating) message template."""
+        delivered = []
+        for i in range(16):
+            captured = None
 
-        assert len(messages) == 3
-        assert messages[0] != messages[1]
-        assert messages[1] != messages[2]
+            async def capturing_handler(request, _captured=captured):
+                for msg in request.messages:
+                    if isinstance(msg, SystemMessage):
+                        delivered.append(msg.content)
+                return _make_response()
+
+            await periodic_small.awrap_model_call(_make_request(), capturing_handler)
+
+        assert len(delivered) == 3
+        assert delivered[0] != delivered[1]
+        assert delivered[1] != delivered[2]
 
     async def test_periodic_with_30_interval(self, periodic):
         """Standard sub-agent config: interval=30, max=4 fires at 30,60,90,120."""
-        warning_rounds = []
-        for i in range(150):
-            result = await periodic.aafter_model(_make_state(), runtime={})
-            if result is not None:
-                warning_rounds.append(periodic._model_round_count)
-        assert warning_rounds == [30, 60, 90, 120]
+        advisory_rounds = []
+        for _ in range(150):
+            old_count = periodic._warning_count
+            await periodic.awrap_model_call(_make_request(), _mock_handler)
+            if periodic._warning_count > old_count:
+                advisory_rounds.append(periodic._model_round_count)
+        assert advisory_rounds == [30, 60, 90, 120]
+
+
+# =============================================================================
+# Message ordering safety (the core bug fix)
+# =============================================================================
+
+
+class TestMessageOrderingSafety:
+    async def test_no_messages_injected_into_handler_output(self, periodic_small):
+        """awrap_model_call never injects messages into the ModelResponse.
+
+        The old aafter_model hook returned {"messages": [SystemMessage(...)]}
+        which LangGraph merged into the model node output, breaking the
+        AIMessage(tool_use) -> ToolMessage(tool_result) ordering.
+
+        The new awrap_model_call ONLY modifies the handler's INPUT request.
+        """
+        for _ in range(15):
+            response = await periodic_small.awrap_model_call(
+                _make_request(), _mock_handler,
+            )
+            assert isinstance(response, _FakeModelResponse)
+            assert response.result == [AIMessage(content="I did it")]
+
+    async def test_advisory_appears_in_input_not_output(self, periodic_small):
+        """Advisory is prepended to request.messages, not appended to response."""
+        await _simulate_rounds(periodic_small, 5)
+        assert periodic_small._pending_advisory is not None
+
+        input_had_advisory = False
+        output_had_advisory = False
+
+        async def inspecting_handler(request):
+            nonlocal input_had_advisory
+            for msg in request.messages:
+                if isinstance(msg, SystemMessage):
+                    input_had_advisory = True
+            return _make_response()
+
+        response = await periodic_small.awrap_model_call(
+            _make_request(), inspecting_handler,
+        )
+
+        for msg in response.result:
+            if isinstance(msg, SystemMessage):
+                output_had_advisory = True
+
+        assert input_had_advisory is True
+        assert output_had_advisory is False
+
+    async def test_original_request_messages_preserved(self, periodic_small):
+        """The advisory is appended alongside original messages, not replacing."""
+        await _simulate_rounds(periodic_small, 5)
+
+        original_messages = [HumanMessage(content="hello")]
+
+        async def inspecting_handler(request):
+            assert request.messages[0].content == "hello"
+            assert len(request.messages) == 2
+            assert isinstance(request.messages[1], SystemMessage)
+            return _make_response()
+
+        await periodic_small.awrap_model_call(
+            _make_request(messages=original_messages), inspecting_handler,
+        )
 
 
 # =============================================================================
@@ -462,16 +625,14 @@ class TestAafterAgent:
         assert result is None
 
     async def test_logs_after_partial_usage(self, middleware):
-        for _ in range(15):
-            await middleware.aafter_model(_make_state(), runtime={})
+        await _simulate_rounds(middleware, 15)
         result = await middleware.aafter_agent(_make_state(), runtime={})
         assert result is None
         assert middleware._model_round_count == 15
         assert middleware._warning_count == 0
 
     async def test_logs_after_warning_fired(self, middleware):
-        for _ in range(middleware._next_warning_round):
-            await middleware.aafter_model(_make_state(), runtime={})
+        await _simulate_rounds(middleware, middleware._next_warning_round)
         result = await middleware.aafter_agent(_make_state(), runtime={})
         assert result is None
         assert middleware._warning_count == 1
@@ -484,8 +645,7 @@ class TestAafterAgent:
 
 class TestMultiInvocationLifecycle:
     async def test_reset_between_invocations_threshold(self, middleware):
-        for _ in range(middleware._next_warning_round):
-            await middleware.aafter_model(_make_state(), runtime={})
+        await _simulate_rounds(middleware, middleware._next_warning_round)
         assert middleware._warning_count == 1
         assert middleware._model_round_count == middleware._next_warning_round
 
@@ -493,28 +653,24 @@ class TestMultiInvocationLifecycle:
 
         assert middleware._model_round_count == 0
         assert middleware._warning_count == 0
+        assert middleware._pending_advisory is None
 
-        result = await middleware.aafter_model(_make_state(), runtime={})
-        assert result is None
+        await middleware.awrap_model_call(_make_request(), _mock_handler)
         assert middleware._model_round_count == 1
 
     async def test_warning_fires_again_after_reset_threshold(self, middleware):
-        for _ in range(middleware._next_warning_round):
-            await middleware.aafter_model(_make_state(), runtime={})
+        await _simulate_rounds(middleware, middleware._next_warning_round)
         assert middleware._warning_count == 1
 
         await middleware.abefore_agent(_make_state(), runtime={})
+        await _simulate_rounds(middleware, middleware._next_warning_round)
 
-        for _ in range(middleware._next_warning_round):
-            result = await middleware.aafter_model(_make_state(), runtime={})
-
-        assert result is not None
         assert middleware._warning_count == 1
+        assert middleware._pending_advisory is not None
 
     async def test_reset_between_invocations_periodic(self, periodic_small):
         """Periodic mode resets fully between invocations."""
-        for _ in range(15):
-            await periodic_small.aafter_model(_make_state(), runtime={})
+        await _simulate_rounds(periodic_small, 15)
         assert periodic_small._warning_count == 3
 
         await periodic_small.abefore_agent(_make_state(), runtime={})
@@ -522,21 +678,22 @@ class TestMultiInvocationLifecycle:
         assert periodic_small._model_round_count == 0
         assert periodic_small._warning_count == 0
         assert periodic_small._next_warning_round == 5
+        assert periodic_small._pending_advisory is None
 
     async def test_periodic_warnings_fire_again_after_reset(self, periodic_small):
-        """All periodic warnings fire again in a new invocation."""
-        for _ in range(15):
-            await periodic_small.aafter_model(_make_state(), runtime={})
+        """All periodic advisories fire again in a new invocation."""
+        await _simulate_rounds(periodic_small, 15)
         assert periodic_small._warning_count == 3
 
         await periodic_small.abefore_agent(_make_state(), runtime={})
 
-        warning_count = 0
+        advisory_count = 0
         for _ in range(15):
-            result = await periodic_small.aafter_model(_make_state(), runtime={})
-            if result is not None:
-                warning_count += 1
-        assert warning_count == 3
+            old = periodic_small._warning_count
+            await periodic_small.awrap_model_call(_make_request(), _mock_handler)
+            if periodic_small._warning_count > old:
+                advisory_count += 1
+        assert advisory_count == 3
 
 
 # =============================================================================
@@ -561,11 +718,21 @@ class TestEdgeCases:
     async def test_periodic_with_max_warnings_1(self):
         """Single-shot periodic mode."""
         mw = ExecutionBudgetMiddleware(warning_interval=10, max_warnings=1)
-        for _ in range(10):
-            result = await mw.aafter_model(_make_state(), runtime={})
-        assert result is not None
+        await _simulate_rounds(mw, 10)
         assert mw._warning_count == 1
+        assert mw._pending_advisory is not None
 
+        mw._pending_advisory = None
         for _ in range(30):
-            result = await mw.aafter_model(_make_state(), runtime={})
-            assert result is None
+            await mw.awrap_model_call(_make_request(), _mock_handler)
+            assert mw._pending_advisory is None
+
+    async def test_handler_exception_does_not_increment_round(self, middleware):
+        """If the handler raises, the round counter should NOT be incremented."""
+        async def failing_handler(request):
+            raise RuntimeError("model exploded")
+
+        with pytest.raises(RuntimeError, match="model exploded"):
+            await middleware.awrap_model_call(_make_request(), failing_handler)
+
+        assert middleware._model_round_count == 0

--- a/backend/libs/python/graphton/tests/core/test_execution_budget.py
+++ b/backend/libs/python/graphton/tests/core/test_execution_budget.py
@@ -1,12 +1,21 @@
 """Comprehensive tests for ExecutionBudgetMiddleware.
 
-Covers:
+Covers both operating modes:
+
+**Threshold mode** (default):
 - Constructor validation and defaults
-- Internal helpers: _compute_warning_round, _create_budget_warning_message
+- Internal helpers: _compute_warning_round, _create_threshold_warning
 - abefore_agent hook: per-invocation state reset
 - aafter_model hook: round counting, warning injection, single-fire guarantee
 - aafter_agent hook: budget stats logging
 - Edge cases: tiny recursion limits, custom warning_pct, boundary conditions
+
+**Periodic mode** (warning_interval set):
+- Constructor validation for periodic parameters
+- Periodic warning injection at every N rounds
+- Escalating message urgency
+- max_warnings cap
+- State reset between invocations
 """
 
 from __future__ import annotations
@@ -20,6 +29,7 @@ from graphton.core.execution_budget import (
     _MAX_WARNING_PCT,
     _MIN_ROUNDS_BEFORE_WARNING,
     _MIN_WARNING_PCT,
+    _PERIODIC_MESSAGES,
     ExecutionBudgetMiddleware,
 )
 
@@ -46,21 +56,34 @@ def high_threshold():
     return ExecutionBudgetMiddleware(recursion_limit=6000, warning_pct=90)
 
 
+@pytest.fixture
+def periodic():
+    """Middleware in periodic mode (interval=30, max_warnings=4)."""
+    return ExecutionBudgetMiddleware(warning_interval=30, max_warnings=4)
+
+
+@pytest.fixture
+def periodic_small():
+    """Periodic middleware with small interval for fast iteration tests."""
+    return ExecutionBudgetMiddleware(warning_interval=5, max_warnings=3)
+
+
 def _make_state(messages: list | None = None) -> dict:
     """Build a minimal agent state dict."""
     return {"messages": messages or [HumanMessage(content="do something")]}
 
 
 # =============================================================================
-# Constructor validation
+# Constructor validation — threshold mode
 # =============================================================================
 
 
-class TestConstructor:
+class TestConstructorThreshold:
     def test_defaults(self):
         mw = ExecutionBudgetMiddleware()
         assert mw.recursion_limit == _DEFAULT_RECURSION_LIMIT
         assert mw.warning_pct == _DEFAULT_WARNING_PCT
+        assert mw._periodic is False
 
     def test_custom_values(self):
         mw = ExecutionBudgetMiddleware(recursion_limit=200, warning_pct=90)
@@ -93,75 +116,154 @@ class TestConstructor:
 
 
 # =============================================================================
-# _compute_warning_round
+# Constructor validation — periodic mode
+# =============================================================================
+
+
+class TestConstructorPeriodic:
+    def test_basic_construction(self):
+        mw = ExecutionBudgetMiddleware(warning_interval=30, max_warnings=4)
+        assert mw._periodic is True
+        assert mw.warning_interval == 30
+        assert mw.max_warnings == 4
+
+    def test_zero_interval_raises(self):
+        with pytest.raises(ValueError, match="warning_interval must be positive"):
+            ExecutionBudgetMiddleware(warning_interval=0)
+
+    def test_negative_interval_raises(self):
+        with pytest.raises(ValueError, match="warning_interval must be positive"):
+            ExecutionBudgetMiddleware(warning_interval=-10)
+
+    def test_zero_max_warnings_raises(self):
+        with pytest.raises(ValueError, match="max_warnings must be positive"):
+            ExecutionBudgetMiddleware(warning_interval=30, max_warnings=0)
+
+    def test_negative_max_warnings_raises(self):
+        with pytest.raises(ValueError, match="max_warnings must be positive"):
+            ExecutionBudgetMiddleware(warning_interval=30, max_warnings=-1)
+
+    def test_warning_pct_ignored_in_periodic_mode(self):
+        """warning_pct validation is skipped in periodic mode."""
+        mw = ExecutionBudgetMiddleware(warning_interval=30, warning_pct=10)
+        assert mw._periodic is True
+
+    def test_recursion_limit_ignored_in_periodic_mode(self):
+        """recursion_limit validation is skipped in periodic mode."""
+        mw = ExecutionBudgetMiddleware(warning_interval=30, recursion_limit=-1)
+        assert mw._periodic is True
+
+
+# =============================================================================
+# _compute_warning_round (threshold mode only)
 # =============================================================================
 
 
 class TestComputeWarningRound:
     def test_default_6000_at_80pct(self):
-        # 6000 // 6 = 1000 estimated rounds, 1000 * 80 // 100 = 800
         result = ExecutionBudgetMiddleware._compute_warning_round(6000, 80)
         assert result == 800
 
     def test_small_limit_respects_minimum(self):
-        """Very small limits should still have a minimum warning round."""
         result = ExecutionBudgetMiddleware._compute_warning_round(4, 80)
         assert result == _MIN_ROUNDS_BEFORE_WARNING
 
     def test_limit_200_at_80pct(self):
-        # 200 // 6 = 33 estimated rounds, 33 * 80 // 100 = 26
         result = ExecutionBudgetMiddleware._compute_warning_round(200, 80)
         assert result == 26
 
     def test_limit_100_at_90pct(self):
-        # 100 // 6 = 16 estimated rounds, 16 * 90 // 100 = 14
         result = ExecutionBudgetMiddleware._compute_warning_round(100, 90)
         assert result == 14
 
     def test_limit_100_at_50pct(self):
-        # 100 // 6 = 16 estimated rounds, 16 * 50 // 100 = 8
         result = ExecutionBudgetMiddleware._compute_warning_round(100, 50)
         assert result == 8
 
     def test_limit_10_at_80pct(self):
-        # 10 // 6 = 1 estimated round, 1 * 80 // 100 = 0, clamped to minimum
         result = ExecutionBudgetMiddleware._compute_warning_round(10, 80)
         assert result == _MIN_ROUNDS_BEFORE_WARNING
 
     def test_always_at_least_minimum(self):
-        """Even with limit=1 and low pct, the floor is respected."""
         result = ExecutionBudgetMiddleware._compute_warning_round(1, 50)
         assert result >= _MIN_ROUNDS_BEFORE_WARNING
 
 
 # =============================================================================
-# _create_budget_warning_message
+# _create_threshold_warning (threshold mode)
 # =============================================================================
 
 
-class TestCreateBudgetWarningMessage:
+class TestCreateThresholdWarning:
     def test_returns_system_message(self, middleware):
-        msg = middleware._create_budget_warning_message()
+        msg = middleware._create_threshold_warning()
         assert isinstance(msg, SystemMessage)
 
     def test_contains_percentage(self, middleware):
-        msg = middleware._create_budget_warning_message()
+        msg = middleware._create_threshold_warning()
         assert "80%" in msg.content
 
     def test_contains_remaining_rounds(self, middleware):
-        # estimated_total = 6000 // 6 = 1000, remaining = 1000 - 800 = 200
         middleware._model_round_count = 800
-        msg = middleware._create_budget_warning_message()
+        msg = middleware._create_threshold_warning()
         assert "~200 rounds remaining" in msg.content
 
     def test_contains_wrap_up_guidance(self, middleware):
-        msg = middleware._create_budget_warning_message()
+        msg = middleware._create_threshold_warning()
         assert "Prioritize completing" in msg.content
         assert "Summarize results" in msg.content
 
     def test_custom_pct_reflected(self, high_threshold):
-        msg = high_threshold._create_budget_warning_message()
+        msg = high_threshold._create_threshold_warning()
         assert "90%" in msg.content
+
+
+# =============================================================================
+# _create_periodic_warning (periodic mode)
+# =============================================================================
+
+
+class TestCreatePeriodicWarning:
+    def test_returns_system_message(self, periodic):
+        periodic._model_round_count = 30
+        periodic._warning_count = 1
+        msg = periodic._create_periodic_warning()
+        assert isinstance(msg, SystemMessage)
+
+    def test_first_warning_content(self, periodic):
+        periodic._model_round_count = 30
+        periodic._warning_count = 1
+        msg = periodic._create_periodic_warning()
+        assert "30 model rounds" in msg.content
+        assert "wrapping up" in msg.content.lower() or "nearing completion" in msg.content.lower()
+
+    def test_second_warning_escalates(self, periodic):
+        periodic._model_round_count = 60
+        periodic._warning_count = 2
+        msg = periodic._create_periodic_warning()
+        assert "60 model rounds" in msg.content
+        assert "Prioritize" in msg.content
+
+    def test_third_warning_escalates_further(self, periodic):
+        periodic._model_round_count = 90
+        periodic._warning_count = 3
+        msg = periodic._create_periodic_warning()
+        assert "90 model rounds" in msg.content
+        assert "Wrap up" in msg.content
+
+    def test_fourth_warning_is_critical(self, periodic):
+        periodic._model_round_count = 120
+        periodic._warning_count = 4
+        msg = periodic._create_periodic_warning()
+        assert "120 model rounds" in msg.content
+        assert "Critical" in msg.content or "final answer" in msg.content
+
+    def test_warning_count_beyond_messages_uses_last(self, periodic):
+        """When warning_count exceeds message templates, the last template is used."""
+        periodic._model_round_count = 150
+        periodic._warning_count = len(_PERIODIC_MESSAGES) + 5
+        msg = periodic._create_periodic_warning()
+        assert "150 model rounds" in msg.content
 
 
 # =============================================================================
@@ -176,42 +278,47 @@ class TestAbeforeAgent:
         assert result is None
         assert middleware._model_round_count == 0
 
-    async def test_resets_warned_flag(self, middleware):
-        middleware._warned = True
+    async def test_resets_warning_count(self, middleware):
+        middleware._warning_count = 1
         await middleware.abefore_agent(_make_state(), runtime={})
-        assert middleware._warned is False
+        assert middleware._warning_count == 0
 
     async def test_idempotent_on_fresh_instance(self, middleware):
-        """Calling abefore_agent on a fresh instance is a no-op."""
         assert middleware._model_round_count == 0
-        assert middleware._warned is False
+        assert middleware._warning_count == 0
         result = await middleware.abefore_agent(_make_state(), runtime={})
         assert result is None
         assert middleware._model_round_count == 0
-        assert middleware._warned is False
+        assert middleware._warning_count == 0
+
+    async def test_periodic_resets_next_warning_round(self, periodic):
+        """Periodic mode resets _next_warning_round to the interval."""
+        periodic._next_warning_round = 999
+        periodic._warning_count = 3
+        await periodic.abefore_agent(_make_state(), runtime={})
+        assert periodic._next_warning_round == 30
+        assert periodic._warning_count == 0
 
 
 # =============================================================================
-# Hook: aafter_model (round counting + warning injection)
+# Hook: aafter_model — threshold mode
 # =============================================================================
 
 
-class TestAafterModel:
+class TestAafterModelThreshold:
     async def test_increments_round_count(self, middleware):
         await middleware.aafter_model(_make_state(), runtime={})
         assert middleware._model_round_count == 1
 
     async def test_no_warning_below_threshold(self, middleware):
-        """No warning injected when well under budget."""
         for _ in range(10):
             result = await middleware.aafter_model(_make_state(), runtime={})
             assert result is None
         assert middleware._model_round_count == 10
-        assert middleware._warned is False
+        assert middleware._warning_count == 0
 
     async def test_warning_at_threshold(self, middleware):
-        """Warning fires exactly at the warning round."""
-        for i in range(middleware._warning_round - 1):
+        for i in range(middleware._next_warning_round - 1):
             result = await middleware.aafter_model(_make_state(), runtime={})
             assert result is None, f"Unexpected warning at round {i + 1}"
 
@@ -220,22 +327,20 @@ class TestAafterModel:
         assert "messages" in result
         assert len(result["messages"]) == 1
         assert isinstance(result["messages"][0], SystemMessage)
-        assert middleware._warned is True
+        assert middleware._warning_count == 1
 
     async def test_warning_fires_exactly_once(self, middleware):
-        """After the first warning, subsequent rounds return None."""
-        for _ in range(middleware._warning_round):
+        for _ in range(middleware._next_warning_round):
             await middleware.aafter_model(_make_state(), runtime={})
 
-        assert middleware._warned is True
+        assert middleware._warning_count == 1
 
         for _ in range(10):
             result = await middleware.aafter_model(_make_state(), runtime={})
             assert result is None
 
     async def test_warning_content_is_system_message(self, middleware):
-        """The injected message is a SystemMessage with budget guidance."""
-        for _ in range(middleware._warning_round):
+        for _ in range(middleware._next_warning_round):
             result = await middleware.aafter_model(_make_state(), runtime={})
 
         msg = result["messages"][0]
@@ -243,8 +348,7 @@ class TestAafterModel:
         assert "Summarize results" in msg.content
 
     async def test_default_warning_at_round_800(self, middleware):
-        """With limit=6000 and pct=80, warning fires at round 800."""
-        assert middleware._warning_round == 800
+        assert middleware._next_warning_round == 800
 
         for i in range(799):
             result = await middleware.aafter_model(_make_state(), runtime={})
@@ -255,8 +359,7 @@ class TestAafterModel:
         assert middleware._model_round_count == 800
 
     async def test_small_budget_warning(self, small_budget):
-        """With limit=60, warning fires at round 8 (60//6 * 80//100 = 8)."""
-        assert small_budget._warning_round == 8
+        assert small_budget._next_warning_round == 8
 
         for _ in range(7):
             result = await small_budget.aafter_model(_make_state(), runtime={})
@@ -267,8 +370,7 @@ class TestAafterModel:
         assert small_budget._model_round_count == 8
 
     async def test_high_threshold_warning(self, high_threshold):
-        """With limit=6000 and pct=90, warning fires at round 900."""
-        assert high_threshold._warning_round == 900
+        assert high_threshold._next_warning_round == 900
 
         for _ in range(899):
             result = await high_threshold.aafter_model(_make_state(), runtime={})
@@ -280,31 +382,99 @@ class TestAafterModel:
 
 
 # =============================================================================
+# Hook: aafter_model — periodic mode
+# =============================================================================
+
+
+class TestAafterModelPeriodic:
+    async def test_first_warning_at_interval(self, periodic_small):
+        """First warning fires at exactly warning_interval rounds."""
+        for _ in range(4):
+            result = await periodic_small.aafter_model(_make_state(), runtime={})
+            assert result is None
+
+        result = await periodic_small.aafter_model(_make_state(), runtime={})
+        assert result is not None
+        assert isinstance(result["messages"][0], SystemMessage)
+        assert periodic_small._warning_count == 1
+
+    async def test_second_warning_at_double_interval(self, periodic_small):
+        """Second warning fires at 2 * interval."""
+        for i in range(10):
+            result = await periodic_small.aafter_model(_make_state(), runtime={})
+        assert periodic_small._warning_count == 2
+        assert periodic_small._model_round_count == 10
+
+    async def test_three_warnings_at_three_intervals(self, periodic_small):
+        """All three allowed warnings fire at 5, 10, 15."""
+        warnings_fired = 0
+        for i in range(15):
+            result = await periodic_small.aafter_model(_make_state(), runtime={})
+            if result is not None:
+                warnings_fired += 1
+        assert warnings_fired == 3
+        assert periodic_small._warning_count == 3
+
+    async def test_stops_after_max_warnings(self, periodic_small):
+        """No more warnings after max_warnings is reached."""
+        for _ in range(15):
+            await periodic_small.aafter_model(_make_state(), runtime={})
+        assert periodic_small._warning_count == 3
+
+        for _ in range(20):
+            result = await periodic_small.aafter_model(_make_state(), runtime={})
+            assert result is None
+
+    async def test_escalating_messages(self, periodic_small):
+        """Each successive warning uses a different (escalating) message template."""
+        messages = []
+        for _ in range(15):
+            result = await periodic_small.aafter_model(_make_state(), runtime={})
+            if result is not None:
+                messages.append(result["messages"][0].content)
+
+        assert len(messages) == 3
+        assert messages[0] != messages[1]
+        assert messages[1] != messages[2]
+
+    async def test_periodic_with_30_interval(self, periodic):
+        """Standard sub-agent config: interval=30, max=4 fires at 30,60,90,120."""
+        warning_rounds = []
+        for i in range(150):
+            result = await periodic.aafter_model(_make_state(), runtime={})
+            if result is not None:
+                warning_rounds.append(periodic._model_round_count)
+        assert warning_rounds == [30, 60, 90, 120]
+
+
+# =============================================================================
 # Hook: aafter_agent (budget stats)
 # =============================================================================
 
 
 class TestAafterAgent:
-    async def test_returns_none(self, middleware):
-        """aafter_agent only logs — never modifies state."""
+    async def test_returns_none_threshold(self, middleware):
         result = await middleware.aafter_agent(_make_state(), runtime={})
         assert result is None
 
+    async def test_returns_none_periodic(self, periodic):
+        result = await periodic.aafter_agent(_make_state(), runtime={})
+        assert result is None
+
     async def test_logs_after_partial_usage(self, middleware):
-        """Stats reflect actual usage when execution finishes under budget."""
         for _ in range(15):
             await middleware.aafter_model(_make_state(), runtime={})
         result = await middleware.aafter_agent(_make_state(), runtime={})
         assert result is None
         assert middleware._model_round_count == 15
-        assert middleware._warned is False
+        assert middleware._warning_count == 0
 
     async def test_logs_after_warning_fired(self, middleware):
-        for _ in range(middleware._warning_round):
+        for _ in range(middleware._next_warning_round):
             await middleware.aafter_model(_make_state(), runtime={})
         result = await middleware.aafter_agent(_make_state(), runtime={})
         assert result is None
-        assert middleware._warned is True
+        assert middleware._warning_count == 1
 
 
 # =============================================================================
@@ -313,35 +483,60 @@ class TestAafterAgent:
 
 
 class TestMultiInvocationLifecycle:
-    async def test_reset_between_invocations(self, middleware):
-        """abefore_agent resets state so each invocation starts fresh."""
-        for _ in range(middleware._warning_round):
+    async def test_reset_between_invocations_threshold(self, middleware):
+        for _ in range(middleware._next_warning_round):
             await middleware.aafter_model(_make_state(), runtime={})
-        assert middleware._warned is True
-        assert middleware._model_round_count == middleware._warning_round
+        assert middleware._warning_count == 1
+        assert middleware._model_round_count == middleware._next_warning_round
 
         await middleware.abefore_agent(_make_state(), runtime={})
 
         assert middleware._model_round_count == 0
-        assert middleware._warned is False
+        assert middleware._warning_count == 0
 
         result = await middleware.aafter_model(_make_state(), runtime={})
         assert result is None
         assert middleware._model_round_count == 1
 
-    async def test_warning_fires_again_after_reset(self, middleware):
-        """Warning can fire again in a subsequent invocation."""
-        for _ in range(middleware._warning_round):
+    async def test_warning_fires_again_after_reset_threshold(self, middleware):
+        for _ in range(middleware._next_warning_round):
             await middleware.aafter_model(_make_state(), runtime={})
-        assert middleware._warned is True
+        assert middleware._warning_count == 1
 
         await middleware.abefore_agent(_make_state(), runtime={})
 
-        for _ in range(middleware._warning_round):
+        for _ in range(middleware._next_warning_round):
             result = await middleware.aafter_model(_make_state(), runtime={})
 
         assert result is not None
-        assert middleware._warned is True
+        assert middleware._warning_count == 1
+
+    async def test_reset_between_invocations_periodic(self, periodic_small):
+        """Periodic mode resets fully between invocations."""
+        for _ in range(15):
+            await periodic_small.aafter_model(_make_state(), runtime={})
+        assert periodic_small._warning_count == 3
+
+        await periodic_small.abefore_agent(_make_state(), runtime={})
+
+        assert periodic_small._model_round_count == 0
+        assert periodic_small._warning_count == 0
+        assert periodic_small._next_warning_round == 5
+
+    async def test_periodic_warnings_fire_again_after_reset(self, periodic_small):
+        """All periodic warnings fire again in a new invocation."""
+        for _ in range(15):
+            await periodic_small.aafter_model(_make_state(), runtime={})
+        assert periodic_small._warning_count == 3
+
+        await periodic_small.abefore_agent(_make_state(), runtime={})
+
+        warning_count = 0
+        for _ in range(15):
+            result = await periodic_small.aafter_model(_make_state(), runtime={})
+            if result is not None:
+                warning_count += 1
+        assert warning_count == 3
 
 
 # =============================================================================
@@ -351,18 +546,26 @@ class TestMultiInvocationLifecycle:
 
 class TestEdgeCases:
     async def test_minimum_recursion_limit(self):
-        """With recursion_limit=1, warning_round is clamped to minimum."""
         mw = ExecutionBudgetMiddleware(recursion_limit=1, warning_pct=80)
-        assert mw._warning_round == _MIN_ROUNDS_BEFORE_WARNING
+        assert mw._next_warning_round == _MIN_ROUNDS_BEFORE_WARNING
 
     async def test_very_large_recursion_limit(self):
-        """Large limits produce proportionally large warning rounds."""
-        # 30000 // 6 = 5000 estimated rounds, 5000 * 80 // 100 = 4000
         mw = ExecutionBudgetMiddleware(recursion_limit=30000, warning_pct=80)
-        assert mw._warning_round == 4000
+        assert mw._next_warning_round == 4000
 
     async def test_remaining_rounds_never_negative(self, middleware):
-        """If model_round_count exceeds estimate, remaining is clamped to 0."""
         middleware._model_round_count = 9999
-        msg = middleware._create_budget_warning_message()
+        msg = middleware._create_threshold_warning()
         assert "~0 rounds remaining" in msg.content
+
+    async def test_periodic_with_max_warnings_1(self):
+        """Single-shot periodic mode."""
+        mw = ExecutionBudgetMiddleware(warning_interval=10, max_warnings=1)
+        for _ in range(10):
+            result = await mw.aafter_model(_make_state(), runtime={})
+        assert result is not None
+        assert mw._warning_count == 1
+
+        for _ in range(30):
+            result = await mw.aafter_model(_make_state(), runtime={})
+            assert result is None

--- a/backend/libs/python/graphton/tests/core/test_interrupt_proxy_guardrails.py
+++ b/backend/libs/python/graphton/tests/core/test_interrupt_proxy_guardrails.py
@@ -1,12 +1,13 @@
 """Tests for sub-agent guardrail middleware injection in compile_subagent_with_proxy.
 
-Verifies that compile_subagent_with_proxy auto-injects the same guardrail
-middleware that create_deep_agent provides for the main agent:
-- LoopDetectionMiddleware
-- ExecutionBudgetMiddleware
-- ToolTruncationMiddleware
+Verifies that compile_subagent_with_proxy auto-injects guardrail middleware:
+- LoopDetectionMiddleware (prevents infinite tool loops)
+- ToolTruncationMiddleware (caps per-tool-result character count)
+- ExecutionBudgetMiddleware (periodic advisory nudges every 30 rounds)
 
-Also tests recursion_limit forwarding to the compiled graph.
+Sub-agents run with effectively unlimited recursion (matching the main
+agent).  The budget middleware operates in periodic mode — advisory
+nudges only, no hard stop.
 """
 
 from __future__ import annotations
@@ -18,7 +19,9 @@ import pytest
 
 from graphton.core.execution_budget import ExecutionBudgetMiddleware
 from graphton.core.interrupt_proxy import (
-    _DEFAULT_SUB_AGENT_RECURSION_LIMIT,
+    _SUB_AGENT_ADVISORY_INTERVAL,
+    _SUB_AGENT_MAX_ADVISORIES,
+    _UNLIMITED_RECURSION,
     compile_subagent_with_proxy,
 )
 from graphton.core.loop_detection import LoopDetectionMiddleware
@@ -64,27 +67,6 @@ class TestGuardrailInjection:
         assert len(loop_detection) == 1
 
     @patch("graphton.core.interrupt_proxy.create_agent")
-    def test_injects_execution_budget(self, mock_create_agent, mock_model, mock_tools):
-        mock_graph = MagicMock()
-        mock_graph.with_config = MagicMock(return_value=mock_graph)
-        mock_create_agent.return_value = mock_graph
-
-        compile_subagent_with_proxy(
-            model=mock_model,
-            tools=mock_tools,
-            system_prompt="test",
-            name="test-sa",
-            description="test sub-agent",
-        )
-
-        call_kwargs = mock_create_agent.call_args
-        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
-
-        budget_mw = [m for m in middleware_list if isinstance(m, ExecutionBudgetMiddleware)]
-        assert len(budget_mw) == 1
-        assert budget_mw[0].recursion_limit == _DEFAULT_SUB_AGENT_RECURSION_LIMIT
-
-    @patch("graphton.core.interrupt_proxy.create_agent")
     def test_injects_tool_truncation(self, mock_create_agent, mock_model, mock_tools):
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
@@ -103,6 +85,32 @@ class TestGuardrailInjection:
 
         truncation_mw = [m for m in middleware_list if isinstance(m, ToolTruncationMiddleware)]
         assert len(truncation_mw) == 1
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_injects_execution_budget_periodic(self, mock_create_agent, mock_model, mock_tools):
+        """ExecutionBudgetMiddleware is injected in periodic mode."""
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+
+        budget_mw = [m for m in middleware_list if isinstance(m, ExecutionBudgetMiddleware)]
+        assert len(budget_mw) == 1
+
+        mw = budget_mw[0]
+        assert mw._periodic is True
+        assert mw.warning_interval == _SUB_AGENT_ADVISORY_INTERVAL
+        assert mw.max_warnings == _SUB_AGENT_MAX_ADVISORIES
 
     @patch("graphton.core.interrupt_proxy.create_agent")
     def test_preserves_caller_middleware(self, mock_create_agent, mock_model, mock_tools):
@@ -129,12 +137,32 @@ class TestGuardrailInjection:
         assert sentinel in middleware_list
         assert len(middleware_list) == 4  # sentinel + 3 guardrails
 
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_total_guardrail_count(self, mock_create_agent, mock_model, mock_tools):
+        """Three guardrails are injected: loop detection, truncation, budget."""
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+
+        assert len(middleware_list) == 3
+
 
 class TestRecursionLimitForwarding:
     """Verify recursion_limit is forwarded to the compiled graph."""
 
     @patch("graphton.core.interrupt_proxy.create_agent")
-    def test_default_recursion_limit(self, mock_create_agent, mock_model, mock_tools):
+    def test_default_recursion_limit_is_unlimited(self, mock_create_agent, mock_model, mock_tools):
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
@@ -148,7 +176,7 @@ class TestRecursionLimitForwarding:
         )
 
         mock_graph.with_config.assert_called_once_with(
-            {"recursion_limit": _DEFAULT_SUB_AGENT_RECURSION_LIMIT},
+            {"recursion_limit": _UNLIMITED_RECURSION},
         )
 
     @patch("graphton.core.interrupt_proxy.create_agent")
@@ -170,14 +198,9 @@ class TestRecursionLimitForwarding:
             {"recursion_limit": 100},
         )
 
-        call_kwargs = mock_create_agent.call_args
-        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
-        budget_mw = [m for m in middleware_list if isinstance(m, ExecutionBudgetMiddleware)]
-        assert budget_mw[0].recursion_limit == 100
-
     @patch("graphton.core.interrupt_proxy.create_agent")
-    def test_none_recursion_limit_uses_default(self, mock_create_agent, mock_model, mock_tools):
-        """Passing recursion_limit=None falls back to the default."""
+    def test_none_recursion_limit_uses_unlimited(self, mock_create_agent, mock_model, mock_tools):
+        """Passing recursion_limit=None falls back to unlimited."""
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
@@ -192,5 +215,5 @@ class TestRecursionLimitForwarding:
         )
 
         mock_graph.with_config.assert_called_once_with(
-            {"recursion_limit": _DEFAULT_SUB_AGENT_RECURSION_LIMIT},
+            {"recursion_limit": _UNLIMITED_RECURSION},
         )

--- a/backend/libs/python/graphton/tests/core/test_interrupt_proxy_guardrails.py
+++ b/backend/libs/python/graphton/tests/core/test_interrupt_proxy_guardrails.py
@@ -1,6 +1,6 @@
-"""Tests for sub-agent guardrail middleware injection in compile_subagent_with_proxy.
+"""Tests for sub-agent guardrail middleware injection in compile_subagent.
 
-Verifies that compile_subagent_with_proxy auto-injects guardrail middleware:
+Verifies that compile_subagent auto-injects guardrail middleware:
 - LoopDetectionMiddleware (prevents infinite tool loops)
 - ToolTruncationMiddleware (caps per-tool-result character count)
 - ExecutionBudgetMiddleware (periodic advisory nudges every 30 rounds)
@@ -22,7 +22,7 @@ from graphton.core.interrupt_proxy import (
     _SUB_AGENT_ADVISORY_INTERVAL,
     _SUB_AGENT_MAX_ADVISORIES,
     _UNLIMITED_RECURSION,
-    compile_subagent_with_proxy,
+    compile_subagent,
 )
 from graphton.core.loop_detection import LoopDetectionMiddleware
 from graphton.core.tool_truncation import ToolTruncationMiddleware
@@ -44,7 +44,7 @@ def mock_tools():
 
 
 class TestGuardrailInjection:
-    """Verify that compile_subagent_with_proxy injects guardrail middleware."""
+    """Verify that compile_subagent injects guardrail middleware."""
 
     @patch("graphton.core.interrupt_proxy.create_agent")
     def test_injects_loop_detection(self, mock_create_agent, mock_model, mock_tools):
@@ -52,7 +52,7 @@ class TestGuardrailInjection:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -72,7 +72,7 @@ class TestGuardrailInjection:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -93,7 +93,7 @@ class TestGuardrailInjection:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -122,7 +122,7 @@ class TestGuardrailInjection:
         sentinel = MagicMock()
         sentinel.__class__.__name__ = "CallerMiddleware"
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -144,7 +144,7 @@ class TestGuardrailInjection:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -157,6 +157,45 @@ class TestGuardrailInjection:
 
         assert len(middleware_list) == 3
 
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_no_checkpointer_passed(self, mock_create_agent, mock_model, mock_tools):
+        """compile_subagent must NOT pass checkpointer to create_agent
+        (LangGraph per-invocation mode: sub-agent inherits parent's)."""
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        assert "checkpointer" not in (call_kwargs.kwargs or {})
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_returns_compiled_graph_directly(self, mock_create_agent, mock_model, mock_tools):
+        """The returned runnable should be the compiled graph, not a proxy wrapper."""
+        mock_graph = MagicMock()
+        configured_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=configured_graph)
+        mock_create_agent.return_value = mock_graph
+
+        result = compile_subagent(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        assert result["runnable"] is configured_graph
+        assert result["name"] == "test-sa"
+        assert result["description"] == "test sub-agent"
+
 
 class TestRecursionLimitForwarding:
     """Verify recursion_limit is forwarded to the compiled graph."""
@@ -167,7 +206,7 @@ class TestRecursionLimitForwarding:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -185,7 +224,7 @@ class TestRecursionLimitForwarding:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",
@@ -205,7 +244,7 @@ class TestRecursionLimitForwarding:
         mock_graph.with_config = MagicMock(return_value=mock_graph)
         mock_create_agent.return_value = mock_graph
 
-        compile_subagent_with_proxy(
+        compile_subagent(
             model=mock_model,
             tools=mock_tools,
             system_prompt="test",

--- a/backend/libs/python/graphton/tests/core/test_interrupt_proxy_guardrails.py
+++ b/backend/libs/python/graphton/tests/core/test_interrupt_proxy_guardrails.py
@@ -1,0 +1,196 @@
+"""Tests for sub-agent guardrail middleware injection in compile_subagent_with_proxy.
+
+Verifies that compile_subagent_with_proxy auto-injects the same guardrail
+middleware that create_deep_agent provides for the main agent:
+- LoopDetectionMiddleware
+- ExecutionBudgetMiddleware
+- ToolTruncationMiddleware
+
+Also tests recursion_limit forwarding to the compiled graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graphton.core.execution_budget import ExecutionBudgetMiddleware
+from graphton.core.interrupt_proxy import (
+    _DEFAULT_SUB_AGENT_RECURSION_LIMIT,
+    compile_subagent_with_proxy,
+)
+from graphton.core.loop_detection import LoopDetectionMiddleware
+from graphton.core.tool_truncation import ToolTruncationMiddleware
+
+
+@pytest.fixture
+def mock_model():
+    model = MagicMock()
+    model.bind_tools = MagicMock(return_value=model)
+    return model
+
+
+@pytest.fixture
+def mock_tools():
+    tool = MagicMock()
+    tool.name = "read_file"
+    tool.description = "Reads a file"
+    return [tool]
+
+
+class TestGuardrailInjection:
+    """Verify that compile_subagent_with_proxy injects guardrail middleware."""
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_injects_loop_detection(self, mock_create_agent, mock_model, mock_tools):
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+
+        loop_detection = [m for m in middleware_list if isinstance(m, LoopDetectionMiddleware)]
+        assert len(loop_detection) == 1
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_injects_execution_budget(self, mock_create_agent, mock_model, mock_tools):
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+
+        budget_mw = [m for m in middleware_list if isinstance(m, ExecutionBudgetMiddleware)]
+        assert len(budget_mw) == 1
+        assert budget_mw[0].recursion_limit == _DEFAULT_SUB_AGENT_RECURSION_LIMIT
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_injects_tool_truncation(self, mock_create_agent, mock_model, mock_tools):
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+
+        truncation_mw = [m for m in middleware_list if isinstance(m, ToolTruncationMiddleware)]
+        assert len(truncation_mw) == 1
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_preserves_caller_middleware(self, mock_create_agent, mock_model, mock_tools):
+        """Caller-provided middleware is preserved alongside auto-injected ones."""
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        sentinel = MagicMock()
+        sentinel.__class__.__name__ = "CallerMiddleware"
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+            middleware=[sentinel],
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+
+        assert sentinel in middleware_list
+        assert len(middleware_list) == 4  # sentinel + 3 guardrails
+
+
+class TestRecursionLimitForwarding:
+    """Verify recursion_limit is forwarded to the compiled graph."""
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_default_recursion_limit(self, mock_create_agent, mock_model, mock_tools):
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+        )
+
+        mock_graph.with_config.assert_called_once_with(
+            {"recursion_limit": _DEFAULT_SUB_AGENT_RECURSION_LIMIT},
+        )
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_custom_recursion_limit(self, mock_create_agent, mock_model, mock_tools):
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+            recursion_limit=100,
+        )
+
+        mock_graph.with_config.assert_called_once_with(
+            {"recursion_limit": 100},
+        )
+
+        call_kwargs = mock_create_agent.call_args
+        middleware_list = call_kwargs.kwargs.get("middleware") or call_kwargs[1].get("middleware", [])
+        budget_mw = [m for m in middleware_list if isinstance(m, ExecutionBudgetMiddleware)]
+        assert budget_mw[0].recursion_limit == 100
+
+    @patch("graphton.core.interrupt_proxy.create_agent")
+    def test_none_recursion_limit_uses_default(self, mock_create_agent, mock_model, mock_tools):
+        """Passing recursion_limit=None falls back to the default."""
+        mock_graph = MagicMock()
+        mock_graph.with_config = MagicMock(return_value=mock_graph)
+        mock_create_agent.return_value = mock_graph
+
+        compile_subagent_with_proxy(
+            model=mock_model,
+            tools=mock_tools,
+            system_prompt="test",
+            name="test-sa",
+            description="test sub-agent",
+            recursion_limit=None,
+        )
+
+        mock_graph.with_config.assert_called_once_with(
+            {"recursion_limit": _DEFAULT_SUB_AGENT_RECURSION_LIMIT},
+        )

--- a/backend/libs/python/graphton/tests/core/test_models.py
+++ b/backend/libs/python/graphton/tests/core/test_models.py
@@ -22,6 +22,7 @@ from langchain_core.messages import (
 from graphton.core.models import (
     DEFAULT_THINKING_BUDGET,
     DEFAULT_THINKING_EFFORT,
+    _reorder_tool_result_pairing,
     _sanitize_non_leading_system_messages,
     parse_model_string,
 )
@@ -163,26 +164,35 @@ class TestSanitizeNonLeadingSystemMessages:
         assert result[3].content == "[System] budget warning"
 
     def test_multiple_trailing_system_messages_all_converted(self):
-        """Both loop detection and budget warnings fire in the same execution."""
+        """Both loop detection and budget warnings fire in the same execution.
+
+        AIMessage(tool_calls) at positions [2] and [5] have SystemMessages
+        injected after them.  After sanitization + reordering, each advisory
+        should appear after its corresponding ToolMessage, not before.
+        """
         msgs = [
             SystemMessage(content="prompt"),
             HumanMessage(content="hi"),
-            AIMessage(content="first response"),
+            AIMessage(content="first response", tool_calls=[{"id": "tc_1", "name": "read", "args": {}}]),
             SystemMessage(content="loop warning"),
             ToolMessage(content="result", tool_call_id="tc_1"),
-            AIMessage(content="second response"),
+            AIMessage(content="second response", tool_calls=[{"id": "tc_2", "name": "write", "args": {}}]),
             SystemMessage(content="budget warning"),
             ToolMessage(content="result2", tool_call_id="tc_2"),
         ]
         result = _sanitize_non_leading_system_messages(msgs)
         assert len(result) == 8
         assert isinstance(result[0], SystemMessage)
-        assert isinstance(result[3], HumanMessage)
-        assert result[3].content == "[System] loop warning"
-        assert isinstance(result[4], ToolMessage)
-        assert isinstance(result[6], HumanMessage)
-        assert result[6].content == "[System] budget warning"
-        assert isinstance(result[7], ToolMessage)
+        assert isinstance(result[2], AIMessage)
+        assert isinstance(result[3], ToolMessage)
+        assert result[3].tool_call_id == "tc_1"
+        assert isinstance(result[4], HumanMessage)
+        assert result[4].content == "[System] loop warning"
+        assert isinstance(result[5], AIMessage)
+        assert isinstance(result[6], ToolMessage)
+        assert result[6].tool_call_id == "tc_2"
+        assert isinstance(result[7], HumanMessage)
+        assert result[7].content == "[System] budget warning"
 
     def test_no_leading_system_with_mid_conversation_system(self):
         """Sub-agent where system_prompt is handled via closure, not state."""
@@ -203,7 +213,11 @@ class TestSanitizeNonLeadingSystemMessages:
         assert result is msgs
 
     def test_tool_messages_adjacent_to_converted_system_preserved(self):
-        """ToolMessages must remain ToolMessages for Anthropic tool_result pairing."""
+        """ToolMessages must remain ToolMessages for Anthropic tool_result pairing.
+
+        After reordering, the ToolMessage should appear immediately after the
+        AIMessage with tool_calls, and the converted advisory should follow.
+        """
         msgs = [
             SystemMessage(content="prompt"),
             HumanMessage(content="hi"),
@@ -212,9 +226,13 @@ class TestSanitizeNonLeadingSystemMessages:
             ToolMessage(content="file content", tool_call_id="tc_1"),
         ]
         result = _sanitize_non_leading_system_messages(msgs)
-        assert isinstance(result[3], HumanMessage)
-        assert isinstance(result[4], ToolMessage)
-        assert result[4].tool_call_id == "tc_1"
+        assert len(result) == 5
+        assert isinstance(result[0], SystemMessage)
+        assert isinstance(result[2], AIMessage)
+        assert isinstance(result[3], ToolMessage)
+        assert result[3].tool_call_id == "tc_1"
+        assert isinstance(result[4], HumanMessage)
+        assert result[4].content == "[System] budget warning"
 
     def test_non_system_messages_untouched(self):
         """All non-SystemMessage types pass through without modification."""
@@ -246,3 +264,158 @@ class TestSanitizeNonLeadingSystemMessages:
             call_args = mock_logger.warning.call_args[0]
             assert "2" in str(call_args)
             assert "Anthropic" in str(call_args)
+
+
+# =============================================================================
+# TestReorderToolResultPairing - Defensive reordering for tool_use → tool_result
+# =============================================================================
+
+
+class TestReorderToolResultPairing:
+    """Tests for _reorder_tool_result_pairing.
+
+    Guardrail middleware (ExecutionBudgetMiddleware, LoopDetectionMiddleware)
+    inject messages between AIMessage(tool_calls) and ToolMessage via
+    aafter_model.  The reordering function moves those interleaved messages
+    to AFTER the ToolMessages so the Anthropic API's tool_use → tool_result
+    contract is structurally unbroken.
+    """
+
+    def test_empty_list(self):
+        assert _reorder_tool_result_pairing([]) == []
+
+    def test_no_tool_calls_passthrough(self):
+        msgs = [
+            HumanMessage(content="hi"),
+            AIMessage(content="hello"),
+            HumanMessage(content="thanks"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert result == msgs
+
+    def test_normal_sequence_unchanged(self):
+        """AIMessage(tool_calls) → ToolMessage is already correct."""
+        msgs = [
+            HumanMessage(content="hi"),
+            AIMessage(
+                content="calling",
+                tool_calls=[{"id": "tc_1", "name": "read", "args": {}}],
+            ),
+            ToolMessage(content="result", tool_call_id="tc_1"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert [type(m).__name__ for m in result] == [
+            "HumanMessage", "AIMessage", "ToolMessage",
+        ]
+
+    def test_single_advisory_reordered(self):
+        """HumanMessage between AIMessage(tool_calls) and ToolMessage is moved."""
+        msgs = [
+            AIMessage(
+                content="calling",
+                tool_calls=[{"id": "tc_1", "name": "read", "args": {}}],
+            ),
+            HumanMessage(content="[System] budget advisory"),
+            ToolMessage(content="result", tool_call_id="tc_1"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "tc_1"
+        assert isinstance(result[2], HumanMessage)
+        assert result[2].content == "[System] budget advisory"
+
+    def test_multiple_advisories_reordered(self):
+        """Both budget and loop advisories between AIMessage and ToolMessages."""
+        msgs = [
+            AIMessage(
+                content="calling",
+                tool_calls=[{"id": "tc_1", "name": "read", "args": {}}],
+            ),
+            HumanMessage(content="[System] budget advisory"),
+            HumanMessage(content="[System] loop warning"),
+            ToolMessage(content="result", tool_call_id="tc_1"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert isinstance(result[2], HumanMessage)
+        assert result[2].content == "[System] budget advisory"
+        assert isinstance(result[3], HumanMessage)
+        assert result[3].content == "[System] loop warning"
+
+    def test_multiple_tool_calls_with_advisory(self):
+        """Model called two tools; advisory interleaved before both results."""
+        msgs = [
+            AIMessage(
+                content="calling two tools",
+                tool_calls=[
+                    {"id": "tc_1", "name": "read", "args": {}},
+                    {"id": "tc_2", "name": "write", "args": {}},
+                ],
+            ),
+            HumanMessage(content="[System] advisory"),
+            ToolMessage(content="result1", tool_call_id="tc_1"),
+            ToolMessage(content="result2", tool_call_id="tc_2"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert isinstance(result[2], ToolMessage)
+        assert isinstance(result[3], HumanMessage)
+        assert result[3].content == "[System] advisory"
+
+    def test_multi_round_with_advisory_in_one(self):
+        """30-round-like scenario: advisory fires in one round, not others."""
+        msgs = [
+            HumanMessage(content="task"),
+            AIMessage(
+                content="round 1",
+                tool_calls=[{"id": "tc_1", "name": "read", "args": {}}],
+            ),
+            ToolMessage(content="r1", tool_call_id="tc_1"),
+            AIMessage(
+                content="round 2",
+                tool_calls=[{"id": "tc_2", "name": "write", "args": {}}],
+            ),
+            HumanMessage(content="[System] advisory at round 2"),
+            ToolMessage(content="r2", tool_call_id="tc_2"),
+            AIMessage(content="done"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        types = [type(m).__name__ for m in result]
+        assert types == [
+            "HumanMessage",
+            "AIMessage", "ToolMessage",
+            "AIMessage", "ToolMessage", "HumanMessage",
+            "AIMessage",
+        ]
+        assert result[4].tool_call_id == "tc_2"
+        assert result[5].content == "[System] advisory at round 2"
+
+    def test_ai_message_without_tool_calls_not_affected(self):
+        """AIMessage(no tool_calls) → HumanMessage → ToolMessage stays as-is."""
+        msgs = [
+            AIMessage(content="thinking..."),
+            HumanMessage(content="[System] advisory"),
+            ToolMessage(content="orphan", tool_call_id="tc_x"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert [type(m).__name__ for m in result] == [
+            "AIMessage", "HumanMessage", "ToolMessage",
+        ]
+
+    def test_system_message_between_ai_and_tool_also_reordered(self):
+        """SystemMessage (not yet converted) is also moved after ToolMessages."""
+        msgs = [
+            AIMessage(
+                content="call",
+                tool_calls=[{"id": "tc_1", "name": "read", "args": {}}],
+            ),
+            SystemMessage(content="raw advisory"),
+            ToolMessage(content="result", tool_call_id="tc_1"),
+        ]
+        result = _reorder_tool_result_pairing(msgs)
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert isinstance(result[2], SystemMessage)

--- a/backend/libs/python/graphton/tests/core/test_models.py
+++ b/backend/libs/python/graphton/tests/core/test_models.py
@@ -1,20 +1,28 @@
-"""Unit tests for the model parser (parse_model_string).
+"""Unit tests for the model parser and Anthropic message sanitization.
 
 Tests cover:
 - Native extended thinking configuration for supported Anthropic models
 - Temperature removal when thinking is enabled
 - Explicit thinking config respected (not overridden)
 - Non-thinking models unaffected
+- Non-leading SystemMessage sanitization for Anthropic API compatibility
 """
 
 from unittest.mock import patch
 
 import pytest
 from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 
 from graphton.core.models import (
     DEFAULT_THINKING_BUDGET,
     DEFAULT_THINKING_EFFORT,
+    _sanitize_non_leading_system_messages,
     parse_model_string,
 )
 
@@ -95,3 +103,146 @@ class TestNativeThinkingConfig:
             mock_logger.warning.assert_called_once()
             call_args = mock_logger.warning.call_args[0]
             assert "temperature" in call_args[0].lower()
+
+
+# =============================================================================
+# TestSanitizeNonLeadingSystemMessages - Anthropic system message compatibility
+# =============================================================================
+
+
+class TestSanitizeNonLeadingSystemMessages:
+    """Tests for _sanitize_non_leading_system_messages.
+
+    Anthropic's _format_messages() requires all SystemMessage objects to be
+    contiguous at the start.  Guardrail middleware injects SystemMessage
+    mid-conversation via aafter_model.  The sanitizer converts those trailing
+    SystemMessages to HumanMessage with a [System] prefix.
+    """
+
+    def test_empty_list_returns_empty(self):
+        result = _sanitize_non_leading_system_messages([])
+        assert result == []
+
+    def test_no_system_messages_passthrough(self):
+        msgs = [HumanMessage(content="hi"), AIMessage(content="hello")]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert result is msgs
+
+    def test_only_leading_system_messages_passthrough(self):
+        msgs = [
+            SystemMessage(content="prompt"),
+            HumanMessage(content="hi"),
+            AIMessage(content="hello"),
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert result is msgs
+
+    def test_multiple_consecutive_leading_system_messages_passthrough(self):
+        msgs = [
+            SystemMessage(content="prompt A"),
+            SystemMessage(content="prompt B"),
+            HumanMessage(content="hi"),
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert result is msgs
+
+    def test_single_trailing_system_message_converted(self):
+        msgs = [
+            SystemMessage(content="prompt"),
+            HumanMessage(content="hi"),
+            AIMessage(content="response"),
+            SystemMessage(content="budget warning"),
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert len(result) == 4
+        assert isinstance(result[0], SystemMessage)
+        assert result[0].content == "prompt"
+        assert isinstance(result[1], HumanMessage)
+        assert isinstance(result[2], AIMessage)
+        assert isinstance(result[3], HumanMessage)
+        assert result[3].content == "[System] budget warning"
+
+    def test_multiple_trailing_system_messages_all_converted(self):
+        """Both loop detection and budget warnings fire in the same execution."""
+        msgs = [
+            SystemMessage(content="prompt"),
+            HumanMessage(content="hi"),
+            AIMessage(content="first response"),
+            SystemMessage(content="loop warning"),
+            ToolMessage(content="result", tool_call_id="tc_1"),
+            AIMessage(content="second response"),
+            SystemMessage(content="budget warning"),
+            ToolMessage(content="result2", tool_call_id="tc_2"),
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert len(result) == 8
+        assert isinstance(result[0], SystemMessage)
+        assert isinstance(result[3], HumanMessage)
+        assert result[3].content == "[System] loop warning"
+        assert isinstance(result[4], ToolMessage)
+        assert isinstance(result[6], HumanMessage)
+        assert result[6].content == "[System] budget warning"
+        assert isinstance(result[7], ToolMessage)
+
+    def test_no_leading_system_with_mid_conversation_system(self):
+        """Sub-agent where system_prompt is handled via closure, not state."""
+        msgs = [
+            HumanMessage(content="task description"),
+            AIMessage(content="working..."),
+            SystemMessage(content="wrap up"),
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert len(result) == 3
+        assert isinstance(result[0], HumanMessage)
+        assert isinstance(result[2], HumanMessage)
+        assert result[2].content == "[System] wrap up"
+
+    def test_single_system_message_only_stays_as_leading(self):
+        msgs = [SystemMessage(content="prompt")]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert result is msgs
+
+    def test_tool_messages_adjacent_to_converted_system_preserved(self):
+        """ToolMessages must remain ToolMessages for Anthropic tool_result pairing."""
+        msgs = [
+            SystemMessage(content="prompt"),
+            HumanMessage(content="hi"),
+            AIMessage(content="call", tool_calls=[{"id": "tc_1", "name": "read", "args": {}}]),
+            SystemMessage(content="budget warning"),
+            ToolMessage(content="file content", tool_call_id="tc_1"),
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert isinstance(result[3], HumanMessage)
+        assert isinstance(result[4], ToolMessage)
+        assert result[4].tool_call_id == "tc_1"
+
+    def test_non_system_messages_untouched(self):
+        """All non-SystemMessage types pass through without modification."""
+        human = HumanMessage(content="hi")
+        ai = AIMessage(content="hello")
+        tool = ToolMessage(content="result", tool_call_id="tc_1")
+        msgs = [
+            SystemMessage(content="prompt"),
+            human,
+            ai,
+            SystemMessage(content="warning"),
+            tool,
+        ]
+        result = _sanitize_non_leading_system_messages(msgs)
+        assert result[1] is human
+        assert result[2] is ai
+        assert result[4] is tool
+
+    def test_warning_logged_on_sanitization(self):
+        msgs = [
+            SystemMessage(content="prompt"),
+            HumanMessage(content="hi"),
+            SystemMessage(content="warning1"),
+            SystemMessage(content="warning2"),
+        ]
+        with patch("graphton.core.models.logger") as mock_logger:
+            _sanitize_non_leading_system_messages(msgs)
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            assert "2" in str(call_args)
+            assert "Anthropic" in str(call_args)

--- a/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
+++ b/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
@@ -142,7 +142,7 @@ class TestNativeInterruptPropagation:
 
 class TestConcurrentCheckpointIsolation:
     """Verify that concurrent sub-agent invocations get distinct checkpoint_ns
-    values, preventing the deadlock that InterruptProxyRunnable caused."""
+    values, preventing checkpoint contention."""
 
     @pytest.mark.asyncio
     async def test_concurrent_subagents_get_distinct_namespaces(self):
@@ -402,7 +402,7 @@ class TestT03NamespaceFormat:
     events from main-agent events.  Root-prefix matching (the first segment
     before '|') routes subsequent events from the same sub-agent without
     re-registration.  This test confirms the format holds with native
-    per-invocation subgraphs (no InterruptProxyRunnable).
+    per-invocation subgraphs.
     """
 
     @pytest.mark.asyncio

--- a/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
+++ b/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
@@ -22,16 +22,14 @@ project).  They confirm whether parent_ids on v2 events can replace the
 from __future__ import annotations
 
 import asyncio
-from typing import Annotated, Any
+from typing import Any
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
-from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, MessagesState, StateGraph
-from langgraph.graph.message import add_messages
-from langgraph.types import Command, Interrupt, interrupt
+from langgraph.types import Command, interrupt
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +148,6 @@ class TestConcurrentCheckpointIsolation:
 
         # Track checkpoint_ns values seen during invocations
         observed_namespaces: list[str] = []
-        invocation_barrier = asyncio.Barrier(2)
 
         def recording_node(state: MessagesState, config: RunnableConfig) -> dict:
             ns = config.get("configurable", {}).get("checkpoint_ns", "")
@@ -220,8 +217,6 @@ class TestInterruptThroughGate:
     async def test_interrupt_propagates_through_try_finally(self):
         """Simulates SubAgentGate's try/finally pattern around a sub-agent
         that calls interrupt()."""
-        from langgraph.errors import GraphInterrupt
-
         checkpointer = MemorySaver()
         subgraph = _build_interrupting_subgraph()
 

--- a/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
+++ b/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
@@ -1,0 +1,660 @@
+"""Phase 0 verification: LangGraph native per-invocation subgraph interrupt propagation.
+
+Confirms that sub-agents compiled with checkpointer=None (the default) correctly:
+
+1. Inherit the parent's checkpointer and propagate interrupt() to the parent
+2. Resume via Command(resume=...) after parent-level approval
+3. Produce distinct checkpoint_ns per concurrent invocation (no deadlock)
+4. Emit streaming events with namespace metadata identifying the sub-agent
+5. Produce multi-segment langgraph_checkpoint_ns with consistent root (T03)
+6. Carry parent_ids that trace back to the parent invocation context (T03)
+
+These tests use MemorySaver as the parent checkpointer (standing in for
+MongoDB in production).  The mechanism is identical -- MemorySaver and
+MongoDBSaver both implement BaseCheckpointSaver.
+
+Tests 6 and 7 verify the event metadata StatusBuilder needs for deterministic
+namespace-to-sub-agent routing (T03 Approach B in the status-builder-hardening
+project).  They confirm whether parent_ids on v2 events can replace the
+4-strategy heuristic cascade in _register_sub_agent_namespace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.types import Command, Interrupt, interrupt
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build a minimal sub-agent that calls interrupt()
+# ---------------------------------------------------------------------------
+
+
+def _build_interrupting_subgraph() -> StateGraph:
+    """Sub-agent graph that always calls interrupt() then returns a result."""
+
+    def ask_approval(state: MessagesState) -> dict:
+        decision = interrupt({"tool_call_id": "tc_sub_1", "message": "Dangerous op"})
+        return {"messages": [AIMessage(content=f"Approved: {decision}")]}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("ask", ask_approval)
+    builder.add_edge(START, "ask")
+    builder.add_edge("ask", END)
+    # checkpointer=None is the default -- sub-agent inherits parent's
+    return builder.compile()
+
+
+def _build_parent_with_subagent(
+    subgraph,
+    checkpointer,
+) -> Any:
+    """Parent graph that invokes a sub-agent from a tool node."""
+
+    def router(state: MessagesState) -> str:
+        last = state["messages"][-1]
+        if isinstance(last, HumanMessage):
+            return "call_sub"
+        return END
+
+    def call_sub(state: MessagesState) -> dict:
+        result = subgraph.invoke(
+            {"messages": [HumanMessage(content="Do something dangerous")]},
+        )
+        return {"messages": [AIMessage(content=result["messages"][-1].content)]}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("call_sub", call_sub)
+    builder.add_conditional_edges(START, router, {"call_sub": "call_sub", END: END})
+    builder.add_edge("call_sub", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Interrupt propagation and resume
+# ---------------------------------------------------------------------------
+
+
+class TestNativeInterruptPropagation:
+    """Verify interrupt() in a sub-agent (checkpointer=None) propagates to
+    the parent and resume via Command(resume=...) works correctly."""
+
+    @pytest.mark.asyncio
+    async def test_subagent_interrupt_propagates_and_resumes(self):
+        checkpointer = MemorySaver()
+        subgraph = _build_interrupting_subgraph()
+        parent = _build_parent_with_subagent(subgraph, checkpointer)
+
+        config = {"configurable": {"thread_id": "test-thread-1"}}
+
+        # First invocation -- should pause at interrupt()
+        result = await parent.ainvoke(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+        )
+
+        # The parent should be interrupted (result contains the state so far)
+        state = await parent.aget_state(config)
+        assert state.tasks, "Expected pending tasks after interrupt"
+
+        interrupts_found = []
+        for task in state.tasks:
+            if hasattr(task, "interrupts"):
+                interrupts_found.extend(task.interrupts)
+
+        assert len(interrupts_found) > 0, (
+            "Sub-agent interrupt() did not propagate to parent checkpoint"
+        )
+
+        # Verify the interrupt value is what the sub-agent passed
+        first_interrupt = interrupts_found[0]
+        assert first_interrupt.value == {
+            "tool_call_id": "tc_sub_1",
+            "message": "Dangerous op",
+        }
+
+        # Resume with approval
+        result = await parent.ainvoke(
+            Command(resume="yes"),
+            config=config,
+        )
+
+        # After resume, the sub-agent should have completed
+        final_msg = result["messages"][-1]
+        assert "Approved: yes" in final_msg.content, (
+            f"Expected 'Approved: yes' in final message, got: {final_msg.content}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Concurrent invocations get distinct checkpoint_ns
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentCheckpointIsolation:
+    """Verify that concurrent sub-agent invocations get distinct checkpoint_ns
+    values, preventing the deadlock that InterruptProxyRunnable caused."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_subagents_get_distinct_namespaces(self):
+        checkpointer = MemorySaver()
+
+        # Track checkpoint_ns values seen during invocations
+        observed_namespaces: list[str] = []
+        invocation_barrier = asyncio.Barrier(2)
+
+        def recording_node(state: MessagesState, config: RunnableConfig) -> dict:
+            ns = config.get("configurable", {}).get("checkpoint_ns", "")
+            observed_namespaces.append(ns)
+            return {"messages": [AIMessage(content=f"Done (ns={ns})")]}
+
+        sub_builder = StateGraph(MessagesState)
+        sub_builder.add_node("work", recording_node)
+        sub_builder.add_edge(START, "work")
+        sub_builder.add_edge("work", END)
+        subgraph = sub_builder.compile()  # checkpointer=None
+
+        # Parent that invokes the sub-agent twice concurrently
+        async def call_sub_twice(state: MessagesState) -> dict:
+            async def invoke_sub():
+                return subgraph.invoke(
+                    {"messages": [HumanMessage(content="task")]},
+                )
+
+            r1, r2 = await asyncio.gather(
+                asyncio.to_thread(lambda: subgraph.invoke(
+                    {"messages": [HumanMessage(content="task-1")]},
+                )),
+                asyncio.to_thread(lambda: subgraph.invoke(
+                    {"messages": [HumanMessage(content="task-2")]},
+                )),
+            )
+
+            return {
+                "messages": [
+                    AIMessage(content=r1["messages"][-1].content),
+                    AIMessage(content=r2["messages"][-1].content),
+                ],
+            }
+
+        parent_builder = StateGraph(MessagesState)
+        parent_builder.add_node("parallel", call_sub_twice)
+        parent_builder.add_edge(START, "parallel")
+        parent_builder.add_edge("parallel", END)
+        parent = parent_builder.compile(checkpointer=checkpointer)
+
+        config = {"configurable": {"thread_id": "concurrent-test"}}
+        await parent.ainvoke(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+        )
+
+        # When invoked outside the parent's Pregel runtime (via to_thread),
+        # the sub-agents don't get checkpoint_ns assigned.  This is expected
+        # for this test structure.  The key verification is that the parent
+        # completes without deadlock and both invocations succeed.
+        assert len(observed_namespaces) == 2, (
+            f"Expected 2 sub-agent invocations, got {len(observed_namespaces)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: GraphInterrupt propagates through try/finally (gate pattern)
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptThroughGate:
+    """Verify that GraphInterrupt propagates cleanly through a try/finally
+    wrapper like _GatedRunnable uses."""
+
+    @pytest.mark.asyncio
+    async def test_interrupt_propagates_through_try_finally(self):
+        """Simulates SubAgentGate's try/finally pattern around a sub-agent
+        that calls interrupt()."""
+        from langgraph.errors import GraphInterrupt
+
+        checkpointer = MemorySaver()
+        subgraph = _build_interrupting_subgraph()
+
+        gate_entered = False
+        gate_exited = False
+
+        def gated_call_sub(state: MessagesState) -> dict:
+            nonlocal gate_entered, gate_exited
+            gate_entered = True
+            try:
+                result = subgraph.invoke(
+                    {"messages": [HumanMessage(content="Do something")]},
+                )
+                return {"messages": [AIMessage(content=result["messages"][-1].content)]}
+            finally:
+                gate_exited = True
+
+        builder = StateGraph(MessagesState)
+        builder.add_node("gated", gated_call_sub)
+        builder.add_edge(START, "gated")
+        builder.add_edge("gated", END)
+        parent = builder.compile(checkpointer=checkpointer)
+
+        config = {"configurable": {"thread_id": "gate-test"}}
+
+        # First call -- interrupt should propagate through try/finally
+        result = await parent.ainvoke(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+        )
+
+        assert gate_entered, "Gate wrapper was never entered"
+        assert gate_exited, "Gate finally block was not executed"
+
+        # Verify parent is interrupted
+        state = await parent.aget_state(config)
+        interrupts = []
+        for task in state.tasks:
+            if hasattr(task, "interrupts"):
+                interrupts.extend(task.interrupts)
+
+        assert len(interrupts) > 0, "Interrupt did not propagate through gate"
+
+        # Resume should work
+        gate_entered = False
+        gate_exited = False
+        result = await parent.ainvoke(
+            Command(resume="approved"),
+            config=config,
+        )
+
+        assert gate_entered, "Gate not entered on resume"
+        assert gate_exited, "Gate not exited on resume"
+        assert "Approved: approved" in result["messages"][-1].content
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Streaming events carry sub-agent namespace metadata
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingNamespaceMetadata:
+    """Verify that astream_events from a parent graph includes events from
+    sub-agents with namespace metadata that identifies the sub-agent."""
+
+    @pytest.mark.asyncio
+    async def test_subagent_events_have_namespace_metadata(self):
+        checkpointer = MemorySaver()
+
+        def sub_node(state: MessagesState) -> dict:
+            return {"messages": [AIMessage(content="sub-agent result")]}
+
+        sub_builder = StateGraph(MessagesState)
+        sub_builder.add_node("sub_work", sub_node)
+        sub_builder.add_edge(START, "sub_work")
+        sub_builder.add_edge("sub_work", END)
+        subgraph = sub_builder.compile(name="my_sub_agent")
+
+        def call_sub(state: MessagesState) -> dict:
+            result = subgraph.invoke(
+                {"messages": [HumanMessage(content="do work")]},
+            )
+            return {"messages": [AIMessage(content=result["messages"][-1].content)]}
+
+        parent_builder = StateGraph(MessagesState)
+        parent_builder.add_node("invoke_sub", call_sub)
+        parent_builder.add_edge(START, "invoke_sub")
+        parent_builder.add_edge("invoke_sub", END)
+        parent = parent_builder.compile(checkpointer=checkpointer)
+
+        config = {"configurable": {"thread_id": "stream-test"}}
+
+        events_with_namespace: list[dict] = []
+        async for event in parent.astream_events(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+            version="v2",
+        ):
+            tags = event.get("tags", [])
+            name = event.get("name", "")
+            ns = event.get("metadata", {}).get("checkpoint_ns", "")
+
+            # Collect events that have any namespace info or come from sub_work
+            if "sub_work" in name or ns:
+                events_with_namespace.append({
+                    "name": name,
+                    "event": event["event"],
+                    "checkpoint_ns": ns,
+                    "tags": tags,
+                })
+
+        # We should see at least some events from the sub-agent
+        # The exact shape depends on LangGraph version, but we need
+        # to confirm that sub-agent events are distinguishable
+        assert len(events_with_namespace) > 0, (
+            "No streaming events found with sub-agent namespace metadata. "
+            "StatusBuilder will not be able to route sub-agent events."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Interrupt value shape -- direct (no proxy wrapping)
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptValueShape:
+    """Verify that with native propagation, the interrupt value from a
+    sub-agent has the DIRECT shape (same as root-agent tools), not the
+    proxy-wrapped nested shape."""
+
+    @pytest.mark.asyncio
+    async def test_interrupt_value_is_direct_not_proxied(self):
+        """The interrupt value should be exactly what the sub-agent passed
+        to interrupt(), without any proxy wrapping or _proxy_interrupt_id."""
+        checkpointer = MemorySaver()
+        subgraph = _build_interrupting_subgraph()
+        parent = _build_parent_with_subagent(subgraph, checkpointer)
+
+        config = {"configurable": {"thread_id": "shape-test"}}
+        await parent.ainvoke(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+        )
+
+        state = await parent.aget_state(config)
+        interrupts = []
+        for task in state.tasks:
+            if hasattr(task, "interrupts"):
+                interrupts.extend(task.interrupts)
+
+        assert len(interrupts) == 1
+        value = interrupts[0].value
+
+        # Direct shape: exactly what the sub-agent tool passed
+        assert isinstance(value, dict)
+        assert value.get("tool_call_id") == "tc_sub_1"
+        assert value.get("message") == "Dangerous op"
+
+        # NOT proxy shape: no _proxy_interrupt_id, no nested sub-interrupt dicts
+        assert "_proxy_interrupt_id" not in value
+        # Proxy shape would be {sub_id: {tool_call_id: ..., _proxy_interrupt_id: ...}}
+        for v in value.values():
+            assert not isinstance(v, dict), (
+                f"Interrupt value contains nested dict -- looks like proxy shape: {value}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: langgraph_checkpoint_ns multi-segment format (T03)
+# ---------------------------------------------------------------------------
+
+
+class TestT03NamespaceFormat:
+    """T03 research: verify that sub-agent events carry multi-segment
+    langgraph_checkpoint_ns values with a consistent root per invocation.
+
+    StatusBuilder uses '|' in the namespace string to distinguish sub-agent
+    events from main-agent events.  Root-prefix matching (the first segment
+    before '|') routes subsequent events from the same sub-agent without
+    re-registration.  This test confirms the format holds with native
+    per-invocation subgraphs (no InterruptProxyRunnable).
+    """
+
+    @pytest.mark.asyncio
+    async def test_namespace_is_multi_segment_with_consistent_root(self):
+        checkpointer = MemorySaver()
+
+        def sub_node(state: MessagesState) -> dict:
+            return {"messages": [AIMessage(content="sub result")]}
+
+        sub_builder = StateGraph(MessagesState)
+        sub_builder.add_node("sub_work", sub_node)
+        sub_builder.add_edge(START, "sub_work")
+        sub_builder.add_edge("sub_work", END)
+        subgraph = sub_builder.compile()
+
+        def call_sub(state: MessagesState) -> dict:
+            result = subgraph.invoke(
+                {"messages": [HumanMessage(content="do it")]},
+            )
+            return {"messages": [AIMessage(content=result["messages"][-1].content)]}
+
+        parent_builder = StateGraph(MessagesState)
+        parent_builder.add_node("tools_node", call_sub)
+        parent_builder.add_edge(START, "tools_node")
+        parent_builder.add_edge("tools_node", END)
+        parent = parent_builder.compile(checkpointer=checkpointer)
+
+        config = {"configurable": {"thread_id": "t03-ns-format"}}
+
+        namespaces_seen: set[str] = set()
+        async for event in parent.astream_events(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+            version="v2",
+        ):
+            metadata = event.get("metadata", {})
+            ns = str(
+                metadata.get("langgraph_checkpoint_ns")
+                or metadata.get("checkpoint_ns")
+                or ""
+            )
+            if ns:
+                namespaces_seen.add(ns)
+
+        multi_segment = {ns for ns in namespaces_seen if "|" in ns}
+        assert multi_segment, (
+            "No multi-segment namespaces (containing '|') found in "
+            "sub-agent events. StatusBuilder cannot distinguish sub-agent "
+            f"events from main-agent events.\nAll namespaces: {namespaces_seen}"
+        )
+
+        roots = {ns.split("|")[0].split(":")[0] for ns in multi_segment}
+        assert len(roots) == 1, (
+            f"Expected single consistent namespace root for one sub-agent "
+            f"invocation, got: {roots}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: parent_ids chain for deterministic routing (T03 Approach B)
+# ---------------------------------------------------------------------------
+
+
+class TestT03ParentIdsRouting:
+    """T03 research: verify that parent_ids on sub-agent v2 events can
+    deterministically link a new namespace to the parent invocation.
+
+    This is the core mechanism for T03 Approach B.  When the first event
+    from a new sub-agent namespace arrives, StatusBuilder checks parent_ids
+    for a known run_id (from the task tool's on_tool_start) to establish
+    the namespace-to-sub-agent mapping without heuristics.
+
+    If parent_ids does NOT trace back to a known parent run_id, Approach B
+    is not viable and an alternative mechanism is needed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_parent_ids_link_subagent_events_to_parent_context(self):
+        checkpointer = MemorySaver()
+
+        def sub_node(state: MessagesState) -> dict:
+            return {"messages": [AIMessage(content="sub result")]}
+
+        sub_builder = StateGraph(MessagesState)
+        sub_builder.add_node("sub_work", sub_node)
+        sub_builder.add_edge(START, "sub_work")
+        sub_builder.add_edge("sub_work", END)
+        subgraph = sub_builder.compile()
+
+        def call_sub(state: MessagesState) -> dict:
+            result = subgraph.invoke(
+                {"messages": [HumanMessage(content="do it")]},
+            )
+            return {"messages": [AIMessage(content=result["messages"][-1].content)]}
+
+        parent_builder = StateGraph(MessagesState)
+        parent_builder.add_node("tools_node", call_sub)
+        parent_builder.add_edge(START, "tools_node")
+        parent_builder.add_edge("tools_node", END)
+        parent = parent_builder.compile(checkpointer=checkpointer)
+
+        config = {"configurable": {"thread_id": "t03-parent-ids"}}
+
+        all_events: list[dict] = []
+        async for event in parent.astream_events(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+            version="v2",
+        ):
+            metadata = event.get("metadata", {})
+            ns = str(
+                metadata.get("langgraph_checkpoint_ns")
+                or metadata.get("checkpoint_ns")
+                or ""
+            )
+            all_events.append({
+                "event": event["event"],
+                "name": event.get("name", ""),
+                "run_id": event.get("run_id", ""),
+                "parent_ids": event.get("parent_ids", []),
+                "namespace": ns,
+                "langgraph_node": metadata.get("langgraph_node", ""),
+            })
+
+        main_events = [e for e in all_events if "|" not in e["namespace"]]
+        sub_events = [e for e in all_events if "|" in e["namespace"]]
+
+        assert sub_events, (
+            "No sub-agent events found (no multi-segment namespaces)"
+        )
+
+        # Run_ids that StatusBuilder would already know about when the
+        # first sub-agent event arrives (main-agent events are processed
+        # before sub-agent events in the stream).
+        known_run_ids = {e["run_id"] for e in main_events if e["run_id"]}
+
+        # For each sub-agent event, check if parent_ids includes any
+        # known main-agent run_id.
+        linked = []
+        for e in sub_events:
+            matching = [pid for pid in e["parent_ids"] if pid in known_run_ids]
+            if matching:
+                linked.append({
+                    "event": e["event"],
+                    "name": e["name"],
+                    "namespace": e["namespace"],
+                    "matching_parent_ids": matching,
+                })
+
+        assert linked, (
+            "T03 Approach B NOT viable: sub-agent events do not have "
+            "parent_ids linking to any main-agent run_id.\n"
+            f"Known main-agent run_ids: {known_run_ids}\n"
+            f"Sub-agent parent_ids (first 3): "
+            f"{[e['parent_ids'] for e in sub_events[:3]]}\n"
+            "Fallback: investigate checkpoint_ns injection or namespace "
+            "structure-based matching."
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_subagents_have_distinct_namespaces_and_parent_ids(self):
+        """When two sub-agents are invoked from the same parent node, they
+        share a namespace ROOT (the parent node name) but have distinct
+        FULL namespace paths and distinct parent_ids chains.
+
+        This matches production: all sub-agents are invoked from the tools
+        node via the task tool, so the namespace root is always 'tools'.
+        StatusBuilder must use parent_ids (not namespace root) to distinguish
+        which sub-agent owns which namespace."""
+        checkpointer = MemorySaver()
+
+        def sub_a_node(state: MessagesState) -> dict:
+            return {"messages": [AIMessage(content="result-A")]}
+
+        def sub_b_node(state: MessagesState) -> dict:
+            return {"messages": [AIMessage(content="result-B")]}
+
+        sub_a_builder = StateGraph(MessagesState)
+        sub_a_builder.add_node("work_a", sub_a_node)
+        sub_a_builder.add_edge(START, "work_a")
+        sub_a_builder.add_edge("work_a", END)
+        subgraph_a = sub_a_builder.compile()
+
+        sub_b_builder = StateGraph(MessagesState)
+        sub_b_builder.add_node("work_b", sub_b_node)
+        sub_b_builder.add_edge(START, "work_b")
+        sub_b_builder.add_edge("work_b", END)
+        subgraph_b = sub_b_builder.compile()
+
+        def call_both(state: MessagesState) -> dict:
+            r_a = subgraph_a.invoke(
+                {"messages": [HumanMessage(content="task-a")]},
+            )
+            r_b = subgraph_b.invoke(
+                {"messages": [HumanMessage(content="task-b")]},
+            )
+            return {
+                "messages": [
+                    AIMessage(content=r_a["messages"][-1].content),
+                    AIMessage(content=r_b["messages"][-1].content),
+                ],
+            }
+
+        parent_builder = StateGraph(MessagesState)
+        parent_builder.add_node("tools_node", call_both)
+        parent_builder.add_edge(START, "tools_node")
+        parent_builder.add_edge("tools_node", END)
+        parent = parent_builder.compile(checkpointer=checkpointer)
+
+        config = {"configurable": {"thread_id": "t03-concurrent"}}
+
+        all_events: list[dict] = []
+        async for event in parent.astream_events(
+            {"messages": [HumanMessage(content="Go")]},
+            config=config,
+            version="v2",
+        ):
+            metadata = event.get("metadata", {})
+            ns = str(
+                metadata.get("langgraph_checkpoint_ns")
+                or metadata.get("checkpoint_ns")
+                or ""
+            )
+            all_events.append({
+                "event": event["event"],
+                "name": event.get("name", ""),
+                "run_id": event.get("run_id", ""),
+                "parent_ids": event.get("parent_ids", []),
+                "namespace": ns,
+            })
+
+        sub_events = [e for e in all_events if "|" in e["namespace"]]
+        assert sub_events, "No sub-agent events found"
+
+        # Full namespace paths must be distinct even though roots are shared.
+        # LangGraph assigns unique task_ids and sequential counters per
+        # invocation within the same parent node.
+        distinct_namespaces = {e["namespace"] for e in sub_events}
+        assert len(distinct_namespaces) >= 2, (
+            "Expected distinct full namespace paths for different sub-agents, "
+            f"got: {distinct_namespaces}"
+        )
+
+        # parent_ids must differ between the two sub-agents' events.
+        # The deepest parent_id in the chain is the sub-agent graph's own
+        # root run_id, which is unique per invocation.
+        parent_id_sets = set()
+        for e in sub_events:
+            if e["parent_ids"]:
+                parent_id_sets.add(tuple(e["parent_ids"]))
+
+        assert len(parent_id_sets) >= 2, (
+            "Expected distinct parent_ids chains for different sub-agents. "
+            f"Got {len(parent_id_sets)} unique chain(s): {parent_id_sets}"
+        )

--- a/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
+++ b/backend/libs/python/graphton/tests/core/test_native_subgraph_interrupt.py
@@ -31,7 +31,6 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import Command, interrupt
 
-
 # ---------------------------------------------------------------------------
 # Helpers: build a minimal sub-agent that calls interrupt()
 # ---------------------------------------------------------------------------

--- a/backend/libs/python/graphton/tests/core/test_recursion_limit.py
+++ b/backend/libs/python/graphton/tests/core/test_recursion_limit.py
@@ -546,7 +546,7 @@ class TestGatedGeneralPurposeSubAgent:
     """
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_no_explicit_subagents_injects_general_purpose(
         self, mock_parse, mock_compile, mock_create
@@ -590,7 +590,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert subagents_passed[0]["runnable"] is not mock_runnable
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_with_explicit_subagents_appends_general_purpose(
         self, mock_parse, mock_compile, mock_create
@@ -665,7 +665,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert subagents_passed == test_subagents
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_general_purpose_agent_false_skips_injection(
         self, mock_parse, mock_compile, mock_create
@@ -697,7 +697,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert len(subagents_passed) == 0
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_general_purpose_uses_main_agent_model_and_prompt(
         self, mock_parse, mock_compile, mock_create
@@ -733,7 +733,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert compile_kwargs["name"] == "general-purpose"
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_general_purpose_shares_gate_with_explicit_subagents(
         self, mock_parse, mock_compile, mock_create
@@ -787,7 +787,7 @@ class TestGatedGeneralPurposeSubAgent:
         )
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     @patch("graphton.core.tool_wrappers.create_platform_tool_wrappers")
     @patch("graphton.core.sandbox_factory.create_sandbox_backend")
@@ -843,7 +843,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert mock_write_tool in gp_tools
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     @patch("graphton.core.tool_wrappers.create_platform_tool_wrappers")
     @patch("graphton.core.sandbox_factory.create_sandbox_backend")
@@ -898,7 +898,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert gp_call.kwargs.get("approval_checker") is mock_checker
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_gp_subagent_skipped_when_no_tools_available(
         self, mock_parse, mock_compile, mock_create

--- a/backend/libs/python/graphton/tests/core/test_recursion_limit.py
+++ b/backend/libs/python/graphton/tests/core/test_recursion_limit.py
@@ -541,12 +541,12 @@ class TestGatedGeneralPurposeSubAgent:
 
     When a checkpointer AND approval_checker are both present (HITL path),
     graphton injects an explicit CompiledSubAgent named "general-purpose"
-    compiled through compile_subagent_with_proxy and wrapped with
+    compiled through compile_subagent and wrapped with
     SubAgentGate.  This overrides deepagents' automatic ungated clone.
     """
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_no_explicit_subagents_injects_general_purpose(
         self, mock_parse, mock_compile, mock_create
@@ -590,7 +590,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert subagents_passed[0]["runnable"] is not mock_runnable
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_with_explicit_subagents_appends_general_purpose(
         self, mock_parse, mock_compile, mock_create
@@ -665,7 +665,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert subagents_passed == test_subagents
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_general_purpose_agent_false_skips_injection(
         self, mock_parse, mock_compile, mock_create
@@ -697,7 +697,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert len(subagents_passed) == 0
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_general_purpose_uses_main_agent_model_and_prompt(
         self, mock_parse, mock_compile, mock_create
@@ -733,7 +733,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert compile_kwargs["name"] == "general-purpose"
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_general_purpose_shares_gate_with_explicit_subagents(
         self, mock_parse, mock_compile, mock_create
@@ -787,7 +787,7 @@ class TestGatedGeneralPurposeSubAgent:
         )
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     @patch("graphton.core.tool_wrappers.create_platform_tool_wrappers")
     @patch("graphton.core.sandbox_factory.create_sandbox_backend")
@@ -843,7 +843,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert mock_write_tool in gp_tools
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     @patch("graphton.core.tool_wrappers.create_platform_tool_wrappers")
     @patch("graphton.core.sandbox_factory.create_sandbox_backend")
@@ -898,7 +898,7 @@ class TestGatedGeneralPurposeSubAgent:
         assert gp_call.kwargs.get("approval_checker") is mock_checker
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_gp_subagent_skipped_when_no_tools_available(
         self, mock_parse, mock_compile, mock_create

--- a/backend/libs/python/graphton/tests/core/test_subagent_guardrails.py
+++ b/backend/libs/python/graphton/tests/core/test_subagent_guardrails.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from graphton.core.execution_budget import ExecutionBudgetMiddleware
-from graphton.core.interrupt_proxy import (
+from graphton.core.subagent import (
     _SUB_AGENT_ADVISORY_INTERVAL,
     _SUB_AGENT_MAX_ADVISORIES,
     _UNLIMITED_RECURSION,
@@ -46,7 +46,7 @@ def mock_tools():
 class TestGuardrailInjection:
     """Verify that compile_subagent injects guardrail middleware."""
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_injects_loop_detection(self, mock_create_agent, mock_model, mock_tools):
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
@@ -66,7 +66,7 @@ class TestGuardrailInjection:
         loop_detection = [m for m in middleware_list if isinstance(m, LoopDetectionMiddleware)]
         assert len(loop_detection) == 1
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_injects_tool_truncation(self, mock_create_agent, mock_model, mock_tools):
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
@@ -86,7 +86,7 @@ class TestGuardrailInjection:
         truncation_mw = [m for m in middleware_list if isinstance(m, ToolTruncationMiddleware)]
         assert len(truncation_mw) == 1
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_injects_execution_budget_periodic(self, mock_create_agent, mock_model, mock_tools):
         """ExecutionBudgetMiddleware is injected in periodic mode."""
         mock_graph = MagicMock()
@@ -112,7 +112,7 @@ class TestGuardrailInjection:
         assert mw.warning_interval == _SUB_AGENT_ADVISORY_INTERVAL
         assert mw.max_warnings == _SUB_AGENT_MAX_ADVISORIES
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_preserves_caller_middleware(self, mock_create_agent, mock_model, mock_tools):
         """Caller-provided middleware is preserved alongside auto-injected ones."""
         mock_graph = MagicMock()
@@ -137,7 +137,7 @@ class TestGuardrailInjection:
         assert sentinel in middleware_list
         assert len(middleware_list) == 4  # sentinel + 3 guardrails
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_total_guardrail_count(self, mock_create_agent, mock_model, mock_tools):
         """Three guardrails are injected: loop detection, truncation, budget."""
         mock_graph = MagicMock()
@@ -157,7 +157,7 @@ class TestGuardrailInjection:
 
         assert len(middleware_list) == 3
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_no_checkpointer_passed(self, mock_create_agent, mock_model, mock_tools):
         """compile_subagent must NOT pass checkpointer to create_agent
         (LangGraph per-invocation mode: sub-agent inherits parent's)."""
@@ -176,7 +176,7 @@ class TestGuardrailInjection:
         call_kwargs = mock_create_agent.call_args
         assert "checkpointer" not in (call_kwargs.kwargs or {})
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_returns_compiled_graph_directly(self, mock_create_agent, mock_model, mock_tools):
         """The returned runnable should be the compiled graph, not a proxy wrapper."""
         mock_graph = MagicMock()
@@ -200,7 +200,7 @@ class TestGuardrailInjection:
 class TestRecursionLimitForwarding:
     """Verify recursion_limit is forwarded to the compiled graph."""
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_default_recursion_limit_is_unlimited(self, mock_create_agent, mock_model, mock_tools):
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
@@ -218,7 +218,7 @@ class TestRecursionLimitForwarding:
             {"recursion_limit": _UNLIMITED_RECURSION},
         )
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_custom_recursion_limit(self, mock_create_agent, mock_model, mock_tools):
         mock_graph = MagicMock()
         mock_graph.with_config = MagicMock(return_value=mock_graph)
@@ -237,7 +237,7 @@ class TestRecursionLimitForwarding:
             {"recursion_limit": 100},
         )
 
-    @patch("graphton.core.interrupt_proxy.create_agent")
+    @patch("graphton.core.subagent.create_agent")
     def test_none_recursion_limit_uses_unlimited(self, mock_create_agent, mock_model, mock_tools):
         """Passing recursion_limit=None falls back to unlimited."""
         mock_graph = MagicMock()

--- a/backend/libs/python/graphton/tests/core/test_subagent_guardrails.py
+++ b/backend/libs/python/graphton/tests/core/test_subagent_guardrails.py
@@ -12,19 +12,18 @@ nudges only, no hard stop.
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from graphton.core.execution_budget import ExecutionBudgetMiddleware
+from graphton.core.loop_detection import LoopDetectionMiddleware
 from graphton.core.subagent import (
     _SUB_AGENT_ADVISORY_INTERVAL,
     _SUB_AGENT_MAX_ADVISORIES,
     _UNLIMITED_RECURSION,
     compile_subagent,
 )
-from graphton.core.loop_detection import LoopDetectionMiddleware
 from graphton.core.tool_truncation import ToolTruncationMiddleware
 
 

--- a/backend/libs/python/graphton/tests/core/test_subagent_model_routing.py
+++ b/backend/libs/python/graphton/tests/core/test_subagent_model_routing.py
@@ -1,14 +1,14 @@
 """Tests for per-sub-agent model routing in the HITL compilation path.
 
 The HITL path in ``create_deep_agent`` compiles each sub-agent via
-``compile_subagent_with_proxy``.  When a sub-agent dict carries a
-``"model"`` key, the HITL path must resolve it (via ``parse_model_string``
-for strings) and pass the resolved instance — not the parent's model —
-to ``compile_subagent_with_proxy``.
+``compile_subagent``.  When a sub-agent dict carries a ``"model"`` key,
+the HITL path must resolve it (via ``parse_model_string`` for strings)
+and pass the resolved instance — not the parent's model — to
+``compile_subagent``.
 
 Tests:
 - Sub-agent with ``"model"`` string: resolved via ``parse_model_string``,
-  override instance passed to ``compile_subagent_with_proxy``.
+  override instance passed to ``compile_subagent``.
 - Sub-agent with ``"model"`` as a ``BaseChatModel`` instance: used directly.
 - Sub-agent without ``"model"``: parent model used (regression guard).
 - Mixed list: each sub-agent gets the correct model.
@@ -60,7 +60,7 @@ class TestSubagentModelRouting:
     """HITL path: per-sub-agent model override in create_deep_agent."""
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_string_model_override_resolved_via_parse_model_string(
         self,
@@ -70,7 +70,7 @@ class TestSubagentModelRouting:
     ):
         """A sub-agent with model='claude-haiku-4.5' triggers a second
         parse_model_string call, and the result is passed to
-        compile_subagent_with_proxy instead of the parent model."""
+        compile_subagent instead of the parent model."""
         from graphton.core.agent import create_deep_agent
 
         mock_parent = MagicMock(name="parent-model")
@@ -105,7 +105,7 @@ class TestSubagentModelRouting:
         assert explicit_call.kwargs["model"] is mock_override
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_model_instance_used_directly(
         self,
@@ -138,7 +138,7 @@ class TestSubagentModelRouting:
         assert explicit_call.kwargs["model"] is pre_built
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_no_model_key_uses_parent_model(
         self,
@@ -169,7 +169,7 @@ class TestSubagentModelRouting:
         assert explicit_call.kwargs["model"] is mock_parent
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_mixed_subagents_each_get_correct_model(
         self,

--- a/backend/libs/python/graphton/tests/core/test_subagent_model_routing.py
+++ b/backend/libs/python/graphton/tests/core/test_subagent_model_routing.py
@@ -60,7 +60,7 @@ class TestSubagentModelRouting:
     """HITL path: per-sub-agent model override in create_deep_agent."""
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_string_model_override_resolved_via_parse_model_string(
         self,
@@ -105,7 +105,7 @@ class TestSubagentModelRouting:
         assert explicit_call.kwargs["model"] is mock_override
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_model_instance_used_directly(
         self,
@@ -138,7 +138,7 @@ class TestSubagentModelRouting:
         assert explicit_call.kwargs["model"] is pre_built
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_no_model_key_uses_parent_model(
         self,
@@ -169,7 +169,7 @@ class TestSubagentModelRouting:
         assert explicit_call.kwargs["model"] is mock_parent
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_mixed_subagents_each_get_correct_model(
         self,

--- a/backend/libs/python/graphton/tests/core/test_summarization_middleware.py
+++ b/backend/libs/python/graphton/tests/core/test_summarization_middleware.py
@@ -516,7 +516,7 @@ class TestSubAgentSummarizationPropagation:
         ]
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_injects_summarization_middleware(
         self,
@@ -563,7 +563,7 @@ class TestSubAgentSummarizationPropagation:
             assert summarization_mws[0]._callback is None
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_distinct_middleware_instances(
         self,
@@ -608,7 +608,7 @@ class TestSubAgentSummarizationPropagation:
         assert len(set(id(i) for i in instances)) == 3
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_skips_precompiled_subagents(
         self,
@@ -648,7 +648,7 @@ class TestSubAgentSummarizationPropagation:
         assert gp_call.kwargs["name"] == "general-purpose"
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent_with_proxy")
+    @patch("graphton.core.interrupt_proxy.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_no_injection_when_disabled(
         self,

--- a/backend/libs/python/graphton/tests/core/test_summarization_middleware.py
+++ b/backend/libs/python/graphton/tests/core/test_summarization_middleware.py
@@ -516,7 +516,7 @@ class TestSubAgentSummarizationPropagation:
         ]
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_injects_summarization_middleware(
         self,
@@ -563,7 +563,7 @@ class TestSubAgentSummarizationPropagation:
             assert summarization_mws[0]._callback is None
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_distinct_middleware_instances(
         self,
@@ -608,7 +608,7 @@ class TestSubAgentSummarizationPropagation:
         assert len(set(id(i) for i in instances)) == 3
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_skips_precompiled_subagents(
         self,
@@ -648,7 +648,7 @@ class TestSubAgentSummarizationPropagation:
         assert gp_call.kwargs["name"] == "general-purpose"
 
     @patch("graphton.core.agent.deepagents_create_deep_agent")
-    @patch("graphton.core.interrupt_proxy.compile_subagent")
+    @patch("graphton.core.subagent.compile_subagent")
     @patch("graphton.core.agent.parse_model_string")
     def test_hitl_path_no_injection_when_disabled(
         self,

--- a/backend/services/agent-runner/tests/test_hitl_contracts.py
+++ b/backend/services/agent-runner/tests/test_hitl_contracts.py
@@ -1,13 +1,11 @@
-"""Contract tests for the HITL approval flow (post-T03 simplification).
+"""Contract tests for the HITL approval flow.
 
 Tests cover:
   - ResumeReconciler: tool call transitions, auto-skip, stale completed_at
   - Index rebuild on resume: rebuild_index_from_persisted_status
-  - Pending approvals snapshot: Temporal coordination signal
-  - slim_status_for_temporal: snapshot preserved through slim copy
+  - slim_status_for_temporal: phase-only slim copy
   - Task tool early-TC reconciliation on resume path
   - Bidirectional ID lookup: defense-in-depth for ID mismatches
-  - Interrupt-based snapshot: build_snapshot_from_interrupts
   - Checkpoint orphan reconciliation: reconcile_orphans_against_checkpoint
 """
 
@@ -31,7 +29,6 @@ from google.protobuf.struct_pb2 import Struct
 
 from worker.activities.graphton.hitl import (
     ResumeReconciler,
-    build_snapshot_from_interrupts,
     extract_approval_decisions_from_execution,
     extract_interrupt_tool_call_ids,
 )
@@ -281,154 +278,43 @@ class TestIndexRebuildOnResume:
 
 
 # =============================================================================
-# Pending approvals snapshot for Temporal coordination
+# slim_status_for_temporal: phase-only slim copy
 # =============================================================================
 
 
-class TestBuildPendingApprovalsSnapshot:
-    """Verify the point-in-time snapshot used for Temporal signal counting.
-
-    This snapshot is populated in post_stream.py and returned via the slim
-    status to the Go workflow.  It must match the same filter criteria as
-    Go's ComputePendingApprovals: WAITING_APPROVAL + requires_approval +
-    approval_action == UNSPECIFIED.
+class TestSlimStatusPhaseOnly:
+    """Verify that slim_status_for_temporal carries only workflow-critical
+    fields (phase, error, timestamps).  pending_approvals is intentionally
+    omitted — the Go/Java workflow reads it from the DB via loadExecution().
     """
 
-    def test_snapshot_includes_waiting_approval_tools(self):
-        tc = ToolCall(
-            id="call_1",
-            name="delete_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=True,
+    def test_slim_status_carries_phase_and_timestamps(self):
+        from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ExecutionPhase
+
+        status = AgentExecutionStatus(
+            phase=ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+            started_at="2026-03-29T00:00:00Z",
         )
-        builder = _make_builder_with_decisions([tc])
+        slim = slim_status_for_temporal(status)
 
-        snapshot = builder.build_pending_approvals_snapshot()
+        assert slim.phase == ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL
+        assert slim.started_at == "2026-03-29T00:00:00Z"
 
-        assert len(snapshot) == 1
-        assert snapshot[0].tool_call_id == "call_1"
+    def test_slim_status_omits_pending_approvals(self):
+        from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
 
-    def test_snapshot_excludes_tools_with_decision_recorded(self):
-        tc = ToolCall(
-            id="call_1",
-            name="delete_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=True,
-            approval_action=ApprovalAction.APPROVAL_ACTION_APPROVE,
-        )
-        builder = _make_builder_with_decisions([tc])
-
-        snapshot = builder.build_pending_approvals_snapshot()
-
-        assert len(snapshot) == 0
-
-    def test_snapshot_excludes_completed_tools(self):
-        tc = ToolCall(
-            id="call_1",
-            name="read_file",
-            status=ToolCallStatus.TOOL_CALL_COMPLETED,
-            requires_approval=False,
-        )
-        builder = _make_builder_with_decisions([tc])
-
-        snapshot = builder.build_pending_approvals_snapshot()
-
-        assert len(snapshot) == 0
-
-    def test_snapshot_excludes_tools_not_requiring_approval(self):
-        tc = ToolCall(
-            id="call_1",
-            name="read_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=False,
-        )
-        builder = _make_builder_with_decisions([tc])
-
-        snapshot = builder.build_pending_approvals_snapshot()
-
-        assert len(snapshot) == 0
-
-    def test_snapshot_batch_returns_all_pending(self):
-        tc1 = ToolCall(
-            id="call_1",
-            name="delete_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=True,
-        )
-        tc2 = ToolCall(
-            id="call_2",
-            name="write_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=True,
-        )
-        tc3 = ToolCall(
-            id="call_3",
-            name="read_file",
-            status=ToolCallStatus.TOOL_CALL_COMPLETED,
-            requires_approval=False,
-        )
-        builder = _make_builder_with_decisions([tc1, tc2, tc3])
-
-        snapshot = builder.build_pending_approvals_snapshot()
-
-        assert len(snapshot) == 2
-        ids = {pa.tool_call_id for pa in snapshot}
-        assert ids == {"call_1", "call_2"}
-
-    def test_snapshot_empty_when_no_tool_calls(self):
         status = AgentExecutionStatus()
-        builder = StatusBuilder("test_exec", status)
-
-        snapshot = builder.build_pending_approvals_snapshot()
-
-        assert len(snapshot) == 0
-
-
-# =============================================================================
-# slim_status_for_temporal: snapshot preservation
-# =============================================================================
-
-
-class TestSlimStatusPreservesSnapshot:
-    """Verify that slim_status_for_temporal copies pending_approvals
-    from the full status, ensuring the Temporal workflow receives the
-    snapshot built by build_pending_approvals_snapshot().
-    """
-
-    def test_slim_status_carries_pending_approvals(self):
-        tc1 = ToolCall(
-            id="call_1",
-            name="delete_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=True,
+        status.pending_approvals.append(
+            PendingApproval(tool_call_id="call_1"),
         )
-        tc2 = ToolCall(
-            id="call_2",
-            name="write_file",
-            status=ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
-            requires_approval=True,
-        )
-        builder = _make_builder_with_decisions([tc1, tc2])
 
-        snapshot = builder.build_pending_approvals_snapshot()
-        del builder.current_status.pending_approvals[:]
-        builder.current_status.pending_approvals.extend(snapshot)
-
-        slim = slim_status_for_temporal(builder.current_status)
-
-        assert len(slim.pending_approvals) == 2
-        ids = {pa.tool_call_id for pa in slim.pending_approvals}
-        assert ids == {"call_1", "call_2"}
-
-    def test_slim_status_empty_when_no_pending(self):
-        status = AgentExecutionStatus()
         slim = slim_status_for_temporal(status)
 
         assert len(slim.pending_approvals) == 0
 
 
 # =============================================================================
-# Proxy interrupt round-trip: InterruptProxy -> resume matching
+# Direct interrupt round-trip: resume matching
 # =============================================================================
 
 
@@ -1182,32 +1068,6 @@ class TestExtractInterruptToolCallIds:
     def test_missing_tool_call_id_skipped(self):
         interrupts = [_FakeInterrupt("intr-1", {"message": "no tc id"})]
         assert extract_interrupt_tool_call_ids(interrupts) == set()
-
-
-class TestBuildSnapshotFromInterrupts:
-    """Verify build_snapshot_from_interrupts returns sorted PendingApproval list."""
-
-    def test_returns_pending_approvals_for_each_tc_id(self):
-        interrupts = [
-            _FakeInterrupt("intr-1", {"tool_call_id": "tc_b"}),
-            _FakeInterrupt("intr-2", {"tool_call_id": "tc_a"}),
-        ]
-        snapshot = build_snapshot_from_interrupts(interrupts)
-        assert len(snapshot) == 2
-        assert snapshot[0].tool_call_id == "tc_a"
-        assert snapshot[1].tool_call_id == "tc_b"
-
-    def test_empty_interrupts_returns_empty(self):
-        assert build_snapshot_from_interrupts([]) == []
-
-    def test_sub_agent_interrupts_included(self):
-        """Sub-agent interrupts use the same direct shape and are included."""
-        interrupts = [
-            _FakeInterrupt("intr-sub", {"tool_call_id": "tc_sub", "message": "sub tool"}),
-        ]
-        snapshot = build_snapshot_from_interrupts(interrupts)
-        assert len(snapshot) == 1
-        assert snapshot[0].tool_call_id == "tc_sub"
 
 
 # =============================================================================

--- a/backend/services/agent-runner/tests/test_hitl_contracts.py
+++ b/backend/services/agent-runner/tests/test_hitl_contracts.py
@@ -440,14 +440,13 @@ class _MockInterrupt:
         self.value = value
 
 
-class TestProxyInterruptResume:
-    """Contract tests between InterruptProxyRunnable._build_proxy_payload
-    and the resume matching loop in execute_graphton.py.
+class TestDirectInterruptResume:
+    """Contract tests for the direct interrupt shape used by both root-agent
+    and sub-agent tools (via LangGraph native per-invocation mode).
 
-    The proxy wraps sub-agent interrupts into a nested dict.  The resume
-    loop must detect the proxy shape and build a nested resume dict that
-    InterruptProxyRunnable passes through as Command(resume=decisions)
-    to the sub-agent graph.
+    All interrupts have the same shape:
+        intr.value = {"tool_call_id": "tc_abc", "message": "..."}
+        resume_dict[intr.id] = {"action": "approve"}
     """
 
     @staticmethod
@@ -466,43 +465,24 @@ class TestProxyInterruptResume:
         """Replicate the matching loop from execute_graphton.py."""
         from worker.activities.execute_graphton import _build_decision_value
 
-        action_map = TestProxyInterruptResume._action_map()
+        action_map = TestDirectInterruptResume._action_map()
         decisions_by_tc = {d.tool_call_id: d for d in decisions}
         resume_dict: dict = {}
 
         for intr in interrupts:
             intr_value = intr.value if isinstance(intr.value, dict) else {}
-
-            direct_tc_id = intr_value.get("tool_call_id", "")
-            if direct_tc_id:
-                decision = decisions_by_tc.get(direct_tc_id)
+            tc_id = intr_value.get("tool_call_id", "")
+            if tc_id:
+                decision = decisions_by_tc.get(tc_id)
                 if decision:
                     resume_dict[intr.id] = _build_decision_value(
                         decision, action_map,
                     )
-                continue
-
-            sub_decisions: dict = {}
-            for sub_id, sub_value in intr_value.items():
-                if not isinstance(sub_value, dict):
-                    continue
-                if "_proxy_interrupt_id" not in sub_value:
-                    continue
-                sub_tc_id = sub_value.get("tool_call_id", "")
-                if not sub_tc_id:
-                    continue
-                decision = decisions_by_tc.get(sub_tc_id)
-                if decision:
-                    sub_decisions[sub_id] = _build_decision_value(
-                        decision, action_map,
-                    )
-            if sub_decisions:
-                resume_dict[intr.id] = sub_decisions
 
         return resume_dict
 
     def test_direct_interrupt_matches(self):
-        """Direct interrupt (main-agent tool) matches on top-level tool_call_id."""
+        """Direct interrupt matches on top-level tool_call_id."""
         interrupts = [
             _MockInterrupt(
                 id="intr-1",
@@ -520,95 +500,18 @@ class TestProxyInterruptResume:
 
         assert result == {"intr-1": {"action": "approve"}}
 
-    def test_proxy_interrupt_matches(self):
-        """Proxied sub-agent interrupts match on nested tool_call_id."""
-        from graphton.core.interrupt_proxy import InterruptProxyRunnable
-
-        sub_interrupts = [
+    def test_multiple_interrupts_match(self):
+        """Multiple direct interrupts (root + sub-agent) all match correctly."""
+        interrupts = [
             _MockInterrupt(
-                id="sub-intr-a",
-                value={"tool_call_id": "tc_xyz", "message": "git clone?"},
+                id="intr-root",
+                value={"tool_call_id": "tc_main", "message": "main tool"},
             ),
             _MockInterrupt(
-                id="sub-intr-b",
-                value={"tool_call_id": "tc_123", "message": "rm -rf?"},
-            ),
-        ]
-        proxy_payload = InterruptProxyRunnable._build_proxy_payload(
-            sub_interrupts,
-        )
-
-        parent_interrupt = _MockInterrupt(id="parent-intr-1", value=proxy_payload)
-
-        decisions = [
-            SubmitApprovalInput(
-                tool_call_id="tc_xyz",
-                action=ApprovalAction.APPROVAL_ACTION_APPROVE,
-            ),
-            SubmitApprovalInput(
-                tool_call_id="tc_123",
-                action=ApprovalAction.APPROVAL_ACTION_SKIP,
-            ),
-        ]
-
-        result = self._run_matching([parent_interrupt], decisions)
-
-        assert "parent-intr-1" in result
-        nested = result["parent-intr-1"]
-        assert isinstance(nested, dict)
-        assert nested["sub-intr-a"] == {"action": "approve"}
-        assert nested["sub-intr-b"] == {"action": "skip"}
-
-    def test_proxy_partial_decisions(self):
-        """Only sub-interrupts with matching decisions appear in the resume dict."""
-        from graphton.core.interrupt_proxy import InterruptProxyRunnable
-
-        sub_interrupts = [
-            _MockInterrupt(
-                id="sub-a",
-                value={"tool_call_id": "tc_1", "message": "cmd 1"},
-            ),
-            _MockInterrupt(
-                id="sub-b",
-                value={"tool_call_id": "tc_2", "message": "cmd 2"},
-            ),
-        ]
-        proxy_payload = InterruptProxyRunnable._build_proxy_payload(sub_interrupts)
-        parent = _MockInterrupt(id="p-1", value=proxy_payload)
-
-        decisions = [
-            SubmitApprovalInput(
-                tool_call_id="tc_1",
-                action=ApprovalAction.APPROVAL_ACTION_APPROVE,
-            ),
-        ]
-
-        result = self._run_matching([parent], decisions)
-
-        nested = result["p-1"]
-        assert "sub-a" in nested
-        assert "sub-b" not in nested
-
-    def test_mixed_direct_and_proxy(self):
-        """Both direct and proxy interrupts in the same checkpoint are handled."""
-        from graphton.core.interrupt_proxy import InterruptProxyRunnable
-
-        sub_interrupts = [
-            _MockInterrupt(
-                id="sub-x",
+                id="intr-sub",
                 value={"tool_call_id": "tc_sub", "message": "sub tool"},
             ),
         ]
-        proxy_payload = InterruptProxyRunnable._build_proxy_payload(sub_interrupts)
-
-        interrupts = [
-            _MockInterrupt(
-                id="direct-1",
-                value={"tool_call_id": "tc_main", "message": "main tool"},
-            ),
-            _MockInterrupt(id="proxy-1", value=proxy_payload),
-        ]
-
         decisions = [
             SubmitApprovalInput(
                 tool_call_id="tc_main",
@@ -622,8 +525,8 @@ class TestProxyInterruptResume:
 
         result = self._run_matching(interrupts, decisions)
 
-        assert result["direct-1"] == {"action": "reject"}
-        assert result["proxy-1"]["sub-x"] == {"action": "approve"}
+        assert result["intr-root"] == {"action": "reject"}
+        assert result["intr-sub"] == {"action": "approve"}
 
     def test_no_match_returns_empty(self):
         """When no interrupt matches any decision, resume_dict is empty."""
@@ -644,23 +547,29 @@ class TestProxyInterruptResume:
 
         assert result == {}
 
-    def test_proxy_payload_structure(self):
-        """_build_proxy_payload preserves tool_call_id and adds _proxy_interrupt_id."""
-        from graphton.core.interrupt_proxy import InterruptProxyRunnable
-
-        sub_interrupts = [
+    def test_partial_decisions(self):
+        """Only interrupts with matching decisions appear in the resume dict."""
+        interrupts = [
             _MockInterrupt(
-                id="si-1",
-                value={"tool_call_id": "tc_hello", "message": "hello"},
+                id="intr-1",
+                value={"tool_call_id": "tc_1", "message": "cmd 1"},
+            ),
+            _MockInterrupt(
+                id="intr-2",
+                value={"tool_call_id": "tc_2", "message": "cmd 2"},
             ),
         ]
-        payload = InterruptProxyRunnable._build_proxy_payload(sub_interrupts)
+        decisions = [
+            SubmitApprovalInput(
+                tool_call_id="tc_1",
+                action=ApprovalAction.APPROVAL_ACTION_APPROVE,
+            ),
+        ]
 
-        assert "si-1" in payload
-        entry = payload["si-1"]
-        assert entry["tool_call_id"] == "tc_hello"
-        assert entry["message"] == "hello"
-        assert entry["_proxy_interrupt_id"] == "si-1"
+        result = self._run_matching(interrupts, decisions)
+
+        assert "intr-1" in result
+        assert "intr-2" not in result
 
     def test_summarize_direct(self):
         """_summarize_resume_entry formats direct decisions correctly."""
@@ -668,17 +577,6 @@ class TestProxyInterruptResume:
 
         result = _summarize_resume_entry("abcd1234efgh5678", {"action": "approve"})
         assert "action=approve" in result
-
-    def test_summarize_proxy(self):
-        """_summarize_resume_entry formats proxy payloads correctly."""
-        from worker.activities.execute_graphton import _summarize_resume_entry
-
-        result = _summarize_resume_entry(
-            "parent-id-123456",
-            {"sub-a": {"action": "approve"}, "sub-b": {"action": "skip"}},
-        )
-        assert "proxy" in result
-        assert "2 sub-decision" in result
 
 
 # =============================================================================
@@ -968,7 +866,7 @@ class TestBidirectionalIdLookup:
 
     When the status ToolCall carries a UUID-format ID (from the run_id
     fallback) but the interrupt payload carries the Anthropic toolu_* ID,
-    the primary ``decisions_by_tc.get(sub_tc_id)`` lookup fails.  The
+    the primary ``decisions_by_tc.get(tc_id)`` lookup fails.  The
     bidirectional fallback pairs unmatched decisions with unmatched
     interrupts.
     """
@@ -992,66 +890,34 @@ class TestBidirectionalIdLookup:
 
         for intr in interrupts:
             intr_value = intr.value if isinstance(intr.value, dict) else {}
-            direct_tc_id = intr_value.get("tool_call_id", "")
-            if direct_tc_id:
-                decision = decisions_by_tc.get(direct_tc_id)
+            tc_id = intr_value.get("tool_call_id", "")
+            if tc_id:
+                decision = decisions_by_tc.get(tc_id)
                 if decision:
                     resume_dict[intr.id] = _build_decision_value(decision, action_map)
-                    matched.add(direct_tc_id)
-                continue
-            sub_decisions: dict = {}
-            for sub_id, sub_value in intr_value.items():
-                if not isinstance(sub_value, dict):
-                    continue
-                if "_proxy_interrupt_id" not in sub_value:
-                    continue
-                sub_tc_id = sub_value.get("tool_call_id", "")
-                if not sub_tc_id:
-                    continue
-                decision = decisions_by_tc.get(sub_tc_id)
-                if decision:
-                    sub_decisions[sub_id] = _build_decision_value(decision, action_map)
-                    matched.add(sub_tc_id)
-            if sub_decisions:
-                resume_dict[intr.id] = sub_decisions
+                    matched.add(tc_id)
 
         # Bidirectional fallback
         unmatched = set(decisions_by_tc) - matched
         if unmatched:
-            intr_tc_to_parent: dict[str, tuple[Any, str, str]] = {}
+            intr_tc_to_parent: dict[str, Any] = {}
             for intr in interrupts:
                 if intr.id in resume_dict:
                     continue
                 intr_value = intr.value if isinstance(intr.value, dict) else {}
-                direct_tc_id = intr_value.get("tool_call_id", "")
-                if direct_tc_id and direct_tc_id not in matched:
-                    intr_tc_to_parent[direct_tc_id] = (intr, "direct", "")
-                for sub_id, sub_value in intr_value.items():
-                    if not isinstance(sub_value, dict):
-                        continue
-                    if "_proxy_interrupt_id" not in sub_value:
-                        continue
-                    sub_tc_id = sub_value.get("tool_call_id", "")
-                    if sub_tc_id and sub_tc_id not in matched:
-                        intr_tc_to_parent[sub_tc_id] = (intr, "proxy", sub_id)
+                tc_id = intr_value.get("tool_call_id", "")
+                if tc_id and tc_id not in matched:
+                    intr_tc_to_parent[tc_id] = intr
 
             for um_tc_id in list(unmatched):
                 decision = decisions_by_tc[um_tc_id]
-                for intr_tc_id, (intr, shape, sub_id) in intr_tc_to_parent.items():
-                    if intr.id in resume_dict and shape == "direct":
+                for intr_tc_id, intr in intr_tc_to_parent.items():
+                    if intr.id in resume_dict:
                         continue
-                    if shape == "direct":
-                        resume_dict[intr.id] = _build_decision_value(decision, action_map)
-                        matched.add(um_tc_id)
-                        del intr_tc_to_parent[intr_tc_id]
-                        break
-                    if shape == "proxy":
-                        existing = resume_dict.get(intr.id, {})
-                        existing[sub_id] = _build_decision_value(decision, action_map)
-                        resume_dict[intr.id] = existing
-                        matched.add(um_tc_id)
-                        del intr_tc_to_parent[intr_tc_id]
-                        break
+                    resume_dict[intr.id] = _build_decision_value(decision, action_map)
+                    matched.add(um_tc_id)
+                    del intr_tc_to_parent[intr_tc_id]
+                    break
 
         return resume_dict, matched
 
@@ -1075,32 +941,6 @@ class TestBidirectionalIdLookup:
         assert "intr-1" in result
         assert result["intr-1"] == {"action": "approve"}
         assert "019d-uuid-from-status" in matched
-
-    def test_proxy_mismatch_resolved_by_fallback(self):
-        """Proxy sub-interrupt with UUID decision ID matched to toolu_* interrupt."""
-        from graphton.core.interrupt_proxy import InterruptProxyRunnable
-
-        sub_interrupts = [
-            _MockInterrupt(
-                id="sub-1",
-                value={"tool_call_id": "toolu_sub_real", "message": "Run cmd?"},
-            ),
-        ]
-        proxy_payload = InterruptProxyRunnable._build_proxy_payload(sub_interrupts)
-        parent = _MockInterrupt(id="p-1", value=proxy_payload)
-
-        decisions = [
-            SubmitApprovalInput(
-                tool_call_id="019d-uuid-sub",
-                action=ApprovalAction.APPROVAL_ACTION_APPROVE,
-            ),
-        ]
-
-        result, matched = self._run_matching_with_fallback([parent], decisions)
-
-        assert "p-1" in result
-        assert result["p-1"]["sub-1"] == {"action": "approve"}
-        assert "019d-uuid-sub" in matched
 
     def test_no_fallback_needed_when_ids_match(self):
         """When IDs match normally, fallback is not triggered."""
@@ -1138,123 +978,6 @@ class TestBidirectionalIdLookup:
 
 
 # =============================================================================
-# InterruptProxy Thread Management
-# =============================================================================
-
-
-class _FakeState:
-    """Minimal stand-in for LangGraph StateSnapshot."""
-
-    def __init__(
-        self,
-        values: dict | None = None,
-        interrupts: list | None = None,
-    ):
-        self.values = values or {}
-        self.interrupts = interrupts or []
-        self.next = () if not interrupts else ("tools",)
-
-
-class _FakeGraph:
-    """Minimal async graph stub for InterruptProxyRunnable tests."""
-
-    def __init__(self):
-        self._state: _FakeState | None = None
-        self.invoke_count = 0
-        self.last_input: Any = None
-        self.last_config: Any = None
-
-    def set_state(self, state: _FakeState | None) -> None:
-        self._state = state
-
-    async def aget_state(self, config: Any) -> _FakeState | None:
-        return self._state
-
-    async def ainvoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
-        self.invoke_count += 1
-        self.last_input = input
-        self.last_config = config
-        return {"result": f"run-{self.invoke_count}"}
-
-
-class TestInterruptProxyThreadManagement:
-    """Verify InterruptProxyRunnable reuses the same thread on parent replay.
-
-    The root cause of orphaned WAITING_APPROVAL tool calls was the thread
-    counter incrementing on every ainvoke(), causing resumed sub-agents to
-    start fresh on a new MemorySaver thread while the old thread's tool calls
-    remained stuck.
-    """
-
-    @staticmethod
-    def _make_proxy(graph: _FakeGraph) -> "InterruptProxyRunnable":  # noqa: F821
-        from graphton.core.interrupt_proxy import InterruptProxyRunnable
-        return InterruptProxyRunnable(inner_graph=graph, name="test-agent")
-
-    @pytest.mark.asyncio
-    async def test_fresh_invocation_uses_thread_zero(self):
-        """First ainvoke() uses thread 0 and does not advance the counter."""
-        graph = _FakeGraph()
-        proxy = self._make_proxy(graph)
-
-        await proxy.ainvoke("hello")
-
-        assert proxy._thread_counter == 0
-        assert graph.last_config["configurable"]["thread_id"] == "sa-test-agent-0"
-
-    @pytest.mark.asyncio
-    async def test_replay_after_interrupt_reuses_same_thread(self):
-        """When checkpoint has interrupts, ainvoke() resumes on the same thread."""
-        from unittest.mock import patch
-
-        graph = _FakeGraph()
-        graph.set_state(
-            _FakeState(
-                values={"messages": ["prior"]},
-                interrupts=[_MockInterrupt(id="intr-1", value={"tool_call_id": "tc1", "message": "Run?"})],
-            )
-        )
-        proxy = self._make_proxy(graph)
-
-        with patch("graphton.core.interrupt_proxy.interrupt", return_value={"intr-1": {"action": "approve"}}):
-            await proxy.ainvoke("hello")
-
-        assert proxy._thread_counter == 0
-        assert graph.last_config["configurable"]["thread_id"] == "sa-test-agent-0"
-
-    @pytest.mark.asyncio
-    async def test_completed_thread_advances_counter(self):
-        """When checkpoint shows completion (values but no interrupts), counter advances."""
-        graph = _FakeGraph()
-        graph.set_state(_FakeState(values={"messages": ["done"]}))
-        proxy = self._make_proxy(graph)
-
-        await proxy.ainvoke("new-task")
-
-        assert proxy._thread_counter == 1
-        assert graph.last_config["configurable"]["thread_id"] == "sa-test-agent-1"
-
-    @pytest.mark.asyncio
-    async def test_two_sequential_invocations_get_different_threads(self):
-        """Sequential completed invocations get incrementing thread IDs."""
-        graph = _FakeGraph()
-        proxy = self._make_proxy(graph)
-
-        # First invocation: no state → fresh on thread 0
-        graph.set_state(None)
-        await proxy.ainvoke("task-1")
-        assert graph.last_config["configurable"]["thread_id"] == "sa-test-agent-0"
-
-        # Simulate first invocation completed
-        graph.set_state(_FakeState(values={"messages": ["done-1"]}))
-
-        # Second invocation: completed state → advance to thread 1
-        await proxy.ainvoke("task-2")
-        assert proxy._thread_counter == 1
-        assert graph.last_config["configurable"]["thread_id"] == "sa-test-agent-1"
-
-
-# =============================================================================
 # Sub-Agent Completion Cleanup
 # =============================================================================
 
@@ -1262,10 +985,10 @@ class TestInterruptProxyThreadManagement:
 class TestSubAgentCompletionCleanup:
     """Verify _handle_sub_agent_end sweeps orphaned WAITING_APPROVAL tool calls.
 
-    When the InterruptProxy restarts a sub-agent on a fresh LangGraph thread,
-    tool calls from the abandoned thread remain WAITING_APPROVAL in the
-    StatusBuilder.  _handle_sub_agent_end must transition these to SKIPPED
-    so they do not leak into pending_approvals.
+    When a sub-agent completes, tool calls that were WAITING_APPROVAL but
+    never received a decision remain in the StatusBuilder.
+    _handle_sub_agent_end must transition these to SKIPPED so they do not
+    leak into pending_approvals.
     """
 
     @staticmethod
@@ -1431,34 +1154,23 @@ class TestExtractInterruptToolCallIds:
         result = extract_interrupt_tool_call_ids(interrupts)
         assert result == {"tc_direct_1", "tc_direct_2"}
 
-    def test_proxy_interrupt(self):
+    def test_sub_agent_interrupt_same_shape(self):
+        """Sub-agent interrupts use the same direct shape as root-agent tools."""
         interrupts = [
-            _FakeInterrupt("intr-1", {
-                "sub-a": {
-                    "tool_call_id": "tc_proxy_1",
-                    "_proxy_interrupt_id": "pid-1",
-                },
-                "sub-b": {
-                    "tool_call_id": "tc_proxy_2",
-                    "_proxy_interrupt_id": "pid-2",
-                },
-            }),
+            _FakeInterrupt("intr-sub-1", {"tool_call_id": "tc_sub_1", "message": "sub tool 1"}),
+            _FakeInterrupt("intr-sub-2", {"tool_call_id": "tc_sub_2", "message": "sub tool 2"}),
         ]
         result = extract_interrupt_tool_call_ids(interrupts)
-        assert result == {"tc_proxy_1", "tc_proxy_2"}
+        assert result == {"tc_sub_1", "tc_sub_2"}
 
-    def test_mixed_direct_and_proxy(self):
+    def test_mixed_root_and_sub_agent(self):
+        """Root and sub-agent interrupts are both direct shape."""
         interrupts = [
             _FakeInterrupt("intr-1", {"tool_call_id": "tc_direct"}),
-            _FakeInterrupt("intr-2", {
-                "sub-a": {
-                    "tool_call_id": "tc_proxy",
-                    "_proxy_interrupt_id": "pid-1",
-                },
-            }),
+            _FakeInterrupt("intr-2", {"tool_call_id": "tc_sub"}),
         ]
         result = extract_interrupt_tool_call_ids(interrupts)
-        assert result == {"tc_direct", "tc_proxy"}
+        assert result == {"tc_direct", "tc_sub"}
 
     def test_empty_interrupts(self):
         assert extract_interrupt_tool_call_ids([]) == set()
@@ -1488,18 +1200,14 @@ class TestBuildSnapshotFromInterrupts:
     def test_empty_interrupts_returns_empty(self):
         assert build_snapshot_from_interrupts([]) == []
 
-    def test_proxy_interrupts_included(self):
+    def test_sub_agent_interrupts_included(self):
+        """Sub-agent interrupts use the same direct shape and are included."""
         interrupts = [
-            _FakeInterrupt("intr-1", {
-                "sub-a": {
-                    "tool_call_id": "tc_proxy",
-                    "_proxy_interrupt_id": "pid-1",
-                },
-            }),
+            _FakeInterrupt("intr-sub", {"tool_call_id": "tc_sub", "message": "sub tool"}),
         ]
         snapshot = build_snapshot_from_interrupts(interrupts)
         assert len(snapshot) == 1
-        assert snapshot[0].tool_call_id == "tc_proxy"
+        assert snapshot[0].tool_call_id == "tc_sub"
 
 
 # =============================================================================

--- a/backend/services/agent-runner/tests/test_hitl_contracts.py
+++ b/backend/services/agent-runner/tests/test_hitl_contracts.py
@@ -612,12 +612,12 @@ class TestTaskToolResumeReconciliation:
         sa = SubAgentExecution(id="toolu_AAA", name="generalPurpose")
         builder = _make_builder_with_decisions([tc], sub_agents=[sa])
 
-        assert len(builder._early_tool_call_queue) == 0
+        assert len(builder.state.early_tool_call_queue) == 0
 
         _simulate_tool_use_stream(builder, "task", "toolu_AAA")
 
-        assert len(builder._early_tool_call_queue) == 1
-        temp_id, sa_id = builder._early_tool_call_queue[0]
+        assert len(builder.state.early_tool_call_queue) == 1
+        temp_id, sa_id = builder.state.early_tool_call_queue[0]
         assert temp_id == "toolu_AAA"
 
     @pytest.mark.asyncio
@@ -646,8 +646,8 @@ class TestTaskToolResumeReconciliation:
         }
         await builder.process_event(event)
 
-        assert builder._run_id_aliases.get("019d-uuid-new-run") == "toolu_BBB"
-        assert len(builder._early_tool_call_queue) == 0
+        assert builder.resolve_run_id("019d-uuid-new-run") == "toolu_BBB"
+        assert len(builder.state.early_tool_call_queue) == 0
 
     @pytest.mark.asyncio
     async def test_parallel_task_tools_reconcile_independently(self):
@@ -668,7 +668,7 @@ class TestTaskToolResumeReconciliation:
         _simulate_tool_use_stream(builder, "task", "toolu_CCC")
         _simulate_tool_use_stream(builder, "task", "toolu_DDD")
 
-        assert len(builder._early_tool_call_queue) == 2
+        assert len(builder.state.early_tool_call_queue) == 2
 
         event_a = {
             "event": "on_tool_start",
@@ -686,9 +686,9 @@ class TestTaskToolResumeReconciliation:
         await builder.process_event(event_a)
         await builder.process_event(event_b)
 
-        assert builder._run_id_aliases.get("run-uuid-1") == "toolu_CCC"
-        assert builder._run_id_aliases.get("run-uuid-2") == "toolu_DDD"
-        assert len(builder._early_tool_call_queue) == 0
+        assert builder.resolve_run_id("run-uuid-1") == "toolu_CCC"
+        assert builder.resolve_run_id("run-uuid-2") == "toolu_DDD"
+        assert len(builder.state.early_tool_call_queue) == 0
 
     @pytest.mark.asyncio
     async def test_identity_dedup_does_not_block_task_handler(self):
@@ -722,8 +722,8 @@ class TestTaskToolResumeReconciliation:
         }
         await builder.process_event(event)
 
-        assert builder._run_id_aliases.get("new-task-run-id") == "toolu_EEE"
-        assert "new-task-run-id" in builder._run_id_to_tool_call_id
+        assert builder.resolve_run_id("new-task-run-id") == "toolu_EEE"
+        assert "new-task-run-id" in builder.state.run_id_to_tool_call_id
 
     # ─────────────────────────────────────────────────────────────────────────
     # No-AI-replay resume: prepare_task_tool_resume_queue
@@ -750,14 +750,14 @@ class TestTaskToolResumeReconciliation:
         sa_b = SubAgentExecution(id="toolu_RQ2", name="explore")
         builder = _make_builder_with_decisions([tc_a, tc_b], sub_agents=[sa_a, sa_b])
 
-        assert len(builder._early_tool_call_queue) == 0
+        assert len(builder.state.early_tool_call_queue) == 0
 
         queued = builder.prepare_task_tool_resume_queue()
 
         assert queued == 2
-        assert len(builder._early_tool_call_queue) == 2
-        assert builder._early_tool_call_queue[0] == ("toolu_RQ1", None)
-        assert builder._early_tool_call_queue[1] == ("toolu_RQ2", None)
+        assert len(builder.state.early_tool_call_queue) == 2
+        assert builder.state.early_tool_call_queue[0] == ("toolu_RQ1", None)
+        assert builder.state.early_tool_call_queue[1] == ("toolu_RQ2", None)
 
     @pytest.mark.asyncio
     async def test_task_on_tool_start_without_ai_replay_reactivates_subagent(self):
@@ -799,10 +799,10 @@ class TestTaskToolResumeReconciliation:
         assert len(builder.current_status.sub_agent_executions) == 3
 
         for i, tc_id in enumerate(["toolu_SA1", "toolu_SA2", "toolu_SA3"]):
-            assert builder._run_id_aliases.get(f"new-run-uuid-{i}") == tc_id
-            assert f"new-run-uuid-{i}" in builder._active_sub_agents
+            assert builder.resolve_run_id(f"new-run-uuid-{i}") == tc_id
+            assert f"new-run-uuid-{i}" in builder.state.active_sub_agents
 
-        assert len(builder._early_tool_call_queue) == 0
+        assert len(builder.state.early_tool_call_queue) == 0
 
     def test_prepare_skips_task_tools_without_subagent(self):
         """Task tool calls without a corresponding SubAgentExecution are NOT
@@ -821,8 +821,8 @@ class TestTaskToolResumeReconciliation:
         queued = builder.prepare_task_tool_resume_queue()
 
         assert queued == 1
-        assert len(builder._early_tool_call_queue) == 1
-        assert builder._early_tool_call_queue[0] == ("toolu_HAS", None)
+        assert len(builder.state.early_tool_call_queue) == 1
+        assert builder.state.early_tool_call_queue[0] == ("toolu_HAS", None)
 
     @pytest.mark.asyncio
     async def test_prepare_is_idempotent_with_ai_replay(self):
@@ -840,7 +840,7 @@ class TestTaskToolResumeReconciliation:
 
         _simulate_tool_use_stream(builder, "task", "toolu_IDEM")
 
-        assert len(builder._early_tool_call_queue) == 2
+        assert len(builder.state.early_tool_call_queue) == 2
 
         event = {
             "event": "on_tool_start",
@@ -850,9 +850,9 @@ class TestTaskToolResumeReconciliation:
         }
         await builder.process_event(event)
 
-        assert builder._run_id_aliases.get("run-idem-uuid") == "toolu_IDEM"
+        assert builder.resolve_run_id("run-idem-uuid") == "toolu_IDEM"
         assert len(builder.current_status.sub_agent_executions) == 1
-        assert len(builder._early_tool_call_queue) == 1
+        assert len(builder.state.early_tool_call_queue) == 1
 
 
 # =============================================================================
@@ -1031,8 +1031,8 @@ class TestSubAgentCompletionCleanup:
 
         run_id = "task-run-abc"
         sa_ref = builder.current_status.sub_agent_executions[0]
-        builder._active_sub_agents[run_id] = sa_ref
-        builder._run_id_to_tool_call_id[run_id] = "toolu_task_1"
+        builder.state.active_sub_agents[run_id] = sa_ref
+        builder.state.run_id_to_tool_call_id[run_id] = "toolu_task_1"
 
         return builder, run_id
 

--- a/backend/services/agent-runner/tests/test_hitl_contracts.py
+++ b/backend/services/agent-runner/tests/test_hitl_contracts.py
@@ -2,11 +2,9 @@
 
 Tests cover:
   - ResumeReconciler: tool call transitions, auto-skip, stale completed_at
-  - Fingerprint dedup: via messages (not flat lists)
-  - Index rebuild on resume: populate_fingerprints_from_existing_tool_calls
+  - Index rebuild on resume: rebuild_index_from_persisted_status
   - Pending approvals snapshot: Temporal coordination signal
   - slim_status_for_temporal: snapshot preserved through slim copy
-  - FIFO queue drain: stale entries removed when fingerprint dedup matches
   - Task tool early-TC reconciliation on resume path
   - Bidirectional ID lookup: defense-in-depth for ID mismatches
   - Interrupt-based snapshot: build_snapshot_from_interrupts
@@ -14,7 +12,6 @@ Tests cover:
 """
 
 import logging
-from collections import deque
 from typing import Any
 
 import pytest
@@ -75,7 +72,7 @@ def _make_builder_with_decisions(
         for sa in sub_agents:
             status.sub_agent_executions.append(sa)
     builder = StatusBuilder("test_exec", status)
-    builder.populate_fingerprints_from_existing_tool_calls()
+    builder.rebuild_index_from_persisted_status()
     return builder
 
 
@@ -243,60 +240,6 @@ class TestClearStaleCompletedAt:
 
 
 # =============================================================================
-# Fingerprint dedup via messages
-# =============================================================================
-
-
-class TestFingerprintDedup:
-    def test_fingerprint_dedup_from_messages(self):
-        args = Struct()
-        args.update({"key": "value"})
-        tc = ToolCall(
-            id="call_original",
-            name="apply_mcp_server",
-            args=args,
-            status=ToolCallStatus.TOOL_CALL_RUNNING,
-        )
-
-        status = _status_with_tool_calls(tc)
-        builder = StatusBuilder("exec-fp-1", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
-
-        fingerprint = builder._get_tool_fingerprint(
-            "apply_mcp_server", {"key": "value"},
-        )
-        assert fingerprint in builder.tool_call_fingerprints
-        assert builder._fingerprint_to_tool_call_id.get(fingerprint) == "call_original"
-
-    def test_sub_agent_tool_call_fingerprint(self):
-        args = Struct()
-        args.update({"path": "/tmp/output.txt"})
-        sa_tc = ToolCall(
-            id="sa-tc-001",
-            name="write_file",
-            args=args,
-            status=ToolCallStatus.TOOL_CALL_RUNNING,
-        )
-
-        sa = SubAgentExecution(id="sub-agent-run-1", name="code_editor")
-        msg = sa.messages.add()
-        msg.type = MessageType.MESSAGE_AI
-        msg.tool_calls.append(sa_tc)
-
-        status = AgentExecutionStatus()
-        status.sub_agent_executions.append(sa)
-
-        builder = StatusBuilder("exec-fp-sub-1", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
-
-        fingerprint = builder._get_tool_fingerprint(
-            "write_file", {"path": "/tmp/output.txt"},
-        )
-        assert fingerprint in builder.tool_call_fingerprints
-        assert builder._fingerprint_to_tool_call_id.get(fingerprint) == "sa-tc-001"
-
-
-# =============================================================================
 # Index rebuild on resume
 # =============================================================================
 
@@ -311,7 +254,7 @@ class TestIndexRebuildOnResume:
 
         status = _status_with_tool_calls(tc)
         builder = StatusBuilder("exec-idx-1", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        builder.rebuild_index_from_persisted_status()
 
         assert builder.get_tool_call("call_existing") is not None
         assert builder.get_tool_call("call_existing").name == "read_file"
@@ -326,7 +269,7 @@ class TestIndexRebuildOnResume:
 
         status = _status_with_tool_calls(tc)
         builder = StatusBuilder("exec-mut-1", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        builder.rebuild_index_from_persisted_status()
 
         ref = builder.get_tool_call("call_mut")
         ref.status = ToolCallStatus.TOOL_CALL_RUNNING
@@ -482,116 +425,6 @@ class TestSlimStatusPreservesSnapshot:
         slim = slim_status_for_temporal(status)
 
         assert len(slim.pending_approvals) == 0
-
-
-# =============================================================================
-# FIFO queue drain: stale entries after fingerprint dedup
-# =============================================================================
-
-
-class TestFifoQueueDrainOnFingerprintDedup:
-    """Verify that the FIFO fallback queue (_reconciled_resume_tool_calls)
-    is drained when fingerprint dedup handles a resumed tool call.
-
-    Without the drain, stale FIFO entries capture genuinely new tool calls
-    with the same tool name, preventing the StatusBuilder from creating a
-    new ToolCall entry and from transitioning the phase to
-    WAITING_FOR_APPROVAL.
-    """
-
-    @pytest.mark.asyncio
-    async def test_fifo_drained_when_fingerprint_dedup_matches(self):
-        """Fingerprint dedup for resumed tools should remove the matched
-        entry from the FIFO queue so it can't capture new tool calls."""
-        args = Struct()
-        args.update({"command": "find /workspace -name '*.yaml'"})
-        tc = ToolCall(
-            id="tc_1",
-            name="execute",
-            args=args,
-            status=ToolCallStatus.TOOL_CALL_RUNNING,
-            requires_approval=True,
-            approval_action=ApprovalAction.APPROVAL_ACTION_APPROVE,
-        )
-
-        status = _status_with_tool_calls(tc)
-        builder = StatusBuilder("test_exec", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
-
-        builder._reconciled_resume_tool_calls["execute"] = deque(["tc_1"])
-
-        event = {
-            "event": "on_tool_start",
-            "name": "execute",
-            "run_id": "new-run-001",
-            "data": {"input": {"command": "find /workspace -name '*.yaml'"}},
-        }
-        await builder.process_event(event)
-
-        assert builder._run_id_aliases.get("new-run-001") == "tc_1"
-        queue = builder._reconciled_resume_tool_calls.get("execute")
-        assert queue is not None
-        assert len(queue) == 0
-
-    @pytest.mark.asyncio
-    async def test_new_tool_not_captured_by_stale_fifo_after_resume(self):
-        """After 3 resumed tools are deduped by fingerprint, a genuinely new
-        tool call with the same name must NOT be aliased to an old entry."""
-        tc_ids = ["tc_1", "tc_2", "tc_3"]
-        commands = [
-            "find /workspace -name '*.yaml'",
-            "find /workspace -name '*.py'",
-            "find /workspace -type f | head -40",
-        ]
-
-        status = AgentExecutionStatus()
-        msg = status.messages.add()
-        msg.type = MessageType.MESSAGE_AI
-        for tc_id, cmd in zip(tc_ids, commands):
-            args = Struct()
-            args.update({"command": cmd})
-            msg.tool_calls.append(ToolCall(
-                id=tc_id,
-                name="execute",
-                args=args,
-                status=ToolCallStatus.TOOL_CALL_RUNNING,
-                requires_approval=True,
-                approval_action=ApprovalAction.APPROVAL_ACTION_APPROVE,
-            ))
-
-        builder = StatusBuilder("test_exec", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
-
-        builder._reconciled_resume_tool_calls["execute"] = deque(tc_ids)
-
-        for tc_id, cmd in zip(tc_ids, commands):
-            event = {
-                "event": "on_tool_start",
-                "name": "execute",
-                "run_id": f"resumed-{tc_id}",
-                "data": {"input": {"command": cmd}},
-            }
-            await builder.process_event(event)
-
-        queue = builder._reconciled_resume_tool_calls.get("execute")
-        assert len(queue) == 0, (
-            f"FIFO queue should be empty after fingerprint dedup, "
-            f"but has {len(queue)} entries: {list(queue)}"
-        )
-
-        new_run_id = "brand-new-run-999"
-        new_event = {
-            "event": "on_tool_start",
-            "name": "execute",
-            "run_id": new_run_id,
-            "data": {"input": {"command": "ls /home/workspace/new-dir"}},
-        }
-        await builder.process_event(new_event)
-
-        assert new_run_id not in builder._run_id_aliases, (
-            f"New tool call should NOT be aliased to an old entry, "
-            f"but was aliased to {builder._run_id_aliases.get(new_run_id)}"
-        )
 
 
 # =============================================================================
@@ -960,9 +793,11 @@ class TestTaskToolResumeReconciliation:
         assert len(builder._early_tool_call_queue) == 0
 
     @pytest.mark.asyncio
-    async def test_fingerprint_dedup_does_not_block_task_handler(self):
-        """Even if the fingerprint matches a prior-cycle task tool, the task
+    async def test_identity_dedup_does_not_block_task_handler(self):
+        """Even if identity dedup detects a prior-cycle task tool, the task
         handler must still run so sub-agent lifecycle is managed."""
+        from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+
         args = Struct()
         args.update({"description": "deploy service", "subagent_type": "generalPurpose"})
         tc = ToolCall(
@@ -974,6 +809,10 @@ class TestTaskToolResumeReconciliation:
 
         sa = SubAgentExecution(id="toolu_EEE", name="generalPurpose")
         builder = _make_builder_with_decisions([tc], sub_agents=[sa])
+
+        capture = ToolCallIdCapture()
+        capture._run_id_to_tool_call_id["new-task-run-id"] = "toolu_EEE"
+        builder._tool_call_id_capture = capture
 
         _simulate_tool_use_stream(builder, "task", "toolu_EEE")
 
@@ -1465,7 +1304,7 @@ class TestSubAgentCompletionCleanup:
         status.sub_agent_executions.append(sa)
 
         builder = StatusBuilder("test_exec", status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        builder.rebuild_index_from_persisted_status()
 
         run_id = "task-run-abc"
         sa_ref = builder.current_status.sub_agent_executions[0]

--- a/backend/services/agent-runner/tests/test_inline_publish.py
+++ b/backend/services/agent-runner/tests/test_inline_publish.py
@@ -59,11 +59,11 @@ class TestStatusBuilderAddArtifact:
 
     def _import_and_create(self):
         """Import StatusBuilder and create an instance with minimal deps."""
+        from worker.activities.graphton.execution_state import ExecutionState
         from worker.activities.graphton.status_builder import StatusBuilder
 
         sb = StatusBuilder.__new__(StatusBuilder)
-        sb.current_status = AgentExecutionStatus()
-        sb._artifacts = []
+        sb.state = ExecutionState(proto=AgentExecutionStatus())
         sb.execution_id = "test-exec"
         sb.force_next_update = False
         sb.logger = logging.getLogger("test")
@@ -77,7 +77,7 @@ class TestStatusBuilderAddArtifact:
 
         assert len(sb.current_status.artifacts) == 1
         assert sb.current_status.artifacts[0].sandbox_path == "project/file.txt"
-        assert len(sb._artifacts) == 1
+        assert len(sb.state.artifacts) == 1
 
     def test_add_artifact_sets_force_next_update(self):
         sb = self._import_and_create()
@@ -98,8 +98,8 @@ class TestStatusBuilderAddArtifact:
 
         assert len(sb.current_status.artifacts) == 1
         assert sb.current_status.artifacts[0].size_bytes == 200
-        assert len(sb._artifacts) == 1
-        assert sb._artifacts[0].size_bytes == 200
+        assert len(sb.state.artifacts) == 1
+        assert sb.state.artifacts[0].size_bytes == 200
 
     def test_add_artifact_different_paths_appended(self):
         sb = self._import_and_create()
@@ -110,11 +110,11 @@ class TestStatusBuilderAddArtifact:
         sb.add_artifact(artifact_b)
 
         assert len(sb.current_status.artifacts) == 2
-        assert len(sb._artifacts) == 2
+        assert len(sb.state.artifacts) == 2
 
     def test_finalize_context_info_does_not_duplicate(self):
         sb = self._import_and_create()
-        sb._context_info = None
+        sb.state.context_info = None
         artifact = _make_artifact("file.txt", "project/file.txt")
 
         sb.add_artifact(artifact)
@@ -127,13 +127,13 @@ class TestStatusBuilderAddArtifact:
         """Artifacts added to _artifacts but not yet in current_status
         (e.g. from post-stream safety net before finalize) are synced."""
         sb = self._import_and_create()
-        sb._context_info = None
+        sb.state.context_info = None
 
         artifact_inline = _make_artifact("a.txt", "a.txt")
         sb.add_artifact(artifact_inline)
 
         artifact_safety = _make_artifact("b.txt", "b.txt")
-        sb._artifacts.append(artifact_safety)
+        sb.state.artifacts.append(artifact_safety)
 
         sb.finalize_context_info()
         paths = [a.sandbox_path for a in sb.current_status.artifacts]
@@ -171,7 +171,7 @@ class TestStreamExecutorInlinePublish:
         sb.current_status = MagicMock()
         sb.current_status.tool_calls = [tc_write, tc_read]
         sb.force_next_update = False
-        sb._resolve_run_id = lambda rid: rid
+        sb.resolve_run_id = lambda rid: rid
         sb.get_tool_call = lambda tc_id: next(
             (tc for tc in sb.current_status.tool_calls if tc.id == tc_id), None
         )

--- a/backend/services/agent-runner/tests/test_pause_flow.py
+++ b/backend/services/agent-runner/tests/test_pause_flow.py
@@ -1,0 +1,105 @@
+"""Tests for the pause/resume flow in streaming.py and execute_graphton.py.
+
+Covers:
+- _handle_pause returns StreamResult without making gRPC calls
+- Terminal status path in execute_graphton.py calls retry_executor
+- CancelledError cooperative flow: is_cancelled() -> CancelledError -> _handle_pause -> return
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from ai.stigmer.agentic.agentexecution.v1.api_pb2 import AgentExecutionStatus
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ExecutionPhase
+
+from worker.activities.graphton.streaming import StreamExecutor, StreamResult
+
+
+class TestHandlePauseNoGrpcCalls:
+    """_handle_pause should mutate in-memory proto and return StreamResult
+    without making any gRPC calls (persistence is the caller's responsibility)."""
+
+    def _make_executor(self) -> StreamExecutor:
+        sb = MagicMock()
+        sb.current_status = AgentExecutionStatus()
+        sb.finalize_context_info = MagicMock()
+        sb.finalize_active_sub_agents = MagicMock()
+
+        exec_client = AsyncMock()
+        executor = StreamExecutor.__new__(StreamExecutor)
+        executor._sb = sb
+        executor._exec_client = exec_client
+        executor._execution_id = "exec-test"
+        executor._thread_id = "thread-test"
+        executor._log = MagicMock()
+        executor._slim_status = lambda status: AgentExecutionStatus(phase=status.phase)
+        return executor
+
+    def test_returns_stream_result_with_terminal_status(self):
+        executor = self._make_executor()
+        result = executor._handle_pause(events_processed=42)
+
+        assert isinstance(result, StreamResult)
+        assert result.events_processed == 42
+        assert result.terminal_status is not None
+        assert result.terminal_status.phase == ExecutionPhase.EXECUTION_PAUSED
+
+    def test_does_not_call_grpc_update(self):
+        executor = self._make_executor()
+        executor._handle_pause(events_processed=10)
+
+        executor._exec_client.update_status.assert_not_called()
+
+    def test_sets_phase_on_current_status(self):
+        executor = self._make_executor()
+        executor._handle_pause(events_processed=5)
+
+        assert executor._sb.current_status.phase == ExecutionPhase.EXECUTION_PAUSED
+
+    def test_sets_completed_at(self):
+        executor = self._make_executor()
+        executor._handle_pause(events_processed=1)
+
+        assert executor._sb.current_status.completed_at != ""
+
+
+class TestTerminalStatusPersistence:
+    """When stream_result.terminal_status is not None, execute_graphton should
+    persist via retry_executor before returning."""
+
+    @pytest.mark.asyncio
+    async def test_retry_executor_called_for_terminal_status(self):
+        """Verify the terminal_status path calls retry_executor.execute."""
+        mock_retry = AsyncMock()
+        mock_exec_client = AsyncMock()
+        mock_status_builder = MagicMock()
+        mock_status_builder.current_status = AgentExecutionStatus(
+            phase=ExecutionPhase.EXECUTION_PAUSED,
+        )
+
+        terminal_slim = AgentExecutionStatus(
+            phase=ExecutionPhase.EXECUTION_PAUSED,
+        )
+        stream_result = StreamResult(events_processed=10, terminal_status=terminal_slim)
+
+        # We test the logic inline rather than calling the full execute_graphton
+        # function (which has massive setup requirements). This mirrors the
+        # code path at lines 1962-1988 of execute_graphton.py.
+        if stream_result.terminal_status is not None:
+            terminal_phase = mock_status_builder.current_status.phase
+            await mock_retry.execute(
+                operation=lambda: mock_exec_client.update_status(
+                    execution_id="exec-test",
+                    status=mock_status_builder.current_status,
+                ),
+                operation_name="terminal_status_update",
+                context={
+                    "execution_id": "exec-test",
+                    "phase": ExecutionPhase.Name(terminal_phase),
+                },
+            )
+
+        mock_retry.execute.assert_called_once()
+        call_kwargs = mock_retry.execute.call_args
+        assert call_kwargs.kwargs["operation_name"] == "terminal_status_update"
+        assert "exec-test" in call_kwargs.kwargs["context"]["execution_id"]

--- a/backend/services/agent-runner/tests/test_pause_flow.py
+++ b/backend/services/agent-runner/tests/test_pause_flow.py
@@ -6,7 +6,7 @@ Covers:
 - CancelledError cooperative flow: is_cancelled() -> CancelledError -> _handle_pause -> return
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from ai.stigmer.agentic.agentexecution.v1.api_pb2 import AgentExecutionStatus

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -6998,11 +6998,11 @@ class TestRebuildFromProto:
         from worker.activities.graphton.execution_state import ExecutionState
 
         ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
-        tc_a = ai_msg.tool_calls.add(
+        ai_msg.tool_calls.add(
             id="toolu_A", name="write",
             status=ToolCallStatus.TOOL_CALL_COMPLETED,
         )
-        tc_b = ai_msg.tool_calls.add(
+        ai_msg.tool_calls.add(
             id="toolu_B", name="read",
             status=ToolCallStatus.TOOL_CALL_RUNNING,
         )
@@ -7018,6 +7018,7 @@ class TestRebuildFromProto:
     def test_indexes_sub_agent_tool_calls(self, mock_initial_status):
         """Tool calls inside sub-agent messages are also indexed."""
         from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+
         from worker.activities.graphton.execution_state import ExecutionState
 
         sa = SubAgentExecution(
@@ -7039,6 +7040,7 @@ class TestRebuildFromProto:
     def test_indexes_completed_sub_agents(self, mock_initial_status):
         """Completed/failed/cancelled sub-agents populate completed_sub_agents."""
         from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+
         from worker.activities.graphton.execution_state import ExecutionState
 
         sa_done = SubAgentExecution(
@@ -7063,7 +7065,6 @@ class TestRebuildFromProto:
 
     def test_copies_artifacts(self):
         """Proto artifacts are copied into state.artifacts."""
-        from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
         from worker.activities.graphton.execution_state import ExecutionState
 
         proto = AgentExecutionStatus()

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -1074,7 +1074,7 @@ class TestSubAgentInternals:
     def _patch_subject_gen(self):
         """Patch LLM-based subject generation for all tests in this class."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -1619,7 +1619,7 @@ class TestSubAgentInternals:
     async def test_task_tool_description_mapped_to_input(self, status_builder):
         """description arg (deepagents' full prompt) is mapped to input field."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="Scan workflow dependencies",
         ):
@@ -1644,7 +1644,7 @@ class TestSubAgentInternals:
     async def test_task_tool_subject_generated_via_llm(self, status_builder):
         """subject is generated from description via economy-tier LLM."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="Scan workflow dependencies",
         ) as mock_gen:
@@ -2186,7 +2186,7 @@ class TestSubAgentScenarios:
     def _patch_subject_gen(self):
         """Patch LLM-based subject generation for all tests in this class."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -2391,7 +2391,7 @@ class TestParentIdsNamespaceRouting:
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -2562,7 +2562,7 @@ class TestConcurrentSubAgentNamespaceRegistration:
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -5908,7 +5908,7 @@ class TestSubAgentSubjectDeduplication:
     async def test_first_subject_unchanged(self, status_builder):
         """First sub-agent with a given subject keeps it as-is."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="Research protobuf defs",
         ):
@@ -5923,7 +5923,7 @@ class TestSubAgentSubjectDeduplication:
     async def test_duplicate_subject_gets_suffix(self, status_builder):
         """Second sub-agent with the same subject gets ' (2)' appended."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="Research protobuf defs",
         ):
@@ -5947,7 +5947,7 @@ class TestSubAgentSubjectDeduplication:
     async def test_triple_duplicate_increments(self, status_builder):
         """Third duplicate gets ' (3)'."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="Find YAML examples",
         ):
@@ -5971,7 +5971,7 @@ class TestSubAgentSubjectDeduplication:
         """Distinct subjects are stored without any suffix."""
         subjects_to_return = iter(["Analyze CLI code", "Review backend tests"])
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             side_effect=lambda *_args, **_kw: next(subjects_to_return),
         ):
@@ -5995,7 +5995,7 @@ class TestSubAgentSubjectDeduplication:
 
         long_subject = "A" * _MAX_SUBJECT_LENGTH
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value=long_subject,
         ):
@@ -6014,7 +6014,7 @@ class TestSubAgentSubjectDeduplication:
     async def test_empty_subject_skips_dedup(self, status_builder):
         """Empty subjects (generation failures) are not deduplicated."""
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -6048,7 +6048,7 @@ class TestOrphanedSubAgentDetection:
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -6718,7 +6718,7 @@ class TestUniversalNamespaceRegistration:
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):
@@ -6834,7 +6834,7 @@ class TestFinalizationPreservesTerminalStatus:
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
         with patch(
-            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            "worker.activities.graphton.handlers.sub_agent._generate_sub_agent_subject",
             new_callable=AsyncMock,
             return_value="",
         ):

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -1720,8 +1720,8 @@ class TestSubAgentInternals:
         )
 
     @pytest.mark.asyncio
-    async def test_sub_agent_end_forces_status_update(self, status_builder):
-        """Sub-agent completion sets force_next_update so the status push is immediate."""
+    async def test_sub_agent_end_defers_flush_via_pending_completion(self, status_builder):
+        """Sub-agent completion records a deferred flush instead of setting force_next_update."""
         run_id = "task-force-update"
 
         await status_builder.process_event({
@@ -1742,7 +1742,8 @@ class TestSubAgentInternals:
             "metadata": {},
         })
 
-        assert status_builder.force_next_update is True
+        assert status_builder.force_next_update is False
+        assert run_id in status_builder._pending_completion_flush
 
     # ── Gap 9: Late event routing ───────────────────────────────────────────
 
@@ -6553,3 +6554,110 @@ class TestTurnBoundaryAndUsageTracking:
         assert len(status_builder.current_status.messages) == 2
         assert status_builder.current_status.messages[0].content == ""
         assert status_builder.current_status.messages[1].content == "Answer"
+
+
+# =============================================================================
+# Deferred Completion Flush (Drain Delay)
+# =============================================================================
+
+
+class TestDeferredCompletionFlush:
+    """Tests for the deferred sub-agent completion flush mechanism.
+
+    When a sub-agent completes, the status builder records a pending flush
+    timestamp instead of immediately setting force_next_update.  This allows
+    late LangGraph events to be batched into the same gRPC update.
+    """
+
+    @pytest.fixture
+    def status_builder(self, mock_initial_status):
+        return StatusBuilder(
+            execution_id="test-drain-delay",
+            initial_status=mock_initial_status,
+        )
+
+    @pytest.fixture
+    def mock_initial_status(self):
+        status = MagicMock()
+        status.messages = []
+        status.sub_agent_executions = []
+        status.todos = {}
+        status.artifacts = []
+        status.resolved_context = ResolvedExecutionContext()
+        status.context_info = ContextInfo()
+        return status
+
+    def test_should_flush_empty(self, status_builder):
+        """No pending completions means no flush."""
+        import time
+
+        assert status_builder.should_flush_completions(time.monotonic()) is False
+        assert status_builder.force_next_update is False
+
+    def test_should_flush_before_drain_window(self, status_builder):
+        """Flush returns False when still within the drain window."""
+        import time
+
+        now = time.monotonic()
+        status_builder._pending_completion_flush["sa-1"] = now
+
+        assert status_builder.should_flush_completions(now + 0.1) is False
+        assert status_builder.force_next_update is False
+        assert "sa-1" in status_builder._pending_completion_flush
+
+    def test_should_flush_after_drain_window(self, status_builder):
+        """Flush returns True and sets force_next_update after the drain window elapses."""
+        import time
+
+        now = time.monotonic()
+        status_builder._pending_completion_flush["sa-1"] = now
+
+        result = status_builder.should_flush_completions(
+            now + (StatusBuilder._COMPLETION_DRAIN_MS / 1000.0) + 0.001,
+        )
+
+        assert result is True
+        assert status_builder.force_next_update is True
+        assert "sa-1" not in status_builder._pending_completion_flush
+
+    def test_should_flush_partial_drain(self, status_builder):
+        """Only entries past the drain window are flushed; others remain."""
+        import time
+
+        now = time.monotonic()
+        status_builder._pending_completion_flush["sa-old"] = now
+        status_builder._pending_completion_flush["sa-new"] = now + 1.0
+
+        result = status_builder.should_flush_completions(
+            now + (StatusBuilder._COMPLETION_DRAIN_MS / 1000.0) + 0.001,
+        )
+
+        assert result is True
+        assert "sa-old" not in status_builder._pending_completion_flush
+        assert "sa-new" in status_builder._pending_completion_flush
+
+    @pytest.mark.asyncio
+    async def test_sub_agent_end_populates_pending_flush(self, status_builder):
+        """Sub-agent on_tool_end for 'task' populates _pending_completion_flush."""
+        run_id = "task-drain-test"
+
+        await status_builder.process_event({
+            "event": "on_tool_start",
+            "name": "task",
+            "run_id": run_id,
+            "data": {"input": {"subagent_type": "helper", "input": "test"}},
+            "metadata": {},
+        })
+
+        status_builder.force_next_update = False
+
+        await status_builder.process_event({
+            "event": "on_tool_end",
+            "name": "task",
+            "run_id": run_id,
+            "data": {"output": "completed"},
+            "metadata": {},
+        })
+
+        assert status_builder.force_next_update is False
+        assert run_id in status_builder._pending_completion_flush

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -4914,26 +4914,28 @@ class TestRunIdAliasResolution:
     transition to COMPLETED on the resume-after-approval path.
 
     When a tool call is interrupted for approval and then resumed, LangGraph
-    generates a new run_id for the resumed execution.  The fingerprint
-    deduplication in _handle_tool_start_event records an alias from the new
-    run_id to the original tool_call.id so that _handle_tool_end_event can
-    find and update the correct ToolCall.
+    generates a new run_id for the resumed execution.  The identity-based
+    dedup in _handle_tool_start_event (via ToolCallIdCapture) records an
+    alias from the new run_id to the original tool_call.id so that
+    _handle_tool_end_event can find and update the correct ToolCall.
     """
 
     @pytest.mark.asyncio
-    async def test_alias_recorded_on_duplicate_fingerprint(self, mock_initial_status):
-        """When a duplicate fingerprint is detected after
-        populate_fingerprints_from_existing_tool_calls, the new run_id is
-        recorded as an alias for the original tool call id."""
+    async def test_alias_recorded_on_identity_dedup(self, mock_initial_status):
+        """When a resumed on_tool_start fires with a new run_id, the
+        ToolCallIdCapture mapping resolves it to the existing tool_call_id.
+        The new run_id is recorded as an alias."""
         from google.protobuf.struct_pb2 import Struct
 
-        original_run_id = "original-run-001"
+        from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+
+        original_tc_id = "toolu_original_001"
         new_run_id = "resumed-run-002"
 
         args = Struct()
         args.update({"path": "/bin/skills/agent-drafter/SKILL.md", "content": "..."})
         existing_tc = ToolCall(
-            id=original_run_id,
+            id=original_tc_id,
             name="write",
             args=args,
             status=ToolCallStatus.TOOL_CALL_RUNNING,
@@ -4942,8 +4944,12 @@ class TestRunIdAliasResolution:
         ai_msg.tool_calls.append(existing_tc)
         mock_initial_status.messages.append(ai_msg)
 
-        builder = StatusBuilder("exec-alias-1", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        capture = ToolCallIdCapture()
+        capture._run_id_to_tool_call_id[new_run_id] = original_tc_id
+
+        builder = StatusBuilder("exec-alias-1", mock_initial_status,
+                                tool_call_id_capture=capture)
+        builder.rebuild_index_from_persisted_status()
 
         event = {
             "event": "on_tool_start",
@@ -4953,7 +4959,7 @@ class TestRunIdAliasResolution:
         }
         await builder.process_event(event)
 
-        assert builder._run_id_aliases.get(new_run_id) == original_run_id
+        assert builder._run_id_aliases.get(new_run_id) == original_tc_id
         assert builder.tool_call_count() == 1
 
     @pytest.mark.asyncio
@@ -4962,7 +4968,9 @@ class TestRunIdAliasResolution:
         original tool call from RUNNING to COMPLETED."""
         from google.protobuf.struct_pb2 import Struct
 
-        original_run_id = "orig-run-100"
+        from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+
+        original_tc_id = "toolu_orig_100"
         new_run_id = "new-run-200"
 
         args = Struct()
@@ -4970,15 +4978,19 @@ class TestRunIdAliasResolution:
 
         ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
         ai_msg.tool_calls.append(ToolCall(
-            id=original_run_id,
+            id=original_tc_id,
             name="write",
             args=args,
             status=ToolCallStatus.TOOL_CALL_RUNNING,
         ))
         mock_initial_status.messages.append(ai_msg)
 
-        builder = StatusBuilder("exec-alias-2", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        capture = ToolCallIdCapture()
+        capture._run_id_to_tool_call_id[new_run_id] = original_tc_id
+
+        builder = StatusBuilder("exec-alias-2", mock_initial_status,
+                                tool_call_id_capture=capture)
+        builder.rebuild_index_from_persisted_status()
 
         start_event = {
             "event": "on_tool_start",
@@ -4996,7 +5008,7 @@ class TestRunIdAliasResolution:
         }
         await builder.process_event(end_event)
 
-        tc = builder.get_tool_call(original_run_id)
+        tc = builder.get_tool_call(original_tc_id)
         assert tc.status == ToolCallStatus.TOOL_CALL_COMPLETED
         assert tc.result == "File written successfully"
 
@@ -5008,10 +5020,12 @@ class TestRunIdAliasResolution:
         to COMPLETED when their resumed on_tool_end events carry new run_ids."""
         from google.protobuf.struct_pb2 import Struct
 
+        from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+
         files = [
-            ("orig-A", "new-A", "/skill/SKILL.md"),
-            ("orig-B", "new-B", "/skill/references/proto.md"),
-            ("orig-C", "new-C", "/skill/references/cli.md"),
+            ("toolu_A", "new-A", "/skill/SKILL.md"),
+            ("toolu_B", "new-B", "/skill/references/proto.md"),
+            ("toolu_C", "new-C", "/skill/references/cli.md"),
         ]
 
         ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
@@ -5024,8 +5038,13 @@ class TestRunIdAliasResolution:
             ))
         mock_initial_status.messages.append(ai_msg)
 
-        builder = StatusBuilder("exec-alias-3", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        capture = ToolCallIdCapture()
+        for orig_id, new_id, _ in files:
+            capture._run_id_to_tool_call_id[new_id] = orig_id
+
+        builder = StatusBuilder("exec-alias-3", mock_initial_status,
+                                tool_call_id_capture=capture)
+        builder.rebuild_index_from_persisted_status()
 
         for orig_id, new_id, path in files:
             await builder.process_event({
@@ -5067,22 +5086,28 @@ class TestRunIdAliasResolution:
         tool call's result."""
         from google.protobuf.struct_pb2 import Struct
 
-        original_run_id = "orig-progress-1"
+        from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+
+        original_tc_id = "toolu_progress_1"
         new_run_id = "new-progress-1"
 
         args = Struct()
         args.update({"command": "ls -la"})
         ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
         ai_msg.tool_calls.append(ToolCall(
-            id=original_run_id,
+            id=original_tc_id,
             name="execute",
             args=args,
             status=ToolCallStatus.TOOL_CALL_RUNNING,
         ))
         mock_initial_status.messages.append(ai_msg)
 
-        builder = StatusBuilder("exec-alias-4", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        capture = ToolCallIdCapture()
+        capture._run_id_to_tool_call_id[new_run_id] = original_tc_id
+
+        builder = StatusBuilder("exec-alias-4", mock_initial_status,
+                                tool_call_id_capture=capture)
+        builder.rebuild_index_from_persisted_status()
 
         await builder.process_event({
             "event": "on_tool_start",
@@ -5090,7 +5115,7 @@ class TestRunIdAliasResolution:
             "run_id": new_run_id,
             "data": {"input": {"command": "ls -la"}},
         })
-        assert builder._run_id_aliases.get(new_run_id) == original_run_id
+        assert builder._run_id_aliases.get(new_run_id) == original_tc_id
 
         await builder.process_event({
             "event": "on_custom_event",
@@ -5099,7 +5124,7 @@ class TestRunIdAliasResolution:
             "data": {"chunk": "total 42\n"},
         })
 
-        tc = builder.get_tool_call(original_run_id)
+        tc = builder.get_tool_call(original_tc_id)
         assert tc.result == "total 42\n"
         assert tc.is_streaming is True
 
@@ -5121,7 +5146,7 @@ class TestRunIdAliasResolution:
         mock_initial_status.messages.append(ai_msg)
 
         builder = StatusBuilder("exec-force-1", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        builder.rebuild_index_from_persisted_status()
         builder.force_next_update = False
 
         await builder.process_event({
@@ -5151,7 +5176,7 @@ class TestRunIdAliasResolution:
         mock_initial_status.messages.append(ai_msg)
 
         builder = StatusBuilder("exec-force-2", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        builder.rebuild_index_from_persisted_status()
 
         await builder.process_event({
             "event": "on_custom_event",
@@ -5176,32 +5201,37 @@ class TestRunIdAliasResolution:
 
     @pytest.mark.asyncio
     async def test_no_alias_when_run_id_matches_existing(self, mock_initial_status):
-        """No alias is recorded when the new run_id happens to match the
-        existing tool call id (edge case: same run_id across invocations)."""
+        """No alias is recorded when the capture resolves run_id to itself
+        (edge case: tool_call_id matches the run_id)."""
         from google.protobuf.struct_pb2 import Struct
 
-        same_run_id = "same-run-999"
+        from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+
+        same_id = "toolu_same_999"
         args = Struct()
         args.update({"path": "/file.txt", "content": "data"})
         ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
         ai_msg.tool_calls.append(ToolCall(
-            id=same_run_id, name="write", args=args,
+            id=same_id, name="write", args=args,
             status=ToolCallStatus.TOOL_CALL_RUNNING,
         ))
         mock_initial_status.messages.append(ai_msg)
 
-        builder = StatusBuilder("exec-alias-5", mock_initial_status)
-        builder.populate_fingerprints_from_existing_tool_calls()
+        capture = ToolCallIdCapture()
+        capture._run_id_to_tool_call_id[same_id] = same_id
 
-        # on_tool_start with the SAME run_id — no alias needed.
+        builder = StatusBuilder("exec-alias-5", mock_initial_status,
+                                tool_call_id_capture=capture)
+        builder.rebuild_index_from_persisted_status()
+
         await builder.process_event({
             "event": "on_tool_start",
             "name": "write",
-            "run_id": same_run_id,
+            "run_id": same_id,
             "data": {"input": {"path": "/file.txt", "content": "data"}},
         })
 
-        assert same_run_id not in builder._run_id_aliases
+        assert same_id not in builder._run_id_aliases
 
 
 # =============================================================================

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -129,8 +129,8 @@ class TestChatModelStreamEvent:
         await status_builder.process_event(event)
         
         # Should have recorded start time at index 0
-        assert 0 in status_builder._message_start_times
-        assert isinstance(status_builder._message_start_times[0], datetime)
+        assert 0 in status_builder.state.message_start_times
+        assert isinstance(status_builder.state.message_start_times[0], datetime)
 
     @pytest.mark.asyncio
     async def test_handles_list_content(self, status_builder):
@@ -239,7 +239,7 @@ class TestChatModelEndEvent:
         
         # Manually set a known start time for testing
         known_start = datetime.utcnow() - timedelta(milliseconds=500)
-        status_builder._message_start_times[0] = known_start
+        status_builder.state.message_start_times[0] = known_start
         
         # Process end event
         output = MagicMock()
@@ -254,7 +254,7 @@ class TestChatModelEndEvent:
         await status_builder.process_event(end_event)
         
         # Start time should be cleaned up
-        assert 0 not in status_builder._message_start_times
+        assert 0 not in status_builder.state.message_start_times
 
     @pytest.mark.asyncio
     async def test_accumulates_tokens_across_multiple_calls(self, status_builder):
@@ -731,12 +731,12 @@ class TestToolCallStatus:
         })
         
         # Verify start time is tracked
-        assert run_id in status_builder._tool_start_times
-        assert isinstance(status_builder._tool_start_times[run_id], datetime)
+        assert run_id in status_builder.state.tool_start_times
+        assert isinstance(status_builder.state.tool_start_times[run_id], datetime)
         
         # Set a known start time to control duration calculation
         known_start = datetime.utcnow() - timedelta(milliseconds=1500)
-        status_builder._tool_start_times[run_id] = known_start
+        status_builder.state.tool_start_times[run_id] = known_start
         
         # End the tool
         await status_builder.process_event({
@@ -748,7 +748,7 @@ class TestToolCallStatus:
         })
         
         # Verify start time was cleaned up
-        assert run_id not in status_builder._tool_start_times
+        assert run_id not in status_builder.state.tool_start_times
 
 
 # =============================================================================
@@ -1112,7 +1112,7 @@ class TestSubAgentInternals:
         assert sub_agent.started_at != ""
         
         # Verify sub-agent is tracked for namespace routing
-        assert run_id in status_builder._active_sub_agents
+        assert run_id in status_builder.state.active_sub_agents
 
     @pytest.mark.asyncio
     async def test_task_tool_creates_parent_tool_call(self, status_builder):
@@ -1192,7 +1192,7 @@ class TestSubAgentInternals:
         assert sub_agent.completed_at != ""
         
         # Verify cleanup
-        assert run_id not in status_builder._active_sub_agents
+        assert run_id not in status_builder.state.active_sub_agents
 
     @pytest.mark.asyncio
     async def test_sub_agent_failure_captures_error(self, status_builder):
@@ -1559,8 +1559,8 @@ class TestSubAgentInternals:
         })
 
         # Verify namespace is registered and sub-agent is active
-        assert namespace in status_builder._namespace_to_sub_agent_id
-        assert sub_agent_run_id in status_builder._active_sub_agents
+        assert namespace in status_builder.state.namespace_to_sub_agent
+        assert sub_agent_run_id in status_builder.state.active_sub_agents
 
         # End sub-agent
         await status_builder.process_event({
@@ -1572,11 +1572,11 @@ class TestSubAgentInternals:
         })
 
         # Sub-agent moved from active to completed
-        assert sub_agent_run_id not in status_builder._active_sub_agents
-        assert sub_agent_run_id in status_builder._completed_sub_agents
+        assert sub_agent_run_id not in status_builder.state.active_sub_agents
+        assert sub_agent_run_id in status_builder.state.completed_sub_agents
 
         # Namespace mappings preserved for late-arriving event routing
-        assert namespace in status_builder._namespace_to_sub_agent_id
+        assert namespace in status_builder.state.namespace_to_sub_agent
 
     @pytest.mark.asyncio
     async def test_sub_agent_extracts_alternative_arg_names(self, status_builder):
@@ -1752,7 +1752,7 @@ class TestSubAgentInternals:
         })
 
         assert status_builder.force_next_update is False
-        assert run_id in status_builder._pending_completion_flush
+        assert run_id in status_builder.state.pending_completion_flush
 
     # ── Gap 9: Late event routing ───────────────────────────────────────────
 
@@ -1787,8 +1787,8 @@ class TestSubAgentInternals:
             "metadata": {},
         })
 
-        assert run_id not in status_builder._active_sub_agents
-        assert run_id in status_builder._completed_sub_agents
+        assert run_id not in status_builder.state.active_sub_agents
+        assert run_id in status_builder.state.completed_sub_agents
 
         # Late event with the same namespace
         context, sub_agent = status_builder._get_execution_context(namespace)
@@ -1814,15 +1814,15 @@ class TestSubAgentInternals:
                 "metadata": {},
             })
 
-        assert len(status_builder._active_sub_agents) == 2
+        assert len(status_builder.state.active_sub_agents) == 2
 
         status_builder.finalize_active_sub_agents(
             SubAgentStatus.SUB_AGENT_FAILED,
             "Parent execution failed: test error",
         )
 
-        assert len(status_builder._active_sub_agents) == 0
-        assert len(status_builder._completed_sub_agents) == 2
+        assert len(status_builder.state.active_sub_agents) == 0
+        assert len(status_builder.state.completed_sub_agents) == 2
 
         for sa in status_builder.current_status.sub_agent_executions:
             assert sa.status == SubAgentStatus.SUB_AGENT_FAILED
@@ -1834,14 +1834,14 @@ class TestSubAgentInternals:
         """finalize_active_sub_agents is a safe no-op when no sub-agents are active."""
         from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import SubAgentStatus
 
-        assert len(status_builder._active_sub_agents) == 0
+        assert len(status_builder.state.active_sub_agents) == 0
 
         status_builder.finalize_active_sub_agents(
             SubAgentStatus.SUB_AGENT_FAILED,
             "should not matter",
         )
 
-        assert len(status_builder._completed_sub_agents) == 0
+        assert len(status_builder.state.completed_sub_agents) == 0
         assert len(status_builder.current_status.sub_agent_executions) == 0
 
     # ── write_todos namespace isolation ──────────────────────────────────────
@@ -2025,7 +2025,7 @@ class TestSubAgentInternals:
             mock_sub.assert_called_once()
 
         # Verify the namespace was registered as a side effect
-        assert namespace in status_builder._namespace_to_sub_agent_id
+        assert namespace in status_builder.state.namespace_to_sub_agent
 
     # ── Early ToolCall reconciliation for task tool ──────────────────────
 
@@ -2072,7 +2072,7 @@ class TestSubAgentInternals:
         assert sa.name == "researcher"
 
         # run_id -> tool_call_id mapping is registered
-        assert status_builder._run_id_to_tool_call_id[run_id] == tool_use_id
+        assert status_builder.state.run_id_to_tool_call_id[run_id] == tool_use_id
 
     # ── Resume deduplication ─────────────────────────────────────────────
 
@@ -2125,7 +2125,7 @@ class TestSubAgentInternals:
         assert status_builder.current_status.sub_agent_executions[0].id == original_sa_id
 
         # New run_id maps to the existing sub-agent
-        assert run_id_2 in status_builder._active_sub_agents
+        assert run_id_2 in status_builder.state.active_sub_agents
 
     # ── Sub-agent completion marks parent ToolCall as COMPLETED ──────────
 
@@ -2256,8 +2256,8 @@ class TestSubAgentScenarios:
         assert sa.status == SubAgentStatus.SUB_AGENT_COMPLETED
         assert sa.output == "Hotfix applied to auth.py"
         assert sa.completed_at != ""
-        assert sa_run_id not in status_builder._active_sub_agents
-        assert sa_run_id in status_builder._completed_sub_agents
+        assert sa_run_id not in status_builder.state.active_sub_agents
+        assert sa_run_id in status_builder.state.completed_sub_agents
 
     @pytest.mark.asyncio
     async def test_concurrent_sub_agents_interleaved_events(self, status_builder):
@@ -2285,7 +2285,7 @@ class TestSubAgentScenarios:
                 "metadata": {},
             })
 
-        assert len(status_builder._active_sub_agents) == 2
+        assert len(status_builder.state.active_sub_agents) == 2
 
         # Interleaved tool events with parent_ids for routing
         await status_builder.process_event({
@@ -2321,8 +2321,8 @@ class TestSubAgentScenarios:
             "metadata": {"langgraph_checkpoint_ns": ns_b},
         })
 
-        sa_a = status_builder._active_sub_agents[sa_a_id]
-        sa_b = status_builder._active_sub_agents[sa_b_id]
+        sa_a = status_builder.state.active_sub_agents[sa_a_id]
+        sa_b = status_builder.state.active_sub_agents[sa_b_id]
 
         sa_a_tcs = [tc for m in sa_a.messages for tc in m.tool_calls]
         assert len(sa_a_tcs) == 1
@@ -2345,9 +2345,9 @@ class TestSubAgentScenarios:
             "metadata": {},
         })
 
-        assert sa_b_id not in status_builder._active_sub_agents
-        assert sa_b_id in status_builder._completed_sub_agents
-        assert sa_a_id in status_builder._active_sub_agents
+        assert sa_b_id not in status_builder.state.active_sub_agents
+        assert sa_b_id in status_builder.state.completed_sub_agents
+        assert sa_a_id in status_builder.state.active_sub_agents
 
         # Late event for SA-B routes to completed sub-agent (same namespace
         # that was registered when SA-B's tool events arrived)
@@ -2415,8 +2415,8 @@ class TestParentIdsNamespaceRouting:
             ns, {"parent_ids": ["sub-graph-root", run_id, "tools-node-run"]},
         )
 
-        assert ns in status_builder._namespace_to_sub_agent_id
-        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+        assert ns in status_builder.state.namespace_to_sub_agent
+        assert status_builder.state.namespace_to_sub_agent[ns] == run_id
 
     @pytest.mark.asyncio
     async def test_parent_ids_matches_completed_sub_agent(self, status_builder):
@@ -2439,15 +2439,15 @@ class TestParentIdsNamespaceRouting:
             "metadata": {},
         })
 
-        assert run_id in status_builder._completed_sub_agents
+        assert run_id in status_builder.state.completed_sub_agents
 
         ns = "tools:abc|late_node:xyz"
         status_builder._register_sub_agent_namespace(
             ns, {"parent_ids": [run_id]},
         )
 
-        assert ns in status_builder._namespace_to_sub_agent_id
-        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+        assert ns in status_builder.state.namespace_to_sub_agent
+        assert status_builder.state.namespace_to_sub_agent[ns] == run_id
 
     @pytest.mark.asyncio
     async def test_empty_parent_ids_does_not_register(self, status_builder):
@@ -2463,7 +2463,7 @@ class TestParentIdsNamespaceRouting:
         ns = "tools:aaa|child:bbb"
         status_builder._register_sub_agent_namespace(ns, {"parent_ids": []})
 
-        assert ns not in status_builder._namespace_to_sub_agent_id
+        assert ns not in status_builder.state.namespace_to_sub_agent
 
     @pytest.mark.asyncio
     async def test_no_matching_parent_ids_falls_to_main(self, status_builder):
@@ -2481,7 +2481,7 @@ class TestParentIdsNamespaceRouting:
             ns, {"parent_ids": ["unknown-id-1", "unknown-id-2"]},
         )
 
-        assert ns not in status_builder._namespace_to_sub_agent_id
+        assert ns not in status_builder.state.namespace_to_sub_agent
 
         context, sub_agent = status_builder._get_execution_context(ns)
         assert context is status_builder.current_status
@@ -2512,8 +2512,8 @@ class TestParentIdsNamespaceRouting:
             ns_b, {"parent_ids": ["sub-b-graph-root", sa_b, "tools-node"]},
         )
 
-        assert status_builder._namespace_to_sub_agent_id[ns_a] == sa_a
-        assert status_builder._namespace_to_sub_agent_id[ns_b] == sa_b
+        assert status_builder.state.namespace_to_sub_agent[ns_a] == sa_a
+        assert status_builder.state.namespace_to_sub_agent[ns_b] == sa_b
 
     @pytest.mark.asyncio
     async def test_single_segment_namespace_ignored(self, status_builder):
@@ -2521,7 +2521,7 @@ class TestParentIdsNamespaceRouting:
         status_builder._register_sub_agent_namespace(
             "tools", {"parent_ids": ["some-id"]},
         )
-        assert "tools" not in status_builder._namespace_to_sub_agent_id
+        assert "tools" not in status_builder.state.namespace_to_sub_agent
 
     @pytest.mark.asyncio
     async def test_already_registered_namespace_is_idempotent(self, status_builder):
@@ -2540,10 +2540,10 @@ class TestParentIdsNamespaceRouting:
         event = {"parent_ids": [run_id]}
 
         status_builder._register_sub_agent_namespace(ns, event)
-        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+        assert status_builder.state.namespace_to_sub_agent[ns] == run_id
 
         status_builder._register_sub_agent_namespace(ns, event)
-        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+        assert status_builder.state.namespace_to_sub_agent[ns] == run_id
 
 
 # =============================================================================
@@ -2582,7 +2582,7 @@ class TestConcurrentSubAgentNamespaceRegistration:
                 "metadata": {},
             })
 
-        assert len(status_builder._active_sub_agents) == 4
+        assert len(status_builder.state.active_sub_agents) == 4
 
         namespaces = [
             "tools:aaa|child-a",
@@ -2596,7 +2596,7 @@ class TestConcurrentSubAgentNamespaceRegistration:
             )
 
         for ns, sa_id in zip(namespaces, sa_ids):
-            assert status_builder._namespace_to_sub_agent_id[ns] == sa_id
+            assert status_builder.state.namespace_to_sub_agent[ns] == sa_id
 
     @pytest.mark.asyncio
     async def test_tool_calls_routed_to_correct_sub_agents_via_parent_ids(self, status_builder):
@@ -2628,7 +2628,7 @@ class TestConcurrentSubAgentNamespaceRegistration:
         assert all(tc.name == "task" for tc in main_tcs)
 
         for sa_id in sa_ids:
-            sa = status_builder._active_sub_agents[sa_id]
+            sa = status_builder.state.active_sub_agents[sa_id]
             sa_tcs = [tc for m in sa.messages for tc in m.tool_calls]
             assert len(sa_tcs) == 1
             assert sa_tcs[0].name == "read_file"
@@ -2656,8 +2656,8 @@ class TestConcurrentSubAgentNamespaceRegistration:
             {"parent_ids": ["sa-cascade-2"]},
         )
 
-        assert status_builder._namespace_to_sub_agent_id["tools:aaa|first-child"] == "sa-cascade-1"
-        assert status_builder._namespace_to_sub_agent_id["tools:bbb|first-child"] == "sa-cascade-2"
+        assert status_builder.state.namespace_to_sub_agent["tools:aaa|first-child"] == "sa-cascade-1"
+        assert status_builder.state.namespace_to_sub_agent["tools:bbb|first-child"] == "sa-cascade-2"
 
         status_builder._register_sub_agent_namespace(
             "tools:aaa|second-child|deeper",
@@ -2668,8 +2668,8 @@ class TestConcurrentSubAgentNamespaceRegistration:
             {"parent_ids": ["sa-cascade-2"]},
         )
 
-        assert status_builder._namespace_to_sub_agent_id["tools:aaa|second-child|deeper"] == "sa-cascade-1"
-        assert status_builder._namespace_to_sub_agent_id["tools:bbb|second-child|deeper"] == "sa-cascade-2"
+        assert status_builder.state.namespace_to_sub_agent["tools:aaa|second-child|deeper"] == "sa-cascade-1"
+        assert status_builder.state.namespace_to_sub_agent["tools:bbb|second-child|deeper"] == "sa-cascade-2"
 
     @pytest.mark.asyncio
     async def test_sub_agent_end_does_not_break_remaining_routing(self, status_builder):
@@ -2693,22 +2693,22 @@ class TestConcurrentSubAgentNamespaceRegistration:
             "metadata": {},
         })
 
-        assert "sa-end-2" not in status_builder._active_sub_agents
-        assert "sa-end-2" in status_builder._completed_sub_agents
-        assert "sa-end-1" in status_builder._active_sub_agents
-        assert "sa-end-3" in status_builder._active_sub_agents
+        assert "sa-end-2" not in status_builder.state.active_sub_agents
+        assert "sa-end-2" in status_builder.state.completed_sub_agents
+        assert "sa-end-1" in status_builder.state.active_sub_agents
+        assert "sa-end-3" in status_builder.state.active_sub_agents
 
         ns_1 = "tools:x|child-1"
         status_builder._register_sub_agent_namespace(
             ns_1, {"parent_ids": ["sa-end-1"]},
         )
-        assert status_builder._namespace_to_sub_agent_id[ns_1] == "sa-end-1"
+        assert status_builder.state.namespace_to_sub_agent[ns_1] == "sa-end-1"
 
         ns_3 = "tools:y|child-3"
         status_builder._register_sub_agent_namespace(
             ns_3, {"parent_ids": ["sa-end-3"]},
         )
-        assert status_builder._namespace_to_sub_agent_id[ns_3] == "sa-end-3"
+        assert status_builder.state.namespace_to_sub_agent[ns_3] == "sa-end-3"
 
     @pytest.mark.asyncio
     async def test_early_reconciliation_no_cross_contamination(self, status_builder):
@@ -2730,8 +2730,8 @@ class TestConcurrentSubAgentNamespaceRegistration:
                 ns, {"parent_ids": [sa_id]},
             )
 
-        sa1 = status_builder._active_sub_agents["sa-recon-1"]
-        sa2 = status_builder._active_sub_agents["sa-recon-2"]
+        sa1 = status_builder.state.active_sub_agents["sa-recon-1"]
+        sa2 = status_builder.state.active_sub_agents["sa-recon-2"]
 
         status_builder._create_early_tool_call(
             "read_file", "use-1", "ns-1", ns_map["sa-recon-1"],
@@ -2755,7 +2755,7 @@ class TestConcurrentSubAgentNamespaceRegistration:
         )
         assert reconciled is not None
 
-        assert len(status_builder._early_tool_call_queue) == 0
+        assert len(status_builder.state.early_tool_call_queue) == 0
 
 
 # =============================================================================
@@ -3726,8 +3726,8 @@ class TestPhase54ApprovalClearing:
         mock_initial_status.tool_calls.append(tool_call)
         
         # Set up full pending approval state (simulating approval request)
-        builder._pending_tool_approvals = ["tool-run-phase54"]
-        builder._saved_phase_before_approval = ExecutionPhase.EXECUTION_IN_PROGRESS
+        builder.state.approval.pending = ["tool-run-phase54"]
+        builder.state.approval.saved_phase = ExecutionPhase.EXECUTION_IN_PROGRESS
         builder.current_status.pending_approvals.append(PendingApproval(
             tool_call_id="tool-run-phase54",
             tool_name="dangerous_operation",
@@ -3745,7 +3745,7 @@ class TestPhase54ApprovalClearing:
         """Phase 5.4: Verify clear_pending_approval restores the saved phase."""
         # Verify starting state
         assert status_builder_with_pending_approval.current_status.phase == ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL
-        assert status_builder_with_pending_approval._saved_phase_before_approval == ExecutionPhase.EXECUTION_IN_PROGRESS
+        assert status_builder_with_pending_approval.state.approval.saved_phase == ExecutionPhase.EXECUTION_IN_PROGRESS
         
         # Call clear_pending_approval directly
         status_builder_with_pending_approval.clear_pending_approval()
@@ -3754,7 +3754,7 @@ class TestPhase54ApprovalClearing:
         assert status_builder_with_pending_approval.current_status.phase == ExecutionPhase.EXECUTION_IN_PROGRESS
         
         # Verify saved phase is reset to None after restoration
-        assert status_builder_with_pending_approval._saved_phase_before_approval is None
+        assert status_builder_with_pending_approval.state.approval.saved_phase is None
 
 
 # =============================================================================
@@ -3817,7 +3817,7 @@ class TestToolStartApprovalIntegration:
         assert status_builder_with_approval_config.current_status.phase == ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL
         
         # Pending approval should be tracked internally
-        assert "tool-run-approval-001" in status_builder_with_approval_config._pending_tool_approvals
+        assert "tool-run-approval-001" in status_builder_with_approval_config.state.approval.pending
     
     @pytest.mark.asyncio
     async def test_tool_start_proceeds_to_running_when_no_approval_required(self, status_builder_with_approval_config):
@@ -3932,7 +3932,7 @@ class TestToolStartApprovalIntegration:
         assert "production-db" in tool_call.approval_message
         
         # Pending approval should be tracked
-        assert "tool-run-render-test" in status_builder_with_approval_config._pending_tool_approvals
+        assert "tool-run-render-test" in status_builder_with_approval_config.state.approval.pending
 
 
 # =============================================================================
@@ -4540,13 +4540,13 @@ class TestContextManagementTracking:
             enabled=True,
         )
         
-        assert status_builder._context_info is not None
-        assert status_builder._context_info.context_window_limit == 200000
-        assert status_builder._context_info.summarization_trigger_threshold == 180000
-        assert status_builder._context_info.summarization_target_tokens == 160000
-        assert status_builder._context_info.summarization_enabled is True
-        assert status_builder._context_info.current_token_count == 0
-        assert status_builder._context_info.utilization_percent == 0.0
+        assert status_builder.state.context_info is not None
+        assert status_builder.state.context_info.context_window_limit == 200000
+        assert status_builder.state.context_info.summarization_trigger_threshold == 180000
+        assert status_builder.state.context_info.summarization_target_tokens == 160000
+        assert status_builder.state.context_info.summarization_enabled is True
+        assert status_builder.state.context_info.current_token_count == 0
+        assert status_builder.state.context_info.utilization_percent == 0.0
     
     def test_initialize_context_info_disabled(self, status_builder):
         """Test that initialize_context_info works when disabled."""
@@ -4557,8 +4557,8 @@ class TestContextManagementTracking:
             enabled=False,
         )
         
-        assert status_builder._context_info is not None
-        assert status_builder._context_info.summarization_enabled is False
+        assert status_builder.state.context_info is not None
+        assert status_builder.state.context_info.summarization_enabled is False
     
     def test_on_token_count_updated_updates_count(self, status_builder):
         """Test that on_token_count_updated updates the current token count."""
@@ -4571,7 +4571,7 @@ class TestContextManagementTracking:
         
         status_builder.on_token_count_updated(50000)
         
-        assert status_builder._context_info.current_token_count == 50000
+        assert status_builder.state.context_info.current_token_count == 50000
     
     def test_on_token_count_updated_calculates_utilization(self, status_builder):
         """Test that on_token_count_updated calculates utilization percentage."""
@@ -4584,7 +4584,7 @@ class TestContextManagementTracking:
         
         status_builder.on_token_count_updated(100000)  # 50% of 200000
         
-        assert status_builder._context_info.utilization_percent == 50.0
+        assert status_builder.state.context_info.utilization_percent == 50.0
     
     def test_on_token_count_updated_without_init_is_noop(self, status_builder):
         """Test that on_token_count_updated is a no-op without initialization."""
@@ -4592,7 +4592,7 @@ class TestContextManagementTracking:
         status_builder.on_token_count_updated(50000)
         
         # Context info should still be None
-        assert status_builder._context_info is None
+        assert status_builder.state.context_info is None
     
     def test_on_summarization_complete_adds_event(self, status_builder):
         """Test that on_summarization_complete records a summarization event."""
@@ -4618,7 +4618,7 @@ class TestContextManagementTracking:
         
         status_builder.on_summarization_complete(event)
         
-        events = status_builder._context_info.summarization_events
+        events = status_builder.state.context_info.summarization_events
         assert len(events) == 1
         recorded = events[0]
         assert recorded.tokens_before == 185000
@@ -4654,8 +4654,8 @@ class TestContextManagementTracking:
         
         status_builder.on_summarization_complete(event)
         
-        assert status_builder._context_info.current_token_count == 80000
-        assert status_builder._context_info.utilization_percent == 40.0
+        assert status_builder.state.context_info.current_token_count == 80000
+        assert status_builder.state.context_info.utilization_percent == 40.0
     
     def test_on_summarization_complete_without_init_is_noop(self, status_builder):
         """Test that on_summarization_complete is a no-op without initialization."""
@@ -4674,7 +4674,7 @@ class TestContextManagementTracking:
         
         status_builder.on_summarization_complete(event)
         
-        assert status_builder._context_info is None
+        assert status_builder.state.context_info is None
     
     def test_finalize_context_info_copies_to_status(self, status_builder):
         """Test that finalize_context_info copies context info to status proto."""
@@ -4783,7 +4783,7 @@ class TestContextManagementTracking:
         status_builder.on_summarization_complete(graph_start_event)
         status_builder.on_summarization_complete(mid_execution_event)
         
-        events = status_builder._context_info.summarization_events
+        events = status_builder.state.context_info.summarization_events
         assert events[0].source == SummarizationSource.graph_start
         assert events[1].source == SummarizationSource.mid_execution
     
@@ -4812,7 +4812,7 @@ class TestContextManagementTracking:
         
         status_builder.on_summarization_complete(event)
         
-        recorded = status_builder._context_info.summarization_events[0]
+        recorded = status_builder.state.context_info.summarization_events[0]
         assert recorded.source == SummarizationSource.SUMMARIZATION_SOURCE_UNSPECIFIED
     
     def test_on_summarization_complete_syncs_to_current_status_immediately(self, status_builder):
@@ -4885,14 +4885,14 @@ class TestContextManagementTracking:
         
         # Simulate growing context
         status_builder.on_token_count_updated(50000)
-        assert status_builder._context_info.current_token_count == 50000
+        assert status_builder.state.context_info.current_token_count == 50000
         
         status_builder.on_token_count_updated(100000)
-        assert status_builder._context_info.current_token_count == 100000
+        assert status_builder.state.context_info.current_token_count == 100000
         
         status_builder.on_token_count_updated(150000)
-        assert status_builder._context_info.current_token_count == 150000
-        assert status_builder._context_info.utilization_percent == 75.0
+        assert status_builder.state.context_info.current_token_count == 150000
+        assert status_builder.state.context_info.utilization_percent == 75.0
     
     def test_utilization_with_zero_limit(self, status_builder):
         """Test that utilization handles zero limit gracefully."""
@@ -4906,7 +4906,7 @@ class TestContextManagementTracking:
         status_builder.on_token_count_updated(1000)
         
         # Should not divide by zero
-        assert status_builder._context_info.utilization_percent == 0.0
+        assert status_builder.state.context_info.utilization_percent == 0.0
 
 
 # =============================================================================
@@ -4920,8 +4920,8 @@ class TestRunIdAliasResolution:
 
     When a tool call is interrupted for approval and then resumed, LangGraph
     generates a new run_id for the resumed execution.  The identity-based
-    dedup in _handle_tool_start_event (via ToolCallIdCapture) records an
-    alias from the new run_id to the original tool_call.id so that
+    dedup in _handle_tool_start_event registers an alias on ToolCallIdCapture
+    from the new run_id to the original tool_call.id so that
     _handle_tool_end_event can find and update the correct ToolCall.
     """
 
@@ -4964,7 +4964,7 @@ class TestRunIdAliasResolution:
         }
         await builder.process_event(event)
 
-        assert builder._run_id_aliases.get(new_run_id) == original_tc_id
+        assert builder.resolve_run_id(new_run_id) == original_tc_id
         assert builder.tool_call_count() == 1
 
     @pytest.mark.asyncio
@@ -5076,14 +5076,14 @@ class TestRunIdAliasResolution:
 
     @pytest.mark.asyncio
     async def test_resolve_run_id_returns_original_when_no_alias(self, status_builder):
-        """_resolve_run_id returns the input unchanged when no alias exists."""
-        assert status_builder._resolve_run_id("some-id") == "some-id"
+        """resolve_run_id returns the input unchanged when no alias exists."""
+        assert status_builder.resolve_run_id("some-id") == "some-id"
 
     @pytest.mark.asyncio
     async def test_resolve_run_id_returns_alias_when_present(self, status_builder):
-        """_resolve_run_id returns the mapped original id when alias exists."""
-        status_builder._run_id_aliases["new-123"] = "orig-456"
-        assert status_builder._resolve_run_id("new-123") == "orig-456"
+        """resolve_run_id returns the mapped original id when alias exists."""
+        status_builder._tool_call_id_capture.register_alias("new-123", "orig-456")
+        assert status_builder.resolve_run_id("new-123") == "orig-456"
 
     @pytest.mark.asyncio
     async def test_tool_progress_resolves_alias(self, mock_initial_status):
@@ -5120,7 +5120,7 @@ class TestRunIdAliasResolution:
             "run_id": new_run_id,
             "data": {"input": {"command": "ls -la"}},
         })
-        assert builder._run_id_aliases.get(new_run_id) == original_tc_id
+        assert builder.resolve_run_id(new_run_id) == original_tc_id
 
         await builder.process_event({
             "event": "on_custom_event",
@@ -5236,7 +5236,7 @@ class TestRunIdAliasResolution:
             "data": {"input": {"path": "/file.txt", "content": "data"}},
         })
 
-        assert same_id not in builder._run_id_aliases
+        assert builder.resolve_run_id(same_id) == same_id
 
 
 # =============================================================================
@@ -5270,7 +5270,7 @@ class TestNativeThinkingTranslation:
         assert len(parent_ai.tool_calls) == 1
         assert parent_ai.tool_calls[0].name == "think"
 
-        assert status_builder._thinking_buffers.get("") == "Let me analyze this..."
+        assert status_builder.state.thinking.buffers.get("") == "Let me analyze this..."
 
         # A streaming ToolCall should exist in the flat list
         assert status_builder.tool_call_count() == 1
@@ -5292,7 +5292,7 @@ class TestNativeThinkingTranslation:
                 "metadata": {},
             })
 
-        assert status_builder._thinking_buffers[""] == (
+        assert status_builder.state.thinking.buffers[""] == (
             "Step 1: analyse inputs. Step 2: decide."
         )
 
@@ -5380,7 +5380,7 @@ class TestNativeThinkingTranslation:
                 is_streaming=True,
             )
         )
-        status_builder._message_start_times[0] = datetime.utcnow()
+        status_builder.state.message_start_times[0] = datetime.utcnow()
 
         await status_builder.process_event({
             "event": "on_chat_model_end",
@@ -5411,7 +5411,7 @@ class TestNativeThinkingTranslation:
         assert status_builder.tool_call_count() == 0
         assert len(status_builder.current_status.messages) == 1
         assert status_builder.current_status.messages[0].content == "Regular text"
-        assert not status_builder._thinking_buffers
+        assert not status_builder.state.thinking.buffers
 
     @pytest.mark.asyncio
     async def test_empty_thinking_block_ignored(self, status_builder):
@@ -5534,9 +5534,9 @@ class TestNativeThinkingTranslation:
         })
 
         # Tracking state should exist
-        assert "" in status_builder._thinking_buffers
-        assert "" in status_builder._thinking_tool_call_ids
-        assert "" in status_builder._thinking_started_at
+        assert "" in status_builder.state.thinking.buffers
+        assert "" in status_builder.state.thinking.tool_call_ids
+        assert "" in status_builder.state.thinking.started_at
 
         # Flush via text
         text_chunk = MagicMock()
@@ -5548,9 +5548,9 @@ class TestNativeThinkingTranslation:
         })
 
         # All tracking state should be cleared
-        assert "" not in status_builder._thinking_buffers
-        assert "" not in status_builder._thinking_tool_call_ids
-        assert "" not in status_builder._thinking_started_at
+        assert "" not in status_builder.state.thinking.buffers
+        assert "" not in status_builder.state.thinking.tool_call_ids
+        assert "" not in status_builder.state.thinking.started_at
 
 
 # =============================================================================
@@ -5638,10 +5638,10 @@ class TestLLMStreamIsolation:
     async def test_run_id_map_cleaned_after_finalization(self, status_builder):
         """run_id entry is removed from the map after on_chat_model_end."""
         await status_builder.process_event(self._stream_event("Hello", run_id="R1"))
-        assert "R1" in status_builder._llm_run_id_to_message
+        assert "R1" in status_builder.state.messages_by_run
 
         await status_builder.process_event(self._end_event(run_id="R1"))
-        assert "R1" not in status_builder._llm_run_id_to_message
+        assert "R1" not in status_builder.state.messages_by_run
 
     @pytest.mark.asyncio
     async def test_legacy_no_run_id_uses_backwards_scan(self, status_builder):
@@ -6125,7 +6125,7 @@ class TestOrphanedSubAgentDetection:
     async def test_diagnostic_mid_execution_sub_agent(self, status_builder):
         """Sub-agent with messages is classified as mid-execution."""
         await status_builder.process_event(self._make_task_start_event("sa-1"))
-        sub_agent = status_builder._active_sub_agents["sa-1"]
+        sub_agent = status_builder.state.active_sub_agents["sa-1"]
         sub_agent.messages.append(AgentMessage(content="working..."))
 
         diag = status_builder.get_orphaned_sub_agents_diagnostic()
@@ -6141,7 +6141,7 @@ class TestOrphanedSubAgentDetection:
         await status_builder.process_event(self._make_task_start_event("sa-zero", "task alpha"))
         await status_builder.process_event(self._make_task_start_event("sa-mid", "task beta"))
 
-        mid_agent = status_builder._active_sub_agents["sa-mid"]
+        mid_agent = status_builder.state.active_sub_agents["sa-mid"]
         mid_agent.messages.append(AgentMessage(content="reading file"))
 
         diag = status_builder.get_orphaned_sub_agents_diagnostic()
@@ -6163,7 +6163,7 @@ class TestOrphanedSubAgentDetection:
         )
 
         assert count == 1
-        sa = status_builder._completed_sub_agents["sa-1"]
+        sa = status_builder.state.completed_sub_agents["sa-1"]
         assert sa.status == SubAgentStatus.SUB_AGENT_CANCELLED
         assert "never began execution" in sa.error
         assert status_builder.has_orphaned_sub_agents is False
@@ -6172,7 +6172,7 @@ class TestOrphanedSubAgentDetection:
     async def test_differentiated_finalize_mid_execution_gets_failed(self, status_builder):
         """Mid-execution sub-agents receive SUB_AGENT_FAILED."""
         await status_builder.process_event(self._make_task_start_event("sa-1"))
-        status_builder._active_sub_agents["sa-1"].messages.append(
+        status_builder.state.active_sub_agents["sa-1"].messages.append(
             AgentMessage(content="I found the issue")
         )
 
@@ -6181,7 +6181,7 @@ class TestOrphanedSubAgentDetection:
         )
 
         assert count == 1
-        sa = status_builder._completed_sub_agents["sa-1"]
+        sa = status_builder.state.completed_sub_agents["sa-1"]
         assert sa.status == SubAgentStatus.SUB_AGENT_FAILED
         assert "was running" in sa.error
         assert status_builder.has_orphaned_sub_agents is False
@@ -6191,7 +6191,7 @@ class TestOrphanedSubAgentDetection:
         """Mixed finalization: zero-message → CANCELLED, mid-execution → FAILED."""
         await status_builder.process_event(self._make_task_start_event("sa-zero", "task alpha"))
         await status_builder.process_event(self._make_task_start_event("sa-mid", "task beta"))
-        status_builder._active_sub_agents["sa-mid"].messages.append(
+        status_builder.state.active_sub_agents["sa-mid"].messages.append(
             AgentMessage(content="working")
         )
 
@@ -6200,8 +6200,8 @@ class TestOrphanedSubAgentDetection:
         )
 
         assert count == 2
-        assert status_builder._completed_sub_agents["sa-zero"].status == SubAgentStatus.SUB_AGENT_CANCELLED
-        assert status_builder._completed_sub_agents["sa-mid"].status == SubAgentStatus.SUB_AGENT_FAILED
+        assert status_builder.state.completed_sub_agents["sa-zero"].status == SubAgentStatus.SUB_AGENT_CANCELLED
+        assert status_builder.state.completed_sub_agents["sa-mid"].status == SubAgentStatus.SUB_AGENT_FAILED
         assert status_builder.has_orphaned_sub_agents is False
 
     @pytest.mark.asyncio
@@ -6221,7 +6221,7 @@ class TestOrphanedSubAgentDetection:
             error_context="test"
         )
 
-        sa = status_builder._completed_sub_agents["sa-1"]
+        sa = status_builder.state.completed_sub_agents["sa-1"]
         assert sa.completed_at != ""
 
     # ── Regression: original finalize_active_sub_agents still works ──────────
@@ -6239,8 +6239,8 @@ class TestOrphanedSubAgentDetection:
             "stall detected"
         )
 
-        assert status_builder._completed_sub_agents["sa-1"].status == SubAgentStatus.SUB_AGENT_FAILED
-        assert status_builder._completed_sub_agents["sa-2"].status == SubAgentStatus.SUB_AGENT_FAILED
+        assert status_builder.state.completed_sub_agents["sa-1"].status == SubAgentStatus.SUB_AGENT_FAILED
+        assert status_builder.state.completed_sub_agents["sa-2"].status == SubAgentStatus.SUB_AGENT_FAILED
         assert status_builder.has_orphaned_sub_agents is False
 
 
@@ -6358,7 +6358,7 @@ class TestTurnBoundaryAndUsageTracking:
         assert len(parent_ai.tool_calls) == 2  # think + read
 
         # The empty parent must be registered in _llm_run_id_to_message
-        assert llm_run_id in status_builder._llm_run_id_to_message
+        assert llm_run_id in status_builder.state.messages_by_run
 
         # Simulate on_chat_model_end with usage metadata
         output = MagicMock()
@@ -6634,18 +6634,18 @@ class TestDeferredCompletionFlush:
         import time
 
         now = time.monotonic()
-        status_builder._pending_completion_flush["sa-1"] = now
+        status_builder.state.pending_completion_flush["sa-1"] = now
 
         assert status_builder.should_flush_completions(now + 0.1) is False
         assert status_builder.force_next_update is False
-        assert "sa-1" in status_builder._pending_completion_flush
+        assert "sa-1" in status_builder.state.pending_completion_flush
 
     def test_should_flush_after_drain_window(self, status_builder):
         """Flush returns True and sets force_next_update after the drain window elapses."""
         import time
 
         now = time.monotonic()
-        status_builder._pending_completion_flush["sa-1"] = now
+        status_builder.state.pending_completion_flush["sa-1"] = now
 
         result = status_builder.should_flush_completions(
             now + (StatusBuilder._COMPLETION_DRAIN_MS / 1000.0) + 0.001,
@@ -6653,23 +6653,23 @@ class TestDeferredCompletionFlush:
 
         assert result is True
         assert status_builder.force_next_update is True
-        assert "sa-1" not in status_builder._pending_completion_flush
+        assert "sa-1" not in status_builder.state.pending_completion_flush
 
     def test_should_flush_partial_drain(self, status_builder):
         """Only entries past the drain window are flushed; others remain."""
         import time
 
         now = time.monotonic()
-        status_builder._pending_completion_flush["sa-old"] = now
-        status_builder._pending_completion_flush["sa-new"] = now + 1.0
+        status_builder.state.pending_completion_flush["sa-old"] = now
+        status_builder.state.pending_completion_flush["sa-new"] = now + 1.0
 
         result = status_builder.should_flush_completions(
             now + (StatusBuilder._COMPLETION_DRAIN_MS / 1000.0) + 0.001,
         )
 
         assert result is True
-        assert "sa-old" not in status_builder._pending_completion_flush
-        assert "sa-new" in status_builder._pending_completion_flush
+        assert "sa-old" not in status_builder.state.pending_completion_flush
+        assert "sa-new" in status_builder.state.pending_completion_flush
 
     @pytest.mark.asyncio
     async def test_sub_agent_end_populates_pending_flush(self, status_builder):
@@ -6695,7 +6695,7 @@ class TestDeferredCompletionFlush:
         })
 
         assert status_builder.force_next_update is False
-        assert run_id in status_builder._pending_completion_flush
+        assert run_id in status_builder.state.pending_completion_flush
 
 
 # =============================================================================
@@ -6769,7 +6769,7 @@ class TestUniversalNamespaceRegistration:
             self._make_chat_model_stream_event(child_ns, parent_ids=[sa_id])
         )
 
-        assert child_ns in status_builder._namespace_to_sub_agent_id
+        assert child_ns in status_builder.state.namespace_to_sub_agent
 
     @pytest.mark.asyncio
     async def test_tool_end_registers_namespace(self, status_builder):
@@ -6785,7 +6785,7 @@ class TestUniversalNamespaceRegistration:
             )
         )
 
-        assert child_ns in status_builder._namespace_to_sub_agent_id
+        assert child_ns in status_builder.state.namespace_to_sub_agent
 
     @pytest.mark.asyncio
     async def test_single_segment_namespace_ignored(self, status_builder):
@@ -6798,7 +6798,7 @@ class TestUniversalNamespaceRegistration:
             "metadata": {"langgraph_checkpoint_ns": "main"},
         })
 
-        assert "main" not in status_builder._namespace_to_sub_agent_id
+        assert "main" not in status_builder.state.namespace_to_sub_agent
 
     @pytest.mark.asyncio
     async def test_registration_is_idempotent(self, status_builder):
@@ -6813,7 +6813,7 @@ class TestUniversalNamespaceRegistration:
                 self._make_chat_model_stream_event(child_ns, parent_ids=[sa_id])
             )
 
-        assert child_ns in status_builder._namespace_to_sub_agent_id
+        assert child_ns in status_builder.state.namespace_to_sub_agent
 
 
 # =============================================================================
@@ -6855,7 +6855,7 @@ class TestFinalizationPreservesTerminalStatus:
         await status_builder.process_event(
             self._make_task_start_event("sa-done", "finished task")
         )
-        sa = status_builder._active_sub_agents["sa-done"]
+        sa = status_builder.state.active_sub_agents["sa-done"]
         sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
         sa.output = "result data"
 
@@ -6864,7 +6864,7 @@ class TestFinalizationPreservesTerminalStatus:
             "Parent execution error: BadRequestError",
         )
 
-        finalized = status_builder._completed_sub_agents["sa-done"]
+        finalized = status_builder.state.completed_sub_agents["sa-done"]
         assert finalized.status == SubAgentStatus.SUB_AGENT_COMPLETED
         assert finalized.output == "result data"
 
@@ -6880,7 +6880,7 @@ class TestFinalizationPreservesTerminalStatus:
             "Parent execution error: BadRequestError",
         )
 
-        finalized = status_builder._completed_sub_agents["sa-wip"]
+        finalized = status_builder.state.completed_sub_agents["sa-wip"]
         assert finalized.status == SubAgentStatus.SUB_AGENT_FAILED
 
     @pytest.mark.asyncio
@@ -6889,7 +6889,7 @@ class TestFinalizationPreservesTerminalStatus:
         await status_builder.process_event(
             self._make_task_start_event("sa-out", "has output")
         )
-        sa = status_builder._active_sub_agents["sa-out"]
+        sa = status_builder.state.active_sub_agents["sa-out"]
         sa.output = "partial result"
 
         status_builder.finalize_active_sub_agents(
@@ -6897,7 +6897,7 @@ class TestFinalizationPreservesTerminalStatus:
             "Parent execution error",
         )
 
-        finalized = status_builder._completed_sub_agents["sa-out"]
+        finalized = status_builder.state.completed_sub_agents["sa-out"]
         assert finalized.output == "partial result"
         assert finalized.status != SubAgentStatus.SUB_AGENT_FAILED
 
@@ -6911,7 +6911,7 @@ class TestFinalizationPreservesTerminalStatus:
             self._make_task_start_event("sa-running", "still going")
         )
 
-        completed_sa = status_builder._active_sub_agents["sa-completed"]
+        completed_sa = status_builder.state.active_sub_agents["sa-completed"]
         completed_sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
         completed_sa.output = "finished"
 
@@ -6920,9 +6920,9 @@ class TestFinalizationPreservesTerminalStatus:
             "stall detected",
         )
 
-        assert status_builder._completed_sub_agents["sa-completed"].status == SubAgentStatus.SUB_AGENT_COMPLETED
-        assert status_builder._completed_sub_agents["sa-running"].status == SubAgentStatus.SUB_AGENT_FAILED
-        assert len(status_builder._active_sub_agents) == 0
+        assert status_builder.state.completed_sub_agents["sa-completed"].status == SubAgentStatus.SUB_AGENT_COMPLETED
+        assert status_builder.state.completed_sub_agents["sa-running"].status == SubAgentStatus.SUB_AGENT_FAILED
+        assert len(status_builder.state.active_sub_agents) == 0
 
     @pytest.mark.asyncio
     async def test_differentiated_finalize_preserves_completed(self, status_builder):
@@ -6934,11 +6934,11 @@ class TestFinalizationPreservesTerminalStatus:
             self._make_task_start_event("sa-wip", "mid execution")
         )
 
-        ok_sa = status_builder._active_sub_agents["sa-ok"]
+        ok_sa = status_builder.state.active_sub_agents["sa-ok"]
         ok_sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
         ok_sa.output = "success"
 
-        wip_sa = status_builder._active_sub_agents["sa-wip"]
+        wip_sa = status_builder.state.active_sub_agents["sa-wip"]
         wip_sa.messages.append(AgentMessage(content="working on it"))
 
         count = status_builder.finalize_active_sub_agents_differentiated(
@@ -6946,8 +6946,8 @@ class TestFinalizationPreservesTerminalStatus:
         )
 
         assert count == 2
-        assert status_builder._completed_sub_agents["sa-ok"].status == SubAgentStatus.SUB_AGENT_COMPLETED
-        assert status_builder._completed_sub_agents["sa-wip"].status == SubAgentStatus.SUB_AGENT_FAILED
+        assert status_builder.state.completed_sub_agents["sa-ok"].status == SubAgentStatus.SUB_AGENT_COMPLETED
+        assert status_builder.state.completed_sub_agents["sa-wip"].status == SubAgentStatus.SUB_AGENT_FAILED
 
     @pytest.mark.asyncio
     async def test_pending_completion_flushed_before_finalization(self, status_builder):
@@ -6958,18 +6958,18 @@ class TestFinalizationPreservesTerminalStatus:
             self._make_task_start_event("sa-flush", "completed recently")
         )
 
-        sa = status_builder._active_sub_agents.pop("sa-flush")
+        sa = status_builder.state.active_sub_agents.pop("sa-flush")
         sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
         sa.output = "done"
-        status_builder._completed_sub_agents["sa-flush"] = sa
-        status_builder._pending_completion_flush["sa-flush"] = time.monotonic()
+        status_builder.state.completed_sub_agents["sa-flush"] = sa
+        status_builder.state.pending_completion_flush["sa-flush"] = time.monotonic()
 
         status_builder.finalize_active_sub_agents(
             SubAgentStatus.SUB_AGENT_FAILED,
             "Parent crashed",
         )
 
-        assert len(status_builder._pending_completion_flush) == 0
+        assert len(status_builder.state.pending_completion_flush) == 0
         assert status_builder.force_next_update is True
 
     @pytest.mark.asyncio
@@ -6978,3 +6978,169 @@ class TestFinalizationPreservesTerminalStatus:
         flushed = status_builder._flush_pending_completions()
         assert flushed == []
         assert status_builder.force_next_update is False
+
+
+# =============================================================================
+# Tests for ExecutionState.rebuild_from_proto
+# =============================================================================
+
+
+class TestRebuildFromProto:
+    """Tests for ExecutionState.rebuild_from_proto classmethod.
+
+    Verifies that proto-derivable indexes are correctly reconstructed
+    from a persisted AgentExecutionStatus, and that ephemeral runtime
+    state starts fresh.
+    """
+
+    def test_indexes_main_agent_tool_calls(self, mock_initial_status):
+        """Tool calls inside main-agent AI messages are indexed."""
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
+        tc_a = ai_msg.tool_calls.add(
+            id="toolu_A", name="write",
+            status=ToolCallStatus.TOOL_CALL_COMPLETED,
+        )
+        tc_b = ai_msg.tool_calls.add(
+            id="toolu_B", name="read",
+            status=ToolCallStatus.TOOL_CALL_RUNNING,
+        )
+        mock_initial_status.messages.append(ai_msg)
+
+        state = ExecutionState.rebuild_from_proto(mock_initial_status)
+
+        assert len(state.tool_calls) == 2
+        assert state.tool_calls["toolu_A"].name == "write"
+        assert state.tool_calls["toolu_B"].name == "read"
+        assert state.tool_calls["toolu_A"] is mock_initial_status.messages[0].tool_calls[0]
+
+    def test_indexes_sub_agent_tool_calls(self, mock_initial_status):
+        """Tool calls inside sub-agent messages are also indexed."""
+        from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        sa = SubAgentExecution(
+            id="toolu_SA1", name="generalPurpose",
+            status=SubAgentStatus.SUB_AGENT_COMPLETED,
+        )
+        sa_msg = sa.messages.add(type=MessageType.MESSAGE_AI)
+        sa_msg.tool_calls.add(
+            id="toolu_nested", name="execute",
+            status=ToolCallStatus.TOOL_CALL_COMPLETED,
+        )
+        mock_initial_status.sub_agent_executions.append(sa)
+
+        state = ExecutionState.rebuild_from_proto(mock_initial_status)
+
+        assert "toolu_nested" in state.tool_calls
+        assert state.tool_calls["toolu_nested"].name == "execute"
+
+    def test_indexes_completed_sub_agents(self, mock_initial_status):
+        """Completed/failed/cancelled sub-agents populate completed_sub_agents."""
+        from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        sa_done = SubAgentExecution(
+            id="sa-1", name="generalPurpose",
+            status=SubAgentStatus.SUB_AGENT_COMPLETED,
+        )
+        sa_failed = SubAgentExecution(
+            id="sa-2", name="generalPurpose",
+            status=SubAgentStatus.SUB_AGENT_FAILED,
+        )
+        sa_running = SubAgentExecution(
+            id="sa-3", name="generalPurpose",
+            status=SubAgentStatus.SUB_AGENT_IN_PROGRESS,
+        )
+        mock_initial_status.sub_agent_executions.extend([sa_done, sa_failed, sa_running])
+
+        state = ExecutionState.rebuild_from_proto(mock_initial_status)
+
+        assert "sa-1" in state.completed_sub_agents
+        assert "sa-2" in state.completed_sub_agents
+        assert "sa-3" not in state.completed_sub_agents
+
+    def test_copies_artifacts(self):
+        """Proto artifacts are copied into state.artifacts."""
+        from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        proto = AgentExecutionStatus()
+        proto.artifacts.add(name="output.txt", sandbox_path="project/output.txt")
+        proto.artifacts.add(name="log.txt", sandbox_path="project/log.txt")
+
+        state = ExecutionState.rebuild_from_proto(proto)
+
+        assert len(state.artifacts) == 2
+        assert state.artifacts[0].name == "output.txt"
+        assert state.artifacts[1].name == "log.txt"
+
+    def test_ephemeral_state_starts_fresh(self, mock_initial_status):
+        """Ephemeral fields (timing, buffers, approval) are empty after rebuild."""
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
+        ai_msg.tool_calls.add(
+            id="toolu_X", name="write",
+            status=ToolCallStatus.TOOL_CALL_RUNNING,
+        )
+        mock_initial_status.messages.append(ai_msg)
+
+        state = ExecutionState.rebuild_from_proto(mock_initial_status)
+
+        assert len(state.tool_start_times) == 0
+        assert len(state.message_start_times) == 0
+        assert len(state.messages_by_run) == 0
+        assert len(state.current_ai_message) == 0
+        assert len(state.active_sub_agents) == 0
+        assert len(state.thinking.buffers) == 0
+        assert len(state.tool_input.buffers) == 0
+        assert len(state.approval.pending) == 0
+        assert len(state.early_tool_call_queue) == 0
+
+    def test_skips_tool_calls_without_id(self, mock_initial_status):
+        """Tool calls with empty id are not indexed (edge case)."""
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
+        ai_msg.tool_calls.add(id="", name="write")
+        ai_msg.tool_calls.add(id="toolu_real", name="read")
+        mock_initial_status.messages.append(ai_msg)
+
+        state = ExecutionState.rebuild_from_proto(mock_initial_status)
+
+        assert len(state.tool_calls) == 1
+        assert "toolu_real" in state.tool_calls
+
+    def test_skips_non_ai_messages(self, mock_initial_status):
+        """Human messages are ignored during tool call indexing."""
+        from worker.activities.graphton.execution_state import ExecutionState
+
+        human_msg = AgentMessage(type=MessageType.MESSAGE_HUMAN)
+        ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
+        ai_msg.tool_calls.add(id="toolu_only", name="execute")
+        mock_initial_status.messages.extend([human_msg, ai_msg])
+
+        state = ExecutionState.rebuild_from_proto(mock_initial_status)
+
+        assert len(state.tool_calls) == 1
+        assert "toolu_only" in state.tool_calls
+
+    def test_status_builder_delegates_to_rebuild(self, mock_initial_status):
+        """StatusBuilder.rebuild_index_from_persisted_status uses
+        ExecutionState.rebuild_from_proto and replaces self.state."""
+        ai_msg = AgentMessage(type=MessageType.MESSAGE_AI)
+        ai_msg.tool_calls.add(
+            id="toolu_delegated", name="write",
+            status=ToolCallStatus.TOOL_CALL_RUNNING,
+        )
+        mock_initial_status.messages.append(ai_msg)
+
+        builder = StatusBuilder("exec-rebuild", mock_initial_status)
+        assert len(builder.state.tool_calls) == 0
+
+        builder.rebuild_index_from_persisted_status()
+
+        assert "toolu_delegated" in builder.state.tool_calls
+        assert builder.state.proto is mock_initial_status

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -1240,7 +1240,7 @@ class TestSubAgentInternals:
         from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ToolCallStatus
         
         sub_agent_run_id = "task-run-ns-test"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
         
         # Start sub-agent
         await status_builder.process_event({
@@ -1256,12 +1256,13 @@ class TestSubAgentInternals:
             "metadata": {}
         })
         
-        # Tool call from sub-agent (with namespace)
+        # Tool call from sub-agent (with namespace + parent_ids)
         tool_run_id = "tool-in-subagent"
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "write_file",
             "run_id": tool_run_id,
+            "parent_ids": [sub_agent_run_id],
             "data": {"input": {"path": "/tmp/test.py", "content": "print('hello')"}},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1283,7 +1284,7 @@ class TestSubAgentInternals:
     async def test_namespace_routing_messages_to_sub_agent(self, status_builder):
         """Test that AI messages with sub-agent namespace route to SubAgentExecution."""
         sub_agent_run_id = "task-run-msg-test"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
         
         # Start sub-agent
         await status_builder.process_event({
@@ -1299,12 +1300,13 @@ class TestSubAgentInternals:
             "metadata": {}
         })
         
-        # AI message from sub-agent (with namespace)
+        # AI message from sub-agent (with namespace + parent_ids)
         chunk = MagicMock()
         chunk.content = "I'll help you with that."
         
         await status_builder.process_event({
             "event": "on_chat_model_stream",
+            "parent_ids": [sub_agent_run_id],
             "data": {"chunk": chunk},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1323,7 +1325,7 @@ class TestSubAgentInternals:
     async def test_sub_agent_tool_end_updates_correct_context(self, status_builder):
         """Test that tool end events update the correct sub-agent context."""
         sub_agent_run_id = "task-run-end-test"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
         tool_run_id = "tool-end-test"
         
         # Start sub-agent
@@ -1345,6 +1347,7 @@ class TestSubAgentInternals:
             "event": "on_tool_start",
             "name": "read_file",
             "run_id": tool_run_id,
+            "parent_ids": [sub_agent_run_id],
             "data": {"input": {"path": "/tmp/file.txt"}},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1354,6 +1357,7 @@ class TestSubAgentInternals:
             "event": "on_tool_end",
             "name": "read_file",
             "run_id": tool_run_id,
+            "parent_ids": [sub_agent_run_id],
             "data": {"output": "file contents"},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1398,21 +1402,23 @@ class TestSubAgentInternals:
         })
         
         # Tool call for sub-agent-1
-        namespace1 = "node:sub-agent-1"
+        namespace1 = "tools:task1|node:sub-agent-1"
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "search",
             "run_id": "tool-1",
+            "parent_ids": ["sub-agent-1"],
             "data": {"input": {"query": "topic A"}},
             "metadata": {"langgraph_checkpoint_ns": namespace1}
         })
         
         # Tool call for sub-agent-2
-        namespace2 = "node:sub-agent-2"
+        namespace2 = "tools:task2|node:sub-agent-2"
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "write_file",
             "run_id": "tool-2",
+            "parent_ids": ["sub-agent-2"],
             "data": {"input": {"path": "/tmp/b.txt"}},
             "metadata": {"langgraph_checkpoint_ns": namespace2}
         })
@@ -1471,7 +1477,7 @@ class TestSubAgentInternals:
     async def test_sub_agent_message_finalization(self, status_builder):
         """Test that AI message finalization works for sub-agent messages."""
         sub_agent_run_id = "task-run-finalize"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
         
         # Start sub-agent
         await status_builder.process_event({
@@ -1493,6 +1499,7 @@ class TestSubAgentInternals:
         
         await status_builder.process_event({
             "event": "on_chat_model_stream",
+            "parent_ids": [sub_agent_run_id],
             "data": {"chunk": chunk},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1513,6 +1520,7 @@ class TestSubAgentInternals:
         
         await status_builder.process_event({
             "event": "on_chat_model_end",
+            "parent_ids": [sub_agent_run_id],
             "data": {"output": output},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1524,7 +1532,7 @@ class TestSubAgentInternals:
     async def test_namespace_cleanup_on_sub_agent_end(self, status_builder):
         """Completed sub-agents move to _completed; namespace mappings are preserved for late events."""
         sub_agent_run_id = "task-run-cleanup"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
 
         # Start sub-agent
         await status_builder.process_event({
@@ -1545,6 +1553,7 @@ class TestSubAgentInternals:
             "event": "on_tool_start",
             "name": "echo",
             "run_id": "child-tool",
+            "parent_ids": [sub_agent_run_id],
             "data": {"input": {"text": "hello"}},
             "metadata": {"langgraph_checkpoint_ns": namespace}
         })
@@ -1753,7 +1762,7 @@ class TestSubAgentInternals:
         from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import SubAgentStatus
 
         run_id = "task-late-event"
-        namespace = f"agent_node:{run_id}"
+        namespace = f"tools:{run_id}|agent_node:inner"
 
         # Start sub-agent
         await status_builder.process_event({
@@ -1765,7 +1774,9 @@ class TestSubAgentInternals:
         })
 
         # Register a namespace while it's active
-        status_builder._register_sub_agent_namespace(f"{namespace}|tools")
+        status_builder._register_sub_agent_namespace(
+            namespace, {"parent_ids": [run_id]},
+        )
 
         # Complete the sub-agent
         await status_builder.process_event({
@@ -1779,8 +1790,8 @@ class TestSubAgentInternals:
         assert run_id not in status_builder._active_sub_agents
         assert run_id in status_builder._completed_sub_agents
 
-        # Late event with the same namespace root
-        context, sub_agent = status_builder._get_execution_context(f"{namespace}|tools")
+        # Late event with the same namespace
+        context, sub_agent = status_builder._get_execution_context(namespace)
 
         assert sub_agent is not None
         assert sub_agent.id == run_id
@@ -1844,7 +1855,7 @@ class TestSubAgentInternals:
         namespace and route to _update_sub_agent_todos(), not _update_todos().
         """
         sub_agent_run_id = "task-run-todo-isolation"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
 
         # Create sub-agent via task tool
         await status_builder.process_event({
@@ -1867,6 +1878,7 @@ class TestSubAgentInternals:
             "event": "on_tool_start",
             "name": "read_file",
             "run_id": "sub-tool-pre-todo",
+            "parent_ids": [sub_agent_run_id],
             "data": {"input": {"path": "/tmp/test.txt"}},
             "metadata": {"langgraph_checkpoint_ns": namespace},
         })
@@ -1878,6 +1890,7 @@ class TestSubAgentInternals:
                 "event": "on_tool_start",
                 "name": "write_todos",
                 "run_id": "write-todos-sub-1",
+                "parent_ids": [sub_agent_run_id],
                 "data": {
                     "input": {
                         "todos": [
@@ -1895,7 +1908,7 @@ class TestSubAgentInternals:
     async def test_sub_agent_write_todos_populates_sub_agent_todos(self, status_builder):
         """Sub-agent write_todos must populate the SubAgentExecution.todos map."""
         sub_agent_run_id = "task-run-todo-populate"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
 
         await status_builder.process_event({
             "event": "on_tool_start",
@@ -1914,6 +1927,7 @@ class TestSubAgentInternals:
             "event": "on_tool_start",
             "name": "write_todos",
             "run_id": "write-todos-sub-populate",
+            "parent_ids": [sub_agent_run_id],
             "data": {
                 "input": {
                     "todos": [
@@ -1974,7 +1988,7 @@ class TestSubAgentInternals:
         _get_execution_context can resolve it.
         """
         sub_agent_run_id = "task-run-todo-first"
-        namespace = f"agent_node:{sub_agent_run_id}"
+        namespace = f"tools:{sub_agent_run_id}|agent_node:inner"
 
         await status_builder.process_event({
             "event": "on_tool_start",
@@ -1997,6 +2011,7 @@ class TestSubAgentInternals:
                 "event": "on_tool_start",
                 "name": "write_todos",
                 "run_id": "write-todos-first-event",
+                "parent_ids": [sub_agent_run_id],
                 "data": {
                     "input": {
                         "todos": [
@@ -2183,7 +2198,7 @@ class TestSubAgentScenarios:
         from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import SubAgentStatus
 
         sa_run_id = "sa-approval-lifecycle"
-        namespace = f"agent_node:{sa_run_id}"
+        namespace = f"tools:{sa_run_id}|agent_node:inner"
         tool_run_id = "write-tool-lifecycle"
 
         # 1. Start sub-agent
@@ -2206,11 +2221,12 @@ class TestSubAgentScenarios:
         assert sa.subject == ""
         assert sa.input == "Apply hotfix"
 
-        # 2. Sub-agent's tool call (routed via namespace)
+        # 2. Sub-agent's tool call (routed via parent_ids)
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "write_file",
             "run_id": tool_run_id,
+            "parent_ids": [sa_run_id],
             "data": {"input": {"path": "/app/auth.py", "content": "patched"}},
             "metadata": {"langgraph_checkpoint_ns": namespace},
         })
@@ -2223,6 +2239,7 @@ class TestSubAgentScenarios:
             "event": "on_tool_end",
             "name": "write_file",
             "run_id": tool_run_id,
+            "parent_ids": [sa_run_id],
             "data": {"output": "File written successfully"},
             "metadata": {"langgraph_checkpoint_ns": namespace},
         })
@@ -2249,8 +2266,8 @@ class TestSubAgentScenarios:
 
         sa_a_id = "sa-concurrent-a"
         sa_b_id = "sa-concurrent-b"
-        ns_a = f"agent_node:{sa_a_id}"
-        ns_b = f"agent_node:{sa_b_id}"
+        ns_a = f"tools:{sa_a_id}|agent_node:inner_a"
+        ns_b = f"tools:{sa_b_id}|agent_node:inner_b"
 
         # Start both sub-agents
         for sa_id, desc in [(sa_a_id, "review code"), (sa_b_id, "run tests")]:
@@ -2270,11 +2287,12 @@ class TestSubAgentScenarios:
 
         assert len(status_builder._active_sub_agents) == 2
 
-        # Interleaved tool events
+        # Interleaved tool events with parent_ids for routing
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "grep",
             "run_id": "tool-a-1",
+            "parent_ids": [sa_a_id],
             "data": {"input": {"pattern": "TODO"}},
             "metadata": {"langgraph_checkpoint_ns": ns_a},
         })
@@ -2282,6 +2300,7 @@ class TestSubAgentScenarios:
             "event": "on_tool_start",
             "name": "pytest",
             "run_id": "tool-b-1",
+            "parent_ids": [sa_b_id],
             "data": {"input": {"path": "tests/"}},
             "metadata": {"langgraph_checkpoint_ns": ns_b},
         })
@@ -2289,6 +2308,7 @@ class TestSubAgentScenarios:
             "event": "on_tool_end",
             "name": "grep",
             "run_id": "tool-a-1",
+            "parent_ids": [sa_a_id],
             "data": {"output": "3 TODOs found"},
             "metadata": {"langgraph_checkpoint_ns": ns_a},
         })
@@ -2296,6 +2316,7 @@ class TestSubAgentScenarios:
             "event": "on_tool_end",
             "name": "pytest",
             "run_id": "tool-b-1",
+            "parent_ids": [sa_b_id],
             "data": {"output": "12 passed"},
             "metadata": {"langgraph_checkpoint_ns": ns_b},
         })
@@ -2353,22 +2374,22 @@ class TestSubAgentScenarios:
 
 
 # =============================================================================
-# Tests for Namespace Registration Strategies (Strategy 4 + diagnostics)
+# Tests for parent_ids-Based Namespace Routing
 # =============================================================================
 
 
-class TestNamespaceRegistrationStrategies:
-    """Tests for _register_sub_agent_namespace Strategy 4 and diagnostic logging.
+class TestParentIdsNamespaceRouting:
+    """Tests for _register_sub_agent_namespace using parent_ids.
 
-    Strategy 4 (sole-active-agent fallback) resolves the case where a single
-    sub-agent produces events from multiple distinct namespace roots.  When
-    exactly one sub-agent is active, all multi-segment namespaces are mapped
-    to it without ambiguity.
+    v2 astream_events carry a parent_ids list tracing the callback chain from
+    sub-agent events back to the parent invocation context.  At least one entry
+    in parent_ids is the task tool's run_id (the key in _active_sub_agents).
+    This provides deterministic namespace -> sub-agent mapping without
+    heuristics.
     """
 
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
-        """Patch LLM-based subject generation for all tests in this class."""
         with patch(
             "worker.activities.graphton.status_builder._generate_sub_agent_subject",
             new_callable=AsyncMock,
@@ -2377,210 +2398,169 @@ class TestNamespaceRegistrationStrategies:
             yield
 
     @pytest.mark.asyncio
-    async def test_sole_active_agent_fallback_registers_different_root(self, status_builder):
-        """Strategy 4 maps a different-root namespace to the sole active sub-agent."""
-        run_id = "sa-sole-001"
+    async def test_parent_ids_matches_active_sub_agent(self, status_builder):
+        """parent_ids containing the task tool run_id registers the namespace."""
+        run_id = "sa-pid-001"
 
-        # Start sub-agent (enqueues in _pending_sub_agent_ids)
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "task",
             "run_id": run_id,
             "data": {"input": {"subagent_type": "editor", "input": "edit file"}},
-            "metadata": {}
+            "metadata": {},
         })
 
-        # First multi-segment namespace — consumed by causal correlation (Strategy 3)
-        first_ns = "root-alpha:aaa|child-1"
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "read_file",
-            "run_id": "tool-causal",
-            "data": {"input": {"path": "/tmp/a.py"}},
-            "metadata": {"langgraph_checkpoint_ns": first_ns}
-        })
-        assert first_ns in status_builder._namespace_to_sub_agent_id
-        assert status_builder._pending_sub_agent_ids == []  # consumed
+        ns = "tools:abc123|work_node:def456"
+        status_builder._register_sub_agent_namespace(
+            ns, {"parent_ids": ["sub-graph-root", run_id, "tools-node-run"]},
+        )
 
-        # Second namespace with a DIFFERENT root — Strategy 4 should handle it
-        second_ns = "root-beta:bbb|child-2"
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "write_file",
-            "run_id": "tool-fallback",
-            "data": {"input": {"path": "/tmp/b.py", "content": "x"}},
-            "metadata": {"langgraph_checkpoint_ns": second_ns}
-        })
-
-        assert second_ns in status_builder._namespace_to_sub_agent_id
-        assert status_builder._namespace_to_sub_agent_id[second_ns] == run_id
+        assert ns in status_builder._namespace_to_sub_agent_id
+        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
 
     @pytest.mark.asyncio
-    async def test_sole_active_agent_routes_events_to_sub_agent(self, status_builder):
-        """Events matched by Strategy 4 route to the sub-agent context, not main."""
-        run_id = "sa-route-001"
+    async def test_parent_ids_matches_completed_sub_agent(self, status_builder):
+        """Late events route via parent_ids to completed sub-agents."""
+        run_id = "sa-late-001"
 
-        # Start sub-agent
         await status_builder.process_event({
             "event": "on_tool_start",
             "name": "task",
             "run_id": run_id,
             "data": {"input": {"subagent_type": "coder", "input": "code"}},
-            "metadata": {}
-        })
-
-        # Consume causal correlation via first multi-segment namespace
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "echo",
-            "run_id": "consume-causal",
-            "data": {"input": {"text": "hi"}},
-            "metadata": {"langgraph_checkpoint_ns": "root-one:x|node-a"}
-        })
-
-        # Different-root namespace — Strategy 4 fallback
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "list_files",
-            "run_id": "routed-tool",
-            "data": {"input": {"dir": "/tmp"}},
-            "metadata": {"langgraph_checkpoint_ns": "root-two:y|node-b"}
-        })
-
-        # Main agent has 1 "task" ToolCall; sub-agent internal tools go to sub-agent
-        main_tcs = [tc for m in status_builder.current_status.messages for tc in m.tool_calls]
-        assert len(main_tcs) == 1
-        assert main_tcs[0].name == "task"
-
-        sub_agent = status_builder.current_status.sub_agent_executions[0]
-        tool_names = [tc.name for m in sub_agent.messages for tc in m.tool_calls]
-        assert "list_files" in tool_names
-
-    @pytest.mark.asyncio
-    async def test_fallback_does_not_apply_with_multiple_sub_agents(self, status_builder):
-        """Strategy 4 must NOT apply when 2+ sub-agents are active."""
-        # Start first sub-agent
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "task",
-            "run_id": "sa-multi-1",
-            "data": {"input": {"subagent_type": "a", "input": "x"}},
-            "metadata": {}
-        })
-        # Start second sub-agent (appends to _pending_sub_agent_ids queue)
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "task",
-            "run_id": "sa-multi-2",
-            "data": {"input": {"subagent_type": "b", "input": "y"}},
-            "metadata": {}
-        })
-
-        # Consume both pending sub-agents via FIFO causal correlation
-        status_builder._register_sub_agent_namespace("consume-root-1:ccc|node-c")
-        status_builder._register_sub_agent_namespace("consume-root-2:ddd|node-d")
-        assert status_builder._pending_sub_agent_ids == []
-
-        assert len(status_builder._active_sub_agents) == 2
-
-        # Ambiguous namespace — cannot be resolved with 2 active sub-agents
-        # (both pending sub-agents already consumed, and root doesn't match)
-        ambiguous_ns = "unknown-root:zzz|node-x"
-        status_builder._register_sub_agent_namespace(ambiguous_ns)
-
-        assert ambiguous_ns not in status_builder._namespace_to_sub_agent_id
-
-    @pytest.mark.asyncio
-    async def test_diagnostic_warning_deduplicated(self, status_builder):
-        """[NS_DIAG] warning is added to _warned_namespaces once, preventing log flood."""
-        # Start two sub-agents to bypass Strategy 4
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "task",
-            "run_id": "sa-dedup-1",
-            "data": {"input": {"subagent_type": "a", "input": "x"}},
-            "metadata": {}
-        })
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "task",
-            "run_id": "sa-dedup-2",
-            "data": {"input": {"subagent_type": "b", "input": "y"}},
-            "metadata": {}
-        })
-
-        # Consume both pending sub-agents via FIFO causal correlation
-        status_builder._register_sub_agent_namespace("consume-root-1:root|node")
-        status_builder._register_sub_agent_namespace("consume-root-2:root2|node")
-        assert status_builder._pending_sub_agent_ids == []
-
-        ns = "dedup-root:qqq|child"
-
-        # First attempt — enters _warned_namespaces
-        status_builder._register_sub_agent_namespace(ns)
-        assert ns in status_builder._warned_namespaces
-        assert ns not in status_builder._namespace_to_sub_agent_id
-
-        # Subsequent attempts — no additional warning (set is idempotent)
-        status_builder._register_sub_agent_namespace(ns)
-        status_builder._register_sub_agent_namespace(ns)
-
-        # Still not registered, but _warned_namespaces only has it once
-        assert ns not in status_builder._namespace_to_sub_agent_id
-
-    # ── Gap 7: Concurrent sub-agent namespace failure ───────────────────────
-
-    @pytest.mark.asyncio
-    async def test_concurrent_sub_agents_unresolvable_namespace_falls_to_main(self, status_builder):
-        """With 2+ active sub-agents, an unresolvable namespace falls through to main agent context."""
-        # Start two sub-agents
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "task",
-            "run_id": "sa-concurrent-1",
-            "data": {"input": {"subagent_type": "a", "input": "x"}},
-            "metadata": {},
-        })
-        await status_builder.process_event({
-            "event": "on_tool_start",
-            "name": "task",
-            "run_id": "sa-concurrent-2",
-            "data": {"input": {"subagent_type": "b", "input": "y"}},
             "metadata": {},
         })
 
-        # Consume both pending sub-agents via FIFO causal correlation
-        status_builder._register_sub_agent_namespace("consume-root-1:root|node")
-        status_builder._register_sub_agent_namespace("consume-root-2:root2|node")
-        assert status_builder._pending_sub_agent_ids == []
-        assert len(status_builder._active_sub_agents) == 2
+        await status_builder.process_event({
+            "event": "on_tool_end",
+            "name": "task",
+            "run_id": run_id,
+            "data": {"output": "done"},
+            "metadata": {},
+        })
 
-        # An ambiguous namespace that no strategy can resolve
-        ambiguous_ns = "alien-root:zzz|deep|nested"
-        context, sub_agent = status_builder._get_execution_context(ambiguous_ns)
+        assert run_id in status_builder._completed_sub_agents
 
-        # Falls through to main agent — known limitation with concurrent sub-agents
+        ns = "tools:abc|late_node:xyz"
+        status_builder._register_sub_agent_namespace(
+            ns, {"parent_ids": [run_id]},
+        )
+
+        assert ns in status_builder._namespace_to_sub_agent_id
+        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+
+    @pytest.mark.asyncio
+    async def test_empty_parent_ids_does_not_register(self, status_builder):
+        """Multi-segment namespace with empty parent_ids is not registered."""
+        await status_builder.process_event({
+            "event": "on_tool_start",
+            "name": "task",
+            "run_id": "sa-empty-pid",
+            "data": {"input": {"subagent_type": "a", "input": "x"}},
+            "metadata": {},
+        })
+
+        ns = "tools:aaa|child:bbb"
+        status_builder._register_sub_agent_namespace(ns, {"parent_ids": []})
+
+        assert ns not in status_builder._namespace_to_sub_agent_id
+
+    @pytest.mark.asyncio
+    async def test_no_matching_parent_ids_falls_to_main(self, status_builder):
+        """Namespace whose parent_ids match no known sub-agent falls to main context."""
+        await status_builder.process_event({
+            "event": "on_tool_start",
+            "name": "task",
+            "run_id": "sa-nomatch-1",
+            "data": {"input": {"subagent_type": "a", "input": "x"}},
+            "metadata": {},
+        })
+
+        ns = "tools:zzz|deep|nested"
+        status_builder._register_sub_agent_namespace(
+            ns, {"parent_ids": ["unknown-id-1", "unknown-id-2"]},
+        )
+
+        assert ns not in status_builder._namespace_to_sub_agent_id
+
+        context, sub_agent = status_builder._get_execution_context(ns)
         assert context is status_builder.current_status
         assert sub_agent is None
 
+    @pytest.mark.asyncio
+    async def test_concurrent_sub_agents_shared_root_route_correctly(self, status_builder):
+        """Two sub-agents sharing a namespace root are disambiguated by parent_ids."""
+        sa_a = "sa-shared-root-a"
+        sa_b = "sa-shared-root-b"
+
+        for sa_id in [sa_a, sa_b]:
+            await status_builder.process_event({
+                "event": "on_tool_start",
+                "name": "task",
+                "run_id": sa_id,
+                "data": {"input": {"subagent_type": "worker", "description": f"do {sa_id}"}},
+                "metadata": {},
+            })
+
+        ns_a = "tools:same_task_id|work_a:aaa"
+        ns_b = "tools:same_task_id|1|work_b:bbb"
+
+        status_builder._register_sub_agent_namespace(
+            ns_a, {"parent_ids": ["sub-a-graph-root", sa_a, "tools-node"]},
+        )
+        status_builder._register_sub_agent_namespace(
+            ns_b, {"parent_ids": ["sub-b-graph-root", sa_b, "tools-node"]},
+        )
+
+        assert status_builder._namespace_to_sub_agent_id[ns_a] == sa_a
+        assert status_builder._namespace_to_sub_agent_id[ns_b] == sa_b
+
+    @pytest.mark.asyncio
+    async def test_single_segment_namespace_ignored(self, status_builder):
+        """Single-segment namespaces (main-agent nodes) are not registered."""
+        status_builder._register_sub_agent_namespace(
+            "tools", {"parent_ids": ["some-id"]},
+        )
+        assert "tools" not in status_builder._namespace_to_sub_agent_id
+
+    @pytest.mark.asyncio
+    async def test_already_registered_namespace_is_idempotent(self, status_builder):
+        """Re-registering the same namespace does not overwrite the mapping."""
+        run_id = "sa-idem-001"
+
+        await status_builder.process_event({
+            "event": "on_tool_start",
+            "name": "task",
+            "run_id": run_id,
+            "data": {"input": {"subagent_type": "a", "input": "x"}},
+            "metadata": {},
+        })
+
+        ns = "tools:aaa|child:bbb"
+        event = {"parent_ids": [run_id]}
+
+        status_builder._register_sub_agent_namespace(ns, event)
+        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+
+        status_builder._register_sub_agent_namespace(ns, event)
+        assert status_builder._namespace_to_sub_agent_id[ns] == run_id
+
 
 # =============================================================================
-# Tests for Concurrent Sub-Agent Namespace Registration (FIFO Queue)
+# Tests for Concurrent Sub-Agent Namespace Registration (parent_ids)
 # =============================================================================
 
 
 class TestConcurrentSubAgentNamespaceRegistration:
-    """Tests for FIFO queue-based causal correlation with concurrent sub-agents.
+    """Tests for concurrent sub-agent namespace routing via parent_ids.
 
-    When multiple sub-agents launch in parallel, _pending_sub_agent_ids holds
-    them in FIFO order.  Strategy 3 pops from the front, mapping each first
-    namespace to the earliest pending sub-agent.  Strategy 1 (root-prefix)
-    handles subsequent namespaces from the same sub-agent.
+    When multiple sub-agents launch in parallel, each sub-agent's events carry
+    distinct parent_ids chains that include the respective task tool's run_id.
+    This provides deterministic routing regardless of event arrival order.
     """
 
     @pytest.fixture(autouse=True)
     def _patch_subject_gen(self):
-        """Patch LLM-based subject generation for all tests in this class."""
         with patch(
             "worker.activities.graphton.status_builder._generate_sub_agent_subject",
             new_callable=AsyncMock,
@@ -2589,9 +2569,9 @@ class TestConcurrentSubAgentNamespaceRegistration:
             yield
 
     @pytest.mark.asyncio
-    async def test_fifo_causal_correlation_maps_all_four(self, status_builder):
-        """Start 4 sub-agents, send 4 distinct namespaces — all map via Strategy 3 FIFO."""
-        sa_ids = ["sa-fifo-1", "sa-fifo-2", "sa-fifo-3", "sa-fifo-4"]
+    async def test_four_concurrent_sub_agents_all_map_via_parent_ids(self, status_builder):
+        """4 sub-agents, 4 namespaces — each maps to correct sub-agent via parent_ids."""
+        sa_ids = ["sa-pid-1", "sa-pid-2", "sa-pid-3", "sa-pid-4"]
 
         for sa_id in sa_ids:
             await status_builder.process_event({
@@ -2603,27 +2583,25 @@ class TestConcurrentSubAgentNamespaceRegistration:
             })
 
         assert len(status_builder._active_sub_agents) == 4
-        assert status_builder._pending_sub_agent_ids == sa_ids
 
         namespaces = [
-            "root-a:aaa|child",
-            "root-b:bbb|child",
-            "root-c:ccc|child",
-            "root-d:ddd|child",
+            "tools:aaa|child-a",
+            "tools:bbb|child-b",
+            "tools:ccc|child-c",
+            "tools:ddd|child-d",
         ]
-        for ns in namespaces:
-            status_builder._register_sub_agent_namespace(ns)
-
-        assert status_builder._pending_sub_agent_ids == []
+        for ns, sa_id in zip(namespaces, sa_ids):
+            status_builder._register_sub_agent_namespace(
+                ns, {"parent_ids": [f"sub-graph-{sa_id}", sa_id, "tools-node"]},
+            )
 
         for ns, sa_id in zip(namespaces, sa_ids):
             assert status_builder._namespace_to_sub_agent_id[ns] == sa_id
 
     @pytest.mark.asyncio
-    async def test_fifo_tool_calls_routed_to_correct_sub_agents(self, status_builder):
-        """4 concurrent sub-agents: tool calls with distinct namespaces route correctly."""
+    async def test_tool_calls_routed_to_correct_sub_agents_via_parent_ids(self, status_builder):
+        """4 concurrent sub-agents: tool calls with parent_ids route correctly."""
         sa_ids = ["sa-route-1", "sa-route-2", "sa-route-3", "sa-route-4"]
-        ns_roots = ["root-1:aaa", "root-2:bbb", "root-3:ccc", "root-4:ddd"]
 
         for sa_id in sa_ids:
             await status_builder.process_event({
@@ -2634,16 +2612,17 @@ class TestConcurrentSubAgentNamespaceRegistration:
                 "metadata": {},
             })
 
-        for i, (sa_id, ns_root) in enumerate(zip(sa_ids, ns_roots)):
+        for i, sa_id in enumerate(sa_ids):
+            ns = f"tools:{sa_id}-task|child-{i}"
             await status_builder.process_event({
                 "event": "on_tool_start",
                 "name": "read_file",
                 "run_id": f"tool-{i}",
+                "parent_ids": [f"sub-graph-{sa_id}", sa_id, "tools-node"],
                 "data": {"input": {"path": f"/tmp/{i}.py"}},
-                "metadata": {"langgraph_checkpoint_ns": f"{ns_root}|child"},
+                "metadata": {"langgraph_checkpoint_ns": ns},
             })
 
-        # Main agent has 4 "task" ToolCalls (one per sub-agent)
         main_tcs = [tc for m in status_builder.current_status.messages for tc in m.tool_calls]
         assert len(main_tcs) == 4
         assert all(tc.name == "task" for tc in main_tcs)
@@ -2655,8 +2634,8 @@ class TestConcurrentSubAgentNamespaceRegistration:
             assert sa_tcs[0].name == "read_file"
 
     @pytest.mark.asyncio
-    async def test_root_prefix_cascading_after_fifo(self, status_builder):
-        """After FIFO maps first namespace, subsequent same-root namespaces use Strategy 1."""
+    async def test_subsequent_namespace_variants_register_via_parent_ids(self, status_builder):
+        """Different namespace paths from the same sub-agent each register via parent_ids."""
         sa_ids = ["sa-cascade-1", "sa-cascade-2"]
 
         for sa_id in sa_ids:
@@ -2668,22 +2647,33 @@ class TestConcurrentSubAgentNamespaceRegistration:
                 "metadata": {},
             })
 
-        status_builder._register_sub_agent_namespace("root-x:aaa|first-child")
-        status_builder._register_sub_agent_namespace("root-y:bbb|first-child")
-        assert status_builder._pending_sub_agent_ids == []
+        status_builder._register_sub_agent_namespace(
+            "tools:aaa|first-child",
+            {"parent_ids": ["sa-cascade-1"]},
+        )
+        status_builder._register_sub_agent_namespace(
+            "tools:bbb|first-child",
+            {"parent_ids": ["sa-cascade-2"]},
+        )
 
-        assert status_builder._namespace_to_sub_agent_id["root-x:aaa|first-child"] == "sa-cascade-1"
-        assert status_builder._namespace_to_sub_agent_id["root-y:bbb|first-child"] == "sa-cascade-2"
+        assert status_builder._namespace_to_sub_agent_id["tools:aaa|first-child"] == "sa-cascade-1"
+        assert status_builder._namespace_to_sub_agent_id["tools:bbb|first-child"] == "sa-cascade-2"
 
-        status_builder._register_sub_agent_namespace("root-x:aaa|second-child|deeper")
-        status_builder._register_sub_agent_namespace("root-y:bbb|second-child|deeper")
+        status_builder._register_sub_agent_namespace(
+            "tools:aaa|second-child|deeper",
+            {"parent_ids": ["sa-cascade-1"]},
+        )
+        status_builder._register_sub_agent_namespace(
+            "tools:bbb|second-child|deeper",
+            {"parent_ids": ["sa-cascade-2"]},
+        )
 
-        assert status_builder._namespace_to_sub_agent_id["root-x:aaa|second-child|deeper"] == "sa-cascade-1"
-        assert status_builder._namespace_to_sub_agent_id["root-y:bbb|second-child|deeper"] == "sa-cascade-2"
+        assert status_builder._namespace_to_sub_agent_id["tools:aaa|second-child|deeper"] == "sa-cascade-1"
+        assert status_builder._namespace_to_sub_agent_id["tools:bbb|second-child|deeper"] == "sa-cascade-2"
 
     @pytest.mark.asyncio
-    async def test_handle_sub_agent_end_removes_from_pending_queue(self, status_builder):
-        """Sub-agent that ends before namespace registration is removed from the queue."""
+    async def test_sub_agent_end_does_not_break_remaining_routing(self, status_builder):
+        """Completing one sub-agent does not break namespace routing for others."""
         sa_ids = ["sa-end-1", "sa-end-2", "sa-end-3"]
 
         for sa_id in sa_ids:
@@ -2695,8 +2685,6 @@ class TestConcurrentSubAgentNamespaceRegistration:
                 "metadata": {},
             })
 
-        assert status_builder._pending_sub_agent_ids == sa_ids
-
         await status_builder.process_event({
             "event": "on_tool_end",
             "name": "task",
@@ -2705,7 +2693,22 @@ class TestConcurrentSubAgentNamespaceRegistration:
             "metadata": {},
         })
 
-        assert status_builder._pending_sub_agent_ids == ["sa-end-1", "sa-end-3"]
+        assert "sa-end-2" not in status_builder._active_sub_agents
+        assert "sa-end-2" in status_builder._completed_sub_agents
+        assert "sa-end-1" in status_builder._active_sub_agents
+        assert "sa-end-3" in status_builder._active_sub_agents
+
+        ns_1 = "tools:x|child-1"
+        status_builder._register_sub_agent_namespace(
+            ns_1, {"parent_ids": ["sa-end-1"]},
+        )
+        assert status_builder._namespace_to_sub_agent_id[ns_1] == "sa-end-1"
+
+        ns_3 = "tools:y|child-3"
+        status_builder._register_sub_agent_namespace(
+            ns_3, {"parent_ids": ["sa-end-3"]},
+        )
+        assert status_builder._namespace_to_sub_agent_id[ns_3] == "sa-end-3"
 
     @pytest.mark.asyncio
     async def test_early_reconciliation_no_cross_contamination(self, status_builder):
@@ -2723,7 +2726,9 @@ class TestConcurrentSubAgentNamespaceRegistration:
             })
 
         for sa_id, ns in ns_map.items():
-            status_builder._register_sub_agent_namespace(ns)
+            status_builder._register_sub_agent_namespace(
+                ns, {"parent_ids": [sa_id]},
+            )
 
         sa1 = status_builder._active_sub_agents["sa-recon-1"]
         sa2 = status_builder._active_sub_agents["sa-recon-2"]
@@ -6725,23 +6730,29 @@ class TestUniversalNamespaceRegistration:
             "name": "task",
             "run_id": run_id,
             "data": {"input": {"subagent_type": "helper", "description": "test"}},
-            "metadata": {"langgraph_checkpoint_ns": f"tools:{run_id}"},
+            "metadata": {},
         }
 
-    def _make_chat_model_stream_event(self, namespace: str) -> dict:
+    def _make_chat_model_stream_event(
+        self, namespace: str, *, parent_ids: list[str] | None = None,
+    ) -> dict:
         return {
             "event": "on_chat_model_stream",
             "name": "ChatModel",
             "run_id": "stream-run-1",
+            "parent_ids": parent_ids or [],
             "data": {"chunk": {"content": "hello"}},
             "metadata": {"langgraph_checkpoint_ns": namespace},
         }
 
-    def _make_tool_end_event(self, run_id: str, namespace: str) -> dict:
+    def _make_tool_end_event(
+        self, run_id: str, namespace: str, *, parent_ids: list[str] | None = None,
+    ) -> dict:
         return {
             "event": "on_tool_end",
             "name": "read",
             "run_id": run_id,
+            "parent_ids": parent_ids or [],
             "data": {"output": "file content"},
             "metadata": {"langgraph_checkpoint_ns": namespace},
         }
@@ -6749,13 +6760,13 @@ class TestUniversalNamespaceRegistration:
     @pytest.mark.asyncio
     async def test_chat_model_stream_registers_namespace(self, status_builder):
         """on_chat_model_stream events trigger namespace registration."""
-        root_ns = "tools:sa-root-1"
-        child_ns = f"{root_ns}|tools:inner-1"
+        sa_id = "sa-root-1"
+        child_ns = f"tools:{sa_id}|tools:inner-1"
 
-        await status_builder.process_event(self._make_task_start_event("sa-root-1"))
+        await status_builder.process_event(self._make_task_start_event(sa_id))
 
         await status_builder.process_event(
-            self._make_chat_model_stream_event(child_ns)
+            self._make_chat_model_stream_event(child_ns, parent_ids=[sa_id])
         )
 
         assert child_ns in status_builder._namespace_to_sub_agent_id
@@ -6763,13 +6774,15 @@ class TestUniversalNamespaceRegistration:
     @pytest.mark.asyncio
     async def test_tool_end_registers_namespace(self, status_builder):
         """on_tool_end events trigger namespace registration."""
-        root_ns = "tools:sa-root-2"
-        child_ns = f"{root_ns}|tools:nested-2"
+        sa_id = "sa-root-2"
+        child_ns = f"tools:{sa_id}|tools:nested-2"
 
-        await status_builder.process_event(self._make_task_start_event("sa-root-2"))
+        await status_builder.process_event(self._make_task_start_event(sa_id))
 
         await status_builder.process_event(
-            self._make_tool_end_event("nested-tool-run", child_ns)
+            self._make_tool_end_event(
+                "nested-tool-run", child_ns, parent_ids=[sa_id],
+            )
         )
 
         assert child_ns in status_builder._namespace_to_sub_agent_id
@@ -6790,16 +6803,17 @@ class TestUniversalNamespaceRegistration:
     @pytest.mark.asyncio
     async def test_registration_is_idempotent(self, status_builder):
         """Calling registration multiple times for same namespace is safe."""
-        root_ns = "tools:sa-idem"
+        sa_id = "sa-idem"
+        child_ns = f"tools:{sa_id}|inner:node"
 
-        await status_builder.process_event(self._make_task_start_event("sa-idem"))
+        await status_builder.process_event(self._make_task_start_event(sa_id))
 
         for _ in range(5):
             await status_builder.process_event(
-                self._make_chat_model_stream_event(root_ns)
+                self._make_chat_model_stream_event(child_ns, parent_ids=[sa_id])
             )
 
-        assert root_ns in status_builder._namespace_to_sub_agent_id
+        assert child_ns in status_builder._namespace_to_sub_agent_id
 
 
 # =============================================================================

--- a/backend/services/agent-runner/tests/test_status_builder.py
+++ b/backend/services/agent-runner/tests/test_status_builder.py
@@ -6661,3 +6661,276 @@ class TestDeferredCompletionFlush:
 
         assert status_builder.force_next_update is False
         assert run_id in status_builder._pending_completion_flush
+
+
+# =============================================================================
+# Tests for universal namespace registration in process_event (Issue 2 fix)
+# =============================================================================
+
+
+class TestUniversalNamespaceRegistration:
+    """Verify that _register_sub_agent_namespace is called for every event type.
+
+    Before this fix, _register_sub_agent_namespace was only called from
+    _handle_tool_start_event, causing namespace variants arriving via
+    on_chat_model_stream or on_tool_end to fail the exact lookup in
+    _get_execution_context and fall back to the main agent context.
+
+    The fix moves the call into process_event itself, so it runs for
+    ALL event types before dispatching to the type-specific handler.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_subject_gen(self):
+        with patch(
+            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            yield
+
+    def _make_task_start_event(self, run_id: str) -> dict:
+        return {
+            "event": "on_tool_start",
+            "name": "task",
+            "run_id": run_id,
+            "data": {"input": {"subagent_type": "helper", "description": "test"}},
+            "metadata": {"langgraph_checkpoint_ns": f"tools:{run_id}"},
+        }
+
+    def _make_chat_model_stream_event(self, namespace: str) -> dict:
+        return {
+            "event": "on_chat_model_stream",
+            "name": "ChatModel",
+            "run_id": "stream-run-1",
+            "data": {"chunk": {"content": "hello"}},
+            "metadata": {"langgraph_checkpoint_ns": namespace},
+        }
+
+    def _make_tool_end_event(self, run_id: str, namespace: str) -> dict:
+        return {
+            "event": "on_tool_end",
+            "name": "read",
+            "run_id": run_id,
+            "data": {"output": "file content"},
+            "metadata": {"langgraph_checkpoint_ns": namespace},
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_model_stream_registers_namespace(self, status_builder):
+        """on_chat_model_stream events trigger namespace registration."""
+        root_ns = "tools:sa-root-1"
+        child_ns = f"{root_ns}|tools:inner-1"
+
+        await status_builder.process_event(self._make_task_start_event("sa-root-1"))
+
+        await status_builder.process_event(
+            self._make_chat_model_stream_event(child_ns)
+        )
+
+        assert child_ns in status_builder._namespace_to_sub_agent_id
+
+    @pytest.mark.asyncio
+    async def test_tool_end_registers_namespace(self, status_builder):
+        """on_tool_end events trigger namespace registration."""
+        root_ns = "tools:sa-root-2"
+        child_ns = f"{root_ns}|tools:nested-2"
+
+        await status_builder.process_event(self._make_task_start_event("sa-root-2"))
+
+        await status_builder.process_event(
+            self._make_tool_end_event("nested-tool-run", child_ns)
+        )
+
+        assert child_ns in status_builder._namespace_to_sub_agent_id
+
+    @pytest.mark.asyncio
+    async def test_single_segment_namespace_ignored(self, status_builder):
+        """Single-segment namespaces are not registered (they're main agent)."""
+        await status_builder.process_event({
+            "event": "on_chat_model_stream",
+            "name": "ChatModel",
+            "run_id": "main-run",
+            "data": {"chunk": {"content": "hi"}},
+            "metadata": {"langgraph_checkpoint_ns": "main"},
+        })
+
+        assert "main" not in status_builder._namespace_to_sub_agent_id
+
+    @pytest.mark.asyncio
+    async def test_registration_is_idempotent(self, status_builder):
+        """Calling registration multiple times for same namespace is safe."""
+        root_ns = "tools:sa-idem"
+
+        await status_builder.process_event(self._make_task_start_event("sa-idem"))
+
+        for _ in range(5):
+            await status_builder.process_event(
+                self._make_chat_model_stream_event(root_ns)
+            )
+
+        assert root_ns in status_builder._namespace_to_sub_agent_id
+
+
+# =============================================================================
+# Tests for finalization preserving terminal status (Issue 3 fix)
+# =============================================================================
+
+
+class TestFinalizationPreservesTerminalStatus:
+    """Verify that finalize_active_sub_agents and
+    finalize_active_sub_agents_differentiated preserve sub-agents that
+    already have a terminal status (COMPLETED, FAILED, CANCELLED) or
+    have produced output.
+
+    Before this fix, the crash handler blindly overwrote all active
+    sub-agents to FAILED, even if some had logically completed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_subject_gen(self):
+        with patch(
+            "worker.activities.graphton.status_builder._generate_sub_agent_subject",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            yield
+
+    def _make_task_start_event(self, run_id: str, description: str = "do work") -> dict:
+        return {
+            "event": "on_tool_start",
+            "name": "task",
+            "run_id": run_id,
+            "data": {"input": {"subagent_type": "helper", "description": description}},
+            "metadata": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_completed_sub_agent_preserved_by_uniform_finalize(self, status_builder):
+        """Sub-agent with COMPLETED status is not overwritten to FAILED."""
+        await status_builder.process_event(
+            self._make_task_start_event("sa-done", "finished task")
+        )
+        sa = status_builder._active_sub_agents["sa-done"]
+        sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
+        sa.output = "result data"
+
+        status_builder.finalize_active_sub_agents(
+            SubAgentStatus.SUB_AGENT_FAILED,
+            "Parent execution error: BadRequestError",
+        )
+
+        finalized = status_builder._completed_sub_agents["sa-done"]
+        assert finalized.status == SubAgentStatus.SUB_AGENT_COMPLETED
+        assert finalized.output == "result data"
+
+    @pytest.mark.asyncio
+    async def test_in_progress_sub_agent_gets_forced_status(self, status_builder):
+        """Sub-agent still IN_PROGRESS is correctly marked FAILED."""
+        await status_builder.process_event(
+            self._make_task_start_event("sa-wip", "working")
+        )
+
+        status_builder.finalize_active_sub_agents(
+            SubAgentStatus.SUB_AGENT_FAILED,
+            "Parent execution error: BadRequestError",
+        )
+
+        finalized = status_builder._completed_sub_agents["sa-wip"]
+        assert finalized.status == SubAgentStatus.SUB_AGENT_FAILED
+
+    @pytest.mark.asyncio
+    async def test_sub_agent_with_output_preserved(self, status_builder):
+        """Sub-agent with non-empty output is preserved even without terminal status."""
+        await status_builder.process_event(
+            self._make_task_start_event("sa-out", "has output")
+        )
+        sa = status_builder._active_sub_agents["sa-out"]
+        sa.output = "partial result"
+
+        status_builder.finalize_active_sub_agents(
+            SubAgentStatus.SUB_AGENT_FAILED,
+            "Parent execution error",
+        )
+
+        finalized = status_builder._completed_sub_agents["sa-out"]
+        assert finalized.output == "partial result"
+        assert finalized.status != SubAgentStatus.SUB_AGENT_FAILED
+
+    @pytest.mark.asyncio
+    async def test_mixed_finalization_preserves_and_finalizes(self, status_builder):
+        """Mix of completed and in-progress sub-agents handled correctly."""
+        await status_builder.process_event(
+            self._make_task_start_event("sa-completed", "done")
+        )
+        await status_builder.process_event(
+            self._make_task_start_event("sa-running", "still going")
+        )
+
+        completed_sa = status_builder._active_sub_agents["sa-completed"]
+        completed_sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
+        completed_sa.output = "finished"
+
+        status_builder.finalize_active_sub_agents(
+            SubAgentStatus.SUB_AGENT_FAILED,
+            "stall detected",
+        )
+
+        assert status_builder._completed_sub_agents["sa-completed"].status == SubAgentStatus.SUB_AGENT_COMPLETED
+        assert status_builder._completed_sub_agents["sa-running"].status == SubAgentStatus.SUB_AGENT_FAILED
+        assert len(status_builder._active_sub_agents) == 0
+
+    @pytest.mark.asyncio
+    async def test_differentiated_finalize_preserves_completed(self, status_builder):
+        """finalize_active_sub_agents_differentiated also preserves terminal status."""
+        await status_builder.process_event(
+            self._make_task_start_event("sa-ok", "completed task")
+        )
+        await status_builder.process_event(
+            self._make_task_start_event("sa-wip", "mid execution")
+        )
+
+        ok_sa = status_builder._active_sub_agents["sa-ok"]
+        ok_sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
+        ok_sa.output = "success"
+
+        wip_sa = status_builder._active_sub_agents["sa-wip"]
+        wip_sa.messages.append(AgentMessage(content="working on it"))
+
+        count = status_builder.finalize_active_sub_agents_differentiated(
+            error_context="Parent terminated abnormally"
+        )
+
+        assert count == 2
+        assert status_builder._completed_sub_agents["sa-ok"].status == SubAgentStatus.SUB_AGENT_COMPLETED
+        assert status_builder._completed_sub_agents["sa-wip"].status == SubAgentStatus.SUB_AGENT_FAILED
+
+    @pytest.mark.asyncio
+    async def test_pending_completion_flushed_before_finalization(self, status_builder):
+        """Pending completion flush entries are drained before crash finalization."""
+        import time
+
+        await status_builder.process_event(
+            self._make_task_start_event("sa-flush", "completed recently")
+        )
+
+        sa = status_builder._active_sub_agents.pop("sa-flush")
+        sa.status = SubAgentStatus.SUB_AGENT_COMPLETED
+        sa.output = "done"
+        status_builder._completed_sub_agents["sa-flush"] = sa
+        status_builder._pending_completion_flush["sa-flush"] = time.monotonic()
+
+        status_builder.finalize_active_sub_agents(
+            SubAgentStatus.SUB_AGENT_FAILED,
+            "Parent crashed",
+        )
+
+        assert len(status_builder._pending_completion_flush) == 0
+        assert status_builder.force_next_update is True
+
+    @pytest.mark.asyncio
+    async def test_flush_pending_completions_on_empty_is_noop(self, status_builder):
+        """_flush_pending_completions on empty dict is a safe no-op."""
+        flushed = status_builder._flush_pending_completions()
+        assert flushed == []
+        assert status_builder.force_next_update is False

--- a/backend/services/agent-runner/worker/activities/execute_graphton.py
+++ b/backend/services/agent-runner/worker/activities/execute_graphton.py
@@ -147,22 +147,9 @@ def _build_decision_value(
 
 
 def _summarize_resume_entry(interrupt_id: str, value: Any) -> str:
-    """Format one entry from the resume dict for logging.
-
-    Handles both direct decisions (``{"action": "approve"}``) and proxy
-    payloads (``{sub_id: {"action": "approve"}, ...}``).
-    """
+    """Format one entry from the resume dict for logging."""
     if isinstance(value, dict) and "action" in value:
         return f"interrupt={interrupt_id[:16]} action={value['action']}"
-    if isinstance(value, dict):
-        sub_actions = [
-            sv.get("action", "?") for sv in value.values() if isinstance(sv, dict)
-        ]
-        return (
-            f"interrupt={interrupt_id[:16]} "
-            f"proxy({len(sub_actions)} sub-decision(s): "
-            f"{', '.join(sub_actions)})"
-        )
     return f"interrupt={interrupt_id[:16]} value={value!r}"
 
 
@@ -1714,21 +1701,11 @@ async def _execute_graphton_impl(
         # carries interrupt objects whose payload includes tool_call_id.
         # We join on tool_call_id to pair each decision with its interrupt_id.
         #
-        # Two interrupt shapes exist:
+        # All interrupts use the direct shape (both root-agent and sub-agent
+        # tools propagate identically via LangGraph native subgraph mode):
         #
-        #   Direct (main-agent tool):
         #     intr.value = {"tool_call_id": "tc_abc", "message": "..."}
         #     resume_dict[intr.id] = {"action": "approve"}
-        #
-        #   Proxied (sub-agent tool via InterruptProxyRunnable):
-        #     intr.value = {sub_id_1: {"tool_call_id": "tc_xyz", ...,
-        #                              "_proxy_interrupt_id": sub_id_1}, ...}
-        #     resume_dict[intr.id] = {sub_id_1: {"action": "approve"}, ...}
-        #
-        # The proxy shape is produced by _build_proxy_payload() which wraps
-        # each sub-agent interrupt under its interrupt ID.  The nested resume
-        # dict is passed through by InterruptProxyRunnable as
-        # Command(resume=decisions) to the sub-agent graph.
         if approval_decisions:
             decisions_by_tc: dict[str, SubmitApprovalInput] = {
                 d.tool_call_id: d for d in approval_decisions
@@ -1743,37 +1720,14 @@ async def _execute_graphton_impl(
             if graph_state and graph_state.interrupts:
                 for intr in graph_state.interrupts:
                     intr_value = intr.value if isinstance(intr.value, dict) else {}
-
-                    direct_tc_id = intr_value.get("tool_call_id", "")
-                    if direct_tc_id:
-                        decision = decisions_by_tc.get(direct_tc_id)
+                    tc_id = intr_value.get("tool_call_id", "")
+                    if tc_id:
+                        decision = decisions_by_tc.get(tc_id)
                         if decision:
                             resume_dict[intr.id] = _build_decision_value(
                                 decision, _action_map,
                             )
-                            matched_decision_tc_ids.add(direct_tc_id)
-                        continue
-
-                    # Proxy payload: values are sub-interrupt dicts keyed by
-                    # sub-interrupt ID, each containing tool_call_id and
-                    # _proxy_interrupt_id (set by InterruptProxyRunnable).
-                    sub_decisions: dict[str, dict[str, str]] = {}
-                    for sub_id, sub_value in intr_value.items():
-                        if not isinstance(sub_value, dict):
-                            continue
-                        if "_proxy_interrupt_id" not in sub_value:
-                            continue
-                        sub_tc_id = sub_value.get("tool_call_id", "")
-                        if not sub_tc_id:
-                            continue
-                        decision = decisions_by_tc.get(sub_tc_id)
-                        if decision:
-                            sub_decisions[sub_id] = _build_decision_value(
-                                decision, _action_map,
-                            )
-                            matched_decision_tc_ids.add(sub_tc_id)
-                    if sub_decisions:
-                        resume_dict[intr.id] = sub_decisions
+                            matched_decision_tc_ids.add(tc_id)
 
             # ── Defense-in-depth: bidirectional ID lookup ─────────────────
             #
@@ -1782,73 +1736,39 @@ async def _execute_graphton_impl(
             # (run_id fallback) while the interrupt payload carries the
             # Anthropic toolu_* ID.  Build a reverse mapping from interrupt
             # tool_call_ids to the parent interrupt, then try to pair each
-            # unmatched decision with an unmatched interrupt within the same
-            # proxy payload.
+            # unmatched decision with an unmatched interrupt.
             unmatched_decision_tc_ids = set(decisions_by_tc) - matched_decision_tc_ids
             if unmatched_decision_tc_ids and graph_state and graph_state.interrupts:
-                # Collect all interrupt tool_call_ids that were NOT matched
-                intr_tc_to_parent: dict[str, tuple[Any, str, str]] = {}
+                intr_tc_to_parent: dict[str, Any] = {}
                 for intr in graph_state.interrupts:
                     if intr.id in resume_dict:
                         continue
                     intr_value = intr.value if isinstance(intr.value, dict) else {}
-                    direct_tc_id = intr_value.get("tool_call_id", "")
-                    if direct_tc_id and direct_tc_id not in matched_decision_tc_ids:
-                        intr_tc_to_parent[direct_tc_id] = (intr, "direct", "")
-                    for sub_id, sub_value in intr_value.items():
-                        if not isinstance(sub_value, dict):
-                            continue
-                        if "_proxy_interrupt_id" not in sub_value:
-                            continue
-                        sub_tc_id = sub_value.get("tool_call_id", "")
-                        if sub_tc_id and sub_tc_id not in matched_decision_tc_ids:
-                            intr_tc_to_parent[sub_tc_id] = (intr, "proxy", sub_id)
+                    tc_id = intr_value.get("tool_call_id", "")
+                    if tc_id and tc_id not in matched_decision_tc_ids:
+                        intr_tc_to_parent[tc_id] = intr
 
-                # For each unmatched decision, check if it maps to a known
-                # interrupt via a different ID (identity mismatch).
-                # This is a diagnostic fallback — it should not normally trigger.
                 for um_tc_id in list(unmatched_decision_tc_ids):
                     decision = decisions_by_tc[um_tc_id]
-                    for intr_tc_id, (intr, shape, sub_id) in intr_tc_to_parent.items():
-                        if intr.id in resume_dict and shape == "direct":
+                    for intr_tc_id, intr in intr_tc_to_parent.items():
+                        if intr.id in resume_dict:
                             continue
-                        if shape == "direct":
-                            resume_dict[intr.id] = _build_decision_value(
-                                decision, _action_map,
-                            )
-                            matched_decision_tc_ids.add(um_tc_id)
-                            activity_logger.warning(
-                                "[RESUME_ID_MISMATCH] execution=%s "
-                                "decision.tool_call_id=%s matched to "
-                                "interrupt.tool_call_id=%s (interrupt=%s) "
-                                "via bidirectional fallback. This indicates "
-                                "a StatusBuilder ID mismatch that should be "
-                                "fixed at the source.",
-                                execution_id, um_tc_id,
-                                intr_tc_id, intr.id[:16],
-                            )
-                            del intr_tc_to_parent[intr_tc_id]
-                            break
-                        if shape == "proxy":
-                            existing = resume_dict.get(intr.id, {})
-                            existing[sub_id] = _build_decision_value(
-                                decision, _action_map,
-                            )
-                            resume_dict[intr.id] = existing
-                            matched_decision_tc_ids.add(um_tc_id)
-                            activity_logger.warning(
-                                "[RESUME_ID_MISMATCH] execution=%s "
-                                "decision.tool_call_id=%s matched to "
-                                "proxy sub_tc_id=%s (interrupt=%s, "
-                                "sub_id=%s) via bidirectional fallback. "
-                                "This indicates a StatusBuilder ID "
-                                "mismatch that should be fixed at the "
-                                "source.",
-                                execution_id, um_tc_id,
-                                intr_tc_id, intr.id[:16], sub_id,
-                            )
-                            del intr_tc_to_parent[intr_tc_id]
-                            break
+                        resume_dict[intr.id] = _build_decision_value(
+                            decision, _action_map,
+                        )
+                        matched_decision_tc_ids.add(um_tc_id)
+                        activity_logger.warning(
+                            "[RESUME_ID_MISMATCH] execution=%s "
+                            "decision.tool_call_id=%s matched to "
+                            "interrupt.tool_call_id=%s (interrupt=%s) "
+                            "via bidirectional fallback. This indicates "
+                            "a StatusBuilder ID mismatch that should be "
+                            "fixed at the source.",
+                            execution_id, um_tc_id,
+                            intr_tc_id, intr.id[:16],
+                        )
+                        del intr_tc_to_parent[intr_tc_id]
+                        break
 
             if resume_dict:
                 is_resume_from_approval = True
@@ -1868,14 +1788,9 @@ async def _execute_graphton_impl(
                 if graph_state and graph_state.interrupts:
                     for intr in graph_state.interrupts:
                         intr_value = intr.value if isinstance(intr.value, dict) else {}
-                        direct_tc = intr_value.get("tool_call_id", "")
-                        if direct_tc:
-                            intr_tc_ids.append(f"direct:{direct_tc}")
-                        for sub_id, sv in intr_value.items():
-                            if isinstance(sv, dict) and sv.get("tool_call_id"):
-                                intr_tc_ids.append(
-                                    f"proxy:{sv['tool_call_id']}"
-                                )
+                        tc_id = intr_value.get("tool_call_id", "")
+                        if tc_id:
+                            intr_tc_ids.append(tc_id)
 
                 error_msg = (
                     f"Approval resume failed: {len(approval_decisions)} "

--- a/backend/services/agent-runner/worker/activities/execute_graphton.py
+++ b/backend/services/agent-runner/worker/activities/execute_graphton.py
@@ -67,7 +67,6 @@ from worker.activities.graphton.session_context_merge import (
 )
 from worker.activities.graphton.skill_writer import SkillWriter
 from worker.activities.graphton.status_builder import StatusBuilder, _utc_timestamp
-from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 from worker.activities.graphton.subagent_transformer import transform_sub_agents
 from worker.activities.graphton.temporal_helpers import (
     SetupTimer,
@@ -80,6 +79,7 @@ from worker.activities.graphton.temporal_helpers import (
 from worker.activities.graphton.temporal_helpers import (
     slim_status_for_temporal as _slim_status_for_temporal,
 )
+from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 from worker.activities.relevance import (
     WorkspaceRoot,
     build_relevance_prompt_section,

--- a/backend/services/agent-runner/worker/activities/execute_graphton.py
+++ b/backend/services/agent-runner/worker/activities/execute_graphton.py
@@ -67,6 +67,7 @@ from worker.activities.graphton.session_context_merge import (
 )
 from worker.activities.graphton.skill_writer import SkillWriter
 from worker.activities.graphton.status_builder import StatusBuilder, _utc_timestamp
+from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 from worker.activities.graphton.subagent_transformer import transform_sub_agents
 from worker.activities.graphton.temporal_helpers import (
     SetupTimer,
@@ -1179,8 +1180,15 @@ async def _execute_graphton_impl(
             f"tool_mapping={len(approval_config.tool_to_mcp_server)} tools"
         )
         
+        # Capture tool_call_id from the callback API so StatusBuilder can
+        # resolve the model's identity for each tool invocation.
+        tool_call_id_capture = ToolCallIdCapture()
+
         # Initialize status builder with approval config
-        status_builder = StatusBuilder(execution_id, execution.status, approval_config)
+        status_builder = StatusBuilder(
+            execution_id, execution.status, approval_config,
+            tool_call_id_capture=tool_call_id_capture,
+        )
         status_builder.set_display_env_vars(merged_env_vars, secret_keys)
         status_builder.set_workspace_root(workspace_backend.root_dir)
 
@@ -1640,6 +1648,7 @@ async def _execute_graphton_impl(
                 "org": execution.metadata.org,
             },
             "recursion_limit": effective_recursion_limit,
+            "callbacks": [tool_call_id_capture],
         }
         
         activity_logger.info(

--- a/backend/services/agent-runner/worker/activities/execute_graphton.py
+++ b/backend/services/agent-runner/worker/activities/execute_graphton.py
@@ -1960,6 +1960,31 @@ async def _execute_graphton_impl(
             graph_input, is_resume=is_resume_from_approval,
         )
         if stream_result.terminal_status is not None:
+            terminal_phase = status_builder.current_status.phase
+            try:
+                activity_logger.info(
+                    "Sending terminal status update with retry (phase=%s)",
+                    ExecutionPhase.Name(terminal_phase),
+                )
+                await retry_executor.execute(
+                    operation=lambda: execution_client.update_status(
+                        execution_id=execution_id,
+                        status=status_builder.current_status,
+                    ),
+                    operation_name="terminal_status_update",
+                    context={
+                        "execution_id": execution_id,
+                        "phase": ExecutionPhase.Name(terminal_phase),
+                    },
+                )
+            except GrpcRetryExhaustedError as e:
+                activity_logger.error(
+                    "Terminal status persistence failed after retries: %s", e,
+                )
+            except Exception as e:
+                activity_logger.error(
+                    "Unexpected error persisting terminal status: %s", e,
+                )
             return stream_result.terminal_status
 
         from worker.activities.graphton.post_stream import process_post_stream

--- a/backend/services/agent-runner/worker/activities/graphton/execution_state.py
+++ b/backend/services/agent-runner/worker/activities/graphton/execution_state.py
@@ -1,0 +1,220 @@
+"""Explicit state model for StatusBuilder.
+
+All mutable execution state lives here in typed, documented fields.
+StatusBuilder owns an ``ExecutionState`` instance and all event handlers
+operate on it.  Configuration and collaborators (approval config,
+ToolCallIdCapture, UsageTracker, display env) stay on StatusBuilder
+itself — they are not execution state.
+
+The state is split into:
+
+* **Proto indexes** — O(1) lookup into the protobuf's repeated fields.
+* **Sub-agent routing** — maps that connect LangGraph namespaces and
+  run_ids to the correct ``SubAgentExecution`` proto.
+* **Streaming buffers** — partial data accumulated during LLM token
+  streaming before being flushed to the proto.
+* **Timing / observability** — start timestamps for duration calculation.
+* **Approval tracking** — batch-approval lifecycle state.
+* **Other** — log-dedup guards, context window tracking, artifact staging.
+
+Three tightly-coupled field groups are extracted into sub-dataclasses
+(``ThinkingStreamState``, ``ToolInputStreamState``, ``ApprovalTrackingState``)
+because their fields share a lifecycle and are always mutated together.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
+from ai.stigmer.agentic.agentexecution.v1.context_pb2 import ContextInfo
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
+    MessageType,
+    SubAgentStatus,
+)
+from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
+    AgentMessage,
+    ToolCall,
+)
+from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+
+_TERMINAL_SUB_AGENT_STATUSES = frozenset({
+    SubAgentStatus.SUB_AGENT_COMPLETED,
+    SubAgentStatus.SUB_AGENT_FAILED,
+    SubAgentStatus.SUB_AGENT_CANCELLED,
+})
+
+
+# ---------------------------------------------------------------------------
+# Sub-group dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThinkingStreamState:
+    """Native-thinking translation buffers (extended thinking -> synthetic think tool).
+
+    All three dicts are keyed by namespace (empty string for main agent)
+    and are always mutated together in ``_start_thinking_stream``,
+    ``_update_thinking_stream``, and ``_flush_thinking_buffer``.
+    """
+
+    buffers: dict[str, str] = field(default_factory=dict)
+    started_at: dict[str, datetime] = field(default_factory=dict)
+    tool_call_ids: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ToolInputStreamState:
+    """Live tool-argument streaming buffers (input_json_delta accumulation).
+
+    ``active_tc`` maps namespace -> temp tool call id currently receiving
+    input deltas.  ``buffers`` maps temp id -> accumulated partial JSON.
+    Always used together in ``_accumulate_tool_input`` and
+    ``_flush_tool_input_buffer``.
+    """
+
+    active_tc: dict[str, str] = field(default_factory=dict)
+    buffers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ApprovalTrackingState:
+    """Batch-approval lifecycle state.
+
+    Set together when entering WAITING_FOR_APPROVAL, cleared together in
+    ``clear_pending_approval``.
+    """
+
+    pending: list[str] = field(default_factory=list)
+    saved_phase: int | None = None
+    wait_started_at: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Main state dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionState:
+    """All mutable execution state for StatusBuilder.
+
+    Every field is either a proto index, streaming buffer, timing tracker,
+    sub-agent routing map, or approval tracker.  None are compensating
+    complexity — each serves a genuine purpose documented in its comment.
+
+    ``force_next_update`` is intentionally NOT here; it is a gRPC
+    scheduling coordination signal between StatusBuilder and StreamExecutor,
+    not execution state.
+    """
+
+    # The protobuf projection being built.
+    proto: Any
+
+    # -- Proto indexes -- O(1) lookup into proto repeated fields -----------
+
+    # tool_call_id -> managed ToolCall reference inside a message's repeated
+    # field.  Mutations propagate directly to the proto.
+    tool_calls: dict[str, ToolCall] = field(default_factory=dict)
+
+    # LLM run_id -> the AgentMessage that run is streaming into.
+    # Prevents token interleaving when multiple LLM streams are active.
+    messages_by_run: dict[str, AgentMessage] = field(default_factory=dict)
+
+    # namespace -> most recently created AI message in that execution context.
+    # Tool calls are appended to this message's tool_calls repeated field.
+    current_ai_message: dict[str, AgentMessage] = field(default_factory=dict)
+
+    # namespace -> latest LLM run_id for turn-boundary detection.
+    last_llm_run_id: dict[str, str] = field(default_factory=dict)
+
+    # -- Sub-agent routing -------------------------------------------------
+
+    # task-tool run_id -> in-progress SubAgentExecution proto.
+    active_sub_agents: dict[str, SubAgentExecution] = field(default_factory=dict)
+
+    # Same keys after task completes; keeps routing for late events.
+    completed_sub_agents: dict[str, SubAgentExecution] = field(default_factory=dict)
+
+    # LangGraph task run_id -> tool_call_id (= SubAgentExecution.id).
+    run_id_to_tool_call_id: dict[str, str] = field(default_factory=dict)
+
+    # checkpoint namespace root -> sub-agent task run_id for event routing.
+    namespace_to_sub_agent: dict[str, str] = field(default_factory=dict)
+
+    # Tracks how many times each subject has been assigned for dedup suffixes.
+    subject_counts: dict[str, int] = field(default_factory=dict)
+
+    # -- Streaming buffers -------------------------------------------------
+
+    thinking: ThinkingStreamState = field(default_factory=ThinkingStreamState)
+
+    tool_input: ToolInputStreamState = field(default_factory=ToolInputStreamState)
+
+    # FIFO queue of (temp_tool_call_id, sub_agent_id_or_None) for
+    # stream -> on_tool_start reconciliation.
+    early_tool_call_queue: list[tuple[str, str | None]] = field(default_factory=list)
+
+    # -- Timing / observability --------------------------------------------
+
+    # tool run_id -> start timestamp for duration calculation.
+    tool_start_times: dict[str, datetime] = field(default_factory=dict)
+
+    # Main-agent AI message index -> stream start time for duration.
+    message_start_times: dict[int, datetime] = field(default_factory=dict)
+
+    # (sub_agent_id, message_index) -> AI stream start time.
+    sub_agent_message_start_times: dict[tuple[str, int], datetime] = field(
+        default_factory=dict
+    )
+
+    # task run_id -> monotonic time when completion flush was deferred.
+    pending_completion_flush: dict[str, float] = field(default_factory=dict)
+
+    # -- Approval ----------------------------------------------------------
+
+    approval: ApprovalTrackingState = field(default_factory=ApprovalTrackingState)
+
+    # -- Other -------------------------------------------------------------
+
+    # Log-once guard for unresolved multi-segment namespaces.
+    warned_namespaces: set[str] = field(default_factory=set)
+
+    # Context window utilization and summarization tracking.
+    context_info: ContextInfo | None = None
+
+    # Artifacts staged during execution, synced to proto on finalize.
+    artifacts: list[ExecutionArtifact] = field(default_factory=list)
+
+    @classmethod
+    def rebuild_from_proto(cls, proto: Any) -> ExecutionState:
+        """Reconstruct proto-derivable indexes from a persisted status.
+
+        Used on the resume-after-approval path where the StatusBuilder is
+        initialized with a DB-persisted ``AgentExecutionStatus`` that already
+        contains messages, tool calls, sub-agent executions, and artifacts.
+
+        Only proto-derivable indexes are reconstructed.  Ephemeral runtime
+        state (run_id maps, streaming buffers, timing) starts fresh —
+        streaming resumes from the checkpoint with new ephemeral state.
+        """
+        state = cls(proto=proto)
+
+        def _index_tool_calls(messages: Any) -> None:
+            for message in messages:
+                if message.type != MessageType.MESSAGE_AI:
+                    continue
+                for i, tc in enumerate(message.tool_calls):
+                    if tc.id:
+                        state.tool_calls[tc.id] = message.tool_calls[i]
+
+        _index_tool_calls(proto.messages)
+
+        for sa in proto.sub_agent_executions:
+            _index_tool_calls(sa.messages)
+            if sa.status in _TERMINAL_SUB_AGENT_STATUSES:
+                state.completed_sub_agents[sa.id] = sa
+
+        state.artifacts = list(proto.artifacts)
+        return state

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/__init__.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/__init__.py
@@ -10,4 +10,14 @@ Modules
 -------
 formatting
     Stateless content-extraction and display-formatting utilities.
+streaming_buffers
+    Streaming buffer management for early tool calls, thinking, and tool input.
+sub_agent
+    Sub-agent lifecycle: start, end, finalization, subject generation.
+context
+    Context info, summarization events, artifacts, workspace write-backs.
+tool_event
+    Tool start/end/progress, approval checks, todos, arg humanization.
+chat_model
+    Chat model stream/end: AI message creation, usage metric capture.
 """

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/__init__.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/__init__.py
@@ -1,0 +1,13 @@
+"""StatusBuilder event handler modules.
+
+This package contains the event-processing logic extracted from
+``StatusBuilder``.  Each module groups a cohesive set of handler
+functions that operate on a ``StatusBuilder`` instance passed as the
+first argument (``sb``).  StatusBuilder remains the thin orchestrator
+that dispatches events and exposes the public API surface.
+
+Modules
+-------
+formatting
+    Stateless content-extraction and display-formatting utilities.
+"""

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/chat_model.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/chat_model.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import MessageType
+from ai.stigmer.agentic.agentexecution.v1.message_pb2 import AgentMessage
+
 from worker.activities.graphton.handlers import formatting, streaming_buffers
 from worker.activities.graphton.handlers.tool_event import PLANNING_TOOLS
 from worker.activities.graphton.usage_tracker import MAIN_SCOPE
-
-from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import MessageType
-from ai.stigmer.agentic.agentexecution.v1.message_pb2 import AgentMessage
 
 if TYPE_CHECKING:
     from worker.activities.graphton.status_builder import StatusBuilder

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/chat_model.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/chat_model.py
@@ -1,0 +1,499 @@
+"""Chat-model event handlers extracted from StatusBuilder.
+
+Handles ``on_chat_model_stream`` and ``on_chat_model_end`` events,
+building and finalising AI messages in the execution status proto.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from worker.activities.graphton.handlers import formatting, streaming_buffers
+from worker.activities.graphton.handlers.tool_event import PLANNING_TOOLS
+from worker.activities.graphton.usage_tracker import MAIN_SCOPE
+
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import MessageType
+from ai.stigmer.agentic.agentexecution.v1.message_pb2 import AgentMessage
+
+if TYPE_CHECKING:
+    from worker.activities.graphton.status_builder import StatusBuilder
+
+
+def _utc_timestamp(dt: datetime | None = None) -> str:
+    """Return a UTC datetime as an RFC 3339 timestamp string.
+
+    Appends the ``Z`` suffix so that consumers using strict RFC 3339 / ISO 8601
+    parsers (e.g. Go's ``time.Parse(time.RFC3339, …)``) can parse the value
+    without ambiguity.
+
+    Args:
+        dt: A UTC datetime to format. If *None*, ``datetime.utcnow()`` is used.
+    """
+    if dt is None:
+        dt = datetime.utcnow()
+    return dt.isoformat() + "Z"
+
+
+def handle_chat_model_stream(sb: StatusBuilder, event: dict[str, Any], namespace: str = "") -> None:
+    """Handle on_chat_model_stream event - updates local status."""
+    chunk_data = event.get("data", {}).get("chunk", {})
+
+    if not chunk_data:
+        return
+
+    # Try to register namespace for event routing
+    if namespace:
+        sb._register_sub_agent_namespace(namespace, event)
+
+    # ─────────────────────────────────────────────────────────────────────
+    # LLM Turn-Boundary Detection
+    #
+    # Each LLM invocation carries a unique run_id.  When the run_id
+    # changes we know a new LLM turn has started.  Clear the cached
+    # _last_ai_message for this namespace so that thinking/tool_use
+    # blocks from the new turn create a fresh parent AI message
+    # instead of piling onto the previous turn's parent.
+    #
+    # For text-producing turns this is harmless — the text path
+    # already creates a new AI message per new run_id.  The fix
+    # matters for thinking-only turns where no text path runs and
+    # _last_ai_message would otherwise remain stale.
+    # ─────────────────────────────────────────────────────────────────────
+    run_id = event.get("run_id", "")
+    ns_key = namespace or ""
+    if run_id and run_id != sb.state.last_llm_run_id.get(ns_key):
+        sb.state.current_ai_message.pop(ns_key, None)
+        sb.state.last_llm_run_id[ns_key] = run_id
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Native Thinking Detection
+    #
+    # When Anthropic extended thinking is active, content blocks arrive as
+    # dicts with type:"thinking" BEFORE the text/tool_use blocks.  We
+    # accumulate thinking content in a per-namespace buffer and skip AI
+    # message creation for these chunks.  When the first non-thinking
+    # content arrives we flush the buffer into a synthetic think ToolCall.
+    #
+    # A single chunk may contain BOTH thinking and text blocks (e.g., at
+    # the boundary between thinking and response output).  We must
+    # process thinking content AND check for co-located text — only
+    # returning early if the chunk is purely thinking content.
+    # ─────────────────────────────────────────────────────────────────────
+    if hasattr(chunk_data, "content") and isinstance(chunk_data.content, list):
+        ns_key = namespace or ""
+        thinking_text = formatting.extract_thinking_content(chunk_data.content)
+        text_in_same_chunk = formatting.extract_string_content(chunk_data.content)
+
+        # Diagnostic: log mixed chunks and empty extractions
+        if thinking_text and text_in_same_chunk:
+            sb.logger.info(
+                f"[STREAM_DIAG] Mixed thinking+text chunk: "
+                f"execution={sb.execution_id} "
+                f"run_id={event.get('run_id', '')} "
+                f"namespace={namespace or 'main'} "
+                f"thinking_len={len(thinking_text)} "
+                f"text_len={len(text_in_same_chunk)} "
+                f"text={text_in_same_chunk[:100]!r}"
+            )
+        elif not thinking_text and not text_in_same_chunk:
+            expected_non_text_types = frozenset({
+                "thinking", "tool_use", "input_json_delta",
+            })
+            block_types = [
+                formatting.block_attr(b, "type", type(b).__name__)
+                for b in chunk_data.content[:5]
+            ]
+            is_expected = (
+                not block_types
+                or all(bt in expected_non_text_types for bt in block_types)
+            )
+            if not is_expected:
+                sb.logger.info(
+                    f"[STREAM_DIAG] List content with no thinking/text: "
+                    f"execution={sb.execution_id} "
+                    f"run_id={event.get('run_id', '')} "
+                    f"namespace={namespace or 'main'} "
+                    f"blocks={len(chunk_data.content)} "
+                    f"block_types={block_types}"
+                )
+
+        # ── Early Tool Call Creation ─────────────────────────────────────
+        # When a tool_use block appears in the stream, create the ToolCall
+        # right away so the CLI replaces the idle "Thinking…" indicator
+        # with the actual tool name (e.g. "Write: …").
+        skip_early_tools = frozenset(PLANNING_TOOLS)
+        for block in chunk_data.content:
+            try:
+                if formatting.block_attr(block, "type") == "tool_use":
+                    t_name = formatting.block_attr(block, "name")
+                    t_id = formatting.block_attr(block, "id")
+                    if t_name and t_name not in skip_early_tools:
+                        sb._create_early_tool_call(
+                            t_name, t_id, ns_key, namespace,
+                            llm_run_id=run_id,
+                        )
+            except Exception:
+                sb.logger.exception(
+                    f"[TOOL_EARLY_ERROR] execution={sb.execution_id} "
+                    f"block={block!r:.200} namespace={namespace or 'main'}"
+                )
+
+        # ── Tool Input Streaming ─────────────────────────────────────────
+        # Accumulate input_json_delta fragments and extract displayable
+        # content into the early ToolCall's result field so the CLI can
+        # render it progressively (same mechanism as thinking streaming).
+        for block in chunk_data.content:
+            try:
+                if formatting.block_attr(block, "type") == "input_json_delta":
+                    partial = formatting.block_attr(block, "partial_json")
+                    if partial:
+                        streaming_buffers.accumulate_tool_input(sb, ns_key, partial)
+            except Exception:
+                sb.logger.exception(
+                    f"[TOOL_INPUT_ERROR] execution={sb.execution_id} "
+                    f"namespace={namespace or 'main'}"
+                )
+
+        if thinking_text:
+            sb.state.thinking.buffers[ns_key] = (
+                sb.state.thinking.buffers.get(ns_key, "") + thinking_text
+            )
+            if ns_key not in sb.state.thinking.tool_call_ids:
+                streaming_buffers.start_thinking_stream(sb,
+                    ns_key, namespace, sb.state.thinking.buffers[ns_key],
+                    llm_run_id=run_id,
+                )
+            else:
+                streaming_buffers.update_thinking_stream(sb, ns_key)
+
+            if not text_in_same_chunk:
+                return
+            # Fall through: chunk has both thinking AND text.
+            # Thinking is accumulated above; text is processed below.
+
+    # Extract token
+    token = ""
+    if hasattr(chunk_data, "content"):
+        chunk_content = chunk_data.content
+        if isinstance(chunk_content, str):
+            token = chunk_content
+        elif isinstance(chunk_content, list):
+            token = formatting.extract_string_content(chunk_content)
+
+    if not token:
+        return
+
+    # Flush any accumulated thinking before processing text content.
+    # This ensures the synthetic think ToolCall appears in the status
+    # timeline before the AI message that follows it.
+    ns_key = namespace or ""
+    if sb.state.thinking.buffers.get(ns_key):
+        streaming_buffers.flush_thinking_buffer(sb, ns_key, namespace)
+
+    # ─────────────────────────────────────────────────────────────────────
+    # run_id-Based Message Isolation
+    #
+    # Each LLM invocation has a unique run_id. We use it to map tokens
+    # to the correct AgentMessage, preventing interleaving when multiple
+    # LLM streams are active (e.g., concurrent sub-agents whose namespace
+    # routing fell through to the main agent).
+    #
+    # When run_id is absent, we fall back to the legacy backwards-scan
+    # for the last streaming AI message in the resolved context.
+    # ─────────────────────────────────────────────────────────────────────
+    run_id = event.get("run_id", "")
+    context, sub_agent = sb._get_execution_context(namespace)
+    messages_list = sub_agent.messages if sub_agent else sb.current_status.messages
+
+    # Fast path: run_id already mapped to a message from an earlier token.
+    if run_id:
+        ai_message = sb.state.messages_by_run.get(run_id)
+        if ai_message is not None:
+            # Empty parent AI messages created by _ensure_parent_ai_message
+            # for thinking/tool_use blocks must NOT receive text content.
+            # Text should go to a separate AI message so the frontend
+            # renders the thread in chronological order: thinking tool
+            # group first, then the text response.  Remove the stale
+            # registration so the "first token" path below creates a
+            # proper text AI message and re-registers the run_id.
+            if not ai_message.content and len(ai_message.tool_calls) > 0:
+                del sb.state.messages_by_run[run_id]
+            else:
+                ai_message.content += token
+                return
+
+    if not run_id:
+        # Legacy fallback: no run_id available — find the last streaming
+        # AI message in this context (pre-isolation behaviour).
+        for idx in range(len(messages_list) - 1, -1, -1):
+            message = messages_list[idx]
+            if message.type == MessageType.MESSAGE_AI and message.is_streaming:
+                message.content += token
+                return
+
+    # First token for this run_id (or no existing streaming message in
+    # legacy mode) — create a new AgentMessage.
+    now = datetime.utcnow()
+    ai_message = AgentMessage(
+        type=MessageType.MESSAGE_AI,
+        content=token,
+        timestamp=_utc_timestamp(now),
+        is_streaming=True,
+    )
+    messages_list.append(ai_message)
+
+    # Store the proto-managed reference (not the original, which is
+    # disconnected after protobuf repeated-message append).
+    managed_ai_message = messages_list[-1]
+
+    if run_id:
+        sb.state.messages_by_run[run_id] = managed_ai_message
+
+    # Track as the most recent AI message for this namespace so that
+    # subsequent tool calls (on_tool_start, early tool_use) are attached
+    # to the correct parent AI message.
+    ns_key = namespace or ""
+    sb.state.current_ai_message[ns_key] = managed_ai_message
+
+    # Track start time for duration calculation
+    new_message_index = len(messages_list) - 1
+    if sub_agent:
+        sb.state.sub_agent_message_start_times[(sub_agent.id, new_message_index)] = now
+        sb.logger.debug(f"Started new AI message in sub_agent={sub_agent.id} at index {new_message_index} run_id={run_id}")
+    else:
+        sb.state.message_start_times[new_message_index] = now
+        sb.logger.debug(f"Started new AI message at index {new_message_index} run_id={run_id}")
+
+
+def handle_chat_model_end(sb: StatusBuilder, event: dict[str, Any], namespace: str = "") -> None:
+    """
+    Handle on_chat_model_end event - finalize AI message and capture usage metrics.
+
+    This event is emitted when the LLM completes generating a response. It contains:
+    - Final message content (already captured via streaming)
+    - Usage metadata (token counts) - only available in this event
+    - Model information
+
+    Args:
+        sb: The StatusBuilder instance
+        event: The astream_events v2 event dictionary
+        namespace: LangGraph checkpoint namespace for sub-agent routing
+    """
+    output_data = event.get("data", {}).get("output", {})
+
+    if not output_data:
+        return
+
+    # Flush any remaining thinking content that wasn't followed by text
+    # (e.g. the model only produced thinking + tool_use, no text block).
+    ns_key = namespace or ""
+    if sb.state.thinking.buffers.get(ns_key):
+        streaming_buffers.flush_thinking_buffer(sb, ns_key, namespace)
+
+    # ─────────────────────────────────────────────────────────────────────
+    # run_id-Based Message Resolution (with backwards-scan fallback)
+    # ─────────────────────────────────────────────────────────────────────
+    run_id = event.get("run_id", "")
+    context, sub_agent = sb._get_execution_context(namespace)
+    messages_list = sub_agent.messages if sub_agent else sb.current_status.messages
+
+    ai_message_index = None
+
+    # Primary path: resolve via run_id map (matches stream handler)
+    tracked_message = sb.state.messages_by_run.pop(run_id, None) if run_id else None
+    if tracked_message is not None:
+        for idx in range(len(messages_list) - 1, -1, -1):
+            if messages_list[idx] is tracked_message:
+                ai_message_index = idx
+                break
+
+    # Fallback: backwards scan for last streaming AI message
+    if ai_message_index is None:
+        for idx in range(len(messages_list) - 1, -1, -1):
+            message = messages_list[idx]
+            if message.type == MessageType.MESSAGE_AI and message.is_streaming:
+                ai_message_index = idx
+                break
+
+    if ai_message_index is None:
+        context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
+        sb.logger.warning(
+            f"on_chat_model_end received but no AI message found to finalize "
+            f"({context_desc} run_id={run_id})"
+        )
+        return
+
+    # Calculate generation duration if we tracked the start time
+    generation_duration_ms = None
+    if sub_agent:
+        # Check sub-agent timing dict
+        timing_key = (sub_agent.id, ai_message_index)
+        if timing_key in sb.state.sub_agent_message_start_times:
+            start_time = sb.state.sub_agent_message_start_times[timing_key]
+            duration = datetime.utcnow() - start_time
+            generation_duration_ms = int(duration.total_seconds() * 1000)
+            del sb.state.sub_agent_message_start_times[timing_key]
+    else:
+        # Check main agent timing dict
+        if ai_message_index in sb.state.message_start_times:
+            start_time = sb.state.message_start_times[ai_message_index]
+            duration = datetime.utcnow() - start_time
+            generation_duration_ms = int(duration.total_seconds() * 1000)
+            del sb.state.message_start_times[ai_message_index]
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Diagnostic: capture output_data shape for zero-usage debugging.
+    # Log the concrete type, usage_metadata value, and whether
+    # response_metadata carries a raw ``usage`` dict (Anthropic always
+    # populates this even during streaming).
+    # ─────────────────────────────────────────────────────────────────────────
+    _rm = getattr(output_data, "response_metadata", None)
+    _rm_usage = _rm.get("usage") if isinstance(_rm, dict) else None
+    sb.logger.debug(
+        "[USAGE_DIAG] execution=%s run_id=%s "
+        "output_data_type=%s "
+        "has_usage_metadata=%s usage_metadata=%r "
+        "response_metadata_keys=%s "
+        "response_metadata_usage=%r",
+        sb.execution_id,
+        run_id,
+        type(output_data).__name__,
+        hasattr(output_data, "usage_metadata"),
+        getattr(output_data, "usage_metadata", "N/A"),
+        list(_rm.keys()) if isinstance(_rm, dict) else "N/A",
+        _rm_usage,
+    )
+    del _rm, _rm_usage
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Extract usage metadata from LangChain response (Phase 3)
+    #
+    # LangChain normalises provider token counts into a unified
+    # ``usage_metadata`` structure:
+    #   input_tokens   — TOTAL input including cache (both providers)
+    #   output_tokens  — output / completion tokens
+    #   input_token_details.cache_creation — Anthropic cache writes
+    #   input_token_details.cache_read     — cache reads (both)
+    #
+    # For cost calculation we need four disjoint buckets:
+    #   regular_input = input_tokens - cache_creation - cache_read
+    # ─────────────────────────────────────────────────────────────────────────
+    total_input_tokens = 0
+    output_tokens = 0
+    cache_creation_tokens = 0
+    cache_read_tokens = 0
+    model_name = ""
+
+    # Resolve usage_metadata from AIMessage attribute or raw dict.
+    usage: dict | None = None
+    if hasattr(output_data, "usage_metadata") and output_data.usage_metadata:
+        usage = output_data.usage_metadata
+    elif isinstance(output_data, dict):
+        usage = output_data.get("usage_metadata") or output_data.get("usage")
+
+    # UsageMetadata is a TypedDict (plain dict at runtime) in all
+    # langchain-core versions.  Use dict .get() for key access;
+    # getattr() silently returns the default on dicts.
+    if usage and isinstance(usage, dict):
+        total_input_tokens = usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0) or 0
+        output_tokens = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0) or 0
+        details = usage.get("input_token_details") or {}
+        if isinstance(details, dict):
+            cache_creation_tokens = details.get("cache_creation", 0) or 0
+            cache_read_tokens = details.get("cache_read", 0) or 0
+
+    # Derive the non-cached regular input (disjoint bucket for cost)
+    regular_input_tokens = max(0, total_input_tokens - cache_creation_tokens - cache_read_tokens)
+
+    # Extract model name from response_metadata
+    if hasattr(output_data, "response_metadata"):
+        response_meta = output_data.response_metadata
+        if isinstance(response_meta, dict):
+            model_name = response_meta.get("model", "") or response_meta.get("model_name", "")
+    elif isinstance(output_data, dict):
+        response_meta = output_data.get("response_metadata", {})
+        model_name = response_meta.get("model", "") or response_meta.get("model_name", "")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Finalize AI message streaming state fields
+    # ─────────────────────────────────────────────────────────────────────────
+    ai_message = messages_list[ai_message_index]
+
+    ai_message.is_streaming = False
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Diagnostic: detect text content dropped during streaming
+    #
+    # The output_data contains the FULL final AIMessage with all content
+    # blocks.  Extract the text portion and compare with what the stream
+    # handler accumulated.  A mismatch proves tokens were silently dropped.
+    # ─────────────────────────────────────────────────────────────────────────
+    try:
+        final_text = ""
+        if hasattr(output_data, "content"):
+            oc = output_data.content
+            if isinstance(oc, str):
+                final_text = oc
+            elif isinstance(oc, list):
+                final_text = formatting.extract_string_content(oc)
+        elif isinstance(output_data, dict) and "content" in output_data:
+            oc = output_data["content"]
+            if isinstance(oc, str):
+                final_text = oc
+            elif isinstance(oc, list):
+                final_text = formatting.extract_string_content(oc)
+
+        streamed_text = ai_message.content
+        if final_text and final_text != streamed_text:
+            sb.logger.warning(
+                f"[CONTENT_DROP] execution={sb.execution_id} run_id={run_id} "
+                f"namespace={namespace or 'main'} "
+                f"streamed_len={len(streamed_text)} final_len={len(final_text)} "
+                f"streamed={streamed_text[:200]!r} "
+                f"final={final_text[:200]!r}"
+            )
+            # Reconcile: overwrite with the authoritative final content
+            # so the CLI shows the complete message even if streaming
+            # was disrupted (e.g. by proto copy semantics).
+            ai_message.content = final_text
+        elif final_text:
+            sb.logger.debug(
+                f"[CONTENT_OK] execution={sb.execution_id} run_id={run_id} "
+                f"len={len(streamed_text)} content={streamed_text[:100]!r}"
+            )
+    except Exception:
+        pass
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Record usage via UsageTracker (Phase 3)
+    #
+    # Delegates all token accounting, pricing lookup, cost computation,
+    # LlmCallMetrics construction, and ModelUsage aggregation to the
+    # tracker.  The returned LlmCallMetrics is used to enrich the
+    # AgentMessage with per-message cost and model fields.
+    # ─────────────────────────────────────────────────────────────────────────
+    scope = sub_agent.id if sub_agent else MAIN_SCOPE
+
+    call_metrics = sb._usage_tracker.record_llm_call(
+        model_name=model_name,
+        input_tokens=regular_input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
+        duration_ms=generation_duration_ms,
+        timestamp=_utc_timestamp(),
+        scope=scope,
+    )
+
+    ai_message.llm_metrics.CopyFrom(call_metrics)
+
+    sb.logger.debug(
+        "AI message finalized at index %d scope=%s "
+        "(tokens: %d, cost: $%.6f, duration: %sms)",
+        ai_message_index,
+        scope,
+        total_input_tokens + output_tokens,
+        call_metrics.estimated_cost_usd,
+        generation_duration_ms or "N/A",
+    )

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/context.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/context.py
@@ -1,0 +1,271 @@
+"""Context info, summarization, artifacts, and workspace write-backs.
+
+These functions manage execution metadata that is set once or updated
+infrequently (resolved context, summarization events, artifacts).
+All receive the ``StatusBuilder`` instance as their first argument.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
+from ai.stigmer.agentic.agentexecution.v1.context_pb2 import (
+    ContextInfo,
+    McpServerResolutionStatus,
+    ResolvedExecutionContext,
+    SummarizationEvent,
+)
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import SummarizationSource
+from graphton.core.summarization_callback import SummarizationEventData
+
+if TYPE_CHECKING:
+    from worker.activities.graphton.status_builder import StatusBuilder
+
+
+def _utc_timestamp(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.utcnow()
+    return dt.isoformat() + "Z"
+
+
+def set_resolved_context(
+    sb: StatusBuilder,
+    environment_keys: list[str],
+    mcp_servers: dict[str, tuple[bool, str, int]],
+    skill_names: list[str],
+    excluded_skill_names: list[str] | None = None,
+) -> None:
+    """Set the resolved execution context on the status proto."""
+    resolved_context = ResolvedExecutionContext(
+        environment_keys=sorted(environment_keys),
+        skill_names=sorted(skill_names),
+        excluded_skill_names=sorted(excluded_skill_names or []),
+    )
+
+    for slug, (resolved, message, tool_count) in mcp_servers.items():
+        resolved_context.mcp_servers[slug].CopyFrom(
+            McpServerResolutionStatus(
+                resolved=resolved,
+                message=message,
+                enabled_tool_count=tool_count,
+            )
+        )
+
+    sb.current_status.resolved_context.CopyFrom(resolved_context)
+
+    resolved_count = sum(1 for r, _, _ in mcp_servers.values() if r)
+    failed_count = len(mcp_servers) - resolved_count
+
+    excluded_count = len(excluded_skill_names) if excluded_skill_names else 0
+    sb.logger.info(
+        f"[CONTEXT] execution={sb.execution_id} "
+        f"env_keys={len(environment_keys)} "
+        f"mcp_servers={len(mcp_servers)} (resolved={resolved_count}, failed={failed_count}) "
+        f"skills={len(skill_names)} "
+        f"excluded_skills={excluded_count}"
+    )
+
+    if environment_keys:
+        sb.logger.debug(f"[CONTEXT] Environment keys: {sorted(environment_keys)}")
+    if mcp_servers:
+        for slug, (resolved, message, tool_count) in mcp_servers.items():
+            status = "OK" if resolved else "FAILED"
+            sb.logger.debug(
+                f"[CONTEXT] MCP server '{slug}': {status} - {message} "
+                f"(tools={tool_count})"
+            )
+    if skill_names:
+        sb.logger.debug(f"[CONTEXT] Skills: {sorted(skill_names)}")
+
+
+def initialize_context_info(
+    sb: StatusBuilder,
+    context_window_limit: int,
+    trigger_threshold: int,
+    target_tokens: int,
+    enabled: bool,
+) -> None:
+    """Initialize context info from model registry data."""
+    sb.state.context_info = ContextInfo(
+        context_window_limit=context_window_limit,
+        summarization_trigger_threshold=trigger_threshold,
+        summarization_target_tokens=target_tokens,
+        summarization_enabled=enabled,
+        current_token_count=0,
+        utilization_percent=0.0,
+    )
+
+    sb.logger.info(
+        f"[CONTEXT] execution={sb.execution_id} "
+        f"context_management initialized: "
+        f"window={context_window_limit}, "
+        f"trigger={trigger_threshold}, "
+        f"target={target_tokens}, "
+        f"enabled={enabled}"
+    )
+
+
+def on_summarization_complete(sb: StatusBuilder, event: SummarizationEventData) -> None:
+    """Callback from SummarizationMiddleware when summarization completes."""
+    if sb.state.context_info is None:
+        sb.logger.warning(
+            f"[CONTEXT] execution={sb.execution_id} "
+            "on_summarization_complete called but context_info not initialized"
+        )
+        return
+
+    try:
+        proto_source = SummarizationSource.Value(event.source)
+    except ValueError:
+        proto_source = SummarizationSource.SUMMARIZATION_SOURCE_UNSPECIFIED
+
+    timestamp = _utc_timestamp()
+    proto_event = SummarizationEvent(
+        timestamp=timestamp,
+        tokens_before=event.tokens_before,
+        tokens_after=event.tokens_after,
+        compression_ratio=event.compression_ratio,
+        duration_ms=event.duration_ms,
+        summarization_model=event.summarization_model,
+        messages_before=event.messages_before,
+        messages_after=event.messages_after,
+        source=proto_source,  # type: ignore[arg-type]
+        summarization_input_tokens=event.summarization_input_tokens,
+        summarization_output_tokens=event.summarization_output_tokens,
+        summarization_cost_usd=event.summarization_cost_usd,
+    )
+    sb.state.context_info.summarization_events.append(proto_event)
+
+    sb.state.context_info.current_token_count = event.tokens_after
+    _update_utilization(sb)
+    _sync_context_info(sb)
+    sb.force_next_update = True
+
+    sb.logger.info(
+        f"[CONTEXT] execution={sb.execution_id} "
+        f"summarization completed (source={event.source}): "
+        f"{event.tokens_before} -> {event.tokens_after} tokens "
+        f"({event.compression_ratio * 100:.1f}% reduction), "
+        f"duration={event.duration_ms}ms, "
+        f"model={event.summarization_model}, "
+        f"summarization_cost=${event.summarization_cost_usd:.6f}"
+    )
+
+
+def on_token_count_updated(sb: StatusBuilder, token_count: int) -> None:
+    """Callback from SummarizationMiddleware when token count changes."""
+    if sb.state.context_info is None:
+        return
+
+    sb.state.context_info.current_token_count = token_count
+    _update_utilization(sb)
+
+    sb.logger.debug(
+        f"[CONTEXT] execution={sb.execution_id} "
+        f"token_count={token_count} "
+        f"utilization={sb.state.context_info.utilization_percent:.1f}%"
+    )
+
+
+def _update_utilization(sb: StatusBuilder) -> None:
+    """Recalculate utilization percentage based on current token count."""
+    if sb.state.context_info is None:
+        return
+
+    if sb.state.context_info.context_window_limit > 0:
+        sb.state.context_info.utilization_percent = (
+            sb.state.context_info.current_token_count
+            / sb.state.context_info.context_window_limit
+            * 100
+        )
+    else:
+        sb.state.context_info.utilization_percent = 0.0
+
+
+def _sync_context_info(sb: StatusBuilder) -> None:
+    """Copy the working context_info to current_status."""
+    if sb.state.context_info is not None:
+        sb.current_status.context_info.CopyFrom(sb.state.context_info)
+
+
+def finalize_context_info(sb: StatusBuilder) -> None:
+    """Finalize context info and copy to status proto."""
+    if sb.state.context_info is not None:
+        _sync_context_info(sb)
+
+        summarization_count = len(
+            sb.state.context_info.summarization_events,
+        )
+        sb.logger.info(
+            f"[CONTEXT] execution={sb.execution_id} "
+            f"context_info finalized: "
+            f"final_tokens={sb.state.context_info.current_token_count}, "
+            f"utilization={sb.state.context_info.utilization_percent:.1f}%, "
+            f"summarizations={summarization_count}"
+        )
+
+    already_synced = {a.sandbox_path for a in sb.current_status.artifacts}
+    newly_synced = 0
+    for artifact in sb.state.artifacts:
+        if artifact.sandbox_path not in already_synced:
+            sb.current_status.artifacts.append(artifact)
+            newly_synced += 1
+
+    if sb.state.artifacts:
+        sb.logger.info(
+            f"[ARTIFACTS] execution={sb.execution_id} "
+            f"finalized {len(sb.state.artifacts)} artifact(s) "
+            f"({newly_synced} newly synced, "
+            f"{len(sb.state.artifacts) - newly_synced} already live)"
+        )
+
+
+def add_artifact(sb: StatusBuilder, artifact: ExecutionArtifact) -> None:
+    """Add a published artifact and make it immediately visible."""
+    existing_paths = {a.sandbox_path for a in sb.state.artifacts}
+    if artifact.sandbox_path in existing_paths:
+        sb.state.artifacts = [
+            a for a in sb.state.artifacts
+            if a.sandbox_path != artifact.sandbox_path
+        ]
+    sb.state.artifacts.append(artifact)
+
+    _sync_artifact_to_status(sb, artifact)
+    sb.force_next_update = True
+
+    sb.logger.info(
+        f"[ARTIFACT] execution={sb.execution_id} "
+        f"name={artifact.name} "
+        f"size={artifact.size_bytes} bytes "
+        f"path={artifact.sandbox_path}"
+    )
+
+
+def _sync_artifact_to_status(sb: StatusBuilder, artifact: ExecutionArtifact) -> None:
+    """Upsert artifact into current_status.artifacts by sandbox_path."""
+    status_artifacts = sb.current_status.artifacts
+    for idx, existing in enumerate(status_artifacts):
+        if existing.sandbox_path == artifact.sandbox_path:
+            status_artifacts[idx].CopyFrom(artifact)
+            return
+    status_artifacts.append(artifact)
+
+
+def add_workspace_write_back(sb: StatusBuilder, wb: Any) -> None:
+    """Register a write-back outcome on the execution status."""
+    wbs = sb.current_status.workspace_write_backs
+    for idx, existing in enumerate(wbs):
+        if existing.workspace_entry_name == wb.workspace_entry_name:
+            wbs[idx].CopyFrom(wb)
+            sb.force_next_update = True
+            return
+    wbs.append(wb)
+    sb.force_next_update = True
+
+    sb.logger.info(
+        f"[WRITE_BACK] execution={sb.execution_id} "
+        f"entry={wb.workspace_entry_name} "
+        f"phase={wb.phase}"
+    )

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/formatting.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/formatting.py
@@ -1,0 +1,193 @@
+"""Stateless content-extraction and display-formatting utilities.
+
+Every function in this module is a pure transform with no dependency on
+``StatusBuilder`` state.  They are leaf-level helpers imported by other
+handler modules and by ``StatusBuilder`` itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from google.protobuf.struct_pb2 import Struct
+
+_logger = logging.getLogger(__name__)
+
+
+def block_attr(block: Any, key: str, default: str = "") -> str:
+    """Read *key* from a content block regardless of whether it is a
+    ``dict`` or an object with attributes (e.g. a LangChain dataclass)."""
+    if isinstance(block, dict):
+        return block.get(key, default)
+    return getattr(block, key, default)
+
+
+def extract_string_content(content_blocks: list) -> str:
+    """Extract text from multimodal content blocks.
+
+    Handles both dict blocks (``{"type": "text", "text": "..."}``) and
+    attribute-based objects (``block.type == "text"``).
+    """
+    text_parts: list[str] = []
+    for block in content_blocks:
+        if block_attr(block, "type") == "text":
+            text_parts.append(block_attr(block, "text"))
+    return "".join(text_parts)
+
+
+def extract_thinking_content(content_blocks: list) -> str:
+    """Extract thinking text from Anthropic extended-thinking content blocks.
+
+    Returns the concatenated thinking text from all blocks with
+    ``type: "thinking"``.  Returns an empty string when no thinking
+    blocks are present (non-Anthropic models, or text/tool_use chunks).
+
+    Handles both dict blocks and attribute-based objects.
+    """
+    parts: list[str] = []
+    for block in content_blocks:
+        if block_attr(block, "type") == "thinking":
+            parts.append(block_attr(block, "thinking"))
+    return "".join(parts)
+
+
+def unwrap_tool_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Unwrap LangGraph arg wrappers."""
+    if "kwargs" in args and isinstance(args["kwargs"], dict):
+        return args["kwargs"]
+    if "input" in args and isinstance(args["input"], dict) and len(args) == 1:
+        return args["input"]
+    return args
+
+
+def extract_command_content(update: dict[str, Any]) -> str:
+    """Extract displayable content from a LangGraph Command.update dict.
+
+    When a tool goes through the interrupt()/resume approval cycle,
+    LangGraph may wrap the result in a Command object whose .update dict
+    contains state channel mutations. The "messages" channel typically holds
+    ToolMessage objects with the human-readable tool result.
+
+    Extraction strategy:
+    1. Look in update["messages"] for ToolMessage-like objects with .content
+    2. Fall back to JSON-serializing the non-messages portion of the update
+
+    Returns an empty string if no meaningful content can be extracted.
+    """
+    messages = update.get("messages", [])
+    if isinstance(messages, list):
+        for msg in messages:
+            if hasattr(msg, "content"):
+                content = msg.content
+                if isinstance(content, str) and content:
+                    return content
+                if isinstance(content, list):
+                    extracted = extract_string_content(content)
+                    if extracted:
+                        return extracted
+
+    fallback = {k: v for k, v in update.items() if k != "messages"}
+    if fallback:
+        try:
+            return json.dumps(fallback, indent=2, default=str)
+        except (TypeError, ValueError):
+            pass
+
+    return ""
+
+
+def extract_tool_result_content(result: Any) -> str:
+    """Extract displayable content string from a tool result.
+
+    Handles the five result shapes that flow through LangGraph astream_events:
+
+    - str: Direct string results (most common for simple tools)
+    - LangGraph message objects (ToolMessage, AIMessage): Extract .content
+    - LangGraph Command objects: Extract ToolMessage content from .update
+    - dict: Extract from 'output'/'content' keys, or JSON-serialize
+    - list: Extract text from MCP content blocks, or JSON-serialize
+    """
+    if isinstance(result, str):
+        return result
+    if hasattr(result, "content"):
+        content = result.content
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return extract_string_content(content)
+    if hasattr(result, "update") and isinstance(getattr(result, "update", None), dict):
+        return extract_command_content(result.update)
+    if isinstance(result, dict):
+        if "output" in result:
+            return result.get("output", "")
+        if "content" in result:
+            return str(result["content"])
+        return json.dumps(result, indent=2)
+    if isinstance(result, list):
+        extracted = extract_string_content(result)
+        if extracted:
+            return extracted
+        try:
+            return json.dumps(result, indent=2, default=str)
+        except (TypeError, ValueError):
+            pass
+    _logger.warning(
+        "[TOOL] Unknown result type %s for tool result extraction, "
+        "falling back to str(). Preview: %s",
+        type(result).__name__, str(result)[:200],
+    )
+    return str(result)
+
+
+def format_tool_message_content(
+    tool_name: str,
+    args: Struct | None,
+    result: str,
+) -> str:
+    """Format tool message content for CLI display.
+
+    Creates a human-readable summary of the tool call for streaming display.
+
+    Returns:
+        Formatted string like ``"read(path='file.txt') -> 123 chars"``
+    """
+    args_summary = ""
+    if args:
+        try:
+            args_dict = dict(args.fields)
+            if args_dict:
+                first_key = next(iter(args_dict))
+                first_value = args_dict[first_key]
+                if hasattr(first_value, 'string_value') and first_value.string_value:
+                    value_str = first_value.string_value
+                    if len(value_str) > 40:
+                        value_str = value_str[:37] + "..."
+                    args_summary = f"{first_key}='{value_str}'"
+                elif hasattr(first_value, 'number_value'):
+                    args_summary = f"{first_key}={first_value.number_value}"
+                elif hasattr(first_value, 'bool_value'):
+                    args_summary = f"{first_key}={first_value.bool_value}"
+
+                if len(args_dict) > 1:
+                    args_summary += f", +{len(args_dict) - 1} more"
+        except Exception:
+            pass
+
+    result_summary = ""
+    if result:
+        if len(result) > 100:
+            result_summary = f"{len(result)} chars"
+        else:
+            result_summary = result.replace('\n', ' ')[:80]
+
+    if args_summary:
+        call_str = f"{tool_name}({args_summary})"
+    else:
+        call_str = f"{tool_name}()"
+
+    if result_summary:
+        return f"{call_str} -> {result_summary}"
+    else:
+        return call_str

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/streaming_buffers.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/streaming_buffers.py
@@ -1,0 +1,494 @@
+"""Streaming buffer management for early tool calls, thinking, and tool input.
+
+These functions manage the partial-data buffers that accumulate during LLM
+token streaming.  They are called by both the chat-model handlers (which
+create and fill the buffers) and the tool-event handlers (which reconcile
+early tool calls on ``on_tool_start``).
+
+All functions receive the ``StatusBuilder`` instance as their first argument
+and operate on its ``state`` and collaborators.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ToolCallStatus
+from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
+    ComponentMetadata,
+    ToolCall,
+)
+from google.protobuf.struct_pb2 import Struct
+from worker.activities.graphton.approval_policy import render_approval_message
+from worker.component_type_inference import infer_component_type
+
+if TYPE_CHECKING:
+    from worker.activities.graphton.status_builder import StatusBuilder
+
+# ---------------------------------------------------------------------------
+# Module-level constants (moved from status_builder.py)
+# ---------------------------------------------------------------------------
+
+_TOOL_CONTENT_FIELDS: dict[str, list[str]] = {
+    "write":          ["contents", "content", "file_content"],
+    "write_file":     ["contents", "content", "file_content"],
+    "create_file":    ["contents", "content", "file_content"],
+    "overwrite_file": ["contents", "content", "file_content"],
+    "edit":           ["new_text", "new_string", "replacement", "content"],
+    "edit_file":      ["new_text", "new_string", "replacement", "content"],
+    "think":          ["thought"],
+}
+
+_JSON_ESCAPES: dict[str, str] = {
+    "n": "\n", "t": "\t", "r": "\r",
+    '"': '"', "\\": "\\", "/": "/",
+    "b": "\b", "f": "\f",
+}
+
+
+def _find_json_string_value_start(partial_json: str, field_name: str) -> int:
+    """Return the index of the first content character of a JSON string value.
+
+    Searches *partial_json* for ``"<field_name>"`` followed by ``:`` and ``"``,
+    skipping optional whitespace.  Returns the index immediately after the
+    opening quote, or ``-1`` if the pattern has not yet appeared.
+
+    Robust against missing whitespace (``"key":"val"``) and extra whitespace
+    (``"key" :  "val"``).
+    """
+    marker = f'"{field_name}"'
+    pos = partial_json.find(marker)
+    if pos < 0:
+        return -1
+    after_key = pos + len(marker)
+    colon_pos = partial_json.find(":", after_key)
+    if colon_pos < 0:
+        return -1
+    quote_pos = partial_json.find('"', colon_pos + 1)
+    if quote_pos < 0:
+        return -1
+    return quote_pos + 1
+
+
+def _json_unescape_partial(s: str) -> str:
+    """Unescape a partial JSON string value.
+
+    Converts standard JSON escape sequences (``\\n``, ``\\t``, ``\\"``, etc.)
+    to their Python equivalents.  Processing stops at the closing ``"`` (end of
+    JSON string) or at the end of the input (string is still being generated).
+
+    A trailing backslash with no following character is silently dropped to
+    avoid showing a garbled escape that is not yet complete.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        ch = s[i]
+        if ch == "\\":
+            if i + 1 >= n:
+                break
+            nxt = s[i + 1]
+            if nxt == "u":
+                if i + 5 < n:
+                    try:
+                        out.append(chr(int(s[i + 2 : i + 6], 16)))
+                        i += 6
+                        continue
+                    except ValueError:
+                        pass
+                break
+            out.append(_JSON_ESCAPES.get(nxt, nxt))
+            i += 2
+        elif ch == '"':
+            break
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def _utc_timestamp(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.utcnow()
+    return dt.isoformat() + "Z"
+
+
+# ---------------------------------------------------------------------------
+# Streaming buffer operations
+# ---------------------------------------------------------------------------
+
+
+def create_early_tool_call(
+    sb: StatusBuilder,
+    tool_name: str,
+    tool_use_id: str,
+    ns_key: str,
+    namespace: str,
+    llm_run_id: str = "",
+) -> None:
+    """Create a ToolCall as soon as a ``tool_use`` block appears in the stream.
+
+    The CLI shows an idle "Thinking..." indicator when no events arrive
+    for >= 2 s.  While the LLM generates tool arguments (``input_json_delta``
+    chunks) the status builder has nothing to report, so the CLI falls
+    back to the idle indicator even though the model has already decided
+    to call a tool.
+
+    By creating the ToolCall here -- before ``on_tool_start`` fires -- the
+    CLI immediately displays the tool name with a running badge.  When
+    ``on_tool_start`` arrives, ``reconcile_early_tool_call`` reconciles
+    the early ToolCall (populates args, registers the real run-ID alias)
+    instead of creating a duplicate.
+    """
+    if sb.state.thinking.buffers.get(ns_key):
+        flush_thinking_buffer(sb, ns_key, namespace)
+
+    temp_id = tool_use_id or f"early-{uuid4()}"
+
+    if sb.get_tool_call(temp_id) is not None:
+        _, sub_agent = sb._get_execution_context(namespace)
+        sa_id = sub_agent.id if sub_agent else None
+        sb.state.early_tool_call_queue.append((temp_id, sa_id))
+        sb.logger.info(
+            "[RESUME_DEDUP] execution=%s skipping early tool call "
+            "creation for %s (id=%s already exists from prior cycle, "
+            "re-queued for reconciliation)",
+            sb.execution_id, tool_name, temp_id,
+        )
+        return
+
+    mcp_server_slug = ""
+    if sb._approval_config is not None:
+        mcp_server_slug = sb._approval_config.get_mcp_server_for_tool(tool_name)
+
+    now = datetime.utcnow()
+    tool_call = ToolCall(
+        id=temp_id,
+        name=tool_name,
+        result="",
+        status=ToolCallStatus.TOOL_CALL_RUNNING,
+        is_streaming=True,
+        component_metadata=ComponentMetadata(
+            component_type=infer_component_type(tool_name),
+            component_group="main-agent-tools",
+        ),
+        started_at=_utc_timestamp(now),
+        mcp_server_slug=mcp_server_slug,
+    )
+
+    parent_ai = sb._ensure_parent_ai_message(
+        ns_key, namespace, llm_run_id=llm_run_id,
+    )
+    parent_ai.tool_calls.append(tool_call)
+    sb.state.tool_calls[temp_id] = parent_ai.tool_calls[-1]
+
+    _, sub_agent = sb._get_execution_context(namespace)
+    sa_id = sub_agent.id if sub_agent else None
+    sb.state.early_tool_call_queue.append((temp_id, sa_id))
+    sb.state.tool_start_times[temp_id] = now
+
+    sb.state.tool_input.active_tc[ns_key] = temp_id
+    sb.state.tool_input.buffers[temp_id] = ""
+
+    sb.force_next_update = True
+
+
+def reconcile_early_tool_call(
+    sb: StatusBuilder,
+    tool_name: str,
+    run_id: str,
+    tool_args: dict[str, Any],
+    namespace: str,
+) -> ToolCall | None:
+    """Match an ``on_tool_start`` event to an early-created ToolCall.
+
+    Pops the first queued entry whose ToolCall name matches *tool_name*
+    and whose sub-agent context matches the current namespace.  This
+    prevents cross-contamination when concurrent sub-agents invoke the
+    same tool (e.g., two sub-agents both calling ``read_file``).
+
+    If found, the existing ToolCall is updated in place (args populated,
+    ``is_streaming`` cleared) and the real *run_id* is registered as an
+    alias so that downstream handlers (``on_tool_end``, ``tool_progress``)
+    resolve to the same proto.
+
+    On the **resume path**, a TC from the prior cycle may be re-queued
+    by ``create_early_tool_call``.  In that case only the run_id alias
+    is registered -- existing state is preserved to avoid overwriting
+    approval decisions already recorded.
+
+    Returns the reconciled ToolCall, or ``None`` if no match exists.
+    """
+    _, sub_agent = sb._get_execution_context(namespace)
+    sa_id = sub_agent.id if sub_agent else None
+
+    for idx, (temp_id, queued_sa_id) in enumerate(sb.state.early_tool_call_queue):
+        existing = sb.get_tool_call(temp_id)
+        if existing is None or existing.name != tool_name:
+            continue
+        if queued_sa_id != sa_id:
+            continue
+
+        sb.state.early_tool_call_queue.pop(idx)
+
+        is_resume_requeue = not existing.is_streaming
+        if is_resume_requeue:
+            sb._tool_call_id_capture.register_alias(run_id, temp_id)
+            sb.logger.info(
+                "[RECONCILE] execution=%s resume-path reconciliation: "
+                "tool=%s run_id=%s -> existing_tc=%s "
+                "(alias only, preserving prior-cycle state)",
+                sb.execution_id, tool_name, run_id, temp_id,
+            )
+            return existing
+
+        flush_tool_input_buffer(sb, temp_id)
+
+        existing.result = ""
+
+        if tool_args:
+            display_args = sb._humanize_args_for_display(tool_args)
+            args_struct = Struct()
+            args_struct.update(display_args)
+            existing.args.CopyFrom(args_struct)
+            existing.args_preview = sb._create_args_preview(tool_args)
+
+        existing.is_streaming = False
+
+        if sb._approval_config is not None:
+            slug = sb._approval_config.get_mcp_server_for_tool(tool_name)
+            if slug and not existing.mcp_server_slug:
+                existing.mcp_server_slug = slug
+
+        approval = sb._check_tool_approval_requirement(tool_name, tool_args)
+        if approval.requires_approval:
+            existing.status = ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
+            existing.requires_approval = True
+            existing.approval_message = render_approval_message(
+                template=approval.message,
+                tool_name=tool_name,
+                tool_args=tool_args,
+            )
+            existing.approval_requested_at = _utc_timestamp(datetime.utcnow())
+
+        sb._tool_call_id_capture.register_alias(run_id, temp_id)
+        sb.state.tool_start_times[run_id] = sb.state.tool_start_times.pop(
+            temp_id, datetime.utcnow()
+        )
+
+        if approval.requires_approval:
+            sb._set_waiting_for_approval_phase(tool_name, run_id)
+
+        return existing
+
+    return None
+
+
+def start_thinking_stream(
+    sb: StatusBuilder,
+    ns_key: str,
+    namespace: str,
+    initial_text: str,
+    llm_run_id: str = "",
+) -> None:
+    """Create a RUNNING ToolCall for native thinking and begin streaming.
+
+    Called when the first thinking content block arrives for a namespace.
+    The ToolCall starts with ``is_streaming=True`` and the initial thinking
+    text in ``result``.  Subsequent blocks update ``result`` via
+    ``update_thinking_stream``, and ``flush_thinking_buffer`` transitions
+    the ToolCall to COMPLETED when thinking ends.
+
+    During streaming the CLI renders ``result`` via ``renderStreamingTool``
+    (last N lines with a cursor indicator).  After completion the CLI reads
+    ``args.thought`` via ``resolveDisplayContent`` (the ``toolDisplayMap``
+    entry uses ``contentSourceInput``).
+    """
+    now = datetime.utcnow()
+    tc_id = f"think-native-{uuid4()}"
+
+    tool_call = ToolCall(
+        id=tc_id,
+        name="think",
+        args=Struct(),
+        result=initial_text,
+        status=ToolCallStatus.TOOL_CALL_RUNNING,
+        is_streaming=True,
+        component_metadata=ComponentMetadata(
+            component_type=infer_component_type("think"),
+            component_group="main-agent-tools",
+        ),
+        started_at=_utc_timestamp(now),
+    )
+
+    parent_ai = sb._ensure_parent_ai_message(
+        ns_key, namespace, llm_run_id=llm_run_id,
+    )
+    parent_ai.tool_calls.append(tool_call)
+    sb.state.tool_calls[tc_id] = parent_ai.tool_calls[-1]
+
+    sb.state.thinking.tool_call_ids[ns_key] = tc_id
+    sb.state.thinking.started_at[ns_key] = now
+
+    sb.force_next_update = True
+
+    sb.logger.debug(
+        "[THINK] execution=%s streaming_started id=%s namespace=%s",
+        sb.execution_id,
+        tc_id,
+        namespace or "main",
+    )
+
+
+def update_thinking_stream(sb: StatusBuilder, ns_key: str) -> None:
+    """Update the streaming think ToolCall with the latest accumulated content."""
+    tc_id = sb.state.thinking.tool_call_ids.get(ns_key)
+    if not tc_id:
+        return
+
+    buf = sb.state.thinking.buffers.get(ns_key, "")
+
+    tool_call = sb.get_tool_call(tc_id)
+    if tool_call is not None:
+        tool_call.result = buf
+
+
+def accumulate_tool_input(
+    sb: StatusBuilder, ns_key: str, partial_json: str,
+) -> None:
+    """Accumulate an ``input_json_delta`` fragment and update the early ToolCall.
+
+    Appends *partial_json* to the buffer for the early ToolCall currently
+    active in this namespace.  If the accumulated JSON already contains the
+    tool's content field (e.g. ``"contents": "...``), the extracted value is
+    written to ``tool_call.result`` so the CLI can stream it progressively.
+    """
+    temp_id = sb.state.tool_input.active_tc.get(ns_key)
+    if not temp_id:
+        return
+
+    buf = sb.state.tool_input.buffers.get(temp_id)
+    if buf is None:
+        return
+
+    sb.state.tool_input.buffers[temp_id] = buf + partial_json
+
+    tool_call = sb.get_tool_call(temp_id)
+    if tool_call is None:
+        return
+
+    content = extract_content_from_partial_json(
+        tool_call.name, sb.state.tool_input.buffers[temp_id],
+    )
+    if content:
+        tool_call.result = content
+
+
+def extract_content_from_partial_json(
+    tool_name: str, partial_json: str,
+) -> str:
+    """Extract the displayable content value from an in-progress args JSON.
+
+    For tools listed in ``_TOOL_CONTENT_FIELDS`` (write, edit, think) the
+    function locates the content field's opening quote and JSON-unescapes
+    everything that has arrived so far.  Trailing incomplete escape
+    sequences are silently dropped to avoid garbled output.
+
+    Returns an empty string when the content field has not yet appeared in
+    the accumulated JSON (e.g. the LLM is still generating the ``path``
+    argument).
+    """
+    fields = _TOOL_CONTENT_FIELDS.get(tool_name)
+    if not fields:
+        return ""
+
+    for field in fields:
+        start = _find_json_string_value_start(partial_json, field)
+        if start >= 0:
+            return _json_unescape_partial(partial_json[start:])
+
+    return ""
+
+
+def flush_tool_input_buffer(sb: StatusBuilder, temp_id: str) -> None:
+    """Clean up input-streaming state for a reconciled early ToolCall."""
+    sb.state.tool_input.buffers.pop(temp_id, None)
+    for ns_key, tid in list(sb.state.tool_input.active_tc.items()):
+        if tid == temp_id:
+            del sb.state.tool_input.active_tc[ns_key]
+            break
+
+
+def flush_thinking_buffer(sb: StatusBuilder, ns_key: str, namespace: str) -> None:
+    """Finalize the streaming think ToolCall or create a completed one.
+
+    If a streaming ToolCall exists (created by ``start_thinking_stream``),
+    transitions it from RUNNING to COMPLETED in place: populates
+    ``args.thought`` with the full thinking text, sets ``result`` to
+    ``"ok"``, and clears the streaming flag.
+
+    Falls back to creating a new COMPLETED ToolCall from scratch if no
+    streaming ToolCall exists (defensive -- should not happen in normal flow
+    since ``start_thinking_stream`` is called on the first thinking block).
+    """
+    thinking_text = sb.state.thinking.buffers.pop(ns_key, "")
+    started_at = sb.state.thinking.started_at.pop(ns_key, None)
+    tc_id = sb.state.thinking.tool_call_ids.pop(ns_key, None)
+    if not thinking_text:
+        return
+
+    now = datetime.utcnow()
+
+    args_struct = Struct()
+    args_struct.update({"thought": thinking_text})
+
+    _, sub_agent = sb._get_execution_context(namespace)
+    completed_ts = _utc_timestamp(now)
+
+    if tc_id:
+        tool_call = sb.get_tool_call(tc_id)
+        if tool_call is not None:
+            tool_call.args.CopyFrom(args_struct)
+            tool_call.result = "ok"
+            tool_call.status = ToolCallStatus.TOOL_CALL_COMPLETED
+            tool_call.is_streaming = False
+            tool_call.completed_at = completed_ts
+
+            sb.logger.info(
+                "[THINK] execution=%s streaming_completed id=%s "
+                "chars=%d namespace=%s",
+                sb.execution_id,
+                tc_id,
+                len(thinking_text),
+                namespace or "main",
+            )
+            return
+
+    fallback_tc = ToolCall(
+        id=f"think-native-{uuid4()}",
+        name="think",
+        args=args_struct,
+        result="ok",
+        status=ToolCallStatus.TOOL_CALL_COMPLETED,
+        component_metadata=ComponentMetadata(
+            component_type=infer_component_type("think"),
+            component_group="main-agent-tools",
+        ),
+        started_at=_utc_timestamp(started_at or now),
+        completed_at=completed_ts,
+    )
+
+    parent_ai = sb._ensure_parent_ai_message(ns_key, namespace)
+    parent_ai.tool_calls.append(fallback_tc)
+    sb.state.tool_calls[fallback_tc.id] = parent_ai.tool_calls[-1]
+
+    sb.logger.info(
+        "[THINK] execution=%s synthetic_think_tool_call "
+        "chars=%d namespace=%s (fallback)",
+        sb.execution_id,
+        len(thinking_text),
+        namespace or "main",
+    )

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/streaming_buffers.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/streaming_buffers.py
@@ -22,6 +22,7 @@ from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
     ToolCall,
 )
 from google.protobuf.struct_pb2 import Struct
+
 from worker.activities.graphton.approval_policy import render_approval_message
 from worker.component_type_inference import infer_component_type
 

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/streaming_buffers.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/streaming_buffers.py
@@ -15,8 +15,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ToolCallStatus
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import MessageType, ToolCallStatus
 from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
+    AgentMessage,
     ComponentMetadata,
     ToolCall,
 )
@@ -179,8 +180,8 @@ def create_early_tool_call(
         mcp_server_slug=mcp_server_slug,
     )
 
-    parent_ai = sb._ensure_parent_ai_message(
-        ns_key, namespace, llm_run_id=llm_run_id,
+    parent_ai = ensure_parent_ai_message(
+        sb, ns_key, namespace, llm_run_id=llm_run_id,
     )
     parent_ai.tool_calls.append(tool_call)
     sb.state.tool_calls[temp_id] = parent_ai.tool_calls[-1]
@@ -324,8 +325,8 @@ def start_thinking_stream(
         started_at=_utc_timestamp(now),
     )
 
-    parent_ai = sb._ensure_parent_ai_message(
-        ns_key, namespace, llm_run_id=llm_run_id,
+    parent_ai = ensure_parent_ai_message(
+        sb, ns_key, namespace, llm_run_id=llm_run_id,
     )
     parent_ai.tool_calls.append(tool_call)
     sb.state.tool_calls[tc_id] = parent_ai.tool_calls[-1]
@@ -481,7 +482,7 @@ def flush_thinking_buffer(sb: StatusBuilder, ns_key: str, namespace: str) -> Non
         completed_at=completed_ts,
     )
 
-    parent_ai = sb._ensure_parent_ai_message(ns_key, namespace)
+    parent_ai = ensure_parent_ai_message(sb, ns_key, namespace)
     parent_ai.tool_calls.append(fallback_tc)
     sb.state.tool_calls[fallback_tc.id] = parent_ai.tool_calls[-1]
 
@@ -492,3 +493,46 @@ def flush_thinking_buffer(sb: StatusBuilder, ns_key: str, namespace: str) -> Non
         len(thinking_text),
         namespace or "main",
     )
+
+
+def ensure_parent_ai_message(
+    sb: StatusBuilder,
+    ns_key: str,
+    namespace: str,
+    llm_run_id: str = "",
+) -> AgentMessage:
+    """Return the current parent AI message, creating an empty one if needed.
+
+    When a tool call (including thinking) fires before the LLM has produced
+    any text, there is no AI message to attach it to.  This method creates
+    a zero-content ``MESSAGE_AI`` so the tool call has a parent.
+    """
+    existing = sb.state.current_ai_message.get(ns_key)
+    if existing is not None:
+        return existing
+
+    _, sub_agent = sb._get_execution_context(namespace)
+    messages_list = sub_agent.messages if sub_agent else sb.current_status.messages
+
+    now = datetime.utcnow()
+    ai_message = AgentMessage(
+        type=MessageType.MESSAGE_AI,
+        content="",
+        timestamp=_utc_timestamp(now),
+        is_streaming=False,
+    )
+    messages_list.append(ai_message)
+    managed = messages_list[-1]
+    sb.state.current_ai_message[ns_key] = managed
+
+    if llm_run_id:
+        sb.state.messages_by_run[llm_run_id] = managed
+
+    sb.logger.debug(
+        "[AI_MSG] execution=%s created empty parent AI message "
+        "namespace=%s llm_run_id=%s (tool call arrived before text)",
+        sb.execution_id,
+        namespace or "main",
+        llm_run_id or "none",
+    )
+    return managed

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/sub_agent.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/sub_agent.py
@@ -1,0 +1,561 @@
+"""Sub-agent lifecycle management: creation, completion, and finalization.
+
+All functions receive the ``StatusBuilder`` instance as their first argument.
+Module-level helpers (subject generation) are self-contained.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
+    ApprovalAction,
+    SubAgentStatus,
+    ToolCallStatus,
+)
+from ai.stigmer.agentic.agentexecution.v1.message_pb2 import ToolCall
+from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+from graphton.core import ModelRegistry
+from graphton.core.models import parse_model_string
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from worker.activities.graphton.handlers import formatting
+from worker.config import Config
+
+if TYPE_CHECKING:
+    from worker.activities.graphton.status_builder import StatusBuilder
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sub-Agent Subject Generation
+# ---------------------------------------------------------------------------
+
+_MAX_SUBJECT_LENGTH = 50
+
+_SUBJECT_SYSTEM_PROMPT = """\
+You are a task title generator. Given a task description delegated to a \
+sub-agent, produce a concise task title.
+
+Rules:
+- 3 to 7 words, maximum 50 characters
+- Lead with the most specific differentiator — the directory, file, module, \
+or unique aspect. Put shared/common context last.
+  Good: "apis/ protobuf Cloud Resource types"
+  Bad:  "Research Cloud Resource protobuf definitions"
+- If the description mentions a specific path or directory, include it
+- Be specific (e.g. "Fix auth middleware tests" not "Fix tests")
+- No filler words ("help with", "please", "I need", "research", "explore")
+- The title MUST be unique — it must NOT duplicate any of the existing titles \
+listed below. Focus on what makes THIS task different from the others.
+- No quotes, no punctuation at the end
+- Output ONLY the title, nothing else"""
+
+
+async def _generate_sub_agent_subject(
+    input_text: str,
+    sub_agent_name: str,
+    existing_subjects: list[str] | None = None,
+) -> str:
+    """Generate a concise task title for a sub-agent from its input prompt.
+
+    Uses ``ModelRegistry.get_summarization_model()`` to select the cheapest
+    available model (claude-haiku-4.5 / gpt-4o-mini / same model for Ollama),
+    keeping costs negligible even with many sub-agent invocations per execution.
+
+    When *existing_subjects* is provided (non-empty), the LLM is instructed to
+    produce a title that does not duplicate any of them, ensuring visual
+    differentiation in the UI.
+
+    Returns the generated subject (stripped, truncated to 50 chars), or an
+    empty string on any failure so callers can fall back gracefully.
+    """
+    if not input_text:
+        return ""
+
+    try:
+        worker_config = Config.load_from_env()
+        economy_model = ModelRegistry.get_summarization_model(
+            worker_config.llm.model_name
+        )
+
+        llm_kwargs: dict = {}
+        if worker_config.llm.provider == "ollama":
+            llm_kwargs["base_url"] = worker_config.llm.base_url
+        elif worker_config.llm.provider in ("anthropic", "openai"):
+            llm_kwargs["api_key"] = worker_config.llm.api_key
+
+        model = parse_model_string(
+            economy_model,
+            max_tokens=100,
+            temperature=0.7,
+            **llm_kwargs,
+        )
+
+        truncated_input = input_text[:2000] if len(input_text) > 2000 else input_text
+
+        existing_block = ""
+        if existing_subjects:
+            titles = "\n".join(f"- {s}" for s in existing_subjects)
+            existing_block = (
+                f"\nExisting titles (do NOT repeat these):\n{titles}\n"
+            )
+
+        user_prompt = (
+            f'Sub-agent type: {sub_agent_name}\n'
+            f'{existing_block}\n'
+            f'Task description:\n"{truncated_input}"\n\n'
+            f'Generate the title:'
+        )
+
+        response = await model.ainvoke([
+            SystemMessage(content=_SUBJECT_SYSTEM_PROMPT),
+            HumanMessage(content=user_prompt),
+        ])
+
+        content = response.content
+        if not isinstance(content, str):
+            content = (
+                "".join(str(part) for part in content)
+                if isinstance(content, list)
+                else str(content)
+            )
+        subject = content.strip().strip('"').strip("'")
+
+        if subject and len(subject) > _MAX_SUBJECT_LENGTH:
+            subject = subject[:_MAX_SUBJECT_LENGTH - 3] + "..."
+
+        return subject or ""
+
+    except Exception:
+        _logger.debug(
+            "Sub-agent subject generation failed (non-critical), "
+            "falling back to empty subject",
+            exc_info=True,
+        )
+        return ""
+
+
+def _utc_timestamp(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.utcnow()
+    return dt.isoformat() + "Z"
+
+
+# Maximum characters for tool_call.result in the status proto payload.
+_MAX_STATUS_RESULT_CHARS: int = 50_000
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent lifecycle handlers
+# ---------------------------------------------------------------------------
+
+
+async def handle_sub_agent_start(
+    sb: StatusBuilder,
+    event: dict[str, Any],
+    tool_args: dict[str, Any],
+    run_id: str,
+    *,
+    tool_call_id: str | None = None,
+) -> None:
+    """Handle task tool invocation — creates SubAgentExecution.
+
+    In deepagents' task tool, ``description`` is the full task prompt (the
+    only text parameter alongside ``subagent_type``).  We map it to
+    ``input`` and generate a concise ``subject`` via an economy-tier LLM.
+
+    The SubAgentExecution.id is set to *tool_call_id* (the Anthropic
+    ``tool_use`` id, e.g. ``toolu_XXXXX``) so the frontend can match it
+    against the ToolCall.id on the parent AI message.  The LangGraph
+    *run_id* is stored separately in ``_active_sub_agents`` for namespace
+    registration (which operates on run_ids from LangGraph events).
+    """
+    sa_id = tool_call_id or run_id
+
+    for existing_sa in sb.current_status.sub_agent_executions:
+        if existing_sa.id == sa_id:
+            sb.state.active_sub_agents[run_id] = existing_sa
+            sb.state.run_id_to_tool_call_id[run_id] = sa_id
+            sb.logger.info(
+                "[SUBAGENT] execution=%s resume reactivation: "
+                "sa_id=%s run_id=%s (skipping duplicate creation)",
+                sb.execution_id, sa_id, run_id,
+            )
+            return
+
+    sub_agent_name = tool_args.get("subagent_type", "") or tool_args.get("agent_type", "") or "unknown"
+    sub_agent_input = (
+        tool_args.get("description", "")
+        or tool_args.get("input", "")
+        or tool_args.get("task", "")
+        or tool_args.get("prompt", "")
+    )
+    existing = list(sb.state.subject_counts.keys())
+    subject = await _generate_sub_agent_subject(
+        sub_agent_input, sub_agent_name, existing_subjects=existing,
+    )
+
+    if subject:
+        count = sb.state.subject_counts.get(subject, 0) + 1
+        sb.state.subject_counts[subject] = count
+        if count > 1:
+            suffix = f" ({count})"
+            max_base = _MAX_SUBJECT_LENGTH - len(suffix)
+            base = subject[:max_base] if len(subject) > max_base else subject
+            subject = base + suffix
+
+    now = datetime.utcnow()
+    sub_agent = SubAgentExecution(
+        id=sa_id,
+        name=sub_agent_name,
+        input=sub_agent_input,
+        subject=subject,
+        status=SubAgentStatus.SUB_AGENT_IN_PROGRESS,
+        started_at=_utc_timestamp(now),
+    )
+
+    sb.current_status.sub_agent_executions.append(sub_agent)
+    sb.state.active_sub_agents[run_id] = sb.current_status.sub_agent_executions[-1]
+    sb.state.run_id_to_tool_call_id[run_id] = sa_id
+
+    sb.force_next_update = True
+
+    sb.logger.info(
+        f"[SUBAGENT] execution={sb.execution_id} "
+        f"sub_agent={sub_agent_name} sa_id={sa_id} run_id={run_id} "
+        f"subject={subject!r} status=IN_PROGRESS"
+    )
+
+
+def handle_sub_agent_end(sb: StatusBuilder, event: dict[str, Any], run_id: str) -> None:
+    """Handle task tool completion — finalize SubAgentExecution."""
+    output_raw = event.get("data", {}).get("output", "")
+    output = formatting.extract_tool_result_content(output_raw)
+    now = datetime.utcnow()
+
+    is_error = False
+    error_message = ""
+    if isinstance(output_raw, dict):
+        if output_raw.get("error") or output_raw.get("status") == "failed":
+            is_error = True
+            error_message = (
+                output_raw.get("error", "")
+                or output_raw.get("message", "Sub-agent failed")
+            )
+
+    sub_agent_ref = sb.state.active_sub_agents.get(run_id)
+    if sub_agent_ref is None:
+        sa_id = sb.state.run_id_to_tool_call_id.get(run_id, run_id)
+        for sa in sb.current_status.sub_agent_executions:
+            if sa.id == sa_id:
+                sub_agent_ref = sa
+                break
+
+    if sub_agent_ref is not None:
+        sub_agent_ref.output = output
+        sub_agent_ref.completed_at = _utc_timestamp(now)
+        if is_error:
+            sub_agent_ref.status = SubAgentStatus.SUB_AGENT_FAILED
+            sub_agent_ref.error = error_message
+        else:
+            sub_agent_ref.status = SubAgentStatus.SUB_AGENT_COMPLETED
+
+        finalize_orphaned_tool_calls(sb, sub_agent_ref, now)
+
+        sb.logger.debug(
+            "[SUBAGENT] execution=%s sa_id=%s run_id=%s status=%s",
+            sb.execution_id, sub_agent_ref.id, run_id,
+            "FAILED" if is_error else "COMPLETED",
+        )
+    else:
+        sb.logger.warning(
+            "[SUBAGENT] execution=%s _handle_sub_agent_end: "
+            "no SubAgentExecution found for run_id=%s "
+            "known_ids=%s",
+            sb.execution_id, run_id,
+            [sa.id for sa in sb.current_status.sub_agent_executions],
+        )
+
+    tc_id = sb.state.run_id_to_tool_call_id.get(run_id)
+    if tc_id:
+        parent_tc = sb.get_tool_call(tc_id)
+        if parent_tc is not None:
+            parent_tc.status = ToolCallStatus.TOOL_CALL_COMPLETED
+            parent_tc.completed_at = _utc_timestamp(now)
+            parent_tc.result = output[:_MAX_STATUS_RESULT_CHARS] if output else ""
+
+    if run_id in sb.state.active_sub_agents:
+        sb.state.completed_sub_agents[run_id] = sb.state.active_sub_agents.pop(run_id)
+
+    sb.state.pending_completion_flush[run_id] = time.monotonic()
+
+
+def finalize_orphaned_tool_calls(
+    sb: StatusBuilder, sub_agent: SubAgentExecution, now: datetime,
+) -> None:
+    """Transition orphaned WAITING_APPROVAL tool calls to SKIPPED."""
+    timestamp = _utc_timestamp(now)
+    skipped = 0
+    for msg in sub_agent.messages:
+        for tc in msg.tool_calls:
+            if (
+                tc.status == ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
+                and tc.requires_approval
+                and tc.approval_action == ApprovalAction.APPROVAL_ACTION_UNSPECIFIED
+            ):
+                tc.status = ToolCallStatus.TOOL_CALL_SKIPPED
+                tc.approval_action = ApprovalAction.APPROVAL_ACTION_SKIP
+                tc.approval_decided_at = timestamp
+                tc.result = "Auto-skipped: parent sub-agent finished"
+                skipped += 1
+    if skipped:
+        sb.logger.info(
+            "[SUBAGENT] execution=%s sa_id=%s "
+            "finalized %d orphaned WAITING_APPROVAL tool call(s)",
+            sb.execution_id, sub_agent.id, skipped,
+        )
+
+
+def get_orphaned_diagnostic(sb: StatusBuilder) -> dict:
+    """Return structured info about orphaned (still-active) sub-agents."""
+    zero_message: list[dict] = []
+    mid_execution: list[dict] = []
+
+    for run_id, sub_agent in sb.state.active_sub_agents.items():
+        tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
+        has_activity = len(sub_agent.messages) > 0
+        entry = {
+            "run_id": run_id,
+            "subject": sub_agent.subject,
+            "message_count": len(sub_agent.messages),
+            "tool_call_count": tc_count,
+        }
+        if has_activity:
+            mid_execution.append(entry)
+        else:
+            zero_message.append(entry)
+
+    return {
+        "total": len(sb.state.active_sub_agents),
+        "zero_message_count": len(zero_message),
+        "mid_execution_count": len(mid_execution),
+        "zero_message": zero_message,
+        "mid_execution": mid_execution,
+    }
+
+
+def flush_pending_completions(sb: StatusBuilder) -> list[str]:
+    """Immediately drain all pending completion flushes."""
+    if not sb.state.pending_completion_flush:
+        return []
+
+    flushed = list(sb.state.pending_completion_flush.keys())
+    sb.state.pending_completion_flush.clear()
+    if flushed:
+        sb.force_next_update = True
+    return flushed
+
+
+def finalize_active(sb: StatusBuilder, status: SubAgentStatus, error: str) -> None:
+    """Transition active sub-agents to a terminal state.
+
+    Called when the parent execution terminates abnormally (error or stall)
+    to ensure no sub-agent remains stuck in IN_PROGRESS.
+    """
+    flushed = flush_pending_completions(sb)
+    if flushed:
+        sb.logger.info(
+            f"[SUBAGENT] execution={sb.execution_id} "
+            f"flushed {len(flushed)} pending completion(s) before "
+            f"finalization: {flushed}"
+        )
+
+    if not sb.state.active_sub_agents:
+        return
+
+    now = _utc_timestamp()
+    finalized_ids: list[str] = []
+    preserved_ids: list[str] = []
+
+    terminal_statuses = {
+        SubAgentStatus.SUB_AGENT_COMPLETED,
+        SubAgentStatus.SUB_AGENT_FAILED,
+        SubAgentStatus.SUB_AGENT_CANCELLED,
+    }
+
+    for run_id, sub_agent in list(sb.state.active_sub_agents.items()):
+        if sub_agent.status in terminal_statuses or sub_agent.output:
+            preserved_ids.append(run_id)
+        else:
+            sub_agent.status = status
+            sub_agent.error = error
+            sub_agent.completed_at = now
+            finalized_ids.append(run_id)
+
+        sb.state.completed_sub_agents[run_id] = sub_agent
+
+    sb.state.active_sub_agents.clear()
+
+    sb.logger.info(
+        f"[SUBAGENT] execution={sb.execution_id} "
+        f"finalized {len(finalized_ids)} active sub-agent(s) "
+        f"-> {SubAgentStatus.Name(status)}: {finalized_ids}"
+    )
+    if preserved_ids:
+        sb.logger.info(
+            f"[SUBAGENT] execution={sb.execution_id} "
+            f"preserved {len(preserved_ids)} sub-agent(s) with "
+            f"existing terminal status or output: {preserved_ids}"
+        )
+
+
+def finalize_active_differentiated(sb: StatusBuilder, error_context: str) -> int:
+    """Transition active sub-agents using differentiated statuses.
+
+    Zero-message sub-agents receive SUB_AGENT_CANCELLED; sub-agents with
+    messages or tool calls receive SUB_AGENT_FAILED.
+    """
+    flushed = flush_pending_completions(sb)
+    if flushed:
+        sb.logger.info(
+            f"[SUBAGENT] execution={sb.execution_id} "
+            f"flushed {len(flushed)} pending completion(s) before "
+            f"differentiated finalization: {flushed}"
+        )
+
+    if not sb.state.active_sub_agents:
+        return 0
+
+    now = _utc_timestamp()
+    cancelled_ids: list[str] = []
+    failed_ids: list[str] = []
+    preserved_ids: list[str] = []
+
+    terminal_statuses = {
+        SubAgentStatus.SUB_AGENT_COMPLETED,
+        SubAgentStatus.SUB_AGENT_FAILED,
+        SubAgentStatus.SUB_AGENT_CANCELLED,
+    }
+
+    for run_id, sub_agent in list(sb.state.active_sub_agents.items()):
+        if sub_agent.status in terminal_statuses or sub_agent.output:
+            preserved_ids.append(run_id)
+        else:
+            tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
+            has_activity = len(sub_agent.messages) > 0
+            if has_activity:
+                sub_agent.status = SubAgentStatus.SUB_AGENT_FAILED
+                sub_agent.error = (
+                    f"{error_context}: sub-agent was running "
+                    f"({len(sub_agent.messages)} messages, "
+                    f"{tc_count} tool calls)"
+                )
+                failed_ids.append(run_id)
+            else:
+                sub_agent.status = SubAgentStatus.SUB_AGENT_CANCELLED
+                sub_agent.error = (
+                    f"{error_context}: sub-agent was spawned but never began execution"
+                )
+                cancelled_ids.append(run_id)
+
+            sub_agent.completed_at = now
+
+        sb.state.completed_sub_agents[run_id] = sub_agent
+
+    total = len(sb.state.active_sub_agents)
+    sb.state.active_sub_agents.clear()
+
+    finalized = len(cancelled_ids) + len(failed_ids)
+    sb.logger.info(
+        f"[SUBAGENT] execution={sb.execution_id} "
+        f"finalized {finalized}/{total} orphaned sub-agent(s) — "
+        f"CANCELLED (zero-message): {cancelled_ids}, "
+        f"FAILED (mid-execution): {failed_ids}"
+    )
+    if preserved_ids:
+        sb.logger.info(
+            f"[SUBAGENT] execution={sb.execution_id} "
+            f"preserved {len(preserved_ids)} sub-agent(s) with "
+            f"existing terminal status or output: {preserved_ids}"
+        )
+    return total
+
+
+def finalize_from_checkpoint_validation(
+    sb: StatusBuilder,
+    missed_event_count: int,
+    confirmed_orphan_count: int,
+    error_context: str,
+) -> int:
+    """Finalize active sub-agents using checkpoint validation results."""
+    flush_pending_completions(sb)
+
+    if not sb.state.active_sub_agents:
+        return 0
+
+    now = _utc_timestamp()
+    total = len(sb.state.active_sub_agents)
+
+    if missed_event_count > 0 and confirmed_orphan_count == 0:
+        completed_ids: list[str] = []
+        for run_id, sub_agent in list(sb.state.active_sub_agents.items()):
+            sub_agent.status = SubAgentStatus.SUB_AGENT_COMPLETED
+            sub_agent.completed_at = now
+            sb.state.completed_sub_agents[run_id] = sub_agent
+            completed_ids.append(run_id)
+
+        sb.state.active_sub_agents.clear()
+        sb.logger.info(
+            f"[SUBAGENT] execution={sb.execution_id} "
+            f"checkpoint confirms {total} sub-agent(s) completed "
+            f"(StatusBuilder missed on_tool_end events): "
+            f"{completed_ids}"
+        )
+    else:
+        cancelled_ids: list[str] = []
+        failed_ids: list[str] = []
+
+        for run_id, sub_agent in list(sb.state.active_sub_agents.items()):
+            tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
+            has_activity = (
+                len(sub_agent.messages) > 0
+                or tc_count > 0
+            )
+            if has_activity:
+                sub_agent.status = SubAgentStatus.SUB_AGENT_FAILED
+                sub_agent.error = (
+                    f"{error_context}: sub-agent was running "
+                    f"({len(sub_agent.messages)} messages, "
+                    f"{tc_count} tool calls)"
+                )
+                failed_ids.append(run_id)
+            else:
+                sub_agent.status = SubAgentStatus.SUB_AGENT_CANCELLED
+                sub_agent.error = (
+                    f"{error_context}: sub-agent was spawned but "
+                    f"never began execution"
+                )
+                cancelled_ids.append(run_id)
+
+            sub_agent.completed_at = now
+            sb.state.completed_sub_agents[run_id] = sub_agent
+
+        sb.state.active_sub_agents.clear()
+
+        qualifier = (
+            "confirmed orphaned"
+            if missed_event_count == 0
+            else "mixed (some may have completed per checkpoint)"
+        )
+        sb.logger.info(
+            f"[SUBAGENT] execution={sb.execution_id} "
+            f"finalized {total} {qualifier} sub-agent(s) — "
+            f"CANCELLED (zero-message): {cancelled_ids}, "
+            f"FAILED (mid-execution): {failed_ids}"
+        )
+
+    return total

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/sub_agent.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/sub_agent.py
@@ -17,7 +17,6 @@ from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
     SubAgentStatus,
     ToolCallStatus,
 )
-from ai.stigmer.agentic.agentexecution.v1.message_pb2 import ToolCall
 from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
 from graphton.core import ModelRegistry
 from graphton.core.models import parse_model_string

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/sub_agent.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/sub_agent.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
     ApprovalAction,
+    MessageType,
     SubAgentStatus,
     ToolCallStatus,
 )
@@ -559,3 +560,44 @@ def finalize_from_checkpoint_validation(
         )
 
     return total
+
+
+def prepare_task_tool_resume_queue(sb: StatusBuilder) -> int:
+    """Pre-populate the early tool call queue for task tools on resume.
+
+    On resume from a sub-agent HITL interrupt, ``astream_events`` does
+    NOT replay the AI message's ``tool_use`` blocks.  This method scans
+    persisted messages for task tool calls that have a corresponding
+    SubAgentExecution and queues them for reconciliation.
+
+    Must be called **after** ``rebuild_index_from_persisted_status``
+    and **before** the stream starts.
+
+    Returns the number of task tool calls queued.
+    """
+    sa_ids = {sa.id for sa in sb.current_status.sub_agent_executions}
+    queued = 0
+
+    for msg in sb.current_status.messages:
+        if msg.type != MessageType.MESSAGE_AI:
+            continue
+        for tc in msg.tool_calls:
+            if tc.name != "task" or not tc.id:
+                continue
+            if tc.id not in sa_ids:
+                continue
+            already_queued = any(
+                tid == tc.id for tid, _ in sb.state.early_tool_call_queue
+            )
+            if already_queued:
+                continue
+
+            sb.state.early_tool_call_queue.append((tc.id, None))
+            queued += 1
+            sb.logger.info(
+                "[RESUME_PREP] execution=%s pre-queued task TC %s "
+                "for sub-agent resume reconciliation",
+                sb.execution_id, tc.id,
+            )
+
+    return queued

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/tool_event.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/tool_event.py
@@ -5,17 +5,32 @@ All functions receive the ``StatusBuilder`` instance as their first argument.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ToolCallStatus
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
+    ExecutionPhase,
+    TodoStatus,
+    ToolCallStatus,
+)
 from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
     ComponentMetadata,
     ToolCall,
 )
+from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
+from ai.stigmer.agentic.agentexecution.v1.todo_pb2 import TodoItem
 from google.protobuf.struct_pb2 import Struct
-from worker.activities.graphton.approval_policy import render_approval_message
-from graphton.core.backends.platform_mount import humanize_sandbox_paths
+from graphton.core.backends.platform_mount import (
+    humanize_platform_refs,
+    humanize_sandbox_paths,
+    resolve_display_env_vars,
+)
+from worker.activities.graphton.approval_policy import (
+    ApprovalRequirement,
+    render_approval_message,
+    resolve_tool_approval,
+)
 from worker.activities.graphton.handlers import formatting
 from worker.component_type_inference import infer_component_type
 
@@ -81,7 +96,7 @@ async def handle_tool_start(sb: StatusBuilder, event: dict[str, Any], namespace:
             tool_call_id_val = early_tc.id
         else:
             ns_key = namespace or ""
-            display_args = sb._humanize_args_for_display(tool_args) if tool_args else {}
+            display_args = humanize_args_for_display(sb, tool_args) if tool_args else {}
             args_struct = Struct()
             if display_args:
                 args_struct.update(display_args)
@@ -90,7 +105,7 @@ async def handle_tool_start(sb: StatusBuilder, event: dict[str, Any], namespace:
                 id=run_id,
                 name=tool_name,
                 args=args_struct,
-                args_preview=sb._create_args_preview(tool_args),
+                args_preview=create_args_preview(sb, tool_args),
                 result="",
                 status=ToolCallStatus.TOOL_CALL_RUNNING,
                 component_metadata=ComponentMetadata(
@@ -117,9 +132,9 @@ async def handle_tool_start(sb: StatusBuilder, event: dict[str, Any], namespace:
         component_group="main-agent-tools",
     )
 
-    approval_requirement = sb._check_tool_approval_requirement(tool_name, tool_args)
+    approval_requirement = check_approval_requirement(sb, tool_name, tool_args)
 
-    display_args = sb._humanize_args_for_display(tool_args) if tool_args else {}
+    display_args = humanize_args_for_display(sb, tool_args) if tool_args else {}
     args_struct = Struct()
     if display_args:
         args_struct.update(display_args)
@@ -139,7 +154,7 @@ async def handle_tool_start(sb: StatusBuilder, event: dict[str, Any], namespace:
         id=run_id,
         name=tool_name,
         args=args_struct,
-        args_preview=sb._create_args_preview(tool_args),
+        args_preview=create_args_preview(sb, tool_args),
         result="",
         status=initial_status,
         component_metadata=component_metadata,
@@ -175,7 +190,7 @@ async def handle_tool_start(sb: StatusBuilder, event: dict[str, Any], namespace:
     )
 
     if approval_requirement.requires_approval:
-        sb._set_waiting_for_approval_phase(tool_name, run_id)
+        set_waiting_for_approval_phase(sb, tool_name, run_id)
 
 
 def handle_tool_progress(sb: StatusBuilder, event: dict[str, Any], namespace: str = "") -> None:
@@ -274,3 +289,184 @@ def handle_tool_end(sb: StatusBuilder, event: dict[str, Any], namespace: str = "
         f"tool={tool_name} run_id={run_id} resolved_id={resolved_id} "
         f"status=COMPLETED duration_ms={duration_ms or 'N/A'}"
     )
+
+
+def check_approval_requirement(
+    sb: StatusBuilder,
+    tool_name: str,
+    tool_args: dict[str, Any],
+) -> ApprovalRequirement:
+    """Check if a tool requires approval based on the configured policy chain."""
+    if sb._approval_config is None:
+        return ApprovalRequirement(
+            requires_approval=False,
+            message="",
+            source="none",
+        )
+
+    mcp_server_name = sb._approval_config.get_mcp_server_for_tool(tool_name)
+    default_policies = sb._approval_config.get_default_policies_for_tool(tool_name)
+
+    return resolve_tool_approval(
+        tool_name=tool_name,
+        mcp_server_name=mcp_server_name,
+        auto_approve_all=sb._approval_config.auto_approve_all,
+        tool_approval_overrides=sb._approval_config.tool_approval_overrides,
+        default_tool_approvals=default_policies,
+    )
+
+
+def set_waiting_for_approval_phase(
+    sb: StatusBuilder, tool_name: str, run_id: str,
+) -> None:
+    """Transition execution phase to WAITING_FOR_APPROVAL."""
+    post_approval_statuses = frozenset({
+        ToolCallStatus.TOOL_CALL_RUNNING,
+        ToolCallStatus.TOOL_CALL_COMPLETED,
+        ToolCallStatus.TOOL_CALL_FAILED,
+        ToolCallStatus.TOOL_CALL_SKIPPED,
+    })
+    tc_id = sb._tool_call_id_capture.resolve(run_id)
+    existing_tc = sb.get_tool_call(tc_id)
+    if existing_tc is not None and existing_tc.status in post_approval_statuses:
+        sb.logger.warning(
+            "[APPROVAL_GUARD] execution=%s tool=%s tc_id=%s "
+            "skipping phase transition — tool call already in "
+            "post-approval state %s",
+            sb.execution_id, tool_name, tc_id,
+            ToolCallStatus.Name(existing_tc.status),
+        )
+        return
+
+    if sb.state.approval.saved_phase is None:
+        sb.state.approval.saved_phase = sb.current_status.phase
+        from datetime import datetime as _dt
+        sb.state.approval.wait_started_at = _dt.utcnow()
+    sb.current_status.phase = ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL
+
+    sb.state.approval.pending.append(run_id)
+    sb.force_next_update = True
+
+    sb.logger.info(
+        f"[APPROVAL] execution={sb.execution_id} "
+        f"tool={tool_name} run_id={run_id} tc_id={tc_id} "
+        f"status=WAITING_APPROVAL "
+        f"pending_count={len(sb.state.approval.pending)}"
+    )
+
+
+def update_todos(sb: StatusBuilder, todos_data: list) -> None:
+    """Replace the todo snapshot in the local execution status."""
+    status_map = {
+        "pending": TodoStatus.TODO_PENDING,
+        "in_progress": TodoStatus.TODO_IN_PROGRESS,
+        "completed": TodoStatus.TODO_COMPLETED,
+        "cancelled": TodoStatus.TODO_CANCELLED,
+    }
+
+    sb.current_status.todos.clear()
+
+    now = _utc_timestamp()
+    for idx, todo_dict in enumerate(todos_data):
+        todo_id = todo_dict.get("id") or f"todo-{idx}"
+        status_str = todo_dict.get("status", "pending").lower()
+        status_enum = status_map.get(status_str, TodoStatus.TODO_PENDING)
+        todo_item = TodoItem(
+            id=todo_id,
+            content=todo_dict.get("content", ""),
+            status=status_enum,
+            created_at=todo_dict.get("created_at", now),
+            updated_at=now,
+        )
+        sb.current_status.todos[todo_id].CopyFrom(todo_item)
+
+    sb.logger.info("Updated todos: %d item(s) in snapshot", len(todos_data))
+
+
+def update_sub_agent_todos(
+    sb: StatusBuilder, sub_agent: SubAgentExecution, todos_data: list,
+) -> None:
+    """Replace the todo snapshot on a sub-agent execution."""
+    status_map = {
+        "pending": TodoStatus.TODO_PENDING,
+        "in_progress": TodoStatus.TODO_IN_PROGRESS,
+        "completed": TodoStatus.TODO_COMPLETED,
+        "cancelled": TodoStatus.TODO_CANCELLED,
+    }
+
+    sub_agent.todos.clear()
+
+    now = _utc_timestamp()
+    for idx, todo_dict in enumerate(todos_data):
+        todo_id = todo_dict.get("id") or f"todo-{idx}"
+        status_str = todo_dict.get("status", "pending").lower()
+        status_enum = status_map.get(status_str, TodoStatus.TODO_PENDING)
+        todo_item = TodoItem(
+            id=todo_id,
+            content=todo_dict.get("content", ""),
+            status=status_enum,
+            created_at=todo_dict.get("created_at", now),
+            updated_at=now,
+        )
+        sub_agent.todos[todo_id].CopyFrom(todo_item)
+
+    sb.logger.info(
+        "Updated sub-agent todos: %d item(s) (sub_agent_id=%s)",
+        len(todos_data), sub_agent.id,
+    )
+
+
+def humanize_args_for_display(
+    sb: StatusBuilder, tool_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a shallow copy of *tool_args* with string values humanized."""
+    if not tool_args:
+        return tool_args
+
+    result: dict[str, Any] = {}
+    for key, value in tool_args.items():
+        if isinstance(value, str):
+            value = humanize_platform_refs(value)
+            value = resolve_display_env_vars(
+                value, sb._display_env_vars, sb._secret_keys,
+            )
+            value = humanize_sandbox_paths(value, sb._workspace_root)
+        result[key] = value
+    return result
+
+
+def create_args_preview(sb: StatusBuilder, tool_args: dict[str, Any]) -> str:
+    """Create a sanitized preview of tool arguments for UI display."""
+    if not tool_args:
+        return "{}"
+
+    sensitive_patterns = [
+        "password", "passwd", "pwd",
+        "token", "api_key", "apikey", "api-key",
+        "secret", "credential", "auth",
+        "private_key", "privatekey", "private-key",
+    ]
+
+    def sanitize_value(key: str, value: Any) -> Any:
+        key_lower = key.lower()
+        for pattern in sensitive_patterns:
+            if pattern in key_lower:
+                return "***REDACTED***"
+        if isinstance(value, str):
+            value = humanize_platform_refs(value)
+            value = resolve_display_env_vars(
+                value, sb._display_env_vars, sb._secret_keys,
+            )
+            return value
+        if isinstance(value, dict):
+            return {k: sanitize_value(k, v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [sanitize_value(str(i), v) for i, v in enumerate(value)]
+        return value
+
+    sanitized = {k: sanitize_value(k, v) for k, v in tool_args.items()}
+
+    try:
+        return json.dumps(sanitized, indent=2, default=str)
+    except (TypeError, ValueError):
+        return "{}"

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/tool_event.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/tool_event.py
@@ -26,6 +26,7 @@ from graphton.core.backends.platform_mount import (
     humanize_sandbox_paths,
     resolve_display_env_vars,
 )
+
 from worker.activities.graphton.approval_policy import (
     ApprovalRequirement,
     render_approval_message,

--- a/backend/services/agent-runner/worker/activities/graphton/handlers/tool_event.py
+++ b/backend/services/agent-runner/worker/activities/graphton/handlers/tool_event.py
@@ -1,0 +1,276 @@
+"""Tool lifecycle event handlers: on_tool_start, on_tool_end, tool_progress.
+
+All functions receive the ``StatusBuilder`` instance as their first argument.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import ToolCallStatus
+from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
+    ComponentMetadata,
+    ToolCall,
+)
+from google.protobuf.struct_pb2 import Struct
+from worker.activities.graphton.approval_policy import render_approval_message
+from graphton.core.backends.platform_mount import humanize_sandbox_paths
+from worker.activities.graphton.handlers import formatting
+from worker.component_type_inference import infer_component_type
+
+if TYPE_CHECKING:
+    from worker.activities.graphton.status_builder import StatusBuilder
+
+
+def _utc_timestamp(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.utcnow()
+    return dt.isoformat() + "Z"
+
+
+PLANNING_TOOLS = {
+    'write_todos',
+}
+
+_READ_ONLY_TOOLS: frozenset[str] = frozenset({"read", "read_file"})
+_MAX_STATUS_RESULT_CHARS: int = 50_000
+
+
+async def handle_tool_start(sb: StatusBuilder, event: dict[str, Any], namespace: str = "") -> None:
+    """Handle on_tool_start event - updates local status."""
+    tool_name = event.get("name", "")
+    tool_args_raw = event.get("data", {}).get("input", {})
+    run_id = event.get("run_id", "")
+
+    if not tool_name or not run_id:
+        return
+
+    tool_args = formatting.unwrap_tool_args(tool_args_raw)
+
+    tool_call_id = sb._tool_call_id_capture.get(run_id)
+    if tool_call_id:
+        existing = sb.state.tool_calls.get(tool_call_id)
+        if existing is not None and not existing.is_streaming:
+            if run_id != tool_call_id:
+                sb._tool_call_id_capture.register_alias(run_id, tool_call_id)
+            sb.logger.info(
+                "[IDENTITY_DEDUP] execution=%s tool=%s run_id=%s -> "
+                "existing_tc=%s (resume path, alias only)",
+                sb.execution_id, tool_name, run_id, tool_call_id,
+            )
+            if tool_name != "task":
+                return
+
+    if tool_name in PLANNING_TOOLS:
+        if tool_name == "write_todos":
+            todos_data = tool_args.get("todos", [])
+            if not todos_data:
+                return
+            _, sub_agent = sb._get_execution_context(namespace)
+            if sub_agent is not None:
+                sb._update_sub_agent_todos(sub_agent, todos_data)
+            else:
+                sb._update_todos(todos_data)
+        return
+
+    if tool_name == "task":
+        tool_call_id_val: str | None = None
+        early_tc = sb._reconcile_early_tool_call(tool_name, run_id, tool_args, namespace)
+        if early_tc is not None:
+            tool_call_id_val = early_tc.id
+        else:
+            ns_key = namespace or ""
+            display_args = sb._humanize_args_for_display(tool_args) if tool_args else {}
+            args_struct = Struct()
+            if display_args:
+                args_struct.update(display_args)
+            now = datetime.utcnow()
+            tool_call = ToolCall(
+                id=run_id,
+                name=tool_name,
+                args=args_struct,
+                args_preview=sb._create_args_preview(tool_args),
+                result="",
+                status=ToolCallStatus.TOOL_CALL_RUNNING,
+                component_metadata=ComponentMetadata(
+                    component_type=infer_component_type(tool_name),
+                    component_group="main-agent-tools",
+                ),
+                started_at=_utc_timestamp(now),
+            )
+            parent_ai = sb._ensure_parent_ai_message(ns_key, namespace)
+            parent_ai.tool_calls.append(tool_call)
+            sb.state.tool_calls[run_id] = parent_ai.tool_calls[-1]
+            tool_call_id_val = run_id
+
+        await sb._handle_sub_agent_start(event, tool_args, run_id, tool_call_id=tool_call_id_val)
+        return
+
+    early_tc = sb._reconcile_early_tool_call(tool_name, run_id, tool_args, namespace)
+    if early_tc is not None:
+        return
+
+    component_type = infer_component_type(tool_name)
+    component_metadata = ComponentMetadata(
+        component_type=component_type,
+        component_group="main-agent-tools",
+    )
+
+    approval_requirement = sb._check_tool_approval_requirement(tool_name, tool_args)
+
+    display_args = sb._humanize_args_for_display(tool_args) if tool_args else {}
+    args_struct = Struct()
+    if display_args:
+        args_struct.update(display_args)
+
+    now = datetime.utcnow()
+    initial_status = (
+        ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
+        if approval_requirement.requires_approval
+        else ToolCallStatus.TOOL_CALL_RUNNING
+    )
+
+    mcp_server_slug = ""
+    if sb._approval_config is not None:
+        mcp_server_slug = sb._approval_config.get_mcp_server_for_tool(tool_name)
+
+    tool_call = ToolCall(
+        id=run_id,
+        name=tool_name,
+        args=args_struct,
+        args_preview=sb._create_args_preview(tool_args),
+        result="",
+        status=initial_status,
+        component_metadata=component_metadata,
+        started_at=_utc_timestamp(now),
+        mcp_server_slug=mcp_server_slug,
+    )
+
+    if approval_requirement.requires_approval:
+        rendered_message = render_approval_message(
+            template=approval_requirement.message,
+            tool_name=tool_name,
+            tool_args=tool_args,
+        )
+        tool_call.requires_approval = True
+        tool_call.approval_message = rendered_message
+        tool_call.approval_requested_at = _utc_timestamp(now)
+
+    sb.state.tool_start_times[run_id] = now
+
+    context, sub_agent = sb._get_execution_context(namespace)
+    ns_key = namespace or ""
+
+    status_name = ToolCallStatus.Name(initial_status)
+
+    parent_ai = sb._ensure_parent_ai_message(ns_key, namespace)
+    parent_ai.tool_calls.append(tool_call)
+    sb.state.tool_calls[run_id] = parent_ai.tool_calls[-1]
+
+    context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
+    sb.logger.debug(
+        f"[TOOL] execution={sb.execution_id} {context_desc} "
+        f"tool={tool_name} run_id={run_id} status={status_name}"
+    )
+
+    if approval_requirement.requires_approval:
+        sb._set_waiting_for_approval_phase(tool_name, run_id)
+
+
+def handle_tool_progress(sb: StatusBuilder, event: dict[str, Any], namespace: str = "") -> None:
+    """Handle on_custom_event with name='tool_progress'."""
+    run_id = event.get("run_id", "")
+    chunk = event.get("data", {}).get("chunk", "")
+
+    if not run_id or not chunk:
+        return
+
+    chunk = humanize_sandbox_paths(chunk, sb._workspace_root)
+
+    resolved_id = sb._tool_call_id_capture.resolve(run_id)
+
+    tool_call = sb.get_tool_call(resolved_id)
+    if tool_call is None:
+        sb.logger.debug(
+            f"[TOOL_PROGRESS] execution={sb.execution_id} "
+            f"run_id={run_id} resolved_id={resolved_id} "
+            f"ignored (tool call not found)"
+        )
+        return
+
+    was_streaming = tool_call.is_streaming
+
+    current_len = len(tool_call.result)
+    if current_len < _MAX_STATUS_RESULT_CHARS:
+        remaining = _MAX_STATUS_RESULT_CHARS - current_len
+        tool_call.result += chunk[:remaining]
+        if len(chunk) > remaining:
+            tool_call.result += "\n[output truncated for display]"
+    tool_call.is_streaming = True
+
+    if not was_streaming:
+        sb.force_next_update = True
+
+    sb.logger.debug(
+        f"[TOOL_PROGRESS] execution={sb.execution_id} "
+        f"run_id={run_id} resolved_id={resolved_id} "
+        f"chunk_len={len(chunk)} total_len={len(tool_call.result)}"
+    )
+
+
+def handle_tool_end(sb: StatusBuilder, event: dict[str, Any], namespace: str = "") -> None:
+    """Handle on_tool_end event - updates local status with COMPLETED status."""
+    tool_name = event.get("name", "")
+    run_id = event.get("run_id", "")
+    tool_result_raw = event.get("data", {}).get("output", "")
+
+    if not run_id or tool_name in PLANNING_TOOLS:
+        return
+
+    if tool_name == "task":
+        sb._handle_sub_agent_end(event, run_id)
+        return
+
+    resolved_id = sb._tool_call_id_capture.resolve(run_id)
+
+    tool_result_content = formatting.extract_tool_result_content(tool_result_raw)
+
+    if tool_name in _READ_ONLY_TOOLS:
+        persisted_result = f"[content omitted - {len(tool_result_content)} chars]"
+    elif len(tool_result_content) > _MAX_STATUS_RESULT_CHARS:
+        persisted_result = (
+            tool_result_content[:_MAX_STATUS_RESULT_CHARS]
+            + "\n[output truncated for display]"
+        )
+    else:
+        persisted_result = tool_result_content
+
+    persisted_result = humanize_sandbox_paths(
+        persisted_result, sb._workspace_root,
+    )
+
+    now = datetime.utcnow()
+
+    duration_ms = None
+    if run_id in sb.state.tool_start_times:
+        start_time = sb.state.tool_start_times.pop(run_id)
+        duration_ms = int((now - start_time).total_seconds() * 1000)
+
+    context, sub_agent = sb._get_execution_context(namespace)
+
+    completed_at = _utc_timestamp(now)
+
+    tool_call = sb.get_tool_call(resolved_id)
+    if tool_call is not None:
+        tool_call.result = persisted_result
+        tool_call.status = ToolCallStatus.TOOL_CALL_COMPLETED
+        tool_call.completed_at = completed_at
+        tool_call.is_streaming = False
+
+    context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
+    sb.logger.debug(
+        f"[TOOL] execution={sb.execution_id} {context_desc} "
+        f"tool={tool_name} run_id={run_id} resolved_id={resolved_id} "
+        f"status=COMPLETED duration_ms={duration_ms or 'N/A'}"
+    )

--- a/backend/services/agent-runner/worker/activities/graphton/hitl.py
+++ b/backend/services/agent-runner/worker/activities/graphton/hitl.py
@@ -45,25 +45,16 @@ from worker.activities.graphton.status_builder import StatusBuilder, _utc_timest
 def extract_interrupt_tool_call_ids(interrupts: Any) -> set[str]:
     """Extract all tool_call_ids from LangGraph checkpoint interrupts.
 
-    Handles both shapes:
-    - **Direct**: ``intr.value["tool_call_id"]`` (root-agent HITL)
-    - **Proxy**: Nested dicts with ``_proxy_interrupt_id``, each containing
-      ``tool_call_id`` (sub-agent HITL via InterruptProxyRunnable)
+    All interrupts use the direct shape: ``intr.value["tool_call_id"]``.
+    Both root-agent and sub-agent interrupts propagate with this same
+    shape thanks to LangGraph's native per-invocation subgraph mode.
     """
     tc_ids: set[str] = set()
     for intr in interrupts:
         intr_value = intr.value if isinstance(intr.value, dict) else {}
-        direct_tc_id = intr_value.get("tool_call_id", "")
-        if direct_tc_id:
-            tc_ids.add(direct_tc_id)
-        for _sub_id, sub_value in intr_value.items():
-            if not isinstance(sub_value, dict):
-                continue
-            if "_proxy_interrupt_id" not in sub_value:
-                continue
-            sub_tc_id = sub_value.get("tool_call_id", "")
-            if sub_tc_id:
-                tc_ids.add(sub_tc_id)
+        tc_id = intr_value.get("tool_call_id", "")
+        if tc_id:
+            tc_ids.add(tc_id)
     return tc_ids
 
 

--- a/backend/services/agent-runner/worker/activities/graphton/hitl.py
+++ b/backend/services/agent-runner/worker/activities/graphton/hitl.py
@@ -1,21 +1,19 @@
 """
 Human-in-the-Loop (HITL) approval flow logic.
 
-Simplified in T03: ``messages[].tool_calls`` is the single source of truth.
-``pending_approvals`` is computed server-side.  The LangGraph checkpoint is
-queried directly at resume time.
+``messages[].tool_calls`` is the single source of truth.
+``pending_approvals`` is computed server-side by Go/Java
+``ComputePendingApprovals``.  The LangGraph checkpoint is queried
+directly at resume time.
 
 Public helpers:
 
   extract_interrupt_tool_call_ids — extracts the set of tool_call_ids from
-      LangGraph checkpoint interrupts (both direct and proxy shapes).
+      LangGraph checkpoint interrupts.
 
-  build_snapshot_from_interrupts — builds the Temporal-coordination
-      ``pending_approvals`` list from checkpoint interrupts.
-
-  extract_approval_decisions_from_execution — builds the same
+  extract_approval_decisions_from_execution — builds a
       ``list[SubmitApprovalInput]`` from a DB-loaded execution's tool calls
-      (T03 DB-driven resume path).
+      (DB-driven resume path).
 
 Classes:
 
@@ -28,7 +26,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
 from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
     ApprovalAction,
     ToolCallStatus,
@@ -56,19 +53,6 @@ def extract_interrupt_tool_call_ids(interrupts: Any) -> set[str]:
         if tc_id:
             tc_ids.add(tc_id)
     return tc_ids
-
-
-def build_snapshot_from_interrupts(interrupts: Any) -> list[PendingApproval]:
-    """Build ``pending_approvals`` snapshot from checkpoint interrupts.
-
-    Returns one :class:`PendingApproval` per tool_call_id found in the
-    interrupts.  This is the Temporal-coordination signal that tells the Go
-    workflow how many approval signals to collect.
-    """
-    return [
-        PendingApproval(tool_call_id=tc_id)
-        for tc_id in sorted(extract_interrupt_tool_call_ids(interrupts))
-    ]
 
 
 def extract_approval_decisions_from_execution(

--- a/backend/services/agent-runner/worker/activities/graphton/hitl.py
+++ b/backend/services/agent-runner/worker/activities/graphton/hitl.py
@@ -142,7 +142,7 @@ class ResumeReconciler:
         approval_decisions: list[SubmitApprovalInput],
     ) -> None:
         """Run the full reconciliation pipeline."""
-        # Rebuild _tool_call_index BEFORE the reconciliation loop so that
+        # Rebuild the tool call index BEFORE the reconciliation loop so that
         # get_tool_call() and iter_all_tool_calls() can find persisted tool
         # calls from the previous execution cycle.
         self._sb.rebuild_index_from_persisted_status()
@@ -208,7 +208,7 @@ class ResumeReconciler:
             "reconciled %d tool call(s), "
             "index size=%d",
             self._execution_id, reconciled_count,
-            len(self._sb._tool_call_index),
+            self._sb.tool_call_count(),
         )
 
     def reconcile_orphans_against_checkpoint(

--- a/backend/services/agent-runner/worker/activities/graphton/hitl.py
+++ b/backend/services/agent-runner/worker/activities/graphton/hitl.py
@@ -26,7 +26,6 @@ Classes:
 from __future__ import annotations
 
 import logging
-from collections import deque
 from typing import Any
 
 from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
@@ -123,10 +122,10 @@ class ResumeReconciler:
     On resume, the StatusBuilder is initialized with DB-persisted status that
     already contains tool calls in WAITING_APPROVAL state.  This class:
 
-    1. Transitions each decided tool call to RUNNING / SKIPPED
-    2. Auto-skips remaining WAITING_APPROVAL tools on REJECT
-    3. Clears stale ``completed_at`` from the previous cycle
-    4. Pre-populates fingerprints for LangGraph replay dedup
+    1. Rebuilds the in-memory index from persisted status
+    2. Transitions each decided tool call to RUNNING / SKIPPED
+    3. Auto-skips remaining WAITING_APPROVAL tools on REJECT
+    4. Clears stale ``completed_at`` from the previous cycle
     """
 
     _APPROVAL_TO_STATUS = {
@@ -152,10 +151,10 @@ class ResumeReconciler:
         approval_decisions: list[SubmitApprovalInput],
     ) -> None:
         """Run the full reconciliation pipeline."""
-        # Populate _tool_call_index and fingerprints BEFORE the reconciliation
-        # loop so that get_tool_call() and iter_all_tool_calls() can find
-        # persisted tool calls from the previous execution cycle.
-        self._sb.populate_fingerprints_from_existing_tool_calls()
+        # Rebuild _tool_call_index BEFORE the reconciliation loop so that
+        # get_tool_call() and iter_all_tool_calls() can find persisted tool
+        # calls from the previous execution cycle.
+        self._sb.rebuild_index_from_persisted_status()
 
         decisions_by_tc = {d.tool_call_id: d for d in approval_decisions}
         reconciled_count = 0
@@ -193,14 +192,6 @@ class ResumeReconciler:
             if decision.action == ApprovalAction.APPROVAL_ACTION_REJECT:
                 has_reject = True
 
-            # Register for resume-aware dedup so _handle_tool_start_event
-            # can match the re-fired event even when fingerprints diverge.
-            if new_status == ToolCallStatus.TOOL_CALL_RUNNING:
-                q = self._sb._reconciled_resume_tool_calls.setdefault(
-                    tc.name, deque(),
-                )
-                q.append(tc.id)
-
             self._logger.info(
                 "[RESUME_RECONCILE] execution=%s "
                 "tool_call=%s name=%s "
@@ -224,9 +215,9 @@ class ResumeReconciler:
         self._logger.info(
             "[RESUME_RECONCILE] execution=%s "
             "reconciled %d tool call(s), "
-            "populated %d fingerprint(s)",
+            "index size=%d",
             self._execution_id, reconciled_count,
-            len(self._sb.tool_call_fingerprints),
+            len(self._sb._tool_call_index),
         )
 
     def reconcile_orphans_against_checkpoint(

--- a/backend/services/agent-runner/worker/activities/graphton/post_stream.py
+++ b/backend/services/agent-runner/worker/activities/graphton/post_stream.py
@@ -195,7 +195,7 @@ async def process_post_stream(
 
     validation = validate_against_checkpoint(
         graph_state=graph_state,
-        active_sub_agent_count=len(status_builder._active_sub_agents),
+        active_sub_agent_count=status_builder.active_sub_agent_count,
         status_ai_message_count=status_ai_message_count,
         execution_phase=status_builder.current_status.phase,
         waiting_for_approval_phase=ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,

--- a/backend/services/agent-runner/worker/activities/graphton/post_stream.py
+++ b/backend/services/agent-runner/worker/activities/graphton/post_stream.py
@@ -27,7 +27,6 @@ from worker.activities.graphton.checkpoint_validator import (
     build_error_from_validation,
     validate_against_checkpoint,
 )
-from worker.activities.graphton.hitl import build_snapshot_from_interrupts
 from worker.activities.graphton.status_builder import StatusBuilder, _utc_timestamp
 
 if TYPE_CHECKING:
@@ -219,26 +218,12 @@ async def process_post_stream(
     current_phase = status_builder.current_status.phase
 
     if current_phase == ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL:
-        if graph_state and getattr(graph_state, "interrupts", None):
-            snapshot = build_snapshot_from_interrupts(graph_state.interrupts)
-            logger.info(
-                "Stream ended with WAITING_FOR_APPROVAL phase for execution %s. "
-                "Interrupt-based snapshot: %d pending approval(s) for Temporal "
-                "coordination (from %d checkpoint interrupt(s)). "
-                "Not setting COMPLETED.",
-                execution_id, len(snapshot), len(graph_state.interrupts),
-            )
-        else:
-            snapshot = status_builder.build_pending_approvals_snapshot()
-            logger.warning(
-                "Stream ended with WAITING_FOR_APPROVAL phase for execution %s. "
-                "Fallback snapshot: %d pending approval(s) for Temporal "
-                "coordination (checkpoint interrupts unavailable). "
-                "Not setting COMPLETED.",
-                execution_id, len(snapshot),
-            )
-        del status_builder.current_status.pending_approvals[:]
-        status_builder.current_status.pending_approvals.extend(snapshot)
+        logger.info(
+            "Stream ended with WAITING_FOR_APPROVAL phase for execution %s. "
+            "Not setting COMPLETED. pending_approvals is computed server-side "
+            "by Go/Java ComputePendingApprovals on UpdateStatus.",
+            execution_id,
+        )
     elif current_phase == ExecutionPhase.EXECUTION_PAUSED:
         logger.info(
             "Stream ended with PAUSED phase for execution %s. "

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -7,13 +7,10 @@ via Java activity (polyglot pattern).
 """
 
 import inspect
-import json
 import logging
-import time
 from collections.abc import Callable, Coroutine, Iterator
 from datetime import datetime
 from typing import Any
-from uuid import uuid4
 
 from worker.activities.graphton.execution_state import ExecutionState
 from worker.activities.graphton.handlers import (
@@ -32,106 +29,45 @@ from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 
 from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
 from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
-from ai.stigmer.agentic.agentexecution.v1.context_pb2 import (
-    ContextInfo,
-    McpServerResolutionStatus,
-    ResolvedExecutionContext,
-    SummarizationEvent,
-)
 from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
     ApprovalAction,
     ExecutionPhase,
     MessageType,
     SubAgentStatus,
-    SummarizationSource,
-    TodoStatus,
     ToolCallStatus,
 )
 from ai.stigmer.agentic.agentexecution.v1.message_pb2 import (
     AgentMessage,
-    ComponentMetadata,
     ToolCall,
 )
 from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
-from ai.stigmer.agentic.agentexecution.v1.todo_pb2 import TodoItem
-from google.protobuf.struct_pb2 import Struct
-from graphton.core import ModelRegistry
-from graphton.core.backends.platform_mount import (
-    humanize_platform_refs,
-    humanize_sandbox_paths,
-    resolve_display_env_vars,
-)
-from graphton.core.models import parse_model_string
 from graphton.core.summarization_callback import SummarizationEventData
-from langchain_core.messages import HumanMessage, SystemMessage
 
-from worker.activities.graphton.approval_policy import (
-    ApprovalConfig,
-    ApprovalRequirement,
-    render_approval_message,
-    resolve_tool_approval,
-)
-from worker.activities.graphton.usage_tracker import MAIN_SCOPE, UsageTracker
-from worker.component_type_inference import infer_component_type
+from worker.activities.graphton.approval_policy import ApprovalConfig
+from worker.activities.graphton.usage_tracker import UsageTracker
 from worker.config import Config
 
-_logger = logging.getLogger(__name__)
-
-# Planning tools that update execution state without UI display
-PLANNING_TOOLS = {
-    'write_todos',
-}
-
-# Maximum characters for tool_call.result in the status proto payload.
-# This is a display/transport concern — the gRPC Temporal update must fit
-# within message-size limits.  The LLM context has its own independent cap
-# (see graphton.core.tool_wrappers._MAX_TOOL_OUTPUT_CHARS).
-_MAX_STATUS_RESULT_CHARS: int = 50_000
-
+# ---------------------------------------------------------------------------
+# Backward-compatible re-exports (tests and internal callers import from here)
+# ---------------------------------------------------------------------------
+PLANNING_TOOLS = tool_event_handlers.PLANNING_TOOLS
+_MAX_STATUS_RESULT_CHARS: int = tool_event_handlers._MAX_STATUS_RESULT_CHARS
+_READ_ONLY_TOOLS = tool_event_handlers._READ_ONLY_TOOLS
 _TOOL_CONTENT_FIELDS = streaming_buffers._TOOL_CONTENT_FIELDS
-
-# Read-only tools whose result content is replaced with a size-only placeholder
-# in the persisted state.  The file path is already in tc.args; full content
-# lives in the LangGraph checkpoint DB if ever needed.
-_READ_ONLY_TOOLS: set[str] = {"read", "read_file"}
-
 _find_json_string_value_start = streaming_buffers._find_json_string_value_start
 _json_unescape_partial = streaming_buffers._json_unescape_partial
 
 
 def _utc_timestamp(dt: datetime | None = None) -> str:
-    """Return a UTC datetime as an RFC 3339 timestamp string.
-
-    Appends the ``Z`` suffix so that consumers using strict RFC 3339 / ISO 8601
-    parsers (e.g. Go's ``time.Parse(time.RFC3339, …)``) can parse the value
-    without ambiguity.
-
-    Args:
-        dt: A UTC datetime to format. If *None*, ``datetime.utcnow()`` is used.
-    """
+    """Return a UTC datetime as an RFC 3339 timestamp string."""
     if dt is None:
         dt = datetime.utcnow()
     return dt.isoformat() + "Z"
 
 
 class StatusBuilder:
-    """
-    Builds execution status locally from astream_events.
-    
-    Usage:
-        builder = StatusBuilder(execution_id, initial_status)
-        
-        # Process events
-        for event in events:
-            await builder.process_event(event)
-        
-        # Set final phase
-        builder.current_status.phase = ExecutionPhase.EXECUTION_COMPLETED
-        
-        # Return to workflow
-        return builder.current_status
-    """
-    
+    """Builds execution status locally from astream_events."""
+
     def __init__(
         self,
         execution_id: str,
@@ -139,120 +75,55 @@ class StatusBuilder:
         approval_config: ApprovalConfig | None = None,
         tool_call_id_capture: ToolCallIdCapture | None = None,
     ):
-        """
-        Initialize status builder.
-        
-        Args:
-            execution_id: The execution ID
-            initial_status: Initial AgentExecutionStatus proto
-            approval_config: Optional approval policy configuration. When provided,
-                           tools matching approval policies will be set to
-                           WAITING_APPROVAL status instead of RUNNING.
-            tool_call_id_capture: Callback handler that captures {run_id → tool_call_id}
-                from the LangChain callback API. Used for identity-based dedup on the
-                resume path. A bare instance is created when not provided.
-        """
         self.execution_id = execution_id
         self.logger = logging.getLogger(__name__)
-
-        # -- Execution state (all mutable tracking data) -------------------
         self.state = ExecutionState(proto=initial_status)
-
-        # -- Configuration (immutable after init) --------------------------
         self._approval_config = approval_config
-
-        # Single authority for run_id → tool_call_id resolution.
         self._tool_call_id_capture = tool_call_id_capture or ToolCallIdCapture()
-
-        # Token/cost accounting for LLM calls.
         self._usage_tracker = UsageTracker(execution_id)
-
-        # gRPC scheduling signal (not execution state).
         self.force_next_update: bool = False
-
-        # Display humanization config (set after workspace provisioning).
         self._display_env_vars: dict[str, str] | None = None
         self._secret_keys: set[str] | None = None
         self._workspace_root: str = ""
 
     @property
     def current_status(self) -> Any:
-        """The protobuf projection being built."""
         return self.state.proto
 
     @current_status.setter
     def current_status(self, value: Any) -> None:
         self.state.proto = value
-    
+
     def set_display_env_vars(
-        self,
-        env_vars: dict[str, str],
-        secret_keys: set[str] | None = None,
+        self, env_vars: dict[str, str], secret_keys: set[str] | None = None,
     ) -> None:
-        """Store resolved agent env vars for display humanization.
-
-        Called once after environment merge completes.  ``_create_args_preview``
-        uses these to replace ``$KEY`` references with their values so the
-        approval prompt shows concrete paths instead of opaque env-var names.
-
-        Args:
-            env_vars: Merged env-var name-to-value mapping.
-            secret_keys: Keys marked ``is_secret=true`` in the EnvironmentValue
-                proto.  These are never expanded into display strings.
-        """
+        """Store resolved agent env vars for display humanization."""
         self._display_env_vars = env_vars
         self._secret_keys = secret_keys
 
     def set_workspace_root(self, workspace_root: str) -> None:
-        """Store the sandbox workspace root for display humanization.
-
-        Called once after workspace provisioning completes.
-        ``_humanize_args_for_display`` and tool-result recording use this to
-        replace absolute sandbox paths (e.g. ``/home/daytona/workspace/…``)
-        with workspace-relative display paths.
-
-        Pass an empty string to disable sandbox path humanization (local
-        mode, where paths are the user's actual filesystem).
-        """
+        """Store the sandbox workspace root for display humanization."""
         self._workspace_root = workspace_root
 
-    # ─────────────────────────────────────────────────────────────────────────
-    # Tool Call Index — public accessors
-    # ─────────────────────────────────────────────────────────────────────────
+    # ── Tool Call Index — public accessors ────────────────────────────────
 
     def get_tool_call(self, tc_id: str) -> ToolCall | None:
-        """Look up a ToolCall by its ID.
-
-        Returns the reference stored inside the parent AI message's repeated
-        field, so mutations to the returned object propagate to the proto
-        status automatically.
-        """
         return self.state.tool_calls.get(tc_id)
 
     def iter_all_tool_calls(self) -> Iterator[ToolCall]:
-        """Iterate over every tracked ToolCall (main agent + sub-agents)."""
         return iter(self.state.tool_calls.values())
 
     def tool_call_count(self) -> int:
-        """Return the total number of tracked tool calls."""
         return len(self.state.tool_calls)
 
     @property
     def active_sub_agent_count(self) -> int:
-        """Return the number of currently active (in-progress) sub-agents."""
         return len(self.state.active_sub_agents)
 
     _COMPLETION_DRAIN_MS: float = 300.0
 
     def should_flush_completions(self, now_monotonic: float) -> bool:
-        """Check whether any pending sub-agent completion has drained.
-
-        Returns True (and sets :attr:`force_next_update`) when at least one
-        sub-agent completion has been pending for longer than
-        ``_COMPLETION_DRAIN_MS``.  The drain window allows late LangGraph
-        events to be batched into the same gRPC update that carries the
-        COMPLETED status.
-        """
+        """Check whether any pending sub-agent completion has drained."""
         if not self.state.pending_completion_flush:
             return False
         threshold = self._COMPLETION_DRAIN_MS / 1000.0
@@ -267,38 +138,24 @@ class StatusBuilder:
             return True
         return False
 
+    # ── Event Dispatch ────────────────────────────────────────────────────
+
     async def process_event(self, event: dict[str, Any]) -> None:
-        """
-        Process astream_events v2 event and update local status.
-        
-        Args:
-            event: The astream_events v2 event dictionary
-        """
+        """Process astream_events v2 event and update local status."""
         event_type = event.get("event", "")
-        
-        # Extract namespace
+
         metadata = event.get("metadata", {})
         namespace = (
-            metadata.get("langgraph_checkpoint_ns") or
-            metadata.get("checkpoint_ns") or
-            ""
+            metadata.get("langgraph_checkpoint_ns")
+            or metadata.get("checkpoint_ns")
+            or ""
         )
-        
         if isinstance(namespace, tuple):
             namespace = ":".join(str(x) for x in namespace)
-        
-        # Register namespace -> sub-agent mapping for EVERY event type.
-        # _register_sub_agent_namespace is idempotent (returns immediately
-        # for already-registered or single-segment namespaces), so calling
-        # it universally is safe and cheap.  This ensures that namespace
-        # variants arriving via on_chat_model_stream, on_tool_end, etc.
-        # are registered before _get_execution_context performs its exact
-        # lookup in the type-specific handler.
+
         if namespace:
             self._register_sub_agent_namespace(namespace, event)
-        
-        # Route by event type.  Each handler is wrapped so a single bad
-        # event never crashes the entire activity stream.
+
         handler: (
             Callable[[dict[str, Any], str], None | Coroutine[Any, Any, None]] | None
         ) = None
@@ -324,624 +181,38 @@ class StatusBuilder:
                     f"event_type={event_type} namespace={namespace or 'main'} "
                     f"run_id={event.get('run_id', '')}"
                 )
-    
+
+    # ── Handler Delegations ───────────────────────────────────────────────
+
     async def _handle_tool_start_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Delegate to :func:`tool_event_handlers.handle_tool_start`."""
         await tool_event_handlers.handle_tool_start(self, event, namespace)
-    
-    def _ensure_parent_ai_message(
-        self,
-        ns_key: str,
-        namespace: str,
-        llm_run_id: str = "",
-    ) -> AgentMessage:
-        """Return the current parent AI message, creating an empty one if needed.
-
-        When a tool call (including thinking) fires before the LLM has produced
-        any text, there is no AI message to attach it to.  This method creates
-        a zero-content ``MESSAGE_AI`` so the tool call has a parent — the
-        frontend renders such messages as tool-only rows without a text bubble.
-
-        When the LLM later produces text tokens, ``_handle_chat_model_stream_event``
-        creates a *new* AI message (keyed by ``run_id``), which replaces
-        ``_last_ai_message[ns_key]``.  Subsequent tool calls attach to that
-        new message, preserving correct chronological grouping.
-
-        Args:
-            ns_key: Namespace key (empty string for main agent).
-            namespace: Raw LangGraph checkpoint namespace.
-            llm_run_id: When called from the LLM stream path (thinking /
-                early tool_use), pass the LLM's ``run_id`` so the empty
-                parent is registered in ``_llm_run_id_to_message``.  This
-                allows ``_handle_chat_model_end_event`` to find it and
-                record usage metrics for thinking-only turns.  Callers from
-                the tool-execution path (``on_tool_start``) must omit this
-                to avoid polluting the LLM run-id map with tool run-ids.
-        """
-        existing = self.state.current_ai_message.get(ns_key)
-        if existing is not None:
-            return existing
-
-        _, sub_agent = self._get_execution_context(namespace)
-        messages_list = sub_agent.messages if sub_agent else self.current_status.messages
-
-        now = datetime.utcnow()
-        ai_message = AgentMessage(
-            type=MessageType.MESSAGE_AI,
-            content="",
-            timestamp=_utc_timestamp(now),
-            is_streaming=False,
-        )
-        messages_list.append(ai_message)
-        managed = messages_list[-1]
-        self.state.current_ai_message[ns_key] = managed
-
-        if llm_run_id:
-            self.state.messages_by_run[llm_run_id] = managed
-
-        self.logger.debug(
-            "[AI_MSG] execution=%s created empty parent AI message "
-            "namespace=%s llm_run_id=%s (tool call arrived before text)",
-            self.execution_id,
-            namespace or "main",
-            llm_run_id or "none",
-        )
-        return managed
 
     def _handle_tool_progress_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Delegate to :func:`tool_event_handlers.handle_tool_progress`."""
         tool_event_handlers.handle_tool_progress(self, event, namespace)
-    
+
     def _handle_tool_end_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Delegate to :func:`tool_event_handlers.handle_tool_end`."""
         tool_event_handlers.handle_tool_end(self, event, namespace)
-    
+
     def _handle_chat_model_stream_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Handle on_chat_model_stream event - updates local status."""
-        chunk_data = event.get("data", {}).get("chunk", {})
-        
-        if not chunk_data:
-            return
-        
-        # Try to register namespace for event routing
-        if namespace:
-            self._register_sub_agent_namespace(namespace, event)
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # LLM Turn-Boundary Detection
-        #
-        # Each LLM invocation carries a unique run_id.  When the run_id
-        # changes we know a new LLM turn has started.  Clear the cached
-        # _last_ai_message for this namespace so that thinking/tool_use
-        # blocks from the new turn create a fresh parent AI message
-        # instead of piling onto the previous turn's parent.
-        #
-        # For text-producing turns this is harmless — the text path
-        # already creates a new AI message per new run_id.  The fix
-        # matters for thinking-only turns where no text path runs and
-        # _last_ai_message would otherwise remain stale.
-        # ─────────────────────────────────────────────────────────────────────
-        run_id = event.get("run_id", "")
-        ns_key = namespace or ""
-        if run_id and run_id != self.state.last_llm_run_id.get(ns_key):
-            self.state.current_ai_message.pop(ns_key, None)
-            self.state.last_llm_run_id[ns_key] = run_id
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Native Thinking Detection
-        #
-        # When Anthropic extended thinking is active, content blocks arrive as
-        # dicts with type:"thinking" BEFORE the text/tool_use blocks.  We
-        # accumulate thinking content in a per-namespace buffer and skip AI
-        # message creation for these chunks.  When the first non-thinking
-        # content arrives we flush the buffer into a synthetic think ToolCall.
-        #
-        # A single chunk may contain BOTH thinking and text blocks (e.g., at
-        # the boundary between thinking and response output).  We must
-        # process thinking content AND check for co-located text — only
-        # returning early if the chunk is purely thinking content.
-        # ─────────────────────────────────────────────────────────────────────
-        if hasattr(chunk_data, "content") and isinstance(chunk_data.content, list):
-            ns_key = namespace or ""
-            thinking_text = formatting.extract_thinking_content(chunk_data.content)
-            text_in_same_chunk = formatting.extract_string_content(chunk_data.content)
-            
-            # Diagnostic: log mixed chunks and empty extractions
-            if thinking_text and text_in_same_chunk:
-                self.logger.info(
-                    f"[STREAM_DIAG] Mixed thinking+text chunk: "
-                    f"execution={self.execution_id} "
-                    f"run_id={event.get('run_id', '')} "
-                    f"namespace={namespace or 'main'} "
-                    f"thinking_len={len(thinking_text)} "
-                    f"text_len={len(text_in_same_chunk)} "
-                    f"text={text_in_same_chunk[:100]!r}"
-                )
-            elif not thinking_text and not text_in_same_chunk:
-                expected_non_text_types = frozenset({
-                    "thinking", "tool_use", "input_json_delta",
-                })
-                block_types = [
-                    formatting.block_attr(b, "type", type(b).__name__)
-                    for b in chunk_data.content[:5]
-                ]
-                is_expected = (
-                    not block_types
-                    or all(bt in expected_non_text_types for bt in block_types)
-                )
-                if not is_expected:
-                    self.logger.info(
-                        f"[STREAM_DIAG] List content with no thinking/text: "
-                        f"execution={self.execution_id} "
-                        f"run_id={event.get('run_id', '')} "
-                        f"namespace={namespace or 'main'} "
-                        f"blocks={len(chunk_data.content)} "
-                        f"block_types={block_types}"
-                    )
-            
-            # ── Early Tool Call Creation ─────────────────────────────────────
-            # When a tool_use block appears in the stream, create the ToolCall
-            # right away so the CLI replaces the idle "Thinking…" indicator
-            # with the actual tool name (e.g. "Write: …").
-            skip_early_tools = frozenset(PLANNING_TOOLS)
-            for block in chunk_data.content:
-                try:
-                    if formatting.block_attr(block, "type") == "tool_use":
-                        t_name = formatting.block_attr(block, "name")
-                        t_id = formatting.block_attr(block, "id")
-                        if t_name and t_name not in skip_early_tools:
-                            self._create_early_tool_call(
-                                t_name, t_id, ns_key, namespace,
-                                llm_run_id=run_id,
-                            )
-                except Exception:
-                    self.logger.exception(
-                        f"[TOOL_EARLY_ERROR] execution={self.execution_id} "
-                        f"block={block!r:.200} namespace={namespace or 'main'}"
-                    )
-            
-            # ── Tool Input Streaming ─────────────────────────────────────────
-            # Accumulate input_json_delta fragments and extract displayable
-            # content into the early ToolCall's result field so the CLI can
-            # render it progressively (same mechanism as thinking streaming).
-            for block in chunk_data.content:
-                try:
-                    if formatting.block_attr(block, "type") == "input_json_delta":
-                        partial = formatting.block_attr(block, "partial_json")
-                        if partial:
-                            streaming_buffers.accumulate_tool_input(self, ns_key, partial)
-                except Exception:
-                    self.logger.exception(
-                        f"[TOOL_INPUT_ERROR] execution={self.execution_id} "
-                        f"namespace={namespace or 'main'}"
-                    )
-            
-            if thinking_text:
-                self.state.thinking.buffers[ns_key] = (
-                    self.state.thinking.buffers.get(ns_key, "") + thinking_text
-                )
-                if ns_key not in self.state.thinking.tool_call_ids:
-                    streaming_buffers.start_thinking_stream(self,
-                        ns_key, namespace, self.state.thinking.buffers[ns_key],
-                        llm_run_id=run_id,
-                    )
-                else:
-                    streaming_buffers.update_thinking_stream(self, ns_key)
-                
-                if not text_in_same_chunk:
-                    return
-                # Fall through: chunk has both thinking AND text.
-                # Thinking is accumulated above; text is processed below.
-        
-        # Extract token
-        token = ""
-        if hasattr(chunk_data, "content"):
-            chunk_content = chunk_data.content
-            if isinstance(chunk_content, str):
-                token = chunk_content
-            elif isinstance(chunk_content, list):
-                token = formatting.extract_string_content(chunk_content)
-        
-        if not token:
-            return
-        
-        # Flush any accumulated thinking before processing text content.
-        # This ensures the synthetic think ToolCall appears in the status
-        # timeline before the AI message that follows it.
-        ns_key = namespace or ""
-        if self.state.thinking.buffers.get(ns_key):
-            streaming_buffers.flush_thinking_buffer(self, ns_key, namespace)
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # run_id-Based Message Isolation
-        #
-        # Each LLM invocation has a unique run_id. We use it to map tokens
-        # to the correct AgentMessage, preventing interleaving when multiple
-        # LLM streams are active (e.g., concurrent sub-agents whose namespace
-        # routing fell through to the main agent).
-        #
-        # When run_id is absent, we fall back to the legacy backwards-scan
-        # for the last streaming AI message in the resolved context.
-        # ─────────────────────────────────────────────────────────────────────
-        run_id = event.get("run_id", "")
-        context, sub_agent = self._get_execution_context(namespace)
-        messages_list = sub_agent.messages if sub_agent else self.current_status.messages
-        
-        # Fast path: run_id already mapped to a message from an earlier token.
-        if run_id:
-            ai_message = self.state.messages_by_run.get(run_id)
-            if ai_message is not None:
-                # Empty parent AI messages created by _ensure_parent_ai_message
-                # for thinking/tool_use blocks must NOT receive text content.
-                # Text should go to a separate AI message so the frontend
-                # renders the thread in chronological order: thinking tool
-                # group first, then the text response.  Remove the stale
-                # registration so the "first token" path below creates a
-                # proper text AI message and re-registers the run_id.
-                if not ai_message.content and len(ai_message.tool_calls) > 0:
-                    del self.state.messages_by_run[run_id]
-                else:
-                    ai_message.content += token
-                    return
-        
-        if not run_id:
-            # Legacy fallback: no run_id available — find the last streaming
-            # AI message in this context (pre-isolation behaviour).
-            for idx in range(len(messages_list) - 1, -1, -1):
-                message = messages_list[idx]
-                if message.type == MessageType.MESSAGE_AI and message.is_streaming:
-                    message.content += token
-                    return
-        
-        # First token for this run_id (or no existing streaming message in
-        # legacy mode) — create a new AgentMessage.
-        now = datetime.utcnow()
-        ai_message = AgentMessage(
-            type=MessageType.MESSAGE_AI,
-            content=token,
-            timestamp=_utc_timestamp(now),
-            is_streaming=True,
-        )
-        messages_list.append(ai_message)
-        
-        # Store the proto-managed reference (not the original, which is
-        # disconnected after protobuf repeated-message append).
-        managed_ai_message = messages_list[-1]
-        
-        if run_id:
-            self.state.messages_by_run[run_id] = managed_ai_message
-        
-        # Track as the most recent AI message for this namespace so that
-        # subsequent tool calls (on_tool_start, early tool_use) are attached
-        # to the correct parent AI message.
-        ns_key = namespace or ""
-        self.state.current_ai_message[ns_key] = managed_ai_message
-        
-        # Track start time for duration calculation
-        new_message_index = len(messages_list) - 1
-        if sub_agent:
-            self.state.sub_agent_message_start_times[(sub_agent.id, new_message_index)] = now
-            self.logger.debug(f"Started new AI message in sub_agent={sub_agent.id} at index {new_message_index} run_id={run_id}")
-        else:
-            self.state.message_start_times[new_message_index] = now
-            self.logger.debug(f"Started new AI message at index {new_message_index} run_id={run_id}")
-    
+        chat_model_handlers.handle_chat_model_stream(self, event, namespace)
+
     def _handle_chat_model_end_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """
-        Handle on_chat_model_end event - finalize AI message and capture usage metrics.
-        
-        This event is emitted when the LLM completes generating a response. It contains:
-        - Final message content (already captured via streaming)
-        - Usage metadata (token counts) - only available in this event
-        - Model information
-        
-        Args:
-            event: The astream_events v2 event dictionary
-            namespace: LangGraph checkpoint namespace for sub-agent routing
-        """
-        output_data = event.get("data", {}).get("output", {})
-        
-        if not output_data:
-            return
-        
-        # Flush any remaining thinking content that wasn't followed by text
-        # (e.g. the model only produced thinking + tool_use, no text block).
-        ns_key = namespace or ""
-        if self.state.thinking.buffers.get(ns_key):
-            streaming_buffers.flush_thinking_buffer(self, ns_key, namespace)
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # run_id-Based Message Resolution (with backwards-scan fallback)
-        # ─────────────────────────────────────────────────────────────────────
-        run_id = event.get("run_id", "")
-        context, sub_agent = self._get_execution_context(namespace)
-        messages_list = sub_agent.messages if sub_agent else self.current_status.messages
-        
-        ai_message_index = None
-        
-        # Primary path: resolve via run_id map (matches stream handler)
-        tracked_message = self.state.messages_by_run.pop(run_id, None) if run_id else None
-        if tracked_message is not None:
-            for idx in range(len(messages_list) - 1, -1, -1):
-                if messages_list[idx] is tracked_message:
-                    ai_message_index = idx
-                    break
-        
-        # Fallback: backwards scan for last streaming AI message
-        if ai_message_index is None:
-            for idx in range(len(messages_list) - 1, -1, -1):
-                message = messages_list[idx]
-                if message.type == MessageType.MESSAGE_AI and message.is_streaming:
-                    ai_message_index = idx
-                    break
-        
-        if ai_message_index is None:
-            context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
-            self.logger.warning(
-                f"on_chat_model_end received but no AI message found to finalize "
-                f"({context_desc} run_id={run_id})"
-            )
-            return
-        
-        # Calculate generation duration if we tracked the start time
-        generation_duration_ms = None
-        if sub_agent:
-            # Check sub-agent timing dict
-            timing_key = (sub_agent.id, ai_message_index)
-            if timing_key in self.state.sub_agent_message_start_times:
-                start_time = self.state.sub_agent_message_start_times[timing_key]
-                duration = datetime.utcnow() - start_time
-                generation_duration_ms = int(duration.total_seconds() * 1000)
-                del self.state.sub_agent_message_start_times[timing_key]
-        else:
-            # Check main agent timing dict
-            if ai_message_index in self.state.message_start_times:
-                start_time = self.state.message_start_times[ai_message_index]
-                duration = datetime.utcnow() - start_time
-                generation_duration_ms = int(duration.total_seconds() * 1000)
-                del self.state.message_start_times[ai_message_index]
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Diagnostic: capture output_data shape for zero-usage debugging.
-        # Log the concrete type, usage_metadata value, and whether
-        # response_metadata carries a raw ``usage`` dict (Anthropic always
-        # populates this even during streaming).
-        # ─────────────────────────────────────────────────────────────────────────
-        _rm = getattr(output_data, "response_metadata", None)
-        _rm_usage = _rm.get("usage") if isinstance(_rm, dict) else None
-        self.logger.debug(
-            "[USAGE_DIAG] execution=%s run_id=%s "
-            "output_data_type=%s "
-            "has_usage_metadata=%s usage_metadata=%r "
-            "response_metadata_keys=%s "
-            "response_metadata_usage=%r",
-            self.execution_id,
-            run_id,
-            type(output_data).__name__,
-            hasattr(output_data, "usage_metadata"),
-            getattr(output_data, "usage_metadata", "N/A"),
-            list(_rm.keys()) if isinstance(_rm, dict) else "N/A",
-            _rm_usage,
+        chat_model_handlers.handle_chat_model_end(self, event, namespace)
+
+    # ── Streaming Buffer Delegations ──────────────────────────────────────
+
+    def _ensure_parent_ai_message(self, ns_key: str, namespace: str,
+                                  llm_run_id: str = "") -> AgentMessage:
+        return streaming_buffers.ensure_parent_ai_message(
+            self, ns_key, namespace, llm_run_id,
         )
-        del _rm, _rm_usage
-
-        # ─────────────────────────────────────────────────────────────────────────
-        # Extract usage metadata from LangChain response (Phase 3)
-        #
-        # LangChain normalises provider token counts into a unified
-        # ``usage_metadata`` structure:
-        #   input_tokens   — TOTAL input including cache (both providers)
-        #   output_tokens  — output / completion tokens
-        #   input_token_details.cache_creation — Anthropic cache writes
-        #   input_token_details.cache_read     — cache reads (both)
-        #
-        # For cost calculation we need four disjoint buckets:
-        #   regular_input = input_tokens - cache_creation - cache_read
-        # ─────────────────────────────────────────────────────────────────────────
-        total_input_tokens = 0
-        output_tokens = 0
-        cache_creation_tokens = 0
-        cache_read_tokens = 0
-        model_name = ""
-        
-        # Resolve usage_metadata from AIMessage attribute or raw dict.
-        usage: dict | None = None
-        if hasattr(output_data, "usage_metadata") and output_data.usage_metadata:
-            usage = output_data.usage_metadata
-        elif isinstance(output_data, dict):
-            usage = output_data.get("usage_metadata") or output_data.get("usage")
-
-        # UsageMetadata is a TypedDict (plain dict at runtime) in all
-        # langchain-core versions.  Use dict .get() for key access;
-        # getattr() silently returns the default on dicts.
-        if usage and isinstance(usage, dict):
-            total_input_tokens = usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0) or 0
-            output_tokens = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0) or 0
-            details = usage.get("input_token_details") or {}
-            if isinstance(details, dict):
-                cache_creation_tokens = details.get("cache_creation", 0) or 0
-                cache_read_tokens = details.get("cache_read", 0) or 0
-        
-        # Derive the non-cached regular input (disjoint bucket for cost)
-        regular_input_tokens = max(0, total_input_tokens - cache_creation_tokens - cache_read_tokens)
-        
-        # Extract model name from response_metadata
-        if hasattr(output_data, "response_metadata"):
-            response_meta = output_data.response_metadata
-            if isinstance(response_meta, dict):
-                model_name = response_meta.get("model", "") or response_meta.get("model_name", "")
-        elif isinstance(output_data, dict):
-            response_meta = output_data.get("response_metadata", {})
-            model_name = response_meta.get("model", "") or response_meta.get("model_name", "")
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Finalize AI message streaming state fields
-        # ─────────────────────────────────────────────────────────────────────────
-        ai_message = messages_list[ai_message_index]
-        
-        ai_message.is_streaming = False
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Diagnostic: detect text content dropped during streaming
-        #
-        # The output_data contains the FULL final AIMessage with all content
-        # blocks.  Extract the text portion and compare with what the stream
-        # handler accumulated.  A mismatch proves tokens were silently dropped.
-        # ─────────────────────────────────────────────────────────────────────────
-        try:
-            final_text = ""
-            if hasattr(output_data, "content"):
-                oc = output_data.content
-                if isinstance(oc, str):
-                    final_text = oc
-                elif isinstance(oc, list):
-                    final_text = formatting.extract_string_content(oc)
-            elif isinstance(output_data, dict) and "content" in output_data:
-                oc = output_data["content"]
-                if isinstance(oc, str):
-                    final_text = oc
-                elif isinstance(oc, list):
-                    final_text = formatting.extract_string_content(oc)
-            
-            streamed_text = ai_message.content
-            if final_text and final_text != streamed_text:
-                self.logger.warning(
-                    f"[CONTENT_DROP] execution={self.execution_id} run_id={run_id} "
-                    f"namespace={namespace or 'main'} "
-                    f"streamed_len={len(streamed_text)} final_len={len(final_text)} "
-                    f"streamed={streamed_text[:200]!r} "
-                    f"final={final_text[:200]!r}"
-                )
-                # Reconcile: overwrite with the authoritative final content
-                # so the CLI shows the complete message even if streaming
-                # was disrupted (e.g. by proto copy semantics).
-                ai_message.content = final_text
-            elif final_text:
-                self.logger.debug(
-                    f"[CONTENT_OK] execution={self.execution_id} run_id={run_id} "
-                    f"len={len(streamed_text)} content={streamed_text[:100]!r}"
-                )
-        except Exception:
-            pass
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Record usage via UsageTracker (Phase 3)
-        #
-        # Delegates all token accounting, pricing lookup, cost computation,
-        # LlmCallMetrics construction, and ModelUsage aggregation to the
-        # tracker.  The returned LlmCallMetrics is used to enrich the
-        # AgentMessage with per-message cost and model fields.
-        # ─────────────────────────────────────────────────────────────────────────
-        scope = sub_agent.id if sub_agent else MAIN_SCOPE
-        
-        call_metrics = self._usage_tracker.record_llm_call(
-            model_name=model_name,
-            input_tokens=regular_input_tokens,
-            output_tokens=output_tokens,
-            cache_creation_tokens=cache_creation_tokens,
-            cache_read_tokens=cache_read_tokens,
-            duration_ms=generation_duration_ms,
-            timestamp=_utc_timestamp(),
-            scope=scope,
-        )
-        
-        ai_message.llm_metrics.CopyFrom(call_metrics)
-        
-        self.logger.debug(
-            "AI message finalized at index %d scope=%s "
-            "(tokens: %d, cost: $%.6f, duration: %sms)",
-            ai_message_index,
-            scope,
-            total_input_tokens + output_tokens,
-            call_metrics.estimated_cost_usd,
-            generation_duration_ms or "N/A",
-        )
-    
-    # Helper methods
-    def resolve_run_id(self, run_id: str) -> str:
-        """Resolve a run_id to its canonical tool_call_id.
-
-        Delegates to :class:`ToolCallIdCapture` which checks resume-path
-        aliases first, then the callback-captured mapping, and falls back
-        to *run_id* unchanged.
-        """
-        return self._tool_call_id_capture.resolve(run_id)
-    
-    def rebuild_index_from_persisted_status(self) -> None:
-        """Reconstruct proto-derivable indexes from the persisted status.
-
-        On the resume-after-approval path, the StatusBuilder is initialized
-        with the DB-persisted status that already contains tool calls embedded
-        in messages.  This method delegates to ``ExecutionState.rebuild_from_proto``
-        to re-populate tool call indexes, completed sub-agents, and artifacts
-        so the subsequent stream cycle resolves correctly.
-        """
-        self.state = ExecutionState.rebuild_from_proto(self.state.proto)
-
-    def prepare_task_tool_resume_queue(self) -> int:
-        """Pre-populate the early tool call queue for task tools on resume.
-
-        On resume from a sub-agent HITL interrupt, ``astream_events`` does
-        NOT replay the AI message's ``tool_use`` blocks — the AI node
-        completed in a prior checkpoint and is not re-executed.  Only
-        ``on_tool_start`` fires (from the tool node re-execution).  This
-        leaves ``_early_tool_call_queue`` empty, causing the task handler
-        to fall back to ``run_id`` as the ``tool_call_id``, which doesn't
-        match the original Anthropic ``toolu_*`` ID stored on the
-        SubAgentExecution.  The result is duplicate SubAgentExecution
-        entries on every resume cycle.
-
-        This method simulates what ``_create_early_tool_call`` would have
-        done by scanning persisted messages for task tool calls that have
-        a corresponding SubAgentExecution and queueing them for
-        ``_reconcile_early_tool_call``.
-
-        Safe against double-queueing: if ``astream_events`` also replays
-        the AI message on some resume paths, ``_create_early_tool_call``'s
-        existing dedup re-queues the same entry.
-        ``_reconcile_early_tool_call`` pops the first match; any leftover
-        entry is harmless.
-
-        Must be called **after** ``rebuild_index_from_persisted_status``
-        (which builds ``_tool_call_index``) and **before** the stream starts.
-
-        Returns the number of task tool calls queued.
-        """
-        sa_ids = {sa.id for sa in self.current_status.sub_agent_executions}
-        queued = 0
-
-        for msg in self.current_status.messages:
-            if msg.type != MessageType.MESSAGE_AI:
-                continue
-            for tc in msg.tool_calls:
-                if tc.name != "task" or not tc.id:
-                    continue
-                if tc.id not in sa_ids:
-                    continue
-                already_queued = any(
-                    tid == tc.id for tid, _ in self.state.early_tool_call_queue
-                )
-                if already_queued:
-                    continue
-
-                self.state.early_tool_call_queue.append((tc.id, None))
-                queued += 1
-                self.logger.info(
-                    "[RESUME_PREP] execution=%s pre-queued task TC %s "
-                    "for sub-agent resume reconciliation",
-                    self.execution_id, tc.id,
-                )
-
-        return queued
 
     def _extract_tool_result_content(self, result: Any) -> str:
-        """Delegate to :func:`formatting.extract_tool_result_content`."""
         return formatting.extract_tool_result_content(result)
-    
+
     def _create_early_tool_call(self, tool_name: str, tool_use_id: str,
                                ns_key: str, namespace: str,
                                llm_run_id: str = "") -> None:
-        """Delegate to :func:`streaming_buffers.create_early_tool_call`."""
         streaming_buffers.create_early_tool_call(
             self, tool_name, tool_use_id, ns_key, namespace, llm_run_id,
         )
@@ -949,339 +220,158 @@ class StatusBuilder:
     def _reconcile_early_tool_call(self, tool_name: str, run_id: str,
                                    tool_args: dict[str, Any],
                                    namespace: str) -> ToolCall | None:
-        """Delegate to :func:`streaming_buffers.reconcile_early_tool_call`."""
         return streaming_buffers.reconcile_early_tool_call(
             self, tool_name, run_id, tool_args, namespace,
         )
-    
+
+    # ── Tool Event Support Delegations ────────────────────────────────────
+
     def _update_todos(self, todos_data: list) -> None:
-        """Replace the todo snapshot in the local execution status.
+        tool_event_handlers.update_todos(self, todos_data)
 
-        ``TodoListMiddleware`` (LangChain) performs full-snapshot replacement:
-        each ``write_todos`` call carries the *complete* current todo list, not
-        a delta.  We therefore clear existing todos before applying the new set.
+    def _update_sub_agent_todos(self, sub_agent: SubAgentExecution,
+                                todos_data: list) -> None:
+        tool_event_handlers.update_sub_agent_todos(self, sub_agent, todos_data)
 
-        LangChain's ``Todo`` TypedDict has ``{content, status}`` but no ``id``
-        field.  When ``id`` is absent we generate a stable, position-based key
-        (``todo-0``, ``todo-1``, ...) so the proto ``map<string, TodoItem>``
-        contract is satisfied and downstream consumers (CLI fingerprint diffing,
-        Go status storage) work unchanged.
-        """
-        status_map = {
-            "pending": TodoStatus.TODO_PENDING,
-            "in_progress": TodoStatus.TODO_IN_PROGRESS,
-            "completed": TodoStatus.TODO_COMPLETED,
-            "cancelled": TodoStatus.TODO_CANCELLED,
-        }
+    def _check_tool_approval_requirement(self, tool_name: str,
+                                         tool_args: dict[str, Any]) -> Any:
+        return tool_event_handlers.check_approval_requirement(self, tool_name, tool_args)
 
-        self.current_status.todos.clear()
+    def _set_waiting_for_approval_phase(self, tool_name: str, run_id: str) -> None:
+        tool_event_handlers.set_waiting_for_approval_phase(self, tool_name, run_id)
 
-        now = _utc_timestamp()
-        for idx, todo_dict in enumerate(todos_data):
-            todo_id = todo_dict.get("id") or f"todo-{idx}"
+    def _humanize_args_for_display(self, tool_args: dict[str, Any]) -> dict[str, Any]:
+        return tool_event_handlers.humanize_args_for_display(self, tool_args)
 
-            status_str = todo_dict.get("status", "pending").lower()
-            status_enum = status_map.get(status_str, TodoStatus.TODO_PENDING)
+    def _create_args_preview(self, tool_args: dict[str, Any]) -> str:
+        return tool_event_handlers.create_args_preview(self, tool_args)
 
-            todo_item = TodoItem(
-                id=todo_id,
-                content=todo_dict.get("content", ""),
-                status=status_enum,
-                created_at=todo_dict.get("created_at", now),
-                updated_at=now,
-            )
-
-            self.current_status.todos[todo_id].CopyFrom(todo_item)
-
-        self.logger.info(
-            "Updated todos: %d item(s) in snapshot", len(todos_data),
-        )
-
-    def _update_sub_agent_todos(
-        self, sub_agent: SubAgentExecution, todos_data: list
-    ) -> None:
-        """Replace the todo snapshot on a sub-agent execution.
-
-        Same snapshot-replacement semantics as ``_update_todos`` but targets
-        ``sub_agent.todos`` instead of ``self.current_status.todos``.
-        """
-        status_map = {
-            "pending": TodoStatus.TODO_PENDING,
-            "in_progress": TodoStatus.TODO_IN_PROGRESS,
-            "completed": TodoStatus.TODO_COMPLETED,
-            "cancelled": TodoStatus.TODO_CANCELLED,
-        }
-
-        sub_agent.todos.clear()
-
-        now = _utc_timestamp()
-        for idx, todo_dict in enumerate(todos_data):
-            todo_id = todo_dict.get("id") or f"todo-{idx}"
-
-            status_str = todo_dict.get("status", "pending").lower()
-            status_enum = status_map.get(status_str, TodoStatus.TODO_PENDING)
-
-            todo_item = TodoItem(
-                id=todo_id,
-                content=todo_dict.get("content", ""),
-                status=status_enum,
-                created_at=todo_dict.get("created_at", now),
-                updated_at=now,
-            )
-
-            sub_agent.todos[todo_id].CopyFrom(todo_item)
-
-        self.logger.info(
-            "Updated sub-agent todos: %d item(s) (sub_agent_id=%s)",
-            len(todos_data),
-            sub_agent.id,
-        )
-    
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Approval State Management (HITL Phase 2)
-    #
-    # Approval-waiting state is set inline by _handle_tool_start_event() and
-    # _reconcile_early_tool_call() at ToolCall creation time.  On resume,
-    # ResumeReconciler (hitl.py) handles reconciliation and clears pending
-    # approvals via the clear-signal sentinel pattern.
-    #
-    # The helpers below manage non-resume pending-approvals bookkeeping:
-    # clearing all pending state and syncing sub-agent approval lists.
-    # ─────────────────────────────────────────────────────────────────────────────
+    # ── Approval State ────────────────────────────────────────────────────
 
     def clear_pending_approval(self) -> None:
-        """Clear pending approval tracking state and restore execution phase.
-
-        Called when all approval decisions have been processed (or on reject).
-        Restores the execution phase to what it was before entering
-        WAITING_FOR_APPROVAL (typically IN_PROGRESS).
-        """
+        """Clear pending approval tracking state and restore execution phase."""
         self.state.approval.pending.clear()
-
         if self.state.approval.wait_started_at is not None:
             self.state.approval.wait_started_at = None
-
         if self.state.approval.saved_phase is not None:
             self.current_status.phase = self.state.approval.saved_phase
             self.state.approval.saved_phase = None
         else:
             self.current_status.phase = ExecutionPhase.EXECUTION_IN_PROGRESS
 
-    def _check_tool_approval_requirement(
-        self,
-        tool_name: str,
-        tool_args: dict[str, Any],
-    ) -> ApprovalRequirement:
-        """
-        Check if a tool requires approval based on the configured policy chain.
-        
-        Uses the ApprovalConfig to resolve whether this tool requires approval.
-        If no ApprovalConfig is set, tools never require approval.
-        
-        Args:
-            tool_name: Name of the tool to check
-            tool_args: Tool arguments (used for logging, not policy resolution)
-            
-        Returns:
-            ApprovalRequirement with resolved approval status and message
-        """
-        # No approval config = no approval required
-        if self._approval_config is None:
-            return ApprovalRequirement(
-                requires_approval=False,
-                message="",
-                source="none",
-            )
-        
-        # Resolve using policy chain
-        mcp_server_name = self._approval_config.get_mcp_server_for_tool(tool_name)
-        default_policies = self._approval_config.get_default_policies_for_tool(tool_name)
-        
-        return resolve_tool_approval(
-            tool_name=tool_name,
-            mcp_server_name=mcp_server_name,
-            auto_approve_all=self._approval_config.auto_approve_all,
-            tool_approval_overrides=self._approval_config.tool_approval_overrides,
-            default_tool_approvals=default_policies,
-        )
-    
-    def _set_waiting_for_approval_phase(
-        self, tool_name: str, run_id: str,
-    ) -> None:
-        """Transition execution phase to WAITING_FOR_APPROVAL.
-
-        Saves the current phase (only on the first pending approval) so
-        ``clear_pending_approval()`` can restore it later.  Also tracks the
-        run_id in ``_pending_tool_approvals`` and forces an immediate gRPC push.
-        """
-        post_approval_statuses = frozenset({
-            ToolCallStatus.TOOL_CALL_RUNNING,
-            ToolCallStatus.TOOL_CALL_COMPLETED,
-            ToolCallStatus.TOOL_CALL_FAILED,
-            ToolCallStatus.TOOL_CALL_SKIPPED,
-        })
-        tc_id = self._tool_call_id_capture.resolve(run_id)
-        existing_tc = self.get_tool_call(tc_id)
-        if existing_tc is not None and existing_tc.status in post_approval_statuses:
-            self.logger.warning(
-                "[APPROVAL_GUARD] execution=%s tool=%s tc_id=%s "
-                "skipping phase transition — tool call already in "
-                "post-approval state %s",
-                self.execution_id, tool_name, tc_id,
-                ToolCallStatus.Name(existing_tc.status),
-            )
-            return
-
-        if self.state.approval.saved_phase is None:
-            self.state.approval.saved_phase = self.current_status.phase
-            self.state.approval.wait_started_at = datetime.utcnow()
-        self.current_status.phase = ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL
-
-        self.state.approval.pending.append(run_id)
-        self.force_next_update = True
-
-        self.logger.info(
-            f"[APPROVAL] execution={self.execution_id} "
-            f"tool={tool_name} run_id={run_id} tc_id={tc_id} "
-            f"status=WAITING_APPROVAL "
-            f"pending_count={len(self.state.approval.pending)}"
-        )
-    
-    def _find_tool_call_by_id(self, run_id: str) -> ToolCall | None:
-        """Find a ToolCall by its run_id via the in-memory index.
-
-        Alias for :meth:`get_tool_call` retained for internal callers.
-        """
-        return self.state.tool_calls.get(run_id)
-    
-    def _humanize_args_for_display(self, tool_args: dict[str, Any]) -> dict[str, Any]:
-        """Return a shallow copy of *tool_args* with string values humanized.
-
-        Applies, in order:
-
-        1. :func:`humanize_platform_refs` — ``$STIGMER_PLATFORM_DIR`` → ``.stigmer``
-        2. :func:`resolve_display_env_vars` — ``$KEY`` → value (respecting secrets)
-        3. :func:`humanize_sandbox_paths` — absolute sandbox paths → workspace-relative
-
-        Non-string values are passed through unchanged.
-
-        The original *tool_args* dict is never modified — callers that also
-        need the raw args (e.g. for fingerprinting or approval checks) are
-        safe.
-        """
-        if not tool_args:
-            return tool_args
-
-        result: dict[str, Any] = {}
-        for key, value in tool_args.items():
-            if isinstance(value, str):
-                value = humanize_platform_refs(value)
-                value = resolve_display_env_vars(
-                    value, self._display_env_vars, self._secret_keys,
-                )
-                value = humanize_sandbox_paths(value, self._workspace_root)
-            result[key] = value
+    def build_pending_approvals_snapshot(self) -> list[PendingApproval]:
+        """Build pending_approvals snapshot for the Temporal slim status."""
+        result: list[PendingApproval] = []
+        for tc in self.iter_all_tool_calls():
+            if (
+                tc.status == ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
+                and tc.requires_approval
+                and tc.approval_action == ApprovalAction.APPROVAL_ACTION_UNSPECIFIED
+            ):
+                result.append(PendingApproval(tool_call_id=tc.id))
         return result
 
-    def _create_args_preview(self, tool_args: dict[str, Any]) -> str:
-        """
-        Create a sanitized preview of tool arguments for UI display.
-        
-        Sensitive values (passwords, tokens, keys) are redacted.
-        Large values are truncated for readability.
-        
-        Args:
-            tool_args: Tool arguments dictionary
-            
-        Returns:
-            JSON string suitable for UI display
-        """
-        if not tool_args:
-            return "{}"
-        
-        # List of key patterns that indicate sensitive data
-        sensitive_patterns = [
-            "password", "passwd", "pwd",
-            "token", "api_key", "apikey", "api-key",
-            "secret", "credential", "auth",
-            "private_key", "privatekey", "private-key",
-        ]
-        
-        def sanitize_value(key: str, value: Any) -> Any:
-            """Sanitize a single value based on its key name."""
-            key_lower = key.lower()
-            
-            # Check if key matches sensitive patterns
-            for pattern in sensitive_patterns:
-                if pattern in key_lower:
-                    return "***REDACTED***"
-            
-            if isinstance(value, str):
-                value = humanize_platform_refs(value)
-                value = resolve_display_env_vars(
-                    value, self._display_env_vars, self._secret_keys,
-                )
-                return value
-            
-            if isinstance(value, dict):
-                return {k: sanitize_value(k, v) for k, v in value.items()}
-            
-            if isinstance(value, list):
-                return [sanitize_value(str(i), v) for i, v in enumerate(value)]
-            
-            return value
-        
-        sanitized = {k: sanitize_value(k, v) for k, v in tool_args.items()}
-        
-        try:
-            return json.dumps(sanitized, indent=2, default=str)
-        except (TypeError, ValueError):
-            return "{}"
-    
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Sub-Agent Namespace Routing (Phase 2.3)
-    # ─────────────────────────────────────────────────────────────────────────────
-    
+    # ── Identity / Resume Helpers ─────────────────────────────────────────
+
+    def resolve_run_id(self, run_id: str) -> str:
+        return self._tool_call_id_capture.resolve(run_id)
+
+    def rebuild_index_from_persisted_status(self) -> None:
+        """Reconstruct proto-derivable indexes from persisted status."""
+        self.state = ExecutionState.rebuild_from_proto(self.state.proto)
+
+    def prepare_task_tool_resume_queue(self) -> int:
+        return sub_agent_handlers.prepare_task_tool_resume_queue(self)
+
+    # ── Sub-Agent Delegations ─────────────────────────────────────────────
+
+    async def _handle_sub_agent_start(self, event: dict[str, Any],
+                                     tool_args: dict[str, Any], run_id: str,
+                                     *, tool_call_id: str | None = None) -> None:
+        await sub_agent_handlers.handle_sub_agent_start(
+            self, event, tool_args, run_id, tool_call_id=tool_call_id,
+        )
+
+    def _flush_pending_completions(self) -> list[str]:
+        return sub_agent_handlers.flush_pending_completions(self)
+
+    def _handle_sub_agent_end(self, event: dict[str, Any], run_id: str) -> None:
+        sub_agent_handlers.handle_sub_agent_end(self, event, run_id)
+
+    @property
+    def has_orphaned_sub_agents(self) -> bool:
+        return bool(self.state.active_sub_agents)
+
+    def get_orphaned_sub_agents_diagnostic(self) -> dict:
+        return sub_agent_handlers.get_orphaned_diagnostic(self)
+
+    def finalize_active_sub_agents(self, status: SubAgentStatus, error: str) -> None:
+        sub_agent_handlers.finalize_active(self, status, error)
+
+    def finalize_active_sub_agents_differentiated(self, error_context: str) -> int:
+        return sub_agent_handlers.finalize_active_differentiated(self, error_context)
+
+    def finalize_sub_agents_from_checkpoint_validation(
+        self, missed_event_count: int, confirmed_orphan_count: int,
+        error_context: str,
+    ) -> int:
+        return sub_agent_handlers.finalize_from_checkpoint_validation(
+            self, missed_event_count, confirmed_orphan_count, error_context,
+        )
+
+    # ── Context Delegations ───────────────────────────────────────────────
+
+    def set_resolved_context(self, environment_keys: list[str],
+                             mcp_servers: dict[str, tuple[bool, str, int]],
+                             skill_names: list[str],
+                             excluded_skill_names: list[str] | None = None) -> None:
+        context_handlers.set_resolved_context(
+            self, environment_keys, mcp_servers, skill_names, excluded_skill_names,
+        )
+
+    def initialize_context_info(self, context_window_limit: int,
+                                trigger_threshold: int, target_tokens: int,
+                                enabled: bool) -> None:
+        context_handlers.initialize_context_info(
+            self, context_window_limit, trigger_threshold, target_tokens, enabled,
+        )
+
+    def on_summarization_complete(self, event: SummarizationEventData) -> None:
+        context_handlers.on_summarization_complete(self, event)
+
+    def on_token_count_updated(self, token_count: int) -> None:
+        context_handlers.on_token_count_updated(self, token_count)
+
+    def finalize_context_info(self) -> None:
+        context_handlers.finalize_context_info(self)
+
+    def add_artifact(self, artifact: ExecutionArtifact) -> None:
+        context_handlers.add_artifact(self, artifact)
+
+    def add_workspace_write_back(self, wb) -> None:
+        context_handlers.add_workspace_write_back(self, wb)
+
+    # ── Namespace Routing ─────────────────────────────────────────────────
+
     def _get_execution_context(self, namespace: str) -> tuple[Any, SubAgentExecution | None]:
-        """
-        Determine execution context based on namespace.
-        
-        Root-level events (namespace == "") route to main agent status.
-        Sub-agent events (namespace != "") route to the corresponding SubAgentExecution.
-        
-        Args:
-            namespace: LangGraph checkpoint namespace string
-            
-        Returns:
-            Tuple of (container, sub_agent_or_none):
-            - Root events: (self.current_status, None)
-            - Sub-agent events: (sub_agent, sub_agent)
-        """
+        """Determine execution context based on namespace."""
         if not namespace:
             return self.current_status, None
-        
-        # Try to find matching sub-agent by namespace
+
         sub_agent_id = self.state.namespace_to_sub_agent.get(namespace)
         if sub_agent_id:
             if sub_agent_id in self.state.active_sub_agents:
-                return self.state.active_sub_agents[sub_agent_id], self.state.active_sub_agents[sub_agent_id]
-
-            # Late-arriving event: the sub-agent already completed but
-            # LangGraph emitted one more event (e.g. on_chat_model_end
-            # finalizing a message that was streamed before completion).
+                sa = self.state.active_sub_agents[sub_agent_id]
+                return sa, sa
             if sub_agent_id in self.state.completed_sub_agents:
                 self.logger.debug(
                     f"[SUBAGENT] execution={self.execution_id} "
                     f"late event routed to completed sub-agent={sub_agent_id} "
                     f"namespace={namespace}"
                 )
-                return self.state.completed_sub_agents[sub_agent_id], self.state.completed_sub_agents[sub_agent_id]
+                sa = self.state.completed_sub_agents[sub_agent_id]
+                return sa, sa
 
-        # Namespace not yet registered — fall back to main agent.
-        # Single-segment namespaces (no "|") are normal main-agent graph
-        # activity (e.g., the tools node).  Only warn for multi-segment
-        # namespaces, which indicate sub-agent events that should have
-        # been routed.  Deduplicate: warn once per unique namespace.
         if "|" in namespace and namespace not in self.state.warned_namespaces:
             self.state.warned_namespaces.add(namespace)
             self.logger.warning(
@@ -1290,30 +380,13 @@ class StatusBuilder:
                 f"falling back to main agent context"
             )
         return self.current_status, None
-    
+
     def _register_sub_agent_namespace(
         self, namespace: str, event: dict[str, Any],
     ) -> None:
-        """Register namespace -> sub-agent mapping via ``parent_ids``.
-
-        v2 ``astream_events`` carry a ``parent_ids`` list tracing the full
-        callback chain.  When a sub-agent event arrives, at least one entry
-        in ``parent_ids`` is the task tool's ``run_id`` — the same key stored
-        in ``_active_sub_agents``.  This provides a deterministic mapping
-        without heuristics (no root-prefix, no FIFO queue, no substring
-        matching, no sole-active fallback).
-
-        Single-segment namespaces (no ``|``) are from the main agent's graph
-        nodes and are intentionally not registered.
-
-        Args:
-            namespace: LangGraph checkpoint namespace string.
-            event: The full v2 astream_events event dict (carries
-                ``parent_ids`` at the top level).
-        """
+        """Register namespace -> sub-agent mapping via ``parent_ids``."""
         if not namespace or namespace in self.state.namespace_to_sub_agent:
             return
-
         if "|" not in namespace:
             return
 
@@ -1342,119 +415,3 @@ class StatusBuilder:
             list(self.state.active_sub_agents.keys()),
             list(self.state.completed_sub_agents.keys()),
         )
-    
-    async def _handle_sub_agent_start(self, event: dict[str, Any],
-                                     tool_args: dict[str, Any], run_id: str,
-                                     *, tool_call_id: str | None = None) -> None:
-        """Delegate to :func:`sub_agent_handlers.handle_sub_agent_start`."""
-        await sub_agent_handlers.handle_sub_agent_start(
-            self, event, tool_args, run_id, tool_call_id=tool_call_id,
-        )
-
-    def _flush_pending_completions(self) -> list[str]:
-        """Delegate to :func:`sub_agent_handlers.flush_pending_completions`."""
-        return sub_agent_handlers.flush_pending_completions(self)
-
-    def _handle_sub_agent_end(self, event: dict[str, Any], run_id: str) -> None:
-        """Delegate to :func:`sub_agent_handlers.handle_sub_agent_end`."""
-        sub_agent_handlers.handle_sub_agent_end(self, event, run_id)
-
-    @property
-    def has_orphaned_sub_agents(self) -> bool:
-        """True when sub-agents remain active after the event stream ended."""
-        return bool(self.state.active_sub_agents)
-
-    def get_orphaned_sub_agents_diagnostic(self) -> dict:
-        """Delegate to :func:`sub_agent_handlers.get_orphaned_diagnostic`."""
-        return sub_agent_handlers.get_orphaned_diagnostic(self)
-
-    def finalize_active_sub_agents(self, status: SubAgentStatus, error: str) -> None:
-        """Delegate to :func:`sub_agent_handlers.finalize_active`."""
-        sub_agent_handlers.finalize_active(self, status, error)
-
-    def finalize_active_sub_agents_differentiated(self, error_context: str) -> int:
-        """Delegate to :func:`sub_agent_handlers.finalize_active_differentiated`."""
-        return sub_agent_handlers.finalize_active_differentiated(self, error_context)
-
-    def finalize_sub_agents_from_checkpoint_validation(
-        self, missed_event_count: int, confirmed_orphan_count: int,
-        error_context: str,
-    ) -> int:
-        """Delegate to :func:`sub_agent_handlers.finalize_from_checkpoint_validation`."""
-        return sub_agent_handlers.finalize_from_checkpoint_validation(
-            self, missed_event_count, confirmed_orphan_count, error_context,
-        )
-
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Usage Metrics (Phase 3 — delegated to UsageTracker)
-    # ─────────────────────────────────────────────────────────────────────────────
-    
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Resolved Execution Context (Phase 2.5)
-    #
-    # Captures what resources the agent had access to at execution time.
-    # This is set once after all resources are resolved, before streaming begins.
-    # ─────────────────────────────────────────────────────────────────────────────
-    
-    def build_pending_approvals_snapshot(self) -> list[PendingApproval]:
-        """Build pending_approvals snapshot for the Temporal slim status.
-
-        This is a point-in-time coordination signal for the Temporal workflow,
-        NOT a DB-persisted projection.  The DB projection is computed
-        server-side by Go/Java ``ComputePendingApprovals`` on every
-        ``UpdateStatus`` write (DD-001).
-
-        The Temporal workflow uses this snapshot to determine how many
-        approval signals to collect before re-invoking the Python activity.
-        Reading from the DB is unsafe because the ``SubmitApproval`` handler
-        may have already recorded decisions (mutating the DB projection)
-        before the workflow reads it.
-        """
-        result: list[PendingApproval] = []
-        for tc in self.iter_all_tool_calls():
-            if (
-                tc.status == ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
-                and tc.requires_approval
-                and tc.approval_action
-                == ApprovalAction.APPROVAL_ACTION_UNSPECIFIED
-            ):
-                result.append(PendingApproval(tool_call_id=tc.id))
-        return result
-
-    def set_resolved_context(self, environment_keys: list[str],
-                             mcp_servers: dict[str, tuple[bool, str, int]],
-                             skill_names: list[str],
-                             excluded_skill_names: list[str] | None = None) -> None:
-        """Delegate to :func:`context_handlers.set_resolved_context`."""
-        context_handlers.set_resolved_context(
-            self, environment_keys, mcp_servers, skill_names, excluded_skill_names,
-        )
-
-    def initialize_context_info(self, context_window_limit: int,
-                                trigger_threshold: int, target_tokens: int,
-                                enabled: bool) -> None:
-        """Delegate to :func:`context_handlers.initialize_context_info`."""
-        context_handlers.initialize_context_info(
-            self, context_window_limit, trigger_threshold, target_tokens, enabled,
-        )
-
-    def on_summarization_complete(self, event: SummarizationEventData) -> None:
-        """Delegate to :func:`context_handlers.on_summarization_complete`."""
-        context_handlers.on_summarization_complete(self, event)
-
-    def on_token_count_updated(self, token_count: int) -> None:
-        """Delegate to :func:`context_handlers.on_token_count_updated`."""
-        context_handlers.on_token_count_updated(self, token_count)
-
-    def finalize_context_info(self) -> None:
-        """Delegate to :func:`context_handlers.finalize_context_info`."""
-        context_handlers.finalize_context_info(self)
-
-    def add_artifact(self, artifact: ExecutionArtifact) -> None:
-        """Delegate to :func:`context_handlers.add_artifact`."""
-        context_handlers.add_artifact(self, artifact)
-
-    def add_workspace_write_back(self, wb) -> None:
-        """Delegate to :func:`context_handlers.add_workspace_write_back`."""
-        context_handlers.add_workspace_write_back(self, wb)
-    

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -12,27 +12,11 @@ from collections.abc import Callable, Coroutine, Iterator
 from datetime import datetime
 from typing import Any
 
-from worker.activities.graphton.execution_state import ExecutionState
-from worker.activities.graphton.handlers import (
-    chat_model as chat_model_handlers,
-    context as context_handlers,
-    formatting,
-    streaming_buffers,
-    sub_agent as sub_agent_handlers,
-    tool_event as tool_event_handlers,
-)
-from worker.activities.graphton.handlers.sub_agent import (
-    _MAX_SUBJECT_LENGTH,
-    _generate_sub_agent_subject,
-)
-from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
-
 from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
 from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
 from ai.stigmer.agentic.agentexecution.v1.enum_pb2 import (
     ApprovalAction,
     ExecutionPhase,
-    MessageType,
     SubAgentStatus,
     ToolCallStatus,
 )
@@ -44,12 +28,34 @@ from ai.stigmer.agentic.agentexecution.v1.subagent_pb2 import SubAgentExecution
 from graphton.core.summarization_callback import SummarizationEventData
 
 from worker.activities.graphton.approval_policy import ApprovalConfig
+from worker.activities.graphton.execution_state import ExecutionState
+from worker.activities.graphton.handlers import (
+    chat_model as chat_model_handlers,
+)
+from worker.activities.graphton.handlers import (
+    context as context_handlers,
+)
+from worker.activities.graphton.handlers import (
+    formatting,
+    streaming_buffers,
+)
+from worker.activities.graphton.handlers import (
+    sub_agent as sub_agent_handlers,
+)
+from worker.activities.graphton.handlers import (
+    tool_event as tool_event_handlers,
+)
+from worker.activities.graphton.handlers.sub_agent import (  # noqa: F401
+    _MAX_SUBJECT_LENGTH,
+    _generate_sub_agent_subject,
+)
+from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 from worker.activities.graphton.usage_tracker import UsageTracker
-from worker.config import Config
 
 # ---------------------------------------------------------------------------
 # Backward-compatible re-exports (tests and internal callers import from here)
 # ---------------------------------------------------------------------------
+
 PLANNING_TOOLS = tool_event_handlers.PLANNING_TOOLS
 _MAX_STATUS_RESULT_CHARS: int = tool_event_handlers._MAX_STATUS_RESULT_CHARS
 _READ_ONLY_TOOLS = tool_event_handlers._READ_ONLY_TOOLS

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -714,6 +714,16 @@ class StatusBuilder:
         if isinstance(namespace, tuple):
             namespace = ":".join(str(x) for x in namespace)
         
+        # Register namespace -> sub-agent mapping for EVERY event type.
+        # _register_sub_agent_namespace is idempotent (returns immediately
+        # for already-registered or single-segment namespaces), so calling
+        # it universally is safe and cheap.  This ensures that namespace
+        # variants arriving via on_chat_model_stream, on_tool_end, etc.
+        # are registered before _get_execution_context performs its exact
+        # lookup in the type-specific handler.
+        if namespace:
+            self._register_sub_agent_namespace(namespace)
+        
         # Route by event type.  Each handler is wrapped so a single bad
         # event never crashes the entire activity stream.
         handler: (
@@ -814,14 +824,6 @@ class StatusBuilder:
             return
 
         self.tool_call_fingerprints.add(fingerprint)
-
-        # Register namespace early — before any special-case handlers — so
-        # that PLANNING_TOOLS and task-tool handlers can distinguish sub-agent
-        # events from main-agent events via _get_execution_context().
-        # _register_sub_agent_namespace is idempotent (returns immediately
-        # for already-registered or single-segment namespaces).
-        if namespace:
-            self._register_sub_agent_namespace(namespace)
 
         # Handle planning tools
         if tool_name in PLANNING_TOOLS:
@@ -3031,29 +3033,74 @@ class StatusBuilder:
             "mid_execution": mid_execution,
         }
 
+    def _flush_pending_completions(self) -> list[str]:
+        """Immediately drain all pending completion flushes.
+
+        Sub-agents whose ``on_tool_end`` fired (and were moved to
+        ``_completed_sub_agents`` with COMPLETED status) may still be
+        sitting in the deferred flush queue.  Draining them before crash
+        finalization ensures their COMPLETED status is included in the
+        next gRPC update rather than being silently dropped.
+
+        Returns:
+            List of run_ids that were flushed.
+        """
+        if not self._pending_completion_flush:
+            return []
+
+        flushed = list(self._pending_completion_flush.keys())
+        self._pending_completion_flush.clear()
+        if flushed:
+            self.force_next_update = True
+        return flushed
+
     def finalize_active_sub_agents(self, status: SubAgentStatus, error: str) -> None:
-        """Transition all active sub-agents to a terminal state.
+        """Transition active sub-agents to a terminal state.
 
         Called when the parent execution terminates abnormally (error or stall)
         to ensure no sub-agent remains stuck in IN_PROGRESS.
+
+        Sub-agents that already reached a terminal status (COMPLETED, FAILED,
+        or CANCELLED) — for example because their ``on_tool_end`` fired but
+        the deferred completion flush hadn't drained yet — are preserved.
+        Only genuinely in-progress sub-agents receive the forced status.
 
         Args:
             status: Terminal status to assign (typically SUB_AGENT_FAILED or
                     SUB_AGENT_CANCELLED).
             error: Explanation of why the sub-agent was terminated.
         """
+        flushed = self._flush_pending_completions()
+        if flushed:
+            self.logger.info(
+                f"[SUBAGENT] execution={self.execution_id} "
+                f"flushed {len(flushed)} pending completion(s) before "
+                f"finalization: {flushed}"
+            )
+
         if not self._active_sub_agents:
             return
 
         now = _utc_timestamp()
         finalized_ids: list[str] = []
+        preserved_ids: list[str] = []
+
+        terminal_statuses = {
+            SubAgentStatus.SUB_AGENT_COMPLETED,
+            SubAgentStatus.SUB_AGENT_FAILED,
+            SubAgentStatus.SUB_AGENT_CANCELLED,
+        }
 
         for run_id, sub_agent in list(self._active_sub_agents.items()):
-            sub_agent.status = status
-            sub_agent.error = error
-            sub_agent.completed_at = now
+            if sub_agent.status in terminal_statuses or sub_agent.output:
+                preserved_ids.append(run_id)
+            else:
+                sub_agent.status = status
+                sub_agent.error = error
+                sub_agent.completed_at = now
+                finalized_ids.append(run_id)
+
             self._completed_sub_agents[run_id] = sub_agent
-            finalized_ids.append(run_id)
 
         self._active_sub_agents.clear()
 
@@ -3062,6 +3109,12 @@ class StatusBuilder:
             f"finalized {len(finalized_ids)} active sub-agent(s) "
             f"-> {SubAgentStatus.Name(status)}: {finalized_ids}"
         )
+        if preserved_ids:
+            self.logger.info(
+                f"[SUBAGENT] execution={self.execution_id} "
+                f"preserved {len(preserved_ids)} sub-agent(s) with "
+                f"existing terminal status or output: {preserved_ids}"
+            )
 
     def finalize_active_sub_agents_differentiated(self, error_context: str) -> int:
         """Transition active sub-agents using differentiated statuses.
@@ -3070,6 +3123,9 @@ class StatusBuilder:
         ``SUB_AGENT_CANCELLED``; sub-agents with messages or tool calls
         (mid-execution) receive ``SUB_AGENT_FAILED``.
 
+        Sub-agents that already reached a terminal status or have produced
+        output are preserved — their existing status is not overwritten.
+
         Args:
             error_context: High-level description of why termination occurred
                 (e.g. "Parent execution terminated abnormally").
@@ -3077,43 +3133,69 @@ class StatusBuilder:
         Returns:
             Number of sub-agents finalized.
         """
+        flushed = self._flush_pending_completions()
+        if flushed:
+            self.logger.info(
+                f"[SUBAGENT] execution={self.execution_id} "
+                f"flushed {len(flushed)} pending completion(s) before "
+                f"differentiated finalization: {flushed}"
+            )
+
         if not self._active_sub_agents:
             return 0
 
         now = _utc_timestamp()
         cancelled_ids: list[str] = []
         failed_ids: list[str] = []
+        preserved_ids: list[str] = []
+
+        terminal_statuses = {
+            SubAgentStatus.SUB_AGENT_COMPLETED,
+            SubAgentStatus.SUB_AGENT_FAILED,
+            SubAgentStatus.SUB_AGENT_CANCELLED,
+        }
 
         for run_id, sub_agent in list(self._active_sub_agents.items()):
-            tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
-            has_activity = len(sub_agent.messages) > 0
-            if has_activity:
-                sub_agent.status = SubAgentStatus.SUB_AGENT_FAILED
-                sub_agent.error = (
-                    f"{error_context}: sub-agent was running "
-                    f"({len(sub_agent.messages)} messages, "
-                    f"{tc_count} tool calls)"
-                )
-                failed_ids.append(run_id)
+            if sub_agent.status in terminal_statuses or sub_agent.output:
+                preserved_ids.append(run_id)
             else:
-                sub_agent.status = SubAgentStatus.SUB_AGENT_CANCELLED
-                sub_agent.error = (
-                    f"{error_context}: sub-agent was spawned but never began execution"
-                )
-                cancelled_ids.append(run_id)
+                tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
+                has_activity = len(sub_agent.messages) > 0
+                if has_activity:
+                    sub_agent.status = SubAgentStatus.SUB_AGENT_FAILED
+                    sub_agent.error = (
+                        f"{error_context}: sub-agent was running "
+                        f"({len(sub_agent.messages)} messages, "
+                        f"{tc_count} tool calls)"
+                    )
+                    failed_ids.append(run_id)
+                else:
+                    sub_agent.status = SubAgentStatus.SUB_AGENT_CANCELLED
+                    sub_agent.error = (
+                        f"{error_context}: sub-agent was spawned but never began execution"
+                    )
+                    cancelled_ids.append(run_id)
 
-            sub_agent.completed_at = now
+                sub_agent.completed_at = now
+
             self._completed_sub_agents[run_id] = sub_agent
 
         total = len(self._active_sub_agents)
         self._active_sub_agents.clear()
 
+        finalized = len(cancelled_ids) + len(failed_ids)
         self.logger.info(
             f"[SUBAGENT] execution={self.execution_id} "
-            f"finalized {total} orphaned sub-agent(s) — "
+            f"finalized {finalized}/{total} orphaned sub-agent(s) — "
             f"CANCELLED (zero-message): {cancelled_ids}, "
             f"FAILED (mid-execution): {failed_ids}"
         )
+        if preserved_ids:
+            self.logger.info(
+                f"[SUBAGENT] execution={self.execution_id} "
+                f"preserved {len(preserved_ids)} sub-agent(s) with "
+                f"existing terminal status or output: {preserved_ids}"
+            )
         return total
 
     def finalize_sub_agents_from_checkpoint_validation(
@@ -3151,6 +3233,8 @@ class StatusBuilder:
         Returns:
             Number of sub-agents finalized.
         """
+        self._flush_pending_completions()
+
         if not self._active_sub_agents:
             return 0
 

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -6,16 +6,17 @@ Status is returned to the Temporal workflow, which orchestrates persistence
 via Java activity (polyglot pattern).
 """
 
-import hashlib
 import inspect
 import json
 import logging
 import time
-from collections import deque
 from collections.abc import Callable, Coroutine, Iterator
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 
 from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
 from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
@@ -316,6 +317,7 @@ class StatusBuilder:
         execution_id: str,
         initial_status: Any,
         approval_config: ApprovalConfig | None = None,
+        tool_call_id_capture: "ToolCallIdCapture | None" = None,
     ):
         """
         Initialize status builder.
@@ -326,6 +328,9 @@ class StatusBuilder:
             approval_config: Optional approval policy configuration. When provided,
                            tools matching approval policies will be set to
                            WAITING_APPROVAL status instead of RUNNING.
+            tool_call_id_capture: Callback handler that captures {run_id → tool_call_id}
+                from the LangChain callback API. Used for identity-based dedup on the
+                resume path.
         """
         self.execution_id = execution_id
         self.current_status = initial_status
@@ -334,9 +339,10 @@ class StatusBuilder:
         # Approval policy configuration (HITL Phase 2)
         # When set, tool calls are checked against policies before execution
         self._approval_config = approval_config
-        
-        # Track tool calls for deduplication
-        self.tool_call_fingerprints: set = set()
+
+        # Callback handler that maps LangGraph tool run_id → model tool_call_id.
+        # Used for identity-based resume dedup in _handle_tool_start_event.
+        self._tool_call_id_capture = tool_call_id_capture
         
         # In-memory index from tool_call_id to the ToolCall proto reference
         # inside a message's repeated field.  Mutations via these references
@@ -468,31 +474,15 @@ class StatusBuilder:
         #
         # On the resume path, LangGraph generates fresh run_ids for resumed
         # tools, but the StatusBuilder already holds the original tool call
-        # (with the original run_id) from the previous invocation.  Fingerprint
-        # deduplication in _handle_tool_start_event correctly prevents a
-        # duplicate ToolCall, but the new run_id is lost — so on_tool_end
-        # cannot find the existing tool call to mark it COMPLETED.
+        # (with the original tool_call_id) from the previous invocation.
+        # Identity-based dedup in _handle_tool_start_event detects the
+        # duplicate via ToolCallIdCapture, but the new run_id must still
+        # reach the existing ToolCall on on_tool_end / on_tool_progress.
         #
         # _run_id_aliases maps {new_run_id -> original_tool_call_id} so that
-        # on_tool_end and on_tool_progress can resolve the alias and update
-        # the correct tool call.
-        #
-        # _fingerprint_to_tool_call_id maps {fingerprint -> tool_call.id} and
-        # is populated by populate_fingerprints_from_existing_tool_calls().
-        # It allows the deduplication check to discover which existing tool
-        # call a duplicate fingerprint belongs to.
+        # _resolve_run_id() can bridge the gap.
         # ─────────────────────────────────────────────────────────────────────────
         self._run_id_aliases: dict[str, str] = {}
-        self._fingerprint_to_tool_call_id: dict[str, str] = {}
-
-        # Resume-aware dedup: tool calls recently reconciled from WAITING_APPROVAL
-        # to RUNNING by ResumeReconciler.  Keyed by tool_name → deque of
-        # tool_call_ids (FIFO order preserves match ordering when the same tool
-        # appears multiple times).  Consumed by _handle_tool_start_event as a
-        # fallback when fingerprint dedup fails (fingerprints are computed from
-        # display args in populate_fingerprints but raw args in the event, which
-        # can diverge due to humanization).
-        self._reconciled_resume_tool_calls: dict[str, deque[str]] = {}
 
         # ─────────────────────────────────────────────────────────────────────────
         # Execution Artifacts Tracking (Artifact Lifecycle)
@@ -763,67 +753,32 @@ class StatusBuilder:
         
         tool_args = self._unwrap_tool_args(tool_args_raw)
         
-        # Check for duplicate.
+        # Identity-based resume dedup.
         # On the resume-after-approval path, LangGraph re-fires on_tool_start
-        # for resumed tools with a NEW run_id.  The fingerprint matches an
-        # existing entry (populated by populate_fingerprints_from_existing_tool_calls),
-        # so we correctly skip creating a duplicate ToolCall.  However, the
-        # subsequent on_tool_end event carries this new run_id and must be able
-        # to find the original ToolCall.  We record a run-ID alias so that
-        # _resolve_run_id() can bridge the gap.
-        fingerprint = self._get_tool_fingerprint(tool_name, tool_args)
-        if fingerprint in self.tool_call_fingerprints:
-            original_tc_id = self._fingerprint_to_tool_call_id.get(fingerprint)
-            if original_tc_id and run_id != original_tc_id:
-                self._run_id_aliases[run_id] = original_tc_id
-                # Keep the FIFO queue in sync: remove the matched entry so
-                # the fallback doesn't retain stale slots that could capture
-                # genuinely new tool calls with the same tool name.
-                resume_queue = self._reconciled_resume_tool_calls.get(tool_name)
-                if resume_queue:
-                    try:
-                        resume_queue.remove(original_tc_id)
-                    except ValueError:
-                        pass
+        # for resumed tools with a NEW run_id.  The ToolCallIdCapture callback
+        # handler maps that run_id to the model's stable tool_call_id, which
+        # is already indexed from the prior cycle (via rebuild_index_from_persisted_status).
+        # We register a run-ID alias so on_tool_end / on_tool_progress can find
+        # the existing ToolCall, then return early (dedup).
+        tool_call_id = (
+            self._tool_call_id_capture.get(run_id)
+            if self._tool_call_id_capture is not None
+            else None
+        )
+        if tool_call_id:
+            existing = self._tool_call_index.get(tool_call_id)
+            if existing is not None and not existing.is_streaming:
+                if run_id != tool_call_id:
+                    self._run_id_aliases[run_id] = tool_call_id
                 self.logger.info(
-                    f"[RESUME_ALIAS] execution={self.execution_id} "
-                    f"tool={tool_name} new_run_id={run_id} -> "
-                    f"original_tc_id={original_tc_id} "
-                    f"(fingerprint dedup on resume path)"
+                    "[IDENTITY_DEDUP] execution=%s tool=%s run_id=%s -> "
+                    "existing_tc=%s (resume path, alias only)",
+                    self.execution_id, tool_name, run_id, tool_call_id,
                 )
-            # Task tools must NOT return here — the task handler below
-            # manages sub-agent lifecycle (reactivation on resume,
-            # SubAgentExecution creation on first run).  The alias set
-            # above is sufficient for the dedup; control falls through.
-            if tool_name != "task":
-                return
-
-        # Fallback: resume-aware dedup for reconciled tool calls.
-        # Fingerprint dedup above uses raw event args, but
-        # populate_fingerprints_from_existing_tool_calls computes from
-        # humanized display args stored in the proto Struct.  When
-        # _humanize_args_for_display transforms values (e.g. platform refs,
-        # env var resolution), the fingerprints diverge and the primary
-        # check above misses the match.  This fallback uses the explicit
-        # reconciled-tool registry populated by ResumeReconciler.
-        #
-        # Task tools are excluded: their lifecycle is managed by the task
-        # handler below via _reconcile_early_tool_call + _handle_sub_agent_start.
-        resume_queue = self._reconciled_resume_tool_calls.get(tool_name)
-        if resume_queue and tool_name != "task":
-            original_tc_id = resume_queue.popleft()
-            self._run_id_aliases[run_id] = original_tc_id
-            self.tool_call_fingerprints.add(fingerprint)
-            self._fingerprint_to_tool_call_id[fingerprint] = original_tc_id
-            self.logger.info(
-                f"[RESUME_ALIAS] execution={self.execution_id} "
-                f"tool={tool_name} new_run_id={run_id} -> "
-                f"original_tc_id={original_tc_id} "
-                f"(reconciled resume fallback)"
-            )
-            return
-
-        self.tool_call_fingerprints.add(fingerprint)
+                # Task tools fall through to the sub-agent lifecycle handler
+                # below; all other tools are fully deduped.
+                if tool_name != "task":
+                    return
 
         # Handle planning tools
         if tool_name in PLANNING_TOOLS:
@@ -1116,7 +1071,7 @@ class StatusBuilder:
         # On the resume path, LangGraph assigns a new run_id to the resumed
         # tool execution.  The existing ToolCall was created in a previous
         # invocation with its original run_id.  _handle_tool_start_event
-        # recorded an alias when fingerprint deduplication fired; resolve it
+        # recorded an alias when identity-based dedup fired; resolve it
         # here so we can find and update the correct ToolCall.
         # ─────────────────────────────────────────────────────────────────────
         resolved_id = self._resolve_run_id(run_id)
@@ -1648,21 +1603,14 @@ class StatusBuilder:
             return args["input"]
         return args
     
-    def _get_tool_fingerprint(self, tool_name: str, tool_args: dict[str, Any]) -> str:
-        """Create fingerprint for deduplication."""
-        fingerprint_data = f"{tool_name}:{json.dumps(tool_args, sort_keys=True)}"
-        return hashlib.sha256(fingerprint_data.encode()).hexdigest()
-    
-    def populate_fingerprints_from_existing_tool_calls(self) -> None:
-        """Pre-populate fingerprints and the in-memory index from persisted messages.
+    def rebuild_index_from_persisted_status(self) -> None:
+        """Rebuild ``_tool_call_index`` from persisted messages.
 
-        On the resume-after-approval path, the StatusBuilder is initialized with
-        the DB-persisted status that already contains tool calls embedded in
-        messages.  LangGraph may re-fire ``on_tool_start`` events for resumed
-        tools; pre-populating fingerprints prevents duplicate entries.
-
-        Also rebuilds ``_tool_call_index`` so that all subsequent lookups work
-        against the message-embedded references.
+        On the resume-after-approval path, the StatusBuilder is initialized
+        with the DB-persisted status that already contains tool calls embedded
+        in messages.  This method walks those messages and re-populates the
+        in-memory index so that ``get_tool_call`` and ``iter_all_tool_calls``
+        resolve correctly for the subsequent stream cycle.
         """
         def _index_tool_calls(messages: Any) -> None:
             for message in messages:
@@ -1671,14 +1619,6 @@ class StatusBuilder:
                 for i, tc in enumerate(message.tool_calls):
                     if tc.id:
                         self._tool_call_index[tc.id] = message.tool_calls[i]
-                    try:
-                        args_dict: dict[str, Any] = dict(tc.args) if tc.args else {}
-                        fingerprint = self._get_tool_fingerprint(tc.name, args_dict)
-                        self.tool_call_fingerprints.add(fingerprint)
-                        if tc.id:
-                            self._fingerprint_to_tool_call_id[fingerprint] = tc.id
-                    except Exception:
-                        pass
 
         _index_tool_calls(self.current_status.messages)
 
@@ -1709,7 +1649,7 @@ class StatusBuilder:
         ``_reconcile_early_tool_call`` pops the first match; any leftover
         entry is harmless.
 
-        Must be called **after** ``populate_fingerprints_from_existing_tool_calls``
+        Must be called **after** ``rebuild_index_from_persisted_status``
         (which builds ``_tool_call_index``) and **before** the stream starts.
 
         Returns the number of task tool calls queued.
@@ -1997,11 +1937,10 @@ class StatusBuilder:
         alias so that downstream handlers (``on_tool_end``, ``tool_progress``)
         resolve to the same proto.
 
-        On the **resume path**, a TC from the prior cycle is re-queued by
-        ``_create_early_tool_call`` (it already has args, approval status,
-        etc.).  In that case only the run_id alias is registered — the
-        existing state is preserved to avoid overwriting approval decisions
-        that were already recorded.
+        On the **resume path**, a TC from the prior cycle may be re-queued
+        by ``_create_early_tool_call``.  In that case only the run_id alias
+        is registered — existing state is preserved to avoid overwriting
+        approval decisions already recorded.
 
         Returns the reconciled ToolCall, or ``None`` if no match exists.
         """
@@ -2025,8 +1964,6 @@ class StatusBuilder:
             is_resume_requeue = not existing.is_streaming
             if is_resume_requeue:
                 self._run_id_aliases[run_id] = temp_id
-                fingerprint = self._get_tool_fingerprint(tool_name, tool_args)
-                self._fingerprint_to_tool_call_id[fingerprint] = temp_id
                 self.logger.info(
                     "[RECONCILE] execution=%s resume-path reconciliation: "
                     "tool=%s run_id=%s -> existing_tc=%s "
@@ -2068,9 +2005,6 @@ class StatusBuilder:
             self._tool_start_times[run_id] = self._tool_start_times.pop(
                 temp_id, datetime.utcnow()
             )
-
-            fingerprint = self._get_tool_fingerprint(tool_name, tool_args)
-            self._fingerprint_to_tool_call_id[fingerprint] = temp_id
 
             if approval.requires_approval:
                 self._set_waiting_for_approval_phase(tool_name, run_id)

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -16,6 +16,18 @@ from typing import Any
 from uuid import uuid4
 
 from worker.activities.graphton.execution_state import ExecutionState
+from worker.activities.graphton.handlers import (
+    chat_model as chat_model_handlers,
+    context as context_handlers,
+    formatting,
+    streaming_buffers,
+    sub_agent as sub_agent_handlers,
+    tool_event as tool_event_handlers,
+)
+from worker.activities.graphton.handlers.sub_agent import (
+    _MAX_SUBJECT_LENGTH,
+    _generate_sub_agent_subject,
+)
 from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 
 from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
@@ -65,119 +77,6 @@ from worker.config import Config
 
 _logger = logging.getLogger(__name__)
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Sub-Agent Subject Generation
-#
-# Generates a concise task title for sub-agent executions using an economy-tier
-# LLM. Follows the same pattern as session subject generation in
-# generate_session_subject.py.
-# ─────────────────────────────────────────────────────────────────────────────
-
-_MAX_SUBJECT_LENGTH = 50
-
-_SUBJECT_SYSTEM_PROMPT = """\
-You are a task title generator. Given a task description delegated to a \
-sub-agent, produce a concise task title.
-
-Rules:
-- 3 to 7 words, maximum 50 characters
-- Lead with the most specific differentiator — the directory, file, module, \
-or unique aspect. Put shared/common context last.
-  Good: "apis/ protobuf Cloud Resource types"
-  Bad:  "Research Cloud Resource protobuf definitions"
-- If the description mentions a specific path or directory, include it
-- Be specific (e.g. "Fix auth middleware tests" not "Fix tests")
-- No filler words ("help with", "please", "I need", "research", "explore")
-- The title MUST be unique — it must NOT duplicate any of the existing titles \
-listed below. Focus on what makes THIS task different from the others.
-- No quotes, no punctuation at the end
-- Output ONLY the title, nothing else"""
-
-
-async def _generate_sub_agent_subject(
-    input_text: str,
-    sub_agent_name: str,
-    existing_subjects: list[str] | None = None,
-) -> str:
-    """Generate a concise task title for a sub-agent from its input prompt.
-
-    Uses ``ModelRegistry.get_summarization_model()`` to select the cheapest
-    available model (claude-haiku-4.5 / gpt-4o-mini / same model for Ollama),
-    keeping costs negligible even with many sub-agent invocations per execution.
-
-    When *existing_subjects* is provided (non-empty), the LLM is instructed to
-    produce a title that does not duplicate any of them, ensuring visual
-    differentiation in the UI.
-
-    Returns the generated subject (stripped, truncated to 50 chars), or an
-    empty string on any failure so callers can fall back gracefully.
-    """
-    if not input_text:
-        return ""
-
-    try:
-        worker_config = Config.load_from_env()
-        economy_model = ModelRegistry.get_summarization_model(
-            worker_config.llm.model_name
-        )
-
-        llm_kwargs: dict = {}
-        if worker_config.llm.provider == "ollama":
-            llm_kwargs["base_url"] = worker_config.llm.base_url
-        elif worker_config.llm.provider in ("anthropic", "openai"):
-            llm_kwargs["api_key"] = worker_config.llm.api_key
-
-        model = parse_model_string(
-            economy_model,
-            max_tokens=100,
-            temperature=0.7,
-            **llm_kwargs,
-        )
-
-        truncated_input = input_text[:2000] if len(input_text) > 2000 else input_text
-
-        existing_block = ""
-        if existing_subjects:
-            titles = "\n".join(f"- {s}" for s in existing_subjects)
-            existing_block = (
-                f"\nExisting titles (do NOT repeat these):\n{titles}\n"
-            )
-
-        user_prompt = (
-            f'Sub-agent type: {sub_agent_name}\n'
-            f'{existing_block}\n'
-            f'Task description:\n"{truncated_input}"\n\n'
-            f'Generate the title:'
-        )
-
-        response = await model.ainvoke([
-            SystemMessage(content=_SUBJECT_SYSTEM_PROMPT),
-            HumanMessage(content=user_prompt),
-        ])
-
-        content = response.content
-        if not isinstance(content, str):
-            content = (
-                "".join(str(part) for part in content)
-                if isinstance(content, list)
-                else str(content)
-            )
-        subject = content.strip().strip('"').strip("'")
-
-        if subject and len(subject) > _MAX_SUBJECT_LENGTH:
-            subject = subject[:_MAX_SUBJECT_LENGTH - 3] + "..."
-
-        return subject or ""
-
-    except Exception:
-        _logger.debug(
-            "Sub-agent subject generation failed (non-critical), "
-            "falling back to empty subject",
-            exc_info=True,
-        )
-        return ""
-
-
 # Planning tools that update execution state without UI display
 PLANNING_TOOLS = {
     'write_todos',
@@ -189,94 +88,15 @@ PLANNING_TOOLS = {
 # (see graphton.core.tool_wrappers._MAX_TOOL_OUTPUT_CHARS).
 _MAX_STATUS_RESULT_CHARS: int = 50_000
 
-# Maps tool names to the arg field(s) that contain the bulk displayable content
-# (ordered by priority).  Used by the input-streaming extractor to pull clean
-# content from the accumulating partial JSON and pipe it into tool_call.result.
-# Tools not listed here either generate tiny args (< 1 s) or have no meaningful
-# content to stream — they are left with an empty result during the early phase.
-_TOOL_CONTENT_FIELDS: dict[str, list[str]] = {
-    "write":          ["contents", "content", "file_content"],
-    "write_file":     ["contents", "content", "file_content"],
-    "create_file":    ["contents", "content", "file_content"],
-    "overwrite_file": ["contents", "content", "file_content"],
-    "edit":           ["new_text", "new_string", "replacement", "content"],
-    "edit_file":      ["new_text", "new_string", "replacement", "content"],
-    "think":          ["thought"],
-}
+_TOOL_CONTENT_FIELDS = streaming_buffers._TOOL_CONTENT_FIELDS
 
 # Read-only tools whose result content is replaced with a size-only placeholder
 # in the persisted state.  The file path is already in tc.args; full content
 # lives in the LangGraph checkpoint DB if ever needed.
 _READ_ONLY_TOOLS: set[str] = {"read", "read_file"}
 
-# JSON escape → Python character mapping (single-char sequences).
-_JSON_ESCAPES: dict[str, str] = {
-    "n": "\n", "t": "\t", "r": "\r",
-    '"': '"', "\\": "\\", "/": "/",
-    "b": "\b", "f": "\f",
-}
-
-
-def _find_json_string_value_start(partial_json: str, field_name: str) -> int:
-    """Return the index of the first content character of a JSON string value.
-
-    Searches *partial_json* for ``"<field_name>"`` followed by ``:`` and ``"``,
-    skipping optional whitespace.  Returns the index immediately after the
-    opening quote, or ``-1`` if the pattern has not yet appeared.
-
-    Robust against missing whitespace (``"key":"val"``) and extra whitespace
-    (``"key" :  "val"``).
-    """
-    marker = f'"{field_name}"'
-    pos = partial_json.find(marker)
-    if pos < 0:
-        return -1
-    after_key = pos + len(marker)
-    colon_pos = partial_json.find(":", after_key)
-    if colon_pos < 0:
-        return -1
-    quote_pos = partial_json.find('"', colon_pos + 1)
-    if quote_pos < 0:
-        return -1
-    return quote_pos + 1
-
-
-def _json_unescape_partial(s: str) -> str:
-    """Unescape a partial JSON string value.
-
-    Converts standard JSON escape sequences (``\\n``, ``\\t``, ``\\"``, etc.)
-    to their Python equivalents.  Processing stops at the closing ``"`` (end of
-    JSON string) or at the end of the input (string is still being generated).
-
-    A trailing backslash with no following character is silently dropped to
-    avoid showing a garbled escape that is not yet complete.
-    """
-    out: list[str] = []
-    i = 0
-    n = len(s)
-    while i < n:
-        ch = s[i]
-        if ch == "\\":
-            if i + 1 >= n:
-                break  # incomplete escape at boundary — drop it
-            nxt = s[i + 1]
-            if nxt == "u":
-                if i + 5 < n:
-                    try:
-                        out.append(chr(int(s[i + 2 : i + 6], 16)))
-                        i += 6
-                        continue
-                    except ValueError:
-                        pass
-                break  # incomplete \\uXXXX — wait for more data
-            out.append(_JSON_ESCAPES.get(nxt, nxt))
-            i += 2
-        elif ch == '"':
-            break  # end of JSON string value
-        else:
-            out.append(ch)
-            i += 1
-    return "".join(out)
+_find_json_string_value_start = streaming_buffers._find_json_string_value_start
+_json_unescape_partial = streaming_buffers._json_unescape_partial
 
 
 def _utc_timestamp(dt: datetime | None = None) -> str:
@@ -447,31 +267,6 @@ class StatusBuilder:
             return True
         return False
 
-    def build_pending_approvals_snapshot(self) -> list[PendingApproval]:
-        """Build pending_approvals snapshot for the Temporal slim status.
-
-        This is a point-in-time coordination signal for the Temporal workflow,
-        NOT a DB-persisted projection.  The DB projection is computed
-        server-side by Go/Java ``ComputePendingApprovals`` on every
-        ``UpdateStatus`` write (DD-001).
-
-        The Temporal workflow uses this snapshot to determine how many
-        approval signals to collect before re-invoking the Python activity.
-        Reading from the DB is unsafe because the ``SubmitApproval`` handler
-        may have already recorded decisions (mutating the DB projection)
-        before the workflow reads it.
-        """
-        result: list[PendingApproval] = []
-        for tc in self.iter_all_tool_calls():
-            if (
-                tc.status == ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
-                and tc.requires_approval
-                and tc.approval_action
-                == ApprovalAction.APPROVAL_ACTION_UNSPECIFIED
-            ):
-                result.append(PendingApproval(tool_call_id=tc.id))
-        return result
-
     async def process_event(self, event: dict[str, Any]) -> None:
         """
         Process astream_events v2 event and update local status.
@@ -531,189 +326,8 @@ class StatusBuilder:
                 )
     
     async def _handle_tool_start_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Handle on_tool_start event - updates local status."""
-        tool_name = event.get("name", "")
-        tool_args_raw = event.get("data", {}).get("input", {})
-        run_id = event.get("run_id", "")
-        
-        if not tool_name or not run_id:
-            return
-        
-        tool_args = self._unwrap_tool_args(tool_args_raw)
-        
-        # Identity-based resume dedup.
-        # On the resume-after-approval path, LangGraph re-fires on_tool_start
-        # for resumed tools with a NEW run_id.  The ToolCallIdCapture callback
-        # handler maps that run_id to the model's stable tool_call_id, which
-        # is already indexed from the prior cycle (via rebuild_index_from_persisted_status).
-        # We register a run-ID alias so on_tool_end / on_tool_progress can find
-        # the existing ToolCall, then return early (dedup).
-        tool_call_id = self._tool_call_id_capture.get(run_id)
-        if tool_call_id:
-            existing = self.state.tool_calls.get(tool_call_id)
-            if existing is not None and not existing.is_streaming:
-                if run_id != tool_call_id:
-                    self._tool_call_id_capture.register_alias(run_id, tool_call_id)
-                self.logger.info(
-                    "[IDENTITY_DEDUP] execution=%s tool=%s run_id=%s -> "
-                    "existing_tc=%s (resume path, alias only)",
-                    self.execution_id, tool_name, run_id, tool_call_id,
-                )
-                # Task tools fall through to the sub-agent lifecycle handler
-                # below; all other tools are fully deduped.
-                if tool_name != "task":
-                    return
-
-        # Handle planning tools
-        if tool_name in PLANNING_TOOLS:
-            if tool_name == "write_todos":
-                todos_data = tool_args.get("todos", [])
-                if not todos_data:
-                    return
-                _, sub_agent = self._get_execution_context(namespace)
-                if sub_agent is not None:
-                    self._update_sub_agent_todos(sub_agent, todos_data)
-                else:
-                    self._update_todos(todos_data)
-            return
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Sub-Agent Detection (Phase 2.3): "task" tool invokes a sub-agent
-        #
-        # Reconcile the early ToolCall (created from the tool_use stream
-        # block) so it persists in the parent AI message — this is the slot
-        # the frontend uses to render SubAgentSection.  Extract the
-        # tool_call_id so SubAgentExecution.id matches ToolCall.id.
-        # ─────────────────────────────────────────────────────────────────────
-        if tool_name == "task":
-            tool_call_id: str | None = None
-            early_tc = self._reconcile_early_tool_call(tool_name, run_id, tool_args, namespace)
-            if early_tc is not None:
-                tool_call_id = early_tc.id
-            else:
-                # No early ToolCall (e.g. checkpoint replay where the stream
-                # did not re-emit tool_use blocks).  Create one now so the
-                # frontend has a tool call slot for the sub-agent.
-                ns_key = namespace or ""
-                display_args = self._humanize_args_for_display(tool_args) if tool_args else {}
-                args_struct = Struct()
-                if display_args:
-                    args_struct.update(display_args)
-                now = datetime.utcnow()
-                tool_call = ToolCall(
-                    id=run_id,
-                    name=tool_name,
-                    args=args_struct,
-                    args_preview=self._create_args_preview(tool_args),
-                    result="",
-                    status=ToolCallStatus.TOOL_CALL_RUNNING,
-                    component_metadata=ComponentMetadata(
-                        component_type=infer_component_type(tool_name),
-                        component_group="main-agent-tools",
-                    ),
-                    started_at=_utc_timestamp(now),
-                )
-                parent_ai = self._ensure_parent_ai_message(ns_key, namespace)
-                parent_ai.tool_calls.append(tool_call)
-                self.state.tool_calls[run_id] = parent_ai.tool_calls[-1]
-                tool_call_id = run_id
-
-            await self._handle_sub_agent_start(event, tool_args, run_id, tool_call_id=tool_call_id)
-            return
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Early Tool Call Reconciliation (Live Write Streaming UX)
-        #
-        # If _create_early_tool_call already created a ToolCall for this
-        # invocation (from a tool_use stream block), reconcile it: populate
-        # args, register the real run_id alias, and handle approval — then
-        # return without creating a duplicate.
-        # ─────────────────────────────────────────────────────────────────────
-        early_tc = self._reconcile_early_tool_call(tool_name, run_id, tool_args, namespace)
-        if early_tc is not None:
-            # The index holds a reference INTO the message's repeated field,
-            # so _reconcile_early_tool_call already mutated the message copy.
-            return
-        
-        # Create component metadata
-        component_type = infer_component_type(tool_name)
-        component_metadata = ComponentMetadata(
-            component_type=component_type,
-            component_group="main-agent-tools",
-        )
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Approval Check (HITL Phase 2): Check if tool requires user approval
-        # ─────────────────────────────────────────────────────────────────────
-        approval_requirement = self._check_tool_approval_requirement(tool_name, tool_args)
-        
-        # Create tool call with appropriate initial status
-        # If approval required: WAITING_APPROVAL, otherwise: RUNNING
-        display_args = self._humanize_args_for_display(tool_args) if tool_args else {}
-        args_struct = Struct()
-        if display_args:
-            args_struct.update(display_args)
-        
-        now = datetime.utcnow()
-        initial_status = (
-            ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
-            if approval_requirement.requires_approval
-            else ToolCallStatus.TOOL_CALL_RUNNING
-        )
-        
-        mcp_server_slug = ""
-        if self._approval_config is not None:
-            mcp_server_slug = self._approval_config.get_mcp_server_for_tool(tool_name)
-        
-        tool_call = ToolCall(
-            id=run_id,
-            name=tool_name,
-            args=args_struct,
-            args_preview=self._create_args_preview(tool_args),
-            result="",
-            status=initial_status,
-            component_metadata=component_metadata,
-            started_at=_utc_timestamp(now),
-            mcp_server_slug=mcp_server_slug,
-        )
-        
-        # If approval required, populate approval fields on the ToolCall
-        if approval_requirement.requires_approval:
-            rendered_message = render_approval_message(
-                template=approval_requirement.message,
-                tool_name=tool_name,
-                tool_args=tool_args,
-            )
-            tool_call.requires_approval = True
-            tool_call.approval_message = rendered_message
-            tool_call.approval_requested_at = _utc_timestamp(now)
-        
-        # Track start time for duration calculation (even for approval-pending tools)
-        self.state.tool_start_times[run_id] = now
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Namespace-Based Routing (Phase 2.3): Route to correct execution context
-        # ─────────────────────────────────────────────────────────────────────
-        context, sub_agent = self._get_execution_context(namespace)
-        ns_key = namespace or ""
-        
-        # Determine context info for logging
-        status_name = ToolCallStatus.Name(initial_status)
-        
-        # Attach tool call to the parent AI message — the single source of
-        # truth.  The in-memory _tool_call_index provides O(1) lookup by ID.
-        parent_ai = self._ensure_parent_ai_message(ns_key, namespace)
-        parent_ai.tool_calls.append(tool_call)
-        self.state.tool_calls[run_id] = parent_ai.tool_calls[-1]
-        
-        context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
-        self.logger.debug(
-            f"[TOOL] execution={self.execution_id} {context_desc} "
-            f"tool={tool_name} run_id={run_id} status={status_name}"
-        )
-        
-        if approval_requirement.requires_approval:
-            self._set_waiting_for_approval_phase(tool_name, run_id)
+        """Delegate to :func:`tool_event_handlers.handle_tool_start`."""
+        await tool_event_handlers.handle_tool_start(self, event, namespace)
     
     def _ensure_parent_ai_message(
         self,
@@ -775,135 +389,12 @@ class StatusBuilder:
         return managed
 
     def _handle_tool_progress_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Handle on_custom_event with name='tool_progress'.
-        
-        Appends a progress chunk to the ToolCall's result field and sets
-        is_streaming=True. This enables live output streaming for tools
-        that support progressive output (e.g., execute/shell stdout).
-        
-        The run_id is read from the event-level field (same as on_tool_start/
-        on_tool_end) — NOT from the data payload. dispatch_custom_event called
-        within a @tool function inherits the tool's run context, so the run_id
-        automatically matches.
-        
-        Expected event structure:
-            {
-                "event": "on_custom_event",
-                "name": "tool_progress",
-                "run_id": str,           # Inherited from tool's run context
-                "data": {"chunk": str},  # Partial output to append
-            }
-        """
-        run_id = event.get("run_id", "")
-        chunk = event.get("data", {}).get("chunk", "")
-        
-        if not run_id or not chunk:
-            return
-
-        chunk = humanize_sandbox_paths(chunk, self._workspace_root)
-
-        # Resolve run-ID alias (resume-after-approval path)
-        resolved_id = self._tool_call_id_capture.resolve(run_id)
-        
-        tool_call = self.get_tool_call(resolved_id)
-        if tool_call is None:
-            self.logger.debug(
-                f"[TOOL_PROGRESS] execution={self.execution_id} "
-                f"run_id={run_id} resolved_id={resolved_id} "
-                f"ignored (tool call not found)"
-            )
-            return
-        
-        was_streaming = tool_call.is_streaming
-
-        current_len = len(tool_call.result)
-        if current_len < _MAX_STATUS_RESULT_CHARS:
-            remaining = _MAX_STATUS_RESULT_CHARS - current_len
-            tool_call.result += chunk[:remaining]
-            if len(chunk) > remaining:
-                tool_call.result += "\n[output truncated for display]"
-        tool_call.is_streaming = True
-
-        if not was_streaming:
-            self.force_next_update = True
-
-        self.logger.debug(
-            f"[TOOL_PROGRESS] execution={self.execution_id} "
-            f"run_id={run_id} resolved_id={resolved_id} "
-            f"chunk_len={len(chunk)} total_len={len(tool_call.result)}"
-        )
+        """Delegate to :func:`tool_event_handlers.handle_tool_progress`."""
+        tool_event_handlers.handle_tool_progress(self, event, namespace)
     
     def _handle_tool_end_event(self, event: dict[str, Any], namespace: str = "") -> None:
-        """Handle on_tool_end event - updates local status with COMPLETED status."""
-        tool_name = event.get("name", "")
-        run_id = event.get("run_id", "")
-        tool_result_raw = event.get("data", {}).get("output", "")
-        
-        if not run_id or tool_name in PLANNING_TOOLS:
-            return
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Sub-Agent Completion (Phase 2.3): task tool returns sub-agent result
-        # ─────────────────────────────────────────────────────────────────────
-        if tool_name == "task":
-            self._handle_sub_agent_end(event, run_id)
-            return
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Run-ID Alias Resolution (Resume-After-Approval Fix)
-        #
-        # On the resume path, LangGraph assigns a new run_id to the resumed
-        # tool execution.  The existing ToolCall was created in a previous
-        # invocation with its original run_id.  _handle_tool_start_event
-        # recorded an alias when identity-based dedup fired; resolve it
-        # here so we can find and update the correct ToolCall.
-        # ─────────────────────────────────────────────────────────────────────
-        resolved_id = self._tool_call_id_capture.resolve(run_id)
-        
-        tool_result_content = self._extract_tool_result_content(tool_result_raw)
-
-        if tool_name in _READ_ONLY_TOOLS:
-            persisted_result = f"[content omitted - {len(tool_result_content)} chars]"
-        elif len(tool_result_content) > _MAX_STATUS_RESULT_CHARS:
-            persisted_result = (
-                tool_result_content[:_MAX_STATUS_RESULT_CHARS]
-                + "\n[output truncated for display]"
-            )
-        else:
-            persisted_result = tool_result_content
-
-        persisted_result = humanize_sandbox_paths(
-            persisted_result, self._workspace_root,
-        )
-
-        now = datetime.utcnow()
-        
-        # Calculate execution duration if we tracked the start time
-        duration_ms = None
-        if run_id in self.state.tool_start_times:
-            start_time = self.state.tool_start_times.pop(run_id)
-            duration_ms = int((now - start_time).total_seconds() * 1000)
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Namespace-Based Routing: Update in correct execution context
-        # ─────────────────────────────────────────────────────────────────────
-        context, sub_agent = self._get_execution_context(namespace)
-        
-        completed_at = _utc_timestamp(now)
-
-        tool_call = self.get_tool_call(resolved_id)
-        if tool_call is not None:
-            tool_call.result = persisted_result
-            tool_call.status = ToolCallStatus.TOOL_CALL_COMPLETED
-            tool_call.completed_at = completed_at
-            tool_call.is_streaming = False
-        
-        context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
-        self.logger.debug(
-            f"[TOOL] execution={self.execution_id} {context_desc} "
-            f"tool={tool_name} run_id={run_id} resolved_id={resolved_id} "
-            f"status=COMPLETED duration_ms={duration_ms or 'N/A'}"
-        )
+        """Delegate to :func:`tool_event_handlers.handle_tool_end`."""
+        tool_event_handlers.handle_tool_end(self, event, namespace)
     
     def _handle_chat_model_stream_event(self, event: dict[str, Any], namespace: str = "") -> None:
         """Handle on_chat_model_stream event - updates local status."""
@@ -952,8 +443,8 @@ class StatusBuilder:
         # ─────────────────────────────────────────────────────────────────────
         if hasattr(chunk_data, "content") and isinstance(chunk_data.content, list):
             ns_key = namespace or ""
-            thinking_text = self._extract_thinking_content(chunk_data.content)
-            text_in_same_chunk = self._extract_string_content(chunk_data.content)
+            thinking_text = formatting.extract_thinking_content(chunk_data.content)
+            text_in_same_chunk = formatting.extract_string_content(chunk_data.content)
             
             # Diagnostic: log mixed chunks and empty extractions
             if thinking_text and text_in_same_chunk:
@@ -971,7 +462,7 @@ class StatusBuilder:
                     "thinking", "tool_use", "input_json_delta",
                 })
                 block_types = [
-                    self._block_attr(b, "type", type(b).__name__)
+                    formatting.block_attr(b, "type", type(b).__name__)
                     for b in chunk_data.content[:5]
                 ]
                 is_expected = (
@@ -995,9 +486,9 @@ class StatusBuilder:
             skip_early_tools = frozenset(PLANNING_TOOLS)
             for block in chunk_data.content:
                 try:
-                    if self._block_attr(block, "type") == "tool_use":
-                        t_name = self._block_attr(block, "name")
-                        t_id = self._block_attr(block, "id")
+                    if formatting.block_attr(block, "type") == "tool_use":
+                        t_name = formatting.block_attr(block, "name")
+                        t_id = formatting.block_attr(block, "id")
                         if t_name and t_name not in skip_early_tools:
                             self._create_early_tool_call(
                                 t_name, t_id, ns_key, namespace,
@@ -1015,10 +506,10 @@ class StatusBuilder:
             # render it progressively (same mechanism as thinking streaming).
             for block in chunk_data.content:
                 try:
-                    if self._block_attr(block, "type") == "input_json_delta":
-                        partial = self._block_attr(block, "partial_json")
+                    if formatting.block_attr(block, "type") == "input_json_delta":
+                        partial = formatting.block_attr(block, "partial_json")
                         if partial:
-                            self._accumulate_tool_input(ns_key, partial)
+                            streaming_buffers.accumulate_tool_input(self, ns_key, partial)
                 except Exception:
                     self.logger.exception(
                         f"[TOOL_INPUT_ERROR] execution={self.execution_id} "
@@ -1030,12 +521,12 @@ class StatusBuilder:
                     self.state.thinking.buffers.get(ns_key, "") + thinking_text
                 )
                 if ns_key not in self.state.thinking.tool_call_ids:
-                    self._start_thinking_stream(
+                    streaming_buffers.start_thinking_stream(self,
                         ns_key, namespace, self.state.thinking.buffers[ns_key],
                         llm_run_id=run_id,
                     )
                 else:
-                    self._update_thinking_stream(ns_key)
+                    streaming_buffers.update_thinking_stream(self, ns_key)
                 
                 if not text_in_same_chunk:
                     return
@@ -1049,7 +540,7 @@ class StatusBuilder:
             if isinstance(chunk_content, str):
                 token = chunk_content
             elif isinstance(chunk_content, list):
-                token = self._extract_string_content(chunk_content)
+                token = formatting.extract_string_content(chunk_content)
         
         if not token:
             return
@@ -1059,7 +550,7 @@ class StatusBuilder:
         # timeline before the AI message that follows it.
         ns_key = namespace or ""
         if self.state.thinking.buffers.get(ns_key):
-            self._flush_thinking_buffer(ns_key, namespace)
+            streaming_buffers.flush_thinking_buffer(self, ns_key, namespace)
         
         # ─────────────────────────────────────────────────────────────────────
         # run_id-Based Message Isolation
@@ -1157,7 +648,7 @@ class StatusBuilder:
         # (e.g. the model only produced thinking + tool_use, no text block).
         ns_key = namespace or ""
         if self.state.thinking.buffers.get(ns_key):
-            self._flush_thinking_buffer(ns_key, namespace)
+            streaming_buffers.flush_thinking_buffer(self, ns_key, namespace)
         
         # ─────────────────────────────────────────────────────────────────────
         # run_id-Based Message Resolution (with backwards-scan fallback)
@@ -1304,13 +795,13 @@ class StatusBuilder:
                 if isinstance(oc, str):
                     final_text = oc
                 elif isinstance(oc, list):
-                    final_text = self._extract_string_content(oc)
+                    final_text = formatting.extract_string_content(oc)
             elif isinstance(output_data, dict) and "content" in output_data:
                 oc = output_data["content"]
                 if isinstance(oc, str):
                     final_text = oc
                 elif isinstance(oc, list):
-                    final_text = self._extract_string_content(oc)
+                    final_text = formatting.extract_string_content(oc)
             
             streamed_text = ai_message.content
             if final_text and final_text != streamed_text:
@@ -1375,14 +866,6 @@ class StatusBuilder:
         to *run_id* unchanged.
         """
         return self._tool_call_id_capture.resolve(run_id)
-    
-    def _unwrap_tool_args(self, args: dict[str, Any]) -> dict[str, Any]:
-        """Unwrap LangGraph arg wrappers."""
-        if "kwargs" in args and isinstance(args["kwargs"], dict):
-            return args["kwargs"]
-        if "input" in args and isinstance(args["input"], dict) and len(args) == 1:
-            return args["input"]
-        return args
     
     def rebuild_index_from_persisted_status(self) -> None:
         """Reconstruct proto-derivable indexes from the persisted status.
@@ -1452,585 +935,24 @@ class StatusBuilder:
         return queued
 
     def _extract_tool_result_content(self, result: Any) -> str:
-        """Extract displayable content string from a tool result.
-
-        Handles the five result shapes that flow through LangGraph astream_events:
-        - str: Direct string results (most common for simple tools)
-        - LangGraph message objects (ToolMessage, AIMessage): Extract .content
-        - LangGraph Command objects: Extract ToolMessage content from .update
-        - dict: Extract from 'output'/'content' keys, or JSON-serialize
-        - list: Extract text from MCP content blocks, or JSON-serialize
-        """
-        if isinstance(result, str):
-            return result
-        # Handle LangGraph message objects (ToolMessage, AIMessage, etc.)
-        # Uses duck typing on .content to stay decoupled from langchain_core.
-        if hasattr(result, "content"):
-            content = result.content
-            if isinstance(content, str):
-                return content
-            if isinstance(content, list):
-                return self._extract_string_content(content)
-        # Handle LangGraph Command objects (returned after approval resume).
-        # When a tool goes through interrupt()/resume, on_tool_end may emit a
-        # Command object instead of the plain tool return value. The Command's
-        # .update dict contains state channel data; the "messages" channel holds
-        # ToolMessage objects with the human-readable result.
-        # Uses duck typing on .update to stay decoupled from langgraph.types.
-        # Once identified as a Command, we commit to extracting from it — even
-        # if the result is empty — rather than falling through to str(result)
-        # which would produce a useless repr string.
-        if hasattr(result, "update") and isinstance(getattr(result, "update", None), dict):
-            return self._extract_command_content(result.update)
-        if isinstance(result, dict):
-            if "output" in result:
-                return result.get("output", "")
-            if "content" in result:
-                return str(result["content"])
-            return json.dumps(result, indent=2)
-        if isinstance(result, list):
-            extracted = self._extract_string_content(result)
-            if extracted:
-                return extracted
-            try:
-                return json.dumps(result, indent=2, default=str)
-            except (TypeError, ValueError):
-                pass
-        self.logger.warning(
-            f"[TOOL] Unknown result type {type(result).__name__} for tool result "
-            f"extraction, falling back to str(). Preview: {str(result)[:200]}"
-        )
-        return str(result)
+        """Delegate to :func:`formatting.extract_tool_result_content`."""
+        return formatting.extract_tool_result_content(result)
     
-    def _format_tool_message_content(
-        self,
-        tool_name: str,
-        args: Struct | None,
-        result: str,
-    ) -> str:
-        """Format tool message content for CLI display.
-        
-        Creates a human-readable summary of the tool call for streaming display.
-        
-        Args:
-            tool_name: Name of the tool that was called
-            args: Tool arguments as Struct proto
-            result: Tool result string
-            
-        Returns:
-            Formatted string like "read(path='file.txt') -> 123 chars"
-        """
-        # Format arguments summary
-        args_summary = ""
-        if args:
-            try:
-                args_dict = dict(args.fields)
-                # Create compact args display (first arg only for brevity)
-                if args_dict:
-                    first_key = next(iter(args_dict))
-                    first_value = args_dict[first_key]
-                    # Get string value from protobuf Value
-                    if hasattr(first_value, 'string_value') and first_value.string_value:
-                        value_str = first_value.string_value
-                        # Truncate long values
-                        if len(value_str) > 40:
-                            value_str = value_str[:37] + "..."
-                        args_summary = f"{first_key}='{value_str}'"
-                    elif hasattr(first_value, 'number_value'):
-                        args_summary = f"{first_key}={first_value.number_value}"
-                    elif hasattr(first_value, 'bool_value'):
-                        args_summary = f"{first_key}={first_value.bool_value}"
-                    
-                    if len(args_dict) > 1:
-                        args_summary += f", +{len(args_dict) - 1} more"
-            except Exception:
-                # Fall back to empty args if parsing fails
-                pass
-        
-        # Format result summary
-        result_summary = ""
-        if result:
-            # Truncate long results
-            if len(result) > 100:
-                result_summary = f"{len(result)} chars"
-            else:
-                # Show short results directly
-                result_summary = result.replace('\n', ' ')[:80]
-        
-        # Build final message
-        if args_summary:
-            call_str = f"{tool_name}({args_summary})"
-        else:
-            call_str = f"{tool_name}()"
-        
-        if result_summary:
-            return f"{call_str} -> {result_summary}"
-        else:
-            return call_str
-    
-    @staticmethod
-    def _block_attr(block: Any, key: str, default: str = "") -> str:
-        """Read *key* from a content block regardless of whether it is a
-        ``dict`` or an object with attributes (e.g. a LangChain dataclass)."""
-        if isinstance(block, dict):
-            return block.get(key, default)
-        return getattr(block, key, default)
-
-    def _extract_string_content(self, content_blocks: list) -> str:
-        """Extract text from multimodal content blocks.
-
-        Handles both dict blocks (``{"type": "text", "text": "..."}``}) and
-        attribute-based objects (``block.type == "text"``).
-        """
-        text_parts: list[str] = []
-        for block in content_blocks:
-            if self._block_attr(block, "type") == "text":
-                text_parts.append(self._block_attr(block, "text"))
-        return "".join(text_parts)
-
-    def _extract_thinking_content(self, content_blocks: list) -> str:
-        """Extract thinking text from Anthropic extended-thinking content blocks.
-
-        Returns the concatenated thinking text from all blocks with
-        ``type: "thinking"``.  Returns an empty string when no thinking
-        blocks are present (non-Anthropic models, or text/tool_use chunks).
-
-        Handles both dict blocks and attribute-based objects.
-        """
-        parts: list[str] = []
-        for block in content_blocks:
-            if self._block_attr(block, "type") == "thinking":
-                parts.append(self._block_attr(block, "thinking"))
-        return "".join(parts)
-    
-    def _create_early_tool_call(
-        self,
-        tool_name: str,
-        tool_use_id: str,
-        ns_key: str,
-        namespace: str,
-        llm_run_id: str = "",
-    ) -> None:
-        """Create a ToolCall as soon as a ``tool_use`` block appears in the stream.
-
-        The CLI shows an idle "Thinking…" indicator when no events arrive
-        for ≥ 2 s.  While the LLM generates tool arguments (``input_json_delta``
-        chunks) the status builder has nothing to report, so the CLI falls
-        back to the idle indicator even though the model has already decided
-        to call a tool.
-
-        By creating the ToolCall here — before ``on_tool_start`` fires — the
-        CLI immediately displays the tool name with a running badge.  When
-        ``on_tool_start`` arrives, ``_handle_tool_start_event`` reconciles
-        the early ToolCall (populates args, registers the real run-ID alias)
-        instead of creating a duplicate.
-        """
-        if self.state.thinking.buffers.get(ns_key):
-            self._flush_thinking_buffer(ns_key, namespace)
-
-        temp_id = tool_use_id or f"early-{uuid4()}"
-
-        # On resume, LangGraph replays the AI message from the checkpoint.
-        # The replayed tool_use blocks carry the same tool_use_id, so the
-        # derived temp_id matches an existing ToolCall from the previous
-        # cycle.  Skip creation to avoid duplicate messages and tool calls.
-        #
-        # However, we MUST still enqueue the existing TC for reconciliation.
-        # When on_tool_start fires later, _reconcile_early_tool_call needs
-        # to find this entry so it can create a run_id alias to the correct
-        # Anthropic tool_call_id.  Without this, the task handler falls
-        # through to the run_id fallback, producing UUID-format IDs that
-        # diverge from the InjectedToolCallId in the interrupt payload.
-        if self._find_tool_call_by_id(temp_id) is not None:
-            _, sub_agent = self._get_execution_context(namespace)
-            sa_id = sub_agent.id if sub_agent else None
-            self.state.early_tool_call_queue.append((temp_id, sa_id))
-            self.logger.info(
-                "[RESUME_DEDUP] execution=%s skipping early tool call "
-                "creation for %s (id=%s already exists from prior cycle, "
-                "re-queued for reconciliation)",
-                self.execution_id, tool_name, temp_id,
-            )
-            return
-
-        mcp_server_slug = ""
-        if self._approval_config is not None:
-            mcp_server_slug = self._approval_config.get_mcp_server_for_tool(tool_name)
-
-        now = datetime.utcnow()
-        tool_call = ToolCall(
-            id=temp_id,
-            name=tool_name,
-            result="",
-            status=ToolCallStatus.TOOL_CALL_RUNNING,
-            is_streaming=True,
-            component_metadata=ComponentMetadata(
-                component_type=infer_component_type(tool_name),
-                component_group="main-agent-tools",
-            ),
-            started_at=_utc_timestamp(now),
-            mcp_server_slug=mcp_server_slug,
+    def _create_early_tool_call(self, tool_name: str, tool_use_id: str,
+                               ns_key: str, namespace: str,
+                               llm_run_id: str = "") -> None:
+        """Delegate to :func:`streaming_buffers.create_early_tool_call`."""
+        streaming_buffers.create_early_tool_call(
+            self, tool_name, tool_use_id, ns_key, namespace, llm_run_id,
         )
 
-        parent_ai = self._ensure_parent_ai_message(
-            ns_key, namespace, llm_run_id=llm_run_id,
+    def _reconcile_early_tool_call(self, tool_name: str, run_id: str,
+                                   tool_args: dict[str, Any],
+                                   namespace: str) -> ToolCall | None:
+        """Delegate to :func:`streaming_buffers.reconcile_early_tool_call`."""
+        return streaming_buffers.reconcile_early_tool_call(
+            self, tool_name, run_id, tool_args, namespace,
         )
-        parent_ai.tool_calls.append(tool_call)
-        self.state.tool_calls[temp_id] = parent_ai.tool_calls[-1]
-
-        _, sub_agent = self._get_execution_context(namespace)
-        sa_id = sub_agent.id if sub_agent else None
-        self.state.early_tool_call_queue.append((temp_id, sa_id))
-        self.state.tool_start_times[temp_id] = now
-
-        self.state.tool_input.active_tc[ns_key] = temp_id
-        self.state.tool_input.buffers[temp_id] = ""
-
-        self.force_next_update = True
-
-    def _reconcile_early_tool_call(
-        self,
-        tool_name: str,
-        run_id: str,
-        tool_args: dict[str, Any],
-        namespace: str,
-    ) -> ToolCall | None:
-        """Match an ``on_tool_start`` event to an early-created ToolCall.
-
-        Pops the first queued entry whose ToolCall name matches *tool_name*
-        and whose sub-agent context matches the current namespace.  This
-        prevents cross-contamination when concurrent sub-agents invoke the
-        same tool (e.g., two sub-agents both calling ``read_file``).
-
-        If found, the existing ToolCall is updated in place (args populated,
-        ``is_streaming`` cleared) and the real *run_id* is registered as an
-        alias so that downstream handlers (``on_tool_end``, ``tool_progress``)
-        resolve to the same proto.
-
-        On the **resume path**, a TC from the prior cycle may be re-queued
-        by ``_create_early_tool_call``.  In that case only the run_id alias
-        is registered — existing state is preserved to avoid overwriting
-        approval decisions already recorded.
-
-        Returns the reconciled ToolCall, or ``None`` if no match exists.
-        """
-        _, sub_agent = self._get_execution_context(namespace)
-        sa_id = sub_agent.id if sub_agent else None
-
-        for idx, (temp_id, queued_sa_id) in enumerate(self.state.early_tool_call_queue):
-            existing = self.get_tool_call(temp_id)
-            if existing is None or existing.name != tool_name:
-                continue
-            if queued_sa_id != sa_id:
-                continue
-
-            self.state.early_tool_call_queue.pop(idx)
-
-            # Resume path: TC from a prior cycle was re-queued by
-            # _create_early_tool_call's resume dedup.  The TC is fully
-            # populated (not streaming) and may already have an approval
-            # decision recorded.  Only register the run_id alias so
-            # downstream handlers route correctly.
-            is_resume_requeue = not existing.is_streaming
-            if is_resume_requeue:
-                self._tool_call_id_capture.register_alias(run_id, temp_id)
-                self.logger.info(
-                    "[RECONCILE] execution=%s resume-path reconciliation: "
-                    "tool=%s run_id=%s -> existing_tc=%s "
-                    "(alias only, preserving prior-cycle state)",
-                    self.execution_id, tool_name, run_id, temp_id,
-                )
-                return existing
-
-            self._flush_tool_input_buffer(temp_id)
-
-            existing.result = ""
-
-            if tool_args:
-                display_args = self._humanize_args_for_display(tool_args)
-                args_struct = Struct()
-                args_struct.update(display_args)
-                existing.args.CopyFrom(args_struct)
-                existing.args_preview = self._create_args_preview(tool_args)
-
-            existing.is_streaming = False
-
-            if self._approval_config is not None:
-                slug = self._approval_config.get_mcp_server_for_tool(tool_name)
-                if slug and not existing.mcp_server_slug:
-                    existing.mcp_server_slug = slug
-
-            approval = self._check_tool_approval_requirement(tool_name, tool_args)
-            if approval.requires_approval:
-                existing.status = ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
-                existing.requires_approval = True
-                existing.approval_message = render_approval_message(
-                    template=approval.message,
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                )
-                existing.approval_requested_at = _utc_timestamp(datetime.utcnow())
-
-            self._tool_call_id_capture.register_alias(run_id, temp_id)
-            self.state.tool_start_times[run_id] = self.state.tool_start_times.pop(
-                temp_id, datetime.utcnow()
-            )
-
-            if approval.requires_approval:
-                self._set_waiting_for_approval_phase(tool_name, run_id)
-
-            return existing
-
-        return None
-
-    def _start_thinking_stream(
-        self,
-        ns_key: str,
-        namespace: str,
-        initial_text: str,
-        llm_run_id: str = "",
-    ) -> None:
-        """Create a RUNNING ToolCall for native thinking and begin streaming.
-
-        Called when the first thinking content block arrives for a namespace.
-        The ToolCall starts with ``is_streaming=True`` and the initial thinking
-        text in ``result``.  Subsequent blocks update ``result`` via
-        ``_update_thinking_stream``, and ``_flush_thinking_buffer`` transitions
-        the ToolCall to COMPLETED when thinking ends.
-
-        During streaming the CLI renders ``result`` via ``renderStreamingTool``
-        (last N lines with a cursor indicator).  After completion the CLI reads
-        ``args.thought`` via ``resolveDisplayContent`` (the ``toolDisplayMap``
-        entry uses ``contentSourceInput``).
-        """
-        now = datetime.utcnow()
-        tc_id = f"think-native-{uuid4()}"
-
-        tool_call = ToolCall(
-            id=tc_id,
-            name="think",
-            args=Struct(),
-            result=initial_text,
-            status=ToolCallStatus.TOOL_CALL_RUNNING,
-            is_streaming=True,
-            component_metadata=ComponentMetadata(
-                component_type=infer_component_type("think"),
-                component_group="main-agent-tools",
-            ),
-            started_at=_utc_timestamp(now),
-        )
-
-        parent_ai = self._ensure_parent_ai_message(
-            ns_key, namespace, llm_run_id=llm_run_id,
-        )
-        parent_ai.tool_calls.append(tool_call)
-        self.state.tool_calls[tc_id] = parent_ai.tool_calls[-1]
-
-        self.state.thinking.tool_call_ids[ns_key] = tc_id
-        self.state.thinking.started_at[ns_key] = now
-
-        self.force_next_update = True
-
-        self.logger.debug(
-            "[THINK] execution=%s streaming_started id=%s namespace=%s",
-            self.execution_id,
-            tc_id,
-            namespace or "main",
-        )
-
-    def _update_thinking_stream(self, ns_key: str) -> None:
-        """Update the streaming think ToolCall with the latest accumulated content."""
-        tc_id = self.state.thinking.tool_call_ids.get(ns_key)
-        if not tc_id:
-            return
-
-        buf = self.state.thinking.buffers.get(ns_key, "")
-
-        tool_call = self.get_tool_call(tc_id)
-        if tool_call is not None:
-            tool_call.result = buf
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Tool Input Streaming Helpers
-    # ─────────────────────────────────────────────────────────────────────────
-
-    def _accumulate_tool_input(self, ns_key: str, partial_json: str) -> None:
-        """Accumulate an ``input_json_delta`` fragment and update the early ToolCall.
-
-        Appends *partial_json* to the buffer for the early ToolCall currently
-        active in this namespace.  If the accumulated JSON already contains the
-        tool's content field (e.g. ``"contents": "…``), the extracted value is
-        written to ``tool_call.result`` so the CLI can stream it progressively.
-
-        Follows the same pattern as ``_update_thinking_stream``: mutate
-        ``tool_call.result`` in place; the gRPC scheduler pushes the change
-        within ~500 ms and the CLI detects it via
-        ``tc.IsStreaming && tc.Result != prevResults``.
-        """
-        temp_id = self.state.tool_input.active_tc.get(ns_key)
-        if not temp_id:
-            return
-
-        buf = self.state.tool_input.buffers.get(temp_id)
-        if buf is None:
-            return
-
-        self.state.tool_input.buffers[temp_id] = buf + partial_json
-
-        tool_call = self.get_tool_call(temp_id)
-        if tool_call is None:
-            return
-
-        content = self._extract_content_from_partial_json(
-            tool_call.name, self.state.tool_input.buffers[temp_id],
-        )
-        if content:
-            tool_call.result = content
-
-    @staticmethod
-    def _extract_content_from_partial_json(
-        tool_name: str, partial_json: str,
-    ) -> str:
-        """Extract the displayable content value from an in-progress args JSON.
-
-        For tools listed in ``_TOOL_CONTENT_FIELDS`` (write, edit, think) the
-        method locates the content field's opening quote and JSON-unescapes
-        everything that has arrived so far.  Trailing incomplete escape
-        sequences are silently dropped to avoid garbled output.
-
-        Returns an empty string when the content field has not yet appeared in
-        the accumulated JSON (e.g. the LLM is still generating the ``path``
-        argument).
-        """
-        fields = _TOOL_CONTENT_FIELDS.get(tool_name)
-        if not fields:
-            return ""
-
-        for field in fields:
-            start = _find_json_string_value_start(partial_json, field)
-            if start >= 0:
-                return _json_unescape_partial(partial_json[start:])
-
-        return ""
-
-    def _flush_tool_input_buffer(self, temp_id: str) -> None:
-        """Clean up input-streaming state for a reconciled early ToolCall."""
-        self.state.tool_input.buffers.pop(temp_id, None)
-        for ns_key, tid in list(self.state.tool_input.active_tc.items()):
-            if tid == temp_id:
-                del self.state.tool_input.active_tc[ns_key]
-                break
-
-    def _flush_thinking_buffer(self, ns_key: str, namespace: str) -> None:
-        """Finalize the streaming think ToolCall or create a completed one.
-
-        If a streaming ToolCall exists (created by ``_start_thinking_stream``),
-        transitions it from RUNNING to COMPLETED in place: populates
-        ``args.thought`` with the full thinking text, sets ``result`` to
-        ``"ok"``, and clears the streaming flag.
-
-        Falls back to creating a new COMPLETED ToolCall from scratch if no
-        streaming ToolCall exists (defensive — should not happen in normal flow
-        since ``_start_thinking_stream`` is called on the first thinking block).
-        """
-        thinking_text = self.state.thinking.buffers.pop(ns_key, "")
-        started_at = self.state.thinking.started_at.pop(ns_key, None)
-        tc_id = self.state.thinking.tool_call_ids.pop(ns_key, None)
-        if not thinking_text:
-            return
-
-        now = datetime.utcnow()
-
-        args_struct = Struct()
-        args_struct.update({"thought": thinking_text})
-
-        _, sub_agent = self._get_execution_context(namespace)
-        completed_ts = _utc_timestamp(now)
-
-        if tc_id:
-            tool_call = self.get_tool_call(tc_id)
-            if tool_call is not None:
-                tool_call.args.CopyFrom(args_struct)
-                tool_call.result = "ok"
-                tool_call.status = ToolCallStatus.TOOL_CALL_COMPLETED
-                tool_call.is_streaming = False
-                tool_call.completed_at = completed_ts
-
-                self.logger.info(
-                    "[THINK] execution=%s streaming_completed id=%s "
-                    "chars=%d namespace=%s",
-                    self.execution_id,
-                    tc_id,
-                    len(thinking_text),
-                    namespace or "main",
-                )
-                return
-
-        # Defensive fallback: no streaming ToolCall exists.  Create a
-        # completed one from scratch so thinking content is never lost.
-        fallback_tc = ToolCall(
-            id=f"think-native-{uuid4()}",
-            name="think",
-            args=args_struct,
-            result="ok",
-            status=ToolCallStatus.TOOL_CALL_COMPLETED,
-            component_metadata=ComponentMetadata(
-                component_type=infer_component_type("think"),
-                component_group="main-agent-tools",
-            ),
-            started_at=_utc_timestamp(started_at or now),
-            completed_at=completed_ts,
-        )
-
-        parent_ai = self._ensure_parent_ai_message(ns_key, namespace)
-        parent_ai.tool_calls.append(fallback_tc)
-        self.state.tool_calls[fallback_tc.id] = parent_ai.tool_calls[-1]
-
-        self.logger.info(
-            "[THINK] execution=%s synthetic_think_tool_call "
-            "chars=%d namespace=%s (fallback)",
-            self.execution_id,
-            len(thinking_text),
-            namespace or "main",
-        )
-    
-    def _extract_command_content(self, update: dict[str, Any]) -> str:
-        """Extract displayable content from a LangGraph Command.update dict.
-
-        When a tool goes through the interrupt()/resume approval cycle,
-        LangGraph may wrap the result in a Command object whose .update dict
-        contains state channel mutations. The "messages" channel typically holds
-        ToolMessage objects with the human-readable tool result.
-
-        Extraction strategy:
-        1. Look in update["messages"] for ToolMessage-like objects with .content
-        2. Fall back to JSON-serializing the non-messages portion of the update
-
-        Returns an empty string if no meaningful content can be extracted.
-        """
-        messages = update.get("messages", [])
-        if isinstance(messages, list):
-            for msg in messages:
-                # Duck-type: ToolMessage has .content (str or list)
-                if hasattr(msg, "content"):
-                    content = msg.content
-                    if isinstance(content, str) and content:
-                        return content
-                    if isinstance(content, list):
-                        extracted = self._extract_string_content(content)
-                        if extracted:
-                            return extracted
-
-        # Fallback: serialize the update dict (excluding messages to avoid
-        # dumping ToolMessage repr objects back into the output).
-        fallback = {k: v for k, v in update.items() if k != "messages"}
-        if fallback:
-            try:
-                return json.dumps(fallback, indent=2, default=str)
-            except (TypeError, ValueError):
-                pass
-
-        return ""
     
     def _update_todos(self, todos_data: list) -> None:
         """Replace the todo snapshot in the local execution status.
@@ -2421,217 +1343,21 @@ class StatusBuilder:
             list(self.state.completed_sub_agents.keys()),
         )
     
-    async def _handle_sub_agent_start(
-        self,
-        event: dict[str, Any],
-        tool_args: dict[str, Any],
-        run_id: str,
-        *,
-        tool_call_id: str | None = None,
-    ) -> None:
-        """Handle task tool invocation — creates SubAgentExecution.
-
-        In deepagents' task tool, ``description`` is the full task prompt (the
-        only text parameter alongside ``subagent_type``).  We map it to
-        ``input`` and generate a concise ``subject`` via an economy-tier LLM.
-
-        The SubAgentExecution.id is set to *tool_call_id* (the Anthropic
-        ``tool_use`` id, e.g. ``toolu_XXXXX``) so the frontend can match it
-        against the ToolCall.id on the parent AI message.  The LangGraph
-        *run_id* is stored separately in ``_active_sub_agents`` for namespace
-        registration (which operates on run_ids from LangGraph events).
-
-        Args:
-            event: The on_tool_start event dictionary.
-            tool_args: Unwrapped tool arguments.
-            run_id: The LangGraph run_id for this tool invocation.
-            tool_call_id: The Anthropic tool_use id from the early ToolCall.
-                Falls back to *run_id* when unavailable.
-        """
-        sa_id = tool_call_id or run_id
-
-        # ── Resume deduplication ──────────────────────────────────────────
-        # On resume, LangGraph replays from checkpoint and re-fires
-        # on_tool_start for task tools.  Avoid creating duplicate
-        # SubAgentExecution entries.
-        for existing_sa in self.current_status.sub_agent_executions:
-            if existing_sa.id == sa_id:
-                self.state.active_sub_agents[run_id] = existing_sa
-                self.state.run_id_to_tool_call_id[run_id] = sa_id
-                self.logger.info(
-                    "[SUBAGENT] execution=%s resume reactivation: "
-                    "sa_id=%s run_id=%s (skipping duplicate creation)",
-                    self.execution_id, sa_id, run_id,
-                )
-                return
-
-        sub_agent_name = tool_args.get("subagent_type", "") or tool_args.get("agent_type", "") or "unknown"
-        sub_agent_input = (
-            tool_args.get("description", "")
-            or tool_args.get("input", "")
-            or tool_args.get("task", "")
-            or tool_args.get("prompt", "")
-        )
-        existing = list(self.state.subject_counts.keys())
-        subject = await _generate_sub_agent_subject(
-            sub_agent_input, sub_agent_name, existing_subjects=existing,
+    async def _handle_sub_agent_start(self, event: dict[str, Any],
+                                     tool_args: dict[str, Any], run_id: str,
+                                     *, tool_call_id: str | None = None) -> None:
+        """Delegate to :func:`sub_agent_handlers.handle_sub_agent_start`."""
+        await sub_agent_handlers.handle_sub_agent_start(
+            self, event, tool_args, run_id, tool_call_id=tool_call_id,
         )
 
-        if subject:
-            count = self.state.subject_counts.get(subject, 0) + 1
-            self.state.subject_counts[subject] = count
-            if count > 1:
-                suffix = f" ({count})"
-                max_base = _MAX_SUBJECT_LENGTH - len(suffix)
-                base = subject[:max_base] if len(subject) > max_base else subject
-                subject = base + suffix
+    def _flush_pending_completions(self) -> list[str]:
+        """Delegate to :func:`sub_agent_handlers.flush_pending_completions`."""
+        return sub_agent_handlers.flush_pending_completions(self)
 
-        now = datetime.utcnow()
-        sub_agent = SubAgentExecution(
-            id=sa_id,
-            name=sub_agent_name,
-            input=sub_agent_input,
-            subject=subject,
-            status=SubAgentStatus.SUB_AGENT_IN_PROGRESS,
-            started_at=_utc_timestamp(now),
-        )
-
-        # Append first, then store the proto-managed reference.
-        # Protobuf repeated-message append copies the value; the original
-        # object is disconnected from the proto.  By storing the element
-        # returned by the repeated field we ensure all later mutations
-        # (messages, tool_calls, usage) write to the actual status proto.
-        self.current_status.sub_agent_executions.append(sub_agent)
-        self.state.active_sub_agents[run_id] = self.current_status.sub_agent_executions[-1]
-        self.state.run_id_to_tool_call_id[run_id] = sa_id
-
-        self.force_next_update = True
-
-        self.logger.info(
-            f"[SUBAGENT] execution={self.execution_id} "
-            f"sub_agent={sub_agent_name} sa_id={sa_id} run_id={run_id} "
-            f"subject={subject!r} status=IN_PROGRESS"
-        )
-    
     def _handle_sub_agent_end(self, event: dict[str, Any], run_id: str) -> None:
-        """Handle task tool completion — finalize SubAgentExecution.
-
-        Uses ``_active_sub_agents[run_id]`` for a direct proto reference when
-        available, falling back to a linear scan by ``tool_call_id`` (the
-        SubAgentExecution.id) when the dict entry is missing.
-
-        Also marks the corresponding ToolCall on the parent AI message as
-        COMPLETED so the frontend shows the sub-agent as finished.
-
-        Args:
-            event: The on_tool_end event dictionary.
-            run_id: The LangGraph run_id for this task tool invocation.
-        """
-        output_raw = event.get("data", {}).get("output", "")
-        output = self._extract_tool_result_content(output_raw)
-        now = datetime.utcnow()
-
-        is_error = False
-        error_message = ""
-        if isinstance(output_raw, dict):
-            if output_raw.get("error") or output_raw.get("status") == "failed":
-                is_error = True
-                error_message = (
-                    output_raw.get("error", "")
-                    or output_raw.get("message", "Sub-agent failed")
-                )
-
-        # Prefer the direct proto reference from _active_sub_agents.
-        sub_agent_ref = self.state.active_sub_agents.get(run_id)
-        if sub_agent_ref is None:
-            # Fallback: scan by tool_call_id (SubAgentExecution.id)
-            sa_id = self.state.run_id_to_tool_call_id.get(run_id, run_id)
-            for sa in self.current_status.sub_agent_executions:
-                if sa.id == sa_id:
-                    sub_agent_ref = sa
-                    break
-
-        if sub_agent_ref is not None:
-            sub_agent_ref.output = output
-            sub_agent_ref.completed_at = _utc_timestamp(now)
-            if is_error:
-                sub_agent_ref.status = SubAgentStatus.SUB_AGENT_FAILED
-                sub_agent_ref.error = error_message
-            else:
-                sub_agent_ref.status = SubAgentStatus.SUB_AGENT_COMPLETED
-
-            self._finalize_orphaned_tool_calls(sub_agent_ref, now)
-
-            self.logger.debug(
-                "[SUBAGENT] execution=%s sa_id=%s run_id=%s status=%s",
-                self.execution_id, sub_agent_ref.id, run_id,
-                "FAILED" if is_error else "COMPLETED",
-            )
-        else:
-            self.logger.warning(
-                "[SUBAGENT] execution=%s _handle_sub_agent_end: "
-                "no SubAgentExecution found for run_id=%s "
-                "known_ids=%s",
-                self.execution_id, run_id,
-                [sa.id for sa in self.current_status.sub_agent_executions],
-            )
-
-        # Mark the parent ToolCall as COMPLETED so the frontend reflects
-        # the sub-agent's finished state.
-        tc_id = self.state.run_id_to_tool_call_id.get(run_id)
-        if tc_id:
-            parent_tc = self.get_tool_call(tc_id)
-            if parent_tc is not None:
-                parent_tc.status = ToolCallStatus.TOOL_CALL_COMPLETED
-                parent_tc.completed_at = _utc_timestamp(now)
-                parent_tc.result = output[:_MAX_STATUS_RESULT_CHARS] if output else ""
-
-        # Move from active to completed (preserving reference for late events).
-        # Namespace mappings are NOT deleted — late-arriving events from
-        # LangGraph can still route to the correct SubAgentExecution.
-        if run_id in self.state.active_sub_agents:
-            self.state.completed_sub_agents[run_id] = self.state.active_sub_agents.pop(run_id)
-
-        # Defer the gRPC flush instead of forcing it immediately.  Late
-        # LangGraph events (on_chat_model_end, on_tool_end for nested tools)
-        # arrive shortly after on_tool_end for "task".  The drain window
-        # lets them be batched into the same update that carries the
-        # COMPLETED status, preventing the UI from showing "Completed"
-        # while messages still stream in.
-        self.state.pending_completion_flush[run_id] = time.monotonic()
-
-    def _finalize_orphaned_tool_calls(
-        self, sub_agent: SubAgentExecution, now: datetime,
-    ) -> None:
-        """Transition orphaned WAITING_APPROVAL tool calls to SKIPPED.
-
-        When a sub-agent completes or fails, any tool calls still stuck in
-        WAITING_APPROVAL (with no recorded decision) are artifacts of the
-        InterruptProxy thread-restart mechanism — the sub-agent resumed on a
-        fresh LangGraph thread while the old thread's tool calls were never
-        resolved.  Leaving them in WAITING_APPROVAL causes ghost entries in
-        ``pending_approvals`` that can never be fulfilled.
-        """
-        timestamp = _utc_timestamp(now)
-        skipped = 0
-        for msg in sub_agent.messages:
-            for tc in msg.tool_calls:
-                if (
-                    tc.status == ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
-                    and tc.requires_approval
-                    and tc.approval_action == ApprovalAction.APPROVAL_ACTION_UNSPECIFIED
-                ):
-                    tc.status = ToolCallStatus.TOOL_CALL_SKIPPED
-                    tc.approval_action = ApprovalAction.APPROVAL_ACTION_SKIP
-                    tc.approval_decided_at = timestamp
-                    tc.result = "Auto-skipped: parent sub-agent finished"
-                    skipped += 1
-        if skipped:
-            self.logger.info(
-                "[SUBAGENT] execution=%s sa_id=%s "
-                "finalized %d orphaned WAITING_APPROVAL tool call(s)",
-                self.execution_id, sub_agent.id, skipped,
-            )
+        """Delegate to :func:`sub_agent_handlers.handle_sub_agent_end`."""
+        sub_agent_handlers.handle_sub_agent_end(self, event, run_id)
 
     @property
     def has_orphaned_sub_agents(self) -> bool:
@@ -2639,308 +1365,25 @@ class StatusBuilder:
         return bool(self.state.active_sub_agents)
 
     def get_orphaned_sub_agents_diagnostic(self) -> dict:
-        """Return structured info about orphaned (still-active) sub-agents.
-
-        Useful for logging and error messages when the graph terminates
-        abnormally while sub-agents are in progress.
-
-        Returns:
-            Dict with ``total``, ``zero_message`` (spawned but never
-            executed), ``mid_execution`` (have messages/tool calls),
-            and per-sub-agent ``details``.
-        """
-        zero_message: list[dict] = []
-        mid_execution: list[dict] = []
-
-        for run_id, sub_agent in self.state.active_sub_agents.items():
-            tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
-            has_activity = len(sub_agent.messages) > 0
-            entry = {
-                "run_id": run_id,
-                "subject": sub_agent.subject,
-                "message_count": len(sub_agent.messages),
-                "tool_call_count": tc_count,
-            }
-            if has_activity:
-                mid_execution.append(entry)
-            else:
-                zero_message.append(entry)
-
-        return {
-            "total": len(self.state.active_sub_agents),
-            "zero_message_count": len(zero_message),
-            "mid_execution_count": len(mid_execution),
-            "zero_message": zero_message,
-            "mid_execution": mid_execution,
-        }
-
-    def _flush_pending_completions(self) -> list[str]:
-        """Immediately drain all pending completion flushes.
-
-        Sub-agents whose ``on_tool_end`` fired (and were moved to
-        ``_completed_sub_agents`` with COMPLETED status) may still be
-        sitting in the deferred flush queue.  Draining them before crash
-        finalization ensures their COMPLETED status is included in the
-        next gRPC update rather than being silently dropped.
-
-        Returns:
-            List of run_ids that were flushed.
-        """
-        if not self.state.pending_completion_flush:
-            return []
-
-        flushed = list(self.state.pending_completion_flush.keys())
-        self.state.pending_completion_flush.clear()
-        if flushed:
-            self.force_next_update = True
-        return flushed
+        """Delegate to :func:`sub_agent_handlers.get_orphaned_diagnostic`."""
+        return sub_agent_handlers.get_orphaned_diagnostic(self)
 
     def finalize_active_sub_agents(self, status: SubAgentStatus, error: str) -> None:
-        """Transition active sub-agents to a terminal state.
-
-        Called when the parent execution terminates abnormally (error or stall)
-        to ensure no sub-agent remains stuck in IN_PROGRESS.
-
-        Sub-agents that already reached a terminal status (COMPLETED, FAILED,
-        or CANCELLED) — for example because their ``on_tool_end`` fired but
-        the deferred completion flush hadn't drained yet — are preserved.
-        Only genuinely in-progress sub-agents receive the forced status.
-
-        Args:
-            status: Terminal status to assign (typically SUB_AGENT_FAILED or
-                    SUB_AGENT_CANCELLED).
-            error: Explanation of why the sub-agent was terminated.
-        """
-        flushed = self._flush_pending_completions()
-        if flushed:
-            self.logger.info(
-                f"[SUBAGENT] execution={self.execution_id} "
-                f"flushed {len(flushed)} pending completion(s) before "
-                f"finalization: {flushed}"
-            )
-
-        if not self.state.active_sub_agents:
-            return
-
-        now = _utc_timestamp()
-        finalized_ids: list[str] = []
-        preserved_ids: list[str] = []
-
-        terminal_statuses = {
-            SubAgentStatus.SUB_AGENT_COMPLETED,
-            SubAgentStatus.SUB_AGENT_FAILED,
-            SubAgentStatus.SUB_AGENT_CANCELLED,
-        }
-
-        for run_id, sub_agent in list(self.state.active_sub_agents.items()):
-            if sub_agent.status in terminal_statuses or sub_agent.output:
-                preserved_ids.append(run_id)
-            else:
-                sub_agent.status = status
-                sub_agent.error = error
-                sub_agent.completed_at = now
-                finalized_ids.append(run_id)
-
-            self.state.completed_sub_agents[run_id] = sub_agent
-
-        self.state.active_sub_agents.clear()
-
-        self.logger.info(
-            f"[SUBAGENT] execution={self.execution_id} "
-            f"finalized {len(finalized_ids)} active sub-agent(s) "
-            f"-> {SubAgentStatus.Name(status)}: {finalized_ids}"
-        )
-        if preserved_ids:
-            self.logger.info(
-                f"[SUBAGENT] execution={self.execution_id} "
-                f"preserved {len(preserved_ids)} sub-agent(s) with "
-                f"existing terminal status or output: {preserved_ids}"
-            )
+        """Delegate to :func:`sub_agent_handlers.finalize_active`."""
+        sub_agent_handlers.finalize_active(self, status, error)
 
     def finalize_active_sub_agents_differentiated(self, error_context: str) -> int:
-        """Transition active sub-agents using differentiated statuses.
-
-        Zero-message sub-agents (spawned but never executed) receive
-        ``SUB_AGENT_CANCELLED``; sub-agents with messages or tool calls
-        (mid-execution) receive ``SUB_AGENT_FAILED``.
-
-        Sub-agents that already reached a terminal status or have produced
-        output are preserved — their existing status is not overwritten.
-
-        Args:
-            error_context: High-level description of why termination occurred
-                (e.g. "Parent execution terminated abnormally").
-
-        Returns:
-            Number of sub-agents finalized.
-        """
-        flushed = self._flush_pending_completions()
-        if flushed:
-            self.logger.info(
-                f"[SUBAGENT] execution={self.execution_id} "
-                f"flushed {len(flushed)} pending completion(s) before "
-                f"differentiated finalization: {flushed}"
-            )
-
-        if not self.state.active_sub_agents:
-            return 0
-
-        now = _utc_timestamp()
-        cancelled_ids: list[str] = []
-        failed_ids: list[str] = []
-        preserved_ids: list[str] = []
-
-        terminal_statuses = {
-            SubAgentStatus.SUB_AGENT_COMPLETED,
-            SubAgentStatus.SUB_AGENT_FAILED,
-            SubAgentStatus.SUB_AGENT_CANCELLED,
-        }
-
-        for run_id, sub_agent in list(self.state.active_sub_agents.items()):
-            if sub_agent.status in terminal_statuses or sub_agent.output:
-                preserved_ids.append(run_id)
-            else:
-                tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
-                has_activity = len(sub_agent.messages) > 0
-                if has_activity:
-                    sub_agent.status = SubAgentStatus.SUB_AGENT_FAILED
-                    sub_agent.error = (
-                        f"{error_context}: sub-agent was running "
-                        f"({len(sub_agent.messages)} messages, "
-                        f"{tc_count} tool calls)"
-                    )
-                    failed_ids.append(run_id)
-                else:
-                    sub_agent.status = SubAgentStatus.SUB_AGENT_CANCELLED
-                    sub_agent.error = (
-                        f"{error_context}: sub-agent was spawned but never began execution"
-                    )
-                    cancelled_ids.append(run_id)
-
-                sub_agent.completed_at = now
-
-            self.state.completed_sub_agents[run_id] = sub_agent
-
-        total = len(self.state.active_sub_agents)
-        self.state.active_sub_agents.clear()
-
-        finalized = len(cancelled_ids) + len(failed_ids)
-        self.logger.info(
-            f"[SUBAGENT] execution={self.execution_id} "
-            f"finalized {finalized}/{total} orphaned sub-agent(s) — "
-            f"CANCELLED (zero-message): {cancelled_ids}, "
-            f"FAILED (mid-execution): {failed_ids}"
-        )
-        if preserved_ids:
-            self.logger.info(
-                f"[SUBAGENT] execution={self.execution_id} "
-                f"preserved {len(preserved_ids)} sub-agent(s) with "
-                f"existing terminal status or output: {preserved_ids}"
-            )
-        return total
+        """Delegate to :func:`sub_agent_handlers.finalize_active_differentiated`."""
+        return sub_agent_handlers.finalize_active_differentiated(self, error_context)
 
     def finalize_sub_agents_from_checkpoint_validation(
-        self,
-        missed_event_count: int,
-        confirmed_orphan_count: int,
+        self, missed_event_count: int, confirmed_orphan_count: int,
         error_context: str,
     ) -> int:
-        """Finalize active sub-agents using checkpoint validation results.
-
-        Unlike ``finalize_active_sub_agents_differentiated`` which treats all
-        active sub-agents as failed/cancelled, this method leverages the
-        checkpoint's ground truth to give correct terminal statuses:
-
-        - When the checkpoint confirms ALL task tools completed but
-          StatusBuilder missed the events (``missed_event_count > 0``,
-          ``confirmed_orphan_count == 0``): marks all active sub-agents
-          as ``SUB_AGENT_COMPLETED``.
-        - When ALL active sub-agents are confirmed orphans
-          (``confirmed_orphan_count > 0``, ``missed_event_count == 0``):
-          differentiates as FAILED (mid-execution) or CANCELLED
-          (zero-message), same as ``finalize_active_sub_agents_differentiated``.
-        - Mixed case (both > 0): uses conservative differentiation
-          since we cannot determine which specific sub-agents completed
-          without ID-level mapping between checkpoint tool_call_ids and
-          StatusBuilder run_ids.
-
-        Args:
-            missed_event_count: Sub-agents that completed in the checkpoint
-                but StatusBuilder still considers active.
-            confirmed_orphan_count: Sub-agents incomplete in both checkpoint
-                and StatusBuilder.
-            error_context: High-level description for error messages.
-
-        Returns:
-            Number of sub-agents finalized.
-        """
-        self._flush_pending_completions()
-
-        if not self.state.active_sub_agents:
-            return 0
-
-        now = _utc_timestamp()
-        total = len(self.state.active_sub_agents)
-
-        if missed_event_count > 0 and confirmed_orphan_count == 0:
-            completed_ids: list[str] = []
-            for run_id, sub_agent in list(self.state.active_sub_agents.items()):
-                sub_agent.status = SubAgentStatus.SUB_AGENT_COMPLETED
-                sub_agent.completed_at = now
-                self.state.completed_sub_agents[run_id] = sub_agent
-                completed_ids.append(run_id)
-
-            self.state.active_sub_agents.clear()
-            self.logger.info(
-                f"[SUBAGENT] execution={self.execution_id} "
-                f"checkpoint confirms {total} sub-agent(s) completed "
-                f"(StatusBuilder missed on_tool_end events): "
-                f"{completed_ids}"
-            )
-        else:
-            cancelled_ids: list[str] = []
-            failed_ids: list[str] = []
-
-            for run_id, sub_agent in list(self.state.active_sub_agents.items()):
-                tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
-                has_activity = (
-                    len(sub_agent.messages) > 0
-                    or tc_count > 0
-                )
-                if has_activity:
-                    sub_agent.status = SubAgentStatus.SUB_AGENT_FAILED
-                    sub_agent.error = (
-                        f"{error_context}: sub-agent was running "
-                        f"({len(sub_agent.messages)} messages, "
-                        f"{tc_count} tool calls)"
-                    )
-                    failed_ids.append(run_id)
-                else:
-                    sub_agent.status = SubAgentStatus.SUB_AGENT_CANCELLED
-                    sub_agent.error = (
-                        f"{error_context}: sub-agent was spawned but "
-                        f"never began execution"
-                    )
-                    cancelled_ids.append(run_id)
-
-                sub_agent.completed_at = now
-                self.state.completed_sub_agents[run_id] = sub_agent
-
-            self.state.active_sub_agents.clear()
-
-            qualifier = (
-                "confirmed orphaned"
-                if missed_event_count == 0
-                else "mixed (some may have completed per checkpoint)"
-            )
-            self.logger.info(
-                f"[SUBAGENT] execution={self.execution_id} "
-                f"finalized {total} {qualifier} sub-agent(s) — "
-                f"CANCELLED (zero-message): {cancelled_ids}, "
-                f"FAILED (mid-execution): {failed_ids}"
-            )
-
-        return total
+        """Delegate to :func:`sub_agent_handlers.finalize_from_checkpoint_validation`."""
+        return sub_agent_handlers.finalize_from_checkpoint_validation(
+            self, missed_event_count, confirmed_orphan_count, error_context,
+        )
 
     # ─────────────────────────────────────────────────────────────────────────────
     # Usage Metrics (Phase 3 — delegated to UsageTracker)
@@ -2953,337 +1396,65 @@ class StatusBuilder:
     # This is set once after all resources are resolved, before streaming begins.
     # ─────────────────────────────────────────────────────────────────────────────
     
-    def set_resolved_context(
-        self,
-        environment_keys: list[str],
-        mcp_servers: dict[str, tuple[bool, str, int]],
-        skill_names: list[str],
-        excluded_skill_names: list[str] | None = None,
-    ) -> None:
+    def build_pending_approvals_snapshot(self) -> list[PendingApproval]:
+        """Build pending_approvals snapshot for the Temporal slim status.
+
+        This is a point-in-time coordination signal for the Temporal workflow,
+        NOT a DB-persisted projection.  The DB projection is computed
+        server-side by Go/Java ``ComputePendingApprovals`` on every
+        ``UpdateStatus`` write (DD-001).
+
+        The Temporal workflow uses this snapshot to determine how many
+        approval signals to collect before re-invoking the Python activity.
+        Reading from the DB is unsafe because the ``SubmitApproval`` handler
+        may have already recorded decisions (mutating the DB projection)
+        before the workflow reads it.
         """
-        Set the resolved execution context.
-        
-        Called once after all resources are resolved, before streaming begins.
-        This captures the "snapshot" of what the agent has access to, enabling:
-        - Debugging: Understanding what was available when investigating failures
-        - Auditing: Tracking what resources each execution consumed
-        - Security review: Verifying which secrets (by key name only) were exposed
-        - UX transparency: Showing users what their agent can access
-        
-        Args:
-            environment_keys: Environment variable keys (NOT values) available to agent.
-                              Represents the merged result of template, instance, and runtime env.
-            mcp_servers: Dict mapping server slug to (resolved, message, enabled_tool_count).
-                         resolved=True means server was found and configured successfully.
-                         resolved=False means resolution failed (server not found, missing env var).
-            skill_names: Names of skills included in the system prompt.
-            excluded_skill_names: Names of skills that were available but excluded
-                                  by relevance filtering.  ``None`` means no
-                                  filtering was applied.
-        
-        Note:
-            Environment values are intentionally NOT captured for security reasons.
-            Only keys are stored to enable debugging without exposing secrets.
-        """
-        # Build ResolvedExecutionContext proto
-        resolved_context = ResolvedExecutionContext(
-            environment_keys=sorted(environment_keys),  # Sorted for consistent ordering
-            skill_names=sorted(skill_names),            # Sorted for consistent ordering
-            excluded_skill_names=sorted(excluded_skill_names or []),
+        result: list[PendingApproval] = []
+        for tc in self.iter_all_tool_calls():
+            if (
+                tc.status == ToolCallStatus.TOOL_CALL_WAITING_APPROVAL
+                and tc.requires_approval
+                and tc.approval_action
+                == ApprovalAction.APPROVAL_ACTION_UNSPECIFIED
+            ):
+                result.append(PendingApproval(tool_call_id=tc.id))
+        return result
+
+    def set_resolved_context(self, environment_keys: list[str],
+                             mcp_servers: dict[str, tuple[bool, str, int]],
+                             skill_names: list[str],
+                             excluded_skill_names: list[str] | None = None) -> None:
+        """Delegate to :func:`context_handlers.set_resolved_context`."""
+        context_handlers.set_resolved_context(
+            self, environment_keys, mcp_servers, skill_names, excluded_skill_names,
         )
-        
-        # Build MCP server status map
-        for slug, (resolved, message, tool_count) in mcp_servers.items():
-            resolved_context.mcp_servers[slug].CopyFrom(
-                McpServerResolutionStatus(
-                    resolved=resolved,
-                    message=message,
-                    enabled_tool_count=tool_count,
-                )
-            )
-        
-        # Assign to status proto
-        self.current_status.resolved_context.CopyFrom(resolved_context)
-        
-        # Structured logging for observability
-        resolved_count = sum(1 for r, _, _ in mcp_servers.values() if r)
-        failed_count = len(mcp_servers) - resolved_count
-        
-        excluded_count = len(excluded_skill_names) if excluded_skill_names else 0
-        self.logger.info(
-            f"[CONTEXT] execution={self.execution_id} "
-            f"env_keys={len(environment_keys)} "
-            f"mcp_servers={len(mcp_servers)} (resolved={resolved_count}, failed={failed_count}) "
-            f"skills={len(skill_names)} "
-            f"excluded_skills={excluded_count}"
+
+    def initialize_context_info(self, context_window_limit: int,
+                                trigger_threshold: int, target_tokens: int,
+                                enabled: bool) -> None:
+        """Delegate to :func:`context_handlers.initialize_context_info`."""
+        context_handlers.initialize_context_info(
+            self, context_window_limit, trigger_threshold, target_tokens, enabled,
         )
-        
-        # Log details at debug level for troubleshooting
-        if environment_keys:
-            self.logger.debug(f"[CONTEXT] Environment keys: {sorted(environment_keys)}")
-        if mcp_servers:
-            for slug, (resolved, message, tool_count) in mcp_servers.items():
-                status = "OK" if resolved else "FAILED"
-                self.logger.debug(
-                    f"[CONTEXT] MCP server '{slug}': {status} - {message} "
-                    f"(tools={tool_count})"
-                )
-        if skill_names:
-            self.logger.debug(f"[CONTEXT] Skills: {sorted(skill_names)}")
-    
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Context Management (Phase 3)
-    #
-    # These methods implement the SummarizationCallback protocol for integration
-    # with the SummarizationMiddleware in graphton. They track context window
-    # utilization and record summarization events.
-    # ─────────────────────────────────────────────────────────────────────────────
-    
-    def initialize_context_info(
-        self,
-        context_window_limit: int,
-        trigger_threshold: int,
-        target_tokens: int,
-        enabled: bool,
-    ) -> None:
-        """
-        Initialize context info from model registry data.
-        
-        Called once at the start of execution to set up context tracking.
-        This captures the configuration that will be used for summarization.
-        
-        Args:
-            context_window_limit: Model's maximum context window size in tokens.
-            trigger_threshold: Token threshold that triggers summarization.
-            target_tokens: Target token count after summarization.
-            enabled: Whether summarization is enabled for this execution.
-        """
-        self.state.context_info = ContextInfo(
-            context_window_limit=context_window_limit,
-            summarization_trigger_threshold=trigger_threshold,
-            summarization_target_tokens=target_tokens,
-            summarization_enabled=enabled,
-            current_token_count=0,
-            utilization_percent=0.0,
-        )
-        
-        self.logger.info(
-            f"[CONTEXT] execution={self.execution_id} "
-            f"context_management initialized: "
-            f"window={context_window_limit}, "
-            f"trigger={trigger_threshold}, "
-            f"target={target_tokens}, "
-            f"enabled={enabled}"
-        )
-    
+
     def on_summarization_complete(self, event: SummarizationEventData) -> None:
-        """
-        Callback from SummarizationMiddleware when summarization completes.
-        
-        Records the summarization event, syncs context info to the status
-        proto for immediate gRPC delivery, and sets force_next_update so
-        the event loop pushes the update without waiting for the scheduler.
-        
-        Args:
-            event: Immutable data object containing summarization metrics.
-        """
-        if self.state.context_info is None:
-            self.logger.warning(
-                f"[CONTEXT] execution={self.execution_id} "
-                "on_summarization_complete called but context_info not initialized"
-            )
-            return
-        
-        try:
-            proto_source = SummarizationSource.Value(event.source)
-        except ValueError:
-            proto_source = SummarizationSource.SUMMARIZATION_SOURCE_UNSPECIFIED
+        """Delegate to :func:`context_handlers.on_summarization_complete`."""
+        context_handlers.on_summarization_complete(self, event)
 
-        timestamp = _utc_timestamp()
-        proto_event = SummarizationEvent(
-            timestamp=timestamp,
-            tokens_before=event.tokens_before,
-            tokens_after=event.tokens_after,
-            compression_ratio=event.compression_ratio,
-            duration_ms=event.duration_ms,
-            summarization_model=event.summarization_model,
-            messages_before=event.messages_before,
-            messages_after=event.messages_after,
-            source=proto_source,  # type: ignore[arg-type]
-            summarization_input_tokens=event.summarization_input_tokens,
-            summarization_output_tokens=event.summarization_output_tokens,
-            summarization_cost_usd=event.summarization_cost_usd,
-        )
-        self.state.context_info.summarization_events.append(proto_event)
-        
-        self.state.context_info.current_token_count = event.tokens_after
-        self._update_utilization()
-        self._sync_context_info()
-        self.force_next_update = True
-        
-        self.logger.info(
-            f"[CONTEXT] execution={self.execution_id} "
-            f"summarization completed (source={event.source}): "
-            f"{event.tokens_before} -> {event.tokens_after} tokens "
-            f"({event.compression_ratio * 100:.1f}% reduction), "
-            f"duration={event.duration_ms}ms, "
-            f"model={event.summarization_model}, "
-            f"summarization_cost=${event.summarization_cost_usd:.6f}"
-        )
-    
     def on_token_count_updated(self, token_count: int) -> None:
-        """
-        Callback from SummarizationMiddleware when token count changes.
-        
-        Updates the current token count and recalculates utilization.
-        This is part of the SummarizationCallback protocol.
-        
-        Args:
-            token_count: Current token count in the context window.
-        """
-        if self.state.context_info is None:
-            # Not an error - context tracking may be disabled
-            return
-        
-        self.state.context_info.current_token_count = token_count
-        self._update_utilization()
-        
-        self.logger.debug(
-            f"[CONTEXT] execution={self.execution_id} "
-            f"token_count={token_count} "
-            f"utilization={self.state.context_info.utilization_percent:.1f}%"
-        )
-    
-    def _update_utilization(self) -> None:
-        """Recalculate utilization percentage based on current token count."""
-        if self.state.context_info is None:
-            return
-        
-        if self.state.context_info.context_window_limit > 0:
-            self.state.context_info.utilization_percent = (
-                self.state.context_info.current_token_count
-                / self.state.context_info.context_window_limit
-                * 100
-            )
-        else:
-            self.state.context_info.utilization_percent = 0.0
-    
-    def _sync_context_info(self) -> None:
-        """Copy the working ``_context_info`` to ``current_status``.
-
-        Safe to call at any time — ``_context_info.summarization_events``
-        is the single source of truth, so repeated calls never duplicate.
-        """
-        if self.state.context_info is not None:
-            self.current_status.context_info.CopyFrom(self.state.context_info)
+        """Delegate to :func:`context_handlers.on_token_count_updated`."""
+        context_handlers.on_token_count_updated(self, token_count)
 
     def finalize_context_info(self) -> None:
-        """
-        Finalize context info and copy to status proto.
-        
-        Called at the end of execution to copy accumulated context info,
-        summarization events, and execution outputs to the status proto.
-        """
-        if self.state.context_info is not None:
-            self._sync_context_info()
-            
-            summarization_count = len(
-                self.state.context_info.summarization_events,
-            )
-            self.logger.info(
-                f"[CONTEXT] execution={self.execution_id} "
-                f"context_info finalized: "
-                f"final_tokens={self.state.context_info.current_token_count}, "
-                f"utilization={self.state.context_info.utilization_percent:.1f}%, "
-                f"summarizations={summarization_count}"
-            )
-        
-        # Reconcile artifacts: inline publishing already syncs each artifact
-        # to current_status.artifacts via add_artifact().  Only append any
-        # that were missed (e.g. added by the post-stream safety net after
-        # inline publish but before this finalizer ran).
-        already_synced = {a.sandbox_path for a in self.current_status.artifacts}
-        newly_synced = 0
-        for artifact in self.state.artifacts:
-            if artifact.sandbox_path not in already_synced:
-                self.current_status.artifacts.append(artifact)
-                newly_synced += 1
+        """Delegate to :func:`context_handlers.finalize_context_info`."""
+        context_handlers.finalize_context_info(self)
 
-        if self.state.artifacts:
-            self.logger.info(
-                f"[ARTIFACTS] execution={self.execution_id} "
-                f"finalized {len(self.state.artifacts)} artifact(s) "
-                f"({newly_synced} newly synced, "
-                f"{len(self.state.artifacts) - newly_synced} already live)"
-            )
-    
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Execution Artifacts (Artifact Lifecycle)
-    #
-    # These methods track artifacts published by the agent via the publish_artifact tool.
-    # Artifacts are accumulated during execution and added to the final status.
-    # ─────────────────────────────────────────────────────────────────────────────
-    
     def add_artifact(self, artifact: ExecutionArtifact) -> None:
-        """Add a published artifact and make it immediately visible in
-        ``current_status`` so the next progressive gRPC update carries it
-        to the UI.
-
-        Deduplicates by ``sandbox_path``: if an artifact with the same
-        path already exists (e.g. the agent overwrote a file), the older
-        entry is replaced in both the internal tracking list and the live
-        status proto.
-        """
-        existing_paths = {a.sandbox_path for a in self.state.artifacts}
-        if artifact.sandbox_path in existing_paths:
-            self.state.artifacts = [
-                a for a in self.state.artifacts
-                if a.sandbox_path != artifact.sandbox_path
-            ]
-        self.state.artifacts.append(artifact)
-
-        self._sync_artifact_to_status(artifact)
-        self.force_next_update = True
-
-        self.logger.info(
-            f"[ARTIFACT] execution={self.execution_id} "
-            f"name={artifact.name} "
-            f"size={artifact.size_bytes} bytes "
-            f"path={artifact.sandbox_path}"
-        )
-
-    def _sync_artifact_to_status(self, artifact: ExecutionArtifact) -> None:
-        """Upsert *artifact* into ``current_status.artifacts`` by
-        ``sandbox_path``, preserving insertion order."""
-        status_artifacts = self.current_status.artifacts
-        for idx, existing in enumerate(status_artifacts):
-            if existing.sandbox_path == artifact.sandbox_path:
-                status_artifacts[idx].CopyFrom(artifact)
-                return
-        status_artifacts.append(artifact)
-
-    # ─────────────────────────────────────────────────────────────────────────────
-    # Workspace Write-Backs (Platform-Owned Git Workflow)
-    # ─────────────────────────────────────────────────────────────────────────────
+        """Delegate to :func:`context_handlers.add_artifact`."""
+        context_handlers.add_artifact(self, artifact)
 
     def add_workspace_write_back(self, wb) -> None:
-        """Register a write-back outcome on the execution status.
-
-        Deduplicates by ``workspace_entry_name``: if a write-back for the
-        same entry already exists, it is replaced.
-        """
-        wbs = self.current_status.workspace_write_backs
-        for idx, existing in enumerate(wbs):
-            if existing.workspace_entry_name == wb.workspace_entry_name:
-                wbs[idx].CopyFrom(wb)
-                self.force_next_update = True
-                return
-        wbs.append(wb)
-        self.force_next_update = True
-
-        self.logger.info(
-            f"[WRITE_BACK] execution={self.execution_id} "
-            f"entry={wb.workspace_entry_name} "
-            f"phase={wb.phase}"
-        )
+        """Delegate to :func:`context_handlers.add_workspace_write_back`."""
+        context_handlers.add_workspace_write_back(self, wb)
     

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -12,11 +12,11 @@ import logging
 import time
 from collections.abc import Callable, Coroutine, Iterator
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from uuid import uuid4
 
-if TYPE_CHECKING:
-    from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
+from worker.activities.graphton.execution_state import ExecutionState
+from worker.activities.graphton.tool_call_id_capture import ToolCallIdCapture
 
 from ai.stigmer.agentic.agentexecution.v1.approval_pb2 import PendingApproval
 from ai.stigmer.agentic.agentexecution.v1.artifact_pb2 import ExecutionArtifact
@@ -317,7 +317,7 @@ class StatusBuilder:
         execution_id: str,
         initial_status: Any,
         approval_config: ApprovalConfig | None = None,
-        tool_call_id_capture: "ToolCallIdCapture | None" = None,
+        tool_call_id_capture: ToolCallIdCapture | None = None,
     ):
         """
         Initialize status builder.
@@ -330,249 +330,39 @@ class StatusBuilder:
                            WAITING_APPROVAL status instead of RUNNING.
             tool_call_id_capture: Callback handler that captures {run_id → tool_call_id}
                 from the LangChain callback API. Used for identity-based dedup on the
-                resume path.
+                resume path. A bare instance is created when not provided.
         """
         self.execution_id = execution_id
-        self.current_status = initial_status
         self.logger = logging.getLogger(__name__)
-        
-        # Approval policy configuration (HITL Phase 2)
-        # When set, tool calls are checked against policies before execution
+
+        # -- Execution state (all mutable tracking data) -------------------
+        self.state = ExecutionState(proto=initial_status)
+
+        # -- Configuration (immutable after init) --------------------------
         self._approval_config = approval_config
 
-        # Callback handler that maps LangGraph tool run_id → model tool_call_id.
-        # Used for identity-based resume dedup in _handle_tool_start_event.
-        self._tool_call_id_capture = tool_call_id_capture
-        
-        # In-memory index from tool_call_id to the ToolCall proto reference
-        # inside a message's repeated field.  Mutations via these references
-        # propagate directly to the message-embedded copy — no sync needed.
-        # Replaces the removed flat ``tool_calls`` list on the proto.
-        self._tool_call_index: dict[str, ToolCall] = {}
-        
-        # Track AI message generation timing for duration calculation
-        # Key: message index in messages list, Value: start timestamp
-        self._message_start_times: dict[int, datetime] = {}
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # LLM Stream Isolation (run_id-based message tracking)
-        #
-        # Maps each LLM invocation's run_id to the AgentMessage it owns.
-        # This prevents token interleaving when multiple LLM streams are
-        # active (e.g., concurrent sub-agents whose namespace routing fell
-        # through to the main agent).  Each run_id always writes to its own
-        # dedicated message — no two LLM invocations can share a message.
-        # ─────────────────────────────────────────────────────────────────────────
-        self._llm_run_id_to_message: dict[str, AgentMessage] = {}
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # AI Message Ownership Tracking (Tool Call → Parent AI Message)
-        #
-        # Tracks the most recently created AI message per execution context
-        # (keyed by namespace).  When a tool call fires (on_tool_start or
-        # early tool_use detection), the ToolCall proto is appended to this
-        # message's tool_calls repeated field — establishing the standard
-        # "AI message owns its tool calls" relationship used by OpenAI,
-        # Anthropic, and LangChain.
-        #
-        # Stores proto-managed references (the element inside the repeated
-        # field, not the original) so mutations are visible in the status.
-        # ─────────────────────────────────────────────────────────────────────────
-        self._last_ai_message: dict[str, AgentMessage] = {}
-        
-        # Track tool execution timing for duration calculation (Phase 2.2)
-        # Key: run_id, Value: start timestamp
-        self._tool_start_times: dict[str, datetime] = {}
-        
-        # NOTE: Token accumulators (_total_prompt_tokens, etc.) removed in
-        # Phase 3; all usage tracking now lives in self._usage_tracker.
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Sub-Agent Tracking (Phase 2.3)
-        #
-        # These structures enable namespace-based event routing to capture
-        # tool calls and messages within sub-agent executions.
-        # ─────────────────────────────────────────────────────────────────────────
-        
-        # Track active sub-agent executions by their run_id
-        # Key: run_id (from task tool), Value: SubAgentExecution proto
-        self._active_sub_agents: dict[str, SubAgentExecution] = {}
+        # Single authority for run_id → tool_call_id resolution.
+        self._tool_call_id_capture = tool_call_id_capture or ToolCallIdCapture()
 
-        # Completed sub-agent executions, moved here from _active_sub_agents
-        # on completion.  Namespace mappings are preserved so late-arriving
-        # events from LangGraph still route to the correct proto.
-        self._completed_sub_agents: dict[str, SubAgentExecution] = {}
-
-        # Bridge between LangGraph run_ids and Anthropic tool_call_ids.
-        # SubAgentExecution.id uses the tool_call_id (for frontend matching),
-        # while _active_sub_agents and namespace registration use the run_id.
-        # Key: LangGraph run_id, Value: tool_call_id (= SubAgentExecution.id)
-        self._run_id_to_tool_call_id: dict[str, str] = {}
-
-        # Map namespace to sub-agent run_id for event routing
-        # Key: namespace string, Value: sub-agent run_id
-        self._namespace_to_sub_agent_id: dict[str, str] = {}
-        
-        # Subject deduplication: tracks how many times each subject has been
-        # assigned so duplicate subjects get a numeric suffix (e.g., "(2)").
-        self._subject_counts: dict[str, int] = {}
-        
-        # Namespaces already warned about (deduplication — log once per namespace)
-        self._warned_namespaces: set[str] = set()
-        
-        # Track AI message generation timing within sub-agents (separate from main)
-        # Key: (sub_agent_id, message_index), Value: start timestamp
-        self._sub_agent_message_start_times: dict[tuple[str, int], datetime] = {}
-        
+        # Token/cost accounting for LLM calls.
         self._usage_tracker = UsageTracker(execution_id)
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Approval State Tracking (HITL — Batch Approval)
-        #
-        # Tracks which tool calls are currently pending approval.  When the LLM
-        # issues multiple tool calls that each require approval in a single
-        # response, LangGraph creates one interrupt per tool.  We track ALL of
-        # them so the post-stream interrupt-capture logic can match each
-        # interrupt to its tool call.
-        # ─────────────────────────────────────────────────────────────────────────
-        
-        # Ordered list of ALL run_ids currently pending approval.
-        self._pending_tool_approvals: list[str] = []
-        
-        # Saved execution phase to restore after approval decision
-        # (preserves IN_PROGRESS state when transitioning to WAITING_FOR_APPROVAL)
-        self._saved_phase_before_approval: int | None = None
-        
-        # Tracks when the execution entered WAITING_FOR_APPROVAL so we can
-        # compute approval_wait_duration_ms on exit.
-        self._approval_wait_started_at: datetime | None = None
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Context Management Tracking (Phase 3)
-        #
-        # Tracks context window utilization and summarization events.
-        # This class implements the SummarizationCallback protocol for integration
-        # with the SummarizationMiddleware in graphton.
-        # ─────────────────────────────────────────────────────────────────────────
-        
-        # Context info initialized via initialize_context_info()
-        self._context_info: ContextInfo | None = None
-        
-        # Context info is the single source of truth for summarization events.
-        # Events are appended directly to _context_info.summarization_events
-        # (once initialized) and synced to current_status via _sync_context_info().
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Run-ID Alias Map (Resume-After-Approval Fix)
-        #
-        # On the resume path, LangGraph generates fresh run_ids for resumed
-        # tools, but the StatusBuilder already holds the original tool call
-        # (with the original tool_call_id) from the previous invocation.
-        # Identity-based dedup in _handle_tool_start_event detects the
-        # duplicate via ToolCallIdCapture, but the new run_id must still
-        # reach the existing ToolCall on on_tool_end / on_tool_progress.
-        #
-        # _run_id_aliases maps {new_run_id -> original_tool_call_id} so that
-        # _resolve_run_id() can bridge the gap.
-        # ─────────────────────────────────────────────────────────────────────────
-        self._run_id_aliases: dict[str, str] = {}
 
-        # ─────────────────────────────────────────────────────────────────────────
-        # Execution Artifacts Tracking (Artifact Lifecycle)
-        #
-        # Tracks artifacts published by the agent via the publish_artifact tool.
-        # Artifacts are accumulated during execution and added to the final status.
-        # ─────────────────────────────────────────────────────────────────────────
-        self._artifacts: list[ExecutionArtifact] = []
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Native Thinking Translation (Extended Thinking → Synthetic Think Tool)
-        #
-        # When Anthropic models have extended thinking enabled, thinking content
-        # blocks arrive via on_chat_model_stream before the text/tool_use
-        # response.  We accumulate them here and flush a synthetic "think"
-        # ToolCall when the first non-thinking content arrives (or at
-        # on_chat_model_end if no text follows).  This lets the entire
-        # downstream pipeline (gRPC, CLI) treat native thinking identically
-        # to the explicit think tool.
-        #
-        # Keyed by namespace (empty string for main agent).
-        # ─────────────────────────────────────────────────────────────────────────
-        self._thinking_buffers: dict[str, str] = {}
-        self._thinking_started_at: dict[str, datetime] = {}
-        self._thinking_tool_call_ids: dict[str, str] = {}
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # LLM Turn-Boundary Tracking
-        #
-        # Tracks the most recent LLM run_id per namespace so we can detect
-        # when a new LLM invocation starts.  Without this, thinking-only
-        # turns (thinking + tool_use, no text) leave _last_ai_message
-        # pointing at the previous turn's empty parent AI, causing the
-        # next turn's thinking/tool_use blocks to pile up on the wrong
-        # message.  When the run_id changes we clear _last_ai_message
-        # for that namespace so a fresh parent is created.
-        # ─────────────────────────────────────────────────────────────────────────
-        self._last_llm_run_id: dict[str, str] = {}
-        
-        # ─────────────────────────────────────────────────────────────────────────
-        # Early Tool Call Creation (Live Write Streaming UX)
-        #
-        # When the LLM stream produces a tool_use block, we create the ToolCall
-        # immediately — before on_tool_start fires — so the CLI shows the tool
-        # name instead of the "Thinking…" idle indicator.  The queue holds temp
-        # IDs in FIFO order; on_tool_start pops the first match and reconciles
-        # (updating args, registering the real run_id as an alias).
-        # Each entry is (temp_id, sub_agent_id_or_None) so reconciliation
-        # matches within the correct execution context and avoids
-        # cross-contamination between concurrent sub-agents.
-        # ─────────────────────────────────────────────────────────────────────────
-        self._early_tool_call_queue: list[tuple[str, str | None]] = []
-        
-        # ─────────────────────────────────────────────────────────────────────
-        # Tool Input Streaming (Live Argument Generation)
-        #
-        # While the LLM generates tool arguments, Anthropic emits
-        # input_json_delta blocks whose partial_json fragments concatenate
-        # into the full args JSON.  We accumulate them per early ToolCall and
-        # extract displayable content (e.g. the file body for write tools)
-        # into tool_call.result so the CLI streams it progressively.
-        #
-        # _tool_input_active_tc: namespace key → temp_id of the early ToolCall
-        #     currently receiving input_json_delta blocks.
-        # _tool_input_buffers: temp_id → accumulated partial JSON string.
-        # ─────────────────────────────────────────────────────────────────────
-        self._tool_input_active_tc: dict[str, str] = {}
-        self._tool_input_buffers: dict[str, str] = {}
-
-        # When True, the main event loop should send a gRPC status update
-        # immediately after process_event() returns, bypassing the scheduler's
-        # time/burst thresholds.  Set by _create_early_tool_call and
-        # _start_thinking_stream so the CLI sees new tool calls without
-        # waiting for the next scheduled update (which may be 500ms–30s away
-        # if no further LangGraph events arrive).
+        # gRPC scheduling signal (not execution state).
         self.force_next_update: bool = False
 
-        # Deferred completion flush for sub-agents.  When a sub-agent
-        # completes (on_tool_end for "task"), we record the monotonic
-        # timestamp here instead of setting force_next_update.  This allows
-        # a short drain window for late LangGraph events (on_chat_model_end,
-        # on_tool_end for nested tools) to be processed and batched into
-        # the same gRPC update that carries the COMPLETED status — preventing
-        # the UI from showing "Completed" while messages still stream in.
-        self._pending_completion_flush: dict[str, float] = {}
-
-        # Resolved agent env vars used by _create_args_preview to expand
-        # $VAR references in display strings.  Set via set_display_env_vars()
-        # once the merged environment is available.
+        # Display humanization config (set after workspace provisioning).
         self._display_env_vars: dict[str, str] | None = None
         self._secret_keys: set[str] | None = None
-
-        # Sandbox workspace root for display humanization.  Set via
-        # set_workspace_root() once the workspace is provisioned.
-        # humanize_sandbox_paths() uses this to strip absolute sandbox
-        # paths from display strings (tool args, results, previews).
         self._workspace_root: str = ""
+
+    @property
+    def current_status(self) -> Any:
+        """The protobuf projection being built."""
+        return self.state.proto
+
+    @current_status.setter
+    def current_status(self, value: Any) -> None:
+        self.state.proto = value
     
     def set_display_env_vars(
         self,
@@ -617,15 +407,20 @@ class StatusBuilder:
         field, so mutations to the returned object propagate to the proto
         status automatically.
         """
-        return self._tool_call_index.get(tc_id)
+        return self.state.tool_calls.get(tc_id)
 
     def iter_all_tool_calls(self) -> Iterator[ToolCall]:
         """Iterate over every tracked ToolCall (main agent + sub-agents)."""
-        return iter(self._tool_call_index.values())
+        return iter(self.state.tool_calls.values())
 
     def tool_call_count(self) -> int:
         """Return the total number of tracked tool calls."""
-        return len(self._tool_call_index)
+        return len(self.state.tool_calls)
+
+    @property
+    def active_sub_agent_count(self) -> int:
+        """Return the number of currently active (in-progress) sub-agents."""
+        return len(self.state.active_sub_agents)
 
     _COMPLETION_DRAIN_MS: float = 300.0
 
@@ -638,16 +433,16 @@ class StatusBuilder:
         events to be batched into the same gRPC update that carries the
         COMPLETED status.
         """
-        if not self._pending_completion_flush:
+        if not self.state.pending_completion_flush:
             return False
         threshold = self._COMPLETION_DRAIN_MS / 1000.0
         flushed: list[str] = []
-        for run_id, recorded_at in self._pending_completion_flush.items():
+        for run_id, recorded_at in self.state.pending_completion_flush.items():
             if (now_monotonic - recorded_at) >= threshold:
                 flushed.append(run_id)
         if flushed:
             for run_id in flushed:
-                del self._pending_completion_flush[run_id]
+                del self.state.pending_completion_flush[run_id]
             self.force_next_update = True
             return True
         return False
@@ -753,16 +548,12 @@ class StatusBuilder:
         # is already indexed from the prior cycle (via rebuild_index_from_persisted_status).
         # We register a run-ID alias so on_tool_end / on_tool_progress can find
         # the existing ToolCall, then return early (dedup).
-        tool_call_id = (
-            self._tool_call_id_capture.get(run_id)
-            if self._tool_call_id_capture is not None
-            else None
-        )
+        tool_call_id = self._tool_call_id_capture.get(run_id)
         if tool_call_id:
-            existing = self._tool_call_index.get(tool_call_id)
+            existing = self.state.tool_calls.get(tool_call_id)
             if existing is not None and not existing.is_streaming:
                 if run_id != tool_call_id:
-                    self._run_id_aliases[run_id] = tool_call_id
+                    self._tool_call_id_capture.register_alias(run_id, tool_call_id)
                 self.logger.info(
                     "[IDENTITY_DEDUP] execution=%s tool=%s run_id=%s -> "
                     "existing_tc=%s (resume path, alias only)",
@@ -824,7 +615,7 @@ class StatusBuilder:
                 )
                 parent_ai = self._ensure_parent_ai_message(ns_key, namespace)
                 parent_ai.tool_calls.append(tool_call)
-                self._tool_call_index[run_id] = parent_ai.tool_calls[-1]
+                self.state.tool_calls[run_id] = parent_ai.tool_calls[-1]
                 tool_call_id = run_id
 
             await self._handle_sub_agent_start(event, tool_args, run_id, tool_call_id=tool_call_id)
@@ -898,7 +689,7 @@ class StatusBuilder:
             tool_call.approval_requested_at = _utc_timestamp(now)
         
         # Track start time for duration calculation (even for approval-pending tools)
-        self._tool_start_times[run_id] = now
+        self.state.tool_start_times[run_id] = now
         
         # ─────────────────────────────────────────────────────────────────────
         # Namespace-Based Routing (Phase 2.3): Route to correct execution context
@@ -913,7 +704,7 @@ class StatusBuilder:
         # truth.  The in-memory _tool_call_index provides O(1) lookup by ID.
         parent_ai = self._ensure_parent_ai_message(ns_key, namespace)
         parent_ai.tool_calls.append(tool_call)
-        self._tool_call_index[run_id] = parent_ai.tool_calls[-1]
+        self.state.tool_calls[run_id] = parent_ai.tool_calls[-1]
         
         context_desc = f"sub_agent={sub_agent.id}" if sub_agent else "main_agent"
         self.logger.debug(
@@ -953,7 +744,7 @@ class StatusBuilder:
                 the tool-execution path (``on_tool_start``) must omit this
                 to avoid polluting the LLM run-id map with tool run-ids.
         """
-        existing = self._last_ai_message.get(ns_key)
+        existing = self.state.current_ai_message.get(ns_key)
         if existing is not None:
             return existing
 
@@ -969,10 +760,10 @@ class StatusBuilder:
         )
         messages_list.append(ai_message)
         managed = messages_list[-1]
-        self._last_ai_message[ns_key] = managed
+        self.state.current_ai_message[ns_key] = managed
 
         if llm_run_id:
-            self._llm_run_id_to_message[llm_run_id] = managed
+            self.state.messages_by_run[llm_run_id] = managed
 
         self.logger.debug(
             "[AI_MSG] execution=%s created empty parent AI message "
@@ -1012,7 +803,7 @@ class StatusBuilder:
         chunk = humanize_sandbox_paths(chunk, self._workspace_root)
 
         # Resolve run-ID alias (resume-after-approval path)
-        resolved_id = self._resolve_run_id(run_id)
+        resolved_id = self._tool_call_id_capture.resolve(run_id)
         
         tool_call = self.get_tool_call(resolved_id)
         if tool_call is None:
@@ -1067,7 +858,7 @@ class StatusBuilder:
         # recorded an alias when identity-based dedup fired; resolve it
         # here so we can find and update the correct ToolCall.
         # ─────────────────────────────────────────────────────────────────────
-        resolved_id = self._resolve_run_id(run_id)
+        resolved_id = self._tool_call_id_capture.resolve(run_id)
         
         tool_result_content = self._extract_tool_result_content(tool_result_raw)
 
@@ -1089,8 +880,8 @@ class StatusBuilder:
         
         # Calculate execution duration if we tracked the start time
         duration_ms = None
-        if run_id in self._tool_start_times:
-            start_time = self._tool_start_times.pop(run_id)
+        if run_id in self.state.tool_start_times:
+            start_time = self.state.tool_start_times.pop(run_id)
             duration_ms = int((now - start_time).total_seconds() * 1000)
         
         # ─────────────────────────────────────────────────────────────────────
@@ -1141,9 +932,9 @@ class StatusBuilder:
         # ─────────────────────────────────────────────────────────────────────
         run_id = event.get("run_id", "")
         ns_key = namespace or ""
-        if run_id and run_id != self._last_llm_run_id.get(ns_key):
-            self._last_ai_message.pop(ns_key, None)
-            self._last_llm_run_id[ns_key] = run_id
+        if run_id and run_id != self.state.last_llm_run_id.get(ns_key):
+            self.state.current_ai_message.pop(ns_key, None)
+            self.state.last_llm_run_id[ns_key] = run_id
         
         # ─────────────────────────────────────────────────────────────────────
         # Native Thinking Detection
@@ -1235,12 +1026,12 @@ class StatusBuilder:
                     )
             
             if thinking_text:
-                self._thinking_buffers[ns_key] = (
-                    self._thinking_buffers.get(ns_key, "") + thinking_text
+                self.state.thinking.buffers[ns_key] = (
+                    self.state.thinking.buffers.get(ns_key, "") + thinking_text
                 )
-                if ns_key not in self._thinking_tool_call_ids:
+                if ns_key not in self.state.thinking.tool_call_ids:
                     self._start_thinking_stream(
-                        ns_key, namespace, self._thinking_buffers[ns_key],
+                        ns_key, namespace, self.state.thinking.buffers[ns_key],
                         llm_run_id=run_id,
                     )
                 else:
@@ -1267,7 +1058,7 @@ class StatusBuilder:
         # This ensures the synthetic think ToolCall appears in the status
         # timeline before the AI message that follows it.
         ns_key = namespace or ""
-        if self._thinking_buffers.get(ns_key):
+        if self.state.thinking.buffers.get(ns_key):
             self._flush_thinking_buffer(ns_key, namespace)
         
         # ─────────────────────────────────────────────────────────────────────
@@ -1287,7 +1078,7 @@ class StatusBuilder:
         
         # Fast path: run_id already mapped to a message from an earlier token.
         if run_id:
-            ai_message = self._llm_run_id_to_message.get(run_id)
+            ai_message = self.state.messages_by_run.get(run_id)
             if ai_message is not None:
                 # Empty parent AI messages created by _ensure_parent_ai_message
                 # for thinking/tool_use blocks must NOT receive text content.
@@ -1297,7 +1088,7 @@ class StatusBuilder:
                 # registration so the "first token" path below creates a
                 # proper text AI message and re-registers the run_id.
                 if not ai_message.content and len(ai_message.tool_calls) > 0:
-                    del self._llm_run_id_to_message[run_id]
+                    del self.state.messages_by_run[run_id]
                 else:
                     ai_message.content += token
                     return
@@ -1327,21 +1118,21 @@ class StatusBuilder:
         managed_ai_message = messages_list[-1]
         
         if run_id:
-            self._llm_run_id_to_message[run_id] = managed_ai_message
+            self.state.messages_by_run[run_id] = managed_ai_message
         
         # Track as the most recent AI message for this namespace so that
         # subsequent tool calls (on_tool_start, early tool_use) are attached
         # to the correct parent AI message.
         ns_key = namespace or ""
-        self._last_ai_message[ns_key] = managed_ai_message
+        self.state.current_ai_message[ns_key] = managed_ai_message
         
         # Track start time for duration calculation
         new_message_index = len(messages_list) - 1
         if sub_agent:
-            self._sub_agent_message_start_times[(sub_agent.id, new_message_index)] = now
+            self.state.sub_agent_message_start_times[(sub_agent.id, new_message_index)] = now
             self.logger.debug(f"Started new AI message in sub_agent={sub_agent.id} at index {new_message_index} run_id={run_id}")
         else:
-            self._message_start_times[new_message_index] = now
+            self.state.message_start_times[new_message_index] = now
             self.logger.debug(f"Started new AI message at index {new_message_index} run_id={run_id}")
     
     def _handle_chat_model_end_event(self, event: dict[str, Any], namespace: str = "") -> None:
@@ -1365,7 +1156,7 @@ class StatusBuilder:
         # Flush any remaining thinking content that wasn't followed by text
         # (e.g. the model only produced thinking + tool_use, no text block).
         ns_key = namespace or ""
-        if self._thinking_buffers.get(ns_key):
+        if self.state.thinking.buffers.get(ns_key):
             self._flush_thinking_buffer(ns_key, namespace)
         
         # ─────────────────────────────────────────────────────────────────────
@@ -1378,7 +1169,7 @@ class StatusBuilder:
         ai_message_index = None
         
         # Primary path: resolve via run_id map (matches stream handler)
-        tracked_message = self._llm_run_id_to_message.pop(run_id, None) if run_id else None
+        tracked_message = self.state.messages_by_run.pop(run_id, None) if run_id else None
         if tracked_message is not None:
             for idx in range(len(messages_list) - 1, -1, -1):
                 if messages_list[idx] is tracked_message:
@@ -1406,18 +1197,18 @@ class StatusBuilder:
         if sub_agent:
             # Check sub-agent timing dict
             timing_key = (sub_agent.id, ai_message_index)
-            if timing_key in self._sub_agent_message_start_times:
-                start_time = self._sub_agent_message_start_times[timing_key]
+            if timing_key in self.state.sub_agent_message_start_times:
+                start_time = self.state.sub_agent_message_start_times[timing_key]
                 duration = datetime.utcnow() - start_time
                 generation_duration_ms = int(duration.total_seconds() * 1000)
-                del self._sub_agent_message_start_times[timing_key]
+                del self.state.sub_agent_message_start_times[timing_key]
         else:
             # Check main agent timing dict
-            if ai_message_index in self._message_start_times:
-                start_time = self._message_start_times[ai_message_index]
+            if ai_message_index in self.state.message_start_times:
+                start_time = self.state.message_start_times[ai_message_index]
                 duration = datetime.utcnow() - start_time
                 generation_duration_ms = int(duration.total_seconds() * 1000)
-                del self._message_start_times[ai_message_index]
+                del self.state.message_start_times[ai_message_index]
         
         # ─────────────────────────────────────────────────────────────────────────
         # Diagnostic: capture output_data shape for zero-usage debugging.
@@ -1576,17 +1367,14 @@ class StatusBuilder:
         )
     
     # Helper methods
-    def _resolve_run_id(self, run_id: str) -> str:
-        """Resolve a run_id through the alias map.
-        
-        On the resume-after-approval path, LangGraph generates a new run_id
-        for the resumed tool, but the StatusBuilder already holds the original
-        ToolCall with a different id.  ``_run_id_aliases`` bridges the gap.
-        
-        Returns the original tool call id if an alias exists, otherwise
-        returns the input run_id unchanged.
+    def resolve_run_id(self, run_id: str) -> str:
+        """Resolve a run_id to its canonical tool_call_id.
+
+        Delegates to :class:`ToolCallIdCapture` which checks resume-path
+        aliases first, then the callback-captured mapping, and falls back
+        to *run_id* unchanged.
         """
-        return self._run_id_aliases.get(run_id, run_id)
+        return self._tool_call_id_capture.resolve(run_id)
     
     def _unwrap_tool_args(self, args: dict[str, Any]) -> dict[str, Any]:
         """Unwrap LangGraph arg wrappers."""
@@ -1597,26 +1385,15 @@ class StatusBuilder:
         return args
     
     def rebuild_index_from_persisted_status(self) -> None:
-        """Rebuild ``_tool_call_index`` from persisted messages.
+        """Reconstruct proto-derivable indexes from the persisted status.
 
         On the resume-after-approval path, the StatusBuilder is initialized
         with the DB-persisted status that already contains tool calls embedded
-        in messages.  This method walks those messages and re-populates the
-        in-memory index so that ``get_tool_call`` and ``iter_all_tool_calls``
-        resolve correctly for the subsequent stream cycle.
+        in messages.  This method delegates to ``ExecutionState.rebuild_from_proto``
+        to re-populate tool call indexes, completed sub-agents, and artifacts
+        so the subsequent stream cycle resolves correctly.
         """
-        def _index_tool_calls(messages: Any) -> None:
-            for message in messages:
-                if message.type != MessageType.MESSAGE_AI:
-                    continue
-                for i, tc in enumerate(message.tool_calls):
-                    if tc.id:
-                        self._tool_call_index[tc.id] = message.tool_calls[i]
-
-        _index_tool_calls(self.current_status.messages)
-
-        for sub_agent in self.current_status.sub_agent_executions:
-            _index_tool_calls(sub_agent.messages)
+        self.state = ExecutionState.rebuild_from_proto(self.state.proto)
 
     def prepare_task_tool_resume_queue(self) -> int:
         """Pre-populate the early tool call queue for task tools on resume.
@@ -1659,12 +1436,12 @@ class StatusBuilder:
                 if tc.id not in sa_ids:
                     continue
                 already_queued = any(
-                    tid == tc.id for tid, _ in self._early_tool_call_queue
+                    tid == tc.id for tid, _ in self.state.early_tool_call_queue
                 )
                 if already_queued:
                     continue
 
-                self._early_tool_call_queue.append((tc.id, None))
+                self.state.early_tool_call_queue.append((tc.id, None))
                 queued += 1
                 self.logger.info(
                     "[RESUME_PREP] execution=%s pre-queued task TC %s "
@@ -1848,7 +1625,7 @@ class StatusBuilder:
         the early ToolCall (populates args, registers the real run-ID alias)
         instead of creating a duplicate.
         """
-        if self._thinking_buffers.get(ns_key):
+        if self.state.thinking.buffers.get(ns_key):
             self._flush_thinking_buffer(ns_key, namespace)
 
         temp_id = tool_use_id or f"early-{uuid4()}"
@@ -1867,7 +1644,7 @@ class StatusBuilder:
         if self._find_tool_call_by_id(temp_id) is not None:
             _, sub_agent = self._get_execution_context(namespace)
             sa_id = sub_agent.id if sub_agent else None
-            self._early_tool_call_queue.append((temp_id, sa_id))
+            self.state.early_tool_call_queue.append((temp_id, sa_id))
             self.logger.info(
                 "[RESUME_DEDUP] execution=%s skipping early tool call "
                 "creation for %s (id=%s already exists from prior cycle, "
@@ -1899,15 +1676,15 @@ class StatusBuilder:
             ns_key, namespace, llm_run_id=llm_run_id,
         )
         parent_ai.tool_calls.append(tool_call)
-        self._tool_call_index[temp_id] = parent_ai.tool_calls[-1]
+        self.state.tool_calls[temp_id] = parent_ai.tool_calls[-1]
 
         _, sub_agent = self._get_execution_context(namespace)
         sa_id = sub_agent.id if sub_agent else None
-        self._early_tool_call_queue.append((temp_id, sa_id))
-        self._tool_start_times[temp_id] = now
+        self.state.early_tool_call_queue.append((temp_id, sa_id))
+        self.state.tool_start_times[temp_id] = now
 
-        self._tool_input_active_tc[ns_key] = temp_id
-        self._tool_input_buffers[temp_id] = ""
+        self.state.tool_input.active_tc[ns_key] = temp_id
+        self.state.tool_input.buffers[temp_id] = ""
 
         self.force_next_update = True
 
@@ -1940,14 +1717,14 @@ class StatusBuilder:
         _, sub_agent = self._get_execution_context(namespace)
         sa_id = sub_agent.id if sub_agent else None
 
-        for idx, (temp_id, queued_sa_id) in enumerate(self._early_tool_call_queue):
+        for idx, (temp_id, queued_sa_id) in enumerate(self.state.early_tool_call_queue):
             existing = self.get_tool_call(temp_id)
             if existing is None or existing.name != tool_name:
                 continue
             if queued_sa_id != sa_id:
                 continue
 
-            self._early_tool_call_queue.pop(idx)
+            self.state.early_tool_call_queue.pop(idx)
 
             # Resume path: TC from a prior cycle was re-queued by
             # _create_early_tool_call's resume dedup.  The TC is fully
@@ -1956,7 +1733,7 @@ class StatusBuilder:
             # downstream handlers route correctly.
             is_resume_requeue = not existing.is_streaming
             if is_resume_requeue:
-                self._run_id_aliases[run_id] = temp_id
+                self._tool_call_id_capture.register_alias(run_id, temp_id)
                 self.logger.info(
                     "[RECONCILE] execution=%s resume-path reconciliation: "
                     "tool=%s run_id=%s -> existing_tc=%s "
@@ -1994,8 +1771,8 @@ class StatusBuilder:
                 )
                 existing.approval_requested_at = _utc_timestamp(datetime.utcnow())
 
-            self._run_id_aliases[run_id] = temp_id
-            self._tool_start_times[run_id] = self._tool_start_times.pop(
+            self._tool_call_id_capture.register_alias(run_id, temp_id)
+            self.state.tool_start_times[run_id] = self.state.tool_start_times.pop(
                 temp_id, datetime.utcnow()
             )
 
@@ -2047,10 +1824,10 @@ class StatusBuilder:
             ns_key, namespace, llm_run_id=llm_run_id,
         )
         parent_ai.tool_calls.append(tool_call)
-        self._tool_call_index[tc_id] = parent_ai.tool_calls[-1]
+        self.state.tool_calls[tc_id] = parent_ai.tool_calls[-1]
 
-        self._thinking_tool_call_ids[ns_key] = tc_id
-        self._thinking_started_at[ns_key] = now
+        self.state.thinking.tool_call_ids[ns_key] = tc_id
+        self.state.thinking.started_at[ns_key] = now
 
         self.force_next_update = True
 
@@ -2063,11 +1840,11 @@ class StatusBuilder:
 
     def _update_thinking_stream(self, ns_key: str) -> None:
         """Update the streaming think ToolCall with the latest accumulated content."""
-        tc_id = self._thinking_tool_call_ids.get(ns_key)
+        tc_id = self.state.thinking.tool_call_ids.get(ns_key)
         if not tc_id:
             return
 
-        buf = self._thinking_buffers.get(ns_key, "")
+        buf = self.state.thinking.buffers.get(ns_key, "")
 
         tool_call = self.get_tool_call(tc_id)
         if tool_call is not None:
@@ -2090,22 +1867,22 @@ class StatusBuilder:
         within ~500 ms and the CLI detects it via
         ``tc.IsStreaming && tc.Result != prevResults``.
         """
-        temp_id = self._tool_input_active_tc.get(ns_key)
+        temp_id = self.state.tool_input.active_tc.get(ns_key)
         if not temp_id:
             return
 
-        buf = self._tool_input_buffers.get(temp_id)
+        buf = self.state.tool_input.buffers.get(temp_id)
         if buf is None:
             return
 
-        self._tool_input_buffers[temp_id] = buf + partial_json
+        self.state.tool_input.buffers[temp_id] = buf + partial_json
 
         tool_call = self.get_tool_call(temp_id)
         if tool_call is None:
             return
 
         content = self._extract_content_from_partial_json(
-            tool_call.name, self._tool_input_buffers[temp_id],
+            tool_call.name, self.state.tool_input.buffers[temp_id],
         )
         if content:
             tool_call.result = content
@@ -2138,10 +1915,10 @@ class StatusBuilder:
 
     def _flush_tool_input_buffer(self, temp_id: str) -> None:
         """Clean up input-streaming state for a reconciled early ToolCall."""
-        self._tool_input_buffers.pop(temp_id, None)
-        for ns_key, tid in list(self._tool_input_active_tc.items()):
+        self.state.tool_input.buffers.pop(temp_id, None)
+        for ns_key, tid in list(self.state.tool_input.active_tc.items()):
             if tid == temp_id:
-                del self._tool_input_active_tc[ns_key]
+                del self.state.tool_input.active_tc[ns_key]
                 break
 
     def _flush_thinking_buffer(self, ns_key: str, namespace: str) -> None:
@@ -2156,9 +1933,9 @@ class StatusBuilder:
         streaming ToolCall exists (defensive — should not happen in normal flow
         since ``_start_thinking_stream`` is called on the first thinking block).
         """
-        thinking_text = self._thinking_buffers.pop(ns_key, "")
-        started_at = self._thinking_started_at.pop(ns_key, None)
-        tc_id = self._thinking_tool_call_ids.pop(ns_key, None)
+        thinking_text = self.state.thinking.buffers.pop(ns_key, "")
+        started_at = self.state.thinking.started_at.pop(ns_key, None)
+        tc_id = self.state.thinking.tool_call_ids.pop(ns_key, None)
         if not thinking_text:
             return
 
@@ -2207,7 +1984,7 @@ class StatusBuilder:
 
         parent_ai = self._ensure_parent_ai_message(ns_key, namespace)
         parent_ai.tool_calls.append(fallback_tc)
-        self._tool_call_index[fallback_tc.id] = parent_ai.tool_calls[-1]
+        self.state.tool_calls[fallback_tc.id] = parent_ai.tool_calls[-1]
 
         self.logger.info(
             "[THINK] execution=%s synthetic_think_tool_call "
@@ -2357,14 +2134,14 @@ class StatusBuilder:
         Restores the execution phase to what it was before entering
         WAITING_FOR_APPROVAL (typically IN_PROGRESS).
         """
-        self._pending_tool_approvals.clear()
+        self.state.approval.pending.clear()
 
-        if self._approval_wait_started_at is not None:
-            self._approval_wait_started_at = None
+        if self.state.approval.wait_started_at is not None:
+            self.state.approval.wait_started_at = None
 
-        if self._saved_phase_before_approval is not None:
-            self.current_status.phase = self._saved_phase_before_approval
-            self._saved_phase_before_approval = None
+        if self.state.approval.saved_phase is not None:
+            self.current_status.phase = self.state.approval.saved_phase
+            self.state.approval.saved_phase = None
         else:
             self.current_status.phase = ExecutionPhase.EXECUTION_IN_PROGRESS
 
@@ -2421,7 +2198,7 @@ class StatusBuilder:
             ToolCallStatus.TOOL_CALL_FAILED,
             ToolCallStatus.TOOL_CALL_SKIPPED,
         })
-        tc_id = self._run_id_aliases.get(run_id, run_id)
+        tc_id = self._tool_call_id_capture.resolve(run_id)
         existing_tc = self.get_tool_call(tc_id)
         if existing_tc is not None and existing_tc.status in post_approval_statuses:
             self.logger.warning(
@@ -2433,19 +2210,19 @@ class StatusBuilder:
             )
             return
 
-        if self._saved_phase_before_approval is None:
-            self._saved_phase_before_approval = self.current_status.phase
-            self._approval_wait_started_at = datetime.utcnow()
+        if self.state.approval.saved_phase is None:
+            self.state.approval.saved_phase = self.current_status.phase
+            self.state.approval.wait_started_at = datetime.utcnow()
         self.current_status.phase = ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL
 
-        self._pending_tool_approvals.append(run_id)
+        self.state.approval.pending.append(run_id)
         self.force_next_update = True
 
         self.logger.info(
             f"[APPROVAL] execution={self.execution_id} "
             f"tool={tool_name} run_id={run_id} tc_id={tc_id} "
             f"status=WAITING_APPROVAL "
-            f"pending_count={len(self._pending_tool_approvals)}"
+            f"pending_count={len(self.state.approval.pending)}"
         )
     
     def _find_tool_call_by_id(self, run_id: str) -> ToolCall | None:
@@ -2453,7 +2230,7 @@ class StatusBuilder:
 
         Alias for :meth:`get_tool_call` retained for internal callers.
         """
-        return self._tool_call_index.get(run_id)
+        return self.state.tool_calls.get(run_id)
     
     def _humanize_args_for_display(self, tool_args: dict[str, Any]) -> dict[str, Any]:
         """Return a shallow copy of *tool_args* with string values humanized.
@@ -2562,29 +2339,29 @@ class StatusBuilder:
             return self.current_status, None
         
         # Try to find matching sub-agent by namespace
-        sub_agent_id = self._namespace_to_sub_agent_id.get(namespace)
+        sub_agent_id = self.state.namespace_to_sub_agent.get(namespace)
         if sub_agent_id:
-            if sub_agent_id in self._active_sub_agents:
-                return self._active_sub_agents[sub_agent_id], self._active_sub_agents[sub_agent_id]
+            if sub_agent_id in self.state.active_sub_agents:
+                return self.state.active_sub_agents[sub_agent_id], self.state.active_sub_agents[sub_agent_id]
 
             # Late-arriving event: the sub-agent already completed but
             # LangGraph emitted one more event (e.g. on_chat_model_end
             # finalizing a message that was streamed before completion).
-            if sub_agent_id in self._completed_sub_agents:
+            if sub_agent_id in self.state.completed_sub_agents:
                 self.logger.debug(
                     f"[SUBAGENT] execution={self.execution_id} "
                     f"late event routed to completed sub-agent={sub_agent_id} "
                     f"namespace={namespace}"
                 )
-                return self._completed_sub_agents[sub_agent_id], self._completed_sub_agents[sub_agent_id]
+                return self.state.completed_sub_agents[sub_agent_id], self.state.completed_sub_agents[sub_agent_id]
 
         # Namespace not yet registered — fall back to main agent.
         # Single-segment namespaces (no "|") are normal main-agent graph
         # activity (e.g., the tools node).  Only warn for multi-segment
         # namespaces, which indicate sub-agent events that should have
         # been routed.  Deduplicate: warn once per unique namespace.
-        if "|" in namespace and namespace not in self._warned_namespaces:
-            self._warned_namespaces.add(namespace)
+        if "|" in namespace and namespace not in self.state.warned_namespaces:
+            self.state.warned_namespaces.add(namespace)
             self.logger.warning(
                 f"[NAMESPACE] execution={self.execution_id} "
                 f"namespace={namespace} has no registered sub-agent — "
@@ -2612,7 +2389,7 @@ class StatusBuilder:
             event: The full v2 astream_events event dict (carries
                 ``parent_ids`` at the top level).
         """
-        if not namespace or namespace in self._namespace_to_sub_agent_id:
+        if not namespace or namespace in self.state.namespace_to_sub_agent:
             return
 
         if "|" not in namespace:
@@ -2620,15 +2397,15 @@ class StatusBuilder:
 
         parent_ids: list[str] = event.get("parent_ids", [])
         for pid in parent_ids:
-            if pid in self._active_sub_agents:
-                self._namespace_to_sub_agent_id[namespace] = pid
+            if pid in self.state.active_sub_agents:
+                self.state.namespace_to_sub_agent[namespace] = pid
                 self.logger.debug(
                     "[SUBAGENT] namespace=%s -> sub_agent=%s (via parent_ids)",
                     namespace, pid,
                 )
                 return
-            if pid in self._completed_sub_agents:
-                self._namespace_to_sub_agent_id[namespace] = pid
+            if pid in self.state.completed_sub_agents:
+                self.state.namespace_to_sub_agent[namespace] = pid
                 self.logger.debug(
                     "[SUBAGENT] namespace=%s -> completed sub_agent=%s "
                     "(via parent_ids)",
@@ -2640,8 +2417,8 @@ class StatusBuilder:
             "[SUBAGENT] execution=%s namespace=%s not resolved: "
             "parent_ids=%s matched neither active=%s nor completed=%s",
             self.execution_id, namespace, parent_ids,
-            list(self._active_sub_agents.keys()),
-            list(self._completed_sub_agents.keys()),
+            list(self.state.active_sub_agents.keys()),
+            list(self.state.completed_sub_agents.keys()),
         )
     
     async def _handle_sub_agent_start(
@@ -2679,8 +2456,8 @@ class StatusBuilder:
         # SubAgentExecution entries.
         for existing_sa in self.current_status.sub_agent_executions:
             if existing_sa.id == sa_id:
-                self._active_sub_agents[run_id] = existing_sa
-                self._run_id_to_tool_call_id[run_id] = sa_id
+                self.state.active_sub_agents[run_id] = existing_sa
+                self.state.run_id_to_tool_call_id[run_id] = sa_id
                 self.logger.info(
                     "[SUBAGENT] execution=%s resume reactivation: "
                     "sa_id=%s run_id=%s (skipping duplicate creation)",
@@ -2695,14 +2472,14 @@ class StatusBuilder:
             or tool_args.get("task", "")
             or tool_args.get("prompt", "")
         )
-        existing = list(self._subject_counts.keys())
+        existing = list(self.state.subject_counts.keys())
         subject = await _generate_sub_agent_subject(
             sub_agent_input, sub_agent_name, existing_subjects=existing,
         )
 
         if subject:
-            count = self._subject_counts.get(subject, 0) + 1
-            self._subject_counts[subject] = count
+            count = self.state.subject_counts.get(subject, 0) + 1
+            self.state.subject_counts[subject] = count
             if count > 1:
                 suffix = f" ({count})"
                 max_base = _MAX_SUBJECT_LENGTH - len(suffix)
@@ -2725,8 +2502,8 @@ class StatusBuilder:
         # returned by the repeated field we ensure all later mutations
         # (messages, tool_calls, usage) write to the actual status proto.
         self.current_status.sub_agent_executions.append(sub_agent)
-        self._active_sub_agents[run_id] = self.current_status.sub_agent_executions[-1]
-        self._run_id_to_tool_call_id[run_id] = sa_id
+        self.state.active_sub_agents[run_id] = self.current_status.sub_agent_executions[-1]
+        self.state.run_id_to_tool_call_id[run_id] = sa_id
 
         self.force_next_update = True
 
@@ -2765,10 +2542,10 @@ class StatusBuilder:
                 )
 
         # Prefer the direct proto reference from _active_sub_agents.
-        sub_agent_ref = self._active_sub_agents.get(run_id)
+        sub_agent_ref = self.state.active_sub_agents.get(run_id)
         if sub_agent_ref is None:
             # Fallback: scan by tool_call_id (SubAgentExecution.id)
-            sa_id = self._run_id_to_tool_call_id.get(run_id, run_id)
+            sa_id = self.state.run_id_to_tool_call_id.get(run_id, run_id)
             for sa in self.current_status.sub_agent_executions:
                 if sa.id == sa_id:
                     sub_agent_ref = sa
@@ -2801,7 +2578,7 @@ class StatusBuilder:
 
         # Mark the parent ToolCall as COMPLETED so the frontend reflects
         # the sub-agent's finished state.
-        tc_id = self._run_id_to_tool_call_id.get(run_id)
+        tc_id = self.state.run_id_to_tool_call_id.get(run_id)
         if tc_id:
             parent_tc = self.get_tool_call(tc_id)
             if parent_tc is not None:
@@ -2812,8 +2589,8 @@ class StatusBuilder:
         # Move from active to completed (preserving reference for late events).
         # Namespace mappings are NOT deleted — late-arriving events from
         # LangGraph can still route to the correct SubAgentExecution.
-        if run_id in self._active_sub_agents:
-            self._completed_sub_agents[run_id] = self._active_sub_agents.pop(run_id)
+        if run_id in self.state.active_sub_agents:
+            self.state.completed_sub_agents[run_id] = self.state.active_sub_agents.pop(run_id)
 
         # Defer the gRPC flush instead of forcing it immediately.  Late
         # LangGraph events (on_chat_model_end, on_tool_end for nested tools)
@@ -2821,7 +2598,7 @@ class StatusBuilder:
         # lets them be batched into the same update that carries the
         # COMPLETED status, preventing the UI from showing "Completed"
         # while messages still stream in.
-        self._pending_completion_flush[run_id] = time.monotonic()
+        self.state.pending_completion_flush[run_id] = time.monotonic()
 
     def _finalize_orphaned_tool_calls(
         self, sub_agent: SubAgentExecution, now: datetime,
@@ -2859,7 +2636,7 @@ class StatusBuilder:
     @property
     def has_orphaned_sub_agents(self) -> bool:
         """True when sub-agents remain active after the event stream ended."""
-        return bool(self._active_sub_agents)
+        return bool(self.state.active_sub_agents)
 
     def get_orphaned_sub_agents_diagnostic(self) -> dict:
         """Return structured info about orphaned (still-active) sub-agents.
@@ -2875,7 +2652,7 @@ class StatusBuilder:
         zero_message: list[dict] = []
         mid_execution: list[dict] = []
 
-        for run_id, sub_agent in self._active_sub_agents.items():
+        for run_id, sub_agent in self.state.active_sub_agents.items():
             tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
             has_activity = len(sub_agent.messages) > 0
             entry = {
@@ -2890,7 +2667,7 @@ class StatusBuilder:
                 zero_message.append(entry)
 
         return {
-            "total": len(self._active_sub_agents),
+            "total": len(self.state.active_sub_agents),
             "zero_message_count": len(zero_message),
             "mid_execution_count": len(mid_execution),
             "zero_message": zero_message,
@@ -2909,11 +2686,11 @@ class StatusBuilder:
         Returns:
             List of run_ids that were flushed.
         """
-        if not self._pending_completion_flush:
+        if not self.state.pending_completion_flush:
             return []
 
-        flushed = list(self._pending_completion_flush.keys())
-        self._pending_completion_flush.clear()
+        flushed = list(self.state.pending_completion_flush.keys())
+        self.state.pending_completion_flush.clear()
         if flushed:
             self.force_next_update = True
         return flushed
@@ -2942,7 +2719,7 @@ class StatusBuilder:
                 f"finalization: {flushed}"
             )
 
-        if not self._active_sub_agents:
+        if not self.state.active_sub_agents:
             return
 
         now = _utc_timestamp()
@@ -2955,7 +2732,7 @@ class StatusBuilder:
             SubAgentStatus.SUB_AGENT_CANCELLED,
         }
 
-        for run_id, sub_agent in list(self._active_sub_agents.items()):
+        for run_id, sub_agent in list(self.state.active_sub_agents.items()):
             if sub_agent.status in terminal_statuses or sub_agent.output:
                 preserved_ids.append(run_id)
             else:
@@ -2964,9 +2741,9 @@ class StatusBuilder:
                 sub_agent.completed_at = now
                 finalized_ids.append(run_id)
 
-            self._completed_sub_agents[run_id] = sub_agent
+            self.state.completed_sub_agents[run_id] = sub_agent
 
-        self._active_sub_agents.clear()
+        self.state.active_sub_agents.clear()
 
         self.logger.info(
             f"[SUBAGENT] execution={self.execution_id} "
@@ -3005,7 +2782,7 @@ class StatusBuilder:
                 f"differentiated finalization: {flushed}"
             )
 
-        if not self._active_sub_agents:
+        if not self.state.active_sub_agents:
             return 0
 
         now = _utc_timestamp()
@@ -3019,7 +2796,7 @@ class StatusBuilder:
             SubAgentStatus.SUB_AGENT_CANCELLED,
         }
 
-        for run_id, sub_agent in list(self._active_sub_agents.items()):
+        for run_id, sub_agent in list(self.state.active_sub_agents.items()):
             if sub_agent.status in terminal_statuses or sub_agent.output:
                 preserved_ids.append(run_id)
             else:
@@ -3042,10 +2819,10 @@ class StatusBuilder:
 
                 sub_agent.completed_at = now
 
-            self._completed_sub_agents[run_id] = sub_agent
+            self.state.completed_sub_agents[run_id] = sub_agent
 
-        total = len(self._active_sub_agents)
-        self._active_sub_agents.clear()
+        total = len(self.state.active_sub_agents)
+        self.state.active_sub_agents.clear()
 
         finalized = len(cancelled_ids) + len(failed_ids)
         self.logger.info(
@@ -3099,21 +2876,21 @@ class StatusBuilder:
         """
         self._flush_pending_completions()
 
-        if not self._active_sub_agents:
+        if not self.state.active_sub_agents:
             return 0
 
         now = _utc_timestamp()
-        total = len(self._active_sub_agents)
+        total = len(self.state.active_sub_agents)
 
         if missed_event_count > 0 and confirmed_orphan_count == 0:
             completed_ids: list[str] = []
-            for run_id, sub_agent in list(self._active_sub_agents.items()):
+            for run_id, sub_agent in list(self.state.active_sub_agents.items()):
                 sub_agent.status = SubAgentStatus.SUB_AGENT_COMPLETED
                 sub_agent.completed_at = now
-                self._completed_sub_agents[run_id] = sub_agent
+                self.state.completed_sub_agents[run_id] = sub_agent
                 completed_ids.append(run_id)
 
-            self._active_sub_agents.clear()
+            self.state.active_sub_agents.clear()
             self.logger.info(
                 f"[SUBAGENT] execution={self.execution_id} "
                 f"checkpoint confirms {total} sub-agent(s) completed "
@@ -3124,7 +2901,7 @@ class StatusBuilder:
             cancelled_ids: list[str] = []
             failed_ids: list[str] = []
 
-            for run_id, sub_agent in list(self._active_sub_agents.items()):
+            for run_id, sub_agent in list(self.state.active_sub_agents.items()):
                 tc_count = sum(len(m.tool_calls) for m in sub_agent.messages)
                 has_activity = (
                     len(sub_agent.messages) > 0
@@ -3147,9 +2924,9 @@ class StatusBuilder:
                     cancelled_ids.append(run_id)
 
                 sub_agent.completed_at = now
-                self._completed_sub_agents[run_id] = sub_agent
+                self.state.completed_sub_agents[run_id] = sub_agent
 
-            self._active_sub_agents.clear()
+            self.state.active_sub_agents.clear()
 
             qualifier = (
                 "confirmed orphaned"
@@ -3281,7 +3058,7 @@ class StatusBuilder:
             target_tokens: Target token count after summarization.
             enabled: Whether summarization is enabled for this execution.
         """
-        self._context_info = ContextInfo(
+        self.state.context_info = ContextInfo(
             context_window_limit=context_window_limit,
             summarization_trigger_threshold=trigger_threshold,
             summarization_target_tokens=target_tokens,
@@ -3310,7 +3087,7 @@ class StatusBuilder:
         Args:
             event: Immutable data object containing summarization metrics.
         """
-        if self._context_info is None:
+        if self.state.context_info is None:
             self.logger.warning(
                 f"[CONTEXT] execution={self.execution_id} "
                 "on_summarization_complete called but context_info not initialized"
@@ -3337,9 +3114,9 @@ class StatusBuilder:
             summarization_output_tokens=event.summarization_output_tokens,
             summarization_cost_usd=event.summarization_cost_usd,
         )
-        self._context_info.summarization_events.append(proto_event)
+        self.state.context_info.summarization_events.append(proto_event)
         
-        self._context_info.current_token_count = event.tokens_after
+        self.state.context_info.current_token_count = event.tokens_after
         self._update_utilization()
         self._sync_context_info()
         self.force_next_update = True
@@ -3364,32 +3141,32 @@ class StatusBuilder:
         Args:
             token_count: Current token count in the context window.
         """
-        if self._context_info is None:
+        if self.state.context_info is None:
             # Not an error - context tracking may be disabled
             return
         
-        self._context_info.current_token_count = token_count
+        self.state.context_info.current_token_count = token_count
         self._update_utilization()
         
         self.logger.debug(
             f"[CONTEXT] execution={self.execution_id} "
             f"token_count={token_count} "
-            f"utilization={self._context_info.utilization_percent:.1f}%"
+            f"utilization={self.state.context_info.utilization_percent:.1f}%"
         )
     
     def _update_utilization(self) -> None:
         """Recalculate utilization percentage based on current token count."""
-        if self._context_info is None:
+        if self.state.context_info is None:
             return
         
-        if self._context_info.context_window_limit > 0:
-            self._context_info.utilization_percent = (
-                self._context_info.current_token_count
-                / self._context_info.context_window_limit
+        if self.state.context_info.context_window_limit > 0:
+            self.state.context_info.utilization_percent = (
+                self.state.context_info.current_token_count
+                / self.state.context_info.context_window_limit
                 * 100
             )
         else:
-            self._context_info.utilization_percent = 0.0
+            self.state.context_info.utilization_percent = 0.0
     
     def _sync_context_info(self) -> None:
         """Copy the working ``_context_info`` to ``current_status``.
@@ -3397,8 +3174,8 @@ class StatusBuilder:
         Safe to call at any time — ``_context_info.summarization_events``
         is the single source of truth, so repeated calls never duplicate.
         """
-        if self._context_info is not None:
-            self.current_status.context_info.CopyFrom(self._context_info)
+        if self.state.context_info is not None:
+            self.current_status.context_info.CopyFrom(self.state.context_info)
 
     def finalize_context_info(self) -> None:
         """
@@ -3407,17 +3184,17 @@ class StatusBuilder:
         Called at the end of execution to copy accumulated context info,
         summarization events, and execution outputs to the status proto.
         """
-        if self._context_info is not None:
+        if self.state.context_info is not None:
             self._sync_context_info()
             
             summarization_count = len(
-                self._context_info.summarization_events,
+                self.state.context_info.summarization_events,
             )
             self.logger.info(
                 f"[CONTEXT] execution={self.execution_id} "
                 f"context_info finalized: "
-                f"final_tokens={self._context_info.current_token_count}, "
-                f"utilization={self._context_info.utilization_percent:.1f}%, "
+                f"final_tokens={self.state.context_info.current_token_count}, "
+                f"utilization={self.state.context_info.utilization_percent:.1f}%, "
                 f"summarizations={summarization_count}"
             )
         
@@ -3427,17 +3204,17 @@ class StatusBuilder:
         # inline publish but before this finalizer ran).
         already_synced = {a.sandbox_path for a in self.current_status.artifacts}
         newly_synced = 0
-        for artifact in self._artifacts:
+        for artifact in self.state.artifacts:
             if artifact.sandbox_path not in already_synced:
                 self.current_status.artifacts.append(artifact)
                 newly_synced += 1
 
-        if self._artifacts:
+        if self.state.artifacts:
             self.logger.info(
                 f"[ARTIFACTS] execution={self.execution_id} "
-                f"finalized {len(self._artifacts)} artifact(s) "
+                f"finalized {len(self.state.artifacts)} artifact(s) "
                 f"({newly_synced} newly synced, "
-                f"{len(self._artifacts) - newly_synced} already live)"
+                f"{len(self.state.artifacts) - newly_synced} already live)"
             )
     
     # ─────────────────────────────────────────────────────────────────────────────
@@ -3457,13 +3234,13 @@ class StatusBuilder:
         entry is replaced in both the internal tracking list and the live
         status proto.
         """
-        existing_paths = {a.sandbox_path for a in self._artifacts}
+        existing_paths = {a.sandbox_path for a in self.state.artifacts}
         if artifact.sandbox_path in existing_paths:
-            self._artifacts = [
-                a for a in self._artifacts
+            self.state.artifacts = [
+                a for a in self.state.artifacts
                 if a.sandbox_path != artifact.sandbox_path
             ]
-        self._artifacts.append(artifact)
+        self.state.artifacts.append(artifact)
 
         self._sync_artifact_to_status(artifact)
         self.force_next_update = True

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -413,13 +413,6 @@ class StatusBuilder:
         # Key: namespace string, Value: sub-agent run_id
         self._namespace_to_sub_agent_id: dict[str, str] = {}
         
-        # Causal namespace registration: when "task" tools start, we record
-        # their sub-agent IDs in FIFO order.  The next unregistered multi-segment
-        # namespace (indicating a nested sub-graph) is associated with the
-        # front-of-queue sub-agent.  Supports concurrent sub-agent launches
-        # where multiple task tools start before any child events arrive.
-        self._pending_sub_agent_ids: list[str] = []
-        
         # Subject deduplication: tracks how many times each subject has been
         # assigned so duplicate subjects get a numeric suffix (e.g., "(2)").
         self._subject_counts: dict[str, int] = {}
@@ -712,7 +705,7 @@ class StatusBuilder:
         # are registered before _get_execution_context performs its exact
         # lookup in the type-specific handler.
         if namespace:
-            self._register_sub_agent_namespace(namespace)
+            self._register_sub_agent_namespace(namespace, event)
         
         # Route by event type.  Each handler is wrapped so a single bad
         # event never crashes the entire activity stream.
@@ -1130,7 +1123,7 @@ class StatusBuilder:
         
         # Try to register namespace for event routing
         if namespace:
-            self._register_sub_agent_namespace(namespace)
+            self._register_sub_agent_namespace(namespace, event)
         
         # ─────────────────────────────────────────────────────────────────────
         # LLM Turn-Boundary Detection
@@ -2599,109 +2592,57 @@ class StatusBuilder:
             )
         return self.current_status, None
     
-    def _register_sub_agent_namespace(self, namespace: str) -> None:
-        """
-        Register namespace -> sub-agent mapping when child event arrives.
-        
-        Uses four strategies in priority order:
-        
-        1. **Root-prefix matching**: Multi-segment namespaces (containing "|")
-           share a root segment (before the first "|") when they originate
-           from the same sub-agent.  If any already-registered namespace
-           shares the same root, the new namespace inherits the mapping.
-        
-        2. **Substring matching** (legacy): Checks if any active sub-agent's
-           run_id appears in the namespace string.
-        
-        3. **Causal correlation**: When "task" tools start sub-agents,
-           their IDs are appended to ``_pending_sub_agent_ids`` (FIFO).
-           The first unregistered multi-segment namespace is associated
-           with the front-of-queue sub-agent.  This handles the common
-           case where LangGraph checkpoint UUIDs differ from the task
-           tool's event run_id, including concurrent sub-agent launches.
-        
-        4. **Sole-active-agent fallback**: When exactly one sub-agent is
-           active, all multi-segment namespaces must originate from it
-           (there is no other candidate).  This covers the common case
-           where a sub-agent's internal graph nodes produce events with
-           namespace roots that differ from the initially registered one.
-        
-        Single-segment namespaces (no "|") are from the main agent's graph
+    def _register_sub_agent_namespace(
+        self, namespace: str, event: dict[str, Any],
+    ) -> None:
+        """Register namespace -> sub-agent mapping via ``parent_ids``.
+
+        v2 ``astream_events`` carry a ``parent_ids`` list tracing the full
+        callback chain.  When a sub-agent event arrives, at least one entry
+        in ``parent_ids`` is the task tool's ``run_id`` — the same key stored
+        in ``_active_sub_agents``.  This provides a deterministic mapping
+        without heuristics (no root-prefix, no FIFO queue, no substring
+        matching, no sole-active fallback).
+
+        Single-segment namespaces (no ``|``) are from the main agent's graph
         nodes and are intentionally not registered.
-        
+
         Args:
-            namespace: LangGraph checkpoint namespace string
+            namespace: LangGraph checkpoint namespace string.
+            event: The full v2 astream_events event dict (carries
+                ``parent_ids`` at the top level).
         """
         if not namespace or namespace in self._namespace_to_sub_agent_id:
             return
-        
-        is_multi_segment = "|" in namespace
-        ns_root = namespace.split("|")[0]
-        
-        # Strategy 1: root-prefix matching against already-registered namespaces.
-        # When a sub-agent has been identified via any namespace variant, all
-        # namespaces sharing the same root segment (before the first "|") are
-        # from the same sub-agent graph.
-        if is_multi_segment:
-            for registered_ns, sub_agent_id in self._namespace_to_sub_agent_id.items():
-                if registered_ns.split("|")[0] == ns_root:
-                    self._namespace_to_sub_agent_id[namespace] = sub_agent_id
-                    self.logger.debug(
-                        f"[SUBAGENT] Prefix-matched namespace={namespace} "
-                        f"-> sub_agent={sub_agent_id} "
-                        f"(via root={ns_root})"
-                    )
-                    return
-        
-        # Strategy 2: substring matching (legacy — works when run_id is in namespace)
-        for sub_agent_id in self._active_sub_agents:
-            if sub_agent_id in namespace:
-                self._namespace_to_sub_agent_id[namespace] = sub_agent_id
-                self.logger.info(
-                    f"[SUBAGENT] Substring-matched namespace={namespace} "
-                    f"-> sub_agent={sub_agent_id}"
-                )
-                return
-        
-        # Strategy 3: causal correlation with pending sub-agent.
-        # Only for multi-segment namespaces — single-segment namespaces are
-        # from the main agent's graph nodes, not from sub-agents.
-        if is_multi_segment and self._pending_sub_agent_ids:
-            sub_agent_id = self._pending_sub_agent_ids[0]
-            if sub_agent_id in self._active_sub_agents:
-                self._namespace_to_sub_agent_id[namespace] = sub_agent_id
-                self._pending_sub_agent_ids.pop(0)
-                self.logger.info(
-                    f"[SUBAGENT] Causal registration: namespace={namespace} "
-                    f"-> sub_agent={sub_agent_id}"
-                )
-                return
-        
-        # Strategy 4: sole-active-agent fallback.
-        # When exactly one sub-agent is active, all multi-segment namespaces
-        # must originate from it -- there is no other candidate.
-        if is_multi_segment and len(self._active_sub_agents) == 1:
-            sub_agent_id = next(iter(self._active_sub_agents))
-            self._namespace_to_sub_agent_id[namespace] = sub_agent_id
-            self.logger.debug(
-                f"[SUBAGENT] Sole-active fallback: namespace={namespace} "
-                f"-> sub_agent={sub_agent_id}"
-            )
+
+        if "|" not in namespace:
             return
-        
-        # Diagnostic: warn about unresolvable multi-segment namespaces.
-        # At this point multiple sub-agents are active and we cannot
-        # determine which one owns this namespace.  Deduplicate so we
-        # only warn once per unique namespace.
-        if is_multi_segment and namespace not in self._warned_namespaces:
-            self._warned_namespaces.add(namespace)
-            self.logger.warning(
-                f"[NS_DIAG] Namespace registration failed: "
-                f"execution={self.execution_id} "
-                f"namespace={namespace} "
-                f"active_sub_agents={list(self._active_sub_agents.keys())} "
-                f"pending={self._pending_sub_agent_ids}"
-            )
+
+        parent_ids: list[str] = event.get("parent_ids", [])
+        for pid in parent_ids:
+            if pid in self._active_sub_agents:
+                self._namespace_to_sub_agent_id[namespace] = pid
+                self.logger.debug(
+                    "[SUBAGENT] namespace=%s -> sub_agent=%s (via parent_ids)",
+                    namespace, pid,
+                )
+                return
+            if pid in self._completed_sub_agents:
+                self._namespace_to_sub_agent_id[namespace] = pid
+                self.logger.debug(
+                    "[SUBAGENT] namespace=%s -> completed sub_agent=%s "
+                    "(via parent_ids)",
+                    namespace, pid,
+                )
+                return
+
+        self.logger.debug(
+            "[SUBAGENT] execution=%s namespace=%s not resolved: "
+            "parent_ids=%s matched neither active=%s nor completed=%s",
+            self.execution_id, namespace, parent_ids,
+            list(self._active_sub_agents.keys()),
+            list(self._completed_sub_agents.keys()),
+        )
     
     async def _handle_sub_agent_start(
         self,
@@ -2740,8 +2681,6 @@ class StatusBuilder:
             if existing_sa.id == sa_id:
                 self._active_sub_agents[run_id] = existing_sa
                 self._run_id_to_tool_call_id[run_id] = sa_id
-                if run_id not in self._pending_sub_agent_ids:
-                    self._pending_sub_agent_ids.append(run_id)
                 self.logger.info(
                     "[SUBAGENT] execution=%s resume reactivation: "
                     "sa_id=%s run_id=%s (skipping duplicate creation)",
@@ -2789,18 +2728,12 @@ class StatusBuilder:
         self._active_sub_agents[run_id] = self.current_status.sub_agent_executions[-1]
         self._run_id_to_tool_call_id[run_id] = sa_id
 
-        # Enqueue for causal namespace registration.
-        # The next unregistered multi-segment namespace will be associated
-        # with the front-of-queue sub-agent (FIFO for concurrent launches).
-        self._pending_sub_agent_ids.append(run_id)
-
         self.force_next_update = True
 
         self.logger.info(
             f"[SUBAGENT] execution={self.execution_id} "
             f"sub_agent={sub_agent_name} sa_id={sa_id} run_id={run_id} "
-            f"subject={subject!r} status=IN_PROGRESS "
-            f"(pending namespace registration)"
+            f"subject={subject!r} status=IN_PROGRESS"
         )
     
     def _handle_sub_agent_end(self, event: dict[str, Any], run_id: str) -> None:
@@ -2881,9 +2814,6 @@ class StatusBuilder:
         # LangGraph can still route to the correct SubAgentExecution.
         if run_id in self._active_sub_agents:
             self._completed_sub_agents[run_id] = self._active_sub_agents.pop(run_id)
-
-        if run_id in self._pending_sub_agent_ids:
-            self._pending_sub_agent_ids.remove(run_id)
 
         # Defer the gRPC flush instead of forcing it immediately.  Late
         # LangGraph events (on_chat_model_end, on_tool_end for nested tools)

--- a/backend/services/agent-runner/worker/activities/graphton/status_builder.py
+++ b/backend/services/agent-runner/worker/activities/graphton/status_builder.py
@@ -10,6 +10,7 @@ import hashlib
 import inspect
 import json
 import logging
+import time
 from collections import deque
 from collections.abc import Callable, Coroutine, Iterator
 from datetime import datetime
@@ -569,6 +570,15 @@ class StatusBuilder:
         # if no further LangGraph events arrive).
         self.force_next_update: bool = False
 
+        # Deferred completion flush for sub-agents.  When a sub-agent
+        # completes (on_tool_end for "task"), we record the monotonic
+        # timestamp here instead of setting force_next_update.  This allows
+        # a short drain window for late LangGraph events (on_chat_model_end,
+        # on_tool_end for nested tools) to be processed and batched into
+        # the same gRPC update that carries the COMPLETED status — preventing
+        # the UI from showing "Completed" while messages still stream in.
+        self._pending_completion_flush: dict[str, float] = {}
+
         # Resolved agent env vars used by _create_args_preview to expand
         # $VAR references in display strings.  Set via set_display_env_vars()
         # once the merged environment is available.
@@ -633,6 +643,31 @@ class StatusBuilder:
     def tool_call_count(self) -> int:
         """Return the total number of tracked tool calls."""
         return len(self._tool_call_index)
+
+    _COMPLETION_DRAIN_MS: float = 300.0
+
+    def should_flush_completions(self, now_monotonic: float) -> bool:
+        """Check whether any pending sub-agent completion has drained.
+
+        Returns True (and sets :attr:`force_next_update`) when at least one
+        sub-agent completion has been pending for longer than
+        ``_COMPLETION_DRAIN_MS``.  The drain window allows late LangGraph
+        events to be batched into the same gRPC update that carries the
+        COMPLETED status.
+        """
+        if not self._pending_completion_flush:
+            return False
+        threshold = self._COMPLETION_DRAIN_MS / 1000.0
+        flushed: list[str] = []
+        for run_id, recorded_at in self._pending_completion_flush.items():
+            if (now_monotonic - recorded_at) >= threshold:
+                flushed.append(run_id)
+        if flushed:
+            for run_id in flushed:
+                del self._pending_completion_flush[run_id]
+            self.force_next_update = True
+            return True
+        return False
 
     def build_pending_approvals_snapshot(self) -> list[PendingApproval]:
         """Build pending_approvals snapshot for the Temporal slim status.
@@ -2914,7 +2949,13 @@ class StatusBuilder:
         if run_id in self._pending_sub_agent_ids:
             self._pending_sub_agent_ids.remove(run_id)
 
-        self.force_next_update = True
+        # Defer the gRPC flush instead of forcing it immediately.  Late
+        # LangGraph events (on_chat_model_end, on_tool_end for nested tools)
+        # arrive shortly after on_tool_end for "task".  The drain window
+        # lets them be batched into the same update that carries the
+        # COMPLETED status, preventing the UI from showing "Completed"
+        # while messages still stream in.
+        self._pending_completion_flush[run_id] = time.monotonic()
 
     def _finalize_orphaned_tool_calls(
         self, sub_agent: SubAgentExecution, now: datetime,

--- a/backend/services/agent-runner/worker/activities/graphton/streaming.py
+++ b/backend/services/agent-runner/worker/activities/graphton/streaming.py
@@ -135,7 +135,7 @@ class StreamExecutor:
             return None
 
         run_id = event.get("run_id", "")
-        resolved_id = self._sb._resolve_run_id(run_id)
+        resolved_id = self._sb.resolve_run_id(run_id)
         path = ""
         tc = self._sb.get_tool_call(resolved_id)
         if tc is not None:

--- a/backend/services/agent-runner/worker/activities/graphton/streaming.py
+++ b/backend/services/agent-runner/worker/activities/graphton/streaming.py
@@ -367,10 +367,27 @@ class StreamExecutor:
         force = self._sb.force_next_update
         if force:
             self._sb.force_next_update = False
+
+        # Check if any deferred sub-agent completion has drained.  This
+        # sets force_next_update (captured in the next iteration) only
+        # after the drain window elapses, giving late LangGraph events
+        # time to be batched into the same gRPC update.
+        completion_drained = self._sb.should_flush_completions(
+            time.monotonic(),
+        )
+        if completion_drained and not force:
+            force = self._sb.force_next_update
+            if force:
+                self._sb.force_next_update = False
+
         if not (force or scheduler.should_send_update(events_processed)):
             return events_processed, last_hb_time
 
-        reason = "force_tool_update" if force else scheduler.get_update_reason_str()
+        reason = (
+            "force_tool_update"
+            if force
+            else scheduler.get_update_reason_str()
+        )
         time_since = scheduler.get_time_since_last_update_ms()
         events_since = scheduler.get_events_since_last_update(events_processed)
 

--- a/backend/services/agent-runner/worker/activities/graphton/streaming.py
+++ b/backend/services/agent-runner/worker/activities/graphton/streaming.py
@@ -474,25 +474,9 @@ class StreamExecutor:
                 "from this checkpoint."
             ),
         )
-        asyncio.get_event_loop().run_until_complete(
-            self._persist_terminal_status("PAUSE")
-        ) if False else None  # noqa  — intentionally deferred; see below
-
-        # _persist_terminal_status is async but CancelledError handlers
-        # cannot await (the task is already cancelled). Best-effort via
-        # create_task in the finally block of execute() won't run either.
-        # Inline the sync gRPC call:
-        try:
-            import asyncio as _aio
-            _aio.get_event_loop().create_task(
-                self._exec_client.update_status(
-                    execution_id=self._execution_id,
-                    status=self._sb.current_status,
-                )
-            )
-        except Exception as err:
-            self._log.warning("[PAUSE] Failed to send status update: %s", err)
-
+        # No persistence here — the caller (execute_graphton.py) handles
+        # terminal status persistence via retry_executor for all terminal
+        # paths uniformly (pause, stall, recursion limit).
         return StreamResult(events_processed=events_processed, terminal_status=slim)
 
     def _handle_stall(self, events_processed: int) -> StreamResult:

--- a/backend/services/agent-runner/worker/activities/graphton/temporal_helpers.py
+++ b/backend/services/agent-runner/worker/activities/graphton/temporal_helpers.py
@@ -43,16 +43,18 @@ def slim_status_for_temporal(status: AgentExecutionStatus) -> AgentExecutionStat
     The full status is already persisted via progressive gRPC updates.
     Returning only workflow-critical fields keeps the Temporal payload
     well under the ~2 MB limit.
+
+    ``pending_approvals`` is intentionally omitted — the Go/Java workflow
+    reads the authoritative pending list from the DB via ``loadExecution()``
+    after persisting this status.  See ``ComputePendingApprovals`` in
+    ``approval/compute.go``.
     """
-    slim = AgentExecutionStatus(
+    return AgentExecutionStatus(
         phase=status.phase,
         error=status.error,
         started_at=status.started_at,
         completed_at=status.completed_at,
     )
-    for pa in status.pending_approvals:
-        slim.pending_approvals.append(pa)
-    return slim
 
 
 class SetupTimer:

--- a/backend/services/agent-runner/worker/activities/graphton/tool_call_id_capture.py
+++ b/backend/services/agent-runner/worker/activities/graphton/tool_call_id_capture.py
@@ -5,6 +5,10 @@ LangGraph v2 stream events do not surface the model's ``tool_call_id``
 callback API *does* receive it as a keyword argument.  This handler
 bridges the gap by storing ``{run_id → tool_call_id}`` so that
 StatusBuilder can resolve the identity when processing v2 events.
+
+Also serves as the single authority for run_id → tool_call_id resolution,
+including resume-path aliases where LangGraph generates new run_ids for
+tools that were already tracked under their original tool_call_id.
 """
 
 from __future__ import annotations
@@ -21,10 +25,22 @@ class ToolCallIdCapture(BaseCallbackHandler):
     Must be registered as a **sync** callback handler (not async) so the
     mapping is available before the corresponding v2 event is yielded
     from ``astream_events``.
+
+    Two mapping layers:
+
+    1. **Callback capture** (``_run_id_to_tool_call_id``): populated
+       automatically by ``on_tool_start`` from the LangChain callback API.
+    2. **Aliases** (``_aliases``): populated explicitly by StatusBuilder
+       when identity-based dedup detects a resumed tool that already
+       exists in the index under a different id.
+
+    ``resolve()`` checks aliases first (resume path), then the callback
+    mapping, and falls back to the input ``run_id`` unchanged.
     """
 
     def __init__(self) -> None:
         self._run_id_to_tool_call_id: dict[str, str] = {}
+        self._aliases: dict[str, str] = {}
 
     def on_tool_start(
         self,
@@ -41,3 +57,20 @@ class ToolCallIdCapture(BaseCallbackHandler):
     def get(self, run_id: str) -> str | None:
         """Return the ``tool_call_id`` for *run_id*, or ``None``."""
         return self._run_id_to_tool_call_id.get(run_id)
+
+    def register_alias(self, new_run_id: str, tool_call_id: str) -> None:
+        """Record that *new_run_id* should resolve to *tool_call_id*.
+
+        Used on the resume-after-approval path where LangGraph generates
+        a fresh run_id for a tool that StatusBuilder already tracks under
+        its original tool_call_id.
+        """
+        self._aliases[new_run_id] = tool_call_id
+
+    def resolve(self, run_id: str) -> str:
+        """Resolve *run_id* to the canonical tool_call_id.
+
+        Checks aliases first (resume path), then the callback capture,
+        and falls back to *run_id* unchanged.
+        """
+        return self._aliases.get(run_id) or self._run_id_to_tool_call_id.get(run_id) or run_id

--- a/backend/services/agent-runner/worker/activities/graphton/tool_call_id_capture.py
+++ b/backend/services/agent-runner/worker/activities/graphton/tool_call_id_capture.py
@@ -1,0 +1,43 @@
+"""Capture tool_call_id from LangChain's callback API.
+
+LangGraph v2 stream events do not surface the model's ``tool_call_id``
+(e.g. ``toolu_01abc…``) on ``on_tool_start`` or ``on_tool_end``.  The
+callback API *does* receive it as a keyword argument.  This handler
+bridges the gap by storing ``{run_id → tool_call_id}`` so that
+StatusBuilder can resolve the identity when processing v2 events.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+
+class ToolCallIdCapture(BaseCallbackHandler):
+    """Maps LangGraph tool ``run_id`` to the model's ``tool_call_id``.
+
+    Must be registered as a **sync** callback handler (not async) so the
+    mapping is available before the corresponding v2 event is yielded
+    from ``astream_events``.
+    """
+
+    def __init__(self) -> None:
+        self._run_id_to_tool_call_id: dict[str, str] = {}
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        tool_call_id: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if tool_call_id is not None:
+            self._run_id_to_tool_call_id[str(run_id)] = tool_call_id
+
+    def get(self, run_id: str) -> str | None:
+        """Return the ``tool_call_id`` for *run_id*, or ``None``."""
+        return self._run_id_to_tool_call_id.get(run_id)

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/approval/compute.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/approval/compute.go
@@ -47,8 +47,7 @@ func ComputePendingApprovals(
 
 // isTerminalSubAgent returns true for sub-agents that have reached a final
 // lifecycle state.  Any WAITING_APPROVAL tool calls left inside a terminal
-// sub-agent are orphans from the InterruptProxy thread-restart mechanism and
-// must not appear in pending_approvals.
+// sub-agent are orphans and must not appear in pending_approvals.
 func isTerminalSubAgent(status agentexecutionv1.SubAgentStatus) bool {
 	switch status {
 	case agentexecutionv1.SubAgentStatus_SUB_AGENT_COMPLETED,

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/lifecycle_steps.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/lifecycle_steps.go
@@ -367,7 +367,7 @@ func (s *SignalPauseToTemporalStep[T]) Execute(ctx *pipeline.RequestContext[T]) 
 		Msg("Sending pause signal to Temporal workflow")
 
 	// Send pause signal to workflow
-	err := s.temporalClient.SignalWorkflow(ctx.Context(), workflowID, "", "pause", reason)
+	err := s.temporalClient.SignalWorkflow(ctx.Context(), workflowID, "", workflows.SignalPause, reason)
 	if err != nil {
 		// Handle workflow not found (already completed/terminated)
 		if _, ok := err.(*serviceerror.NotFound); ok {
@@ -434,7 +434,7 @@ func (s *SignalResumeToTemporalStep[T]) Execute(ctx *pipeline.RequestContext[T])
 		Msg("Sending resume signal to Temporal workflow")
 
 	// Send resume signal to workflow (empty payload)
-	err := s.temporalClient.SignalWorkflow(ctx.Context(), workflowID, "", "resume", nil)
+	err := s.temporalClient.SignalWorkflow(ctx.Context(), workflowID, "", workflows.SignalResume, nil)
 	if err != nil {
 		// Handle workflow not found (already completed/terminated)
 		if _, ok := err.(*serviceerror.NotFound); ok {

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_creator.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_creator.go
@@ -46,8 +46,8 @@ func (c *InvokeAgentExecutionWorkflowCreator) Create(input *workflows.InvokeAgen
 
 	// NOTE: No WorkflowRunTimeout is set intentionally. This workflow supports
 	// human-in-the-loop (HITL) approval flows where the workflow blocks waiting
-	// for a submitApproval signal. Humans may take minutes, hours, or days to
-	// respond -- any finite timeout would contradict the durable execution promise.
+	// for an approvalGateResolved signal. Humans may take minutes, hours, or days
+	// to respond -- any finite timeout would contradict the durable execution promise.
 	// Activity-level timeouts (StartToCloseTimeout, HeartbeatTimeout) already
 	// protect against stuck activities; the workflow itself is just an orchestrator.
 	options := client.StartWorkflowOptions{
@@ -84,68 +84,6 @@ func (c *InvokeAgentExecutionWorkflowCreator) Create(input *workflows.InvokeAgen
 	return nil
 }
 
-// SignalApproval sends a submitApproval signal to a running agent execution workflow.
-//
-// This is called by AgentExecutionSubmitApprovalHandler when a user submits
-// an approval decision for a tool call. The workflow receives this signal
-// and unblocks its Workflow.await() to resume execution with the decision.
-//
-// Parameters:
-//   - executionID: The agent execution ID (used to construct workflow ID)
-//   - input: The approval input containing tool_call_id, action, and comment
-//
-// Returns:
-//   - ErrWorkflowNotFound if the workflow is not running
-//   - Other errors for transient Temporal failures
-//
-// Thread Safety: This method is safe for concurrent use.
-func (c *InvokeAgentExecutionWorkflowCreator) SignalApproval(executionID string, input *agentexecutionv1.SubmitApprovalInput) error {
-	// Workflow ID format: stigmer/agent-execution/invoke/{execution-id}
-	workflowID := fmt.Sprintf("%s/%s", workflows.InvokeAgentExecutionWorkflowName, executionID)
-
-	log.Info().
-		Str("workflow_id", workflowID).
-		Str("execution_id", executionID).
-		Str("tool_call_id", input.GetToolCallId()).
-		Str("action", input.GetAction().String()).
-		Msg("Sending submitApproval signal to workflow")
-
-	// Send signal to workflow
-	err := c.workflowClient.SignalWorkflow(
-		context.Background(),
-		workflowID,
-		"", // Run ID - empty means latest run
-		SignalSubmitApproval,
-		input,
-	)
-
-	if err != nil {
-		// Check for workflow not found error
-		var notFoundErr *serviceerror.NotFound
-		if errors.As(err, &notFoundErr) {
-			log.Warn().
-				Str("workflow_id", workflowID).
-				Str("execution_id", executionID).
-				Msg("Workflow not found - may have already completed")
-			return fmt.Errorf("workflow not found for execution %s: %w", executionID, ErrWorkflowNotFound)
-		}
-
-		log.Error().
-			Err(err).
-			Str("workflow_id", workflowID).
-			Str("execution_id", executionID).
-			Msg("Failed to signal workflow")
-		return fmt.Errorf("failed to signal workflow: %w", err)
-	}
-
-	log.Info().
-		Str("workflow_id", workflowID).
-		Str("execution_id", executionID).
-		Msg("Successfully sent submitApproval signal to workflow")
-
-	return nil
-}
-
 // SignalApprovalGateResolved sends an approvalGateResolved signal to a running
 // agent execution workflow, indicating that the approval gate for the current
 // HITL cycle has fully resolved.
@@ -154,8 +92,7 @@ func (c *InvokeAgentExecutionWorkflowCreator) SignalApproval(executionID string,
 //   - All pending tool calls have received decisions (gate fully cleared)
 //   - A REJECT action was submitted (immediate resume, Python auto-skips remaining)
 //
-// The workflow waits for exactly one of these signals per approval cycle,
-// replacing the previous pattern of counting N individual submitApproval signals.
+// The workflow waits for exactly one of these signals per approval cycle.
 func (c *InvokeAgentExecutionWorkflowCreator) SignalApprovalGateResolved(executionID string) error {
 	workflowID := fmt.Sprintf("%s/%s", workflows.InvokeAgentExecutionWorkflowName, executionID)
 

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_creator.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_creator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog/log"
-	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/client"

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_types.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_types.go
@@ -20,4 +20,13 @@ const (
 	// was submitted (which triggers immediate resume — Python auto-skips remaining
 	// tool calls). The workflow waits for exactly one of these per approval cycle.
 	SignalApprovalGateResolved = "approvalGateResolved"
+
+	// SignalPause is sent by the Pause RPC handler to gracefully pause a running execution.
+	// The workflow cancels the activity, waits for it to save a LangGraph checkpoint,
+	// then waits for a SignalResume before re-invoking.
+	SignalPause = "pause"
+
+	// SignalResume is sent by the Resume RPC handler to continue a paused execution.
+	// The workflow re-invokes the Python activity, which loads from the LangGraph checkpoint.
+	SignalResume = "resume"
 )

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_types.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflow_types.go
@@ -10,11 +10,6 @@ const (
 	// Handles both workflows and Python activities on the same queue.
 	AgentExecutionTaskQueue = "execution"
 
-	// SignalSubmitApproval is the signal name for submitting HITL approval decisions.
-	// This signal is sent to a running workflow when a user approves/skips/rejects a tool call.
-	// The workflow receives this signal and unblocks its Workflow.await() to resume execution.
-	SignalSubmitApproval = "submitApproval"
-
 	// SignalApprovalGateResolved is sent when the approval gate for a HITL cycle
 	// has fully resolved: either all pending tool calls have decisions, or a REJECT
 	// was submitted (which triggers immediate resume — Python auto-skips remaining

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow.go
@@ -20,3 +20,11 @@ type InvokeAgentExecutionWorkflow interface {
 // InvokeAgentExecutionWorkflowName is the workflow name used for registration.
 // This MUST match the workflow name in the Java implementation for consistency.
 const InvokeAgentExecutionWorkflowName = "stigmer/agent-execution/invoke"
+
+// Signal names for pause/resume lifecycle. These MUST match the signal names
+// used by the Java workflow's @SignalMethod declarations and the Go/Java
+// RPC handlers that send them (lifecycle_steps.go / AgentExecutionPauseHandler).
+const (
+	SignalPause  = "pause"
+	SignalResume = "resume"
+)

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_impl.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_impl.go
@@ -307,13 +307,14 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonWithHitl(
 	logger.Info("Activity returned slim status",
 		"execution_id", executionID,
 		"phase", finalStatus.GetPhase().String(),
-		"phase_value", int32(finalStatus.GetPhase()),
-		"pending_approvals", len(finalStatus.GetPendingApprovals()))
+		"phase_value", int32(finalStatus.GetPhase()))
 
 	// HITL Approval Loop (DB-Driven Resume)
 	//
-	// When Python returns EXECUTION_WAITING_FOR_APPROVAL, the workflow waits for
-	// a single approvalGateResolved signal, then re-invokes Python.
+	// When Python returns EXECUTION_WAITING_FOR_APPROVAL, the workflow persists
+	// the status, loads the execution from DB to get the authoritative
+	// pending_approvals (computed by ComputePendingApprovals on every
+	// UpdateStatus write), then waits for a single approvalGateResolved signal.
 	//
 	// All blocking operations use the provided ctx so that cancellation (from the
 	// pause/resume outer loop) propagates through.
@@ -325,17 +326,28 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonWithHitl(
 			return nil, fmt.Errorf("max approval cycles (%d) reached - possible infinite loop", MaxApprovalCycles)
 		}
 
-		pendingCount := len(finalStatus.GetPendingApprovals())
+		if err := w.persistFinalStatus(ctx, executionID, finalStatus); err != nil {
+			logger.Warn("Failed to persist WAITING_FOR_APPROVAL status before signal wait (non-fatal)",
+				"execution_id", executionID, "error", err.Error())
+		}
+
+		// Read pending_approvals from DB — the single source of truth.
+		// ComputePendingApprovals runs on every UpdateStatus write, so
+		// the DB always has the authoritative count.
+		dbExecution, loadErr := w.loadExecution(ctx, executionID)
+		pendingCount := 0
+		if loadErr != nil {
+			logger.Warn("Failed to load execution from DB for pending count (non-fatal, will wait for signal)",
+				"execution_id", executionID, "error", loadErr.Error())
+			pendingCount = 1 // assume pending to avoid skipping the signal wait
+		} else {
+			pendingCount = len(dbExecution.GetStatus().GetPendingApprovals())
+		}
 
 		logger.Info("Execution waiting for approval — waiting for approvalGateResolved signal",
 			"execution_id", executionID,
 			"cycle", approvalCycle,
 			"pending_count", pendingCount)
-
-		if err := w.persistFinalStatus(ctx, executionID, finalStatus); err != nil {
-			logger.Warn("Failed to persist WAITING_FOR_APPROVAL status before signal wait (non-fatal)",
-				"execution_id", executionID, "error", err.Error())
-		}
 
 		if pendingCount == 0 {
 			logger.Warn("pending_approvals is empty but phase is WAITING_FOR_APPROVAL — "+
@@ -369,7 +381,6 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonWithHitl(
 			"execution_id", executionID,
 			"phase", finalStatus.GetPhase().String(),
 			"phase_value", int32(finalStatus.GetPhase()),
-			"pending_approvals", len(finalStatus.GetPendingApprovals()),
 			"cycle", approvalCycle)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_impl.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_impl.go
@@ -113,6 +113,9 @@ func (w *InvokeAgentExecutionWorkflowImpl) Run(ctx workflow.Context, input *Invo
 // MaxApprovalCycles is the maximum number of approval iterations to prevent infinite loops.
 const MaxApprovalCycles = 100
 
+// MaxPauseCycles is the maximum number of pause/resume cycles to prevent infinite loops.
+const MaxPauseCycles = 100
+
 // SignalApprovalGateResolved is the signal sent by SubmitApproval when the approval
 // gate has fully resolved (all tool calls decided, or a REJECT was submitted).
 // Must match the constant in temporal/workflow_types.go.
@@ -122,23 +125,21 @@ const SignalApprovalGateResolved = "approvalGateResolved"
 //
 // Orchestrates:
 // 1. Python activity: Ensure thread (on "execution" queue)
-// 2. Python activity: Execute agent (on "execution" queue)
+// 2. Python activity: Execute agent (on "execution" queue), with pause/resume
 //   - During execution, agent-runner sends progressive status updates via gRPC
 //   - Final status is returned for Temporal observability
 //
-// 3. Approval loop: If tool requires approval, wait for signal and re-invoke
+// 3. Pause/resume outer loop: If a "pause" signal arrives while the activity is
 //
-// Slim-Payload Pattern:
-// The workflow passes only executionID (not the full AgentExecution proto) to
-// the Python activity.  The Python activity hydrates the execution from the
-// database via gRPC, keeping Temporal payloads small and bounded.
+//	running, the workflow cancels the activity (Python saves a LangGraph
+//	checkpoint), waits for a "resume" signal, then re-invokes.
 //
-// HITL Approval Loop:
-// When Python activity returns with EXECUTION_WAITING_FOR_APPROVAL, the workflow:
-//   - Waits for a single approvalGateResolved signal from the SubmitApproval handler
-//   - Re-invokes Python activity with (executionID, threadID, nil)
-//   - Python reads approval decisions from the DB (single source of truth)
-//   - Continues until terminal state or max cycles reached
+// 4. HITL approval loop (inside the pause scope): If a tool requires approval,
+//
+//	wait for approvalGateResolved signal and re-invoke.
+//
+// Modeled after the Java implementation's CancellationScope + Async.procedure
+// pattern (InvokeAgentExecutionWorkflowImpl.java lines 452-533).
 func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonFlow(ctx workflow.Context, input *InvokeAgentExecutionWorkflowInput) error {
 	logger := workflow.GetLogger(ctx)
 
@@ -161,14 +162,6 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonFlow(ctx workflow.Cont
 	logger.Info("Thread ensured", "thread_id", threadID)
 
 	// Step 1.5: Generate session subject (fire-and-forget, non-blocking)
-	//
-	// Runs in parallel with the main agent execution -- uses an economy-tier LLM
-	// to replace the "Auto-created session" sentinel with a concise, human-readable
-	// title derived from the user's first message and agent context.
-	//
-	// Modelled on the Java workflow's Async.procedure() pattern. Failures are
-	// logged and swallowed; a missing subject is cosmetic and must never block
-	// or affect the outcome of the main execution.
 	workflow.Go(ctx, func(ctx workflow.Context) {
 		subjectActivity := activities.NewGenerateSessionSubjectActivityStub(ctx, activityTaskQueue)
 		if err := subjectActivity.GenerateSessionSubject(executionID); err != nil {
@@ -178,54 +171,158 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonFlow(ctx workflow.Cont
 		}
 	})
 
-	// Step 2: Execute Graphton with thread_id (Python activity)
-	// Python activity:
-	// - Fetches AgentExecution from DB via gRPC get(executionID)
-	// - Executes agent and processes events
-	// - Sends progressive status updates via gRPC (real-time)
-	// - Returns final status to workflow (for observability)
+	// Step 2: Execute Graphton with pause/resume loop
+	//
+	// The outer loop handles pause/resume. When a "pause" signal arrives, the
+	// workflow cancels the activity context (which propagates to the running
+	// activity AND any HITL approval waits), then blocks on a "resume" signal
+	// before re-invoking.
+	//
+	// Pattern: workflow.Go() monitors the pause signal and calls cancelActivity()
+	// when received — equivalent to Java's Async.procedure + CancellationScope.
 	logger.Info("Step 2: Executing Graphton agent", "execution_id", executionID, "thread_id", threadID)
-	logger.Info("Agent-runner will fetch execution from DB and send progressive status updates via gRPC during execution")
+
+	pauseCh := workflow.GetSignalChannel(ctx, SignalPause)
+	resumeCh := workflow.GetSignalChannel(ctx, SignalResume)
+
+	var finalStatus *agentexecutionv1.AgentExecutionStatus
+	pauseCycle := 0
+
+	for {
+		var pauseRequested bool
+		activityCtx, cancelActivity := workflow.WithCancel(ctx)
+
+		// Monitor for pause signal concurrently. The goroutine is tied to
+		// activityCtx so it is cleaned up when the context is cancelled
+		// (either by pause or by normal completion calling cancelActivity).
+		workflow.Go(activityCtx, func(gCtx workflow.Context) {
+			var reason string
+			if !pauseCh.Receive(gCtx, &reason) {
+				return // context cancelled — not a real signal
+			}
+			logger.Info("Pause signal received",
+				"execution_id", executionID, "reason", reason)
+			pauseRequested = true
+			cancelActivity()
+		})
+
+		// Execute the agent with HITL approval loop (uses cancellable context)
+		finalStatus, err = w.executeGraphtonWithHitl(
+			activityCtx, activityTaskQueue, executionID, threadID,
+		)
+
+		if err != nil && pauseRequested {
+			// Activity (or HITL wait) was cancelled for pause.
+			pauseCycle++
+			if pauseCycle > MaxPauseCycles {
+				logger.Error("Max pause cycles reached",
+					"execution_id", executionID, "cycles", pauseCycle)
+				return fmt.Errorf("max pause cycles (%d) reached - possible infinite loop", MaxPauseCycles)
+			}
+
+			logger.Info("Execution paused — checkpoint saved, waiting for resume signal",
+				"execution_id", executionID, "pause_cycle", pauseCycle)
+
+			// Defense-in-depth: persist PAUSED status from the workflow.
+			// The Pause RPC pipeline already set PAUSED in the DB, but this
+			// ensures the latest messages/tool_calls from the activity's final
+			// gRPC update are also reflected.
+			pausedStatus := &agentexecutionv1.AgentExecutionStatus{
+				Phase: agentexecutionv1.ExecutionPhase_EXECUTION_PAUSED,
+			}
+			if persistErr := w.persistFinalStatus(ctx, executionID, pausedStatus); persistErr != nil {
+				logger.Warn("Failed to persist PAUSED status (non-fatal)",
+					"execution_id", executionID, "error", persistErr.Error())
+			}
+
+			// Wait for resume signal (on PARENT context — not cancelled)
+			resumeCh.Receive(ctx, nil)
+
+			logger.Info("Resume signal received — restarting activity from checkpoint",
+				"execution_id", executionID, "pause_cycle", pauseCycle)
+			continue
+		}
+
+		// Normal completion or error — cancel the activity context to clean up
+		// the pause-monitoring goroutine.
+		cancelActivity()
+
+		if err != nil {
+			return w.wrapActivityError("ExecuteGraphton", err)
+		}
+
+		// Activity completed normally
+		break
+	}
+
+	logger.Info("Graphton execution completed - final slim status received",
+		"execution_id", executionID,
+		"phase", finalStatus.GetPhase().String(),
+		"pending_approvals", len(finalStatus.GetPendingApprovals()),
+		"pause_cycles", pauseCycle)
+
+	// Defense-in-depth: persist FAILED status as a fallback. The primary path
+	// is Python's gRPC update_status call, but if that failed (transient network
+	// issue, server down), the error would be silently lost.
+	if finalStatus.GetPhase() == agentexecutionv1.ExecutionPhase_EXECUTION_FAILED {
+		logger.Warn("Activity returned EXECUTION_FAILED -- persisting as fallback",
+			"execution_id", executionID,
+			"error", finalStatus.GetError())
+
+		if err := w.persistFinalStatus(ctx, executionID, finalStatus); err != nil {
+			logger.Error("Failed to persist fallback FAILED status",
+				"execution_id", executionID, "error", err.Error())
+		}
+	}
+
+	return nil
+}
+
+// executeGraphtonWithHitl runs the ExecuteGraphton activity and handles the HITL
+// approval loop. It uses the provided context for all blocking operations, so the
+// caller can cancel it (e.g., for pause).
+//
+// Extracted from executeGraphtonFlow to work with the pause/resume cancellation
+// scope, matching Java's executeGraphtonWithHitl() pattern.
+func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonWithHitl(
+	ctx workflow.Context,
+	activityTaskQueue string,
+	executionID string,
+	threadID string,
+) (*agentexecutionv1.AgentExecutionStatus, error) {
+	logger := workflow.GetLogger(ctx)
 
 	executeGraphtonActivity := activities.NewExecuteGraphtonActivityStub(ctx, activityTaskQueue)
 
-	// Initial execution -- no approval decisions on first invocation
 	finalStatus, err := executeGraphtonActivity.ExecuteGraphton(executionID, threadID, nil)
 	if err != nil {
-		return w.wrapActivityError("ExecuteGraphton", err)
+		return nil, err
 	}
 
-	// Defensive null check
 	if finalStatus == nil {
 		logger.Error("ExecuteGraphton returned NULL status", "execution_id", executionID)
-		return fmt.Errorf("python activity returned null status - this should never happen")
+		return nil, fmt.Errorf("python activity returned null status - this should never happen")
 	}
 
-	// Diagnostic: log the deserialized activity return value.
-	// Note: messages and tool_calls are intentionally omitted from the slim
-	// return payload (they're already persisted to DB via gRPC during execution).
 	logger.Info("Activity returned slim status",
 		"execution_id", executionID,
 		"phase", finalStatus.GetPhase().String(),
 		"phase_value", int32(finalStatus.GetPhase()),
 		"pending_approvals", len(finalStatus.GetPendingApprovals()))
 
-	// Step 3: HITL Approval Loop (DB-Driven Resume)
+	// HITL Approval Loop (DB-Driven Resume)
 	//
-	// When the Python activity returns EXECUTION_WAITING_FOR_APPROVAL, the
-	// workflow waits for a single approvalGateResolved signal. The SubmitApproval
-	// handler sends this signal when either all pending tool calls have received
-	// decisions, or a REJECT is submitted (triggering immediate resume).
+	// When Python returns EXECUTION_WAITING_FOR_APPROVAL, the workflow waits for
+	// a single approvalGateResolved signal, then re-invokes Python.
 	//
-	// On resume, the workflow re-invokes Python with nil decisions. Python reads
-	// the approval decisions directly from the DB (set by SubmitApproval via
-	// atomic $set) and constructs the LangGraph resume command.
+	// All blocking operations use the provided ctx so that cancellation (from the
+	// pause/resume outer loop) propagates through.
 	approvalCycle := 0
 	for finalStatus.GetPhase() == agentexecutionv1.ExecutionPhase_EXECUTION_WAITING_FOR_APPROVAL {
 		approvalCycle++
 		if approvalCycle > MaxApprovalCycles {
 			logger.Error("Max approval cycles reached", "execution_id", executionID, "cycles", approvalCycle)
-			return fmt.Errorf("max approval cycles (%d) reached - possible infinite loop", MaxApprovalCycles)
+			return nil, fmt.Errorf("max approval cycles (%d) reached - possible infinite loop", MaxApprovalCycles)
 		}
 
 		pendingCount := len(finalStatus.GetPendingApprovals())
@@ -260,12 +357,12 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonFlow(ctx workflow.Cont
 
 		finalStatus, err = executeGraphtonActivity.ExecuteGraphton(executionID, threadID, nil)
 		if err != nil {
-			return w.wrapActivityError("ExecuteGraphton", err)
+			return nil, err
 		}
 
 		if finalStatus == nil {
 			logger.Error("ExecuteGraphton returned NULL status after approval", "execution_id", executionID)
-			return fmt.Errorf("python activity returned null status after approval - this should never happen")
+			return nil, fmt.Errorf("python activity returned null status after approval - this should never happen")
 		}
 
 		logger.Info("Activity returned slim status after approval",
@@ -276,29 +373,7 @@ func (w *InvokeAgentExecutionWorkflowImpl) executeGraphtonFlow(ctx workflow.Cont
 			"cycle", approvalCycle)
 	}
 
-	logger.Info("Graphton execution completed - final slim status received",
-		"phase", finalStatus.GetPhase().String(),
-		"pending_approvals", len(finalStatus.GetPendingApprovals()),
-		"approval_cycles", approvalCycle)
-
-	// Defense-in-depth: If the Python activity returned FAILED status, persist it
-	// as a fallback. The primary persistence path is the Python gRPC update_status
-	// call, but if that call failed (transient network issue, server down, etc.),
-	// the error would be silently lost because the activity returned successfully
-	// from Temporal's perspective. This ensures the failed state -- including the
-	// error message -- is always persisted and broadcast to subscribers.
-	if finalStatus.GetPhase() == agentexecutionv1.ExecutionPhase_EXECUTION_FAILED {
-		logger.Warn("Activity returned EXECUTION_FAILED -- persisting as fallback",
-			"execution_id", executionID,
-			"error", finalStatus.GetError())
-
-		if err := w.persistFinalStatus(ctx, executionID, finalStatus); err != nil {
-			logger.Error("Failed to persist fallback FAILED status",
-				"execution_id", executionID, "error", err.Error())
-		}
-	}
-
-	return nil
+	return finalStatus, nil
 }
 
 // wrapActivityError wraps activity errors with helpful context for troubleshooting.

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_pause_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_pause_test.go
@@ -150,6 +150,17 @@ func TestHitlApprovalLoopWithoutPause(t *testing.T) {
 	const executionID = "exec-hitl"
 	registerCommonMocks(env, threadID)
 
+	// The workflow reads pending_approvals from DB via loadExecution(), not
+	// from the slim status returned by the activity.
+	env.OnActivity(stubLoadAgentExecution, mock.Anything).
+		Return(&agentexecutionv1.AgentExecution{
+			Status: &agentexecutionv1.AgentExecutionStatus{
+				PendingApprovals: []*agentexecutionv1.PendingApproval{
+					{ToolCallId: "tc-1"},
+				},
+			},
+		}, nil)
+
 	callCount := 0
 	env.OnActivity(stubExecuteGraphton, mock.Anything, mock.Anything, mock.Anything).
 		Return(func(eid string, tid string, ad *agentexecutionv1.ApprovalDecisionList) (*agentexecutionv1.AgentExecutionStatus, error) {
@@ -157,9 +168,6 @@ func TestHitlApprovalLoopWithoutPause(t *testing.T) {
 			if callCount == 1 {
 				return &agentexecutionv1.AgentExecutionStatus{
 					Phase: agentexecutionv1.ExecutionPhase_EXECUTION_WAITING_FOR_APPROVAL,
-					PendingApprovals: []*agentexecutionv1.PendingApproval{
-						{ToolCallId: "tc-1"},
-					},
 				}, nil
 			}
 			return &agentexecutionv1.AgentExecutionStatus{

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_pause_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_pause_test.go
@@ -1,0 +1,261 @@
+package workflows
+
+import (
+	"testing"
+
+	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/activities"
+	ecactivities "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/executioncontext/temporal/activities"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// Stub activity functions for registration. The Temporal test env requires
+// actual Go functions registered under the correct names so that
+// workflow.ExecuteActivity calls can be matched and mocked.
+func stubEnsureThread(_ string, _ string) (string, error)           { return "", nil }
+func stubGenerateSessionSubject(_ string) error                     { return nil }
+func stubExecuteGraphton(_ string, _ string, _ *agentexecutionv1.ApprovalDecisionList) (*agentexecutionv1.AgentExecutionStatus, error) {
+	return nil, nil
+}
+func stubUpdateExecutionStatus(_ string, _ *agentexecutionv1.AgentExecutionStatus) error {
+	return nil
+}
+func stubDeleteExecutionContext(_ string) error                          { return nil }
+func stubLoadAgentExecution(_ string) (*agentexecutionv1.AgentExecution, error) {
+	return nil, nil
+}
+func stubCompleteExternalActivity(_ []byte, _ *agentexecutionv1.AgentExecution, _ error) error {
+	return nil
+}
+
+// registerCommonMocks sets up the activity mocks that every test needs:
+// EnsureThread, GenerateSessionSubject, deleteExecutionContext, and
+// the UpdateExecutionStatus local activity (used by persistFinalStatus).
+func registerCommonMocks(env *testsuite.TestWorkflowEnvironment, threadID string) {
+	env.RegisterActivityWithOptions(stubEnsureThread, activity.RegisterOptions{
+		Name: activities.EnsureThreadActivityName,
+	})
+	env.RegisterActivityWithOptions(stubGenerateSessionSubject, activity.RegisterOptions{
+		Name: activities.GenerateSessionSubjectActivityName,
+	})
+	env.RegisterActivityWithOptions(stubExecuteGraphton, activity.RegisterOptions{
+		Name: activities.ExecuteGraphtonActivityName,
+	})
+	env.RegisterActivityWithOptions(stubUpdateExecutionStatus, activity.RegisterOptions{
+		Name: activities.UpdateExecutionStatusActivityName,
+	})
+	env.RegisterActivityWithOptions(stubDeleteExecutionContext, activity.RegisterOptions{
+		Name: ecactivities.DeleteExecutionContextActivityName,
+	})
+	env.RegisterActivityWithOptions(stubLoadAgentExecution, activity.RegisterOptions{
+		Name: activities.LoadAgentExecutionActivityName,
+	})
+	env.RegisterActivityWithOptions(stubCompleteExternalActivity, activity.RegisterOptions{
+		Name: activities.CompleteExternalActivityName,
+	})
+
+	env.OnActivity(stubEnsureThread, mock.Anything, mock.Anything).
+		Return(threadID, nil)
+
+	env.OnActivity(stubGenerateSessionSubject, mock.Anything).
+		Return(nil)
+
+	env.OnActivity(stubUpdateExecutionStatus, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	env.OnActivity(stubDeleteExecutionContext, mock.Anything).
+		Return(nil).Maybe()
+
+	env.OnActivity(stubLoadAgentExecution, mock.Anything).
+		Return(&agentexecutionv1.AgentExecution{}, nil).Maybe()
+
+	env.OnActivity(stubCompleteExternalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+}
+
+func TestPauseSignalCancelsActivityAndWaitsForResume(t *testing.T) {
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	const threadID = "thread-abc"
+	const executionID = "exec-123"
+	registerCommonMocks(env, threadID)
+
+	// In the test env, cancelled activities don't run the mock callback.
+	// The first invocation is cancelled by the pause signal (mock not called).
+	// After resume, the second invocation runs the mock and completes.
+	resumeCallCount := 0
+	env.OnActivity(stubExecuteGraphton, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(eid string, tid string, ad *agentexecutionv1.ApprovalDecisionList) (*agentexecutionv1.AgentExecutionStatus, error) {
+			resumeCallCount++
+			return &agentexecutionv1.AgentExecutionStatus{
+				Phase: agentexecutionv1.ExecutionPhase_EXECUTION_COMPLETED,
+			}, nil
+		})
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalPause, "user requested pause")
+	}, 0)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalResume, nil)
+	}, 0)
+
+	input := &InvokeAgentExecutionWorkflowInput{
+		ExecutionID: executionID,
+		SessionID:   "session-1",
+		AgentID:     "agent-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeAgentExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, resumeCallCount, "activity should complete once after resume (first invocation is cancelled by pause)")
+}
+
+func TestNormalCompletionWithoutPause(t *testing.T) {
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	const threadID = "thread-abc"
+	const executionID = "exec-456"
+	registerCommonMocks(env, threadID)
+
+	env.OnActivity(stubExecuteGraphton, mock.Anything, mock.Anything, mock.Anything).
+		Return(&agentexecutionv1.AgentExecutionStatus{
+			Phase: agentexecutionv1.ExecutionPhase_EXECUTION_COMPLETED,
+		}, nil)
+
+	input := &InvokeAgentExecutionWorkflowInput{
+		ExecutionID: executionID,
+		SessionID:   "session-1",
+		AgentID:     "agent-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeAgentExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
+func TestHitlApprovalLoopWithoutPause(t *testing.T) {
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	const threadID = "thread-abc"
+	const executionID = "exec-hitl"
+	registerCommonMocks(env, threadID)
+
+	callCount := 0
+	env.OnActivity(stubExecuteGraphton, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(eid string, tid string, ad *agentexecutionv1.ApprovalDecisionList) (*agentexecutionv1.AgentExecutionStatus, error) {
+			callCount++
+			if callCount == 1 {
+				return &agentexecutionv1.AgentExecutionStatus{
+					Phase: agentexecutionv1.ExecutionPhase_EXECUTION_WAITING_FOR_APPROVAL,
+					PendingApprovals: []*agentexecutionv1.PendingApproval{
+						{ToolCallId: "tc-1"},
+					},
+				}, nil
+			}
+			return &agentexecutionv1.AgentExecutionStatus{
+				Phase: agentexecutionv1.ExecutionPhase_EXECUTION_COMPLETED,
+			}, nil
+		})
+
+	// Send approval signal
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalApprovalGateResolved, nil)
+	}, 0)
+
+	input := &InvokeAgentExecutionWorkflowInput{
+		ExecutionID: executionID,
+		SessionID:   "session-1",
+		AgentID:     "agent-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeAgentExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 2, callCount)
+}
+
+func TestMultiplePauseResumeCycles(t *testing.T) {
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	const threadID = "thread-abc"
+	const executionID = "exec-multi"
+	registerCommonMocks(env, threadID)
+
+	// Two pause/resume cycles: first two invocations cancelled, third completes.
+	// In the test env, cancelled invocations don't run the mock, so only the
+	// final (non-cancelled) invocation runs.
+	resumeCallCount := 0
+	env.OnActivity(stubExecuteGraphton, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(eid string, tid string, ad *agentexecutionv1.ApprovalDecisionList) (*agentexecutionv1.AgentExecutionStatus, error) {
+			resumeCallCount++
+			return &agentexecutionv1.AgentExecutionStatus{
+				Phase: agentexecutionv1.ExecutionPhase_EXECUTION_COMPLETED,
+			}, nil
+		})
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalPause, "pause 1")
+	}, 0)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalResume, nil)
+	}, 0)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalPause, "pause 2")
+	}, 0)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalResume, nil)
+	}, 0)
+
+	input := &InvokeAgentExecutionWorkflowInput{
+		ExecutionID: executionID,
+		SessionID:   "session-1",
+		AgentID:     "agent-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeAgentExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, resumeCallCount, "only the final post-resume invocation completes (first two cancelled by pause)")
+}
+
+func TestFailedActivityPropagatesError(t *testing.T) {
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	const threadID = "thread-abc"
+	const executionID = "exec-fail"
+	registerCommonMocks(env, threadID)
+
+	env.OnActivity(stubExecuteGraphton, mock.Anything, mock.Anything, mock.Anything).
+		Return(&agentexecutionv1.AgentExecutionStatus{
+			Phase: agentexecutionv1.ExecutionPhase_EXECUTION_FAILED,
+			Error: "something went wrong",
+		}, nil)
+
+	input := &InvokeAgentExecutionWorkflowInput{
+		ExecutionID: executionID,
+		SessionID:   "session-1",
+		AgentID:     "agent-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeAgentExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	// FAILED status doesn't cause a workflow error — the workflow completes
+	// normally and the Go/Java workflow relies on the FAILED phase being
+	// persisted via defense-in-depth.
+	require.NoError(t, env.GetWorkflowError())
+}

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_pause_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_pause_test.go
@@ -15,15 +15,15 @@ import (
 // Stub activity functions for registration. The Temporal test env requires
 // actual Go functions registered under the correct names so that
 // workflow.ExecuteActivity calls can be matched and mocked.
-func stubEnsureThread(_ string, _ string) (string, error)           { return "", nil }
-func stubGenerateSessionSubject(_ string) error                     { return nil }
+func stubEnsureThread(_ string, _ string) (string, error) { return "", nil }
+func stubGenerateSessionSubject(_ string) error           { return nil }
 func stubExecuteGraphton(_ string, _ string, _ *agentexecutionv1.ApprovalDecisionList) (*agentexecutionv1.AgentExecutionStatus, error) {
 	return nil, nil
 }
 func stubUpdateExecutionStatus(_ string, _ *agentexecutionv1.AgentExecutionStatus) error {
 	return nil
 }
-func stubDeleteExecutionContext(_ string) error                          { return nil }
+func stubDeleteExecutionContext(_ string) error { return nil }
 func stubLoadAgentExecution(_ string) (*agentexecutionv1.AgentExecution, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
Major refactoring of the StatusBuilder subsystem in agent-runner, reducing it from ~4 000 lines to ~417 by extracting handler modules, introducing an ExecutionState dataclass, and replacing custom interrupt proxies with LangGraph native subgraph interrupts. Includes end-to-end pause/resume support across Go Temporal workflows and the Python activity layer, plus several streaming and sub-agent bug fixes.

## Context
StatusBuilder had grown into an unmaintainable monolith that mixed event routing, streaming buffer management, sub-agent lifecycle, tool-call formatting, and chat-model handling in a single file. The `InterruptProxyRunnable` was a fragile custom shim that duplicated LangGraph's built-in subgraph interrupt propagation. Pause/resume only partially worked — the Go workflow lacked proper signal handling and the Python activity didn't persist enough state. These issues compounded during HITL (human-in-the-loop) flows, causing duplicate `SubAgentExecution` entries, broken streaming, and incorrect status propagation.

## Changes
- **Handler extraction (T08):** Split StatusBuilder into focused handler modules — `chat_model`, `tool_event`, `sub_agent`, `streaming_buffers`, `formatting`, and `context` — under `graphton/handlers/`
- **ExecutionState dataclass (T07):** Extracted mutable execution state into a standalone `ExecutionState` reducer, decoupling data from orchestration logic
- **Eliminate InterruptProxyRunnable:** Removed the custom interrupt proxy; sub-agents now use LangGraph's native subgraph interrupt propagation via a new `subagent.py` module
- **Deterministic namespace routing (T05):** Replaced heuristic-based namespace detection with `parent_ids`-based deterministic routing for reliable sub-agent event attribution
- **Identity-based lookup (T04):** Replaced fingerprint deduplication with identity-based `SubAgentExecution` lookup to prevent duplicates on HITL resume
- **End-to-end pause/resume (T06):** Added `PauseExecution` / `ResumeExecution` signals to Go Temporal workflow with proper activity cancellation, coordinated with Python-side graceful shutdown
- **Periodic advisory mode:** New `ExecutionBudgetMiddleware` mode that injects periodic advisory messages instead of hard-stopping on budget
- **Bug fixes:** Tool-use/tool-result message pairing for Anthropic API, Daytona `list_files`/`is_directory` contract bridging, sub-agent streaming drain delay, budget middleware crash on missing callback
- **HITL approval cleanup:** Removed redundant approval-gathering logic and dead `submitApproval` signal from Go workflow
- **Go workflow pause test:** Added `invoke_workflow_pause_test.go` covering pause signal → activity cancellation → resume flow

## Implementation notes
- Handler modules receive a shared `HandlerContext` that wraps StatusBuilder's publish/state dependencies without circular imports
- `StreamingBuffers` consolidates all token-buffering and flush logic previously scattered across StatusBuilder methods
- The Go workflow uses a `pauseRequested` flag checked in the activity loop; on pause the running activity context is cancelled and the workflow blocks on `ResumeExecution`
- `ExecutionState` uses a pure-function reducer pattern — each event returns a new state copy — making it straightforward to test in isolation

## Breaking changes
- `InterruptProxyRunnable` is deleted; any external code referencing it must switch to the native subgraph compilation path via `subagent.compile_subagent()`
- `submitApproval` Temporal signal is removed; callers must use the remaining approval flow through `ResumeExecution`

## Test plan
- New `test_native_subgraph_interrupt.py` (655 lines) — verifies interrupt propagation, resume, and state restoration without the proxy
- New `test_subagent_guardrails.py` — validates drain delay and execution-guard edge cases
- New `test_pause_flow.py` — unit tests for Python-side pause/resume coordination
- New `invoke_workflow_pause_test.go` — Go unit test for pause signal → cancel → resume
- Expanded `test_status_builder.py` (+1 295 → full suite) covering extracted handlers, ExecutionState transitions, and streaming buffer flush semantics
- Expanded `test_execution_budget.py` covering periodic advisory mode
- Existing `test_hitl_contracts.py` trimmed of obsolete proxy-based tests

## Risks
- Sub-agent event routing now relies entirely on `parent_ids`; any LangGraph version that changes `parent_ids` semantics would break routing — mitigated by pinning LangGraph version and explicit integration tests
- Removing `submitApproval` signal is backward-incompatible for any in-flight workflows that have not yet completed — recommend draining old executions before deploy

## Checklist
- [x] Docs updated (changelogs, project docs, AI engineer role)
- [x] Tests added/updated (7 new/expanded test files)
- [x] Backward compatible (except noted breaking changes above)