### PR TITLE
feat(sdk/java): add kind field to ResourceRef for typed resource references

### DIFF
--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/ResourceRef.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/ResourceRef.java
@@ -3,34 +3,49 @@
 package ai.stigmer.sdk.gen;
 
 import ai.stigmer.commons.apiresource.ApiResourceReference;
+import ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind;
 
 public final class ResourceRef {
     private final String org;
     private final String slug;
     private final String version;
+    private final ApiResourceKind kind;
 
-    private ResourceRef(String org, String slug, String version) {
+    private ResourceRef(String org, String slug, String version, ApiResourceKind kind) {
         this.org = org;
         this.slug = slug;
         this.version = version;
+        this.kind = kind;
     }
 
     public static ResourceRef of(String org, String slug) {
-        return new ResourceRef(org, slug, null);
+        return new ResourceRef(org, slug, null, ApiResourceKind.api_resource_kind_unspecified);
     }
 
     public static ResourceRef of(String org, String slug, String version) {
-        return new ResourceRef(org, slug, version);
+        return new ResourceRef(org, slug, version, ApiResourceKind.api_resource_kind_unspecified);
+    }
+
+    public static ResourceRef skill(String org, String slug) {
+        return new ResourceRef(org, slug, null, ApiResourceKind.skill);
+    }
+
+    public static ResourceRef skill(String org, String slug, String version) {
+        return new ResourceRef(org, slug, version, ApiResourceKind.skill);
     }
 
     public String getOrg() { return org; }
     public String getSlug() { return slug; }
     public String getVersion() { return version; }
+    public ApiResourceKind getKind() { return kind; }
 
     ApiResourceReference toProto() {
         ApiResourceReference.Builder builder = ApiResourceReference.newBuilder()
             .setOrg(this.org)
             .setSlug(this.slug);
+        if (this.kind != null && this.kind != ApiResourceKind.api_resource_kind_unspecified) {
+            builder.setKind(this.kind);
+        }
         if (this.version != null) {
             builder.setVersion(this.version);
         }


### PR DESCRIPTION
## Summary

Add `ApiResourceKind` support to the Java SDK's `ResourceRef` class so that `toProto()` sets the `kind` field on `ApiResourceReference`. This unblocks agent apply operations that include skill refs, which the Stigmer API now validates must have `kind=skill`.

## Context

The Stigmer API added validation requiring `skill_refs` on agents to include `kind=skill` in each `ApiResourceReference`. The Java SDK's `ResourceRef` class only set `org` and `slug` on the proto, never `kind`. This caused every `agents().apply()` call with skill refs to fail with: `skill_refs must reference resources with kind=skill`. Planton's talent service (and backstage service) both hit this when provisioning agents with inline or external skills.

## Changes

- Add `ApiResourceKind kind` field to `ResourceRef` (private, immutable)
- Add `skill(org, slug)` and `skill(org, slug, version)` factory methods that set `kind=SKILL`
- Update `toProto()` to include `kind` when set to a non-default value
- Existing `of()` factory methods remain backward-compatible (kind defaults to `api_resource_kind_unspecified`, which is omitted from the proto)

## Implementation notes

- `of()` methods are unchanged in behavior -- callers that don't need kind (e.g., agent refs, environment refs) continue to work identically
- The `kind` field is only serialized when non-default, so existing wire format is preserved for legacy callers
- This is a generated file (`Code generated by stigmer-codegen. DO NOT EDIT`) -- the codegen template should be updated in a follow-up to generate this pattern for all resource kinds

## Breaking changes

- None. All existing `ResourceRef.of()` calls compile and behave identically.

## Test plan

- Verified `ResourceRef.skill("planton", "aws-vpc-design").toProto()` produces `ApiResourceReference` with `kind=SKILL`, `org=planton`, `slug=aws-vpc-design`
- Verified `ResourceRef.of("planton", "my-agent").toProto()` omits `kind` (backward-compatible)
- Planton monorepo build (`make build-java only=talent,backstage-backend`) passes after switching callers to `ResourceRef.skill()`

## Risks

- Low. Additive change with no behavioral difference for existing `of()` callers.

## Checklist

- [ ] Docs updated (if needed)
- [ ] Tests added/updated (if needed)
- [x] Backward compatible