### PR TITLE
fix(codegen): auto-inject resource reference kind across all SDKs

### DIFF
--- a/.github/workflows/release.buf.yaml
+++ b/.github/workflows/release.buf.yaml
@@ -1,0 +1,33 @@
+name: release.buf
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push-to-bsr:
+    name: Push to Buf Schema Registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint protos
+        working-directory: apis
+        run: buf lint
+
+      - name: Push to BSR
+        working-directory: apis
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: buf push

--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,6 @@ gen-llms: ## Generate LLM-friendly output (llms.txt, llms-full.txt, per-page .md
 
 .PHONY: release
 release: ## Tag and push a release (usage: make release [bump=patch|minor|major])
-	-$(MAKE) -C apis release
 	@LATEST_TAG=$$(git tag -l "v*" | sort -V | tail -n1); \
 	[ -z "$$LATEST_TAG" ] && LATEST_TAG="v0.0.0"; \
 	VERSION=$$(echo $$LATEST_TAG | sed 's/^v//'); \
@@ -417,6 +416,7 @@ release: ## Tag and push a release (usage: make release [bump=patch|minor|major]
 	done
 	@echo ""
 	@echo "Tags pushed. CI will handle:"
+	@echo "  - Protos to BSR                  (release.buf.yaml)"
 	@echo "  - CLI binaries + GitHub release  (release.cli.yaml)"
 	@echo "  - @stigmer/* npm packages        (release.npm-libs.yaml)"
 	@echo "  - Go SDK (go get)                (sdk/go tag auto-cached by proxy.golang.org)"

--- a/_changelog/2026-04/2026-04-23-104241-sdk-codegen-resource-ref-kind-auto-injection.md
+++ b/_changelog/2026-04/2026-04-23-104241-sdk-codegen-resource-ref-kind-auto-injection.md
@@ -1,0 +1,100 @@
+# SDK Codegen: Auto-Inject `kind` in Resource References
+
+**Date**: April 23, 2026
+
+## Summary
+
+All four SDK codegens (Go, Java, Python, TypeScript) now automatically set the `kind` field on `ApiResourceReference` messages when the proto field carries a `reference_kind` annotation. This eliminates a class of validation errors where the server rejected requests due to missing `kind` values, and removes the burden from SDK consumers to know and set the correct resource kind for every reference field.
+
+A secondary change moves the BSR (Buf Schema Registry) publish step from the local `make release` command into a dedicated GitHub Actions workflow, aligning it with the existing CI-driven release pattern.
+
+## Problem Statement
+
+PR #130 from a customer added a `kind` field to the Java SDK's `ResourceRef` class because the server's CEL validation was rejecting requests with empty `kind`. Investigation revealed the root cause was not in the Java SDK's `ResourceRef` type, but in the codegen pipeline: none of the four SDK codegens were reading the `reference_kind` proto field option to auto-populate `kind` during serialization.
+
+### Pain Points
+
+- Customers had to manually set `kind` on every `ResourceRef` — error-prone and undiscoverable
+- The MCP codegen already handled `reference_kind` correctly; the SDK codegens did not
+- `environment_refs` fields on `AgentInstanceSpec` and `WorkflowInstanceSpec` were missing the `reference_kind` annotation entirely
+- The `apiResourceKindEnumNames` and `versionedKinds` maps in `mcp.go` were hardcoded, requiring manual updates whenever a new `ApiResourceKind` was added
+- The BSR publish (`buf push`) was part of the local `make release` command, requiring local Buf authentication and coupling proto publishing with tag creation
+
+## Solution
+
+### SDK Codegen Kind Auto-Injection
+
+For every `ApiResourceReference` field that carries `(reference_kind) = <kind>`, the codegen now emits code that sets `kind` to the annotated value during `toProto()` / serialization. This covers both singular and repeated reference fields.
+
+For "multi-kind" fields (no `reference_kind` annotation), the Java `ResourceRef` was enhanced with explicit `kind` factory methods so users can set it when needed.
+
+### Proto Reflection for Kind Maps
+
+Replaced the hardcoded `apiResourceKindEnumNames` and `versionedKinds` maps with runtime derivation from the Go proto stubs using protobuf descriptor reflection. A new `resource_kind.go` imports the generated `ApiResourceKind` enum, iterates its values and `kind_meta` extensions at `init()` time, and populates both maps — zero maintenance when new resource kinds are added.
+
+### Missing `reference_kind` Annotations
+
+Added `(reference_kind) = environment` to `environment_refs` on both `AgentInstanceSpec` and `WorkflowInstanceSpec`, plus the required `field_options.proto` import.
+
+### BSR Push to CI
+
+Created `.github/workflows/release.buf.yaml` triggered on `v*` tags. Removed `$(MAKE) -C apis release` from the root Makefile's `release` target.
+
+## Implementation Details
+
+### Codegen Changes (4 SDKs)
+
+- **Go** (`sdk_client.go`): Detects `ReferenceKind != 0`, forces imperative mode for the nested type, and emits `Kind: apiresourcekind.ApiResourceKind_<name>` on the constructed proto message.
+- **Java** (`sdk_client_java.go`): Emits `.toProto().toBuilder().setKind(ApiResourceKind.<name>).build()` for annotated fields. Updated `ResourceRef` with `kind` field and typed factory methods.
+- **Python** (`sdk_client_python.go`): Emits `_ref.kind = <int>` after constructing the `ApiResourceReference` message.
+- **TypeScript** (`sdk_client_ts.go`): Emits spread syntax `{ ...ref, kind: <int> }` to overlay the kind value.
+
+### New File: `resource_kind.go`
+
+Uses `protoreflect` to walk the `ApiResourceKind` enum descriptor, building `apiResourceKindEnumNames` (num→name) and `versionedKinds` (num→bool) maps. Replaces 30+ lines of hand-maintained constants.
+
+### Proto Annotations
+
+```protobuf
+// agentinstance/v1/spec.proto & workflowinstance/v1/spec.proto
+repeated ApiResourceReference environment_refs = N [
+    (ai.stigmer.commons.apiresource.reference_kind) = environment
+];
+```
+
+### CI Workflow: `release.buf.yaml`
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+```
+
+Runs `buf lint` as a quality gate, then `buf push` with `BUF_TOKEN` from GitHub secrets.
+
+## Benefits
+
+- **Zero-effort kind correctness**: SDK users never need to think about `kind` for single-kind reference fields
+- **Multi-kind flexibility**: Java `ResourceRef.of(org, kind, slug)` factory for fields without `reference_kind`
+- **Maintenance-free kind maps**: Adding a new `ApiResourceKind` to the proto enum automatically flows to all codegens — no manual map updates
+- **CI-driven BSR publish**: BSR push happens automatically on tag push, consistent with all other release artifacts
+- **BUF_TOKEN secret**: Now set in the repo, fixing the pre-existing gap in `release.cli.yaml`
+
+## Impact
+
+- **SDK consumers**: Requests with `ApiResourceReference` fields no longer fail server-side CEL validation for missing `kind`
+- **Platform maintainers**: No manual map maintenance when resource kinds change; BSR publishing is fully automated
+- **All SDKs**: Go, Java, Python, TypeScript all behave consistently
+- **Release pipeline**: `make release` is now a pure tag-and-push operation; all artifact publishing is in CI
+
+## Related Work
+
+- [PR #130](https://github.com/stigmer/stigmer/pull/130) — customer-submitted Java SDK fix (identified the symptom)
+- `reference_kind` field option (proto extension 90204) — the mechanism that enables kind derivation
+- `kind_meta.is_versioned` extension — drives the `versionedKinds` map
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: Single session

--- a/apis/ai/stigmer/agentic/agentinstance/v1/spec.proto
+++ b/apis/ai/stigmer/agentic/agentinstance/v1/spec.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package ai.stigmer.agentic.agentinstance.v1;
 
+import "ai/stigmer/commons/apiresource/field_options.proto";
 import "ai/stigmer/commons/apiresource/io.proto";
 import "buf/validate/validate.proto";
 
@@ -23,9 +24,12 @@ message AgentInstanceSpec {
   // Environments are merged in order: later environments override earlier ones.
   // Example: [base-env, aws-prod-env, github-team-env]
   // This allows layering of configurations (base → specific overrides).
-  repeated ai.stigmer.commons.apiresource.ApiResourceReference environment_refs = 3 [(buf.validate.field).repeated.items.cel = {
-    id: "environment_refs.kind"
-    message: "environment_refs must reference resources with kind=environment"
-    expression: "this.kind == 53" // 53 = environment enum value
-  }];
+  repeated ai.stigmer.commons.apiresource.ApiResourceReference environment_refs = 3 [
+    (ai.stigmer.commons.apiresource.reference_kind) = environment,
+    (buf.validate.field).repeated.items.cel = {
+      id: "environment_refs.kind"
+      message: "environment_refs must reference resources with kind=environment"
+      expression: "this.kind == 53"
+    }
+  ];
 }

--- a/apis/ai/stigmer/agentic/workflowinstance/v1/spec.proto
+++ b/apis/ai/stigmer/agentic/workflowinstance/v1/spec.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 // Package workflowinstance contains the WorkflowInstanceSpec definition.
 package ai.stigmer.agentic.workflowinstance.v1;
 
+import "ai/stigmer/commons/apiresource/field_options.proto";
 import "ai/stigmer/commons/apiresource/io.proto";
 import "buf/validate/validate.proto";
 
@@ -62,9 +63,12 @@ message WorkflowInstanceSpec {
   //
   // At execution time, the WorkflowExecution runtime merges these environments
   // and provides the combined configuration to all agents in the workflow.
-  repeated ai.stigmer.commons.apiresource.ApiResourceReference environment_refs = 3 [(buf.validate.field).repeated.items.cel = {
-    id: "environment_refs.kind"
-    message: "environment_refs must reference resources with kind=environment"
-    expression: "this.kind == 53" // 53 = environment enum value
-  }];
+  repeated ai.stigmer.commons.apiresource.ApiResourceReference environment_refs = 3 [
+    (ai.stigmer.commons.apiresource.reference_kind) = environment,
+    (buf.validate.field).repeated.items.cel = {
+      id: "environment_refs.kind"
+      message: "environment_refs must reference resources with kind=environment"
+      expression: "this.kind == 53"
+    }
+  ];
 }

--- a/apis/stubs/go/ai/stigmer/agentic/agentinstance/v1/spec.pb.go
+++ b/apis/stubs/go/ai/stigmer/agentic/agentinstance/v1/spec.pb.go
@@ -100,12 +100,12 @@ var File_ai_stigmer_agentic_agentinstance_v1_spec_proto protoreflect.FileDescrip
 
 const file_ai_stigmer_agentic_agentinstance_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	".ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xb1\x02\n" +
+	".ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a2ai/stigmer/commons/apiresource/field_options.proto\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xb5\x02\n" +
 	"\x11AgentInstanceSpec\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aagentId\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd5\x01\n" +
-	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n" +
-	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0fenvironmentRefsB\xc3\x02\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd9\x01\n" +
+	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n" +
+	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0fenvironmentRefsB\xc3\x02\n" +
 	"'com.ai.stigmer.agentic.agentinstance.v1B\tSpecProtoP\x01Z\\github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentinstance/v1;agentinstancev1\xa2\x02\x04ASAA\xaa\x02#Ai.Stigmer.Agentic.Agentinstance.V1\xca\x02#Ai\\Stigmer\\Agentic\\Agentinstance\\V1\xe2\x02/Ai\\Stigmer\\Agentic\\Agentinstance\\V1\\GPBMetadata\xea\x02'Ai::Stigmer::Agentic::Agentinstance::V1b\x06proto3"
 
 var (

--- a/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1/spec.pb.go
+++ b/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1/spec.pb.go
@@ -141,13 +141,13 @@ var File_ai_stigmer_agentic_workflowinstance_v1_spec_proto protoreflect.FileDesc
 
 const file_ai_stigmer_agentic_workflowinstance_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	"1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xba\x02\n" +
+	"1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a2ai/stigmer/commons/apiresource/field_options.proto\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xbe\x02\n" +
 	"\x14WorkflowInstanceSpec\x12(\n" +
 	"\vworkflow_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\n" +
 	"workflowId\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd5\x01\n" +
-	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n" +
-	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0fenvironmentRefsB\xd8\x02\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd9\x01\n" +
+	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n" +
+	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0fenvironmentRefsB\xd8\x02\n" +
 	"*com.ai.stigmer.agentic.workflowinstance.v1B\tSpecProtoP\x01Zbgithub.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1;workflowinstancev1\xa2\x02\x04ASAW\xaa\x02&Ai.Stigmer.Agentic.Workflowinstance.V1\xca\x02&Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\xe2\x022Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\\GPBMetadata\xea\x02*Ai::Stigmer::Agentic::Workflowinstance::V1b\x06proto3"
 
 var (

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/agentinstance/v1/SpecProto.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/agentinstance/v1/SpecProto.java
@@ -42,25 +42,27 @@ public final class SpecProto extends com.google.protobuf.GeneratedFile {
     java.lang.String[] descriptorData = {
       "\n.ai/stigmer/agentic/agentinstance/v1/sp" +
       "ec.proto\022#ai.stigmer.agentic.agentinstan" +
-      "ce.v1\032\'ai/stigmer/commons/apiresource/io" +
-      ".proto\032\033buf/validate/validate.proto\"\261\002\n\021" +
-      "AgentInstanceSpec\022\"\n\010agent_id\030\001 \001(\tB\007\272H\004" +
-      "r\002\020\001R\007agentId\022 \n\013description\030\002 \001(\tR\013desc" +
-      "ription\022\325\001\n\020environment_refs\030\003 \003(\01324.ai." +
-      "stigmer.commons.apiresource.ApiResourceR" +
-      "eferenceBt\272Hq\222\001n\"l\272\001i\n\025environment_refs." +
-      "kind\022?environment_refs must reference re" +
-      "sources with kind=environment\032\017this.kind" +
-      " == 53R\017environmentRefsB\274\001B\tSpecProtoP\001\242" +
-      "\002\004ASAA\252\002#Ai.Stigmer.Agentic.Agentinstanc" +
-      "e.V1\312\002#Ai\\Stigmer\\Agentic\\Agentinstance\\" +
-      "V1\342\002/Ai\\Stigmer\\Agentic\\Agentinstance\\V1" +
-      "\\GPBMetadata\352\002\'Ai::Stigmer::Agentic::Age" +
-      "ntinstance::V1b\006proto3"
+      "ce.v1\0322ai/stigmer/commons/apiresource/fi" +
+      "eld_options.proto\032\'ai/stigmer/commons/ap" +
+      "iresource/io.proto\032\033buf/validate/validat" +
+      "e.proto\"\265\002\n\021AgentInstanceSpec\022\"\n\010agent_i" +
+      "d\030\001 \001(\tB\007\272H\004r\002\020\001R\007agentId\022 \n\013description" +
+      "\030\002 \001(\tR\013description\022\331\001\n\020environment_refs" +
+      "\030\003 \003(\01324.ai.stigmer.commons.apiresource." +
+      "ApiResourceReferenceBx\272Hq\222\001n\"l\272\001i\n\025envir" +
+      "onment_refs.kind\022?environment_refs must " +
+      "reference resources with kind=environmen" +
+      "t\032\017this.kind == 53\340\205,5R\017environmentRefsB" +
+      "\274\001B\tSpecProtoP\001\242\002\004ASAA\252\002#Ai.Stigmer.Agen" +
+      "tic.Agentinstance.V1\312\002#Ai\\Stigmer\\Agenti" +
+      "c\\Agentinstance\\V1\342\002/Ai\\Stigmer\\Agentic\\" +
+      "Agentinstance\\V1\\GPBMetadata\352\002\'Ai::Stigm" +
+      "er::Agentic::Agentinstance::V1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
+          ai.stigmer.commons.apiresource.FieldOptionsProto.getDescriptor(),
           ai.stigmer.commons.apiresource.IoProto.getDescriptor(),
           build.buf.validate.ValidateProto.getDescriptor(),
         });
@@ -71,10 +73,12 @@ public final class SpecProto extends com.google.protobuf.GeneratedFile {
         internal_static_ai_stigmer_agentic_agentinstance_v1_AgentInstanceSpec_descriptor,
         new java.lang.String[] { "AgentId", "Description", "EnvironmentRefs", });
     descriptor.resolveAllFeaturesImmutable();
+    ai.stigmer.commons.apiresource.FieldOptionsProto.getDescriptor();
     ai.stigmer.commons.apiresource.IoProto.getDescriptor();
     build.buf.validate.ValidateProto.getDescriptor();
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
+    registry.add(ai.stigmer.commons.apiresource.FieldOptionsProto.referenceKind);
     registry.add(build.buf.validate.ValidateProto.field);
     com.google.protobuf.Descriptors.FileDescriptor
         .internalUpdateFileDescriptor(descriptor, registry);

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/workflowinstance/v1/SpecProto.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/workflowinstance/v1/SpecProto.java
@@ -42,26 +42,28 @@ public final class SpecProto extends com.google.protobuf.GeneratedFile {
     java.lang.String[] descriptorData = {
       "\n1ai/stigmer/agentic/workflowinstance/v1" +
       "/spec.proto\022&ai.stigmer.agentic.workflow" +
-      "instance.v1\032\'ai/stigmer/commons/apiresou" +
-      "rce/io.proto\032\033buf/validate/validate.prot" +
-      "o\"\272\002\n\024WorkflowInstanceSpec\022(\n\013workflow_i" +
-      "d\030\001 \001(\tB\007\272H\004r\002\020\001R\nworkflowId\022 \n\013descript" +
-      "ion\030\002 \001(\tR\013description\022\325\001\n\020environment_r" +
-      "efs\030\003 \003(\01324.ai.stigmer.commons.apiresour" +
-      "ce.ApiResourceReferenceBt\272Hq\222\001n\"l\272\001i\n\025en" +
-      "vironment_refs.kind\022?environment_refs mu" +
-      "st reference resources with kind=environ" +
-      "ment\032\017this.kind == 53R\017environmentRefsB\310" +
-      "\001B\tSpecProtoP\001\242\002\004ASAW\252\002&Ai.Stigmer.Agent" +
-      "ic.Workflowinstance.V1\312\002&Ai\\Stigmer\\Agen" +
-      "tic\\Workflowinstance\\V1\342\0022Ai\\Stigmer\\Age" +
-      "ntic\\Workflowinstance\\V1\\GPBMetadata\352\002*A" +
-      "i::Stigmer::Agentic::Workflowinstance::V" +
-      "1b\006proto3"
+      "instance.v1\0322ai/stigmer/commons/apiresou" +
+      "rce/field_options.proto\032\'ai/stigmer/comm" +
+      "ons/apiresource/io.proto\032\033buf/validate/v" +
+      "alidate.proto\"\276\002\n\024WorkflowInstanceSpec\022(" +
+      "\n\013workflow_id\030\001 \001(\tB\007\272H\004r\002\020\001R\nworkflowId" +
+      "\022 \n\013description\030\002 \001(\tR\013description\022\331\001\n\020e" +
+      "nvironment_refs\030\003 \003(\01324.ai.stigmer.commo" +
+      "ns.apiresource.ApiResourceReferenceBx\272Hq" +
+      "\222\001n\"l\272\001i\n\025environment_refs.kind\022?environ" +
+      "ment_refs must reference resources with " +
+      "kind=environment\032\017this.kind == 53\340\205,5R\017e" +
+      "nvironmentRefsB\310\001B\tSpecProtoP\001\242\002\004ASAW\252\002&" +
+      "Ai.Stigmer.Agentic.Workflowinstance.V1\312\002" +
+      "&Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\342" +
+      "\0022Ai\\Stigmer\\Agentic\\Workflowinstance\\V1" +
+      "\\GPBMetadata\352\002*Ai::Stigmer::Agentic::Wor" +
+      "kflowinstance::V1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
+          ai.stigmer.commons.apiresource.FieldOptionsProto.getDescriptor(),
           ai.stigmer.commons.apiresource.IoProto.getDescriptor(),
           build.buf.validate.ValidateProto.getDescriptor(),
         });
@@ -72,10 +74,12 @@ public final class SpecProto extends com.google.protobuf.GeneratedFile {
         internal_static_ai_stigmer_agentic_workflowinstance_v1_WorkflowInstanceSpec_descriptor,
         new java.lang.String[] { "WorkflowId", "Description", "EnvironmentRefs", });
     descriptor.resolveAllFeaturesImmutable();
+    ai.stigmer.commons.apiresource.FieldOptionsProto.getDescriptor();
     ai.stigmer.commons.apiresource.IoProto.getDescriptor();
     build.buf.validate.ValidateProto.getDescriptor();
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
+    registry.add(ai.stigmer.commons.apiresource.FieldOptionsProto.referenceKind);
     registry.add(build.buf.validate.ValidateProto.field);
     com.google.protobuf.Descriptors.FileDescriptor
         .internalUpdateFileDescriptor(descriptor, registry);

--- a/apis/stubs/python/stigmer/ai/stigmer/agentic/agentinstance/v1/spec_pb2.py
+++ b/apis/stubs/python/stigmer/ai/stigmer/agentic/agentinstance/v1/spec_pb2.py
@@ -22,11 +22,12 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
+from ai.stigmer.commons.apiresource import field_options_pb2 as ai_dot_stigmer_dot_commons_dot_apiresource_dot_field__options__pb2
 from ai.stigmer.commons.apiresource import io_pb2 as ai_dot_stigmer_dot_commons_dot_apiresource_dot_io__pb2
 from buf.validate import validate_pb2 as buf_dot_validate_dot_validate__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n.ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a\'ai/stigmer/commons/apiresource/io.proto\x1a\x1b\x62uf/validate/validate.proto\"\xb1\x02\n\x11\x41gentInstanceSpec\x12\"\n\x08\x61gent_id\x18\x01 \x01(\tB\x07\xbaH\x04r\x02\x10\x01R\x07\x61gentId\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription\x12\xd5\x01\n\x10\x65nvironment_refs\x18\x03 \x03(\x0b\x32\x34.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n\x15\x65nvironment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0f\x65nvironmentRefsB\xe5\x01\n\'com.ai.stigmer.agentic.agentinstance.v1B\tSpecProtoP\x01\xa2\x02\x04\x41SAA\xaa\x02#Ai.Stigmer.Agentic.Agentinstance.V1\xca\x02#Ai\\Stigmer\\Agentic\\Agentinstance\\V1\xe2\x02/Ai\\Stigmer\\Agentic\\Agentinstance\\V1\\GPBMetadata\xea\x02\'Ai::Stigmer::Agentic::Agentinstance::V1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n.ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a\x32\x61i/stigmer/commons/apiresource/field_options.proto\x1a\'ai/stigmer/commons/apiresource/io.proto\x1a\x1b\x62uf/validate/validate.proto\"\xb5\x02\n\x11\x41gentInstanceSpec\x12\"\n\x08\x61gent_id\x18\x01 \x01(\tB\x07\xbaH\x04r\x02\x10\x01R\x07\x61gentId\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription\x12\xd9\x01\n\x10\x65nvironment_refs\x18\x03 \x03(\x0b\x32\x34.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n\x15\x65nvironment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0f\x65nvironmentRefsB\xe5\x01\n\'com.ai.stigmer.agentic.agentinstance.v1B\tSpecProtoP\x01\xa2\x02\x04\x41SAA\xaa\x02#Ai.Stigmer.Agentic.Agentinstance.V1\xca\x02#Ai\\Stigmer\\Agentic\\Agentinstance\\V1\xe2\x02/Ai\\Stigmer\\Agentic\\Agentinstance\\V1\\GPBMetadata\xea\x02\'Ai::Stigmer::Agentic::Agentinstance::V1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -37,7 +38,7 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_AGENTINSTANCESPEC'].fields_by_name['agent_id']._loaded_options = None
   _globals['_AGENTINSTANCESPEC'].fields_by_name['agent_id']._serialized_options = b'\272H\004r\002\020\001'
   _globals['_AGENTINSTANCESPEC'].fields_by_name['environment_refs']._loaded_options = None
-  _globals['_AGENTINSTANCESPEC'].fields_by_name['environment_refs']._serialized_options = b'\272Hq\222\001n\"l\272\001i\n\025environment_refs.kind\022?environment_refs must reference resources with kind=environment\032\017this.kind == 53'
-  _globals['_AGENTINSTANCESPEC']._serialized_start=158
-  _globals['_AGENTINSTANCESPEC']._serialized_end=463
+  _globals['_AGENTINSTANCESPEC'].fields_by_name['environment_refs']._serialized_options = b'\272Hq\222\001n\"l\272\001i\n\025environment_refs.kind\022?environment_refs must reference resources with kind=environment\032\017this.kind == 53\340\205,5'
+  _globals['_AGENTINSTANCESPEC']._serialized_start=210
+  _globals['_AGENTINSTANCESPEC']._serialized_end=519
 # @@protoc_insertion_point(module_scope)

--- a/apis/stubs/python/stigmer/ai/stigmer/agentic/agentinstance/v1/spec_pb2.pyi
+++ b/apis/stubs/python/stigmer/ai/stigmer/agentic/agentinstance/v1/spec_pb2.pyi
@@ -1,3 +1,4 @@
+from ai.stigmer.commons.apiresource import field_options_pb2 as _field_options_pb2
 from ai.stigmer.commons.apiresource import io_pb2 as _io_pb2
 from buf.validate import validate_pb2 as _validate_pb2
 from google.protobuf.internal import containers as _containers

--- a/apis/stubs/python/stigmer/ai/stigmer/agentic/workflowinstance/v1/spec_pb2.py
+++ b/apis/stubs/python/stigmer/ai/stigmer/agentic/workflowinstance/v1/spec_pb2.py
@@ -22,11 +22,12 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
+from ai.stigmer.commons.apiresource import field_options_pb2 as ai_dot_stigmer_dot_commons_dot_apiresource_dot_field__options__pb2
 from ai.stigmer.commons.apiresource import io_pb2 as ai_dot_stigmer_dot_commons_dot_apiresource_dot_io__pb2
 from buf.validate import validate_pb2 as buf_dot_validate_dot_validate__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a\'ai/stigmer/commons/apiresource/io.proto\x1a\x1b\x62uf/validate/validate.proto\"\xba\x02\n\x14WorkflowInstanceSpec\x12(\n\x0bworkflow_id\x18\x01 \x01(\tB\x07\xbaH\x04r\x02\x10\x01R\nworkflowId\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription\x12\xd5\x01\n\x10\x65nvironment_refs\x18\x03 \x03(\x0b\x32\x34.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n\x15\x65nvironment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0f\x65nvironmentRefsB\xf4\x01\n*com.ai.stigmer.agentic.workflowinstance.v1B\tSpecProtoP\x01\xa2\x02\x04\x41SAW\xaa\x02&Ai.Stigmer.Agentic.Workflowinstance.V1\xca\x02&Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\xe2\x02\x32\x41i\\Stigmer\\Agentic\\Workflowinstance\\V1\\GPBMetadata\xea\x02*Ai::Stigmer::Agentic::Workflowinstance::V1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a\x32\x61i/stigmer/commons/apiresource/field_options.proto\x1a\'ai/stigmer/commons/apiresource/io.proto\x1a\x1b\x62uf/validate/validate.proto\"\xbe\x02\n\x14WorkflowInstanceSpec\x12(\n\x0bworkflow_id\x18\x01 \x01(\tB\x07\xbaH\x04r\x02\x10\x01R\nworkflowId\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription\x12\xd9\x01\n\x10\x65nvironment_refs\x18\x03 \x03(\x0b\x32\x34.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n\x15\x65nvironment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0f\x65nvironmentRefsB\xf4\x01\n*com.ai.stigmer.agentic.workflowinstance.v1B\tSpecProtoP\x01\xa2\x02\x04\x41SAW\xaa\x02&Ai.Stigmer.Agentic.Workflowinstance.V1\xca\x02&Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\xe2\x02\x32\x41i\\Stigmer\\Agentic\\Workflowinstance\\V1\\GPBMetadata\xea\x02*Ai::Stigmer::Agentic::Workflowinstance::V1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -37,7 +38,7 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_WORKFLOWINSTANCESPEC'].fields_by_name['workflow_id']._loaded_options = None
   _globals['_WORKFLOWINSTANCESPEC'].fields_by_name['workflow_id']._serialized_options = b'\272H\004r\002\020\001'
   _globals['_WORKFLOWINSTANCESPEC'].fields_by_name['environment_refs']._loaded_options = None
-  _globals['_WORKFLOWINSTANCESPEC'].fields_by_name['environment_refs']._serialized_options = b'\272Hq\222\001n\"l\272\001i\n\025environment_refs.kind\022?environment_refs must reference resources with kind=environment\032\017this.kind == 53'
-  _globals['_WORKFLOWINSTANCESPEC']._serialized_start=164
-  _globals['_WORKFLOWINSTANCESPEC']._serialized_end=478
+  _globals['_WORKFLOWINSTANCESPEC'].fields_by_name['environment_refs']._serialized_options = b'\272Hq\222\001n\"l\272\001i\n\025environment_refs.kind\022?environment_refs must reference resources with kind=environment\032\017this.kind == 53\340\205,5'
+  _globals['_WORKFLOWINSTANCESPEC']._serialized_start=216
+  _globals['_WORKFLOWINSTANCESPEC']._serialized_end=534
 # @@protoc_insertion_point(module_scope)

--- a/apis/stubs/python/stigmer/ai/stigmer/agentic/workflowinstance/v1/spec_pb2.pyi
+++ b/apis/stubs/python/stigmer/ai/stigmer/agentic/workflowinstance/v1/spec_pb2.pyi
@@ -1,3 +1,4 @@
+from ai.stigmer.commons.apiresource import field_options_pb2 as _field_options_pb2
 from ai.stigmer.commons.apiresource import io_pb2 as _io_pb2
 from buf.validate import validate_pb2 as _validate_pb2
 from google.protobuf.internal import containers as _containers

--- a/apis/stubs/ts/ai/stigmer/agentic/agentinstance/v1/spec_pb.ts
+++ b/apis/stubs/ts/ai/stigmer/agentic/agentinstance/v1/spec_pb.ts
@@ -4,6 +4,7 @@
 
 import type { GenFile, GenMessage } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
+import { file_ai_stigmer_commons_apiresource_field_options } from "../../../commons/apiresource/field_options_pb";
 import type { ApiResourceReference } from "../../../commons/apiresource/io_pb";
 import { file_ai_stigmer_commons_apiresource_io } from "../../../commons/apiresource/io_pb";
 import { file_buf_validate_validate } from "../../../../../buf/validate/validate_pb";
@@ -13,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file ai/stigmer/agentic/agentinstance/v1/spec.proto.
  */
 export const file_ai_stigmer_agentic_agentinstance_v1_spec: GenFile = /*@__PURE__*/
-  fileDesc("Ci5haS9zdGlnbWVyL2FnZW50aWMvYWdlbnRpbnN0YW5jZS92MS9zcGVjLnByb3RvEiNhaS5zdGlnbWVyLmFnZW50aWMuYWdlbnRpbnN0YW5jZS52MSKKAgoRQWdlbnRJbnN0YW5jZVNwZWMSGQoIYWdlbnRfaWQYASABKAlCB7pIBHICEAESEwoLZGVzY3JpcHRpb24YAiABKAkSxAEKEGVudmlyb25tZW50X3JlZnMYAyADKAsyNC5haS5zdGlnbWVyLmNvbW1vbnMuYXBpcmVzb3VyY2UuQXBpUmVzb3VyY2VSZWZlcmVuY2VCdLpIcZIBbiJsugFpChVlbnZpcm9ubWVudF9yZWZzLmtpbmQSP2Vudmlyb25tZW50X3JlZnMgbXVzdCByZWZlcmVuY2UgcmVzb3VyY2VzIHdpdGgga2luZD1lbnZpcm9ubWVudBoPdGhpcy5raW5kID09IDUzYgZwcm90bzM", [file_ai_stigmer_commons_apiresource_io, file_buf_validate_validate]);
+  fileDesc("Ci5haS9zdGlnbWVyL2FnZW50aWMvYWdlbnRpbnN0YW5jZS92MS9zcGVjLnByb3RvEiNhaS5zdGlnbWVyLmFnZW50aWMuYWdlbnRpbnN0YW5jZS52MSKOAgoRQWdlbnRJbnN0YW5jZVNwZWMSGQoIYWdlbnRfaWQYASABKAlCB7pIBHICEAESEwoLZGVzY3JpcHRpb24YAiABKAkSyAEKEGVudmlyb25tZW50X3JlZnMYAyADKAsyNC5haS5zdGlnbWVyLmNvbW1vbnMuYXBpcmVzb3VyY2UuQXBpUmVzb3VyY2VSZWZlcmVuY2VCeLpIcZIBbiJsugFpChVlbnZpcm9ubWVudF9yZWZzLmtpbmQSP2Vudmlyb25tZW50X3JlZnMgbXVzdCByZWZlcmVuY2UgcmVzb3VyY2VzIHdpdGgga2luZD1lbnZpcm9ubWVudBoPdGhpcy5raW5kID09IDUz4IUsNWIGcHJvdG8z", [file_ai_stigmer_commons_apiresource_field_options, file_ai_stigmer_commons_apiresource_io, file_buf_validate_validate]);
 
 /**
  * AgentInstanceSpec defines the configurable properties of an agent instance.

--- a/apis/stubs/ts/ai/stigmer/agentic/workflowinstance/v1/spec_pb.ts
+++ b/apis/stubs/ts/ai/stigmer/agentic/workflowinstance/v1/spec_pb.ts
@@ -6,6 +6,7 @@
 
 import type { GenFile, GenMessage } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
+import { file_ai_stigmer_commons_apiresource_field_options } from "../../../commons/apiresource/field_options_pb";
 import type { ApiResourceReference } from "../../../commons/apiresource/io_pb";
 import { file_ai_stigmer_commons_apiresource_io } from "../../../commons/apiresource/io_pb";
 import { file_buf_validate_validate } from "../../../../../buf/validate/validate_pb";
@@ -15,7 +16,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file ai/stigmer/agentic/workflowinstance/v1/spec.proto.
  */
 export const file_ai_stigmer_agentic_workflowinstance_v1_spec: GenFile = /*@__PURE__*/
-  fileDesc("CjFhaS9zdGlnbWVyL2FnZW50aWMvd29ya2Zsb3dpbnN0YW5jZS92MS9zcGVjLnByb3RvEiZhaS5zdGlnbWVyLmFnZW50aWMud29ya2Zsb3dpbnN0YW5jZS52MSKQAgoUV29ya2Zsb3dJbnN0YW5jZVNwZWMSHAoLd29ya2Zsb3dfaWQYASABKAlCB7pIBHICEAESEwoLZGVzY3JpcHRpb24YAiABKAkSxAEKEGVudmlyb25tZW50X3JlZnMYAyADKAsyNC5haS5zdGlnbWVyLmNvbW1vbnMuYXBpcmVzb3VyY2UuQXBpUmVzb3VyY2VSZWZlcmVuY2VCdLpIcZIBbiJsugFpChVlbnZpcm9ubWVudF9yZWZzLmtpbmQSP2Vudmlyb25tZW50X3JlZnMgbXVzdCByZWZlcmVuY2UgcmVzb3VyY2VzIHdpdGgga2luZD1lbnZpcm9ubWVudBoPdGhpcy5raW5kID09IDUzYgZwcm90bzM", [file_ai_stigmer_commons_apiresource_io, file_buf_validate_validate]);
+  fileDesc("CjFhaS9zdGlnbWVyL2FnZW50aWMvd29ya2Zsb3dpbnN0YW5jZS92MS9zcGVjLnByb3RvEiZhaS5zdGlnbWVyLmFnZW50aWMud29ya2Zsb3dpbnN0YW5jZS52MSKUAgoUV29ya2Zsb3dJbnN0YW5jZVNwZWMSHAoLd29ya2Zsb3dfaWQYASABKAlCB7pIBHICEAESEwoLZGVzY3JpcHRpb24YAiABKAkSyAEKEGVudmlyb25tZW50X3JlZnMYAyADKAsyNC5haS5zdGlnbWVyLmNvbW1vbnMuYXBpcmVzb3VyY2UuQXBpUmVzb3VyY2VSZWZlcmVuY2VCeLpIcZIBbiJsugFpChVlbnZpcm9ubWVudF9yZWZzLmtpbmQSP2Vudmlyb25tZW50X3JlZnMgbXVzdCByZWZlcmVuY2UgcmVzb3VyY2VzIHdpdGgga2luZD1lbnZpcm9ubWVudBoPdGhpcy5raW5kID09IDUz4IUsNWIGcHJvdG8z", [file_ai_stigmer_commons_apiresource_field_options, file_ai_stigmer_commons_apiresource_io, file_buf_validate_validate]);
 
 /**
  * WorkflowInstanceSpec defines the configurable properties of a workflow instance.

--- a/mcp-server/gen/agentic/agentinstance/agent_instance_gen.go
+++ b/mcp-server/gen/agentic/agentinstance/agent_instance_gen.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stigmer/stigmer/mcp-server/internal/convert"
 	agentinstancev1 "github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/agentic/agentinstance/v1"
 	"github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/commons/apiresource"
-	apiresourcekind "github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/commons/apiresource/apiresourcekind"
 )
 
 // AgentInstanceSpec defines the configurable properties of an agent instance.
@@ -33,19 +33,15 @@ type AgentInstanceInput struct {
 	// Human-readable description for UI and API display.
 	Description string `json:"description,omitempty" jsonschema:"Human-readable description for UI and API display."`
 	// References to Environment resources providing secrets and configuration at runtime. @internal Environments are merged in order: later environments override earlier ones. Example: [base-env, aws-prod-env, github-team-env] This allows layering of configurations (base → specific overrides).
-	EnvironmentRefs []ApiResourceReferenceInput `json:"environment_refs,omitempty" jsonschema:"References to Environment resources providing secrets and configuration at runtime. @internal Environments are merged in order: later environments override earlier ones. Example: [base-env, aws-prod-env, github-team-env] This allows layering of configurations (base → specific overrides)."`
+	EnvironmentRefs []EnvironmentRefInput `json:"environment_refs,omitempty" jsonschema:"References to Environment resources providing secrets and configuration at runtime. @internal Environments are merged in order: later environments override earlier ones. Example: [base-env, aws-prod-env, github-team-env] This allows layering of configurations (base → specific overrides)."`
 }
 
-// Generic reference to any API resource by org and slug. Used across resources to reference other resources (e.g., Environment, Agent, Skill). Canonical format: "org/slug" (e.g., "stigmer/web-search", "acme/my-agent").
-type ApiResourceReferenceInput struct {
+// Identifies a resource by org, slug, and optional version. Kind is auto-populated.
+type EnvironmentRefInput struct {
 	// Organization that owns the referenced resource. When non-empty: must be a valid org slug (lowercase alphanumeric with hyphens, starts with a letter, 1-63 characters). Example: "stigmer", "acme-corp". When empty: the reference is relative — the server resolves it to the parent resource's organization at write time. All stored and returned references always have org populated (absolute form). Use empty org for same-org references (the common case). Use explicit org for cross-org references (e.g., marketplace resources).
 	Org string `json:"org,omitempty" jsonschema:"Organization that owns the referenced resource. When non-empty: must be a valid org slug (lowercase alphanumeric with hyphens, starts with a letter, 1-63 characters). Example: 'stigmer', 'acme-corp'. When empty: the reference is relative — the server resolves it to the parent resource's organization at write time. All stored and returned references always have org populated (absolute form). Use empty org for same-org references (the common case). Use explicit org for cross-org references (e.g., marketplace resources)."`
-	// Kind of the referenced resource (e.g., SKILL, AGENT, MCP_SERVER).
-	Kind string `json:"kind,omitempty" jsonschema:"Kind of the referenced resource (e.g., SKILL, AGENT, MCP_SERVER). Allowed values: api_resource_version, iam_policy, identity_account, api_key, invitation, identity_provider, oauth_app, platform_client, organization, platform, agent, agent_execution, session, skill, mcp_server, agent_instance, workflow, workflow_instance, workflow_execution, environment, execution_context, project."`
 	// Resource slug (user-friendly identifier, unique within org). Format: lowercase alphanumeric with hyphens, must start with a letter (e.g., "web-search", "code-reviewer"). Length: 1-63 characters.
 	Slug string `json:"slug" jsonschema:"Resource slug (user-friendly identifier, unique within org). Format: lowercase alphanumeric with hyphens, must start with a letter (e.g., 'web-search', 'code-reviewer'). Length: 1-63 characters."`
-	// Version of the resource (optional, only applicable to versioned resources like Skills). Supports three formats: 1. Empty/unset → Resolves to "latest" (most recent version) 2. Tag name → Resolves to version with this tag (e.g., "stable", "v1.0") 3. Exact hash → Immutable reference to specific version (e.g., "abc123...") Default behavior: Empty means "latest" (current version). This field is ignored for non-versioned resources. Examples: - version: "" → Use latest version - version: "latest" → Use latest version (explicit) - version: "stable" → Use version tagged as "stable" - version: "v1.0" → Use version tagged as "v1.0" - version: "abc123..." → Use exact version with this hash (immutable)
-	Version string `json:"version,omitempty" jsonschema:"Version of the resource (optional, only applicable to versioned resources like Skills). Supports three formats: 1. Empty/unset → Resolves to 'latest' (most recent version) 2. Tag name → Resolves to version with this tag (e.g., 'stable', 'v1.0') 3. Exact hash → Immutable reference to specific version (e.g., 'abc123...') Default behavior: Empty means 'latest' (current version). This field is ignored for non-versioned resources. Examples: - version: '' → Use latest version - version: 'latest' → Use latest version (explicit) - version: 'stable' → Use version tagged as 'stable' - version: 'v1.0' → Use version tagged as 'v1.0' - version: 'abc123...' → Use exact version with this hash (immutable)"`
 }
 
 // ToProto converts the flat MCP input into a fully-formed AgentInstance proto message.
@@ -90,12 +86,10 @@ func (input *AgentInstanceInput) specToProto() (*agentinstancev1.AgentInstanceSp
 	return spec, nil
 }
 
-func (input *ApiResourceReferenceInput) toProto() (*apiresource.ApiResourceReference, error) {
-	result := &apiresource.ApiResourceReference{}
-
-	result.Org = input.Org
-	result.Kind = apiresourcekind.ApiResourceKind(apiresourcekind.ApiResourceKind_value[input.Kind])
-	result.Slug = input.Slug
-	result.Version = input.Version
-	return result, nil
+func (input *EnvironmentRefInput) toProto() (*apiresource.ApiResourceReference, error) {
+	return &apiresource.ApiResourceReference{
+		Org:  input.Org,
+		Slug: input.Slug,
+		Kind: apiresourcekind.ApiResourceKind_environment,
+	}, nil
 }

--- a/mcp-server/gen/agentic/workflowinstance/workflow_instance_gen.go
+++ b/mcp-server/gen/agentic/workflowinstance/workflow_instance_gen.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stigmer/stigmer/mcp-server/internal/convert"
 	workflowinstancev1 "github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/agentic/workflowinstance/v1"
 	"github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/commons/apiresource"
-	apiresourcekind "github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/commons/apiresource/apiresourcekind"
 )
 
 // WorkflowInstanceSpec defines the configurable properties of a workflow instance.
@@ -43,19 +43,15 @@ type WorkflowInstanceInput struct {
 	// Human-readable description of this workflow instance.
 	Description string `json:"description,omitempty" jsonschema:"Human-readable description of this workflow instance."`
 	// Ordered list of Environment resources providing configuration and secrets. Environments are merged in declaration order — later entries override earlier ones when keys conflict. @internal Environments are layered configuration containers that provide: - Environment variables (API keys, endpoints, flags) - Secrets (credentials, tokens, passwords) - Configuration values (timeouts, limits, settings) Example layering: [base-env, aws-prod-env, github-team-env] └─ base-env: Common settings for all instances └─ aws-prod-env: AWS production credentials (overrides base AWS settings) └─ github-team-env: Team-specific GitHub tokens (overrides generic tokens) Use Cases: - Single env: [prod-env] - Simple, all config in one place - Base + specific: [base, prod] - Common config + environment-specific - Layered: [base, cloud, team] - Base + cloud credentials + team settings References use ApiResourceReference which supports: - By ID: {id: "env_abc123"} - By slug: {slug: "aws-prod-env"} At execution time, the WorkflowExecution runtime merges these environments and provides the combined configuration to all agents in the workflow.
-	EnvironmentRefs []ApiResourceReferenceInput `json:"environment_refs,omitempty" jsonschema:"Ordered list of Environment resources providing configuration and secrets. Environments are merged in declaration order — later entries override earlier ones when keys conflict. @internal Environments are layered configuration containers that provide: - Environment variables (API keys, endpoints, flags) - Secrets (credentials, tokens, passwords) - Configuration values (timeouts, limits, settings) Example layering: [base-env, aws-prod-env, github-team-env] └─ base-env: Common settings for all instances └─ aws-prod-env: AWS production credentials (overrides base AWS settings) └─ github-team-env: Team-specific GitHub tokens (overrides generic tokens) Use Cases: - Single env: [prod-env] - Simple, all config in one place - Base + specific: [base, prod] - Common config + environment-specific - Layered: [base, cloud, team] - Base + cloud credentials + team settings References use ApiResourceReference which supports: - By ID: {id: 'env_abc123'} - By slug: {slug: 'aws-prod-env'} At execution time, the WorkflowExecution runtime merges these environments and provides the combined configuration to all agents in the workflow."`
+	EnvironmentRefs []EnvironmentRefInput `json:"environment_refs,omitempty" jsonschema:"Ordered list of Environment resources providing configuration and secrets. Environments are merged in declaration order — later entries override earlier ones when keys conflict. @internal Environments are layered configuration containers that provide: - Environment variables (API keys, endpoints, flags) - Secrets (credentials, tokens, passwords) - Configuration values (timeouts, limits, settings) Example layering: [base-env, aws-prod-env, github-team-env] └─ base-env: Common settings for all instances └─ aws-prod-env: AWS production credentials (overrides base AWS settings) └─ github-team-env: Team-specific GitHub tokens (overrides generic tokens) Use Cases: - Single env: [prod-env] - Simple, all config in one place - Base + specific: [base, prod] - Common config + environment-specific - Layered: [base, cloud, team] - Base + cloud credentials + team settings References use ApiResourceReference which supports: - By ID: {id: 'env_abc123'} - By slug: {slug: 'aws-prod-env'} At execution time, the WorkflowExecution runtime merges these environments and provides the combined configuration to all agents in the workflow."`
 }
 
-// Generic reference to any API resource by org and slug. Used across resources to reference other resources (e.g., Environment, Agent, Skill). Canonical format: "org/slug" (e.g., "stigmer/web-search", "acme/my-agent").
-type ApiResourceReferenceInput struct {
+// Identifies a resource by org, slug, and optional version. Kind is auto-populated.
+type EnvironmentRefInput struct {
 	// Organization that owns the referenced resource. When non-empty: must be a valid org slug (lowercase alphanumeric with hyphens, starts with a letter, 1-63 characters). Example: "stigmer", "acme-corp". When empty: the reference is relative — the server resolves it to the parent resource's organization at write time. All stored and returned references always have org populated (absolute form). Use empty org for same-org references (the common case). Use explicit org for cross-org references (e.g., marketplace resources).
 	Org string `json:"org,omitempty" jsonschema:"Organization that owns the referenced resource. When non-empty: must be a valid org slug (lowercase alphanumeric with hyphens, starts with a letter, 1-63 characters). Example: 'stigmer', 'acme-corp'. When empty: the reference is relative — the server resolves it to the parent resource's organization at write time. All stored and returned references always have org populated (absolute form). Use empty org for same-org references (the common case). Use explicit org for cross-org references (e.g., marketplace resources)."`
-	// Kind of the referenced resource (e.g., SKILL, AGENT, MCP_SERVER).
-	Kind string `json:"kind,omitempty" jsonschema:"Kind of the referenced resource (e.g., SKILL, AGENT, MCP_SERVER). Allowed values: api_resource_version, iam_policy, identity_account, api_key, invitation, identity_provider, oauth_app, platform_client, organization, platform, agent, agent_execution, session, skill, mcp_server, agent_instance, workflow, workflow_instance, workflow_execution, environment, execution_context, project."`
 	// Resource slug (user-friendly identifier, unique within org). Format: lowercase alphanumeric with hyphens, must start with a letter (e.g., "web-search", "code-reviewer"). Length: 1-63 characters.
 	Slug string `json:"slug" jsonschema:"Resource slug (user-friendly identifier, unique within org). Format: lowercase alphanumeric with hyphens, must start with a letter (e.g., 'web-search', 'code-reviewer'). Length: 1-63 characters."`
-	// Version of the resource (optional, only applicable to versioned resources like Skills). Supports three formats: 1. Empty/unset → Resolves to "latest" (most recent version) 2. Tag name → Resolves to version with this tag (e.g., "stable", "v1.0") 3. Exact hash → Immutable reference to specific version (e.g., "abc123...") Default behavior: Empty means "latest" (current version). This field is ignored for non-versioned resources. Examples: - version: "" → Use latest version - version: "latest" → Use latest version (explicit) - version: "stable" → Use version tagged as "stable" - version: "v1.0" → Use version tagged as "v1.0" - version: "abc123..." → Use exact version with this hash (immutable)
-	Version string `json:"version,omitempty" jsonschema:"Version of the resource (optional, only applicable to versioned resources like Skills). Supports three formats: 1. Empty/unset → Resolves to 'latest' (most recent version) 2. Tag name → Resolves to version with this tag (e.g., 'stable', 'v1.0') 3. Exact hash → Immutable reference to specific version (e.g., 'abc123...') Default behavior: Empty means 'latest' (current version). This field is ignored for non-versioned resources. Examples: - version: '' → Use latest version - version: 'latest' → Use latest version (explicit) - version: 'stable' → Use version tagged as 'stable' - version: 'v1.0' → Use version tagged as 'v1.0' - version: 'abc123...' → Use exact version with this hash (immutable)"`
 }
 
 // ToProto converts the flat MCP input into a fully-formed WorkflowInstance proto message.
@@ -100,12 +96,10 @@ func (input *WorkflowInstanceInput) specToProto() (*workflowinstancev1.WorkflowI
 	return spec, nil
 }
 
-func (input *ApiResourceReferenceInput) toProto() (*apiresource.ApiResourceReference, error) {
-	result := &apiresource.ApiResourceReference{}
-
-	result.Org = input.Org
-	result.Kind = apiresourcekind.ApiResourceKind(apiresourcekind.ApiResourceKind_value[input.Kind])
-	result.Slug = input.Slug
-	result.Version = input.Version
-	return result, nil
+func (input *EnvironmentRefInput) toProto() (*apiresource.ApiResourceReference, error) {
+	return &apiresource.ApiResourceReference{
+		Org:  input.Org,
+		Slug: input.Slug,
+		Kind: apiresourcekind.ApiResourceKind_environment,
+	}, nil
 }

--- a/mcp-server/proto/ai/stigmer/agentic/agentinstance/v1/spec.pb.go
+++ b/mcp-server/proto/ai/stigmer/agentic/agentinstance/v1/spec.pb.go
@@ -100,12 +100,12 @@ var File_ai_stigmer_agentic_agentinstance_v1_spec_proto protoreflect.FileDescrip
 
 const file_ai_stigmer_agentic_agentinstance_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	".ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xb1\x02\n" +
+	".ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a2ai/stigmer/commons/apiresource/field_options.proto\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xb5\x02\n" +
 	"\x11AgentInstanceSpec\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aagentId\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd5\x01\n" +
-	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n" +
-	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0fenvironmentRefsB\xc6\x02\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd9\x01\n" +
+	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n" +
+	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0fenvironmentRefsB\xc6\x02\n" +
 	"'com.ai.stigmer.agentic.agentinstance.v1B\tSpecProtoP\x01Z_github.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/agentic/agentinstance/v1;agentinstancev1\xa2\x02\x04ASAA\xaa\x02#Ai.Stigmer.Agentic.Agentinstance.V1\xca\x02#Ai\\Stigmer\\Agentic\\Agentinstance\\V1\xe2\x02/Ai\\Stigmer\\Agentic\\Agentinstance\\V1\\GPBMetadata\xea\x02'Ai::Stigmer::Agentic::Agentinstance::V1b\x06proto3"
 
 var (

--- a/mcp-server/proto/ai/stigmer/agentic/workflowinstance/v1/spec.pb.go
+++ b/mcp-server/proto/ai/stigmer/agentic/workflowinstance/v1/spec.pb.go
@@ -141,13 +141,13 @@ var File_ai_stigmer_agentic_workflowinstance_v1_spec_proto protoreflect.FileDesc
 
 const file_ai_stigmer_agentic_workflowinstance_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	"1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xba\x02\n" +
+	"1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a2ai/stigmer/commons/apiresource/field_options.proto\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xbe\x02\n" +
 	"\x14WorkflowInstanceSpec\x12(\n" +
 	"\vworkflow_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\n" +
 	"workflowId\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd5\x01\n" +
-	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n" +
-	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0fenvironmentRefsB\xdb\x02\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd9\x01\n" +
+	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n" +
+	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0fenvironmentRefsB\xdb\x02\n" +
 	"*com.ai.stigmer.agentic.workflowinstance.v1B\tSpecProtoP\x01Zegithub.com/stigmer/stigmer/mcp-server/proto/ai/stigmer/agentic/workflowinstance/v1;workflowinstancev1\xa2\x02\x04ASAW\xaa\x02&Ai.Stigmer.Agentic.Workflowinstance.V1\xca\x02&Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\xe2\x022Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\\GPBMetadata\xea\x02*Ai::Stigmer::Agentic::Workflowinstance::V1b\x06proto3"
 
 var (

--- a/sdk/go/internal/gen/agent.go
+++ b/sdk/go/internal/gen/agent.go
@@ -163,7 +163,9 @@ func (i *AgentInput) toProto() *agentv1.Agent {
 		resource.Spec.McpServerUsages = append(resource.Spec.McpServerUsages, item.toProto())
 	}
 	for _, r := range i.SkillRefs {
-		resource.Spec.SkillRefs = append(resource.Spec.SkillRefs, r.toProto())
+		ref := r.toProto()
+		ref.Kind = apiresourcekind.ApiResourceKind_skill
+		resource.Spec.SkillRefs = append(resource.Spec.SkillRefs, ref)
 	}
 	for _, item := range i.SubAgents {
 		resource.Spec.SubAgents = append(resource.Spec.SubAgents, item.toProto())
@@ -178,10 +180,12 @@ func (i *AgentInput) toProto() *agentv1.Agent {
 }
 
 func (i *McpServerUsageInput) toProto() *agentv1.McpServerUsage {
-	return &agentv1.McpServerUsage{
-		McpServerRef: i.McpServerRef.toProto(),
-		EnabledTools: i.EnabledTools,
-	}
+	p := &agentv1.McpServerUsage{}
+	ref := i.McpServerRef.toProto()
+	ref.Kind = apiresourcekind.ApiResourceKind_mcp_server
+	p.McpServerRef = ref
+	p.EnabledTools = i.EnabledTools
+	return p
 }
 
 func (i *ToolApprovalOverrideInput) toProto() *agentv1.ToolApprovalOverride {
@@ -193,12 +197,12 @@ func (i *ToolApprovalOverrideInput) toProto() *agentv1.ToolApprovalOverride {
 }
 
 func (i *SubAgentInput) toProto() *agentv1.SubAgent {
-	return &agentv1.SubAgent{
-		Name:          i.Name,
-		Description:   i.Description,
-		Instructions:  i.Instructions,
-		ModelOverride: i.ModelOverride,
-	}
+	p := &agentv1.SubAgent{}
+	p.Name = i.Name
+	p.Description = i.Description
+	p.Instructions = i.Instructions
+	p.ModelOverride = i.ModelOverride
+	return p
 }
 
 func (i *McpAccessInput) toProto() *agentv1.McpAccess {

--- a/sdk/go/internal/gen/agentinstance.go
+++ b/sdk/go/internal/gen/agentinstance.go
@@ -91,7 +91,9 @@ func (i *AgentInstanceInput) toProto() *agentinstancev1.AgentInstance {
 	resource.Spec.AgentId = i.AgentId
 	resource.Spec.Description = i.Description
 	for _, r := range i.EnvironmentRefs {
-		resource.Spec.EnvironmentRefs = append(resource.Spec.EnvironmentRefs, r.toProto())
+		ref := r.toProto()
+		ref.Kind = apiresourcekind.ApiResourceKind_environment
+		resource.Spec.EnvironmentRefs = append(resource.Spec.EnvironmentRefs, ref)
 	}
 	return resource
 }

--- a/sdk/go/internal/gen/mcpserver.go
+++ b/sdk/go/internal/gen/mcpserver.go
@@ -238,13 +238,15 @@ func (i *ToolApprovalPolicyInput) toProto() *mcpserverv1.ToolApprovalPolicy {
 }
 
 func (i *McpServerAuthInput) toProto() *mcpserverv1.McpServerAuth {
-	return &mcpserverv1.McpServerAuth{
-		OauthAppRef:       i.OauthAppRef.toProto(),
-		TargetEnvVar:      i.TargetEnvVar,
-		TokenLifetimeHint: i.TokenLifetimeHint,
-		ScopeHints:        i.ScopeHints,
-		DiscoveryUrl:      i.DiscoveryUrl,
-	}
+	p := &mcpserverv1.McpServerAuth{}
+	ref := i.OauthAppRef.toProto()
+	ref.Kind = apiresourcekind.ApiResourceKind_oauth_app
+	p.OauthAppRef = ref
+	p.TargetEnvVar = i.TargetEnvVar
+	p.TokenLifetimeHint = i.TokenLifetimeHint
+	p.ScopeHints = i.ScopeHints
+	p.DiscoveryUrl = i.DiscoveryUrl
+	return p
 }
 
 // McpServerInputFromProto creates a McpServerInput from a proto McpServer resource.

--- a/sdk/go/internal/gen/session.go
+++ b/sdk/go/internal/gen/session.go
@@ -7,6 +7,7 @@ import (
 
 	sessionv1 "github.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/agentic/session/v1"
 	apiresource "github.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/commons/apiresource"
+	apiresourcekind "github.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/commons/apiresource/apiresourcekind"
 	"google.golang.org/grpc"
 )
 
@@ -134,7 +135,9 @@ func (i *SessionInput) toProto() *sessionv1.Session {
 		resource.Spec.McpServerUsages = append(resource.Spec.McpServerUsages, item.toProto())
 	}
 	for _, r := range i.SkillRefs {
-		resource.Spec.SkillRefs = append(resource.Spec.SkillRefs, r.toProto())
+		ref := r.toProto()
+		ref.Kind = apiresourcekind.ApiResourceKind_skill
+		resource.Spec.SkillRefs = append(resource.Spec.SkillRefs, ref)
 	}
 	return resource
 }

--- a/sdk/go/internal/gen/workflowinstance.go
+++ b/sdk/go/internal/gen/workflowinstance.go
@@ -86,7 +86,9 @@ func (i *WorkflowInstanceInput) toProto() *workflowinstancev1.WorkflowInstance {
 	resource.Spec.WorkflowId = i.WorkflowId
 	resource.Spec.Description = i.Description
 	for _, r := range i.EnvironmentRefs {
-		resource.Spec.EnvironmentRefs = append(resource.Spec.EnvironmentRefs, r.toProto())
+		ref := r.toProto()
+		ref.Kind = apiresourcekind.ApiResourceKind_environment
+		resource.Spec.EnvironmentRefs = append(resource.Spec.EnvironmentRefs, ref)
 	}
 	return resource
 }

--- a/sdk/go/proto/ai/stigmer/agentic/agentinstance/v1/spec.pb.go
+++ b/sdk/go/proto/ai/stigmer/agentic/agentinstance/v1/spec.pb.go
@@ -100,12 +100,12 @@ var File_ai_stigmer_agentic_agentinstance_v1_spec_proto protoreflect.FileDescrip
 
 const file_ai_stigmer_agentic_agentinstance_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	".ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xb1\x02\n" +
+	".ai/stigmer/agentic/agentinstance/v1/spec.proto\x12#ai.stigmer.agentic.agentinstance.v1\x1a2ai/stigmer/commons/apiresource/field_options.proto\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xb5\x02\n" +
 	"\x11AgentInstanceSpec\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aagentId\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd5\x01\n" +
-	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n" +
-	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0fenvironmentRefsB\xc2\x02\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd9\x01\n" +
+	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n" +
+	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0fenvironmentRefsB\xc2\x02\n" +
 	"'com.ai.stigmer.agentic.agentinstance.v1B\tSpecProtoP\x01Z[github.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/agentic/agentinstance/v1;agentinstancev1\xa2\x02\x04ASAA\xaa\x02#Ai.Stigmer.Agentic.Agentinstance.V1\xca\x02#Ai\\Stigmer\\Agentic\\Agentinstance\\V1\xe2\x02/Ai\\Stigmer\\Agentic\\Agentinstance\\V1\\GPBMetadata\xea\x02'Ai::Stigmer::Agentic::Agentinstance::V1b\x06proto3"
 
 var (

--- a/sdk/go/proto/ai/stigmer/agentic/workflowinstance/v1/spec.pb.go
+++ b/sdk/go/proto/ai/stigmer/agentic/workflowinstance/v1/spec.pb.go
@@ -141,13 +141,13 @@ var File_ai_stigmer_agentic_workflowinstance_v1_spec_proto protoreflect.FileDesc
 
 const file_ai_stigmer_agentic_workflowinstance_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	"1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xba\x02\n" +
+	"1ai/stigmer/agentic/workflowinstance/v1/spec.proto\x12&ai.stigmer.agentic.workflowinstance.v1\x1a2ai/stigmer/commons/apiresource/field_options.proto\x1a'ai/stigmer/commons/apiresource/io.proto\x1a\x1bbuf/validate/validate.proto\"\xbe\x02\n" +
 	"\x14WorkflowInstanceSpec\x12(\n" +
 	"\vworkflow_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\n" +
 	"workflowId\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd5\x01\n" +
-	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBt\xbaHq\x92\x01n\"l\xba\x01i\n" +
-	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53R\x0fenvironmentRefsB\xd7\x02\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\xd9\x01\n" +
+	"\x10environment_refs\x18\x03 \x03(\v24.ai.stigmer.commons.apiresource.ApiResourceReferenceBx\xbaHq\x92\x01n\"l\xba\x01i\n" +
+	"\x15environment_refs.kind\x12?environment_refs must reference resources with kind=environment\x1a\x0fthis.kind == 53\xe0\x85,5R\x0fenvironmentRefsB\xd7\x02\n" +
 	"*com.ai.stigmer.agentic.workflowinstance.v1B\tSpecProtoP\x01Zagithub.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/agentic/workflowinstance/v1;workflowinstancev1\xa2\x02\x04ASAW\xaa\x02&Ai.Stigmer.Agentic.Workflowinstance.V1\xca\x02&Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\xe2\x022Ai\\Stigmer\\Agentic\\Workflowinstance\\V1\\GPBMetadata\xea\x02*Ai::Stigmer::Agentic::Workflowinstance::V1b\x06proto3"
 
 var (

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/AgentInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/AgentInput.java
@@ -10,6 +10,7 @@ import ai.stigmer.agentic.agent.v1.SubAgent;
 import ai.stigmer.agentic.agent.v1.ToolApprovalOverride;
 import ai.stigmer.agentic.environment.v1.EnvVarDeclaration;
 import ai.stigmer.commons.apiresource.ApiResourceMetadata;
+import ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind;
 
 /** Input for creating/updating a Agent. */
 public final class AgentInput {
@@ -57,7 +58,8 @@ public final class AgentInput {
         }
         if (this.skillRefs != null) {
             for (ResourceRef item : this.skillRefs) {
-                spec.addSkillRefs(item.toProto());
+                spec.addSkillRefs(item.toProto().toBuilder()
+                    .setKind(ApiResourceKind.skill).build());
             }
         }
         if (this.subAgents != null) {
@@ -134,7 +136,8 @@ public final class AgentInput {
         McpServerUsage toProto() {
             McpServerUsage.Builder builder = McpServerUsage.newBuilder();
             if (this.mcpServerRef != null) {
-                builder.setMcpServerRef(this.mcpServerRef.toProto());
+                builder.setMcpServerRef(this.mcpServerRef.toProto().toBuilder()
+                    .setKind(ApiResourceKind.mcp_server).build());
             }
             if (this.enabledTools != null) {
                 builder.addAllEnabledTools(this.enabledTools);
@@ -241,7 +244,8 @@ public final class AgentInput {
             }
             if (this.skillRefs != null) {
                 for (ResourceRef item : this.skillRefs) {
-                    builder.addSkillRefs(item.toProto());
+                    builder.addSkillRefs(item.toProto().toBuilder()
+                        .setKind(ApiResourceKind.skill).build());
                 }
             }
             if (this.modelOverride != null) {

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/AgentInstanceInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/AgentInstanceInput.java
@@ -5,6 +5,7 @@ package ai.stigmer.sdk.gen;
 import ai.stigmer.agentic.agentinstance.v1.AgentInstance;
 import ai.stigmer.agentic.agentinstance.v1.AgentInstanceSpec;
 import ai.stigmer.commons.apiresource.ApiResourceMetadata;
+import ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind;
 
 /** Input for creating/updating a AgentInstance. */
 public final class AgentInstanceInput {
@@ -36,7 +37,8 @@ public final class AgentInstanceInput {
         }
         if (this.environmentRefs != null) {
             for (ResourceRef item : this.environmentRefs) {
-                spec.addEnvironmentRefs(item.toProto());
+                spec.addEnvironmentRefs(item.toProto().toBuilder()
+                    .setKind(ApiResourceKind.environment).build());
             }
         }
         ApiResourceMetadata.Builder metaBuilder = ApiResourceMetadata.newBuilder()

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/McpServerInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/McpServerInput.java
@@ -10,6 +10,7 @@ import ai.stigmer.agentic.mcpserver.v1.McpServerSpec;
 import ai.stigmer.agentic.mcpserver.v1.StdioServerConfig;
 import ai.stigmer.agentic.mcpserver.v1.ToolApprovalPolicy;
 import ai.stigmer.commons.apiresource.ApiResourceMetadata;
+import ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind;
 
 /** Input for creating/updating a McpServer. */
 public final class McpServerInput {
@@ -319,7 +320,8 @@ public final class McpServerInput {
         McpServerAuth toProto() {
             McpServerAuth.Builder builder = McpServerAuth.newBuilder();
             if (this.oauthAppRef != null) {
-                builder.setOauthAppRef(this.oauthAppRef.toProto());
+                builder.setOauthAppRef(this.oauthAppRef.toProto().toBuilder()
+                    .setKind(ApiResourceKind.oauth_app).build());
             }
             if (this.targetEnvVar != null) {
                 builder.setTargetEnvVar(this.targetEnvVar);

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/ResourceRef.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/ResourceRef.java
@@ -19,19 +19,19 @@ public final class ResourceRef {
     }
 
     public static ResourceRef of(String org, String slug) {
-        return new ResourceRef(org, slug, null, ApiResourceKind.api_resource_kind_unspecified);
+        return new ResourceRef(org, slug, null, ApiResourceKind.api_resource_kind_unknown);
     }
 
     public static ResourceRef of(String org, String slug, String version) {
-        return new ResourceRef(org, slug, version, ApiResourceKind.api_resource_kind_unspecified);
+        return new ResourceRef(org, slug, version, ApiResourceKind.api_resource_kind_unknown);
     }
 
-    public static ResourceRef skill(String org, String slug) {
-        return new ResourceRef(org, slug, null, ApiResourceKind.skill);
+    public static ResourceRef of(String org, ApiResourceKind kind, String slug) {
+        return new ResourceRef(org, slug, null, kind);
     }
 
-    public static ResourceRef skill(String org, String slug, String version) {
-        return new ResourceRef(org, slug, version, ApiResourceKind.skill);
+    public static ResourceRef of(String org, ApiResourceKind kind, String slug, String version) {
+        return new ResourceRef(org, slug, version, kind);
     }
 
     public String getOrg() { return org; }
@@ -43,7 +43,7 @@ public final class ResourceRef {
         ApiResourceReference.Builder builder = ApiResourceReference.newBuilder()
             .setOrg(this.org)
             .setSlug(this.slug);
-        if (this.kind != null && this.kind != ApiResourceKind.api_resource_kind_unspecified) {
+        if (this.kind != null && this.kind != ApiResourceKind.api_resource_kind_unknown) {
             builder.setKind(this.kind);
         }
         if (this.version != null) {

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/SessionInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/SessionInput.java
@@ -12,6 +12,7 @@ import ai.stigmer.agentic.session.v1.SessionSpec;
 import ai.stigmer.agentic.session.v1.WorkspaceEntry;
 import ai.stigmer.agentic.session.v1.WorkspaceSource;
 import ai.stigmer.commons.apiresource.ApiResourceMetadata;
+import ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind;
 
 /** Input for creating/updating a Session. */
 public final class SessionInput {
@@ -72,7 +73,8 @@ public final class SessionInput {
         }
         if (this.skillRefs != null) {
             for (ResourceRef item : this.skillRefs) {
-                spec.addSkillRefs(item.toProto());
+                spec.addSkillRefs(item.toProto().toBuilder()
+                    .setKind(ApiResourceKind.skill).build());
             }
         }
         ApiResourceMetadata.Builder metaBuilder = ApiResourceMetadata.newBuilder()
@@ -297,7 +299,8 @@ public final class SessionInput {
         McpServerUsage toProto() {
             McpServerUsage.Builder builder = McpServerUsage.newBuilder();
             if (this.mcpServerRef != null) {
-                builder.setMcpServerRef(this.mcpServerRef.toProto());
+                builder.setMcpServerRef(this.mcpServerRef.toProto().toBuilder()
+                    .setKind(ApiResourceKind.mcp_server).build());
             }
             if (this.enabledTools != null) {
                 builder.addAllEnabledTools(this.enabledTools);

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/WorkflowInstanceInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/WorkflowInstanceInput.java
@@ -5,6 +5,7 @@ package ai.stigmer.sdk.gen;
 import ai.stigmer.agentic.workflowinstance.v1.WorkflowInstance;
 import ai.stigmer.agentic.workflowinstance.v1.WorkflowInstanceSpec;
 import ai.stigmer.commons.apiresource.ApiResourceMetadata;
+import ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind;
 
 /** Input for creating/updating a WorkflowInstance. */
 public final class WorkflowInstanceInput {
@@ -36,7 +37,8 @@ public final class WorkflowInstanceInput {
         }
         if (this.environmentRefs != null) {
             for (ResourceRef item : this.environmentRefs) {
-                spec.addEnvironmentRefs(item.toProto());
+                spec.addEnvironmentRefs(item.toProto().toBuilder()
+                    .setKind(ApiResourceKind.environment).build());
             }
         }
         ApiResourceMetadata.Builder metaBuilder = ApiResourceMetadata.newBuilder()

--- a/sdk/python/src/stigmer/_gen/_agent.py
+++ b/sdk/python/src/stigmer/_gen/_agent.py
@@ -130,7 +130,9 @@ class AgentInput:
         for item in self.mcp_server_usages:
             spec.mcp_server_usages.append(item._to_proto())
         for ref in self.skill_refs:
-            spec.skill_refs.append(ref._to_proto())
+            _ref = ref._to_proto()
+            _ref.kind = 43
+            spec.skill_refs.append(_ref)
         for item in self.sub_agents:
             spec.sub_agents.append(item._to_proto())
         for k, v in self.env.items():
@@ -162,7 +164,9 @@ class McpServerUsageInput:
     def _to_proto(self) -> spec_pb2.McpServerUsage:
         msg = spec_pb2.McpServerUsage()
         if self.mcp_server_ref is not None:
-            msg.mcp_server_ref.CopyFrom(self.mcp_server_ref._to_proto())
+            _ref = self.mcp_server_ref._to_proto()
+            _ref.kind = 44
+            msg.mcp_server_ref.CopyFrom(_ref)
         if self.enabled_tools:
             msg.enabled_tools.extend(self.enabled_tools)
         for item in self.tool_approval_overrides:
@@ -208,7 +212,9 @@ class SubAgentInput:
         for item in self.mcp_access:
             msg.mcp_access.append(item._to_proto())
         for ref in self.skill_refs:
-            msg.skill_refs.append(ref._to_proto())
+            _ref = ref._to_proto()
+            _ref.kind = 43
+            msg.skill_refs.append(_ref)
         return msg
 
 

--- a/sdk/python/src/stigmer/_gen/_agentinstance.py
+++ b/sdk/python/src/stigmer/_gen/_agentinstance.py
@@ -95,7 +95,9 @@ class AgentInstanceInput:
             description=self.description,
         )
         for ref in self.environment_refs:
-            spec.environment_refs.append(ref._to_proto())
+            _ref = ref._to_proto()
+            _ref.kind = 53
+            spec.environment_refs.append(_ref)
         metadata = metadata_pb2.ApiResourceMetadata(
             name=self.name,
             org=self.org,

--- a/sdk/python/src/stigmer/_gen/_mcpserver.py
+++ b/sdk/python/src/stigmer/_gen/_mcpserver.py
@@ -272,7 +272,9 @@ class McpServerAuthInput:
             discovery_url=self.discovery_url,
         )
         if self.oauth_app_ref is not None:
-            msg.oauth_app_ref.CopyFrom(self.oauth_app_ref._to_proto())
+            _ref = self.oauth_app_ref._to_proto()
+            _ref.kind = 22
+            msg.oauth_app_ref.CopyFrom(_ref)
         if self.scope_hints:
             msg.scope_hints.extend(self.scope_hints)
         return msg

--- a/sdk/python/src/stigmer/_gen/_session.py
+++ b/sdk/python/src/stigmer/_gen/_session.py
@@ -111,7 +111,9 @@ class SessionInput:
         for item in self.mcp_server_usages:
             spec.mcp_server_usages.append(item._to_proto())
         for ref in self.skill_refs:
-            spec.skill_refs.append(ref._to_proto())
+            _ref = ref._to_proto()
+            _ref.kind = 43
+            spec.skill_refs.append(_ref)
         metadata = metadata_pb2.ApiResourceMetadata(
             name=self.name,
             org=self.org,

--- a/sdk/python/src/stigmer/_gen/_workflowinstance.py
+++ b/sdk/python/src/stigmer/_gen/_workflowinstance.py
@@ -89,7 +89,9 @@ class WorkflowInstanceInput:
             description=self.description,
         )
         for ref in self.environment_refs:
-            spec.environment_refs.append(ref._to_proto())
+            _ref = ref._to_proto()
+            _ref.kind = 53
+            spec.environment_refs.append(_ref)
         metadata = metadata_pb2.ApiResourceMetadata(
             name=self.name,
             org=self.org,

--- a/sdk/typescript/src/gen/agent.ts
+++ b/sdk/typescript/src/gen/agent.ts
@@ -159,7 +159,7 @@ function buildToolApprovalOverrideProto(input: ToolApprovalOverrideInput) {
 
 function buildMcpServerUsageProto(input: McpServerUsageInput) {
   const msg = create(McpServerUsageSchema);
-  if (input.mcpServerRef) msg.mcpServerRef = create(ApiResourceReferenceSchema, input.mcpServerRef);
+  if (input.mcpServerRef) msg.mcpServerRef = create(ApiResourceReferenceSchema, { ...input.mcpServerRef, kind: 44 });
   if (input.enabledTools) msg.enabledTools = input.enabledTools;
   if (input.toolApprovalOverrides) msg.toolApprovalOverrides = input.toolApprovalOverrides.map(buildToolApprovalOverrideProto);
   return msg;
@@ -178,7 +178,7 @@ function buildSubAgentProto(input: SubAgentInput) {
   if (input.description !== undefined) msg.description = input.description;
   if (input.instructions !== undefined) msg.instructions = input.instructions;
   if (input.mcpAccess) msg.mcpAccess = input.mcpAccess.map(buildMcpAccessProto);
-  if (input.skillRefs) msg.skillRefs = input.skillRefs.map(r => create(ApiResourceReferenceSchema, r));
+  if (input.skillRefs) msg.skillRefs = input.skillRefs.map(r => create(ApiResourceReferenceSchema, { ...r, kind: 43 }));
   if (input.modelOverride !== undefined) msg.modelOverride = input.modelOverride;
   return msg;
 }
@@ -193,7 +193,7 @@ function buildEnvVarDeclarationProto(input: EnvVarDeclarationInput) {
 
 function buildAgentProto(input: AgentInput): Agent {
   const mcpServerUsages = input.mcpServerUsages?.map(buildMcpServerUsageProto);
-  const skillRefs = input.skillRefs?.map(r => create(ApiResourceReferenceSchema, r));
+  const skillRefs = input.skillRefs?.map(r => create(ApiResourceReferenceSchema, { ...r, kind: 43 }));
   const subAgents = input.subAgents?.map(buildSubAgentProto);
   let env;
   if (input.env) {

--- a/sdk/typescript/src/gen/agentinstance.ts
+++ b/sdk/typescript/src/gen/agentinstance.ts
@@ -85,7 +85,7 @@ export interface AgentInstanceInput {
 }
 
 function buildAgentInstanceProto(input: AgentInstanceInput): AgentInstance {
-  const environmentRefs = input.environmentRefs?.map(r => create(ApiResourceReferenceSchema, r));
+  const environmentRefs = input.environmentRefs?.map(r => create(ApiResourceReferenceSchema, { ...r, kind: 53 }));
   return Object.assign(create(AgentInstanceSchema), {
     apiVersion: "agentic.stigmer.ai/v1",
     kind: "AgentInstance",

--- a/sdk/typescript/src/gen/mcpserver.ts
+++ b/sdk/typescript/src/gen/mcpserver.ts
@@ -232,7 +232,7 @@ function buildToolApprovalPolicyProto(input: ToolApprovalPolicyInput) {
 
 function buildMcpServerAuthProto(input: McpServerAuthInput) {
   const msg = create(McpServerAuthSchema);
-  if (input.oauthAppRef) msg.oauthAppRef = create(ApiResourceReferenceSchema, input.oauthAppRef);
+  if (input.oauthAppRef) msg.oauthAppRef = create(ApiResourceReferenceSchema, { ...input.oauthAppRef, kind: 22 });
   if (input.targetEnvVar !== undefined) msg.targetEnvVar = input.targetEnvVar;
   if (input.tokenLifetimeHint !== undefined) msg.tokenLifetimeHint = input.tokenLifetimeHint;
   if (input.scopeHints) msg.scopeHints = input.scopeHints;

--- a/sdk/typescript/src/gen/session.ts
+++ b/sdk/typescript/src/gen/session.ts
@@ -180,7 +180,7 @@ function buildToolApprovalOverrideProto(input: ToolApprovalOverrideInput) {
 
 function buildMcpServerUsageProto(input: McpServerUsageInput) {
   const msg = create(McpServerUsageSchema);
-  if (input.mcpServerRef) msg.mcpServerRef = create(ApiResourceReferenceSchema, input.mcpServerRef);
+  if (input.mcpServerRef) msg.mcpServerRef = create(ApiResourceReferenceSchema, { ...input.mcpServerRef, kind: 44 });
   if (input.enabledTools) msg.enabledTools = input.enabledTools;
   if (input.toolApprovalOverrides) msg.toolApprovalOverrides = input.toolApprovalOverrides.map(buildToolApprovalOverrideProto);
   return msg;
@@ -189,7 +189,7 @@ function buildMcpServerUsageProto(input: McpServerUsageInput) {
 function buildSessionProto(input: SessionInput): Session {
   const workspaceEntries = input.workspaceEntries?.map(buildWorkspaceEntryProto);
   const mcpServerUsages = input.mcpServerUsages?.map(buildMcpServerUsageProto);
-  const skillRefs = input.skillRefs?.map(r => create(ApiResourceReferenceSchema, r));
+  const skillRefs = input.skillRefs?.map(r => create(ApiResourceReferenceSchema, { ...r, kind: 43 }));
   return Object.assign(create(SessionSchema), {
     apiVersion: "agentic.stigmer.ai/v1",
     kind: "Session",

--- a/sdk/typescript/src/gen/workflowinstance.ts
+++ b/sdk/typescript/src/gen/workflowinstance.ts
@@ -79,7 +79,7 @@ export interface WorkflowInstanceInput {
 }
 
 function buildWorkflowInstanceProto(input: WorkflowInstanceInput): WorkflowInstance {
-  const environmentRefs = input.environmentRefs?.map(r => create(ApiResourceReferenceSchema, r));
+  const environmentRefs = input.environmentRefs?.map(r => create(ApiResourceReferenceSchema, { ...r, kind: 53 }));
   return Object.assign(create(WorkflowInstanceSchema), {
     apiVersion: "agentic.stigmer.ai/v1",
     kind: "WorkflowInstance",

--- a/site/src/components/docs/demos/scenarios/agent-creation-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/agent-creation-tour/narration/manifest.json
@@ -3,26 +3,26 @@
     null,
     {
       "src": "/demos/agent-creation-tour/step-1.mp3",
-      "durationMs": 5100
+      "durationMs": 5138
     },
     null,
     null,
     {
       "src": "/demos/agent-creation-tour/step-4.mp3",
-      "durationMs": 4375
+      "durationMs": 4550
     },
     null,
     null,
     {
       "src": "/demos/agent-creation-tour/step-7.mp3",
-      "durationMs": 8488
+      "durationMs": 8225
     },
     null,
     null,
     null,
     {
       "src": "/demos/agent-creation-tour/step-11.mp3",
-      "durationMs": 4525
+      "durationMs": 4500
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/api-key-setup/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/api-key-setup/narration/manifest.json
@@ -2,14 +2,14 @@
   "steps": [
     {
       "src": "/demos/api-key-setup/step-0.mp3",
-      "durationMs": 5338
+      "durationMs": 5238
     },
     null,
     null,
     null,
     {
       "src": "/demos/api-key-setup/step-4.mp3",
-      "durationMs": 3963
+      "durationMs": 3725
     },
     null,
     null,

--- a/site/src/components/docs/demos/scenarios/approval-flow-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/approval-flow-playback/narration/manifest.json
@@ -2,12 +2,12 @@
   "steps": [
     {
       "src": "/demos/approval-flow-playback/step-0.mp3",
-      "durationMs": 7125
+      "durationMs": 6938
     },
     null,
     {
       "src": "/demos/approval-flow-playback/step-2.mp3",
-      "durationMs": 6200
+      "durationMs": 5963
     },
     {
       "src": "/demos/approval-flow-playback/step-3.mp3",

--- a/site/src/components/docs/demos/scenarios/authentication-flow-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/authentication-flow-playback/narration/manifest.json
@@ -10,7 +10,7 @@
     },
     {
       "src": "/demos/authentication-flow-playback/step-2.mp3",
-      "durationMs": 8550
+      "durationMs": 8688
     },
     {
       "src": "/demos/authentication-flow-playback/step-3.mp3",
@@ -22,7 +22,7 @@
     },
     {
       "src": "/demos/authentication-flow-playback/step-5.mp3",
-      "durationMs": 6013
+      "durationMs": 6388
     },
     {
       "src": "/demos/authentication-flow-playback/step-6.mp3",

--- a/site/src/components/docs/demos/scenarios/connect-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/connect-playback/narration/manifest.json
@@ -2,7 +2,7 @@
   "steps": [
     {
       "src": "/demos/connect-playback/step-0.mp3",
-      "durationMs": 4275
+      "durationMs": 4425
     },
     null,
     {

--- a/site/src/components/docs/demos/scenarios/connect-tools-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/connect-tools-tour/narration/manifest.json
@@ -6,7 +6,7 @@
     },
     {
       "src": "/demos/connect-tools-tour/step-1.mp3",
-      "durationMs": 5750
+      "durationMs": 5888
     },
     {
       "src": "/demos/connect-tools-tour/step-2.mp3",

--- a/site/src/components/docs/demos/scenarios/federation-overview-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/federation-overview-tour/narration/manifest.json
@@ -6,11 +6,11 @@
     },
     {
       "src": "/demos/federation-overview-tour/step-1.mp3",
-      "durationMs": 10425
+      "durationMs": 10350
     },
     {
       "src": "/demos/federation-overview-tour/step-2.mp3",
-      "durationMs": 10375
+      "durationMs": 10313
     },
     {
       "src": "/demos/federation-overview-tour/step-3.mp3",

--- a/site/src/components/docs/demos/scenarios/marketplace-connect-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/marketplace-connect-tour/narration/manifest.json
@@ -7,7 +7,7 @@
     null,
     {
       "src": "/demos/marketplace-connect-tour/step-2.mp3",
-      "durationMs": 11450
+      "durationMs": 11125
     },
     null,
     {

--- a/site/src/components/docs/demos/scenarios/mcp-server-creation-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/mcp-server-creation-tour/narration/manifest.json
@@ -3,26 +3,26 @@
     null,
     {
       "src": "/demos/mcp-server-creation-tour/step-1.mp3",
-      "durationMs": 7938
+      "durationMs": 8188
     },
     null,
     null,
     null,
     {
       "src": "/demos/mcp-server-creation-tour/step-5.mp3",
-      "durationMs": 6688
+      "durationMs": 6963
     },
     null,
     {
       "src": "/demos/mcp-server-creation-tour/step-7.mp3",
-      "durationMs": 6413
+      "durationMs": 6400
     },
     null,
     null,
     null,
     {
       "src": "/demos/mcp-server-creation-tour/step-11.mp3",
-      "durationMs": 7713
+      "durationMs": 7650
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/multi-tenant-jit-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/multi-tenant-jit-playback/narration/manifest.json
@@ -6,7 +6,7 @@
     },
     {
       "src": "/demos/multi-tenant-jit-playback/step-1.mp3",
-      "durationMs": 8975
+      "durationMs": 9188
     },
     {
       "src": "/demos/multi-tenant-jit-playback/step-2.mp3",
@@ -18,7 +18,7 @@
     },
     {
       "src": "/demos/multi-tenant-jit-playback/step-4.mp3",
-      "durationMs": 11225
+      "durationMs": 11413
     },
     {
       "src": "/demos/multi-tenant-jit-playback/step-5.mp3",

--- a/site/src/components/docs/demos/scenarios/multi-tenant-setup-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/multi-tenant-setup-playback/narration/manifest.json
@@ -2,11 +2,11 @@
   "steps": [
     {
       "src": "/demos/multi-tenant-setup-playback/step-0.mp3",
-      "durationMs": 9750
+      "durationMs": 9613
     },
     {
       "src": "/demos/multi-tenant-setup-playback/step-1.mp3",
-      "durationMs": 12988
+      "durationMs": 12663
     },
     {
       "src": "/demos/multi-tenant-setup-playback/step-2.mp3",
@@ -26,7 +26,7 @@
     },
     {
       "src": "/demos/multi-tenant-setup-playback/step-6.mp3",
-      "durationMs": 11713
+      "durationMs": 11625
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/oauth-connect-flow/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/oauth-connect-flow/narration/manifest.json
@@ -7,7 +7,7 @@
     null,
     {
       "src": "/demos/oauth-connect-flow/step-2.mp3",
-      "durationMs": 9588
+      "durationMs": 9688
     },
     {
       "src": "/demos/oauth-connect-flow/step-3.mp3",

--- a/site/src/components/docs/demos/scenarios/provision-grant-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/provision-grant-playback/narration/manifest.json
@@ -6,7 +6,7 @@
     },
     {
       "src": "/demos/provision-grant-playback/step-1.mp3",
-      "durationMs": 9063
+      "durationMs": 8863
     },
     {
       "src": "/demos/provision-grant-playback/step-2.mp3",

--- a/site/src/components/docs/demos/scenarios/quickstart-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/quickstart-playback/narration/manifest.json
@@ -2,18 +2,18 @@
   "steps": [
     {
       "src": "/demos/quickstart-playback/step-0.mp3",
-      "durationMs": 4175
+      "durationMs": 4188
     },
     null,
     null,
     {
       "src": "/demos/quickstart-playback/step-3.mp3",
-      "durationMs": 6800
+      "durationMs": 6888
     },
     null,
     {
       "src": "/demos/quickstart-playback/step-5.mp3",
-      "durationMs": 4213
+      "durationMs": 4288
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/quickstart-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/quickstart-tour/narration/manifest.json
@@ -6,16 +6,16 @@
     },
     {
       "src": "/demos/quickstart-tour/step-1.mp3",
-      "durationMs": 6350
+      "durationMs": 6150
     },
     {
       "src": "/demos/quickstart-tour/step-2.mp3",
-      "durationMs": 5638
+      "durationMs": 5550
     },
     null,
     {
       "src": "/demos/quickstart-tour/step-4.mp3",
-      "durationMs": 4963
+      "durationMs": 5013
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/register-idp-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/register-idp-playback/narration/manifest.json
@@ -6,15 +6,15 @@
     },
     {
       "src": "/demos/register-idp-playback/step-1.mp3",
-      "durationMs": 8638
+      "durationMs": 8813
     },
     {
       "src": "/demos/register-idp-playback/step-2.mp3",
-      "durationMs": 11763
+      "durationMs": 11650
     },
     {
       "src": "/demos/register-idp-playback/step-3.mp3",
-      "durationMs": 10513
+      "durationMs": 10163
     },
     {
       "src": "/demos/register-idp-playback/step-4.mp3",

--- a/site/src/components/docs/demos/scenarios/session-memory-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/session-memory-playback/narration/manifest.json
@@ -2,18 +2,18 @@
   "steps": [
     {
       "src": "/demos/session-memory-playback/step-0.mp3",
-      "durationMs": 6863
+      "durationMs": 6888
     },
     null,
     null,
     {
       "src": "/demos/session-memory-playback/step-3.mp3",
-      "durationMs": 6275
+      "durationMs": 6088
     },
     null,
     {
       "src": "/demos/session-memory-playback/step-5.mp3",
-      "durationMs": 6250
+      "durationMs": 6463
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/skill-creation-tour/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/skill-creation-tour/narration/manifest.json
@@ -3,29 +3,29 @@
     null,
     {
       "src": "/demos/skill-creation-tour/step-1.mp3",
-      "durationMs": 5350
+      "durationMs": 5238
     },
     null,
     null,
     null,
     {
       "src": "/demos/skill-creation-tour/step-5.mp3",
-      "durationMs": 4775
+      "durationMs": 4750
     },
     null,
     {
       "src": "/demos/skill-creation-tour/step-7.mp3",
-      "durationMs": 6388
+      "durationMs": 6400
     },
     null,
     {
       "src": "/demos/skill-creation-tour/step-9.mp3",
-      "durationMs": 4038
+      "durationMs": 4300
     },
     null,
     {
       "src": "/demos/skill-creation-tour/step-11.mp3",
-      "durationMs": 3800
+      "durationMs": 3913
     }
   ]
 }

--- a/site/src/components/docs/demos/scenarios/tool-calls-playback/narration/manifest.json
+++ b/site/src/components/docs/demos/scenarios/tool-calls-playback/narration/manifest.json
@@ -4,11 +4,11 @@
     null,
     {
       "src": "/demos/tool-calls-playback/step-2.mp3",
-      "durationMs": 5925
+      "durationMs": 5863
     },
     {
       "src": "/demos/tool-calls-playback/step-3.mp3",
-      "durationMs": 7113
+      "durationMs": 7200
     }
   ]
 }

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -2207,16 +2207,16 @@ __metadata:
 
 "@stigmer/protos@file:../apis/stubs/ts::locator=stigmer-site%40workspace%3A.":
   version: 0.0.0-dev
-  resolution: "@stigmer/protos@file:../apis/stubs/ts#../apis/stubs/ts::hash=c0e3c7&locator=stigmer-site%40workspace%3A."
+  resolution: "@stigmer/protos@file:../apis/stubs/ts#../apis/stubs/ts::hash=65c01f&locator=stigmer-site%40workspace%3A."
   dependencies:
     "@bufbuild/protobuf": "npm:^2.5.1"
-  checksum: 10c0/f9b6c042ac0d10c329e5dc9710e2deac0cda7ff5c783ad230295b07227796bd40d8758f975c8d5dbd839c408d570eb39a36f34686c3c9b2b90d45e0a2b955a02
+  checksum: 10c0/b3abec82bd764b8b824ba98e62771e2a9af9efee684deb90265595fa1ae41c517062480eaa38705f132e478d8198e88ab0b4242e9de65185b88643ff5f3aa47d
   languageName: node
   linkType: hard
 
 "@stigmer/react@file:../sdk/react::locator=stigmer-site%40workspace%3A.":
   version: 0.0.0-dev
-  resolution: "@stigmer/react@file:../sdk/react#../sdk/react::hash=664bfa&locator=stigmer-site%40workspace%3A."
+  resolution: "@stigmer/react@file:../sdk/react#../sdk/react::hash=42a461&locator=stigmer-site%40workspace%3A."
   dependencies:
     "@stigmer/theme": "npm:*"
     react-markdown: "npm:^10.1.0"
@@ -2232,13 +2232,13 @@ __metadata:
   peerDependenciesMeta:
     "@base-ui/react":
       optional: true
-  checksum: 10c0/54a4d805cc8b890b4a9e9c2335d5ef697be215e437bea7b6d371698e710f5550bfc6a7d961918f071ac8bf97dcc8168b13b11718119e2c9c18105da2b5b1fc05
+  checksum: 10c0/728f7f954a5dc25f473674a8f13e689dd77622a24b8e17fec925e278994ff858af46a3dbfb08c9267e91a37adb92d22869761c3ccd638847f302c5943439ec66
   languageName: node
   linkType: hard
 
 "@stigmer/sdk@file:../sdk/typescript::locator=stigmer-site%40workspace%3A.":
   version: 0.0.0-dev
-  resolution: "@stigmer/sdk@file:../sdk/typescript#../sdk/typescript::hash=8e4ae2&locator=stigmer-site%40workspace%3A."
+  resolution: "@stigmer/sdk@file:../sdk/typescript#../sdk/typescript::hash=e38e03&locator=stigmer-site%40workspace%3A."
   dependencies:
     "@connectrpc/connect": "npm:^2.0.0"
     "@connectrpc/connect-web": "npm:^2.0.0"
@@ -2249,7 +2249,7 @@ __metadata:
   peerDependenciesMeta:
     "@connectrpc/connect-node":
       optional: true
-  checksum: 10c0/3899af4adb013dacca46048c4a17bf868ee182fbce4a00dec1ee7a1e81fbececeab90fc4a8a447d3f8e9ab720ec2ec977a14d1df1be4853d9a9a873c1af347be
+  checksum: 10c0/9d43b33a249e22d22a6cd8e6b68298cd69d6d92681d0464efa906c377b89cce196a0c35544cc3f8574949a8fae429dea4539654713474d3df3b227697b9f7727
   languageName: node
   linkType: hard
 

--- a/tools/codegen/generator/BUILD.bazel
+++ b/tools/codegen/generator/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "main.go",
         "mcp.go",
+        "resource_kind.go",
         "sdk_client.go",
         "sdk_client_java.go",
         "sdk_client_python.go",
@@ -18,6 +19,7 @@ go_library(
         "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
         "//apis/stubs/go/ai/stigmer/iam/v1:iam",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/descriptorpb",
     ],
 )
 

--- a/tools/codegen/generator/mcp.go
+++ b/tools/codegen/generator/mcp.go
@@ -10,22 +10,6 @@ import (
 	"strings"
 )
 
-// apiResourceKindEnumNames maps ApiResourceKind proto enum values to Go constant
-// suffix names. This list must stay in sync with api_resource_kind.proto.
-var apiResourceKindEnumNames = map[int32]string{
-	22: "oauth_app",
-	40: "agent",
-	43: "skill",
-	44: "mcp_server",
-	50: "workflow",
-	53: "environment",
-}
-
-// versionedKinds tracks which resource kinds support versioning.
-var versionedKinds = map[int32]bool{
-	43: true, // skill
-}
-
 // mcpInputType describes one Go struct to generate.
 type mcpInputType struct {
 	name        string

--- a/tools/codegen/generator/resource_kind.go
+++ b/tools/codegen/generator/resource_kind.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"google.golang.org/protobuf/proto"
+	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+
+	apiresourcekind "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+)
+
+// apiResourceKindEnumNames maps ApiResourceKind proto enum numeric values to
+// their lowercase constant names (e.g. 43 -> "skill"). Derived at init time
+// from the generated proto stubs so it never drifts from api_resource_kind.proto.
+//
+// Used by MCP and SDK codegens to emit typed kind constants.
+var apiResourceKindEnumNames map[int32]string
+
+// versionedKinds tracks which resource kinds support versioning. Derived at
+// init time from the kind_meta.is_versioned extension on each enum value.
+var versionedKinds map[int32]bool
+
+func init() {
+	apiResourceKindEnumNames = make(map[int32]string, len(apiresourcekind.ApiResourceKind_name))
+	for num, name := range apiresourcekind.ApiResourceKind_name {
+		apiResourceKindEnumNames[num] = name
+	}
+
+	versionedKinds = make(map[int32]bool)
+	enumDesc := apiresourcekind.ApiResourceKind(0).Descriptor().Values()
+	for i := 0; i < enumDesc.Len(); i++ {
+		val := enumDesc.Get(i)
+		opts := val.Options().(*descriptorpb.EnumValueOptions)
+		if opts == nil {
+			continue
+		}
+		ext := proto.GetExtension(opts, apiresourcekind.E_KindMeta)
+		meta, ok := ext.(*apiresourcekind.ApiResourceKindMeta)
+		if ok && meta != nil && meta.IsVersioned {
+			versionedKinds[int32(val.Number())] = true
+		}
+	}
+}

--- a/tools/codegen/generator/sdk_client.go
+++ b/tools/codegen/generator/sdk_client.go
@@ -382,6 +382,7 @@ func generateResourceClient(schema *ServiceSchemaFile, cfg sdkResourceConfig, sp
 	needsEnvironmentV1 := false
 	needsTimestamppb := false
 	needsStructpb := false
+	needsRefKindOverride := false
 	if specSchema != nil {
 		scanFieldsForImports := func(fields []*FieldSchema) {
 			for _, f := range fields {
@@ -403,6 +404,9 @@ func generateResourceClient(schema *ServiceSchemaFile, cfg sdkResourceConfig, sp
 				}
 				if f.Type.Kind == "struct" {
 					needsStructpb = true
+				}
+				if f.ReferenceKind != 0 {
+					needsRefKindOverride = true
 				}
 			}
 		}
@@ -444,7 +448,7 @@ func generateResourceClient(schema *ServiceSchemaFile, cfg sdkResourceConfig, sp
 	if needsApiResource || hasInputType {
 		buf.WriteString("\tapiresource \"github.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/commons/apiresource\"\n")
 	}
-	if needsSearch || needsApiResourceRef {
+	if needsSearch || needsApiResourceRef || needsRefKindOverride {
 		buf.WriteString("\tapiresourcekind \"github.com/stigmer/stigmer/sdk/go/proto/ai/stigmer/commons/apiresource/apiresourcekind\"\n")
 	}
 	if needsSearch {
@@ -864,7 +868,14 @@ func emitToProtoField(buf *bytes.Buffer, f *FieldSchema, alias string, typeMap m
 
 	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference":
 		fmt.Fprintf(buf, "\tif i.%s.Org != \"\" || i.%s.Slug != \"\" {\n", f.Name, f.Name)
-		fmt.Fprintf(buf, "\t\tresource.Spec.%s = i.%s.toProto()\n", protoField, f.Name)
+		if f.ReferenceKind != 0 {
+			enumName := apiResourceKindEnumNames[f.ReferenceKind]
+			fmt.Fprintf(buf, "\t\tref := i.%s.toProto()\n", f.Name)
+			fmt.Fprintf(buf, "\t\tref.Kind = apiresourcekind.ApiResourceKind_%s\n", enumName)
+			fmt.Fprintf(buf, "\t\tresource.Spec.%s = ref\n", protoField)
+		} else {
+			fmt.Fprintf(buf, "\t\tresource.Spec.%s = i.%s.toProto()\n", protoField, f.Name)
+		}
 		buf.WriteString("\t}\n")
 
 	case f.Type.Kind == "message" && f.OneofGroup != "":
@@ -884,7 +895,14 @@ func emitToProtoField(buf *bytes.Buffer, f *FieldSchema, alias string, typeMap m
 		elemMsg := f.Type.ElementType.MessageType
 		if elemMsg == "ApiResourceReference" {
 			fmt.Fprintf(buf, "\tfor _, r := range i.%s {\n", f.Name)
-			fmt.Fprintf(buf, "\t\tresource.Spec.%s = append(resource.Spec.%s, r.toProto())\n", protoField, protoField)
+			if f.ReferenceKind != 0 {
+				enumName := apiResourceKindEnumNames[f.ReferenceKind]
+				buf.WriteString("\t\tref := r.toProto()\n")
+				fmt.Fprintf(buf, "\t\tref.Kind = apiresourcekind.ApiResourceKind_%s\n", enumName)
+				fmt.Fprintf(buf, "\t\tresource.Spec.%s = append(resource.Spec.%s, ref)\n", protoField, protoField)
+			} else {
+				fmt.Fprintf(buf, "\t\tresource.Spec.%s = append(resource.Spec.%s, r.toProto())\n", protoField, protoField)
+			}
 			buf.WriteString("\t}\n")
 		} else {
 			fmt.Fprintf(buf, "\tfor _, item := range i.%s {\n", f.Name)
@@ -1004,6 +1022,10 @@ func emitNestedToProto(buf *bytes.Buffer, f *FieldSchema, alias string, typeMap 
 			needsImperative = true
 			break
 		}
+		if field.ReferenceKind != 0 {
+			needsImperative = true
+			break
+		}
 	}
 
 	if needsImperative {
@@ -1022,7 +1044,14 @@ func emitNestedToProto(buf *bytes.Buffer, f *FieldSchema, alias string, typeMap 
 				buf.WriteString("\t\t}\n\t}\n")
 			} else if field.Type.Kind == "message" {
 				if field.Type.MessageType == "ApiResourceReference" {
-					fmt.Fprintf(buf, "\tp.%s = i.%s.toProto()\n", pf, field.Name)
+					if field.ReferenceKind != 0 {
+						enumName := apiResourceKindEnumNames[field.ReferenceKind]
+						fmt.Fprintf(buf, "\tref := i.%s.toProto()\n", field.Name)
+						fmt.Fprintf(buf, "\tref.Kind = apiresourcekind.ApiResourceKind_%s\n", enumName)
+						fmt.Fprintf(buf, "\tp.%s = ref\n", pf)
+					} else {
+						fmt.Fprintf(buf, "\tp.%s = i.%s.toProto()\n", pf, field.Name)
+					}
 				}
 			} else if field.Type.Kind == "array" && field.Type.ElementType != nil && field.Type.ElementType.Kind == "message" {
 				continue

--- a/tools/codegen/generator/sdk_client_java.go
+++ b/tools/codegen/generator/sdk_client_java.go
@@ -534,35 +534,50 @@ func generateJavaDeleteResourceInput(outputDir string) error {
 func generateJavaResourceRef(outputDir string) error {
 	imports := newJavaImportSet()
 	imports.add("ai.stigmer.commons.apiresource.ApiResourceReference")
+	imports.add("ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind")
 
 	var body bytes.Buffer
 	body.WriteString(`public final class ResourceRef {
     private final String org;
     private final String slug;
     private final String version;
+    private final ApiResourceKind kind;
 
-    private ResourceRef(String org, String slug, String version) {
+    private ResourceRef(String org, String slug, String version, ApiResourceKind kind) {
         this.org = org;
         this.slug = slug;
         this.version = version;
+        this.kind = kind;
     }
 
     public static ResourceRef of(String org, String slug) {
-        return new ResourceRef(org, slug, null);
+        return new ResourceRef(org, slug, null, ApiResourceKind.api_resource_kind_unknown);
     }
 
     public static ResourceRef of(String org, String slug, String version) {
-        return new ResourceRef(org, slug, version);
+        return new ResourceRef(org, slug, version, ApiResourceKind.api_resource_kind_unknown);
+    }
+
+    public static ResourceRef of(String org, ApiResourceKind kind, String slug) {
+        return new ResourceRef(org, slug, null, kind);
+    }
+
+    public static ResourceRef of(String org, ApiResourceKind kind, String slug, String version) {
+        return new ResourceRef(org, slug, version, kind);
     }
 
     public String getOrg() { return org; }
     public String getSlug() { return slug; }
     public String getVersion() { return version; }
+    public ApiResourceKind getKind() { return kind; }
 
     ApiResourceReference toProto() {
         ApiResourceReference.Builder builder = ApiResourceReference.newBuilder()
             .setOrg(this.org)
             .setSlug(this.slug);
+        if (this.kind != null && this.kind != ApiResourceKind.api_resource_kind_unknown) {
+            builder.setKind(this.kind);
+        }
         if (this.version != null) {
             builder.setVersion(this.version);
         }
@@ -1127,6 +1142,7 @@ func generateJavaInputClass(schema *ServiceSchemaFile, cfg sdkResourceConfig, sp
 	needsStruct := false
 	needsExecCtx := false
 	needsEnvV1 := false
+	needsRefKindOverride := false
 	scanJavaImports := func(fields []*FieldSchema) {
 		for _, f := range fields {
 			if f.Type.Kind == "timestamp" {
@@ -1140,6 +1156,9 @@ func generateJavaInputClass(schema *ServiceSchemaFile, cfg sdkResourceConfig, sp
 			}
 			if f.Type.Kind == "map" && f.Type.ValueType != nil && f.Type.ValueType.MessageType == "EnvironmentValue" {
 				needsEnvV1 = true
+			}
+			if f.ReferenceKind != 0 {
+				needsRefKindOverride = true
 			}
 		}
 	}
@@ -1161,6 +1180,9 @@ func generateJavaInputClass(schema *ServiceSchemaFile, cfg sdkResourceConfig, sp
 	}
 	if needsEnvV1 {
 		imports.add("ai.stigmer.agentic.environment.v1.EnvironmentValue")
+	}
+	if needsRefKindOverride {
+		imports.add("ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind")
 	}
 
 	for _, t := range specTypes {
@@ -1405,7 +1427,13 @@ func emitJavaToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[string]
 
 	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference":
 		fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
-		fmt.Fprintf(buf, "%s    spec.%s(this.%s.toProto());\n", indent, javaSetterName(f.ProtoField), fieldName)
+		if f.ReferenceKind != 0 {
+			enumName := apiResourceKindEnumNames[f.ReferenceKind]
+			fmt.Fprintf(buf, "%s    spec.%s(this.%s.toProto().toBuilder()\n", indent, javaSetterName(f.ProtoField), fieldName)
+			fmt.Fprintf(buf, "%s        .setKind(ApiResourceKind.%s).build());\n", indent, enumName)
+		} else {
+			fmt.Fprintf(buf, "%s    spec.%s(this.%s.toProto());\n", indent, javaSetterName(f.ProtoField), fieldName)
+		}
 		fmt.Fprintf(buf, "%s}\n", indent)
 
 	case f.Type.Kind == "message":
@@ -1423,7 +1451,13 @@ func emitJavaToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[string]
 		if elemMsg == "ApiResourceReference" {
 			fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
 			fmt.Fprintf(buf, "%s    for (ResourceRef item : this.%s) {\n", indent, fieldName)
-			fmt.Fprintf(buf, "%s        spec.%s(item.toProto());\n", indent, javaAddName(f.ProtoField))
+			if f.ReferenceKind != 0 {
+				enumName := apiResourceKindEnumNames[f.ReferenceKind]
+				fmt.Fprintf(buf, "%s        spec.%s(item.toProto().toBuilder()\n", indent, javaAddName(f.ProtoField))
+				fmt.Fprintf(buf, "%s            .setKind(ApiResourceKind.%s).build());\n", indent, enumName)
+			} else {
+				fmt.Fprintf(buf, "%s        spec.%s(item.toProto());\n", indent, javaAddName(f.ProtoField))
+			}
 			fmt.Fprintf(buf, "%s    }\n", indent)
 			fmt.Fprintf(buf, "%s}\n", indent)
 		} else {
@@ -1518,7 +1552,13 @@ func emitJavaNestedToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[s
 
 	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference":
 		fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
-		fmt.Fprintf(buf, "%s    builder.%s(this.%s.toProto());\n", indent, javaSetterName(f.ProtoField), fieldName)
+		if f.ReferenceKind != 0 {
+			enumName := apiResourceKindEnumNames[f.ReferenceKind]
+			fmt.Fprintf(buf, "%s    builder.%s(this.%s.toProto().toBuilder()\n", indent, javaSetterName(f.ProtoField), fieldName)
+			fmt.Fprintf(buf, "%s        .setKind(ApiResourceKind.%s).build());\n", indent, enumName)
+		} else {
+			fmt.Fprintf(buf, "%s    builder.%s(this.%s.toProto());\n", indent, javaSetterName(f.ProtoField), fieldName)
+		}
 		fmt.Fprintf(buf, "%s}\n", indent)
 
 	case f.Type.Kind == "message":
@@ -1536,7 +1576,13 @@ func emitJavaNestedToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[s
 		if elemMsg == "ApiResourceReference" {
 			fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
 			fmt.Fprintf(buf, "%s    for (ResourceRef item : this.%s) {\n", indent, fieldName)
-			fmt.Fprintf(buf, "%s        builder.%s(item.toProto());\n", indent, javaAddName(f.ProtoField))
+			if f.ReferenceKind != 0 {
+				enumName := apiResourceKindEnumNames[f.ReferenceKind]
+				fmt.Fprintf(buf, "%s        builder.%s(item.toProto().toBuilder()\n", indent, javaAddName(f.ProtoField))
+				fmt.Fprintf(buf, "%s            .setKind(ApiResourceKind.%s).build());\n", indent, enumName)
+			} else {
+				fmt.Fprintf(buf, "%s        builder.%s(item.toProto());\n", indent, javaAddName(f.ProtoField))
+			}
 			fmt.Fprintf(buf, "%s    }\n", indent)
 			fmt.Fprintf(buf, "%s}\n", indent)
 		} else {

--- a/tools/codegen/generator/sdk_client_python.go
+++ b/tools/codegen/generator/sdk_client_python.go
@@ -1091,6 +1091,12 @@ func emitPyToProtoFieldAssign(buf *bytes.Buffer, f *FieldSchema, msgVar, selfVar
 		fmt.Fprintf(buf, "%sif %s.%s:\n", indent, selfVar, selfField)
 		fmt.Fprintf(buf, "%s    %s.update(%s.%s)\n", indent, protoAccess(msgVar, protoField), selfVar, selfField)
 
+	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference" && f.ReferenceKind != 0:
+		fmt.Fprintf(buf, "%sif %s.%s is not None:\n", indent, selfVar, selfField)
+		fmt.Fprintf(buf, "%s    _ref = %s.%s._to_proto()\n", indent, selfVar, selfField)
+		fmt.Fprintf(buf, "%s    _ref.kind = %d\n", indent, f.ReferenceKind)
+		fmt.Fprintf(buf, "%s    %s.CopyFrom(_ref)\n", indent, protoAccess(msgVar, protoField))
+
 	case f.Type.Kind == "message":
 		fmt.Fprintf(buf, "%sif %s.%s is not None:\n", indent, selfVar, selfField)
 		fmt.Fprintf(buf, "%s    %s.CopyFrom(%s.%s._to_proto())\n", indent, protoAccess(msgVar, protoField), selfVar, selfField)
@@ -1100,8 +1106,15 @@ func emitPyToProtoFieldAssign(buf *bytes.Buffer, f *FieldSchema, msgVar, selfVar
 		fmt.Fprintf(buf, "%s    %s.extend(%s.%s)\n", indent, protoAccess(msgVar, protoField), selfVar, selfField)
 
 	case f.Type.Kind == "array" && f.Type.ElementType != nil && f.Type.ElementType.Kind == "message" && f.Type.ElementType.MessageType == "ApiResourceReference":
-		fmt.Fprintf(buf, "%sfor ref in %s.%s:\n", indent, selfVar, selfField)
-		fmt.Fprintf(buf, "%s    %s.append(ref._to_proto())\n", indent, protoAccess(msgVar, protoField))
+		if f.ReferenceKind != 0 {
+			fmt.Fprintf(buf, "%sfor ref in %s.%s:\n", indent, selfVar, selfField)
+			fmt.Fprintf(buf, "%s    _ref = ref._to_proto()\n", indent)
+			fmt.Fprintf(buf, "%s    _ref.kind = %d\n", indent, f.ReferenceKind)
+			fmt.Fprintf(buf, "%s    %s.append(_ref)\n", indent, protoAccess(msgVar, protoField))
+		} else {
+			fmt.Fprintf(buf, "%sfor ref in %s.%s:\n", indent, selfVar, selfField)
+			fmt.Fprintf(buf, "%s    %s.append(ref._to_proto())\n", indent, protoAccess(msgVar, protoField))
+		}
 
 	case f.Type.Kind == "array" && f.Type.ElementType != nil && f.Type.ElementType.Kind == "message":
 		fmt.Fprintf(buf, "%sfor item in %s.%s:\n", indent, selfVar, selfField)

--- a/tools/codegen/generator/sdk_client_ts.go
+++ b/tools/codegen/generator/sdk_client_ts.go
@@ -1064,7 +1064,11 @@ func emitTSPreComputeField(buf *bytes.Buffer, f *FieldSchema, typeMap map[string
 
 	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference":
 		imports.addValue("@stigmer/protos/ai/stigmer/commons/apiresource/io_pb", "ApiResourceReferenceSchema")
-		fmt.Fprintf(buf, "  const %s = input.%s ? create(ApiResourceReferenceSchema, input.%s) : undefined;\n", fieldName, fieldName, fieldName)
+		if f.ReferenceKind != 0 {
+			fmt.Fprintf(buf, "  const %s = input.%s ? create(ApiResourceReferenceSchema, { ...input.%s, kind: %d }) : undefined;\n", fieldName, fieldName, fieldName, f.ReferenceKind)
+		} else {
+			fmt.Fprintf(buf, "  const %s = input.%s ? create(ApiResourceReferenceSchema, input.%s) : undefined;\n", fieldName, fieldName, fieldName)
+		}
 
 	case f.Type.Kind == "message":
 		builderName := "build" + f.Type.MessageType + "Proto"
@@ -1072,7 +1076,11 @@ func emitTSPreComputeField(buf *bytes.Buffer, f *FieldSchema, typeMap map[string
 
 	case f.Type.Kind == "array" && f.Type.ElementType != nil && f.Type.ElementType.Kind == "message" && f.Type.ElementType.MessageType == "ApiResourceReference":
 		imports.addValue("@stigmer/protos/ai/stigmer/commons/apiresource/io_pb", "ApiResourceReferenceSchema")
-		fmt.Fprintf(buf, "  const %s = input.%s?.map(r => create(ApiResourceReferenceSchema, r));\n", fieldName, fieldName)
+		if f.ReferenceKind != 0 {
+			fmt.Fprintf(buf, "  const %s = input.%s?.map(r => create(ApiResourceReferenceSchema, { ...r, kind: %d }));\n", fieldName, fieldName, f.ReferenceKind)
+		} else {
+			fmt.Fprintf(buf, "  const %s = input.%s?.map(r => create(ApiResourceReferenceSchema, r));\n", fieldName, fieldName)
+		}
 
 	case f.Type.Kind == "array" && f.Type.ElementType != nil && f.Type.ElementType.Kind == "message":
 		builderName := "build" + f.Type.ElementType.MessageType + "Proto"
@@ -1224,8 +1232,13 @@ func emitTSNestedFieldAssign(buf *bytes.Buffer, f *FieldSchema, typeMap map[stri
 
 	case f.Type.Kind == "array" && f.Type.ElementType != nil && f.Type.ElementType.Kind == "message" && f.Type.ElementType.MessageType == "ApiResourceReference":
 		imports.addValue("@stigmer/protos/ai/stigmer/commons/apiresource/io_pb", "ApiResourceReferenceSchema")
-		fmt.Fprintf(buf, "  if (input.%s) msg.%s = input.%s.map(r => create(ApiResourceReferenceSchema, r));\n",
-			fieldName, fieldName, fieldName)
+		if f.ReferenceKind != 0 {
+			fmt.Fprintf(buf, "  if (input.%s) msg.%s = input.%s.map(r => create(ApiResourceReferenceSchema, { ...r, kind: %d }));\n",
+				fieldName, fieldName, fieldName, f.ReferenceKind)
+		} else {
+			fmt.Fprintf(buf, "  if (input.%s) msg.%s = input.%s.map(r => create(ApiResourceReferenceSchema, r));\n",
+				fieldName, fieldName, fieldName)
+		}
 
 	case f.Type.Kind == "array" && f.Type.ElementType != nil && f.Type.ElementType.Kind == "message":
 		elemMsg := f.Type.ElementType.MessageType
@@ -1247,8 +1260,13 @@ func emitTSNestedFieldAssign(buf *bytes.Buffer, f *FieldSchema, typeMap map[stri
 
 	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference":
 		imports.addValue("@stigmer/protos/ai/stigmer/commons/apiresource/io_pb", "ApiResourceReferenceSchema")
-		fmt.Fprintf(buf, "  if (input.%s) msg.%s = create(ApiResourceReferenceSchema, input.%s);\n",
-			fieldName, fieldName, fieldName)
+		if f.ReferenceKind != 0 {
+			fmt.Fprintf(buf, "  if (input.%s) msg.%s = create(ApiResourceReferenceSchema, { ...input.%s, kind: %d });\n",
+				fieldName, fieldName, fieldName, f.ReferenceKind)
+		} else {
+			fmt.Fprintf(buf, "  if (input.%s) msg.%s = create(ApiResourceReferenceSchema, input.%s);\n",
+				fieldName, fieldName, fieldName)
+		}
 
 	case f.Type.Kind == "message":
 		msgType := f.Type.MessageType

--- a/tools/codegen/schemas/agentic/agentinstance/agentinstance.json
+++ b/tools/codegen/schemas/agentic/agentinstance/agentinstance.json
@@ -40,7 +40,8 @@
         }
       },
       "description": "References to Environment resources providing secrets and configuration at runtime.\n\n @internal\n Environments are merged in order: later environments override earlier ones.\n Example: [base-env, aws-prod-env, github-team-env]\n This allows layering of configurations (base → specific overrides).",
-      "required": false
+      "required": false,
+      "referenceKind": 53
     }
   ]
 }

--- a/tools/codegen/schemas/agentic/workflowinstance/workflowinstance.json
+++ b/tools/codegen/schemas/agentic/workflowinstance/workflowinstance.json
@@ -40,7 +40,8 @@
         }
       },
       "description": "Ordered list of Environment resources providing configuration and secrets.\n\n Environments are merged in declaration order — later entries override\n earlier ones when keys conflict.\n\n @internal\n Environments are layered configuration containers that provide:\n - Environment variables (API keys, endpoints, flags)\n - Secrets (credentials, tokens, passwords)\n - Configuration values (timeouts, limits, settings)\n\n Example layering:\n   [base-env, aws-prod-env, github-team-env]\n   └─ base-env: Common settings for all instances\n   └─ aws-prod-env: AWS production credentials (overrides base AWS settings)\n   └─ github-team-env: Team-specific GitHub tokens (overrides generic tokens)\n\n Use Cases:\n - Single env: [prod-env] - Simple, all config in one place\n - Base + specific: [base, prod] - Common config + environment-specific\n - Layered: [base, cloud, team] - Base + cloud credentials + team settings\n\n References use ApiResourceReference which supports:\n - By ID: {id: \"env_abc123\"}\n - By slug: {slug: \"aws-prod-env\"}\n\n At execution time, the WorkflowExecution runtime merges these environments\n and provides the combined configuration to all agents in the workflow.",
-      "required": false
+      "required": false,
+      "referenceKind": 53
     }
   ]
 }


### PR DESCRIPTION
## Summary

All four SDK codegens (Go, Java, Python, TypeScript) now automatically set the `kind` field on `ApiResourceReference` messages when the proto field carries a `reference_kind` annotation. A secondary change moves BSR publishing from the local `make release` command into a dedicated GitHub Actions workflow triggered on `v*` tags.

## Context

PR #130 from a customer added a `kind` field to the Java SDK's `ResourceRef` because the server's CEL validation was rejecting requests with an empty `kind`. Investigation revealed the root cause was in the codegen pipeline: none of the four SDK codegens were reading the `reference_kind` proto field option to auto-populate `kind` during serialization. The MCP codegen already handled this correctly — the SDKs did not.

Separately, `buf push` was running locally inside `make release`, requiring local Buf authentication and coupling proto publishing with tag creation — unlike every other release artifact which is CI-driven.

## Changes

### SDK Codegen — kind auto-injection
- **Go** (`sdk_client.go`): Detect `ReferenceKind != 0`, force imperative mode, emit `Kind: apiresourcekind.ApiResourceKind_<name>` on the proto message
- **Java** (`sdk_client_java.go`): Emit `.toProto().toBuilder().setKind(ApiResourceKind.<name>).build()` for annotated fields; add `kind` field and typed factory methods to `ResourceRef`
- **Python** (`sdk_client_python.go`): Emit `_ref.kind = <int>` after constructing the `ApiResourceReference`
- **TypeScript** (`sdk_client_ts.go`): Emit `{ ...ref, kind: <int> }` spread to overlay the kind value

### Proto annotations
- Add `(reference_kind) = environment` to `environment_refs` on `AgentInstanceSpec` and `WorkflowInstanceSpec`
- Add `field_options.proto` import to both spec files

### Codegen infrastructure
- New `resource_kind.go`: derives `apiResourceKindEnumNames` and `versionedKinds` maps from proto stubs via protobuf reflection at `init()` time — replaces hardcoded maps in `mcp.go`
- Update `BUILD.bazel` with new Go proto stubs dependency

### CI — BSR push
- New `.github/workflows/release.buf.yaml`: `buf lint` + `buf push` on `v*` tags
- Remove `$(MAKE) -C apis release` from root Makefile `release` target
- Add "Protos to BSR" to CI summary echo
- Set `BUF_TOKEN` GitHub secret (fixes pre-existing gap in `release.cli.yaml`)

### Regenerated output
- All proto stubs (Go, Java, Python, TypeScript) for agentinstance and workflowinstance
- All SDK generated files (Go, Java, Python, TypeScript)
- MCP server generated files
- Codegen JSON schemas
- Site yarn.lock and demo narration manifests (checksums updated from proto changes)

## Implementation notes

- The `resource_kind.go` file uses `protoreflect` to walk the `ApiResourceKind` enum descriptor and read the `kind_meta.is_versioned` extension, eliminating manual maintenance when new resource kinds are added
- For "multi-kind" fields (no `reference_kind` annotation, e.g. project `member_refs`), the Java SDK now exposes `ResourceRef.of(org, kind, slug)` factory methods so users can explicitly set the kind
- The `apis/Makefile` `release` and `push` targets are kept as-is for manual ad-hoc use; they just aren't called by `make release` anymore

## Breaking changes

- None. The `kind` is now auto-populated where it was previously empty — strictly additive behavior. Existing SDK code that doesn't set `kind` continues to work; the codegen now does it for them.

## Test plan

- Java SDK: `make build` in `sdk/java` passes (verified correct `ApiResourceKind` import resolution)
- Go codegen: `go build` in `tools/codegen/generator` passes with proto stubs dependency
- All generated SDK files compile in their respective language targets
- `BUF_TOKEN` verified present via `gh secret list`

## Risks

- The `BUF_TOKEN` was set from the existing local `~/.netrc` token rather than a dedicated CI-scoped token — consider rotating to a dedicated token with narrower scope in the future
- `resource_kind.go` uses `protoreflect` which adds a runtime dependency on the Go proto stubs — already a build dependency via `tools/go.mod`

## Checklist

- [x] Docs updated (changelog added)
- [x] Backward compatible
- [ ] Tests added/updated (codegen output verified via build; no new unit tests)

<!-- Closes #130 (supersedes the customer's manual fix) -->