### PR TITLE
fix(backend): bill Cursor fast-mode variants at fast rates

### DIFF
--- a/_changelog/2026-06/2026-06-04-182047-cursor-fast-mode-billing-variant-pricing.md
+++ b/_changelog/2026-06/2026-06-04-182047-cursor-fast-mode-billing-variant-pricing.md
@@ -1,0 +1,73 @@
+# Cursor Fast-Mode Billing: Speed-Variant Pricing
+
+**Date**: June 4, 2026
+
+## Summary
+
+Made Cursor "fast" mode a first-class pricing concept so fast-tier usage is billed at Cursor's actual fast rates instead of the standard rate. Previously, when a user selected the default/auto Cursor harness, Cursor routed to `composer-2.5-fast` and the billing pipeline priced it at the standard Composer rate ($0.5/$2.5 per million) — roughly a 6x undercharge versus Cursor's published fast rate ($3/$15). Fast pricing now lives on the base model entry under a new `pricingVariants` block, the billing engine resolves wire names like `composer-2.5-fast` to base + variant rates, and a guard refuses to bill a fast call at the base rate if its fast price is missing.
+
+## Problem Statement
+
+Cursor's Auto/Composer pool defaults to the **fast** variant of Composer 2.5, which Cursor charges at a materially higher per-token rate than the standard tier. Cursor documents this only on the model doc page, not the main pricing table. Our registry carried a separate `composer-2.5-fast` entry whose prices were mistakenly copied from standard Composer, so every fast call was billed at ~1/6th of the real input/output rate.
+
+The same class of bug existed for any Cursor `-fast` wire name: the variant-normalization fallback stripped `-fast` and silently billed the base (normal) price, which would undercharge Anthropic/OpenAI fast modes too.
+
+### Pain Points
+
+- Composer 2.5 fast usage billed at standard rates — the reported `$0.0925` vs Cursor's `$0.26` gap
+- A duplicate `composer-2.5-fast` registry entry with wrong (copied-standard) pricing
+- `-fast` speed suffixes silently stripped to the base price — a quiet undercharge with no signal
+- No single "fast multiplier" exists across providers (Composer fast is 6x input/output but unchanged cache; GPT-5 fast is 2x; Opus fast is 6x on all buckets), so fast pricing must be explicit per-model data, never a formula
+
+## Solution
+
+One base model entry with an optional `pricingVariants` block keyed by speed mode. Billing decomposes the wire model into `(base, variant)` and applies the variant's rates. The duplicate `composer-2.5-fast` entry is removed; the wire name now resolves through the base model's fast variant.
+
+## Implementation Details
+
+**stigmer-cloud (authoritative billing)**
+
+- `model-registry.json` — added `pricingVariants.fast` to `composer-2.5` (`$3/$15`, cache unchanged, with `wireIds: ["composer-2.5-fast"]`) and to the two fully-published Anthropic fast rows (`claude-opus-4-6`, `claude-opus-4-7`). Removed the standalone `composer-2.5-fast` entry. Each variant records `source`/`sourceNote` provenance.
+- `ModelPricingService` — loads variants into harness-aware indexes plus a wire-id index; new `findVariant`, `findVariantByWireId`, and `ModelPricing.withVariantRates`. The flat `ModelPricing` record shape is preserved so existing call sites are unaffected.
+- New `CursorModelPricingResolver` — ordered resolution: exact base id → explicit variant wire id → normalized base + suffix. Speed suffixes get fast-tier rates; effort suffixes (`-high`, `-thinking`) keep base rates. A fast variant with no fast pricing returns a distinct missing-variant outcome.
+- `CursorModelNormalizer` — `composer-*` is no longer short-circuited, so `composer-2.5-fast` decomposes to `composer-2.5` + `fast`; added an `isSpeedVariant` classifier (speed vs. price-neutral effort).
+- `RecordLlmCallUsageHandler` — uses the resolver, stamps `pricing_variant`/`pricing_base_model` audit labels, and on a missing fast price records `PRICE_NOT_FOUND` (not billable) with a loud error rather than undercharging.
+- `update-model-registry.mdc` — new Step 1b (extract fast pricing from the three doc shapes), variant coverage check, revised variant-id guidance, and `pricingVariants` schema docs.
+
+**stigmer (OSS)**
+
+- `execute-cursor/model-pricing.ts` + `model-pricing-data.ts` (runner) — the in-session cost preview now mirrors base + variant resolution so a `composer-2.5-fast` estimate matches the authoritative cloud bill instead of falling back to Auto-pool defaults.
+- `workflow/validation` — the workflow model registry and validator now accept the base `composer-2.5` slug (the requestable model) rather than the internal `composer-2.5-fast` wire name; Go and Java validation tests updated to match.
+
+**Anti-undercharge guard (key design decision)**: a detected speed variant with no `pricingVariants.fast` is never silently billed at the base rate. It is recorded as `PRICE_NOT_FOUND`/not-billable and logged loudly, so a missing fast price surfaces as unbilled usage rather than quiet revenue loss.
+
+## Benefits
+
+- Composer 2.5 fast now reconstructs to ~`$0.284` on the reported token shape (was ~`$0.084` at the standard rate), closing the undercharge gap
+- Fast pricing is explicit, sourced, and maintainable per model — no formula guessing
+- Runner display estimate and authoritative cloud billing stay consistent
+- Future `-fast` models cannot silently undercharge; missing prices are loud
+
+## Impact
+
+- **Billing accuracy**: fast-mode Cursor usage (today: the Auto/Composer default) is billed at the correct rate
+- **Scope**: all Cursor-harness speed variants; fast pricing populated for models the platform dispatches today (Composer 2.5, Opus 4.6/4.7)
+- **No selector change**: `-fast` is billing-only; the model selector continues to expose base models only
+
+## Out of Scope (documented, not half-implemented)
+
+- Max Mode surcharge (applies to legacy request-based plans; current Teams plan bills Max at API rate — no surcharge to model)
+- Long-context 2x multipliers, image-output tokens, regional surcharges, Premium-pool routing
+- Cursor Admin API `chargedCents` reconciliation
+- Retroactive correction of historical `llm_call_usage_record` rows
+
+## Related Work
+
+- [Fix Cursor Variant Model Pricing Lookup](2026-06-01-183928-fix-cursor-variant-model-pricing-lookup.md) — added the normalization layer this change builds on (effort variants → base price); this change extends it to price speed variants correctly
+- [Cursor Token Rate usage proto fields](2026-06-02-160723-cursor-token-rate-usage-proto-fields.md) — the Cursor Token Rate that fast variants inherit from the base entry
+- [Model registry Cursor catalog coverage check](2026-06-02-175312-model-registry-cursor-catalog-coverage-check.md) — the registry maintenance gate now extended with variant coverage
+
+---
+
+**Status**: ✅ Production Ready
+**Repos**: stigmer-cloud (core billing: 2 new + 5 modified), stigmer (runner display + workflow validation: 1 new + 4 modified)

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/model-pricing.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/model-pricing.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+/**
+ * Verifies the cursor-runner display estimate resolves Cursor speed variants
+ * (e.g. composer-2.5-fast) to the base model's fast-tier rates, mirroring the
+ * authoritative cloud billing path.
+ */
+describe("getCursorModelPricing — speed variant resolution", () => {
+  let getCursorModelPricing: typeof import("../model-pricing.js").getCursorModelPricing;
+  let computeTurnCost: typeof import("../model-pricing.js").computeTurnCost;
+
+  beforeAll(async () => {
+    const registry = {
+      models: [
+        {
+          id: "composer-2.5",
+          displayName: "Composer 2.5",
+          provider: "cursor",
+          harness: "cursor",
+          costTier: "economy",
+          pricing: {
+            inputPricePerMillion: 0.5,
+            outputPricePerMillion: 2.5,
+            cacheWritePricePerMillion: 0,
+            cacheReadPricePerMillion: 0.2,
+          },
+          pricingVariants: {
+            fast: {
+              inputPricePerMillion: 3.0,
+              outputPricePerMillion: 15.0,
+              cacheWritePricePerMillion: 0,
+              cacheReadPricePerMillion: 0.2,
+            },
+          },
+        },
+        {
+          id: "claude-opus-4-6",
+          displayName: "Claude 4.6 Opus",
+          provider: "anthropic",
+          harness: "cursor",
+          costTier: "premium",
+          pricing: {
+            inputPricePerMillion: 5.0,
+            outputPricePerMillion: 25.0,
+            cacheWritePricePerMillion: 6.25,
+            cacheReadPricePerMillion: 0.5,
+          },
+        },
+      ],
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => registry })),
+    );
+    process.env.STIGMER_TOKEN = "test-token";
+
+    const mod = await import("../model-pricing.js");
+    await mod.ensureLoaded();
+    getCursorModelPricing = mod.getCursorModelPricing;
+    computeTurnCost = mod.computeTurnCost;
+  });
+
+  it("resolves composer-2.5-fast to the fast tier ($3/$15)", () => {
+    const p = getCursorModelPricing("composer-2.5-fast");
+    expect(p.model).toBe("composer-2.5-fast");
+    expect(p.inputPricePerMillion).toBe(3.0);
+    expect(p.outputPricePerMillion).toBe(15.0);
+    expect(p.cacheReadPricePerMillion).toBe(0.2);
+  });
+
+  it("resolves the base composer-2.5 to the standard tier ($0.5/$2.5)", () => {
+    const p = getCursorModelPricing("composer-2.5");
+    expect(p.inputPricePerMillion).toBe(0.5);
+    expect(p.outputPricePerMillion).toBe(2.5);
+  });
+
+  it("uses base rates when a -fast model has no fast variant", () => {
+    // claude-opus-4-6 has no fast variant in this stub → fall back to base.
+    const p = getCursorModelPricing("claude-opus-4-6-fast");
+    // No variant and no exact/normalized match → DEFAULT_PRICING (Auto pool).
+    expect(p.inputPricePerMillion).toBe(1.25);
+  });
+
+  it("computeTurnCost on the fast tier reproduces the higher charge", () => {
+    const p = getCursorModelPricing("composer-2.5-fast");
+    // Cursor reports inputTokens inclusive of cache; regular input = 44,513.
+    // (266,945 - 222,432 cache read). 44,513*$3 + 7,069*$15 + 222,432*$0.2 ≈ $0.284
+    const cost = computeTurnCost(p, 266_945, 7_069, 0, 222_432);
+    expect(cost).toBeCloseTo(0.28406, 5);
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/model-pricing-data.ts
+++ b/backend/services/runner/src/activities/execute-cursor/model-pricing-data.ts
@@ -11,6 +11,14 @@
  * - STIGMER_AUTH_TOKEN: Bearer token for authentication (required)
  */
 
+/** Per-million rates for a speed/mode variant (e.g. "fast") of a base model. */
+export interface CursorVariantPricing {
+  readonly inputPricePerMillion: number;
+  readonly outputPricePerMillion: number;
+  readonly cacheWritePricePerMillion: number;
+  readonly cacheReadPricePerMillion: number;
+}
+
 export interface CursorModelPricing {
   readonly model: string;
   readonly displayName: string;
@@ -19,6 +27,15 @@ export interface CursorModelPricing {
   readonly outputPricePerMillion: number;
   readonly cacheWritePricePerMillion: number;
   readonly cacheReadPricePerMillion: number;
+  /** Speed-mode price overrides keyed by variant (e.g. "fast"); optional. */
+  readonly speedVariants?: Readonly<Record<string, CursorVariantPricing>>;
+}
+
+interface RegistryVariantEntry {
+  inputPricePerMillion: number;
+  outputPricePerMillion: number;
+  cacheWritePricePerMillion: number;
+  cacheReadPricePerMillion: number;
 }
 
 interface RegistryEntry {
@@ -33,6 +50,7 @@ interface RegistryEntry {
     cacheWritePricePerMillion: number;
     cacheReadPricePerMillion: number;
   };
+  pricingVariants?: Record<string, RegistryVariantEntry>;
 }
 
 const DEFAULT_API_URL = "https://api.stigmer.ai";
@@ -74,7 +92,25 @@ function parsePricingTable(json: unknown): CursorModelPricing[] {
       outputPricePerMillion: m.pricing!.outputPricePerMillion,
       cacheWritePricePerMillion: m.pricing!.cacheWritePricePerMillion,
       cacheReadPricePerMillion: m.pricing!.cacheReadPricePerMillion,
+      speedVariants: parseVariants(m.pricingVariants),
     }));
+}
+
+function parseVariants(
+  variants: Record<string, RegistryVariantEntry> | undefined,
+): Record<string, CursorVariantPricing> | undefined {
+  if (!variants || typeof variants !== "object") return undefined;
+  const out: Record<string, CursorVariantPricing> = {};
+  for (const [key, v] of Object.entries(variants)) {
+    if (!v || typeof v !== "object") continue;
+    out[key] = {
+      inputPricePerMillion: v.inputPricePerMillion,
+      outputPricePerMillion: v.outputPricePerMillion,
+      cacheWritePricePerMillion: v.cacheWritePricePerMillion,
+      cacheReadPricePerMillion: v.cacheReadPricePerMillion,
+    };
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 async function fetchFromApi(): Promise<readonly CursorModelPricing[]> {

--- a/backend/services/runner/src/activities/execute-cursor/model-pricing.ts
+++ b/backend/services/runner/src/activities/execute-cursor/model-pricing.ts
@@ -20,6 +20,44 @@ function normalizeModelId(model: string): string {
   return model.replace(/-\d{8}(?:v\d+)?$/, "");
 }
 
+/**
+ * Speed-mode suffixes Cursor appends to a base model id (longest first).
+ * Only speed variants change the per-token price; effort suffixes do not.
+ */
+const SPEED_SUFFIXES = ["-high-fast", "-medium-fast", "-low-fast", "-fast"];
+
+/**
+ * If `model` carries a speed suffix, return the base id; otherwise null.
+ * e.g. "composer-2.5-fast" -> "composer-2.5".
+ */
+function stripSpeedSuffix(model: string): string | null {
+  for (const suffix of SPEED_SUFFIXES) {
+    if (model.endsWith(suffix)) return model.slice(0, -suffix.length);
+  }
+  return null;
+}
+
+/**
+ * Return a copy of a base pricing entry with its "fast" variant rates applied,
+ * preserving the original (wire) model id. Returns null when the base declares
+ * no fast variant.
+ */
+function applyFastVariant(
+  base: CursorModelPricing,
+  wireModel: string,
+): CursorModelPricing | null {
+  const fast = base.speedVariants?.fast;
+  if (!fast) return null;
+  return {
+    ...base,
+    model: wireModel,
+    inputPricePerMillion: fast.inputPricePerMillion,
+    outputPricePerMillion: fast.outputPricePerMillion,
+    cacheWritePricePerMillion: fast.cacheWritePricePerMillion,
+    cacheReadPricePerMillion: fast.cacheReadPricePerMillion,
+  };
+}
+
 let pricingByModel: Map<string, CursorModelPricing> | null = null;
 let initPromise: Promise<void> | null = null;
 
@@ -77,6 +115,17 @@ export function getCursorModelPricing(model: string): CursorModelPricing {
   const map = getMap();
   const exact = map.get(model);
   if (exact) return exact;
+
+  // Speed variant (e.g. "composer-2.5-fast"): resolve the base entry and apply
+  // its fast-tier rates so the display estimate matches the authoritative bill.
+  const speedBase = stripSpeedSuffix(model);
+  if (speedBase) {
+    const baseEntry = map.get(speedBase) ?? map.get(normalizeModelId(speedBase));
+    if (baseEntry) {
+      const fast = applyFastVariant(baseEntry, model);
+      if (fast) return fast;
+    }
+  }
 
   const normalized = normalizeModelId(model);
   if (normalized !== model) {

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/data/model-registry.json
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/data/model-registry.json
@@ -22,7 +22,7 @@
     {"id": "llama3.2:3b", "harness": "native"},
     {"id": "mistral:7b", "harness": "native"},
     {"id": "default", "harness": "cursor"},
-    {"id": "composer-2.5-fast", "harness": "cursor"},
+    {"id": "composer-2.5", "harness": "cursor"},
     {"id": "composer-2", "harness": "cursor"},
     {"id": "composer-1.5", "harness": "cursor"},
     {"id": "claude-opus-4-7", "harness": "cursor"},

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/model_validation_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/model_validation_test.go
@@ -74,7 +74,7 @@ func TestValidateModelReferences_ValidCursorModels(t *testing.T) {
 	spec := &workflowv1.WorkflowSpec{
 		Tasks: []*workflowv1.WorkflowTask{
 			makeAgentCallTask("analyze", "cursor", "claude-opus-4-6"),
-			makeAgentCallTask("design", "cursor", "composer-2.5-fast"),
+			makeAgentCallTask("design", "cursor", "composer-2.5"),
 			makeAgentCallTask("review", "cursor", "gpt-5.3-codex"),
 		},
 	}


### PR DESCRIPTION
## Summary
Bills Cursor fast-mode pool variants (e.g. `composer-2.5-fast`) at Cursor's fast-tier rate instead of the standard Composer rate, fixing an under-billing gap (reported `$0.0925` vs actual `$0.26`).

## Context
Cursor's default Auto/Composer pool routes to `composer-2.5-fast`, which Cursor charges ~6x the standard Composer rate. The platform priced it at the standard rate. Authoritative billing lives in `stigmer-cloud` (the cloud twin merged in stigmer/stigmer-cloud#128); this is the OSS-side counterpart for in-session cost preview and workflow model validation parity.

## Changes
- Runner cost preview (`execute-cursor`): resolve a `-fast` wire model to its base model's fast-tier rates so the in-session estimate matches the cloud bill instead of falling back to Auto-pool defaults.
- Workflow model validation: accept the base `composer-2.5` slug (the requestable model) rather than the internal `composer-2.5-fast` wire name.
- Changelog documenting the cross-repo fix.

## Test plan
- `go test ./backend/services/stigmer-server/pkg/domain/workflow/validation/...` — pass.
- `model-pricing.test.ts` added for the runner cost-preview resolution (runs in CI).

## Risks
- None for the sandbox work — this is unrelated to the Kubernetes sandbox provisioner (which is cloud-only). Note: touching `backend/services/runner/src/**` will rebuild the cloud sandbox runner image via `release.sandbox-cloud`, bumping `sandbox-ci/prod.sandbox-image` (newer runner, same contract).

## Checklist
- [x] Tests added/updated
- [x] Backward compatible
