### PR TITLE
refactor(ops): resolve config via config-manager $var/$secret grammar

### DIFF
--- a/.github/workflows/release.sandbox-cloud.yaml
+++ b/.github/workflows/release.sandbox-cloud.yaml
@@ -129,20 +129,9 @@ jobs:
           PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/runner:main-${{ steps.tags.outputs.short_sha }}"
-          cat > /tmp/sandbox-ci-vargroup.yaml <<EOF
-          apiVersion: service-hub.planton.ai/v1
-          kind: VariablesGroup
-          metadata:
-            name: sandbox-ci
-            org: stigmer
-          spec:
-            description: CI-managed sandbox configuration. Updated exclusively by release.sandbox-cloud.
-            entries:
-              - name: prod.sandbox-image
-                value: ${IMAGE}
-                description: Immutable image tag for Daytona sandbox provisioning
-          EOF
-          planton apply -f /tmp/sandbox-ci-vargroup.yaml
+          # config-manager standalone env-scoped Variable (slug: sandbox-ci-sandbox-image, env: prod).
+          # Resolved at deploy as $var/@prod/sandbox-ci-sandbox-image.
+          planton variable set sandbox-ci-sandbox-image --env prod "${IMAGE}"
 
       - name: Redeploy stigmer-service to pick up new image variable
         env:
@@ -180,5 +169,5 @@ jobs:
           echo "**Image:** \`ghcr.io/${{ github.repository_owner }}/runner\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags:** \`latest\`, \`main-${{ steps.tags.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Architecture:** linux/amd64" >> $GITHUB_STEP_SUMMARY
-          echo "**Planton variable:** updated \`sandbox-ci/prod.sandbox-image\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Planton variable:** updated \`sandbox-ci-sandbox-image\` (env prod)" >> $GITHUB_STEP_SUMMARY
           echo "**Daytona cache warm:** attempted with SHA tag (continue-on-error)" >> $GITHUB_STEP_SUMMARY

--- a/client-apps/web/_kustomize/overlays/prod/service.yaml
+++ b/client-apps/web/_kustomize/overlays/prod/service.yaml
@@ -20,15 +20,15 @@ spec:
       env:
         variables:
           - name: NEXT_PUBLIC_API_URL
-            value: $variables-group/stigmer-web-config/prod.api-url
+            value: $var/@prod/stigmer-web-config/api-url
           - name: NEXT_PUBLIC_AUTH_MODE
-            value: $variables-group/stigmer-web-config/prod.auth-mode
+            value: $var/@prod/stigmer-web-config/auth-mode
           - name: NEXT_PUBLIC_OIDC_ISSUER
-            value: $variables-group/stigmer-web-config/prod.oidc-issuer
+            value: $var/@prod/stigmer-web-config/oidc-issuer
           - name: NEXT_PUBLIC_OIDC_CLIENT_ID
-            value: $variables-group/stigmer-web-config/prod.oidc-client-id
+            value: $var/@prod/stigmer-web-config/oidc-client-id
           - name: NEXT_PUBLIC_OIDC_AUDIENCE
-            value: $variables-group/stigmer-web-config/prod.oidc-audience
+            value: $var/@prod/stigmer-web-config/oidc-audience
   ingress:
     enabled: true
     hostname: app.stigmer.ai

--- a/mcp-server/_kustomize/overlays/prod/service.yaml
+++ b/mcp-server/_kustomize/overlays/prod/service.yaml
@@ -60,7 +60,7 @@ spec:
           # which validates it (Auth0 JWTs, federated org-IdP JWTs, or stk_ API
           # keys). No issuer is assumed here, so bring-your-own-IdP works.
           - name: STIGMER_SERVER_ADDRESS
-            value: $variables-group/stigmer-api/prod.kube-endpoint
+            value: $var/@prod/stigmer-api/kube-endpoint
       # Health probes for zero-downtime deployments (HTTP /health).
       readinessProbe:
         httpGet:


### PR DESCRIPTION
## Summary

Migrates the org's config references off the demolished service-hub `VariablesGroup`/`SecretsGroup` API onto config-manager. OSS half of the stigmer config-manager migration (paired with the stigmer-cloud PR, which authors + seeds the config-manager data live).

## Changes
- `client-apps/web/_kustomize/overlays/prod/service.yaml`: `stigmer-web-config` refs -> `$var/@prod/stigmer-web-config/*`.
- `mcp-server/_kustomize/overlays/prod/service.yaml`: `$var/@prod/stigmer-api/kube-endpoint`.
- `.github/workflows/release.sandbox-cloud.yaml`: bump the sandbox image via `planton variable set sandbox-ci-sandbox-image --env prod` instead of `planton apply`-ing a `kind: VariablesGroup` heredoc (now-removed API).

Full context in the stigmer-cloud changelog `2026-06-05-181005-stigmer-config-manager-migration.md`.