### PR TITLE
fix(runner): replay presigned-upload signed headers verbatim (SignatureDoesNotMatch)

### DIFF
--- a/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
+++ b/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
@@ -106,6 +106,80 @@ describe("ProxyArtifactStorage", () => {
     expect(calls[1].method).toBe("PUT");
   });
 
+  // ── Signed-header contract (regression for SignatureDoesNotMatch) ──────
+  //
+  // The proxy presigns `content-type` (and `host`). The runner must replay the
+  // signed set verbatim: duplicating `content-type` corrupts the signed value
+  // and the store returns 403 SignatureDoesNotMatch. These tests drive a
+  // NON-empty signed-header response (the prior tests mocked `headers: {}`,
+  // which is exactly why this bug went uncaught) and assert what fetch sends.
+
+  function captureUploadHeaders(signedHeaders: Record<string, unknown>): Promise<Headers> {
+    return new Promise((resolve) => {
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("presigned-upload-url")) {
+          return new Response(
+            JSON.stringify({ url: "https://r2.example.com/put", headers: signedHeaders }),
+            { status: 200 },
+          );
+        }
+        // Build a real Headers from what the runner passed, so concatenation /
+        // case-folding behavior matches a live PUT.
+        resolve(new Headers(init?.headers as HeadersInit));
+        return new Response(null, { status: 200 });
+      }) as typeof fetch;
+    });
+  }
+
+  it("replays the signed content-type exactly once (no duplication)", async () => {
+    const headersPromise = captureUploadHeaders({
+      "content-type": "text/markdown",
+      "host": "test-bucket.localhost:9000",
+    });
+    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    await storage.upload("artifacts/exec-1/plan.md", Buffer.from("# Plan"), "text/markdown");
+
+    const sent = await headersPromise;
+    expect(sent.get("content-type")).toBe("text/markdown");
+  });
+
+  it("does not forward the signed host header (fetch sets it from the URL)", async () => {
+    const headersPromise = captureUploadHeaders({
+      "content-type": "text/markdown",
+      "host": "test-bucket.localhost:9000",
+    });
+    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    await storage.upload("artifacts/exec-1/plan.md", Buffer.from("# Plan"), "text/markdown");
+
+    const sent = await headersPromise;
+    expect(sent.has("host")).toBe(false);
+  });
+
+  it("tolerates legacy array-valued signed headers without duplicating", async () => {
+    // Older proxy builds return Map<String,List<String>> -> JSON arrays.
+    const headersPromise = captureUploadHeaders({
+      "content-type": ["text/markdown"],
+      "host": ["test-bucket.localhost:9000"],
+    });
+    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    await storage.upload("artifacts/exec-1/plan.md", Buffer.from("# Plan"), "text/markdown");
+
+    const sent = await headersPromise;
+    expect(sent.get("content-type")).toBe("text/markdown");
+  });
+
+  it("sets content-type itself only when the presigner did not sign it", async () => {
+    const headersPromise = captureUploadHeaders({
+      "host": "test-bucket.localhost:9000",
+    });
+    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    await storage.upload("artifacts/exec-1/f.bin", Buffer.from("x"), "application/octet-stream");
+
+    const sent = await headersPromise;
+    expect(sent.get("content-type")).toBe("application/octet-stream");
+  });
+
   it("throws on presign failure", async () => {
     globalThis.fetch = vi.fn(async () =>
       new Response("forbidden", { status: 403 }),

--- a/backend/services/runner/src/shared/artifact-storage.ts
+++ b/backend/services/runner/src/shared/artifact-storage.ts
@@ -87,10 +87,28 @@ export class ProxyArtifactStorage implements ArtifactStorage {
     }
 
     const data = await presignResp.json() as { url: string; headers?: Record<string, string> };
-    const uploadHeaders: Record<string, string> = {
-      ...data.headers,
-      "Content-Type": ct,
-    };
+
+    // Send exactly the headers the proxy signed. The presigner is the single
+    // source of truth for what must be on the wire: a SigV4 presigned PUT signs
+    // `content-type` (and `host`), so re-adding or duplicating any signed header
+    // changes its value and the store rejects the upload with
+    // `SignatureDoesNotMatch`. We therefore replay the signed set verbatim —
+    // never appending our own `Content-Type` when the signer already covered it.
+    // `host` is set by fetch from the URL and cannot be overridden, so drop it.
+    const signedHeaders = data.headers ?? {};
+    const uploadHeaders: Record<string, string> = {};
+    let contentTypeSigned = false;
+    for (const [name, value] of Object.entries(signedHeaders)) {
+      if (name.toLowerCase() === "host") continue;
+      if (name.toLowerCase() === "content-type") contentTypeSigned = true;
+      uploadHeaders[name] = value;
+    }
+    // Only set Content-Type ourselves if the presigner did NOT sign it (so the
+    // stored object still records the right type); when it IS signed, adding it
+    // would corrupt the signed value.
+    if (!contentTypeSigned) {
+      uploadHeaders["Content-Type"] = ct;
+    }
 
     const putResp = await fetch(data.url, {
       method: "PUT",

--- a/test/integration/harness/service.go
+++ b/test/integration/harness/service.go
@@ -364,6 +364,10 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_ENDPOINT=%s", r2Endpoint(cfg)),
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_ACCESS_KEY_ID=%s", r2AccessKey(cfg)),
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_SECRET_ACCESS_KEY=%s", r2SecretKey(cfg)),
+		// MinIO can't resolve a bucket subdomain, so the presigner must use
+		// path-style addressing or presigned uploads fail with SignatureDoesNotMatch.
+		// Production R2 keeps the virtual-host default (flag is false there).
+		"AGENT_EXECUTION_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED=true",
 
 		// Claim check R2 config
 		"CLAIMCHECK_R2_BUCKET=test-claimcheck-bucket",


### PR DESCRIPTION
## Summary

Artifact uploads through the side-channel proxy failed with `403 SignatureDoesNotMatch`. `ProxyArtifactStorage.upload` spread the proxy's signed headers and then re-added its own `Content-Type`, so `fetch` sent a doubled, comma-joined `content-type` (`text/markdown, text/markdown`) that no longer matched the SigV4-signed value. This is environment-independent and silently broke the **production** streaming auto-publish path (`InlinePublisher`) — masked because artifact uploads are fire-and-forget and no test asserted `status.artifacts`.

The presigner is the single source of truth for upload headers. The runner now:
- replays the signed header set verbatim,
- drops `host` (fetch sets it from the URL),
- only sets `Content-Type` itself when the presigner did not sign it,
- tolerates legacy array-valued responses, so runner/proxy rollout order is safe.

Harness: sets `AGENT_EXECUTION_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED` for MinIO. This flag stays **env-gated** (production R2 keeps the virtual-host default) because it reflects a real environmental difference, not a workaround — distinct from the header fix, which is universal.

Paired cloud PR (honest header contract at the proxy boundary): stigmer/stigmer-cloud#132

## Test plan

- [x] Runner Vitest: 4 new `artifact-storage.test.ts` cases drive a **non-empty** signed-header response (prior tests mocked `headers: {}`, which is why the bug was uncaught) — assert single unconcatenated content-type, host not forwarded, legacy-array tolerance, self-set only when unsigned. 25 file tests pass.
- [x] Integration: `TestAgentExecution_PlanMode_PublishesPlanArtifact` passes on **both** harnesses (native `InlinePublisher` + cursor), previously red with `SignatureDoesNotMatch`.