### PR TITLE
feat(runner,react): reviewable plan artifact + native read-only enforcement

### DIFF
--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/agentexecution/v1/SubmitApprovalInput.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/agentexecution/v1/SubmitApprovalInput.java
@@ -173,7 +173,7 @@ private static final long serialVersionUID = 0L;
   private int action_ = 0;
   /**
    * <pre>
-   * User's decision: APPROVE, SKIP, or REJECT.
+   * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
    * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
    * </pre>
    *
@@ -185,7 +185,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * User's decision: APPROVE, SKIP, or REJECT.
+   * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
    * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
    * </pre>
    *
@@ -837,7 +837,7 @@ private static final long serialVersionUID = 0L;
     private int action_ = 0;
     /**
      * <pre>
-     * User's decision: APPROVE, SKIP, or REJECT.
+     * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
      * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
      * </pre>
      *
@@ -849,7 +849,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * User's decision: APPROVE, SKIP, or REJECT.
+     * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
      * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
      * </pre>
      *
@@ -866,7 +866,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * User's decision: APPROVE, SKIP, or REJECT.
+     * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
      * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
      * </pre>
      *
@@ -880,7 +880,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * User's decision: APPROVE, SKIP, or REJECT.
+     * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
      * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
      * </pre>
      *
@@ -897,7 +897,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * User's decision: APPROVE, SKIP, or REJECT.
+     * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
      * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
      * </pre>
      *

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/agentexecution/v1/SubmitApprovalInputOrBuilder.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/agentexecution/v1/SubmitApprovalInputOrBuilder.java
@@ -58,7 +58,7 @@ public interface SubmitApprovalInputOrBuilder extends
 
   /**
    * <pre>
-   * User's decision: APPROVE, SKIP, or REJECT.
+   * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
    * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
    * </pre>
    *
@@ -68,7 +68,7 @@ public interface SubmitApprovalInputOrBuilder extends
   int getActionValue();
   /**
    * <pre>
-   * User's decision: APPROVE, SKIP, or REJECT.
+   * User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
    * APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
    * </pre>
    *

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -43,6 +43,8 @@ import { CursorMode } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_p
 import { determineCursorMode, isCloudMode } from "./cursor-mode.js";
 import { MessageAccumulator, reconcileDeniedToolCalls, cancelInProgressSubAgentProtos } from "./message-translator.js";
 import { utcTimestamp, persistStatus, reportSetupProgress, slimStatus } from "../../shared/status.js";
+import { createArtifactStorage, loadArtifactStorageConfig } from "../../shared/artifact-storage.js";
+import { publishPlanArtifact } from "../../shared/plan-artifact.js";
 import { DeltaEnricher } from "./delta-enricher.js";
 import { TodoTracker } from "./todo-tracker.js";
 import { createCursorEventRecorder } from "./cursor-event-recorder.js";
@@ -1018,6 +1020,22 @@ async function executeCursorInner(
 
       if (structuredOutput !== undefined) {
         status.structuredOutput = structuredOutput as JsonObject;
+      }
+
+      // Plan mode: publish the final plan message as a plan.md artifact. The
+      // Cursor harness has no auto-publish pipeline, so this is the only
+      // artifact path; build storage from the same config-driven factory the
+      // native harness uses.
+      if (interactionMode === InteractionMode.PLAN && finalText) {
+        try {
+          const artifactStorage = createArtifactStorage(loadArtifactStorageConfig(config));
+          await publishPlanArtifact({ status, executionId, planText: finalText, artifactStorage });
+        } catch (err) {
+          console.warn(
+            `ExecuteCursor plan artifact publish skipped (non-fatal): ` +
+            `execution=${executionId}, error=${err}`,
+          );
+        }
       }
     }
 

--- a/backend/services/runner/src/activities/execute-deep-agent/index.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/index.ts
@@ -13,9 +13,10 @@ import { Context, CancelledFailure } from "@temporalio/activity";
 import { create, type JsonObject } from "@bufbuild/protobuf";
 import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { AgentMessageSchema, ToolCallSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
-import { ExecutionPhase, MessageType, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ExecutionPhase, InteractionMode, MessageType, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { activityStarted, activityFinished } from "../../idle-watchdog.js";
 import { persistStatus, slimStatus, utcTimestamp } from "../../shared/status.js";
+import { publishPlanArtifact } from "../../shared/plan-artifact.js";
 import { classifyTool } from "../../shared/tool-kind.js";
 import type { Config } from "../../config.js";
 import { StigmerClient } from "../../client/stigmer-client.js";
@@ -238,6 +239,22 @@ export function createDeepAgentActivities(config: Config) {
           if (structuredOutput !== undefined) {
             initialStatus.structuredOutput = structuredOutput;
           }
+        }
+
+        // Plan mode: the agent's final message is the plan. Publish it as a
+        // first-class plan.md artifact so the UI can render a reviewable Plan
+        // card and a follow-up Implement run can reference it. Read-only mode
+        // produces no file to auto-publish, so this is the only artifact path.
+        if (
+          setup.execution.spec?.executionConfig?.interactionMode === InteractionMode.PLAN &&
+          finalText
+        ) {
+          await publishPlanArtifact({
+            status: initialStatus,
+            executionId,
+            planText: finalText,
+            artifactStorage: setup.artifactStorage,
+          });
         }
 
         await persistStatus(client, executionId, initialStatus);

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -8,7 +8,8 @@
  * the streaming phase needs.
  */
 
-import { createDeepAgent, FilesystemBackend } from "deepagents";
+import { createDeepAgent, FilesystemBackend, type FilesystemPermission } from "deepagents";
+import { InteractionMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
@@ -369,6 +370,17 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       responseFormat = jsonSchemaToZod(outputSchema as unknown as Record<string, unknown>);
     }
 
+    // Plan mode is read-only. Deny every filesystem write operation at the tool
+    // level so write_file/edit_file/etc. cannot mutate the workspace — enforcing
+    // the InteractionMode.PLAN contract by construction, not by prompt. Rules are
+    // first-match-wins with a permissive default, so a single deny-all-writes
+    // rule is sufficient. (The Cursor harness enforces plan mode via its prompt
+    // prefix; the native harness enforces it here.)
+    const isPlanMode = execConfig?.interactionMode === InteractionMode.PLAN;
+    const planModePermissions: FilesystemPermission[] = [
+      { operations: ["write"], paths: ["/**"], mode: "deny" },
+    ];
+
     const agentGraph = await createDeepAgent({
       model,
       checkpointer: checkpointer as any,
@@ -378,6 +390,7 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       middleware: middleware as any,
       subagents: compiledSubagents ?? undefined,
       ...(responseFormat ? { responseFormat } : {}),
+      ...(isPlanMode ? { permissions: planModePermissions } : {}),
     } as Parameters<typeof createDeepAgent>[0]);
 
     // Step 11: Prepare invocation input and config

--- a/backend/services/runner/src/shared/__tests__/plan-artifact.test.ts
+++ b/backend/services/runner/src/shared/__tests__/plan-artifact.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import {
+  ExecutionArtifactKind,
+  MessageType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { ArtifactStorage } from "../artifact-storage.js";
+import {
+  extractFinalPlanText,
+  publishPlanArtifact,
+  PLAN_ARTIFACT_NAME,
+  PLAN_ARTIFACT_SANDBOX_PATH,
+} from "../plan-artifact.js";
+
+/** Records uploads and returns deterministic download URLs. */
+function fakeStorage(): ArtifactStorage & { uploads: { key: string; content: Buffer; contentType?: string }[] } {
+  const uploads: { key: string; content: Buffer; contentType?: string }[] = [];
+  return {
+    uploads,
+    async upload(key, content, contentType) {
+      uploads.push({ key, content, contentType });
+      return key;
+    },
+    async getDownloadUrl(key) {
+      return `https://example.test/download/${key}`;
+    },
+    async exists() {
+      return true;
+    },
+  };
+}
+
+function statusWith(...messages: { type: MessageType; content: string }[]) {
+  return create(AgentExecutionStatusSchema, {
+    messages: messages.map((m) =>
+      create(AgentMessageSchema, { type: m.type, content: m.content }),
+    ),
+  });
+}
+
+describe("extractFinalPlanText", () => {
+  it("returns the last non-empty AI message content", () => {
+    const status = statusWith(
+      { type: MessageType.MESSAGE_HUMAN, content: "make a plan" },
+      { type: MessageType.MESSAGE_AI, content: "first" },
+      { type: MessageType.MESSAGE_AI, content: "the real plan" },
+    );
+    expect(extractFinalPlanText(status)).toBe("the real plan");
+  });
+
+  it("skips trailing empty AI messages (e.g. tool-call-only turns)", () => {
+    const status = statusWith(
+      { type: MessageType.MESSAGE_AI, content: "the plan body" },
+      { type: MessageType.MESSAGE_AI, content: "   " },
+    );
+    expect(extractFinalPlanText(status)).toBe("the plan body");
+  });
+
+  it("returns undefined when there is no AI message with content", () => {
+    const status = statusWith({ type: MessageType.MESSAGE_HUMAN, content: "hi" });
+    expect(extractFinalPlanText(status)).toBeUndefined();
+  });
+});
+
+describe("publishPlanArtifact", () => {
+  it("uploads plan.md and registers a FILE artifact on the status", async () => {
+    const status = create(AgentExecutionStatusSchema, {});
+    const storage = fakeStorage();
+
+    await publishPlanArtifact({
+      status,
+      executionId: "aex_123",
+      planText: "# Plan\n1. step one\n2. step two\n",
+      artifactStorage: storage,
+    });
+
+    expect(storage.uploads).toHaveLength(1);
+    expect(storage.uploads[0].key).toBe("artifacts/aex_123/plan.md");
+    expect(storage.uploads[0].contentType).toBe("text/markdown");
+
+    expect(status.artifacts).toHaveLength(1);
+    const artifact = status.artifacts[0];
+    expect(artifact.name).toBe(PLAN_ARTIFACT_NAME);
+    expect(artifact.sandboxPath).toBe(PLAN_ARTIFACT_SANDBOX_PATH);
+    expect(artifact.kind).toBe(ExecutionArtifactKind.FILE);
+    expect(artifact.storageKey).toBe("artifacts/aex_123/plan.md");
+    expect(artifact.downloadUrl).toBe("https://example.test/download/artifacts/aex_123/plan.md");
+    expect(artifact.sizeBytes).toBeGreaterThan(0n);
+    expect(artifact.contentHash).toHaveLength(64);
+  });
+
+  it("is a no-op for empty plan text (nothing to publish)", async () => {
+    const status = create(AgentExecutionStatusSchema, {});
+    const storage = fakeStorage();
+
+    await publishPlanArtifact({
+      status,
+      executionId: "aex_empty",
+      planText: "   \n  ",
+      artifactStorage: storage,
+    });
+
+    expect(storage.uploads).toHaveLength(0);
+    expect(status.artifacts).toHaveLength(0);
+  });
+
+  it("replaces an existing plan.md rather than appending a duplicate", async () => {
+    const status = create(AgentExecutionStatusSchema, {});
+    const storage = fakeStorage();
+
+    await publishPlanArtifact({ status, executionId: "aex_re", planText: "v1", artifactStorage: storage });
+    await publishPlanArtifact({ status, executionId: "aex_re", planText: "v2 longer plan", artifactStorage: storage });
+
+    expect(status.artifacts).toHaveLength(1);
+    expect(storage.uploads).toHaveLength(2);
+    // The surviving artifact reflects the latest content hash.
+    const latestHash = storage.uploads[1].content;
+    expect(status.artifacts[0].sizeBytes).toBe(BigInt(latestHash.length));
+  });
+
+  it("never throws when the upload fails (publish is non-fatal)", async () => {
+    const status = create(AgentExecutionStatusSchema, {});
+    const failing: ArtifactStorage = {
+      async upload() {
+        throw new Error("network down");
+      },
+      async getDownloadUrl() {
+        return "";
+      },
+      async exists() {
+        return false;
+      },
+    };
+
+    await expect(
+      publishPlanArtifact({ status, executionId: "aex_fail", planText: "plan", artifactStorage: failing }),
+    ).resolves.toBeUndefined();
+    expect(status.artifacts).toHaveLength(0);
+  });
+});

--- a/backend/services/runner/src/shared/plan-artifact.ts
+++ b/backend/services/runner/src/shared/plan-artifact.ts
@@ -1,0 +1,120 @@
+/**
+ * Plan-mode artifact publishing.
+ *
+ * When an execution runs in Plan mode (InteractionMode.PLAN), the agent's final
+ * message IS the plan. We publish that text as a first-class `plan.md`
+ * ExecutionArtifact so the UI can render a reviewable Plan card with
+ * copy/download, and a follow-up "Implement" execution can reference it
+ * deterministically.
+ *
+ * This is deliberately a single, harness-agnostic helper:
+ * - The native (deepagents) harness already auto-publishes files an agent
+ *   writes (InlinePublisher), but Plan mode is read-only, so there is no file to
+ *   publish — the plan lives only in the final message.
+ * - The Cursor harness has no artifact pipeline at all.
+ *
+ * Publishing the final message here, at finalization, gives both harnesses an
+ * identical, durable plan artifact derived from the single source of truth (the
+ * final AI message). It mirrors the InlinePublisher "publish a derived artifact"
+ * pattern: one immutable artifact, published once, never a parallel copy that
+ * can drift.
+ *
+ * The plan content is NOT duplicated as a separate stored blob beyond this
+ * artifact — the chat message remains the live/streamed view; the artifact is
+ * the durable/exportable view, detected by convention (a FILE artifact named
+ * `plan.md`).
+ */
+
+import { createHash } from "node:crypto";
+import { create } from "@bufbuild/protobuf";
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionArtifactSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
+import {
+  ExecutionArtifactKind,
+  MessageType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { ArtifactStorage } from "./artifact-storage.js";
+import { utcTimestamp } from "./status.js";
+
+/** Canonical filename for a plan artifact. UI detection keys on this name. */
+export const PLAN_ARTIFACT_NAME = "plan.md";
+
+/**
+ * Sandbox path recorded on the artifact. Routes under `.stigmer/` (the
+ * session platform dir), so it never pollutes the user's workspace, and a
+ * follow-up execution can reference it via workspace file refs if desired.
+ */
+export const PLAN_ARTIFACT_SANDBOX_PATH = ".stigmer/plans/plan.md";
+
+/**
+ * Returns the text of the last AI message in a completed status, trimmed.
+ * Returns `undefined` when there is no AI message with content — the plan was
+ * empty and nothing should be published.
+ */
+export function extractFinalPlanText(status: AgentExecutionStatus): string | undefined {
+  for (let i = status.messages.length - 1; i >= 0; i--) {
+    const msg = status.messages[i];
+    if (msg.type === MessageType.MESSAGE_AI && msg.content.trim().length > 0) {
+      return msg.content;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Publishes `planText` as a `plan.md` ExecutionArtifact and registers it on
+ * `status.artifacts`. Idempotent: re-publishing replaces any existing `plan.md`
+ * rather than appending a duplicate, preserving a single source of truth.
+ *
+ * Fire-and-forget by contract: a plan that fails to upload must never fail the
+ * execution. Errors are logged and swallowed.
+ */
+export async function publishPlanArtifact(opts: {
+  readonly status: AgentExecutionStatus;
+  readonly executionId: string;
+  readonly planText: string;
+  readonly artifactStorage: ArtifactStorage;
+}): Promise<void> {
+  const { status, executionId, planText, artifactStorage } = opts;
+
+  if (planText.trim().length === 0) {
+    return;
+  }
+
+  try {
+    const content = Buffer.from(planText, "utf-8");
+    const contentHash = createHash("sha256").update(content).digest("hex");
+    const storageKey = `artifacts/${executionId}/${PLAN_ARTIFACT_NAME}`;
+
+    await artifactStorage.upload(storageKey, content, "text/markdown");
+    const downloadUrl = await artifactStorage.getDownloadUrl(storageKey);
+
+    const artifact = create(ExecutionArtifactSchema, {
+      name: PLAN_ARTIFACT_NAME,
+      sandboxPath: PLAN_ARTIFACT_SANDBOX_PATH,
+      kind: ExecutionArtifactKind.FILE,
+      sizeBytes: BigInt(content.length),
+      storageKey,
+      downloadUrl,
+      createdAt: utcTimestamp(),
+      contentHash,
+    });
+
+    const existingIdx = status.artifacts.findIndex((a) => a.name === PLAN_ARTIFACT_NAME);
+    if (existingIdx >= 0) {
+      status.artifacts[existingIdx] = artifact;
+    } else {
+      status.artifacts.push(artifact);
+    }
+
+    console.log(
+      `[plan-artifact] execution=${executionId} — published ${PLAN_ARTIFACT_NAME} ` +
+      `(${content.length} bytes, hash=${contentHash.slice(0, 12)})`,
+    );
+  } catch (err) {
+    console.warn(
+      `[plan-artifact] execution=${executionId} — ` +
+      `failed to publish plan (non-fatal): ${err}`,
+    );
+  }
+}

--- a/docs/sdk/react/composer.mdx
+++ b/docs/sdk/react/composer.mdx
@@ -124,7 +124,9 @@ pre-fill and focus the input.
 const composerRef = useRef<SessionComposerHandle>(null);
 
 function handleBuildFromPlan() {
-  composerRef.current?.setMessage("Implement the plan above");
+  composerRef.current?.setMessage(
+    "Implement the plan above (saved as plan.md). Follow it step by step and make the changes it describes.",
+  );
   composerRef.current?.focus();
 }
 

--- a/mcp-server/proto/ai/stigmer/agentic/agentexecution/v1/io.pb.go
+++ b/mcp-server/proto/ai/stigmer/agentic/agentexecution/v1/io.pb.go
@@ -508,7 +508,7 @@ type SubmitApprovalInput struct {
 	// Must match status.pending_approval.tool_call_id exactly.
 	// Format: Tool call ID from agent runtime (e.g., "call_abc123")
 	ToolCallId string `protobuf:"bytes,2,opt,name=tool_call_id,json=toolCallId,proto3" json:"tool_call_id,omitempty"`
-	// User's decision: APPROVE, SKIP, or REJECT.
+	// User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
 	// APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
 	Action ApprovalAction `protobuf:"varint,3,opt,name=action,proto3,enum=ai.stigmer.agentic.agentexecution.v1.ApprovalAction" json:"action,omitempty"`
 	// Optional reason/comment for the decision.

--- a/sdk/go/proto/ai/stigmer/agentic/agentexecution/v1/io.pb.go
+++ b/sdk/go/proto/ai/stigmer/agentic/agentexecution/v1/io.pb.go
@@ -508,7 +508,7 @@ type SubmitApprovalInput struct {
 	// Must match status.pending_approval.tool_call_id exactly.
 	// Format: Tool call ID from agent runtime (e.g., "call_abc123")
 	ToolCallId string `protobuf:"bytes,2,opt,name=tool_call_id,json=toolCallId,proto3" json:"tool_call_id,omitempty"`
-	// User's decision: APPROVE, SKIP, or REJECT.
+	// User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.
 	// APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.
 	Action ApprovalAction `protobuf:"varint,3,opt,name=action,proto3,enum=ai.stigmer.agentic.agentexecution.v1.ApprovalAction" json:"action,omitempty"`
 	// Optional reason/comment for the decision.

--- a/sdk/react/src/execution/MessageThread.tsx
+++ b/sdk/react/src/execution/MessageThread.tsx
@@ -7,6 +7,7 @@ import type { AgentMessage, ToolCall } from "@stigmer/protos/ai/stigmer/agentic/
 import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
 import type { PendingApproval } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
 import {
   ApprovalAction,
   ExecutionPhase,
@@ -24,6 +25,8 @@ import { SetupProgress } from "./SetupProgress";
 import { ApprovalCard } from "./ApprovalCard";
 import { SummarizationCard } from "./SummarizationCard";
 import { PlanCompletionCard } from "./PlanCompletionCard";
+import { PlanArtifactCard } from "./PlanArtifactCard";
+import { findPlanArtifact } from "../library/detect-plan-artifact";
 import type { SummarizationEventView } from "./useContextWindow";
 import { isInternalTool } from "./tool-categories";
 import { FilePathContext, type FilePathContextValue } from "./FilePathContext";
@@ -169,7 +172,12 @@ export type ThreadItem =
   | { readonly kind: "approval-request"; readonly pendingApproval: PendingApproval; readonly key: string }
   | { readonly kind: "setup-progress"; readonly workspaceEntries: readonly WorkspaceEntry[]; readonly serverPhase?: string; readonly isAwaitingResponse?: boolean; readonly key: string }
   | { readonly kind: "context-compacted"; readonly event: SummarizationEventView; readonly key: string }
-  | { readonly kind: "plan-completion"; readonly key: string };
+  | {
+      readonly kind: "plan-completion";
+      readonly key: string;
+      readonly executionId: string;
+      readonly planArtifact?: ExecutionArtifact;
+    };
 
 function hasAiMessages(execution: AgentExecution): boolean {
   const messages = execution.status?.messages;
@@ -378,7 +386,12 @@ export function buildThreadItems(
     lastPhase === ExecutionPhase.EXECUTION_COMPLETED &&
     lastExec?.spec?.executionConfig?.interactionMode === InteractionMode.PLAN
   ) {
-    items.push({ kind: "plan-completion", key: "plan-completion" });
+    items.push({
+      kind: "plan-completion",
+      key: "plan-completion",
+      executionId: lastExec?.metadata?.id ?? "",
+      planArtifact: findPlanArtifact(lastExec),
+    });
   }
 
   if (includeApprovals) {
@@ -674,7 +687,18 @@ export function ThreadItemRenderer({
     case "context-compacted":
       return <SummarizationCard event={item.event} />;
     case "plan-completion":
-      return <PlanCompletionCard onImplement={onBuildFromPlan} />;
+      // When the plan was published as an artifact, show the richer reviewable
+      // card (preview / copy / download / implement). Otherwise fall back to the
+      // bare Implement CTA (older executions, or a plan that failed to publish).
+      return item.planArtifact && item.executionId ? (
+        <PlanArtifactCard
+          executionId={item.executionId}
+          artifact={item.planArtifact}
+          onImplement={onBuildFromPlan}
+        />
+      ) : (
+        <PlanCompletionCard onImplement={onBuildFromPlan} />
+      );
   }
 }
 

--- a/sdk/react/src/execution/PlanArtifactCard.tsx
+++ b/sdk/react/src/execution/PlanArtifactCard.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { memo, useCallback, useState } from "react";
+import { cn } from "@stigmer/theme";
+import type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
+import { useArtifactContent } from "./useArtifactContent";
+import { ArtifactContentRenderer } from "./ArtifactContentRenderer";
+import { formatArtifactSize } from "./artifact-utils";
+
+/** Plans above this size are not inlined for preview — download instead. */
+const MAX_PREVIEW_BYTES = 512 * 1024;
+
+/** Props for {@link PlanArtifactCard}. */
+export interface PlanArtifactCardProps {
+  /** Execution that produced the plan — used to fetch the plan content. */
+  readonly executionId: string;
+  /** The published `plan.md` artifact (from `findPlanArtifact`). */
+  readonly artifact: ExecutionArtifact;
+  /** Called when the user clicks "Implement". Hidden when omitted. */
+  readonly onImplement?: () => void;
+  /** Disables the Implement CTA (e.g., while an execution is active). */
+  readonly disabled?: boolean;
+  /** Additional CSS classes for the root element. */
+  readonly className?: string;
+}
+
+/**
+ * Reviewable card shown after a completed Plan-mode execution when the agent
+ * published a `plan.md` artifact.
+ *
+ * Unlike {@link PlanCompletionCard} (a bare Implement CTA), this card makes the
+ * plan a first-class, durable object: expand to review the rendered plan, copy
+ * it, download the `plan.md` file, or proceed to implement. The plan content is
+ * the single source of truth (the published artifact), fetched on demand via
+ * {@link useArtifactContent} rather than duplicated into component state.
+ *
+ * All visual properties flow through `--stgm-*` tokens; the component is
+ * self-contained and embeddable.
+ */
+export const PlanArtifactCard = memo(function PlanArtifactCard({
+  executionId,
+  artifact,
+  onImplement,
+  disabled,
+  className,
+}: PlanArtifactCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Plans are small markdown; fetch eagerly (within the size cap) so both the
+  // preview and Copy have content ready. contentHash invalidates the cache when
+  // the plan is re-published in the same execution.
+  const fetchable = Number(artifact.sizeBytes) < MAX_PREVIEW_BYTES;
+  const { content, contentType, isTruncated, isLoading } = useArtifactContent(
+    fetchable ? executionId : null,
+    fetchable ? artifact.storageKey : null,
+    undefined,
+    artifact.contentHash || undefined,
+  );
+
+  const handleCopy = useCallback(async () => {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be unavailable (insecure context / denied permission).
+      // Silently no-op: Download remains available as the durable fallback.
+    }
+  }, [content]);
+
+  return (
+    <div
+      role="region"
+      aria-label="Plan ready to review"
+      className={cn(
+        "mx-4 overflow-hidden rounded-md border border-border-muted bg-muted-faint",
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <PlanIcon />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-foreground">
+            Plan ready to review
+          </div>
+          <div className="text-xs tabular-nums text-muted-foreground">
+            {artifact.name} · {formatArtifactSize(artifact.sizeBytes)}
+          </div>
+        </div>
+        {onImplement && (
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={onImplement}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5",
+              "text-xs font-medium transition-colors",
+              "bg-primary text-primary-foreground hover:bg-primary-hover",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "disabled:pointer-events-none disabled:opacity-50",
+            )}
+          >
+            <ImplementIcon />
+            Implement
+          </button>
+        )}
+      </div>
+
+      {/* Secondary actions */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-border-muted px-3 py-1.5">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+          className={cn(
+            "inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary-muted",
+            FOCUS_RING,
+          )}
+        >
+          <ChevronIcon expanded={expanded} />
+          {expanded ? "Hide plan" : "Review plan"}
+        </button>
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={!content}
+          className={cn(
+            "text-xs font-medium text-muted-foreground transition-colors hover:text-foreground",
+            "disabled:pointer-events-none disabled:opacity-50",
+            FOCUS_RING,
+          )}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+        <a
+          href={artifact.downloadUrl}
+          download={artifact.name}
+          className={cn(
+            "inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground",
+            FOCUS_RING,
+          )}
+        >
+          <DownloadIcon />
+          Download
+        </a>
+      </div>
+
+      {/* Expandable plan preview */}
+      {expanded && (
+        <div className="max-h-96 overflow-auto border-t border-border-muted px-3 py-2">
+          {!fetchable ? (
+            <p className="text-xs text-muted-foreground">
+              This plan is large — use Download to view the full file.
+            </p>
+          ) : isLoading ? (
+            <div className="h-4 w-40 animate-pulse rounded bg-muted" aria-hidden="true" />
+          ) : content ? (
+            <ArtifactContentRenderer
+              content={content}
+              fileName={artifact.name}
+              contentType={contentType}
+              isTruncated={isTruncated}
+            />
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Plan content is unavailable. Use Download to retrieve the file.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-sm";
+
+function PlanIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0 text-muted-foreground-faint"
+      aria-hidden="true"
+    >
+      <path d="M3 4h10M3 8h7M3 12h8" />
+      <path d="M12.5 10.5l1.5 1.5-1.5 1.5" />
+    </svg>
+  );
+}
+
+function ImplementIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 6h8M7 3l3 3-3 3" />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <path d="M6 1.5V8.5" />
+      <path d="M3 6L6 9L9 6" />
+      <path d="M2 10.5H10" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ expanded }: { readonly expanded: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("shrink-0 transition-transform", expanded && "rotate-90")}
+      aria-hidden="true"
+    >
+      <path d="M4 2l4 4-4 4" />
+    </svg>
+  );
+}

--- a/sdk/react/src/execution/index.ts
+++ b/sdk/react/src/execution/index.ts
@@ -32,6 +32,9 @@ export type { SummarizationCardProps } from "./SummarizationCard";
 export { PlanCompletionCard } from "./PlanCompletionCard";
 export type { PlanCompletionCardProps } from "./PlanCompletionCard";
 
+export { PlanArtifactCard } from "./PlanArtifactCard";
+export type { PlanArtifactCardProps } from "./PlanArtifactCard";
+
 export { useExecutionArtifacts } from "./useExecutionArtifacts";
 export type { UseExecutionArtifactsReturn } from "./useExecutionArtifacts";
 

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -842,6 +842,8 @@ export {
   isSkillPackage,
   detectSkillPackage,
   useDetectSkillPackage,
+  isPlanArtifact,
+  findPlanArtifact,
   parseResourceYaml,
   serializeAgentYaml,
   serializeMcpServerYaml,

--- a/sdk/react/src/library/__tests__/detect-plan-artifact.test.ts
+++ b/sdk/react/src/library/__tests__/detect-plan-artifact.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionArtifactSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
+import { ExecutionArtifactKind } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  isPlanArtifact,
+  findPlanArtifact,
+  PLAN_ARTIFACT_NAME,
+} from "../detect-plan-artifact";
+
+function artifact(opts: { name: string; kind?: ExecutionArtifactKind; storageKey?: string }) {
+  return create(ExecutionArtifactSchema, {
+    name: opts.name,
+    kind: opts.kind ?? ExecutionArtifactKind.FILE,
+    storageKey: opts.storageKey ?? `artifacts/exec/${opts.name}`,
+  });
+}
+
+function executionWith(...artifacts: ReturnType<typeof artifact>[]) {
+  return create(AgentExecutionSchema, {
+    status: create(AgentExecutionStatusSchema, { artifacts }),
+  });
+}
+
+describe("isPlanArtifact", () => {
+  it("is true for a FILE artifact named plan.md", () => {
+    expect(isPlanArtifact(artifact({ name: PLAN_ARTIFACT_NAME }))).toBe(true);
+  });
+
+  it("is false for a directory named plan.md", () => {
+    expect(
+      isPlanArtifact(artifact({ name: "plan.md", kind: ExecutionArtifactKind.DIRECTORY })),
+    ).toBe(false);
+  });
+
+  it("is false for other file names", () => {
+    expect(isPlanArtifact(artifact({ name: "report.md" }))).toBe(false);
+    expect(isPlanArtifact(artifact({ name: "plan.txt" }))).toBe(false);
+  });
+});
+
+describe("findPlanArtifact", () => {
+  it("returns undefined for null/empty executions", () => {
+    expect(findPlanArtifact(null)).toBeUndefined();
+    expect(findPlanArtifact(undefined)).toBeUndefined();
+    expect(findPlanArtifact(executionWith())).toBeUndefined();
+  });
+
+  it("finds the plan.md among other artifacts", () => {
+    const exec = executionWith(
+      artifact({ name: "notes.txt" }),
+      artifact({ name: PLAN_ARTIFACT_NAME, storageKey: "artifacts/exec/plan.md" }),
+      artifact({ name: "data.json" }),
+    );
+    const plan = findPlanArtifact(exec);
+    expect(plan?.name).toBe(PLAN_ARTIFACT_NAME);
+    expect(plan?.storageKey).toBe("artifacts/exec/plan.md");
+  });
+
+  it("returns the latest plan.md when more than one is present", () => {
+    const exec = executionWith(
+      artifact({ name: PLAN_ARTIFACT_NAME, storageKey: "artifacts/exec/plan.md#old" }),
+      artifact({ name: PLAN_ARTIFACT_NAME, storageKey: "artifacts/exec/plan.md#new" }),
+    );
+    expect(findPlanArtifact(exec)?.storageKey).toBe("artifacts/exec/plan.md#new");
+  });
+
+  it("returns undefined when no plan artifact exists", () => {
+    expect(findPlanArtifact(executionWith(artifact({ name: "report.md" })))).toBeUndefined();
+  });
+});

--- a/sdk/react/src/library/detect-plan-artifact.ts
+++ b/sdk/react/src/library/detect-plan-artifact.ts
@@ -1,0 +1,43 @@
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
+import { ExecutionArtifactKind } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+/**
+ * Canonical filename a Plan-mode execution publishes its plan under. Kept in
+ * sync with the runner's `publishPlanArtifact` (shared/plan-artifact.ts).
+ */
+export const PLAN_ARTIFACT_NAME = "plan.md";
+
+/**
+ * Returns `true` when an artifact is the published plan: a FILE artifact named
+ * `plan.md`.
+ *
+ * Detection is by convention — the same lightweight, content-free approach used
+ * for skill packages ({@link isSkillPackage}) — so the UI never needs an extra
+ * RPC to know a plan exists. The plan's text is fetched on demand via
+ * {@link useArtifactContent} only when the user expands the Plan card.
+ */
+export function isPlanArtifact(artifact: ExecutionArtifact): boolean {
+  return (
+    artifact.kind === ExecutionArtifactKind.FILE &&
+    artifact.name === PLAN_ARTIFACT_NAME
+  );
+}
+
+/**
+ * Finds the plan artifact on a completed execution, or `undefined` when none
+ * was published (older executions, or a plan that failed to upload).
+ *
+ * Returns the latest `plan.md` if more than one is present — the runner
+ * replaces rather than appends, so this is defensive.
+ */
+export function findPlanArtifact(
+  execution: AgentExecution | null | undefined,
+): ExecutionArtifact | undefined {
+  const artifacts = execution?.status?.artifacts;
+  if (!artifacts || artifacts.length === 0) return undefined;
+  for (let i = artifacts.length - 1; i >= 0; i--) {
+    if (isPlanArtifact(artifacts[i])) return artifacts[i];
+  }
+  return undefined;
+}

--- a/sdk/react/src/library/index.ts
+++ b/sdk/react/src/library/index.ts
@@ -24,6 +24,12 @@ export {
 } from "./detect-skill-package";
 export type { SkillPackageDetection } from "./detect-skill-package";
 
+export {
+  isPlanArtifact,
+  findPlanArtifact,
+  PLAN_ARTIFACT_NAME,
+} from "./detect-plan-artifact";
+
 export { useDetectSkillPackage } from "./useDetectSkillPackage";
 export type { UseDetectSkillPackageReturn } from "./useDetectSkillPackage";
 

--- a/sdk/react/src/session/SessionViewer.tsx
+++ b/sdk/react/src/session/SessionViewer.tsx
@@ -137,7 +137,12 @@ export function SessionViewer({
 
   const handleBuildFromPlan = useCallback(() => {
     setInteractionMode("agent");
-    composerRef.current?.setMessage("Implement the plan above");
+    // Reference the plan explicitly (it is also published as plan.md) and direct
+    // the agent to act on it, rather than a bare "implement" that relies on the
+    // model re-reading its own prior message.
+    composerRef.current?.setMessage(
+      "Implement the plan above (saved as plan.md). Follow it step by step and make the changes it describes.",
+    );
     composerRef.current?.focus();
   }, []);
 

--- a/test/integration/agent_execution_15_plan_mode_test.go
+++ b/test/integration/agent_execution_15_plan_mode_test.go
@@ -1,0 +1,310 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	agentexecv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
+	"github.com/stigmer/stigmer/test/integration/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// planPrompt induces a substantial, multi-step plan so the agent turn produces
+// a meaningful token count. A trivial prompt would make the agent turn nearly
+// indistinguishable in size from the cheap session-title generation call, which
+// would hide the "only the title call is metered" defect this test guards.
+const planPrompt = "You are in plan mode. Produce a detailed, numbered, multi-step " +
+	"implementation plan (at least five steps) for adding a GET /health endpoint to a " +
+	"Node.js Express service that returns service uptime and version. Explain the " +
+	"reasoning for each step. Do NOT create, edit, or delete any files."
+
+// TestAgentExecution_PlanMode_CursorUsage reproduces the reported defect where a
+// Plan-mode execution on the Cursor harness shows no usage for the actual plan —
+// only the separate, cheap session-title generation call (claude-haiku) is
+// metered, so the Usage tab understates real cost by orders of magnitude.
+//
+// It mirrors TestAgentExecution_CursorUsage_FullPipeline but with
+// InteractionMode = PLAN. The decisive signal is the cross-reference between
+// runner-reported streaming_usage (which reflects the Cursor SDK agent turns)
+// and the billing aggregate (LlmCallUsageRecord). When the agent turns are not
+// metered, billing collapses to just the title call while streaming reflects the
+// full plan, so the totals diverge far beyond the tolerance band.
+//
+// Phase 0 expectation: this test FAILS on the Cursor harness until the metering
+// gap (defect A) is fixed; it documents the contract the fix must satisfy.
+func TestAgentExecution_PlanMode_CursorUsage(t *testing.T) {
+	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+	harness.RequireCursorPrereqs(t, testHarness)
+
+	ctx, cancel := harness.TestContext(t, 6*time.Minute)
+	defer cancel()
+
+	clients := harness.NewClients(grpcConn)
+	harness.RequireServiceHealthy(t, ctx, clients)
+
+	agent := harness.CreateAgent(t, ctx, clients, "test-plan-usage-cursor",
+		"You are a helpful software engineer. When in Plan mode, analyze the request "+
+			"and produce a detailed plan without making any changes.")
+
+	session := harness.CreateTestSession(t, ctx, clients,
+		agent.GetStatus().GetDefaultInstanceId(), harness.Harnesses[1].Harness)
+	sessionID := session.GetMetadata().GetId()
+
+	exec := harness.CreateTestAgentExecution(t, ctx, clients, sessionID, planPrompt,
+		harness.WithExecutionConfig(&agentexecv1.ExecutionConfig{
+			InteractionMode: agentexecv1.InteractionMode_INTERACTION_MODE_PLAN,
+		}),
+	)
+	executionID := exec.GetMetadata().GetId()
+
+	waiter := harness.NewAgentExecutionWaiter(clients.AgentExecutionQuery, suiteLogger)
+	result, err := waiter.WaitForPhase(ctx, executionID,
+		agentexecv1.ExecutionPhase_EXECUTION_COMPLETED, 5*time.Minute)
+	require.NoError(t, err, "plan-mode execution should complete")
+
+	// ─── Source 1: streaming_usage (Cursor SDK turn-ended, DISPLAY_ONLY) ─────
+	usage := result.GetStatus().GetStreamingUsage()
+	require.NotNil(t, usage, "streaming_usage should be populated for the plan turn")
+	assert.Greater(t, usage.GetInputTokens(), int64(0), "streaming input_tokens > 0")
+	assert.Greater(t, usage.GetOutputTokens(), int64(0), "streaming output_tokens > 0")
+	assert.GreaterOrEqual(t, usage.GetTurnCount(), int32(1), "streaming turn_count >= 1")
+
+	t.Logf("PLAN_STREAMING_USAGE: input=%d output=%d turns=%d cost=$%.6f model=%s",
+		usage.GetInputTokens(), usage.GetOutputTokens(),
+		usage.GetTurnCount(), usage.GetEstimatedCostUsd(), usage.GetModel())
+
+	// ─── Source 2: GetExecutionUsageReport (billing records) ─────────────────
+	time.Sleep(2 * time.Second)
+
+	execReport, err := clients.AgentExecutionQuery.GetExecutionUsageReport(ctx,
+		&agentexecv1.GetExecutionUsageReportInput{ExecutionId: executionID})
+	require.NoError(t, err, "GetExecutionUsageReport should succeed")
+	require.NotNil(t, execReport, "execution report should not be nil")
+
+	agg := execReport.GetAggregate()
+	require.NotNil(t, agg, "execution report aggregate should be populated")
+
+	t.Logf("PLAN_EXECUTION_REPORT: input=%d output=%d calls=%d provider=%d billable=%d models=%d",
+		agg.GetInputTokens(), agg.GetOutputTokens(), agg.GetLlmCallCount(),
+		agg.GetProviderCostMicros(), agg.GetBillableCostMicros(),
+		len(execReport.GetModelBreakdown()))
+
+	assert.Greater(t, agg.GetLlmCallCount(), int32(0), "report llm_call_count > 0")
+	assert.Greater(t, agg.GetInputTokens(), int64(0), "report input_tokens > 0")
+	assert.Greater(t, agg.GetOutputTokens(), int64(0), "report output_tokens > 0")
+	assert.Greater(t, agg.GetBillableCostMicros(), int64(0),
+		"report billable_cost_micros > 0 (billing policy must be seeded)")
+
+	// ─── Decisive cross-reference ────────────────────────────────────────────
+	// The Cursor SDK agent turns drive streaming_usage; if those turns are
+	// metered, the billing aggregate must track them closely. If only the cheap
+	// session-title call is metered, billing_total stays tiny while
+	// streaming_total reflects the full plan — the divergence below catches it.
+	streamingTotal := usage.GetInputTokens() + usage.GetOutputTokens()
+	billingTotal := agg.GetInputTokens() + agg.GetOutputTokens()
+	require.Greater(t, streamingTotal, int64(0), "streaming total must be > 0 to cross-check")
+	require.Greater(t, billingTotal, int64(0), "billing total must be > 0 to cross-check")
+
+	ratio := float64(billingTotal) / float64(streamingTotal)
+	t.Logf("PLAN_CROSS_REF: streaming_total=%d billing_total=%d ratio=%.2f",
+		streamingTotal, billingTotal, ratio)
+	assert.InDelta(t, 1.0, ratio, 0.5,
+		"plan-mode billing and streaming token totals should be within 50%% of each other; "+
+			"a large gap means the Cursor agent turns were not metered (only the title call was)")
+
+	// ─── Session report parity ───────────────────────────────────────────────
+	sessionReport, err := clients.AgentExecutionQuery.GetSessionUsageReport(ctx,
+		&agentexecv1.GetSessionUsageReportInput{SessionId: sessionID})
+	require.NoError(t, err, "GetSessionUsageReport should succeed")
+	require.NotNil(t, sessionReport.GetTotalUsage(), "session total_usage should be populated")
+	assert.Greater(t, sessionReport.GetTotalUsage().GetBillableCostMicros(), int64(0),
+		"session billable_cost_micros > 0")
+}
+
+// TestAgentExecution_PlanMode_Streaming reproduces the reported defect where a
+// Plan-mode execution shows no live progress — the whole plan appears only in
+// the final snapshot. It subscribes to the execution and asserts that the AI
+// plan message is observed mid-flight (is_streaming=true with non-empty content)
+// on at least one non-terminal snapshot, proving the plan streamed incrementally
+// rather than arriving all at once at completion.
+//
+// Runs for both harnesses: native is the reference that already streams; cursor
+// is the one under investigation.
+func TestAgentExecution_PlanMode_Streaming(t *testing.T) {
+	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+
+	for _, h := range harness.Harnesses {
+		t.Run(h.Name, func(t *testing.T) {
+			h.Skip(t, testHarness)
+
+			ctx, cancel := harness.TestContext(t, 6*time.Minute)
+			defer cancel()
+
+			clients := harness.NewClients(grpcConn)
+			harness.RequireServiceHealthy(t, ctx, clients)
+
+			agent := harness.CreateAgent(t, ctx, clients, "test-plan-stream-"+h.Name,
+				"You are a helpful software engineer. When in Plan mode, produce a "+
+					"detailed plan without making any changes.")
+
+			session := harness.CreateTestSession(t, ctx, clients,
+				agent.GetStatus().GetDefaultInstanceId(), h.Harness)
+
+			exec := harness.CreateTestAgentExecution(t, ctx, clients,
+				session.GetMetadata().GetId(), planPrompt,
+				harness.WithExecutionConfig(&agentexecv1.ExecutionConfig{
+					InteractionMode: agentexecv1.InteractionMode_INTERACTION_MODE_PLAN,
+				}),
+			)
+			executionID := exec.GetMetadata().GetId()
+
+			streamCtx, streamCancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer streamCancel()
+
+			stream, err := clients.AgentExecutionQuery.Subscribe(streamCtx,
+				&agentexecv1.AgentExecutionId{Value: executionID})
+			require.NoError(t, err, "subscribe should succeed for execution %s", executionID)
+
+			type streamResult struct {
+				// sawStreamingPlanText is true if any NON-terminal snapshot carried
+				// an AI message that was actively streaming with non-empty content.
+				sawStreamingPlanText bool
+				// maxMidFlightLen is the longest AI content seen before terminal —
+				// proves partial content was delivered, not just the final blob.
+				maxMidFlightLen int
+				snapshotCount   int
+				err             error
+			}
+
+			resultCh := make(chan streamResult, 1)
+			go func() {
+				var res streamResult
+				for {
+					snap, recvErr := stream.Recv()
+					if recvErr != nil {
+						if !errors.Is(recvErr, io.EOF) && streamCtx.Err() == nil {
+							res.err = recvErr
+						}
+						resultCh <- res
+						return
+					}
+
+					res.snapshotCount++
+					phase := snap.GetStatus().GetPhase()
+					terminal := isTerminalPhase(phase)
+
+					if !terminal {
+						for _, msg := range snap.GetStatus().GetMessages() {
+							if msg.GetType() != agentexecv1.MessageType_MESSAGE_AI {
+								continue
+							}
+							content := strings.TrimSpace(msg.GetContent())
+							if len(content) > res.maxMidFlightLen {
+								res.maxMidFlightLen = len(content)
+							}
+							if msg.GetIsStreaming() && len(content) > 0 {
+								res.sawStreamingPlanText = true
+							}
+						}
+					}
+
+					if terminal {
+						resultCh <- res
+						return
+					}
+				}
+			}()
+
+			res := <-resultCh
+			streamCancel()
+
+			if res.err != nil {
+				harness.LogExecutionMessages(t, ctx, clients, executionID)
+				require.NoError(t, res.err, "stream should not error for execution %s", executionID)
+			}
+
+			t.Logf("plan streaming: harness=%s execution=%s snapshots=%d sawStreamingText=%t maxMidFlightLen=%d",
+				h.Name, executionID, res.snapshotCount, res.sawStreamingPlanText, res.maxMidFlightLen)
+
+			assert.True(t, res.sawStreamingPlanText,
+				"expected to observe the plan streaming live (an AI message with "+
+					"is_streaming=true and non-empty content on a non-terminal snapshot); "+
+					"if false, the plan only appeared at completion (no live processing) for %s",
+				executionID)
+		})
+	}
+}
+
+// TestAgentExecution_PlanMode_PublishesPlanArtifact verifies the Phase 4
+// contract: a completed Plan-mode execution publishes its plan as a first-class
+// `plan.md` FILE artifact on status.artifacts, for BOTH harnesses (the Cursor
+// harness gains an artifact path it did not previously have). This is the data
+// the web console's Plan card renders and that an Implement follow-up
+// references.
+func TestAgentExecution_PlanMode_PublishesPlanArtifact(t *testing.T) {
+	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+
+	for _, h := range harness.Harnesses {
+		t.Run(h.Name, func(t *testing.T) {
+			h.Skip(t, testHarness)
+
+			ctx, cancel := harness.TestContext(t, 6*time.Minute)
+			defer cancel()
+
+			clients := harness.NewClients(grpcConn)
+			harness.RequireServiceHealthy(t, ctx, clients)
+
+			agent := harness.CreateAgent(t, ctx, clients, "test-plan-artifact-"+h.Name,
+				"You are a helpful software engineer. When in Plan mode, produce a "+
+					"detailed plan without making any changes.")
+
+			session := harness.CreateTestSession(t, ctx, clients,
+				agent.GetStatus().GetDefaultInstanceId(), h.Harness)
+
+			exec := harness.CreateTestAgentExecution(t, ctx, clients,
+				session.GetMetadata().GetId(), planPrompt,
+				harness.WithExecutionConfig(&agentexecv1.ExecutionConfig{
+					InteractionMode: agentexecv1.InteractionMode_INTERACTION_MODE_PLAN,
+				}),
+			)
+			executionID := exec.GetMetadata().GetId()
+
+			waiter := harness.NewAgentExecutionWaiter(clients.AgentExecutionQuery, suiteLogger)
+			result, err := waiter.WaitForPhase(ctx, executionID,
+				agentexecv1.ExecutionPhase_EXECUTION_COMPLETED, 5*time.Minute)
+			require.NoError(t, err, "plan-mode execution should complete")
+
+			artifacts := result.GetStatus().GetArtifacts()
+			var plan *agentexecv1.ExecutionArtifact
+			for _, a := range artifacts {
+				if a.GetName() == "plan.md" {
+					plan = a
+					break
+				}
+			}
+
+			require.NotNil(t, plan,
+				"plan-mode execution should publish a plan.md artifact (got %d artifacts) for %s",
+				len(artifacts), executionID)
+
+			assert.Equal(t,
+				agentexecv1.ExecutionArtifactKind_EXECUTION_ARTIFACT_KIND_FILE, plan.GetKind(),
+				"plan.md should be a FILE artifact")
+			assert.NotEmpty(t, plan.GetStorageKey(), "plan.md should have a storage_key")
+			assert.Contains(t, plan.GetStorageKey(), executionID,
+				"plan.md storage_key should be scoped to the execution")
+			assert.NotEmpty(t, plan.GetDownloadUrl(), "plan.md should have a download_url")
+			assert.Greater(t, plan.GetSizeBytes(), int64(0), "plan.md should be non-empty")
+
+			t.Logf("plan artifact: harness=%s execution=%s name=%s size=%d storage_key=%s",
+				h.Name, executionID, plan.GetName(), plan.GetSizeBytes(), plan.GetStorageKey())
+		})
+	}
+}

--- a/tools/codegen/schemas/services/agentexecution.json
+++ b/tools/codegen/schemas/services/agentexecution.json
@@ -310,7 +310,7 @@
               "APPROVAL_ACTION_APPROVE_ALL"
             ]
           },
-          "description": "User's decision: APPROVE, SKIP, or REJECT.\n APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.",
+          "description": "User's decision: APPROVE, SKIP, REJECT, or APPROVE_ALL.\n APPROVAL_ACTION_UNSPECIFIED (0) is rejected by validation.",
           "required": false
         },
         {


### PR DESCRIPTION
## Summary

Plan-mode executions now publish their final plan as a first-class `plan.md` `ExecutionArtifact` for **both** harnesses (native deepagents + Cursor), and the console renders a reviewable **Plan card** (`PlanArtifactCard`) with expand-to-review, Copy, Download, and Implement — instead of a bare CTA on an ordinary chat message. Native PLAN mode is also now read-only by construction.

- `shared/plan-artifact.ts` `publishPlanArtifact()` uploads the final plan as `artifacts/{executionId}/plan.md` via the existing `ArtifactStorage` factory and registers an immutable artifact on `status.artifacts` (idempotent, non-fatal). Wired into both `execute-deep-agent` and `execute-cursor` finalization, gated on `InteractionMode.PLAN`. Chat message = live view; artifact = durable/exportable view (single source of truth).
- React: `library/detect-plan-artifact.ts` + `execution/PlanArtifactCard.tsx`; `MessageThread` renders the card when a plan artifact exists, else falls back to `PlanCompletionCard`.
- Native PLAN read-only: `execute-deep-agent/setup.ts` passes `permissions` deny-write to `createDeepAgent` under `InteractionMode.PLAN`, enforcing the proto contract by construction.

The second commit is an unrelated `chore(codegen)`: agentexecution stub sync for the merged `APPROVE_ALL` proto change (kept as a separate, generated-only commit).

> Dependency: the `PublishesPlanArtifact` integration assertion requires the paired presigned-upload header-contract fix (stigmer#159 / stigmer-cloud#132). Live integration tests need API keys and don't run in standard CI. Merge the presigner fix first.

Paired cloud PR (changelog + stub sync): stigmer/stigmer-cloud#133

## Test plan

- [x] Runner Vitest: `shared/__tests__/plan-artifact.test.ts`
- [x] React: `library/__tests__/detect-plan-artifact.test.ts`
- [x] Integration (live): `TestAgentExecution_PlanMode_PublishesPlanArtifact` passes on both harnesses (with the presigner fix); `_Streaming` and `_CursorUsage` exercised (see metering note in the cloud PR).