### PR TITLE
ci: publish stigmer-runner-host (crates.io) and @stigmer/runner (npm)

### DIFF
--- a/.github/workflows/ci.crate.yaml
+++ b/.github/workflows/ci.crate.yaml
@@ -1,0 +1,104 @@
+# =============================================================================
+# Rust crate quality gate: stigmer-runner-host
+# =============================================================================
+# This is the only CI that exercises the Rust crate as a standalone artifact
+# (elsewhere Rust is compiled solely inside release.desktop). It guards the
+# crate before it ships to crates.io, so it must stay green on `main`.
+#
+# Two independent jobs:
+#   - `rust`         — fmt, clippy (both feature sets), build + test. The crate
+#                      MUST build without Tauri (framework-agnostic core) and
+#                      with it (the desktop binding), so we check both.
+#   - `ipc-fixtures` — proves the crate's vendored IPC fixture is still
+#                      byte-identical to what the canonical runner contract
+#                      (backend/services/runner/src/ipc-protocol.ts) generates.
+#                      Triggered on the runner protocol source too, so a
+#                      contract change that forgets to regenerate the crate copy
+#                      fails here rather than silently drifting.
+# =============================================================================
+
+name: ci.crate
+
+on:
+  pull_request:
+    paths:
+      - "crates/stigmer-runner-host/**"
+      - "backend/services/runner/src/ipc-protocol.ts"
+      - "backend/services/runner/src/ipc-protocol-fixtures.ts"
+      - ".github/workflows/ci.crate.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/stigmer-runner-host/**"
+      - "backend/services/runner/src/ipc-protocol.ts"
+      - "backend/services/runner/src/ipc-protocol-fixtures.ts"
+      - ".github/workflows/ci.crate.yaml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ci-crate-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: fmt / clippy / build / test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/stigmer-runner-host
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "crates/stigmer-runner-host -> target"
+
+      # The `tauri` feature pulls in the Tauri crate, which needs system webkit
+      # libraries to compile on Linux (mirrors release.desktop's Linux deps).
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy (default, no Tauri)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Clippy (tauri feature)
+        run: cargo clippy --all-targets --features tauri -- -D warnings
+
+      - name: Build + test (no Tauri)
+        run: cargo build && cargo test
+
+      - name: Build (tauri feature)
+        run: cargo build --features tauri
+
+  ipc-fixtures:
+    name: IPC fixture freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # `make gen-ipc-fixtures-check` installs the runner's deps on demand, then
+      # regenerates the golden fixtures and fails if either committed copy (the
+      # runner's or the crate's) differs.
+      - name: Verify golden IPC fixtures are fresh
+        run: make gen-ipc-fixtures-check

--- a/.github/workflows/release.crate.yaml
+++ b/.github/workflows/release.crate.yaml
@@ -1,0 +1,101 @@
+# =============================================================================
+# Publish the stigmer-runner-host crate to crates.io
+# =============================================================================
+# Joins the platform's v* lockstep release train: a `v*` tag publishes this
+# crate at the same version as every other artifact (npm, Maven, PyPI, ...).
+#
+# WHY lockstep for a crate with no proto dependency: the crate's only real
+# compatibility axis is IPC_PROTOCOL_VERSION (see src/protocol.rs), not the
+# proto/SDK contract. We still ride the platform version for uniformity — one
+# version number describes the whole system. The accepted cost: a *breaking*
+# Rust API change to this crate must land in a platform MAJOR bump, never a
+# minor/patch, or it violates Cargo semver. Revisit independent versioning if
+# that ever becomes constraining.
+#
+# Auth: token-based via the CARGO_REGISTRY_TOKEN secret (matching the NPM_TOKEN
+# / MAVEN_CENTRAL_* convention). OIDC Trusted Publishing is a deferred hardening.
+# =============================================================================
+
+name: release.crate
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${{ github.ref_name }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="v${{ github.event.inputs.version }}"
+          fi
+          VERSION_NO_V="${VERSION#v}"
+          echo "version=$VERSION_NO_V" >> $GITHUB_OUTPUT
+          echo "Publishing stigmer-runner-host at version: $VERSION_NO_V"
+
+  publish:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "crates/stigmer-runner-host -> target"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Cargo-native version stamping (analogue of maven versions:set / the python
+      # regex). Prebuilt binary so it installs in seconds.
+      - name: Install cargo-edit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-edit
+
+      - name: Stamp crate version from tag
+        working-directory: crates/stigmer-runner-host
+        run: cargo set-version "${{ needs.determine-version.outputs.version }}"
+
+      # Builds the no-Tauri core and runs the conformance tests (crate vs its
+      # vendored IPC fixture). The fixture's freshness against the canonical
+      # runner contract is already enforced pre-merge by ci.crate.
+      - name: Build + test (no Tauri)
+        run: make test-runner-host
+
+      - name: Verify golden IPC fixtures are fresh
+        run: make gen-ipc-fixtures-check
+
+      - name: Publish dry-run
+        working-directory: crates/stigmer-runner-host
+        run: cargo publish --dry-run --allow-dirty
+
+      - name: Publish to crates.io
+        working-directory: crates/stigmer-runner-host
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --allow-dirty

--- a/.github/workflows/release.runner.yaml
+++ b/.github/workflows/release.runner.yaml
@@ -1,0 +1,139 @@
+# =============================================================================
+# Publish the @stigmer/runner npm package
+# =============================================================================
+# Joins the platform's v* lockstep release train: a `v*` tag publishes the
+# runner at the same version as @stigmer/protos and the SDKs, with its
+# @stigmer/protos dependency pinned to that exact version (the runner's analogue
+# of how release.maven / release.python-sdk pin the protos package).
+#
+# The runner is deliberately NOT an npm workspace (see root package.json), so it
+# is built via `make build-runner` rather than the workspace publish-libs.mjs
+# path — which keeps that script a clean workspace-only iterator.
+#
+# Ordering: @stigmer/protos@<version> is published by release.npm-libs on the
+# same tag, in parallel. We wait for it to appear before publishing so a
+# consumer of @stigmer/runner never resolves a missing protos dependency
+# (mirrors the wait-for-@stigmer/ink guard in release.cli).
+# =============================================================================
+
+name: release.runner
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 1.0.0 or 1.0.0-rc.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      npm_tag: ${{ steps.version.outputs.npm_tag }}
+    steps:
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${{ github.ref_name }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="v${{ github.event.inputs.version }}"
+          fi
+          VERSION_NO_V="${VERSION#v}"
+          # Pre-release versions (e.g. 1.2.0-rc.0) publish under the npm "next"
+          # dist-tag so they never become the default `npm install` target.
+          if [[ "$VERSION_NO_V" == *-* ]]; then
+            NPM_TAG="next"
+          else
+            NPM_TAG="latest"
+          fi
+          echo "version=$VERSION_NO_V" >> $GITHUB_OUTPUT
+          echo "npm_tag=$NPM_TAG" >> $GITHUB_OUTPUT
+          echo "Publishing @stigmer/runner@$VERSION_NO_V (dist-tag: $NPM_TAG)"
+
+  publish:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate TypeScript proto stubs
+        run: make -C apis ts-stubs
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Builds @stigmer/protos dist, installs the runner's own deps, and compiles
+      # the runner to dist/. Runs while @stigmer/protos is still the local file:
+      # link so tsc resolves types against the in-repo stubs.
+      - name: Build runner
+        run: make build-runner
+
+      # Stamp the release version and pin @stigmer/protos from the local file:
+      # link to the exact published version, so the published manifest is
+      # self-contained. The committed package.json is only mutated in this
+      # ephemeral CI checkout.
+      - name: Stamp version and pin protos dependency
+        working-directory: backend/services/runner
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const path = 'package.json';
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            pkg.version = process.env.VERSION;
+            pkg.dependencies['@stigmer/protos'] = process.env.VERSION;
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+            console.log('stamped @stigmer/runner@' + pkg.version + ' (protos: ' + pkg.dependencies['@stigmer/protos'] + ')');
+          "
+
+      - name: Verify published file list
+        working-directory: backend/services/runner
+        run: npm pack --dry-run
+
+      - name: Wait for @stigmer/protos on npm
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          echo "Waiting for @stigmer/protos@$VERSION on npm (published by release.npm-libs)..."
+          for i in $(seq 1 60); do
+            if npm view "@stigmer/protos@$VERSION" version >/dev/null 2>&1; then
+              echo "Found @stigmer/protos@$VERSION"
+              exit 0
+            fi
+            echo "Attempt $i/60: not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "ERROR: @stigmer/protos@$VERSION not found on npm after 10 minutes."
+          echo "@stigmer/runner pins it as a dependency; publishing now would leave consumers unresolvable."
+          exit 1
+
+      - name: Publish to npm
+        working-directory: backend/services/runner
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag "${{ needs.determine-version.outputs.npm_tag }}"

--- a/crates/stigmer-runner-host/Cargo.toml
+++ b/crates/stigmer-runner-host/Cargo.toml
@@ -1,14 +1,21 @@
 [package]
 name = "stigmer-runner-host"
+# Placeholder; the published version is stamped from the release `v*` tag in
+# release.crate.yaml (lockstep with the rest of the platform). The desktop app
+# consumes this crate by path, so the committed value is irrelevant to it.
 version = "0.1.0"
 edition = "2021"
+# MSRV is driven by the optional `tauri` feature (Tauri 2 requires >= 1.77.2). The
+# default no-Tauri build compiles on older toolchains, but a package has one
+# rust-version, so we declare the higher floor to stay honest for every feature set.
+rust-version = "1.78"
 description = "Embed the Stigmer runner as a manager-mode subprocess over its stdin/stdout JSON IPC."
 authors = ["Stigmer <oss@stigmer.ai>"]
 license = "Apache-2.0"
 repository = "https://github.com/stigmer/stigmer"
-# Vendored in-repo (path dependency from the desktop app) until an external consumer
-# needs it from crates.io. See _projects T06 / design-decisions/001.
-publish = false
+readme = "README.md"
+keywords = ["stigmer", "runner", "ipc", "subprocess", "agents"]
+categories = ["asynchronous", "api-bindings"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -24,3 +31,8 @@ tauri = { version = "2", optional = true }
 # The Tauri binding (RunnerState + #[tauri::command] surface). Off by default so the core
 # driver stays framework-agnostic for non-Tauri hosts (CLIs, daemons, test harnesses).
 tauri = ["dep:tauri"]
+
+# docs.rs builds with the Tauri binding enabled so the `tauri` module is documented;
+# the default build hides it behind the feature flag.
+[package.metadata.docs.rs]
+features = ["tauri"]

--- a/crates/stigmer-runner-host/src/host.rs
+++ b/crates/stigmer-runner-host/src/host.rs
@@ -95,8 +95,14 @@ impl RunnerHost {
         cmd.stderr(std::process::Stdio::piped());
 
         let mut child = cmd.spawn().map_err(RunnerHostError::Spawn)?;
-        let stdin = child.stdin.take().ok_or_else(|| RunnerHostError::pipe("stdin"))?;
-        let stdout = child.stdout.take().ok_or_else(|| RunnerHostError::pipe("stdout"))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| RunnerHostError::pipe("stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| RunnerHostError::pipe("stdout"))?;
 
         if let Some(stderr) = child.stderr.take() {
             let log = self.log.clone();
@@ -283,7 +289,9 @@ fn negotiate_ready(line: &str) -> Result<u32, RunnerHostError> {
             Ok(runner)
         }
         IpcResponse::Error { message, .. } => Err(RunnerHostError::RunnerStartup { message }),
-        other => Err(RunnerHostError::UnexpectedFirstMessage(format!("{other:?}"))),
+        other => Err(RunnerHostError::UnexpectedFirstMessage(format!(
+            "{other:?}"
+        ))),
     }
 }
 
@@ -371,16 +379,13 @@ mod tests {
 
     #[test]
     fn non_ready_first_message_is_unexpected() {
-        let err =
-            negotiate_ready(r#"{"type":"sessionAdded","sessionId":"s","taskQueue":"q"}"#)
-                .unwrap_err();
+        let err = negotiate_ready(r#"{"type":"sessionAdded","sessionId":"s","taskQueue":"q"}"#)
+            .unwrap_err();
         assert!(matches!(err, RunnerHostError::UnexpectedFirstMessage(_)));
     }
 
     fn env_value<'a>(env: &'a [(String, String)], key: &str) -> Option<&'a str> {
-        env.iter()
-            .find(|(k, _)| k == key)
-            .map(|(_, v)| v.as_str())
+        env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
     }
 
     fn minimal_config() -> RunnerConfig {

--- a/crates/stigmer-runner-host/src/protocol.rs
+++ b/crates/stigmer-runner-host/src/protocol.rs
@@ -22,14 +22,24 @@ pub const IPC_PROTOCOL_VERSION: u32 = 1;
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum IpcCommand {
     #[serde(rename_all = "camelCase")]
-    AddSession { session_id: String },
+    AddSession {
+        session_id: String,
+    },
     #[serde(rename_all = "camelCase")]
-    RemoveSession { session_id: String },
+    RemoveSession {
+        session_id: String,
+    },
     #[serde(rename_all = "camelCase")]
-    AddWorkflowExecution { execution_id: String },
+    AddWorkflowExecution {
+        execution_id: String,
+    },
     #[serde(rename_all = "camelCase")]
-    RemoveWorkflowExecution { execution_id: String },
-    UpdateToken { token: Option<String> },
+    RemoveWorkflowExecution {
+        execution_id: String,
+    },
+    UpdateToken {
+        token: Option<String>,
+    },
     Shutdown,
 }
 
@@ -54,16 +64,23 @@ pub enum IpcResponse {
         task_queue: String,
     },
     #[serde(rename_all = "camelCase")]
-    SessionRemoved { session_id: String },
+    SessionRemoved {
+        session_id: String,
+    },
     #[serde(rename_all = "camelCase")]
     WorkflowExecutionAdded {
         execution_id: String,
         task_queue: String,
     },
     #[serde(rename_all = "camelCase")]
-    WorkflowExecutionRemoved { execution_id: String },
+    WorkflowExecutionRemoved {
+        execution_id: String,
+    },
     TokenUpdated,
-    Error { message: String, fatal: bool },
+    Error {
+        message: String,
+        fatal: bool,
+    },
     ShutdownComplete,
 }
 
@@ -90,7 +107,11 @@ mod tests {
             serde_json::from_str(r#"{"type":"ready","protocolVersion":1}"#).unwrap();
         match resp {
             IpcResponse::Ready { protocol_version } => {
-                assert_eq!(protocol_version, Some(1), "should read the advertised version");
+                assert_eq!(
+                    protocol_version,
+                    Some(1),
+                    "should read the advertised version"
+                );
             }
             other => panic!("expected Ready, got {other:?}"),
         }
@@ -109,7 +130,10 @@ mod tests {
 
     #[test]
     fn protocol_version_is_one() {
-        assert_eq!(IPC_PROTOCOL_VERSION, 1, "bump only on a breaking IPC change");
+        assert_eq!(
+            IPC_PROTOCOL_VERSION, 1,
+            "bump only on a breaking IPC change"
+        );
     }
 
     // The version this crate speaks must equal the version the canonical contract stamps.
@@ -130,23 +154,33 @@ mod tests {
         let cases: [(&str, IpcCommand); 7] = [
             (
                 "addSession",
-                IpcCommand::AddSession { session_id: "ses_example".into() },
+                IpcCommand::AddSession {
+                    session_id: "ses_example".into(),
+                },
             ),
             (
                 "removeSession",
-                IpcCommand::RemoveSession { session_id: "ses_example".into() },
+                IpcCommand::RemoveSession {
+                    session_id: "ses_example".into(),
+                },
             ),
             (
                 "addWorkflowExecution",
-                IpcCommand::AddWorkflowExecution { execution_id: "wfe_example".into() },
+                IpcCommand::AddWorkflowExecution {
+                    execution_id: "wfe_example".into(),
+                },
             ),
             (
                 "removeWorkflowExecution",
-                IpcCommand::RemoveWorkflowExecution { execution_id: "wfe_example".into() },
+                IpcCommand::RemoveWorkflowExecution {
+                    execution_id: "wfe_example".into(),
+                },
             ),
             (
                 "updateTokenSet",
-                IpcCommand::UpdateToken { token: Some("tok_example".into()) },
+                IpcCommand::UpdateToken {
+                    token: Some("tok_example".into()),
+                },
             ),
             (
                 "updateTokenCleared",
@@ -175,14 +209,21 @@ mod tests {
 
         assert!(matches!(
             from("ready"),
-            IpcResponse::Ready { protocol_version: Some(1) }
+            IpcResponse::Ready {
+                protocol_version: Some(1)
+            }
         ));
         assert!(matches!(
             from("readyLegacy"),
-            IpcResponse::Ready { protocol_version: None }
+            IpcResponse::Ready {
+                protocol_version: None
+            }
         ));
         match from("sessionAdded") {
-            IpcResponse::SessionAdded { session_id, task_queue } => {
+            IpcResponse::SessionAdded {
+                session_id,
+                task_queue,
+            } => {
                 assert_eq!(session_id, "ses_example");
                 assert_eq!(task_queue, "session:ses_example");
             }
@@ -193,7 +234,10 @@ mod tests {
             other => panic!("expected SessionRemoved, got {other:?}"),
         }
         match from("workflowExecutionAdded") {
-            IpcResponse::WorkflowExecutionAdded { execution_id, task_queue } => {
+            IpcResponse::WorkflowExecutionAdded {
+                execution_id,
+                task_queue,
+            } => {
                 assert_eq!(execution_id, "wfe_example");
                 assert_eq!(task_queue, "wfexec:wfe_example");
             }
@@ -213,6 +257,9 @@ mod tests {
             }
             other => panic!("expected Error, got {other:?}"),
         }
-        assert!(matches!(from("shutdownComplete"), IpcResponse::ShutdownComplete));
+        assert!(matches!(
+            from("shutdownComplete"),
+            IpcResponse::ShutdownComplete
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Makes both runner artifacts public on the existing `v*` lockstep release train, each independently installable, so external integrators (e.g. Planton) can consume them:

- **`stigmer-runner-host` → crates.io** via `release.crate.yaml` (version stamped from the `v*` tag, gated by `test-runner-host` + IPC fixture freshness, token-based with `CARGO_REGISTRY_TOKEN`).
- **`@stigmer/runner` → npm** via `release.runner.yaml` (built with `make build-runner`, `@stigmer/protos` pinned to the tag version, waits for `protos@version` like `release.cli` waits for `@stigmer/ink`, publishes with `NPM_TOKEN`).
- **`ci.crate.yaml`** — the first Rust CI gate (fmt, clippy `-D warnings` on both feature sets, build + test, IPC fixture freshness).

`Cargo.toml`: drops `publish = false`, adds crates.io metadata. `host.rs`/`protocol.rs` are `cargo fmt` canonicalization only (no logic change) to satisfy the new fmt gate.

## Design notes

- Both artifacts join the `v*` lockstep train rather than inventing bespoke tags — consistent with `release.npm-libs`/`maven`/`python-sdk`/`cli`/`mcp-server`/`desktop`/`buf`.
- The crate has no proto dependency; its real compat axis is `IPC_PROTOCOL_VERSION`. Accepted caveat (documented in the workflow header): a breaking Rust API change must land in a platform MAJOR bump.
- crates.io auth is token-based (matching `NPM_TOKEN`/`MAVEN_CENTRAL_*`); OIDC Trusted Publishing is a deferred hardening.

## Test plan

- [x] `cargo fmt --check`, `clippy -D warnings` (default + `tauri`), `cargo build` (both), `cargo test`
- [x] `cargo publish --dry-run` packages cleanly (12 files)
- [x] `make gen-ipc-fixtures-check` green
- [ ] CI green on this PR (`ci.crate`)
- [ ] First crates.io publish (name claim) — requires `CARGO_REGISTRY_TOKEN` secret
- [ ] First `@stigmer/runner` publish on next `v*` release

## Follow-ups before publish

- Set `CARGO_REGISTRY_TOKEN` repo secret (rotate the token first).
- Decide crate owner GitHub team for `cargo owner --add`.

Made with [Cursor](https://cursor.com)