### PR TITLE
ci(mcp-server): drop flaky type=gha build cache

### DIFF
--- a/.github/workflows/release.mcp-server.yaml
+++ b/.github/workflows/release.mcp-server.yaml
@@ -95,6 +95,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # No build cache: the image is a single `npm install --global` layer that
+      # builds in well under a minute per platform, so the GitHub Actions cache
+      # (type=gha) buys nothing. Worse, `cache-to type=gha,mode=max` has hung the
+      # export for up to an hour (see the v3.1.11 release), so we omit it entirely.
       - name: Build and push Docker image
         env:
           VERSION: ${{ needs.determine-version.outputs.version }}
@@ -106,8 +110,6 @@ jobs:
             --build-arg MCP_SERVER_VERSION=$NPM_VERSION \
             --tag ghcr.io/stigmer/mcp-server-stigmer:$VERSION \
             --tag ghcr.io/stigmer/mcp-server-stigmer:latest \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
             --push \
             .
 


### PR DESCRIPTION
## Summary

The `release.mcp-server` Docker build hung for ~1 hour on the **v3.1.11** release, stalling in the `cache-to type=gha,mode=max` cache-export step (the re-run hung the same way). This removes the GitHub Actions build cache from the job.

- The image is a single `npm install --global @stigmer/mcp-server@<version>` layer that builds in **well under a minute per platform** — verified at ~34s total locally with **no** cache.
- `type=gha` therefore provides no meaningful speedup while being the **sole source of the hangs** (the intermittently-degraded Actions cache backend).
- Dropping `--cache-from`/`--cache-to type=gha` makes the release build fast and reliable. Combined with the already-merged `timeout-minutes: 25` and explicit `Set up QEMU` step, the job now fails fast and no longer depends on the flaky cache.

### Evidence

| Run | Build step duration |
|---|---|
| v3.1.10 (healthy) | 47s |
| v3.1.11 original | hung ~1h |
| v3.1.11 re-run | hung 15+ min (cancelled) |
| Local build, no `type=gha` cache | **34s total** |

Note: the v3.1.11 image (`v3.1.11` + `latest`, multi-arch amd64/arm64) was already published manually to `ghcr.io/stigmer/mcp-server-stigmer` to unblock the release.

## Test plan

- [ ] Next `v*` tag push triggers `release.mcp-server` and the `build-docker-image` job completes in ~1 min without hanging.
- [ ] Published image is multi-arch (`linux/amd64` + `linux/arm64`) and `latest` advances.

Made with [Cursor](https://cursor.com)