### PR TITLE
feat(runner-host): add LLM credential fields and guarded extra_env

### DIFF
--- a/client-apps/cli/src/local/daemon/components.test.ts
+++ b/client-apps/cli/src/local/daemon/components.test.ts
@@ -47,6 +47,21 @@ describe("buildRunnerEnv", () => {
     expect(withKey.STIGMER_ACTIVITY_ROUTING).toBe("session");
   });
 
+  it("forwards LLM provider keys only when set, resolved value winning over the base env", () => {
+    const bare = buildRunnerEnv(config, {});
+    expect(bare.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(bare.OPENAI_API_KEY).toBeUndefined();
+
+    // The contract value is authoritative: the launcher already applied the
+    // env > config precedence, so whatever sits in the child's base env must
+    // not override the resolved key.
+    const env = buildRunnerEnv(
+      { ...config, anthropicApiKey: "sk-ant-resolved" },
+      { ANTHROPIC_API_KEY: "sk-ant-other" },
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-resolved");
+  });
+
   // The regression guard for the queue bug: the server dispatches to, and the
   // runner polls, the exact same queue.
   it("pins the runner's poll queue to the server's dispatch queue", () => {

--- a/client-apps/cli/src/local/daemon/components.ts
+++ b/client-apps/cli/src/local/daemon/components.ts
@@ -51,6 +51,10 @@ export function buildRunnerEnv(config: DaemonConfig, base: NodeJS.ProcessEnv = p
     LOG_LEVEL: base.LOG_LEVEL ?? "info",
   };
   if (config.cursorApiKey !== undefined) env.CURSOR_API_KEY = config.cursorApiKey;
+  // Explicit set (after the base spread) so the launcher-resolved key wins over any
+  // stale inherited value — the delivery path for a `stigmer setup`-persisted key.
+  if (config.anthropicApiKey !== undefined) env.ANTHROPIC_API_KEY = config.anthropicApiKey;
+  if (config.openaiApiKey !== undefined) env.OPENAI_API_KEY = config.openaiApiKey;
   if (config.activityRouting !== undefined) env.STIGMER_ACTIVITY_ROUTING = config.activityRouting;
   return env;
 }

--- a/client-apps/cli/src/local/daemon/env.test.ts
+++ b/client-apps/cli/src/local/daemon/env.test.ts
@@ -26,6 +26,8 @@ describe("buildDaemonEnv + readDaemonConfig", () => {
       serverBin: "/usr/local/bin/stigmer-server",
       runner: { nodeBin: "/usr/bin/node", entryPath: "/repo/runner/dist/main.js", appDir: "/repo/runner" },
       cursorApiKey: undefined,
+      anthropicApiKey: undefined,
+      openaiApiKey: undefined,
       activityRouting: undefined,
     });
   });
@@ -42,6 +44,22 @@ describe("buildDaemonEnv + readDaemonConfig", () => {
     const config = readDaemonConfig(env);
     expect(config.cursorApiKey).toBe("ck");
     expect(config.activityRouting).toBe("session");
+  });
+
+  // The config-file-only delivery path: a key from `stigmer setup` is not in the
+  // shell env, so the launcher must write it into the contract explicitly.
+  it("delivers a launcher-resolved LLM key with no help from the base env", () => {
+    const env = buildDaemonEnv({ ...baseInputs, anthropicApiKey: "sk-ant-cfg" }, {});
+    const config = readDaemonConfig(env);
+    expect(config.anthropicApiKey).toBe("sk-ant-cfg");
+    expect(config.openaiApiKey).toBeUndefined();
+  });
+
+  it("passes shell-exported LLM keys through from the base env", () => {
+    const env = buildDaemonEnv(baseInputs, { ANTHROPIC_API_KEY: "sk-ant-env", OPENAI_API_KEY: "sk-oai-env" });
+    const config = readDaemonConfig(env);
+    expect(config.anthropicApiKey).toBe("sk-ant-env");
+    expect(config.openaiApiKey).toBe("sk-oai-env");
   });
 
   it("requires the data dir and server binary", () => {

--- a/client-apps/cli/src/local/daemon/env.ts
+++ b/client-apps/cli/src/local/daemon/env.ts
@@ -17,6 +17,8 @@ export const DaemonEnvVar = {
   RunnerEntry: "STIGMER_RUNNER_ENTRY",
   RunnerAppDir: "STIGMER_RUNNER_APP_DIR",
   CursorApiKey: "CURSOR_API_KEY",
+  AnthropicApiKey: "ANTHROPIC_API_KEY",
+  OpenAiApiKey: "OPENAI_API_KEY",
   ActivityRouting: "STIGMER_ACTIVITY_ROUTING",
 } as const;
 
@@ -38,6 +40,8 @@ export interface DaemonConfig {
   serverBin: string;
   runner?: RunnerLaunch;
   cursorApiKey?: string;
+  anthropicApiKey?: string;
+  openaiApiKey?: string;
   activityRouting?: string;
 }
 
@@ -51,6 +55,12 @@ export interface DaemonEnvInputs {
   noWeb: boolean;
   serverBin: string;
   runner?: RunnerLaunch;
+  // LLM provider key resolved by the launcher (env > config file). Must be written
+  // into the daemon env explicitly: unlike a shell-exported key, a key persisted by
+  // `stigmer setup` exists only in the config file and would otherwise never reach
+  // the runner. Only the effective provider's key is set.
+  anthropicApiKey?: string;
+  openaiApiKey?: string;
 }
 
 /**
@@ -72,6 +82,8 @@ export function buildDaemonEnv(inputs: DaemonEnvInputs, base: NodeJS.ProcessEnv 
     env[DaemonEnvVar.RunnerEntry] = inputs.runner.entryPath;
     env[DaemonEnvVar.RunnerAppDir] = inputs.runner.appDir;
   }
+  if (inputs.anthropicApiKey !== undefined) env[DaemonEnvVar.AnthropicApiKey] = inputs.anthropicApiKey;
+  if (inputs.openaiApiKey !== undefined) env[DaemonEnvVar.OpenAiApiKey] = inputs.openaiApiKey;
   return env;
 }
 
@@ -93,6 +105,8 @@ export function readDaemonConfig(env: NodeJS.ProcessEnv = process.env): DaemonCo
     serverBin: required(env, DaemonEnvVar.ServerBin),
     runner: serverOnly ? undefined : runner,
     cursorApiKey: nonEmpty(env[DaemonEnvVar.CursorApiKey]),
+    anthropicApiKey: nonEmpty(env[DaemonEnvVar.AnthropicApiKey]),
+    openaiApiKey: nonEmpty(env[DaemonEnvVar.OpenAiApiKey]),
     activityRouting: nonEmpty(env[DaemonEnvVar.ActivityRouting]),
   };
 }

--- a/client-apps/cli/src/local/daemon/launch.ts
+++ b/client-apps/cli/src/local/daemon/launch.ts
@@ -21,10 +21,11 @@ import { readPidFile, removePidFile } from "../state/pidfile.js";
 import { findProcessByPort, isProcessAlive, killProcess } from "../state/proc.js";
 import { type StartupConfig, removeStartupConfig, saveStartupConfig } from "../state/startup-config.js";
 import { rotateLogs } from "../state/log-rotation.js";
+import { resolveApiKey, resolveProvider } from "../llm-config.js";
 import { ensureRunner } from "../runtime/runner.js";
 import { ensureServerBinary } from "../runtime/server.js";
 import { TemporalManager } from "../temporal/manager.js";
-import { buildDaemonEnv } from "./env.js";
+import { buildDaemonEnv, type DaemonEnvInputs } from "./env.js";
 
 /** How long `up` waits for the server's gRPC port after spawning the daemon. */
 const READY_TIMEOUT_MS = 60_000;
@@ -75,6 +76,7 @@ export async function up(options: UpOptions = {}, home: string = homedir()): Pro
       noWeb: options.noWeb === true,
       serverBin,
       runner,
+      ...resolveLlmKeyInputs(config),
     },
     process.env,
   );
@@ -219,6 +221,25 @@ async function stopManagedTemporal(home: string): Promise<void> {
     await TemporalManager.forHome(home).stop();
   } catch (err) {
     log.debug("managed Temporal stop skipped", { error: String(err) });
+  }
+}
+
+// LLM-key delivery for the runner: a key persisted by `stigmer setup` lives only in
+// the config file, so the launcher must write it into the daemon contract explicitly
+// — unlike a shell-exported key, it cannot flow by env inheritance. resolveApiKey's
+// precedence (env var > config file) makes both cases one code path; when the env
+// var is set this re-writes the same value. Only the effective provider's key is
+// passed: the config file stores a single key, keyed to the chosen provider.
+function resolveLlmKeyInputs(config: Config): Pick<DaemonEnvInputs, "anthropicApiKey" | "openaiApiKey"> {
+  const key = resolveApiKey(config);
+  if (key === "") return {};
+  switch (resolveProvider(config)) {
+    case "anthropic":
+      return { anthropicApiKey: key };
+    case "openai":
+      return { openaiApiKey: key };
+    default:
+      return {};
   }
 }
 

--- a/crates/stigmer-runner-host/README.md
+++ b/crates/stigmer-runner-host/README.md
@@ -21,13 +21,16 @@ host.start(RunnerConfig {
     // resolves a relative entry against the working directory, which is `/` for a
     // GUI app. A path that does not resolve fails fast with `RunnerEntryNotFound`.
     runner_entry: "/path/to/resources/runner/dist/main.js".into(),
-    temporal_address: "localhost:7233".into(),
+    temporal_address: Some("localhost:7233".into()),
     stigmer_endpoint: "http://localhost:7234".into(),
     temporal_namespace: None,
     stigmer_token: None,
     cursor_api_key: None,
+    anthropic_api_key: None,
+    openai_api_key: None,
     workspace_root_dir: None,
     proxy_endpoint: None,
+    extra_env: Default::default(),
 })
 .await?;
 
@@ -39,6 +42,29 @@ host.stop().await?;
 
 The crate does not bundle the Node runner; point `node_binary` + `runner_entry` at an
 installed `@stigmer/runner`.
+
+## LLM credentials (BYOK / direct mode)
+
+The runner resolves model credentials in one of two modes, decided by `proxy_endpoint`:
+
+- **Proxy mode** (`proxy_endpoint: Some(..)`) — model traffic routes through the Stigmer
+  proxy, which injects provider keys server-side. The runner authenticates with
+  `stigmer_token`; do not pass provider keys. This is how the Stigmer desktop app runs
+  against Stigmer Cloud.
+- **Direct mode** (`proxy_endpoint: None`) — the runner calls the providers itself with
+  keys you supply: `anthropic_api_key` and/or `openai_api_key` for the native harness,
+  `cursor_api_key` for the Cursor harness. Without them, executions fail at model-call
+  time with `LLM_MISSING_API_KEY`.
+
+Pass credentials through these typed fields, not by mutating your own process
+environment before `start()` — the spawn env is composed from the config, so the typed
+fields are the supported channel (and the only discoverable one).
+
+`extra_env` forwards any additional environment to the spawned runner (for example
+`LOG_LEVEL`, or `STIGMER_RUNNER_HITL_SECRET` to pin a HITL fingerprint key across
+replicas). Keys the host owns — everything the crate composes itself, including the
+credential vars above — are **reserved**: `start()` rejects them with
+`ReservedEnvKey`, pointing at the typed field to use instead.
 
 ## Tauri binding
 

--- a/crates/stigmer-runner-host/src/config.rs
+++ b/crates/stigmer-runner-host/src/config.rs
@@ -4,6 +4,8 @@
 //! TOML/JSON or building it in code uses this directly; the Tauri binding maps its
 //! camelCase JS input onto it (see the `tauri` module).
 
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 /// Inputs the host supplies to launch the runner. The crate does not bundle the Node
@@ -21,8 +23,21 @@ pub struct RunnerConfig {
     pub temporal_namespace: Option<String>,
     pub stigmer_token: Option<String>,
     pub cursor_api_key: Option<String>,
+    /// Anthropic API key for BYOK direct mode (no `proxy_endpoint`), where the runner's
+    /// native harness calls the provider itself. Unused in proxy mode — the proxy
+    /// injects provider keys server-side.
+    pub anthropic_api_key: Option<String>,
+    /// OpenAI API key for BYOK direct mode. Same contract as `anthropic_api_key`.
+    pub openai_api_key: Option<String>,
     // Resolved working directory for the runner. The core forwards it as-is; deriving a
     // default (e.g. a desktop's ~/.stigmer path) is host policy and lives in the binding.
     pub workspace_root_dir: Option<String>,
     pub proxy_endpoint: Option<String>,
+    /// Additional env vars for the spawned runner (e.g. `LOG_LEVEL`, or
+    /// `STIGMER_RUNNER_HITL_SECRET` for a HITL fingerprint key stable across replicas).
+    /// Keys the host owns (everything `build_env` emits) and the provider keys above are
+    /// reserved: `start()` rejects them with `ReservedEnvKey` instead of letting an
+    /// embedder shadow a typed field or break the manager-mode contract.
+    #[serde(default)]
+    pub extra_env: HashMap<String, String>,
 }

--- a/crates/stigmer-runner-host/src/error.rs
+++ b/crates/stigmer-runner-host/src/error.rs
@@ -21,6 +21,12 @@ pub enum RunnerHostError {
     )]
     RunnerEntryNotFound { entry: String, cwd: String },
 
+    #[error(
+        "extra_env key `{key}` is reserved: the host owns it{hint}",
+        hint = typed_field_hint(.key)
+    )]
+    ReservedEnvKey { key: String },
+
     #[error("failed to spawn runner process: {0}")]
     Spawn(#[source] std::io::Error),
 
@@ -55,5 +61,22 @@ impl RunnerHostError {
             std::io::ErrorKind::BrokenPipe,
             format!("failed to capture runner {which}"),
         ))
+    }
+}
+
+// Points a rejected reserved key at the typed `RunnerConfig` field that sets it, so the
+// error is actionable without reading crate source.
+fn typed_field_hint(key: &str) -> &'static str {
+    match key {
+        "ANTHROPIC_API_KEY" => "; use the `anthropic_api_key` field instead",
+        "OPENAI_API_KEY" => "; use the `openai_api_key` field instead",
+        "STIGMER_TOKEN" => "; use the `stigmer_token` field instead",
+        "CURSOR_API_KEY" => "; use the `cursor_api_key` field instead",
+        "TEMPORAL_SERVICE_ADDRESS" => "; use the `temporal_address` field instead",
+        "TEMPORAL_NAMESPACE" => "; use the `temporal_namespace` field instead",
+        "STIGMER_BACKEND_ENDPOINT" => "; use the `stigmer_endpoint` field instead",
+        "WORKSPACE_ROOT_DIR" => "; use the `workspace_root_dir` field instead",
+        "STIGMER_PROXY_ENDPOINT" => "; use the `proxy_endpoint` field instead",
+        _ => "",
     }
 }

--- a/crates/stigmer-runner-host/src/host.rs
+++ b/crates/stigmer-runner-host/src/host.rs
@@ -99,6 +99,10 @@ impl RunnerHost {
         // would surface much later as an opaque EOF/serde error on the `ready` line,
         // long after the real cause.
         validate_runner_entry(&config.runner_entry)?;
+        // Fail fast on extra_env entries that shadow host-owned keys, for the same
+        // reason: a silently-clobbered STIGMER_TOKEN or TEMPORAL_NAMESPACE would
+        // surface as a confusing runtime failure far from the misconfiguration.
+        validate_extra_env(&config)?;
 
         let mut cmd = Command::new(&config.node_binary);
         cmd.arg(&config.runner_entry);
@@ -417,6 +421,25 @@ fn negotiate_ready(line: &str) -> Result<u32, RunnerHostError> {
     }
 }
 
+/// Env keys `extra_env` may not set: every key [`build_env`] can emit. Each has a typed
+/// `RunnerConfig` field (or, for `STIGMER_RUNNER_MODE` / `NODE_TLS_REJECT_UNAUTHORIZED`,
+/// is derived by the host), so an `extra_env` entry could only shadow or contradict it.
+/// The `reserved_env_covers_everything_build_env_emits` test keeps this list and
+/// `build_env` from drifting apart.
+const RESERVED_ENV_KEYS: &[&str] = &[
+    "STIGMER_RUNNER_MODE",
+    "STIGMER_BACKEND_ENDPOINT",
+    "TEMPORAL_SERVICE_ADDRESS",
+    "TEMPORAL_NAMESPACE",
+    "STIGMER_TOKEN",
+    "CURSOR_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "WORKSPACE_ROOT_DIR",
+    "STIGMER_PROXY_ENDPOINT",
+    "NODE_TLS_REJECT_UNAUTHORIZED",
+];
+
 /// Build the environment the runner subprocess inherits from a [`RunnerConfig`].
 ///
 /// Pure and total (no process, no I/O) so the env mapping is unit-testable. The
@@ -424,6 +447,9 @@ fn negotiate_ready(line: &str) -> Result<u32, RunnerHostError> {
 /// only when the host provides an address: omitting it is the token-only
 /// embedding path, where the runner self-discovers Temporal from the control
 /// plane using `STIGMER_TOKEN`.
+///
+/// Assumes `extra_env` passed [`validate_extra_env`], so appending it cannot
+/// duplicate a key emitted above.
 fn build_env(config: &RunnerConfig) -> Vec<(String, String)> {
     let mut env: Vec<(String, String)> = vec![
         ("STIGMER_RUNNER_MODE".to_string(), "manager".to_string()),
@@ -445,6 +471,12 @@ fn build_env(config: &RunnerConfig) -> Vec<(String, String)> {
     if let Some(key) = &config.cursor_api_key {
         env.push(("CURSOR_API_KEY".to_string(), key.clone()));
     }
+    if let Some(key) = &config.anthropic_api_key {
+        env.push(("ANTHROPIC_API_KEY".to_string(), key.clone()));
+    }
+    if let Some(key) = &config.openai_api_key {
+        env.push(("OPENAI_API_KEY".to_string(), key.clone()));
+    }
     if let Some(dir) = &config.workspace_root_dir {
         env.push(("WORKSPACE_ROOT_DIR".to_string(), dir.clone()));
     }
@@ -457,7 +489,31 @@ fn build_env(config: &RunnerConfig) -> Vec<(String, String)> {
         }
     }
 
+    // Sorted so the child env is deterministic (HashMap iteration order is not).
+    let mut extra: Vec<(String, String)> = config
+        .extra_env
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    extra.sort_by(|(a, _), (b, _)| a.cmp(b));
+    env.extend(extra);
+
     env
+}
+
+/// Reject `extra_env` keys the host owns, before anything is spawned.
+///
+/// Reserved keys are always rejected — even when the current config would not emit them
+/// (e.g. `STIGMER_TOKEN` with `stigmer_token: None`) — because each has a typed field
+/// that is the one discoverable way to set it. Silently accepting the env spelling would
+/// recreate the undocumented side channel this crate exists to replace (issue #250).
+fn validate_extra_env(config: &RunnerConfig) -> Result<(), RunnerHostError> {
+    for key in config.extra_env.keys() {
+        if RESERVED_ENV_KEYS.contains(&key.as_str()) {
+            return Err(RunnerHostError::ReservedEnvKey { key: key.clone() });
+        }
+    }
+    Ok(())
 }
 
 /// Ensure the runner entry points at a file that exists before we hand it to `node`.
@@ -611,8 +667,11 @@ mod tests {
             temporal_namespace: None,
             stigmer_token: Some("tok".to_string()),
             cursor_api_key: None,
+            anthropic_api_key: None,
+            openai_api_key: None,
             workspace_root_dir: None,
             proxy_endpoint: None,
+            extra_env: std::collections::HashMap::new(),
         }
     }
 
@@ -642,6 +701,114 @@ mod tests {
             env_value(&env, "TEMPORAL_SERVICE_ADDRESS"),
             Some("temporal.example:7233")
         );
+    }
+
+    #[test]
+    fn build_env_sets_llm_provider_keys_only_when_provided() {
+        // BYOK direct mode (issue #250): the typed fields must land as the exact env
+        // vars the runner's model client reads, and stay absent otherwise.
+        let env = build_env(&minimal_config());
+        assert_eq!(env_value(&env, "ANTHROPIC_API_KEY"), None);
+        assert_eq!(env_value(&env, "OPENAI_API_KEY"), None);
+
+        let mut config = minimal_config();
+        config.anthropic_api_key = Some("sk-ant-test".to_string());
+        config.openai_api_key = Some("sk-oai-test".to_string());
+        let env = build_env(&config);
+        assert_eq!(env_value(&env, "ANTHROPIC_API_KEY"), Some("sk-ant-test"));
+        assert_eq!(env_value(&env, "OPENAI_API_KEY"), Some("sk-oai-test"));
+    }
+
+    #[test]
+    fn build_env_appends_extra_env_sorted_by_key() {
+        let mut config = minimal_config();
+        config.extra_env = [
+            ("LOG_LEVEL".to_string(), "debug".to_string()),
+            ("A_CUSTOM_VAR".to_string(), "1".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let env = build_env(&config);
+
+        assert_eq!(env_value(&env, "LOG_LEVEL"), Some("debug"));
+        assert_eq!(env_value(&env, "A_CUSTOM_VAR"), Some("1"));
+        // Deterministic ordering: extras come after the host-owned block, sorted.
+        let tail: Vec<&str> = env.iter().rev().take(2).map(|(k, _)| k.as_str()).collect();
+        assert_eq!(tail, vec!["LOG_LEVEL", "A_CUSTOM_VAR"]);
+    }
+
+    #[test]
+    fn every_reserved_key_is_rejected_in_extra_env() {
+        for key in RESERVED_ENV_KEYS {
+            let mut config = minimal_config();
+            config.extra_env = [(key.to_string(), "x".to_string())].into_iter().collect();
+
+            match validate_extra_env(&config).unwrap_err() {
+                RunnerHostError::ReservedEnvKey { key: rejected } => {
+                    assert_eq!(&rejected, key)
+                }
+                other => panic!("expected ReservedEnvKey for {key}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn reserved_key_error_points_at_the_typed_field() {
+        // The rejection must be actionable: an embedder who reached for the env
+        // spelling is told which RunnerConfig field to use instead.
+        let mut config = minimal_config();
+        config.extra_env = [("ANTHROPIC_API_KEY".to_string(), "sk".to_string())]
+            .into_iter()
+            .collect();
+
+        let message = validate_extra_env(&config).unwrap_err().to_string();
+        assert!(
+            message.contains("anthropic_api_key"),
+            "error must name the typed field: {message}"
+        );
+    }
+
+    #[test]
+    fn non_reserved_extra_env_passes_validation() {
+        // STIGMER_RUNNER_HITL_SECRET is the documented way to pin a HITL fingerprint
+        // key across replicas — a deliberate extra_env use case, not a reserved key.
+        let mut config = minimal_config();
+        config.extra_env = [("STIGMER_RUNNER_HITL_SECRET".to_string(), "s".to_string())]
+            .into_iter()
+            .collect();
+        assert!(validate_extra_env(&config).is_ok());
+    }
+
+    #[test]
+    fn reserved_env_covers_everything_build_env_emits() {
+        // Honesty check (same spirit as the IPC golden fixtures): populate every
+        // config field so build_env emits its full vocabulary, then require each
+        // emitted key to be reserved. Adding a var to build_env without reserving
+        // it fails here — the guard cannot silently rot.
+        let config = RunnerConfig {
+            node_binary: "node".to_string(),
+            runner_entry: "main.js".to_string(),
+            temporal_address: Some("temporal.example:7233".to_string()),
+            stigmer_endpoint: "https://api.stigmer.ai".to_string(),
+            temporal_namespace: Some("ns".to_string()),
+            stigmer_token: Some("tok".to_string()),
+            cursor_api_key: Some("ck".to_string()),
+            anthropic_api_key: Some("ak".to_string()),
+            openai_api_key: Some("ok".to_string()),
+            workspace_root_dir: Some("/tmp/ws".to_string()),
+            // https so the derived NODE_TLS_REJECT_UNAUTHORIZED is emitted too.
+            proxy_endpoint: Some("https://proxy.example".to_string()),
+            extra_env: std::collections::HashMap::new(),
+        };
+
+        for (key, _) in build_env(&config) {
+            assert!(
+                RESERVED_ENV_KEYS.contains(&key.as_str()),
+                "build_env emits `{key}` but RESERVED_ENV_KEYS does not reserve it; \
+                 an extra_env entry could silently shadow it"
+            );
+        }
     }
 
     #[test]

--- a/crates/stigmer-runner-host/src/lib.rs
+++ b/crates/stigmer-runner-host/src/lib.rs
@@ -31,8 +31,13 @@
 //!     temporal_namespace: None,
 //!     stigmer_token: Some("stigmer_token".into()),
 //!     cursor_api_key: None,
+//!     // BYOK direct mode (self-managed, no proxy): pass the provider keys here
+//!     // instead of priming your own process env before start().
+//!     anthropic_api_key: None,
+//!     openai_api_key: None,
 //!     workspace_root_dir: None,
 //!     proxy_endpoint: Some("https://api.stigmer.ai".into()),
+//!     extra_env: Default::default(),
 //! })
 //! .await?;
 //! host.add_session("ses_abc123").await?;

--- a/crates/stigmer-runner-host/src/tauri.rs
+++ b/crates/stigmer-runner-host/src/tauri.rs
@@ -70,9 +70,17 @@ pub struct RunnerConfigInput {
     #[serde(default)]
     pub cursor_api_key: Option<String>,
     #[serde(default)]
+    pub anthropic_api_key: Option<String>,
+    #[serde(default)]
+    pub openai_api_key: Option<String>,
+    #[serde(default)]
     pub workspace_root_dir: Option<String>,
     #[serde(default)]
     pub proxy_endpoint: Option<String>,
+    /// JS `Record<string, string>` of additional env vars for the runner. Host-owned
+    /// keys are rejected at `start_runner` (see `RunnerConfig::extra_env`).
+    #[serde(default)]
+    pub extra_env: std::collections::HashMap<String, String>,
 }
 
 impl RunnerConfigInput {
@@ -91,8 +99,11 @@ impl RunnerConfigInput {
             temporal_namespace: self.temporal_namespace,
             stigmer_token: self.stigmer_token,
             cursor_api_key: self.cursor_api_key,
+            anthropic_api_key: self.anthropic_api_key,
+            openai_api_key: self.openai_api_key,
             workspace_root_dir: Some(workspace_root_dir),
             proxy_endpoint: self.proxy_endpoint,
+            extra_env: self.extra_env,
         })
     }
 }
@@ -223,4 +234,50 @@ pub async fn update_runner_token(
 #[tauri::command]
 pub async fn runner_status(state: State<'_, RunnerState>) -> Result<RunnerStatusResponse, String> {
     Ok(state.host.status().await.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_input_deserializes_llm_credentials_and_extra_env() {
+        // The JS wire shape: camelCase keys, extraEnv as a Record<string, string>.
+        // Everything beyond the required trio must be omittable.
+        let input: RunnerConfigInput = serde_json::from_str(
+            r#"{
+                "nodeBinary": "node",
+                "runnerEntry": "/app/runner/main.js",
+                "stigmerEndpoint": "http://localhost:7234",
+                "anthropicApiKey": "sk-ant-test",
+                "openaiApiKey": "sk-oai-test",
+                "extraEnv": {"LOG_LEVEL": "debug"}
+            }"#,
+        )
+        .expect("camelCase input must deserialize");
+
+        assert_eq!(input.anthropic_api_key.as_deref(), Some("sk-ant-test"));
+        assert_eq!(input.openai_api_key.as_deref(), Some("sk-oai-test"));
+        assert_eq!(
+            input.extra_env.get("LOG_LEVEL").map(String::as_str),
+            Some("debug")
+        );
+    }
+
+    #[test]
+    fn config_input_defaults_new_fields_when_omitted() {
+        // Existing frontends that predate the LLM-credential fields keep working.
+        let input: RunnerConfigInput = serde_json::from_str(
+            r#"{
+                "nodeBinary": "node",
+                "runnerEntry": "/app/runner/main.js",
+                "stigmerEndpoint": "http://localhost:7234"
+            }"#,
+        )
+        .expect("minimal input must deserialize");
+
+        assert_eq!(input.anthropic_api_key, None);
+        assert_eq!(input.openai_api_key, None);
+        assert!(input.extra_env.is_empty());
+    }
 }

--- a/docs/guides/runners/embedding.mdx
+++ b/docs/guides/runners/embedding.mdx
@@ -37,11 +37,11 @@ supply depends on your deployment. The table below is the minimal surface for
 each audience; the full list lives in the runner README
 (`backend/services/runner/README.md`), under its configuration reference.
 
-| Your situation                                   | Stigmer token        | Backend endpoint      | Temporal address        | Cursor key                |
-| ------------------------------------------------ | -------------------- | --------------------- | ----------------------- | ------------------------- |
-| **Cloud, cloud execution** (no embedding)        | Pass to the SDK only | Platform-managed      | Platform-managed        | Platform-managed          |
-| **Cloud, embedded local execution** (desktop)    | Required             | Required (your Cloud) | Discovered (token)      | Not needed (proxied)      |
-| **Self-managed (OSS or self-hosted full stack)** | Optional             | Defaults to localhost | Discovered or localhost | Required (Cursor harness) |
+| Your situation                                   | Stigmer token        | Backend endpoint      | Temporal address        | Cursor key                | LLM provider keys         |
+| ------------------------------------------------ | -------------------- | --------------------- | ----------------------- | ------------------------- | ------------------------- |
+| **Cloud, cloud execution** (no embedding)        | Pass to the SDK only | Platform-managed      | Platform-managed        | Platform-managed          | Platform-managed          |
+| **Cloud, embedded local execution** (desktop)    | Required             | Required (your Cloud) | Discovered (token)      | Not needed (proxied)      | Not needed (proxied)      |
+| **Self-managed (OSS or self-hosted full stack)** | Optional             | Defaults to localhost | Discovered or localhost | Required (Cursor harness) | Required (native harness) |
 
 How to read each row:
 
@@ -59,11 +59,16 @@ How to read each row:
 - **Self-managed.** You run your own Temporal and Stigmer Server. In the default
   `MODE=local`, `TEMPORAL_SERVICE_ADDRESS` defaults to `localhost:7233` and
   `STIGMER_BACKEND_ENDPOINT` to `http://localhost:7234`. `STIGMER_TOKEN` is
-  optional because a local server has no auth, and you pass `CURSOR_API_KEY`
-  directly for the Cursor harness. A **managed self-hosted** deployment, where
-  you run the full Stigmer stack on your own infrastructure with Stigmer
-  support, uses this same surface — point the endpoints at your hosts instead of
-  localhost.
+  optional because a local server has no auth. Credentials are **bring your
+  own**: you pass `CURSOR_API_KEY` directly for the Cursor harness, and
+  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` for the native harness (there is no
+  proxy to inject them — an execution that needs a missing key fails with
+  `LLM_MISSING_API_KEY`). The Rust host crate exposes all three as typed config
+  fields (`cursor_api_key`, `anthropic_api_key`, `openai_api_key`), so an
+  embedder never has to prime its own process environment. A **managed
+  self-hosted** deployment, where you run the full Stigmer stack on your own
+  infrastructure with Stigmer support, uses this same surface — point the
+  endpoints at your hosts instead of localhost.
 
 ## Temporal self-discovery
 
@@ -307,9 +312,16 @@ host.start(RunnerConfig {
     stigmer_endpoint: "https://api.stigmer.ai".into(),
     temporal_namespace: None,
     stigmer_token: Some("stigmer_token".into()),
+    // Credentials for direct (BYOK) mode. With a proxy_endpoint set, leave all
+    // three None — the proxy injects the real keys server-side.
     cursor_api_key: None,
+    anthropic_api_key: None,
+    openai_api_key: None,
     workspace_root_dir: None,
     proxy_endpoint: Some("https://api.stigmer.ai".into()),
+    // Additional env for the runner (e.g. LOG_LEVEL). Keys the host composes
+    // itself, including the credential vars above, are reserved and rejected.
+    extra_env: Default::default(),
 })
 .await?;
 


### PR DESCRIPTION
## Summary

Adds first-class LLM credential fields to the embedded runner so hosts can deliver Anthropic/OpenAI keys through typed config instead of mutating their own process environment, and fixes a sibling CLI bug where a `stigmer setup`-persisted key never reached the runner.

## Context

The runner's native harness reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from `process.env` in direct (BYOK) mode. `stigmer-runner-host`'s `RunnerConfig` had no typed place for them and `build_env` composes an explicit allowlist, so embedders had no supported channel — the only workaround was priming the host's own process env before `host.start(..)` (global, race-prone under Rust 2024, undiscoverable). Reported in #250.

Separately, `stigmer setup --api-key` persisted the key to the config file (and `stigmer status` reported "Configured"), but the daemon launcher never delivered it to the runner unless it was also exported in the shell.

## Changes

- **Crate (`crates/stigmer-runner-host`)**
  - `RunnerConfig` gains `anthropic_api_key`, `openai_api_key`, and a `HashMap` `extra_env`.
  - `build_env` maps the typed fields to the provider env vars and appends `extra_env` sorted by key.
  - Reserved-key guard (`validate_extra_env` + `RESERVED_ENV_KEYS`) rejects host-owned keys at `start()` with a new `ReservedEnvKey` error that names the typed field to use.
  - Tauri `RunnerConfigInput` mirrors the fields (camelCase); `lib.rs` doctest updated.
- **CLI (`client-apps/cli/src/local/daemon`)**
  - `DaemonEnvVar` + contract gain the provider keys; `launch.ts` resolves the effective key (env > config file) and injects it; `buildRunnerEnv` sets it explicitly.
- **Docs** — crate README (new BYOK section) and `docs/guides/runners/embedding.mdx` (integrator table column + snippet).

## Implementation notes

- Typed fields *and* a guarded `extra_env`: typed for discoverability (the property whose absence caused #250), the map to future-proof without a foot-gun. A drift-proof test asserts every key `build_env` emits is reserved.
- OSS-only: no proto, Node runner, cloud, or desktop changes (desktop runs proxy mode).

## Breaking changes

- Additive source break: new public `RunnerConfig` fields require existing struct literals to add them (typically `None` / `Default::default()`) on upgrade. Same additive pattern as `workspace_root_dir` / `proxy_endpoint`.

## Test plan

- Crate: `cargo fmt --check`, `clippy --all-targets -D warnings` (default + `tauri`), `build`, `test` (incl. doctest) — clean.
- CLI: `tsc --noEmit` clean; full vitest suite (795 tests) green.
- Docs: `make gen-cli-docs-check`, `lint-docs`, `format-docs-check` pass.

## Checklist

- [x] Docs updated
- [x] Tests added/updated
- [ ] Backward compatible (additive source break on `RunnerConfig` — see Breaking changes)

Closes #250
Closes #251

Made with [Cursor](https://cursor.com)