### PR TITLE
fix(codegen): escape reserved Java identifiers in generated SDK builders

### DIFF
--- a/.github/workflows/ci.java-sdk.yaml
+++ b/.github/workflows/ci.java-sdk.yaml
@@ -1,0 +1,78 @@
+# =============================================================================
+# Java SDK quality gate: stigmer-java
+# =============================================================================
+# This is the only CI that compiles the Java SDK before it ships to Maven
+# Central (elsewhere Java is built solely inside release.maven). It exists
+# because the v3.3.0 release failed at publish time: generated client code
+# containing a Java reserved keyword (`default`) reached main uncompiled and
+# the release job was the first compiler to see it (issue #294).
+#
+# Two gates, one job:
+#   - freshness — regenerates the SDK client code and fails if the committed
+#     copy differs, so stale (or hand-edited) generated code fails here
+#     rather than silently drifting from the generator.
+#   - compile + test — builds the SDK against locally-installed proto stubs,
+#     exactly as release.maven's publish-sdk job does, so any codegen output
+#     that cannot compile fails pre-merge instead of at publish time.
+# =============================================================================
+
+name: ci.java-sdk
+
+on:
+  pull_request:
+    paths:
+      - "apis/**"
+      - "sdk/java/**"
+      - "tools/codegen/**"
+      - ".github/workflows/ci.java-sdk.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "apis/**"
+      - "sdk/java/**"
+      - "tools/codegen/**"
+      - ".github/workflows/ci.java-sdk.yaml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ci-java-sdk-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  java-sdk:
+    name: codegen freshness / compile / test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      # The SDK pom depends on stigmer-java-protos:0.0.1-SNAPSHOT, so the
+      # stubs must be in the local repository before the SDK can compile
+      # (mirrors release.maven's "Install protos locally" step).
+      - name: Install proto stubs locally
+        working-directory: apis/stubs/java
+        run: mvn --batch-mode install -DskipTests
+
+      - name: Generate SDK client code
+        run: make -C sdk/java codegen
+
+      - name: Verify committed generated code is fresh
+        run: git diff --exit-code sdk/java/src/main/java/ai/stigmer/sdk/gen
+
+      - name: Compile and test
+        run: make -C sdk/java verify

--- a/.github/workflows/release.maven.yaml
+++ b/.github/workflows/release.maven.yaml
@@ -60,7 +60,26 @@ jobs:
           mvn --batch-mode versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false
           echo "Set stigmer-java-protos version to $VERSION"
 
+      # Central rejects re-publishing an existing version, so a rerun after a
+      # partial failure (e.g. protos published, SDK didn't) must skip the
+      # already-live artifact instead of failing the whole release. repo1
+      # sync lags a fresh publish by a few minutes, so a rerun within that
+      # window may still attempt a duplicate upload — acceptable, since real
+      # recovery runs happen well after the sync completes.
+      - name: Check if version is already on Central
+        id: central-check
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          URL="https://repo1.maven.org/maven2/ai/stigmer/stigmer-java-protos/$VERSION/stigmer-java-protos-$VERSION.pom"
+          if curl --silent --fail --output /dev/null "$URL"; then
+            echo "stigmer-java-protos:$VERSION is already on Central; skipping publish."
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to Maven Central
+        if: steps.central-check.outputs.published != 'true'
         working-directory: apis/stubs/java
         # The Central Portal upload endpoint can return transient 403/5xx
         # responses (rate limiting, in-flight publishes). Retry with backoff
@@ -124,7 +143,21 @@ jobs:
           mvn --batch-mode versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false
           mvn --batch-mode install -DskipTests
 
+      # Same duplicate-version skip as publish-protos; see the comment there.
+      - name: Check if version is already on Central
+        id: central-check
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          URL="https://repo1.maven.org/maven2/ai/stigmer/stigmer-java/$VERSION/stigmer-java-$VERSION.pom"
+          if curl --silent --fail --output /dev/null "$URL"; then
+            echo "stigmer-java:$VERSION is already on Central; skipping publish."
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to Maven Central
+        if: steps.central-check.outputs.published != 'true'
         working-directory: sdk/java
         # The protos job returns once its deployment is *validated*, then
         # autoPublish finishes asynchronously. Uploading the SDK bundle while

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/DatastoreInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/DatastoreInput.java
@@ -434,7 +434,7 @@ public final class DatastoreInput {
         private final String name;
         private final FieldType type;
         private final boolean required;
-        private final Object default;
+        private final Object default_;
         private final java.util.List<String> enumValues;
         private final String description;
 
@@ -442,7 +442,7 @@ public final class DatastoreInput {
             this.name = builder.name;
             this.type = builder.type;
             this.required = builder.required;
-            this.default = builder.default;
+            this.default_ = builder.default_;
             this.enumValues = builder.enumValues;
             this.description = builder.description;
         }
@@ -456,8 +456,8 @@ public final class DatastoreInput {
                 builder.setType(this.type);
             }
             builder.setRequired(this.required);
-            if (this.default != null) {
-                builder.setDefault(ProtoConvert.objectToValue(this.default));
+            if (this.default_ != null) {
+                builder.setDefault(ProtoConvert.objectToValue(this.default_));
             }
             if (this.enumValues != null) {
                 builder.addAllEnumValues(this.enumValues);
@@ -474,7 +474,7 @@ public final class DatastoreInput {
             private String name;
             private FieldType type;
             private boolean required;
-            private Object default;
+            private Object default_;
             private java.util.List<String> enumValues;
             private String description;
 
@@ -483,7 +483,7 @@ public final class DatastoreInput {
             public Builder name(String name) { this.name = name; return this; }
             public Builder type(FieldType type) { this.type = type; return this; }
             public Builder required(boolean required) { this.required = required; return this; }
-            public Builder default(Object default) { this.default = default; return this; }
+            public Builder default_(Object default_) { this.default_ = default_; return this; }
             public Builder enumValues(java.util.List<String> enumValues) { this.enumValues = enumValues; return this; }
             public Builder description(String description) { this.description = description; return this; }
 
@@ -544,11 +544,11 @@ public final class DatastoreInput {
     /** SDK input type for UniqueWhere. */
     public static final class UniqueWhereInput {
         private final String field;
-        private final Object equals;
+        private final Object equals_;
 
         private UniqueWhereInput(Builder builder) {
             this.field = builder.field;
-            this.equals = builder.equals;
+            this.equals_ = builder.equals_;
         }
 
         UniqueWhere toProto() {
@@ -556,8 +556,8 @@ public final class DatastoreInput {
             if (this.field != null) {
                 builder.setField(this.field);
             }
-            if (this.equals != null) {
-                builder.setEquals(ProtoConvert.objectToValue(this.equals));
+            if (this.equals_ != null) {
+                builder.setEquals(ProtoConvert.objectToValue(this.equals_));
             }
             return builder.build();
         }
@@ -566,12 +566,12 @@ public final class DatastoreInput {
 
         public static final class Builder {
             private String field;
-            private Object equals;
+            private Object equals_;
 
             private Builder() {}
 
             public Builder field(String field) { this.field = field; return this; }
-            public Builder equals(Object equals) { this.equals = equals; return this; }
+            public Builder equals_(Object equals_) { this.equals_ = equals_; return this; }
 
             public UniqueWhereInput build() { return new UniqueWhereInput(this); }
         }

--- a/tools/codegen/generator/main_test.go
+++ b/tools/codegen/generator/main_test.go
@@ -1130,6 +1130,23 @@ func TestJavaCamel(t *testing.T) {
 		{"base_url", "baseUrl"},
 		{"resource_id", "resourceId"},
 		{"", ""},
+		// Java keywords must be escaped with a trailing underscore
+		// (broke the v3.3.0 Maven publish via FieldDeclaration.default).
+		{"default", "default_"},
+		{"class", "class_"},
+		{"static", "static_"},
+		{"null", "null_"},
+		// java.lang.Object method names too: `Builder equals(Object)` is an
+		// invalid override of Object.equals (datastore UniqueWhere.equals).
+		{"equals", "equals_"},
+		{"hash_code", "hashCode_"},
+		{"to_string", "toString_"},
+		{"wait", "wait_"},
+		// ...but only exact collisions: multi-part names that merely
+		// contain a reserved name camel-case away from it.
+		{"default_value", "defaultValue"},
+		{"catch_all", "catchAll"},
+		{"equals_any", "equalsAny"},
 	}
 
 	for _, tc := range tests {

--- a/tools/codegen/generator/sdk_client_java.go
+++ b/tools/codegen/generator/sdk_client_java.go
@@ -73,14 +73,51 @@ func javaCapCamel(protoField string) string {
 	return strings.Join(parts, "")
 }
 
-// javaCamel converts a proto snake_case field name to camelCase.
-// "tool_approval_policy" -> "toolApprovalPolicy"
+// javaReservedNames is the set of identifiers that cannot be used as bare
+// Java names in generated code. Two classes:
+//   - reserved keywords (JLS §3.9) plus the boolean/null literals, which are
+//     syntax errors as identifiers (broke the v3.3.0 release via
+//     FieldDeclaration.default);
+//   - java.lang.Object method names, because builder methods share every
+//     object's inherited method namespace — `Builder equals(Object)` fails to
+//     compile as an invalid override of Object.equals (datastore
+//     UniqueWhere.equals). Escaped by name rather than by clashing signature
+//     so a field's type can never change its public builder method name.
+var javaReservedNames = map[string]bool{
+	"abstract": true, "assert": true, "boolean": true, "break": true,
+	"byte": true, "case": true, "catch": true, "char": true, "class": true,
+	"const": true, "continue": true, "default": true, "do": true,
+	"double": true, "else": true, "enum": true, "extends": true,
+	"final": true, "finally": true, "float": true, "for": true,
+	"goto": true, "if": true, "implements": true, "import": true,
+	"instanceof": true, "int": true, "interface": true, "long": true,
+	"native": true, "new": true, "package": true, "private": true,
+	"protected": true, "public": true, "return": true, "short": true,
+	"static": true, "strictfp": true, "super": true, "switch": true,
+	"synchronized": true, "this": true, "throw": true, "throws": true,
+	"transient": true, "try": true, "void": true, "volatile": true,
+	"while": true,
+	"true":  true, "false": true, "null": true,
+	"equals": true, "hashCode": true, "toString": true, "getClass": true,
+	"notify": true, "notifyAll": true, "wait": true, "clone": true,
+	"finalize": true,
+}
+
+// javaCamel converts a proto snake_case field name to a safe camelCase Java
+// identifier, appending a trailing underscore if the result is a reserved
+// name (e.g. "default" -> "default_", "equals" -> "equals_"), mirroring
+// pyFieldName and protoc-java's own escaping convention. Prefixed accessor
+// names (setDefault, addAllX) are built via javaCapCamel and never collide.
 func javaCamel(protoField string) string {
 	cc := javaCapCamel(protoField)
 	if len(cc) == 0 {
 		return cc
 	}
-	return strings.ToLower(cc[:1]) + cc[1:]
+	name := strings.ToLower(cc[:1]) + cc[1:]
+	if javaReservedNames[name] {
+		return name + "_"
+	}
+	return name
 }
 
 func javaSetterName(protoField string) string { return "set" + javaCapCamel(protoField) }

--- a/tools/codegen/generator/sdk_docs.go
+++ b/tools/codegen/generator/sdk_docs.go
@@ -585,7 +585,11 @@ func docFieldName(protoField, lang string) string {
 		}
 		return strings.Join(parts, "")
 	case "python":
-		return protoField
+		// Route through the client generator's naming so docs never show an
+		// identifier the generated SDK doesn't have (keyword escaping).
+		return pyFieldName(protoField)
+	case "java":
+		return javaCamel(protoField)
 	default:
 		return tsProtoFieldName(protoField)
 	}


### PR DESCRIPTION
## Summary
Fixes the deterministic compile failure that blocked `ai.stigmer:stigmer-java:3.3.0` from reaching Maven Central, and hardens the pipeline so generated Java that cannot compile can never reach a release again.

## Context
The v3.3.0 tag's `release.maven` run failed in `publish-sdk`: the Datastore feature added proto fields named `default` (`FieldDeclaration`) and `equals` (`UniqueWhere`), and the Java SDK client generator emitted them as bare identifiers — `default` is a reserved keyword (syntax error), and `Builder equals(Object)` is an invalid override of `Object.equals`. No CI compiled `sdk/java`, so the release job was the first compiler to see the generated code. The `equals` failure was masked in the release log because the `default` syntax errors aborted compilation before semantic analysis.

## Changes
- `tools/codegen/generator/sdk_client_java.go`: `javaCamel` now escapes reserved names with a trailing underscore (`default` → `default_`, `equals` → `equals_`), covering all JLS keywords + literals and `java.lang.Object` method names. Mirrors the existing `pyFieldName` convention and protoc-java's own escaping. Prefixed proto accessors (`setDefault`) are untouched.
- `tools/codegen/generator/sdk_docs.go`: `docFieldName` now routes Java through `javaCamel` and Python through `pyFieldName`, so generated docs can never show an identifier the generated SDK doesn't have (verified zero output drift for current schemas).
- `sdk/java/.../DatastoreInput.java`: regenerated; diff is exactly the two renames.
- `tools/codegen/generator/main_test.go`: reserved-name cases added to `TestJavaCamel`.
- `.github/workflows/ci.java-sdk.yaml` (new): pre-merge gate that regenerates the client code (fails on dirty diff) and compiles + tests `sdk/java`, mirroring `release.maven`'s build steps.
- `.github/workflows/release.maven.yaml`: both publish jobs now skip (green) when the version is already live on Central, so a partial-failure release can be recovered with a plain re-dispatch — needed because `stigmer-java-protos:3.3.0` is already published and Central rejects duplicates.

## Implementation notes
- Escaping is by name, not by clashing signature, so a field's type can never change its public builder method name.
- The 3.3.0 artifact itself will be published from a recovery branch cut from the `v3.3.0` tag with this generator fix cherry-picked, keeping the jar faithful to the tag (main has moved past it).

## Breaking changes
- None on the wire. Java SDK builder surface for the affected datastore inputs is `default_(...)`/`equals_(...)`; no released artifact ever exposed the broken names (3.3.0 never compiled).

## Test plan
- `go test ./...` in `tools/codegen` (includes new reserved-name cases) — pass
- `make -C sdk/java codegen` — regeneration diff is exactly the two renames
- `mvn install` (protos stubs) + `make -C sdk/java verify` (compile + test) — pass
- SDK docs regenerated — zero drift
- Guard URLs validated against live Central (protos 3.3.0 found → skip; sdk 3.3.0 absent → publish)

## Risks
- Low: generated-code rename is confined to datastore inputs that never shipped. Rollback is reverting this PR.

Closes #294

Made with [Cursor](https://cursor.com)