### PR TITLE
fix(ci): make desktop release survive tags cut behind the branch tip

### DIFF
--- a/.github/workflows/release.desktop.yaml
+++ b/.github/workflows/release.desktop.yaml
@@ -104,10 +104,11 @@ jobs:
           retention-days: 1
 
 
-  # Pre-create a single draft release up front so every parallel build leg can
-  # upload its bundles to the same release via releaseId. The updater manifest
-  # is assembled once in the publish job (see below), which is what lets the
-  # builds run concurrently without racing on latest.json.
+  # Resolve a single release up front (reusing the canonical one for the tag
+  # when it exists) so every parallel build leg can upload its bundles to the
+  # same release via releaseId. The updater manifest is assembled once in the
+  # publish job (see below), which is what lets the builds run concurrently
+  # without racing on latest.json.
   create-release:
     needs: determine-version
     if: needs.determine-version.outputs.should_release == 'true'
@@ -125,33 +126,56 @@ jobs:
         with:
           script: |
             const tag = process.env.VERSION;
-            // No target_commitish: the Actions token 403s ("Resource not
-            // accessible by integration") when it names a SHA that is not a
-            // branch tip, and that gate fires even when the tag already
-            // exists. On tag-push runs the tag exists, so GitHub resolves the
-            // commit from the tag itself.
-            const params = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: `Stigmer Desktop ${tag}`,
-              body: 'Download the desktop installer for your platform below.',
-              draft: true,
-              prerelease: false,
+
+            // Desktop assets must land on the canonical release for the tag
+            // (the "Release vX.Y.Z" that release.cli publishes). Creating our
+            // own draft instead strands the installers forever: drafts do not
+            // collide on tag_name (no 422), and the publish job's
+            // `gh release edit <tag>` resolves to the published release, so a
+            // parallel draft is never flipped public (this is how the
+            // v3.3.0/v3.4.0 desktop drafts got stranded). On a tag push the
+            // CLI release appears a couple of minutes in, so poll briefly.
+            const findByTag = async () => {
+              try {
+                const { data } = await github.rest.repos.getReleaseByTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag,
+                });
+                return data;
+              } catch (err) {
+                if (err.status !== 404) throw err;
+                return null;
+              }
             };
-            try {
-              const { data } = await github.rest.repos.createRelease(params);
-              core.setOutput('release_id', data.id);
-            } catch (err) {
-              // A re-run may hit an existing release for this tag; reuse it.
-              if (err.status !== 422) throw err;
-              const { data } = await github.rest.repos.getReleaseByTag({
+
+            // Dev dispatch builds use 0.0.0-N versions that never have a
+            // canonical release; skip the poll and go straight to a draft.
+            const isVersionTag = /^v/.test(tag);
+            const deadline = Date.now() + 5 * 60 * 1000;
+            let release = isVersionTag ? await findByTag() : null;
+            while (isVersionTag && !release && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 15000));
+              release = await findByTag();
+            }
+
+            if (!release) {
+              // No target_commitish: the Actions token 403s ("Resource not
+              // accessible by integration") when it names a SHA that is not a
+              // branch tip, and that gate fires even when the tag already
+              // exists. GitHub resolves the commit from the tag itself.
+              const { data } = await github.rest.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                tag,
+                tag_name: tag,
+                name: `Stigmer Desktop ${tag}`,
+                body: 'Download the desktop installer for your platform below.',
+                draft: true,
+                prerelease: false,
               });
-              core.setOutput('release_id', data.id);
+              release = data;
             }
+            core.setOutput('release_id', release.id);
 
   build:
     needs: [determine-version, generate-protos, create-release]

--- a/.github/workflows/release.desktop.yaml
+++ b/.github/workflows/release.desktop.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      version:
+        description: 'Existing tag to build and release (e.g. v3.4.1). Leave empty for a dev build.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -32,6 +37,11 @@ jobs:
         run: |
           if [ "${{ github.ref_type }}" = "tag" ]; then
             VERSION="${{ github.ref_name }}"
+            SHOULD_RELEASE="true"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            # Recovery path: re-release an existing tag when its tag-push run
+            # failed (the tag itself can't be re-pushed).
+            VERSION="${{ github.event.inputs.version }}"
             SHOULD_RELEASE="true"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Numeric-only pre-release id; Windows MSI rejects non-numeric identifiers.
@@ -115,11 +125,15 @@ jobs:
         with:
           script: |
             const tag = process.env.VERSION;
+            // No target_commitish: the Actions token 403s ("Resource not
+            // accessible by integration") when it names a SHA that is not a
+            // branch tip, and that gate fires even when the tag already
+            // exists. On tag-push runs the tag exists, so GitHub resolves the
+            // commit from the tag itself.
             const params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
-              target_commitish: context.sha,
               name: `Stigmer Desktop ${tag}`,
               body: 'Download the desktop installer for your platform below.',
               draft: true,

--- a/client-apps/desktop/scripts/ci-latest-json.mjs
+++ b/client-apps/desktop/scripts/ci-latest-json.mjs
@@ -87,7 +87,17 @@ function buildFragment({ targetDir, tag, repo }) {
 
   const platforms = {};
   for (const sigPath of sigFiles) {
-    const bundleName = basename(sigPath).replace(/\.sig$/, '');
+    let bundleName = basename(sigPath).replace(/\.sig$/, '');
+    // tauri-action uploads the universal macOS bundle renamed with an arch
+    // suffix (Stigmer.app.tar.gz -> Stigmer_universal.app.tar.gz), so the
+    // manifest URL must use the uploaded name, not the on-disk one.
+    if (
+      bundleName.endsWith('.app.tar.gz') &&
+      sigPath.includes('universal-apple-darwin') &&
+      !bundleName.includes('_universal')
+    ) {
+      bundleName = bundleName.replace(/\.app\.tar\.gz$/, '_universal.app.tar.gz');
+    }
     const keys = platformKeysFor(bundleName);
     if (!keys) continue;
 


### PR DESCRIPTION
## Summary
Fixes the `release.desktop` pipeline failing with `HttpError: Resource not accessible by integration` when the release tag points to a commit that is no longer the tip of `main`, adds a `workflow_dispatch` recovery path to re-release an existing tag, and fixes two latent bugs that were silently breaking every desktop release: installers stranded on never-published draft releases, and a macOS auto-update URL pointing at a filename that doesn't exist.

## Context
The v3.4.1 tag was cut on a commit 4 commits behind `main`'s tip. The `create-release` job passed `target_commitish: context.sha` to `createRelease`, and the Actions `GITHUB_TOKEN` is categorically rejected (403) when it names a SHA that is not a branch HEAD — even though the token had `contents: write` and the tag already existed. Previous tags (v3.3.0, v3.4.0) worked only because they happened to be cut at `main`'s tip. Re-running the failed run cannot help since runs are pinned to the workflow file at the tagged commit.

Recovering v3.4.1 exposed two more problems that affected even "successful" desktop releases:
- **Stranded drafts.** `create-release` always created its own draft "Stigmer Desktop vX". Drafts don't collide on `tag_name`, so the 422-reuse fallback never fired, and the publish job's `gh release edit <tag>` resolves to the *published* "Release vX" (created by release.cli) — so the draft holding all the installers was never published. The v3.3.0 and v3.4.0 installers are still sitting on invisible drafts today.
- **Broken macOS updater URL.** The `latest.json` fragment used the on-disk bundle name (`Stigmer.app.tar.gz`), but tauri-action uploads the universal bundle renamed to `Stigmer_universal.app.tar.gz`, so the darwin update URL 404'd in every manifest shipped so far.

## Changes
- Drop `target_commitish` from release creation; on tag-push runs the tag already pins the commit, so it was redundant and only served to trip the token's SHA gate.
- `create-release` now resolves the canonical published release for the tag first (polling up to 5 minutes for release.cli to create it on tag-push runs) and only falls back to creating a draft (dev dispatch builds keep their old behavior). Desktop installers and `latest.json` now land on the same public release as the server binaries.
- Add an optional `version` input to `workflow_dispatch` so an existing tag (e.g. `v3.4.1`) can be built and released after a failed tag-push run, without re-pushing the tag.
- `ci-latest-json.mjs` maps the universal macOS bundle to the `_universal` asset name tauri-action actually uploads.

## Test plan
- Dispatched this workflow from this branch (based on the v3.4.1 tagged commit) with `version=v3.4.1`: all jobs green, installers built for all three platforms. Run: https://github.com/stigmer/stigmer/actions/runs/30453634790
- v3.4.1 installers + corrected `latest.json` are now live on the published [Release v3.4.1](https://github.com/stigmer/stigmer/releases/tag/v3.4.1) (assets were transferred from the draft manually; the reuse + manifest fixes in this PR automate exactly that for future tags).
- `node --check` on the manifest script; workflow YAML parse-checked.

## Risks
- If release.cli fails or is slow beyond 5 minutes on a tag push, `create-release` falls back to the previous draft behavior — no worse than today.
- Dev-build dispatches without `version` behave as before.

## Checklist
- [x] Backward compatible