### PR TITLE
test(integration): provision OpenBAO in the harness — vault becomes a boot requirement

### DIFF
--- a/test/integration-offline/suite_test.go
+++ b/test/integration-offline/suite_test.go
@@ -64,6 +64,8 @@ func TestMain(m *testing.M) {
 		RedisHost:       testHarness.Redis.Host,
 		RedisPort:       testHarness.Redis.Port,
 		TemporalAddress: testHarness.Temporal.Address(),
+		VaultAddr:       testHarness.OpenBao.Addr,
+		VaultToken:      testHarness.OpenBao.RootToken,
 		LogDir:          logDir,
 
 		ActivityRouting:         "session",

--- a/test/integration-security/suite_test.go
+++ b/test/integration-security/suite_test.go
@@ -120,6 +120,8 @@ func TestMain(m *testing.M) {
 		RedisHost:        testHarness.Redis.Host,
 		RedisPort:        testHarness.Redis.Port,
 		TemporalAddress:  testHarness.Temporal.Address(),
+		VaultAddr:        testHarness.OpenBao.Addr,
+		VaultToken:       testHarness.OpenBao.RootToken,
 		LogDir:           logDir,
 		Security:         harness.SecurityModeProduction,
 		Auth0IssuerURL:   mockAuth0.Issuer,

--- a/test/integration-session-routing/suite_test.go
+++ b/test/integration-session-routing/suite_test.go
@@ -65,6 +65,8 @@ func TestMain(m *testing.M) {
 		RedisHost:       testHarness.Redis.Host,
 		RedisPort:       testHarness.Redis.Port,
 		TemporalAddress: testHarness.Temporal.Address(),
+		VaultAddr:       testHarness.OpenBao.Addr,
+		VaultToken:      testHarness.OpenBao.RootToken,
 		CursorAPIKey:    cursorKey,
 		LogDir:          logDir,
 

--- a/test/integration-wfexec-routing/suite_test.go
+++ b/test/integration-wfexec-routing/suite_test.go
@@ -62,6 +62,8 @@ func TestMain(m *testing.M) {
 		RedisHost:       testHarness.Redis.Host,
 		RedisPort:       testHarness.Redis.Port,
 		TemporalAddress: testHarness.Temporal.Address(),
+		VaultAddr:       testHarness.OpenBao.Addr,
+		VaultToken:      testHarness.OpenBao.RootToken,
 		LogDir:          logDir,
 
 		ActivityRouting:         "session",

--- a/test/integration/cmd/conformance-cloudenv/main.go
+++ b/test/integration/cmd/conformance-cloudenv/main.go
@@ -102,6 +102,8 @@ func run(logger *slog.Logger) error {
 		MinIOEndpoint:   h.MinIO.Endpoint,
 		MinIOAccessKey:  h.MinIO.AccessKey,
 		MinIOSecretKey:  h.MinIO.SecretKey,
+		VaultAddr:       h.OpenBao.Addr,
+		VaultToken:      h.OpenBao.RootToken,
 		LogDir:          h.LogDir(),
 		Security:        harness.SecurityModeTest,
 	}, logger)

--- a/test/integration/harness/BUILD.bazel
+++ b/test/integration/harness/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "mock_jwks_server.go",
         "mock_llm_proxy.go",
         "mock_oauth_server.go",
+        "openbao.go",
         "openfga.go",
         "org_helpers.go",
         "otel.go",

--- a/test/integration/harness/harness.go
+++ b/test/integration/harness/harness.go
@@ -30,6 +30,7 @@ type TestHarness struct {
 	Redis         *RedisContainer
 	Temporal      *TemporalDevServer
 	OpenFGA       *OpenFGAContainer
+	OpenBao       *OpenBaoContainer
 	MinIO         *MinIOContainer
 	Postgres      *PostgresContainer
 	AppPostgres   *AppPostgresContainer
@@ -129,10 +130,10 @@ func Start(ctx context.Context, cfg Config) (*TestHarness, error) {
 
 	otelEnabled := IsOTelRequested()
 
-	var redisErr, temporalErr, minioErr, postgresErr, appPostgresErr, jaegerErr error
+	var redisErr, temporalErr, minioErr, postgresErr, appPostgresErr, openBaoErr, jaegerErr error
 	var wg sync.WaitGroup
 
-	startCount := 5
+	startCount := 6
 	if otelEnabled {
 		startCount++
 	}
@@ -183,6 +184,15 @@ func Start(ctx context.Context, cfg Config) (*TestHarness, error) {
 		}
 	}()
 
+	go func() {
+		defer wg.Done()
+		logger.Info("starting openbao (secret encryption)")
+		h.OpenBao, openBaoErr = StartOpenBao(ctx)
+		if openBaoErr == nil {
+			logger.Info("openbao ready", "addr", h.OpenBao.Addr)
+		}
+	}()
+
 	if otelEnabled {
 		go func() {
 			defer wg.Done()
@@ -218,6 +228,10 @@ func Start(ctx context.Context, cfg Config) (*TestHarness, error) {
 	if appPostgresErr != nil {
 		h.Stop(ctx)
 		return nil, fmt.Errorf("app postgres: %w", appPostgresErr)
+	}
+	if openBaoErr != nil {
+		h.Stop(ctx)
+		return nil, fmt.Errorf("openbao: %w", openBaoErr)
 	}
 	if jaegerErr != nil {
 		h.Stop(ctx)
@@ -271,6 +285,12 @@ func (h *TestHarness) Stop(ctx context.Context) {
 	if h.OpenFGA != nil {
 		if err := StopContainer(ctx, h.OpenFGA.Container); err != nil {
 			h.logger.Error("failed to stop openfga", "error", err)
+		}
+	}
+
+	if h.OpenBao != nil {
+		if err := StopContainer(ctx, h.OpenBao.Container); err != nil {
+			h.logger.Error("failed to stop openbao", "error", err)
 		}
 	}
 

--- a/test/integration/harness/openbao.go
+++ b/test/integration/harness/openbao.go
@@ -1,0 +1,115 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// OpenBaoContainer holds a running dev-mode OpenBAO instance backing the
+// cloud service's secret encryption (the `vault` Spring profile). The Java
+// service connects via the VAULT_* env vars emitted by buildServiceEnv.
+//
+// Vault is a BOOT requirement, not an optional feature: the service's secret
+// codecs (enc:v2 envelope encryption, enc:v3 vault-KV pointers) exist only
+// when vault is enabled, and with the v1 static-key codec retired there is no
+// codec — and therefore no boot — without it. The harness always provisions
+// this container, like AppPostgres.
+type OpenBaoContainer struct {
+	Container testcontainers.Container
+	// Addr is the full http endpoint (VAULT_ADDR) the service connects to.
+	Addr string
+	// RootToken authenticates the service via token auth (VAULT_TOKEN).
+	// Dev mode has no Kubernetes auth; the production-policy-scoped access
+	// contract is proven separately by the cloud repo's `make test-vault`.
+	RootToken string
+}
+
+const (
+	// Pinned to the production OpenBAO version — the same image
+	// VaultClientOpenBaoTest (stigmer-cloud) locks to, so what boots here is
+	// what runs in prod.
+	openBaoImage = "openbao/openbao:2.4.4"
+
+	openBaoRootToken = "integration-test-root-token"
+)
+
+// StartOpenBao starts a dev-mode OpenBAO container and mounts the Transit
+// engine. Dev mode auto-mounts only KV v2 (at secret/, the service's
+// VAULT_KV_MOUNT default); Transit — where the per-org key-encryption keys
+// live — must be mounted explicitly, exactly as the production bootstrap
+// runbook does (stigmer-cloud _ops/setup-guides/07-openbao-bootstrap.md).
+func StartOpenBao(ctx context.Context) (*OpenBaoContainer, error) {
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        openBaoImage,
+			ExposedPorts: []string{"8200/tcp"},
+			// Both env spellings: OpenBAO's entrypoint reads BAO_*, and older
+			// entrypoint revisions still honor the VAULT_* names.
+			Env: map[string]string{
+				"BAO_DEV_ROOT_TOKEN_ID":    openBaoRootToken,
+				"VAULT_DEV_ROOT_TOKEN_ID":  openBaoRootToken,
+				"BAO_DEV_LISTEN_ADDRESS":   "0.0.0.0:8200",
+				"VAULT_DEV_LISTEN_ADDRESS": "0.0.0.0:8200",
+			},
+			Cmd:        []string{"server", "-dev"},
+			WaitingFor: wait.ForHTTP("/v1/sys/health").WithPort("8200/tcp"),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start openbao container: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get openbao host: %w", err)
+	}
+	port, err := container.MappedPort(ctx, "8200/tcp")
+	if err != nil {
+		return nil, fmt.Errorf("get openbao port: %w", err)
+	}
+	addr := fmt.Sprintf("http://%s:%s", host, port.Port())
+
+	if err := mountTransit(ctx, addr, openBaoRootToken); err != nil {
+		return nil, fmt.Errorf("mount transit engine: %w", err)
+	}
+
+	return &OpenBaoContainer{
+		Container: container,
+		Addr:      addr,
+		RootToken: openBaoRootToken,
+	}, nil
+}
+
+// mountTransit enables the Transit secrets engine at the service's
+// VAULT_TRANSIT_MOUNT default path via the sys/mounts API.
+func mountTransit(ctx context.Context, addr, token string) error {
+	body := bytes.NewReader([]byte(`{"type":"transit"}`))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, addr+"/v1/sys/mounts/transit", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Vault-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// sys/mounts returns 204 on success; 400 with "path is already in use"
+	// would mean a double mount, which only a harness bug can cause — fail
+	// loudly rather than tolerate it.
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/test/integration/harness/service.go
+++ b/test/integration/harness/service.go
@@ -120,6 +120,16 @@ type ServiceConfig struct {
 	AppPGUser     string
 	AppPGPassword string
 
+	// OpenBAO — the secret-encryption backend behind the vault Spring
+	// profile. VAULT_* env vars point the service at this instance via token
+	// auth (dev-mode; production uses Kubernetes auth). The harness always
+	// provisions this container (StartOpenBao): vault is a boot requirement —
+	// with the v1 static-key codec retired, every secret codec is
+	// vault-backed and the service refuses to start without one. Leaving
+	// these empty fails the fail-fast boot loudly.
+	VaultAddr  string
+	VaultToken string
+
 	// LogDir is the directory for the service log file.
 	// If empty, a temporary directory is used.
 	LogDir string
@@ -337,9 +347,9 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 	productionSecurity := cfg.Security == SecurityModeProduction
 
 	// This list deliberately reproduces the cloud service's required profile
-	// set (application.yaml) minus what tests stub out (vault); a new
-	// always-on cloud profile that gates required beans must be added here
-	// too, or the Spring context fails to boot with a missing-bean error.
+	// set (application.yaml); a new always-on cloud profile that gates
+	// required beans must be added here too, or the Spring context fails to
+	// boot with a missing-bean error.
 	//
 	// The app-postgres system of record needs no profile (its config is
 	// unconditional in application.yaml): the harness always starts the
@@ -353,7 +363,12 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 	// live. When a suite leaves RecordsPGHost empty, the lazy pool
 	// (initializationFailTimeout = -1) still lets the service boot against
 	// the localhost:5432 defaults; record RPCs then fail loudly on first use.
-	profiles := "temporal,iam,logging,auth0,skill-r2,agent-execution-r2,claimcheck-r2,records-postgres"
+	//
+	// vault + encryption: required for the secret codecs to exist. Vault was
+	// once "what tests stub out"; since the v1 static-key retirement every
+	// codec is vault-backed, so the harness always starts an OpenBAO
+	// container (StartOpenBao) and suites pass it via ServiceConfig.Vault*.
+	profiles := "temporal,iam,logging,auth0,skill-r2,agent-execution-r2,claimcheck-r2,records-postgres,vault,encryption"
 	if cfg.SandboxType != "" {
 		profiles += ",sandbox"
 	}
@@ -408,8 +423,16 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 		"STIGMER_STRIPE_SECRET_KEY=sk_test_integration_dummy",
 		"STIGMER_STRIPE_WEBHOOK_SECRET=whsec_test_dummy",
 
+		// OpenBAO (secret encryption) — token auth against the harness's
+		// dev-mode container. Production uses Kubernetes auth; the
+		// production-policy access contract is proven by the cloud repo's
+		// `make test-vault`, not here.
+		"VAULT_ENABLED=true",
+		fmt.Sprintf("VAULT_ADDR=%s", cfg.VaultAddr),
+		"VAULT_AUTH_METHOD=token",
+		fmt.Sprintf("VAULT_TOKEN=%s", cfg.VaultToken),
+
 		// Disable optional features
-		"STIGMER_VAULT_ENABLED=false",
 		fmt.Sprintf("OBSERVABILITY_ENABLED=%t", cfg.OTLPEndpoint != ""),
 		"STIGMER_BILLING_RECONCILIATION_ENABLED=false",
 		"STIGMER_BILLING_RESERVATION_EXPIRY_ENABLED=false",

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -114,6 +114,12 @@ func TestMain(m *testing.M) {
 	suiteLogger.Info("app Postgres wired for Java service",
 		"host", svcCfg.AppPGHost, "port", svcCfg.AppPGPort)
 
+	// Secret encryption backend: vault is a boot requirement (the v1
+	// static-key codec is retired; every codec is vault-backed).
+	svcCfg.VaultAddr = testHarness.OpenBao.Addr
+	svcCfg.VaultToken = testHarness.OpenBao.RootToken
+	suiteLogger.Info("openbao wired for Java service", "addr", svcCfg.VaultAddr)
+
 	svc, err := harness.StartJavaService(ctx, svcCfg, suiteLogger)
 	if err != nil {
 		suiteLogger.Error("failed to start java service", "error", err)


### PR DESCRIPTION
## Summary
Teach the integration harness to always provision a dev-mode OpenBAO container and boot the cloud service's fat JAR with vault enabled (token auth), replacing the hardcoded `STIGMER_VAULT_ENABLED=false` stub.

## Context
The cloud service is retiring its v1 static-key secret codec (PR-3 of the secrets-vault migration, stigmer-cloud). After that lands, every secret codec is vault-backed and the service **refuses to boot without vault** — so the harness's vault stub would kill `make test-conformance-cloud` and every integration lane that launches the JAR. This PR removes the stub ahead of time, and is backward-compatible with the current JAR (vault enabled but unused for writes behaves exactly as today).

## Changes
- New `test/integration/harness/openbao.go`: dev-mode OpenBAO container (pinned to `openbao/openbao:2.4.4`, the production version and the same image stigmer-cloud's `make test-vault` locks to), with the Transit engine mounted the way the production bootstrap runbook does. Follows the harness's per-infrastructure file pattern (`postgres.go`, `openfga.go`, …).
- `harness.go`: OpenBAO joins the always-started infrastructure group (like Redis/Temporal/AppPostgres) with matching teardown.
- `service.go`: `ServiceConfig` gains `VaultAddr`/`VaultToken`; `buildServiceEnv` adds the `vault,encryption` Spring profiles (the profile list now reproduces the production set in full) and emits `VAULT_ENABLED=true` + token-auth coordinates.
- All five suite setups and the conformance cloud-env launcher wire the container's coordinates through `ServiceConfig`.

## Implementation notes
- Token auth (dev-mode root token) is deliberate: the production-policy-scoped access contract is proven by stigmer-cloud's `make test-vault` suite; the harness's job is a faithful boot, not vault authz testing.
- Dev mode auto-mounts only KV v2 at `secret/`; Transit is mounted explicitly via `sys/mounts`, matching `_ops/setup-guides/07-openbao-bootstrap.md`.

## Breaking changes
- None for the current cloud JAR (verified below). Suites that construct `ServiceConfig` by hand must pass `VaultAddr`/`VaultToken` once the cloud-side v1 retirement merges — all in-repo suites are updated here.

## Test plan
- `make test-conformance-cloud` against the current stigmer-cloud `main` fat JAR: **209/209 tests green**, service boots with vault enabled, OpenBAO container starts and mounts Transit.
- `go build`/`go vet` on `test/integration`; all tagged suite packages compile; `bazel build //test/integration/harness` green.

## Risks
- Adds one small container to every integration run (~600ms startup, parallelized with the other containers). Rollback is a revert.

## Checklist
- [x] Tests added/updated (if needed)
- [x] Backward compatible

Made with [Cursor](https://cursor.com)