### PR TITLE
fix(ci): eliminate registry-timeout and unmocked-fetch CI flakes

### DIFF
--- a/.github/workflows/ci.conformance-cloud.yaml
+++ b/.github/workflows/ci.conformance-cloud.yaml
@@ -107,6 +107,10 @@ jobs:
     name: Conformance (cloud)
     runs-on: ubuntu-latest
     needs: build-service-jar
+    # Harness images come from the GHCR mirror, not Docker Hub (issue #334);
+    # see test/integration/harness/images.go.
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.integration-canary.yaml
+++ b/.github/workflows/ci.integration-canary.yaml
@@ -76,6 +76,10 @@ jobs:
     needs: build-service-jar
     timeout-minutes: 15
     environment: provider-integration
+    # Harness images come from the GHCR mirror, not Docker Hub (issue #334);
+    # see test/integration/harness/images.go.
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -144,6 +144,12 @@ jobs:
     name: "Integration Tests (${{ matrix.label }})"
     runs-on: ubuntu-latest
     needs: build-service-jar
+    # Pull harness images from the GHCR mirror instead of Docker Hub —
+    # anonymous Hub pulls made harness boot a recurring flake (issue #334).
+    # testcontainers-go rewrites every bare-Hub reference, Ryuk included;
+    # see test/integration/harness/images.go for the mirrored list.
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.integration-providers.yaml
+++ b/.github/workflows/ci.integration-providers.yaml
@@ -71,6 +71,10 @@ jobs:
     needs: build-service-jar
     timeout-minutes: 15
     environment: provider-integration
+    # Harness images come from the GHCR mirror, not Docker Hub (issue #334);
+    # see test/integration/harness/images.go.
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.integration-stress.yaml
+++ b/.github/workflows/ci.integration-stress.yaml
@@ -77,6 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-service-jar
     timeout-minutes: 30
+    # Harness images come from the GHCR mirror, not Docker Hub (issue #334);
+    # see test/integration/harness/images.go.
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/mirror-test-images.yaml
+++ b/.github/workflows/mirror-test-images.yaml
@@ -1,0 +1,80 @@
+# =============================================================================
+# Mirror Test Images — copy integration-harness images from Docker Hub to GHCR
+# =============================================================================
+#
+# Why: every integration suite boots ~7 containers per CI leg, across 5
+# parallel legs. Pulling them anonymously from Docker Hub made harness boot a
+# recurring flake (rate limits, registry outages — issue #334). CI instead
+# pulls from a GHCR mirror via TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX; this
+# workflow keeps that mirror populated.
+#
+# The image list is derived from the harness source itself
+# (test/integration/harness/images.go, MirrorImages), so the mirror can never
+# drift from what the harness boots — including the testcontainers Ryuk
+# reaper, whose version follows the testcontainers-go dependency.
+#
+# The mirror packages (ghcr.io/stigmer/mirror/*) are public, so CI and local
+# runs pull them anonymously with no login step. New packages created by this
+# workflow default to PRIVATE visibility and must be flipped to public once:
+#   gh api -X PATCH /orgs/stigmer/packages/container/<url-encoded-name> \
+#     -f visibility=public
+#
+# When a PR changes an image (or bumps testcontainers-go), run this workflow
+# manually from the PR branch so the mirror has the new image before the
+# integration legs re-run. Copies are idempotent; re-runs are cheap.
+
+name: Mirror Test Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      # The image list itself.
+      - "test/integration/harness/images.go"
+      # A testcontainers-go bump in any suite module can move the Ryuk version.
+      - "test/*/go.mod"
+      - ".github/workflows/mirror-test-images.yaml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    name: Mirror to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+
+      # crane copies images registry-to-registry, preserving multi-arch
+      # manifest lists byte-for-byte (no local docker pull/push round-trip).
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      # crane reads the credentials docker/login-action writes to the
+      # Docker config keychain.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror harness images
+        working-directory: test/integration
+        run: |
+          set -euo pipefail
+          MIRROR_PREFIX="ghcr.io/${{ github.repository_owner }}/mirror"
+          go run ./cmd/print-mirror-images | while read -r image; do
+            echo "::group::Mirroring ${image}"
+            crane copy "${image}" "${MIRROR_PREFIX}/${image}"
+            echo "::endgroup::"
+          done

--- a/sdk/react/src/execution/__tests__/PlanArtifactCard.test.tsx
+++ b/sdk/react/src/execution/__tests__/PlanArtifactCard.test.tsx
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { create } from "@bufbuild/protobuf";
 import type { Stigmer } from "@stigmer/sdk";
@@ -46,6 +52,17 @@ function renderCard(ui: ReactNode) {
 }
 
 afterEach(cleanup);
+
+// The download flow ends in a transient-anchor click with target="_blank".
+// Left unstubbed, happy-dom treats that click as a real popup navigation and
+// fetches the fixture URL over the actual network — after this test has
+// already returned, so the DNS failure gets attributed to whichever test the
+// worker is running by then (the flake in issue #334).
+beforeEach(() => {
+  vi.spyOn(HTMLAnchorElement.prototype, "click")
+    .mockImplementation(() => {})
+    .mockClear();
+});
 
 describe("PlanArtifactCard — compact document card", () => {
   it("is an accessible region with the plan's title, filename, and size", () => {
@@ -178,6 +195,7 @@ describe("PlanArtifactCard — compact document card", () => {
 
   it("downloads the artifact on demand via a freshly minted URL", async () => {
     const { stigmer, getArtifactDownloadUrl } = createStigmerMock();
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, "click");
     render(
       withStigmer(
         <PlanArtifactCard executionId="aex_1" artifact={planArtifact} org="acme" />,
@@ -191,6 +209,9 @@ describe("PlanArtifactCard — compact document card", () => {
     const req = getArtifactDownloadUrl.mock.calls[0][0];
     expect(req.executionId).toBe("aex_1");
     expect(req.storageKey).toBe("artifacts/aex_1/plan.md");
+    // Wait for the mint-URL → anchor-click continuation INSIDE the test body;
+    // returning while it is still in flight is what let it escape.
+    await waitFor(() => expect(anchorClick).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/sdk/react/vitest.config.ts
+++ b/sdk/react/vitest.config.ts
@@ -9,6 +9,24 @@ export default defineConfig({
     // default suite never tries to load them.
     exclude: ["**/node_modules/**", "**/*.a11y.test.tsx", "**/*.layout.test.tsx"],
     environment: "happy-dom",
+    // Never let happy-dom follow a navigation over the real network. An
+    // anchor click with target="_blank" (the browser-download flows) becomes
+    // a popup navigation whose request happy-dom issues with its INTERNAL
+    // Fetch class — a globalThis.fetch stub cannot intercept it; only these
+    // settings block it, before any request is created. Unblocked, the stray
+    // DNS lookup resolves after its test has returned and the error lands on
+    // an unrelated test (the AgentShareList flake in issue #334).
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          navigation: {
+            disableMainFrameNavigation: true,
+            disableChildFrameNavigation: true,
+            disableChildPageNavigation: true,
+          },
+        },
+      },
+    },
     // Raises testing-library's suite-wide async timeout (portaled Base UI
     // content mounts asynchronously and flakes under CI load at the 1s
     // default); see the rationale in the setup file.

--- a/sdk/react/vitest.setup.ts
+++ b/sdk/react/vitest.setup.ts
@@ -11,3 +11,17 @@ import { configure } from "@testing-library/react";
 // wait still surfaces the informative testing-library error with a DOM dump,
 // never a bare vitest "test timed out".
 configure({ asyncUtilTimeout: 4000 });
+
+// No test may reach the real network. Any code path that calls the global
+// fetch unmocked fails immediately, in the right test file, instead of
+// escaping to the OS resolver and flaking order-dependently (issue #334).
+// Tests that need fetch install their own stub (vi.stubGlobal / assignment),
+// which simply replaces this default. Navigations that bypass the global
+// fetch are blocked separately via happy-dom settings in vitest.config.ts.
+globalThis.fetch = (input: RequestInfo | URL): Promise<Response> => {
+  throw new Error(
+    `Unmocked network call in test: fetch(${String(input)}). ` +
+      "Stub fetch in this test file (e.g. vi.stubGlobal) instead of letting " +
+      "requests reach the network.",
+  );
+};

--- a/test/integration-offline/suite_test.go
+++ b/test/integration-offline/suite_test.go
@@ -40,7 +40,10 @@ func TestMain(m *testing.M) {
 		cfg.OutputDir = ".test-output-offline"
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// The boot budget also absorbs testcontainers-go's image-pull retry
+	// backoff, so a slow registry gets headroom instead of killing the run
+	// at the context deadline (issue #334).
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	var err error

--- a/test/integration-security/suite_test.go
+++ b/test/integration-security/suite_test.go
@@ -70,7 +70,10 @@ func TestMain(m *testing.M) {
 	cfg := harness.DefaultConfig()
 	cfg.OutputDir = ".test-output-security"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// The boot budget also absorbs testcontainers-go's image-pull retry
+	// backoff, so a slow registry gets headroom instead of killing the run
+	// at the context deadline (issue #334).
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	var err error

--- a/test/integration-session-routing/suite_test.go
+++ b/test/integration-session-routing/suite_test.go
@@ -41,7 +41,10 @@ func TestMain(m *testing.M) {
 		cfg.OutputDir = ".test-output-session-routing"
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// The boot budget also absorbs testcontainers-go's image-pull retry
+	// backoff, so a slow registry gets headroom instead of killing the run
+	// at the context deadline (issue #334).
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	var err error

--- a/test/integration-wfexec-routing/suite_test.go
+++ b/test/integration-wfexec-routing/suite_test.go
@@ -40,7 +40,10 @@ func TestMain(m *testing.M) {
 		cfg.OutputDir = ".test-output-wfexec-routing"
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// The boot budget also absorbs testcontainers-go's image-pull retry
+	// backoff, so a slow registry gets headroom instead of killing the run
+	// at the context deadline (issue #334).
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	var err error

--- a/test/integration/cmd/print-mirror-images/main.go
+++ b/test/integration/cmd/print-mirror-images/main.go
@@ -1,0 +1,23 @@
+// Command print-mirror-images prints every Docker Hub image the integration
+// harness can pull, one per line — the interface between the Go source of
+// truth (harness.MirrorImages) and the GHCR mirror-sync workflow
+// (.github/workflows/mirror-test-images.yaml), which copies each printed
+// image to ghcr.io/stigmer/mirror/.
+//
+// Deriving the list by running the code, rather than maintaining a manifest
+// beside it, makes drift between the harness and the mirror impossible: the
+// list includes the Ryuk reaper image at whatever version the resolved
+// testcontainers-go dependency ships.
+package main
+
+import (
+	"fmt"
+
+	"github.com/stigmer/stigmer/test/integration/harness"
+)
+
+func main() {
+	for _, image := range harness.MirrorImages() {
+		fmt.Println(image)
+	}
+}

--- a/test/integration/harness/images.go
+++ b/test/integration/harness/images.go
@@ -1,0 +1,67 @@
+package harness
+
+import "github.com/testcontainers/testcontainers-go"
+
+// Container images for every service the harness boots, in one place.
+//
+// All references are deliberately bare Docker Hub names. In CI the
+// TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX environment variable rewrites every
+// bare-Hub reference — including the testcontainers Ryuk reaper, which never
+// appears in this repo's source — to the GHCR mirror under
+// ghcr.io/stigmer/mirror/, taking Docker Hub's rate limits and outages off
+// the CI critical path (issue #334). Local runs set no prefix and pull from
+// Docker Hub as always.
+//
+// The mirror is populated by .github/workflows/mirror-test-images.yaml,
+// which derives its image list from MirrorImages below — this file is the
+// single source of truth; there is no separate manifest to keep in sync.
+//
+// Changing an image here (or bumping testcontainers-go, which moves the Ryuk
+// version) means CI needs the new image in the mirror BEFORE the integration
+// legs can pass: the sync workflow runs on merge to main, so on the PR itself
+// trigger "Mirror Test Images" manually (workflow_dispatch) from the branch,
+// then re-run the failed legs.
+const (
+	redisImage = "redis:7-alpine"
+
+	// postgres:16-alpine matches the image the cloud repo's Testcontainers
+	// suites pin (RecordsPostgresContainerSmokeTest and friends).
+	postgresImage = "postgres:16-alpine"
+
+	// Pinned to the release the previously-floating :latest resolved to when
+	// the mirror was introduced. A floating tag would make the mirror capture
+	// a moving target and let CI drift from local runs.
+	minioImage = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+
+	// Pinned to the production OpenBAO version — the same image
+	// VaultClientOpenBaoTest (stigmer-cloud) locks to, so what boots here is
+	// what runs in prod.
+	openBaoImage = "openbao/openbao:2.4.4"
+
+	openFGAImage = "openfga/openfga:v1.8.2"
+
+	// Started only when INTEGRATION_TEST_OTEL is set (the CI core leg), but
+	// mirrored unconditionally so enabling OTel never depends on Docker Hub.
+	jaegerImage = "jaegertracing/all-in-one:1.76.0"
+)
+
+// MirrorImages returns every Docker Hub image an integration run can pull:
+// the six harness services plus the Ryuk resource reaper that
+// testcontainers-go starts implicitly. Ryuk's version comes from the library
+// itself, so a testcontainers-go upgrade updates this list automatically.
+//
+// testcontainers-go must stay a direct dependency only of this module
+// (test/integration); the sibling suite modules hold it as an indirect
+// dependency at the same version. Pinning it independently in a sibling
+// would let that suite's Ryuk version diverge from the mirrored one.
+func MirrorImages() []string {
+	return []string{
+		redisImage,
+		postgresImage,
+		minioImage,
+		openBaoImage,
+		openFGAImage,
+		jaegerImage,
+		testcontainers.ReaperDefaultImage,
+	}
+}

--- a/test/integration/harness/infra.go
+++ b/test/integration/harness/infra.go
@@ -16,7 +16,7 @@ type RedisContainer struct {
 }
 
 func StartRedis(ctx context.Context) (*RedisContainer, error) {
-	container, err := redis.Run(ctx, "redis:7-alpine")
+	container, err := redis.Run(ctx, redisImage)
 	if err != nil {
 		return nil, fmt.Errorf("start redis container: %w", err)
 	}

--- a/test/integration/harness/jaeger.go
+++ b/test/integration/harness/jaeger.go
@@ -25,7 +25,7 @@ type JaegerContainer struct {
 func StartJaeger(ctx context.Context) (*JaegerContainer, error) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "jaegertracing/all-in-one:1.76.0",
+			Image:        jaegerImage,
 			ExposedPorts: []string{"4317/tcp", "16686/tcp"},
 			Env: map[string]string{
 				"COLLECTOR_OTLP_ENABLED": "true",

--- a/test/integration/harness/minio.go
+++ b/test/integration/harness/minio.go
@@ -29,7 +29,7 @@ var minioBuckets = []string{"test-bucket", "test-claimcheck-bucket"}
 // StartMinIO starts a MinIO container with default credentials and
 // pre-creates the required S3 buckets.
 func StartMinIO(ctx context.Context) (*MinIOContainer, error) {
-	container, err := minio.Run(ctx, "minio/minio:latest",
+	container, err := minio.Run(ctx, minioImage,
 		minio.WithUsername(minioDefaultUser),
 		minio.WithPassword(minioDefaultPassword),
 	)

--- a/test/integration/harness/openbao.go
+++ b/test/integration/harness/openbao.go
@@ -30,14 +30,7 @@ type OpenBaoContainer struct {
 	RootToken string
 }
 
-const (
-	// Pinned to the production OpenBAO version — the same image
-	// VaultClientOpenBaoTest (stigmer-cloud) locks to, so what boots here is
-	// what runs in prod.
-	openBaoImage = "openbao/openbao:2.4.4"
-
-	openBaoRootToken = "integration-test-root-token"
-)
+const openBaoRootToken = "integration-test-root-token"
 
 // StartOpenBao starts a dev-mode OpenBAO container and mounts the Transit
 // engine. Dev mode auto-mounts only KV v2 (at secret/, the service's

--- a/test/integration/harness/openfga.go
+++ b/test/integration/harness/openfga.go
@@ -32,7 +32,7 @@ type OpenFGAContainer struct {
 //
 // Requires the `fga` CLI on PATH for DSL-to-JSON transformation.
 func StartOpenFGA(ctx context.Context, fgaModelDir string) (*OpenFGAContainer, error) {
-	container, err := openfga.Run(ctx, "openfga/openfga:v1.8.2")
+	container, err := openfga.Run(ctx, openFGAImage)
 	if err != nil {
 		return nil, fmt.Errorf("start openfga container: %w", err)
 	}

--- a/test/integration/harness/postgres.go
+++ b/test/integration/harness/postgres.go
@@ -125,7 +125,7 @@ func StartAppPostgres(ctx context.Context) (*AppPostgresContainer, error) {
 }
 
 func runPostgres16(ctx context.Context, database, user, password string) (*postgres.PostgresContainer, string, string, error) {
-	container, err := postgres.Run(ctx, "postgres:16-alpine",
+	container, err := postgres.Run(ctx, postgresImage,
 		postgres.WithDatabase(database),
 		postgres.WithUsername(user),
 		postgres.WithPassword(password),

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -36,7 +36,10 @@ func TestMain(m *testing.M) {
 
 	cfg := harness.DefaultConfig()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// The boot budget also absorbs testcontainers-go's image-pull retry
+	// backoff, so a slow registry gets headroom instead of killing the run
+	// at the context deadline (issue #334).
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	var err error


### PR DESCRIPTION
## Summary

Fixes both CI flakes from #334: integration suites now pull every harness image — including the implicit testcontainers Ryuk reaper — from a GHCR mirror instead of anonymous Docker Hub, and the sdk/react test that leaked a real network fetch is fixed at its true source with two suite-wide guards so the class cannot reappear.

## Context

Two flakes surfaced while shipping #333. A Docker Hub registry timeout aborted an integration suite during `TestMain` harness boot (zero test records, so `--rerun-fails` cannot help), and an sdk/react test failed with a real DNS lookup for `example.test` that was misattributed to `AgentShareList.test.tsx` — the leak actually came from `PlanArtifactCard.test.tsx`, whose download continuation ran after the test body returned.

## Changes

- **Harness images centralized** in `test/integration/harness/images.go`; `minio/minio:latest` pinned to the release it resolved to (a floating tag makes the mirror a moving target).
- **Single-source mirror list**: `MirrorImages()` + `cmd/print-mirror-images` derive the mirror contents from the code itself, Ryuk included at the library's own version — drift between harness and mirror is impossible by construction.
- **New `mirror-test-images.yaml` workflow** syncs the list to `ghcr.io/stigmer/mirror/*` via `crane copy` (multi-arch-safe); triggers on dispatch and on pushes touching `images.go` or any suite `go.mod`.
- **Five harness-booting workflows** set `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror` (offline, providers, stress, canary, conformance-cloud). Local dev is untouched.
- **Boot budget 5 → 8 min** in the five `suite_test.go` files so testcontainers-go's built-in pull retry has headroom.
- **`PlanArtifactCard.test.tsx`** stubs the anchor click and awaits the download continuation inside the test body.
- **Suite-wide guards**: happy-dom navigation disabled in `vitest.config.ts` (popup navigations use happy-dom's internal `Fetch`, which no global fetch stub can intercept) and a throwing default `globalThis.fetch` in `vitest.setup.ts` so future unmocked calls fail loudly in the right file.

## Implementation notes

- "Add retry with backoff" from the issue was deliberately not implemented: testcontainers-go already retries pulls with exponential backoff bounded by the caller's context — the observed `context deadline exceeded` was that retry running out of the 5-minute boot budget. Only a mirror survives a real Hub outage.
- Docker Hub authentication was rejected: the captured error is a connection timeout, not a 429 rate-limit response, so auth addresses a cause the log does not implicate.
- A fetch stub/MSW in `AgentShareList.test.tsx` (the issue's suggestion) would not have worked — that file makes no network calls, and the real leak bypasses global `fetch` entirely.

## Breaking changes

- None for users. **Merge prerequisite for CI**: the seven `ghcr.io/stigmer/mirror/*` packages were created with `internal` visibility and must be flipped to **public** (UI-only; GitHub has no API for it) before this merges, or integration legs fail at boot. The initial sync has already been run.

## Test plan

- All five Go suite modules compile and vet clean (`-tags integration`).
- End-to-end substitution proven locally: with the prefix set, a probe boot pulled `mirror/redis:7-alpine` and `mirror/testcontainers/ryuk:0.13.0` through GHCR.
- Full sdk/react suite with both guards active: 350 files, 3,836 tests, all passing.

## Risks

- If a mirror package is missing or private, harness boot fails with a clear image-pull error; rollback is deleting the env var from the five workflows (images fall back to Docker Hub).
- Image bumps need a manual "Mirror Test Images" dispatch from the PR branch before the legs pass — documented in `images.go`.

Closes #334

Made with [Cursor](https://cursor.com)