### PR TITLE
feat(runner,mcp-server): attach the send_channel_message tool and the templates prompt section

### DIFF
--- a/backend/services/runner/src/__test-utils__/mock-client.ts
+++ b/backend/services/runner/src/__test-utils__/mock-client.ts
@@ -26,6 +26,10 @@ export function mockStigmerClient(overrides: MockMethods = {}): StigmerClient {
     getRunnerScopedToken: vi.fn().mockResolvedValue(undefined),
     getSession: vi.fn().mockResolvedValue({}),
     updateSession: vi.fn().mockResolvedValue({}),
+    // No proactive channels by default — the everyday answer for most
+    // agents (DD-006 D2); tests opt in to a channel-bound agent.
+    listMessagingChannels: vi.fn().mockResolvedValue([]),
+    listChannelTemplates: vi.fn().mockResolvedValue([]),
     getAgent: vi.fn().mockResolvedValue({}),
     getAgentInstance: vi.fn().mockResolvedValue({}),
     getMcpServer: vi.fn().mockResolvedValue({}),

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -60,10 +60,12 @@ import { StreamingUpdateScheduler, loadStreamingConfig } from "../../shared/stre
 import { createCursorEventRecorder } from "./cursor-event-recorder.js";
 import { resolveMcpServers, toCursorMcpConfig, validateMcpServerEnv } from "./mcp-resolver.js";
 import { resolveMcpTransportPosture } from "../../shared/mcp-transport-guard.js";
+import { synthesizeDatastoreAttachment } from "../../shared/datastore-attachment.js";
 import {
-  injectDatastoreAttachment,
-  synthesizeDatastoreAttachment,
-} from "../../shared/datastore-attachment.js";
+  discoverChannelMessaging,
+  synthesizeChannelAttachment,
+} from "../../shared/channel-attachment.js";
+import { injectSynthesizedAttachment } from "../../shared/synthesized-attachment.js";
 import { mergeApprovalPolicies } from "./approval-policy.js";
 import { deriveActiveLeases, isUnattendedApprovalMode } from "../../shared/approval-policy.js";
 import { backfillMcpServersIfNeeded } from "./connect-backfill.js";
@@ -607,6 +609,19 @@ async function executeCursorInner(
     );
     setupTiming.mark("backfill_mcp");
 
+    // The synthesized attachments' credential story (DD-006 D4): the
+    // exchanged token authenticates the discovery reads per-call (a
+    // desktop runner's ambient embedded_runner credential is refused by
+    // the messaging reach; undefined lets a cloud sandbox runner's
+    // ambient session-scoped token or OSS's no-auth apply). The
+    // attachment header falls back to the ambient credential where no
+    // exchange happens.
+    const exchangedRunnerToken =
+      await client.acquireScopedRunnerToken({ agentExecutionId: executionId });
+    const attachmentCredential = exchangedRunnerToken
+      ?? config.stigmerTokenRef?.current
+      ?? config.stigmerToken;
+
     // Phase 4a2: Synthesize the datastore records attachment (T05).
     // Deliberately AFTER resolve + backfill: the attachment has no
     // McpServerUsage and reports discovered capabilities, so the
@@ -614,18 +629,38 @@ async function executeCursorInner(
     // delete_record (which on channels would be silently skipped).
     // Empty approval maps keep it approval-free by construction.
     if (blueprint.datastoreUsages.length > 0) {
-      const scopedCredential =
-        (await client.acquireScopedRunnerToken({ agentExecutionId: executionId }))
-        ?? config.stigmerTokenRef?.current
-        ?? config.stigmerToken;
       const attachment = synthesizeDatastoreAttachment(blueprint.datastoreUsages, {
         bridgeEndpoint: config.mcpBridgeEndpoint,
-        credential: scopedCredential,
+        credential: attachmentCredential,
         backendEndpoint: config.stigmerBackendEndpoint,
       });
       if (attachment) {
-        const resolvedServers = injectDatastoreAttachment(
-          mcpResolution.resolvedServers, attachment,
+        const resolvedServers = injectSynthesizedAttachment(
+          mcpResolution.resolvedServers, attachment, "datastore records",
+        );
+        mcpResolution = {
+          resolvedServers,
+          cursorConfig: toCursorMcpConfig(resolvedServers),
+        };
+      }
+    }
+
+    // Phase 4a3: Synthesize the channel messaging attachment (DD-006
+    // D7/D8), the records attachment's twin. The discovery read is the
+    // attachment decision — the control plane runs the SAME candidate
+    // computation the send authorization uses — and every failure mode
+    // (no channel, OSS, registry down, pre-3a control plane) degrades
+    // to honest absence: no tool, no section, execution unharmed.
+    const channelMessaging = await discoverChannelMessaging(client, exchangedRunnerToken);
+    if (channelMessaging.length > 0) {
+      const attachment = synthesizeChannelAttachment(channelMessaging, {
+        bridgeEndpoint: config.mcpBridgeEndpoint,
+        credential: attachmentCredential,
+        backendEndpoint: config.stigmerBackendEndpoint,
+      });
+      if (attachment) {
+        const resolvedServers = injectSynthesizedAttachment(
+          mcpResolution.resolvedServers, attachment, "channel messaging",
         );
         mcpResolution = {
           resolvedServers,
@@ -992,6 +1027,7 @@ async function executeCursorInner(
       userMessage: spec.message,
       skills: skillMetadata,
       datastoreUsages: blueprint.datastoreUsages,
+      channelMessaging,
       subAgents: blueprint.subAgents,
       workspaceDirs: blueprint.workspaceDirs,
       workspaceFileRefs: spec.workspaceFileRefs ?? [],
@@ -1605,6 +1641,7 @@ async function executeCursorInner(
             userMessage: spec.message,
             skills: skillMetadata,
             datastoreUsages: blueprint.datastoreUsages,
+            channelMessaging,
             subAgents: blueprint.subAgents,
             workspaceDirs: blueprint.workspaceDirs,
             workspaceFileRefs: spec.workspaceFileRefs ?? [],
@@ -2169,6 +2206,11 @@ export interface BuildPromptInput {
   skills: import("./prompt-builder.js").SkillMetadata[];
   /** Datastores attached via `datastore_usages` — the `<available_datastores>` section. */
   datastoreUsages?: import("@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb").DatastoreUsage[];
+  /**
+   * Serving proactive channels + their templates (the DD-006 D2
+   * discovery read) — the `<available_channel_templates>` section.
+   */
+  channelMessaging?: import("../../shared/channel-attachment.js").ChannelMessagingInfo[];
   subAgents: import("@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb").SubAgent[];
   workspaceDirs: string[];
   workspaceFileRefs: string[];
@@ -2276,6 +2318,7 @@ export function buildPrompt(input: BuildPromptInput): string {
     userMessage,
     skills,
     datastoreUsages: input.datastoreUsages ?? [],
+    channelMessaging: input.channelMessaging ?? [],
     subAgents,
     workspaceDirs,
     workspaceFileRefs,

--- a/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
@@ -23,6 +23,10 @@ import { ApprovalAction, InteractionMode } from "@stigmer/protos/ai/stigmer/agen
 import { formatContextBridgeText } from "../../shared/context-bridge.js";
 import { formatDatastoresSection } from "../../shared/datastore-attachment.js";
 import {
+  formatChannelTemplatesSection,
+  type ChannelMessagingInfo,
+} from "../../shared/channel-attachment.js";
+import {
   formatSenderIdentityText,
   type SenderIdentity,
 } from "../../shared/sender-identity.js";
@@ -61,6 +65,12 @@ export interface EnhancedPromptOptions {
    * pointing the model at the synthesized record tools.
    */
   datastoreUsages?: DatastoreUsage[];
+  /**
+   * Serving proactive channels + their approved templates — rendered as
+   * the `<available_channel_templates>` section (proactive-messaging
+   * DD-003 D5) beside the synthesized send_channel_message tool.
+   */
+  channelMessaging?: ChannelMessagingInfo[];
   subAgents: SubAgent[];
   workspaceDirs: string[];
   workspaceFileRefs: string[];
@@ -131,6 +141,15 @@ export function buildEnhancedPrompt(options: EnhancedPromptOptions): string {
 
   if (options.datastoreUsages !== undefined && options.datastoreUsages.length > 0) {
     sections.push(formatDatastoresSection(options.datastoreUsages));
+  }
+
+  if (options.channelMessaging !== undefined && options.channelMessaging.length > 0) {
+    // "" when nothing is sendable — the tool alone still serves text
+    // sends inside a 24-hour window (DD-006 D6).
+    const channelSection = formatChannelTemplatesSection(options.channelMessaging);
+    if (channelSection !== "") {
+      sections.push(channelSection);
+    }
   }
 
   if (options.subAgents.length > 0) {

--- a/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
@@ -98,6 +98,12 @@ export interface PromptBuilderInput {
    * formatDatastoresSection); empty when the agent uses no datastores.
    */
   datastoresPromptSection?: string;
+  /**
+   * The `<available_channel_templates>` section
+   * (shared/channel-attachment.ts formatChannelTemplatesSection); absent
+   * when the agent serves no proactive channel or nothing is sendable.
+   */
+  channelTemplatesPromptSection?: string;
   workspaceFileRefs: string[];
   workspaceRoot: string;
   injectedFiles: InjectedFile[];
@@ -172,6 +178,10 @@ export function buildEnhancedSystemPrompt(input: PromptBuilderInput): string {
 
   if (input.datastoresPromptSection) {
     prompt += "\n\n" + input.datastoresPromptSection;
+  }
+
+  if (input.channelTemplatesPromptSection) {
+    prompt += "\n\n" + input.channelTemplatesPromptSection;
   }
 
   if (input.workspaceFileRefs.length > 0) {

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -33,9 +33,14 @@ import { resolveMcpTransportPosture } from "../../shared/mcp-transport-guard.js"
 import { backfillMcpServersIfNeeded } from "../../shared/connect-backfill.js";
 import {
   formatDatastoresSection,
-  injectDatastoreAttachment,
   synthesizeDatastoreAttachment,
 } from "../../shared/datastore-attachment.js";
+import {
+  discoverChannelMessaging,
+  formatChannelTemplatesSection,
+  synthesizeChannelAttachment,
+} from "../../shared/channel-attachment.js";
+import { injectSynthesizedAttachment } from "../../shared/synthesized-attachment.js";
 import { WorkspaceProvisioner } from "../../shared/workspace/provisioner.js";
 import { LocalWorkspaceBackend } from "../../shared/workspace/local-backend.js";
 import type { WorkspaceBackend, ProvisionResult } from "../../shared/workspace/types.js";
@@ -334,8 +339,26 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     ];
     const datastoreUsages = agent.spec!.datastoreUsages || [];
 
+    // The synthesized attachments' credential story (DD-006 D4): the
+    // exchanged token authenticates the discovery reads per-call (the
+    // messaging reach refuses a desktop runner's ambient embedded_runner
+    // credential; undefined lets the ambient credential apply). The
+    // attachment header falls back to the ambient credential.
+    const exchangedRunnerToken =
+      await client.acquireScopedRunnerToken({ agentExecutionId: executionId });
+    const attachmentCredential = exchangedRunnerToken
+      ?? config.stigmerTokenRef?.current
+      ?? config.stigmerToken;
+
+    // The channel discovery read runs BEFORE the MCP gate below: an
+    // agent whose ONLY tool source is a proactive channel would
+    // otherwise never enter MCP resolution and never connect the
+    // attachment (DD-006 D7). Every failure mode degrades to an empty
+    // answer — no tool, no section, execution unharmed.
+    const channelMessaging = await discoverChannelMessaging(client, exchangedRunnerToken);
+
     let resolvedMcpServers: Awaited<ReturnType<typeof resolveMcpServers>> | null = null;
-    if (mcpServerUsages.length > 0 || datastoreUsages.length > 0) {
+    if (mcpServerUsages.length > 0 || datastoreUsages.length > 0 || channelMessaging.length > 0) {
       await reportSetupProgress(client, executionId, "Connecting tools…");
       const transportPosture = resolveMcpTransportPosture(config.mode);
       resolvedMcpServers = await resolveMcpServers(
@@ -360,17 +383,30 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       // approval maps keep it approval-free by construction (see
       // shared/datastore-attachment.ts).
       if (datastoreUsages.length > 0) {
-        const scopedCredential =
-          (await client.acquireScopedRunnerToken({ agentExecutionId: executionId }))
-          ?? config.stigmerTokenRef?.current
-          ?? config.stigmerToken;
         const attachment = synthesizeDatastoreAttachment(datastoreUsages, {
           bridgeEndpoint: config.mcpBridgeEndpoint,
-          credential: scopedCredential,
+          credential: attachmentCredential,
           backendEndpoint: config.stigmerBackendEndpoint,
         });
         if (attachment) {
-          backfilledServers = injectDatastoreAttachment(backfilledServers, attachment);
+          backfilledServers = injectSynthesizedAttachment(
+            backfilledServers, attachment, "datastore records",
+          );
+        }
+      }
+
+      // The channel messaging attachment (DD-006 D7/D8) — the records
+      // attachment's twin, injected under the same after-backfill rule.
+      if (channelMessaging.length > 0) {
+        const attachment = synthesizeChannelAttachment(channelMessaging, {
+          bridgeEndpoint: config.mcpBridgeEndpoint,
+          credential: attachmentCredential,
+          backendEndpoint: config.stigmerBackendEndpoint,
+        });
+        if (attachment) {
+          backfilledServers = injectSynthesizedAttachment(
+            backfilledServers, attachment, "channel messaging",
+          );
         }
       }
       resolvedMcpServers = { resolvedServers: backfilledServers };
@@ -444,6 +480,11 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       skillsPromptSection,
       datastoresPromptSection: datastoreUsages.length > 0
         ? formatDatastoresSection(datastoreUsages)
+        : undefined,
+      // "" (nothing sendable) threads as undefined: the tool alone still
+      // serves text sends inside a 24-hour window (DD-006 D6).
+      channelTemplatesPromptSection: channelMessaging.length > 0
+        ? formatChannelTemplatesSection(channelMessaging) || undefined
         : undefined,
       workspaceFileRefs: execution.spec!.workspaceFileRefs || [],
       workspaceRoot: workspaceBackend.rootDir,

--- a/backend/services/runner/src/client/stigmer-client.ts
+++ b/backend/services/runner/src/client/stigmer-client.ts
@@ -50,6 +50,8 @@ import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/ap
 import { WorkflowInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/query_pb";
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import { PlatformQueryController, GetRunnerScopedTokenInputSchema } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import { ChannelMessageQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_query_pb";
+import type { ChannelTemplate, MessagingChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
 import { isEmbeddedRunnerToken } from "./token-claims.js";
 import { assertCreateRequirements, assertReferenceRequirements } from "./server-contracts.js";
 
@@ -156,6 +158,7 @@ export class StigmerClient {
   private readonly workflowQuery: Client<typeof WorkflowQueryController>;
   private readonly workflowInstanceQuery: Client<typeof WorkflowInstanceQueryController>;
   private readonly platformQuery: Client<typeof PlatformQueryController>;
+  private readonly channelMessageQuery: Client<typeof ChannelMessageQueryController>;
 
   private readonly tokenRef: TokenRef | null;
   private readonly runnerTokenRef: TokenRef | null;
@@ -239,6 +242,7 @@ export class StigmerClient {
     this.workflowQuery = createClient(WorkflowQueryController, this.transport);
     this.workflowInstanceQuery = createClient(WorkflowInstanceQueryController, this.transport);
     this.platformQuery = createClient(PlatformQueryController, this.transport);
+    this.channelMessageQuery = createClient(ChannelMessageQueryController, this.transport);
   }
 
   /**
@@ -378,6 +382,48 @@ export class StigmerClient {
       );
       return undefined;
     }
+  }
+
+  /**
+   * The agent's serving proactive-messaging channels, as data
+   * (proactive-messaging DD-006 D2) — the runner's tool-attachment
+   * decision. An empty list is the everyday answer (most agents have no
+   * proactive channel).
+   *
+   * When a scoped runner token is supplied, the read authenticates with
+   * it per-call (the {@link getExecutionContextByExecutionId} precedent):
+   * the messaging reach refuses the desktop runner's ambient
+   * embedded_runner credential outright, and one desktop runner process
+   * serves many sessions concurrently, so the credential cannot live in
+   * a shared ref. A cloud sandbox runner's ambient credential is already
+   * the session-scoped token; OSS sends nothing and answers empty.
+   */
+  async listMessagingChannels(scopedToken?: string): Promise<MessagingChannel[]> {
+    const res = await this.channelMessageQuery.listMessagingChannels(
+      {},
+      scopedToken
+        ? { headers: { authorization: `Bearer ${scopedToken}` } }
+        : undefined,
+    );
+    return res.entries;
+  }
+
+  /**
+   * The channel's provider template registry, approved entries only —
+   * the `<available_channel_templates>` prompt section's source
+   * (proactive-messaging DD-003 D5). Entries carry the DD-006 D1
+   * sendability verdict (`unsupportedReason`, empty means sendable);
+   * the section formatter filters on it. Credential rules as
+   * {@link listMessagingChannels}.
+   */
+  async listChannelTemplates(channel: string, scopedToken?: string): Promise<ChannelTemplate[]> {
+    const res = await this.channelMessageQuery.listTemplates(
+      { channel, approvedOnly: true },
+      scopedToken
+        ? { headers: { authorization: `Bearer ${scopedToken}` } }
+        : undefined,
+    );
+    return res.entries;
   }
 
   async getSession(sessionId: string): Promise<Session> {

--- a/backend/services/runner/src/shared/__tests__/channel-attachment.test.ts
+++ b/backend/services/runner/src/shared/__tests__/channel-attachment.test.ts
@@ -1,0 +1,276 @@
+/**
+ * The channel messaging attachment (proactive-messaging DD-006 D7/D8):
+ * discovery with the never-throw failure posture, both connection
+ * shapes, the structural approval-freedom the datastore attachment
+ * pinned before it, and the prompt section's filter/order/cap rules
+ * (DD-006 D6). The cross-repo pinned strings (slug, route, roster) are
+ * guarded here and in the mcp-server integration test — the
+ * TOOL_CALL_LIMIT precedent.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { Code, ConnectError } from "@connectrpc/connect";
+import type {
+  ChannelTemplate,
+  MessagingChannel,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+
+import { mockStigmerClient } from "../../__test-utils__/mock-client.js";
+import { mergeApprovalPolicies, type ActiveLeases } from "../approval-policy.js";
+import { needsBackfill } from "../connect-backfill.js";
+import {
+  CHANNEL_ATTACHMENT_SLUG,
+  CHANNELS_ROUTE,
+  TEMPLATE_SECTION_CAP,
+  discoverChannelMessaging,
+  formatChannelTemplatesSection,
+  synthesizeChannelAttachment,
+  type ChannelMessagingInfo,
+} from "../channel-attachment.js";
+import type { ResolvedMcpServer } from "../mcp-resolver.js";
+
+function channel(slug: string): MessagingChannel {
+  return { channel: slug, provider: "whatsapp" } as MessagingChannel;
+}
+
+function template(overrides: Partial<ChannelTemplate>): ChannelTemplate {
+  return {
+    name: "fee_reminder",
+    language: "en",
+    category: "UTILITY",
+    status: "APPROVED",
+    parameterFormat: "POSITIONAL",
+    parameterNames: ["1", "2"],
+    bodyText: "Hi {{1}}, your fee of {{2}} is due.",
+    headerFormat: "",
+    rejectionReason: "",
+    unsupportedReason: "",
+    ...overrides,
+  } as ChannelTemplate;
+}
+
+function info(slug: string, templates: ChannelTemplate[]): ChannelMessagingInfo {
+  return { channel: channel(slug), templates };
+}
+
+const noLeases: ActiveLeases = {
+  global: false,
+  categories: new Set(),
+  servers: new Set(),
+};
+
+describe("discoverChannelMessaging (the DD-006 D4 failure posture)", () => {
+  it("returns channels with their templates, threading the scoped credential", async () => {
+    const client = mockStigmerClient({
+      listMessagingChannels: vi.fn().mockResolvedValue([channel("isc-whatsapp")]),
+      listChannelTemplates: vi.fn().mockResolvedValue([template({})]),
+    });
+
+    const result = await discoverChannelMessaging(client, "scoped-tok");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].channel.channel).toBe("isc-whatsapp");
+    expect(result[0].templates).toHaveLength(1);
+    expect(client.listMessagingChannels).toHaveBeenCalledWith("scoped-tok");
+    expect(client.listChannelTemplates).toHaveBeenCalledWith("isc-whatsapp", "scoped-tok");
+  });
+
+  it("answers empty for the everyday no-channel agent without fetching templates", async () => {
+    const client = mockStigmerClient();
+
+    expect(await discoverChannelMessaging(client, undefined)).toEqual([]);
+    expect(client.listChannelTemplates).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["UNIMPLEMENTED (a control plane predating 3a)", Code.Unimplemented],
+    ["FAILED_PRECONDITION (the OSS posture on older servers)", Code.FailedPrecondition],
+    ["PERMISSION_DENIED (an unexpected reach refusal)", Code.PermissionDenied],
+  ])("degrades %s to honest absence, never a throw", async (_label, code) => {
+    const client = mockStigmerClient({
+      listMessagingChannels: vi.fn().mockRejectedValue(new ConnectError("nope", code)),
+    });
+    const quiet = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(await discoverChannelMessaging(client, undefined)).toEqual([]);
+
+    quiet.mockRestore();
+    warn.mockRestore();
+  });
+
+  it("a template-read failure degrades PER CHANNEL — the tool survives, the section entry does not", async () => {
+    const client = mockStigmerClient({
+      listMessagingChannels: vi.fn().mockResolvedValue([channel("wa-a"), channel("wa-b")]),
+      listChannelTemplates: vi.fn()
+        .mockImplementation(async (slug: string) => {
+          if (slug === "wa-a") throw new ConnectError("registry down", Code.Unavailable);
+          return [template({})];
+        }),
+    });
+    const quiet = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    const result = await discoverChannelMessaging(client, undefined);
+
+    expect(result.map((r) => [r.channel.channel, r.templates.length])).toEqual([
+      ["wa-a", 0],
+      ["wa-b", 1],
+    ]);
+    quiet.mockRestore();
+  });
+});
+
+describe("synthesizeChannelAttachment", () => {
+  const options = {
+    bridgeEndpoint: "https://mcp.stigmer.ai/",
+    credential: "sandbox-token",
+    backendEndpoint: "http://localhost:7234",
+  };
+
+  it("returns undefined when the agent serves no proactive channel", () => {
+    expect(synthesizeChannelAttachment([], options)).toBeUndefined();
+  });
+
+  it("builds the HTTP shape against the bridge /channels route with the credential", () => {
+    const attachment = synthesizeChannelAttachment([info("isc-whatsapp", [])], options);
+    expect(attachment).toMatchObject({
+      slug: CHANNEL_ATTACHMENT_SLUG,
+      connectionType: "http",
+      url: "https://mcp.stigmer.ai/channels",
+      headers: { Authorization: "Bearer sandbox-token" },
+    });
+  });
+
+  it("builds the OSS stdio shape: the CLI-embedded bridge with the channels roster", () => {
+    const attachment = synthesizeChannelAttachment([info("isc-whatsapp", [])], {
+      bridgeEndpoint: null,
+      credential: null,
+      backendEndpoint: "http://localhost:7234",
+    });
+    expect(attachment).toMatchObject({
+      connectionType: "stdio",
+      command: "stigmer",
+      args: ["mcp-server"],
+      env: {
+        STIGMER_MCP_ROSTER: "channels",
+        STIGMER_SERVER_ADDRESS: "localhost:7234",
+      },
+    });
+  });
+
+  it("pins the cross-repo strings the mcp-server side guards too", () => {
+    expect(CHANNEL_ATTACHMENT_SLUG).toBe("stigmer-channels");
+    expect(CHANNELS_ROUTE).toBe("/channels");
+  });
+
+  it("is approval-free by construction: zero entries in the merged approval map", () => {
+    const attachment = synthesizeChannelAttachment([info("isc-whatsapp", [])], options)!;
+    // Forced, not convenient (DD-002 D6): both calling surfaces run
+    // UNATTENDED mode, where a gated tool resolves as skip-and-adapt —
+    // a gated send tool means reminders never send.
+    const merged = mergeApprovalPolicies(
+      [attachment as ResolvedMcpServer], [], noLeases,
+    );
+    expect(merged.size).toBe(0);
+  });
+
+  it("is structurally immune to the connect backfill (destructiveHint tightener)", () => {
+    const attachment = synthesizeChannelAttachment([info("isc-whatsapp", [])], options)!;
+    expect(attachment.discoveredCapabilitiesEmpty).toBe(false);
+    expect(needsBackfill(attachment)).toBe(false);
+  });
+});
+
+describe("formatChannelTemplatesSection (DD-006 D6)", () => {
+  it("renders sendable templates with body text, parameters, and the image-header requirement", () => {
+    const section = formatChannelTemplatesSection([
+      info("isc-whatsapp", [
+        template({}),
+        template({
+          name: "invoice_qr",
+          parameterFormat: "NAMED",
+          parameterNames: ["member_name", "amount"],
+          bodyText: "Hello {{member_name}}, pay {{amount}}.",
+          headerFormat: "IMAGE",
+        }),
+      ]),
+    ]);
+
+    expect(section).toContain("<available_channel_templates>");
+    expect(section).toContain("channel: isc-whatsapp (whatsapp)");
+    expect(section).toContain("- fee_reminder (en) [UTILITY], parameters: 1, 2");
+    expect(section).toContain('"Hi {{1}}, your fee of {{2}} is due."');
+    expect(section).toContain(
+      "- invoice_qr (en) [UTILITY], parameters: member_name, amount"
+        + " (requires header_image_link: a public HTTPS image URL)",
+    );
+    expect(section).toContain("send_channel_message");
+    expect(section).toContain("</available_channel_templates>");
+  });
+
+  it("filters unsendable templates out entirely — the console is the diagnosis surface", () => {
+    const section = formatChannelTemplatesSection([
+      info("isc-whatsapp", [
+        template({}),
+        template({
+          name: "dynamic_promo",
+          unsupportedReason: "this template has a dynamic-URL button, which this platform"
+            + " version cannot supply parameters for",
+        }),
+      ]),
+    ]);
+
+    expect(section).toContain("fee_reminder");
+    expect(section).not.toContain("dynamic_promo");
+  });
+
+  it("returns \"\" when nothing is sendable — the tool alone still serves text sends", () => {
+    expect(formatChannelTemplatesSection([info("isc-whatsapp", [])])).toBe("");
+    expect(formatChannelTemplatesSection([
+      info("isc-whatsapp", [template({ unsupportedReason: "unsupported" })]),
+    ])).toBe("");
+  });
+
+  it("orders deterministically by (name, language) — never registry order", () => {
+    const section = formatChannelTemplatesSection([
+      info("isc-whatsapp", [
+        template({ name: "b_second", language: "en" }),
+        template({ name: "a_first", language: "hi" }),
+        template({ name: "a_first", language: "en" }),
+      ]),
+    ]);
+
+    const first = section.indexOf("a_first (en)");
+    const second = section.indexOf("a_first (hi)");
+    const third = section.indexOf("b_second (en)");
+    expect(first).toBeGreaterThan(-1);
+    expect(second).toBeGreaterThan(first);
+    expect(third).toBeGreaterThan(second);
+  });
+
+  it("caps the section and names how many were withheld", () => {
+    const many = Array.from({ length: TEMPLATE_SECTION_CAP + 5 }, (_, i) =>
+      template({ name: `t_${String(i).padStart(3, "0")}` }));
+
+    const section = formatChannelTemplatesSection([info("isc-whatsapp", many)]);
+
+    expect(section).toContain(`t_${String(TEMPLATE_SECTION_CAP - 1).padStart(3, "0")}`);
+    expect(section).not.toContain(`t_${String(TEMPLATE_SECTION_CAP).padStart(3, "0")}`);
+    expect(section).toContain("(5 more approved templates not shown)");
+  });
+
+  it("the cap spans channels; a later channel with no budget left is omitted whole", () => {
+    const fill = Array.from({ length: TEMPLATE_SECTION_CAP }, (_, i) =>
+      template({ name: `t_${String(i).padStart(3, "0")}` }));
+
+    const section = formatChannelTemplatesSection([
+      info("wa-a", fill),
+      info("wa-b", [template({ name: "starved" })]),
+    ]);
+
+    expect(section).toContain("channel: wa-a (whatsapp)");
+    expect(section).not.toContain("channel: wa-b (whatsapp)");
+    expect(section).not.toContain("starved");
+    expect(section).toContain("(1 more approved template not shown)");
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/datastore-attachment.test.ts
+++ b/backend/services/runner/src/shared/__tests__/datastore-attachment.test.ts
@@ -14,9 +14,9 @@ import { needsBackfill } from "../connect-backfill.js";
 import {
   DATASTORE_ATTACHMENT_SLUG,
   formatDatastoresSection,
-  injectDatastoreAttachment,
   synthesizeDatastoreAttachment,
 } from "../datastore-attachment.js";
+import { injectSynthesizedAttachment } from "../synthesized-attachment.js";
 import type { ResolvedMcpServer } from "../mcp-resolver.js";
 
 function usage(slug: string) {
@@ -113,7 +113,7 @@ describe("synthesizeDatastoreAttachment", () => {
   });
 });
 
-describe("injectDatastoreAttachment", () => {
+describe("injectSynthesizedAttachment (the shared injection path)", () => {
   const attachment = synthesizeDatastoreAttachment([usage("clinic")], {
     bridgeEndpoint: "https://mcp.stigmer.ai",
     credential: "tok",
@@ -129,7 +129,7 @@ describe("injectDatastoreAttachment", () => {
       pinnedToolApprovals: [],
       discoveredCapabilitiesEmpty: false,
     };
-    const result = injectDatastoreAttachment([other], attachment);
+    const result = injectSynthesizedAttachment([other], attachment, "datastore records");
     expect(result.map((s) => s.slug)).toEqual(["github", DATASTORE_ATTACHMENT_SLUG]);
   });
 
@@ -144,7 +144,7 @@ describe("injectDatastoreAttachment", () => {
       discoveredCapabilitiesEmpty: false,
     };
 
-    const result = injectDatastoreAttachment([impostor], attachment);
+    const result = injectSynthesizedAttachment([impostor], attachment, "datastore records");
 
     expect(result).toHaveLength(1);
     expect(result[0].url).toBe("https://mcp.stigmer.ai/records");

--- a/backend/services/runner/src/shared/channel-attachment.ts
+++ b/backend/services/runner/src/shared/channel-attachment.ts
@@ -1,0 +1,237 @@
+/**
+ * The runner-synthesized channel messaging attachment (proactive-messaging
+ * DD-006 D7/D8) — the datastore records attachment's structural twin.
+ *
+ * When the control plane says an agent serves at least one
+ * proactive-messaging channel (the `listMessagingChannels` discovery
+ * read, DD-006 D2 — the SAME candidate computation the send
+ * authorization runs, so attachment and authority cannot disagree), the
+ * runner synthesizes ONE MCP attachment serving `send_channel_message`,
+ * and injects the `<available_channel_templates>` prompt section so the
+ * model composes template sends in context without spending a tool
+ * round (DD-003 D5).
+ *
+ * Two connection shapes, one roster (the records pattern):
+ *   - Bridge endpoint configured (cloud): Streamable HTTP against the
+ *     bridge's /channels route with the execution's own session-scoped
+ *     credential as the Bearer token.
+ *   - No bridge endpoint (OSS/local): a spawned `stigmer mcp-server`
+ *     stdio child with STIGMER_MCP_ROSTER=channels. In practice OSS
+ *     answers the discovery read with an empty list (DD-006 D3), so
+ *     this shape only serves local deployments that grow a messaging
+ *     runtime later — it exists for symmetry with the deployment
+ *     topology, not for a live OSS path today.
+ *
+ * Approval-free by construction, and FORCED, not convenient (DD-002
+ * D6): both calling surfaces run APPROVAL_MODE_UNATTENDED, where a
+ * gated tool resolves as skip-and-adapt — a gated send tool would mean
+ * reminders never send. Empty approval maps + no McpServerUsage keep
+ * the connect backfill structurally unable to gate it (see
+ * synthesized-attachment.ts). Callers inject AFTER resolve + backfill.
+ *
+ * Failure posture (DD-006 D4): every discovery failure — OSS's empty
+ * answer, a registry outage, a control plane predating the RPC
+ * (UNIMPLEMENTED), a reach refusal — degrades to honest absence: no
+ * tool, no section, execution unharmed.
+ */
+
+import { Code, ConnectError } from "@connectrpc/connect";
+import type {
+  ChannelTemplate,
+  MessagingChannel,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+import type { StigmerClient } from "../client/stigmer-client.js";
+import type { ResolvedMcpServer } from "./mcp-resolver.js";
+import { grpcTarget, type SynthesizedAttachmentOptions } from "./synthesized-attachment.js";
+
+/**
+ * The synthesized attachment's slug. Reserved: a user McpServer with
+ * this slug is shadowed by the synthesized attachment, with a warning.
+ * Pinned cross-repo by the mcp-server integration test (the
+ * TOOL_CALL_LIMIT precedent).
+ */
+export const CHANNEL_ATTACHMENT_SLUG = "stigmer-channels";
+
+/** The bridge route serving the channels-only roster (mcp-server DD-006 D8). */
+export const CHANNELS_ROUTE = "/channels";
+
+/**
+ * The most templates the prompt section carries (DD-006 D6): Meta
+ * allows hundreds per WABA, and an unbounded section would tax every
+ * run's context. Deterministic (name, language) order plus a withheld
+ * count keep the agent's behavior independent of registry ordering.
+ */
+export const TEMPLATE_SECTION_CAP = 30;
+
+/** One channel plus its sendable approved templates, ready to format. */
+export interface ChannelMessagingInfo {
+  channel: MessagingChannel;
+  templates: ChannelTemplate[];
+}
+
+/**
+ * The discovery read plus the per-channel template fetch, with the
+ * DD-006 D4 failure posture applied: this function NEVER throws — any
+ * failure returns an empty list (no tool, no section), because a
+ * messaging hiccup must not fail an execution that may not even want
+ * to send anything.
+ */
+export async function discoverChannelMessaging(
+  client: StigmerClient,
+  scopedCredential: string | undefined,
+): Promise<ChannelMessagingInfo[]> {
+  let channels: MessagingChannel[];
+  try {
+    channels = await client.listMessagingChannels(scopedCredential);
+  } catch (err) {
+    logDiscoveryFailure("listMessagingChannels", err);
+    return [];
+  }
+  if (channels.length === 0) {
+    return [];
+  }
+
+  // Template reads degrade PER CHANNEL: a registry outage on one
+  // channel must not strip the section for another, and never the tool
+  // (a channel with unreadable templates can still send text inside a
+  // 24-hour window).
+  return Promise.all(channels.map(async (channel) => {
+    try {
+      return {
+        channel,
+        templates: await client.listChannelTemplates(channel.channel, scopedCredential),
+      };
+    } catch (err) {
+      logDiscoveryFailure(`listTemplates(${channel.channel})`, err);
+      return { channel, templates: [] };
+    }
+  }));
+}
+
+/**
+ * Synthesize the channel messaging attachment. Returns undefined when
+ * the agent serves no proactive channel — the attachment exists exactly
+ * when the discovery read says so.
+ */
+export function synthesizeChannelAttachment(
+  channels: ChannelMessagingInfo[],
+  options: SynthesizedAttachmentOptions,
+): ResolvedMcpServer | undefined {
+  if (channels.length === 0) {
+    return undefined;
+  }
+
+  // Approval-free by construction + backfill-proof: see file header.
+  const base = {
+    slug: CHANNEL_ATTACHMENT_SLUG,
+    toolApprovals: [],
+    pinnedToolApprovals: [],
+    discoveredCapabilitiesEmpty: false,
+  };
+
+  if (options.bridgeEndpoint !== null && options.bridgeEndpoint !== "") {
+    return {
+      ...base,
+      connectionType: "http",
+      url: options.bridgeEndpoint.replace(/\/+$/, "") + CHANNELS_ROUTE,
+      headers: options.credential !== null && options.credential !== ""
+        ? { Authorization: `Bearer ${options.credential}` }
+        : undefined,
+    };
+  }
+
+  return {
+    ...base,
+    connectionType: "stdio",
+    command: "stigmer",
+    args: ["mcp-server"],
+    env: {
+      STIGMER_MCP_ROSTER: "channels",
+      STIGMER_SERVER_ADDRESS: grpcTarget(options.backendEndpoint),
+    },
+  };
+}
+
+/**
+ * The `<available_channel_templates>` prompt section (DD-003 D5):
+ * approved AND sendable templates with their full body text, so the
+ * model fills positional placeholders beside the values it composes.
+ * Unsendable entries are filtered, not annotated (DD-006 D6 — the
+ * console panel is the diagnosis surface, the prompt is a composition
+ * aid). Returns "" when nothing survives the filter — the tool alone
+ * still serves text sends inside a 24-hour window.
+ */
+export function formatChannelTemplatesSection(channels: ChannelMessagingInfo[]): string {
+  let withheld = 0;
+  let budget = TEMPLATE_SECTION_CAP;
+
+  const channelBlocks: string[] = [];
+  for (const { channel, templates } of channels) {
+    // Sendable-only (unsupportedReason empty), deterministic order —
+    // agent behavior must never depend on registry ordering (DD-006 D6).
+    const sendable = templates
+      .filter((t) => t.unsupportedReason === "")
+      .sort((a, b) => a.name.localeCompare(b.name) || a.language.localeCompare(b.language));
+
+    const kept = sendable.slice(0, Math.max(budget, 0));
+    withheld += sendable.length - kept.length;
+    budget -= kept.length;
+    if (kept.length === 0) {
+      continue;
+    }
+
+    const lines = kept.map((t) => {
+      const parameters = t.parameterNames.length > 0
+        ? `, parameters: ${t.parameterNames.join(", ")}`
+        : "";
+      const header = t.headerFormat === "IMAGE"
+        ? " (requires header_image_link: a public HTTPS image URL)"
+        : "";
+      return [
+        `  - ${t.name} (${t.language}) [${t.category}]${parameters}${header}`,
+        `    "${t.bodyText}"`,
+      ].join("\n");
+    });
+    channelBlocks.push([`channel: ${channel.channel} (${channel.provider})`, ...lines].join("\n"));
+  }
+
+  if (channelBlocks.length === 0) {
+    return "";
+  }
+
+  const footer = withheld > 0
+    ? [`(${withheld} more approved template${withheld === 1 ? "" : "s"} not shown)`]
+    : [];
+  return [
+    "<available_channel_templates>",
+    "You can send business-initiated messages on the channels below with the",
+    "send_channel_message tool. Outside a 24-hour customer-service window the",
+    "provider only accepts a pre-approved template, so prefer a template. Fill",
+    "every placeholder from the conversation; never invent a value.",
+    "",
+    ...channelBlocks,
+    ...footer,
+    "</available_channel_templates>",
+  ].join("\n");
+}
+
+/**
+ * Expected absences log quietly; anything else warns so an operator can
+ * diagnose a mis-provisioned credential without failing the execution.
+ * UNIMPLEMENTED is a control plane predating the discovery RPC — the
+ * DD-006 D4 deploy-order self-healing case.
+ */
+function logDiscoveryFailure(what: string, err: unknown): void {
+  const ce = ConnectError.from(err);
+  const expected =
+    ce.code === Code.Unimplemented ||
+    ce.code === Code.FailedPrecondition ||
+    ce.code === Code.Unavailable;
+  if (expected) {
+    console.debug(`[channel-attachment] ${what} degraded to honest absence: ${ce.message}`);
+  } else {
+    console.warn(
+      `[channel-attachment] ${what} failed unexpectedly (no tool, no section): ${ce.message}`,
+    );
+  }
+}

--- a/backend/services/runner/src/shared/datastore-attachment.ts
+++ b/backend/services/runner/src/shared/datastore-attachment.ts
@@ -33,6 +33,7 @@
 
 import type { DatastoreUsage } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb";
 import type { ResolvedMcpServer } from "./mcp-resolver.js";
+import { grpcTarget, type SynthesizedAttachmentOptions } from "./synthesized-attachment.js";
 
 /**
  * The synthesized attachment's slug. Reserved: a user McpServer with
@@ -44,25 +45,6 @@ export const DATASTORE_ATTACHMENT_SLUG = "stigmer-records";
 /** The bridge route serving the records-only roster (mcp-server T05 R1). */
 export const RECORDS_ROUTE = "/records";
 
-export interface DatastoreAttachmentOptions {
-  /**
-   * The bridge's HTTP endpoint (STIGMER_MCP_BRIDGE_ENDPOINT, e.g.
-   * https://mcp.stigmer.ai). Null selects the OSS stdio shape.
-   */
-  bridgeEndpoint: string | null;
-  /**
-   * The execution's session-scoped credential (the sandbox token a
-   * cloud runner holds, or the desktop runner's exchanged scoped
-   * token). Null attaches no Authorization header (OSS/local).
-   */
-  credential: string | null;
-  /**
-   * The stigmer backend endpoint the stdio child dials
-   * (config.stigmerBackendEndpoint). Only used for the OSS shape.
-   */
-  backendEndpoint: string;
-}
-
 /**
  * Synthesize the records attachment for an agent's datastore usages.
  * Returns undefined when the agent uses no datastores — the attachment
@@ -70,7 +52,7 @@ export interface DatastoreAttachmentOptions {
  */
 export function synthesizeDatastoreAttachment(
   datastoreUsages: DatastoreUsage[],
-  options: DatastoreAttachmentOptions,
+  options: SynthesizedAttachmentOptions,
 ): ResolvedMcpServer | undefined {
   if (datastoreUsages.length === 0) {
     return undefined;
@@ -108,28 +90,6 @@ export function synthesizeDatastoreAttachment(
 }
 
 /**
- * Inject the synthesized attachment into a resolved server list —
- * AFTER resolve + backfill (see file header). A user server shadowing
- * the reserved slug is replaced, loudly.
- */
-export function injectDatastoreAttachment(
-  resolvedServers: ResolvedMcpServer[],
-  attachment: ResolvedMcpServer,
-): ResolvedMcpServer[] {
-  const shadowed = resolvedServers.some((s) => s.slug === attachment.slug);
-  if (shadowed) {
-    console.warn(
-      `MCP server slug "${attachment.slug}" is reserved for the datastore ` +
-      "records attachment; the user-defined server is replaced.",
-    );
-  }
-  return [
-    ...resolvedServers.filter((s) => s.slug !== attachment.slug),
-    attachment,
-  ];
-}
-
-/**
  * The `<available_datastores>` prompt section (DD-005 SD-5, the
  * skills-section precedent): names the attached datastores and points
  * the model at describe_datastore first. Shared by both harnesses so
@@ -151,16 +111,4 @@ export function formatDatastoresSection(datastoreUsages: DatastoreUsage[]): stri
     ...entries,
     "</available_datastores>",
   ].join("\n");
-}
-
-/**
- * The gRPC dial target (host:port) for a backend endpoint URL — the
- * shape STIGMER_SERVER_ADDRESS wants (the bridge warns on schemes).
- */
-function grpcTarget(endpoint: string): string {
-  try {
-    return new URL(endpoint).host;
-  } catch {
-    return endpoint;
-  }
 }

--- a/backend/services/runner/src/shared/synthesized-attachment.ts
+++ b/backend/services/runner/src/shared/synthesized-attachment.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared mechanics of runner-synthesized MCP attachments — the pieces
+ * the datastore records attachment (T05) and the channel messaging
+ * attachment (proactive-messaging DD-006 D8) have in common, extracted
+ * when the second attachment arrived.
+ *
+ * A synthesized attachment is a first-party MCP server entry the runner
+ * builds itself (no McpServer resource, no Environment, no credential in
+ * any manifest) on a RESERVED slug. Approval-freedom is structural, not
+ * configured: empty toolApprovals + pinnedToolApprovals mean
+ * mergeApprovalPolicies emits no entries, and discoveredCapabilitiesEmpty
+ * false + no McpServerUsage keep the connect backfill's destructiveHint
+ * tightener structurally unable to touch it. Callers must still inject
+ * AFTER resolve + backfill; every harness call site does.
+ */
+
+import type { ResolvedMcpServer } from "./mcp-resolver.js";
+
+/**
+ * Connection options for a synthesized attachment — one shape for every
+ * attachment because the deployment topology, not the domain, decides
+ * the connection.
+ */
+export interface SynthesizedAttachmentOptions {
+  /**
+   * The bridge's HTTP endpoint (STIGMER_MCP_BRIDGE_ENDPOINT, e.g.
+   * https://mcp.stigmer.ai). Null selects the OSS/local stdio shape.
+   */
+  bridgeEndpoint: string | null;
+  /**
+   * The execution's session-scoped credential (the sandbox token a
+   * cloud runner holds, or the desktop runner's exchanged scoped
+   * token). Null attaches no Authorization header (OSS/local).
+   */
+  credential: string | null;
+  /**
+   * The stigmer backend endpoint the stdio child dials
+   * (config.stigmerBackendEndpoint). Only used for the OSS shape.
+   */
+  backendEndpoint: string;
+}
+
+/**
+ * Inject a synthesized attachment into a resolved server list — AFTER
+ * resolve + backfill (see the module header). A user server shadowing
+ * the reserved slug is replaced, loudly; `label` names the attachment
+ * in that warning (e.g. "datastore records").
+ */
+export function injectSynthesizedAttachment(
+  resolvedServers: ResolvedMcpServer[],
+  attachment: ResolvedMcpServer,
+  label: string,
+): ResolvedMcpServer[] {
+  const shadowed = resolvedServers.some((s) => s.slug === attachment.slug);
+  if (shadowed) {
+    console.warn(
+      `MCP server slug "${attachment.slug}" is reserved for the ${label} ` +
+      "attachment; the user-defined server is replaced.",
+    );
+  }
+  return [
+    ...resolvedServers.filter((s) => s.slug !== attachment.slug),
+    attachment,
+  ];
+}
+
+/**
+ * The gRPC dial target (host:port) for a backend endpoint URL — the
+ * shape STIGMER_SERVER_ADDRESS wants (the bridge warns on schemes).
+ */
+export function grpcTarget(endpoint: string): string {
+  try {
+    return new URL(endpoint).host;
+  } catch {
+    return endpoint;
+  }
+}

--- a/docs/_inventory/classification.yaml
+++ b/docs/_inventory/classification.yaml
@@ -254,6 +254,15 @@ pages:
       depictable stills; Slack's own screens stay prose — we depict only our
       product.
 
+  guides/channels/send-proactive-messages-with-templates:
+    fate: keep
+    diataxis: how-to
+    teaches:
+      Enable proactive messaging on a WhatsApp channel, author an approved
+      template in WhatsApp Manager, and have the Agent send reminders and
+      invoices with it.
+    medium: none
+
   guides/channels/set-up-your-meta-app:
     fate: keep
     diataxis: how-to

--- a/docs/guides/channels/meta.json
+++ b/docs/guides/channels/meta.json
@@ -4,6 +4,7 @@
     "connect-slack",
     "bring-your-own-slack-app",
     "connect-whatsapp",
-    "set-up-your-meta-app"
+    "set-up-your-meta-app",
+    "send-proactive-messages-with-templates"
   ]
 }

--- a/docs/guides/channels/send-proactive-messages-with-templates.mdx
+++ b/docs/guides/channels/send-proactive-messages-with-templates.mdx
@@ -1,0 +1,134 @@
+---
+title: Send Proactive Messages with Templates
+description:
+  Let your Agent start WhatsApp conversations — reminders, notifications, and
+  invoices — using message templates approved by WhatsApp.
+---
+
+By default, a connected WhatsApp channel only replies: the Agent answers when
+someone writes to it. This guide shows you how to let the Agent start the
+conversation instead — send a fee reminder, a booking notification, or an
+invoice — using message templates that WhatsApp has approved.
+
+<Callout type="info">
+  Proactive messaging requires Stigmer Cloud, and a WhatsApp channel that is
+  already connected. If you haven't connected one yet, start with [Connect an
+  Agent to WhatsApp](/docs/guides/channels/connect-whatsapp).
+</Callout>
+
+## How it works
+
+WhatsApp only delivers a free-form text message inside a 24-hour
+customer-service window — the day after the person last wrote to you. Outside
+that window, WhatsApp requires a **message template**: a pre-approved message
+shape with placeholders, like "Hi &#123;&#123;1&#125;&#125;, your fee of
+&#123;&#123;2&#125;&#125; is due &#123;&#123;3&#125;&#125;."
+
+You author templates in **WhatsApp Manager** (Meta's own console) and WhatsApp
+approves them. Stigmer keeps no copy: your Agent reads the approved list live
+and sees each template's full text in its context, so it fills the placeholders
+with real values from the conversation or your data. When it sends, Stigmer
+delivers the message, retries transient failures in the background, and gives
+the Agent an honest outcome either way.
+
+## Turn on proactive messaging
+
+Proactive sending is off until the channel's owner turns it on. Set
+`proactive_messaging_enabled` on the channel:
+
+```yaml
+apiVersion: agentic.stigmer.ai/v1
+kind: AgentChannel
+metadata:
+  name: isc-whatsapp
+  org: isc
+spec:
+  agent_ref:
+    kind: agent
+    org: isc
+    slug: assistant
+  enabled: true
+  proactive_messaging_enabled: true
+  whatsapp:
+    phone_number_id: "106540352242922"
+  app_ref:
+    kind: channel_app
+    org: isc
+    slug: isc-whatsapp-app
+```
+
+Apply it with `stigmer apply -f channel.yaml`. From the next run onward, the
+Agent gets a `send_channel_message` tool and a list of the channel's approved
+templates in its context. Turning the flag off removes both — no Agent change
+needed.
+
+## Author a template in WhatsApp Manager
+
+Templates are created in WhatsApp Manager, not in Stigmer:
+
+1. Open
+   [WhatsApp Manager](https://business.facebook.com/wa/manage/message-templates/)
+   for the WhatsApp Business Account that owns your number.
+2. Create a template. Pick the **Utility** category for reminders and
+   notifications. Write the body with numbered placeholders — "Hi
+   &#123;&#123;1&#125;&#125;, your &#123;&#123;2&#125;&#125; fee of
+   &#123;&#123;3&#125;&#125; is due today."
+3. Submit it and wait for WhatsApp's approval. Utility templates are usually
+   approved within minutes.
+
+Once approved, the template shows up for your Agent automatically — there is
+nothing to import.
+
+These template shapes work today: body placeholders (numbered or named), plain
+text headers, footers, static buttons, and **image headers** — for an image
+header, the Agent supplies a public HTTPS link to the image at send time (for
+example a hosted UPI QR code). Templates that need more — a placeholder inside
+the header text, video or document headers, buttons with dynamic links or
+copy-codes — are not sendable through Stigmer yet, and the Agent's template list
+leaves them out so it never composes against one.
+
+## Ask the Agent to send
+
+With the flag on and a template approved, tell the Agent what to do — in a
+console test Session, or on a schedule:
+
+> Find members with fees due in the next 3 days and send each one a
+> fee_reminder.
+
+The Agent sees each template's exact text beside its parameters, fills the
+placeholders, and calls its send tool once per recipient. Each call returns one
+of three outcomes:
+
+- **accepted** — WhatsApp took the message.
+- **queued** — a temporary failure; Stigmer keeps retrying in the background.
+  The Agent should not resend.
+- **refused** — a final no, with the reason in plain words (an unknown template,
+  a paused template, a missing image link, a rate cap). The Agent adapts instead
+  of retrying.
+
+## Who the Agent can message
+
+The rules depend on how the run started:
+
+- A run that a **channel conversation** started can only message people who have
+  already written to that channel — it replies proactively, but never
+  cold-messages.
+- A run an **operator** started (a console Session, or a schedule) can message
+  any recipient, within the platform's rolling send caps.
+
+Recipients are always phone-number IDs on the channel's provider, and every send
+is recorded with its outcome for audit.
+
+## Troubleshooting
+
+- **The Agent says it has no messaging channel.** The channel is not installed,
+  is switched off, or `proactive_messaging_enabled` is not set. All three are on
+  the channel — the Agent's definition needs no change.
+- **The template list is empty but WhatsApp Manager shows approved templates.**
+  The channel app's access token is missing the `whatsapp_business_management`
+  permission. Regenerate the token with that permission (see
+  [Set up your Meta app](/docs/guides/channels/set-up-your-meta-app)). Sending
+  is unaffected while you fix this — only discovery degrades.
+- **A send is refused with "not approved for sending".** The template is
+  pending, paused, or rejected in WhatsApp Manager. The refusal names the status
+  and what to do about it.

--- a/mcp-server/src/config.ts
+++ b/mcp-server/src/config.ts
@@ -19,8 +19,12 @@ export type Transport = "stdio" | "http" | "both";
  *   argument surface. This is what the runner-synthesized datastore
  *   attachment spawns over stdio (T05 R1); over HTTP the same roster is
  *   served on the /records route regardless of this setting.
+ * - "channels": only send_channel_message (proactive-messaging DD-006
+ *   D8) with the agent-facing argument surface. This is what the
+ *   runner-synthesized channel attachment spawns over stdio; over HTTP
+ *   the same roster is served on the /channels route.
  */
-export type Roster = "full" | "records";
+export type Roster = "full" | "records" | "channels";
 
 /**
  * OAuth 2.0 Protected Resource Metadata (RFC 9728) discovery settings.
@@ -58,7 +62,7 @@ export interface Config {
 }
 
 const VALID_TRANSPORTS: readonly string[] = ["stdio", "http", "both"];
-const VALID_ROSTERS: readonly string[] = ["full", "records"];
+const VALID_ROSTERS: readonly string[] = ["full", "records", "channels"];
 const VALID_LOG_FORMATS: readonly string[] = ["text", "json"];
 const VALID_LOG_LEVELS: readonly string[] = ["debug", "info", "warn", "error"];
 
@@ -97,7 +101,9 @@ export function validateConfig(cfg: Config): void {
   }
 
   if (!VALID_ROSTERS.includes(cfg.roster)) {
-    throw new Error(`invalid STIGMER_MCP_ROSTER "${cfg.roster}": must be full or records`);
+    throw new Error(
+      `invalid STIGMER_MCP_ROSTER "${cfg.roster}": must be full, records, or channels`,
+    );
   }
 
   if (cfg.stigmerServerAddress === "") {

--- a/mcp-server/src/domains/channels/calls.ts
+++ b/mcp-server/src/domains/channels/calls.ts
@@ -1,0 +1,86 @@
+// Channel-messaging RPC invocations for the send_channel_message tool —
+// a 1:1 projection of ChannelMessageCommandController.sendMessage
+// (proactive-messaging DD-006 D5: the tool layer adds no semantics;
+// reach, recipient policy, caps, and the template pre-check all live in
+// the cloud handler, and the OSS edition refuses with the documented
+// FAILED_PRECONDITION).
+//
+// The records-domain calls.ts shape: build request, call, marshal. The
+// typed outcome (accepted/queued/refused + detail) rides back VERBATIM
+// as proto JSON — a refusal is an ANSWER the model adapts to (DD-002
+// D4), never a tool error.
+
+import { create } from "@bufbuild/protobuf";
+import {
+  ChannelMessageCommandController,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_command_pb";
+import {
+  ChannelOutboundPayloadSchema,
+  SendChannelMessageInputSchema,
+  SendChannelMessageOutputSchema,
+  TemplatePayloadSchema,
+  TextPayloadSchema,
+  type ChannelOutboundPayload,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+import { withClient } from "../client.js";
+import { toProtoJson } from "../marshal.js";
+
+/** The template arm as the model supplies it (mirrors TemplatePayload). */
+export interface TemplateArg {
+  name: string;
+  language?: string;
+  parameters?: Record<string, string>;
+  header_image_link?: string;
+}
+
+export interface SendArgs {
+  recipient: string;
+  text?: string;
+  template?: TemplateArg;
+  channel?: string;
+}
+
+export async function sendChannelMessage(
+  serverAddress: string,
+  token: string,
+  args: SendArgs,
+): Promise<string> {
+  const request = create(SendChannelMessageInputSchema, {
+    channel: args.channel ?? "",
+    // org is deliberately never sent: a session-bound caller's org is
+    // server-derived, and an explicit value is rejected (the records
+    // T05 R3 rule applied to messaging).
+    recipient: args.recipient,
+    payload: buildPayload(args),
+  });
+  return withClient(ChannelMessageCommandController, serverAddress, token, async (client, opts) =>
+    toProtoJson(SendChannelMessageOutputSchema, await client.sendMessage(request, opts)),
+  );
+}
+
+/**
+ * The payload oneof from the tool's mutually exclusive arguments. The
+ * tool handler enforces exactly-one before calling; the server's
+ * required-oneof validation is the backstop.
+ */
+function buildPayload(args: SendArgs): ChannelOutboundPayload {
+  if (args.template !== undefined) {
+    return create(ChannelOutboundPayloadSchema, {
+      kind: {
+        case: "template",
+        value: create(TemplatePayloadSchema, {
+          name: args.template.name,
+          language: args.template.language ?? "",
+          parameters: args.template.parameters ?? {},
+          headerImageLink: args.template.header_image_link ?? "",
+        }),
+      },
+    });
+  }
+  return create(ChannelOutboundPayloadSchema, {
+    kind: {
+      case: "text",
+      value: create(TextPayloadSchema, { body: args.text ?? "" }),
+    },
+  });
+}

--- a/mcp-server/src/domains/channels/channels.integration.test.ts
+++ b/mcp-server/src/domains/channels/channels.integration.test.ts
@@ -1,0 +1,272 @@
+// In-process integration test for the channels roster (the
+// records.integration.test.ts pattern: real Connect backend with a
+// stubbed messaging service, real MCP client over an in-memory
+// transport).
+//
+// Verifies the DD-006 D5/D8 contract surface:
+//   - the channels-only roster is exactly send_channel_message with NO
+//     org argument (agent audience);
+//   - argument → request mapping mirrors the ChannelOutboundPayload
+//     oneof (text | template, exactly one, checked before any RPC);
+//   - typed outcomes (accepted/queued/refused) are ANSWERS — success
+//     results the model adapts to, never isError;
+//   - the channels-own error mapper passes domain messages verbatim as
+//     {error, code, reason} JSON; transport errors delegate to the
+//     shared classifier.
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, type ConnectRouter } from "@connectrpc/connect";
+import { connectNodeAdapter } from "@connectrpc/connect-node";
+import {
+  createServer as createHttp2Server,
+  type Http2Server,
+  type ServerHttp2Session,
+} from "node:http2";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ChannelMessageCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_command_pb";
+import {
+  ChannelSendOutcome,
+  SendChannelMessageOutputSchema,
+  type SendChannelMessageInput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+import { ErrorInfoSchema } from "@stigmer/protos/google/rpc/error_details_pb";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { configureLogger } from "../../logger";
+import { CHANNELS_ROUTE, createChannelsServer } from "../../server";
+
+configureLogger({ level: "error", format: "text" });
+
+let backend: Http2Server;
+let client: Client;
+const openSessions = new Set<ServerHttp2Session>();
+
+/** The next stubbed outcome; tests set this. */
+let sendResponse: () => ReturnType<typeof create<typeof SendChannelMessageOutputSchema>>;
+
+/** Requests the stub captured (object property for closure narrowing). */
+const captured: { send?: SendChannelMessageInput } = {};
+
+interface ToolResult {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+async function send(args: Record<string, unknown>): Promise<ToolResult> {
+  return (await client.callTool({
+    name: "send_channel_message",
+    arguments: args,
+  })) as ToolResult;
+}
+
+beforeAll(async () => {
+  const routes = (router: ConnectRouter) => {
+    router.service(ChannelMessageCommandController, {
+      sendMessage: (req) => {
+        captured.send = req;
+        return sendResponse();
+      },
+    });
+  };
+  backend = createHttp2Server(connectNodeAdapter({ routes }));
+  backend.on("session", (session) => {
+    openSessions.add(session);
+    session.on("close", () => openSessions.delete(session));
+  });
+  await new Promise<void>((resolve) => backend.listen(0, "127.0.0.1", resolve));
+  const port = (backend.address() as AddressInfo).port;
+
+  const mcp = createChannelsServer({ serverAddress: `127.0.0.1:${port}`, apiKey: "" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: "channels-integration", version: "test" });
+  await Promise.all([mcp.connect(serverTransport), client.connect(clientTransport)]);
+});
+
+afterAll(async () => {
+  await client?.close();
+  for (const session of openSessions) session.destroy();
+  await new Promise<void>((resolve) => backend.close(() => resolve()));
+});
+
+describe("channels roster (DD-006 D8)", () => {
+  it("exposes exactly send_channel_message with no org argument", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["send_channel_message"]);
+
+    // The agent audience gets no org argument — a session-bound
+    // caller's org is server-derived, and offering the argument would
+    // only invite INVALID_ARGUMENT rejections (the records T05 R3 rule).
+    const properties = (tools[0].inputSchema as { properties?: Record<string, unknown> })
+      .properties;
+    expect(Object.keys(properties ?? {}).sort()).toEqual([
+      "channel",
+      "recipient",
+      "template",
+      "text",
+    ]);
+  });
+
+  it("pins the cross-repo attachment strings (the TOOL_CALL_LIMIT precedent)", () => {
+    // The runner's channel-attachment.ts builds these independently
+    // (shared/channel-attachment.ts and its mirror guard); a drift here
+    // strands every synthesized attachment on a 404 or a full roster.
+    expect(CHANNELS_ROUTE).toBe("/channels");
+  });
+});
+
+describe("argument → request mapping (the ChannelOutboundPayload oneof)", () => {
+  it("maps a text send; org never travels, channel defaults empty", async () => {
+    sendResponse = () =>
+      create(SendChannelMessageOutputSchema, {
+        outcome: ChannelSendOutcome.accepted,
+        outboundMessageId: "chom_1",
+        providerMessageId: "wamid.abc",
+      });
+    captured.send = undefined;
+
+    const result = await send({ recipient: "919000000001", text: "see you at 6" });
+
+    expect(result.isError).toBeFalsy();
+    const req = captured.send as SendChannelMessageInput | undefined;
+    expect(req?.recipient).toBe("919000000001");
+    expect(req?.org).toBe(""); // agent audience: org never travels
+    expect(req?.channel).toBe("");
+    expect(req?.payload?.kind.case).toBe("text");
+    expect(req?.payload?.kind.case === "text" && req.payload.kind.value.body).toBe("see you at 6");
+
+    // toProtoJson emits proto (snake_case) field names — the Go parity rule.
+    const body = JSON.parse(result.content[0]?.text ?? "{}") as Record<string, string>;
+    expect(body.outcome).toBe("accepted");
+    expect(body.provider_message_id).toBe("wamid.abc");
+  });
+
+  it("maps a template send with language, parameters, header link, and a named channel", async () => {
+    sendResponse = () =>
+      create(SendChannelMessageOutputSchema, { outcome: ChannelSendOutcome.accepted });
+    captured.send = undefined;
+
+    const result = await send({
+      recipient: "919000000001",
+      channel: "isc-whatsapp",
+      template: {
+        name: "invoice_qr",
+        language: "en",
+        parameters: { member_name: "Asha", amount: "1500" },
+        header_image_link: "https://isc.example/qr.png",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const req = captured.send as SendChannelMessageInput | undefined;
+    expect(req?.channel).toBe("isc-whatsapp");
+    expect(req?.payload?.kind.case).toBe("template");
+    if (req?.payload?.kind.case === "template") {
+      expect(req.payload.kind.value.name).toBe("invoice_qr");
+      expect(req.payload.kind.value.language).toBe("en");
+      expect(req.payload.kind.value.parameters).toMatchObject({
+        member_name: "Asha",
+        amount: "1500",
+      });
+      expect(req.payload.kind.value.headerImageLink).toBe("https://isc.example/qr.png");
+    }
+  });
+
+  it("refuses both/neither arms with corrective copy, before any RPC", async () => {
+    captured.send = undefined;
+
+    const both = await send({
+      recipient: "919000000001",
+      text: "hi",
+      template: { name: "fee_reminder" },
+    });
+    expect(both.isError).toBe(true);
+    expect(both.content[0]?.text).toContain("exactly one of text | template");
+
+    const neither = await send({ recipient: "919000000001" });
+    expect(neither.isError).toBe(true);
+    expect(neither.content[0]?.text).toContain("exactly one of text | template");
+
+    expect(captured.send).toBeUndefined();
+  });
+});
+
+describe("typed outcomes are answers, not errors (DD-002 D4)", () => {
+  it("a refused outcome returns as a SUCCESS result carrying the detail", async () => {
+    sendResponse = () =>
+      create(SendChannelMessageOutputSchema, {
+        outcome: ChannelSendOutcome.refused,
+        outboundMessageId: "",
+        detail:
+          "recipient has not messaged this channel — proactive sends from a channel"
+          + " conversation are limited to known senders",
+      });
+
+    const result = await send({ recipient: "919000000002", text: "hello" });
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0]?.text ?? "{}") as Record<string, string>;
+    expect(body.outcome).toBe("refused");
+    expect(body.detail).toContain("known senders");
+  });
+});
+
+describe("channels error mapper", () => {
+  it("passes a reach denial through verbatim — never the shared rewrite", async () => {
+    sendResponse = () => {
+      throw new ConnectError(
+        "this agent has no proactive-messaging channel it can use",
+        Code.PermissionDenied,
+      );
+    };
+
+    const result = await send({ recipient: "919000000001", text: "hello" });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual({
+      error: "this agent has no proactive-messaging channel it can use",
+      code: "PERMISSION_DENIED",
+    });
+  });
+
+  it("carries the ErrorInfo reason on operator-actionable preconditions (DD-005 D8)", async () => {
+    sendResponse = () => {
+      throw new ConnectError(
+        "proactive channel messaging requires Stigmer Cloud",
+        Code.FailedPrecondition,
+        undefined,
+        [
+          {
+            desc: ErrorInfoSchema,
+            value: create(ErrorInfoSchema, {
+              reason: "WHATSAPP_MANAGEMENT_SCOPE_MISSING",
+              domain: "stigmer.ai",
+            }),
+          },
+        ],
+      );
+    };
+
+    const result = await send({ recipient: "919000000001", text: "hello" });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0]?.text ?? "{}") as Record<string, string>;
+    expect(body.code).toBe("FAILED_PRECONDITION");
+    expect(body.reason).toBe("WHATSAPP_MANAGEMENT_SCOPE_MISSING");
+  });
+
+  it("delegates transport codes to the shared classifier", async () => {
+    sendResponse = () => {
+      throw new ConnectError("upstream down", Code.Unavailable);
+    };
+
+    const result = await send({ recipient: "919000000001", text: "hello" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe(
+      "Stigmer server is unavailable. Ensure it is running and reachable.",
+    );
+  });
+});

--- a/mcp-server/src/domains/channels/errors.ts
+++ b/mcp-server/src/domains/channels/errors.ts
@@ -1,0 +1,94 @@
+// The channels-domain error mapper — the records-domain sibling
+// (DD-004 S-7's recorded posture: siblings share the idiom, never an
+// abstraction over it; each domain documents its own contract).
+//
+// Channel-messaging domain errors carry agent-relayable messages that
+// are contract bytes (proactive-messaging DD-002 D4's error table):
+// "this agent has no proactive-messaging channel it can use", "channel
+// is required: this agent serves multiple proactive-enabled channels:
+// …", the OSS "proactive channel messaging requires Stigmer Cloud".
+// The shared ../rpcerr.ts would rewrite them into transport advice and
+// discard google.rpc.ErrorInfo; here the domain codes pass the server's
+// message through VERBATIM as isError JSON `{error, code, reason}` so
+// the model can self-correct (name the channel on INVALID_ARGUMENT;
+// stop and relay on PERMISSION_DENIED). Transport codes still delegate
+// to the shared helper, whose advice is right for them.
+//
+// Typed send outcomes (accepted/queued/refused) never reach this file:
+// they are successful responses by design (DD-002 D4 — policy refusals
+// are answers, not errors).
+
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ErrorInfoSchema } from "@stigmer/protos/google/rpc/error_details_pb";
+import { rpcError } from "../rpcerr.js";
+import { errorResult, textResult } from "../toolresult.js";
+
+/**
+ * The gRPC codes whose messages are the channel-messaging domain
+ * contract: reach denials (PERMISSION_DENIED, one fail-closed text per
+ * failure class), contract misuse with corrective copy
+ * (INVALID_ARGUMENT — ambiguous channel, ambiguous template language),
+ * and actionable preconditions (FAILED_PRECONDITION — the OSS refusal,
+ * not-installed, registry misconfiguration with its ErrorInfo reason).
+ */
+const DOMAIN_CODES: ReadonlySet<Code> = new Set([
+  Code.PermissionDenied,
+  Code.InvalidArgument,
+  Code.FailedPrecondition,
+]);
+
+/** The structured error payload channel tools return for domain errors. */
+export interface ChannelToolError {
+  /** The server's relayable message, byte-for-byte. */
+  error: string;
+  /** gRPC status name in SCREAMING_SNAKE (e.g. PERMISSION_DENIED). */
+  code: string;
+  /** ErrorInfo reason (e.g. WHATSAPP_MANAGEMENT_SCOPE_MISSING), when present. */
+  reason?: string;
+}
+
+/**
+ * Run a channel-tool body: a string payload becomes a text result; a
+ * domain error becomes an isError JSON result carrying the verbatim
+ * message + ErrorInfo reason; a transport error delegates to the shared
+ * classifier. The only try/catch in this domain.
+ */
+export async function channelResult(
+  toolContext: string,
+  produce: () => Promise<string>,
+): Promise<CallToolResult> {
+  try {
+    return textResult(await produce());
+  } catch (err) {
+    const ce = ConnectError.from(err);
+    if (DOMAIN_CODES.has(ce.code)) {
+      return {
+        content: [{ type: "text", text: JSON.stringify(domainError(ce)) }],
+        isError: true,
+      };
+    }
+    return errorResult(rpcError(ce, toolContext));
+  }
+}
+
+/** Project a domain ConnectError into the structured tool payload. */
+export function domainError(ce: ConnectError): ChannelToolError {
+  const payload: ChannelToolError = {
+    error: ce.rawMessage,
+    code: grpcStatusName(ce.code),
+  };
+  // The messaging RPCs attach google.rpc.ErrorInfo to operator-actionable
+  // preconditions (DD-005 D8); absence means the message alone carries
+  // the contract.
+  const details = ce.findDetails(ErrorInfoSchema);
+  if (details.length > 0 && details[0].reason !== "") {
+    payload.reason = details[0].reason;
+  }
+  return payload;
+}
+
+/** Connect's PascalCase code name → the gRPC SCREAMING_SNAKE status name. */
+function grpcStatusName(code: Code): string {
+  return Code[code].replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase();
+}

--- a/mcp-server/src/domains/channels/tools.ts
+++ b/mcp-server/src/domains/channels/tools.ts
@@ -1,0 +1,112 @@
+// The send_channel_message tool — the ONE tool of the channels roster
+// (proactive-messaging DD-002 D7, arguments amended by DD-006 D5 to
+// mirror the ChannelOutboundPayload oneof: `text` | `template`, exactly
+// one).
+//
+// Agent audience only, by construction: this roster is what the
+// runner-synthesized channel attachment connects to, and a session-bound
+// caller's org derives from its token (an explicit org is rejected —
+// the records T05 R3 rule), so no `org` argument exists to invite
+// rejected calls. A direct-audience variant on the full roster is
+// deliberately NOT registered: operators send through the console, CLI,
+// and SDK, which carry the org+channel addressing the direct reach path
+// requires.
+//
+// The typed outcome is the tool's answer, verbatim proto JSON:
+// `accepted` (delivered to the provider), `queued` (transient failure —
+// the platform retries in the background; do NOT resend), `refused`
+// (terminal; `detail` says why — adapt, never retry the same send).
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { resolveToken, type BackendTarget } from "../client.js";
+import { sendChannelMessage, type TemplateArg } from "./calls.js";
+import { channelResult } from "./errors.js";
+import { errorResult } from "../toolresult.js";
+
+const templateShape = z.object({
+  name: z.string().describe("Approved template name on the channel's provider registry."),
+  language: z
+    .string()
+    .optional()
+    .describe(
+      "Template language code (e.g. en, en_US). Omit when the template exists in exactly one language.",
+    ),
+  parameters: z
+    .record(z.string())
+    .optional()
+    .describe(
+      'Placeholder values. Positional templates key by position ("1", "2", …); ' +
+        'named templates key by parameter name ("member_name").',
+    ),
+  header_image_link: z
+    .string()
+    .optional()
+    .describe(
+      "Public HTTPS URL for the image header. Required exactly when the template " +
+        "declares an image header.",
+    ),
+});
+
+/** Register the channel messaging tool; returns the tool names. */
+export function registerChannelTools(server: McpServer, target: BackendTarget): string[] {
+  server.registerTool(
+    "send_channel_message",
+    {
+      description:
+        "Send a business-initiated message to a recipient on this agent's messaging channel " +
+        "(e.g. WhatsApp). Exactly one of text | template. Outside a 24-hour customer-service " +
+        "window the provider only accepts a pre-approved template, so prefer a template from " +
+        "<available_channel_templates>. The result carries a typed outcome: accepted (sent), " +
+        "queued (the platform retries in the background — do not resend), or refused " +
+        "(terminal; detail says why — adapt, never retry the same send).",
+      inputSchema: {
+        recipient: z
+          .string()
+          .describe("Recipient's key on the channel's provider (WhatsApp: the wa_id / phone number)."),
+        text: z
+          .string()
+          .optional()
+          .describe(
+            "Plain text body. Only deliverable inside an open 24-hour customer-service window.",
+          ),
+        template: templateShape
+          .optional()
+          .describe("Pre-approved template send — required outside a 24-hour window."),
+        channel: z
+          .string()
+          .optional()
+          .describe(
+            "Channel slug. Only needed when this agent serves more than one " +
+              "proactive-messaging channel (a refusal will list them).",
+          ),
+      },
+    },
+    (args, extra) => {
+      // Exactly-one, checked here with corrective copy the model can act
+      // on immediately; the server's required-oneof validation is the
+      // backstop (DD-006 D5).
+      const hasText = args.text !== undefined && args.text !== "";
+      const hasTemplate = args.template !== undefined;
+      if (hasText === hasTemplate) {
+        return Promise.resolve(errorResult(
+          hasText
+            ? "supply exactly one of text | template, not both"
+            : "supply exactly one of text | template — text for an open 24-hour window, " +
+              "template otherwise",
+        ));
+      }
+      return channelResult(`message to "${args.recipient}"`, () =>
+        sendChannelMessage(target.serverAddress, resolveToken(extra, target.apiKey), {
+          recipient: args.recipient,
+          text: args.text,
+          template: args.template as TemplateArg | undefined,
+          channel: args.channel,
+        }),
+      );
+    },
+  );
+
+  return ["send_channel_message"];
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -22,6 +22,7 @@ import type { Config } from "./config.js";
 import { registerAgentExecutionTools } from "./domains/agentexecutions/tools.js";
 import { registerAgentResources } from "./domains/agents/resources.js";
 import { registerAgentTools } from "./domains/agents/tools.js";
+import { registerChannelTools } from "./domains/channels/tools.js";
 import type { BackendTarget } from "./domains/client.js";
 import { registerDatastoreResources } from "./domains/datastores/resources.js";
 import { registerDatastoreTools } from "./domains/datastores/tools.js";
@@ -80,6 +81,21 @@ export function createRecordsServer(target: BackendTarget): McpServer {
   const server = new McpServer({ name: "mcp-server-stigmer-records", version: SERVER_VERSION });
   const tools = registerRecordTools(server, target, "agent");
   log.info("tools registered (records roster)", { count: tools.length, tools });
+  return server;
+}
+
+/**
+ * Build a channels-only MCP server: send_channel_message with the
+ * agent-facing argument surface, and nothing else (proactive-messaging
+ * DD-006 D8 — the records-roster pattern). This is the roster the
+ * runner-synthesized channel attachment connects to; the structural
+ * guarantee mirrors the records roster's. Served on the /channels HTTP
+ * route and as the stdio roster when STIGMER_MCP_ROSTER=channels.
+ */
+export function createChannelsServer(target: BackendTarget): McpServer {
+  const server = new McpServer({ name: "mcp-server-stigmer-channels", version: SERVER_VERSION });
+  const tools = registerChannelTools(server, target);
+  log.info("tools registered (channels roster)", { count: tools.length, tools });
   return server;
 }
 
@@ -167,12 +183,20 @@ export type RouteServerFactory = (path: string) => McpServer;
 /** HTTP route serving the records-only roster (T05 R1). */
 export const RECORDS_ROUTE = "/records";
 
+/** HTTP route serving the channels-only roster (DD-006 D8). */
+export const CHANNELS_ROUTE = "/channels";
+
 /**
  * The standard HTTP route dispatch: the records-only roster on
- * {@link RECORDS_ROUTE}, the full roster everywhere else.
+ * {@link RECORDS_ROUTE}, the channels-only roster on
+ * {@link CHANNELS_ROUTE}, the full roster everywhere else.
  */
 export function routedServerFactory(target: BackendTarget): RouteServerFactory {
-  return (path) => (path === RECORDS_ROUTE ? createRecordsServer(target) : createServer(target));
+  return (path) => {
+    if (path === RECORDS_ROUTE) return createRecordsServer(target);
+    if (path === CHANNELS_ROUTE) return createChannelsServer(target);
+    return createServer(target);
+  };
 }
 
 /**
@@ -350,12 +374,14 @@ async function routeRequest(
 }
 
 /**
- * The stdio server for the configured roster: the records-only roster
- * when STIGMER_MCP_ROSTER=records (what the OSS runner-synthesized
- * datastore attachment spawns), the full roster otherwise.
+ * The stdio server for the configured roster: the records-only or
+ * channels-only roster when STIGMER_MCP_ROSTER names one (what the OSS
+ * runner-synthesized attachments spawn), the full roster otherwise.
  */
 export function stdioServer(target: BackendTarget, cfg: Config): McpServer {
-  return cfg.roster === "records" ? createRecordsServer(target) : createServer(target);
+  if (cfg.roster === "records") return createRecordsServer(target);
+  if (cfg.roster === "channels") return createChannelsServer(target);
+  return createServer(target);
 }
 
 /** Return a single header value, collapsing the array form Node may produce. */


### PR DESCRIPTION
## Summary

T02 slice 3b (proactive-messaging DD-006 D4–D8) — the last mile over the merged 3a contract ([stigmer#339](https://github.com/stigmer/stigmer/pull/339), [stigmer-cloud#247](https://github.com/stigmer/stigmer-cloud/pull/247)). After this PR, an agent whose channel owner set `proactive_messaging_enabled` can actually send business-initiated WhatsApp messages.

- **A channels roster on mcp-server** (the records-roster pattern: `/channels` HTTP route on the bridge, `STIGMER_MCP_ROSTER=channels` over stdio): ONE tool, `send_channel_message`, whose arguments mirror the `ChannelOutboundPayload` oneof exactly — `text` | `template{name, language?, parameters?, header_image_link?}`, exactly one, `channel?` only for multi-channel agents. Typed `accepted`/`queued`/`refused` outcomes return verbatim as the tool result (answers, not errors); the channels-own error mapper passes domain messages through byte-for-byte, the records-domain sibling (the DD-004 S-7 "siblings share the idiom" posture).
- **The runner synthesizes the attachment** when the DD-006 D2 discovery read (`listMessagingChannels`) says the agent serves a proactive channel — the SAME candidate computation the send authorization runs, so the attachment decision and the send authority cannot disagree. Approval-free by construction and deliberately so: both calling surfaces run UNATTENDED approval mode, where a gated tool resolves as skip-and-adapt — a gated send tool means reminders never send. The generic injection logic (reserved slug, warn, append) moved to `shared/synthesized-attachment.ts` now that it has two consumers.
- **The `<available_channel_templates>` prompt section** (DD-003 D5): approved AND sendable templates with full body text, so the model fills placeholders in context with zero extra tool rounds. Filtered on the wire's `unsupported_reason`, deterministic (name, language) order, capped at 30 with a withheld count (DD-006 D6). Threaded per each harness's existing convention.
- **Load-bearing wiring details**: the discovery read runs BEFORE deep-agent's MCP gate (an agent whose only tool source is a channel would otherwise never connect anything); it authenticates like the ExecutionContext read (per-call scoped token on desktop — the messaging reach refuses the ambient `embedded_runner` credential — ambient sandbox token on cloud, nothing on OSS); and every failure mode (no channel, OSS's empty answer, registry outage, `UNIMPLEMENTED` from a pre-3a control plane) degrades to honest absence: no tool, no section, execution unharmed.
- **Docs**: the "Send proactive messages with templates" how-to, classified in the inventory and the sidebar.

## Test plan

- [x] mcp-server: tsc + full Vitest **127/127**, including the new `channels.integration.test.ts` (roster shape, oneof mapping, exactly-one refusal before any RPC, outcomes-as-answers, verbatim domain errors, transport delegation, the pinned `/channels` route)
- [x] runner: tsc + `channel-attachment.test.ts` (18 tests: discovery failure posture incl. per-channel degradation, both connection shapes, approval-freedom via `mergeApprovalPolicies`, backfill immunity via `needsBackfill`, section filter/order/cap/withheld, pinned slug + route) + the migrated datastore twin (9 tests)
- [x] Full runner suite: failures reproduced byte-identical on clean `main` (pre-existing sqlite-native collection errors + Temporal-timing local flakes) — CI is the arbiter
- [x] Docs: `make check-docs-inventory` + `make check-docs-yaml` green

**Known gap, stated plainly**: no wire-level integration test exercises tool → bridge → cloud send end to end; the Go harness lacks channel fixtures and a service-env seam (the recorded DD-004 S-8 follow-up, prerequisites unchanged).

Made with [Cursor](https://cursor.com)