### PR TITLE
test(integration): prove the schedule clock against real Temporal (T04 slice 2a)

### DIFF
--- a/test/integration/harness/schedule_inspector.go
+++ b/test/integration/harness/schedule_inspector.go
@@ -1,0 +1,106 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/client"
+)
+
+// Cross-repo pinned strings (cloud: ScheduleArtifact.TICK_ID_PREFIX /
+// PROBE_ID_PREFIX in stigmer-cloud). The tick prefix is baked into every
+// per-resource Temporal Schedule artifact's id AND base workflow id —
+// changing it on either side strands every existing artifact, so both
+// sides pin it in tests.
+const (
+	// ScheduleTickIDPrefix prefixes each Schedule resource's Temporal
+	// Schedule artifact id: schedule/tick/{scheduleResourceId}.
+	ScheduleTickIDPrefix = "schedule/tick/"
+
+	// ScheduleProbeIDPrefix prefixes the write path's throwaway fire-time
+	// probe schedules. Always paused; leftovers mean a crashed request and
+	// are reaped by the cloud reconciliation sweep.
+	ScheduleProbeIDPrefix = "schedule/probe/"
+)
+
+// ScheduleArtifactID returns the Temporal Schedule artifact id for a
+// Schedule resource id — the cloud runtime's identity convention.
+func ScheduleArtifactID(scheduleResourceID string) string {
+	return ScheduleTickIDPrefix + scheduleResourceID
+}
+
+// ScheduleInspector asserts on the Temporal Schedule artifacts the cloud
+// service derives from Schedule resources (T04 slice 2a) — the
+// TemporalInspector sibling for the schedules API, and the first consumer
+// of the Temporal Go SDK's ScheduleClient in this repo.
+type ScheduleInspector struct {
+	client client.Client
+}
+
+// NewScheduleInspector wraps an existing Temporal client connection.
+func NewScheduleInspector(c client.Client) *ScheduleInspector {
+	return &ScheduleInspector{client: c}
+}
+
+// DescribeArtifact returns the live artifact for a Schedule resource id.
+func (si *ScheduleInspector) DescribeArtifact(
+	ctx context.Context, scheduleResourceID string) (*client.ScheduleDescription, error) {
+	desc, err := si.client.ScheduleClient().
+		GetHandle(ctx, ScheduleArtifactID(scheduleResourceID)).Describe(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("describe schedule artifact %s: %w",
+			ScheduleArtifactID(scheduleResourceID), err)
+	}
+	return desc, nil
+}
+
+// ArtifactExists reports whether the resource's artifact exists, mapping
+// Temporal's not-found error to false rather than an error.
+func (si *ScheduleInspector) ArtifactExists(
+	ctx context.Context, scheduleResourceID string) (bool, error) {
+	_, err := si.client.ScheduleClient().
+		GetHandle(ctx, ScheduleArtifactID(scheduleResourceID)).Describe(ctx)
+	if err == nil {
+		return true, nil
+	}
+	var notFound *serviceerror.NotFound
+	if errors.As(err, &notFound) {
+		return false, nil
+	}
+	return false, fmt.Errorf("describe schedule artifact %s: %w",
+		ScheduleArtifactID(scheduleResourceID), err)
+}
+
+// TriggerArtifact forces an immediate fire — the fast, deterministic test
+// path (spike-verified: a triggered action carries the same nominal-time
+// search attribute and workflow-id suffix a cron fire does), instead of
+// parking the suite on a cron minute boundary.
+func (si *ScheduleInspector) TriggerArtifact(
+	ctx context.Context, scheduleResourceID string) error {
+	return si.client.ScheduleClient().
+		GetHandle(ctx, ScheduleArtifactID(scheduleResourceID)).
+		Trigger(ctx, client.ScheduleTriggerOptions{})
+}
+
+// ListProbeLeftovers returns the ids of any fire-time probe schedules
+// still live — a refusal path must leave nothing behind.
+func (si *ScheduleInspector) ListProbeLeftovers(ctx context.Context) ([]string, error) {
+	iter, err := si.client.ScheduleClient().List(ctx, client.ScheduleListOptions{PageSize: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list schedules: %w", err)
+	}
+	var leftovers []string
+	for iter.HasNext() {
+		entry, err := iter.Next()
+		if err != nil {
+			return nil, fmt.Errorf("iterate schedules: %w", err)
+		}
+		if strings.HasPrefix(entry.ID, ScheduleProbeIDPrefix) {
+			leftovers = append(leftovers, entry.ID)
+		}
+	}
+	return leftovers, nil
+}

--- a/test/integration/schedule_test.go
+++ b/test/integration/schedule_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stigmer/stigmer/test/integration/harness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -22,11 +23,15 @@ import (
 // backend (this suite boots the stigmer-service fat JAR — see
 // suite_test.go): the declarative apply loop, the read surface (get,
 // getByReference, getByAgent), the update immutability rules, the cron
-// grammar refusals, and delete. The edition-specific pipelines are pinned
-// in each edition's own controller suites (schedule/controller tests in
-// Go, ScheduleSpecRulesTest + the repo contract suite in Java); this
-// asserts the shared contract over the wire (T04 slice 1). Nothing fires:
-// the clock is slice 2 — this slice's contract is storage and validation.
+// grammar refusals, and delete (T04 slice 1) — plus the clock (T04 slice
+// 2a): every write converges a Temporal Schedule artifact on the SAME
+// Temporal dev server this harness runs, so TestSchedule_ClockLifecycle
+// asserts the artifact directly through the Temporal ScheduleClient (the
+// first use of that API in this repo) and proves a fire lands on status.
+// The edition-specific pipelines are pinned in each edition's own suites
+// (schedule/controller tests in Go; ScheduleSpecRulesTest, the schedule
+// temporal package tests, and the repo contract suite in Java). The OSS
+// Go server's own clock is T04 slice 3.
 
 // scheduleManifestFor builds a Schedule manifest as a YAML apply would
 // send it: relative agent_ref (empty org — the server normalizes it).
@@ -209,4 +214,150 @@ func TestSchedule_ContractRefusals(t *testing.T) {
 		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 		assert.Contains(t, err.Error(), "spec.agent.agent_ref is immutable")
 	})
+
+	t.Run("the interval floor is enforced from Temporal's own fire times", func(t *testing.T) {
+		// */2 passes the lexical grammar (slice 1) but fires every two
+		// minutes — below the 5-minute platform floor, which the probe
+		// step computes from Temporal's projected fire times (DD-010 D-C:
+		// the platform parses no cron).
+		fast := scheduleManifestFor(org, "refusal-floor", agentSlug)
+		fast.Spec.Cron = "*/2 * * * *"
+		_, err := clients.ScheduleCommand.Apply(ctx, fast)
+		require.Error(t, err)
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+		assert.Contains(t, err.Error(), "minimum interval")
+
+		// Refusal happens BEFORE the first write: no row exists.
+		_, err = clients.ScheduleQuery.GetByReference(ctx, &apiresource.ApiResourceReference{
+			Kind: apiresourcekind.ApiResourceKind_schedule,
+			Org:  org,
+			Slug: "refusal-floor",
+		})
+		require.Error(t, err, "a floor refusal must persist nothing")
+	})
+
+	t.Run("a lexically valid cron Temporal rejects is refused with Temporal's verdict", func(t *testing.T) {
+		// Minute 99 passes the lexical grammar (digits, five fields) but
+		// is out of range — the probe relays Temporal's own parser verdict
+		// as INVALID_ARGUMENT instead of letting the spec detonate at
+		// arming time (the C-4 gap, closed by DD-010 D-A).
+		bad := scheduleManifestFor(org, "refusal-temporal-verdict", agentSlug)
+		bad.Spec.Cron = "99 * * * *"
+		_, err := clients.ScheduleCommand.Apply(ctx, bad)
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+}
+
+// TestSchedule_ClockLifecycle verifies the clock end to end (T04 slice
+// 2a): every schedule write converges a Temporal Schedule artifact with
+// the complete desired state (asserted directly through the Temporal
+// ScheduleClient against the same dev server the service under test
+// uses), a triggered fire lands on status through the tick workflow, the
+// enabled flag round-trips to the artifact's paused state, and delete
+// tears the artifact down.
+func TestSchedule_ClockLifecycle(t *testing.T) {
+	require.NotNil(t, grpcConn)
+	require.NotNil(t, testHarness.Temporal, "Temporal dev server must be available")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	temporalClient, err := testHarness.Temporal.Client()
+	require.NoError(t, err, "should connect to Temporal")
+	t.Cleanup(temporalClient.Close)
+	inspector := harness.NewScheduleInspector(temporalClient)
+
+	clients := harness.NewClients(grpcConn)
+	org := harness.TestOrg
+
+	agent := harness.CreateAgent(t, ctx, clients, "test-schedule-clock",
+		"You are a helpful agent for schedule clock tests.")
+
+	created, err := clients.ScheduleCommand.Apply(ctx,
+		scheduleManifestFor(org, "clock-schedule", agent.GetMetadata().GetSlug()))
+	require.NoError(t, err)
+	scheduleID := created.GetMetadata().GetId()
+
+	// ── 1. The artifact is armed with the complete desired state ──
+	desc, err := inspector.DescribeArtifact(ctx, scheduleID)
+	require.NoError(t, err, "apply must create the Temporal artifact")
+	assert.Equal(t, "cron=0 9 * * * tz=Asia/Kolkata", desc.Schedule.State.Note,
+		"the state note is the drift fingerprint (cron does not round-trip)")
+	assert.False(t, desc.Schedule.State.Paused, "an enabled schedule must not be paused")
+	assert.Equal(t, "Asia/Kolkata", desc.Schedule.Spec.TimeZoneName)
+	assert.Equal(t, enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, desc.Schedule.Policy.Overlap,
+		"SKIP must be explicit — a tracked tick makes it real (DD-008 D6)")
+	assert.False(t, desc.Schedule.Policy.PauseOnFailure,
+		"Temporal must never pause behind the platform's back (DD-010 D-D)")
+
+	// The apply response mirrors the armed state — no stale read needed.
+	assert.NotNil(t, created.GetStatus().GetNextFireAt(),
+		"an armed schedule answers with its next fire time")
+
+	// ── 2. A fire lands on status through the tick workflow ──
+	// trigger() replaces waiting on a cron minute boundary and exercises
+	// the same mechanism (nominal-time search attribute + id suffix).
+	require.NoError(t, inspector.TriggerArtifact(ctx, scheduleID))
+
+	var lastFire time.Time
+	require.Eventually(t, func() bool {
+		fetched, getErr := clients.ScheduleQuery.Get(ctx,
+			&schedulev1.ScheduleId{Value: scheduleID})
+		if getErr != nil || fetched.GetStatus().GetLastFireAt() == nil {
+			return false
+		}
+		lastFire = fetched.GetStatus().GetLastFireAt().AsTime()
+		return true
+	}, 30*time.Second, 500*time.Millisecond,
+		"the tick must record last_fire_at after a triggered fire")
+
+	assert.Zero(t, lastFire.Nanosecond(),
+		"last_fire_at is the NOMINAL fire time — whole seconds by construction")
+	assert.WithinDuration(t, time.Now(), lastFire, 2*time.Minute,
+		"a triggered fire's nominal time is the trigger moment")
+
+	// ── 3. Disabling pauses the artifact and clears next_fire_at ──
+	fetched, err := clients.ScheduleQuery.Get(ctx, &schedulev1.ScheduleId{Value: scheduleID})
+	require.NoError(t, err)
+	fetched.Spec.Enabled = false
+	disabled, err := clients.ScheduleCommand.Apply(ctx, fetched)
+	require.NoError(t, err)
+	assert.Nil(t, disabled.GetStatus().GetNextFireAt(),
+		"next_fire_at is absent while disabled — the field's contract")
+
+	desc, err = inspector.DescribeArtifact(ctx, scheduleID)
+	require.NoError(t, err)
+	assert.True(t, desc.Schedule.State.Paused, "disabling must pause the artifact")
+
+	// ── 4. Re-enabling with a new cron updates the artifact in place ──
+	fetched, err = clients.ScheduleQuery.Get(ctx, &schedulev1.ScheduleId{Value: scheduleID})
+	require.NoError(t, err)
+	fetched.Spec.Enabled = true
+	fetched.Spec.Cron = "30 18 * * *"
+	reenabled, err := clients.ScheduleCommand.Apply(ctx, fetched)
+	require.NoError(t, err)
+	assert.NotNil(t, reenabled.GetStatus().GetNextFireAt(),
+		"re-enabling re-arms and answers with the next fire time")
+
+	desc, err = inspector.DescribeArtifact(ctx, scheduleID)
+	require.NoError(t, err)
+	assert.Equal(t, "cron=30 18 * * * tz=Asia/Kolkata", desc.Schedule.State.Note)
+	assert.False(t, desc.Schedule.State.Paused)
+
+	// ── 5. Delete tears the artifact down ──
+	_, err = clients.ScheduleCommand.Delete(ctx, &schedulev1.ScheduleId{Value: scheduleID})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		exists, existsErr := inspector.ArtifactExists(ctx, scheduleID)
+		return existsErr == nil && !exists
+	}, 10*time.Second, 250*time.Millisecond,
+		"delete must tear the Temporal artifact down")
+
+	// ── 6. The write path leaves no probe residue behind ──
+	leftovers, err := inspector.ListProbeLeftovers(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, leftovers,
+		"every fire-time probe must be deleted within its request")
 }


### PR DESCRIPTION
## Summary

The integration-side half of T04 slice 2a (the schedule clock — stigmer-cloud#250): the harness gains a `ScheduleInspector` (the repo's first consumer of the Temporal Go SDK's `ScheduleClient`), and the schedule wire suite gains the tests that prove the clock end to end against the real Temporal dev server this harness already runs — the same server the cloud fat JAR under test is connected to.

## What's here

- **`harness/schedule_inspector.go`** — pins the cross-repo id conventions (`schedule/tick/{scheduleId}`, `schedule/probe/…`; the tick prefix is baked into every artifact on the cloud side, so both repos guard it in tests), and exposes `DescribeArtifact`, `ArtifactExists` (not-found ⇒ false), `TriggerArtifact` (the fast deterministic fire path — spike-verified to carry the same nominal-time search attribute and workflow-id suffix a cron fire does, instead of parking the suite on a cron minute boundary), and `ListProbeLeftovers`.
- **`TestSchedule_ClockLifecycle`** — apply arms the artifact with the complete desired state (note fingerprint, unpaused, explicit SKIP overlap, `pauseOnFailure=false`); the apply response carries `next_fire_at`; `trigger()` drives a real fire through the tick workflow inside the JAR and `status.last_fire_at` lands as the nominal time in whole seconds; disabling pauses the artifact and clears `next_fire_at`; re-enabling with a new cron updates the artifact in place; delete tears the artifact down; the write path leaves zero probe residue.
- **Two new refusal subtests** — the interval floor (`*/2 * * * *` refused with `FAILED_PRECONDITION` and *nothing persisted*) and Temporal's own cron verdict (`99 * * * *` passes the lexical grammar, Temporal rejects it, the probe relays `INVALID_ARGUMENT`).

## Verification

`go vet` clean; `TestSchedule_DeclarativeLifecycle`, `TestSchedule_ContractRefusals` (7 subtests), and `TestSchedule_ClockLifecycle` all PASS against a freshly built cloud fat JAR — verified verbosely, since the suite exits 0 when the JAR is missing.

The OSS Go server's own clock is T04 slice 3; these tests assert the cloud JAR's behavior, which is where this suite has always pointed (see `suite_test.go`).
