### PR TITLE
fix(runner): stop stdio MCP servers from inheriting the runner process env

### DIFF
--- a/apis/ai/stigmer/agentic/mcpserver/docs/server-types.md
+++ b/apis/ai/stigmer/agentic/mcpserver/docs/server-types.md
@@ -71,21 +71,20 @@ spec:
 
 ### Credential Injection for Stdio
 
-Environment variables are the standard mechanism for injecting credentials into stdio servers. Declare them in `env_spec` — the agent runner will populate them from the AgentInstance's environment before starting the process:
+Environment variables are the standard mechanism for injecting credentials into stdio servers. Declare them in the spec's `env` map — the agent runner will populate them from the AgentInstance's environment before starting the process:
 
 ```yaml
 spec:
   stdio:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-github"]
-  env_spec:
-    data:
-      GITHUB_TOKEN:
-        description: "GitHub personal access token with repo scope"
-        is_secret: true
+  env:
+    GITHUB_TOKEN:
+      description: "GitHub personal access token with repo scope"
+      is_secret: true
 ```
 
-The subprocess inherits the full environment including all resolved variables. The MCP server process reads `GITHUB_TOKEN` from its environment exactly as it would if run locally.
+The subprocess receives exactly the declared variables plus a minimal base environment (`PATH`, `HOME`, and similar) — never the runner's own process environment, which carries runner-internal credentials. The MCP server process reads `GITHUB_TOKEN` from its environment exactly as it would if run locally; anything else the server needs must be declared the same way.
 
 ---
 

--- a/backend/services/runner/src/shared/__tests__/mcp-manager.test.ts
+++ b/backend/services/runner/src/shared/__tests__/mcp-manager.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Connection } from "@langchain/mcp-adapters";
 import { toMcpClientConfig } from "../mcp-manager.js";
 import type { ResolvedMcpServer } from "../mcp-resolver.js";
 
@@ -11,6 +12,18 @@ function makeServer(overrides: Partial<ResolvedMcpServer>): ResolvedMcpServer {
     discoveredCapabilitiesEmpty: false,
     ...overrides,
   };
+}
+
+/** Narrow a Connection to its stdio variant and return its env. */
+function stdioEnv(
+  config: Record<string, Connection>,
+  slug: string,
+): Record<string, string> | undefined {
+  const conn = config[slug];
+  if (!conn || !("command" in conn)) {
+    throw new Error(`expected a stdio connection for '${slug}'`);
+  }
+  return conn.env;
 }
 
 describe("toMcpClientConfig", () => {
@@ -79,5 +92,78 @@ describe("toMcpClientConfig", () => {
 
   it("handles empty server list", () => {
     expect(toMcpClientConfig([])).toEqual({});
+  });
+});
+
+// Runner-internal credentials that must never reach an MCP stdio subprocess
+// (oss#256). Names mirror what the runner actually reads: config.ts,
+// fingerprint-secret.ts, model-client.ts, registry-endpoint.ts.
+const RUNNER_CREDENTIAL_KEYS = [
+  "STIGMER_RUNNER_HITL_SECRET",
+  "STIGMER_TOKEN",
+  "STIGMER_AUTH_TOKEN",
+  "CURSOR_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+] as const;
+
+describe("toMcpClientConfig — stdio env isolation (oss#256)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("gives a stdio server with no declared env none of the runner's variables", () => {
+    for (const key of RUNNER_CREDENTIAL_KEYS) {
+      vi.stubEnv(key, `leaked-${key}`);
+    }
+    vi.stubEnv("STIGMER_TEST_LEAK_SENTINEL", "canary");
+
+    const config = toMcpClientConfig([
+      makeServer({ slug: "bare", command: "some-mcp-server", env: undefined }),
+    ]);
+
+    // Passing no env means the MCP SDK supplies its minimal base environment
+    // (HOME, LOGNAME, PATH, SHELL, TERM, USER) — the runner must add nothing.
+    expect(stdioEnv(config, "bare")).toBeUndefined();
+  });
+
+  it("never copies process.env into a stdio config (fallback-reintroduction tripwire)", () => {
+    vi.stubEnv("STIGMER_TEST_LEAK_SENTINEL", "canary");
+
+    const config = toMcpClientConfig([
+      makeServer({ slug: "bare", command: "some-mcp-server", env: undefined }),
+    ]);
+
+    const env = stdioEnv(config, "bare") ?? {};
+    for (const key of Object.keys(process.env)) {
+      expect(
+        env,
+        `process.env key '${key}' must not leak into an MCP stdio env`,
+      ).not.toHaveProperty(key);
+    }
+  });
+
+  it("passes a declared env through exactly, without merging process.env", () => {
+    vi.stubEnv("STIGMER_TOKEN", "runner-secret");
+
+    const config = toMcpClientConfig([
+      makeServer({
+        slug: "declared",
+        command: "some-mcp-server",
+        env: { API_KEY: "user-value" },
+      }),
+    ]);
+
+    expect(stdioEnv(config, "declared")).toEqual({ API_KEY: "user-value" });
+  });
+
+  it("passes an empty declared env through unchanged (same child env as undeclared)", () => {
+    vi.stubEnv("STIGMER_TOKEN", "runner-secret");
+
+    const config = toMcpClientConfig([
+      makeServer({ slug: "empty", command: "some-mcp-server", env: {} }),
+    ]);
+
+    expect(stdioEnv(config, "empty")).toEqual({});
   });
 });

--- a/backend/services/runner/src/shared/mcp-manager.ts
+++ b/backend/services/runner/src/shared/mcp-manager.ts
@@ -10,9 +10,22 @@
  * resolution time by shared/mcp-transport-guard.ts — servers reaching
  * this manager have already passed it.
  *
+ * Stdio env contract (oss#256): a subprocess receives exactly the
+ * variables declared in the server's spec.env (resolved upstream by
+ * filterEnvToDeclaredKeys) plus the MCP SDK's minimal base environment
+ * (HOME, LOGNAME, PATH, SHELL, TERM, USER — getDefaultEnvironment in
+ * @modelcontextprotocol/sdk, merged under whatever we pass). The
+ * runner's own process env is never passed: it carries runner-internal
+ * credentials (STIGMER_TOKEN, STIGMER_RUNNER_HITL_SECRET,
+ * CURSOR_API_KEY, LLM provider keys) that no third-party MCP subprocess
+ * may see. A declared-empty env and an undeclared env are deliberately
+ * equivalent — both yield the SDK base environment.
+ *
  * The Cursor execution path does NOT use this manager — it passes MCP
  * configs directly to the Cursor SDK via toCursorMcpConfig(). This
- * manager is exclusively for LangGraph-based deep agent executions.
+ * manager serves LangGraph-based deep agent executions, and discovery
+ * (activities/discover-mcp-server.ts) builds its spawn config through
+ * toMcpClientConfig too.
  */
 
 import { MultiServerMCPClient } from "@langchain/mcp-adapters";
@@ -32,11 +45,18 @@ export function toMcpClientConfig(
   for (const server of servers) {
     if (server.connectionType === "stdio") {
       if (!server.command) continue;
+      if (!server.env || Object.keys(server.env).length === 0) {
+        console.log(
+          `[MCP] Server '${server.slug}' declares no env — its subprocess ` +
+          `starts with the minimal base environment only. Declare variables ` +
+          `in the McpServer's spec.env to pass them.`,
+        );
+      }
       config[server.slug] = {
         transport: "stdio",
         command: server.command,
         args: server.args ?? [],
-        env: server.env ?? processEnvAsStrings(),
+        env: server.env,
         cwd: server.cwd,
       };
     } else if (server.connectionType === "http" || server.connectionType === "sse") {
@@ -90,24 +110,4 @@ export async function connectMcpServers(
   );
 
   return { client, tools, serverToolMap };
-}
-
-/**
- * Snapshot of process.env as a string-only record (no undefined values).
- * Used as a fallback when an MCP server has no declared env — the
- * subprocess inherits the runner's full environment, matching standard
- * Unix child-process behavior.
- *
- * Without this, @modelcontextprotocol/sdk only passes a restricted
- * whitelist (HOME, PATH, USER, etc.) which drops platform variables
- * like STIGMER_SERVER_ADDRESS.
- */
-function processEnvAsStrings(): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) {
-      env[key] = value;
-    }
-  }
-  return env;
 }

--- a/docs/concepts/environments.mdx
+++ b/docs/concepts/environments.mdx
@@ -146,10 +146,10 @@ When an Agent runs, Stigmer merges the Environments attached to its Agent
 Instance into a single **ExecutionContext**. That merged map is what the runner
 uses at execution time. Different surfaces see different slices of it:
 
-| Surface                                            | What the Agent sees                                                                                                                                                      |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Shell commands** (native harness `execute` tool) | The runner's own process variables, minus runner-internal credentials, with ExecutionContext values overlaid on top. Overlay wins when a name exists in both.            |
-| **MCP stdio servers**                              | Only variables declared in the MCP server's `env_spec`, taken from ExecutionContext. If the server declares no env, the runner falls back to its full process variables. |
+| Surface                                            | What the Agent sees                                                                                                                                                                                                                   |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Shell commands** (native harness `execute` tool) | The runner's own process variables, minus runner-internal credentials, with ExecutionContext values overlaid on top. Overlay wins when a name exists in both.                                                                         |
+| **MCP stdio servers**                              | Only variables declared in the MCP server's `env` map, taken from ExecutionContext, plus a minimal base set (`PATH`, `HOME`, and similar). A server that declares nothing gets only that base set — never the runner's own variables. |
 
 Shell commands inherit `PATH` and other host settings from the runner so local
 CLIs work, while ExecutionContext supplies API keys and service URLs your Agent

--- a/test/integration/harness/mcp_helpers.go
+++ b/test/integration/harness/mcp_helpers.go
@@ -47,8 +47,11 @@ func BuildTestMcpServer(outputDir string) (string, error) {
 }
 
 // CreateStdioMcpServer creates an McpServer resource pointing to the test
-// stdio binary. The server is auto-deleted on test cleanup.
-func CreateStdioMcpServer(t *testing.T, ctx context.Context, clients *Clients, binaryPath string) *mcpserverv1.McpServer {
+// stdio binary, passing any extra args (e.g. "--env-report", path) to the
+// subprocess. No spec.env is declared, so the resource also models the
+// zero-declaration shape the env-isolation guard exercises. The server is
+// auto-deleted on test cleanup.
+func CreateStdioMcpServer(t *testing.T, ctx context.Context, clients *Clients, binaryPath string, args ...string) *mcpserverv1.McpServer {
 	t.Helper()
 
 	name := "test-mcp-" + uuid.New().String()[:8]
@@ -64,6 +67,7 @@ func CreateStdioMcpServer(t *testing.T, ctx context.Context, clients *Clients, b
 			ServerType: &mcpserverv1.McpServerSpec_Stdio{
 				Stdio: &mcpserverv1.StdioServerConfig{
 					Command: binaryPath,
+					Args:    args,
 				},
 			},
 		},

--- a/test/integration/harness/unified_runner.go
+++ b/test/integration/harness/unified_runner.go
@@ -692,6 +692,14 @@ func buildUnifiedRunnerEnv(cfg UnifiedRunnerConfig, mode, taskQueue string) []st
 		fmt.Sprintf("STIGMER_SERVER_ADDRESS=%s", cfg.StigmerServiceAddress),
 
 		"SKIP_MCP_CONNECT_BACKFILL=true",
+
+		// Sentinels for the stdio env-isolation guard (oss#256): the runner
+		// process carries these, and mcp_stdio_env_isolation_test.go asserts
+		// that a stdio MCP subprocess does NOT. STIGMER_RUNNER_HITL_SECRET is
+		// the real credential name (a stable value is a supported runner
+		// config); the second is a neutral canary nothing else reads.
+		"STIGMER_RUNNER_HITL_SECRET=integration-hitl-fingerprint-key",
+		"STIGMER_TEST_LEAK_SENTINEL=leak-canary",
 	)
 
 	if mode == "manager" {

--- a/test/integration/mcp_stdio_env_isolation_test.go
+++ b/test/integration/mcp_stdio_env_isolation_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
+	"github.com/stigmer/stigmer/test/integration/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMcpStdio_EnvIsolation_NoDeclaredEnv is the end-to-end guard for
+// oss#256: a stdio MCP subprocess must never inherit the runner's process
+// environment.
+//
+// It drives the real spawn path — McpServerCommand.Connect → connect
+// workflow → DiscoverMcpServerCapabilities activity → toMcpClientConfig →
+// MultiServerMCPClient — with a server that declares no spec.env (the
+// exact shape that used to receive the runner's full environment), and
+// asserts on an env report the subprocess writes at startup. The report
+// carries variable NAMES only, never values, so it is safe in CI logs.
+//
+// Deliberately discovery-driven rather than agent-execution-driven:
+// discovery spawns through the same toMcpClientConfig line, is
+// deterministic, and needs no LLM. The report is written before the
+// workflow's classification stage runs, so the test does not require
+// ANTHROPIC_API_KEY — Connect is fired in the background and only the
+// report is awaited (a keyless classifier failing later is irrelevant
+// to what the subprocess environment contained).
+//
+// Beyond guarding against a reintroduced process-env fallback, the PATH
+// and HOME assertions pin the upstream contract this fix relies on: the
+// MCP SDK merges its minimal base environment (getDefaultEnvironment)
+// under whatever the runner passes. If a library upgrade ever changes
+// that merge, this test fails.
+func TestMcpStdio_EnvIsolation_NoDeclaredEnv(t *testing.T) {
+	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+	if testHarness.UnifiedRunner == nil {
+		t.Skip("unified runner not available — skipping stdio env isolation test")
+	}
+	if mcpTestServerBinary == "" {
+		t.Skip("test MCP server binary not available")
+	}
+
+	ctx, cancel := harness.TestContext(t, 3*time.Minute)
+	defer cancel()
+
+	clients := harness.NewClients(grpcConn)
+
+	reportPath := filepath.Join(t.TempDir(), "env-report.txt")
+	server := harness.CreateStdioMcpServer(t, ctx, clients, mcpTestServerBinary,
+		"--env-report", reportPath)
+
+	// Fire connect without waiting for the whole workflow: discovery (which
+	// spawns the subprocess and produces the report) is stage one; the
+	// LLM classification stage that follows may fail in keyless runs and
+	// is irrelevant here. Errors are deliberately discarded — if discovery
+	// itself never spawns the server, the report poll below fails the test.
+	go func() {
+		connectCtx, connectCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer connectCancel()
+		_, _ = clients.McpServerCommand.Connect(connectCtx, &mcpserverv1.ConnectInput{
+			McpServerId: server.GetMetadata().GetId(),
+			Org:         harness.TestOrg,
+		})
+	}()
+
+	var report string
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(reportPath)
+		if err != nil {
+			return false
+		}
+		report = string(data)
+		return true
+	}, 90*time.Second, 500*time.Millisecond,
+		"discovery never spawned the stdio MCP server (no env report at %s)", reportPath)
+
+	present := make(map[string]bool)
+	for _, key := range strings.Split(strings.TrimSpace(report), "\n") {
+		present[key] = true
+	}
+
+	// The MCP SDK's minimal base environment must arrive — PATH is what makes
+	// npx/python-style servers resolvable, HOME is what package caches need.
+	require.True(t, present["PATH"],
+		"subprocess must receive PATH from the MCP SDK base environment; got keys: %v", keysOf(present))
+	require.True(t, present["HOME"],
+		"subprocess must receive HOME from the MCP SDK base environment; got keys: %v", keysOf(present))
+
+	// Runner-internal credentials must NOT arrive. The harness plants
+	// STIGMER_RUNNER_HITL_SECRET and STIGMER_TEST_LEAK_SENTINEL on the
+	// runner process (buildUnifiedRunnerEnv) so these assertions hold
+	// regardless of which real secrets a given CI environment carries.
+	for _, key := range []string{
+		"STIGMER_RUNNER_HITL_SECRET",
+		"STIGMER_TEST_LEAK_SENTINEL",
+		"STIGMER_TOKEN",
+		"STIGMER_AUTH_TOKEN",
+		"CURSOR_API_KEY",
+		"ANTHROPIC_API_KEY",
+		"OPENAI_API_KEY",
+	} {
+		require.False(t, present[key],
+			"runner credential %q leaked into the stdio MCP subprocess environment", key)
+	}
+
+	t.Logf("stdio env isolation verified: subprocess saw %d env var(s)", len(present))
+}
+
+func keysOf(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/test/integration/testdata/mcp-test-server/main.go
+++ b/test/integration/testdata/mcp-test-server/main.go
@@ -1,9 +1,16 @@
 // mcp-test-server is a deterministic MCP server for integration tests.
-// It communicates over stdio using JSON-RPC 2.0 and exposes four tools:
+// It communicates over stdio using JSON-RPC 2.0 and exposes five tools:
 //   - echo: returns its input unchanged
 //   - add: sums two numbers
 //   - fail: always returns an error
 //   - slow: sleeps for the given duration then returns "done"
+//   - crash: exits immediately
+//
+// Flags:
+//   --env-report <path>: at startup, write the NAMES of this process's
+//     environment variables to <path>, one per line, sorted. Used by the
+//     stdio env-isolation guard (oss#256) to assert what the spawning
+//     runner passed into the subprocess.
 package main
 
 import (
@@ -11,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -130,6 +139,12 @@ var tools = []toolInfo{
 }
 
 func main() {
+	if path := envReportPath(os.Args[1:]); path != "" {
+		if err := writeEnvReport(path); err != nil {
+			fmt.Fprintf(os.Stderr, "mcp-test-server: env report: %v\n", err)
+		}
+	}
+
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 
@@ -227,6 +242,32 @@ func handleToolCall(id any, params *callToolParams) {
 	default:
 		writeError(id, -32602, "Unknown tool: "+params.Name)
 	}
+}
+
+// envReportPath extracts the --env-report flag value from args, if present.
+func envReportPath(args []string) string {
+	for i, arg := range args {
+		if arg == "--env-report" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// writeEnvReport writes the NAMES of this process's environment variables to
+// path, one per line, sorted. Names only, never values: the report is read by
+// tests asserting env isolation and must stay safe to surface in CI logs even
+// when the parent process holds real credentials.
+func writeEnvReport(path string) error {
+	environ := os.Environ()
+	keys := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		if i := strings.IndexByte(entry, '='); i > 0 {
+			keys = append(keys, entry[:i])
+		}
+	}
+	sort.Strings(keys)
+	return os.WriteFile(path, []byte(strings.Join(keys, "\n")+"\n"), 0o644)
 }
 
 func writeResult(id any, result any) {


### PR DESCRIPTION
## Summary

An stdio MCP server that declared no `spec.env` was spawned with the runner's **full process environment** — including `STIGMER_RUNNER_HITL_SECRET` (the key deriving HITL approval fingerprints), `STIGMER_TOKEN`, `CURSOR_API_KEY`, and the LLM provider keys. Any operator-installed MCP binary could read the credentials that prove "a human approved this."

The bug was an inversion, not a design choice: `filterEnvToDeclaredKeys` deliberately restricts a server to its declared variables ("prevents secret over-sharing"), but the resolver converts its deliberately-empty result to `undefined`, and `toMcpClientConfig` turned `undefined` into a full `process.env` copy. The fallback's justifying comment was stale — nothing reads `STIGMER_SERVER_ADDRESS` from the runner env (it is injected declare-to-receive via `injectPlatformEnv`), and the MCP SDK merges its minimal base environment (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) under whatever the client passes, so `PATH`-dependent servers keep working without inheritance.

### The change
- `toMcpClientConfig` passes `env: server.env` — the process-env fallback and its helper are deleted. Discovery (`discover-mcp-server.ts`) builds its spawn config through the same function, so connect-time enumeration is fixed by the same line.
- A one-line notice logs when a stdio server resolves with no declared env (the only case whose behavior changed).
- Declared-empty and undeclared env are now equivalent — both yield the SDK base environment, removing the old cliff (declare one variable: get six; declare zero: get hundreds).

### Blast radius
All 33 seedpack MCP servers are HTTP (catalog is HTTP-only by policy); the two internally-synthesized stdio attachments set env explicitly and already run on a two-key environment. The only affected population is a user-registered stdio server with no declared env on a local runner — remedied by declaring what it needs in `spec.env`.

### Guards
- **Unit** (`mcp-manager.test.ts`): leak reproduction with planted credentials plus a fallback-reintroduction tripwire; observed failing pre-fix, passing post-fix.
- **Integration** (`mcp_stdio_env_isolation_test.go`): drives the real connect workflow (Temporal → discovery activity → real subprocess) against a stdio server that writes an env report (variable **names** only) at startup; asserts `PATH`/`HOME` arrive and planted runner sentinels do not. Negative-controlled: fails on the pre-fix build with `runner credential "STIGMER_RUNNER_HITL_SECRET" leaked`, passes post-fix with the subprocess seeing exactly 6 variables. Discovery-driven, so it needs no LLM key.
- The `PATH`/`HOME` assertions also pin the upstream SDK merge contract this fix relies on — a library upgrade changing it fails the test.

### Docs
`docs/concepts/environments.mdx` documented the fallback as a written promise — rewritten to the declare-to-receive rule; `apis/.../mcpserver/docs/server-types.md` carried the same claim plus a stale `env_spec` field name and YAML shape, both corrected.

## Test plan
- [x] `npm test` runner unit suite — the 9 `mcp-manager` tests pass (2 new leak tests fail pre-fix); remaining suite failures are pre-existing environment issues (`node:sqlite` on old Node, #257 class) in modules that do not import `mcp-manager`
- [x] `npx tsc --noEmit` clean; `go vet -tags integration` clean
- [x] Integration test passes post-fix (subprocess sees exactly 6 env vars) and fails pre-fix (negative control)
- [x] `make check-docs-yaml` and `make format-docs-check` pass

Closes #256

Made with [Cursor](https://cursor.com)