### PR TITLE
fix(backend/stigmer-server): redact and encrypt WhatsApp ChannelApp secrets

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/channelapp/controller/channelapp_test.go
+++ b/backend/services/stigmer-server/pkg/domain/channelapp/controller/channelapp_test.go
@@ -74,6 +74,114 @@ func newSlackApp(name, org string) *channelappv1.ChannelApp {
 	}
 }
 
+func newWhatsAppApp(name, org string) *channelappv1.ChannelApp {
+	return &channelappv1.ChannelApp{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "ChannelApp",
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name: name,
+			Org:  org,
+		},
+		Spec: &channelappv1.ChannelAppSpec{
+			ProviderConfig: &channelappv1.ChannelAppSpec_Whatsapp{
+				Whatsapp: &channelappv1.WhatsAppChannelAppConfig{
+					AppId:       "108954",
+					AppSecret:   "shh-app-secret",
+					AccessToken: "shh-access-token",
+					VerifyToken: "shh-verify-token",
+				},
+			},
+		},
+	}
+}
+
+// TestRedactAndEncryptCoverEveryProviderArm is the tripwire for the class
+// of gap fixed in #324 (the WhatsApp arm shipped with neither redaction
+// nor encryption): every arm of the ChannelAppSpec provider_config oneof
+// must have a case here proving its secrets are redacted in responses and
+// encrypted at rest. Adding a provider arm to the proto fails this test
+// until the arm gets redaction, encryption, and a case entry — the
+// schema-reflection posture of the sdk/react agentToInput new-field
+// tripwire.
+func TestRedactAndEncryptCoverEveryProviderArm(t *testing.T) {
+	// Per arm: an app whose secrets hold known plaintexts, and a getter
+	// for every secret field so the assertions below stay field-by-field.
+	cases := map[string]struct {
+		newApp  func(name, org string) *channelappv1.ChannelApp
+		secrets func(app *channelappv1.ChannelApp) map[string]string
+	}{
+		"slack": {
+			newApp: newSlackApp,
+			secrets: func(app *channelappv1.ChannelApp) map[string]string {
+				return map[string]string{
+					"client_secret":  app.GetSpec().GetSlack().GetClientSecret(),
+					"signing_secret": app.GetSpec().GetSlack().GetSigningSecret(),
+				}
+			},
+		},
+		"whatsapp": {
+			newApp: newWhatsAppApp,
+			secrets: func(app *channelappv1.ChannelApp) map[string]string {
+				return map[string]string{
+					"app_secret":   app.GetSpec().GetWhatsapp().GetAppSecret(),
+					"access_token": app.GetSpec().GetWhatsapp().GetAccessToken(),
+					"verify_token": app.GetSpec().GetWhatsapp().GetVerifyToken(),
+				}
+			},
+		},
+	}
+
+	// The tripwire proper: the case table must cover every oneof arm.
+	oneofArms := (&channelappv1.ChannelAppSpec{}).ProtoReflect().Descriptor().
+		Oneofs().ByName("provider_config").Fields()
+	for i := 0; i < oneofArms.Len(); i++ {
+		arm := string(oneofArms.Get(i).Name())
+		if _, ok := cases[arm]; !ok {
+			t.Fatalf("provider arm %q has no redaction/encryption coverage: "+
+				"handle it in RedactChannelApp and encryptChannelAppSecretsStep, "+
+				"then add its case here", arm)
+		}
+	}
+	if len(cases) != oneofArms.Len() {
+		t.Fatalf("case table has %d entries but the oneof has %d arms — remove stale cases",
+			len(cases), oneofArms.Len())
+	}
+
+	for arm, tc := range cases {
+		t.Run(arm, func(t *testing.T) {
+			h := newTestHarness(t)
+
+			original := tc.newApp("Acme "+arm+" App", "acme")
+			plaintexts := tc.secrets(original)
+
+			created, err := h.controller.Create(appCtx(), tc.newApp("Acme "+arm+" App", "acme"))
+			if err != nil {
+				t.Fatalf("create failed: %v", err)
+			}
+			for field, value := range tc.secrets(created) {
+				if value != RedactedMarker {
+					t.Errorf("%s must be redacted in the create response, got %q", field, value)
+				}
+			}
+
+			stored := &channelappv1.ChannelApp{}
+			if err := h.store.GetResource(context.Background(),
+				apiresourcekind.ApiResourceKind_channel_app,
+				created.GetMetadata().GetId(), stored); err != nil {
+				t.Fatalf("stored app not found: %v", err)
+			}
+			for field, value := range tc.secrets(stored) {
+				if !h.secrets.IsEncrypted(value) {
+					t.Errorf("stored %s must be encrypted, got %q", field, value)
+				}
+				if h.secrets.MustDecrypt(value) != plaintexts[field] {
+					t.Errorf("stored %s must decrypt to the original plaintext", field)
+				}
+			}
+		})
+	}
+}
+
 func TestChannelAppController_CreateEncryptsAndRedacts(t *testing.T) {
 	h := newTestHarness(t)
 
@@ -245,19 +353,98 @@ func TestChannelAppController_QueriesRedactSecrets(t *testing.T) {
 	}
 }
 
+func TestChannelAppController_WhatsAppQueriesRedactSecrets(t *testing.T) {
+	h := newTestHarness(t)
+
+	created, err := h.controller.Create(appCtx(), newWhatsAppApp("Clinic Meta App", "acme"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	fetched, err := h.controller.Get(appCtx(), &apiresource.ApiResourceId{
+		Value: created.GetMetadata().GetId()})
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if fetched.GetSpec().GetWhatsapp().GetAppSecret() != RedactedMarker ||
+		fetched.GetSpec().GetWhatsapp().GetAccessToken() != RedactedMarker ||
+		fetched.GetSpec().GetWhatsapp().GetVerifyToken() != RedactedMarker {
+		t.Error("get must redact all three WhatsApp secret fields")
+	}
+	if fetched.GetSpec().GetWhatsapp().GetAppId() != "108954" {
+		t.Error("app_id is public and must NOT be redacted")
+	}
+
+	byRef, err := h.controller.GetByReference(appCtx(), &apiresource.ApiResourceReference{
+		Org:  "acme",
+		Kind: apiresourcekind.ApiResourceKind_channel_app,
+		Slug: created.GetMetadata().GetSlug(),
+	})
+	if err != nil {
+		t.Fatalf("getByReference failed: %v", err)
+	}
+	if byRef.GetSpec().GetWhatsapp().GetAppSecret() != RedactedMarker {
+		t.Error("getByReference must redact WhatsApp secrets")
+	}
+
+	list, err := h.controller.ListByOrg(appCtx(), &channelappv1.ListChannelAppsByOrgInput{Org: "acme"})
+	if err != nil {
+		t.Fatalf("listByOrg failed: %v", err)
+	}
+	if len(list.GetEntries()) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(list.GetEntries()))
+	}
+	if list.GetEntries()[0].GetSpec().GetWhatsapp().GetAccessToken() != RedactedMarker {
+		t.Error("listByOrg must redact WhatsApp secrets on every entry")
+	}
+}
+
+func TestChannelAppController_WhatsAppUpdateMarkerPreservesPerField(t *testing.T) {
+	h := newTestHarness(t)
+
+	created, err := h.controller.Create(appCtx(), newWhatsAppApp("Clinic Meta App", "acme"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	// A mixed update: rotate the access token, keep app_secret and
+	// verify_token — the Slack per-field independence contract, on the
+	// three-secret arm.
+	update := newWhatsAppApp("Clinic Meta App", "acme")
+	update.Metadata.Id = created.GetMetadata().GetId()
+	update.Metadata.Slug = created.GetMetadata().GetSlug()
+	update.GetSpec().GetWhatsapp().AppSecret = RedactedMarker
+	update.GetSpec().GetWhatsapp().AccessToken = "rotated-access-token"
+	update.GetSpec().GetWhatsapp().VerifyToken = RedactedMarker
+
+	if _, err := h.controller.Update(appCtx(), update); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	stored := &channelappv1.ChannelApp{}
+	if err := h.store.GetResource(context.Background(),
+		apiresourcekind.ApiResourceKind_channel_app,
+		created.GetMetadata().GetId(), stored); err != nil {
+		t.Fatalf("stored app not found: %v", err)
+	}
+	if h.secrets.MustDecrypt(stored.GetSpec().GetWhatsapp().GetAppSecret()) != "shh-app-secret" {
+		t.Error("marker must preserve the ORIGINAL app_secret")
+	}
+	if h.secrets.MustDecrypt(stored.GetSpec().GetWhatsapp().GetAccessToken()) != "rotated-access-token" {
+		t.Error("the plaintext access_token must rotate to the new value")
+	}
+	if h.secrets.MustDecrypt(stored.GetSpec().GetWhatsapp().GetVerifyToken()) != "shh-verify-token" {
+		t.Error("marker must preserve the ORIGINAL verify_token")
+	}
+}
+
 // TestValidateProviderImmutableStep pins the provider-arm immutability at
-// the step level. Only one provider arm (slack) exists in v1, so a real
-// cross-provider flip cannot pass proto validation through the full
-// pipeline yet — the step is exercised directly, exactly the agentchannel
-// provider-immutability test's posture, to pin the refusal a second arm
-// (WhatsApp, T05) will hit.
+// the step level with a real slack-to-whatsapp flip (the empty-spec
+// stand-in this test used before WhatsApp existed is gone with T05).
 func TestValidateProviderImmutableStep(t *testing.T) {
 	existing := newSlackApp("Acme Support App", "acme")
 
-	// The input carries NO provider arm — the closest constructible
-	// stand-in for "a different provider" until a second arm exists.
-	input := newSlackApp("Acme Support App", "acme")
-	input.Spec = &channelappv1.ChannelAppSpec{}
+	input := newWhatsAppApp("Acme Support App", "acme")
 
 	reqCtx := pipeline.NewRequestContext(appCtx(), input)
 	reqCtx.Set(steps.ExistingResourceKey, existing)

--- a/backend/services/stigmer-server/pkg/domain/channelapp/controller/steps.go
+++ b/backend/services/stigmer-server/pkg/domain/channelapp/controller/steps.go
@@ -24,8 +24,8 @@ const RedactedMarker = "***REDACTED***"
 
 // encryptChannelAppSecretsStep encrypts the ChannelApp secret fields before
 // persistence — the oauthapp encryptClientSecretStep generalized to a
-// provider oneof carrying multiple secrets (Slack: client_secret AND
-// signing_secret).
+// provider oneof carrying multiple secrets (Slack: client_secret and
+// signing_secret; WhatsApp: app_secret, access_token and verify_token).
 //
 // Each field is handled independently, per field:
 //   - Create: encrypts the plaintext value; the redaction marker is
@@ -55,13 +55,23 @@ func (s *encryptChannelAppSecretsStep) Name() string {
 	return "EncryptChannelAppSecrets"
 }
 
+// Every provider arm must be handled here. TestRedactAndEncryptCoverEveryProviderArm
+// fails the build if an arm is added to the spec oneof without encryption.
 func (s *encryptChannelAppSecretsStep) Execute(ctx *pipeline.RequestContext[*channelappv1.ChannelApp]) error {
-	app := ctx.NewState()
-	slack := app.GetSpec().GetSlack()
-	if slack == nil {
-		return nil
+	spec := ctx.NewState().GetSpec()
+	switch {
+	case spec.GetSlack() != nil:
+		return s.encryptSlack(ctx, spec.GetSlack())
+	case spec.GetWhatsapp() != nil:
+		return s.encryptWhatsApp(ctx, spec.GetWhatsapp())
 	}
+	return nil
+}
 
+func (s *encryptChannelAppSecretsStep) encryptSlack(
+	ctx *pipeline.RequestContext[*channelappv1.ChannelApp],
+	slack *channelappv1.SlackChannelAppConfig,
+) error {
 	clientSecret, err := s.resolveSecret(ctx, "client_secret", slack.GetClientSecret(),
 		func(existing *channelappv1.ChannelApp) string {
 			return existing.GetSpec().GetSlack().GetClientSecret()
@@ -80,6 +90,40 @@ func (s *encryptChannelAppSecretsStep) Execute(ctx *pipeline.RequestContext[*cha
 
 	slack.ClientSecret = clientSecret
 	slack.SigningSecret = signingSecret
+	return nil
+}
+
+func (s *encryptChannelAppSecretsStep) encryptWhatsApp(
+	ctx *pipeline.RequestContext[*channelappv1.ChannelApp],
+	whatsapp *channelappv1.WhatsAppChannelAppConfig,
+) error {
+	appSecret, err := s.resolveSecret(ctx, "app_secret", whatsapp.GetAppSecret(),
+		func(existing *channelappv1.ChannelApp) string {
+			return existing.GetSpec().GetWhatsapp().GetAppSecret()
+		})
+	if err != nil {
+		return err
+	}
+
+	accessToken, err := s.resolveSecret(ctx, "access_token", whatsapp.GetAccessToken(),
+		func(existing *channelappv1.ChannelApp) string {
+			return existing.GetSpec().GetWhatsapp().GetAccessToken()
+		})
+	if err != nil {
+		return err
+	}
+
+	verifyToken, err := s.resolveSecret(ctx, "verify_token", whatsapp.GetVerifyToken(),
+		func(existing *channelappv1.ChannelApp) string {
+			return existing.GetSpec().GetWhatsapp().GetVerifyToken()
+		})
+	if err != nil {
+		return err
+	}
+
+	whatsapp.AppSecret = appSecret
+	whatsapp.AccessToken = accessToken
+	whatsapp.VerifyToken = verifyToken
 	return nil
 }
 
@@ -143,18 +187,40 @@ func (s *encryptChannelAppSecretsStep) preserveExistingSecret(
 
 // RedactChannelApp replaces every non-empty secret field with
 // RedactedMarker on the given app — used in all API responses (get,
-// getByReference, create, update, listByOrg), the RedactOAuthApp shape
-// over the provider oneof.
+// getByReference, create, update, delete, listByOrg), the RedactOAuthApp
+// shape over the provider oneof.
+//
+// Every provider arm must be handled here. TestRedactAndEncryptCoverEveryProviderArm
+// fails the build if an arm is added to the spec oneof without redaction.
 func RedactChannelApp(app *channelappv1.ChannelApp) {
-	slack := app.GetSpec().GetSlack()
-	if slack == nil {
-		return
+	switch {
+	case app.GetSpec().GetSlack() != nil:
+		redactSlack(app.GetSpec().GetSlack())
+	case app.GetSpec().GetWhatsapp() != nil:
+		redactWhatsApp(app.GetSpec().GetWhatsapp())
 	}
+}
+
+func redactSlack(slack *channelappv1.SlackChannelAppConfig) {
 	if slack.GetClientSecret() != "" {
 		slack.ClientSecret = RedactedMarker
 	}
 	if slack.GetSigningSecret() != "" {
 		slack.SigningSecret = RedactedMarker
+	}
+}
+
+// redactWhatsApp redacts app_secret, access_token and verify_token —
+// app_id is public and stays.
+func redactWhatsApp(whatsapp *channelappv1.WhatsAppChannelAppConfig) {
+	if whatsapp.GetAppSecret() != "" {
+		whatsapp.AppSecret = RedactedMarker
+	}
+	if whatsapp.GetAccessToken() != "" {
+		whatsapp.AccessToken = RedactedMarker
+	}
+	if whatsapp.GetVerifyToken() != "" {
+		whatsapp.VerifyToken = RedactedMarker
 	}
 }
 


### PR DESCRIPTION
## Summary

`RedactChannelApp` and `encryptChannelAppSecretsStep` both early-returned for any non-Slack provider arm, so WhatsApp `app_secret`, `access_token` and `verify_token` were returned verbatim on every ChannelApp response path and stored unencrypted at rest. This PR handles every provider arm explicitly and adds a tripwire test so a future arm cannot ship unprotected.

## Context

Filed as #324 for the redaction gap. Investigation found the encryption step in the same file shares the identical early-return, and the two fixes are inseparable: with redaction fixed, clients echo `***REDACTED***` back on update, and an encrypt step that ignores the WhatsApp arm would store that literal marker as the secret. The cloud edition (`RedactChannelAppSecrets`) already handles both arms; this restores OSS↔Cloud parity. `app_secret` is the HMAC key for the `X-Hub-Signature-256` webhook signature, so its disclosure lets an attacker forge inbound webhook payloads.

## Changes

- `RedactChannelApp` dispatches per provider arm: `redactSlack` (unchanged behavior) and `redactWhatsApp` (redacts `app_secret`, `access_token`, `verify_token`; `app_id` is public and stays)
- `encryptChannelAppSecretsStep.Execute` dispatches per arm; the WhatsApp secrets flow through the existing `resolveSecret` helper, so create-encrypts / update-rotates / marker-preserves semantics apply per field
- `TestRedactAndEncryptCoverEveryProviderArm`: protoreflect tripwire over the `provider_config` oneof — adding a provider arm fails the build until it gets redaction, encryption, and a test case (the `agentToInput.test.ts` new-field-tripwire posture, in Go)
- WhatsApp behavior tests mirroring the Slack suite: queries redact all three secrets, mixed update rotates one secret while markers preserve the others
- `TestValidateProviderImmutableStep` upgraded to a real slack-to-whatsapp flip (its empty-spec stand-in predated the WhatsApp arm and its comment anticipated this upgrade)

## Implementation notes

- Explicit per-arm handling was chosen over reflection-driven redaction (secret-name heuristics are the same silent-miss class as this bug) and over a custom proto `secret` field option (no FieldOptions machinery exists in `apis/` today; not warranted for a two-arm oneof)

## Breaking changes

- None for clients: the CLI/console already assume redacted responses (the CLI integration fixture documents all three WhatsApp secrets as `***REDACTED***`). No OSS runtime consumer reads WhatsApp ChannelApp secrets (verified: the runner never touches the type; webhook ingress is cloud-side)
- Rows stored with plaintext secrets before this fix keep working (`SecretService.Decrypt` passes non-encrypted values through) and get encrypted on their next update

## Test plan

- `go test ./backend/services/stigmer-server/pkg/domain/channelapp/...` — all pass, including the new tripwire (both arms), WhatsApp query-redaction and marker-preservation tests
- `gofmt`, `go vet`, and a clean `go build ./backend/services/stigmer-server/...`

## Risks

- Low: single choke point, all seven RPC response paths funnel through the one fixed function. Rollback is a revert

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [ ] Docs updated (not needed — proto docs already state "Encrypted at rest, redacted in responses and logs")

Closes #324

Made with [Cursor](https://cursor.com)