### PR TITLE
fix(runner,backend): end silent workflow event-log loss with workflow-assigned sequences

### DIFF
--- a/backend/libs/go/store/interface.go
+++ b/backend/libs/go/store/interface.go
@@ -313,9 +313,17 @@ type Store interface {
 	// ===========================================================================
 
 	// AppendWorkflowExecutionEvents appends events to the execution's event log.
-	// Enforces monotonically increasing sequence_numbers — rejects the batch
-	// if any event's sequence_number is <= the current highest persisted sequence.
-	// Returns the number of events appended.
+	//
+	// Insert-or-skip, first-writer-wins: an event whose
+	// (execution_id, sequence_number) is already persisted is silently
+	// skipped; the rest of the batch still lands. This makes retried
+	// batches idempotent (the runner assigns sequence numbers
+	// deterministically in the workflow, so a retry re-sends the same
+	// numbers) and tolerates out-of-order arrival from parallel branches.
+	// Same contract as the cloud edition's event repo.
+	//
+	// Returns the number of events actually inserted (skipped duplicates
+	// are not counted).
 	AppendWorkflowExecutionEvents(ctx context.Context, executionID string, events []*WorkflowExecutionEventRecord) (int, error)
 
 	// GetWorkflowExecutionEvents retrieves events for an execution with cursor-based pagination.

--- a/backend/libs/go/store/sqlite/BUILD.bazel
+++ b/backend/libs/go/store/sqlite/BUILD.bazel
@@ -16,7 +16,10 @@ go_library(
 
 go_test(
     name = "sqlite_test",
-    srcs = ["store_test.go"],
+    srcs = [
+        "store_test.go",
+        "store_workflow_execution_events_test.go",
+    ],
     embed = [":sqlite"],
     deps = [
         "//apis/stubs/go/ai/stigmer/agentic/agent/v1:agent",

--- a/backend/libs/go/store/sqlite/store.go
+++ b/backend/libs/go/store/sqlite/store.go
@@ -1649,8 +1649,19 @@ func (s *Store) ClearBootstrapState(ctx context.Context) error {
 // =============================================================================
 
 // AppendWorkflowExecutionEvents appends events to the execution's event log.
-// Enforces monotonically increasing sequence_numbers — rejects the batch
-// if any event's sequence_number is <= the current highest persisted sequence.
+//
+// Insert-or-skip, first-writer-wins: `INSERT OR IGNORE` on the
+// (execution_id, sequence_number) primary key silently skips
+// already-persisted sequences while the rest of the batch lands. Sequence
+// numbers are assigned deterministically in the runner's workflow sandbox,
+// so a retried batch re-sends the same numbers (idempotent no-op) and
+// parallel branches may deliver out of order (a lower sequence arriving
+// after a higher one is still valid, not stale). This replaces the old
+// all-or-nothing stale-sequence rejection that silently dropped whole
+// batches on retry (oss#308), and matches the cloud edition's
+// `ON CONFLICT DO NOTHING` contract.
+//
+// Returns the number of events actually inserted.
 func (s *Store) AppendWorkflowExecutionEvents(ctx context.Context, executionID string, events []*store.WorkflowExecutionEventRecord) (int, error) {
 	if len(events) == 0 {
 		return 0, nil
@@ -1672,42 +1683,32 @@ func (s *Store) AppendWorkflowExecutionEvents(ctx context.Context, executionID s
 	}
 	defer tx.Rollback()
 
-	// Get current max sequence for this execution
-	var maxSeq int64
-	err = tx.QueryRowContext(ctx,
-		`SELECT COALESCE(MAX(sequence_number), 0) FROM workflow_execution_events WHERE execution_id = ?`,
-		executionID).Scan(&maxSeq)
-	if err != nil {
-		return 0, fmt.Errorf("query max sequence: %w", err)
-	}
-
-	// Validate all events have sequence > max
-	for _, evt := range events {
-		if evt.SequenceNumber <= maxSeq {
-			return 0, fmt.Errorf("event sequence_number %d is <= current max %d for execution %s",
-				evt.SequenceNumber, maxSeq, executionID)
-		}
-	}
-
 	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO workflow_execution_events (execution_id, sequence_number, event_type, task_name, data)
+		`INSERT OR IGNORE INTO workflow_execution_events (execution_id, sequence_number, event_type, task_name, data)
 		 VALUES (?, ?, ?, ?, ?)`)
 	if err != nil {
 		return 0, fmt.Errorf("prepare insert: %w", err)
 	}
 	defer stmt.Close()
 
+	inserted := 0
 	for _, evt := range events {
-		if _, err := stmt.ExecContext(ctx, executionID, evt.SequenceNumber, evt.EventType, evt.TaskName, evt.Data); err != nil {
+		res, err := stmt.ExecContext(ctx, executionID, evt.SequenceNumber, evt.EventType, evt.TaskName, evt.Data)
+		if err != nil {
 			return 0, fmt.Errorf("insert event seq=%d: %w", evt.SequenceNumber, err)
 		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("rows affected for event seq=%d: %w", evt.SequenceNumber, err)
+		}
+		inserted += int(rows)
 	}
 
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("commit transaction: %w", err)
 	}
 
-	return len(events), nil
+	return inserted, nil
 }
 
 // GetWorkflowExecutionEvents retrieves events for an execution with cursor-based pagination.

--- a/backend/libs/go/store/sqlite/store_workflow_execution_events_test.go
+++ b/backend/libs/go/store/sqlite/store_workflow_execution_events_test.go
@@ -1,0 +1,188 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Workflow Execution Event Log Tests
+//
+// Pins the insert-or-skip, first-writer-wins append contract (oss#308):
+// an already-persisted (execution_id, sequence_number) is silently
+// skipped, the rest of the batch lands, and the returned count reflects
+// only actual inserts. This is what makes the runner's whole-batch
+// retries idempotent, and it mirrors the cloud edition's
+// WorkflowExecutionEventRepoContractTest semantics so the editions
+// cannot drift apart again.
+// =============================================================================
+
+func newEventTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewStore(filepath.Join(t.TempDir(), "test.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func eventRecord(executionID string, seq int64) *store.WorkflowExecutionEventRecord {
+	return &store.WorkflowExecutionEventRecord{
+		ExecutionID:    executionID,
+		SequenceNumber: seq,
+		EventType:      "task_started",
+		TaskName:       fmt.Sprintf("task-%d", seq),
+		Data:           []byte(fmt.Sprintf("payload-%d", seq)),
+	}
+}
+
+func eventRecords(executionID string, seqs ...int64) []*store.WorkflowExecutionEventRecord {
+	records := make([]*store.WorkflowExecutionEventRecord, 0, len(seqs))
+	for _, seq := range seqs {
+		records = append(records, eventRecord(executionID, seq))
+	}
+	return records
+}
+
+func persistedSequences(t *testing.T, s *Store, executionID string) []int64 {
+	t.Helper()
+	events, err := s.GetWorkflowExecutionEvents(context.Background(), executionID, 0, "", "", 0)
+	require.NoError(t, err)
+	seqs := make([]int64, 0, len(events))
+	for _, evt := range events {
+		seqs = append(seqs, evt.SequenceNumber)
+	}
+	return seqs
+}
+
+func TestStore_AppendWorkflowExecutionEvents_FreshBatch(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+
+	appended, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-1", eventRecords("wfx-1", 1, 2, 3))
+	require.NoError(t, err)
+	assert.Equal(t, 3, appended)
+	assert.Equal(t, []int64{1, 2, 3}, persistedSequences(t, s, "wfx-1"))
+}
+
+func TestStore_AppendWorkflowExecutionEvents_EmptyBatch(t *testing.T) {
+	s := newEventTestStore(t)
+
+	appended, err := s.AppendWorkflowExecutionEvents(context.Background(), "wfx-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, appended)
+}
+
+// A retried batch re-sends identical sequence numbers (the runner assigns
+// them deterministically in the workflow). Every row must be skipped, not
+// rejected — and definitely not duplicated.
+func TestStore_AppendWorkflowExecutionEvents_ExactDuplicateBatchIsIdempotent(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+	batch := eventRecords("wfx-1", 1, 2, 3)
+
+	appended, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-1", batch)
+	require.NoError(t, err)
+	require.Equal(t, 3, appended)
+
+	appended, err = s.AppendWorkflowExecutionEvents(ctx, "wfx-1", batch)
+	require.NoError(t, err)
+	assert.Equal(t, 0, appended)
+	assert.Equal(t, []int64{1, 2, 3}, persistedSequences(t, s, "wfx-1"))
+}
+
+// The oss#308 scenario: an RPC that persisted events but failed before the
+// runner saw the response is retried with a batch whose prefix is already
+// stored. The unstored suffix must land instead of the whole batch being
+// rejected and silently lost.
+func TestStore_AppendWorkflowExecutionEvents_PartialOverlapAppendsSuffix(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+
+	appended, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-1", eventRecords("wfx-1", 1, 2))
+	require.NoError(t, err)
+	require.Equal(t, 2, appended)
+
+	appended, err = s.AppendWorkflowExecutionEvents(ctx, "wfx-1", eventRecords("wfx-1", 1, 2, 3, 4))
+	require.NoError(t, err)
+	assert.Equal(t, 2, appended)
+	assert.Equal(t, []int64{1, 2, 3, 4}, persistedSequences(t, s, "wfx-1"))
+}
+
+// First-writer-wins: a duplicate sequence with different content does not
+// overwrite the persisted row.
+func TestStore_AppendWorkflowExecutionEvents_DuplicateKeepsFirstWriterContent(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+
+	first := eventRecord("wfx-1", 1)
+	first.Data = []byte("first-writer")
+	_, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-1", []*store.WorkflowExecutionEventRecord{first})
+	require.NoError(t, err)
+
+	second := eventRecord("wfx-1", 1)
+	second.Data = []byte("second-writer")
+	appended, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-1", []*store.WorkflowExecutionEventRecord{second})
+	require.NoError(t, err)
+	assert.Equal(t, 0, appended)
+
+	events, err := s.GetWorkflowExecutionEvents(ctx, "wfx-1", 0, "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, []byte("first-writer"), events[0].Data)
+}
+
+// Parallel branches (fork) can deliver a lower sequence after a higher one
+// already landed. A late-but-new sequence is valid, not stale.
+func TestStore_AppendWorkflowExecutionEvents_OutOfOrderArrivalAppends(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+
+	appended, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-1", eventRecords("wfx-1", 5))
+	require.NoError(t, err)
+	require.Equal(t, 1, appended)
+
+	appended, err = s.AppendWorkflowExecutionEvents(ctx, "wfx-1", eventRecords("wfx-1", 4))
+	require.NoError(t, err)
+	assert.Equal(t, 1, appended)
+	assert.Equal(t, []int64{4, 5}, persistedSequences(t, s, "wfx-1"))
+}
+
+// Sequence numbers are namespaced per execution: identical sequences in
+// different executions never collide.
+func TestStore_AppendWorkflowExecutionEvents_ExecutionsAreIndependent(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+
+	appended, err := s.AppendWorkflowExecutionEvents(ctx, "wfx-a", eventRecords("wfx-a", 1, 2))
+	require.NoError(t, err)
+	require.Equal(t, 2, appended)
+
+	appended, err = s.AppendWorkflowExecutionEvents(ctx, "wfx-b", eventRecords("wfx-b", 1, 2))
+	require.NoError(t, err)
+	assert.Equal(t, 2, appended)
+
+	assert.Equal(t, []int64{1, 2}, persistedSequences(t, s, "wfx-a"))
+	assert.Equal(t, []int64{1, 2}, persistedSequences(t, s, "wfx-b"))
+}
+
+func TestStore_GetMaxEventSequence(t *testing.T) {
+	s := newEventTestStore(t)
+	ctx := context.Background()
+
+	maxSeq, err := s.GetMaxEventSequence(ctx, "wfx-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), maxSeq)
+
+	_, err = s.AppendWorkflowExecutionEvents(ctx, "wfx-1", eventRecords("wfx-1", 1, 2, 7))
+	require.NoError(t, err)
+
+	maxSeq, err = s.GetMaxEventSequence(ctx, "wfx-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), maxSeq)
+}

--- a/backend/services/runner/src/activities/__tests__/workflow-event-activities.test.ts
+++ b/backend/services/runner/src/activities/__tests__/workflow-event-activities.test.ts
@@ -7,11 +7,15 @@ import type { WorkflowEventDescriptor } from "../../workflow-engine/types.js";
 
 const mockGetEventLogHighWaterMark = vi.fn<(executionId: string) => Promise<bigint>>();
 const mockGetWorkflowExecution = vi.fn<(executionId: string) => Promise<unknown>>();
+const mockUpdateStatus = vi.fn<(input: unknown) => Promise<unknown>>();
 
 vi.mock("../../client/stigmer-client.js", () => ({
   StigmerClient: vi.fn().mockImplementation(() => ({
     getEventLogHighWaterMark: (...args: unknown[]) => mockGetEventLogHighWaterMark(...(args as [string])),
     getWorkflowExecution: (...args: unknown[]) => mockGetWorkflowExecution(...(args as [string])),
+    workflowExecutionCommand: {
+      updateStatus: (...args: unknown[]) => mockUpdateStatus(args[0]),
+    },
   })),
 }));
 
@@ -29,8 +33,9 @@ describe("initSequenceFromEventLog", () => {
     mockGetEventLogHighWaterMark.mockReset();
   });
 
-  it("sets counter to 0 when executionId is empty", async () => {
-    await initSequenceFromEventLog("");
+  it("returns 0 and resets the legacy counter when executionId is empty", async () => {
+    const highWaterMark = await initSequenceFromEventLog("");
+    expect(highWaterMark).toBe(0);
 
     const evt = toProtoEvent({
       type: "task_started",
@@ -43,10 +48,11 @@ describe("initSequenceFromEventLog", () => {
     expect(mockGetEventLogHighWaterMark).not.toHaveBeenCalled();
   });
 
-  it("sets counter to 0 when server returns no events", async () => {
+  it("returns 0 when server has no events", async () => {
     mockGetEventLogHighWaterMark.mockResolvedValue(BigInt(0));
 
-    await initSequenceFromEventLog("wfx_test-1");
+    const highWaterMark = await initSequenceFromEventLog("wfx_test-1");
+    expect(highWaterMark).toBe(0);
 
     const evt = toProtoEvent({
       type: "task_started",
@@ -58,7 +64,15 @@ describe("initSequenceFromEventLog", () => {
     expect(evt.sequenceNumber).toBe(BigInt(1));
   });
 
-  it("continues from high-water mark when events exist", async () => {
+  it("returns the high-water mark as a plain number (Temporal payload converter cannot carry BigInt)", async () => {
+    mockGetEventLogHighWaterMark.mockResolvedValue(BigInt(42));
+
+    const highWaterMark = await initSequenceFromEventLog("wfx_recovery-1");
+    expect(highWaterMark).toBe(42);
+    expect(typeof highWaterMark).toBe("number");
+  });
+
+  it("seeds the legacy counter so pre-patch replays continue from N+1", async () => {
     mockGetEventLogHighWaterMark.mockResolvedValue(BigInt(42));
 
     await initSequenceFromEventLog("wfx_recovery-1");
@@ -87,7 +101,8 @@ describe("initSequenceFromEventLog", () => {
   it("handles large sequence numbers", async () => {
     mockGetEventLogHighWaterMark.mockResolvedValue(BigInt(999999));
 
-    await initSequenceFromEventLog("wfx_large-seq");
+    const highWaterMark = await initSequenceFromEventLog("wfx_large-seq");
+    expect(highWaterMark).toBe(999999);
 
     const evt = toProtoEvent({
       type: "task_started",
@@ -112,7 +127,52 @@ describe("toProtoEvent", () => {
   });
 
   describe("sequence numbering", () => {
-    it("assigns monotonically increasing sequence numbers", () => {
+    it("honors the workflow-assigned sequenceNumber when stamped on the descriptor", () => {
+      const evt = toProtoEvent({
+        type: "task_started",
+        taskName: "t1",
+        occurredAt: NOW,
+        taskKind: "set",
+        attemptNumber: 1,
+        sequenceNumber: 77,
+      });
+
+      expect(evt.sequenceNumber).toBe(BigInt(77));
+    });
+
+    it("workflow-assigned sequences are stable across conversions (retry idempotency)", () => {
+      const desc: WorkflowEventDescriptor = {
+        type: "task_started",
+        taskName: "t1",
+        occurredAt: NOW,
+        taskKind: "set",
+        attemptNumber: 1,
+        sequenceNumber: 5,
+      };
+
+      // Simulates an activity retry re-converting the same descriptors:
+      // the sequence must not change between attempts.
+      expect(toProtoEvent(desc).sequenceNumber).toBe(BigInt(5));
+      expect(toProtoEvent(desc).sequenceNumber).toBe(BigInt(5));
+    });
+
+    it("a stamped descriptor does not consume the legacy counter", () => {
+      const unstamped: WorkflowEventDescriptor = {
+        type: "task_started",
+        taskName: "t",
+        occurredAt: NOW,
+        taskKind: "set",
+        attemptNumber: 1,
+      };
+
+      const e1 = toProtoEvent(unstamped);
+      toProtoEvent({ ...unstamped, sequenceNumber: 99 });
+      const e2 = toProtoEvent(unstamped);
+
+      expect(e2.sequenceNumber).toBe(e1.sequenceNumber + BigInt(1));
+    });
+
+    it("legacy path: assigns monotonically increasing sequence numbers when unstamped", () => {
       const desc: WorkflowEventDescriptor = {
         type: "task_started",
         taskName: "t1",
@@ -130,7 +190,7 @@ describe("toProtoEvent", () => {
       expect(e3.sequenceNumber).toBe(BigInt(3));
     });
 
-    it("resets to 1 after re-initializing with empty executionId", async () => {
+    it("legacy path: resets to 1 after re-initializing with empty executionId", async () => {
       toProtoEvent({
         type: "task_started",
         taskName: "t",
@@ -654,8 +714,13 @@ describe("toProtoEvent", () => {
 });
 
 describe("emitWorkflowEvents", () => {
+  beforeEach(() => {
+    mockUpdateStatus.mockReset();
+  });
+
   it("returns silently for empty events array", async () => {
     await expect(emitWorkflowEvents("exec-1", [])).resolves.toBeUndefined();
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
   });
 
   it("returns silently for empty executionId", async () => {
@@ -667,6 +732,40 @@ describe("emitWorkflowEvents", () => {
       attemptNumber: 1,
     }];
     await expect(emitWorkflowEvents("", events)).resolves.toBeUndefined();
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("sends workflow-assigned sequence numbers through to the RPC", async () => {
+    mockUpdateStatus.mockResolvedValue({});
+
+    await emitWorkflowEvents("exec-1", [{
+      type: "task_started",
+      taskName: "t",
+      occurredAt: NOW,
+      taskKind: "set",
+      attemptNumber: 1,
+      sequenceNumber: 12,
+    }]);
+
+    expect(mockUpdateStatus).toHaveBeenCalledTimes(1);
+    const input = mockUpdateStatus.mock.calls[0][0] as { events: { sequenceNumber: bigint }[] };
+    expect(input.events).toHaveLength(1);
+    expect(input.events[0].sequenceNumber).toBe(BigInt(12));
+  });
+
+  it("propagates RPC errors so the local activity retry policy fires", async () => {
+    mockUpdateStatus.mockRejectedValue(new Error("server unavailable"));
+
+    const events: WorkflowEventDescriptor[] = [{
+      type: "task_started",
+      taskName: "t",
+      occurredAt: NOW,
+      taskKind: "set",
+      attemptNumber: 1,
+      sequenceNumber: 1,
+    }];
+
+    await expect(emitWorkflowEvents("exec-1", events)).rejects.toThrow("server unavailable");
   });
 });
 

--- a/backend/services/runner/src/activities/workflow-event-activities.ts
+++ b/backend/services/runner/src/activities/workflow-event-activities.ts
@@ -3,8 +3,12 @@
  *
  * Converts plain event descriptors (safe for the Temporal deterministic
  * sandbox) into WorkflowExecutionEvent proto objects and sends them
- * alongside a status update via gRPC. Best-effort — failures are logged
- * but do not fail the activity.
+ * alongside a status update via gRPC. Failures propagate so the local
+ * activity's retry policy fires — safe because sequence numbers are
+ * workflow-assigned (stable across attempts) and the store skips
+ * already-persisted sequences, making retries idempotent. The workflow's
+ * emit wrappers catch after retries are exhausted; event emission never
+ * fails a run.
  *
  * Registered as proxyLocalActivities in engine-core.ts so the workflow
  * sandbox can emit events at task boundaries and approval gates.
@@ -140,6 +144,17 @@ function buildClient(): StigmerClient {
   });
 }
 
+/**
+ * LEGACY sequence assignment — only for descriptors that arrive without a
+ * workflow-assigned `sequenceNumber`, i.e. replays of histories recorded
+ * before the "workflow-assigned-event-sequences" patch (see
+ * engine-core.ts). This counter is process-global: it is shared across
+ * every execution on the worker and resets on worker restart, which is
+ * the root cause of oss#308's silent event loss. Deliberately NOT fixed —
+ * pre-patch executions keep their old (flawed) behavior for the
+ * migration window. Delete together with the patch gate once pre-patch
+ * executions have drained.
+ */
 let sequenceCounter = 0;
 
 function nextSequence(): bigint {
@@ -148,33 +163,44 @@ function nextSequence(): bigint {
 }
 
 /**
- * Initialize the event sequence counter from the persisted high-water mark.
+ * Return the persisted event-log high-water mark for the execution, and
+ * seed the legacy process-global counter from it.
  *
- * On first run (no prior events), the counter stays at 0 and the first
- * event gets sequence_number = 1 — identical to the original behavior.
+ * The workflow seeds its own sequence counter from the returned value
+ * (patched path); the legacy global seed remains for pre-patch replays,
+ * whose emit path still assigns sequences here in the activity.
  *
- * On recovery (events already persisted from a failed run), the counter
- * is set to the highest persisted sequence_number so that new events
- * continue from N+1, avoiding duplicate-key collisions in storage.
+ * On first run (no prior events) returns 0, so the first event gets
+ * sequence_number = 1. On recovery (events already persisted from a
+ * failed run) returns the highest persisted sequence_number, so new
+ * events continue from N+1.
  *
  * When executionId is empty (direct executeServerlessWorkflow without a
- * persisted execution), the counter resets to 0 as a safe fallback.
+ * persisted execution), returns 0 as a safe fallback.
+ *
+ * Returns a plain number — the value crosses back into the workflow
+ * through Temporal's JSON payload converter, which cannot carry BigInt.
  */
-export async function initSequenceFromEventLog(executionId: string): Promise<void> {
+export async function initSequenceFromEventLog(executionId: string): Promise<number> {
   if (!executionId) {
     sequenceCounter = 0;
-    return;
+    return 0;
   }
   const client = buildClient();
   const highWaterMark = await client.getEventLogHighWaterMark(executionId);
   sequenceCounter = Number(highWaterMark);
+  return sequenceCounter;
 }
 
 /** @internal Exported for unit testing only. */
 export function toProtoEvent(desc: WorkflowEventDescriptor): WorkflowExecutionEvent {
   const base = create(WorkflowExecutionEventSchema, {
     eventId: crypto.randomUUID(),
-    sequenceNumber: nextSequence(),
+    // Workflow-assigned sequence when present (stable across activity
+    // retries); legacy activity-side assignment only for pre-patch replays.
+    sequenceNumber: desc.sequenceNumber !== undefined
+      ? BigInt(desc.sequenceNumber)
+      : nextSequence(),
     occurredAt: desc.occurredAt,
     taskName: desc.taskName ?? "",
   });
@@ -382,6 +408,14 @@ export function toProtoEvent(desc: WorkflowEventDescriptor): WorkflowExecutionEv
   return base;
 }
 
+/**
+ * Emit workflow events (with the accompanying status snapshot) to the
+ * server. Errors propagate so the local activity retry policy fires;
+ * retries are idempotent because workflow-assigned sequence numbers are
+ * stable across attempts and the store skips already-persisted ones. The
+ * workflow-side emit wrappers absorb the failure after retries are
+ * exhausted, so a broken timeline write never fails the run.
+ */
 export async function emitWorkflowEvents(
   executionId: string,
   events: WorkflowEventDescriptor[],
@@ -389,64 +423,57 @@ export async function emitWorkflowEvents(
 ): Promise<void> {
   if (!executionId || events.length === 0) return;
 
-  try {
-    const client = buildClient();
-    const protoEvents = events.map(toProtoEvent);
+  const client = buildClient();
+  const protoEvents = events.map(toProtoEvent);
 
-    const protoTasks = (taskStatuses ?? []).map(ts =>
-      create(WorkflowTaskSchema, {
-        taskId: ts.taskId ?? "",
-        taskName: ts.taskName,
-        taskType: TASK_KIND_TO_TYPE_MAP[ts.taskKind] ?? WorkflowTaskType.WORKFLOW_TASK_TYPE_UNSPECIFIED,
-        status: TASK_STATUS_MAP[ts.status],
-        startedAt: ts.startedAt ?? "",
-        completedAt: ts.completedAt ?? "",
-        error: ts.error ?? "",
-        input: toJsonObject(ts.input),
-        output: toJsonObject(ts.output),
-        metadata: toJsonObject(ts.metadata),
-        costMicros: BigInt(ts.costMicros ?? 0),
-        inputTokens: BigInt(ts.inputTokens ?? 0),
-        outputTokens: BigInt(ts.outputTokens ?? 0),
-        uiHint: ts.uiHint ?? "",
-      }),
-    );
+  const protoTasks = (taskStatuses ?? []).map(ts =>
+    create(WorkflowTaskSchema, {
+      taskId: ts.taskId ?? "",
+      taskName: ts.taskName,
+      taskType: TASK_KIND_TO_TYPE_MAP[ts.taskKind] ?? WorkflowTaskType.WORKFLOW_TASK_TYPE_UNSPECIFIED,
+      status: TASK_STATUS_MAP[ts.status],
+      startedAt: ts.startedAt ?? "",
+      completedAt: ts.completedAt ?? "",
+      error: ts.error ?? "",
+      input: toJsonObject(ts.input),
+      output: toJsonObject(ts.output),
+      metadata: toJsonObject(ts.metadata),
+      costMicros: BigInt(ts.costMicros ?? 0),
+      inputTokens: BigInt(ts.inputTokens ?? 0),
+      outputTokens: BigInt(ts.outputTokens ?? 0),
+      uiHint: ts.uiHint ?? "",
+    }),
+  );
 
-    const startedEvent = events.find(e => e.type === "execution_started");
-    const completedEvent = events.find(e => e.type === "execution_completed");
-    const failedEvent = events.find(e => e.type === "execution_failed");
+  const startedEvent = events.find(e => e.type === "execution_started");
+  const completedEvent = events.find(e => e.type === "execution_completed");
+  const failedEvent = events.find(e => e.type === "execution_failed");
 
-    const statusFields: Record<string, unknown> = { tasks: protoTasks };
+  const statusFields: Record<string, unknown> = { tasks: protoTasks };
 
-    if (startedEvent) {
-      statusFields.phase = ExecutionPhase.EXECUTION_IN_PROGRESS;
-      statusFields.startedAt = startedEvent.occurredAt;
-    }
-    if (completedEvent && completedEvent.type === "execution_completed") {
-      statusFields.phase = ExecutionPhase.EXECUTION_COMPLETED;
-      statusFields.completedAt = completedEvent.occurredAt;
-      statusFields.totalCostMicros = BigInt(completedEvent.totalCostMicros);
-      statusFields.totalInputTokens = BigInt(completedEvent.totalInputTokens ?? 0);
-      statusFields.totalOutputTokens = BigInt(completedEvent.totalOutputTokens ?? 0);
-    }
-    if (failedEvent && failedEvent.type === "execution_failed") {
-      statusFields.phase = ExecutionPhase.EXECUTION_FAILED;
-      statusFields.completedAt = failedEvent.occurredAt;
-      statusFields.error = failedEvent.error;
-    }
-
-    const input = create(WorkflowExecutionUpdateStatusInputSchema, {
-      executionId,
-      status: create(WorkflowExecutionStatusSchema, statusFields as Parameters<typeof create>[1]),
-      events: protoEvents,
-    });
-    await client.workflowExecutionCommand.updateStatus(input);
-  } catch (err) {
-    console.error(
-      `Failed to emit ${events.length} workflow event(s) for ${executionId}:`,
-      err,
-    );
+  if (startedEvent) {
+    statusFields.phase = ExecutionPhase.EXECUTION_IN_PROGRESS;
+    statusFields.startedAt = startedEvent.occurredAt;
   }
+  if (completedEvent && completedEvent.type === "execution_completed") {
+    statusFields.phase = ExecutionPhase.EXECUTION_COMPLETED;
+    statusFields.completedAt = completedEvent.occurredAt;
+    statusFields.totalCostMicros = BigInt(completedEvent.totalCostMicros);
+    statusFields.totalInputTokens = BigInt(completedEvent.totalInputTokens ?? 0);
+    statusFields.totalOutputTokens = BigInt(completedEvent.totalOutputTokens ?? 0);
+  }
+  if (failedEvent && failedEvent.type === "execution_failed") {
+    statusFields.phase = ExecutionPhase.EXECUTION_FAILED;
+    statusFields.completedAt = failedEvent.occurredAt;
+    statusFields.error = failedEvent.error;
+  }
+
+  const input = create(WorkflowExecutionUpdateStatusInputSchema, {
+    executionId,
+    status: create(WorkflowExecutionStatusSchema, statusFields as Parameters<typeof create>[1]),
+    events: protoEvents,
+  });
+  await client.workflowExecutionCommand.updateStatus(input);
 }
 
 const PROTO_STATUS_TO_STRING: Record<number, string> = {

--- a/backend/services/runner/src/workflow-engine/types.ts
+++ b/backend/services/runner/src/workflow-engine/types.ts
@@ -800,6 +800,24 @@ export type WorkflowEventDescriptor =
 interface EventBase {
   readonly taskName?: string;
   readonly occurredAt: string;
+  /**
+   * Workflow-assigned event sequence number, stamped at the emit funnels
+   * (engine-core's emitEvents and the agent-call orchestrator's
+   * emitProgress) from the workflow-owned monotonic counter. Assigning
+   * inside the deterministic sandbox makes the number stable across
+   * activity retries and worker restarts, so persistence is idempotent
+   * (the store skips already-persisted sequences).
+   *
+   * A plain `number`, not `bigint`: descriptors cross the
+   * workflow→activity boundary through Temporal's JSON payload converter,
+   * which cannot serialize BigInt. The emit activity converts to the
+   * proto's uint64.
+   *
+   * Absent only when replaying histories recorded before the
+   * "workflow-assigned-event-sequences" patch — the emit activity then
+   * falls back to its legacy process-global counter.
+   */
+  readonly sequenceNumber?: number;
 }
 
 export interface ExecutionStartedEvent extends EventBase {

--- a/backend/services/runner/src/workflows/__tests__/execute-serverless-workflow.test.ts
+++ b/backend/services/runner/src/workflows/__tests__/execute-serverless-workflow.test.ts
@@ -4,6 +4,8 @@ import type { WorkflowModel } from "../../workflow-engine/types.js";
 import type { ExecuteServerlessWorkflowInput } from "../execute-serverless-workflow.js";
 
 const mockEvaluateExpressions = vi.fn();
+const mockResetEventSequence = vi.fn();
+const mockEmitWorkflowEvents = vi.fn();
 
 vi.mock("@temporalio/workflow", () => ({
   proxyLocalActivities: vi.fn(() => ({
@@ -12,8 +14,9 @@ vi.mock("@temporalio/workflow", () => ({
       input: unknown,
       stateVars: Record<string, unknown>,
     ) => mockEvaluateExpressions(exprs, input, stateVars),
-    ResetEventSequence: vi.fn(),
-    EmitWorkflowEvents: vi.fn(),
+    ResetEventSequence: (executionId: string) => mockResetEventSequence(executionId),
+    EmitWorkflowEvents: (executionId: string, events: unknown[], taskStatuses: unknown[]) =>
+      mockEmitWorkflowEvents(executionId, events, taskStatuses),
   })),
   proxyActivities: vi.fn(() => ({
     CallHttp: vi.fn(),
@@ -243,6 +246,69 @@ describe("executeServerlessWorkflow", () => {
       await expect(
         runWorkflow({ model, workflow_input: null, env: {} }),
       ).rejects.toThrow("jq evaluation error");
+    });
+  });
+
+  describe("workflow-assigned event sequences", () => {
+    interface StampedEvent {
+      type: string;
+      sequenceNumber?: number;
+    }
+
+    function emittedEvents(): StampedEvent[] {
+      return mockEmitWorkflowEvents.mock.calls.flatMap(call => call[1] as StampedEvent[]);
+    }
+
+    const model: WorkflowModel = {
+      document: { dsl: "1.0.0", name: "test-sequences" },
+      do: [
+        { key: "step1", task: { kind: "set", set: { a: 1 } } },
+        { key: "step2", task: { kind: "set", set: { b: 2 } } },
+      ],
+    };
+
+    it("stamps a strictly monotonic sequence continuing from the high-water mark", async () => {
+      mockResetEventSequence.mockResolvedValue(10);
+
+      await runWorkflow({
+        model,
+        workflow_input: null,
+        env: {},
+        metadata: { execution_id: "wfx-seq-1" },
+      });
+
+      const events = emittedEvents();
+      expect(events.length).toBeGreaterThan(0);
+      // execution_started, task events, execution_completed — all from one
+      // counter, gapless, continuing after the persisted high-water mark.
+      const sequences = events.map(e => e.sequenceNumber);
+      const expected = Array.from({ length: events.length }, (_, i) => 11 + i);
+      expect(sequences).toEqual(expected);
+    });
+
+    it("starts at 1 for a fresh execution (high-water mark 0)", async () => {
+      mockResetEventSequence.mockResolvedValue(0);
+
+      await runWorkflow({
+        model,
+        workflow_input: null,
+        env: {},
+        metadata: { execution_id: "wfx-seq-2" },
+      });
+
+      expect(emittedEvents()[0]?.sequenceNumber).toBe(1);
+    });
+
+    it("emits no events without an execution_id (direct invocation, child workflows)", async () => {
+      mockResetEventSequence.mockResolvedValue(0);
+
+      await runWorkflow({
+        model,
+        workflow_input: null,
+        env: {},
+      });
+
+      expect(mockEmitWorkflowEvents).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/services/runner/src/workflows/call-agent-orchestrator.ts
+++ b/backend/services/runner/src/workflows/call-agent-orchestrator.ts
@@ -94,6 +94,15 @@ export interface AgentCallOrchestrationInput {
   parentWorkflowId: string;
   taskName: string;
   workflowExecutionId: string;
+  /**
+   * Allocator for the workflow-owned event sequence counter, shared with
+   * engine-core's emit funnel so progress events and task events draw
+   * from one monotonic series. Safe to pass as a closure — the
+   * orchestrator is a plain function call inside the same workflow run,
+   * not a child workflow. Undefined when replaying pre-patch histories
+   * (the emit activity then assigns from its legacy counter).
+   */
+  nextEventSequence?: () => number;
 }
 
 /**
@@ -318,6 +327,7 @@ async function emitProgress(
       type: "agent_call_progress",
       taskName: input.taskName,
       occurredAt: new Date().toISOString(),
+      sequenceNumber: input.nextEventSequence?.(),
       childExecutionId: childExecId,
       agentSlug: input.config.agent ?? "",
       agentPhase: progress?.agentPhase ?? 0,

--- a/backend/services/runner/src/workflows/engine-core.ts
+++ b/backend/services/runner/src/workflows/engine-core.ts
@@ -145,7 +145,21 @@ export async function runWorkflowEngine(
 
   recordExecutionStartMetric(model.document.name);
 
-  await eventProxy.ResetEventSequence(executionId);
+  // Event sequence numbers are workflow state: assigned here in the
+  // deterministic sandbox (seeded from the persisted high-water mark) so
+  // they are stable across activity retries, worker restarts, and
+  // concurrent executions — the store can then treat re-sent sequences as
+  // idempotent duplicates. Pre-patch histories recorded the activity
+  // result as void and assigned sequences inside the emit activity from a
+  // process-global counter; they must keep doing so on replay, hence the
+  // gate. Remove the gate (and the activity's legacy counter) once
+  // pre-patch executions have drained.
+  const workflowAssignedSequences = patched("workflow-assigned-event-sequences");
+  const eventLogHighWaterMark = await eventProxy.ResetEventSequence(executionId);
+  let eventSequence = workflowAssignedSequences ? Number(eventLogHighWaterMark ?? 0) : 0;
+  const nextEventSequence = workflowAssignedSequences
+    ? () => ++eventSequence
+    : undefined;
 
   let recoveryContext: RecoveryContext | undefined;
   if (options?.recoveryMode && executionId) {
@@ -170,9 +184,15 @@ export async function runWorkflowEngine(
 
   const emitEvents = async (events: WorkflowEventDescriptor[]): Promise<void> => {
     if (!executionId || events.length === 0) return;
+    const stamped = nextEventSequence
+      ? events.map(e => ({ ...e, sequenceNumber: nextEventSequence() }))
+      : events;
     try {
-      await eventProxy.EmitWorkflowEvents(executionId, events, taskStatusAccumulator.toArray());
+      await eventProxy.EmitWorkflowEvents(executionId, stamped, taskStatusAccumulator.toArray());
     } catch (err) {
+      // Final guard after the activity's retries are exhausted: a run must
+      // not die because its timeline write failed. With workflow-assigned
+      // sequences the result is a gap in the log, never a poisoned log.
       log.warn("Failed to emit workflow events (non-fatal)", {
         executionId,
         eventCount: events.length,
@@ -246,6 +266,7 @@ export async function runWorkflowEngine(
         parentWorkflowId: agentMeta.parentWorkflowId || workflowInfo().workflowId,
         taskName: agentMeta.taskName,
         workflowExecutionId: agentMeta.workflowExecutionId || executionId,
+        nextEventSequence,
       }),
     promoteTaskOutput: (taskOutput: unknown, wexId: string, taskName: string, displayName?: string) =>
       promoteProxy.PromoteTaskOutput(taskOutput, wexId || executionId, taskName, displayName),

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/update_status.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/update_status.go
@@ -302,8 +302,11 @@ func (s *PersistExecutionStep) Execute(ctx *pipeline.RequestContext[*workflowexe
 }
 
 // PersistEventsStep appends workflow execution events to the event log.
-// Events are supplementary — a failure here logs a warning but does NOT
-// fail the pipeline because status persistence already succeeded.
+// Events are supplementary — a failure here does NOT fail the pipeline
+// because status persistence (PersistExecutionStep, which runs first)
+// already succeeded. But a real append failure means timeline data loss,
+// so it logs at error level; skipped duplicates are the expected result
+// of the runner's idempotent batch retries and only log at debug.
 type PersistEventsStep struct {
 	store store.Store
 }
@@ -329,11 +332,12 @@ func (s *PersistEventsStep) Execute(ctx *pipeline.RequestContext[*workflowexecut
 	for _, evt := range events {
 		data, err := proto.Marshal(evt)
 		if err != nil {
-			log.Warn().
+			log.Error().
 				Err(err).
 				Str("execution_id", executionID).
 				Uint64("sequence_number", evt.GetSequenceNumber()).
-				Msg("Failed to marshal event, skipping batch")
+				Int("event_count", len(events)).
+				Msg("Failed to marshal event — dropping batch (non-fatal, timeline data lost)")
 			return nil
 		}
 
@@ -348,18 +352,26 @@ func (s *PersistEventsStep) Execute(ctx *pipeline.RequestContext[*workflowexecut
 
 	appended, err := s.store.AppendWorkflowExecutionEvents(ctx.Context(), executionID, records)
 	if err != nil {
-		log.Warn().
+		log.Error().
 			Err(err).
 			Str("execution_id", executionID).
-			Int("event_count", len(records)).
-			Msg("Failed to persist execution events (non-fatal)")
+			Int("submitted", len(records)).
+			Msg("Failed to persist execution events (non-fatal, timeline data lost)")
 		return nil
 	}
 
-	log.Debug().
-		Str("execution_id", executionID).
-		Int("appended", appended).
-		Msg("Persisted execution events")
+	if skipped := len(records) - appended; skipped > 0 {
+		log.Debug().
+			Str("execution_id", executionID).
+			Int("appended", appended).
+			Int("skipped_duplicates", skipped).
+			Msg("Persisted execution events (idempotent retry skipped already-persisted sequences)")
+	} else {
+		log.Debug().
+			Str("execution_id", executionID).
+			Int("appended", appended).
+			Msg("Persisted execution events")
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Workflow execution events were being lost silently: the store rejected an entire batch when any event carried a stale sequence number, and every caller swallowed the error. The investigation found the root cause upstream of the issue's framing — the runner assigns sequence numbers from a **process-global counter** that is shared across all concurrent executions on a worker and resets on worker restart. This PR moves sequence assignment into the Temporal workflow sandbox (deterministic, replay-safe, per-run by construction) and makes the store append idempotent.

## Context

oss#308 described the retry-loss path: a batch retried after partial persistence was rejected whole and dropped with no signal. Three more live loss paths fell out of the investigation, all with the same silent outcome:

1. **Cross-execution clobber** — execution B's `ResetEventSequence` rewinds the shared global counter below execution A's persisted max; all of A's subsequent batches are stale and dropped.
2. **Worker restart** — the counter resets to 0 in the new process (Temporal replay does not re-run the init activity), so every batch after resume is stale.
3. **Out-of-order parallel branches** — under `fork`, a lower-sequence batch arriving after a higher one was rejected as stale even though it was never persisted.

## Changes

- **Runner (workflow sandbox)** — `engine-core.ts` seeds a workflow-owned counter from the persisted high-water mark (`ResetEventSequence` now returns it) and stamps every descriptor at the two emit funnels; the allocator threads into `orchestrateAgentCall` for progress events. Gated with `patched("workflow-assigned-event-sequences")` so histories recorded before this change replay unchanged.
- **Runner (activity)** — `toProtoEvent` honors a workflow-assigned `sequenceNumber`; the legacy global counter remains only for pre-patch replays, documented for removal. `emitWorkflowEvents` no longer swallows errors, so the configured local-activity retries actually fire; the workflow-level catch stays as the final non-fatal guard.
- **Store (sqlite)** — `AppendWorkflowExecutionEvents` is now `INSERT OR IGNORE` on the `(execution_id, sequence_number)` PK: insert-or-skip, first-writer-wins, returning the count actually inserted. This is the same contract the cloud edition pinned in `WorkflowExecutionEventRepoContractTest`, so the editions converge.
- **Server** — `PersistEventsStep` stays non-fatal (status persists first) but logs real append failures at error level with submitted/appended counts; skipped duplicates log at debug.

## Implementation notes

- Sequence numbers are workflow state: fixing them before the activity runs is what makes retries exactly-once — a retried attempt re-sends identical numbers and the store skips them. Assigning inside the activity (the previous design) can never be retry-safe, because each attempt would re-assign.
- Descriptor `sequenceNumber` is a plain `number`, not `bigint` — descriptors cross the workflow→activity boundary through Temporal's JSON payload converter, which cannot carry BigInt. The activity converts to the proto's uint64.
- The `patched()` gate does not change the command sequence (same local activity call in both branches; only whether its result is read differs), so in-flight executions replay cleanly across the deploy.
- **Cloud impact**: the runner is shared by both editions, so the global-counter bug affects cloud today — cloud's `ON CONFLICT DO NOTHING` masks distinct-event collisions as silent first-writer-wins drops. This PR closes that for cloud too; no cloud-repo change needed.

## Breaking changes

- None for callers. Reviewer-visible semantic change: a write that conflicts with an already-persisted `(execution_id, sequence_number)` is now skipped instead of rejecting the batch — the trade-off cloud already pinned deliberately, and workflow-owned assignment makes genuine conflicts impossible by construction.

## Test plan

- New `store_workflow_execution_events_test.go` (the append path previously had zero Go coverage): fresh batch, empty batch, exact-duplicate retry, partial-overlap suffix, first-writer-wins content, out-of-order arrival, cross-execution independence, max-sequence. All pass.
- `workflow-event-activities.test.ts` updated to pin the new contract: high-water-mark return (plain number), stamped sequences honored and stable across conversions, legacy auto-assignment when unstamped, RPC error propagation.
- `execute-serverless-workflow.test.ts` gains workflow-level allocator tests: gapless monotonic stamping continuing from the high-water mark, fresh-execution start at 1, no emission without an execution_id.
- Full verification: runner `tsc --noEmit` clean; 1,028 runner tests across 48 files pass; `go build`/`go vet`/`go test` clean for the store and workflowexecution packages.

## Risks

- The `patched()` gate is the load-bearing piece for zero-downtime deploy; it follows the repo's documented `isPatched` precedent. Executions started before the deploy keep the legacy behavior (no worse than today) and drain out; the gate and legacy counter are marked for removal afterward.
- Rollback: revert the PR — the store change is backward-compatible with activity-assigned sequences, and no schema changed.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible (patch-gated for in-flight executions)
- [ ] Docs updated (not needed — internal contract, documented inline)

Closes #308

Made with [Cursor](https://cursor.com)