### PR TITLE
fix(runner): encrypt Temporal history payloads so workflow secrets never rest in plaintext

### DIFF
--- a/backend/services/runner/README.md
+++ b/backend/services/runner/README.md
@@ -173,9 +173,20 @@ All configuration is environment-driven. Names and defaults below are verified a
 | `LOCAL_ARTIFACT_PATH` | Local storage | No | `~/.stigmer/data/artifacts` | Filesystem root of the local artifact store. **Must equal the stigmer-server's `ARTIFACT_LOCAL_BASE_PATH`** — in local mode the server writes an artifact to `<ARTIFACT_LOCAL_BASE_PATH>/<key>` and the runner reads it from `<LOCAL_ARTIFACT_PATH>/<key>`, so a mismatch makes every storage-key attachment and offload fail to resolve. The defaults align out of the box; the CLI local daemon sets both explicitly. |
 | `LOCAL_ARTIFACT_SERVE_URL` | Local storage | No | `http://localhost:7235` | Base URL of the server's artifact HTTP file server (its `ARTIFACT_HTTP_PORT`, default `GRPC_PORT + 1`). Used for blob downloads; the runner's own read-back goes straight to disk. |
 
+### Payload encryption (Temporal history at rest)
+
+The encryption codec encrypts every Temporal payload the runner produces (AES-256-GCM), so decrypted execution-context secrets never rest in workflow history or the Temporal UI. Payloads the runner did not encrypt (orchestrator inputs, signals, pre-rollout histories) pass through untouched. A key without its id — or a malformed key — fails the boot rather than silently running plaintext.
+
+| Variable | Applies to | Required | Default | Purpose |
+|----------|-----------|----------|---------|---------|
+| `STIGMER_PAYLOAD_ENCRYPTION_KEY` | All | No | _(unset — encryption off)_ | Base64-encoded 32-byte AES-256 key. Setting it enables the codec. |
+| `STIGMER_PAYLOAD_ENCRYPTION_KEY_ID` | Payload encryption | With the key | _(none)_ | Identifier stamped on every encrypted payload so rotation can tell keys apart. Required when the key is set. |
+| `STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY` | Payload encryption | No | _(unset)_ | Decrypt-only key accepted during rotation windows (payloads written under the previous key stay readable). |
+| `STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID` | Payload encryption | With the secondary key | _(none)_ | Key id of the secondary key. |
+
 ### Claim-check (large Temporal payloads)
 
-The claim-check codec offloads oversized Temporal payloads to artifact storage and passes a reference instead.
+The claim-check codec offloads oversized Temporal payloads to artifact storage and passes a reference instead. When payload encryption is enabled, encryption runs first, so offloaded blobs are ciphertext.
 
 | Variable | Applies to | Required | Default | Purpose |
 |----------|-----------|----------|---------|---------|

--- a/backend/services/runner/src/__tests__/claimcheck-codec.test.ts
+++ b/backend/services/runner/src/__tests__/claimcheck-codec.test.ts
@@ -152,6 +152,42 @@ describe("ClaimcheckPayloadCodec", () => {
       expect(Buffer.from(decoded.data!)).toEqual(original.data);
     });
 
+    it("restores the original payload metadata (round-trip)", async () => {
+      // The restored payload must carry its ORIGINAL encoding, not the
+      // marker's binary/claimcheck — otherwise no payload converter can
+      // interpret it and composition with the encryption codec breaks.
+      const original: Payload = {
+        metadata: {
+          encoding: Buffer.from("json/plain"),
+          "custom-key": Buffer.from("custom-value"),
+        },
+        data: Buffer.alloc(2048, "y"),
+      };
+
+      const [encoded] = await codec.encode([original]);
+      const [decoded] = await codec.decode([encoded]);
+
+      expect(Buffer.from(decoded.metadata!["encoding"]!).toString()).toBe("json/plain");
+      expect(Buffer.from(decoded.metadata!["custom-key"]!).toString()).toBe("custom-value");
+      expect(Buffer.from(decoded.data!)).toEqual(original.data);
+    });
+
+    it("decodes legacy markers written before metadata preservation", async () => {
+      const original = makeLargePayload(2048);
+      const [encoded] = await codec.encode([original]);
+
+      // Simulate a pre-fix marker: strip the metadata field.
+      const marker = JSON.parse(Buffer.from(encoded.data!).toString());
+      delete marker.metadata;
+      const legacy: Payload = {
+        metadata: encoded.metadata,
+        data: Buffer.from(JSON.stringify(marker)),
+      };
+
+      const [decoded] = await codec.decode([legacy]);
+      expect(Buffer.from(decoded.data!)).toEqual(original.data);
+    });
+
     it("retrieves uncompressed payloads correctly", async () => {
       codec = new ClaimcheckPayloadCodec(
         storage,

--- a/backend/services/runner/src/__tests__/encryption-codec.test.ts
+++ b/backend/services/runner/src/__tests__/encryption-codec.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the payload-encryption codec (stigmer-cloud#227).
+ *
+ * Covers the codec in isolation, its composition with the claim-check
+ * codec (order is load-bearing: encrypt before relocate, so object
+ * storage only ever sees ciphertext), the config loader's fail-fast
+ * contract, and the committed cross-language conformance fixture that
+ * pins the envelope format the Java decode-only codec (stigmer-cloud
+ * temporal-starter) must match.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Payload } from "@temporalio/common";
+import { EncryptionPayloadCodec } from "../encryption/payload-codec.js";
+import { loadPayloadEncryptionConfig } from "../encryption/config.js";
+import type { PayloadEncryptionConfig } from "../encryption/config.js";
+import { ClaimcheckPayloadCodec } from "../claimcheck/payload-codec.js";
+import { makeInMemoryArtifactStorage } from "../__test-utils__/fake-artifact-storage.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function makeKeyConfig(overrides: Partial<PayloadEncryptionConfig> = {}): PayloadEncryptionConfig {
+  return {
+    primary: { keyId: "test-key-1", key: randomBytes(32) },
+    ...overrides,
+  };
+}
+
+function makeJsonPayload(value: unknown): Payload {
+  return {
+    metadata: { encoding: Buffer.from("json/plain") },
+    data: Buffer.from(JSON.stringify(value)),
+  };
+}
+
+function metadataString(payload: Payload, key: string): string | undefined {
+  const bytes = payload.metadata?.[key];
+  return bytes ? Buffer.from(bytes).toString("utf-8") : undefined;
+}
+
+describe("EncryptionPayloadCodec", () => {
+  it("round-trips a payload, restoring metadata and data exactly", async () => {
+    const codec = new EncryptionPayloadCodec(makeKeyConfig());
+    const original = makeJsonPayload({ secret: "s3cret-value" });
+
+    const [encoded] = await codec.encode([original]);
+    expect(metadataString(encoded, "encoding")).toBe("binary/encrypted");
+    expect(metadataString(encoded, "encryption-key-id")).toBe("test-key-1");
+    expect(Buffer.from(encoded.data!).includes("s3cret-value")).toBe(false);
+
+    const [decoded] = await codec.decode([encoded]);
+    expect(metadataString(decoded, "encoding")).toBe("json/plain");
+    expect(Buffer.from(decoded.data!)).toEqual(original.data);
+  });
+
+  it("passes through payloads it did not encode", async () => {
+    const codec = new EncryptionPayloadCodec(makeKeyConfig());
+    const plaintext = makeJsonPayload({ from: "java-orchestrator" });
+    const [decoded] = await codec.decode([plaintext]);
+    expect(decoded).toBe(plaintext);
+  });
+
+  it("skips data-less payloads on encode (binary/null void results)", async () => {
+    const codec = new EncryptionPayloadCodec(makeKeyConfig());
+    const nullPayload: Payload = {
+      metadata: { encoding: Buffer.from("binary/null") },
+      data: undefined,
+    };
+    const [encoded] = await codec.encode([nullPayload]);
+    expect(encoded).toBe(nullPayload);
+  });
+
+  it("fails closed on tampered ciphertext", async () => {
+    const codec = new EncryptionPayloadCodec(makeKeyConfig());
+    const [encoded] = await codec.encode([makeJsonPayload({ a: 1 })]);
+
+    const tampered = Buffer.from(encoded.data!);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    await expect(
+      codec.decode([{ metadata: encoded.metadata, data: tampered }]),
+    ).rejects.toThrow(/corrupt or the configured key does not match/);
+  });
+
+  it("fails closed on an unknown key id", async () => {
+    const writer = new EncryptionPayloadCodec(makeKeyConfig());
+    const [encoded] = await writer.encode([makeJsonPayload({ a: 1 })]);
+
+    const reader = new EncryptionPayloadCodec(
+      makeKeyConfig({ primary: { keyId: "other-key", key: randomBytes(32) } }),
+    );
+    await expect(reader.decode([encoded])).rejects.toThrow(
+      /unknown key id 'test-key-1'/,
+    );
+  });
+
+  it("fails closed when the key id metadata is missing", async () => {
+    const codec = new EncryptionPayloadCodec(makeKeyConfig());
+    const [encoded] = await codec.encode([makeJsonPayload({ a: 1 })]);
+
+    const stripped: Payload = {
+      metadata: { encoding: Buffer.from("binary/encrypted") },
+      data: encoded.data,
+    };
+    await expect(codec.decode([stripped])).rejects.toThrow(
+      /missing its encryption-key-id/,
+    );
+  });
+
+  it("decodes payloads written under the secondary key (rotation window)", async () => {
+    const oldKey = { keyId: "2026-01", key: randomBytes(32) };
+    const writer = new EncryptionPayloadCodec({ primary: oldKey });
+    const [encoded] = await writer.encode([makeJsonPayload({ rotated: true })]);
+
+    const rotatedReader = new EncryptionPayloadCodec({
+      primary: { keyId: "2026-08", key: randomBytes(32) },
+      secondary: oldKey,
+    });
+    const [decoded] = await rotatedReader.decode([encoded]);
+    expect(JSON.parse(Buffer.from(decoded.data!).toString())).toEqual({ rotated: true });
+  });
+});
+
+describe("composition with claim-check (encrypt, then relocate)", () => {
+  it("stores only ciphertext in object storage and round-trips exactly", async () => {
+    const { storage, blobs } = makeInMemoryArtifactStorage();
+    const encryption = new EncryptionPayloadCodec(makeKeyConfig());
+    const claimcheck = new ClaimcheckPayloadCodec(storage, {
+      enabled: true,
+      thresholdBytes: 128,
+      compressionEnabled: false,
+      keyPrefix: "claimcheck/",
+    });
+
+    const secret = "very-large-and-very-secret-".repeat(32);
+    const original = makeJsonPayload({ secret });
+
+    // Temporal applies codec arrays in order on encode, reverse on decode.
+    const [encrypted] = await encryption.encode([original]);
+    const [relocated] = await claimcheck.encode([encrypted]);
+    expect(metadataString(relocated, "encoding")).toBe("binary/claimcheck");
+
+    expect(blobs.size).toBe(1);
+    const blob: Buffer = blobs.values().next().value!;
+    expect(blob.includes("very-large-and-very-secret-")).toBe(false);
+
+    const [restored] = await claimcheck.decode([relocated]);
+    const [decrypted] = await encryption.decode([restored]);
+    expect(metadataString(decrypted, "encoding")).toBe("json/plain");
+    expect(Buffer.from(decrypted.data!)).toEqual(original.data);
+  });
+});
+
+describe("loadPayloadEncryptionConfig", () => {
+  const ENV_VARS = [
+    "STIGMER_PAYLOAD_ENCRYPTION_KEY",
+    "STIGMER_PAYLOAD_ENCRYPTION_KEY_ID",
+    "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY",
+    "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID",
+  ];
+
+  afterEach(() => {
+    for (const name of ENV_VARS) delete process.env[name];
+  });
+
+  it("returns undefined when no key is configured", () => {
+    expect(loadPayloadEncryptionConfig()).toBeUndefined();
+  });
+
+  it("loads primary and secondary keys", () => {
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(32).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY_ID = "k2";
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY = randomBytes(32).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID = "k1";
+
+    const config = loadPayloadEncryptionConfig();
+    expect(config?.primary.keyId).toBe("k2");
+    expect(config?.primary.key.length).toBe(32);
+    expect(config?.secondary?.keyId).toBe("k1");
+  });
+
+  it("fails the boot when a key is set without an id", () => {
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(32).toString("base64");
+    expect(() => loadPayloadEncryptionConfig()).toThrow(
+      /STIGMER_PAYLOAD_ENCRYPTION_KEY_ID is required/,
+    );
+  });
+
+  it("fails the boot on a key of the wrong length", () => {
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(16).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY_ID = "k1";
+    expect(() => loadPayloadEncryptionConfig()).toThrow(/must decode to 32 bytes/);
+  });
+});
+
+describe("cross-language conformance fixture", () => {
+  // The committed fixture pins the envelope as a wire contract. A copy
+  // lives in stigmer-cloud (temporal-starter test resources) where the
+  // Java decode-only codec must decrypt it to the same payload. Never
+  // regenerate it casually: changing the fixture means changing the
+  // cross-SDK envelope, which requires both implementations to move in
+  // lockstep.
+  it("decrypts the committed fixture to the expected payload", async () => {
+    const fixture = JSON.parse(
+      readFileSync(join(__dirname, "fixtures", "encrypted-payload-fixture.json"), "utf-8"),
+    );
+
+    const codec = new EncryptionPayloadCodec({
+      primary: {
+        keyId: fixture.keyId,
+        key: Buffer.from(fixture.keyBase64, "base64"),
+      },
+    });
+
+    const encrypted: Payload = {
+      metadata: Object.fromEntries(
+        Object.entries(fixture.encrypted.metadataBase64 as Record<string, string>).map(
+          ([k, v]) => [k, Buffer.from(v, "base64")],
+        ),
+      ),
+      data: Buffer.from(fixture.encrypted.dataBase64, "base64"),
+    };
+
+    const [decoded] = await codec.decode([encrypted]);
+    expect(metadataString(decoded, "encoding")).toBe("json/plain");
+    expect(Buffer.from(decoded.data!).toString("utf-8")).toBe(
+      fixture.original.dataJson,
+    );
+  });
+});

--- a/backend/services/runner/src/__tests__/fixtures/encrypted-payload-fixture.json
+++ b/backend/services/runner/src/__tests__/fixtures/encrypted-payload-fixture.json
@@ -1,0 +1,15 @@
+{
+  "description": "Cross-language conformance fixture for the Temporal payload-encryption envelope (stigmer-cloud#227). data = iv(12) || AES-256-GCM ciphertext || tag(16); plaintext is the serialized original Payload proto. The TS codec (stigmer OSS runner) and the Java decode-only codec (stigmer-cloud temporal-starter) must both decrypt this to original.dataJson with encoding json/plain. The key is TEST-ONLY. Do not regenerate without moving both implementations in lockstep.",
+  "keyId": "conformance-2026-08-11",
+  "keyBase64": "LwN0jDzOwm0aPH8lyRRqsTMali/7RAgKKB9CY6psNFw=",
+  "encrypted": {
+    "metadataBase64": {
+      "encoding": "YmluYXJ5L2VuY3J5cHRlZA==",
+      "encryption-key-id": "Y29uZm9ybWFuY2UtMjAyNi0wOC0xMQ=="
+    },
+    "dataBase64": "CzL44tAoZwoawET5ApaDKGLYcJO2P8eTPS4hZnoEOUvZ7jkD5mkCnD9krgY9etYWO+06y779i8xRCs7QrnOKo5xo74HtlY0bwxYjr2dOra9TGRbtv3PlrW+DcfmEFAQ3Efem"
+  },
+  "original": {
+    "dataJson": "{\"secret\":\"cross-language-conformance-value\"}"
+  }
+}

--- a/backend/services/runner/src/__tests__/history-encryption-e2e.test.ts
+++ b/backend/services/runner/src/__tests__/history-encryption-e2e.test.ts
@@ -1,0 +1,243 @@
+/**
+ * History-encryption tripwire (stigmer-cloud#227).
+ *
+ * Runs a secret-bearing workflow through a real Temporal server with the
+ * encryption codec installed, then scans the RAW workflow history and
+ * asserts the secret bytes appear in no payload. This is the test that
+ * proves the issue's claim is closed: without the codec, the secret
+ * appears in the hydrate activity result, in every per-task activity
+ * input (the engine passes the full env map), and in local-activity
+ * markers from expression evaluation.
+ *
+ * Also pins the cross-language completion contract: the
+ * execute-from-execution workflow must complete with a data-less result
+ * (void), because the Java parent awaits it as Void and Temporal Java's
+ * converter has no Void special-case — a data-bearing encrypted result
+ * would fail its converter lookup.
+ *
+ * Follows the golden-e2e pattern: tests skip gracefully when the
+ * Temporal test server cannot start.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadWorkflowFromYaml } from "../workflow-engine/loader.js";
+import { evaluateExpressionBatch } from "../workflow-engine/expression.js";
+import { EncryptionPayloadCodec } from "../encryption/payload-codec.js";
+import type { ExecuteServerlessWorkflowInput } from "../workflows/execute-serverless-workflow.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKFLOWS_PATH = join(__dirname, "../workflows/index.ts");
+const TASK_QUEUE = "history-encryption-e2e";
+
+const SECRET = "sup3r-s3cret-t0ken-do-not-persist";
+
+const SECRET_BEARING_YAML = `
+document:
+  dsl: '1.0.0'
+  namespace: tripwire
+  name: secret-bearing
+  version: '1.0.0'
+  description: Exercises every env-to-history crossing with a secret value
+do:
+  # Expression evaluation: the secret flows through an EvaluateExpressions
+  # local activity whose result is recorded as a history marker.
+  - stampToken:
+      set:
+        authHeader: \${ "Bearer " + $env.API_TOKEN }
+  # Per-task activity: CallHttp receives the interpolated config AND the
+  # full runtime env map as activity input.
+  - callApi:
+      call: http
+      with:
+        method: GET
+        endpoint:
+          uri: https://example.com/data
+        headers:
+          Authorization: \${ $context.authHeader }
+  - done:
+      set:
+        finished: true
+`;
+
+type TestWorkflowEnvironment = import("@temporalio/testing").TestWorkflowEnvironment;
+type Worker = import("@temporalio/worker").Worker;
+
+let env: TestWorkflowEnvironment | null = null;
+let worker: Worker | null = null;
+let workerRunPromise: Promise<void> | null = null;
+let envReady = false;
+
+function createMockActivities() {
+  return {
+    HydrateWorkflowExecution: async (): Promise<ExecuteServerlessWorkflowInput> => ({
+      model: loadWorkflowFromYaml(SECRET_BEARING_YAML),
+      workflow_input: null,
+      env: { API_TOKEN: SECRET },
+      metadata: { execution_id: "tripwire-exec", org_id: "tripwire-org" },
+    }),
+    EvaluateExpressions: async (
+      expressions: Record<string, string>,
+      input: unknown,
+      stateVars: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      return evaluateExpressionBatch(expressions, input, stateVars);
+    },
+    CallHttp: async (): Promise<unknown> => ({ ok: true }),
+    ResetEventSequence: async (): Promise<number> => 0,
+    EmitWorkflowEvents: async (): Promise<void> => {},
+    LoadRecoveryContext: async (): Promise<unknown[]> => [],
+    PromoteTaskOutput: async (): Promise<void> => {},
+  };
+}
+
+/** Recursively collects every byte field in the raw history proto. */
+function collectByteFields(value: unknown, out: Uint8Array[]): void {
+  if (value instanceof Uint8Array) {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectByteFields(item, out);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) collectByteFields(item, out);
+  }
+}
+
+describe("History encryption tripwire — Temporal TestWorkflowEnvironment", () => {
+  beforeAll(async () => {
+    try {
+      const { TestWorkflowEnvironment: TWE } = await import("@temporalio/testing");
+      const { Worker: W } = await import("@temporalio/worker");
+
+      env = await TWE.createLocal();
+      worker = await W.create({
+        connection: env.nativeConnection,
+        taskQueue: TASK_QUEUE,
+        workflowsPath: WORKFLOWS_PATH,
+        activities: createMockActivities(),
+        dataConverter: {
+          payloadCodecs: [
+            new EncryptionPayloadCodec({
+              primary: { keyId: "tripwire-key", key: randomBytes(32) },
+            }),
+          ],
+        },
+      });
+      workerRunPromise = worker.run();
+      envReady = true;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Temporal test server unavailable (tests will be skipped): ${msg}`);
+      envReady = false;
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    if (worker) {
+      worker.shutdown();
+      await workerRunPromise?.catch(() => {});
+    }
+    if (env) await env.teardown();
+  }, 30_000);
+
+  it("records no plaintext secret bytes anywhere in workflow history", async () => {
+    if (!envReady || !env) return;
+
+    const workflowId = `tripwire-${Date.now()}`;
+    // The starting client has NO codec, mirroring the Java/Go
+    // orchestrators: the slim input is plaintext and the void result must
+    // be readable without a key.
+    const result = await env.client.workflow.execute(
+      "stigmer/workflow/execute-from-execution",
+      {
+        taskQueue: TASK_QUEUE,
+        workflowId,
+        args: [
+          {
+            execution_id: "tripwire-exec",
+            workflow_instance_id: "",
+            workflow_id: "tripwire-wf",
+            org_id: "tripwire-org",
+          },
+        ],
+        workflowExecutionTimeout: "30s",
+      },
+    );
+    expect(result).toBeUndefined();
+
+    // Fetch the RAW history (no codec on this read — we want the bytes
+    // exactly as Temporal persisted them).
+    const secretBytes = Buffer.from(SECRET);
+    const byteFields: Uint8Array[] = [];
+    let encryptedPayloadCount = 0;
+    let completedResultHasData = false;
+
+    let nextPageToken: Uint8Array | undefined;
+    do {
+      const response = await env.client.workflowService.getWorkflowExecutionHistory({
+        namespace: "default",
+        execution: { workflowId },
+        nextPageToken,
+      });
+      for (const event of response.history?.events ?? []) {
+        collectByteFields(event, byteFields);
+
+        const completed = event.workflowExecutionCompletedEventAttributes;
+        if (completed?.result?.payloads?.some((p) => p.data && p.data.length > 0)) {
+          completedResultHasData = true;
+        }
+      }
+      encryptedPayloadCount += countEncryptedEncodings(response.history?.events ?? []);
+      nextPageToken =
+        response.nextPageToken && response.nextPageToken.length > 0
+          ? response.nextPageToken
+          : undefined;
+    } while (nextPageToken);
+
+    // The tripwire itself: the secret must not appear in any byte field
+    // of any history event — payload data, marker details, anywhere.
+    expect(byteFields.length).toBeGreaterThan(0);
+    for (const bytes of byteFields) {
+      expect(Buffer.from(bytes).includes(secretBytes)).toBe(false);
+    }
+
+    // Sanity: encryption was actually active (otherwise this test would
+    // pass vacuously against a broken codec setup).
+    expect(encryptedPayloadCount).toBeGreaterThan(0);
+
+    // Cross-language completion contract: void result, no data payload.
+    expect(completedResultHasData).toBe(false);
+  }, 60_000);
+});
+
+function countEncryptedEncodings(events: unknown[]): number {
+  let count = 0;
+  const encodings: Uint8Array[] = [];
+  for (const event of events) {
+    collectEncodingMetadata(event, encodings);
+  }
+  for (const encoding of encodings) {
+    if (Buffer.from(encoding).toString("utf-8") === "binary/encrypted") count++;
+  }
+  return count;
+}
+
+function collectEncodingMetadata(value: unknown, out: Uint8Array[]): void {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectEncodingMetadata(item, out);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  const metadata = record["metadata"];
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    const encoding = (metadata as Record<string, unknown>)["encoding"];
+    if (encoding instanceof Uint8Array) out.push(encoding);
+  }
+  for (const item of Object.values(record)) collectEncodingMetadata(item, out);
+}

--- a/backend/services/runner/src/claimcheck/payload-codec.ts
+++ b/backend/services/runner/src/claimcheck/payload-codec.ts
@@ -22,6 +22,14 @@ interface ClaimcheckMarker {
   key: string;
   size: number;
   compressed: boolean;
+  /**
+   * The relocated payload's original metadata, base64-encoded per value.
+   * Without it the restored payload would carry the marker's own
+   * "binary/claimcheck" encoding and no payload converter could interpret
+   * it. Absent on markers written before this field existed; those decode
+   * with the legacy (metadata-less) behavior.
+   */
+  metadata?: Record<string, string>;
 }
 
 export class ClaimcheckPayloadCodec implements PayloadCodec {
@@ -63,6 +71,7 @@ export class ClaimcheckPayloadCodec implements PayloadCodec {
       key,
       size: data.length,
       compressed,
+      metadata: serializeMetadata(payload.metadata),
     };
 
     return {
@@ -94,7 +103,9 @@ export class ClaimcheckPayloadCodec implements PayloadCodec {
     const dataBuf = marker.compressed ? decompress(rawBuf) : rawBuf;
 
     return {
-      metadata: payload.metadata,
+      metadata: marker.metadata
+        ? deserializeMetadata(marker.metadata)
+        : payload.metadata,
       data: dataBuf,
     };
   }
@@ -104,4 +115,25 @@ export class ClaimcheckPayloadCodec implements PayloadCodec {
     if (!encoding) return false;
     return Buffer.from(encoding).toString("utf-8") === MARKER_ENCODING_VALUE;
   }
+}
+
+function serializeMetadata(
+  metadata: Payload["metadata"],
+): Record<string, string> | undefined {
+  if (!metadata) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value) out[key] = Buffer.from(value).toString("base64");
+  }
+  return out;
+}
+
+function deserializeMetadata(
+  metadata: Record<string, string>,
+): Record<string, Uint8Array> {
+  const out: Record<string, Uint8Array> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    out[key] = Buffer.from(value, "base64");
+  }
+  return out;
 }

--- a/backend/services/runner/src/encryption/config.ts
+++ b/backend/services/runner/src/encryption/config.ts
@@ -1,0 +1,91 @@
+/**
+ * Payload-encryption configuration (stigmer-cloud#227).
+ *
+ * Encryption is enabled iff STIGMER_PAYLOAD_ENCRYPTION_KEY is present —
+ * the same enabled-iff-configured pattern as the claim-check codec. A
+ * malformed key fails the boot rather than silently running plaintext:
+ * an operator who set the key intended history to be encrypted.
+ *
+ * Key rotation: payloads carry the id of the key that encrypted them.
+ * During a rotation window the previous key stays readable via
+ * STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY(_ID) while new payloads are
+ * written under the primary key.
+ */
+
+export interface EncryptionKey {
+  readonly keyId: string;
+  /** 32-byte AES-256 key. */
+  readonly key: Buffer;
+}
+
+export interface PayloadEncryptionConfig {
+  /** Key used to encrypt outgoing payloads (and decrypt its own). */
+  readonly primary: EncryptionKey;
+  /** Decrypt-only key accepted during rotation windows. */
+  readonly secondary?: EncryptionKey;
+}
+
+const KEY_ENV = "STIGMER_PAYLOAD_ENCRYPTION_KEY";
+const KEY_ID_ENV = "STIGMER_PAYLOAD_ENCRYPTION_KEY_ID";
+const SECONDARY_KEY_ENV = "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY";
+const SECONDARY_KEY_ID_ENV = "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID";
+
+const AES_256_KEY_BYTES = 32;
+
+/**
+ * Returns the encryption config, or undefined when encryption is not
+ * configured (the codec is then simply not installed).
+ *
+ * @throws when a key is present but malformed, or a key id is missing —
+ *   key misconfiguration must stop the boot, not degrade to plaintext.
+ */
+export function loadPayloadEncryptionConfig(): PayloadEncryptionConfig | undefined {
+  const rawKey = process.env[KEY_ENV];
+  if (!rawKey) {
+    return undefined;
+  }
+
+  const primary: EncryptionKey = {
+    keyId: requireKeyId(KEY_ID_ENV),
+    key: parseKey(rawKey, KEY_ENV),
+  };
+
+  const rawSecondary = process.env[SECONDARY_KEY_ENV];
+  const secondary: EncryptionKey | undefined = rawSecondary
+    ? {
+        keyId: requireKeyId(SECONDARY_KEY_ID_ENV),
+        key: parseKey(rawSecondary, SECONDARY_KEY_ENV),
+      }
+    : undefined;
+
+  return { primary, secondary };
+}
+
+function requireKeyId(envName: string): string {
+  const keyId = process.env[envName];
+  // An explicit id is required (no default): during rotation two keys
+  // coexist, and payloads must name which one encrypted them.
+  if (!keyId) {
+    throw new Error(
+      `Payload encryption misconfigured: ${envName} is required when the ` +
+        `corresponding key is set`,
+    );
+  }
+  return keyId;
+}
+
+function parseKey(rawBase64: string, envName: string): Buffer {
+  let key: Buffer;
+  try {
+    key = Buffer.from(rawBase64, "base64");
+  } catch {
+    throw new Error(`Payload encryption misconfigured: ${envName} is not valid base64`);
+  }
+  if (key.length !== AES_256_KEY_BYTES) {
+    throw new Error(
+      `Payload encryption misconfigured: ${envName} must decode to ` +
+        `${AES_256_KEY_BYTES} bytes (AES-256), got ${key.length}`,
+    );
+  }
+  return key;
+}

--- a/backend/services/runner/src/encryption/index.ts
+++ b/backend/services/runner/src/encryption/index.ts
@@ -1,0 +1,3 @@
+export { EncryptionPayloadCodec } from "./payload-codec.js";
+export { loadPayloadEncryptionConfig } from "./config.js";
+export type { PayloadEncryptionConfig, EncryptionKey } from "./config.js";

--- a/backend/services/runner/src/encryption/payload-codec.ts
+++ b/backend/services/runner/src/encryption/payload-codec.ts
@@ -1,0 +1,144 @@
+/**
+ * Temporal PayloadCodec that encrypts payloads at rest in workflow
+ * history (stigmer-cloud#227).
+ *
+ * Why: the workflow engine runs inside the Temporal deterministic
+ * sandbox, so decrypted execution-context values cross the history
+ * boundary in many places — the hydrate activity result, the runtime
+ * env passed as an input to every per-task activity, and expression
+ * results recorded as local-activity markers. Encrypting at the payload
+ * codec layer closes the entire class with one mechanism instead of
+ * chasing each crossing.
+ *
+ * Envelope (cross-SDK contract — the Java decode-only codec in
+ * stigmer-cloud's temporal-starter must match it byte-for-byte, pinned
+ * by the conformance fixture in __tests__/fixtures/):
+ *
+ *   metadata: encoding            = "binary/encrypted"
+ *             encryption-key-id   = <key id that encrypted this payload>
+ *   data:     iv (12 bytes) ‖ AES-256-GCM(ciphertext ‖ tag (16 bytes))
+ *
+ * The plaintext is the serialized ORIGINAL Payload proto (metadata AND
+ * data), so decode restores the payload exactly — including its
+ * original encoding — with no side channel.
+ *
+ * Decode passes through payloads it did not encode. This is what keeps
+ * plaintext signals from the Java/Go orchestrators and pre-rollout
+ * in-flight histories working with zero migration. Everything else
+ * fails closed: unknown key id, missing key id, and ciphertext tampering
+ * all throw rather than surfacing bogus payloads.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import type { Payload, PayloadCodec } from "@temporalio/common";
+import { temporal } from "@temporalio/proto";
+import type { EncryptionKey, PayloadEncryptionConfig } from "./config.js";
+
+const ENCODING_METADATA_KEY = "encoding";
+const ENCRYPTED_ENCODING_VALUE = "binary/encrypted";
+const KEY_ID_METADATA_KEY = "encryption-key-id";
+
+/** AES-GCM parameters shared with the Java implementation. */
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+
+export class EncryptionPayloadCodec implements PayloadCodec {
+  private readonly decryptKeysById: Map<string, Buffer>;
+
+  constructor(private readonly config: PayloadEncryptionConfig) {
+    this.decryptKeysById = new Map([[config.primary.keyId, config.primary.key]]);
+    if (config.secondary) {
+      this.decryptKeysById.set(config.secondary.keyId, config.secondary.key);
+    }
+  }
+
+  async encode(payloads: Payload[]): Promise<Payload[]> {
+    return payloads.map((p) => this.encodePayload(p));
+  }
+
+  async decode(payloads: Payload[]): Promise<Payload[]> {
+    return payloads.map((p) => this.decodePayload(p));
+  }
+
+  private encodePayload(payload: Payload): Payload {
+    // Data-less payloads (binary/null from void results) stay as-is:
+    // there is nothing to protect, and the cross-language parents that
+    // await our workflows as void must be able to read them without a key.
+    if (!payload.data || payload.data.length === 0) {
+      return payload;
+    }
+
+    const plaintext = temporal.api.common.v1.Payload.encode(payload).finish();
+    return {
+      metadata: {
+        [ENCODING_METADATA_KEY]: Buffer.from(ENCRYPTED_ENCODING_VALUE),
+        [KEY_ID_METADATA_KEY]: Buffer.from(this.config.primary.keyId),
+      },
+      data: encrypt(plaintext, this.config.primary),
+    };
+  }
+
+  private decodePayload(payload: Payload): Payload {
+    if (!isEncryptedPayload(payload)) {
+      return payload;
+    }
+
+    const keyIdBytes = payload.metadata?.[KEY_ID_METADATA_KEY];
+    if (!keyIdBytes) {
+      throw new Error(
+        "Encrypted payload is missing its encryption-key-id metadata — refusing to decode",
+      );
+    }
+    const keyId = Buffer.from(keyIdBytes).toString("utf-8");
+    const key = this.decryptKeysById.get(keyId);
+    if (!key) {
+      throw new Error(
+        `Encrypted payload uses unknown key id '${keyId}' — configure it as the ` +
+          `primary or secondary payload encryption key (rotation window?)`,
+      );
+    }
+
+    const plaintext = decrypt(payload.data!, key, keyId);
+    return temporal.api.common.v1.Payload.decode(plaintext);
+  }
+}
+
+function isEncryptedPayload(payload: Payload): boolean {
+  const encoding = payload.metadata?.[ENCODING_METADATA_KEY];
+  if (!encoding) return false;
+  return Buffer.from(encoding).toString("utf-8") === ENCRYPTED_ENCODING_VALUE;
+}
+
+function encrypt(plaintext: Uint8Array, key: EncryptionKey): Buffer {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key.key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  // Layout iv ‖ ciphertext ‖ tag matches Java's AES/GCM/NoPadding, whose
+  // doFinal() output is ciphertext ‖ tag.
+  return Buffer.concat([iv, ciphertext, cipher.getAuthTag()]);
+}
+
+function decrypt(data: Uint8Array, key: Buffer, keyId: string): Buffer {
+  if (data.length < IV_BYTES + AUTH_TAG_BYTES) {
+    throw new Error(
+      `Encrypted payload under key id '${keyId}' is truncated (${data.length} bytes)`,
+    );
+  }
+  const buf = Buffer.from(data);
+  const iv = buf.subarray(0, IV_BYTES);
+  const ciphertext = buf.subarray(IV_BYTES, buf.length - AUTH_TAG_BYTES);
+  const tag = buf.subarray(buf.length - AUTH_TAG_BYTES);
+
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  try {
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    // GCM auth failure: tampered ciphertext or a key that does not match
+    // its advertised id. Never surface partially decrypted bytes.
+    throw new Error(
+      `Failed to decrypt payload under key id '${keyId}' — ciphertext is ` +
+        `corrupt or the configured key does not match`,
+    );
+  }
+}

--- a/backend/services/runner/src/payload-codecs.ts
+++ b/backend/services/runner/src/payload-codecs.ts
@@ -1,0 +1,56 @@
+/**
+ * Single assembly point for the worker's payload codec chain, shared by
+ * the standalone runner (runner.ts) and the runner manager
+ * (runner-manager.ts) so the two entrypoints cannot drift.
+ *
+ * Codec order is a correctness property, not a style choice. Temporal
+ * applies codecs in array order on encode and in reverse on decode, so
+ * with [encryption, claimcheck]:
+ *
+ *   encode: encrypt → claim-check   (payloads the claim-check codec
+ *           relocates to object storage are already ciphertext)
+ *   decode: claim-check → decrypt   (restore the blob, then decrypt)
+ */
+
+import type { PayloadCodec } from "@temporalio/common";
+import type { Config } from "./config.js";
+
+export async function createPayloadCodecs(
+  config: Config,
+): Promise<PayloadCodec[] | undefined> {
+  const codecs: PayloadCodec[] = [];
+
+  const { loadPayloadEncryptionConfig, EncryptionPayloadCodec } = await import(
+    "./encryption/index.js"
+  );
+  const encryptionConfig = loadPayloadEncryptionConfig();
+  if (encryptionConfig) {
+    codecs.push(new EncryptionPayloadCodec(encryptionConfig));
+    console.log(
+      `[runner] Payload encryption enabled (key_id=${encryptionConfig.primary.keyId}` +
+        (encryptionConfig.secondary
+          ? `, secondary_key_id=${encryptionConfig.secondary.keyId})`
+          : ")"),
+    );
+  }
+
+  const { loadClaimcheckConfig, ClaimcheckPayloadCodec } = await import(
+    "./claimcheck/index.js"
+  );
+  const claimcheckConfig = loadClaimcheckConfig();
+  if (claimcheckConfig.enabled) {
+    const { loadArtifactStorageConfig, createArtifactStorage } = await import(
+      "./shared/artifact-storage.js"
+    );
+    const storageConfig = loadArtifactStorageConfig(config);
+    const storage = createArtifactStorage(storageConfig);
+    codecs.push(new ClaimcheckPayloadCodec(storage, claimcheckConfig));
+    console.log(
+      `[runner] Claimcheck enabled (threshold=${claimcheckConfig.thresholdBytes}B, ` +
+        `compression=${claimcheckConfig.compressionEnabled}, ` +
+        `storage=${storageConfig.type})`,
+    );
+  }
+
+  return codecs.length > 0 ? codecs : undefined;
+}

--- a/backend/services/runner/src/runner-manager.ts
+++ b/backend/services/runner/src/runner-manager.ts
@@ -22,7 +22,6 @@ import {
   type InjectedSinks,
   type WorkflowBundleOption,
 } from "@temporalio/worker";
-import type { PayloadCodec } from "@temporalio/common";
 import type { Config } from "./config.js";
 import { DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS, DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS, DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS } from "./config.js";
 // Boot marks mirror the static runner's segment names where the work is the
@@ -354,7 +353,8 @@ export async function createStigmerRunnerManager(
       `[runner-manager] Artifact store: could not resolve config for boot log: ${err}`,
     );
   }
-  const payloadCodec = await createPayloadCodec(config);
+  const { createPayloadCodecs } = await import("./payload-codecs.js");
+  const payloadCodecs = await createPayloadCodecs(config);
 
   const connection = await NativeConnection.connect({
     address: config.temporalAddress,
@@ -399,9 +399,7 @@ export async function createStigmerRunnerManager(
       activities,
       workflowBundle,
       maxConcurrentActivityTaskExecutions: config.maxConcurrentActivities,
-      dataConverter: payloadCodec
-        ? { payloadCodecs: [payloadCodec] }
-        : undefined,
+      dataConverter: payloadCodecs?.length ? { payloadCodecs } : undefined,
       sinks: interceptorConfig.sinks,
       interceptors: interceptorConfig.interceptors,
     });
@@ -740,25 +738,6 @@ async function createAllActivities(config: Config): Promise<WorkerActivities> {
     ...createPromoteTaskOutputActivities(),
     ...createAttachSessionActivities(config),
   };
-}
-
-async function createPayloadCodec(
-  config: Config,
-): Promise<PayloadCodec | undefined> {
-  const { loadClaimcheckConfig, ClaimcheckPayloadCodec } = await import(
-    "./claimcheck/index.js"
-  );
-  const claimcheckConfig = loadClaimcheckConfig();
-  if (!claimcheckConfig.enabled) {
-    return undefined;
-  }
-
-  const { loadArtifactStorageConfig, createArtifactStorage } = await import(
-    "./shared/artifact-storage.js"
-  );
-  const storageConfig = loadArtifactStorageConfig(config);
-  const storage = createArtifactStorage(storageConfig);
-  return new ClaimcheckPayloadCodec(storage, claimcheckConfig);
 }
 
 interface InterceptorConfig {

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -15,7 +15,6 @@
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
-import type { PayloadCodec } from "@temporalio/common";
 import type { Config } from "./config.js";
 import { DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS, DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS, DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS } from "./config.js";
 import type { WorkerActivities } from "./worker.js";
@@ -305,10 +304,11 @@ export async function createStigmerRunner(
     );
   }
 
-  const payloadCodec = await createPayloadCodec(config);
+  const { createPayloadCodecs } = await import("./payload-codecs.js");
+  const payloadCodecs = await createPayloadCodecs(config);
 
   const { startWorker } = await import("./worker.js");
-  const worker = await startWorker({ config, activities, payloadCodec });
+  const worker = await startWorker({ config, activities, payloadCodecs });
   markBoot("worker_created");
 
   return {
@@ -456,28 +456,6 @@ async function createAllActivities(config: Config): Promise<WorkerActivities> {
     ...createPromoteTaskOutputActivities(),
     ...createAttachSessionActivities(config),
   };
-}
-
-async function createPayloadCodec(config: Config): Promise<PayloadCodec | undefined> {
-  const { loadClaimcheckConfig, ClaimcheckPayloadCodec } = await import("./claimcheck/index.js");
-  const claimcheckConfig = loadClaimcheckConfig();
-  if (!claimcheckConfig.enabled) {
-    return undefined;
-  }
-
-  const { loadArtifactStorageConfig, createArtifactStorage } = await import(
-    "./shared/artifact-storage.js"
-  );
-  const storageConfig = loadArtifactStorageConfig(config);
-  const storage = createArtifactStorage(storageConfig);
-
-  console.log(
-    `[runner] Claimcheck enabled (threshold=${claimcheckConfig.thresholdBytes}B, ` +
-      `compression=${claimcheckConfig.compressionEnabled}, ` +
-      `storage=${storageConfig.type})`,
-  );
-
-  return new ClaimcheckPayloadCodec(storage, claimcheckConfig);
 }
 
 function resolveDefaultWorkspaceDir(): string {

--- a/backend/services/runner/src/worker.ts
+++ b/backend/services/runner/src/worker.ts
@@ -27,11 +27,12 @@ export interface WorkerActivities {
 export interface StartWorkerOptions {
   config: Config;
   activities: WorkerActivities;
-  payloadCodec?: PayloadCodec;
+  /** Ordered codec chain from createPayloadCodecs (order is load-bearing). */
+  payloadCodecs?: PayloadCodec[];
 }
 
 export async function startWorker(opts: StartWorkerOptions): Promise<Worker> {
-  const { config, activities, payloadCodec } = opts;
+  const { config, activities, payloadCodecs } = opts;
 
   const connection = await NativeConnection.connect({
     address: config.temporalAddress,
@@ -89,9 +90,7 @@ export async function startWorker(opts: StartWorkerOptions): Promise<Worker> {
       ? { workflowBundle: { codePath: workflowSource.codePath } }
       : { workflowsPath: workflowSource.workflowsPath }),
     maxConcurrentActivityTaskExecutions: config.maxConcurrentActivities,
-    dataConverter: payloadCodec
-      ? { payloadCodecs: [payloadCodec] }
-      : undefined,
+    dataConverter: payloadCodecs?.length ? { payloadCodecs } : undefined,
     sinks,
     interceptors: {
       ...(activityInterceptors.length > 0 ? { activity: activityInterceptors } : {}),

--- a/backend/services/runner/src/workflows/execute-from-execution.ts
+++ b/backend/services/runner/src/workflows/execute-from-execution.ts
@@ -63,7 +63,7 @@ export interface ExecuteFromExecutionInput {
 
 export async function executeFromExecution(
   input: ExecuteFromExecutionInput,
-): Promise<unknown> {
+): Promise<void> {
   const { checkPause } = setupPauseResumeHandlers();
 
   log.info("Hydrating workflow execution from slim IDs", {
@@ -86,7 +86,17 @@ export async function executeFromExecution(
   });
 
   try {
-    return await runWorkflowEngine(materialized, {
+    // The engine's output is deliberately NOT returned. Both orchestrator
+    // parents discard this workflow's result (Java awaits it as Void, Go
+    // passes nil to Get), and the output already reaches users through
+    // PromoteTaskOutput and the event log. Returning it would (a) persist
+    // the full workflow output — which may embed secrets — as a plaintext
+    // payload in the cross-language parent's history, and (b) hand the Java
+    // parent a payload it must decode: once the payload-encryption codec is
+    // active, an encrypted result would fail Java's converter lookup
+    // (fromPayloads has no Void special-case). A void return produces a
+    // data-less binary/null payload that every SDK handles natively.
+    await runWorkflowEngine(materialized, {
       checkPause,
       recoveryMode: input.recovery_mode ?? false,
     });


### PR DESCRIPTION
## Summary

Adds an AES-256-GCM `PayloadCodec` to the runner's Temporal data converter so every payload the runner produces is encrypted at rest in workflow history. Fixes [stigmer-cloud#227](https://github.com/stigmer/stigmer-cloud/issues/227): decrypted execution-context secrets were recorded in durable Temporal history, visible in the Temporal UI.

Paired cloud PR (decode-only codec + key provisioning): [stigmer-cloud#300](https://github.com/stigmer/stigmer-cloud/pull/300).

## Context

The issue identified one leak (the `HydrateWorkflowExecution` activity result) and proposed a fetch-inside fix. Investigation found ~8 crossings, because the CNCF engine runs inline in the Temporal deterministic sandbox: the full env map is re-serialized as an INPUT on every per-task activity call (`CallHttp`/`CallGrpc`/`CallFunction`/`CallAgent`/`RunScript`/`RunShell`), `$env` expression results land in local-activity markers, and `state.output` crossed into the parent's history in plaintext. Fetch-inside cannot close the class — interpolated secrets would still reach history via markers and activity inputs. The codec closes every crossing with one mechanism.

## Changes

- **`src/encryption/`** — `EncryptionPayloadCodec` + config. Envelope: metadata `encoding: binary/encrypted` + `encryption-key-id`; data `iv(12) ‖ ciphertext ‖ tag(16)` over the serialized ORIGINAL Payload proto (metadata-preserving by construction). Enabled iff `STIGMER_PAYLOAD_ENCRYPTION_KEY`(+`_ID`) is set; decrypt-only secondary key for rotation windows; fail-closed on tamper, unknown key id, malformed key (boot failure, never silent plaintext).
- **`src/payload-codecs.ts`** — single codec-chain assembly shared by `runner.ts` and `runner-manager.ts` (replaces two duplicated `createPayloadCodec` functions). Order is load-bearing: encrypt before claim-check, so relocated R2 blobs are ciphertext.
- **`src/workflows/execute-from-execution.ts`** — returns void instead of `state.output`. Both orchestrator parents discard the value (Java `Void.class`, Go `Get(ctx, nil)`); output reaches users via `PromoteTaskOutput` + the event log. Closes the whole-output plaintext leak AND keeps the cross-language completion readable without a key (Temporal Java's `fromPayloads` has no Void special-case and throws on unknown encodings).
- **`src/claimcheck/payload-codec.ts`** — preserves the original payload metadata in the relocation marker (previously dropped: restored payloads carried `binary/claimcheck` encoding no converter could interpret — latent standalone bug, hard blocker for composition). Legacy markers decode with the old behavior.
- **README** — env-var documentation for the new codec.

## Implementation notes

- Decode passes through payloads the codec did not encrypt — plaintext inputs/signals from the Java/Go orchestrators and pre-rollout in-flight histories keep working with zero migration. No `patched()` gate needed: codecs operate on payload bytes below the determinism layer.
- The envelope is a cross-SDK wire contract. `src/__tests__/fixtures/encrypted-payload-fixture.json` is committed and decrypted by BOTH this repo's TS test and the Java decode-only twin's test in stigmer-cloud (byte-for-byte copy) — envelope drift fails CI on one side.
- Cloud rollout is key-gated and safe in any deploy order (sandboxes boot with encryption off until the shared Secret exists). Desktop runners and OSS enablement are deferred to #398 (per-runner persistent keys + the Go decode-only codec twin).

## Breaking changes

- None for orchestrators: both parents already discard the wrapper's result. The `stigmer/workflow/execute` direct entry (consumed by TS `run.workflow` tasks) still returns output.

## Test plan

- 13 codec unit tests (round-trip restores metadata+data, pass-through, data-less skip, tamper/unknown-key-id/missing-key-id fail closed, rotation decode, config fail-fast) + encryption⊕claim-check composition (blob is ciphertext) + claim-check metadata round-trip and legacy-marker decode.
- **Raw-history tripwire** (`history-encryption-e2e.test.ts`): runs a secret-bearing workflow against a real Temporal test server, scans every byte field of raw history — asserts the secret appears nowhere, encrypted payloads exist, and the completion result is data-less. Negative-controlled: the test FAILS with the codec removed.
- Full golden e2e regression suite passes (16 workflows). Full runner suite: 4095/4111 pass; the 11 file-level failures are the documented pre-existing #257 environment issue (`No such built-in module: node:sqlite` on Node 23.1) plus vitest worker RPC flakes — identical on pristine `main` (verified via stash).

## Risks

- Encrypted payloads are opaque in the Temporal UI until the codec-server follow-up ([stigmer-cloud#298](https://github.com/stigmer/stigmer-cloud/issues/298)) ships. Rollback: remove the key env — new payloads revert to plaintext; already-encrypted history remains readable as long as the key stays configured for decode.

## Checklist

- [x] Docs updated (runner README env contract)
- [x] Tests added/updated
- [x] Backward compatible (pass-through decode; key-gated enablement)

Made with [Cursor](https://cursor.com)