### PR TITLE
fix(runner): demote the "system" audit placeholder to the anonymous caller identity

### DIFF
--- a/backend/services/runner/src/shared/__tests__/caller-identity.test.ts
+++ b/backend/services/runner/src/shared/__tests__/caller-identity.test.ts
@@ -11,6 +11,7 @@ import {
   CALLER_IDENTITY_VALUE_ENV_KEY,
   SESSION_ID_ENV_KEY,
   STIGMER_USER_KIND,
+  SYSTEM_CREATOR_SENTINEL,
   anonymousCallerIdentity,
   injectAnonymousCallerIdentityForDiscovery,
   injectCallerIdentityEnv,
@@ -68,6 +69,30 @@ describe("resolveCallerIdentity precedence", () => {
       kind: ANONYMOUS_KIND,
       value: "",
     });
+  });
+
+  it('the "system" audit placeholder is never a caller — falls to anonymous (contract guard)', () => {
+    // The OSS server stamps created_by.id = "system" on every create (no
+    // local auth) and the cloud's AuditActorBuilder falls back to the
+    // same literal — one string shared by ALL such traffic. Presenting it
+    // would let a single MCP binding for "system" grant every one of
+    // those sessions, so it must resolve to the anonymous sentinel.
+    expect(resolveCallerIdentity(undefined, { id: SYSTEM_CREATOR_SENTINEL })).toEqual({
+      kind: ANONYMOUS_KIND,
+      value: "",
+    });
+    expect(resolveCallerIdentity({}, { id: " system ", email: "" })).toEqual({
+      kind: ANONYMOUS_KIND,
+      value: "",
+    });
+  });
+
+  it('a real email always wins — an account is never demoted for its id alone', () => {
+    // Email-first ordering: the sentinel check only ever sees creators
+    // that have no email, so a resolvable principal cannot be demoted.
+    expect(
+      resolveCallerIdentity(undefined, { id: SYSTEM_CREATOR_SENTINEL, email: "ops@example.com" }),
+    ).toEqual({ kind: STIGMER_USER_KIND, value: "ops@example.com" });
   });
 
   it("a half-present channel identity (value without kind) is NOT a channel sender", () => {

--- a/backend/services/runner/src/shared/caller-identity.ts
+++ b/backend/services/runner/src/shared/caller-identity.ts
@@ -10,8 +10,10 @@
  *   2. The session creator (`stigmer_user`) from the Session resource's
  *      audit actor — console/CLI sessions have no channel sender, but the
  *      platform knows exactly who created the session.
- *   3. The anonymous sentinel — discovery (no session exists) and sessions
- *      with no readable creator. Consumers must treat anonymous as a
+ *   3. The anonymous sentinel — discovery (no session exists), sessions
+ *      with no readable creator, and sessions whose creator is the
+ *      backend's "system" audit placeholder (not a principal — see
+ *      SYSTEM_CREATOR_SENTINEL). Consumers must treat anonymous as a
  *      first-class caller: answer tools/list, refuse tool calls.
  *
  * Injection is opt-in by construction: the values enter the env map used
@@ -54,6 +56,20 @@ export const STIGMER_USER_KIND = "stigmer_user";
  */
 export const ANONYMOUS_KIND = "anonymous";
 
+/**
+ * Audit-actor id that backends stamp when NO caller identity exists —
+ * the OSS server writes it on every create (no local auth), and the
+ * cloud's AuditActorBuilder falls back to it for caller-less internal
+ * writes. It names "nobody in particular": unrelated sessions from
+ * unrelated people all carry it, so presenting it as a caller identity
+ * would make the one string a grantable value that silently covers ALL
+ * such traffic in an MCP server's binding sheet. A creator matching this
+ * sentinel (and carrying no email) is therefore unresolvable and falls
+ * to anonymous — the deny-by-default the docs guide already promises
+ * for self-hosted backends.
+ */
+export const SYSTEM_CREATOR_SENTINEL = "system";
+
 /** The resolved caller identity. */
 export interface CallerIdentity {
   kind: string;
@@ -79,6 +95,12 @@ export function anonymousCallerIdentity(): CallerIdentity {
  * humans, and the audit actor's `id` field is historically mixed
  * (identity-account id vs email — see the proto's own @internal note).
  * Binding matchers should compare emails case-insensitively.
+ *
+ * A creator with no email whose id is the "system" audit placeholder is
+ * NOT a principal (see SYSTEM_CREATOR_SENTINEL) and resolves to
+ * anonymous. Email-first is deliberate here too: a real account that
+ * merely has "system" somewhere in its id is never demoted, because its
+ * email wins before the sentinel check runs.
  */
 export function resolveCallerIdentity(
   sessionMetadata: Record<string, string> | undefined,
@@ -90,10 +112,23 @@ export function resolveCallerIdentity(
   }
 
   const email = creator?.email?.trim();
+  if (email) {
+    return { kind: STIGMER_USER_KIND, value: email };
+  }
+
   const id = creator?.id?.trim();
-  const value = email || id;
-  if (value) {
-    return { kind: STIGMER_USER_KIND, value };
+  if (id === SYSTEM_CREATOR_SENTINEL) {
+    // Operator tripwire: identity-gated MCP tools will refuse this
+    // session; the fix is real caller attribution, never a "system" grant.
+    console.info(
+      `Session creator is the "${SYSTEM_CREATOR_SENTINEL}" audit placeholder ` +
+      `(no email) — not a resolvable principal; presenting the anonymous ` +
+      `caller identity to MCP servers`,
+    );
+    return anonymousCallerIdentity();
+  }
+  if (id) {
+    return { kind: STIGMER_USER_KIND, value: id };
   }
 
   return anonymousCallerIdentity();


### PR DESCRIPTION
## Summary

- `resolveCallerIdentity` now treats a session creator with **no email and id `"system"`** as unresolvable: it presents the **anonymous** caller identity to caller-identity-templating MCP servers instead of `(stigmer_user, "system")`.
- Why: the OSS server stamps `created_by.id = "system"` on every create (`defaults.go` — local auth is not implemented), so every session on every self-hosted install presented the identical bindable value. One MCP binding for the literal string `"system"` silently covered ALL local traffic from ALL users, present and future — a grantable sentinel.
- This makes the code honor two contracts we already published: the caller-identity docs guide ("On a self-hosted backend, scheduled runs present the `anonymous` identity") and DD-001's "OSS local sessions may lack audit actors → anonymous sentinel". No docs change is needed.
- Email-first ordering is untouched: a creator with a real email is never demoted, whatever its id. Each demotion logs a `console.info` as the operator tripwire.
- Companion cloud PR removes the last "system"-manufacturing arm on the cloud side and pins the machine-account caller-identity contract. Originating investigation: stigmer/stigmer-cloud#286.

## Breaking behavior note (release notes)

A self-hosted operator who — against the docs — wrote an MCP binding for the value `"system"` will see those calls arrive as `anonymous` and be refused after upgrading. This is deliberate fail-closed behavior; the demotion log line identifies affected sessions. The tracked path to identity-gated MCP tools from self-hosted is real local caller attribution: #400.

## Test plan

- [x] `caller-identity.test.ts`: new contract-guard cases — `"system"` id (trimmed too) → anonymous; email presence always wins over the sentinel check
- [x] Full runner suite in a clean worktree: typecheck clean, 4103 passed (4 unrelated load-flake timeouts in Temporal/sandbox suites; pass in isolation with and without this change)

Made with [Cursor](https://cursor.com)