### PR TITLE
fix(stigmer-server): seal pending_oauth_state handshake secrets at rest

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/complete_oauth_connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/complete_oauth_connect.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -10,6 +11,7 @@ import (
 	apiresourcekind "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
 )
 
 // CompleteOAuthConnect finishes the OAuth flow by exchanging the authorization
@@ -64,6 +66,19 @@ func (c *McpServerController) CompleteOAuthConnect(
 		return nil, grpclib.FailedPreconditionError(
 			"state parameter does not match the requested mcp_server_id",
 		)
+	}
+
+	// Unseal the handshake secrets that initiateOAuthConnect sealed at rest
+	// (oss#394), at the last moment before their only use. The row was
+	// consumed by GetAndDelete (single-use is atomic), so a decryption
+	// failure costs the user one re-initiate — the same posture as the
+	// expiry refusal; the error message points them there.
+	if err := unsealPendingOAuthState(c.encryptionService, pendingState); err != nil {
+		log.Error().Err(err).
+			Str("mcp_server_id", mcpServerID).
+			Msg("Failed to decrypt pending OAuth state secrets")
+		return nil, grpclib.InternalError(err,
+			"failed to decrypt OAuth handshake secrets — please retry the connect flow")
 	}
 
 	// Exchange authorization code for tokens
@@ -164,6 +179,39 @@ func (c *McpServerController) CompleteOAuthConnect(
 		TargetEnvVar:      pendingState.TargetEnvVar,
 		TokenLifetimeHint: auth.GetTokenLifetimeHint(),
 	}, nil
+}
+
+// unsealPendingOAuthState decrypts the secrets that sealPendingOAuthState
+// encrypted before the row rested (oss#394) — the read seam paired with the
+// write seam in initiate_oauth_connect.go.
+//
+// Decrypt dispatches on the value's own enc:v1: prefix and passes plaintext
+// through unchanged, which quietly covers every legacy shape: rows written
+// before the sealing release, rows written while encryption was disabled,
+// and the DCR path's deliberately empty client secret. No migration — the
+// table turns over in 10 minutes.
+//
+// A sealed row on a deployment whose key has since vanished fails here
+// (loudly, before any token-exchange attempt) rather than sending ciphertext
+// to the vendor's token endpoint.
+func unsealPendingOAuthState(svc *encryption.SecretService, state *oauth.PendingOAuthState) error {
+	if svc == nil {
+		return nil
+	}
+
+	verifier, err := svc.Decrypt(state.CodeVerifier)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt code_verifier: %w", err)
+	}
+	state.CodeVerifier = verifier
+
+	secret, err := svc.Decrypt(state.ClientSecret)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt client_secret: %w", err)
+	}
+	state.ClientSecret = secret
+
+	return nil
 }
 
 // resolveOrCreateManagedEnvironment checks whether an existing OAuthGrant

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_oauth_connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_oauth_connect.go
@@ -14,6 +14,7 @@ import (
 	oauthappv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/oauthapp/v1"
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -117,6 +118,12 @@ func (c *McpServerController) InitiateOAuthConnect(
 		AuthMethod:        authMethod,
 		RedirectURI:       c.oauthRedirectURI,
 		Org:               input.GetOrg(),
+	}
+
+	// Fail-closed: an encryption error fails the request; plaintext never
+	// reaches the store.
+	if err := sealPendingOAuthState(c.encryptionService, pendingState); err != nil {
+		return nil, grpclib.InternalError(err, "failed to encrypt OAuth handshake secrets")
 	}
 
 	if err := c.pendingOAuthStateStore.Save(ctx, pendingState); err != nil {
@@ -320,4 +327,49 @@ func generateState() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// sealPendingOAuthState encrypts the two real secrets in the pending row —
+// code_verifier (every flow) and client_secret (vendor flow) — before they
+// rest in SQLite, so handshake secrets never leak through filesystem backups
+// of the database (oss#394; ports stigmer-cloud#294). The store itself stays
+// a byte-faithful adapter; this call site is the single write seam.
+//
+// The row is a self-contained SNAPSHOT, never an alias of the OAuthApp's
+// stored ciphertext: initiateVendorOAuth decrypts the app's secret (failing
+// loudly if the key is unavailable), and the seal re-encrypts that plaintext
+// with a fresh nonce. The token exchange must use the credentials the
+// authorization code was minted for, not whatever a later resolution of the
+// OAuthApp would return.
+//
+// The DCR path's empty client secret stays empty — never ciphertext-of-"" —
+// so completeOAuthConnect and the token exchange keep seeing the emptiness
+// that means "public client".
+//
+// Disabled encryption (no key configured) passes plaintext through with a
+// WARN, matching the deployment-wide posture for environment, OAuthApp and
+// ChannelApp secrets under the same key (see the channelapp resolveSecret
+// step). A real encryption error while enabled is returned so the caller
+// fails the request instead of persisting plaintext.
+func sealPendingOAuthState(svc *encryption.SecretService, state *oauth.PendingOAuthState) error {
+	if svc == nil || !svc.IsEnabled() {
+		log.Warn().Msg("Encryption disabled: pending OAuth state secrets will be stored in plaintext")
+		return nil
+	}
+
+	sealedVerifier, err := svc.Encrypt(state.CodeVerifier)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt code_verifier: %w", err)
+	}
+	state.CodeVerifier = sealedVerifier
+
+	if state.ClientSecret != "" {
+		sealedSecret, err := svc.Encrypt(state.ClientSecret)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt client_secret: %w", err)
+		}
+		state.ClientSecret = sealedSecret
+	}
+
+	return nil
 }

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/oauth_connect_secrets_test.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/oauth_connect_secrets_test.go
@@ -1,0 +1,315 @@
+package mcpserver
+
+// Tests for the pending_oauth_state at-rest sealing (oss#394; the OSS twin
+// of stigmer-cloud#193 / cloud PR #294).
+//
+// The suite uses a real keyed SecretService over a real SQLite store —
+// actual encrypt/decrypt round-trips and raw-row assertions, never mock
+// echoes (the channelapp suite's precedent). The seal/unseal seams are
+// exercised directly where the full RPC would need a live environment
+// gRPC client; the vendor initiate path does no network I/O, so it is
+// covered end-to-end through the controller.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	oauthappv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/oauthapp/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+)
+
+// A real 32-byte key so seal/unseal round-trips are exercised for real
+// (mirrors the channelapp suite).
+var oauthSecretsTestKey = []byte("0123456789abcdef0123456789abcdef")
+
+type oauthSecretsHarness struct {
+	controller   *McpServerController
+	store        *sqlite.Store
+	pendingStore *oauth.PendingOAuthStateStore
+	secrets      *encryption.SecretService
+}
+
+// setupOAuthSecretsHarness wires a controller with the OAuth Connect
+// dependencies the way server.go does: SQLite-backed stores plus the shared
+// SecretService instance.
+func setupOAuthSecretsHarness(t *testing.T, secrets *encryption.SecretService) *oauthSecretsHarness {
+	t.Helper()
+
+	st, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	pendingStore, err := oauth.NewPendingOAuthStateStore(st.DB())
+	if err != nil {
+		t.Fatalf("failed to create pending state store: %v", err)
+	}
+	grantStore, err := oauth.NewOAuthGrantStore(st.DB())
+	if err != nil {
+		t.Fatalf("failed to create grant store: %v", err)
+	}
+
+	controller := NewMcpServerController(st)
+	controller.SetOAuthDependencies(grantStore, pendingStore, secrets, "http://127.0.0.1/oauth/callback")
+
+	return &oauthSecretsHarness{
+		controller:   controller,
+		store:        st,
+		pendingStore: pendingStore,
+		secrets:      secrets,
+	}
+}
+
+// saveVendorFixtures stores an OAuthApp (client secret encrypted at rest, as
+// the oauthapp controller would persist it) and an McpServer whose auth block
+// references it. Returns the McpServer ID and the OAuthApp's stored ciphertext.
+func saveVendorFixtures(t *testing.T, h *oauthSecretsHarness, plainClientSecret string) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	storedSecret := h.secrets.MustEncrypt(plainClientSecret)
+	app := &oauthappv1.OAuthApp{
+		Metadata: &apiresource.ApiResourceMetadata{
+			Id:   "oauthapp-testvendor",
+			Name: "Test Vendor",
+			Slug: "test-vendor",
+			Org:  "test-org",
+		},
+		Spec: &oauthappv1.OAuthAppSpec{
+			Provider:         "TestVendor",
+			ClientId:         "client-123",
+			ClientSecret:     storedSecret,
+			AuthorizationUrl: "https://vendor.example.com/oauth/authorize",
+			TokenUrl:         "https://vendor.example.com/oauth/token",
+			Scopes:           []string{"read"},
+		},
+	}
+	if err := h.store.SaveResource(ctx, apiresourcekind.ApiResourceKind_oauth_app, app.GetMetadata().GetId(), app); err != nil {
+		t.Fatalf("failed to save oauth app: %v", err)
+	}
+
+	mcpServerID := "mcpserver-vendor-test"
+	mcpServer := createTestMcpServer("vendor-oauth-server")
+	mcpServer.Metadata.Id = mcpServerID
+	mcpServer.Spec.Auth = &mcpserverv1.McpServerAuth{
+		OauthAppRef:  &apiresource.ApiResourceReference{Slug: "test-vendor"},
+		TargetEnvVar: "VENDOR_TOKEN",
+	}
+	if err := h.store.SaveResource(ctx, apiresourcekind.ApiResourceKind_mcp_server, mcpServerID, mcpServer); err != nil {
+		t.Fatalf("failed to save mcp server: %v", err)
+	}
+
+	return mcpServerID, storedSecret
+}
+
+// readPendingRowRaw reads the pending row exactly as it rests in SQLite,
+// bypassing the controllers — the at-rest truth the fix is about.
+func readPendingRowRaw(t *testing.T, h *oauthSecretsHarness, state string) (codeVerifier, clientSecret string) {
+	t.Helper()
+	err := h.store.DB().QueryRow(
+		`SELECT code_verifier, client_secret FROM pending_oauth_state WHERE state = ?`, state,
+	).Scan(&codeVerifier, &clientSecret)
+	if err != nil {
+		t.Fatalf("failed to read pending row: %v", err)
+	}
+	return codeVerifier, clientSecret
+}
+
+// TestInitiateVendorOAuth_SealsPendingSecretsAtRest runs the vendor initiate
+// path end-to-end (it does no network I/O) and asserts the row rests sealed.
+func TestInitiateVendorOAuth_SealsPendingSecretsAtRest(t *testing.T) {
+	secrets, err := encryption.NewSecretService(oauthSecretsTestKey)
+	if err != nil {
+		t.Fatalf("failed to create secret service: %v", err)
+	}
+	h := setupOAuthSecretsHarness(t, secrets)
+	const plainClientSecret = "super-secret-vendor-credential"
+	mcpServerID, appStoredCiphertext := saveVendorFixtures(t, h, plainClientSecret)
+
+	out, err := h.controller.InitiateOAuthConnect(context.Background(), &mcpserverv1.InitiateOAuthConnectInput{
+		McpServerId: mcpServerID,
+		Org:         "test-org",
+	})
+	if err != nil {
+		t.Fatalf("InitiateOAuthConnect failed: %v", err)
+	}
+
+	restingVerifier, restingSecret := readPendingRowRaw(t, h, out.GetState())
+
+	if !secrets.IsEncrypted(restingVerifier) {
+		t.Errorf("code_verifier must rest sealed, got %q", restingVerifier)
+	}
+	if !secrets.IsEncrypted(restingSecret) {
+		t.Errorf("client_secret must rest sealed, got %q", restingSecret)
+	}
+
+	// Snapshot, not alias: the pending row must carry its own ciphertext,
+	// never the OAuthApp's stored value.
+	if restingSecret == appStoredCiphertext {
+		t.Error("pending row aliases the OAuthApp's stored ciphertext instead of holding its own snapshot")
+	}
+
+	if got := secrets.MustDecrypt(restingSecret); got != plainClientSecret {
+		t.Errorf("sealed client_secret round-trip = %q, want %q", got, plainClientSecret)
+	}
+
+	// The sealed verifier must be THE verifier of this flow: its S256 hash
+	// must match the code_challenge that went to the authorization server.
+	authURL, err := url.Parse(out.GetAuthorizationUrl())
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+	challenge := authURL.Query().Get("code_challenge")
+	verifierHash := sha256.Sum256([]byte(secrets.MustDecrypt(restingVerifier)))
+	if got := base64.RawURLEncoding.EncodeToString(verifierHash[:]); got != challenge {
+		t.Errorf("sealed verifier does not match the flow's code_challenge: S256(verifier) = %q, challenge = %q", got, challenge)
+	}
+}
+
+// TestSealPendingOAuthState covers the write seam directly: the DCR shape
+// (empty client secret) and the disabled-encryption posture.
+func TestSealPendingOAuthState(t *testing.T) {
+	keyed, err := encryption.NewSecretService(oauthSecretsTestKey)
+	if err != nil {
+		t.Fatalf("failed to create secret service: %v", err)
+	}
+
+	t.Run("DCR empty client secret stays empty", func(t *testing.T) {
+		state := &oauth.PendingOAuthState{CodeVerifier: "verifier-abc", ClientSecret: ""}
+		if err := sealPendingOAuthState(keyed, state); err != nil {
+			t.Fatalf("seal failed: %v", err)
+		}
+		if !keyed.IsEncrypted(state.CodeVerifier) {
+			t.Errorf("code_verifier must be sealed, got %q", state.CodeVerifier)
+		}
+		if state.ClientSecret != "" {
+			t.Errorf("empty client_secret must stay empty (public client), got %q", state.ClientSecret)
+		}
+	})
+
+	t.Run("disabled encryption passes plaintext through", func(t *testing.T) {
+		// The deployment-wide posture when no key is configured (see the
+		// channelapp resolveSecret step): plaintext with a WARN, not a refusal.
+		disabled, err := encryption.NewSecretService(nil)
+		if err != nil {
+			t.Fatalf("failed to create disabled secret service: %v", err)
+		}
+		state := &oauth.PendingOAuthState{CodeVerifier: "verifier-abc", ClientSecret: "secret-xyz"}
+		if err := sealPendingOAuthState(disabled, state); err != nil {
+			t.Fatalf("seal failed: %v", err)
+		}
+		if state.CodeVerifier != "verifier-abc" || state.ClientSecret != "secret-xyz" {
+			t.Errorf("disabled encryption must pass values through, got verifier=%q secret=%q",
+				state.CodeVerifier, state.ClientSecret)
+		}
+	})
+
+	t.Run("nil service passes plaintext through", func(t *testing.T) {
+		state := &oauth.PendingOAuthState{CodeVerifier: "verifier-abc"}
+		if err := sealPendingOAuthState(nil, state); err != nil {
+			t.Fatalf("seal failed: %v", err)
+		}
+		if state.CodeVerifier != "verifier-abc" {
+			t.Errorf("nil service must pass values through, got %q", state.CodeVerifier)
+		}
+	})
+}
+
+// TestUnsealPendingOAuthState covers the read seam directly: sealed rows,
+// legacy plaintext rows, and corrupt ciphertext.
+func TestUnsealPendingOAuthState(t *testing.T) {
+	keyed, err := encryption.NewSecretService(oauthSecretsTestKey)
+	if err != nil {
+		t.Fatalf("failed to create secret service: %v", err)
+	}
+
+	t.Run("sealed row yields original plaintexts", func(t *testing.T) {
+		state := &oauth.PendingOAuthState{
+			CodeVerifier: keyed.MustEncrypt("verifier-abc"),
+			ClientSecret: keyed.MustEncrypt("secret-xyz"),
+		}
+		if err := unsealPendingOAuthState(keyed, state); err != nil {
+			t.Fatalf("unseal failed: %v", err)
+		}
+		if state.CodeVerifier != "verifier-abc" || state.ClientSecret != "secret-xyz" {
+			t.Errorf("unseal round-trip = verifier=%q secret=%q", state.CodeVerifier, state.ClientSecret)
+		}
+	})
+
+	t.Run("legacy plaintext row passes through", func(t *testing.T) {
+		// Rows written before the sealing release (or while encryption was
+		// disabled) must still complete — the zero-downtime guarantee.
+		state := &oauth.PendingOAuthState{CodeVerifier: "verifier-abc", ClientSecret: ""}
+		if err := unsealPendingOAuthState(keyed, state); err != nil {
+			t.Fatalf("unseal failed on legacy row: %v", err)
+		}
+		if state.CodeVerifier != "verifier-abc" || state.ClientSecret != "" {
+			t.Errorf("legacy row must pass through, got verifier=%q secret=%q",
+				state.CodeVerifier, state.ClientSecret)
+		}
+	})
+
+	t.Run("corrupt ciphertext errors loudly", func(t *testing.T) {
+		state := &oauth.PendingOAuthState{CodeVerifier: "enc:v1:%%%not-base64%%%"}
+		if err := unsealPendingOAuthState(keyed, state); err == nil {
+			t.Fatal("corrupt ciphertext must error, got nil")
+		}
+	})
+}
+
+// TestCompleteOAuthConnect_CorruptCiphertextFailsBeforeExchange pins the
+// short-circuit ordering: a row that cannot be unsealed must never reach the
+// vendor's token endpoint (ciphertext must not be sent as credentials).
+func TestCompleteOAuthConnect_CorruptCiphertextFailsBeforeExchange(t *testing.T) {
+	secrets, err := encryption.NewSecretService(oauthSecretsTestKey)
+	if err != nil {
+		t.Fatalf("failed to create secret service: %v", err)
+	}
+	h := setupOAuthSecretsHarness(t, secrets)
+	// Gives the controller a non-nil managedEnvService so CompleteOAuthConnect
+	// passes its dependency checks; the flow must fail before any use of it.
+	h.controller.SetConnectDependencies(nil, nil, nil, nil)
+
+	tokenEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("token endpoint must not be reached when the pending row cannot be unsealed")
+	}))
+	defer tokenEndpoint.Close()
+
+	ctx := context.Background()
+	const stateParam = "corrupt-row-state"
+	if err := h.pendingStore.Save(ctx, &oauth.PendingOAuthState{
+		State:         stateParam,
+		CodeVerifier:  "enc:v1:%%%not-base64%%%",
+		ClientID:      "client-123",
+		TokenEndpoint: tokenEndpoint.URL,
+		McpServerID:   "mcpserver-vendor-test",
+		AuthMethod:    "vendor_oauth",
+		RedirectURI:   "http://127.0.0.1/oauth/callback",
+	}); err != nil {
+		t.Fatalf("failed to save pending row: %v", err)
+	}
+
+	_, err = h.controller.CompleteOAuthConnect(ctx, &mcpserverv1.CompleteOAuthConnectInput{
+		McpServerId:       "mcpserver-vendor-test",
+		State:             stateParam,
+		AuthorizationCode: "auth-code-123",
+	})
+	if err == nil {
+		t.Fatal("CompleteOAuthConnect must fail on a corrupt row, got nil")
+	}
+	if !strings.Contains(err.Error(), "retry the connect flow") {
+		t.Errorf("error must guide the user to re-initiate (the row is consumed), got: %v", err)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/pending_state_store.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/pending_state_store.go
@@ -13,11 +13,15 @@ const pendingStateTTL = 10 * time.Minute
 
 // PendingOAuthState holds the ephemeral state between initiateOAuthConnect
 // and completeOAuthConnect. Expires after 10 minutes.
+//
+// CodeVerifier and ClientSecret rest sealed (enc:v1:) — the controllers
+// seal/unseal at their seams (oss#394); this store persists whatever bytes
+// it is handed, byte-faithfully.
 type PendingOAuthState struct {
 	State             string // Random, lookup key + CSRF protection
-	CodeVerifier      string // PKCE, needed for token exchange
+	CodeVerifier      string // PKCE, needed for token exchange; sealed at rest
 	ClientID          string // From DCR response or OAuthApp
-	ClientSecret      string // Empty for DCR/public clients; from OAuthApp for vendor OAuth
+	ClientSecret      string // Empty for DCR/public clients; from OAuthApp for vendor OAuth; sealed at rest when non-empty
 	TokenEndpoint     string // Discovered or from OAuthApp
 	McpServerID       string
 	IdentityAccountID string


### PR DESCRIPTION
## Summary

Seals the two real secrets in the OSS server's OAuth-connect handshake store — the PKCE `code_verifier` (every flow) and the vendor `client_secret` (vendor path) — with the existing `enc:v1` `SecretService` before they rest in the `pending_oauth_state` SQLite table, and unseals them at the last moment before the token exchange.

## Context

`initiateOAuthConnect` wrote both secrets in the clear; the server's `SecretService` (which already protects environment, OAuthApp, and channel-app secrets at rest, cf. #324) was never involved. Plaintext at rest outlives the 10-minute row lifetime through filesystem backups of the SQLite database. This is the OSS Go twin of [stigmer-cloud#193](https://github.com/stigmer/stigmer-cloud/issues/193), discovered while fixing it; the reference implementation is [stigmer-cloud#294](https://github.com/stigmer/stigmer-cloud/pull/294) and its shape ports directly.

## Changes

- **`initiate_oauth_connect.go`** — new `sealPendingOAuthState` seam between building the pending row and `Save`: encrypts `CodeVerifier` and non-empty `ClientSecret`. Fail-closed while encryption is enabled (an encryption error fails the request; plaintext never persists). The DCR path's empty client secret stays empty — never ciphertext-of-`""`.
- **`complete_oauth_connect.go`** — new `unsealPendingOAuthState` seam between `GetAndDelete` (and the state-match validation) and `ExchangeCode`. Corrupt ciphertext fails loudly **before** any token-exchange attempt, and the error message tells the user to retry the connect flow (the single-use row was already consumed — same posture as the expiry refusal).
- **`pending_state_store.go`** — doc comments only; the store stays a byte-faithful adapter (the controllers own the seal/unseal seams, matching the cloud repo-stays-byte-faithful doctrine).
- **`oauth_connect_secrets_test.go`** — new suite (9 cases), real keyed `SecretService` over real SQLite, raw-row at-rest assertions.

## Implementation notes

- **Snapshot, not alias**: the vendor path decrypts the OAuthApp's stored secret and the seal re-encrypts that plaintext with a fresh nonce — the pending row never carries the app's own ciphertext (the cloud#193 design lesson; the exchange must use the credentials the authorization code was minted for). Pinned by a test asserting the resting ciphertext differs from the OAuthApp's stored value.
- **Disabled-encryption posture**: seal-when-enabled, WARN-and-pass-through-when-disabled — verbatim the channelapp `resolveSecret` convention for the same class of secret under the same key. OSS deployments without a key keep working, consistent with every other secret holder.
- **Zero downtime, no migration**: `Decrypt` dispatches on the value's own `enc:v1:` prefix and passes plaintext through, so rows written before this release (or while encryption was disabled) still complete. The table turns over in 10 minutes.

## Breaking changes

- None.

## Test plan

- New `oauth_connect_secrets_test.go`: end-to-end vendor initiate (offline) asserting via raw SQL that both secrets rest as `enc:v1:` ciphertext, that the sealed secret is a snapshot (≠ the OAuthApp's stored ciphertext), that both round-trip, and that S256(unsealed verifier) equals the `code_challenge` sent to the authorization server; seal seam (DCR empty secret stays empty, disabled/nil service passes through); unseal seam (sealed round-trip, legacy plaintext pass-through, corrupt ciphertext errors); `CompleteOAuthConnect` short-circuit (corrupt row never reaches an `httptest` token endpoint).
- Full `stigmer-server` module: `go test -race ./...` — all packages green. `go build ./...`, `go vet`, `gofmt -s`, `go mod tidy` clean.
- NOT verified: a live end-to-end OAuth handshake against a real provider (needs a running deployment with a browser flow).

## Risks

- Low. The unseal pass-through covers all legacy row shapes, so a mixed-version window (rows written pre-deploy, completed post-deploy) works; the reverse window (sealed row, pre-deploy binary) cannot occur on a single-binary OSS install. Rollback is reverting the commit — sealed in-flight rows would then fail their handshake once (10-minute self-heal).

## Checklist

- [x] Docs updated (in-code contract docs; no user-facing docs describe this table)
- [x] Tests added/updated
- [x] Backward compatible

Closes #394

Made with [Cursor](https://cursor.com)