### PR TITLE
fix(server): reject ciphertext-shaped client input at every secret write boundary

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/channelapp/controller/channelapp_test.go
+++ b/backend/services/stigmer-server/pkg/domain/channelapp/controller/channelapp_test.go
@@ -235,6 +235,51 @@ func TestChannelAppController_CreateRefusesRedactionMarker(t *testing.T) {
 	}
 }
 
+// TestChannelAppController_RefusesCiphertextShapedSecrets pins the oss#395
+// boundary on the shared resolveSecret helper: a client-supplied enc:v<N>:
+// value must be refused with INVALID_ARGUMENT on create and update alike.
+// One field per arm suffices — every provider secret funnels through the
+// same helper, and TestRedactAndEncryptCoverEveryProviderArm keeps the arm
+// coverage honest.
+func TestChannelAppController_RefusesCiphertextShapedSecrets(t *testing.T) {
+	h := newTestHarness(t)
+
+	t.Run("slack create", func(t *testing.T) {
+		app := newSlackApp("Acme Slack App", "acme")
+		app.GetSpec().GetSlack().ClientSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ="
+
+		if _, err := h.controller.Create(appCtx(), app); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument for ciphertext-shaped client_secret, got %v", err)
+		}
+	})
+
+	t.Run("whatsapp create", func(t *testing.T) {
+		app := newWhatsAppApp("Acme WhatsApp App", "acme")
+		app.GetSpec().GetWhatsapp().AccessToken = "enc:v2:ZnV0dXJlLXZlcnNpb24="
+
+		if _, err := h.controller.Create(appCtx(), app); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument for ciphertext-shaped access_token, got %v", err)
+		}
+	})
+
+	t.Run("slack update", func(t *testing.T) {
+		created, err := h.controller.Create(appCtx(), newSlackApp("Acme Update App", "acme"))
+		if err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+
+		update := newSlackApp("Acme Update App", "acme")
+		update.Metadata.Id = created.GetMetadata().GetId()
+		update.Metadata.Slug = created.GetMetadata().GetSlug()
+		update.GetSpec().GetSlack().ClientSecret = RedactedMarker
+		update.GetSpec().GetSlack().SigningSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ="
+
+		if _, err := h.controller.Update(appCtx(), update); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument for ciphertext-shaped signing_secret on update, got %v", err)
+		}
+	})
+}
+
 func TestChannelAppController_UpdateMarkerPreservesPerField(t *testing.T) {
 	h := newTestHarness(t)
 

--- a/backend/services/stigmer-server/pkg/domain/channelapp/controller/steps.go
+++ b/backend/services/stigmer-server/pkg/domain/channelapp/controller/steps.go
@@ -34,6 +34,9 @@ const RedactedMarker = "***REDACTED***"
 //   - Update with the marker: preserves the existing encrypted value from
 //     the loaded resource. Independence matters: one request may rotate
 //     one secret while keeping the other.
+//   - A ciphertext-shaped (enc:v<N>:) value is refused on both create and
+//     update (oss#395): the prefix is server-reserved and clients only
+//     ever see redacted secrets.
 type encryptChannelAppSecretsStep struct {
 	secretService *encryption.SecretService
 	isCreate      bool
@@ -128,6 +131,10 @@ func (s *encryptChannelAppSecretsStep) encryptWhatsApp(
 }
 
 // resolveSecret computes the storage-ready value for one secret field.
+//
+// Arm order is load-bearing: the marker arm restores STORED ciphertext and
+// returns before the ciphertext-shape rejection, which therefore only ever
+// sees raw client input (oss#395).
 func (s *encryptChannelAppSecretsStep) resolveSecret(
 	ctx *pipeline.RequestContext[*channelappv1.ChannelApp],
 	fieldName string,
@@ -142,8 +149,12 @@ func (s *encryptChannelAppSecretsStep) resolveSecret(
 		return s.preserveExistingSecret(ctx, fieldName, readExisting)
 	}
 
-	if s.secretService.IsEncrypted(requestValue) {
-		return requestValue, nil
+	// Unconditional (not gated on IsEnabled): the enc:v<N>: prefix is
+	// server-reserved regardless of key state.
+	if encryption.IsCiphertextShaped(requestValue) {
+		return "", grpclib.InvalidArgumentError(
+			"%s must be plaintext — values carrying the 'enc:' "+
+				"encryption prefix are not accepted from clients", fieldName)
 	}
 
 	if !s.secretService.IsEnabled() {

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
@@ -18,8 +18,9 @@ import (
 // 3. CheckDuplicate - Verify no duplicate exists (slug-level)
 // 4. EnforcePersonalEnvUniqueness - At most one personal env per org
 // 5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
-// 6. Persist - Save environment to repository
-// 7. IndexSearch - Update search index
+// 6. PreserveRedactedSecrets - Reject secret sentinels (redaction marker, enc:v<N>: prefix)
+// 7. Persist - Save environment to repository
+// 8. IndexSearch - Update search index
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:
 // - Authorize step (no multi-tenant auth in OSS)
@@ -48,7 +49,8 @@ func (c *EnvironmentController) buildCreatePipeline() *pipeline.Pipeline[*enviro
 		AddStep(steps.NewCheckDuplicateStep[*environmentv1.Environment](c.store)).                                 // 3. Check duplicate
 		AddStep(domainSteps.NewEnforcePersonalUniquenessStep(c.store)).                                            // 4. At most one personal env per org
 		AddStep(steps.NewBuildNewStateStep[*environmentv1.Environment]()).                                         // 5. Build new state
-		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                        // 6. Persist environment
-		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 7. Update search index
+		AddStep(domainSteps.NewPreserveRedactedSecretsStep()).                                                     // 6. Reject secret sentinels (no existing resource: marker and enc: prefix both refused)
+		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                        // 7. Persist environment
+		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 8. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/environment_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/environment_controller_test.go
@@ -10,7 +10,10 @@ import (
 	apiresourceinterceptor "github.com/stigmer/stigmer/backend/libs/go/grpc/interceptors/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // contextWithEnvironmentKind creates a context with the environment resource kind injected
@@ -205,6 +208,137 @@ func TestEnvironmentController_Create(t *testing.T) {
 
 		if created.Spec.Data["EMPTY_VALUE"].Value != "" {
 			t.Error("Expected empty value to be preserved")
+		}
+	})
+}
+
+// newEnvWithData is a fixture helper for the secret-sentinel tests below.
+func newEnvWithData(name string, data map[string]*environmentv1.EnvironmentValue) *environmentv1.Environment {
+	return &environmentv1.Environment{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "Environment",
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name: name,
+			Org:  "test-org",
+		},
+		Spec: &environmentv1.EnvironmentSpec{Data: data},
+	}
+}
+
+// TestEnvironmentController_SecretSentinels pins the oss#395 write-boundary
+// contract across all three environment write pipelines. The harness runs
+// KEYLESS (NewSecretService(nil)), so passing here also proves the
+// rejection is unconditional — not gated on encryption being enabled.
+func TestEnvironmentController_SecretSentinels(t *testing.T) {
+	controller, store := setupTestController(t)
+	defer store.Close()
+	ctx := contextWithEnvironmentKind()
+
+	t.Run("create rejects ciphertext-shaped secret", func(t *testing.T) {
+		env := newEnvWithData("Smuggle Create", map[string]*environmentv1.EnvironmentValue{
+			"API_KEY": {Value: "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=", IsSecret: true},
+		})
+		if _, err := controller.Create(ctx, env); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("create rejects the redaction marker", func(t *testing.T) {
+		env := newEnvWithData("Marker Create", map[string]*environmentv1.EnvironmentValue{
+			"API_KEY": {Value: envsteps.RedactedMarker, IsSecret: true},
+		})
+		if _, err := controller.Create(ctx, env); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument (nothing to preserve on create), got %v", err)
+		}
+	})
+
+	t.Run("create accepts a non-secret value that merely looks prefixed", func(t *testing.T) {
+		// Deliberate exemption: every decrypt path gates on is_secret, so a
+		// non-secret prefixed string is inert; flipping it to secret later
+		// re-enters the guard.
+		env := newEnvWithData("Inert Create", map[string]*environmentv1.EnvironmentValue{
+			"DOCS_EXAMPLE": {Value: "enc:v1:just-an-example", IsSecret: false},
+		})
+		if _, err := controller.Create(ctx, env); err != nil {
+			t.Fatalf("non-secret prefixed value must be accepted, got %v", err)
+		}
+	})
+
+	t.Run("update rejects ciphertext-shaped secret", func(t *testing.T) {
+		created, err := controller.Create(ctx, newEnvWithData("Smuggle Update",
+			map[string]*environmentv1.EnvironmentValue{
+				"API_KEY": {Value: "real-secret", IsSecret: true},
+			}))
+		if err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+
+		created.Spec.Data["API_KEY"] = &environmentv1.EnvironmentValue{
+			Value: "enc:v2:ZnV0dXJlLXZlcnNpb24=", IsSecret: true}
+		if _, err := controller.Update(ctx, created); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("update marker still preserves the stored secret", func(t *testing.T) {
+		// Arm-ordering pin: the marker arm restores the STORED value and
+		// must run before the prefix rejection ever sees it.
+		created, err := controller.Create(ctx, newEnvWithData("Marker Update",
+			map[string]*environmentv1.EnvironmentValue{
+				"API_KEY": {Value: "original-secret", IsSecret: true},
+			}))
+		if err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+
+		created.Spec.Data["API_KEY"] = &environmentv1.EnvironmentValue{
+			Value: envsteps.RedactedMarker, IsSecret: true}
+		updated, err := controller.Update(ctx, created)
+		if err != nil {
+			t.Fatalf("marker update failed: %v", err)
+		}
+		if updated.Spec.Data["API_KEY"].GetValue() != "original-secret" {
+			t.Errorf("marker must preserve the stored secret, got %q",
+				updated.Spec.Data["API_KEY"].GetValue())
+		}
+	})
+
+	t.Run("updateVariables rejects ciphertext-shaped secret", func(t *testing.T) {
+		created, err := controller.Create(ctx, newEnvWithData("Smuggle Merge",
+			map[string]*environmentv1.EnvironmentValue{
+				"EXISTING": {Value: "keep-me", IsSecret: false},
+			}))
+		if err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+
+		_, err = controller.UpdateVariables(ctx, &environmentv1.UpdateEnvironmentVariablesRequest{
+			EnvironmentId: created.GetMetadata().GetId(),
+			Variables: map[string]*environmentv1.EnvironmentValue{
+				"API_KEY": {Value: "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=", IsSecret: true},
+			},
+		})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("updateVariables accepts a non-secret prefixed value", func(t *testing.T) {
+		created, err := controller.Create(ctx, newEnvWithData("Inert Merge",
+			map[string]*environmentv1.EnvironmentValue{
+				"EXISTING": {Value: "keep-me", IsSecret: false},
+			}))
+		if err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+
+		if _, err := controller.UpdateVariables(ctx, &environmentv1.UpdateEnvironmentVariablesRequest{
+			EnvironmentId: created.GetMetadata().GetId(),
+			Variables: map[string]*environmentv1.EnvironmentValue{
+				"DOCS_EXAMPLE": {Value: "enc:v1:just-an-example", IsSecret: false},
+			},
+		}); err != nil {
+			t.Fatalf("non-secret prefixed value must be accepted, got %v", err)
 		}
 	})
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/merge_variables_and_persist.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/merge_variables_and_persist.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	pipelinesteps "github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -58,6 +59,14 @@ func (s *mergeVariablesAndPersistStep) Execute(ctx *pipeline.RequestContext[*env
 			}
 			return grpclib.InvalidArgumentError(
 				"variable '%s': cannot use the redaction marker as a secret value", key)
+		}
+		// Ciphertext-shaped client input is rejected at every secret write
+		// boundary (oss#395); see preserveRedactedSecretsStep for the full
+		// rationale. Non-secret values are deliberately exempt (inert).
+		if val.GetIsSecret() && encryption.IsCiphertextShaped(val.GetValue()) {
+			return grpclib.InvalidArgumentError(
+				"variable '%s' must be plaintext — values carrying the 'enc:' "+
+					"encryption prefix are not accepted from clients", key)
 		}
 		env.Spec.Data[key] = val
 	}

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/preserve_redacted_secrets.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/preserve_redacted_secrets.go
@@ -6,6 +6,7 @@ import (
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	pipelinesteps "github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
 )
 
 // RedactedMarker is the sentinel string used by the response pipeline to
@@ -14,13 +15,29 @@ import (
 // secret" — not "store the literal marker".
 const RedactedMarker = "***REDACTED***"
 
-// preserveRedactedSecretsStep is a defense-in-depth step for the
-// Environment full-resource update pipeline. After BuildUpdateState
-// replaces the spec wholesale, this step detects any EnvironmentValue
-// whose value equals the redaction marker and restores the pre-update
-// encrypted value from the existing resource.
+// preserveRedactedSecretsStep handles client-supplied secret SENTINELS on
+// write — the mirror of the cloud edition's PreserveRedactedSecrets step,
+// serving both the create and full-resource update pipelines:
 //
-// Requires LoadExistingStep and BuildUpdateStateStep to have run first.
+//   - A secret whose incoming value is the ***REDACTED*** marker is
+//     restored from the existing resource (update). When there is nothing
+//     to preserve — a create, or an update for a key that had no prior
+//     secret — the marker is meaningless and rejected with
+//     INVALID_ARGUMENT rather than stored literally.
+//   - A secret carrying the ciphertext-shaped enc:v<N>: prefix is rejected
+//     with INVALID_ARGUMENT (oss#395): the prefix is server-reserved, so a
+//     prefixed request value is forged ciphertext or an attempt to plant a
+//     value that getSecretValue would later decrypt with the deployment
+//     key. The marker arm must run FIRST — after preservation, legitimate
+//     stored ciphertext is present by design and must not hit this arm.
+//   - Non-secret values pass through untouched. They are exempt from the
+//     prefix rejection deliberately: every decrypt path gates on
+//     is_secret && IsEncrypted, so a non-secret prefixed string is inert,
+//     and flipping it to secret later re-enters this guard.
+//
+// Runs while spec.data is still raw client input: after BuildUpdateState
+// (update; requires LoadExistingStep) or after BuildNewState (create,
+// where ExistingResourceKey is absent and every marker is rejected).
 type preserveRedactedSecretsStep struct{}
 
 func NewPreserveRedactedSecretsStep() *preserveRedactedSecretsStep {
@@ -37,32 +54,40 @@ func (s *preserveRedactedSecretsStep) Execute(ctx *pipeline.RequestContext[*envi
 		return nil
 	}
 
-	existingVal := ctx.Get(pipelinesteps.ExistingResourceKey)
-	existing, ok := existingVal.(*environmentv1.Environment)
-	if !ok || existing == nil {
-		return nil
-	}
-
-	existingData := existing.GetSpec().GetData()
-	if existingData == nil {
-		existingData = map[string]*environmentv1.EnvironmentValue{}
+	// Absent existing resource (the create pipeline) means there is nothing
+	// to preserve: fall through with an empty map so every marker is
+	// rejected instead of silently skipping the guards.
+	existingData := map[string]*environmentv1.EnvironmentValue{}
+	if existing, ok := ctx.Get(pipelinesteps.ExistingResourceKey).(*environmentv1.Environment); ok && existing != nil {
+		if data := existing.GetSpec().GetData(); data != nil {
+			existingData = data
+		}
 	}
 
 	preservedCount := 0
 	for key, val := range newState.Spec.Data {
-		if !val.GetIsSecret() || val.GetValue() != RedactedMarker {
+		if !val.GetIsSecret() {
 			continue
 		}
 
-		existingEntry, found := existingData[key]
-		if found && existingEntry.GetIsSecret() {
-			newState.Spec.Data[key] = existingEntry
-			preservedCount++
-			continue
+		if val.GetValue() == RedactedMarker {
+			existingEntry, found := existingData[key]
+			if found && existingEntry.GetIsSecret() {
+				newState.Spec.Data[key] = existingEntry
+				preservedCount++
+				continue
+			}
+			return grpclib.InvalidArgumentError(
+				"variable '%s': cannot use the redaction marker as a secret value", key)
 		}
 
-		return grpclib.InvalidArgumentError(
-			"variable '%s': cannot use the redaction marker as a secret value", key)
+		// Unconditional (not gated on encryption being enabled): the prefix
+		// is server-reserved regardless of key state.
+		if encryption.IsCiphertextShaped(val.GetValue()) {
+			return grpclib.InvalidArgumentError(
+				"variable '%s' must be plaintext — values carrying the 'enc:' "+
+					"encryption prefix are not accepted from clients", key)
+		}
 	}
 
 	if preservedCount > 0 {

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/managed_env.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/managed_env.go
@@ -91,7 +91,10 @@ func (s *ManagedEnvironmentService) DeleteManagedEnvironment(
 }
 
 // UpdateSecrets writes secret variables into a managed environment.
-// Values are passed as plaintext — the environment pipeline encrypts them.
+// Values must be plaintext (never enc:v<N>:-prefixed — the environment
+// pipeline rejects ciphertext-shaped input, oss#395) and are stored as
+// passed: the OSS environment pipeline does not encrypt at write time
+// (at-rest encryption for environment values is tracked separately).
 func (s *ManagedEnvironmentService) UpdateSecrets(
 	ctx context.Context,
 	environmentID string,

--- a/backend/services/stigmer-server/pkg/domain/oauthapp/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/oauthapp/controller/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "controller",
@@ -26,5 +26,23 @@ go_library(
         "//backend/services/stigmer-server/pkg/encryption",
         "@com_github_rs_zerolog//log",
         "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "controller_test",
+    srcs = ["oauthapp_secrets_test.go"],
+    embed = [":controller"],
+    deps = [
+        "//apis/stubs/go/ai/stigmer/commons/apiresource",
+        "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
+        "//apis/stubs/go/ai/stigmer/iam/oauthapp/v1:oauthapp",
+        "//backend/libs/go/grpc/interceptors/apiresource",
+        "//backend/libs/go/store",
+        "//backend/libs/go/store/sqlite",
+        "//backend/services/stigmer-server/pkg/domain/oauthapp/controller/steps",
+        "//backend/services/stigmer-server/pkg/encryption",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/backend/services/stigmer-server/pkg/domain/oauthapp/controller/oauthapp_secrets_test.go
+++ b/backend/services/stigmer-server/pkg/domain/oauthapp/controller/oauthapp_secrets_test.go
@@ -1,0 +1,171 @@
+package oauthapp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	oauthappv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/oauthapp/v1"
+	apiresourceinterceptor "github.com/stigmer/stigmer/backend/libs/go/grpc/interceptors/apiresource"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	oauthsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/oauthapp/controller/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// appCtx simulates the apiresource interceptor, which injects the RPC's
+// resource kind into the request context in production.
+func appCtx() context.Context {
+	return context.WithValue(context.Background(),
+		apiresourceinterceptor.ApiResourceKindKey, apiresourcekind.ApiResourceKind_oauth_app)
+}
+
+type testHarness struct {
+	store      store.Store
+	controller *OAuthAppController
+	secrets    *encryption.SecretService
+}
+
+// newTestHarness builds a controller over a real sqlite store with a real
+// 32-byte key so encrypt/redact round-trips are exercised for real (the
+// channelapp harness shape).
+func newTestHarness(t *testing.T) *testHarness {
+	t.Helper()
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	secrets, err := encryption.NewSecretService([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("failed to create secret service: %v", err)
+	}
+
+	return &testHarness{
+		store:      s,
+		controller: NewOAuthAppController(s, secrets),
+		secrets:    secrets,
+	}
+}
+
+func newOAuthApp(name, org string) *oauthappv1.OAuthApp {
+	return &oauthappv1.OAuthApp{
+		ApiVersion: "iam.stigmer.ai/v1",
+		Kind:       "OAuthApp",
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name: name,
+			Org:  org,
+		},
+		Spec: &oauthappv1.OAuthAppSpec{
+			Provider:         "github",
+			ClientId:         "client-id-1234",
+			ClientSecret:     "shh-client-secret",
+			AuthorizationUrl: "https://github.com/login/oauth/authorize",
+			TokenUrl:         "https://github.com/login/oauth/access_token",
+		},
+	}
+}
+
+// TestCreateRejectsCiphertextShapedClientSecret pins the oss#395 boundary:
+// a client-supplied enc:v<N>: client_secret must be refused with
+// INVALID_ARGUMENT, never stored verbatim (where a later decrypt would
+// treat it as genuine deployment-key ciphertext).
+func TestCreateRejectsCiphertextShapedClientSecret(t *testing.T) {
+	h := newTestHarness(t)
+
+	for _, smuggled := range []string{
+		"enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=",
+		"enc:v2:ZnV0dXJlLXZlcnNpb24=", // whole family, not just v1
+	} {
+		app := newOAuthApp("Acme GitHub App", "acme")
+		app.Spec.ClientSecret = smuggled
+
+		_, err := h.controller.Create(appCtx(), app)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Errorf("create with client_secret %q: expected InvalidArgument, got %v", smuggled, err)
+		}
+	}
+}
+
+func TestUpdateRejectsCiphertextShapedClientSecret(t *testing.T) {
+	h := newTestHarness(t)
+
+	created, err := h.controller.Create(appCtx(), newOAuthApp("Acme GitHub App", "acme"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	update := newOAuthApp("Acme GitHub App", "acme")
+	update.Metadata.Id = created.GetMetadata().GetId()
+	update.Metadata.Slug = created.GetMetadata().GetSlug()
+	update.Spec.ClientSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ="
+
+	if _, err := h.controller.Update(appCtx(), update); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for ciphertext-shaped client_secret on update, got %v", err)
+	}
+}
+
+// The rejection is unconditional: it must fire on a keyless deployment
+// too, or a deployment that later gains a key would wake up holding
+// smuggled "ciphertext".
+func TestKeylessCreateStillRejectsCiphertextShapedClientSecret(t *testing.T) {
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	keyless, _ := encryption.NewSecretService(nil)
+	controller := NewOAuthAppController(s, keyless)
+
+	app := newOAuthApp("Acme GitHub App", "acme")
+	app.Spec.ClientSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ="
+
+	if _, err := controller.Create(appCtx(), app); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument on keyless deployment, got %v", err)
+	}
+}
+
+// TestApplyRoundTripsWithMarker pins the arm ordering the rejection must
+// not break: get returns the ***REDACTED*** marker, applying it back
+// preserves the STORED ciphertext — which is enc:v1:-shaped by definition
+// and must be restored by the marker arm before the prefix arm can see it.
+func TestApplyRoundTripsWithMarker(t *testing.T) {
+	h := newTestHarness(t)
+
+	created, err := h.controller.Apply(appCtx(), newOAuthApp("Acme GitHub App", "acme"))
+	if err != nil {
+		t.Fatalf("apply-create failed: %v", err)
+	}
+	if created.GetSpec().GetClientSecret() != oauthsteps.RedactedMarker {
+		t.Fatalf("client_secret must be redacted in responses, got %q",
+			created.GetSpec().GetClientSecret())
+	}
+
+	fetched, err := h.controller.Get(appCtx(), &apiresource.ApiResourceId{
+		Value: created.GetMetadata().GetId()})
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if _, err := h.controller.Apply(appCtx(), fetched); err != nil {
+		t.Fatalf("apply-update with redacted secret failed: %v", err)
+	}
+
+	stored := &oauthappv1.OAuthApp{}
+	if err := h.store.GetResource(context.Background(),
+		apiresourcekind.ApiResourceKind_oauth_app,
+		created.GetMetadata().GetId(), stored); err != nil {
+		t.Fatalf("stored app not found: %v", err)
+	}
+	if !h.secrets.IsEncrypted(stored.GetSpec().GetClientSecret()) {
+		t.Errorf("stored client_secret must be encrypted, got %q",
+			stored.GetSpec().GetClientSecret())
+	}
+	if h.secrets.MustDecrypt(stored.GetSpec().GetClientSecret()) != "shh-client-secret" {
+		t.Error("apply round-trip must preserve the original client_secret")
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/oauthapp/controller/steps/encrypt_client_secret.go
+++ b/backend/services/stigmer-server/pkg/domain/oauthapp/controller/steps/encrypt_client_secret.go
@@ -25,7 +25,13 @@ const RedactedMarker = "***REDACTED***"
 //   - If the client sends RedactedMarker, copies the existing encrypted
 //     value from the loaded resource (ExistingResourceKey).
 //   - If the client sends a new plaintext value, encrypts it.
-//   - If the value is already encrypted, leaves it unchanged.
+//
+// On both, a ciphertext-shaped (enc:v<N>:) value is rejected (oss#395): the
+// prefix is server-reserved, clients only ever see redacted secrets, so a
+// prefixed request value is either forged ciphertext or an attempt to pin
+// the row to a format of the client's choosing. The marker arm must stay
+// FIRST — it restores stored ciphertext, which is legitimate and returns
+// before this check.
 //
 // The isCreate flag controls which mode is active.
 type encryptClientSecretStep struct {
@@ -70,8 +76,13 @@ func (s *encryptClientSecretStep) Execute(ctx *pipeline.RequestContext[*oauthapp
 		return s.preserveExistingSecret(ctx, app)
 	}
 
-	if s.secretService.IsEncrypted(clientSecret) {
-		return nil
+	// Unconditional (not gated on IsEnabled): the prefix is server-reserved
+	// regardless of key state — a keyless deployment that later gains a key
+	// must not wake up holding smuggled "ciphertext".
+	if encryption.IsCiphertextShaped(clientSecret) {
+		return grpclib.InvalidArgumentError(
+			"client_secret must be plaintext — values carrying the 'enc:' " +
+				"encryption prefix are not accepted from clients")
 	}
 
 	if !s.secretService.IsEnabled() {

--- a/backend/services/stigmer-server/pkg/encryption/encryption.go
+++ b/backend/services/stigmer-server/pkg/encryption/encryption.go
@@ -39,6 +39,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -53,6 +54,13 @@ const (
 	// This allows detection of encrypted values and supports future key rotation.
 	EncryptedPrefix = "enc:v1:"
 )
+
+// versionedPrefix matches ciphertext in ANY supported-or-future version of the
+// enc:v<N>: family. Matching all versions (not just v1) is load-bearing: an
+// unmatched version would be treated as plaintext at every dispatch site and
+// fail open (returned or re-encrypted as if it were a real value). Mirrors the
+// cloud edition's SecretEncryptionService.VERSIONED_PREFIX.
+var versionedPrefix = regexp.MustCompile(`^enc:v\d+:`)
 
 var (
 	// ErrInvalidKeySize is returned when the encryption key is not 32 bytes
@@ -127,6 +135,15 @@ func (s *SecretService) IsEnabled() bool {
 //
 // If encryption is disabled, returns the plaintext unchanged.
 // If the value is already encrypted, returns it unchanged.
+//
+// The idempotent pass-through below TRUSTS its callers: it exists for
+// store-restored ciphertext (the ***REDACTED*** round-trip copies stored
+// values back into the new state before this runs), which must survive a
+// second pass unchanged. It is NOT a safe place to validate provenance —
+// only the request pipeline knows whether a prefixed value came from the
+// store or from a client. Client-supplied enc:v<N>: input is rejected at
+// every write boundary via IsCiphertextShaped (oss#395); do not "fix"
+// smuggling here, it would break the marker round-trip.
 func (s *SecretService) Encrypt(plaintext string) (string, error) {
 	if !s.enabled {
 		return plaintext, nil
@@ -192,10 +209,31 @@ func (s *SecretService) Decrypt(encrypted string) (string, error) {
 	return string(plaintext), nil
 }
 
-// IsEncrypted checks if a value appears to be encrypted.
-// Detection is based on the version prefix.
+// IsEncrypted checks if a value appears to be encrypted, in any version of
+// the enc:v<N>: family.
+//
+// Use this instance method when dispatching on STORED values (decrypt,
+// preserve, re-encrypt). For validating CLIENT-SUPPLIED input at a request
+// boundary, use the package-level IsCiphertextShaped — same test, different
+// intent.
 func (s *SecretService) IsEncrypted(value string) bool {
-	return strings.HasPrefix(value, EncryptedPrefix)
+	return IsCiphertextShaped(value)
+}
+
+// IsCiphertextShaped reports whether a value merely has the SHAPE of
+// ciphertext — the enc:v<N>: prefix — regardless of whether it is genuine.
+//
+// This is the request-boundary provenance test (oss#395, the Go twin of
+// cloud#229): the prefix is a server-reserved sentinel, so client-supplied
+// values matching it must be rejected with INVALID_ARGUMENT before they
+// reach Encrypt, whose idempotent pass-through would otherwise persist them
+// verbatim (letting a client store forged ciphertext that getSecretValue
+// later decrypts with the deployment key, or pin a row to whatever format
+// the prefix claims). Package-level, like the redaction-marker constants,
+// so boundary steps need no service instance and the rejection stays
+// unconditional on keyless deployments.
+func IsCiphertextShaped(value string) bool {
+	return versionedPrefix.MatchString(value)
 }
 
 // MustEncrypt is like Encrypt but panics on error.

--- a/backend/services/stigmer-server/pkg/encryption/encryption_test.go
+++ b/backend/services/stigmer-server/pkg/encryption/encryption_test.go
@@ -142,7 +142,11 @@ func TestIsEncrypted(t *testing.T) {
 		{EncryptedPrefix + "base64data", true},
 		{"enc:v1:SGVsbG8gV29ybGQ=", true},
 		{"plaintext", false},
-		{"enc:v2:future-version", false}, // Different version
+		// Family-wide on purpose (oss#395): an unmatched future version
+		// would be treated as plaintext and fail OPEN at every dispatch
+		// site — returned verbatim on read, passed through on encrypt.
+		{"enc:v2:future-version", true},
+		{"enc:v99:whatever", true},
 		{"", false},
 		{"enc:", false},
 		{"enc:v1", false},
@@ -155,6 +159,44 @@ func TestIsEncrypted(t *testing.T) {
 				t.Errorf("IsEncrypted(%q) = %v, want %v", tt.value, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestIsCiphertextShaped(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"enc:v1:SGVsbG8=", true},
+		{"enc:v2:anything", true},
+		{"enc:v99:anything", true},
+		{"plaintext", false},
+		{"", false},
+		{"enc:v:missing-number", false},
+		{"enc:vX:not-a-number", false},
+		{" enc:v1:leading-space", false},        // prefix must be anchored
+		{"my secret enc:v1: mid-string", false}, // not a prefix
+		{"ENC:V1:upper", false},                 // the sentinel is lowercase
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := IsCiphertextShaped(tt.value); got != tt.expected {
+				t.Errorf("IsCiphertextShaped(%q) = %v, want %v", tt.value, got, tt.expected)
+			}
+		})
+	}
+}
+
+// A stored value in an unknown enc:v<N>: version must fail decrypt loudly
+// (ErrInvalidCiphertext), never be returned verbatim as if it were
+// plaintext — the fail-closed half of the family-wide IsEncrypted.
+func TestDecryptUnknownVersionFailsLoudly(t *testing.T) {
+	svc, _ := NewSecretService(testKey)
+
+	_, err := svc.Decrypt("enc:v2:c29tZS1mdXR1cmUtZm9ybWF0")
+	if err == nil {
+		t.Fatal("decrypting an unknown-version value must fail, not pass through")
 	}
 }
 

--- a/test/conformance/src/suites/environment.conformance.test.ts
+++ b/test/conformance/src/suites/environment.conformance.test.ts
@@ -310,6 +310,100 @@ describe("Environment conformance — redaction-marker preservation", () => {
       "redaction marker for a non-existent secret",
     );
   });
+
+  it("create rejects the redaction marker (nothing to preserve, InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+
+    await expectGrpcCode(
+      () =>
+        clients.environmentCommand.create(
+          makeEnvironment({
+            org,
+            name: uniqueName("env"),
+            data: { API_KEY: { value: REDACTED_MARKER, isSecret: true } },
+          }),
+        ),
+      Code.InvalidArgument,
+      "redaction marker on create",
+    );
+  });
+});
+
+describe("Environment conformance — ciphertext-shaped input rejection", () => {
+  // The enc:v<N>: prefix is a server-reserved encryption sentinel. A
+  // client-supplied secret carrying it is either forged ciphertext or an
+  // attempt to plant a value the server would later decrypt with its own
+  // key, so every write boundary rejects it (stigmer#395 / stigmer-cloud#229).
+  // Clients only ever see redacted secrets, so no legitimate round-trip
+  // sends a prefixed value.
+  const CIPHERTEXT_SHAPED = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
+
+  it("create rejects a ciphertext-shaped secret value (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+
+    await expectGrpcCode(
+      () =>
+        clients.environmentCommand.create(
+          makeEnvironment({
+            org,
+            name: uniqueName("env"),
+            data: { API_KEY: { value: CIPHERTEXT_SHAPED, isSecret: true } },
+          }),
+        ),
+      Code.InvalidArgument,
+      "ciphertext-shaped secret on create",
+    );
+  });
+
+  it("update rejects a ciphertext-shaped secret value (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createEnvironment(org, uniqueName("env"), {
+      data: { API_KEY: { value: "real-secret", isSecret: true } },
+    });
+    const { id } = created.metadata!;
+
+    await expectGrpcCode(
+      () =>
+        clients.environmentCommand.update({
+          apiVersion: ENVIRONMENT_API_VERSION,
+          kind: ENVIRONMENT_KIND,
+          metadata: { id, name: created.metadata!.name, org },
+          spec: makeEnvironmentSpec({ data: { API_KEY: { value: CIPHERTEXT_SHAPED, isSecret: true } } }),
+        }),
+      Code.InvalidArgument,
+      "ciphertext-shaped secret on update",
+    );
+  });
+
+  it("updateVariables rejects a ciphertext-shaped secret value (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createEnvironment(org, uniqueName("env"));
+    const { id } = created.metadata!;
+
+    await expectGrpcCode(
+      () =>
+        clients.environmentCommand.updateVariables({
+          environmentId: id,
+          variables: { API_KEY: { value: CIPHERTEXT_SHAPED, isSecret: true, description: "" } },
+        }),
+      Code.InvalidArgument,
+      "ciphertext-shaped secret on updateVariables",
+    );
+  });
+
+  it("accepts a NON-secret value that merely looks prefixed (deliberate exemption)", async () => {
+    // Every decrypt path gates on is_secret, so a non-secret prefixed string
+    // is inert — and flipping it to secret later re-enters the guard.
+    const { org } = await target.provisionTenancy();
+
+    const created = await createEnvironment(org, uniqueName("env"), {
+      data: { DOCS_EXAMPLE: { value: CIPHERTEXT_SHAPED, isSecret: false } },
+    });
+
+    expect(created.spec?.data?.DOCS_EXAMPLE?.value, "non-secret prefixed values pass through").toBe(
+      CIPHERTEXT_SHAPED,
+    );
+  });
 });
 
 describe("Environment conformance — incremental variable management", () => {


### PR DESCRIPTION
## Summary

Rejects client-supplied `enc:v<N>:`-shaped secret values with `INVALID_ARGUMENT` at every Go server write boundary — oauthapp `client_secret`, all five channelapp provider secrets, and environment create / update / updateVariables. This is the Go twin of stigmer-cloud#229 (cloud [PR #299](https://github.com/stigmer/stigmer-cloud/pull/299)), keeping the editions mirrored down to the step shape.

Closes #395

## Context

On keyed deployments (OSS auto-generates a key), the encryption facade's idempotent pass-through persisted any client value that merely *looked* encrypted. `getSecretValue` then decrypts it with the deployment's single static key — so ciphertext exfiltrated from the store (e.g. an oauthapp `client_secret` row) could be planted as an environment secret and read back as plaintext. The pass-through itself is load-bearing (the `***REDACTED***` marker round-trip re-feeds stored ciphertext through encrypt) and stays; provenance is validated where it can be known — the request boundaries.

## Changes

- **encryption**: package-level `IsCiphertextShaped` (matches the whole `enc:v<N>:` family, mirroring the cloud's static `isCiphertextShaped` intent split); instance `IsEncrypted` now delegates to it, so a stored unknown-version value fails decrypt loudly instead of passing through as fake plaintext; the pass-through in `Encrypt` carries the cloud's "do not fix smuggling here" warning.
- **oauthapp / channelapp**: the `IsEncrypted` skip arms in `encrypt_client_secret.go` and `resolveSecret` become unconditional rejections (not gated on `IsEnabled` — a keyless deployment that later gains a key must not wake up holding a smuggled oracle). Marker arms stay first: preserved stored ciphertext must never reach the prefix check.
- **environment**: `preserveRedactedSecretsStep` generalized into the sentinel-handling step for BOTH create and update (the cloud's single-step shape, whose javadoc cross-references this file): marker-preserve on update, marker-reject on create / no-prior-secret, prefix-reject on both; its silent skip when the existing resource was absent is now fail-closed. The create pipeline previously had NO sentinel guard at all (a literal `***REDACTED***` was stored verbatim — the same "lacked both guards" pattern cloud#229 found on setOrgOAuthApp). `merge_variables_and_persist.go` (updateVariables) grows the same rejection arm. Non-secret prefixed values are deliberately exempt: every decrypt path gates on `is_secret`, and a later flip-to-secret re-enters the guard.
- **managed_env.go**: corrected the false claim that "the environment pipeline encrypts" — it does not; discovered while auditing and filed as #405.
- **conformance**: environment suite pins the contract in both editions (cloud already rejects since PR #299): prefixed secret rejected on create/update/updateVariables, marker rejected on create, non-secret prefixed value accepted.

## Implementation notes

- Internal-writer audit (the issue's mandated verification) came back clean: DCR registers a *public* client (PKCE, no secret, client_id rests in the OAuthGrant store); channelapp has no internal writer; `update_visibility` bypasses the pipelines at the store layer; managed-env token writes pass vendor plaintext through the now-guarded updateVariables path.
- The oauthapp domain had zero tests; this PR adds its first suite (channelapp harness shape), including the marker round-trip pin that locks the arm ordering.

## Breaking changes

- Rows smuggled *before* this fix become un-round-trippable through full-resource update (the guard now rejects the prefixed value); the remedy is replacing the value. Same consequence the cloud fix accepted.
- Environment create with a literal `***REDACTED***` secret is now rejected instead of storing the marker verbatim (the stored marker was corrupt data, never a working secret).

## Test plan

- `go test -race ./backend/services/stigmer-server/...` — full module green (49 packages).
- New: `IsCiphertextShaped` table + family-wide `IsEncrypted` + loud unknown-version decrypt; oauthapp create/update/keyless rejections + marker round-trip; channelapp per-arm rejections; environment create/update/updateVariables rejections + marker preservation + non-secret exemption (keyless harness proves the rejection is unconditional).
- Conformance: `CONFORMANCE_TARGET=local-go` environment suite — 36/36 passing against the server built from this branch.

## Risks

- Low: rejection paths only fire on input no legitimate client sends (responses are always redacted, never ciphertext). Rollback is a straight revert.

Made with [Cursor](https://cursor.com)