### PR TITLE
fix(runner): resolve direct-mode LLM credentials through the backend seam (T03)

### DIFF
--- a/backend/services/runner/src/activities/__tests__/call-llm.test.ts
+++ b/backend/services/runner/src/activities/__tests__/call-llm.test.ts
@@ -5,6 +5,45 @@ import { _resetRegistryCache } from "../../shared/model-registry.js";
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
 
+const { vertexCreateRequests } = vi.hoisted(() => ({
+  vertexCreateRequests: [] as Array<Record<string, unknown>>,
+}));
+
+// Mocked at the SDK class (the vertex-adapter.test.ts pattern) so no real
+// google-auth credential resolution ever runs inside a unit test — locally
+// it fails fast, but in CI it can probe the GCE metadata server. ChatAnthropic
+// consumes the client's parsed event stream, so the streaming arm returns a
+// plain async generator of Anthropic stream events.
+vi.mock("@anthropic-ai/vertex-sdk", () => ({
+  AnthropicVertex: class {
+    readonly messages = {
+      create: async (request: Record<string, unknown>) => {
+        vertexCreateRequests.push(request);
+        if (request.stream === true) {
+          return (async function* () {
+            yield { type: "message_start", message: { id: "msg_vertex_call_llm", type: "message", role: "assistant", model: request.model, content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 11, output_tokens: 1 } } };
+            yield { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } };
+            yield { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Vertex direct." } };
+            yield { type: "content_block_stop", index: 0 };
+            yield { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 4 } };
+            yield { type: "message_stop" };
+          })();
+        }
+        return {
+          id: "msg_vertex_call_llm",
+          type: "message",
+          role: "assistant",
+          model: request.model,
+          content: [{ type: "text", text: "Vertex direct." }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 11, output_tokens: 4 },
+        };
+      },
+    };
+  },
+}));
+
 describe("callLlmAction", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
 
@@ -16,6 +55,12 @@ describe("callLlmAction", () => {
     delete process.env.STIGMER_TOKEN;
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+    // Deterministic regardless of the developer's shell: a leaked
+    // STIGMER_ANTHROPIC_BACKEND=vertex would reroute every direct-mode test.
+    delete process.env.STIGMER_ANTHROPIC_BACKEND;
+    delete process.env.STIGMER_OPENAI_BACKEND;
+    delete process.env.CLOUD_ML_REGION;
+    vertexCreateRequests.length = 0;
   });
 
   afterEach(() => {
@@ -231,6 +276,36 @@ describe("callLlmAction", () => {
       await expect(
         callLlmAction(baseAnthropicConfig, {}, "exec-1"),
       ).rejects.toThrow("ANTHROPIC_API_KEY");
+    });
+  });
+
+  describe("direct mode — Anthropic on the vertex backend", () => {
+    it("serves the call with no ANTHROPIC_API_KEY anywhere (ADC is the credential path)", async () => {
+      // The regression pin for the backend-blind key check: a correctly
+      // configured Vertex deployment holds no Anthropic key, and llm_call
+      // tasks must not fail with LLM_MISSING_API_KEY before construction.
+      process.env.STIGMER_ANTHROPIC_BACKEND = "vertex";
+      process.env.CLOUD_ML_REGION = "global";
+      mockFetchWithRegistry(() => {
+        throw new Error("unexpected fetch: vertex traffic must go through the SDK client");
+      });
+
+      const result = await callLlmAction(baseAnthropicConfig, {}, "exec-1");
+
+      expect(result.result).toBe("Vertex direct.");
+      expect(result.provider).toBe("anthropic");
+      expect(result.input_tokens).toBe(11);
+      expect(result.output_tokens).toBe(4);
+      expect(vertexCreateRequests.length).toBeGreaterThan(0);
+    });
+
+    it("keeps the LLM_MISSING_API_KEY contract on the public backend, now naming the backend remedy", async () => {
+      const err = await callLlmAction(baseAnthropicConfig, {}, "exec-1").catch((e: unknown) => e as Error & { type?: string });
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as { type?: string }).type).toBe("LLM_MISSING_API_KEY");
+      expect((err as Error).message).toContain("ANTHROPIC_API_KEY");
+      expect((err as Error).message).toContain("STIGMER_ANTHROPIC_BACKEND=vertex");
     });
   });
 

--- a/backend/services/runner/src/activities/__tests__/classify-tool-approvals.test.ts
+++ b/backend/services/runner/src/activities/__tests__/classify-tool-approvals.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ClassifyToolApprovalsInput, ToolDescriptor } from "../classify-tool-approvals.js";
 
 vi.mock("../../idle-watchdog.js", () => ({
@@ -595,6 +595,122 @@ describe("ClassifyToolApprovals activity", () => {
       const lastCall = vi.mocked(ChatOpenAI).mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
       const headers = (lastCall?.configuration as Record<string, unknown>)?.defaultHeaders as Record<string, string>;
       expect(headers).not.toHaveProperty("X-Stigmer-Mcp-Server-Id");
+    });
+  });
+
+  describe("direct mode (no proxy)", () => {
+    // The regression suite for the stigmerBackendEndpoint-as-LLM-proxy bug:
+    // an unproxied runner must call the provider directly with the real key,
+    // and must fail closed with one clear message when it has none.
+    const directOptions = { proxyEndpoint: null, stigmerToken: null, primaryModel: "gpt-4.1" };
+
+    beforeEach(() => {
+      // Deterministic regardless of the developer's shell: blank reads as
+      // missing, and backend/proxy vars must not leak in from outside.
+      vi.stubEnv("OPENAI_API_KEY", "");
+      vi.stubEnv("ANTHROPIC_API_KEY", "");
+      vi.stubEnv("STIGMER_ANTHROPIC_BACKEND", "");
+      vi.stubEnv("STIGMER_OPENAI_BACKEND", "");
+      vi.stubEnv("STIGMER_PROXY_ENDPOINT", "");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("fails closed without any credential path: every tool gated, no client constructed", async () => {
+      const { ChatAnthropic } = await import("@langchain/anthropic");
+      const { ChatOpenAI } = await import("@langchain/openai");
+      const { classifyTools } = await import("../classify-tool-approvals.js");
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const tools: ToolDescriptor[] = [
+        { name: "search_code", description: "Search code" },
+        { name: "delete_file", description: "Delete a file" },
+      ];
+
+      const result = await classifyTools(
+        { tools, serverName: "github", serverDescription: "GitHub", mcpServerId: null },
+        directOptions,
+      );
+
+      expect(result).toEqual([
+        { tool_name: "search_code", requires_approval: true, message: "Execute search_code" },
+        { tool_name: "delete_file", requires_approval: true, message: "Execute delete_file" },
+      ]);
+      expect(ChatOpenAI).not.toHaveBeenCalled();
+      expect(ChatAnthropic).not.toHaveBeenCalled();
+      expect(mockInvoke).not.toHaveBeenCalled();
+      // The message must name the model and provider (classification's
+      // provider follows the economy model, not the operator's key) and
+      // carry the predicate's remedy text.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("'gpt-4o-mini' (openai)"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("OPENAI_API_KEY"));
+      warn.mockRestore();
+    });
+
+    it("uses the provider key directly — no proxy baseURL, no Authorization header", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "sk-direct-test");
+      const { ChatOpenAI } = await import("@langchain/openai");
+      const { classifyTools } = await import("../classify-tool-approvals.js");
+
+      mockInvoke.mockResolvedValueOnce({
+        approvals: [{ tool_name: "t", requires_approval: false, message: "" }],
+      });
+
+      const result = await classifyTools(
+        { tools: [{ name: "t", description: "d" }], serverName: "s", serverDescription: "", mcpServerId: null },
+        directOptions,
+      );
+
+      expect(result).toEqual([]);
+      const args = vi.mocked(ChatOpenAI).mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(args.apiKey).toBe("sk-direct-test");
+      // The bug this suite pins: the gRPC control-plane endpoint must never
+      // reappear as a baseURL/Authorization transport override.
+      expect(args).not.toHaveProperty("configuration");
+    });
+
+    it("routes an Anthropic economy model directly through ChatAnthropic with the real key", async () => {
+      vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-direct");
+      const { ChatAnthropic } = await import("@langchain/anthropic");
+      const { getSummarizationModel } = await import("../../shared/model-registry.js");
+      vi.mocked(getSummarizationModel).mockResolvedValueOnce("claude-haiku-4.5");
+      const { classifyTools } = await import("../classify-tool-approvals.js");
+
+      mockInvoke.mockResolvedValueOnce({
+        approvals: [{ tool_name: "t", requires_approval: false, message: "" }],
+      });
+
+      await classifyTools(
+        { tools: [{ name: "t", description: "d" }], serverName: "s", serverDescription: "", mcpServerId: null },
+        directOptions,
+      );
+
+      const args = vi.mocked(ChatAnthropic).mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(args.apiKey).toBe("sk-ant-direct");
+      expect(args).not.toHaveProperty("clientOptions");
+    });
+
+    it("defers an un-inferable economy model to the per-batch fail-closed path", async () => {
+      // Real scenario: the registry-empty fallback returns the primary model
+      // verbatim (model-registry.ts), whatever its name. The pre-check must
+      // not guess a provider — the batch path owns the precise error.
+      const { getSummarizationModel } = await import("../../shared/model-registry.js");
+      vi.mocked(getSummarizationModel).mockResolvedValueOnce("mystery-model");
+      const { classifyTools } = await import("../classify-tool-approvals.js");
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await classifyTools(
+        { tools: [{ name: "t", description: "d" }], serverName: "s", serverDescription: "", mcpServerId: null },
+        directOptions,
+      );
+
+      expect(result).toEqual([
+        { tool_name: "t", requires_approval: true, message: "Execute t" },
+      ]);
+      expect(error).toHaveBeenCalled();
+      error.mockRestore();
     });
   });
 });

--- a/backend/services/runner/src/activities/call-llm.ts
+++ b/backend/services/runner/src/activities/call-llm.ts
@@ -31,6 +31,7 @@ import {
 import { computeLlmCostMicros, ensureLoaded as ensurePricingLoaded } from "../shared/model-pricing.js";
 import { resolveToApiModelId } from "../shared/model-registry.js";
 import { buildChatModel } from "../shared/model-client.js";
+import { checkDirectCredentials } from "../shared/llm-backend.js";
 import { classifyModelCallError } from "../shared/model-error.js";
 
 export interface LlmCallConfig {
@@ -169,23 +170,15 @@ export async function callLlmAction(
     `structured=${!!config.response_schema} execution=${executionId}`,
   );
 
-  // Direct mode (no proxy) requires the provider's own API key. Validated here
-  // rather than in buildChatModel so the shared module stays free of Temporal
-  // failure types.
+  // Direct mode (no proxy) requires a usable credential path — the provider's
+  // own API key, or a configured model backend that authenticates itself
+  // (vertex uses Google ADC; requiring an Anthropic key there would reject a
+  // correctly-configured deployment). Validated here rather than in
+  // buildChatModel so the shared module stays free of Temporal failure types.
   if (!proxyActive) {
-    if (provider === "openai" && !process.env.OPENAI_API_KEY) {
-      throw ApplicationFailure.nonRetryable(
-        `OPENAI_API_KEY is not set and no proxy is configured. ` +
-        `Set the API key in your environment or connect to a Stigmer Cloud deployment.`,
-        "LLM_MISSING_API_KEY",
-      );
-    }
-    if (provider === "anthropic" && !process.env.ANTHROPIC_API_KEY) {
-      throw ApplicationFailure.nonRetryable(
-        `ANTHROPIC_API_KEY is not set and no proxy is configured. ` +
-        `Set the API key in your environment or connect to a Stigmer Cloud deployment.`,
-        "LLM_MISSING_API_KEY",
-      );
+    const missing = checkDirectCredentials(provider);
+    if (missing !== null) {
+      throw ApplicationFailure.nonRetryable(missing, "LLM_MISSING_API_KEY");
     }
   }
 

--- a/backend/services/runner/src/activities/classify-tool-approvals.ts
+++ b/backend/services/runner/src/activities/classify-tool-approvals.ts
@@ -23,6 +23,8 @@ import { SystemMessage, HumanMessage } from "@langchain/core/messages";
 import { activityStarted, activityFinished } from "../idle-watchdog.js";
 import { getSummarizationModel } from "../shared/model-registry.js";
 import { buildChatModel } from "../shared/model-client.js";
+import { checkDirectCredentials } from "../shared/llm-backend.js";
+import { tryInferProvider } from "../shared/llm-proxy.js";
 import type { Config } from "../config.js";
 
 const BATCH_SIZE = 40;
@@ -149,7 +151,8 @@ Output one classification per tool, maintaining the input order.`;
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface ClassifyToolsOptions {
-  proxyEndpoint: string;
+  /** Null when the deployment has no proxy — the runner calls providers directly. */
+  proxyEndpoint: string | null;
   stigmerToken: string | null;
   primaryModel: string;
 }
@@ -165,6 +168,26 @@ export async function classifyTools(
   }
 
   const model = await getSummarizationModel(options.primaryModel);
+
+  // Direct mode with no credential path fails closed up front, with one
+  // actionable message instead of a provider 401 per batch. The message
+  // names the economy model and its provider because classification's
+  // provider follows the economy-model resolution, not the operator's key:
+  // "OPENAI_API_KEY is missing" is baffling to an operator holding an
+  // Anthropic key unless the log says which model classification wanted.
+  if (!options.proxyEndpoint) {
+    const provider = tryInferProvider(model);
+    const missing = provider === null ? null : checkDirectCredentials(provider);
+    if (missing !== null) {
+      console.warn(
+        `[ClassifyToolApprovals] Cannot classify ${tools.length} tool(s) for ` +
+        `'${serverName}': the classifier model '${model}' (${provider}) has no ` +
+        `credential path — failing closed, every tool requires approval until ` +
+        `a reconnect re-classifies it. ${missing}`,
+      );
+      return fallbackApprovals(tools);
+    }
+  }
 
   const batches: ToolDescriptor[][] = [];
   for (let i = 0; i < tools.length; i += BATCH_SIZE) {
@@ -236,7 +259,7 @@ interface ClassifyBatchParams {
   serverName: string;
   serverDescription: string;
   model: string;
-  proxyEndpoint: string;
+  proxyEndpoint: string | null;
   stigmerToken: string | null;
   mcpServerId: string | null;
   batchIdx: number;
@@ -256,7 +279,7 @@ async function classifyBatch(params: ClassifyBatchParams): Promise<ToolApprovalR
   // primary this routes to Claude, not the hardcoded OpenAI path it used to.
   const { model: llm } = await buildChatModel({
     modelName: model,
-    proxyEndpoint,
+    proxyEndpoint: proxyEndpoint ?? undefined,
     stigmerToken: stigmerToken ?? undefined,
     headerScope: { mcpServerId: mcpServerId ?? undefined },
     maxTokens,
@@ -388,8 +411,15 @@ export function createClassifyToolApprovalsActivities(config: Config) {
           `[ClassifyToolApprovals] Activity started: ${input.tools.length} tools for '${input.serverName}'`,
         );
 
+        // Only a real proxy is an LLM proxy. stigmerBackendEndpoint (the
+        // gRPC control plane) serves no /v1/proxy/llm route — coercing it
+        // into one here used to 404 every classification in unproxied OSS
+        // and silently disable the vertex backend for this activity. (The
+        // registry fetch legitimately falls back to the backend endpoint —
+        // see shared/registry-endpoint.ts — because the control plane DOES
+        // serve /v1/proxy/model-registry; that fallback does not port here.)
         return await classifyTools(input, {
-          proxyEndpoint: config.proxyEndpoint ?? config.stigmerBackendEndpoint,
+          proxyEndpoint: config.proxyEndpoint,
           stigmerToken: config.stigmerToken,
           primaryModel: config.primaryModel,
         });

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/extract-structured-output.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/extract-structured-output.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Config } from "../../../config.js";
+
+vi.mock("../../../shared/model-registry.js", () => ({
+  getEconomyModel: vi.fn().mockResolvedValue("gpt-4o-mini"),
+}));
+
+const mockInvoke = vi.fn();
+const mockWithStructuredOutput = vi.fn().mockReturnValue({ invoke: mockInvoke });
+
+vi.mock("../../../shared/model-client.js", () => ({
+  buildChatModel: vi.fn().mockResolvedValue({
+    model: { withStructuredOutput: (...args: unknown[]) => mockWithStructuredOutput(...args) },
+    provider: "openai",
+    apiModelId: "gpt-4o-mini",
+  }),
+}));
+
+// llm-backend.js and llm-proxy.js stay real: the pre-check behavior under
+// test IS their composition, and both are pure modules.
+
+const SCHEMA = { type: "object", properties: { answer: { type: "string" } } };
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    proxyEndpoint: null,
+    stigmerToken: null,
+    ...overrides,
+  } as Config;
+}
+
+describe("extractStructuredOutput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Deterministic regardless of the developer's shell: blank reads as
+    // missing, and backend vars must not leak in from outside.
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("STIGMER_ANTHROPIC_BACKEND", "");
+    vi.stubEnv("STIGMER_OPENAI_BACKEND", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("direct mode with a key builds a direct-mode model (no endpoint threaded)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-direct");
+    const { buildChatModel } = await import("../../../shared/model-client.js");
+    const { extractStructuredOutput } = await import("../extract-structured-output.js");
+    mockInvoke.mockResolvedValueOnce({ answer: "42" });
+
+    const result = await extractStructuredOutput("the answer is 42", SCHEMA, makeConfig(), "gpt-4.1");
+
+    expect(result).toEqual({ answer: "42" });
+    // The regression pin: the gRPC control-plane endpoint must never
+    // reappear here as a stand-in LLM proxy.
+    expect(buildChatModel).toHaveBeenCalledWith(
+      expect.objectContaining({ proxyEndpoint: undefined }),
+    );
+  });
+
+  it("throws the credential message before any construction when no path exists", async () => {
+    const { buildChatModel } = await import("../../../shared/model-client.js");
+    const { extractStructuredOutput } = await import("../extract-structured-output.js");
+
+    await expect(
+      extractStructuredOutput("text", SCHEMA, makeConfig(), "gpt-4.1"),
+    ).rejects.toThrow(/'gpt-4o-mini'.*OPENAI_API_KEY/s);
+    expect(buildChatModel).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("proxy mode threads the proxy endpoint and token, consulting no keys", async () => {
+    const { buildChatModel } = await import("../../../shared/model-client.js");
+    const { extractStructuredOutput } = await import("../extract-structured-output.js");
+    mockInvoke.mockResolvedValueOnce({ answer: "ok" });
+
+    const result = await extractStructuredOutput(
+      "text", SCHEMA,
+      makeConfig({ proxyEndpoint: "https://api.stigmer.ai", stigmerToken: "tok" }),
+      "gpt-4.1",
+    );
+
+    expect(result).toEqual({ answer: "ok" });
+    expect(buildChatModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxyEndpoint: "https://api.stigmer.ai",
+        stigmerToken: "tok",
+      }),
+    );
+  });
+
+  it("defers an un-inferable extraction model to buildChatModel's own error", async () => {
+    // The registry-empty fallback returns the primary model verbatim; when
+    // its provider can't be inferred the pre-check must not guess — the
+    // construction path owns the precise message.
+    const { getEconomyModel } = await import("../../../shared/model-registry.js");
+    vi.mocked(getEconomyModel).mockResolvedValueOnce("mystery-model");
+    const { buildChatModel } = await import("../../../shared/model-client.js");
+    const { extractStructuredOutput } = await import("../extract-structured-output.js");
+    mockInvoke.mockResolvedValueOnce({ answer: "ok" });
+
+    await extractStructuredOutput("text", SCHEMA, makeConfig(), "mystery-model");
+
+    expect(buildChatModel).toHaveBeenCalledWith(
+      expect.objectContaining({ modelName: "mystery-model" }),
+    );
+  });
+
+  it("normalizes an empty extraction result to null", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-direct");
+    const { extractStructuredOutput } = await import("../extract-structured-output.js");
+    mockInvoke.mockResolvedValueOnce(undefined);
+
+    const result = await extractStructuredOutput("text", SCHEMA, makeConfig(), "gpt-4.1");
+
+    expect(result).toBeNull();
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/extract-structured-output.ts
+++ b/backend/services/runner/src/activities/execute-cursor/extract-structured-output.ts
@@ -1,0 +1,72 @@
+/**
+ * Tier-2 structured-output extraction for the Cursor harness.
+ *
+ * When tier-1 text extraction (shared/extract-json.ts) cannot find JSON in
+ * the agent's free-text response, this tier asks an economy-tier LLM to
+ * extract it via withStructuredOutput (function-calling), which guarantees
+ * schema-conformant output through the API's tool-use mechanism.
+ *
+ * Lives in its own module (rather than inside execute-cursor/index.ts) so
+ * the LangChain construction path stays out of the Cursor activity's module
+ * graph until a run actually needs tier 2 — index.ts imports this module
+ * lazily at the call site, mirroring its tier-1 import, which is what
+ * bundle-slim's deferred evaluation preserves.
+ */
+
+import type { Config } from "../../config.js";
+import { getEconomyModel } from "../../shared/model-registry.js";
+import { buildChatModel } from "../../shared/model-client.js";
+import { checkDirectCredentials } from "../../shared/llm-backend.js";
+import { tryInferProvider } from "../../shared/llm-proxy.js";
+import { jsonSchemaToZod } from "../../shared/json-schema-to-zod.js";
+
+/**
+ * Extract structured data from an agent's free-text response using an
+ * economy-tier LLM with withStructuredOutput (function-calling).
+ *
+ * Construction (registry-id resolution, provider inference, proxy wiring) is
+ * delegated to the shared buildChatModel so the economy model's registry id
+ * is always resolved to a provider API id before the call.
+ *
+ * Throws when no LLM is reachable (no proxy and no credential path for the
+ * extraction model's provider) — the caller treats any throw here as "tier 2
+ * unavailable", logs it, and returns the agent's text without structured
+ * output, so the failure mode is a diagnosable log line, never a lost run.
+ */
+export async function extractStructuredOutput(
+  agentResponse: string,
+  schema: Record<string, unknown>,
+  config: Config,
+  primaryModel: string,
+): Promise<unknown | null> {
+  const extractionModel = await getEconomyModel(primaryModel);
+  const proxyEndpoint = config.proxyEndpoint ?? undefined;
+
+  if (!proxyEndpoint) {
+    const provider = tryInferProvider(extractionModel);
+    const missing = provider === null ? null : checkDirectCredentials(provider);
+    if (missing !== null) {
+      throw new Error(
+        `Structured-output extraction needs the ${provider} model ` +
+        `'${extractionModel}' but has no credential path. ${missing}`,
+      );
+    }
+  }
+
+  const { model: llm } = await buildChatModel({
+    modelName: extractionModel,
+    proxyEndpoint,
+    stigmerToken: config.stigmerToken ?? undefined,
+    maxTokens: 4096,
+  });
+
+  const zodSchema = jsonSchemaToZod(schema);
+  const structured = llm.withStructuredOutput(zodSchema);
+
+  const result = await structured.invoke([
+    { role: "system", content: "Extract the structured data from the agent's response. Return only the data that matches the schema." },
+    { role: "user", content: agentResponse },
+  ]);
+
+  return result ?? null;
+}

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -1992,6 +1992,7 @@ async function executeCursorInner(
             `finalTextLength=${finalText.length}`,
           );
           try {
+            const { extractStructuredOutput } = await import("./extract-structured-output.js");
             structuredOutput = await extractStructuredOutput(
               finalText, structuredOutputSchema, config, requestedModel,
             );
@@ -2315,53 +2316,6 @@ function seedCursorTranscriptFromExecution(
   }
   return persisted.subAgentExecutions.map((sub) => clone(SubAgentExecutionSchema, sub));
 }
-
-// ---------------------------------------------------------------------------
-// Structured Output Extraction (Cursor Harness Tier 2)
-// ---------------------------------------------------------------------------
-
-/**
- * Extract structured data from an agent's free-text response using an
- * economy-tier LLM with withStructuredOutput (function-calling).
- * Guarantees schema-conformant JSON output via the API's tool-use mechanism.
- *
- * Construction (registry-id resolution, provider inference, proxy wiring) is
- * delegated to the shared buildChatModel so the economy model's registry id is
- * always resolved to a provider API id before the call.
- */
-async function extractStructuredOutput(
-  agentResponse: string,
-  schema: Record<string, unknown>,
-  config: Config,
-  primaryModel: string,
-): Promise<unknown | null> {
-  const { getEconomyModel } = await import("../../shared/model-registry.js");
-  const { buildChatModel } = await import("../../shared/model-client.js");
-
-  const extractionModel = await getEconomyModel(primaryModel);
-  const proxyEndpoint = config.proxyEndpoint ?? config.stigmerBackendEndpoint;
-
-  const { model: llm } = await buildChatModel({
-    modelName: extractionModel,
-    proxyEndpoint,
-    stigmerToken: config.stigmerToken ?? undefined,
-    maxTokens: 4096,
-  });
-
-  const zodSchema = jsonSchemaToZod(schema);
-  const structured = llm.withStructuredOutput(zodSchema);
-
-  const result = await structured.invoke([
-    { role: "system", content: "Extract the structured data from the agent's response. Return only the data that matches the schema." },
-    { role: "user", content: agentResponse },
-  ]);
-
-  return result ?? null;
-}
-
-// Re-export for use within this module; shared implementation eliminates
-// the three duplicate converters that previously drifted independently.
-import { jsonSchemaToZod } from "../../shared/json-schema-to-zod.js";
 
 // ---------------------------------------------------------------------------
 // Prompt selection

--- a/backend/services/runner/src/shared/__tests__/llm-backend.test.ts
+++ b/backend/services/runner/src/shared/__tests__/llm-backend.test.ts
@@ -6,6 +6,7 @@ import {
   parseOpenAiBackend,
   resolveAnthropicBackend,
   checkVertexPrerequisites,
+  checkDirectCredentials,
   preflightLlmBackends,
 } from "../llm-backend.js";
 
@@ -136,6 +137,70 @@ describe("checkVertexPrerequisites", () => {
       expect(message).toContain("asia-south1");
     },
   );
+});
+
+describe("checkDirectCredentials", () => {
+  describe("anthropic", () => {
+    it("is satisfied by a non-blank ANTHROPIC_API_KEY", () => {
+      expect(checkDirectCredentials("anthropic", { ANTHROPIC_API_KEY: "sk-ant-x" })).toBeNull();
+    });
+
+    it.each([[undefined], [""], ["   "]])(
+      "treats key %j as missing on the public backend",
+      (key) => {
+        const message = checkDirectCredentials("anthropic", { ANTHROPIC_API_KEY: key });
+        expect(message).toContain("ANTHROPIC_API_KEY");
+        expect(message).toContain("STIGMER_ANTHROPIC_BACKEND=vertex");
+        expect(message).toContain("docs.stigmer.ai");
+      },
+    );
+
+    it("is satisfied by the vertex backend with no key (ADC authenticates)", () => {
+      // The finding-4 pin: a correctly-configured Vertex deployment holds no
+      // Anthropic API key, and must not be reported as credential-less.
+      expect(
+        checkDirectCredentials("anthropic", { STIGMER_ANTHROPIC_BACKEND: "vertex" }),
+      ).toBeNull();
+    });
+
+    it("defers an invalid backend value to construction (one message per condition)", () => {
+      // resolveAnthropicBackend owns the catalog message for invalid values;
+      // reporting "missing credentials" here would mask it.
+      expect(
+        checkDirectCredentials("anthropic", { STIGMER_ANTHROPIC_BACKEND: "verteks" }),
+      ).toBeNull();
+    });
+  });
+
+  describe("openai", () => {
+    it("is satisfied by a non-blank OPENAI_API_KEY", () => {
+      expect(checkDirectCredentials("openai", { OPENAI_API_KEY: "sk-x" })).toBeNull();
+    });
+
+    it.each([[undefined], [""], ["   "]])(
+      "treats key %j as missing",
+      (key) => {
+        const message = checkDirectCredentials("openai", { OPENAI_API_KEY: key });
+        expect(message).toContain("OPENAI_API_KEY");
+        expect(message).toContain("docs.stigmer.ai");
+      },
+    );
+
+    it("offers no backend remedy while azure is unshipped", () => {
+      // STIGMER_OPENAI_BACKEND=azure would fail with "not implemented in
+      // this build" — an error message must not suggest a broken remedy.
+      const message = checkDirectCredentials("openai", {});
+      expect(message).not.toContain("STIGMER_OPENAI_BACKEND");
+    });
+
+    it("ignores the anthropic key and backend when checking openai", () => {
+      const message = checkDirectCredentials("openai", {
+        ANTHROPIC_API_KEY: "sk-ant-x",
+        STIGMER_ANTHROPIC_BACKEND: "vertex",
+      });
+      expect(message).toContain("OPENAI_API_KEY");
+    });
+  });
 });
 
 describe("preflightLlmBackends", () => {

--- a/backend/services/runner/src/shared/llm-backend.ts
+++ b/backend/services/runner/src/shared/llm-backend.ts
@@ -14,6 +14,8 @@
  * `design-decisions/001-provider-backends.md`.
  */
 
+import type { LlmProvider } from "./llm-proxy.js";
+
 // ─── Backend selection ───────────────────────────────────────────────────────
 
 /** Env var selecting where Anthropic models are served. */
@@ -139,6 +141,55 @@ export function checkVertexPrerequisites(
   return (
     `The vertex backend requires CLOUD_ML_REGION (e.g. "asia-south1", or ` +
     `"global" for the global endpoint). See ${BACKEND_DOC_URL}.`
+  );
+}
+
+/**
+ * Check that direct-mode (unproxied) calls to `provider` have a usable
+ * credential path, or return the operator message describing what is
+ * missing. Null means "a request can authenticate":
+ *
+ * - `anthropic`: a non-blank `ANTHROPIC_API_KEY`, or any non-public backend
+ *   (vertex authenticates through Application Default Credentials, and
+ *   `ChatAnthropic` waives its API-key requirement when `createClient` is
+ *   supplied — pinned by vertex-seam.test.ts).
+ * - `openai`: a non-blank `OPENAI_API_KEY`. The message deliberately offers
+ *   no backend remedy until the azure adapter ships — advertising
+ *   STIGMER_OPENAI_BACKEND today would point the operator at a value that
+ *   fails with "not implemented in this build".
+ *
+ * An invalid backend value also returns null: `resolveAnthropicBackend` at
+ * model construction owns that condition's precise catalog message, and
+ * reporting it here too would create a second copy that can drift.
+ *
+ * This is the single copy of the "do we have a credential?" question. The
+ * reaction stays with each caller, because the right one differs per site:
+ * `call-llm.ts` raises a non-retryable LLM_MISSING_API_KEY, tool
+ * classification fails closed (every tool gated), and Cursor tier-2
+ * extraction skips to "no structured output". Callers consult it only when
+ * no proxy is configured — a proxied deployment authenticates with
+ * STIGMER_TOKEN and holds no provider credentials at all.
+ */
+export function checkDirectCredentials(
+  provider: LlmProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  if (provider === "openai") {
+    if (env.OPENAI_API_KEY?.trim()) return null;
+    return (
+      `OPENAI_API_KEY is not set and no proxy is configured. Set the API ` +
+      `key in your environment or connect to a Stigmer Cloud deployment. ` +
+      `See ${BACKEND_DOC_URL}.`
+    );
+  }
+  if (env.ANTHROPIC_API_KEY?.trim()) return null;
+  const parsed = parseAnthropicBackend(env);
+  if (!parsed.ok || parsed.backend !== "public") return null;
+  return (
+    `ANTHROPIC_API_KEY is not set, no model backend is configured, and no ` +
+    `proxy is configured. Set the API key, configure a backend (e.g. ` +
+    `${ANTHROPIC_BACKEND_ENV}=vertex), or connect to a Stigmer Cloud ` +
+    `deployment. See ${BACKEND_DOC_URL}.`
   );
 }
 

--- a/backend/services/runner/src/shared/llm-proxy.ts
+++ b/backend/services/runner/src/shared/llm-proxy.ts
@@ -75,6 +75,21 @@ export function inferProvider(modelName: string): LlmProvider {
 }
 
 /**
+ * {@link inferProvider}, returning null instead of throwing on an unknown
+ * prefix. For credential pre-checks that must not preempt the construction
+ * path: when the provider cannot be determined here, the caller proceeds and
+ * lets `buildChatModel` raise inferProvider's precise message inside its own
+ * error handling, instead of a guess being made up front.
+ */
+export function tryInferProvider(modelName: string): LlmProvider | null {
+  try {
+    return inferProvider(modelName);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Strip an explicit "provider:" prefix from the model name, returning
  * just the model ID portion. If no explicit prefix is present, returns
  * the original name unchanged.

--- a/test/integration-offline/mcp_connect_classify_offline_test.go
+++ b/test/integration-offline/mcp_connect_classify_offline_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+package offline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stigmer/stigmer/test/integration/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MCP Connect Tool Classification: direct-path credential resolution ---
+//
+// Regression suite for the stigmerBackendEndpoint-as-LLM-proxy bug: the
+// ClassifyToolApprovals activity used to coerce the gRPC control-plane
+// endpoint into an LLM proxy base URL when no proxy was configured, so in
+// unproxied deployments every classification request 404ed and every tool
+// fail-closed — the LLM classifier never ran at all.
+//
+// The connect workflow always dispatches to the GLOBAL runner queue
+// ("stigmer_runner"): McpServerConnectHandler resolves the queue with a null
+// session id, which bypasses the suite's session routing. So unlike the other
+// offline tests (per-test manager runners), these start a per-test STATIC
+// runner on that queue — in genuine direct mode, the deployment shape the bug
+// broke. Direct provider traffic reaches the mock via ANTHROPIC_BASE_URL,
+// which the @anthropic-ai/sdk honors when no explicit baseURL is configured
+// (the same seam TestOffline_ModelResolution_LlmCall_DirectMode uses).
+//
+// The two tests are a deliberate pair:
+//   - WithKey: classification reaches the provider and gates selectively —
+//     impossible before the fix (the request died at the control plane).
+//   - NoCredentials: the runner fails closed WITHOUT attempting an LLM call
+//     (Consumed()==0 distinguishes the deliberate skip from the old 404 path,
+//     which also ended all-gated but only after a doomed network attempt).
+
+// startClassifyStaticRunner starts a static unified runner on the global
+// connect queue in direct mode (no STIGMER_PROXY_ENDPOINT). The mock serves
+// only the model registry by default; extraEnv appends last and overrides,
+// so tests decide the credential story (keys present or explicitly blank).
+func startClassifyStaticRunner(
+	t *testing.T,
+	ctx context.Context,
+	mockLLM *harness.MockLLMProxyServer,
+	extraEnv ...string,
+) *harness.UnifiedRunnerStatic {
+	t.Helper()
+
+	cfg := harness.UnifiedRunnerConfig{
+		StigmerServiceAddress: testHarness.Service.GRPCAddress(),
+		TemporalAddress:       testHarness.Temporal.Address(),
+		LogDir:                testHarness.LogDir(),
+		// Direct mode: the harness emits no STIGMER_PROXY_ENDPOINT for an
+		// empty ProxyEndpoint, and the explicit blank below neutralizes any
+		// ambient value from the developer's shell (env passthrough).
+		ProxyEndpoint: "",
+		// Registry/pricing fetches still resolve against the mock so the
+		// economy model resolves exactly as production (claude-sonnet-4.6 ->
+		// economy tier -> claude-haiku-4.5 -> api id claude-haiku-4-5-20251001).
+		CloudAPIURL: mockLLM.URL(),
+		LogLabel:    t.Name(),
+		ExtraEnv: append([]string{
+			"STIGMER_CHECKPOINTER_TYPE=memory",
+			"STIGMER_PROXY_ENDPOINT=",
+			"STIGMER_ANTHROPIC_BACKEND=",
+			"STIGMER_OPENAI_BACKEND=",
+			// Anthropic primary so classification resolves an Anthropic
+			// economy model — the provider the ANTHROPIC_BASE_URL seam mocks.
+			"STIGMER_PRIMARY_MODEL=claude-sonnet-4.6",
+			// The harness emits artifact-storage env only in proxy mode; pin
+			// local storage so the runner boots without a proxy.
+			"ARTIFACT_STORAGE_TYPE=local",
+			"LOCAL_ARTIFACT_PATH=" + t.TempDir(),
+		}, extraEnv...),
+	}
+
+	runner, err := harness.StartUnifiedRunnerStatic(ctx, cfg, "stigmer_runner", suiteLogger)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			t.Skipf("unified runner not available: %v", err)
+		}
+		t.Fatalf("failed to start static classify runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Stop(); err != nil {
+			t.Logf("warning: failed to stop static runner: %v", err)
+		}
+	})
+
+	return runner
+}
+
+func TestOffline_McpConnect_Classification_DirectModeWithKey(t *testing.T) {
+	requireOfflinePrereqs(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	// One recorded classification turn. withStructuredOutput binds a forced
+	// tool named "extract" (@langchain/anthropic default), and the classifier
+	// schema is {approvals: [{tool_name, requires_approval, message}]}.
+	// The mock-test-server exposes exactly five tools; the entry classifies
+	// all five so reconciliation has nothing to fail closed.
+	entries := []harness.RecordedLLMEntry{
+		harness.BuildLLMEntry(0, harness.AnthropicToolUseResponse(
+			"toolu_classify_01", "extract",
+			map[string]any{
+				"approvals": []map[string]any{
+					{"tool_name": "echo", "requires_approval": false, "message": ""},
+					{"tool_name": "add", "requires_approval": false, "message": ""},
+					{"tool_name": "fail", "requires_approval": true, "message": "Fail with {{args.message}}"},
+					{"tool_name": "slow", "requires_approval": false, "message": ""},
+					{"tool_name": "crash", "requires_approval": true, "message": "Crash the server"},
+				},
+			},
+			500, 120,
+		)),
+	}
+
+	mockLLM := harness.NewMockLLMProxyServerFromEntries(entries)
+	t.Cleanup(func() { mockLLM.Close() })
+
+	startClassifyStaticRunner(t, ctx, mockLLM,
+		"ANTHROPIC_API_KEY=offline-test-key",
+		"ANTHROPIC_BASE_URL="+mockLLM.URL(),
+	)
+
+	clients := harness.NewClients(grpcConn)
+	harness.RequireServiceHealthy(t, ctx, clients)
+
+	mcpServer := harness.CreateStdioMcpServer(t, ctx, clients, mcpTestServerBinary)
+	connected := harness.ConnectMcpServer(t, ctx, clients, mcpServer.GetMetadata().GetId())
+
+	require.Len(t, connected.GetStatus().GetDiscoveredCapabilities().GetTools(), 5,
+		"discovery should surface all five mock-test-server tools")
+
+	gated := map[string]string{}
+	for _, approval := range connected.GetStatus().GetToolApprovals() {
+		gated[approval.GetToolName()] = approval.GetMessage()
+	}
+
+	// The classifier's selective decisions survived to the persisted policy —
+	// before the fix this was unreachable (all five failed closed via 404).
+	assert.Contains(t, gated, "fail", "classifier gated 'fail'")
+	assert.Contains(t, gated, "crash", "classifier gated 'crash'")
+	assert.NotContains(t, gated, "echo", "classifier cleared 'echo'")
+	assert.NotContains(t, gated, "add", "classifier cleared 'add'")
+	assert.NotContains(t, gated, "slow", "classifier cleared 'slow'")
+	assert.Equal(t, "Fail with {{args.message}}", gated["fail"],
+		"classifier-authored approval message must persist verbatim")
+
+	// The provider mock — not the control plane — served the classification,
+	// and it received the resolved economy-model api id.
+	assert.Equal(t, 0, mockLLM.Remaining(), "the classification entry should be consumed")
+	models := mockLLM.RequestModels()
+	require.NotEmpty(t, models, "the classification request must reach the provider")
+	assert.Equal(t, "claude-haiku-4-5-20251001", models[0],
+		"classification must use the resolved anthropic economy model")
+}
+
+func TestOffline_McpConnect_Classification_DirectModeNoCredentials(t *testing.T) {
+	requireOfflinePrereqs(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	// No recorded entries: any LLM attempt would 500 loudly. The point is
+	// stronger — with no credential path the runner must not attempt one.
+	mockLLM := harness.NewMockLLMProxyServerFromEntries(nil)
+	t.Cleanup(func() { mockLLM.Close() })
+
+	startClassifyStaticRunner(t, ctx, mockLLM,
+		"ANTHROPIC_API_KEY=",
+		"OPENAI_API_KEY=",
+	)
+
+	clients := harness.NewClients(grpcConn)
+	harness.RequireServiceHealthy(t, ctx, clients)
+
+	mcpServer := harness.CreateStdioMcpServer(t, ctx, clients, mcpTestServerBinary)
+	connected := harness.ConnectMcpServer(t, ctx, clients, mcpServer.GetMetadata().GetId())
+
+	require.Len(t, connected.GetStatus().GetDiscoveredCapabilities().GetTools(), 5,
+		"discovery is credential-free and must still surface all five tools")
+
+	gated := map[string]bool{}
+	for _, approval := range connected.GetStatus().GetToolApprovals() {
+		gated[approval.GetToolName()] = true
+	}
+	for _, tool := range []string{"echo", "add", "fail", "slow", "crash"} {
+		assert.True(t, gated[tool],
+			"tool %q must fail closed (requires_approval) when no credential path exists", tool)
+	}
+
+	assert.Equal(t, 0, mockLLM.Consumed(),
+		"no LLM request may be attempted without a credential path — the skip is deliberate, not a failed call")
+}

--- a/test/integration/harness/unified_runner.go
+++ b/test/integration/harness/unified_runner.go
@@ -592,6 +592,15 @@ func (r *UnifiedRunnerStatic) Stop() error {
 // --- Shared helpers ---
 
 func findUnifiedRunnerDir() string {
+	// An explicit override always wins over relative-path auto-discovery —
+	// it exists so a test run can point at a runner build outside the
+	// checkout (e.g. an isolated worktree build while the checkout carries
+	// unrelated in-flight changes). As a fallback it could never fire in a
+	// normal checkout, where auto-discovery always succeeds first.
+	if envPath := os.Getenv("UNIFIED_RUNNER_DIR"); envPath != "" {
+		return envPath
+	}
+
 	candidates := []string{
 		"../../../../backend/services/runner",
 		"../../backend/services/runner",
@@ -605,10 +614,6 @@ func findUnifiedRunnerDir() string {
 		if _, err := os.Stat(pkgJSON); err == nil {
 			return abs
 		}
-	}
-
-	if envPath := os.Getenv("UNIFIED_RUNNER_DIR"); envPath != "" {
-		return envPath
 	}
 
 	return ""


### PR DESCRIPTION
## Summary

Direct-mode (unproxied) LLM credential handling was backend-blind, and two consumers misrouted LLM traffic to the gRPC control plane. This PR introduces one shared credential predicate in the backend seam and removes the misroute, so unproxied deployments — with a provider API key OR a configured model backend (e.g. Vertex) — classify tools, run `llm_call` tasks, and extract structured output correctly.

## Context

Session-3 findings of the multi-cloud provider-backends project (design decision record: `001-provider-backends.md`, direct-path credential resolution addendum):

- Tool classification and Cursor tier-2 extraction fell back to `config.stigmerBackendEndpoint` when no proxy was set. The control plane serves `/v1/proxy/model-registry` but NOT `/v1/proxy/llm`, so the fallback 404'd every classification in unproxied OSS, discarded the operator's real key, and silently forced the `public` backend.
- `call-llm`'s key check was backend-blind: it demanded `ANTHROPIC_API_KEY` even when the vertex backend (Google ADC) was correctly configured, failing every `llm_call` task with `LLM_MISSING_API_KEY`.

## Changes

- `shared/llm-backend.ts`: new `checkDirectCredentials(provider, env)` — the single copy of "can direct-mode calls to this provider authenticate?" (`check*` → message-or-null convention). Anthropic passes with a non-blank key or any self-authenticating backend; OpenAI requires the key (no backend remedy advertised until the azure adapter ships).
- `activities/call-llm.ts`: consults the shared predicate; error TYPE `LLM_MISSING_API_KEY` preserved (public contract — embedding.mdx, Rust host README).
- `activities/classify-tool-approvals.ts`: proxy endpoint is now honestly `string | null`; with no credential path it fails closed up front with ONE actionable warning naming the economy model and its provider, instead of a provider 401 per batch.
- `activities/execute-cursor/`: `extractStructuredOutput` moved to its own module (move-only; lazily imported to preserve bundle-slim's deferred evaluation) with new unit coverage; the control-plane fallback removed.
- `shared/llm-proxy.ts`: `tryInferProvider` — pre-checks defer to `buildChatModel`'s precise error on un-inferable model names instead of guessing.
- `test/integration-offline/mcp_connect_classify_offline_test.go`: drives the real Java-orchestrated MCP connect workflow on a per-test STATIC runner polling `stigmer_runner` (the connect handler resolves the queue with a null session id — verified in `McpServerConnectHandler.java` and empirically).
- `test/integration/harness/unified_runner.go`: `UNIFIED_RUNNER_DIR` now overrides auto-discovery (as an after-discovery fallback it was unreachable in any normal checkout).

## Breaking changes

- None. Proxied deployments are untouched (they consult none of these paths); unproxied deployments with keys behave identically; the fix only changes previously-broken paths.

## Test plan

- Full runner suite (`CI=1 npx vitest run`): 4189 passed, 0 failed, 6 skipped (credential-gated Cursor smoke tests).
- New/updated unit tests: `llm-backend.test.ts` (credential predicate table), `call-llm.test.ts`, `classify-tool-approvals.test.ts` (fail-closed path), `extract-structured-output.test.ts`.
- New offline integration test exercises the connect workflow end-to-end against the cloud service fat JAR.

## Risks

- Low: single-copy predicate with per-consumer reactions; revert restores prior (broken-in-direct-mode) behavior only.

Made with [Cursor](https://cursor.com)