### PR TITLE
fix(seedpack): migrate webflow and intercom MCP endpoints from retired /sse to /mcp

### DIFF
--- a/seedpack/canary/credential-manifest.yaml
+++ b/seedpack/canary/credential-manifest.yaml
@@ -144,7 +144,7 @@ servers:
     status: oauth_only
     auth_type: dcr_oauth
     env_var: INTERCOM_ACCESS_TOKEN
-    notes: "Hosted endpoint likely OAuth-only; untested"
+    notes: "Hosted endpoint likely OAuth-only; untested. Endpoint moved /sse -> /mcp 2026-08 (vendor deprecated legacy SSE; stigmer/stigmer#238)"
 
   monday:
     status: oauth_only
@@ -192,7 +192,7 @@ servers:
     status: oauth_only
     auth_type: dcr_oauth
     env_var: WEBFLOW_ACCESS_TOKEN
-    notes: "Hosted endpoint likely OAuth-only; untested"
+    notes: "Endpoint moved /sse -> /mcp 2026-08 (vendor retired /sse; stigmer/stigmer#238 — reporter verified OAuth connect discovers 28 tools on /mcp)"
 
   wix:
     status: oauth_only

--- a/seedpack/mcp-servers/CONTRIBUTING.md
+++ b/seedpack/mcp-servers/CONTRIBUTING.md
@@ -49,6 +49,16 @@ remains fully supported for **user-defined** servers on local runners; it is
 only the curated catalog that requires a hosted HTTP endpoint. If the vendor
 does not offer one, the server does not belong in the seedpack.
 
+**Use the vendor's streamable HTTP endpoint, never a legacy `/sse` one.** The
+MCP spec deprecated the HTTP+SSE transport in 2025-03-26, and vendors are
+retiring their `/sse` paths (Webflow's retirement broke connect outright —
+stigmer/stigmer#238). Stigmer's client stack is streamable-first by
+construction: the Go discovery transport is streamable-HTTP-only, and the
+runner's SSE fallback is a fragile compatibility path (stigmer/stigmer#231).
+When a vendor documents both, always take the streamable HTTP URL (typically
+`/mcp`). Endpoints known to be retired or deprecated are denylisted in
+`TestMcpServers_NoRetiredEndpoints`.
+
 **HTTP (hosted/remote servers)**
 
 ```yaml

--- a/seedpack/mcp-servers/intercom.yaml
+++ b/seedpack/mcp-servers/intercom.yaml
@@ -16,7 +16,7 @@ spec:
     - messaging
     - helpdesk
   http:
-    url: "https://mcp.intercom.com/sse"
+    url: "https://mcp.intercom.com/mcp"
     headers:
       Authorization: "Bearer ${INTERCOM_ACCESS_TOKEN}"
   env:

--- a/seedpack/mcp-servers/webflow.yaml
+++ b/seedpack/mcp-servers/webflow.yaml
@@ -16,7 +16,7 @@ spec:
     - cms
     - web-design
   http:
-    url: "https://mcp.webflow.com/sse"
+    url: "https://mcp.webflow.com/mcp"
     headers:
       Authorization: "Bearer ${WEBFLOW_ACCESS_TOKEN}"
   env:

--- a/seedpack/mcp_servers_test.go
+++ b/seedpack/mcp_servers_test.go
@@ -409,6 +409,42 @@ func TestMcpServers_OAuthOnlyDeclared(t *testing.T) {
 	}
 }
 
+// TestMcpServers_NoRetiredEndpoints locks in that no seedpack server points at
+// an endpoint URL the vendor has retired or deprecated. A retired endpoint fails
+// connect with an opaque transport error (stigmer/stigmer#238); a deprecated one
+// works today but relies on the legacy HTTP+SSE transport, which our client
+// stack does not speak natively — the Go transport is streamable-HTTP-only
+// (mcpdiscovery sets DisableStandaloneSSE) and the runner's SSE fallback is the
+// fragile path stigmer/stigmer#231 documents.
+//
+// This is a cited denylist, not a blanket no-/sse rule, on purpose: some vendors
+// (square) still document /sse as their ONLY endpoint, so a blanket rule would
+// force an unverifiable guess. Add an entry here only with a vendor source
+// confirming the replacement endpoint.
+func TestMcpServers_NoRetiredEndpoints(t *testing.T) {
+	servers := loadAllMcpServers(t)
+
+	// URL -> vendor evidence for its retirement/deprecation and replacement.
+	retiredEndpoints := map[string]string{
+		// Webflow changelog 2025-12-09: /sse retired in the SSE -> streamable
+		// HTTP migration; production endpoint is https://mcp.webflow.com/mcp.
+		"https://mcp.webflow.com/sse": "retired; use https://mcp.webflow.com/mcp (Webflow changelog 2025-12-09, stigmer/stigmer#238)",
+		// Intercom MCP docs (developers.intercom.com/docs/guides/mcp): /mcp is
+		// "Recommended", /sse is "Legacy SSE (deprecated)".
+		"https://mcp.intercom.com/sse": "deprecated; use https://mcp.intercom.com/mcp (Intercom MCP docs)",
+	}
+
+	for name, server := range servers {
+		if server.Spec.HTTP == nil {
+			continue
+		}
+		if reason, retired := retiredEndpoints[server.Spec.HTTP.URL]; retired {
+			t.Errorf("%s points at a retired/deprecated endpoint %s — %s",
+				name, server.Spec.HTTP.URL, reason)
+		}
+	}
+}
+
 func TestMcpServers_OAuthEndpointAudit(t *testing.T) {
 	servers := loadAllMcpServers(t)
 	hostedMcpPattern := regexp.MustCompile(`^https://mcp\.[^/]+\.(com|io|dev)/`)


### PR DESCRIPTION
## Summary

Webflow's marketplace connect fails outright because the seedpack still points at `https://mcp.webflow.com/sse`, an endpoint Webflow retired in its SSE → streamable HTTP migration (changelog 2025-12-09). This PR moves webflow — and intercom, whose `/sse` endpoint the vendor has deprecated — to their `/mcp` streamable HTTP endpoints, and adds a cited denylist test so a retired endpoint can never silently ride in the seedpack again.

Closes #238

## Context

- Reporter verified the webflow fix end-to-end: with the `/mcp` URL, OAuth connect succeeds and auto-discovers **28 tools, 20 policies, 1 resource** (see #238).
- The issue asked for an audit of the other hosted `/sse` endpoints. Results:
  - **intercom** — vendor docs list `/mcp` as "Recommended" and `/sse` as "Legacy SSE (deprecated)". Included here (one-line, same shape).
  - **square** — vendor still documents `/sse` as its *only* endpoint. Deliberately left unchanged.
  - **paypal** — broken for stacked reasons; stays with its own issue #231.
- Our client stack is streamable-first by construction: the Go discovery transport is streamable-HTTP-only (`DisableStandaloneSSE: true` in `backend/libs/go/mcpdiscovery/transport.go`), and the runner's SSE fallback is the fragile path #231 documents.

## Changes

- `seedpack/mcp-servers/webflow.yaml` — endpoint `/sse` → `/mcp` (retired by vendor)
- `seedpack/mcp-servers/intercom.yaml` — endpoint `/sse` → `/mcp` (deprecated by vendor)
- `seedpack/mcp_servers_test.go` — new `TestMcpServers_NoRetiredEndpoints`: a cited denylist of vendor-retired/deprecated endpoint URLs (deliberately not a blanket no-`/sse` rule, because square legitimately has no alternative)
- `seedpack/mcp-servers/CONTRIBUTING.md` — endpoint-selection guidance: always take the vendor's streamable HTTP endpoint
- `seedpack/canary/credential-manifest.yaml` — notes updated to record both migrations

## Safety of the URL change (verified, both editions)

- OAuth discovery derives from the URL **origin only** (Go `buildWellKnownURL`; Java `McpOAuthDiscoveryService`) — the path change is invisible to discovery.
- Neither edition sends an RFC 8707 `resource` parameter, so tokens are not audience-bound to the path: **existing working intercom grants keep working with zero migration**. Webflow has no connected state to migrate (connect failed at transport).

## Test plan

- `gofmt` / `go vet` / `go test -count=1 ./...` green on the seedpack module.
- Tripwire mutation-checked: reverting webflow.yaml to `/sse` makes `TestMcpServers_NoRetiredEndpoints` fail as intended.
- Live probe: both `/mcp` endpoints answer with a proper MCP OAuth challenge (`WWW-Authenticate: Bearer resource_metadata=...`).

## Deploy note (cloud)

The cloud marketplace has **no auto-sync** from the seedpack. After this ships in the next OSS release, an operator must run `stigmer seedpack apply --force` against the cloud backend for `app.stigmer.ai`'s Webflow/Intercom entries to pick up the new URLs.

## Breaking changes

- None. OSS installs pick up the change automatically on next `stigmer up` (slug-keyed upsert).

Made with [Cursor](https://cursor.com)