### PR TITLE
feat(runner): serve Claude from AWS Bedrock via the provider-backend seam (T04)

### DIFF
--- a/backend/services/runner/package-lock.json
+++ b/backend/services/runner/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
+        "@anthropic-ai/bedrock-sdk": "^0.32.1",
         "@anthropic-ai/vertex-sdk": "^0.19.1",
         "@bufbuild/protobuf": "2.12.0",
         "@connectrpc/connect": "^2.0.0",
@@ -76,6 +77,46 @@
         "node": ">=18"
       }
     },
+    "node_modules/@anthropic-ai/bedrock-sdk": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.32.1.tgz",
+      "integrity": "sha512-nURBd2U7GpF38Ul4Qbw/IVSsN4YR/O9+VXMmgQubvNQqmB7m1Sys7FuHSydtuPtanoOA9t4Q+a+jcylMfJuQZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.115.1 <1",
+        "@aws-crypto/sha256-js": "^4.0.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.797.0",
+        "@aws-sdk/credential-providers": "^3.796.0",
+        "@smithy/eventstream-serde-node": "^2.0.10",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^3.1.1",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-base64": "^2.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@anthropic-ai/sdk": {
+      "version": "0.116.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
+      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.95.2",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.2.tgz",
@@ -126,6 +167,743 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-4.0.0.tgz",
+      "integrity": "sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^4.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1107.0.tgz",
+      "integrity": "sha512-qeaRwHqwPx7OU3d3zuI4Kivtq3vF3WL4w83vuWpZosmbQzgQCka8jsMoHhIVr1ewmuTekYhcPsYY32TqjC6HcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/eventstream-handler-node": "^3.972.31",
+        "@aws-sdk/middleware-eventstream": "^3.972.26",
+        "@aws-sdk/middleware-websocket": "^3.972.49",
+        "@aws-sdk/token-providers": "3.1107.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.66.tgz",
+      "integrity": "sha512-i4HTkP21eHaXA+XKoc6dYxlKPvYUqbusGGIsFRcSGTF8ln/q6RrWoRdVJ6UVODTCW59Ot1mVcbJXRAEf6kxa3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1107.0.tgz",
+      "integrity": "sha512-f25hUOdz23Xsi2tzxMnyfIpR98CgX9ilCI/mkc2rZFJex5E+KXc7UdQiOgOnPkE2saKQJvUh9/0564uUeXJj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.66",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
+      "integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1107.0.tgz",
+      "integrity": "sha512-cZXQRFWBxswmcUOin+ZvzTyGEE1Daj9E2n+1jdBSAsWCD+56jlfSgCd+I2qVE6h3ZJBDNI9aTSwWLX0f4lpLhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2297,6 +3075,594 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -3537,6 +4903,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",

--- a/backend/services/runner/package.json
+++ b/backend/services/runner/package.json
@@ -68,10 +68,11 @@
     "directory": "backend/services/runner"
   },
   "dependencies": {
+    "@anthropic-ai/bedrock-sdk": "^0.32.1",
+    "@anthropic-ai/vertex-sdk": "^0.19.1",
     "@bufbuild/protobuf": "2.12.0",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
-    "@anthropic-ai/vertex-sdk": "^0.19.1",
     "@cursor/sdk": "^1.0.13",
     "@langchain/anthropic": "^1.4.0",
     "@langchain/core": "^1.1.47",

--- a/backend/services/runner/scripts/check-langchain-deps.sh
+++ b/backend/services/runner/scripts/check-langchain-deps.sh
@@ -68,26 +68,28 @@ fi
 
 # --- 3. Check @anthropic-ai/sdk copies (known, contained dual) ---
 #
-# The tree deliberately carries TWO copies of @anthropic-ai/sdk:
+# The tree deliberately carries TWO versions of @anthropic-ai/sdk:
 #   - @langchain/anthropic -> ^0.95.x  (hoisted; serves the public-API path)
-#   - @anthropic-ai/vertex-sdk -> >=0.115 (nested; serves only the Vertex
-#     backend client constructed via ChatAnthropic's createClient factory)
-# The copies never exchange class instances (LangChain consumes stream events
-# structurally and classifies errors by HTTP status, not instanceof), and the
-# vertex-seam characterization test pins the cross-version combination in CI.
+#   - @anthropic-ai/vertex-sdk AND @anthropic-ai/bedrock-sdk -> >=0.115
+#     (nested, deduped onto one version; serve only the backend clients
+#     constructed via ChatAnthropic's createClient factory)
+# The versions never exchange class instances (LangChain consumes stream
+# events structurally and classifies errors by HTTP status, not instanceof),
+# and the vertex-seam/bedrock-seam characterization tests pin the
+# cross-version combinations in CI.
 #
 # Collapse condition: when the LangChain stack bump lands (@langchain/core
 # 1.2.x + @langchain/anthropic 1.5.x, which pins @anthropic-ai/sdk ^0.115),
 # npm dedupes to a single copy — tighten this check to single-copy then.
-# Any dependent other than these two, or a third distinct version, is drift
-# and fails the check.
+# Any dependent other than these three, or a third distinct version, is
+# drift and fails the check.
 
 echo ""
 ANTHROPIC_SDK_REPORT=$(npm ls @anthropic-ai/sdk --all --json 2>/dev/null \
   | node -e "
     const json = require('fs').readFileSync('/dev/stdin', 'utf8');
     const tree = JSON.parse(json);
-    const ALLOWED_PARENTS = new Set(['@langchain/anthropic', '@anthropic-ai/vertex-sdk']);
+    const ALLOWED_PARENTS = new Set(['@langchain/anthropic', '@anthropic-ai/vertex-sdk', '@anthropic-ai/bedrock-sdk']);
     const found = new Map(); // parent -> Set<version>
     function walk(node, parentName) {
       if (!node || !node.dependencies) return;
@@ -122,14 +124,14 @@ echo "$ANTHROPIC_SDK_REPORT" | grep -v '^PASS$' | grep -v '^FAIL:' || true
 if echo "$ANTHROPIC_SDK_REPORT" | grep -q '^FAIL:'; then
   echo ""
   echo "FAIL: @anthropic-ai/sdk copy check: $(echo "$ANTHROPIC_SDK_REPORT" | grep '^FAIL:' | sed 's/^FAIL://')"
-  echo "Only @langchain/anthropic (0.95.x) and @anthropic-ai/vertex-sdk (>=0.115)"
-  echo "may pull @anthropic-ai/sdk. See the comment above this check for the"
-  echo "rationale and the collapse condition."
+  echo "Only @langchain/anthropic (0.95.x), @anthropic-ai/vertex-sdk (>=0.115),"
+  echo "and @anthropic-ai/bedrock-sdk (>=0.115) may pull @anthropic-ai/sdk. See"
+  echo "the comment above this check for the rationale and collapse condition."
   exit 1
 fi
 
 if echo "$ANTHROPIC_SDK_REPORT" | grep -q '^PASS$'; then
-  echo "OK: @anthropic-ai/sdk copies match the known langchain + vertex-sdk pair"
+  echo "OK: @anthropic-ai/sdk copies match the known langchain + vertex/bedrock-sdk set"
 else
   echo "WARN: Could not determine @anthropic-ai/sdk copies (is npm ci done?)"
 fi

--- a/backend/services/runner/src/shared/__tests__/bedrock-adapter.test.ts
+++ b/backend/services/runner/src/shared/__tests__/bedrock-adapter.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Adapter test for the bedrock backend branch of buildChatModel — the
+ * complement of bedrock-seam.test.ts, mirroring vertex-adapter.test.ts.
+ *
+ * The seam test pins the REAL AnthropicBedrock client's wire behavior under
+ * a hand-built ChatAnthropic. This file pins OUR production wiring: a real
+ * `buildChatModel` and a real `ChatAnthropic` drive a mocked
+ * `@anthropic-ai/bedrock-sdk`, so LangChain's lazy `createClient` invocation
+ * path (client constructed on first request, once per cached client) is
+ * exercised exactly as production does it. Together the two files cover the
+ * whole chain without any test-only injection seam in production code.
+ *
+ * Pinned here:
+ * - the factory forwards LangChain's `maxRetries: 0` to the client (a
+ *   factory that drops it nests SDK retries inside LangChain's own loop),
+ * - construction and invocation succeed with NO ANTHROPIC_API_KEY (Bedrock
+ *   auth is AWS's, and ChatAnthropic waives the key when createClient is
+ *   provided),
+ * - the translated `anthropic.…-v1:0` id (with the deployment's inference
+ *   prefix and map overrides applied) crosses the wire while the returned
+ *   apiModelId stays canonical (the canonical-id invariant),
+ * - the maxTokens landmine: Bedrock ids miss LangChain's per-model default
+ *   table, so the adapter must inject the CANONICAL id's default,
+ * - usage_metadata survives the adapter (what billing reads).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+
+const { bedrockCtorArgs, createRequests } = vi.hoisted(() => ({
+  bedrockCtorArgs: [] as Array<{ maxRetries?: number }>,
+  createRequests: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@anthropic-ai/bedrock-sdk", () => ({
+  AnthropicBedrock: class {
+    readonly maxRetries: number | undefined;
+    readonly messages = {
+      create: async (request: Record<string, unknown>) => {
+        createRequests.push(request);
+        return {
+          id: "msg_bedrock_adapter_01",
+          type: "message",
+          role: "assistant",
+          model: request.model,
+          content: [{ type: "text", text: "Namaste from Bedrock." }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 7, output_tokens: 5 },
+        };
+      },
+    };
+
+    constructor(opts: { maxRetries?: number }) {
+      bedrockCtorArgs.push(opts);
+      this.maxRetries = opts.maxRetries;
+    }
+  },
+}));
+
+import { ChatAnthropic } from "@langchain/anthropic";
+
+import { buildChatModel } from "../model-client.js";
+import { _resetRegistryCache } from "../model-registry.js";
+
+describe("buildChatModel bedrock adapter", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    _resetRegistryCache();
+    bedrockCtorArgs.length = 0;
+    createRequests.length = 0;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.STIGMER_BEDROCK_MODEL_MAP;
+    delete process.env.STIGMER_BEDROCK_INFERENCE_PREFIX;
+    process.env.STIGMER_ANTHROPIC_BACKEND = "bedrock";
+    process.env.AWS_REGION = "ap-south-1";
+    // Registry offline → resolveToApiModelId passes the id through, keeping
+    // this test free of registry fixtures (that path has its own tests).
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("registry offline"));
+  });
+
+  afterEach(() => {
+    _resetRegistryCache();
+    vi.restoreAllMocks();
+    process.env = { ...savedEnv };
+  });
+
+  it("drives the mocked client through the real createClient path with the invariants intact", async () => {
+    const { model, apiModelId } = await buildChatModel({
+      modelName: "claude-sonnet-4-5-20250929",
+      maxTokens: 1024,
+    });
+
+    // Canonical id returned; the client is not constructed yet (lazy factory).
+    expect(apiModelId).toBe("claude-sonnet-4-5-20250929");
+    expect(bedrockCtorArgs).toHaveLength(0);
+
+    const result = await model.invoke([new HumanMessage("Weather in Chennai?")]);
+
+    // First request constructed exactly one (batch) client, with LangChain's
+    // maxRetries: 0 honored — LangChain owns retrying.
+    expect(bedrockCtorArgs).toHaveLength(1);
+    expect(bedrockCtorArgs[0].maxRetries).toBe(0);
+
+    // The wire carries the Bedrock-translated id; billing already got the
+    // canonical one above.
+    expect(createRequests).toHaveLength(1);
+    expect(createRequests[0].model).toBe("anthropic.claude-sonnet-4-5-20250929-v1:0");
+    expect(createRequests[0].max_tokens).toBe(1024);
+
+    // Response and usage flow back through LangChain untouched.
+    expect(result).toBeInstanceOf(AIMessage);
+    expect(result.text).toBe("Namaste from Bedrock.");
+    expect((result as AIMessage).usage_metadata).toMatchObject({
+      input_tokens: 7,
+      output_tokens: 5,
+      total_tokens: 12,
+    });
+  });
+
+  it("applies the deployment's inference prefix to the wire id, canonical id untouched", async () => {
+    process.env.STIGMER_BEDROCK_INFERENCE_PREFIX = "us";
+
+    const { model, apiModelId } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(apiModelId).toBe("claude-sonnet-4-6");
+    expect(createRequests.at(-1)?.model).toBe("us.anthropic.claude-sonnet-4-6-v1:0");
+  });
+
+  it("honors a model-map override over prefix and rule", async () => {
+    process.env.STIGMER_BEDROCK_MODEL_MAP =
+      "claude-sonnet-4-6=eu.anthropic.claude-sonnet-4-6-custom-v2:0";
+    process.env.STIGMER_BEDROCK_INFERENCE_PREFIX = "us";
+
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(createRequests.at(-1)?.model).toBe("eu.anthropic.claude-sonnet-4-6-custom-v2:0");
+  });
+
+  it("injects the CANONICAL id's default maxTokens when the caller omits it (the 4096 landmine)", async () => {
+    // LangChain's per-model default table prefix-matches the model string.
+    // `anthropic.…` ids match nothing and silently fall back to 4096 —
+    // setup.ts omits maxTokens, so every deep-agent call would be capped.
+    // The adapter must inject what the canonical id would have received on
+    // the public API or vertex, whatever that is at the installed LangChain
+    // version (16384 for 4.5/4.6-generation ids at 1.4.0).
+    const canonicalDefault = new ChatAnthropic({
+      model: "claude-sonnet-4-5-20250929",
+      apiKey: "probe",
+    }).maxTokens;
+    const bedrockFallback = new ChatAnthropic({
+      model: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+      apiKey: "probe",
+    }).maxTokens;
+    // The landmine this guards against: if these ever agree, the injection
+    // is redundant (but still correct) — the pin below is what matters.
+    expect(bedrockFallback).not.toBe(canonicalDefault);
+
+    const { model } = await buildChatModel({ modelName: "claude-sonnet-4-5-20250929" });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(createRequests.at(-1)?.max_tokens).toBe(canonicalDefault);
+  });
+
+  it("constructs and invokes with no ANTHROPIC_API_KEY anywhere in the environment", async () => {
+    expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    const result = await model.invoke([new HumanMessage("hi")]);
+
+    expect(result).toBeInstanceOf(AIMessage);
+    expect(createRequests.at(-1)?.model).toBe("anthropic.claude-sonnet-4-6-v1:0");
+  });
+
+  it("fails at dispatch with the catalog message when AWS_REGION is missing", async () => {
+    delete process.env.AWS_REGION;
+
+    await expect(
+      buildChatModel({ modelName: "claude-sonnet-4-6", maxTokens: 256 }),
+    ).rejects.toThrow(/AWS_REGION/);
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/bedrock-seam.test.ts
+++ b/backend/services/runner/src/shared/__tests__/bedrock-seam.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Characterization test for the ChatAnthropic `createClient` ->
+ * AnthropicBedrock seam — the integration the T04 bedrock backend adapter
+ * is built on. Sibling of vertex-seam.test.ts; same rules: this pins REAL
+ * cross-package behavior (`@langchain/anthropic` bundling @anthropic-ai/sdk
+ * 0.95.x driving `@anthropic-ai/bedrock-sdk` bundling its own nested
+ * >=0.115 copy), so a future bump of either side fails here in CI instead
+ * of in production. See scripts/check-langchain-deps.sh for why the two
+ * @anthropic-ai/sdk versions coexist and when they collapse to one.
+ *
+ * Determinism: zero live credentials, zero network. SigV4 signing runs for
+ * real — it is pure HMAC over static test keys passed through the SDK's
+ * own `awsAccessKey`/`awsSecretKey` options (the AWS credential provider
+ * chain is bypassed entirely, so no IMDS/config-file probing) — and
+ * transport is a recording `fetch` injected through the SDK's `fetch`
+ * option. Streaming fixtures are binary AWS EventStream frames built with
+ * the SDK's OWN exported marshaller (getMinimalSerdeContext), so the
+ * EventStream -> SSE normalization path that every real Bedrock stream
+ * takes is exercised, not bypassed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { AnthropicBedrock } from "@anthropic-ai/bedrock-sdk";
+import { getMinimalSerdeContext } from "@anthropic-ai/bedrock-sdk/core/streaming";
+import { HumanMessage, AIMessage, AIMessageChunk } from "@langchain/core/messages";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/**
+ * Bedrock's id form for a dated pre-4.6 Claude: `anthropic.` vendor prefix
+ * and `-v1:0` version suffix (see llm-backend.ts translation, T04).
+ */
+const BEDROCK_MODEL_ID = "anthropic.claude-sonnet-4-5-20250929-v1:0";
+const REGION = "asia-south1";
+const ACCESS_KEY = "AKIA-SEAM-TEST";
+const SECRET_KEY = "seam-test-secret";
+
+const WEATHER_TOOL = {
+  name: "get_weather",
+  description: "Get the current weather for a city.",
+  input_schema: {
+    type: "object" as const,
+    properties: { city: { type: "string" } },
+    required: ["city"],
+  },
+};
+
+/** Non-streaming (`/invoke`) response: text + tool_use + usage. */
+const MESSAGE_RESPONSE = {
+  id: "msg_bedrock_test_01",
+  type: "message",
+  role: "assistant",
+  model: BEDROCK_MODEL_ID,
+  content: [
+    { type: "text", text: "I'll check the weather." },
+    { type: "tool_use", id: "toolu_test_01", name: "get_weather", input: { city: "Chennai" } },
+  ],
+  stop_reason: "tool_use",
+  stop_sequence: null,
+  usage: { input_tokens: 25, output_tokens: 17 },
+};
+
+/**
+ * Streaming (`/invoke-with-response-stream`) events in Anthropic's grammar.
+ * On the Bedrock wire each rides base64-encoded inside a binary EventStream
+ * `chunk` frame; the SDK's eventStreamToSSEResponse turns them back into
+ * the SSE the nested @anthropic-ai/sdk parses.
+ */
+const STREAM_EVENTS: ReadonlyArray<Record<string, unknown>> = [
+  {
+    type: "message_start",
+    message: {
+      id: "msg_bedrock_test_02", type: "message", role: "assistant",
+      model: BEDROCK_MODEL_ID, content: [], stop_reason: null, stop_sequence: null,
+      usage: { input_tokens: 25, output_tokens: 1 },
+    },
+  },
+  { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+  { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "I'll check the weather." } },
+  { type: "content_block_stop", index: 0 },
+  { type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_test_02", name: "get_weather", input: {} } },
+  { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"city":"Chennai"}' } },
+  { type: "content_block_stop", index: 1 },
+  { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 17 } },
+  { type: "message_stop" },
+];
+
+/**
+ * Serialize Anthropic events into Bedrock's binary EventStream framing
+ * using the SDK's own marshaller — the same codec its deserializer runs —
+ * so the fixture is wire-faithful by construction, not by hand-rolling.
+ */
+async function binaryEventStreamBody(
+  events: ReadonlyArray<Record<string, unknown>>,
+): Promise<Buffer> {
+  const { eventStreamMarshaller } = getMinimalSerdeContext();
+  async function* input(): AsyncGenerator<Record<string, unknown>> {
+    yield* events;
+  }
+  const serialized = eventStreamMarshaller.serialize(input(), (event) => ({
+    headers: {
+      ":event-type": { type: "string", value: "chunk" },
+      ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
+    },
+    body: new TextEncoder().encode(
+      JSON.stringify({ bytes: Buffer.from(JSON.stringify(event)).toString("base64") }),
+    ),
+  }));
+  const chunks: Buffer[] = [];
+  for await (const chunk of serialized) {
+    chunks.push(Buffer.from(chunk as Uint8Array));
+  }
+  return Buffer.concat(chunks);
+}
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}
+
+interface SeamHarness {
+  model: ChatAnthropic;
+  requests: RecordedRequest[];
+  /** Options ChatAnthropic passed to the createClient factory. */
+  factoryOptions: Array<{ maxRetries?: number }>;
+  /** The AnthropicBedrock instances the factory constructed. */
+  clients: AnthropicBedrock[];
+}
+
+/**
+ * Build a real ChatAnthropic wired to a real AnthropicBedrock through the
+ * `createClient` seam, with transport replaced by a recording fetch.
+ *
+ * The factory honors `maxRetries` from the incoming options: LangChain owns
+ * retrying (its AsyncCaller wraps every request) and passes `maxRetries: 0`
+ * so the underlying SDK must not retry underneath it — same contract the
+ * vertex seam pins, preserved by the T04 adapter.
+ */
+function buildSeamHarness(streamBody?: Buffer): SeamHarness {
+  const requests: RecordedRequest[] = [];
+  const factoryOptions: SeamHarness["factoryOptions"] = [];
+  const clients: AnthropicBedrock[] = [];
+
+  const recordingFetch: typeof fetch = async (input, init) => {
+    const headers: Record<string, string> = {};
+    new Headers(init?.headers).forEach((value, key) => {
+      headers[key] = value;
+    });
+    requests.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers,
+      body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+    });
+    const streaming = String(input).includes("invoke-with-response-stream");
+    return streaming
+      ? new Response(streamBody, {
+          status: 200,
+          // The real Bedrock wire content type — adaptResponse matches it
+          // positively and transcodes the binary frames back to SSE.
+          headers: { "Content-Type": "application/vnd.amazon.eventstream" },
+        })
+      : new Response(JSON.stringify(MESSAGE_RESPONSE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+  };
+
+  const model = new ChatAnthropic({
+    model: BEDROCK_MODEL_ID,
+    temperature: 0,
+    maxTokens: 1024,
+    createClient: (options) => {
+      factoryOptions.push({ maxRetries: options.maxRetries });
+      const client = new AnthropicBedrock({
+        awsRegion: REGION,
+        awsAccessKey: ACCESS_KEY,
+        awsSecretKey: SECRET_KEY,
+        fetch: recordingFetch,
+        maxRetries: options.maxRetries,
+      });
+      clients.push(client);
+      return client;
+    },
+  });
+
+  return { model, requests, factoryOptions, clients };
+}
+
+/**
+ * Bedrock moves the model id into the URL path. Pinned: the installed
+ * 0.32.x interpolates it UNENCODED — the `-v1:0` colon stays literal in
+ * the path (newer SDK source URI-encodes via its `path` template helper;
+ * if an upgrade flips this to `%3A`, AWS accepts both, but this pin makes
+ * the change visible instead of silent).
+ */
+const expectedUrl = (specifier: "invoke" | "invoke-with-response-stream") =>
+  `https://bedrock-runtime.${REGION}.amazonaws.com/model/` +
+  `${BEDROCK_MODEL_ID}/${specifier}`;
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("ChatAnthropic createClient -> AnthropicBedrock seam", () => {
+  it("constructs without an Anthropic API key when createClient is provided", () => {
+    // chat_models.js waives the "Anthropic API key not found" check for
+    // factory-constructed clients — the waiver the bedrock backend depends on.
+    expect(() => buildSeamHarness()).not.toThrow();
+  });
+
+  it("defaults awsRegion to us-east-1 when AWS_REGION is unset (why preflight requires it)", () => {
+    // Pinned deliberately: the SDK will happily route traffic to us-east-1
+    // on a missing region. For a deployment-controlled data-residency
+    // feature that silent cross-region default is unacceptable, so
+    // checkBedrockPrerequisites (llm-backend.ts) refuses to start without
+    // an explicit AWS_REGION. If the SDK ever drops the default, this test
+    // tells us the preflight rationale needs rewording.
+    const saved = process.env.AWS_REGION;
+    delete process.env.AWS_REGION;
+    try {
+      const client = new AnthropicBedrock({
+        awsAccessKey: ACCESS_KEY,
+        awsSecretKey: SECRET_KEY,
+      });
+      expect(client.awsRegion).toBe("us-east-1");
+    } finally {
+      if (saved !== undefined) process.env.AWS_REGION = saved;
+    }
+  });
+
+  it("shapes a non-streaming request into Bedrock wire form (/invoke) and SigV4-signs it", async () => {
+    const h = buildSeamHarness();
+
+    const result = await h.model.invoke([new HumanMessage("Weather in Chennai?")]);
+
+    expect(h.requests).toHaveLength(1);
+    const req = h.requests[0];
+
+    // Model id rides in the URL path (URI-encoded), never in the body;
+    // stream flag is likewise URL routing, not body content.
+    expect(req.url).toBe(expectedUrl("invoke"));
+    expect(req.method).toBe("POST");
+    expect(req.body).not.toHaveProperty("model");
+    expect(req.body).not.toHaveProperty("stream");
+    expect(req.body.anthropic_version).toBe("bedrock-2023-05-31");
+    expect(req.body.max_tokens).toBe(1024);
+
+    // SigV4 signature over the adapted request reached the wire, scoped to
+    // the region and the bedrock service — the signature must cover the
+    // FINAL (middleware-adapted) request or AWS rejects it.
+    expect(req.headers.authorization).toMatch(/^AWS4-HMAC-SHA256 /);
+    expect(req.headers.authorization).toContain(`/${REGION}/bedrock/aws4_request`);
+    expect(req.headers["x-amz-date"]).toMatch(/^\d{8}T\d{6}Z$/);
+
+    expect(result).toBeInstanceOf(AIMessage);
+  });
+
+  it("round-trips tool definitions and tool_use blocks into tool_calls", async () => {
+    const h = buildSeamHarness();
+    const withTools = h.model.bindTools([WEATHER_TOOL]);
+
+    const result = (await withTools.invoke([
+      new HumanMessage("Weather in Chennai?"),
+    ])) as AIMessage;
+
+    // Tool definition survived request shaping through the Bedrock adapter.
+    const tools = h.requests[0].body.tools as Array<{ name: string }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("get_weather");
+
+    // The tool_use response block became a LangChain tool_call with its id —
+    // the identity the HITL approval flow keys on.
+    expect(result.tool_calls).toHaveLength(1);
+    expect(result.tool_calls?.[0]).toMatchObject({
+      id: "toolu_test_01",
+      name: "get_weather",
+      args: { city: "Chennai" },
+    });
+  });
+
+  it("reports usage_metadata on non-streaming responses (what billing reads)", async () => {
+    const h = buildSeamHarness();
+
+    const result = (await h.model.invoke([
+      new HumanMessage("Weather in Chennai?"),
+    ])) as AIMessage;
+
+    expect(result.usage_metadata).toMatchObject({
+      input_tokens: 25,
+      output_tokens: 17,
+      total_tokens: 42,
+    });
+  });
+
+  it("streams via /invoke-with-response-stream, transcoding EventStream frames to tool_calls and usage", async () => {
+    const h = buildSeamHarness(await binaryEventStreamBody(STREAM_EVENTS));
+
+    let final: AIMessageChunk | undefined;
+    for await (const chunk of await h.model.stream([
+      new HumanMessage("Weather in Chennai?"),
+    ])) {
+      final = final === undefined ? chunk : final.concat(chunk);
+    }
+
+    expect(h.requests).toHaveLength(1);
+    expect(h.requests[0].url).toBe(expectedUrl("invoke-with-response-stream"));
+    expect(h.requests[0].body).not.toHaveProperty("stream");
+    expect(h.requests[0].body).not.toHaveProperty("model");
+
+    expect(final).toBeDefined();
+    expect(final?.text).toBe("I'll check the weather.");
+    expect(final?.tool_calls).toHaveLength(1);
+    expect(final?.tool_calls?.[0]).toMatchObject({
+      id: "toolu_test_02",
+      name: "get_weather",
+      args: { city: "Chennai" },
+    });
+
+    // input from message_start; output accumulated across message events.
+    // Pinned to the observed accumulation (same math the vertex seam pins)
+    // so a LangChain bump that changes usage accounting fails here first.
+    expect(final?.usage_metadata).toMatchObject({
+      input_tokens: 25,
+      output_tokens: 18,
+    });
+  });
+
+  it("passes maxRetries: 0 to the factory and the honored value reaches the client", async () => {
+    const h = buildSeamHarness(await binaryEventStreamBody(STREAM_EVENTS));
+
+    await h.model.invoke([new HumanMessage("hi")]);
+    for await (const chunk of await h.model.stream([new HumanMessage("hi")])) {
+      void chunk;
+    }
+
+    // LangChain owns retrying: it must hand the factory maxRetries: 0, once
+    // per cached client (batch + streaming are constructed independently).
+    expect(h.factoryOptions).toHaveLength(2);
+    expect(h.factoryOptions.every((o) => o.maxRetries === 0)).toBe(true);
+    expect(h.clients).toHaveLength(2);
+    expect(h.clients.every((c) => c.maxRetries === 0)).toBe(true);
+  });
+
+  it("cannot serve countTokens: the request is never adapted to a Bedrock route", async () => {
+    // Bedrock supports neither token counting nor prompt caching — a
+    // documented limitation of the bedrock backend (operator doc,
+    // docs/guides/runners/model-backends.mdx). The installed 0.32.x still
+    // EXPOSES messages.countTokens (newer SDK source deletes the resource
+    // at construction), but its request bypasses the /model/… rewrite —
+    // MODEL_ENDPOINTS covers only /v1/complete and /v1/messages — so it
+    // targets a path that does not exist on the Bedrock runtime and can
+    // never succeed against AWS. Pinned so an SDK upgrade that either
+    // deletes the method or starts adapting it surfaces here, prompting a
+    // docs review instead of silent drift.
+    const requests: string[] = [];
+    const notFoundFetch: typeof fetch = async (input) => {
+      requests.push(String(input));
+      return new Response("{}", { status: 404 });
+    };
+    const client = new AnthropicBedrock({
+      awsRegion: REGION,
+      awsAccessKey: ACCESS_KEY,
+      awsSecretKey: SECRET_KEY,
+      fetch: notFoundFetch,
+      maxRetries: 0,
+    });
+
+    // 0.32.x quirk: the TYPES already omit countTokens while the RUNTIME
+    // still exposes it — the cast reaches the runtime truth this test pins.
+    const messages = client.messages as unknown as {
+      countTokens: (req: Record<string, unknown>) => Promise<unknown>;
+    };
+    await expect(
+      messages.countTokens({
+        model: BEDROCK_MODEL_ID,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+    // Anthropic-shaped path on the Bedrock host — not a /model/… route.
+    expect(requests[0]).toBe(
+      `https://bedrock-runtime.${REGION}.amazonaws.com/v1/messages/count_tokens`,
+    );
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/llm-backend.test.ts
+++ b/backend/services/runner/src/shared/__tests__/llm-backend.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from "vitest";
 
 import {
   toVertexModelId,
+  toBedrockModelId,
   parseAnthropicBackend,
   parseOpenAiBackend,
+  parseBedrockModelMap,
   resolveAnthropicBackend,
   checkVertexPrerequisites,
+  checkBedrockPrerequisites,
   checkDirectCredentials,
   preflightLlmBackends,
 } from "../llm-backend.js";
@@ -58,19 +61,11 @@ describe("parseAnthropicBackend", () => {
     ["vertex", "vertex"],
     ["Vertex", "vertex"],
     ["  VERTEX  ", "vertex"],
+    ["bedrock", "bedrock"],
+    ["  Bedrock ", "bedrock"],
   ])("value %j parses to %s", (value, backend) => {
     const result = parseAnthropicBackend({ STIGMER_ANTHROPIC_BACKEND: value });
     expect(result).toEqual({ ok: true, backend });
-  });
-
-  it("rejects bedrock as recognized but not implemented, never a silent public fallback", () => {
-    const result = parseAnthropicBackend({ STIGMER_ANTHROPIC_BACKEND: "bedrock" });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.message).toContain("STIGMER_ANTHROPIC_BACKEND");
-      expect(result.message).toContain("not implemented in this build");
-      expect(result.message).toContain("public, vertex");
-    }
   });
 
   it("rejects an unknown value naming the var, the value, and the supported set", () => {
@@ -78,7 +73,7 @@ describe("parseAnthropicBackend", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.message).toContain('STIGMER_ANTHROPIC_BACKEND="verteks"');
-      expect(result.message).toContain("Supported: public, vertex");
+      expect(result.message).toContain("Supported: public, vertex, bedrock");
     }
   });
 });
@@ -139,6 +134,129 @@ describe("checkVertexPrerequisites", () => {
   );
 });
 
+describe("checkBedrockPrerequisites", () => {
+  it("passes with an explicit AWS_REGION", () => {
+    expect(checkBedrockPrerequisites({ AWS_REGION: "ap-south-1" })).toBeNull();
+  });
+
+  it.each([[undefined], [""], ["   "]])(
+    "fails when region is %j — the SDK's us-east-1 default must never apply silently",
+    (region) => {
+      const message = checkBedrockPrerequisites({ AWS_REGION: region });
+      expect(message).toContain("AWS_REGION");
+      expect(message).toContain("us-east-1");
+      expect(message).toContain("docs.stigmer.ai");
+    },
+  );
+
+  it("fails on a malformed model map at boot, not at the first model call", () => {
+    const message = checkBedrockPrerequisites({
+      AWS_REGION: "ap-south-1",
+      STIGMER_BEDROCK_MODEL_MAP: "claude-sonnet-4-6",
+    });
+    expect(message).toContain("STIGMER_BEDROCK_MODEL_MAP");
+    expect(message).toContain("canonical=bedrockId");
+  });
+
+  it("accepts a well-formed model map", () => {
+    expect(
+      checkBedrockPrerequisites({
+        AWS_REGION: "eu-central-1",
+        STIGMER_BEDROCK_MODEL_MAP:
+          "claude-sonnet-4-6=eu.anthropic.claude-sonnet-4-6-v1:0, claude-fable-5=eu.anthropic.claude-fable-5-v1:0",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseBedrockModelMap", () => {
+  it("parses unset / blank to an empty map", () => {
+    for (const value of [undefined, "", "   "]) {
+      const result = parseBedrockModelMap({ STIGMER_BEDROCK_MODEL_MAP: value });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.map.size).toBe(0);
+    }
+  });
+
+  it("parses comma-separated pairs, trimming whitespace and skipping empty entries", () => {
+    const result = parseBedrockModelMap({
+      STIGMER_BEDROCK_MODEL_MAP:
+        " claude-sonnet-4-6 = us.anthropic.claude-sonnet-4-6-v1:0 ,, claude-fable-5=global.anthropic.claude-fable-5-v1:0 ",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.map.get("claude-sonnet-4-6")).toBe("us.anthropic.claude-sonnet-4-6-v1:0");
+      expect(result.map.get("claude-fable-5")).toBe("global.anthropic.claude-fable-5-v1:0");
+    }
+  });
+
+  it.each([["no-equals-sign"], ["=missing-canonical"], ["missing-id="]])(
+    "rejects malformed entry %j naming the entry and the expected form",
+    (entry) => {
+      const result = parseBedrockModelMap({ STIGMER_BEDROCK_MODEL_MAP: entry });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain(entry);
+        expect(result.message).toContain("canonical=bedrockId");
+      }
+    },
+  );
+});
+
+describe("toBedrockModelId", () => {
+  // Layer 3 alone: the deterministic rule, verified against AWS's model
+  // catalog for the registry's dated ids (the model card lists
+  // anthropic.claude-sonnet-4-5-20250929-v1:0 for claude-sonnet-4-5).
+  it.each([
+    ["claude-sonnet-4-5-20250929", "anthropic.claude-sonnet-4-5-20250929-v1:0"],
+    ["claude-haiku-4-5-20251001", "anthropic.claude-haiku-4-5-20251001-v1:0"],
+    ["claude-opus-4-5-20251101", "anthropic.claude-opus-4-5-20251101-v1:0"],
+    ["claude-sonnet-4-6", "anthropic.claude-sonnet-4-6-v1:0"],
+    ["claude-fable-5", "anthropic.claude-fable-5-v1:0"],
+  ])("derives %s -> %s with no prefix or map", (canonical, bedrockId) => {
+    expect(toBedrockModelId(canonical, {})).toBe(bedrockId);
+  });
+
+  // Layer 2: the geography prefix is a deployment decision — never
+  // defaulted (a missing prefix yields the bare id; AWS's inference-profile
+  // rejection is classified with the remedy in model-error.ts).
+  it.each([
+    ["us", "us.anthropic.claude-sonnet-4-6-v1:0"],
+    ["eu", "eu.anthropic.claude-sonnet-4-6-v1:0"],
+    ["global", "global.anthropic.claude-sonnet-4-6-v1:0"],
+    // Lenient on a trailing dot — "us." and "us" both read as intent.
+    ["us.", "us.anthropic.claude-sonnet-4-6-v1:0"],
+    ["  jp  ", "jp.anthropic.claude-sonnet-4-6-v1:0"],
+  ])("applies inference prefix %j", (prefix, expected) => {
+    expect(
+      toBedrockModelId("claude-sonnet-4-6", { STIGMER_BEDROCK_INFERENCE_PREFIX: prefix }),
+    ).toBe(expected);
+  });
+
+  it("consults the operator map FIRST, bypassing both prefix and rule", () => {
+    expect(
+      toBedrockModelId("claude-sonnet-4-6", {
+        STIGMER_BEDROCK_MODEL_MAP: "claude-sonnet-4-6=arn:aws:bedrock:eu-central-1:123:inference-profile/custom",
+        STIGMER_BEDROCK_INFERENCE_PREFIX: "us",
+      }),
+    ).toBe("arn:aws:bedrock:eu-central-1:123:inference-profile/custom");
+  });
+
+  it("applies prefix and rule to models the map does not cover", () => {
+    expect(
+      toBedrockModelId("claude-fable-5", {
+        STIGMER_BEDROCK_MODEL_MAP: "claude-sonnet-4-6=us.anthropic.claude-sonnet-4-6-v1:0",
+        STIGMER_BEDROCK_INFERENCE_PREFIX: "us",
+      }),
+    ).toBe("us.anthropic.claude-fable-5-v1:0");
+  });
+
+  it("throws the catalog message on a malformed map (defense in depth)", () => {
+    expect(() => toBedrockModelId("claude-sonnet-4-6", { STIGMER_BEDROCK_MODEL_MAP: "broken" }))
+      .toThrow(/STIGMER_BEDROCK_MODEL_MAP entry "broken"/);
+  });
+});
+
 describe("checkDirectCredentials", () => {
   describe("anthropic", () => {
     it("is satisfied by a non-blank ANTHROPIC_API_KEY", () => {
@@ -161,6 +279,19 @@ describe("checkDirectCredentials", () => {
       expect(
         checkDirectCredentials("anthropic", { STIGMER_ANTHROPIC_BACKEND: "vertex" }),
       ).toBeNull();
+    });
+
+    it("is satisfied by the bedrock backend with no key (AWS chain authenticates)", () => {
+      // Covered by the same non-public test that covered vertex — pinned
+      // separately so the bedrock adapter's credential story stays locked.
+      expect(
+        checkDirectCredentials("anthropic", { STIGMER_ANTHROPIC_BACKEND: "bedrock" }),
+      ).toBeNull();
+    });
+
+    it("names both shipped backends in the missing-key remedy", () => {
+      const message = checkDirectCredentials("anthropic", {});
+      expect(message).toContain("vertex or bedrock");
     });
 
     it("defers an invalid backend value to construction (one message per condition)", () => {
@@ -219,6 +350,28 @@ describe("preflightLlmBackends", () => {
   it("fails vertex without a region, naming CLOUD_ML_REGION", () => {
     const result = preflightLlmBackends({ STIGMER_ANTHROPIC_BACKEND: "vertex" });
     expect(result.error).toContain("CLOUD_ML_REGION");
+  });
+
+  it("is clean for a fully-configured bedrock deployment", () => {
+    const result = preflightLlmBackends({
+      STIGMER_ANTHROPIC_BACKEND: "bedrock",
+      AWS_REGION: "ap-south-1",
+    });
+    expect(result).toEqual({ error: null, warnings: [] });
+  });
+
+  it("fails bedrock without a region, naming AWS_REGION", () => {
+    const result = preflightLlmBackends({ STIGMER_ANTHROPIC_BACKEND: "bedrock" });
+    expect(result.error).toContain("AWS_REGION");
+  });
+
+  it("fails bedrock with a malformed model map at boot", () => {
+    const result = preflightLlmBackends({
+      STIGMER_ANTHROPIC_BACKEND: "bedrock",
+      AWS_REGION: "ap-south-1",
+      STIGMER_BEDROCK_MODEL_MAP: "not-a-pair",
+    });
+    expect(result.error).toContain("STIGMER_BEDROCK_MODEL_MAP");
   });
 
   it("fails on invalid values for either var, reporting all problems at once", () => {

--- a/backend/services/runner/src/shared/__tests__/model-error.test.ts
+++ b/backend/services/runner/src/shared/__tests__/model-error.test.ts
@@ -307,6 +307,106 @@ describe("classifyModelCallError — vertex backend", () => {
   });
 });
 
+describe("classifyModelCallError — bedrock backend", () => {
+  // The Bedrock arms activate only for direct-mode Anthropic calls under
+  // STIGMER_ANTHROPIC_BACKEND=bedrock, mirroring the vertex suite above.
+  function stubBedrockEnv() {
+    vi.stubEnv("STIGMER_ANTHROPIC_BACKEND", "bedrock");
+    vi.stubEnv("AWS_REGION", "ap-south-1");
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const bedrockCtx = {
+    proxyMode: false,
+    provider: "anthropic" as const,
+    modelId: "claude-sonnet-4-6",
+  };
+
+  it("classifies AWS credential-chain failures as non-retryable with the AWS fix", () => {
+    stubBedrockEnv();
+    for (const raw of [
+      "Could not load credentials from any providers",
+      "Resolved credential object is not valid",
+    ]) {
+      const classified = classifyModelCallError(middlewareWrap(new Error(raw)), bedrockCtx);
+      expect(classified?.code, raw).toBe("LLM_BACKEND_CREDENTIALS");
+      expect(classified?.retryable, raw).toBe(false);
+      expect(classified?.message, raw).toContain("AWS");
+      expect(classified?.message, raw).toContain("AWS_BEARER_TOKEN_BEDROCK");
+    }
+  });
+
+  it("does NOT classify credential prose when the backend is not bedrock (no relabeling drift)", () => {
+    const classified = classifyModelCallError(
+      new Error("Could not load credentials from any providers"),
+      bedrockCtx,
+    );
+    expect(classified).toBeUndefined();
+  });
+
+  it("translates the bare-id inference-profile rejection into the one-var remedy", () => {
+    stubBedrockEnv();
+    // AWS's actual ValidationException prose for newer Claude models
+    // invoked by bare model id.
+    const classified = classifyModelCallError(
+      sdkError(
+        400,
+        "Invocation of model ID anthropic.claude-sonnet-4-6-v1:0 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+      ),
+      bedrockCtx,
+    );
+    expect(classified?.code).toBe("LLM_BACKEND_MODEL_ROUTING");
+    expect(classified?.retryable).toBe(false);
+    expect(classified?.message).toContain("STIGMER_BEDROCK_INFERENCE_PREFIX");
+    expect(classified?.message).toContain("STIGMER_BEDROCK_MODEL_MAP");
+  });
+
+  it("words 401 around AWS identity, not an API key", () => {
+    stubBedrockEnv();
+    const classified = classifyModelCallError(sdkError(401, "unauthorized"), bedrockCtx);
+    expect(classified?.code).toBe("LLM_AUTHENTICATION_ERROR");
+    expect(classified?.message).toContain("AWS rejected this Bedrock call");
+    expect(classified?.message).not.toContain("API key");
+  });
+
+  it("words 403 around Bedrock model access and IAM, not an API key", () => {
+    stubBedrockEnv();
+    const classified = classifyModelCallError(sdkError(403, "forbidden"), bedrockCtx);
+    expect(classified?.code).toBe("LLM_PERMISSION_DENIED");
+    expect(classified?.message).toContain("Model access");
+    expect(classified?.message).toContain("bedrock:InvokeModel");
+    expect(classified?.message).not.toContain("API key");
+  });
+
+  it("words 404 around region availability and the id-resolution knobs", () => {
+    stubBedrockEnv();
+    const classified = classifyModelCallError(sdkError(404, "not found"), bedrockCtx);
+    expect(classified?.code).toBe("LLM_MODEL_NOT_FOUND");
+    expect(classified?.message).toContain('region "ap-south-1"');
+    expect(classified?.message).toContain("STIGMER_BEDROCK_MODEL_MAP");
+  });
+
+  it("stays inert in proxy mode even with the backend var set (proxy owns routing)", () => {
+    stubBedrockEnv();
+    const classified = classifyModelCallError(
+      sdkError(401, "unauthorized"),
+      { proxyMode: true, provider: "anthropic" },
+    );
+    expect(classified?.message).toContain("Stigmer platform");
+    expect(classified?.message).not.toContain("Bedrock");
+  });
+
+  it("keeps vertex wordings and bedrock wordings from cross-contaminating", () => {
+    stubBedrockEnv();
+    const classified = classifyModelCallError(sdkError(403, "forbidden"), bedrockCtx);
+    expect(classified?.message).not.toContain("Vertex");
+    expect(classified?.message).not.toContain("Model Garden");
+  });
+});
+
 describe("describeExecutionError", () => {
   it("labels classified model errors with the stable code, not the wrapper class", () => {
     const { errorType, errorMessage } = describeExecutionError(

--- a/backend/services/runner/src/shared/llm-backend.ts
+++ b/backend/services/runner/src/shared/llm-backend.ts
@@ -1,7 +1,7 @@
 /**
  * LLM provider-backend utilities — pure routing helpers for serving a
  * provider's models through an alternative cloud backend (GCP Vertex AI,
- * and later AWS Bedrock / Azure OpenAI) instead of the provider's public API.
+ * AWS Bedrock, and later Azure OpenAI) instead of the provider's public API.
  *
  * Layering mirrors `llm-proxy.ts`: this module is pure string/config
  * utilities with no LangChain or SDK dependency. Consumers: the runner
@@ -28,12 +28,12 @@ export const BACKEND_DOC_URL = "https://docs.stigmer.ai/guides/runners/model-bac
 
 /**
  * Backends implemented in this build. The design vocabulary also reserves
- * `bedrock` (Anthropic) and `azure` (OpenAI); until those adapters land,
- * selecting them is a distinct "recognized but not implemented" failure —
- * never a silent fallback to the public API, which would quietly route
- * traffic outside the compliance boundary the operator asked for.
+ * `azure` (OpenAI); until that adapter lands, selecting it is a distinct
+ * "recognized but not implemented" failure — never a silent fallback to
+ * the public API, which would quietly route traffic outside the compliance
+ * boundary the operator asked for.
  */
-export type AnthropicBackend = "public" | "vertex";
+export type AnthropicBackend = "public" | "vertex" | "bedrock";
 export type OpenAiBackend = "public";
 
 /**
@@ -47,7 +47,7 @@ export type BackendParseResult<B> =
   | { readonly ok: false; readonly message: string };
 
 /** Planned-but-unshipped values get a "not in this build" message. */
-const PLANNED_ANTHROPIC = ["bedrock"];
+const PLANNED_ANTHROPIC: string[] = [];
 const PLANNED_OPENAI = ["azure"];
 
 function parseBackend<B extends string>(
@@ -87,7 +87,7 @@ export function parseAnthropicBackend(
   return parseBackend(
     ANTHROPIC_BACKEND_ENV,
     env[ANTHROPIC_BACKEND_ENV],
-    ["public", "vertex"],
+    ["public", "vertex", "bedrock"],
     PLANNED_ANTHROPIC,
   );
 }
@@ -144,6 +144,80 @@ export function checkVertexPrerequisites(
   );
 }
 
+/** Operator override map: canonical id -> exact Bedrock id, consulted first. */
+export const BEDROCK_MODEL_MAP_ENV = "STIGMER_BEDROCK_MODEL_MAP";
+/** Inference-profile geography prefix (`us`, `eu`, `global`, …), no default. */
+export const BEDROCK_INFERENCE_PREFIX_ENV = "STIGMER_BEDROCK_INFERENCE_PREFIX";
+
+/**
+ * Static prerequisite check for the bedrock backend, or null when satisfied.
+ *
+ * AWS_REGION is REQUIRED even though the Bedrock SDK would default it to
+ * us-east-1 (pinned by bedrock-seam.test.ts): for a deployment-controlled
+ * data-residency feature, silently routing model traffic to a US region on
+ * a missing var is exactly the failure backends exist to prevent. Same
+ * shape as vertex's CLOUD_ML_REGION requirement. Credentials are
+ * deliberately NOT checked — the AWS chain (env keys, IRSA / instance
+ * metadata, config files, AWS_BEARER_TOKEN_BEDROCK) legitimately resolves
+ * at request time; requiring env keys would reject valid deployments.
+ * Runtime credential failures get actionable classification in
+ * `model-error.ts` instead.
+ *
+ * A malformed STIGMER_BEDROCK_MODEL_MAP is also fatal here: it is
+ * deployment-static, and finding out at the first model call would fail
+ * executions a boot check could have refused.
+ */
+export function checkBedrockPrerequisites(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  if (!env.AWS_REGION?.trim()) {
+    return (
+      `The bedrock backend requires AWS_REGION (e.g. "ap-south-1"). It is ` +
+      `required even though the AWS SDK would default to us-east-1 — a ` +
+      `deployment that chose Bedrock for data residency must never fall ` +
+      `back to another region silently. See ${BACKEND_DOC_URL}.`
+    );
+  }
+  const map = parseBedrockModelMap(env);
+  if (!map.ok) return map.message;
+  return null;
+}
+
+/**
+ * Parse `STIGMER_BEDROCK_MODEL_MAP`: comma-separated `canonical=bedrockId`
+ * pairs, e.g. "claude-sonnet-4-6=us.anthropic.claude-sonnet-4-6-v1:0".
+ * Unset or blank parses to an empty map (the deterministic rule serves
+ * every model). The message is the single copy of the malformed-map text;
+ * preflight and translation surface the same string.
+ */
+export function parseBedrockModelMap(
+  env: NodeJS.ProcessEnv = process.env,
+): { readonly ok: true; readonly map: ReadonlyMap<string, string> } | { readonly ok: false; readonly message: string } {
+  const raw = env[BEDROCK_MODEL_MAP_ENV]?.trim();
+  const map = new Map<string, string>();
+  if (!raw) return { ok: true, map };
+
+  for (const entry of raw.split(",")) {
+    const pair = entry.trim();
+    if (pair === "") continue;
+    const eq = pair.indexOf("=");
+    const canonical = eq === -1 ? "" : pair.slice(0, eq).trim();
+    const bedrockId = eq === -1 ? "" : pair.slice(eq + 1).trim();
+    if (!canonical || !bedrockId) {
+      return {
+        ok: false,
+        message:
+          `${BEDROCK_MODEL_MAP_ENV} entry "${pair}" is not of the form ` +
+          `canonical=bedrockId (e.g. "claude-sonnet-4-6=` +
+          `us.anthropic.claude-sonnet-4-6-v1:0"). Entries are ` +
+          `comma-separated. See ${BACKEND_DOC_URL}.`,
+      };
+    }
+    map.set(canonical, bedrockId);
+  }
+  return { ok: true, map };
+}
+
 /**
  * Check that direct-mode (unproxied) calls to `provider` have a usable
  * credential path, or return the operator message describing what is
@@ -188,8 +262,8 @@ export function checkDirectCredentials(
   return (
     `ANTHROPIC_API_KEY is not set, no model backend is configured, and no ` +
     `proxy is configured. Set the API key, configure a backend (e.g. ` +
-    `${ANTHROPIC_BACKEND_ENV}=vertex), or connect to a Stigmer Cloud ` +
-    `deployment. See ${BACKEND_DOC_URL}.`
+    `${ANTHROPIC_BACKEND_ENV}=vertex or bedrock), or connect to a Stigmer ` +
+    `Cloud deployment. See ${BACKEND_DOC_URL}.`
   );
 }
 
@@ -242,6 +316,9 @@ export function preflightLlmBackends(
   } else if (anthropic.backend === "vertex") {
     const prereq = checkVertexPrerequisites(env);
     if (prereq !== null) errors.push(prereq);
+  } else if (anthropic.backend === "bedrock") {
+    const prereq = checkBedrockPrerequisites(env);
+    if (prereq !== null) errors.push(prereq);
   }
   const openai = parseOpenAiBackend(env);
   if (!openai.ok) errors.push(openai.message);
@@ -282,4 +359,46 @@ const TRAILING_SNAPSHOT_DATE = /-(\d{8})$/;
  */
 export function toVertexModelId(apiModelId: string): string {
   return apiModelId.replace(TRAILING_SNAPSHOT_DATE, "@$1");
+}
+
+/**
+ * Translate a canonical Anthropic API model id into Bedrock's form, in
+ * three layers (approved design, T04) — each a deployment-level knob:
+ *
+ * 1. `STIGMER_BEDROCK_MODEL_MAP` override, consulted first: the escape
+ *    hatch for ids the deterministic rule cannot derive (Bedrock ids for
+ *    dateless canonicals may carry AWS-side snapshot dates we cannot know).
+ * 2. `STIGMER_BEDROCK_INFERENCE_PREFIX` (e.g. "us", "eu", "global"),
+ *    applied to the derived id. Newer Claude models on Bedrock are invoked
+ *    through geography-prefixed inference profiles (AWS lists the base id's
+ *    in-region endpoint as N/A) — but WHICH geography is a deployment
+ *    decision (data residency), underivable from the model id, and never
+ *    defaulted: a missing prefix yields the bare id, and if AWS rejects it
+ *    with its "use an inference profile" error, model-error.ts translates
+ *    that into "set ${BEDROCK_INFERENCE_PREFIX_ENV}".
+ * 3. Deterministic rule: `anthropic.{canonical}-v1:0` — verified against
+ *    AWS's model catalog for the registry's dated ids (e.g.
+ *    claude-sonnet-4-5-20250929 -> anthropic.claude-sonnet-4-5-20250929-v1:0).
+ *
+ * Like the Vertex translation, the result is wire detail only: it rides in
+ * the request URL and must never escape the adapter into usage metrics or
+ * pricing, which key on the canonical id (the canonical-id invariant).
+ *
+ * Throws the catalog message on a malformed map — defense in depth for
+ * paths that construct models without the factories; a normally-booted
+ * runner already refused to start in `checkBedrockPrerequisites`.
+ */
+export function toBedrockModelId(
+  apiModelId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const parsed = parseBedrockModelMap(env);
+  if (!parsed.ok) throw new Error(parsed.message);
+  const mapped = parsed.map.get(apiModelId);
+  if (mapped !== undefined) return mapped;
+
+  // Lenient on a trailing dot ("us." and "us" both read as intent).
+  const prefix = env[BEDROCK_INFERENCE_PREFIX_ENV]?.trim().replace(/\.$/, "");
+  const derived = `anthropic.${apiModelId}-v1:0`;
+  return prefix ? `${prefix}.${derived}` : derived;
 }

--- a/backend/services/runner/src/shared/model-client.ts
+++ b/backend/services/runner/src/shared/model-client.ts
@@ -27,7 +27,9 @@ import {
 import {
   resolveAnthropicBackend,
   checkVertexPrerequisites,
+  checkBedrockPrerequisites,
   toVertexModelId,
+  toBedrockModelId,
 } from "./llm-backend.js";
 import { resolveToApiModelId } from "./model-registry.js";
 
@@ -88,29 +90,53 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
       ? resolveAnthropicBackend()
       : "public";
 
-  // The Vertex SDK (and its google-auth-library subtree) loads lazily so
-  // deployments that never configure the vertex backend never evaluate it —
-  // cheap cold starts stay cheap, and bundle-slim's CJS output preserves
-  // exactly this deferred evaluation (see scripts/bundle-slim.mjs). The
-  // factory is invoked lazily by ChatAnthropic once per cached client
-  // (batch + streaming), so the class is captured here, in async context.
+  // Backend SDKs (and their auth subtrees: google-auth-library, AWS smithy)
+  // load lazily so deployments that never configure a backend never
+  // evaluate them — cheap cold starts stay cheap, and bundle-slim's CJS
+  // output preserves exactly this deferred evaluation (see
+  // scripts/bundle-slim.mjs). The factory is invoked lazily by
+  // ChatAnthropic once per cached client (batch + streaming), so the class
+  // is captured here, in async context.
   //
-  // The factory MUST honor options.maxRetries: LangChain owns retrying and
+  // Each factory MUST honor options.maxRetries: LangChain owns retrying and
   // hands the factory maxRetries: 0 — a factory that drops it nests the
-  // Vertex SDK's default 2 retries inside LangChain's retry loop,
-  // multiplying every transient failure. Pinned by vertex-seam.test.ts.
-  // Region/project/credentials are read natively by the SDK from standard
-  // GCP conventions (CLOUD_ML_REGION, ANTHROPIC_VERTEX_PROJECT_ID, ADC).
-  let vertexCreateClient: ((options: { maxRetries?: number }) => unknown) | undefined;
+  // SDK's default 2 retries inside LangChain's retry loop, multiplying
+  // every transient failure. Pinned by vertex-seam.test.ts and
+  // bedrock-seam.test.ts. Prerequisites are re-checked here (not only in
+  // the factories' preflight) so paths that construct models without a
+  // runner factory still fail at dispatch with the catalog message instead
+  // of mid-request. Credentials are read natively by each SDK from its
+  // standard conventions (GCP: CLOUD_ML_REGION + ADC; AWS: AWS_REGION +
+  // the credential chain / AWS_BEARER_TOKEN_BEDROCK).
+  let backendCreateClient: ((options: { maxRetries?: number }) => unknown) | undefined;
+  let wireModelId = apiModelId;
+  let maxTokens = opts.maxTokens;
   if (anthropicBackend === "vertex") {
-    // Re-checked here (not only in the factories' preflight) so paths that
-    // construct models without a runner factory still fail at dispatch with
-    // the catalog message instead of mid-request.
     const prereq = checkVertexPrerequisites();
     if (prereq !== null) throw new Error(prereq);
     const { AnthropicVertex } = await import("@anthropic-ai/vertex-sdk");
-    vertexCreateClient = (options) =>
+    backendCreateClient = (options) =>
       new AnthropicVertex({ maxRetries: options.maxRetries });
+    wireModelId = toVertexModelId(apiModelId);
+  } else if (anthropicBackend === "bedrock") {
+    const prereq = checkBedrockPrerequisites();
+    if (prereq !== null) throw new Error(prereq);
+    const { AnthropicBedrock } = await import("@anthropic-ai/bedrock-sdk");
+    backendCreateClient = (options) =>
+      new AnthropicBedrock({ maxRetries: options.maxRetries });
+    wireModelId = toBedrockModelId(apiModelId);
+    if (maxTokens === undefined) {
+      // LangChain's per-model maxTokens table prefix-matches the model
+      // name. Vertex's translated ids still match their canonical prefix;
+      // Bedrock's `anthropic.…` ids match nothing and silently fall back
+      // to 4096 — a silent output cap. Probe the CANONICAL id with a
+      // throwaway construction (pure field assignment, no I/O; the key is
+      // never used) so bedrock inherits exactly the default the public API
+      // and vertex get for the same model — including models the table
+      // doesn't know yet, where all backends agree on the fallback.
+      // Pinned by the canonical-parity test in bedrock-adapter.test.ts.
+      maxTokens = new ChatAnthropic({ model: apiModelId, apiKey: "max-tokens-probe" }).maxTokens;
+    }
   }
 
   const baseUrl = opts.proxyEndpoint
@@ -131,7 +157,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   const common = {
     temperature: opts.temperature ?? 0,
     apiKey,
-    ...(opts.maxTokens ? { maxTokens: opts.maxTokens } : {}),
+    ...(maxTokens ? { maxTokens } : {}),
     ...(opts.timeoutMs ? { maxRetries: opts.maxRetries ?? 0, timeout: opts.timeoutMs } : {}),
   };
 
@@ -151,15 +177,15 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
             }
           : {}),
       })
-    : vertexCreateClient
-      ? // Vertex backend: the translated id is wire detail only — the client
-        // moves it from the JSON body into the Vertex URL path. The waiver in
-        // ChatAnthropic (an API key is not required when createClient is
+    : backendCreateClient
+      ? // Backend adapter: the translated id is wire detail only — each
+        // client moves it from the JSON body into its URL path. The waiver
+        // in ChatAnthropic (an API key is not required when createClient is
         // provided) is what lets this construct with no ANTHROPIC_API_KEY.
         new ChatAnthropic({
-          model: toVertexModelId(apiModelId),
+          model: wireModelId,
           ...common,
-          createClient: vertexCreateClient,
+          createClient: backendCreateClient,
         })
       : new ChatAnthropic({
           model: apiModelId,

--- a/backend/services/runner/src/shared/model-error.ts
+++ b/backend/services/runner/src/shared/model-error.ts
@@ -26,7 +26,12 @@
  */
 
 import type { LlmProvider } from "./llm-proxy.js";
-import { parseAnthropicBackend, BACKEND_DOC_URL } from "./llm-backend.js";
+import {
+  parseAnthropicBackend,
+  BACKEND_DOC_URL,
+  BEDROCK_INFERENCE_PREFIX_ENV,
+  type AnthropicBackend,
+} from "./llm-backend.js";
 
 /**
  * Machine-readable code the cloud proxy embeds in rewritten platform-fault
@@ -97,7 +102,7 @@ export function classifyModelCallError(
 ): ClassifiedModelError | undefined {
   const root = unwrapModelError(err);
   const message = root instanceof Error ? root.message : String(root);
-  const vertex = isVertexDirectCall(ctx);
+  const backend = resolveDirectBackend(ctx);
 
   // 1. Platform sentinel — before status mapping (see module doc).
   if (message.includes(PLATFORM_CAPACITY_SENTINEL)) {
@@ -108,12 +113,13 @@ export function classifyModelCallError(
     };
   }
 
-  // 1b. Vertex credential acquisition — also before status mapping: these
-  //     failures come from google-auth (thrown while adapting the request,
-  //     usually with no HTTP status) and won't self-heal on retry. Raw, they
-  //     read like library internals ("Could not load the default
-  //     credentials"); the operator needs to hear "fix your GCP credentials".
-  if (vertex && isGoogleCredentialMessage(message)) {
+  // 1b. Backend credential acquisition — also before status mapping: these
+  //     failures come from the auth library (thrown while adapting the
+  //     request, usually with no HTTP status) and won't self-heal on retry.
+  //     Raw, they read like library internals ("Could not load the default
+  //     credentials"); the operator needs to hear "fix your cloud
+  //     credentials".
+  if (backend === "vertex" && isGoogleCredentialMessage(message)) {
     return {
       code: "LLM_BACKEND_CREDENTIALS",
       retryable: false,
@@ -122,6 +128,35 @@ export function classifyModelCallError(
         `Set GOOGLE_APPLICATION_CREDENTIALS to a service-account key, or run on a GCP ` +
         `identity (workload identity / metadata server). ANTHROPIC_VERTEX_PROJECT_ID is ` +
         `only needed when the credentials don't carry a project. See ${BACKEND_DOC_URL}. ` +
+        `Underlying error: ${message}`,
+    };
+  }
+  if (backend === "bedrock" && isAwsCredentialMessage(message)) {
+    return {
+      code: "LLM_BACKEND_CREDENTIALS",
+      retryable: false,
+      message:
+        `The bedrock backend could not acquire AWS credentials for ${modelLabel(ctx)}. ` +
+        `Provide credentials through the standard AWS chain (environment keys, an IAM ` +
+        `role / IRSA, config files) or set AWS_BEARER_TOKEN_BEDROCK. See ${BACKEND_DOC_URL}. ` +
+        `Underlying error: ${message}`,
+    };
+  }
+
+  // 1c. Bedrock's inference-profile rejection — a config condition, not a
+  //     bad request: newer Claude models cannot be invoked by bare model id
+  //     (AWS lists their in-region endpoint as N/A). The operator remedy is
+  //     one env var, so say exactly that instead of relaying AWS prose that
+  //     talks about ARNs and provisioned throughput.
+  if (backend === "bedrock" && isBedrockInferenceProfileMessage(message)) {
+    return {
+      code: "LLM_BACKEND_MODEL_ROUTING",
+      retryable: false,
+      message:
+        `Bedrock requires an inference profile for ${modelLabel(ctx)} — the bare model ` +
+        `id cannot be invoked on-demand. Set ${BEDROCK_INFERENCE_PREFIX_ENV} to your ` +
+        `deployment's geography (e.g. "us", "eu", or "global"), or map this model ` +
+        `explicitly in STIGMER_BEDROCK_MODEL_MAP. See ${BACKEND_DOC_URL}. ` +
         `Underlying error: ${message}`,
     };
   }
@@ -155,7 +190,7 @@ export function classifyModelCallError(
     ? (root as { status: number }).status
     : undefined;
   if (status !== undefined) {
-    return classifyByStatus(status, message, ctx, vertex);
+    return classifyByStatus(status, message, ctx, backend);
   }
 
   // 4. Connection/timeout heuristics on the root error's class name. Strict
@@ -195,7 +230,7 @@ function classifyByStatus(
   status: number,
   rawMessage: string,
   ctx: ModelErrorContext,
-  vertex: boolean,
+  backend: AnthropicBackend,
 ): ClassifiedModelError {
   const context = modelLabel(ctx);
 
@@ -207,12 +242,17 @@ function classifyByStatus(
         message: ctx.proxyMode
           ? `The Stigmer platform rejected this model call (authentication, HTTP 401) for ${context}. ` +
             `Your session token may have expired — retry the execution, and contact support if it persists.`
-          : vertex
-            // On Vertex the credential is a Google identity — "check your API
-            // key" would send the operator hunting for a key that isn't in play.
+          // On a cloud backend the credential is a cloud identity — "check
+          // your API key" would send the operator hunting for a key that
+          // isn't in play.
+          : backend === "vertex"
             ? `Google rejected this Vertex AI call (authentication, HTTP 401) for ${context}. ` +
               `The credentials are expired or not valid for this project — check ` +
               `GOOGLE_APPLICATION_CREDENTIALS or the runner's GCP identity. See ${BACKEND_DOC_URL}.`
+          : backend === "bedrock"
+            ? `AWS rejected this Bedrock call (authentication, HTTP 401) for ${context}. ` +
+              `The credentials are expired or invalid — check the runner's AWS identity ` +
+              `(environment keys, IAM role / IRSA) or AWS_BEARER_TOKEN_BEDROCK. See ${BACKEND_DOC_URL}.`
             : `Authentication failed for ${context}. Check that your API key is valid and not expired.`,
       };
     case 403:
@@ -222,10 +262,18 @@ function classifyByStatus(
         message: ctx.proxyMode
           ? `The Stigmer platform denied this model call (authorization, HTTP 403) for ${context}. ` +
             `Verify this execution is permitted to use the model, and contact support if it persists.`
-          : vertex
+          : backend === "vertex"
             ? `Vertex AI denied this call (HTTP 403) for ${context}. Grant the runner's ` +
               `service account the "Vertex AI User" role (aiplatform.endpoints.predict) ` +
               `in the target project. See ${BACKEND_DOC_URL}.`
+          : backend === "bedrock"
+            // The most common Bedrock setup mistake: Anthropic models must
+            // be enabled per account ("Model access" in the Bedrock console,
+            // including the use-case submission), on top of IAM.
+            ? `Bedrock denied this call (HTTP 403) for ${context}. Enable this Claude model ` +
+              `under "Model access" in the Bedrock console (Anthropic models require a ` +
+              `use-case submission), and grant the runner's identity bedrock:InvokeModel ` +
+              `for the model and its inference profile. See ${BACKEND_DOC_URL}.`
             : `Access denied for ${context}. Verify that your API key has permission to use this model.`,
       };
     case 404:
@@ -234,11 +282,16 @@ function classifyByStatus(
         retryable: false,
         // The most common Vertex setup mistake: Claude models must be enabled
         // per project in Model Garden, and availability varies by region.
-        message: vertex
+        message: backend === "vertex"
           ? `Model not found on Vertex AI: ${context}. Enable this Claude model for your ` +
             `project in the Vertex AI Model Garden, and confirm it is available in ` +
             `${describeVertexRegion()} — availability varies by region. See ${BACKEND_DOC_URL}.`
-          : `Model not found: ${context}. Verify the model name is correct and available in your account.`,
+          : backend === "bedrock"
+            ? `Model not found on Bedrock: ${context}. Confirm the model is available in ` +
+              `${describeBedrockRegion()} — availability varies by region — and that the ` +
+              `resolved Bedrock id is right for your deployment (STIGMER_BEDROCK_MODEL_MAP ` +
+              `overrides, ${BEDROCK_INFERENCE_PREFIX_ENV} for inference profiles). See ${BACKEND_DOC_URL}.`
+            : `Model not found: ${context}. Verify the model name is correct and available in your account.`,
       };
     case 400:
       return {
@@ -298,18 +351,19 @@ export function describeExecutionError(
 }
 
 /**
- * True when this failure came from a direct-mode Anthropic call served by
- * the vertex backend — the only condition under which the Vertex-specific
- * arms may speak. The backend is resolved from env here (deployment-static,
- * like the API keys model-client reads) rather than threaded through every
- * activity's ModelErrorContext; an invalid var value reads as public, since
+ * The backend serving this direct-mode Anthropic call — the only condition
+ * under which a backend's specific arms may speak. Proxied calls and other
+ * providers read as "public" (no backend wording applies). The backend is
+ * resolved from env here (deployment-static, like the API keys
+ * model-client reads) rather than threaded through every activity's
+ * ModelErrorContext; an invalid var value also reads as public, since
  * classification must never throw and invalid values are already fatal at
  * the factories' preflight and at model construction.
  */
-function isVertexDirectCall(ctx: ModelErrorContext): boolean {
-  if (ctx.proxyMode || ctx.provider !== "anthropic") return false;
+function resolveDirectBackend(ctx: ModelErrorContext): AnthropicBackend {
+  if (ctx.proxyMode || ctx.provider !== "anthropic") return "public";
   const parsed = parseAnthropicBackend();
-  return parsed.ok && parsed.backend === "vertex";
+  return parsed.ok ? parsed.backend : "public";
 }
 
 /**
@@ -330,10 +384,43 @@ function isGoogleCredentialMessage(message: string): boolean {
   );
 }
 
+/**
+ * AWS credential-acquisition prose, matched against the raw message.
+ * Narrow by design (mirrors isGoogleCredentialMessage): pinned to the AWS
+ * credential provider chain's terminal failure
+ * (@aws-sdk/credential-providers' CredentialsProviderError wordings) and
+ * the SigV4 signer's invalid-shape error. A miss falls through to status
+ * classification — never worse than the raw error.
+ */
+function isAwsCredentialMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("could not load credentials from any providers")
+    || lower.includes("credential is missing")
+    || lower.includes("resolved credential object is not valid")
+  );
+}
+
+/**
+ * Bedrock's bare-model-id rejection prose (HTTP 400 ValidationException):
+ * "Invocation of model ID … with on-demand throughput isn't supported.
+ * Retry your request with the ID or ARN of an inference profile …".
+ * Matched narrowly on the phrase that only this condition carries.
+ */
+function isBedrockInferenceProfileMessage(message: string): boolean {
+  return message.toLowerCase().includes("on-demand throughput isn't supported");
+}
+
 /** "region {value}" when CLOUD_ML_REGION is set, else a pointer to the var. */
 function describeVertexRegion(): string {
   const region = process.env.CLOUD_ML_REGION?.trim();
   return region ? `region "${region}"` : "your CLOUD_ML_REGION";
+}
+
+/** "region {value}" when AWS_REGION is set, else a pointer to the var. */
+function describeBedrockRegion(): string {
+  const region = process.env.AWS_REGION?.trim();
+  return region ? `region "${region}"` : "your AWS_REGION";
 }
 
 /**

--- a/docs/guides/runners/model-backends.mdx
+++ b/docs/guides/runners/model-backends.mdx
@@ -2,25 +2,26 @@
 title: Run models in your own cloud
 description:
   Serve a provider's models from your own cloud account instead of the
-  provider's public API. Configure the GCP Vertex AI backend for Claude models
-  with two environment variables on the runner.
+  provider's public API. Configure the GCP Vertex AI or AWS Bedrock backend for
+  Claude models with two environment variables on the runner.
 ---
 
 By default, a runner in direct mode calls each model provider's public API —
 api.anthropic.com for Claude, api.openai.com for GPT. A **backend** changes
-where those models are served. Point the runner at your own GCP project and
-every Claude call runs inside your cloud account's compliance boundary: your
-region, your contracts, your audit trail. Nothing else changes — Agents, model
-names, usage reporting, and the console all behave exactly as before.
+where those models are served. Point the runner at your own GCP project or AWS
+account and every Claude call runs inside your cloud account's compliance
+boundary: your region, your contracts, your audit trail. Nothing else changes —
+Agents, model names, usage reporting, and the console all behave exactly as
+before.
 
 Backends are a deployment decision, set through environment variables on the
 runner. Agents stay portable: the same Agent runs unchanged on a laptop against
-the public API and on a production runner against Vertex AI.
+the public API and on a production runner against Vertex AI or Bedrock.
 
-| Provider  | Backends                                          |
-| --------- | ------------------------------------------------- |
-| Anthropic | `public` (default), `vertex` — Bedrock is planned |
-| OpenAI    | `public` (default) — Azure OpenAI is planned      |
+| Provider  | Backends                                     |
+| --------- | -------------------------------------------- |
+| Anthropic | `public` (default), `vertex`, `bedrock`      |
+| OpenAI    | `public` (default) — Azure OpenAI is planned |
 
 <Callout type="info">
   Backends apply to runners in **direct mode** — runners you operate with your
@@ -96,23 +97,118 @@ the GCP console under Vertex AI monitoring.
 </Step>
 </Steps>
 
-## How model names map to Vertex
+## Serve Claude from AWS Bedrock
 
-You never configure Vertex model ids. The runner translates each canonical model
-id to Vertex's form on the wire (for example, `claude-sonnet-4-5-20250929`
-becomes `claude-sonnet-4-5@20250929`; dateless ids like `claude-sonnet-4-6` are
-identical on both). Usage metrics and pricing always report the canonical id.
+<Steps>
+<Step>
+
+## Enable the Claude models in your AWS account
+
+In the Bedrock console under **Model access**, enable the Claude models you plan
+to use. Anthropic models require a use-case submission (once per account or
+centrally through your AWS organization), and availability varies by region.
+
+</Step>
+<Step>
+
+## Give the runner an AWS identity
+
+The runner authenticates with the standard AWS credential chain. Any of these
+work:
+
+- **An IAM role** (recommended — IRSA on EKS, or an instance profile) — no keys
+  to manage.
+- **Environment keys** — `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+- **A Bedrock API key** — set `AWS_BEARER_TOKEN_BEDROCK`.
+
+Whichever identity you use, grant it `bedrock:InvokeModel` and
+`bedrock:InvokeModelWithResponseStream` for the models — and, if you use
+cross-region inference, for their inference profiles.
+
+</Step>
+<Step>
+
+## Configure and start the runner
+
+Two variables select the backend and the region. Anthropic API keys are not
+needed — authentication is AWS's:
+
+```bash
+# Stigmer-owned decision: which backend serves Anthropic models.
+export STIGMER_ANTHROPIC_BACKEND=bedrock
+
+# Standard AWS convention, read natively by the Bedrock SDK. Required
+# explicitly: the runner never falls back to the SDK's us-east-1 default —
+# a deployment that chose Bedrock for data residency must pick its region.
+export AWS_REGION=ap-south-1
+
+# Newer Claude models are invoked through cross-region inference profiles.
+# Set your deployment's geography once; it prefixes every derived model id.
+export STIGMER_BEDROCK_INFERENCE_PREFIX=us   # or "eu", "jp", "global", …
+
+stigmer up
+```
+
+The runner validates this configuration at startup. If the backend value is
+wrong or the region is missing, it refuses to start and prints exactly what to
+fix — a misconfigured deployment never accepts work it cannot serve.
+
+</Step>
+<Step>
+
+## Verify with a Session
+
+Run any Agent that uses a Claude model. Usage and cost reporting key on the same
+model names as before — you can confirm the traffic is reaching your account in
+CloudWatch under Bedrock metrics.
+
+</Step>
+</Steps>
+
+<Callout type="warn">
+  Bedrock does not support Anthropic's token-counting or prompt-caching APIs.
+  Executions behave identically otherwise; if a future capability depends on
+  these, it will say so rather than degrade silently.
+</Callout>
+
+## How model names map to Vertex and Bedrock
+
+You never configure backend model ids for the common case. The runner translates
+each canonical model id on the wire — usage metrics and pricing always report
+the canonical id:
+
+- **Vertex**: `claude-sonnet-4-5-20250929` becomes `claude-sonnet-4-5@20250929`;
+  dateless ids like `claude-sonnet-4-6` are identical on both.
+- **Bedrock**: `claude-sonnet-4-5-20250929` becomes
+  `anthropic.claude-sonnet-4-5-20250929-v1:0`, prefixed with
+  `STIGMER_BEDROCK_INFERENCE_PREFIX` when set (e.g.
+  `us.anthropic.claude-sonnet-4-5-20250929-v1:0`).
+
+When a Bedrock id can't be derived this way (AWS occasionally versions ids on
+its own schedule), map that model explicitly — the map wins over the derivation
+rule:
+
+```bash
+export STIGMER_BEDROCK_MODEL_MAP="claude-sonnet-4-6=us.anthropic.claude-sonnet-4-6-v2:0"
+```
+
+Entries are comma-separated `canonical=bedrockId` pairs; the id side accepts
+anything Bedrock accepts, including inference-profile ARNs.
 
 ## Troubleshooting
 
 Every failure names the variable or permission to fix. The common ones:
 
-| Symptom                                          | Fix                                                                                                      |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Runner refuses to start, names `CLOUD_ML_REGION` | Set the region (e.g. `asia-south1`, or `global`).                                                        |
-| "could not acquire Google credentials"           | Set `GOOGLE_APPLICATION_CREDENTIALS`, or run on a GCP identity (workload identity / metadata server).    |
-| HTTP 403 from Vertex AI                          | Grant the runner's identity the **Vertex AI User** role in the target project.                           |
-| Model not found (HTTP 404)                       | Enable the model in the Model Garden for your project, and confirm it is available in `CLOUD_ML_REGION`. |
+| Symptom                                          | Fix                                                                                                   |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Runner refuses to start, names `CLOUD_ML_REGION` | Set the region (e.g. `asia-south1`, or `global`).                                                     |
+| Runner refuses to start, names `AWS_REGION`      | Set the region explicitly (e.g. `ap-south-1`) — the runner never assumes `us-east-1`.                 |
+| "could not acquire Google credentials"           | Set `GOOGLE_APPLICATION_CREDENTIALS`, or run on a GCP identity (workload identity / metadata server). |
+| "could not acquire AWS credentials"              | Provide the AWS chain (environment keys, IAM role / IRSA) or set `AWS_BEARER_TOKEN_BEDROCK`.          |
+| HTTP 403 from Vertex AI                          | Grant the runner's identity the **Vertex AI User** role in the target project.                        |
+| HTTP 403 from Bedrock                            | Enable the model under **Model access** in the Bedrock console, and grant `bedrock:InvokeModel`.      |
+| "requires an inference profile"                  | Set `STIGMER_BEDROCK_INFERENCE_PREFIX` to your geography (`us`, `eu`, `global`, …).                   |
+| Model not found (HTTP 404)                       | Enable the model for your project/account, and confirm it is available in your configured region.     |
 
 ## What's next
 

--- a/docs/guides/runners/overview.mdx
+++ b/docs/guides/runners/overview.mdx
@@ -43,9 +43,9 @@ let Stigmer Cloud provision a runner for you.
     href="/docs/guides/runners/model-backends"
     title="Run models in your own cloud"
   >
-    Serve Claude from your own GCP project with Vertex AI: two environment
-    variables on a direct-mode runner, standard Google credentials, and zero
-    changes to your Agents.
+    Serve Claude from your own cloud — GCP Vertex AI or AWS Bedrock: two
+    environment variables on a direct-mode runner, your cloud's standard
+    credentials, and zero changes to your Agents.
   </Card>
 </Cards>
 


### PR DESCRIPTION
## Summary

`STIGMER_ANTHROPIC_BACKEND=bedrock` now routes every native-harness Claude call through the deployment's own AWS account — the second backend on the provider-backend seam, built in the same evidence-first shape as the Vertex adapter (T02). Zero proto/UI/billing changes; unconfigured and vertex-configured deployments are byte-for-byte unaffected.

**Stacked on #407** (T03 direct-path credential resolution) — the adapter builds on `checkDirectCredentials` and the parser from that branch. Merge #407 first; this PR then rebases to a clean diff.

## Design decisions (recorded for the DD)

- **Explicit `AWS_REGION` required at preflight.** The Bedrock SDK silently defaults to `us-east-1` (pinned by a seam test) — for a deployment-controlled data-residency feature, a silent cross-region default is exactly the failure backends exist to prevent. Mirrors Vertex's `CLOUD_ML_REGION` requirement.
- **Three-layer model-id resolution** (approved during planning): `STIGMER_BEDROCK_MODEL_MAP` per-model override → optional `STIGMER_BEDROCK_INFERENCE_PREFIX` (`us`/`eu`/`global`… — geography is a deployment decision, never defaulted) → deterministic `anthropic.{canonical}-v1:0` rule, verified against AWS's model catalog. A bare-id "use an inference profile" rejection classifies to the one-var remedy.
- **The maxTokens landmine defused by canonical-parity probe.** `anthropic.…` ids miss LangChain's per-model default table and silently cap at 4096 (`setup.ts` omits `maxTokens`). The adapter probes the CANONICAL id with a throwaway construction so bedrock inherits exactly what public/vertex get for the same model — including models the table doesn't know yet, where all backends agree on the fallback. Pinned as a regression test.
- **`model-error.ts` refactor**: the `vertex: boolean` threading became a resolved-backend value before a third backend turns it into boolean proliferation. Vertex behavior is unchanged (existing tests pass untouched).

## Changes

- `llm-backend.ts`: `bedrock` supported; `checkBedrockPrerequisites` (region + map syntax fail at boot, credentials deliberately unchecked — the AWS chain/IRSA/`AWS_BEARER_TOKEN_BEDROCK` resolve at request time); `parseBedrockModelMap`; `toBedrockModelId`; remedy wordings updated.
- `model-client.ts`: bedrock branch mirroring vertex — lazy SDK import (bundle-slim's deferred evaluation verified), factory honors `maxRetries`, prerequisites re-checked at dispatch, canonical-id invariant intact.
- `model-error.ts`: AWS credential-chain classification (narrow pinned wordings), 401/403/404 around AWS identities and Bedrock **Model access** enablement, `LLM_BACKEND_MODEL_ROUTING` for the inference-profile rejection.
- `check-langchain-deps.sh`: `@anthropic-ai/bedrock-sdk` joins the allowed dependents; npm dedupes its `@anthropic-ai/sdk` onto the existing nested 0.116.0 — still exactly two versions.
- New `bedrock-seam.test.ts` (8 tests) pins the INSTALLED 0.32.1 cross-package behavior: SigV4 over the adapted request, URL shaping, binary EventStream→SSE transcoding (fixtures built with the SDK's own marshaller — the real wire path, not an SSE bypass), streaming usage accounting, the `countTokens` gap, the us-east-1 default.
- New `bedrock-adapter.test.ts` (7 tests) pins OUR wiring through the real `createClient` path: lazy construction, `maxRetries: 0`, translated id on the wire with canonical id returned, prefix/map layering, the maxTokens injection, no-API-key construction, region fail-fast.
- Operator docs: full Bedrock guide on the model-backends page (model access, IAM, env contract, id mapping, limitations, troubleshooting) + overview card.

## Breaking changes

- None. `bedrock` was previously a "recognized but not implemented" fatal value; every other configuration behaves identically.

## Test plan

- Full runner suite (CI=1): **4241 passed, 0 failed** (+52 over the T03 baseline).
- Slim bundle: 83.2 MB ≤ 120 MB budget, authed boot guard green, bedrock-sdk confirmed inside deferred `__esm` wrappers (cold starts unaffected for deployments that never configure it).
- `check-deps` green on the three-parent set; docs inventory gate green (198 pages); vale 0 errors.
- Live AWS verification deliberately out of scope — T06's cross-backend matrix owns the live gate decision, consistent with how the Vertex adapter shipped.

## Risks

- Low: the entire branch is unreachable unless a deployment opts in via `STIGMER_ANTHROPIC_BACKEND=bedrock`. Known limitation (documented + pinned): no token counting / prompt caching on Bedrock.

Made with [Cursor](https://cursor.com)