### PR TITLE
fix(runner,cli,server): make MCP connect discovery hang-proof and its failures diagnosable

### DIFF
--- a/backend/services/runner/src/activities/__tests__/discover-mcp-server.hang.test.ts
+++ b/backend/services/runner/src/activities/__tests__/discover-mcp-server.hang.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression pin for issue #239's hang mechanism, against the REAL MCP client
+ * stack (no @langchain/mcp-adapters mock — that's why this lives in its own
+ * file, apart from discover-mcp-server.test.ts's mocked suite).
+ *
+ * The monday.com failure shape: the endpoint answers the streamable-HTTP
+ * initialize POST with a 4xx, mcp-adapters automatically falls back to SSE at
+ * the same URL, the endpoint accepts the stream and never sends the legacy
+ * `endpoint` event — and the MCP SDK's SSEClientTransport has no timer of its
+ * own, so initialization hangs forever. Before the transport-aware init bound,
+ * that hang rode until Temporal killed the activity opaquely; this test pins
+ * that discovery now fails fast (in fake time) with an error that names the
+ * endpoint.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+
+vi.mock("../../idle-watchdog.js", () => ({
+  activityStarted: vi.fn(),
+  activityFinished: vi.fn(),
+}));
+
+// classifyHttpOAuthFailure re-probes the endpoint on the failure path; keep it
+// deterministic here (its own behavior is covered by mcp-oauth-detect tests).
+vi.mock("../../shared/mcp-oauth-detect.js", () => ({
+  detectOAuthChallenge: vi.fn().mockResolvedValue(null),
+}));
+
+describe("discovery against a 4xx-then-silent-SSE endpoint (issue #239)", () => {
+  let server: Server;
+  let url: string;
+
+  beforeEach(async () => {
+    server = createServer((req, res) => {
+      if (req.method === "POST") {
+        // monday-shaped: reject the streamable-HTTP initialize outright.
+        res.writeHead(405, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "method not allowed" }));
+        return;
+      }
+      // The SSE fallback: accept the stream, never send an `endpoint` event.
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write(": silent stream\n\n");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "string" || address === null) throw new Error("no port");
+    url = `http://127.0.0.1:${address.port}/mcp`;
+  });
+
+  afterEach(() => {
+    // closeAllConnections: the hung SSE stream is a live socket that would
+    // otherwise keep server.close() (and the vitest worker) waiting.
+    server.closeAllConnections();
+    server.close();
+    vi.useRealTimers();
+  });
+
+  it("fails within the HTTP init bound with an endpoint-naming error", async () => {
+    const { discoverMcpServer } = await import("../discover-mcp-server.js");
+
+    const stigmerClient = {
+      getMcpServer: vi.fn().mockResolvedValue({
+        metadata: { slug: "monday", id: "mcp-monday" },
+        spec: {
+          serverType: {
+            case: "http",
+            value: { url, headers: {}, queryParams: {}, timeoutSeconds: 0 },
+          },
+          env: {},
+          pinnedToolApprovals: [],
+        },
+        status: undefined,
+      }),
+      getExecutionContextByExecutionId: vi.fn(),
+    };
+
+    // shouldAdvanceTime keeps real I/O flowing (the POST → 405 → SSE fallback
+    // happens over real sockets) while letting the test jump the 60s bound.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const promise = discoverMcpServer(
+      { mcpServerId: "mcp-monday" },
+      { stigmerClient: stigmerClient as never, transportPosture: "stdio-forbidden" },
+    );
+    // Attach the rejection expectation BEFORE advancing so the rejection is
+    // never momentarily unhandled.
+    const expectation = expect(promise).rejects.toThrow(
+      new RegExp(`at ${url.replaceAll(".", "\\.")}.*did not complete MCP initialization`, "s"),
+    );
+
+    // Give the real client a beat to reach the hang (POST + fallback), then
+    // jump past the 30s HTTP bound in fake time.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await expectation;
+  }, 15_000);
+});

--- a/backend/services/runner/src/activities/__tests__/discover-mcp-server.test.ts
+++ b/backend/services/runner/src/activities/__tests__/discover-mcp-server.test.ts
@@ -10,6 +10,14 @@ vi.mock("../../idle-watchdog.js", () => ({
   activityFinished: vi.fn(),
 }));
 
+// The factory starts a Temporal heartbeat loop; outside an activity context
+// its ticks would throw, so replace it with a stop-spy and assert the
+// start/stop contract instead.
+const mockHeartbeatStop = vi.fn();
+vi.mock("../../shared/heartbeat.js", () => ({
+  startHeartbeat: vi.fn(() => ({ stop: mockHeartbeatStop, cancelled: false, workerShutdown: false })),
+}));
+
 const mockInitializeConnections = vi.fn();
 const mockGetClient = vi.fn();
 const mockClose = vi.fn().mockResolvedValue(undefined);
@@ -600,6 +608,122 @@ describe("DiscoverMcpServer activity", () => {
       expect(result.newToolsFingerprint).toBe("");
     });
 
+    it("fails closed when the EC read errors and the server requires credentials", async () => {
+      // Issue #239: limping ahead with an empty env either died later as an
+      // opaque PlaceholderResolutionError or dialed the endpoint with a
+      // garbage credential and wedged in the 4xx → SSE-fallback limbo. The
+      // failure must name the root cause: credential delivery.
+      const { discoverMcpServer, CredentialResolutionError } = await import("../discover-mcp-server.js");
+
+      const spec = makeHttpSpec("https://mcp.monday.com/mcp");
+      spec.env = { MONDAY_ACCESS_TOKEN: { isSecret: true } };
+      const mockClient = makeMockStigmerClient({
+        mcpServer: makeMcpServer({ metadata: { slug: "monday" }, spec }),
+      });
+      mockClient.getExecutionContextByExecutionId = vi
+        .fn()
+        .mockRejectedValue(new Error("PERMISSION_DENIED: not scope-bound"));
+
+      await expect(
+        discoverMcpServer(
+          { mcpServerId: "mcp-monday", executionContextId: "ctx-1" },
+          { stigmerClient: mockClient as any, transportPosture: "stdio-forbidden" },
+        ),
+      ).rejects.toThrow(CredentialResolutionError);
+      expect(mockInitializeConnections).not.toHaveBeenCalled();
+    });
+
+    it("keeps the lenient path when the EC read errors but no env is declared", async () => {
+      const { discoverMcpServer } = await import("../discover-mcp-server.js");
+
+      const mockClient = makeMockStigmerClient({
+        mcpServer: makeMcpServer({
+          metadata: { slug: "no-env" },
+          spec: makeHttpSpec("https://mcp.example.com"),
+        }),
+      });
+      mockClient.getExecutionContextByExecutionId = vi
+        .fn()
+        .mockRejectedValue(new Error("transient"));
+
+      mockInitializeConnections.mockResolvedValue({});
+      mockGetClient.mockResolvedValue(makeMockMcpClient({ tools: [] }));
+
+      const result = await discoverMcpServer(
+        { mcpServerId: "mcp-lenient", executionContextId: "ctx-2" },
+        { stigmerClient: mockClient as any, transportPosture: "stdio-forbidden" },
+      );
+      expect(result.tools).toEqual([]);
+    });
+
+    it("keeps the lenient path when all declared env vars are optional", async () => {
+      // Caller-identity-style servers declare only optional keys; discovery
+      // legitimately proceeds without an EC for them (the injections below
+      // resolveEnvVarsForDiscovery supply the values).
+      const { discoverMcpServer } = await import("../discover-mcp-server.js");
+
+      const spec = makeHttpSpec("https://mcp.example.com");
+      spec.env = { STIGMER_CALLER_IDENTITY_KIND: { optional: true } };
+      const mockClient = makeMockStigmerClient({
+        mcpServer: makeMcpServer({ metadata: { slug: "optional-only" }, spec }),
+      });
+      mockClient.getExecutionContextByExecutionId = vi
+        .fn()
+        .mockRejectedValue(new Error("transient"));
+
+      mockInitializeConnections.mockResolvedValue({});
+      mockGetClient.mockResolvedValue(makeMockMcpClient({ tools: [] }));
+
+      const result = await discoverMcpServer(
+        { mcpServerId: "mcp-optional", executionContextId: "ctx-3" },
+        { stigmerClient: mockClient as any, transportPosture: "stdio-forbidden" },
+      );
+      expect(result.tools).toEqual([]);
+    });
+
+    it("fails closed when the EC is empty and the server requires credentials", async () => {
+      const { discoverMcpServer, CredentialResolutionError } = await import("../discover-mcp-server.js");
+
+      const spec = makeHttpSpec("https://mcp.monday.com/mcp");
+      spec.env = { MONDAY_ACCESS_TOKEN: { isSecret: true } };
+      const mockClient = makeMockStigmerClient({
+        mcpServer: makeMcpServer({ metadata: { slug: "monday" }, spec }),
+        executionContext: { spec: { data: {} } },
+      });
+
+      const promise = discoverMcpServer(
+        { mcpServerId: "mcp-monday", executionContextId: "ctx-4" },
+        { stigmerClient: mockClient as any, transportPosture: "stdio-forbidden" },
+      );
+      await expect(promise).rejects.toThrow(CredentialResolutionError);
+      await expect(promise).rejects.toThrow(/delivered no credentials/);
+      expect(mockInitializeConnections).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when a delivered credential is the redaction sentinel", async () => {
+      // A redacted value means the server-side decrypt gate refused this
+      // runner's credential class/scope — dialing with the literal sentinel
+      // can only produce a misleading 401 (the issue-#239 M2 mechanism).
+      const { discoverMcpServer, CredentialResolutionError } = await import("../discover-mcp-server.js");
+
+      const spec = makeHttpSpec("https://mcp.monday.com/mcp");
+      spec.env = { MONDAY_ACCESS_TOKEN: { isSecret: true } };
+      const mockClient = makeMockStigmerClient({
+        mcpServer: makeMcpServer({ metadata: { slug: "monday" }, spec }),
+        executionContext: {
+          spec: { data: { MONDAY_ACCESS_TOKEN: { value: "***REDACTED***", isSecret: true } } },
+        },
+      });
+
+      const promise = discoverMcpServer(
+        { mcpServerId: "mcp-monday", executionContextId: "ctx-5" },
+        { stigmerClient: mockClient as any, transportPosture: "stdio-forbidden" },
+      );
+      await expect(promise).rejects.toThrow(CredentialResolutionError);
+      await expect(promise).rejects.toThrow(/MONDAY_ACCESS_TOKEN.*delivered redacted|delivered redacted.*MONDAY_ACCESS_TOKEN/s);
+      expect(mockInitializeConnections).not.toHaveBeenCalled();
+    });
+
     it("closes MCP client even when discovery fails", async () => {
       const { discoverMcpServer } = await import("../discover-mcp-server.js");
 
@@ -617,6 +741,82 @@ describe("DiscoverMcpServer activity", () => {
       ).rejects.toThrow("Connection refused");
 
       expect(mockClose).toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Transport-aware init bounds (issue #239)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("transport-aware init bounds", () => {
+    it("bounds HTTP endpoints at 30s and stdio at 270s", async () => {
+      // HTTP has no cold-start excuse: a healthy endpoint completes the MCP
+      // handshake in seconds, so a short bound converts the silent-SSE hang
+      // into a fast actionable failure. 30s (not more) keeps the error
+      // reachable under the OSS server's 45s connect-workflow deadline.
+      // stdio keeps the cold-start allowance (issue #243).
+      const { initTimeoutMsFor } = await import("../discover-mcp-server.js");
+      expect(initTimeoutMsFor("http")).toBe(30_000);
+      expect(initTimeoutMsFor("sse")).toBe(30_000);
+      expect(initTimeoutMsFor("stdio")).toBe(270_000);
+    });
+
+    it("names the endpoint URL in the HTTP timeout message", async () => {
+      const { initTimeoutMessageFor } = await import("../discover-mcp-server.js");
+      const message = initTimeoutMessageFor("monday", {
+        slug: "monday",
+        connectionType: "http",
+        url: "https://mcp.monday.com/mcp",
+        toolApprovals: [],
+        pinnedToolApprovals: [],
+        discoveredCapabilitiesEmpty: true,
+      });
+      expect(message).toContain("https://mcp.monday.com/mcp");
+      expect(message).toContain("30s");
+      expect(message).toContain("SSE fallback");
+    });
+
+    it("names the command in the stdio timeout message", async () => {
+      const { initTimeoutMessageFor } = await import("../discover-mcp-server.js");
+      const message = initTimeoutMessageFor("filesystem", {
+        slug: "filesystem",
+        connectionType: "stdio",
+        command: "npx",
+        toolApprovals: [],
+        pinnedToolApprovals: [],
+        discoveredCapabilitiesEmpty: true,
+      });
+      expect(message).toContain("npx");
+      expect(message).toContain("270s");
+      expect(message).toContain("cold start");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Heartbeat contract (issue #239)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("heartbeat contract", () => {
+    it("starts a heartbeat for the activity and stops it on completion", async () => {
+      // The connect workflow proxies this activity with a 60s heartbeatTimeout.
+      // Without a heartbeat loop, any discovery slower than 60s was killed by
+      // Temporal with an opaque heartbeat timeout — never reaching the
+      // actionable init-timeout errors (issues #239/#243).
+      const { createDiscoverMcpServerActivities } = await import("../discover-mcp-server.js");
+      const { startHeartbeat } = await import("../../shared/heartbeat.js");
+
+      vi.mocked(startHeartbeat).mockClear();
+      mockHeartbeatStop.mockClear();
+
+      const { DiscoverMcpServerCapabilities } = createDiscoverMcpServerActivities(makeConfig());
+      try {
+        await DiscoverMcpServerCapabilities({ mcpServerId: "test" });
+      } catch {
+        // Expected — no real backend behind the factory's own client.
+      }
+
+      expect(startHeartbeat).toHaveBeenCalledTimes(1);
+      expect(mockHeartbeatStop).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/services/runner/src/activities/discover-mcp-server.ts
+++ b/backend/services/runner/src/activities/discover-mcp-server.ts
@@ -22,7 +22,7 @@ import { createHash } from "node:crypto";
 import { MultiServerMCPClient } from "@langchain/mcp-adapters";
 import { activityStarted, activityFinished } from "../idle-watchdog.js";
 import { StigmerClient } from "../client/stigmer-client.js";
-import { mcpServerToResolved } from "../shared/mcp-resolver.js";
+import { mcpServerToResolved, type ResolvedMcpServer } from "../shared/mcp-resolver.js";
 import { toMcpClientConfig } from "../shared/mcp-manager.js";
 import {
   assertTransportAllowed,
@@ -31,11 +31,43 @@ import {
 } from "../shared/mcp-transport-guard.js";
 import { detectOAuthChallenge } from "../shared/mcp-oauth-detect.js";
 import { injectAnonymousCallerIdentityForDiscovery } from "../shared/caller-identity.js";
+import { startHeartbeat } from "../shared/heartbeat.js";
 import { withTimeout } from "../shared/with-timeout.js";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { EnvVarDeclaration } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
 import type { Config } from "../config.js";
 
-const SESSION_INIT_TIMEOUT_MS = 270_000;
+/**
+ * MCP session-init bounds, per transport (issue #239).
+ *
+ * A remote endpoint that accepts a connection but never completes the MCP
+ * handshake would otherwise hang initialization forever: the MCP SDK's SSE
+ * transport resolves only on the server's `endpoint` event, with no timer of
+ * its own, and mcp-adapters silently falls back to SSE whenever the
+ * streamable-HTTP POST is answered with a 4xx (monday.com's endpoint did
+ * exactly this — 4xx on POST, then a silently-open SSE stream).
+ *
+ * HTTP endpoints get a short bound: there is nothing to install or compile,
+ * so a healthy endpoint completes the handshake in seconds. 30s is chosen to
+ * fit inside the OSS server's 45s connect-workflow run timeout with room for
+ * the 10s OAuth re-probe on the failure path — any larger and this error
+ * could never surface on OSS (the workflow deadline would fire first).
+ * stdio servers keep the generous bound because their first run may compile
+ * or install packages (`go run`, `npx`) — the cold-start case (issue #243).
+ */
+const HTTP_INIT_TIMEOUT_MS = 30_000;
+const STDIO_INIT_TIMEOUT_MS = 270_000;
+
+/**
+ * The server-side secret-redaction sentinel. Byte-for-byte the value both
+ * editions substitute for secret values a caller may not decrypt
+ * (`SecretEncryptionService.REDACTED_MARKER` in stigmer-cloud,
+ * `RedactedMarker` in the OSS Go server). Discovery dialing an
+ * endpoint with a redacted credential is guaranteed to fail confusingly
+ * (e.g. `Authorization: Bearer ***REDACTED***` → 401 → SSE-fallback limbo),
+ * so it is refused up front with an actionable error instead.
+ */
+const REDACTED_MARKER = "***REDACTED***";
 
 const PLATFORM_INJECTABLE_MAP: Record<string, string> = {
   STIGMER_SERVER_ADDRESS: "STIGMER_MCP_PUBLIC_ENDPOINT",
@@ -93,6 +125,28 @@ export interface ToolApprovalDict {
   toolName: string;
   requiresApproval: boolean;
   message: string;
+}
+
+/**
+ * Raised when the credentials a server declares could not be delivered to
+ * discovery — the ExecutionContext read failed, came back empty, or returned
+ * redacted values (issue #239).
+ *
+ * Exists because the alternative is strictly worse: proceeding without the
+ * declared credentials either dies later as an opaque
+ * PlaceholderResolutionError (when a header/arg templates the missing var) or
+ * dials the endpoint with a garbage credential and strands the connect in the
+ * 4xx → SSE-fallback limbo this file's init bounds exist to contain. Failing
+ * here names the ROOT cause — credential delivery — instead of its downstream
+ * symptom. The message is user-facing and self-contained: it survives the
+ * Temporal boundary and the Go/Java connect wrappers include it in the
+ * user-facing failure text.
+ */
+export class CredentialResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CredentialResolutionError";
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -242,14 +296,15 @@ export async function discoverMcpServer(
   const slug = mcpServer.metadata?.slug || mcpServerId;
   const previousState = extractPreviousState(mcpServer);
 
+  const declaredEnv = mcpServer.spec.env ?? {};
   const envVars = await resolveEnvVarsForDiscovery(
     stigmerClient,
     executionContextId ?? null,
+    slug,
+    declaredEnv,
   );
 
-  const declaredEnvKeys = mcpServer.spec.env
-    ? new Set(Object.keys(mcpServer.spec.env))
-    : new Set<string>();
+  const declaredEnvKeys = new Set(Object.keys(declaredEnv));
   const platformEnv = injectPlatformEnv(declaredEnvKeys, envVars);
 
   // Discovery runs with no session, so every declared caller-identity key
@@ -277,6 +332,7 @@ export async function discoverMcpServer(
   const { tools, resourceTemplates } = await connectAndDiscover(
     slug,
     connectionConfig,
+    resolved,
   );
 
   const newFp = toolsFingerprint(tools);
@@ -300,51 +356,144 @@ export async function discoverMcpServer(
 // Env Var Resolution
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Resolve the discovery env from the connect flow's ExecutionContext,
+ * failing CLOSED when a server's declared credentials cannot be delivered.
+ *
+ * The strictness is keyed on whether the server declares any NON-OPTIONAL
+ * env var ("credentials expected"):
+ *
+ * - Credentials expected + the EC read errors, or the EC is missing/empty →
+ *   {@link CredentialResolutionError}. The backend only creates a connect EC
+ *   when it resolved credentials to deliver, so an unreadable or empty EC is
+ *   a delivery failure (auth/scope refusal, transient backend error), never a
+ *   normal state. Limping ahead was issue #239's failure mode: discovery died
+ *   later as an opaque PlaceholderResolutionError or a doomed dial.
+ * - Any delivered value equal to the redaction sentinel →
+ *   {@link CredentialResolutionError}, regardless of optionality. A redacted
+ *   value means the server-side decrypt gate refused THIS runner's credential
+ *   class/scope and fell closed to redaction — dialing with the literal
+ *   sentinel can only produce a misleading 401.
+ * - No non-optional declarations → the old lenient path (warn and continue):
+ *   servers declaring nothing (or only optional/injected keys like the
+ *   caller-identity family) legitimately discover without an EC.
+ */
 async function resolveEnvVarsForDiscovery(
   client: StigmerClient,
   executionContextId: string | null,
+  slug: string,
+  declaredEnv: Record<string, EnvVarDeclaration>,
 ): Promise<Record<string, string>> {
+  const requiredKeys = Object.entries(declaredEnv)
+    .filter(([, decl]) => !decl.optional)
+    .map(([key]) => key);
+  const credentialsExpected = requiredKeys.length > 0;
+
   if (!executionContextId) return {};
 
+  let execCtx: Awaited<ReturnType<typeof client.getExecutionContextByExecutionId>>;
   try {
-    const execCtx = await client.getExecutionContextByExecutionId(
-      executionContextId,
-    );
-
-    if (!execCtx?.spec?.data || Object.keys(execCtx.spec.data).length === 0) {
-      console.warn(
-        `[DiscoverMcpServer] ExecutionContext '${executionContextId}' not found ` +
-        `or empty — MCP server may not require environment variables`,
-      );
-      return {};
-    }
-
-    const envVars: Record<string, string> = {};
-    for (const [key, execValue] of Object.entries(execCtx.spec.data)) {
-      envVars[key] = execValue.value;
-    }
-
-    console.log(
-      `[DiscoverMcpServer] Resolved ${Object.keys(envVars).length} env var(s) ` +
-      `from ExecutionContext '${executionContextId}'`,
-    );
-    return envVars;
+    execCtx = await client.getExecutionContextByExecutionId(executionContextId);
   } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    if (credentialsExpected) {
+      throw new CredentialResolutionError(
+        `Could not resolve the credentials MCP server '${slug}' requires ` +
+        `(${requiredKeys.join(", ")}): the connect credential store was ` +
+        `unreadable (${cause}). This is a platform-side delivery failure, ` +
+        `not a problem with your credentials — retry the connect, and if it ` +
+        `persists, re-run the OAuth sign-in or re-enter the credentials.`,
+      );
+    }
     console.warn(
       `[DiscoverMcpServer] Failed to resolve ExecutionContext '${executionContextId}': ` +
-      `${err instanceof Error ? err.message : err}`,
+      `${cause}`,
     );
     return {};
   }
+
+  const data = execCtx?.spec?.data ?? {};
+  if (Object.keys(data).length === 0) {
+    if (credentialsExpected) {
+      throw new CredentialResolutionError(
+        `MCP server '${slug}' requires ${requiredKeys.join(", ")}, but the ` +
+        `connect flow delivered no credentials. Re-run the OAuth sign-in ` +
+        `(or re-enter the credentials) and connect again.`,
+      );
+    }
+    console.warn(
+      `[DiscoverMcpServer] ExecutionContext '${executionContextId}' not found ` +
+      `or empty — MCP server may not require environment variables`,
+    );
+    return {};
+  }
+
+  const redactedKeys = Object.entries(data)
+    .filter(([, execValue]) => execValue.value === REDACTED_MARKER)
+    .map(([key]) => key);
+  if (redactedKeys.length > 0) {
+    throw new CredentialResolutionError(
+      `The credentials for MCP server '${slug}' were delivered redacted ` +
+      `(${redactedKeys.join(", ")}): the platform refused to decrypt them ` +
+      `for this runner. This is a platform-side authorization failure — ` +
+      `retry the connect, and report it if it persists.`,
+    );
+  }
+
+  const envVars: Record<string, string> = {};
+  for (const [key, execValue] of Object.entries(data)) {
+    envVars[key] = execValue.value;
+  }
+
+  console.log(
+    `[DiscoverMcpServer] Resolved ${Object.keys(envVars).length} env var(s) ` +
+    `from ExecutionContext '${executionContextId}'`,
+  );
+  return envVars;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MCP Connection + Enumeration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Pick the session-init bound for a resolved server's transport.
+ *
+ * Exported for tests; pure so the timeout choice (the load-bearing half of
+ * the issue-#239 fix) can be pinned without wiring a slow clock.
+ */
+export function initTimeoutMsFor(connectionType: ResolvedMcpServer["connectionType"]): number {
+  return connectionType === "stdio" ? STDIO_INIT_TIMEOUT_MS : HTTP_INIT_TIMEOUT_MS;
+}
+
+/**
+ * The user-facing message for a session-init timeout. Names the endpoint (or
+ * command) so the failure is diagnosable from the message alone, and explains
+ * the known silent-hang shape for HTTP endpoints — issue #239's mechanism.
+ */
+export function initTimeoutMessageFor(slug: string, resolved: ResolvedMcpServer): string {
+  const seconds = Math.round(initTimeoutMsFor(resolved.connectionType) / 1000);
+  if (resolved.connectionType === "stdio") {
+    return (
+      `MCP server '${slug}' (command: ${resolved.command}) did not complete ` +
+      `MCP initialization within ${seconds}s. If this server requires ` +
+      `compilation or package installation on first run (e.g. go run, npx), ` +
+      `the cold start may have exceeded the discovery timeout.`
+    );
+  }
+  return (
+    `MCP server '${slug}' at ${resolved.url} did not complete MCP ` +
+    `initialization within ${seconds}s. The endpoint accepted the connection ` +
+    `but never finished the handshake — commonly an endpoint that rejects ` +
+    `streamable HTTP while leaving its SSE fallback stream silently open. ` +
+    `Verify the URL points at a live streamable-HTTP MCP endpoint.`
+  );
+}
+
 async function connectAndDiscover(
   slug: string,
   connectionConfig: ReturnType<typeof toMcpClientConfig>,
+  resolved: ResolvedMcpServer,
 ): Promise<{
   tools: DiscoveredToolResult[];
   resourceTemplates: DiscoveredResourceTemplateResult[];
@@ -354,12 +503,10 @@ async function connectAndDiscover(
   const resourceTemplates: DiscoveredResourceTemplateResult[] = [];
 
   try {
-    const timeoutMessage =
-      `MCP server '${slug}' did not respond within ` +
-      `${Math.round(SESSION_INIT_TIMEOUT_MS / 1000)}s. If this server requires compilation or ` +
-      `package installation on first run (e.g. go run, npx), the cold ` +
-      `start may have exceeded the discovery timeout.`;
-    await withTimeout(SESSION_INIT_TIMEOUT_MS, timeoutMessage, async () => {
+    await withTimeout(
+      initTimeoutMsFor(resolved.connectionType),
+      () => initTimeoutMessageFor(slug, resolved),
+      async () => {
       await client.initializeConnections();
 
       const mcpClient = await client.getClient(slug);
@@ -461,12 +608,22 @@ export function createDiscoverMcpServerActivities(config: Config) {
       input: DiscoverMcpServerInput,
     ): Promise<DiscoverMcpServerOutput> => {
       activityStarted();
+      // The connect workflow proxies this activity with a 60s heartbeatTimeout,
+      // so it MUST heartbeat: before this loop existed, any discovery slower
+      // than 60s (stdio cold start — issue #243) or wedged on a silent remote
+      // (issue #239) was killed by Temporal with an opaque heartbeat timeout
+      // instead of reaching this file's actionable init-timeout errors.
+      const hb = startHeartbeat(15_000, () => ({
+        phase: "discovering_mcp_server",
+        mcpServerId: input.mcpServerId,
+      }));
       try {
         return await discoverMcpServer(input, {
           stigmerClient,
           transportPosture: resolveMcpTransportPosture(config.mode),
         });
       } finally {
+        hb.stop();
         activityFinished();
       }
     },

--- a/backend/services/runner/src/workflows/connect-mcp-server.ts
+++ b/backend/services/runner/src/workflows/connect-mcp-server.ts
@@ -41,6 +41,13 @@ import type {
 type DiscoverActivities = ReturnType<typeof createDiscoverMcpServerActivities>;
 type ClassifyActivities = ReturnType<typeof createClassifyToolApprovalsActivities>;
 
+// Discovery's bounds ladder (issue #239): the activity heartbeats every 15s,
+// so heartbeatTimeout is pure LIVENESS (dead worker/pod detection) — it no
+// longer kills slow-but-alive discoveries. The activity bounds its own WORK
+// with a transport-aware init timeout (30s HTTP / 270s stdio) that fails with
+// an actionable, endpoint-naming error; startToCloseTimeout is the hard cap
+// above both. Keep the ordering: work bound < hard cap, heartbeat interval
+// (15s) < heartbeatTimeout.
 const discover = proxyActivities<DiscoverActivities>({
   startToCloseTimeout: "600s",
   heartbeatTimeout: "60s",

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect.go
@@ -521,7 +521,12 @@ func (c *McpServerController) executeConnectWorkflow(
 
 		switch {
 		case errors.As(err, &appErr):
-			return nil, status.Error(codes.Internal,
+			// FAILED_PRECONDITION, not INTERNAL (issue #239): an application
+			// error from the connect workflow means the TARGET server (or its
+			// credentials/config) refused the connect — the runner's message is
+			// crafted for the user, and clients render FAILED_PRECONDITION
+			// messages verbatim while (correctly) hiding INTERNAL detail.
+			return nil, status.Error(codes.FailedPrecondition,
 				buildConnectFailureMessage(mcpServer, appErr.Message()))
 		case errors.As(err, &timeoutErr):
 			return nil, status.Errorf(codes.DeadlineExceeded,

--- a/client-apps/cli/docs/commands/connect.mdx
+++ b/client-apps/cli/docs/commands/connect.mdx
@@ -96,13 +96,18 @@ the Stigmer backend.
 stigmer connect mcp-server stigmer/mcp-server-stigmer
 ```
 
-### Handle slow-starting servers
+### Bound the wait
 
 ```bash
-stigmer connect mcp-server my-server --timeout 60s
+stigmer connect mcp-server my-server --timeout 90
 ```
 
-Increase the timeout for servers that take longer to initialize.
+The value is a number of seconds. `--timeout` always bounds `--dry-run`'s
+local discovery; for a real connect it bounds the wait only when set
+explicitly — the connect keeps running server-side and persists its result,
+so a timeout here means "stop waiting", not "the connect failed". Without an
+explicit `--timeout`, a real connect waits for the server to finish (sandbox
+start, discovery, and tool classification can take a few minutes).
 
 {/* AUTO_GLOBAL_FLAGS */}
 

--- a/client-apps/cli/src/commands/connect.ts
+++ b/client-apps/cli/src/commands/connect.ts
@@ -26,7 +26,12 @@ export function registerConnect(program: Command): void {
   connect
     .command("mcp-server <slug-or-id>")
     .description("connect to an MCP server and discover its tools")
-    .option("--timeout <seconds>", "timeout for connection and discovery", String(DEFAULT_TIMEOUT_SECONDS))
+    .option(
+      "--timeout <seconds>",
+      "bound the wait for connection and discovery (always bounds --dry-run; " +
+        "bounds the server-side connect only when set explicitly)",
+      String(DEFAULT_TIMEOUT_SECONDS),
+    )
     .option("--dry-run", "discover and display results without pushing to the backend")
     .option(
       "--env <KEY=VALUE>",
@@ -39,6 +44,12 @@ export function registerConnect(program: Command): void {
 
 async function runConnect(reference: string, options: ConnectFlags, command: Command): Promise<void> {
   const timeoutMs = parseTimeout(options.timeout);
+  // The 30s default exists for --dry-run's local discovery. A real connect
+  // legitimately takes minutes (server-side sandbox boot + discovery + tool
+  // classification), so bounding it by the DEFAULT would fail healthy
+  // connects — the wait is bounded only when the user set --timeout
+  // explicitly (issue #239: the flag used to be silently ignored here).
+  const timeoutIsExplicit = command.getOptionValueSource("timeout") === "cli";
   const [{ connectBackend }, { connectMcpServer }, { renderConnectResult }] = await Promise.all([
     import("../backend.js"),
     import("../resources/connect/connect.js"),
@@ -67,6 +78,7 @@ async function runConnect(reference: string, options: ConnectFlags, command: Com
     reference,
     org,
     timeoutMs,
+    pushTimeoutMs: timeoutIsExplicit ? timeoutMs : undefined,
     dryRun: options.dryRun === true,
     envOverrides: options.env,
     backendType: client.config.backend.type,

--- a/client-apps/cli/src/resources/connect/connect.integration.test.ts
+++ b/client-apps/cli/src/resources/connect/connect.integration.test.ts
@@ -34,12 +34,17 @@ const openSessions = new Set<ServerHttp2Session>();
 
 let connectCalls: ConnectInput[] = [];
 let grantConnected = false;
+// Delay before the mock Connect RPC answers; lets the --timeout tests
+// simulate a long-running server-side connect. The timer is unref'd so a
+// still-pending delayed response can never hold the test process open.
+let connectDelayMs = 0;
 // The server returned by getByReference; mutated per test for auth scenarios.
 let servedSpec: ReturnType<typeof create<typeof McpServerSchema>>;
 
 beforeEach(() => {
   connectCalls = [];
   grantConnected = false;
+  connectDelayMs = 0;
   servedSpec = create(McpServerSchema, {
     metadata: { id: "mcp_1", name: "github", slug: "github", org: "acme" },
     spec: {
@@ -72,8 +77,11 @@ beforeAll(async () => {
       // Mirror the backend's protovalidate rule (org min_len=1): reject an empty
       // org so a regression that drops org fails loudly here instead of silently
       // passing (the mock adapter does not run protovalidate on its own).
-      connect: (req) => {
+      connect: async (req) => {
         if (req.org === "") throw new ConnectError("org – value length must be at least 1 characters", Code.InvalidArgument);
+        if (connectDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, connectDelayMs).unref());
+        }
         connectCalls.push(req);
         return updatedServer;
       },
@@ -117,6 +125,42 @@ describe("connect push path", () => {
 
     expect(result.updated?.metadata?.id).toBe("mcp_1");
     expect(result.capabilities?.tools.map((t) => t.name)).toEqual(["search_issues"]);
+  });
+});
+
+describe("--timeout bounds the server-side connect (issue #239)", () => {
+  it("stops waiting with actionable guidance when pushTimeoutMs elapses", async () => {
+    connectDelayMs = 5_000;
+    await expect(
+      connectMcpServer(client, {
+        reference: "github",
+        org: "acme",
+        timeoutMs: 30_000,
+        pushTimeoutMs: 150,
+        dryRun: false,
+        envOverrides: ["GITHUB_TOKEN=ghp-x"],
+        backendType: "cloud",
+        interactive: false,
+      }),
+    ).rejects.toThrow(/Stopped waiting for the connect of MCP server 'github' after 0\.15s/);
+  });
+
+  it("does not bound the wait when pushTimeoutMs is unset (default --timeout)", async () => {
+    // The flag's 30s default is sized for --dry-run local discovery; a real
+    // connect legitimately outlives it, so only an explicit --timeout bounds
+    // the push. 200ms of server delay stands in for "longer than the bound
+    // would have been".
+    connectDelayMs = 200;
+    const result = await connectMcpServer(client, {
+      reference: "github",
+      org: "acme",
+      timeoutMs: 100,
+      dryRun: false,
+      envOverrides: ["GITHUB_TOKEN=ghp-x"],
+      backendType: "cloud",
+      interactive: false,
+    });
+    expect(result.updated?.metadata?.id).toBe("mcp_1");
   });
 });
 

--- a/client-apps/cli/src/resources/connect/connect.ts
+++ b/client-apps/cli/src/resources/connect/connect.ts
@@ -16,7 +16,7 @@ import type { DiscoveredCapabilities } from "@stigmer/protos/ai/stigmer/agentic/
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { Stigmer } from "@stigmer/sdk";
 import type { BackendType } from "../../config/config.js";
-import { UsageError } from "../../errors/index.js";
+import { CliExitError, ExitCode, UsageError } from "../../errors/index.js";
 import { defaultRegistry } from "../../registry/index.js";
 import { PlaceholderResolutionError } from "../mcp/placeholder-resolver.js";
 import { buildRuntimeEnv } from "../mcp/runtime-env.js";
@@ -27,6 +27,15 @@ export interface ConnectOptions {
   readonly reference: string;
   readonly org: string;
   readonly timeoutMs: number;
+  /**
+   * Bound the wait on the server-side connect RPC. Unset by default: a real
+   * connect legitimately takes minutes (sandbox boot + discovery + tool
+   * classification), so only an EXPLICIT --timeout bounds it — the flag's
+   * 30s default is sized for --dry-run's local discovery and would fail
+   * healthy connects. The bound is soft (the CLI stops waiting; the backend
+   * finishes the connect on its own).
+   */
+  readonly pushTimeoutMs?: number;
   readonly dryRun: boolean;
   readonly envOverrides: readonly string[];
   /** Backend type, for resolving the OAuth web-console URL. */
@@ -66,14 +75,51 @@ export async function connectMcpServer(client: Stigmer, opts: ConnectOptions): P
 
   await ensureOAuthSatisfied(client, server, opts);
 
-  const updated = await client.mcpServer.connect(
+  const push = client.mcpServer.connect(
     create(ConnectInputSchema, {
       mcpServerId: server.metadata?.id ?? "",
       org: opts.org,
       runtimeEnv: buildRuntimeEnv(server, opts.envOverrides),
     }),
   );
+  const updated = opts.pushTimeoutMs === undefined
+    ? await push
+    : await boundedPush(push, opts.pushTimeoutMs, server);
   return { server, capabilities: updated.status?.discoveredCapabilities, updated };
+}
+
+// Soft timeout on the server-side connect (the client/client.ts idiom): races
+// the RPC against a timer without cancelling it — the backend's connect
+// workflow keeps running and persists its result on its own, so the message
+// says exactly that instead of implying the connect failed.
+async function boundedPush<T>(push: Promise<T>, timeoutMs: number, server: McpServer): Promise<T> {
+  const slug = server.metadata?.slug ?? server.metadata?.id ?? "the server";
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new CliExitError(
+            `Stopped waiting for the connect of MCP server '${slug}' after ${timeoutMs / 1000}s (--timeout)`,
+            ExitCode.Connection,
+            [
+              "The server-side connect is still running and will persist its result if it succeeds.",
+              `Check the outcome with: stigmer get mcp-server ${slug}`,
+              "Re-run without --timeout to wait for completion.",
+            ],
+          ),
+        ),
+      timeoutMs,
+    );
+  });
+  // The losing push may settle after the CLI has started exiting; swallow its
+  // late rejection so it cannot surface as an unhandled-rejection crash.
+  void push.catch(() => {});
+  try {
+    return await Promise.race([push, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 // Resolve a reference (id, org/slug, or bare slug) to an McpServer. Mirrors Go's

--- a/docs/cli/commands/connect.mdx
+++ b/docs/cli/commands/connect.mdx
@@ -29,11 +29,11 @@ connect to an MCP server and discover its tools
 stigmer connect mcp-server <slug-or-id> [flags]
 ```
 
-| Flag        | Type     | Default | Description                                                 |
-| ----------- | -------- | ------- | ----------------------------------------------------------- |
-| `--dry-run` | `bool`   |         | discover and display results without pushing to the backend |
-| `--env`     | `string` |         | environment variable for the MCP server (repeatable)        |
-| `--timeout` | `string` | `30`    | timeout for connection and discovery                        |
+| Flag        | Type     | Default | Description                                                                                                                    |
+| ----------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `--dry-run` | `bool`   |         | discover and display results without pushing to the backend                                                                    |
+| `--env`     | `string` |         | environment variable for the MCP server (repeatable)                                                                           |
+| `--timeout` | `string` | `30`    | bound the wait for connection and discovery (always bounds --dry-run; bounds the server-side connect only when set explicitly) |
 
 ### How connection works
 
@@ -120,13 +120,18 @@ Stigmer backend.
 stigmer connect mcp-server stigmer/mcp-server-stigmer
 ```
 
-### Handle slow-starting servers
+### Bound the wait
 
 ```bash
-stigmer connect mcp-server my-server --timeout 60s
+stigmer connect mcp-server my-server --timeout 90
 ```
 
-Increase the timeout for servers that take longer to initialize.
+The value is a number of seconds. `--timeout` always bounds `--dry-run`'s local
+discovery; for a real connect it bounds the wait only when set explicitly — the
+connect keeps running server-side and persists its result, so a timeout here
+means "stop waiting", not "the connect failed". Without an explicit `--timeout`,
+a real connect waits for the server to finish (sandbox start, discovery, and
+tool classification can take a few minutes).
 
 ## Global Flags
 


### PR DESCRIPTION
## Summary

Fixes the monday.com connect regression ([#239](https://github.com/stigmer/stigmer/issues/239)) at the failure-class level: MCP connect discovery can no longer hang on a misbehaving endpoint, credential-delivery failures fail closed with root-cause messages, and connect errors reach users with actionable text on every surface (web, CLI).

## Context

Investigation found #239 to be **two stacked failures plus a fail-open**, none of them Monday-specific machinery:

1. **The hang (reproduced against a live mock)**: an HTTP endpoint that answers the streamable-HTTP initialize POST with a 4xx triggers mcp-adapters' automatic SSE fallback; an endpoint that then accepts the SSE stream but never sends the legacy `endpoint` event hangs session init forever — the MCP SDK's `SSEClientTransport` has no timer. The discovery activity declared a 60s `heartbeatTimeout` but never heartbeated, so Temporal killed it opaquely ("Internal server error", web green, 0 tools) instead of it reaching any actionable error.
2. **The 5.5-minute escalation (confirmed in prod Temporal history)**: the reporter's Aug 4 `TIMEOUT_TYPE_START_TO_CLOSE` at ~5.5 min is the cloud workflow **run timeout (330s)** firing after the per-connect sandbox never served its task queue — a live Aug 10 specimen shows the identical 3-event history (task scheduled, never started, timed out at exactly 330s) inside the stigmer-cloud#288 saturation window. Filed as [stigmer-cloud#302](https://github.com/stigmer/stigmer-cloud/issues/302); the paired cloud PR classifies it honestly as `DEADLINE_EXCEEDED` meanwhile.
3. **The fail-open**: `resolveEnvVarsForDiscovery` swallowed ExecutionContext read failures (WARN + empty env), so a credential-delivery failure surfaced downstream as an opaque `PlaceholderResolutionError` or a doomed dial with a garbage/redacted Bearer token.

## Changes

- **runner** (`discover-mcp-server.ts`, `connect-mcp-server.ts`):
  - The discovery activity heartbeats (15s loop) — the declared 60s `heartbeatTimeout` becomes pure liveness and no longer kills slow-but-alive discoveries (also the failure mode behind #243's stdio cold-start deaths).
  - Transport-aware session-init bound: **30s HTTP** (chosen to stay reachable under the OSS server's 45s connect deadline, with margin for the 10s OAuth re-probe) / **270s stdio** (cold-start allowance). The HTTP timeout error names the endpoint URL and describes the silent-SSE-fallback shape.
  - Credential delivery fails closed with `CredentialResolutionError` naming the root cause: unreadable EC, empty EC when non-optional env is declared, or values equal to the cross-edition `***REDACTED***` sentinel (a redacted credential means the server-side decrypt gate refused this runner — dialing with it can only produce a misleading 401). Servers declaring no env, or only optional keys, keep the lenient path.
- **server (Go)** (`connect.go`): connect workflow application failures map to `FAILED_PRECONDITION` instead of `INTERNAL` — the target server (or its credentials/config) refused the connect; the runner's messages are user-facing, and clients render `FAILED_PRECONDITION` verbatim while (correctly) hiding `INTERNAL` detail behind a generic line. This is the same classification this controller already uses for user-config failures. The paired cloud PR does the same for the Java handler and adds the missing timeout arm (Go parity).
- **cli** (`commands/connect.ts`, `resources/connect/connect.ts`): `--timeout` now bounds the real connect wait — but **only when passed explicitly**. The 30s default is sized for `--dry-run` local discovery; applying it implicitly would cut off healthy cloud connects (sandbox boot + discovery + classification legitimately take minutes). The bound is soft: the message says the server-side connect continues and how to check the outcome. Fixed the docs example that passed an invalid `60s` value (the parser takes plain seconds).

## Implementation notes

- The SSE fallback itself is deliberately kept: four seedpack servers (square, intercom, webflow, paypal) declare `/sse` URLs under `http:` and depend on it. The activity's own bounds now contain it.
- The discovery bounds ladder is documented at the proxy config: heartbeat interval (15s) < heartbeatTimeout (60s, liveness) < work bound (30s/270s, actionable) < startToClose (600s, hard cap).
- `mcp-resolver.ts` (shared with the Cursor harness's near-duplicate, #387) is untouched — all changes live in the discovery activity.

## Breaking changes

- Connect failures previously surfaced as `INTERNAL` now surface as `FAILED_PRECONDITION` (target-server failures) — clients matching on the status code will see the new, more accurate code. No conformance or integration test pinned the old code.

## Test plan

- New regression pin: real `MultiServerMCPClient` against a live 4xx-then-silent-SSE mock server fails within the HTTP bound with the endpoint-naming error (`discover-mcp-server.hang.test.ts`).
- New unit coverage: fail-closed EC read error / empty EC / redacted sentinel (each asserting the client is never dialed), lenient paths for no-env and all-optional-env servers, transport-aware bound selection, heartbeat start/stop contract.
- CLI: integration tests for the explicit `--timeout` bound (stops with actionable guidance) and the unbounded default (a slow connect completes).
- Full runner vitest suite green in an isolated worktree except 3 pre-existing collection failures (`node:sqlite`, the #257 class) and 5 parallel-load flakes — all verified identical/passing on clean `origin/main`. Full `stigmer-server` Go module green. CLI typecheck + suite green.

## Risks

- The 30s HTTP bound could theoretically cut off an extraordinarily slow-but-healthy endpoint (observed healthy handshakes complete in ~2s; the bound is 15x). Rollback is reverting this PR; no data migrations.

Closes #239

Made with [Cursor](https://cursor.com)