### PR TITLE
fix(sdk/react): make post-OAuth discovery failures honest and recoverable

### DIFF
--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -528,6 +528,7 @@ export {
   useMcpServerSetup,
   useMcpServerConnect,
   useMcpServerOAuthConnect,
+  getOAuthConnectErrorMessage,
   useMcpServerCredentials,
   useOAuthGrantStatus,
   useDisconnectOAuth,

--- a/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
+++ b/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
@@ -179,6 +179,13 @@ function ConnectDialogContent({
 
   const handleOAuthSignIn = useCallback(() => {
     if (!serverId) return;
+    // A previous failure in the "connecting" phase means sign-in already
+    // succeeded and only discovery failed — retry bare discovery instead
+    // of relaunching the OAuth popup (stigmer/stigmer#229).
+    if (oauth.failedPhase === "connecting") {
+      void handleConnect();
+      return;
+    }
     oauth.startOAuth(serverId, activeOrg, declaredEnvKeys).then(
       () => {
         creds.refetch();
@@ -186,10 +193,15 @@ function ConnectDialogContent({
         onConnected?.(serverName);
       },
       () => {
+        // completeOAuthConnect persists the grant BEFORE the chained
+        // discovery runs, so even a failed attempt may have changed
+        // server state — refetch so the dialog offers "Discover Tools"
+        // instead of another popup round.
+        creds.refetch();
         setPhase("error");
       },
     );
-  }, [serverId, activeOrg, declaredEnvKeys, oauth, creds, onConnected, serverName]);
+  }, [serverId, activeOrg, declaredEnvKeys, oauth, creds, onConnected, serverName, handleConnect]);
 
   // Auto-trigger connect when credentials become ready (manual-only servers)
   useEffect(() => {
@@ -285,10 +297,25 @@ function ConnectDialogContent({
         <div className="mb-4">
           <ErrorMessage
             error={activeError}
+            title={
+              // Honest header for the two-act failure: the grant is stored,
+              // only the discovery leg broke. Without it the raw RPC error
+              // reads as a failed sign-in.
+              oauth.error && oauth.failedPhase === "connecting"
+                ? "Signed in, but tool discovery failed"
+                : undefined
+            }
             retry={() => {
+              // Capture before clearError() resets it: a discovery-leg
+              // failure retries discovery directly — sign-in is done.
+              const wasDiscoveryFailure = oauth.failedPhase === "connecting";
               clearConnectError();
               oauth.clearError();
-              setPhase("credentials");
+              if (wasDiscoveryFailure) {
+                void handleConnect();
+              } else {
+                setPhase("credentials");
+              }
             }}
           />
         </div>

--- a/sdk/react/src/mcp-server/McpServerDetailView.tsx
+++ b/sdk/react/src/mcp-server/McpServerDetailView.tsx
@@ -19,7 +19,10 @@ import { useUpdateMcpServer } from "./useUpdateMcpServer.js";
 import { mcpServerToInput } from "./internal/mcpServerToInput.js";
 import { useMcpServerConnect } from "./useMcpServerConnect.js";
 import { useMcpServerCredentials } from "./useMcpServerCredentials.js";
-import { useMcpServerOAuthConnect } from "./useMcpServerOAuthConnect.js";
+import {
+  useMcpServerOAuthConnect,
+  getOAuthConnectErrorMessage,
+} from "./useMcpServerOAuthConnect.js";
 import type { OAuthConnectPhase } from "./useMcpServerOAuthConnect.js";
 import { StdioSandboxNotice } from "./StdioSandboxNotice.js";
 import { OAuthRequiredNotice } from "./OAuthRequiredNotice.js";
@@ -250,9 +253,23 @@ export function McpServerDetailView({
       credentials.refetch();
       refetch();
     } catch {
-      // error state is managed by the oauth hook
+      // Error state is managed by the oauth hook — but refetch anyway:
+      // completeOAuthConnect persists the grant BEFORE the chained
+      // discovery runs, so a discovery-leg failure still changed server
+      // state. Without this, stale isOAuthConnected=false makes the next
+      // Connect click relaunch the popup instead of retrying discovery
+      // (stigmer/stigmer#229).
+      credentials.refetch();
+      refetch();
     }
   }, [mcpServer, oauth, credentials, refetch]);
+
+  // A failure in the "connecting" phase proves sign-in already succeeded —
+  // the grant exists server-side even while the grant-status refetch is
+  // still in flight. Retry bare discovery; never relaunch the popup and
+  // never demand credentials the flow already has.
+  const isDiscoveryRetry =
+    credentials.authMode === "oauth" && oauth.failedPhase === "connecting";
 
   const handleConnectClick = useCallback(async () => {
     if (!mcpServer?.metadata?.id) return;
@@ -260,13 +277,14 @@ export function McpServerDetailView({
     if (
       credentials.authMode === "oauth" &&
       !credentials.isOAuthConnected &&
-      !credentials.manualOverride
+      !credentials.manualOverride &&
+      !isDiscoveryRetry
     ) {
       handleOAuthSignIn();
       return;
     }
 
-    if (!credentials.isReady) {
+    if (!credentials.isReady && !isDiscoveryRetry) {
       setShowCredentialForm(true);
       return;
     }
@@ -274,11 +292,15 @@ export function McpServerDetailView({
     const envKeys = Object.keys(mcpServer.spec?.env ?? {});
     try {
       await connection.connect(mcpServer.metadata.id, activeOrg ?? org, undefined, envKeys);
+      // Discovery succeeded — retire the OAuth chain's stale
+      // discovery-failure error so the banner doesn't outlive the state
+      // it described.
+      oauth.clearError();
       refetch();
     } catch {
       // error state is managed by the hook
     }
-  }, [mcpServer, credentials.authMode, credentials.isOAuthConnected, credentials.manualOverride, credentials.isReady, connection, refetch, handleOAuthSignIn]);
+  }, [mcpServer, credentials.authMode, credentials.isOAuthConnected, credentials.manualOverride, credentials.isReady, isDiscoveryRetry, connection, oauth.clearError, refetch, handleOAuthSignIn, activeOrg, org]);
 
   const handleCredentialSubmit = useCallback(
     async (
@@ -367,6 +389,20 @@ export function McpServerDetailView({
   const resourceTemplates = capabilities?.resourceTemplates ?? [];
   const hasDiscoveredTools = tools.length > 0;
 
+  // "Signed in but never discovered" (stigmer/stigmer#229): the OAuth flow
+  // persists the grant in completeOAuthConnect BEFORE the chained discovery
+  // runs, so a failed/interrupted discovery leg leaves a healthy grant with
+  // empty discovered_capabilities. Both inputs are server truth, so this
+  // derivation survives reloads and self-heals once discovery lands (even
+  // when the workflow outlives the browser's RPC). Token-expired grants are
+  // excluded — re-auth, not discovery, is their next step.
+  const isOAuthStranded =
+    credentials.authMode === "oauth" &&
+    credentials.isOAuthConnected &&
+    credentials.connectionHealth !==
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED &&
+    !hasDiscoveredTools;
+
   const capabilityTabs: TabItem[] = useMemo(() => {
     const items: TabItem[] = [
       { id: "tools", label: "Tools", badge: tools.length },
@@ -383,6 +419,14 @@ export function McpServerDetailView({
   }, [tools.length, totalPolicyCount, resourceTemplates.length]);
 
   const combinedError = connection.error ?? oauth.error;
+  // OAuth-chain errors compose through the phase-aware helper so a
+  // discovery-leg failure reads "signed in, but discovery failed" instead
+  // of masquerading as a failed sign-in.
+  const combinedErrorMessage = connection.error
+    ? getUserMessage(connection.error)
+    : oauth.error
+      ? getOAuthConnectErrorMessage(oauth.error, oauth.failedPhase)
+      : null;
   const combinedClearError = useCallback(() => {
     connection.clearError();
     oauth.clearError();
@@ -548,9 +592,11 @@ export function McpServerDetailView({
           manualEntrySupported={credentials.manualEntrySupported}
           isConnecting={connection.isConnecting || oauth.isInProgress}
           connectionError={combinedError}
+          connectionErrorMessage={combinedErrorMessage}
           onConnect={handleConnectClick}
           onClearConnectionError={combinedClearError}
           hasDiscoveredTools={hasDiscoveredTools}
+          isOAuthStranded={isOAuthStranded}
           credentialsLoading={credentials.isLoading}
           oauthPhase={oauth.phase}
           authMode={credentials.authMode}
@@ -638,7 +684,12 @@ export function McpServerDetailView({
           aria-label="MCP server capabilities"
         >
           {capabilityTab === "tools" && (
-            <ToolsTabContent tools={tools} />
+            <ToolsTabContent
+              tools={tools}
+              isOAuthStranded={isOAuthStranded}
+              onDiscover={handleConnectClick}
+              isDiscovering={connection.isConnecting || oauth.isInProgress}
+            />
           )}
 
           {capabilityTab === "policies" && (
@@ -646,6 +697,7 @@ export function McpServerDetailView({
               pinnedPolicies={pinnedPolicies}
               classifiedPolicies={classifiedPolicies}
               hasDiscoveredTools={hasDiscoveredTools}
+              isOAuthStranded={isOAuthStranded}
             />
           )}
 
@@ -740,9 +792,11 @@ type RemoveOrgAppPhase = "idle" | "confirming" | "removing";
 function ConnectBar({
   isConnecting,
   connectionError,
+  connectionErrorMessage,
   onConnect,
   onClearConnectionError,
   hasDiscoveredTools,
+  isOAuthStranded,
   credentialsLoading,
   oauthPhase,
   authMode,
@@ -774,9 +828,13 @@ function ConnectBar({
 }: {
   readonly isConnecting: boolean;
   readonly connectionError: Error | null;
+  /** Display copy for `connectionError`, pre-composed by the parent (phase-aware for OAuth-chain failures). */
+  readonly connectionErrorMessage: string | null;
   readonly onConnect: () => void;
   readonly onClearConnectionError: () => void;
   readonly hasDiscoveredTools: boolean;
+  /** OAuth grant is healthy but discovery never landed — see the derivation in the parent. */
+  readonly isOAuthStranded: boolean;
   readonly credentialsLoading: boolean;
   readonly oauthPhase: OAuthConnectPhase;
   readonly authMode: "manual" | "oauth";
@@ -832,6 +890,7 @@ function ConnectBar({
     if (isConnecting) return "Connecting...";
     if (isOrgOAuthApp && showOAuthPrimary) return "Sign in with your app";
     if (showOAuthPrimary || needsReAuth) return "Sign in to connect";
+    if (isOAuthStranded) return "Discover tools";
     if (hasDiscoveredTools) return "Reconnect";
     return "Connect";
   })();
@@ -845,6 +904,9 @@ function ConnectBar({
 
   const statusText = (() => {
     if (authMode === "oauth" && isOAuthConnected) {
+      // Stranded takes precedence over token health: "tokens refresh
+      // automatically" reads as all-done while the Tools tab is empty.
+      if (isOAuthStranded) return "Signed in \u2014 tools not discovered yet";
       const base = healthStatusText(connectionHealth, accessTokenExpiresAt, tokenLifetimeHint);
       return isOrgOAuthApp ? `${base} \u00B7 Using your OAuth app` : base;
     }
@@ -1153,7 +1215,7 @@ function ConnectBar({
         >
           <WarningIcon className="mt-0.5 size-3.5 shrink-0 text-destructive" />
           <p className="flex-1 text-xs text-destructive">
-            {getUserMessage(connectionError)}
+            {connectionErrorMessage ?? getUserMessage(connectionError)}
           </p>
           <div className="flex shrink-0 items-center gap-2">
             {isRetryableError(connectionError) && (
@@ -1843,8 +1905,17 @@ function TagsSection({
 
 function ToolsTabContent({
   tools,
+  isOAuthStranded,
+  onDiscover,
+  isDiscovering,
 }: {
   readonly tools: readonly DiscoveredTool[];
+  /** OAuth grant is healthy but discovery never landed — renders the recovery empty state. */
+  readonly isOAuthStranded: boolean;
+  /** Runs tool discovery (the parent's connect handler). */
+  readonly onDiscover: () => void;
+  /** `true` while a discovery attempt is in flight. */
+  readonly isDiscovering: boolean;
 }) {
   const [search, setSearch] = useState("");
   const [expandedTool, setExpandedTool] = useState<string | null>(null);
@@ -1860,12 +1931,37 @@ function ToolsTabContent({
   }, [tools, search]);
 
   if (tools.length === 0) {
+    // Two distinct empty states: "never connected" (informational) vs
+    // "signed in but discovery never landed" (stigmer/stigmer#229) — the
+    // latter must carry its own recovery action, because the user already
+    // did the thing the informational copy asks for.
     return (
       <div className="px-3 py-8 text-center">
         <ConnectIcon className="mx-auto mb-2 size-6 text-muted-foreground-faint" />
-        <p className="text-xs text-muted-foreground">
-          Connect to this MCP server to discover its available tools.
-        </p>
+        {isOAuthStranded ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Signed in, but tools haven&apos;t been discovered yet.
+            </p>
+            <button
+              type="button"
+              onClick={onDiscover}
+              disabled={isDiscovering}
+              className={cn(
+                "mt-3 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium",
+                "bg-primary text-primary-foreground hover:bg-primary-hover",
+                "disabled:pointer-events-none disabled:opacity-50",
+              )}
+            >
+              {isDiscovering && <Spinner />}
+              {isDiscovering ? "Discovering tools..." : "Discover tools"}
+            </button>
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Connect to this MCP server to discover its available tools.
+          </p>
+        )}
       </div>
     );
   }
@@ -1969,10 +2065,13 @@ function PoliciesTabContent({
   pinnedPolicies,
   classifiedPolicies,
   hasDiscoveredTools,
+  isOAuthStranded,
 }: {
   readonly pinnedPolicies: readonly ToolApprovalPolicy[];
   readonly classifiedPolicies: readonly ToolApprovalPolicy[];
   readonly hasDiscoveredTools: boolean;
+  /** OAuth grant is healthy but discovery never landed — adjusts the empty-state copy. */
+  readonly isOAuthStranded: boolean;
 }) {
   const [search, setSearch] = useState("");
 
@@ -2009,7 +2108,9 @@ function PoliciesTabContent({
         <p className="text-xs text-muted-foreground">
           {hasDiscoveredTools
             ? "No approval policies yet. Reconnect to reclassify tools."
-            : "Connect to discover tools and auto-classify approval policies."}
+            : isOAuthStranded
+              ? "Signed in \u2014 discover tools to auto-classify approval policies."
+              : "Connect to discover tools and auto-classify approval policies."}
         </p>
       </div>
     );

--- a/sdk/react/src/mcp-server/__tests__/McpServerDetailView.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/McpServerDetailView.test.tsx
@@ -1,13 +1,19 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, within, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
 import { Stigmer } from "@stigmer/sdk";
 import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import {
+  OAuthConnectionHealth,
+  GetOAuthGrantStatusOutputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import {
   McpServerSpecSchema,
+  McpServerAuthSchema,
   HttpServerConfigSchema,
   ToolApprovalPolicySchema,
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
@@ -90,6 +96,31 @@ function buildConnectedServer(): McpServer {
     ],
   });
   return server;
+}
+
+/** The same server as an OAuth integration (target var declared in env). */
+function buildOAuthServer(): McpServer {
+  const server = buildBaseServer();
+  server.spec!.auth = create(McpServerAuthSchema, {
+    targetEnvVar: "API_TOKEN",
+    oauthOnly: true,
+  });
+  return server;
+}
+
+/**
+ * Grant-status fixture for the given health. `connected: true` reflects the
+ * two-act persistence contract: completeOAuthConnect stores the grant before
+ * the chained discovery runs, so a grant can exist with zero discovered tools.
+ */
+function grantStatus(health: OAuthConnectionHealth) {
+  return () =>
+    create(GetOAuthGrantStatusOutputSchema, {
+      connected: true,
+      connectionHealth: health,
+      targetEnvVar: "API_TOKEN",
+      authMethod: "mcp_oauth",
+    });
 }
 
 /** Hoisted-state bag in its settled, data-loaded shape. */
@@ -291,6 +322,136 @@ describe("McpServerDetailView — connect bar and capability tabs", () => {
     expect(within(panel).getByText(/Auto-classified/)).toBeTruthy();
     expect(within(panel).getByText("process_return")).toBeTruthy();
     expect(within(panel).getByText("requires approval")).toBeTruthy();
+  });
+});
+
+describe("McpServerDetailView — signed in but undiscovered (oss#229)", () => {
+  it("renders the stranded state: honest status text, Discover tools action, recovery empty state", async () => {
+    renderView(
+      <McpServerDetailView
+        org={ORG}
+        slug={SLUG}
+        mcpServerState={loadedState(buildOAuthServer())}
+      />,
+      (router) => {
+        router.service(McpServerQueryController, {
+          getOAuthGrantStatus: grantStatus(
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY,
+          ),
+        });
+      },
+    );
+
+    // The grant is healthy, so the pill honestly reads Connected — but the
+    // status text must carry the tools gap, not "tokens refresh automatically".
+    expect(
+      await screen.findByText("Signed in \u2014 tools not discovered yet"),
+    ).toBeTruthy();
+    expect(screen.getByText("Connected")).toBeTruthy();
+    // One action in the connect bar, one in the Tools tab empty state.
+    expect(
+      screen.getAllByRole("button", { name: /^Discover tools$/ }),
+    ).toHaveLength(2);
+
+    // The Tools tab empty state carries its own recovery action instead of
+    // the dead-end "Connect to this MCP server..." copy.
+    const panel = screen.getByRole("tabpanel");
+    expect(
+      within(panel).getByText("Signed in, but tools haven't been discovered yet."),
+    ).toBeTruthy();
+    expect(
+      within(panel).getByRole("button", { name: /^Discover tools$/ }),
+    ).toBeTruthy();
+    expect(
+      within(panel).queryByText(
+        "Connect to this MCP server to discover its available tools.",
+      ),
+    ).toBeNull();
+  });
+
+  it("runs bare discovery from the Tools tab action — never the OAuth popup", async () => {
+    const connect = vi.fn(() => buildConnectedServer());
+    const initiateOAuthConnect = vi.fn(() => {
+      throw new ConnectError("must not relaunch OAuth", Code.FailedPrecondition);
+    });
+
+    renderView(
+      <McpServerDetailView
+        org={ORG}
+        slug={SLUG}
+        mcpServerState={loadedState(buildOAuthServer())}
+      />,
+      (router) => {
+        router.service(McpServerQueryController, {
+          getOAuthGrantStatus: grantStatus(
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY,
+          ),
+        });
+        router.service(McpServerCommandController, {
+          connect,
+          initiateOAuthConnect,
+        });
+      },
+    );
+
+    const panel = screen.getByRole("tabpanel");
+    const discover = await within(panel).findByRole("button", {
+      name: /^Discover tools$/,
+    });
+    fireEvent.click(discover);
+
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    expect(initiateOAuthConnect).not.toHaveBeenCalled();
+  });
+
+  it("adjusts the Policies tab empty copy in the stranded state", async () => {
+    renderView(
+      <McpServerDetailView
+        org={ORG}
+        slug={SLUG}
+        defaultCapabilityTab="policies"
+        mcpServerState={loadedState(buildOAuthServer())}
+      />,
+      (router) => {
+        router.service(McpServerQueryController, {
+          getOAuthGrantStatus: grantStatus(
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY,
+          ),
+        });
+      },
+    );
+
+    expect(
+      await screen.findByText(
+        "Signed in \u2014 discover tools to auto-classify approval policies.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("keeps re-auth ahead of discovery when the token is expired", async () => {
+    renderView(
+      <McpServerDetailView
+        org={ORG}
+        slug={SLUG}
+        mcpServerState={loadedState(buildOAuthServer())}
+      />,
+      (router) => {
+        router.service(McpServerQueryController, {
+          getOAuthGrantStatus: grantStatus(
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED,
+          ),
+        });
+      },
+    );
+
+    // An expired grant with no tools needs a fresh sign-in first —
+    // discovery would fail against a dead token anyway.
+    expect(
+      await screen.findByRole("button", { name: /Sign in to connect/ }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /^Discover tools$/ }),
+    ).toBeNull();
   });
 });
 

--- a/sdk/react/src/mcp-server/__tests__/useMcpServerOAuthConnect.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/useMcpServerOAuthConnect.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { create } from "@bufbuild/protobuf";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { Stigmer } from "@stigmer/sdk";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import {
+  InitiateOAuthConnectOutputSchema,
+  CompleteOAuthConnectOutputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { StigmerContext } from "../../context";
+import {
+  useMcpServerOAuthConnect,
+  getOAuthConnectErrorMessage,
+} from "../useMcpServerOAuthConnect";
+
+// The popup machinery is window-dependent (window.open, postMessage,
+// BroadcastChannel); tests drive the RPC chain, so replace it with a
+// deterministic callback handshake.
+vi.mock("../../internal/oauthPopup.js", () => ({
+  openOAuthPopup: vi.fn(() => ({ location: { href: "" }, closed: false })),
+  popupBlockedError: vi.fn(
+    () => new Error("Popup was blocked by the browser."),
+  ),
+  waitForOAuthCallback: vi.fn(async () => ({
+    code: "auth-code",
+    state: "state-1",
+  })),
+  closeOAuthPopup: vi.fn(),
+  OAUTH_CALLBACK_MESSAGE_TYPE: "stigmer:oauth:callback",
+  OAUTH_BROADCAST_CHANNEL: "stigmer:oauth:broadcast",
+}));
+
+afterEach(cleanup);
+
+const SERVER_ID = "mcps_01test";
+const ORG = "acme";
+
+function renderOAuthHook(
+  register: Parameters<typeof createRouterTransport>[0],
+) {
+  const client = new Stigmer({
+    baseUrl: "/",
+    getAccessToken: () => "test-token",
+    customTransport: createRouterTransport(register),
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <StigmerContext.Provider value={client}>{children}</StigmerContext.Provider>
+  );
+  return renderHook(() => useMcpServerOAuthConnect(), { wrapper });
+}
+
+/** initiate + complete succeed — the failure point is chosen per test. */
+function happyOAuthLegs() {
+  return {
+    initiateOAuthConnect: () =>
+      create(InitiateOAuthConnectOutputSchema, {
+        authorizationUrl: "https://vendor.example/authorize",
+        state: "state-1",
+      }),
+    completeOAuthConnect: () =>
+      create(CompleteOAuthConnectOutputSchema, { connected: true }),
+  };
+}
+
+describe("useMcpServerOAuthConnect — failedPhase", () => {
+  it("records 'connecting' when only the chained discovery fails (sign-in succeeded)", async () => {
+    const { result } = renderOAuthHook((router) => {
+      router.service(McpServerCommandController, {
+        ...happyOAuthLegs(),
+        connect: () => {
+          throw new ConnectError("discovery workflow failed", Code.Internal);
+        },
+      });
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.startOAuth(SERVER_ID, ORG),
+      ).rejects.toThrow();
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.failedPhase).toBe("connecting");
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("records 'completing' when the token exchange itself fails", async () => {
+    const { result } = renderOAuthHook((router) => {
+      router.service(McpServerCommandController, {
+        initiateOAuthConnect: happyOAuthLegs().initiateOAuthConnect,
+        completeOAuthConnect: () => {
+          throw new ConnectError("token exchange failed", Code.Unavailable);
+        },
+      });
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.startOAuth(SERVER_ID, ORG),
+      ).rejects.toThrow();
+    });
+
+    expect(result.current.failedPhase).toBe("completing");
+  });
+
+  it("clears failedPhase on clearError and on a fresh startOAuth", async () => {
+    let failConnect = true;
+    const { result } = renderOAuthHook((router) => {
+      router.service(McpServerCommandController, {
+        ...happyOAuthLegs(),
+        connect: () => {
+          if (failConnect) {
+            throw new ConnectError("discovery workflow failed", Code.Internal);
+          }
+          return {};
+        },
+      });
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.startOAuth(SERVER_ID, ORG),
+      ).rejects.toThrow();
+    });
+    expect(result.current.failedPhase).toBe("connecting");
+
+    act(() => result.current.clearError());
+    expect(result.current.failedPhase).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    failConnect = false;
+    await act(async () => {
+      await result.current.startOAuth(SERVER_ID, ORG);
+    });
+    expect(result.current.failedPhase).toBeNull();
+    expect(result.current.phase).toBe("done");
+  });
+});
+
+describe("getOAuthConnectErrorMessage", () => {
+  it("leads with the sign-in-succeeded fact for discovery-leg failures", () => {
+    const error = new ConnectError("workflow timed out", Code.Internal);
+    expect(getOAuthConnectErrorMessage(error, "connecting")).toBe(
+      "Signed in successfully, but tool discovery failed: workflow timed out",
+    );
+  });
+
+  it("passes other phases through unprefixed", () => {
+    const error = new ConnectError("token exchange failed", Code.Unavailable);
+    expect(getOAuthConnectErrorMessage(error, "completing")).toBe(
+      "token exchange failed",
+    );
+    expect(getOAuthConnectErrorMessage(error, null)).toBe(
+      "token exchange failed",
+    );
+  });
+});

--- a/sdk/react/src/mcp-server/index.ts
+++ b/sdk/react/src/mcp-server/index.ts
@@ -65,7 +65,10 @@ export type {
 export { useMcpServerConnect } from "./useMcpServerConnect.js";
 export type { UseMcpServerConnectReturn } from "./useMcpServerConnect.js";
 
-export { useMcpServerOAuthConnect } from "./useMcpServerOAuthConnect.js";
+export {
+  useMcpServerOAuthConnect,
+  getOAuthConnectErrorMessage,
+} from "./useMcpServerOAuthConnect.js";
 export type {
   UseMcpServerOAuthConnectReturn,
   OAuthConnectPhase,

--- a/sdk/react/src/mcp-server/useMcpServerOAuthConnect.ts
+++ b/sdk/react/src/mcp-server/useMcpServerOAuthConnect.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { create } from "@bufbuild/protobuf";
+import { getUserMessage } from "@stigmer/sdk";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import {
   InitiateOAuthConnectInputSchema,
@@ -36,6 +37,34 @@ export type OAuthConnectPhase =
   | "connecting"
   | "done";
 
+/**
+ * User-facing message for an OAuth connect failure, honest about *where*
+ * the chain broke.
+ *
+ * The flow persists state in two acts: `completeOAuthConnect` stores the
+ * grant ("Connected" from then on), and only afterwards does the chained
+ * `connect` run tool discovery. A failure in the `"connecting"` phase
+ * therefore means sign-in itself SUCCEEDED — presenting the raw RPC error
+ * alone reads as if OAuth failed and sends users back through the popup
+ * for nothing (stigmer/stigmer#229). Every surface that renders
+ * {@link UseMcpServerOAuthConnectReturn.error} should compose its copy
+ * through this helper.
+ *
+ * The error object is never wrapped or mutated: `classifyError` /
+ * `isRetryableError` dispatch on the original `StigmerError`/`ConnectError`
+ * instance, so retry affordances keep working on the error as thrown.
+ */
+export function getOAuthConnectErrorMessage(
+  error: Error,
+  failedPhase: OAuthConnectPhase | null,
+): string {
+  const base = getUserMessage(error);
+  if (failedPhase === "connecting") {
+    return `Signed in successfully, but tool discovery failed: ${base}`;
+  }
+  return base;
+}
+
 /** Return value of {@link useMcpServerOAuthConnect}. */
 export interface UseMcpServerOAuthConnectReturn {
   /**
@@ -63,6 +92,17 @@ export interface UseMcpServerOAuthConnectReturn {
   readonly phase: OAuthConnectPhase;
   /** Error from the most recent unsuccessful attempt, or `null`. */
   readonly error: Error | null;
+  /**
+   * The phase the flow was in when {@link error} was thrown, or `null`
+   * when there is no error.
+   *
+   * The load-bearing value is `"connecting"`: it means OAuth sign-in
+   * completed (the grant is stored server-side) and only the chained
+   * tool-discovery `connect` failed. Consumers should branch on it to
+   * (a) render honest copy via {@link getOAuthConnectErrorMessage} and
+   * (b) retry with a bare `connect` instead of relaunching the popup.
+   */
+  readonly failedPhase: OAuthConnectPhase | null;
   /** Reset the hook to idle state, clearing any error. */
   readonly clearError: () => void;
 }
@@ -107,10 +147,20 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
   const stigmer = useStigmer();
   const [phase, setPhase] = useState<OAuthConnectPhase>("idle");
   const [error, setError] = useState<Error | null>(null);
+  const [failedPhase, setFailedPhase] = useState<OAuthConnectPhase | null>(null);
 
   const popupRef = useRef<Window | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const cancelledRef = useRef(false);
+  // Mirrors the phase state for the catch block: React state reads would be
+  // stale inside the async flow, and failedPhase must record exactly where
+  // the chain broke (completeOAuthConnect vs the chained connect).
+  const phaseRef = useRef<OAuthConnectPhase>("idle");
+
+  const advancePhase = useCallback((next: OAuthConnectPhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -126,14 +176,16 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
       popupRef.current = null;
       cleanupRef.current = null;
     }
-    setPhase("idle");
+    advancePhase("idle");
     setError(null);
-  }, []);
+    setFailedPhase(null);
+  }, [advancePhase]);
 
   const startOAuth = useCallback(
     async (mcpServerId: string, org: string, declaredEnvKeys?: readonly string[]): Promise<McpServer> => {
-      setPhase("initiating");
+      advancePhase("initiating");
       setError(null);
+      setFailedPhase(null);
       cancelledRef.current = false;
 
       cleanupRef.current?.();
@@ -142,7 +194,8 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
       if (!popup) {
         const blocked = popupBlockedError();
         setError(blocked);
-        setPhase("idle");
+        setFailedPhase("initiating");
+        advancePhase("idle");
         throw blocked;
       }
 
@@ -154,7 +207,7 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
         );
 
         popup.location.href = initOutput.authorizationUrl;
-        setPhase("awaiting-callback");
+        advancePhase("awaiting-callback");
 
         const { code, state } = await waitForOAuthCallback(
           popup,
@@ -164,7 +217,7 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
           },
         );
 
-        setPhase("completing");
+        advancePhase("completing");
 
         await stigmer.mcpServer.completeOAuthConnect(
           create(CompleteOAuthConnectInputSchema, {
@@ -174,7 +227,7 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
           }),
         );
 
-        setPhase("connecting");
+        advancePhase("connecting");
 
         const systemEnv = declaredEnvKeys
           ? await resolveDeclaredSystemEnvVars(stigmer, declaredEnvKeys)
@@ -197,13 +250,14 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
 
         const server = await stigmer.mcpServer.connect(input);
 
-        setPhase("done");
+        advancePhase("done");
         return server;
       } catch (err) {
         const wrapped = toError(err);
         if (!cancelledRef.current) {
           setError(wrapped);
-          setPhase("idle");
+          setFailedPhase(phaseRef.current);
+          advancePhase("idle");
           closeOAuthPopup(popup);
         }
         cancelledRef.current = false;
@@ -213,7 +267,7 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
         cleanupRef.current = null;
       }
     },
-    [stigmer],
+    [stigmer, advancePhase],
   );
 
   return {
@@ -221,6 +275,7 @@ export function useMcpServerOAuthConnect(): UseMcpServerOAuthConnectReturn {
     isInProgress: phase !== "idle" && phase !== "done",
     phase,
     error,
+    failedPhase,
     clearError,
   };
 }


### PR DESCRIPTION
Closes #229

## Problem

The web console's OAuth "Sign in to connect" flow persists state in two acts: `completeOAuthConnect` stores the grant (the UI reads **"Connected"** from that moment), and only afterwards does the client-chained `connect` RPC run tool discovery. Discovery **does** auto-run for every server — but when that leg fails or is interrupted (monday.com's discovery failure is #239), the user is stranded in a dishonest state:

- pill: **Connected**, status: "Tokens refresh automatically · expires ~6d"
- Tools tab: empty, with copy asking them to "Connect to this MCP server…" — the thing they just did
- the error was transient client state, gone on reload; no recovery short of the CLI (which simply re-issues the same `connect` RPC)

## Fix (all in `@stigmer/react`; no backend or proto changes)

**The stranded state is derived from server truth** — healthy grant (`getOAuthGrantStatus`) + empty `discovered_capabilities` — so it survives reloads and self-heals if a workflow that outlived the browser's RPC eventually lands tools.

- `useMcpServerOAuthConnect` exposes **`failedPhase`**: `"connecting"` proves sign-in succeeded and only discovery failed. New `getOAuthConnectErrorMessage` helper composes "Signed in successfully, but tool discovery failed: …" without wrapping the error (classification/`isRetryableError` keep dispatching on the original `ConnectError`/`StigmerError`).
- `McpServerDetailView`: stranded state renders status **"Signed in — tools not discovered yet"**, the bar button becomes **"Discover tools"**, and the Tools/Policies empty states carry their own recovery action. Token-expired grants keep "Sign in to connect" precedence (discovery against a dead token would fail anyway).
- **Retry never relaunches the popup** after a discovery-leg failure — detail view and `McpServerConnectDialog` retry bare `connect`; credentials are refetched on chain failure so stale `isOAuthConnected=false` can't route the next click back into OAuth.
- Web + desktop both consume these SDK components — parity is automatic (DD-016).

Deliberately **not** done: auto-firing discovery on page mount for stranded servers — `connect` starts a Temporal workflow plus an LLM classification call, and a deterministically failing server would re-burn that on every page view. The chain already auto-runs at the right moment (post-sign-in); this makes the failure recoverable in one obvious click.

`McpServerPicker` (session setup) shares the ambiguous-retry defect but its "connected" notion derives from personal-env token presence and it has no bare-discovery path in the `useMcpServerSetup` machinery — filed separately as a follow-up.

## Verification

- `sdk/react` vitest suite: **4338/4338 green** (4 new stranded-state view tests + new `useMcpServerOAuthConnect` hook suite incl. `failedPhase` semantics and the message helper)
- `tsc --noEmit` clean; eslint clean on all touched files; `verify-esm-node.mjs` OK (DD-018)
- Not verified: live end-to-end OAuth against a failing vendor (monday's server-side discovery failure itself is #239's scope)

Made with [Cursor](https://cursor.com)