### PR TITLE
fix(seedpack): repoint PayPal MCP from legacy /sse to live /mcp endpoint

### DIFF
--- a/seedpack/canary/credential-manifest.yaml
+++ b/seedpack/canary/credential-manifest.yaml
@@ -162,7 +162,7 @@ servers:
     status: oauth_only
     auth_type: dcr_oauth
     env_var: PAYPAL_ACCESS_TOKEN
-    notes: "Hosted endpoint likely OAuth-only; untested"
+    notes: "OAuth confirmed by live probe 2026-08-11: /mcp and /sse both answer 401 with an RFC 9728 WWW-Authenticate challenge; anonymous DCR live at /register. Endpoint moved /sse -> /mcp (vendor quickstart is stale: its documented /http returns 404; stigmer/stigmer#231). Authenticated tools/list not yet verified — reporter to confirm post-deploy."
 
   slack:
     status: oauth_only

--- a/seedpack/mcp-servers/paypal.yaml
+++ b/seedpack/mcp-servers/paypal.yaml
@@ -16,7 +16,13 @@ spec:
     - e-commerce
     - invoicing
   http:
-    url: "https://mcp.paypal.com/sse"
+    # Streamable HTTP endpoint. PayPal's quickstart still documents /sse and
+    # /http, but the live server contradicts it (verified 2026-08-11): /http
+    # returns 404, while /mcp answers with a spec-correct OAuth challenge
+    # (RFC 9728 resource_metadata) and is the URL third-party MCP registries
+    # list. /sse is the legacy transport our clients cannot use
+    # (stigmer/stigmer#231; denylisted in mcp_servers_test.go).
+    url: "https://mcp.paypal.com/mcp"
     headers:
       Authorization: "Bearer ${PAYPAL_ACCESS_TOKEN}"
   env:

--- a/seedpack/mcp_servers_test.go
+++ b/seedpack/mcp_servers_test.go
@@ -432,6 +432,13 @@ func TestMcpServers_NoRetiredEndpoints(t *testing.T) {
 		// Intercom MCP docs (developers.intercom.com/docs/guides/mcp): /mcp is
 		// "Recommended", /sse is "Legacy SSE (deprecated)".
 		"https://mcp.intercom.com/sse": "deprecated; use https://mcp.intercom.com/mcp (Intercom MCP docs)",
+		// PayPal's quickstart is stale (still documents /sse and /http) but the
+		// live server contradicts it, verified 2026-08-11: POST /http returns
+		// 404 while /mcp answers a spec-correct OAuth 401 challenge (RFC 9728
+		// resource_metadata) and is the endpoint third-party MCP registries
+		// (Cequence, Apigene) list. /sse is the legacy transport our clients
+		// cannot use — the exact failure stigmer/stigmer#231 reports.
+		"https://mcp.paypal.com/sse": "legacy; use https://mcp.paypal.com/mcp (live probe 2026-08-11 + MCP registries, stigmer/stigmer#231 — PayPal's own /http doc is dead)",
 	}
 
 	for name, server := range servers {


### PR DESCRIPTION
## Summary

PayPal's marketplace tile dead-ends after a successful OAuth sign-in: connect fails during tool discovery with a cryptic transport + regex error (both web and CLI). The seedpack pointed streamable-HTTP discovery at PayPal's legacy `/sse` URL. This PR repoints it to the live `/mcp` streamable-HTTP endpoint, denylists the old URL, and refreshes the canary credential-manifest with the verified OAuth facts.

## Context

- The issue (July) reported POST to `/sse` returning Not Found, and suggested `/http` per PayPal's quickstart. **Both are now wrong**: live probes on 2026-08-11 show `POST https://mcp.paypal.com/http` → **404** (the vendor quickstart is stale, contradicted by PayPal's own server), while `https://mcp.paypal.com/mcp` answers a spec-correct OAuth 401 challenge (RFC 9728 `resource_metadata`) and is the endpoint third-party MCP registries (Cequence, Apigene) list.
- The stacked `SyntaxError: Invalid regular expression: /^https\:\/\//u` is PayPal's own tool JSON-schema `pattern` compiled under the unicode flag by `@cfworker/json-schema` — reproduced against today's locked deps: it no longer breaks tool **loading**, only **invoking** the affected tool. Filed separately (see follow-up issue) rather than bolted on here.
- Migration-safe: OAuth discovery is origin-only per RFC 8414 (`buildWellKnownURL` in `backend/services/stigmer-server/pkg/domain/mcpserver/oauth/discovery.go` uses scheme + host), so existing PayPal grants survive the path change. Fixes the Go edition too — its transport is streamable-HTTP-only and could never work against `/sse`.

## Changes

- `seedpack/mcp-servers/paypal.yaml`: `url` → `https://mcp.paypal.com/mcp`, with an evidence comment
- `seedpack/mcp_servers_test.go`: `TestMcpServers_NoRetiredEndpoints` denylist entry for `https://mcp.paypal.com/sse` (cited: live probes + registries; PayPal has no first-party doc for `/mcp` because their quickstart is stale)
- `seedpack/canary/credential-manifest.yaml`: PayPal note upgraded from "likely OAuth-only; untested" to the probe-verified facts

## Test plan

- `go test ./seedpack/` green
- Mutation check: reverting the yaml to `/sse` makes `TestMcpServers_NoRetiredEndpoints` fail with the cited message; restored, green
- Live probes (2026-08-11): `/http` 404; `/mcp` + `/sse` OAuth 401 with `WWW-Authenticate` challenge; anonymous DCR live at `/register`
- **Not verified pre-merge**: authenticated `tools/list` on `/mcp` (no PayPal account available). The issue wrap-up asks the reporter to confirm post-deploy — the same pattern as the Webflow fix (#409)

## Risks

- If PayPal's `/mcp` post-auth behavior differs from every registry listing, the tile stays broken — strictly no worse than today's dead end. Rollback is a one-line revert.

## Ops note

No new ops step: the `stigmer seedpack apply --force` already owed from #409's release picks this change up too.

Closes #231

Made with [Cursor](https://cursor.com)