### PR TITLE
fix(server): raise the MCP connect workflow budget from 45s to 420s so stdio cold starts can finish

### DIFF
--- a/backend/services/runner/src/activities/__tests__/discover-mcp-server.test.ts
+++ b/backend/services/runner/src/activities/__tests__/discover-mcp-server.test.ts
@@ -752,9 +752,10 @@ describe("DiscoverMcpServer activity", () => {
     it("bounds HTTP endpoints at 30s and stdio at 270s", async () => {
       // HTTP has no cold-start excuse: a healthy endpoint completes the MCP
       // handshake in seconds, so a short bound converts the silent-SSE hang
-      // into a fast actionable failure. 30s (not more) keeps the error
-      // reachable under the OSS server's 45s connect-workflow deadline.
-      // stdio keeps the cold-start allowance (issue #243).
+      // into a fast actionable failure. stdio keeps the cold-start allowance
+      // (issue #243). The OSS server's connect-workflow budget (connectTimeout,
+      // controller/connect.go — pinned there) is derived from the stdio bound
+      // + the classification floor, so both bounds stay reachable under it.
       const { initTimeoutMsFor } = await import("../discover-mcp-server.js");
       expect(initTimeoutMsFor("http")).toBe(30_000);
       expect(initTimeoutMsFor("sse")).toBe(30_000);

--- a/backend/services/runner/src/activities/discover-mcp-server.ts
+++ b/backend/services/runner/src/activities/discover-mcp-server.ts
@@ -48,12 +48,13 @@ import type { Config } from "../config.js";
  * exactly this — 4xx on POST, then a silently-open SSE stream).
  *
  * HTTP endpoints get a short bound: there is nothing to install or compile,
- * so a healthy endpoint completes the handshake in seconds. 30s is chosen to
- * fit inside the OSS server's 45s connect-workflow run timeout with room for
- * the 10s OAuth re-probe on the failure path — any larger and this error
- * could never surface on OSS (the workflow deadline would fire first).
- * stdio servers keep the generous bound because their first run may compile
- * or install packages (`go run`, `npx`) — the cold-start case (issue #243).
+ * so a healthy endpoint completes the handshake in seconds — a short bound is
+ * what converts the silent hang into a fast, actionable failure (with room for
+ * the 10s OAuth re-probe on the failure path). stdio servers keep the generous
+ * bound because their first run may compile or install packages (`go run`,
+ * `npx`) — the cold-start case (issue #243). The OSS server's connect-workflow
+ * run timeout (connectTimeout, controller/connect.go) is derived from the
+ * stdio bound + the classification floor, so both errors stay reachable.
  */
 const HTTP_INIT_TIMEOUT_MS = 30_000;
 const STDIO_INIT_TIMEOUT_MS = 270_000;

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect.go
@@ -31,8 +31,30 @@ import (
 
 const (
 	connectWorkflowName = "stigmer/mcp-server/connect"
-	connectTimeout      = 45 * time.Second
-	personalEnvLabel    = "stigmer.ai/personal"
+
+	// connectTimeout is the connect workflow's WorkflowRunTimeout — the total
+	// budget for discovery + tool-approval classification. It is sized from the
+	// runner's own bounds (issue #243): the 270s stdio init allowance
+	// (STDIO_INIT_TIMEOUT_MS in activities/discover-mcp-server.ts — a first run
+	// may download and compile packages via npx/uvx/go run) + the 120s
+	// classification floor (classifyWithTimeout in workflows/connect-mcp-server.ts)
+	// + margin for tool listing and persistence. Anything smaller makes the
+	// runner's cold-start allowance — and its actionable timeout error —
+	// unreachable by construction, which is exactly how the pre-#243 45s value
+	// killed every heavy stdio connect.
+	//
+	// Deliberately NOT sized for classification retries (maximumAttempts: 2) or
+	// >~160-tool stdio servers, whose budgets scale past any flat ceiling —
+	// async/pollable discovery is the cure for those, not a longer wait.
+	//
+	// Trade-off, accepted: this is also the bound on "no runner ever picked up
+	// the task", so a connect against a dead runner now waits the full budget
+	// before DEADLINE_EXCEEDED. The local daemon supervises the runner
+	// (crash-restart), making that state pathological rather than designed; a
+	// CLI --timeout remains the caller's soft bound.
+	connectTimeout = 420 * time.Second
+
+	personalEnvLabel = "stigmer.ai/personal"
 
 	// bestEffortConnectGetBuffer is added to connectTimeout to bound the
 	// background goroutine's wait on the connect workflow result. The workflow's
@@ -529,8 +551,13 @@ func (c *McpServerController) executeConnectWorkflow(
 			return nil, status.Error(codes.FailedPrecondition,
 				buildConnectFailureMessage(mcpServer, appErr.Message()))
 		case errors.As(err, &timeoutErr):
+			// Name the budget that fired (issue #243): the runner's own bounds
+			// fail earlier with specific, actionable errors, so reaching this
+			// ceiling usually means the runner never served the task at all.
 			return nil, status.Errorf(codes.DeadlineExceeded,
-				"connect did not complete within timeout for MCP server '%s'", mcpServerID)
+				"connect did not complete within the %s budget for MCP server '%s' — "+
+					"if this repeats, check that your runner is running and healthy",
+				connectTimeout, mcpServerID)
 		case errors.As(err, &notFoundErr):
 			return nil, grpclib.UnavailableError(
 				"connect service temporarily unavailable for MCP server '%s'", mcpServerID)

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect_test.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
@@ -322,4 +323,28 @@ func TestPersistConnectResult(t *testing.T) {
 		assert.True(t, errors.Is(err, store.ErrNotFound),
 			"a deleted/absent resource must surface store.ErrNotFound so callers can skip; got: %v", err)
 	})
+}
+
+// TestConnectTimeout_CoversRunnerColdStartBudget pins the connect workflow's
+// total budget against the runner bounds it is derived from (issue #243). The
+// runner grants stdio servers a 270s init allowance (STDIO_INIT_TIMEOUT_MS in
+// activities/discover-mcp-server.ts) and classification a 120s floor
+// (classifyWithTimeout in workflows/connect-mcp-server.ts); the workflow-level
+// budget must exceed their sum or the allowance — and its actionable timeout
+// error — is unreachable by construction, which is exactly how the pre-#243
+// 45s value killed every heavy stdio connect. The literals here restate the
+// runner's values deliberately: if either side moves, this test forces the
+// derivation comment on connectTimeout to be revisited rather than silently
+// drifting. (The runner pins its half in discover-mcp-server.test.ts.)
+func TestConnectTimeout_CoversRunnerColdStartBudget(t *testing.T) {
+	const (
+		runnerStdioInitAllowance  = 270 * time.Second
+		runnerClassificationFloor = 120 * time.Second
+	)
+
+	assert.Greater(t, int64(connectTimeout), int64(runnerStdioInitAllowance+runnerClassificationFloor),
+		"connectTimeout must exceed the runner's stdio cold-start allowance + classification floor, "+
+			"or heavy stdio connects die at the workflow ceiling before the runner's actionable error can fire")
+	assert.Equal(t, 420*time.Second, connectTimeout,
+		"connectTimeout is a user-facing wait ceiling — change it deliberately (update the derivation comment) rather than incidentally")
 }


### PR DESCRIPTION
## Summary

Fixes the time-budget half of #243 (the heartbeat half shipped in #416). The runner grants stdio MCP servers a 270s init allowance (`STDIO_INIT_TIMEOUT_MS` — a first run may download and compile packages via `npx`/`uvx`/`go run`) and tool-approval classification a 120s floor, but the OSS server capped the entire connect workflow at 45s. The allowance — and the actionable "cold start took too long" error #416 built — was unreachable by construction: every heavy stdio connect died at the workflow ceiling with a generic timeout.

- **`connectTimeout` 45s → 420s** (270s stdio init + 120s classification floor + margin), with the derivation, the deliberate non-goals (classification retries, >~160-tool stdio servers — async/pollable discovery owns those), and the accepted trade-off documented at the constant.
- **The `DEADLINE_EXCEEDED` message names the budget that fired** and points at the likely cause (the runner's own bounds fail earlier with specific errors, so reaching this ceiling usually means the runner never served the task).
- **Pin test** (`TestConnectTimeout_CoversRunnerColdStartBudget`) locks the budget against the runner bounds it derives from, so the next edit to either side forces the derivation to be revisited rather than silently drifting. Mirrors how the runner pins its half in `discover-mcp-server.test.ts`.
- **Runner comment refresh only** (no behavioral change): the two comments that sized the 30s HTTP bound "to fit inside the OSS server's 45s deadline" now state the real rationale (HTTP has no cold-start excuse) and point at the derived server budget.

## Trade-off, accepted deliberately

The workflow run timeout is also the bound on "no runner ever picked up the task": a connect against a dead runner now waits 420s instead of 45s before `DEADLINE_EXCEEDED`. The local daemon supervises the runner (crash-restart + health probing), so that state is pathological rather than designed, and an explicit CLI `--timeout` remains the caller's soft bound. The error message now tells the user what to check.

## Out of scope, tracked

- **Cloud's 330s ceiling** stays untouched per owner decision — raising it before stigmer/stigmer-cloud#302 (sandbox-starvation fast-fail) lands would only lengthen the starvation hang. It is env-overridable (`TEMPORAL_AGENT_EXECUTION_DISCOVERY_WORKFLOW_RUN_TIMEOUT_SECONDS`) once #302 ships.
- **Async/pollable discovery** (browser RPC-lifetime wall, very-large-server budgets, dead-runner fast-fail pre-flight) — filed separately.

## Verification

- Full `stigmer-server` module green under `go test -race` (includes the new pin test); `gofmt`/`go vet` clean on the touched package. (`make lint` currently fails on clean main in `schedule/temporal/runstarter_test.go` — pre-existing copylocks vet error, unrelated, reported separately.)
- Runner: touched suites 67/67; full suite run — the only failures are the known pre-existing set (3 `node:sqlite` collection failures, oss#257 class, + 5 parallel-load timeout flakes), all in untouched files and all passing in isolation (102/102).
- Integration lane checked: no test depends on the old 45s kill (the failure-path test fails pre-workflow; happy paths complete in seconds).

Closes #243

Made with [Cursor](https://cursor.com)