### PR TITLE
fix(mcpserver): pre-flight the DCR authorize URL — fail fast on redirect-host allowlist rejections

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_oauth_connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_oauth_connect.go
@@ -210,6 +210,26 @@ func (c *McpServerController) initiateDCR(
 		"scope",
 	)
 
+	// Some providers accept DCR for any redirect URI but enforce a
+	// redirect-host allowlist at the authorization endpoint; without this
+	// pre-flight the rejection would surface only as a vendor error page
+	// inside the popup, which never redirects back (stigmer/stigmer#235).
+	// Fail-open by contract: only a definite rejection blocks initiate.
+	if rejection, probeErr := oauth.PreflightAuthorize(ctx, authURL); probeErr != nil {
+		log.Debug().Err(probeErr).
+			Str("mcp_server_id", mcpServer.GetMetadata().GetId()).
+			Msg("authorize pre-flight probe inconclusive; proceeding")
+	} else if rejection != nil {
+		log.Warn().
+			Int("status_code", rejection.StatusCode).
+			Str("mcp_server_id", mcpServer.GetMetadata().GetId()).
+			Str("body_snippet", rejection.BodySnippet).
+			Msg("authorization endpoint rejected the sign-in request pre-flight")
+		return nil, grpclib.FailedPreconditionError(
+			"%s", dcrRejectionMessage(mcpServer.GetMetadata().GetName(), c.oauthRedirectURI, rejection),
+		)
+	}
+
 	return &initiateResult{
 		authorizationURL: authURL,
 		providerName:     mcpServer.GetMetadata().GetName(),
@@ -319,6 +339,31 @@ func buildAuthorizationURL(
 		separator = "&"
 	}
 	return authEndpoint + separator + params.Encode()
+}
+
+// dcrRejectionMessage renders the user-facing copy for a pre-flight
+// authorize rejection (see oauth.PreflightAuthorize). The wording is hedged
+// — a 400 can in principle have other causes — but leads with the
+// redirect-host allowlist because it is the only cause observed in the wild
+// (Canva, stigmer/stigmer#235), and it names this deployment's callback host
+// so self-hosted operators can act on it. Surfaces which render initiate
+// errors pass this text through verbatim (getUserMessage in @stigmer/sdk),
+// so it must stand on its own for an end user.
+func dcrRejectionMessage(providerName, redirectURI string, rejection *oauth.AuthorizeRejection) string {
+	callbackHost := redirectURI
+	if parsed, err := url.Parse(redirectURI); err == nil && parsed.Host != "" {
+		callbackHost = parsed.Host
+	}
+	msg := fmt.Sprintf(
+		"%s rejected the sign-in request before showing a login page (HTTP %d). "+
+			"The most common cause is a redirect-host allowlist: this deployment's OAuth callback host (%s) "+
+			"is not on the provider's approved list. Self-hosted deployments with a localhost callback are typically unaffected.",
+		providerName, rejection.StatusCode, callbackHost,
+	)
+	if rejection.VendorDetail != "" {
+		msg += " Provider detail: " + rejection.VendorDetail
+	}
+	return msg
 }
 
 func generateState() (string, error) {

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/oauth_preflight_test.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/oauth_preflight_test.go
@@ -1,0 +1,204 @@
+package mcpserver
+
+// End-to-end pins for the DCR initiate pre-flight (oss#235): discovery →
+// DCR → authorize probe, through the real controller against a fake
+// authorization server. The blocked arm asserts the whole contract — code,
+// user-facing copy, and that no pending state row is left behind. The
+// fail-open arm pins that only HTTP 400 blocks (bot-protection 4xx/5xx must
+// pass through), reusing the classification proven unit-level in
+// oauth/preflight_test.go.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeAuthServer is a minimal MCP authorization server: RFC 8414 metadata,
+// RFC 7591 registration, and an /authorize whose response is configurable
+// per test — the single knob the pre-flight classifies on.
+type fakeAuthServer struct {
+	srv *httptest.Server
+
+	authorizeStatus      int
+	authorizeContentType string
+	authorizeBody        string
+}
+
+func startFakeAuthServer(t *testing.T) *fakeAuthServer {
+	t.Helper()
+	fake := &fakeAuthServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                           fake.srv.URL,
+			"authorization_endpoint":           fake.srv.URL + "/authorize",
+			"token_endpoint":                   fake.srv.URL + "/token",
+			"registration_endpoint":            fake.srv.URL + "/register",
+			"code_challenge_methods_supported": []string{"S256"},
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"client_id": "preflight-test-client"})
+	})
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		if fake.authorizeStatus == http.StatusFound {
+			http.Redirect(w, r, fake.srv.URL+"/login", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", fake.authorizeContentType)
+		w.WriteHeader(fake.authorizeStatus)
+		_, _ = w.Write([]byte(fake.authorizeBody))
+	})
+
+	fake.srv = httptest.NewServer(mux)
+	t.Cleanup(fake.srv.Close)
+	return fake
+}
+
+// saveDcrMcpServer stores an McpServer whose http.url points at the fake
+// authorization server, with no oauth_app_ref — the DCR initiate arm.
+func saveDcrMcpServer(t *testing.T, h *oauthSecretsHarness, fake *fakeAuthServer, name string) string {
+	t.Helper()
+	mcpServerID := "mcpserver-preflight-" + name
+	mcpServer := createTestMcpServerWithHttp(name)
+	mcpServer.Metadata.Id = mcpServerID
+	mcpServer.Spec.GetHttp().Url = fake.srv.URL + "/mcp"
+	mcpServer.Spec.Auth = &mcpserverv1.McpServerAuth{TargetEnvVar: "TEST_TOKEN"}
+	if err := h.store.SaveResource(context.Background(), apiresourcekind.ApiResourceKind_mcp_server, mcpServerID, mcpServer); err != nil {
+		t.Fatalf("failed to save mcp server: %v", err)
+	}
+	return mcpServerID
+}
+
+func countPendingRows(t *testing.T, h *oauthSecretsHarness) int {
+	t.Helper()
+	var count int
+	if err := h.store.DB().QueryRow(`SELECT COUNT(*) FROM pending_oauth_state`).Scan(&count); err != nil {
+		t.Fatalf("failed to count pending rows: %v", err)
+	}
+	return count
+}
+
+func newPreflightHarness(t *testing.T) *oauthSecretsHarness {
+	t.Helper()
+	secrets, err := encryption.NewSecretService(oauthSecretsTestKey)
+	if err != nil {
+		t.Fatalf("failed to create secret service: %v", err)
+	}
+	return setupOAuthSecretsHarness(t, secrets)
+}
+
+// TestInitiateDCR_PreflightBlocked pins the Canva shape: DCR succeeds but
+// the authorization endpoint 400s the built authorize URL (redirect-host
+// allowlist). Initiate must fail FAILED_PRECONDITION with copy an end user
+// can act on, and must not leave a pending handshake row behind.
+func TestInitiateDCR_PreflightBlocked(t *testing.T) {
+	h := newPreflightHarness(t)
+	fake := startFakeAuthServer(t)
+	fake.authorizeStatus = http.StatusBadRequest
+	fake.authorizeContentType = "text/html"
+	fake.authorizeBody = `<html><body>Invalid redirect URI. It must be from an allowed host.</body></html>`
+
+	mcpServerID := saveDcrMcpServer(t, h, fake, "canva-like")
+
+	_, err := h.controller.InitiateOAuthConnect(context.Background(), &mcpserverv1.InitiateOAuthConnectInput{
+		McpServerId: mcpServerID,
+	})
+	if err == nil {
+		t.Fatal("expected initiate to fail when the authorization endpoint rejects pre-flight")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+
+	msg := status.Convert(err).Message()
+	for _, want := range []string{
+		"canva-like",         // names the provider
+		"HTTP 400",           // names the observed refusal
+		"127.0.0.1",          // names this deployment's callback host (from the harness redirect URI)
+		"redirect-host allowlist", // names the actionable cause
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q missing %q", msg, want)
+		}
+	}
+
+	if n := countPendingRows(t, h); n != 0 {
+		t.Errorf("blocked initiate left %d pending row(s); handshake state must not outlive a refused flow", n)
+	}
+}
+
+// TestInitiateDCR_PreflightBlockedWithVendorDetail pins that an RFC-shaped
+// JSON rejection surfaces the provider's own words in the user copy.
+func TestInitiateDCR_PreflightBlockedWithVendorDetail(t *testing.T) {
+	h := newPreflightHarness(t)
+	fake := startFakeAuthServer(t)
+	fake.authorizeStatus = http.StatusBadRequest
+	fake.authorizeContentType = "application/json"
+	fake.authorizeBody = `{"error":"invalid_request","error_description":"redirect_uri host is not permitted"}`
+
+	mcpServerID := saveDcrMcpServer(t, h, fake, "json-detail")
+
+	_, err := h.controller.InitiateOAuthConnect(context.Background(), &mcpserverv1.InitiateOAuthConnectInput{
+		McpServerId: mcpServerID,
+	})
+	if err == nil {
+		t.Fatal("expected initiate to fail")
+	}
+	if msg := status.Convert(err).Message(); !strings.Contains(msg, "redirect_uri host is not permitted") {
+		t.Errorf("message %q missing the provider's error_description", msg)
+	}
+}
+
+// TestInitiateDCR_PreflightFailsOpen pins that non-400 authorize responses
+// never block initiate: 403/503 are what bot-protection layers return to
+// server-side GETs from healthy providers, and 302 is a healthy login
+// redirect. Each must yield a normal authorize URL and a pending row.
+func TestInitiateDCR_PreflightFailsOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"bot-protection-403", http.StatusForbidden},
+		{"outage-503", http.StatusServiceUnavailable},
+		{"healthy-302", http.StatusFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newPreflightHarness(t)
+			fake := startFakeAuthServer(t)
+			fake.authorizeStatus = tc.status
+			fake.authorizeContentType = "text/html"
+			fake.authorizeBody = "irrelevant"
+
+			mcpServerID := saveDcrMcpServer(t, h, fake, fmt.Sprintf("open-%d", tc.status))
+
+			out, err := h.controller.InitiateOAuthConnect(context.Background(), &mcpserverv1.InitiateOAuthConnectInput{
+				McpServerId: mcpServerID,
+			})
+			if err != nil {
+				t.Fatalf("initiate must fail open on HTTP %d, got: %v", tc.status, err)
+			}
+			if out.GetAuthorizationUrl() == "" {
+				t.Error("expected an authorization URL")
+			}
+			if n := countPendingRows(t, h); n != 1 {
+				t.Errorf("expected 1 pending row, got %d", n)
+			}
+		})
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/preflight.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/preflight.go
@@ -1,0 +1,99 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// AuthorizeRejection describes a definite refusal from an authorization
+// endpoint, observed before any browser was involved.
+type AuthorizeRejection struct {
+	// StatusCode is the HTTP status the authorization endpoint returned.
+	StatusCode int
+	// VendorDetail is the provider's own explanation, extracted from an
+	// RFC 6749-shaped JSON error body (error_description, falling back to
+	// error). Empty when the body is HTML or otherwise unparseable.
+	VendorDetail string
+	// BodySnippet is a truncated copy of the raw response body, for logs.
+	BodySnippet string
+}
+
+// Redirects are deliberately not followed: a healthy authorization endpoint
+// answers a fresh GET with either a login/consent page (2xx) or a redirect
+// into the vendor's login flow (3xx), and the first response alone is enough
+// to classify. The timeout is small because this probe sits on the
+// user-facing initiate path, after discovery and DCR round trips.
+var preflightHTTPClient = &http.Client{
+	Timeout: 4 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// PreflightAuthorize probes an authorization URL server-side and reports
+// whether the provider will refuse it before ever showing a login page.
+//
+// Some providers (e.g. Canva) accept Dynamic Client Registration for any
+// redirect URI but enforce a redirect-host allowlist at the authorization
+// endpoint. The rejection then surfaces only inside the OAuth popup, on a
+// vendor error page that never redirects back — so the connect flow never
+// learns it failed (stigmer/stigmer#235). This probe moves that discovery
+// to initiate time, where it can fail fast with an honest error.
+//
+// Classification is deliberately narrow — blocked means HTTP 400, nothing
+// else. RFC 6749 §4.1.2.1 requires an invalid-redirect rejection to be shown
+// at the authorization server without redirecting, which providers implement
+// as a 400. Everything else fails open (nil, possibly with a diagnostic
+// error): bot-protection layers answer server-side GETs with 403/503 while
+// real browsers pass, and treating those as blocked would turn healthy
+// providers into false dead ends. A fail-open miss merely preserves today's
+// behavior; a false positive would break a working connect flow.
+//
+// The probe is side-effect-free: state and PKCE parameters are opaque to the
+// authorization server at this point, and nothing is consumed until the
+// callback leg, which the probe never reaches.
+func PreflightAuthorize(ctx context.Context, authorizationURL string) (*AuthorizeRejection, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authorizationURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := preflightHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		return nil, nil
+	}
+
+	// Bounded read: error pages are small; anything longer is noise.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	return &AuthorizeRejection{
+		StatusCode:   resp.StatusCode,
+		VendorDetail: extractVendorDetail(body),
+		BodySnippet:  truncateBody(body),
+	}, nil
+}
+
+// extractVendorDetail pulls the provider's own words from an RFC 6749-shaped
+// JSON error body. HTML error pages (Canva's case) yield "" — scraping
+// prose out of markup is not worth the fragility.
+func extractVendorDetail(body []byte) string {
+	var parsed struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	if parsed.ErrorDescription != "" {
+		return parsed.ErrorDescription
+	}
+	return parsed.Error
+}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/preflight_test.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/preflight_test.go
@@ -1,0 +1,140 @@
+package oauth
+
+// Classification pins for the authorize pre-flight probe (oss#235).
+//
+// The load-bearing invariant is the fail-open arm: 403/5xx/redirects must
+// NOT classify as blocked, because bot-protection layers answer server-side
+// GETs with exactly those while real browsers pass. A regression here turns
+// healthy providers into false dead ends — strictly worse than the popup
+// dead end the probe exists to prevent.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func probeStatus(t *testing.T, statusCode int, contentType, body string) (*AuthorizeRejection, error) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return PreflightAuthorize(context.Background(), srv.URL+"/authorize?client_id=x")
+}
+
+func TestPreflightAuthorize_400WithJSONDetail(t *testing.T) {
+	rejection, err := probeStatus(t, http.StatusBadRequest, "application/json",
+		`{"error":"invalid_request","error_description":"Redirect host not allowed"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rejection == nil {
+		t.Fatal("expected a rejection for HTTP 400")
+	}
+	if rejection.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want 400", rejection.StatusCode)
+	}
+	if rejection.VendorDetail != "Redirect host not allowed" {
+		t.Errorf("VendorDetail = %q, want error_description", rejection.VendorDetail)
+	}
+}
+
+func TestPreflightAuthorize_400JSONFallsBackToErrorCode(t *testing.T) {
+	rejection, err := probeStatus(t, http.StatusBadRequest, "application/json",
+		`{"error":"invalid_request"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rejection == nil {
+		t.Fatal("expected a rejection for HTTP 400")
+	}
+	if rejection.VendorDetail != "invalid_request" {
+		t.Errorf("VendorDetail = %q, want error code fallback", rejection.VendorDetail)
+	}
+}
+
+func TestPreflightAuthorize_400WithHTMLBody(t *testing.T) {
+	// Canva's shape: an HTML error page. No detail extraction — the snippet
+	// is for logs only.
+	rejection, err := probeStatus(t, http.StatusBadRequest, "text/html",
+		`<html><body>Invalid redirect URI. It must be from an allowed host.</body></html>`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rejection == nil {
+		t.Fatal("expected a rejection for HTTP 400")
+	}
+	if rejection.VendorDetail != "" {
+		t.Errorf("VendorDetail = %q, want empty for HTML body", rejection.VendorDetail)
+	}
+	if !strings.Contains(rejection.BodySnippet, "Invalid redirect URI") {
+		t.Errorf("BodySnippet = %q, want the raw body for logging", rejection.BodySnippet)
+	}
+}
+
+func TestPreflightAuthorize_FailsOpenOnNon400(t *testing.T) {
+	// 403/503 are bot-protection signatures; 200 is a login page; all must
+	// fall open.
+	for _, statusCode := range []int{
+		http.StatusOK,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	} {
+		rejection, err := probeStatus(t, statusCode, "text/html", "irrelevant")
+		if err != nil {
+			t.Errorf("HTTP %d: unexpected error: %v", statusCode, err)
+		}
+		if rejection != nil {
+			t.Errorf("HTTP %d classified as blocked; only 400 may block", statusCode)
+		}
+	}
+}
+
+func TestPreflightAuthorize_DoesNotFollowRedirects(t *testing.T) {
+	// A healthy authorize endpoint 302s into the vendor's login flow. The
+	// probe must classify on the first response and never chase it — the
+	// redirect target could be slow, external, or (in tests) nonexistent.
+	redirectTargetHits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHits++
+	})
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/login", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rejection, err := PreflightAuthorize(context.Background(), srv.URL+"/authorize")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rejection != nil {
+		t.Fatal("302 classified as blocked; redirects mean healthy")
+	}
+	if redirectTargetHits != 0 {
+		t.Errorf("probe followed the redirect (%d hits); it must classify on the first response", redirectTargetHits)
+	}
+}
+
+func TestPreflightAuthorize_NetworkErrorIsDiagnosticOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // guarantee a connection refusal
+
+	rejection, err := PreflightAuthorize(context.Background(), srv.URL+"/authorize")
+	if rejection != nil {
+		t.Fatal("network error classified as blocked; it must fall open")
+	}
+	if err == nil {
+		t.Error("expected a diagnostic error for the caller's debug log")
+	}
+}

--- a/docs/guides/integrations/oauth-architecture.mdx
+++ b/docs/guides/integrations/oauth-architecture.mdx
@@ -148,7 +148,16 @@ When you click **Sign in to connect**, the backend performs three steps:
 
 1. **Initiate** — Generates an authorization URL with a PKCE challenge, state
    parameter, and the scopes from the OAuthApp. For DCR servers, this step also
-   discovers the authorization server and registers a client.
+   discovers the authorization server and registers a client, then probes the
+   built authorization URL server-side before returning it. Some vendors accept
+   any redirect URI at registration but enforce a redirect-host allowlist at
+   the authorization endpoint (Canva, for example, requires public callback
+   hosts to be approved through its MCP waitlist). Without the probe, that
+   rejection would only ever appear as a vendor error page inside the popup —
+   the flow would never learn it failed. A definite rejection (HTTP 400) fails
+   the initiate with an explanation of the deployment's callback host; any
+   other response proceeds normally, so an unreachable or bot-protected
+   authorization endpoint never blocks a working sign-in.
 2. **Authorize** — You approve the request in the vendor's authorization page.
    The vendor redirects back with an authorization code.
 3. **Complete** — The backend exchanges the code for tokens using the PKCE

--- a/seedpack/canary/credential-manifest.yaml
+++ b/seedpack/canary/credential-manifest.yaml
@@ -120,7 +120,7 @@ servers:
     status: oauth_only
     auth_type: dcr_oauth
     env_var: CANVA_ACCESS_TOKEN
-    notes: "Hosted endpoint likely OAuth-only; untested"
+    notes: "Verified 2026-08-11 (oss#235): OAuth-only (dummy bearer gets a 401 challenge). DCR works, but the authorize endpoint enforces a redirect-host allowlist — localhost callbacks connect end-to-end, public callback hosts (e.g. Stigmer Cloud) get HTTP 400 until approved via Canva's MCP waitlist."
 
   contentful:
     status: oauth_only

--- a/seedpack/mcp-servers/canva.yaml
+++ b/seedpack/mcp-servers/canva.yaml
@@ -22,7 +22,14 @@ spec:
   env:
     CANVA_ACCESS_TOKEN:
       is_secret: true
-      description: "Canva OAuth access token"
+      description: "Canva OAuth access token, obtained automatically via Connect. Canva's hosted MCP endpoint requires OAuth 2.1 (PKCE) and has no manual token path."
   auth:
     target_env_var: "CANVA_ACCESS_TOKEN"
     token_lifetime_hint: "1h"
+    # Canva's hosted endpoint has no manually-obtainable token (verified
+    # 2026-08-11: a dummy bearer gets a 401 OAuth challenge), so the connect
+    # UI hides manual token entry. NOTE: Canva enforces a redirect-host
+    # allowlist at the authorization endpoint — localhost callbacks work,
+    # public callback hosts must be approved via Canva's MCP waitlist
+    # (stigmer/stigmer#235). The DCR pre-flight surfaces this honestly.
+    oauth_only: true

--- a/seedpack/mcp_servers_test.go
+++ b/seedpack/mcp_servers_test.go
@@ -388,7 +388,9 @@ func TestMcpServers_OAuthOnlyDeclared(t *testing.T) {
 
 	// Flagship OAuth-only endpoints verified to reject static tokens. Extend this
 	// list as the remaining dcr_oauth servers are rolled out.
-	oauthOnlySlugs := []string{"notion", "monday"}
+	// canva verified 2026-08-11 (oss#235): a dummy bearer token gets a 401
+	// OAuth challenge from mcp.canva.com; there is no manual token path.
+	oauthOnlySlugs := []string{"notion", "monday", "canva"}
 
 	for _, slug := range oauthOnlySlugs {
 		t.Run(slug, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fixes [#235](https://github.com/stigmer/stigmer/issues/235)** (Canva MCP OAuth "Invalid redirect URI"). Premise corrected by live probe: Canva's allowlist is enforced at `/authorize`, **per host, not per client** — localhost callbacks 302 into the real consent flow (self-hosted desktop works today), while `app.stigmer.ai` gets HTTP 400. Only hosted deployments are blocked, so neither tile removal (the #232 precedent) nor a static seedpack flag can be accurate for both editions; BYOA cannot help either (same host allowlist regardless of client).
- **DCR authorize pre-flight** (owner-approved design): after DCR, the initiate path probes the built authorize URL server-side. A definite **HTTP 400** fails initiate with FAILED_PRECONDITION copy that names this deployment's callback host, the redirect-host-allowlist cause, and the vendor's own `error_description` when the body is RFC-shaped JSON. **Everything else fails open** — 403/5xx are bot-protection signatures against server-side GETs; a false positive would break a working vendor, a fail-open miss merely preserves today's behavior. Redirects are never followed; the probe is side-effect-free and self-heals the moment Canva approves the host (external approval tracked as [#424](https://github.com/stigmer/stigmer/issues/424)).
- **Seedpack corrections**: `canva.yaml` gains the missing `oauth_only: true` (verified: dummy bearer → 401 OAuth challenge; the #148 dead-end class), canva joins the `TestMcpServers_OAuthOnlyDeclared` pin list, credential-manifest notes replaced with verified findings, `oauth-architecture.mdx` documents the probe.
- **No frontend/CLI changes needed** (verified): the #229 error surface renders initiate failures verbatim with popup cleanup (`failedPhase: "initiating"`); the CLI opens the web console rather than calling initiate.

Paired cloud PR ports the identical probe + copy to the Java initiate handler.

## Test plan

- [x] New classification unit suite (`oauth/preflight_test.go`): 400+JSON detail / 400+error-code fallback / 400+HTML / 2xx-401-403-404-429-5xx fall open / redirect never followed / network error falls open
- [x] New controller end-to-end pins (`controller/oauth_preflight_test.go`): blocked → FAILED_PRECONDITION naming provider + HTTP 400 + callback host + cause, **no pending row left behind**; JSON `error_description` reaches the user; 403/503/302 fail open with a pending row
- [x] Full `stigmer-server` module green under `go test -race` (49 pkgs); `go vet` clean
- [x] Seedpack static suite green (incl. the new canva oauth_only pin)
- [ ] Cloud connect against Canva post-deploy — blocked by the allowlist itself (that's the bug); reproduced by live probe, copy pinned by tests

## Deploy notes

No new ops step: `canva.yaml` reaches the cloud marketplace via the `stigmer seedpack apply --force` already owed by the #238 session.

Made with [Cursor](https://cursor.com)