### PR TITLE
feat(runner): serve Claude from Microsoft Foundry via the provider-backend seam (T05)

### DIFF
--- a/backend/services/runner/package-lock.json
+++ b/backend/services/runner/package-lock.json
@@ -10,7 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.32.1",
+        "@anthropic-ai/foundry-sdk": "^0.4.1",
         "@anthropic-ai/vertex-sdk": "^0.19.1",
+        "@azure/identity": "^4.13.1",
         "@bufbuild/protobuf": "2.12.0",
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
@@ -98,6 +100,36 @@
       }
     },
     "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@anthropic-ai/sdk": {
+      "version": "0.116.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
+      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/foundry-sdk": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/foundry-sdk/-/foundry-sdk-0.4.1.tgz",
+      "integrity": "sha512-OEBcC4l2tPOthnlZgBRKGTYVl81Itx8bPuXuaKHL2T3vkbkY/EYtgDyHA38hWKTOlJvrY80yrpjLTzOoquiwvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.115.1 <1"
+      }
+    },
+    "node_modules/@anthropic-ai/foundry-sdk/node_modules/@anthropic-ai/sdk": {
       "version": "0.116.0",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
       "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
@@ -905,6 +937,163 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
+      "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
+      "integrity": "sha512-SPTeHYZghdEdRddJzNjhH+CI5MSQtquNYwGJnYXfOHIBRXCmrWimBS85OhwXpXFIlrCtNTbBPm5mPAWRNEoktA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.12.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.12.0.tgz",
+      "integrity": "sha512-hgLgfRdbG2AmhXPygebf1KYJEvse86+ZZLWufdiTKaGRYEUqOzHdlf6AS1IiuUCHWbynkgbHc451jSNkbfhWlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.5.0.tgz",
+      "integrity": "sha512-A/2WIsuH0vsC6JVkkafjS4kHpi2LDR4AzDT0kJ+oIRtXYeYtvGQ2pwN2X88thQPhSek+82ela3MprsKXWQRrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.12.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/runtime": {
@@ -4327,6 +4516,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -5003,6 +5241,21 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5399,6 +5652,46 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delegates": {
@@ -6492,6 +6785,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6520,6 +6828,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-lambda": {
@@ -6555,6 +6881,21 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6653,6 +6994,34 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -6724,6 +7093,48 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -7279,6 +7690,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "6.38.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
@@ -7821,6 +8250,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -9754,6 +10195,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/backend/services/runner/package.json
+++ b/backend/services/runner/package.json
@@ -70,7 +70,9 @@
   },
   "dependencies": {
     "@anthropic-ai/bedrock-sdk": "^0.32.1",
+    "@anthropic-ai/foundry-sdk": "^0.4.1",
     "@anthropic-ai/vertex-sdk": "^0.19.1",
+    "@azure/identity": "^4.13.1",
     "@bufbuild/protobuf": "2.12.0",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",

--- a/backend/services/runner/scripts/check-langchain-deps.sh
+++ b/backend/services/runner/scripts/check-langchain-deps.sh
@@ -70,18 +70,19 @@ fi
 #
 # The tree deliberately carries TWO versions of @anthropic-ai/sdk:
 #   - @langchain/anthropic -> ^0.95.x  (hoisted; serves the public-API path)
-#   - @anthropic-ai/vertex-sdk AND @anthropic-ai/bedrock-sdk -> >=0.115
-#     (nested, deduped onto one version; serve only the backend clients
-#     constructed via ChatAnthropic's createClient factory)
+#   - @anthropic-ai/vertex-sdk, @anthropic-ai/bedrock-sdk, AND
+#     @anthropic-ai/foundry-sdk -> >=0.115 (nested, deduped onto one
+#     version; serve only the backend clients constructed via
+#     ChatAnthropic's createClient factory)
 # The versions never exchange class instances (LangChain consumes stream
 # events structurally and classifies errors by HTTP status, not instanceof),
-# and the vertex-seam/bedrock-seam characterization tests pin the
-# cross-version combinations in CI.
+# and the vertex-seam/bedrock-seam/foundry-seam characterization tests pin
+# the cross-version combinations in CI.
 #
 # Collapse condition: when the LangChain stack bump lands (@langchain/core
 # 1.2.x + @langchain/anthropic 1.5.x, which pins @anthropic-ai/sdk ^0.115),
 # npm dedupes to a single copy — tighten this check to single-copy then.
-# Any dependent other than these three, or a third distinct version, is
+# Any dependent other than these four, or a third distinct version, is
 # drift and fails the check.
 
 echo ""
@@ -89,7 +90,7 @@ ANTHROPIC_SDK_REPORT=$(npm ls @anthropic-ai/sdk --all --json 2>/dev/null \
   | node -e "
     const json = require('fs').readFileSync('/dev/stdin', 'utf8');
     const tree = JSON.parse(json);
-    const ALLOWED_PARENTS = new Set(['@langchain/anthropic', '@anthropic-ai/vertex-sdk', '@anthropic-ai/bedrock-sdk']);
+    const ALLOWED_PARENTS = new Set(['@langchain/anthropic', '@anthropic-ai/vertex-sdk', '@anthropic-ai/bedrock-sdk', '@anthropic-ai/foundry-sdk']);
     const found = new Map(); // parent -> Set<version>
     function walk(node, parentName) {
       if (!node || !node.dependencies) return;
@@ -124,14 +125,15 @@ echo "$ANTHROPIC_SDK_REPORT" | grep -v '^PASS$' | grep -v '^FAIL:' || true
 if echo "$ANTHROPIC_SDK_REPORT" | grep -q '^FAIL:'; then
   echo ""
   echo "FAIL: @anthropic-ai/sdk copy check: $(echo "$ANTHROPIC_SDK_REPORT" | grep '^FAIL:' | sed 's/^FAIL://')"
-  echo "Only @langchain/anthropic (0.95.x), @anthropic-ai/vertex-sdk (>=0.115),"
-  echo "and @anthropic-ai/bedrock-sdk (>=0.115) may pull @anthropic-ai/sdk. See"
-  echo "the comment above this check for the rationale and collapse condition."
+  echo "Only @langchain/anthropic (0.95.x) and the backend SDKs (>=0.115):"
+  echo "@anthropic-ai/vertex-sdk, @anthropic-ai/bedrock-sdk, and"
+  echo "@anthropic-ai/foundry-sdk may pull @anthropic-ai/sdk. See the comment"
+  echo "above this check for the rationale and collapse condition."
   exit 1
 fi
 
 if echo "$ANTHROPIC_SDK_REPORT" | grep -q '^PASS$'; then
-  echo "OK: @anthropic-ai/sdk copies match the known langchain + vertex/bedrock-sdk set"
+  echo "OK: @anthropic-ai/sdk copies match the known langchain + backend-sdk set"
 else
   echo "WARN: Could not determine @anthropic-ai/sdk copies (is npm ci done?)"
 fi

--- a/backend/services/runner/src/shared/__tests__/foundry-adapter.test.ts
+++ b/backend/services/runner/src/shared/__tests__/foundry-adapter.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Adapter test for the foundry backend branch of buildChatModel — the
+ * complement of foundry-seam.test.ts, mirroring vertex-adapter.test.ts and
+ * bedrock-adapter.test.ts.
+ *
+ * The seam test pins the REAL AnthropicFoundry client's wire behavior under
+ * a hand-built ChatAnthropic. This file pins OUR production wiring: a real
+ * `buildChatModel` and a real `ChatAnthropic` drive a mocked
+ * `@anthropic-ai/foundry-sdk` (and a mocked `@azure/identity`), so
+ * LangChain's lazy `createClient` invocation path is exercised exactly as
+ * production does it. Together the two files cover the whole chain without
+ * any test-only injection seam in production code.
+ *
+ * Pinned here:
+ * - the factory forwards LangChain's `maxRetries: 0` to the client,
+ * - construction and invocation succeed with NO ANTHROPIC_API_KEY (Foundry
+ *   auth is Azure's, and ChatAnthropic waives the key when createClient is
+ *   provided),
+ * - the deployment name (strip-date rule, map overrides applied) crosses
+ *   the wire while the returned apiModelId stays canonical (the
+ *   canonical-id invariant),
+ * - auth selection: ANTHROPIC_FOUNDRY_API_KEY present -> no token provider
+ *   and @azure/identity never touched; absent -> the Entra chain provider
+ *   built with the Foundry scope and handed to the client,
+ * - maxTokens parity: stripping the date preserves LangChain's per-model
+ *   default, so the adapter needs NO injection (unlike bedrock's 4096
+ *   landmine) — pinned so a LangChain bump that diverges the two forms
+ *   fails here instead of silently capping Foundry deployments,
+ * - usage_metadata survives the adapter (what billing reads).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+
+const { foundryCtorArgs, createRequests, identityCalls } = vi.hoisted(() => ({
+  foundryCtorArgs: [] as Array<{
+    maxRetries?: number;
+    azureADTokenProvider?: () => Promise<string>;
+  }>,
+  createRequests: [] as Array<Record<string, unknown>>,
+  identityCalls: {
+    credentialConstructions: 0,
+    tokenProviderScopes: [] as string[],
+  },
+}));
+
+vi.mock("@anthropic-ai/foundry-sdk", () => ({
+  AnthropicFoundry: class {
+    readonly maxRetries: number | undefined;
+    readonly messages = {
+      create: async (request: Record<string, unknown>) => {
+        createRequests.push(request);
+        return {
+          id: "msg_foundry_adapter_01",
+          type: "message",
+          role: "assistant",
+          model: request.model,
+          content: [{ type: "text", text: "Namaste from Foundry." }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 7, output_tokens: 5 },
+        };
+      },
+    };
+
+    constructor(opts: {
+      maxRetries?: number;
+      azureADTokenProvider?: () => Promise<string>;
+    }) {
+      foundryCtorArgs.push(opts);
+      this.maxRetries = opts.maxRetries;
+    }
+  },
+}));
+
+vi.mock("@azure/identity", () => ({
+  DefaultAzureCredential: class {
+    constructor() {
+      identityCalls.credentialConstructions += 1;
+    }
+  },
+  getBearerTokenProvider: (_credential: unknown, scope: string) => {
+    identityCalls.tokenProviderScopes.push(scope);
+    return async () => "entra-adapter-token";
+  },
+}));
+
+import { ChatAnthropic } from "@langchain/anthropic";
+
+import { buildChatModel } from "../model-client.js";
+import { _resetRegistryCache } from "../model-registry.js";
+
+describe("buildChatModel foundry adapter", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    _resetRegistryCache();
+    foundryCtorArgs.length = 0;
+    createRequests.length = 0;
+    identityCalls.credentialConstructions = 0;
+    identityCalls.tokenProviderScopes.length = 0;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_FOUNDRY_BASE_URL;
+    delete process.env.STIGMER_FOUNDRY_DEPLOYMENT_MAP;
+    process.env.STIGMER_ANTHROPIC_BACKEND = "foundry";
+    process.env.ANTHROPIC_FOUNDRY_RESOURCE = "adapter-test-resource";
+    process.env.ANTHROPIC_FOUNDRY_API_KEY = "foundry-adapter-test-key";
+    // Registry offline → resolveToApiModelId passes the id through, keeping
+    // this test free of registry fixtures (that path has its own tests).
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("registry offline"));
+  });
+
+  afterEach(() => {
+    _resetRegistryCache();
+    vi.restoreAllMocks();
+    process.env = { ...savedEnv };
+  });
+
+  it("drives the mocked client through the real createClient path with the invariants intact", async () => {
+    const { model, apiModelId } = await buildChatModel({
+      modelName: "claude-sonnet-4-5-20250929",
+      maxTokens: 1024,
+    });
+
+    // Canonical id returned; the client is not constructed yet (lazy factory).
+    expect(apiModelId).toBe("claude-sonnet-4-5-20250929");
+    expect(foundryCtorArgs).toHaveLength(0);
+
+    const result = await model.invoke([new HumanMessage("Weather in Chennai?")]);
+
+    // First request constructed exactly one (batch) client, with LangChain's
+    // maxRetries: 0 honored — LangChain owns retrying.
+    expect(foundryCtorArgs).toHaveLength(1);
+    expect(foundryCtorArgs[0].maxRetries).toBe(0);
+
+    // The wire carries the deployment name (date stripped); billing already
+    // got the canonical id above.
+    expect(createRequests).toHaveLength(1);
+    expect(createRequests[0].model).toBe("claude-sonnet-4-5");
+    expect(createRequests[0].max_tokens).toBe(1024);
+
+    // Response and usage flow back through LangChain untouched.
+    expect(result).toBeInstanceOf(AIMessage);
+    expect(result.text).toBe("Namaste from Foundry.");
+    expect((result as AIMessage).usage_metadata).toMatchObject({
+      input_tokens: 7,
+      output_tokens: 5,
+      total_tokens: 12,
+    });
+  });
+
+  it("honors a deployment-map override over the strip-date rule", async () => {
+    process.env.STIGMER_FOUNDRY_DEPLOYMENT_MAP =
+      "claude-sonnet-4-6=my-sonnet-deployment";
+
+    const { model, apiModelId } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(apiModelId).toBe("claude-sonnet-4-6");
+    expect(createRequests.at(-1)?.model).toBe("my-sonnet-deployment");
+  });
+
+  it("uses API-key auth when ANTHROPIC_FOUNDRY_API_KEY is set — @azure/identity untouched", async () => {
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    // The SDK reads the key from its own env var; the adapter must not
+    // pass a token provider alongside it (the constructor treats them as
+    // mutually exclusive) and must not touch the Azure credential chain.
+    expect(foundryCtorArgs.at(-1)?.azureADTokenProvider).toBeUndefined();
+    expect(identityCalls.credentialConstructions).toBe(0);
+    expect(identityCalls.tokenProviderScopes).toHaveLength(0);
+  });
+
+  it("falls back to the Entra chain with the Foundry scope when no key is set", async () => {
+    delete process.env.ANTHROPIC_FOUNDRY_API_KEY;
+
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    // One DefaultAzureCredential, one provider with the ai.azure.com scope,
+    // handed to the client so every request authenticates as Bearer.
+    expect(identityCalls.credentialConstructions).toBe(1);
+    expect(identityCalls.tokenProviderScopes).toEqual(["https://ai.azure.com/.default"]);
+    const provider = foundryCtorArgs.at(-1)?.azureADTokenProvider;
+    expect(provider).toBeTypeOf("function");
+    await expect(provider!()).resolves.toBe("entra-adapter-token");
+  });
+
+  it("treats a whitespace-only key as absent (Entra, not a blank x-api-key)", async () => {
+    process.env.ANTHROPIC_FOUNDRY_API_KEY = "   ";
+
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(foundryCtorArgs.at(-1)?.azureADTokenProvider).toBeTypeOf("function");
+  });
+
+  it("needs no maxTokens injection: the deployment name inherits the canonical default", async () => {
+    // The vertex-style parity pin (contrast with bedrock's 4096 landmine):
+    // LangChain's per-model default table prefix-matches the model string,
+    // and a date-stripped id is a prefix of its own canonical form, so both
+    // resolve identically — probed 2026-08-11 across the full catalog. If a
+    // LangChain bump ever adds date-qualified table entries that diverge
+    // the two forms, this fails and the adapter needs bedrock's
+    // canonical-probe injection.
+    const canonicalDefault = new ChatAnthropic({
+      model: "claude-sonnet-4-5-20250929",
+      apiKey: "probe",
+    }).maxTokens;
+    const deploymentDefault = new ChatAnthropic({
+      model: "claude-sonnet-4-5",
+      apiKey: "probe",
+    }).maxTokens;
+    expect(deploymentDefault).toBe(canonicalDefault);
+
+    const { model } = await buildChatModel({ modelName: "claude-sonnet-4-5-20250929" });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(createRequests.at(-1)?.max_tokens).toBe(canonicalDefault);
+  });
+
+  it("constructs and invokes with no ANTHROPIC_API_KEY anywhere in the environment", async () => {
+    expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+    });
+    const result = await model.invoke([new HumanMessage("hi")]);
+
+    expect(result).toBeInstanceOf(AIMessage);
+    expect(createRequests.at(-1)?.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("fails at dispatch with the catalog message when no endpoint is configured", async () => {
+    delete process.env.ANTHROPIC_FOUNDRY_RESOURCE;
+
+    await expect(
+      buildChatModel({ modelName: "claude-sonnet-4-6", maxTokens: 256 }),
+    ).rejects.toThrow(/ANTHROPIC_FOUNDRY_RESOURCE/);
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/foundry-seam.test.ts
+++ b/backend/services/runner/src/shared/__tests__/foundry-seam.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Characterization test for the ChatAnthropic `createClient` ->
+ * AnthropicFoundry seam — the integration the T05 foundry backend adapter
+ * is built on. Sibling of vertex-seam.test.ts and bedrock-seam.test.ts;
+ * same rules: this pins REAL cross-package behavior (`@langchain/anthropic`
+ * bundling @anthropic-ai/sdk 0.95.x driving `@anthropic-ai/foundry-sdk`
+ * bundling its own nested >=0.115 copy), so a future bump of either side
+ * fails here in CI instead of in production. See
+ * scripts/check-langchain-deps.sh for why the two @anthropic-ai/sdk
+ * versions coexist and when they collapse to one.
+ *
+ * Determinism: zero live credentials, zero network. API-key auth is a
+ * static test key; Entra ID auth is a fake `azureADTokenProvider` (the
+ * SDK's supported constructor option — a plain `() => Promise<string>`,
+ * so no @azure/identity is needed here); transport is a recording `fetch`
+ * injected through the SDK's own `fetch` option.
+ *
+ * Foundry-specific wire facts this suite pins (vs. its two siblings):
+ *   - The deployment name stays in the BODY as `model` — Foundry routes by
+ *     deployment name, not by URL path (Vertex/Bedrock move the id into
+ *     the path). One /v1/messages URL serves both modes; `stream: true`
+ *     in the body selects streaming.
+ *   - The constructor enforces its config contract itself: a credential
+ *     (apiKey XOR azureADTokenProvider) and an endpoint (resource XOR
+ *     baseURL) are both mandatory, each pair mutually exclusive. These
+ *     throws are what checkFoundryPrerequisites front-runs at boot.
+ *   - withStructuredOutput compiles to forced tool use (tools +
+ *     tool_choice), NOT Anthropic's native structured-output parameter —
+ *     which is why it works on "Hosted on Azure" Foundry deployments,
+ *     where the native feature returns 400 by design (operator doc,
+ *     docs/guides/runners/model-backends.mdx).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { AnthropicFoundry } from "@anthropic-ai/foundry-sdk";
+import { HumanMessage, AIMessage, AIMessageChunk } from "@langchain/core/messages";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/**
+ * Foundry's default deployment names are the DATELESS Claude ids — this is
+ * a dated registry id after the strip-date translation in llm-backend.ts
+ * (claude-sonnet-4-5-20250929 -> claude-sonnet-4-5).
+ */
+const FOUNDRY_DEPLOYMENT = "claude-sonnet-4-5";
+const RESOURCE = "seam-test-resource";
+const API_KEY = "foundry-seam-test-key";
+
+const WEATHER_TOOL = {
+  name: "get_weather",
+  description: "Get the current weather for a city.",
+  input_schema: {
+    type: "object" as const,
+    properties: { city: { type: "string" } },
+    required: ["city"],
+  },
+};
+
+/** Non-streaming response: text + tool_use + usage. */
+const MESSAGE_RESPONSE = {
+  id: "msg_foundry_test_01",
+  type: "message",
+  role: "assistant",
+  model: FOUNDRY_DEPLOYMENT,
+  content: [
+    { type: "text", text: "I'll check the weather." },
+    { type: "tool_use", id: "toolu_test_01", name: "get_weather", input: { city: "Chennai" } },
+  ],
+  stop_reason: "tool_use",
+  stop_sequence: null,
+  usage: { input_tokens: 25, output_tokens: 17 },
+};
+
+/**
+ * Streaming response as Anthropic SSE — Foundry speaks the standard
+ * Messages API event grammar (no transcoding layer like Bedrock's binary
+ * EventStream): a text block, a tool_use block assembled from
+ * input_json_delta, then cumulative usage in message_delta.
+ */
+const SSE_EVENTS: ReadonlyArray<[string, object]> = [
+  ["message_start", {
+    type: "message_start",
+    message: {
+      id: "msg_foundry_test_02", type: "message", role: "assistant",
+      model: FOUNDRY_DEPLOYMENT, content: [], stop_reason: null, stop_sequence: null,
+      usage: { input_tokens: 25, output_tokens: 1 },
+    },
+  }],
+  ["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+  ["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "I'll check the weather." } }],
+  ["content_block_stop", { type: "content_block_stop", index: 0 }],
+  ["content_block_start", { type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_test_02", name: "get_weather", input: {} } }],
+  ["content_block_delta", { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"city":"Chennai"}' } }],
+  ["content_block_stop", { type: "content_block_stop", index: 1 }],
+  ["message_delta", { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 17 } }],
+  ["message_stop", { type: "message_stop" }],
+];
+
+function sseBody(): string {
+  return SSE_EVENTS
+    .map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+    .join("");
+}
+
+// ─── Env hygiene ─────────────────────────────────────────────────────────────
+
+/**
+ * The AnthropicFoundry constructor reads these as option defaults, so a
+ * developer machine with a real Foundry setup would silently change what
+ * the constructor-contract tests observe. Cleared for every test; the
+ * harness passes everything explicitly.
+ */
+const FOUNDRY_ENV_VARS = [
+  "ANTHROPIC_FOUNDRY_API_KEY",
+  "ANTHROPIC_FOUNDRY_RESOURCE",
+  "ANTHROPIC_FOUNDRY_BASE_URL",
+] as const;
+
+const savedEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const name of FOUNDRY_ENV_VARS) {
+    savedEnv.set(name, process.env[name]);
+    delete process.env[name];
+  }
+});
+
+afterEach(() => {
+  for (const name of FOUNDRY_ENV_VARS) {
+    const value = savedEnv.get(name);
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}
+
+interface SeamHarness {
+  model: ChatAnthropic;
+  requests: RecordedRequest[];
+  /** Options ChatAnthropic passed to the createClient factory. */
+  factoryOptions: Array<{ maxRetries?: number }>;
+  /** The AnthropicFoundry instances the factory constructed. */
+  clients: AnthropicFoundry[];
+}
+
+/**
+ * Build a real ChatAnthropic wired to a real AnthropicFoundry through the
+ * `createClient` seam, with transport replaced by a recording fetch.
+ *
+ * The factory honors `maxRetries` from the incoming options: LangChain owns
+ * retrying (its AsyncCaller wraps every request) and passes `maxRetries: 0`
+ * so the underlying SDK must not retry underneath it — same contract the
+ * vertex and bedrock seams pin, preserved by the T05 adapter.
+ *
+ * Auth is either the static test API key or a caller-supplied Entra token
+ * provider — the same either/or the production adapter selects between.
+ */
+function buildSeamHarness(auth?: { azureADTokenProvider: () => Promise<string> }): SeamHarness {
+  const requests: RecordedRequest[] = [];
+  const factoryOptions: SeamHarness["factoryOptions"] = [];
+  const clients: AnthropicFoundry[] = [];
+
+  const recordingFetch: typeof fetch = async (input, init) => {
+    const headers: Record<string, string> = {};
+    new Headers(init?.headers).forEach((value, key) => {
+      headers[key] = value;
+    });
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    requests.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers,
+      body,
+    });
+    // One URL serves both modes on Foundry — the body's stream flag picks.
+    return body.stream === true
+      ? new Response(sseBody(), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      : new Response(JSON.stringify(MESSAGE_RESPONSE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+  };
+
+  const model = new ChatAnthropic({
+    model: FOUNDRY_DEPLOYMENT,
+    temperature: 0,
+    maxTokens: 1024,
+    createClient: (options) => {
+      factoryOptions.push({ maxRetries: options.maxRetries });
+      const client = new AnthropicFoundry({
+        resource: RESOURCE,
+        ...(auth ?? { apiKey: API_KEY }),
+        fetch: recordingFetch,
+        maxRetries: options.maxRetries,
+      });
+      clients.push(client);
+      return client;
+    },
+  });
+
+  return { model, requests, factoryOptions, clients };
+}
+
+/** Foundry's one Messages URL: resource-derived host, /anthropic prefix. */
+const EXPECTED_URL =
+  `https://${RESOURCE}.services.ai.azure.com/anthropic/v1/messages`;
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("ChatAnthropic createClient -> AnthropicFoundry seam", () => {
+  it("constructs without an Anthropic API key when createClient is provided", () => {
+    // chat_models.js waives the "Anthropic API key not found" check for
+    // factory-constructed clients — the waiver the foundry backend depends on.
+    expect(() => buildSeamHarness()).not.toThrow();
+  });
+
+  it("enforces its config contract in the constructor (what preflight front-runs)", () => {
+    // These four throws are the SDK's own; checkFoundryPrerequisites
+    // (llm-backend.ts) exists to catch the endpoint half at boot with the
+    // catalog message instead of at the first model call. The credential
+    // half resolves at construction (key if present, else Entra chain), so
+    // the "missing credentials" arm is unreachable in production — pinned
+    // here so an SDK contract change surfaces as a failing pin.
+    expect(() => new AnthropicFoundry({ resource: RESOURCE })).toThrow(
+      /Missing credentials/,
+    );
+    expect(
+      () =>
+        new AnthropicFoundry({
+          resource: RESOURCE,
+          apiKey: API_KEY,
+          azureADTokenProvider: async () => "token",
+        }),
+    ).toThrow(/mutually exclusive/);
+    expect(() => new AnthropicFoundry({ apiKey: API_KEY })).toThrow(
+      /baseURL.*resource|resource.*baseURL/,
+    );
+    expect(
+      () =>
+        new AnthropicFoundry({
+          apiKey: API_KEY,
+          resource: RESOURCE,
+          baseURL: "https://example.services.ai.azure.com/anthropic/",
+        }),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it("shapes a non-streaming request: deployment name in the BODY, key in x-api-key", async () => {
+    const h = buildSeamHarness();
+
+    const result = await h.model.invoke([new HumanMessage("Weather in Chennai?")]);
+
+    expect(h.requests).toHaveLength(1);
+    const req = h.requests[0];
+
+    // Unlike Vertex/Bedrock, the model field survives in the body — it IS
+    // the routing key (the deployment name). The URL never carries it.
+    expect(req.url).toBe(EXPECTED_URL);
+    expect(req.method).toBe("POST");
+    expect(req.body.model).toBe(FOUNDRY_DEPLOYMENT);
+    expect(req.body.max_tokens).toBe(1024);
+
+    // API-key mode authenticates with x-api-key (Entra uses Authorization:
+    // Bearer — pinned separately); the standard version header rides along.
+    expect(req.headers["x-api-key"]).toBe(API_KEY);
+    expect(req.headers.authorization).toBeUndefined();
+    expect(req.headers["anthropic-version"]).toBe("2023-06-01");
+
+    expect(result).toBeInstanceOf(AIMessage);
+  });
+
+  it("round-trips tool definitions and tool_use blocks into tool_calls", async () => {
+    const h = buildSeamHarness();
+    const withTools = h.model.bindTools([WEATHER_TOOL]);
+
+    const result = (await withTools.invoke([
+      new HumanMessage("Weather in Chennai?"),
+    ])) as AIMessage;
+
+    // Tool definition survived request shaping through the Foundry client.
+    const tools = h.requests[0].body.tools as Array<{ name: string }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("get_weather");
+
+    // The tool_use response block became a LangChain tool_call with its id —
+    // the identity the HITL approval flow keys on.
+    expect(result.tool_calls).toHaveLength(1);
+    expect(result.tool_calls?.[0]).toMatchObject({
+      id: "toolu_test_01",
+      name: "get_weather",
+      args: { city: "Chennai" },
+    });
+  });
+
+  it("reports usage_metadata on non-streaming responses (what billing reads)", async () => {
+    const h = buildSeamHarness();
+
+    const result = (await h.model.invoke([
+      new HumanMessage("Weather in Chennai?"),
+    ])) as AIMessage;
+
+    expect(result.usage_metadata).toMatchObject({
+      input_tokens: 25,
+      output_tokens: 17,
+      total_tokens: 42,
+    });
+  });
+
+  it("streams over the same URL with stream: true, assembling tool_calls and usage from SSE", async () => {
+    const h = buildSeamHarness();
+
+    let final: AIMessageChunk | undefined;
+    for await (const chunk of await h.model.stream([
+      new HumanMessage("Weather in Chennai?"),
+    ])) {
+      final = final === undefined ? chunk : final.concat(chunk);
+    }
+
+    expect(h.requests).toHaveLength(1);
+    expect(h.requests[0].url).toBe(EXPECTED_URL);
+    expect(h.requests[0].body.stream).toBe(true);
+    expect(h.requests[0].body.model).toBe(FOUNDRY_DEPLOYMENT);
+
+    expect(final).toBeDefined();
+    expect(final?.text).toBe("I'll check the weather.");
+    expect(final?.tool_calls).toHaveLength(1);
+    expect(final?.tool_calls?.[0]).toMatchObject({
+      id: "toolu_test_02",
+      name: "get_weather",
+      args: { city: "Chennai" },
+    });
+
+    // input from message_start; output accumulated across message events.
+    // Pinned to the observed accumulation (same math the vertex and bedrock
+    // seams pin) so a LangChain bump that changes usage accounting (billing
+    // input) fails here first.
+    expect(final?.usage_metadata).toMatchObject({
+      input_tokens: 25,
+      output_tokens: 18,
+    });
+  });
+
+  it("passes maxRetries: 0 to the factory and the honored value reaches the client", async () => {
+    const h = buildSeamHarness();
+
+    await h.model.invoke([new HumanMessage("hi")]);
+    for await (const chunk of await h.model.stream([new HumanMessage("hi")])) {
+      void chunk;
+    }
+
+    // LangChain owns retrying: it must hand the factory maxRetries: 0, once
+    // per cached client (batch + streaming are constructed independently).
+    expect(h.factoryOptions).toHaveLength(2);
+    expect(h.factoryOptions.every((o) => o.maxRetries === 0)).toBe(true);
+    expect(h.clients).toHaveLength(2);
+    expect(h.clients.every((c) => c.maxRetries === 0)).toBe(true);
+  });
+
+  it("Entra mode: sends Authorization: Bearer, invoking the provider per request", async () => {
+    // The provider must be consulted on EVERY request, never cached by the
+    // SDK — Entra tokens expire, and a long-lived runner that cached one
+    // would start failing an hour in. Pinned by counting invocations.
+    let calls = 0;
+    const h = buildSeamHarness({
+      azureADTokenProvider: async () => {
+        calls += 1;
+        return `entra-token-${calls}`;
+      },
+    });
+
+    await h.model.invoke([new HumanMessage("hi")]);
+    await h.model.invoke([new HumanMessage("hi again")]);
+
+    expect(calls).toBe(2);
+    expect(h.requests[0].headers.authorization).toBe("Bearer entra-token-1");
+    expect(h.requests[1].headers.authorization).toBe("Bearer entra-token-2");
+    expect(h.requests[0].headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("Entra mode: a failing token provider throws the message model-error.ts matches", async () => {
+    // The exact prefix is the LLM_BACKEND_CREDENTIALS matcher in
+    // model-error.ts (isFoundryCredentialMessage) — it arrives with no HTTP
+    // status, so classification must catch it by prose, like the Google ADC
+    // and AWS chain failures. If an SDK bump rewords it, this pin fails
+    // before the classifier silently degrades.
+    const client = new AnthropicFoundry({
+      resource: RESOURCE,
+      azureADTokenProvider: async () => {
+        throw new Error("ManagedIdentityCredential: no managed identity endpoint found");
+      },
+      maxRetries: 0,
+    });
+
+    await expect(
+      client.messages.create({
+        model: FOUNDRY_DEPLOYMENT,
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow(/Failed to get token from azureADTokenProvider/);
+  });
+
+  it("withStructuredOutput compiles to forced tool use — no native structured-output param", async () => {
+    // Load-bearing for the hosted-on-Azure deployment mode: Foundry
+    // deployments hosted on Azure return 400 for Anthropic's NATIVE
+    // structured-output feature, but plain tool use is fully supported.
+    // LangChain implements withStructuredOutput as tools + tool_choice, so
+    // every runner call site (call-llm, classify-tool-approvals, Cursor
+    // extraction) works on either hosting mode. If a LangChain bump swaps
+    // the implementation to the native parameter, this pin fails and the
+    // operator doc's hosting-mode guidance must be revisited.
+    const requests: Array<Record<string, unknown>> = [];
+    const structuredFetch: typeof fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      requests.push(body);
+      return new Response(
+        JSON.stringify({
+          ...MESSAGE_RESPONSE,
+          content: [{
+            type: "tool_use",
+            id: "toolu_so_01",
+            name: "record_weather",
+            input: { city: "Chennai", temperature_c: 31 },
+          }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const model = new ChatAnthropic({
+      model: FOUNDRY_DEPLOYMENT,
+      temperature: 0,
+      maxTokens: 1024,
+      createClient: (options) =>
+        new AnthropicFoundry({
+          resource: RESOURCE,
+          apiKey: API_KEY,
+          fetch: structuredFetch,
+          maxRetries: options.maxRetries,
+        }),
+    });
+
+    const structured = model.withStructuredOutput(
+      {
+        type: "object",
+        properties: {
+          city: { type: "string" },
+          temperature_c: { type: "number" },
+        },
+        required: ["city", "temperature_c"],
+      },
+      { name: "record_weather" },
+    );
+
+    const result = await structured.invoke([new HumanMessage("Weather in Chennai?")]);
+
+    expect(requests).toHaveLength(1);
+    const body = requests[0];
+    // The schema rides as a tool with a forced tool_choice…
+    const tools = body.tools as Array<{ name: string }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("record_weather");
+    expect(body.tool_choice).toMatchObject({ type: "tool", name: "record_weather" });
+    // …and never as the native structured-output request fields.
+    expect(body).not.toHaveProperty("output_format");
+    expect(body).not.toHaveProperty("response_format");
+
+    expect(result).toMatchObject({ city: "Chennai", temperature_c: 31 });
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/llm-backend.test.ts
+++ b/backend/services/runner/src/shared/__tests__/llm-backend.test.ts
@@ -3,12 +3,15 @@ import { describe, it, expect } from "vitest";
 import {
   toVertexModelId,
   toBedrockModelId,
+  toFoundryDeploymentName,
   parseAnthropicBackend,
   parseOpenAiBackend,
   parseBedrockModelMap,
+  parseFoundryDeploymentMap,
   resolveAnthropicBackend,
   checkVertexPrerequisites,
   checkBedrockPrerequisites,
+  checkFoundryPrerequisites,
   checkDirectCredentials,
   preflightLlmBackends,
 } from "../llm-backend.js";
@@ -63,6 +66,8 @@ describe("parseAnthropicBackend", () => {
     ["  VERTEX  ", "vertex"],
     ["bedrock", "bedrock"],
     ["  Bedrock ", "bedrock"],
+    ["foundry", "foundry"],
+    ["  Foundry ", "foundry"],
   ])("value %j parses to %s", (value, backend) => {
     const result = parseAnthropicBackend({ STIGMER_ANTHROPIC_BACKEND: value });
     expect(result).toEqual({ ok: true, backend });
@@ -73,7 +78,19 @@ describe("parseAnthropicBackend", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.message).toContain('STIGMER_ANTHROPIC_BACKEND="verteks"');
-      expect(result.message).toContain("Supported: public, vertex, bedrock");
+      expect(result.message).toContain("Supported: public, vertex, bedrock, foundry");
+    }
+  });
+
+  it("rejects the cloud name where the service name is the value (azure vs foundry)", () => {
+    // The service that hosts Claude on Azure is Microsoft Foundry; "azure"
+    // as an Anthropic backend value would collide with the unrelated Azure
+    // OpenAI service reserved on the OpenAI axis. The unsupported-value
+    // message lists foundry, steering the operator to the right value.
+    const result = parseAnthropicBackend({ STIGMER_ANTHROPIC_BACKEND: "azure" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("foundry");
     }
   });
 });
@@ -169,6 +186,96 @@ describe("checkBedrockPrerequisites", () => {
   });
 });
 
+describe("checkFoundryPrerequisites", () => {
+  it("passes with a resource name alone", () => {
+    expect(
+      checkFoundryPrerequisites({ ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource" }),
+    ).toBeNull();
+  });
+
+  it("passes with a base URL alone", () => {
+    expect(
+      checkFoundryPrerequisites({
+        ANTHROPIC_FOUNDRY_BASE_URL: "https://my-foundry-resource.services.ai.azure.com/anthropic/",
+      }),
+    ).toBeNull();
+  });
+
+  it.each([[{}], [{ ANTHROPIC_FOUNDRY_RESOURCE: "  " }], [{ ANTHROPIC_FOUNDRY_BASE_URL: "" }]])(
+    "fails with an actionable message when no endpoint is configured (%j)",
+    (env) => {
+      const message = checkFoundryPrerequisites(env);
+      expect(message).toContain("ANTHROPIC_FOUNDRY_RESOURCE");
+      expect(message).toContain("ANTHROPIC_FOUNDRY_BASE_URL");
+      expect(message).toContain("docs.stigmer.ai");
+    },
+  );
+
+  it("fails when both resource and base URL are set (the SDK's own contract, at boot)", () => {
+    // The Foundry SDK constructor throws on this combination; catching it
+    // here turns a first-model-call crash into a boot refusal.
+    const message = checkFoundryPrerequisites({
+      ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource",
+      ANTHROPIC_FOUNDRY_BASE_URL: "https://other.services.ai.azure.com/anthropic/",
+    });
+    expect(message).toContain("mutually exclusive");
+  });
+
+  it("does not require a credential — keyless Entra deployments are valid", () => {
+    // ANTHROPIC_FOUNDRY_API_KEY absence is not an error: the adapter falls
+    // back to the Azure credential chain, which resolves at request time
+    // like Vertex ADC and the AWS chain.
+    expect(
+      checkFoundryPrerequisites({ ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource" }),
+    ).toBeNull();
+  });
+
+  it("fails on a malformed deployment map at boot, not at the first model call", () => {
+    const message = checkFoundryPrerequisites({
+      ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource",
+      STIGMER_FOUNDRY_DEPLOYMENT_MAP: "claude-sonnet-4-6",
+    });
+    expect(message).toContain("STIGMER_FOUNDRY_DEPLOYMENT_MAP");
+    expect(message).toContain("canonical=deploymentName");
+  });
+
+  it("accepts a well-formed deployment map", () => {
+    expect(
+      checkFoundryPrerequisites({
+        ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource",
+        STIGMER_FOUNDRY_DEPLOYMENT_MAP:
+          "claude-sonnet-4-6=my-sonnet-deployment, claude-fable-5=my-fable-deployment",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseFoundryDeploymentMap", () => {
+  // The shared pair-parsing behavior (trimming, empty entries, blank ->
+  // empty map) is exercised exhaustively by the parseBedrockModelMap table;
+  // these pin what is foundry-specific: the var name and message wording.
+  it("parses pairs into canonical -> deployment name", () => {
+    const result = parseFoundryDeploymentMap({
+      STIGMER_FOUNDRY_DEPLOYMENT_MAP: "claude-sonnet-4-6=my-sonnet-deployment",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.map.get("claude-sonnet-4-6")).toBe("my-sonnet-deployment");
+    }
+  });
+
+  it("rejects a malformed entry naming its own var and form", () => {
+    const result = parseFoundryDeploymentMap({
+      STIGMER_FOUNDRY_DEPLOYMENT_MAP: "no-equals-sign",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('STIGMER_FOUNDRY_DEPLOYMENT_MAP entry "no-equals-sign"');
+      expect(result.message).toContain("canonical=deploymentName");
+    }
+  });
+});
+
 describe("parseBedrockModelMap", () => {
   it("parses unset / blank to an empty map", () => {
     for (const value of [undefined, "", "   "]) {
@@ -257,6 +364,60 @@ describe("toBedrockModelId", () => {
   });
 });
 
+describe("toFoundryDeploymentName", () => {
+  // Layer 2 alone: the deterministic strip-date rule, verified against
+  // Anthropic's published Foundry model table — every registry id (both
+  // shapes the registry serves) maps onto a real DEFAULT deployment name.
+  // Note the inversion vs toVertexModelId: Vertex keeps the snapshot date
+  // (reseparated with `@`), Foundry drops it.
+  it.each([
+    // Pre-4.6 snapshot ids: the trailing date is stripped.
+    ["claude-sonnet-4-5-20250929", "claude-sonnet-4-5"],
+    ["claude-haiku-4-5-20251001", "claude-haiku-4-5"],
+    ["claude-opus-4-5-20251101", "claude-opus-4-5"],
+
+    // 4.6-generation and later: dateless ids ARE the default deployment
+    // names and pass through untouched.
+    ["claude-sonnet-4-6", "claude-sonnet-4-6"],
+    ["claude-opus-4-6", "claude-opus-4-6"],
+    ["claude-opus-4-7", "claude-opus-4-7"],
+    ["claude-opus-4-8", "claude-opus-4-8"],
+    ["claude-sonnet-5", "claude-sonnet-5"],
+    ["claude-fable-5", "claude-fable-5"],
+
+    // Translating twice is a no-op: a stripped id has no date to strip.
+    ["claude-sonnet-4-5", "claude-sonnet-4-5"],
+
+    // Version segments are not dates; nothing to strip.
+    ["claude-3-5-sonnet", "claude-3-5-sonnet"],
+    ["", ""],
+  ])("%s -> %s with no map", (canonical, deployment) => {
+    expect(toFoundryDeploymentName(canonical, {})).toBe(deployment);
+  });
+
+  it("consults the operator map FIRST, bypassing the strip-date rule", () => {
+    expect(
+      toFoundryDeploymentName("claude-sonnet-4-5-20250929", {
+        STIGMER_FOUNDRY_DEPLOYMENT_MAP: "claude-sonnet-4-5-20250929=my-sonnet-deployment",
+      }),
+    ).toBe("my-sonnet-deployment");
+  });
+
+  it("applies the rule to models the map does not cover", () => {
+    expect(
+      toFoundryDeploymentName("claude-haiku-4-5-20251001", {
+        STIGMER_FOUNDRY_DEPLOYMENT_MAP: "claude-sonnet-4-6=my-sonnet-deployment",
+      }),
+    ).toBe("claude-haiku-4-5");
+  });
+
+  it("throws the catalog message on a malformed map (defense in depth)", () => {
+    expect(() =>
+      toFoundryDeploymentName("claude-sonnet-4-6", { STIGMER_FOUNDRY_DEPLOYMENT_MAP: "broken" }),
+    ).toThrow(/STIGMER_FOUNDRY_DEPLOYMENT_MAP entry "broken"/);
+  });
+});
+
 describe("checkDirectCredentials", () => {
   describe("anthropic", () => {
     it("is satisfied by a non-blank ANTHROPIC_API_KEY", () => {
@@ -289,9 +450,18 @@ describe("checkDirectCredentials", () => {
       ).toBeNull();
     });
 
-    it("names both shipped backends in the missing-key remedy", () => {
+    it("is satisfied by the foundry backend with no key (Foundry key or Entra authenticates)", () => {
+      // Same non-public waiver: a Foundry deployment authenticates with
+      // ANTHROPIC_FOUNDRY_API_KEY or the Azure credential chain, never
+      // with an Anthropic API key.
+      expect(
+        checkDirectCredentials("anthropic", { STIGMER_ANTHROPIC_BACKEND: "foundry" }),
+      ).toBeNull();
+    });
+
+    it("names all shipped backends in the missing-key remedy", () => {
       const message = checkDirectCredentials("anthropic", {});
-      expect(message).toContain("vertex or bedrock");
+      expect(message).toContain("vertex, bedrock, or foundry");
     });
 
     it("defers an invalid backend value to construction (one message per condition)", () => {
@@ -372,6 +542,38 @@ describe("preflightLlmBackends", () => {
       STIGMER_BEDROCK_MODEL_MAP: "not-a-pair",
     });
     expect(result.error).toContain("STIGMER_BEDROCK_MODEL_MAP");
+  });
+
+  it("is clean for a fully-configured foundry deployment", () => {
+    const result = preflightLlmBackends({
+      STIGMER_ANTHROPIC_BACKEND: "foundry",
+      ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource",
+    });
+    expect(result).toEqual({ error: null, warnings: [] });
+  });
+
+  it("fails foundry without an endpoint, naming both endpoint vars", () => {
+    const result = preflightLlmBackends({ STIGMER_ANTHROPIC_BACKEND: "foundry" });
+    expect(result.error).toContain("ANTHROPIC_FOUNDRY_RESOURCE");
+    expect(result.error).toContain("ANTHROPIC_FOUNDRY_BASE_URL");
+  });
+
+  it("fails foundry with both endpoint vars set (mutually exclusive)", () => {
+    const result = preflightLlmBackends({
+      STIGMER_ANTHROPIC_BACKEND: "foundry",
+      ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource",
+      ANTHROPIC_FOUNDRY_BASE_URL: "https://other.services.ai.azure.com/anthropic/",
+    });
+    expect(result.error).toContain("mutually exclusive");
+  });
+
+  it("fails foundry with a malformed deployment map at boot", () => {
+    const result = preflightLlmBackends({
+      STIGMER_ANTHROPIC_BACKEND: "foundry",
+      ANTHROPIC_FOUNDRY_RESOURCE: "my-foundry-resource",
+      STIGMER_FOUNDRY_DEPLOYMENT_MAP: "not-a-pair",
+    });
+    expect(result.error).toContain("STIGMER_FOUNDRY_DEPLOYMENT_MAP");
   });
 
   it("fails on invalid values for either var, reporting all problems at once", () => {

--- a/backend/services/runner/src/shared/__tests__/model-error.test.ts
+++ b/backend/services/runner/src/shared/__tests__/model-error.test.ts
@@ -407,6 +407,98 @@ describe("classifyModelCallError — bedrock backend", () => {
   });
 });
 
+describe("classifyModelCallError — foundry backend", () => {
+  // The Foundry arms activate only for direct-mode Anthropic calls under
+  // STIGMER_ANTHROPIC_BACKEND=foundry, mirroring the vertex and bedrock
+  // suites above.
+  function stubFoundryEnv() {
+    vi.stubEnv("STIGMER_ANTHROPIC_BACKEND", "foundry");
+    vi.stubEnv("ANTHROPIC_FOUNDRY_RESOURCE", "my-foundry-resource");
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const foundryCtx = {
+    proxyMode: false,
+    provider: "anthropic" as const,
+    modelId: "claude-sonnet-4-6",
+  };
+
+  it("classifies Entra token-acquisition failures as non-retryable with the Azure fix", () => {
+    stubFoundryEnv();
+    // The Foundry SDK wraps every token-provider failure in this one
+    // prefix (pinned by foundry-seam.test.ts), so a single wording covers
+    // the whole @azure/identity credential-chain family.
+    const classified = classifyModelCallError(
+      middlewareWrap(
+        new Error(
+          "Failed to get token from azureADTokenProvider: " +
+          "ChainedTokenCredential authentication failed. CredentialUnavailableError: " +
+          "ManagedIdentityCredential: no managed identity endpoint found.",
+        ),
+      ),
+      foundryCtx,
+    );
+    expect(classified?.code).toBe("LLM_BACKEND_CREDENTIALS");
+    expect(classified?.retryable).toBe(false);
+    expect(classified?.message).toContain("Microsoft Entra ID");
+    expect(classified?.message).toContain("ANTHROPIC_FOUNDRY_API_KEY");
+  });
+
+  it("does NOT classify credential prose when the backend is not foundry (no relabeling drift)", () => {
+    const classified = classifyModelCallError(
+      new Error("Failed to get token from azureADTokenProvider: boom"),
+      foundryCtx,
+    );
+    expect(classified).toBeUndefined();
+  });
+
+  it("words 401 around the Foundry credential, not the Anthropic API key", () => {
+    stubFoundryEnv();
+    const classified = classifyModelCallError(sdkError(401, "unauthorized"), foundryCtx);
+    expect(classified?.code).toBe("LLM_AUTHENTICATION_ERROR");
+    expect(classified?.message).toContain("Azure rejected this Microsoft Foundry call");
+    expect(classified?.message).toContain("ANTHROPIC_FOUNDRY_API_KEY");
+    expect(classified?.message).not.toContain("your API key");
+  });
+
+  it("words 403 around the Foundry RBAC role", () => {
+    stubFoundryEnv();
+    const classified = classifyModelCallError(sdkError(403, "forbidden"), foundryCtx);
+    expect(classified?.code).toBe("LLM_PERMISSION_DENIED");
+    expect(classified?.message).toContain("Foundry User");
+    expect(classified?.message).not.toContain("API key");
+  });
+
+  it("words 404 around deployment names, the resource, and the deployment map", () => {
+    stubFoundryEnv();
+    const classified = classifyModelCallError(sdkError(404, "not found"), foundryCtx);
+    expect(classified?.code).toBe("LLM_MODEL_NOT_FOUND");
+    expect(classified?.message).toContain("deployment name");
+    expect(classified?.message).toContain('resource "my-foundry-resource"');
+    expect(classified?.message).toContain("STIGMER_FOUNDRY_DEPLOYMENT_MAP");
+  });
+
+  it("stays inert in proxy mode even with the backend var set (proxy owns routing)", () => {
+    stubFoundryEnv();
+    const classified = classifyModelCallError(
+      sdkError(401, "unauthorized"),
+      { proxyMode: true, provider: "anthropic" },
+    );
+    expect(classified?.message).toContain("Stigmer platform");
+    expect(classified?.message).not.toContain("Foundry");
+  });
+
+  it("keeps foundry wordings from cross-contaminating with the other backends", () => {
+    stubFoundryEnv();
+    const classified = classifyModelCallError(sdkError(404, "not found"), foundryCtx);
+    expect(classified?.message).not.toContain("Vertex");
+    expect(classified?.message).not.toContain("Bedrock");
+  });
+});
+
 describe("describeExecutionError", () => {
   it("labels classified model errors with the stable code, not the wrapper class", () => {
     const { errorType, errorMessage } = describeExecutionError(

--- a/backend/services/runner/src/shared/llm-backend.ts
+++ b/backend/services/runner/src/shared/llm-backend.ts
@@ -1,7 +1,7 @@
 /**
  * LLM provider-backend utilities — pure routing helpers for serving a
  * provider's models through an alternative cloud backend (GCP Vertex AI,
- * AWS Bedrock, and later Azure OpenAI) instead of the provider's public API.
+ * AWS Bedrock, Microsoft Foundry) instead of the provider's public API.
  *
  * Layering mirrors `llm-proxy.ts`: this module is pure string/config
  * utilities with no LangChain or SDK dependency. Consumers: the runner
@@ -27,13 +27,17 @@ export const OPENAI_BACKEND_ENV = "STIGMER_OPENAI_BACKEND";
 export const BACKEND_DOC_URL = "https://docs.stigmer.ai/guides/runners/model-backends";
 
 /**
- * Backends implemented in this build. The design vocabulary also reserves
- * `azure` (OpenAI); until that adapter lands, selecting it is a distinct
- * "recognized but not implemented" failure — never a silent fallback to
- * the public API, which would quietly route traffic outside the compliance
- * boundary the operator asked for.
+ * Backends implemented in this build. Anthropic's values name the serving
+ * SERVICE, not the cloud (`foundry` is Microsoft Foundry, the Azure
+ * service that hosts Claude — "azure" would collide with the unrelated
+ * Azure OpenAI service). The design vocabulary also reserves `azure`
+ * (OpenAI); until that adapter lands — contingent on OpenAI models
+ * entering the native catalog — selecting it is a distinct "recognized
+ * but not implemented" failure, never a silent fallback to the public
+ * API, which would quietly route traffic outside the compliance boundary
+ * the operator asked for.
  */
-export type AnthropicBackend = "public" | "vertex" | "bedrock";
+export type AnthropicBackend = "public" | "vertex" | "bedrock" | "foundry";
 export type OpenAiBackend = "public";
 
 /**
@@ -87,7 +91,7 @@ export function parseAnthropicBackend(
   return parseBackend(
     ANTHROPIC_BACKEND_ENV,
     env[ANTHROPIC_BACKEND_ENV],
-    ["public", "vertex", "bedrock"],
+    ["public", "vertex", "bedrock", "foundry"],
     PLANNED_ANTHROPIC,
   );
 }
@@ -183,39 +187,134 @@ export function checkBedrockPrerequisites(
   return null;
 }
 
+type ModelMapParseResult =
+  | { readonly ok: true; readonly map: ReadonlyMap<string, string> }
+  | { readonly ok: false; readonly message: string };
+
 /**
- * Parse `STIGMER_BEDROCK_MODEL_MAP`: comma-separated `canonical=bedrockId`
- * pairs, e.g. "claude-sonnet-4-6=us.anthropic.claude-sonnet-4-6-v1:0".
- * Unset or blank parses to an empty map (the deterministic rule serves
- * every model). The message is the single copy of the malformed-map text;
+ * Shared parser for the per-backend override maps: comma-separated
+ * `canonical=target` pairs. Unset or blank parses to an empty map (the
+ * backend's deterministic rule serves every model). Each env var keeps its
+ * own single copy of the malformed-entry text through `form`/`example` —
  * preflight and translation surface the same string.
  */
-export function parseBedrockModelMap(
-  env: NodeJS.ProcessEnv = process.env,
-): { readonly ok: true; readonly map: ReadonlyMap<string, string> } | { readonly ok: false; readonly message: string } {
-  const raw = env[BEDROCK_MODEL_MAP_ENV]?.trim();
+function parseModelMap(
+  envVar: string,
+  raw: string | undefined,
+  form: string,
+  example: string,
+): ModelMapParseResult {
+  const trimmed = raw?.trim();
   const map = new Map<string, string>();
-  if (!raw) return { ok: true, map };
+  if (!trimmed) return { ok: true, map };
 
-  for (const entry of raw.split(",")) {
+  for (const entry of trimmed.split(",")) {
     const pair = entry.trim();
     if (pair === "") continue;
     const eq = pair.indexOf("=");
     const canonical = eq === -1 ? "" : pair.slice(0, eq).trim();
-    const bedrockId = eq === -1 ? "" : pair.slice(eq + 1).trim();
-    if (!canonical || !bedrockId) {
+    const target = eq === -1 ? "" : pair.slice(eq + 1).trim();
+    if (!canonical || !target) {
       return {
         ok: false,
         message:
-          `${BEDROCK_MODEL_MAP_ENV} entry "${pair}" is not of the form ` +
-          `canonical=bedrockId (e.g. "claude-sonnet-4-6=` +
-          `us.anthropic.claude-sonnet-4-6-v1:0"). Entries are ` +
-          `comma-separated. See ${BACKEND_DOC_URL}.`,
+          `${envVar} entry "${pair}" is not of the form ${form} ` +
+          `(e.g. "${example}"). Entries are comma-separated. ` +
+          `See ${BACKEND_DOC_URL}.`,
       };
     }
-    map.set(canonical, bedrockId);
+    map.set(canonical, target);
   }
   return { ok: true, map };
+}
+
+/**
+ * Parse `STIGMER_BEDROCK_MODEL_MAP`: comma-separated `canonical=bedrockId`
+ * pairs, e.g. "claude-sonnet-4-6=us.anthropic.claude-sonnet-4-6-v1:0".
+ */
+export function parseBedrockModelMap(
+  env: NodeJS.ProcessEnv = process.env,
+): ModelMapParseResult {
+  return parseModelMap(
+    BEDROCK_MODEL_MAP_ENV,
+    env[BEDROCK_MODEL_MAP_ENV],
+    "canonical=bedrockId",
+    "claude-sonnet-4-6=us.anthropic.claude-sonnet-4-6-v1:0",
+  );
+}
+
+// ─── Microsoft Foundry (Azure) ───────────────────────────────────────────────
+
+/**
+ * Operator override map: canonical id -> Foundry deployment name, consulted
+ * first. Named DEPLOYMENT_MAP, not MODEL_MAP, because the target is Azure's
+ * term of art — the operator-chosen deployment name, not another model id.
+ */
+export const FOUNDRY_DEPLOYMENT_MAP_ENV = "STIGMER_FOUNDRY_DEPLOYMENT_MAP";
+/** The Foundry resource name (SDK-native; builds the endpoint host). */
+export const FOUNDRY_RESOURCE_ENV = "ANTHROPIC_FOUNDRY_RESOURCE";
+/** Full endpoint override (SDK-native; mutually exclusive with resource). */
+export const FOUNDRY_BASE_URL_ENV = "ANTHROPIC_FOUNDRY_BASE_URL";
+
+/**
+ * Parse `STIGMER_FOUNDRY_DEPLOYMENT_MAP`: comma-separated
+ * `canonical=deploymentName` pairs, e.g.
+ * "claude-sonnet-4-6=my-sonnet-deployment".
+ */
+export function parseFoundryDeploymentMap(
+  env: NodeJS.ProcessEnv = process.env,
+): ModelMapParseResult {
+  return parseModelMap(
+    FOUNDRY_DEPLOYMENT_MAP_ENV,
+    env[FOUNDRY_DEPLOYMENT_MAP_ENV],
+    "canonical=deploymentName",
+    "claude-sonnet-4-6=my-sonnet-deployment",
+  );
+}
+
+/**
+ * Static prerequisite check for the foundry backend, or null when satisfied.
+ *
+ * The endpoint is the ONE hard requirement checkable without I/O: the
+ * Foundry SDK's constructor throws without exactly one of the resource
+ * name or a full base URL, so both halves of its contract (missing AND
+ * both-set) are refused here at boot with catalog messages instead of at
+ * the first model call. Credentials are deliberately NOT checked —
+ * ANTHROPIC_FOUNDRY_API_KEY is optional by design (without it the adapter
+ * authenticates through Microsoft Entra ID via the Azure credential chain,
+ * which resolves at request time exactly like Vertex ADC and the AWS
+ * chain), so requiring it would reject correctly-configured keyless
+ * deployments. Runtime credential failures get actionable classification
+ * in `model-error.ts` instead.
+ *
+ * A malformed STIGMER_FOUNDRY_DEPLOYMENT_MAP is also fatal here: it is
+ * deployment-static, and finding out at the first model call would fail
+ * executions a boot check could have refused.
+ */
+export function checkFoundryPrerequisites(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const resource = env[FOUNDRY_RESOURCE_ENV]?.trim();
+  const baseUrl = env[FOUNDRY_BASE_URL_ENV]?.trim();
+  if (!resource && !baseUrl) {
+    return (
+      `The foundry backend requires ${FOUNDRY_RESOURCE_ENV} (your Microsoft ` +
+      `Foundry resource name, e.g. "my-foundry-resource") or ` +
+      `${FOUNDRY_BASE_URL_ENV} (the full endpoint, e.g. ` +
+      `"https://my-foundry-resource.services.ai.azure.com/anthropic/"). ` +
+      `See ${BACKEND_DOC_URL}.`
+    );
+  }
+  if (resource && baseUrl) {
+    return (
+      `${FOUNDRY_RESOURCE_ENV} and ${FOUNDRY_BASE_URL_ENV} are mutually ` +
+      `exclusive — the base URL is derived from the resource name. Set ` +
+      `exactly one. See ${BACKEND_DOC_URL}.`
+    );
+  }
+  const map = parseFoundryDeploymentMap(env);
+  if (!map.ok) return map.message;
+  return null;
 }
 
 /**
@@ -262,8 +361,8 @@ export function checkDirectCredentials(
   return (
     `ANTHROPIC_API_KEY is not set, no model backend is configured, and no ` +
     `proxy is configured. Set the API key, configure a backend (e.g. ` +
-    `${ANTHROPIC_BACKEND_ENV}=vertex or bedrock), or connect to a Stigmer ` +
-    `Cloud deployment. See ${BACKEND_DOC_URL}.`
+    `${ANTHROPIC_BACKEND_ENV}=vertex, bedrock, or foundry), or connect to ` +
+    `a Stigmer Cloud deployment. See ${BACKEND_DOC_URL}.`
   );
 }
 
@@ -318,6 +417,9 @@ export function preflightLlmBackends(
     if (prereq !== null) errors.push(prereq);
   } else if (anthropic.backend === "bedrock") {
     const prereq = checkBedrockPrerequisites(env);
+    if (prereq !== null) errors.push(prereq);
+  } else if (anthropic.backend === "foundry") {
+    const prereq = checkFoundryPrerequisites(env);
     if (prereq !== null) errors.push(prereq);
   }
   const openai = parseOpenAiBackend(env);
@@ -401,4 +503,42 @@ export function toBedrockModelId(
   const prefix = env[BEDROCK_INFERENCE_PREFIX_ENV]?.trim().replace(/\.$/, "");
   const derived = `anthropic.${apiModelId}-v1:0`;
   return prefix ? `${prefix}.${derived}` : derived;
+}
+
+/**
+ * Translate a canonical Anthropic API model id into a Microsoft Foundry
+ * deployment name, in two layers (approved design, T05):
+ *
+ * 1. `STIGMER_FOUNDRY_DEPLOYMENT_MAP` override, consulted first: Foundry
+ *    routes by DEPLOYMENT NAME, and the portal lets operators name
+ *    deployments anything ("my-sonnet-deployment"). This is the escape
+ *    hatch for those custom names.
+ * 2. Deterministic rule: strip a trailing `-YYYYMMDD` snapshot date —
+ *    Foundry's DEFAULT deployment names are the dateless Claude ids
+ *    (claude-sonnet-4-5-20250929 -> claude-sonnet-4-5; dateless ids pass
+ *    through unchanged). Verified against Anthropic's published Foundry
+ *    model table: every native-catalog id maps onto a real default
+ *    deployment name. Note this is the INVERSE of toVertexModelId, which
+ *    keeps the date and reseparates it with `@`.
+ *
+ * Like the other translations, the result is wire detail only: it rides in
+ * the request body's `model` field (Foundry keeps it in the body — see
+ * foundry-seam.test.ts — unlike Vertex/Bedrock, which move it into the URL
+ * path) and must never escape the adapter into usage metrics or pricing,
+ * which key on the canonical id (the canonical-id invariant).
+ *
+ * Throws the catalog message on a malformed map — defense in depth for
+ * paths that construct models without the factories; a normally-booted
+ * runner already refused to start in `checkFoundryPrerequisites`.
+ */
+export function toFoundryDeploymentName(
+  apiModelId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const parsed = parseFoundryDeploymentMap(env);
+  if (!parsed.ok) throw new Error(parsed.message);
+  const mapped = parsed.map.get(apiModelId);
+  if (mapped !== undefined) return mapped;
+
+  return apiModelId.replace(TRAILING_SNAPSHOT_DATE, "");
 }

--- a/backend/services/runner/src/shared/model-client.ts
+++ b/backend/services/runner/src/shared/model-client.ts
@@ -28,8 +28,10 @@ import {
   resolveAnthropicBackend,
   checkVertexPrerequisites,
   checkBedrockPrerequisites,
+  checkFoundryPrerequisites,
   toVertexModelId,
   toBedrockModelId,
+  toFoundryDeploymentName,
 } from "./llm-backend.js";
 import { resolveToApiModelId } from "./model-registry.js";
 
@@ -107,7 +109,9 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   // runner factory still fail at dispatch with the catalog message instead
   // of mid-request. Credentials are read natively by each SDK from its
   // standard conventions (GCP: CLOUD_ML_REGION + ADC; AWS: AWS_REGION +
-  // the credential chain / AWS_BEARER_TOKEN_BEDROCK).
+  // the credential chain / AWS_BEARER_TOKEN_BEDROCK; Foundry:
+  // ANTHROPIC_FOUNDRY_API_KEY, or the Azure credential chain when no key
+  // is set).
   let backendCreateClient: ((options: { maxRetries?: number }) => unknown) | undefined;
   let wireModelId = apiModelId;
   let maxTokens = opts.maxTokens;
@@ -137,6 +141,39 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
       // Pinned by the canonical-parity test in bedrock-adapter.test.ts.
       maxTokens = new ChatAnthropic({ model: apiModelId, apiKey: "max-tokens-probe" }).maxTokens;
     }
+  } else if (anthropicBackend === "foundry") {
+    const prereq = checkFoundryPrerequisites();
+    if (prereq !== null) throw new Error(prereq);
+    const { AnthropicFoundry } = await import("@anthropic-ai/foundry-sdk");
+    // Auth is an explicit either/or (the Foundry constructor throws when
+    // given both a key and a token provider): ANTHROPIC_FOUNDRY_API_KEY if
+    // present, otherwise keyless Microsoft Entra ID through the Azure
+    // credential chain (env service principal -> workload identity ->
+    // managed identity -> az CLI) — the Azure analogue of Vertex ADC and
+    // the AWS chain, resolved at request time. The provider is built once
+    // here (getBearerTokenProvider caches tokens until near-expiry) and
+    // shared by both cached clients; the SDK still consults it per request,
+    // so refreshed tokens flow without reconstruction (pinned by
+    // foundry-seam.test.ts). Endpoint (resource or base URL) and the key
+    // are read natively by the SDK from its own env vars.
+    let azureADTokenProvider: (() => Promise<string>) | undefined;
+    if (!process.env.ANTHROPIC_FOUNDRY_API_KEY?.trim()) {
+      const { DefaultAzureCredential, getBearerTokenProvider } = await import("@azure/identity");
+      azureADTokenProvider = getBearerTokenProvider(
+        new DefaultAzureCredential(),
+        "https://ai.azure.com/.default",
+      );
+    }
+    backendCreateClient = (options) =>
+      new AnthropicFoundry({
+        maxRetries: options.maxRetries,
+        ...(azureADTokenProvider ? { azureADTokenProvider } : {}),
+      });
+    // Unlike the vertex/bedrock ids, the deployment name needs no maxTokens
+    // handling: stripping the snapshot date preserves LangChain's per-model
+    // default (probed 2026-08-11 across the full catalog; pinned by the
+    // parity test in foundry-adapter.test.ts).
+    wireModelId = toFoundryDeploymentName(apiModelId);
   }
 
   const baseUrl = opts.proxyEndpoint

--- a/backend/services/runner/src/shared/model-error.ts
+++ b/backend/services/runner/src/shared/model-error.ts
@@ -30,6 +30,8 @@ import {
   parseAnthropicBackend,
   BACKEND_DOC_URL,
   BEDROCK_INFERENCE_PREFIX_ENV,
+  FOUNDRY_DEPLOYMENT_MAP_ENV,
+  FOUNDRY_RESOURCE_ENV,
   type AnthropicBackend,
 } from "./llm-backend.js";
 
@@ -139,6 +141,21 @@ export function classifyModelCallError(
         `The bedrock backend could not acquire AWS credentials for ${modelLabel(ctx)}. ` +
         `Provide credentials through the standard AWS chain (environment keys, an IAM ` +
         `role / IRSA, config files) or set AWS_BEARER_TOKEN_BEDROCK. See ${BACKEND_DOC_URL}. ` +
+        `Underlying error: ${message}`,
+    };
+  }
+  if (backend === "foundry" && isFoundryCredentialMessage(message)) {
+    // Only the keyless Entra path can land here: API-key failures arrive
+    // as HTTP 401s (status arm below), while a failing token provider
+    // throws statusless from inside the Foundry SDK's authHeaders.
+    return {
+      code: "LLM_BACKEND_CREDENTIALS",
+      retryable: false,
+      message:
+        `The foundry backend could not acquire a Microsoft Entra ID token for ${modelLabel(ctx)}. ` +
+        `Give the runner an Azure identity the credential chain can resolve (workload ` +
+        `identity / managed identity, service-principal env vars, or az login), or set ` +
+        `ANTHROPIC_FOUNDRY_API_KEY to use API-key auth instead. See ${BACKEND_DOC_URL}. ` +
         `Underlying error: ${message}`,
     };
   }
@@ -253,6 +270,11 @@ function classifyByStatus(
             ? `AWS rejected this Bedrock call (authentication, HTTP 401) for ${context}. ` +
               `The credentials are expired or invalid — check the runner's AWS identity ` +
               `(environment keys, IAM role / IRSA) or AWS_BEARER_TOKEN_BEDROCK. See ${BACKEND_DOC_URL}.`
+          : backend === "foundry"
+            ? `Azure rejected this Microsoft Foundry call (authentication, HTTP 401) for ${context}. ` +
+              `The credential is expired or not valid for this Foundry resource — check ` +
+              `ANTHROPIC_FOUNDRY_API_KEY (find it on the deployment's Details tab) or the ` +
+              `runner's Azure identity. See ${BACKEND_DOC_URL}.`
             : `Authentication failed for ${context}. Check that your API key is valid and not expired.`,
       };
     case 403:
@@ -274,6 +296,10 @@ function classifyByStatus(
               `under "Model access" in the Bedrock console (Anthropic models require a ` +
               `use-case submission), and grant the runner's identity bedrock:InvokeModel ` +
               `for the model and its inference profile. See ${BACKEND_DOC_URL}.`
+          : backend === "foundry"
+            ? `Microsoft Foundry denied this call (HTTP 403) for ${context}. Grant the ` +
+              `runner's Azure identity the "Foundry User" (or "Cognitive Services User") ` +
+              `RBAC role on the Foundry resource. See ${BACKEND_DOC_URL}.`
             : `Access denied for ${context}. Verify that your API key has permission to use this model.`,
       };
     case 404:
@@ -291,6 +317,16 @@ function classifyByStatus(
               `${describeBedrockRegion()} — availability varies by region — and that the ` +
               `resolved Bedrock id is right for your deployment (STIGMER_BEDROCK_MODEL_MAP ` +
               `overrides, ${BEDROCK_INFERENCE_PREFIX_ENV} for inference profiles). See ${BACKEND_DOC_URL}.`
+          : backend === "foundry"
+            // The most common Foundry setup mistake: Foundry routes by
+            // DEPLOYMENT NAME, and deployments are created one by one in
+            // the portal — a model with no deployment (or a custom name)
+            // 404s even though the model itself exists on Foundry.
+            ? `Model deployment not found on Microsoft Foundry: ${context}. Foundry routes ` +
+              `by deployment name — confirm a deployment for this model exists in ` +
+              `${describeFoundryResource()} (default deployment names are the dateless ` +
+              `model ids), or map it to your custom deployment name in ` +
+              `${FOUNDRY_DEPLOYMENT_MAP_ENV}. See ${BACKEND_DOC_URL}.`
             : `Model not found: ${context}. Verify the model name is correct and available in your account.`,
       };
     case 400:
@@ -411,6 +447,19 @@ function isBedrockInferenceProfileMessage(message: string): boolean {
   return message.toLowerCase().includes("on-demand throughput isn't supported");
 }
 
+/**
+ * Entra ID token-acquisition prose, matched against the raw message.
+ * Narrow by design (mirrors the Google/AWS matchers), and narrower than it
+ * looks: the Foundry SDK wraps EVERY token-provider failure — whatever
+ * @azure/identity's credential chain threw — in this one prefix before
+ * rethrowing (pinned by foundry-seam.test.ts), so a single phrase covers
+ * the whole family. A miss falls through to status classification — never
+ * worse than the raw error.
+ */
+function isFoundryCredentialMessage(message: string): boolean {
+  return message.toLowerCase().includes("failed to get token from azureadtokenprovider");
+}
+
 /** "region {value}" when CLOUD_ML_REGION is set, else a pointer to the var. */
 function describeVertexRegion(): string {
   const region = process.env.CLOUD_ML_REGION?.trim();
@@ -421,6 +470,12 @@ function describeVertexRegion(): string {
 function describeBedrockRegion(): string {
   const region = process.env.AWS_REGION?.trim();
   return region ? `region "${region}"` : "your AWS_REGION";
+}
+
+/** `resource "{value}"` when the resource var is set, else a generic label. */
+function describeFoundryResource(): string {
+  const resource = process.env[FOUNDRY_RESOURCE_ENV]?.trim();
+  return resource ? `resource "${resource}"` : "your Foundry resource";
 }
 
 /**

--- a/docs/guides/runners/model-backends.mdx
+++ b/docs/guides/runners/model-backends.mdx
@@ -2,26 +2,34 @@
 title: Run models in your own cloud
 description:
   Serve a provider's models from your own cloud account instead of the
-  provider's public API. Configure the GCP Vertex AI or AWS Bedrock backend for
-  Claude models with two environment variables on the runner.
+  provider's public API. Configure the GCP Vertex AI, AWS Bedrock, or Microsoft
+  Foundry (Azure) backend for Claude models with two environment variables on
+  the runner.
 ---
 
 By default, a runner in direct mode calls each model provider's public API —
 api.anthropic.com for Claude, api.openai.com for GPT. A **backend** changes
-where those models are served. Point the runner at your own GCP project or AWS
-account and every Claude call runs inside your cloud account's compliance
-boundary: your region, your contracts, your audit trail. Nothing else changes —
-Agents, model names, usage reporting, and the console all behave exactly as
-before.
+where those models are served. Point the runner at your own GCP project, AWS
+account, or Azure subscription and every Claude call runs inside your cloud
+account's compliance boundary: your region, your contracts, your audit trail.
+Nothing else changes — Agents, model names, usage reporting, and the console all
+behave exactly as before.
 
 Backends are a deployment decision, set through environment variables on the
 runner. Agents stay portable: the same Agent runs unchanged on a laptop against
-the public API and on a production runner against Vertex AI or Bedrock.
+the public API and on a production runner against Vertex AI, Bedrock, or
+Foundry.
 
-| Provider  | Backends                                     |
-| --------- | -------------------------------------------- |
-| Anthropic | `public` (default), `vertex`, `bedrock`      |
-| OpenAI    | `public` (default) — Azure OpenAI is planned |
+| Provider  | Backends                                           |
+| --------- | -------------------------------------------------- |
+| Anthropic | `public` (default), `vertex`, `bedrock`, `foundry` |
+| OpenAI    | `public` (default)                                 |
+
+Backend values name the serving _service_, not the cloud — `foundry` is
+[Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/), the
+Azure service that hosts Claude. Azure OpenAI (a different Azure service, for
+GPT models) becomes relevant if OpenAI models join the native model catalog,
+which today is Claude-only.
 
 <Callout type="info">
   Backends apply to runners in **direct mode** — runners you operate with your
@@ -171,7 +179,84 @@ CloudWatch under Bedrock metrics.
   these, it will say so rather than degrade silently.
 </Callout>
 
-## How model names map to Vertex and Bedrock
+## Serve Claude from Azure (Microsoft Foundry)
+
+<Steps>
+<Step>
+
+## Create a Foundry resource and deploy the Claude models
+
+In the [Foundry portal](https://ai.azure.com/), create a Foundry resource, then
+deploy each Claude model you plan to use from the model catalog (on the first
+deployment you accept the Azure Marketplace terms for Anthropic models). Keep
+the default deployment names — they match the model ids — unless you have a
+reason not to; custom names work too (see the mapping section below).
+
+Each deployment chooses a **hosting option**: _Hosted on Azure_ keeps inference
+inside Azure (fewer models, currently no structured outputs or server-side tools
+— Stigmer's native harness uses neither natively, so executions are unaffected),
+while _Hosted on Anthropic infrastructure_ offers the full Claude catalog served
+by Anthropic under your Azure billing. Pick per deployment based on your
+residency requirements.
+
+</Step>
+<Step>
+
+## Give the runner an Azure credential
+
+Foundry accepts either of these; the runner picks the API key when it is set and
+Microsoft Entra ID otherwise:
+
+- **An API key** — set `ANTHROPIC_FOUNDRY_API_KEY` (find it on the deployment's
+  **Details** tab in the Foundry portal).
+- **Microsoft Entra ID** (recommended — no keys to manage) — give the runner an
+  Azure identity through the standard credential chain: workload identity or
+  managed identity in Azure, service-principal environment variables, or
+  `az login` for local testing. Grant the identity the **Foundry User** (or
+  **Cognitive Services User**) RBAC role on the resource. Some models —
+  currently the Mythos research previews — accept Entra ID only.
+
+</Step>
+<Step>
+
+## Configure and start the runner
+
+Two variables select the backend and the resource. Anthropic API keys are not
+needed — authentication is Azure's:
+
+```bash
+# Stigmer-owned decision: which backend serves Anthropic models.
+export STIGMER_ANTHROPIC_BACKEND=foundry
+
+# Standard Foundry convention, read natively by the Foundry SDK. Use the
+# resource name, or ANTHROPIC_FOUNDRY_BASE_URL for a full endpoint override —
+# exactly one of the two.
+export ANTHROPIC_FOUNDRY_RESOURCE=my-foundry-resource
+
+# API-key auth; omit to authenticate with Microsoft Entra ID instead.
+export ANTHROPIC_FOUNDRY_API_KEY=...
+
+stigmer up
+```
+
+The runner validates this configuration at startup. If the backend value is
+wrong or no resource is configured, it refuses to start and prints exactly what
+to fix — a misconfigured deployment never accepts work it cannot serve.
+
+</Step>
+<Step>
+
+## Verify with a Session
+
+Run any Agent that uses a Claude model. Usage and cost reporting key on the same
+model names as before — you can confirm the traffic is reaching your
+subscription in the Foundry portal under the deployment's metrics, and the spend
+on your Azure bill (Foundry meters Claude through the Azure Marketplace).
+
+</Step>
+</Steps>
+
+## How model names map to Vertex, Bedrock, and Foundry
 
 You never configure backend model ids for the common case. The runner translates
 each canonical model id on the wire — usage metrics and pricing always report
@@ -183,6 +268,9 @@ the canonical id:
   `anthropic.claude-sonnet-4-5-20250929-v1:0`, prefixed with
   `STIGMER_BEDROCK_INFERENCE_PREFIX` when set (e.g.
   `us.anthropic.claude-sonnet-4-5-20250929-v1:0`).
+- **Foundry**: routes by _deployment name_, and default deployment names are the
+  dateless model ids — `claude-sonnet-4-5-20250929` becomes `claude-sonnet-4-5`;
+  dateless ids pass through unchanged.
 
 When a Bedrock id can't be derived this way (AWS occasionally versions ids on
 its own schedule), map that model explicitly — the map wins over the derivation
@@ -195,20 +283,31 @@ export STIGMER_BEDROCK_MODEL_MAP="claude-sonnet-4-6=us.anthropic.claude-sonnet-4
 Entries are comma-separated `canonical=bedrockId` pairs; the id side accepts
 anything Bedrock accepts, including inference-profile ARNs.
 
+Foundry has the same escape hatch for custom deployment names — map the
+canonical id to whatever you named the deployment in the portal:
+
+```bash
+export STIGMER_FOUNDRY_DEPLOYMENT_MAP="claude-sonnet-4-6=my-sonnet-deployment"
+```
+
 ## Troubleshooting
 
 Every failure names the variable or permission to fix. The common ones:
 
-| Symptom                                          | Fix                                                                                                   |
-| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| Runner refuses to start, names `CLOUD_ML_REGION` | Set the region (e.g. `asia-south1`, or `global`).                                                     |
-| Runner refuses to start, names `AWS_REGION`      | Set the region explicitly (e.g. `ap-south-1`) — the runner never assumes `us-east-1`.                 |
-| "could not acquire Google credentials"           | Set `GOOGLE_APPLICATION_CREDENTIALS`, or run on a GCP identity (workload identity / metadata server). |
-| "could not acquire AWS credentials"              | Provide the AWS chain (environment keys, IAM role / IRSA) or set `AWS_BEARER_TOKEN_BEDROCK`.          |
-| HTTP 403 from Vertex AI                          | Grant the runner's identity the **Vertex AI User** role in the target project.                        |
-| HTTP 403 from Bedrock                            | Enable the model under **Model access** in the Bedrock console, and grant `bedrock:InvokeModel`.      |
-| "requires an inference profile"                  | Set `STIGMER_BEDROCK_INFERENCE_PREFIX` to your geography (`us`, `eu`, `global`, …).                   |
-| Model not found (HTTP 404)                       | Enable the model for your project/account, and confirm it is available in your configured region.     |
+| Symptom                                                     | Fix                                                                                                                     |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Runner refuses to start, names `CLOUD_ML_REGION`            | Set the region (e.g. `asia-south1`, or `global`).                                                                       |
+| Runner refuses to start, names `AWS_REGION`                 | Set the region explicitly (e.g. `ap-south-1`) — the runner never assumes `us-east-1`.                                   |
+| Runner refuses to start, names `ANTHROPIC_FOUNDRY_RESOURCE` | Set the Foundry resource name (or `ANTHROPIC_FOUNDRY_BASE_URL` — exactly one of the two).                               |
+| "could not acquire Google credentials"                      | Set `GOOGLE_APPLICATION_CREDENTIALS`, or run on a GCP identity (workload identity / metadata server).                   |
+| "could not acquire AWS credentials"                         | Provide the AWS chain (environment keys, IAM role / IRSA) or set `AWS_BEARER_TOKEN_BEDROCK`.                            |
+| "could not acquire a Microsoft Entra ID token"              | Give the runner an Azure identity (workload / managed identity, service principal), or set `ANTHROPIC_FOUNDRY_API_KEY`. |
+| HTTP 403 from Vertex AI                                     | Grant the runner's identity the **Vertex AI User** role in the target project.                                          |
+| HTTP 403 from Bedrock                                       | Enable the model under **Model access** in the Bedrock console, and grant `bedrock:InvokeModel`.                        |
+| HTTP 403 from Foundry                                       | Grant the runner's Azure identity the **Foundry User** RBAC role on the Foundry resource.                               |
+| "requires an inference profile"                             | Set `STIGMER_BEDROCK_INFERENCE_PREFIX` to your geography (`us`, `eu`, `global`, …).                                     |
+| Model not found (HTTP 404)                                  | Enable the model for your project/account, and confirm it is available in your configured region.                       |
+| Deployment not found on Foundry (HTTP 404)                  | Deploy the model in the Foundry portal, or map its custom deployment name in `STIGMER_FOUNDRY_DEPLOYMENT_MAP`.          |
 
 ## What's next
 

--- a/docs/guides/runners/overview.mdx
+++ b/docs/guides/runners/overview.mdx
@@ -43,9 +43,9 @@ let Stigmer Cloud provision a runner for you.
     href="/docs/guides/runners/model-backends"
     title="Run models in your own cloud"
   >
-    Serve Claude from your own cloud — GCP Vertex AI or AWS Bedrock: two
-    environment variables on a direct-mode runner, your cloud's standard
-    credentials, and zero changes to your Agents.
+    Serve Claude from your own cloud — GCP Vertex AI, AWS Bedrock, or Microsoft
+    Foundry (Azure): two environment variables on a direct-mode runner, your
+    cloud's standard credentials, and zero changes to your Agents.
   </Card>
 </Cards>
 


### PR DESCRIPTION
## Summary
Adds a third Anthropic backend to the native-harness runner: `STIGMER_ANTHROPIC_BACKEND=foundry` serves the entire native Claude catalog from an operator's Azure subscription via Microsoft Foundry, selected purely by deployment configuration. Zero behavior change for unconfigured deployments.

## Context
Part of the multi-cloud LLM provider-endpoints effort (public API, Vertex, Bedrock, and now Azure/Foundry). Originally planned as an Azure OpenAI backend, but the native catalog is Claude-only — that knob would have routed zero models — while Foundry speaks the real Anthropic Messages API through `@anthropic-ai/foundry-sdk` on the existing `createClient` seam. `STIGMER_OPENAI_BACKEND=azure` stays reserved for when OpenAI models enter the catalog.

## Changes
- **Preflight**: Foundry resource XOR base URL validated at boot (front-runs both SDK constructor throws); malformed `STIGMER_FOUNDRY_DEPLOYMENT_MAP` is fatal.
- **Auth**: `ANTHROPIC_FOUNDRY_API_KEY` if present, else keyless Entra ID via a lazily imported `@azure/identity` credential chain (+0.9 MB slim).
- **Deployment-name translation**: map override first, then strip the trailing `-YYYYMMDD` — Foundry's default deployment names are the dateless Claude ids. The shared `parseModelMap` now serves both bedrock and foundry.
- **Error catalog**: statusless Entra-failure arm plus Foundry-specific 401/403/404 wordings (404 = deployment-name problem, pointing at the map).
- **Docs**: `model-backends.mdx` gains the Foundry section; runners overview updated.

## Implementation notes
- Two behavior probes were resolved favorably and pinned in tests: `withStructuredOutput` compiles to forced tool use (safe on hosted-on-Azure deployments), and `maxTokens` canonical parity holds (no bedrock-style injection needed).
- Tests follow the established seam/adapter reference-pair pattern: `foundry-seam.test.ts` (10) + `foundry-adapter.test.ts` (8), including both auth wire shapes with a fake token provider and a pinned constructor config contract.

## Breaking changes
- None. Deployments without `STIGMER_ANTHROPIC_BACKEND=foundry` are untouched.

## Test plan
- Full suite 4,310 passed / 0 failed (6 skipped, exit 0).
- `verify:dist`, `verify:slim` (84.1 MB ≤ 120 MB, freshly rebuilt bundle), `check-deps` (two SDK versions, four allowed dependents), and docs inventory all green.
- Live verification against a real Azure subscription is deferred to the hardening task (T06) alongside Vertex and Bedrock.

## Risks
- Low: new code paths are only reachable behind the `foundry` backend selection. Rollback = revert the commit; no data or schema impact.

## Checklist
- [x] Docs updated
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)