### PR TITLE
fix(backend/runner): surface structured Cursor run errors instead of "[object Object]"

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/error-classifier-extraction.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/error-classifier-extraction.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the shape-aware run.wait() error extraction (oss#299).
+ *
+ * A bare String() on a structured error value yields "[object Object]",
+ * which end users saw verbatim AND which shadowed every lower-priority
+ * classifier source (stream, rejection, conversation introspection) because
+ * classification stops at the first non-empty source. These tests pin:
+ *
+ * - the extractRunErrorSources shape matrix (strings, Errors, field objects,
+ *   hopeless values)
+ * - first-USABLE-candidate chain order (a hopeless object no longer hides a
+ *   usable string one field later; an empty string no longer short-circuits)
+ * - end-to-end: structured errors classify and re-enable fresh-agent retry;
+ *   hopeless extraction yields to the introspection sources
+ * - the "[object Object]" defense-in-depth guard in classifyFromSources
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  extractRunErrorSources,
+  synthesizeError,
+  shouldRetryWithFreshAgent,
+} from "../error-classifier.js";
+
+const FALLBACK = { model: "default", mode: "cloud", agentId: "agent-1" };
+
+function base() {
+  return {
+    sdkResultFields: undefined,
+    streamErrorMessage: undefined,
+    capturedRejection: undefined,
+    isResumedHandle: false,
+    fallbackContext: FALLBACK,
+  } as const;
+}
+
+/** A run.wait()-shaped error result carrying the given error-detail fields. */
+function errorResult(fields: Record<string, unknown>): unknown {
+  return { id: "run-1", status: "error", ...fields };
+}
+
+const NOTHING = { sdkError: undefined, sdkResultFields: undefined };
+
+describe("extractRunErrorSources shape matrix", () => {
+  it("routes a plain string to sdkResultFields", () => {
+    expect(extractRunErrorSources(errorResult({ result: "rate limit exceeded" })))
+      .toEqual({ sdkError: undefined, sdkResultFields: "rate limit exceeded" });
+  });
+
+  it("lifts an Error instance into the structured channel", () => {
+    expect(extractRunErrorSources(errorResult({ result: new Error("connection lost") })))
+      .toEqual({ sdkError: { message: "connection lost" }, sdkResultFields: undefined });
+  });
+
+  it("lifts an Error carrying a code (Node/SDK error shape)", () => {
+    const err = Object.assign(new Error("stream torn down"), { code: "unavailable" });
+    expect(extractRunErrorSources(errorResult({ result: err })))
+      .toEqual({ sdkError: { code: "unavailable", message: "stream torn down" }, sdkResultFields: undefined });
+  });
+
+  it("lifts { code, status, message } from a plain object", () => {
+    expect(extractRunErrorSources(errorResult({ error: { code: "unauthenticated", status: 401, message: "bad token" } })))
+      .toEqual({
+        sdkError: { code: "unauthenticated", status: 401, message: "bad token" },
+        sdkResultFields: undefined,
+      });
+  });
+
+  it("lifts a message-only object", () => {
+    expect(extractRunErrorSources(errorResult({ error: { message: "boom" } })))
+      .toEqual({ sdkError: { message: "boom" }, sdkResultFields: undefined });
+  });
+
+  it("lifts a code-only object", () => {
+    expect(extractRunErrorSources(errorResult({ error: { code: "resource_exhausted" } })))
+      .toEqual({ sdkError: { code: "resource_exhausted" }, sdkResultFields: undefined });
+  });
+
+  it("yields nothing for an object with no recognizable fields (no JSON.stringify junk)", () => {
+    expect(extractRunErrorSources(errorResult({ result: { weird: "shape" } }))).toEqual(NOTHING);
+  });
+
+  it("yields nothing for a circular object", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(extractRunErrorSources(errorResult({ result: circular }))).toEqual(NOTHING);
+  });
+
+  it("refuses the '[object Object]' junk string itself", () => {
+    expect(extractRunErrorSources(errorResult({ result: "[object Object]" }))).toEqual(NOTHING);
+  });
+
+  it("stringifies non-string primitives losslessly", () => {
+    expect(extractRunErrorSources(errorResult({ result: 503 })))
+      .toEqual({ sdkError: undefined, sdkResultFields: "503" });
+  });
+
+  it("yields nothing when no candidate field is present", () => {
+    expect(extractRunErrorSources(errorResult({}))).toEqual(NOTHING);
+  });
+
+  it("yields nothing for non-object results", () => {
+    expect(extractRunErrorSources(undefined)).toEqual(NOTHING);
+    expect(extractRunErrorSources(null)).toEqual(NOTHING);
+    expect(extractRunErrorSources("not-a-result-object")).toEqual(NOTHING);
+  });
+});
+
+describe("extractRunErrorSources chain order (first USABLE candidate wins)", () => {
+  it("a hopeless object in result no longer hides a usable string in message", () => {
+    const extracted = extractRunErrorSources(
+      errorResult({ result: { weird: "shape" }, message: "the real reason" }),
+    );
+    expect(extracted).toEqual({ sdkError: undefined, sdkResultFields: "the real reason" });
+  });
+
+  it("an empty string in result no longer short-circuits the chain", () => {
+    const extracted = extractRunErrorSources(
+      errorResult({ result: "", reason: "torn down mid-stream" }),
+    );
+    expect(extracted).toEqual({ sdkError: undefined, sdkResultFields: "torn down mid-stream" });
+  });
+
+  it("respects the documented field order: result before error before message before reason", () => {
+    const extracted = extractRunErrorSources(
+      errorResult({ result: "from-result", error: "from-error", message: "from-message" }),
+    );
+    expect(extracted.sdkResultFields).toBe("from-result");
+  });
+
+  it("yields nothing when every candidate is hopeless", () => {
+    const extracted = extractRunErrorSources(
+      errorResult({ result: {}, error: "", message: "[object Object]" }),
+    );
+    expect(extracted).toEqual(NOTHING);
+  });
+});
+
+describe("end-to-end through synthesizeError", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("a structured retryable error classifies and re-enables fresh-agent recovery", () => {
+    // The regression at the heart of oss#299: String() turned this into
+    // "[object Object]" -> category=unknown, retryable=false -> the
+    // poisoned-handle retry could never fire for a plain network flake.
+    const extracted = extractRunErrorSources(
+      errorResult({ error: { code: "unavailable", message: "upstream connect error" } }),
+    );
+    const classified = synthesizeError({ ...base(), ...extracted });
+
+    expect(classified.source).toBe("sdk");
+    expect(classified.category).toBe("network");
+    expect(classified.message).toBe("upstream connect error");
+    expect(classified.retryable).toBe(true);
+    expect(shouldRetryWithFreshAgent(classified)).toBe(true);
+  });
+
+  it("hopeless extraction yields to the conversation introspection source", () => {
+    const extracted = extractRunErrorSources(errorResult({ result: { weird: "shape" } }));
+    const classified = synthesizeError({
+      ...base(),
+      ...extracted,
+      conversationErrorText: "grpc-status 12: routing failure",
+    });
+
+    expect(classified.source).toBe("conversation");
+    expect(classified.message).toBe("grpc-status 12: routing failure");
+  });
+
+  it("hopeless extraction yields to the captured rejection source", () => {
+    const extracted = extractRunErrorSources(errorResult({ result: { weird: "shape" } }));
+    const classified = synthesizeError({
+      ...base(),
+      ...extracted,
+      capturedRejection: { code: "unavailable", message: "socket hang up", timestamp: Date.now() },
+    });
+
+    expect(classified.source).toBe("rejection");
+    expect(classified.message).toContain("socket hang up");
+  });
+});
+
+describe("classifyFromSources '[object Object]' defense-in-depth guard", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("treats a leaked '[object Object]' sdkResultFields as absent", () => {
+    // Extraction never emits it, but any other producer of the junk string
+    // must not shadow the sources below it.
+    const classified = synthesizeError({
+      ...base(),
+      sdkResultFields: "[object Object]",
+      streamErrorMessage: "fetch failed",
+    });
+
+    expect(classified.source).toBe("stream");
+    expect(classified.category).toBe("network");
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/turn-stream.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/turn-stream.test.ts
@@ -222,6 +222,19 @@ describe("consumeCursorTurnStream", () => {
     expect(state.streamErrorMessage).toBe("boom");
   });
 
+  it("does not capture a non-string stream ERROR message (oss#299 hardening)", async () => {
+    // message is untyped at runtime; a structured value assigned here would
+    // crash classifyText downstream (.toLowerCase() on a non-string).
+    const { deps, state } = buildDeps();
+
+    await consumeCursorTurnStream(
+      mockRun([ev({ type: "status", status: "ERROR", message: { code: 14 } })]),
+      deps,
+    );
+
+    expect(state.streamErrorMessage).toBeUndefined();
+  });
+
   describe("first-denial early stop", () => {
     let hitlDir: string;
 

--- a/backend/services/runner/src/activities/execute-cursor/error-classifier.ts
+++ b/backend/services/runner/src/activities/execute-cursor/error-classifier.ts
@@ -7,8 +7,9 @@
  * 3. Surface isRetryable for future workflow-level retry decisions
  *
  * Error detail can come from several sources (in priority order):
- * - A thrown CursorSdkError's structured fields (highest fidelity)
- * - run.wait().result (SDK-provided string, often bare/generic)
+ * - Structured fields, either from a thrown CursorSdkError or lifted from a
+ *   structured run.wait() error value (highest fidelity)
+ * - run.wait() error text (SDK-provided string, often bare/generic)
  * - SDKStatusMessage with status "ERROR" from the stream
  * - ConnectError captured from process unhandledRejection
  * - Text extracted from the failing run.conversation() turn
@@ -39,13 +40,95 @@ export interface ClassifiedError {
 
 /**
  * Structured fields lifted from a thrown CursorSdkError (errors.d.ts:
- * { code, status, isRetryable, cause, endpoint, requestId, operation }).
+ * { code, status, isRetryable, cause, endpoint, requestId, operation }) or
+ * from a structured run.wait() error value (see extractRunErrorSources).
  * Only the fields used for classification are retained.
  */
 export interface SdkErrorFields {
   code?: string;
   status?: number;
   message?: string;
+}
+
+/**
+ * What String() produces for any plain object. Carries zero signal, so it is
+ * refused everywhere: extraction never emits it, and classifyFromSources
+ * treats it as absent should any other producer leak it through.
+ */
+const OBJECT_JUNK_STRING = "[object Object]";
+
+/**
+ * Error detail lifted from a run.wait() result, split by fidelity: structured
+ * values land in sdkError, plain text in sdkResultFields. At most one of the
+ * two is set; both undefined means the result carried nothing usable and the
+ * classifier's lower-priority sources should decide.
+ */
+export interface RunErrorSources {
+  sdkError: SdkErrorFields | undefined;
+  sdkResultFields: string | undefined;
+}
+
+const NO_RUN_ERROR_SOURCES: RunErrorSources = {
+  sdkError: undefined,
+  sdkResultFields: undefined,
+};
+
+/**
+ * Lift error detail from a run.wait() result whose status is "error".
+ *
+ * The SDK types RunResult.result as `string`, but structured values (Error
+ * instances, { code, message } objects) have been observed at runtime, both
+ * in `result` and in the undeclared error/message/reason fields (oss#299).
+ * A bare String() on those yields "[object Object]", which both destroys the
+ * message users see and — worse — shadows the lower-priority classifier
+ * sources (stream, rejection, conversation introspection) that often hold
+ * the real reason.
+ *
+ * Walks the candidate fields in order and answers from the FIRST one that
+ * yields usable content: strings keep flowing to the string channel
+ * (sdkResultFields), structured values are lifted into the same structured
+ * channel a thrown CursorSdkError uses (sdkError), and hopeless values are
+ * skipped so a later candidate — or the classifier's fallback sources — can
+ * win. (The previous `??` chain stopped at the first non-nullish value, so a
+ * hopeless object or empty string hid usable text one field later.)
+ *
+ * Deliberately NO JSON.stringify fallback for unrecognized object shapes:
+ * the error arm already logs the raw result in full server-side, and a JSON
+ * blob shown to the user would shadow the introspection sources that exist
+ * precisely to recover the real reason.
+ */
+export function extractRunErrorSources(result: unknown): RunErrorSources {
+  if (result === null || typeof result !== "object") return NO_RUN_ERROR_SOURCES;
+  const r = result as Record<string, unknown>;
+  for (const candidate of [r.result, r.error, r.message, r.reason]) {
+    const extracted = extractFromCandidate(candidate);
+    if (extracted) return extracted;
+  }
+  return NO_RUN_ERROR_SOURCES;
+}
+
+function extractFromCandidate(v: unknown): RunErrorSources | undefined {
+  if (v == null) return undefined;
+  if (typeof v === "string") {
+    if (v.length === 0 || v === OBJECT_JUNK_STRING) return undefined;
+    return { sdkError: undefined, sdkResultFields: v };
+  }
+  if (typeof v === "object") {
+    // Covers Error instances too: their message (and, on SDK/Node error
+    // shapes, code/status) are readable as plain properties.
+    const o = v as Record<string, unknown>;
+    const fields: SdkErrorFields = {};
+    if (typeof o.code === "string" && o.code.length > 0) fields.code = o.code;
+    if (typeof o.status === "number") fields.status = o.status;
+    if (typeof o.message === "string" && o.message.length > 0) fields.message = o.message;
+    if (fields.code !== undefined || fields.status !== undefined || fields.message !== undefined) {
+      return { sdkError: fields, sdkResultFields: undefined };
+    }
+    return undefined;
+  }
+  // Remaining primitives (number, boolean, ...) stringify losslessly.
+  const text = String(v);
+  return text.length > 0 ? { sdkError: undefined, sdkResultFields: text } : undefined;
 }
 
 const AUTH_PATTERNS = [
@@ -168,7 +251,11 @@ function classifyFromSources(opts: SynthesizeErrorOpts): ClassifiedError {
   }
 
   if (opts.sdkResultFields) {
-    const isBareGeneric = opts.sdkResultFields === "Cursor run failed";
+    // "Cursor run failed" is the SDK's bare generic; "[object Object]" is
+    // String()-coerced junk from any producer that bypassed the shape-aware
+    // extraction. Neither carries signal — fall through to better sources.
+    const isBareGeneric = opts.sdkResultFields === "Cursor run failed"
+      || opts.sdkResultFields === OBJECT_JUNK_STRING;
     if (!isBareGeneric) {
       const { category, retryable } = classifyText(opts.sdkResultFields);
       return {

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -140,7 +140,7 @@ import { StreamingUsageSummarySchema } from "@stigmer/protos/ai/stigmer/agentic/
 import { activityStarted, activityFinished } from "../../idle-watchdog.js";
 import { normalizeActivityInput, type ExecuteActivityInput } from "../../shared/activity-input.js";
 import { getCapturedRejection, clearCapturedRejection } from "./rejection-capture.js";
-import { synthesizeError, formatClassifiedError, shouldRetryWithFreshAgent } from "./error-classifier.js";
+import { synthesizeError, formatClassifiedError, shouldRetryWithFreshAgent, extractRunErrorSources } from "./error-classifier.js";
 import type { ClassifiedError } from "./error-classifier.js";
 import { createAgent, createCloudAgent } from "./session-lifecycle.js";
 import { setMaxListeners } from "node:events";
@@ -1739,12 +1739,10 @@ async function executeCursorInner(
         status.phase = ExecutionPhase.EXECUTION_COMPLETED;
         break;
       case "error": {
-        const resultAny = result as unknown as Record<string, unknown>;
-        const sdkError = result.result
-          ?? resultAny.error
-          ?? resultAny.message
-          ?? resultAny.reason;
-        const sdkErrorStr = sdkError ? String(sdkError) : undefined;
+        // Shape-aware extraction, NOT String(): the result's error fields are
+        // structured at runtime often enough that a bare coercion showed users
+        // "[object Object]" and shadowed every fallback source below (oss#299).
+        const runErrorSources = extractRunErrorSources(result);
 
         // The SDK frequently resolves run.wait() to a bare { status: "error" }
         // while the real reason (e.g. the original grpc-status 12 routing
@@ -1756,7 +1754,8 @@ async function executeCursorInner(
         if (capturedRejection) clearCapturedRejection(executionId);
 
         const classified = synthesizeError({
-          sdkResultFields: sdkErrorStr,
+          sdkError: runErrorSources.sdkError,
+          sdkResultFields: runErrorSources.sdkResultFields,
           streamErrorMessage: turnState.streamErrorMessage,
           capturedRejection,
           conversationErrorText,
@@ -1874,8 +1873,14 @@ async function executeCursorInner(
 
           const retryConversationErrorText = await introspectConversation(retryRun, executionId);
 
+          // Same shape-aware extraction as the primary error arm — the retry
+          // previously String()-coerced result.result alone, so a structured
+          // retry failure both read "[object Object]" and ignored the
+          // error/message/reason fields the primary arm consults.
+          const retryErrorSources = extractRunErrorSources(retryResult);
           const retryClassified = synthesizeError({
-            sdkResultFields: retryResult.result ? String(retryResult.result) : undefined,
+            sdkError: retryErrorSources.sdkError,
+            sdkResultFields: retryErrorSources.sdkResultFields,
             streamErrorMessage: turnState.streamErrorMessage,
             capturedRejection: retryRejection,
             conversationErrorText: retryConversationErrorText,

--- a/backend/services/runner/src/activities/execute-cursor/turn-stream.ts
+++ b/backend/services/runner/src/activities/execute-cursor/turn-stream.ts
@@ -387,8 +387,11 @@ export async function consumeCursorTurnStream(
         console.log(
           `ExecuteCursor stream status: execution=${executionId}, status=${JSON.stringify(event)}`,
         );
-        const statusEvent = event as { status?: string; message?: string };
-        if (statusEvent.status === "ERROR" && statusEvent.message) {
+        const statusEvent = event as { status?: string; message?: unknown };
+        // The cast is a claim, not a guarantee: message is untyped at runtime
+        // (the oss#299 class of bug). A structured value here would crash
+        // classification downstream, so only capture actual text.
+        if (statusEvent.status === "ERROR" && typeof statusEvent.message === "string" && statusEvent.message.length > 0) {
           state.streamErrorMessage = statusEvent.message;
         }
       }


### PR DESCRIPTION
## Summary
When a Cursor-harness run ends in `status: "error"` with a structured error value (an `Error` instance or a `{ code, message }` object), the runner `String()`-coerced it into `"[object Object]"` — the string end users saw verbatim. Worse, that junk string was the classifier's highest-priority non-empty source, so it disabled retry classification and shadowed the higher-fidelity fallback sources (conversation-turn introspection, captured rejection). This PR replaces the coercion with shape-aware extraction that routes structured values into the classifier's existing structured `SdkErrorFields` channel.

## Context
Reported in #299 (observed live on v3.4.0). The SDK types `RunResult.result` as `string`, but structured values arrive at runtime both in `result` and in the undeclared `error`/`message`/`reason` fields — the existing untyped candidate chain exists for exactly that reason, but its terminal `String()` destroyed anything non-string.

## Changes
- **`error-classifier.ts`**: new exported `extractRunErrorSources(result)` — walks the existing candidate chain (`result` → `error` → `message` → `reason`) and answers from the first candidate yielding usable content: non-empty strings flow to `sdkResultFields` (the string channel, unchanged), `Error` instances and `{ code, status, message }` objects are lifted into `sdkError` (the same structured channel a thrown `CursorSdkError` uses), hopeless values are skipped so a later candidate — or the fallback sources — can win. Also adds a defense-in-depth guard in `classifyFromSources`: a leaked `"[object Object]"` in `sdkResultFields` is treated as absent, alongside the existing `"Cursor run failed"` bare-generic guard.
- **`index.ts`**: both the primary error arm and the poisoned-handle retry arm now use the one extraction helper. The retry arm previously `String()`-coerced `retryResult.result` alone; it now also consults the full candidate chain (parity with the primary path).
- **`turn-stream.ts`** (hardening the issue missed): the stream ERROR `message` is captured only when it is actually a string — a structured value there would have crashed classification downstream (`.toLowerCase()` on a non-string).
- Tests: new `error-classifier-extraction.test.ts` (20 cases: shape matrix, first-usable-candidate chain order, end-to-end classification/retry pins, junk-string guard) + a non-string stream-message pin in `turn-stream.test.ts`.

## Implementation notes
- Structured values go to the classifier's existing structured channel rather than being flattened to a string: `classifyFromSources` already classifies across `code + status + message` joined while displaying `message` alone — rebuilding that in string-space would have duplicated it with an invented format.
- **Deliberate deviation from the issue's suggested fix: no `JSON.stringify` fallback for unrecognized object shapes.** The error arm already logs the raw result in full server-side (`rawResult=` in the agent-error log line), so a JSON blob shown to the user adds nothing and would shadow the introspection sources that exist precisely to recover the real reason. Returning nothing lets them fire — which the issue itself identifies as mattering as much as the extraction.
- The extraction takes the first *usable* candidate, not the first non-nullish one: previously a hopeless object (or empty string) in `result` hid a perfectly good string one field later in the chain.

## Breaking changes
- None. Error-path only; worst-case behavioral delta is a better-worded error message and previously-disabled fresh-agent retries now firing for genuinely retryable structured errors.

## Test plan
- `npx vitest run` on the five classifier/turn-stream suites: 81 tests green (20 new extraction + 1 new stream pin).
- Full runner suite: 4307 passed. The only failures are environmental: three suites need `node:sqlite` (local Node flag; untouched checkpointer code) and one bash-dependent HITL test timed out under full-suite load but passes 6/6 in isolation.
- `tsc --noEmit` clean.

## Risks
- Low. If the SDK ever emits a structured shape with none of `code`/`status`/`message`, the user sees the classifier's fallback message instead of a JSON blob — and the raw result remains in the server log. Rollback is a single revert.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible
- [ ] Docs updated (not needed — internal error path)

Closes #299

Made with [Cursor](https://cursor.com)