### PR TITLE
fix(backend/runner): enforce plan-mode read-only on sub-agents by construction

### DIFF
--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-plan-mode-permissions.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-plan-mode-permissions.test.ts
@@ -1,0 +1,173 @@
+/**
+ * End-to-end proof (real deepagents + LangGraph runtime, no LLM/network) that a
+ * plan-mode SUB-AGENT is read-only BY CONSTRUCTION (issue #255).
+ *
+ * The parent graph receives PLAN_MODE_PERMISSIONS in setup.ts, but deepagents'
+ * parent-permission inheritance covers only spec-style sub-agents — our
+ * pre-built CompiledSubAgents bypass `normalizeSubagentSpec` entirely, so
+ * `compileSubagents` must bake the rules into each sub-agent graph itself.
+ * These tests exercise that exact wiring with NO approval gate installed (the
+ * auto-approve-all shape): any denial must come from the permission rules
+ * alone, proving plan mode's "read-only by construction, not by gate"
+ * contract at the sub-agent level. A contrast case pins that without the
+ * rules (act mode) the same write flows — this change is a plan-mode-only
+ * delta.
+ *
+ * The rule under test is the PRODUCTION constant from
+ * shared/plan-mode-permissions.ts (the same one setup.ts applies to both
+ * graph sites), not a test copy, so a change to the plan-mode permission set
+ * re-proves sub-agent coverage automatically.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, writeFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HumanMessage, ToolMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { PLAN_MODE_PERMISSIONS } from "../../../shared/plan-mode-permissions.js";
+import { CasCaptureObserver } from "../cas-capture-observer.js";
+import { compileSubagents } from "../subagent-transformer.js";
+import { ScriptedModel, type ScriptSelector } from "../__test-utils__/scripted-model.js";
+
+const SEEDED_CONTENT = "PLAN_MODE_README_TOKEN: hello from the seeded file";
+
+describe("plan-mode sub-agent filesystem permissions (issue #255)", () => {
+  let root: string;
+  let observer: CasCaptureObserver;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "sa-plan-"));
+    await mkdir(join(root, "dist"), { recursive: true });
+    await writeFile(join(root, "notes.md"), SEEDED_CONTENT);
+    // Everything is gitignored from the observer's view — the strictest case:
+    // every write would be CAS-observed if it ever reached the backend.
+    observer = new CasCaptureObserver({ rootDir: root, isIgnored: async () => true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /**
+   * Compile a worker through the production path with NO approval gate, so the
+   * permission rules are the only thing standing between the model and the
+   * filesystem. `permissions` present = the plan-mode wiring under test;
+   * absent = the act-mode contrast.
+   */
+  async function compileWorker(script: ScriptSelector, planMode: boolean) {
+    const compiled = await compileSubagents(
+      [{ name: "worker", description: "test worker", systemPrompt: "do the work", tools: [] }],
+      {
+        approvalGate: null,
+        parentModelName: "test-model",
+        workspaceRootDir: root,
+        casObserver: observer,
+        modelFactory: async () => new ScriptedModel(script),
+        ...(planMode ? { permissions: PLAN_MODE_PERMISSIONS } : {}),
+      },
+    );
+    expect(compiled).toHaveLength(1);
+    return compiled[0];
+  }
+
+  function toolResultById(messages: BaseMessage[], toolCallId: string): string {
+    const match = messages.find(
+      (m): m is ToolMessage => m instanceof ToolMessage && m.tool_call_id === toolCallId,
+    );
+    expect(match, `expected a tool result for call '${toolCallId}'`).toBeDefined();
+    return typeof match!.content === "string" ? match!.content : JSON.stringify(match!.content);
+  }
+
+  it("denies write_file and edit_file at the tool level, while read_file still works", async () => {
+    // One turn, three tool calls: both mutation tools must be denied by the
+    // permission rules; the read must pass through untouched (the deny rule
+    // covers the `write` operation class only).
+    // Real absolute workspace paths, as production models use (the prompt's
+    // file tree is absolute, and the tools' contract says absolute). With
+    // permission rules present this is also the only shape that reaches the
+    // rules at all: enforcePermission's canonicalization refuses relative
+    // paths with a validation error before any rule or backend runs — a
+    // different denial, but still nothing written.
+    const script: ScriptSelector = () => ({
+      toolCalls: [
+        { name: "write_file", args: { file_path: join(root, "dist/out.txt"), content: "new file" }, id: "c_write" },
+        { name: "edit_file", args: { file_path: join(root, "notes.md"), old_string: "hello", new_string: "HACKED" }, id: "c_edit" },
+        { name: "read_file", args: { file_path: join(root, "notes.md") }, id: "c_read" },
+      ],
+      done: "worker done",
+    });
+
+    const worker = await compileWorker(script, true);
+    const result = (await worker.runnable.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: "t1" }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+
+    // Both mutations denied with deepagents' permission error, and nothing on disk:
+    // the new file was never created and the seeded file is byte-identical.
+    expect(toolResultById(result.messages, "c_write")).toMatch(/permission denied for write/i);
+    expect(toolResultById(result.messages, "c_edit")).toMatch(/permission denied for write/i);
+    await expect(access(join(root, "dist/out.txt"))).rejects.toThrow();
+    expect(await readFile(join(root, "notes.md"), "utf8")).toBe(SEEDED_CONTENT);
+
+    // The read flowed: its result carries the seeded content, not a denial.
+    const readResult = toolResultById(result.messages, "c_read");
+    expect(readResult).toContain("PLAN_MODE_README_TOKEN");
+    expect(readResult).not.toMatch(/permission denied/i);
+
+    // The denial fired INSIDE the tool handler, before any backend was reached:
+    // the CAS observer (which records pre-write bytes on the backend's write/edit
+    // seams) saw neither mutation.
+    expect(observer.before.size).toBe(0);
+  });
+
+  it("act-mode contrast: without the permissions option the same write lands (zero-delta outside plan mode)", async () => {
+    const script: ScriptSelector = () => ({
+      toolCalls: [
+        { name: "write_file", args: { file_path: join(root, "dist/out.txt"), content: "new file" }, id: "c_write" },
+      ],
+      done: "worker done",
+    });
+
+    const worker = await compileWorker(script, false);
+    const result = (await worker.runnable.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: "t2" }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+
+    expect(toolResultById(result.messages, "c_write")).not.toMatch(/permission denied/i);
+    expect(await readFile(join(root, "dist/out.txt"), "utf8")).toBe("new file");
+    // And the backend WAS reached this time — the observer recorded a write.
+    // (Key shape is DD-19 territory, deliberately not pinned here.)
+    expect(observer.before.size).toBe(1);
+  });
+
+  it("relative-path mutations are refused too — by validation, before the rules", async () => {
+    // The native prompt steers models to workspace-relative paths, but
+    // deepagents' permission canonicalization accepts only absolute ones, so
+    // with rules present a relative-path call fails validation before any
+    // rule (or backend) runs. Read-only still holds — nothing is written —
+    // but the model sees "path must be absolute", not "permission denied",
+    // and prompt-compliant relative READS degrade the same way. That
+    // relative-vs-absolute friction is a pre-existing parent-plan-mode
+    // behavior, tracked as issue #429; this pins that the sub-agent's
+    // read-only contract survives it.
+    const script: ScriptSelector = () => ({
+      toolCalls: [
+        { name: "write_file", args: { file_path: "dist/out.txt", content: "new file" }, id: "c_write_rel" },
+      ],
+      done: "worker done",
+    });
+
+    const worker = await compileWorker(script, true);
+    const result = (await worker.runnable.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: "t3" }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+
+    expect(toolResultById(result.messages, "c_write_rel")).toMatch(/path must be absolute/i);
+    await expect(access(join(root, "dist/out.txt"))).rejects.toThrow();
+    expect(observer.before.size).toBe(0);
+  });
+});

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-wiring.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-wiring.test.ts
@@ -7,10 +7,11 @@ describe("buildSubAgentMiddleware", () => {
   it("returns the correct middleware order without cost cap", () => {
     const stack = buildSubAgentMiddleware();
 
-    expect(stack).toHaveLength(3);
+    expect(stack).toHaveLength(4);
     expect(stack[0].name).toBe("LoopDetectionMiddleware");
     expect(stack[1].name).toBe("ExecutionBudgetMiddleware");
     expect(stack[2].name).toBe("ToolTruncationMiddleware");
+    expect(stack[3].name).toBe("ErrorHintsMiddleware");
   });
 
   it("includes cost cap view when parent cost cap is provided", () => {
@@ -24,8 +25,9 @@ describe("buildSubAgentMiddleware", () => {
 
     const stack = buildSubAgentMiddleware({ costCap: parentCostCap });
 
-    expect(stack).toHaveLength(4);
+    expect(stack).toHaveLength(5);
     expect(stack[3].name).toBe("CostCapSubAgentView");
+    expect(stack[4].name).toBe("ErrorHintsMiddleware");
   });
 
   it("sub-agent cost cap view shares parent state", () => {
@@ -75,8 +77,8 @@ describe("buildSubAgentMiddleware", () => {
       approvalGate: { policies: new Map(), toolServerMap: new Map() },
     });
 
-    // loop, budget, truncation, approval gate
-    expect(stack).toHaveLength(4);
+    // loop, budget, truncation, approval gate, error hints
+    expect(stack).toHaveLength(5);
     expect(stack[3].name).toBe("ApprovalGateMiddleware");
     expect(stack[3].wrapToolCall).toBeDefined();
   });
@@ -84,7 +86,7 @@ describe("buildSubAgentMiddleware", () => {
   it("omits the approval gate when approvalGate is null (auto-approve-all parity)", () => {
     const stack = buildSubAgentMiddleware({ approvalGate: null });
 
-    expect(stack).toHaveLength(3);
+    expect(stack).toHaveLength(4);
     expect(stack.some((m) => m.name === "ApprovalGateMiddleware")).toBe(false);
   });
 
@@ -102,10 +104,13 @@ describe("buildSubAgentMiddleware", () => {
       approvalGate: { policies: new Map(), toolServerMap: new Map() },
     });
 
-    // loop, budget, truncation, approval gate, cost cap view
-    expect(stack).toHaveLength(5);
+    // loop, budget, truncation, approval gate, cost cap view, error hints.
+    // Hints AFTER the gate matches the parent nesting: the gate's HITL
+    // interrupt stays outside the hints' try/catch (issue #255).
+    expect(stack).toHaveLength(6);
     expect(stack[3].name).toBe("ApprovalGateMiddleware");
     expect(stack[4].name).toBe("CostCapSubAgentView");
+    expect(stack[5].name).toBe("ErrorHintsMiddleware");
   });
 
   // captureIgnored is the structural coupling that makes sub-agent gitignored

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -8,7 +8,7 @@
  * the streaming phase needs.
  */
 
-import { createDeepAgent, type FilesystemPermission } from "deepagents";
+import { createDeepAgent } from "deepagents";
 import { InteractionMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 import { z } from "zod";
@@ -56,6 +56,7 @@ import { LocalWorkspaceBackend } from "../../shared/workspace/local-backend.js";
 import type { WorkspaceBackend, ProvisionResult } from "../../shared/workspace/types.js";
 import { createCasCaptureBackend } from "./cas-capture-backend.js";
 import { buildShellEnv } from "./shell-env.js";
+import { PLAN_MODE_PERMISSIONS } from "../../shared/plan-mode-permissions.js";
 import { CasCaptureObserver } from "./cas-capture-observer.js";
 import { isGitWorkTree, isPathCapturable } from "../../shared/filereview/git-substrate.js";
 import { deriveCaptureMode } from "../../shared/filereview/capture.js";
@@ -783,6 +784,10 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
         // Presence of shellEnv is the shell-capability switch for sub-agent
         // backends too (undefined in plan mode; see buildShellEnv above).
         shellEnv,
+        // Plan mode's deny-all-writes rule, mirrored onto every sub-agent graph
+        // (issue #255) — pre-built CompiledSubAgents never inherit the parent's
+        // permissions, so read-only-by-construction must be baked in here.
+        ...(isPlanMode ? { permissions: PLAN_MODE_PERMISSIONS } : {}),
       });
       timing.mark("compile_subagents");
     }
@@ -795,16 +800,6 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     if (outputSchema) {
       responseFormat = jsonSchemaToZod(outputSchema as unknown as Record<string, unknown>);
     }
-
-    // Plan mode is read-only. Deny every filesystem write operation at the tool
-    // level so write_file/edit_file/etc. cannot mutate the workspace — enforcing
-    // the InteractionMode.PLAN contract by construction, not by prompt. Rules are
-    // first-match-wins with a permissive default, so a single deny-all-writes
-    // rule is sufficient. (The Cursor harness enforces plan mode via its prompt
-    // prefix; the native harness enforces it here.)
-    const planModePermissions: FilesystemPermission[] = [
-      { operations: ["write"], paths: ["/**"], mode: "deny" },
-    ];
 
     // File capture point. Apply-then-review is universal (Slice 2b), so the
     // CAS-observing backend: git-tracked edits flow to disk (the turn-boundary
@@ -826,7 +821,7 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       middleware: middleware as any,
       subagents: compiledSubagents ?? undefined,
       ...(responseFormat ? { responseFormat } : {}),
-      ...(isPlanMode ? { permissions: planModePermissions } : {}),
+      ...(isPlanMode ? { permissions: PLAN_MODE_PERMISSIONS } : {}),
     } as Parameters<typeof createDeepAgent>[0]);
 
     // Step 11: Prepare invocation input and config. The conversation catchup

--- a/backend/services/runner/src/activities/execute-deep-agent/subagent-transformer.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/subagent-transformer.ts
@@ -15,12 +15,15 @@
  *   no approval gate — see deepagents-profiles.ts for the suppression half)
  * - Sub-agent backends are shell-capable outside plan mode (issue #248), mirroring
  *   the parent's backend selection in setup.ts
+ * - Sub-agent graphs carry the parent's filesystem permissions explicitly
+ *   (issue #255): pre-built CompiledSubAgents never inherit them, so plan
+ *   mode's deny-all-writes rule is baked into each graph at compile time
  * - Invalid configurations are logged and skipped (graceful degradation)
  * - Empty subagent list returns null (no subagents configured)
  */
 
 import { createDeepAgent, FilesystemBackend, LocalShellBackend, DEFAULT_GENERAL_PURPOSE_DESCRIPTION, DEFAULT_SUBAGENT_PROMPT } from "deepagents";
-import type { CompiledSubAgent } from "deepagents";
+import type { CompiledSubAgent, FilesystemPermission } from "deepagents";
 import type { StructuredTool } from "@langchain/core/tools";
 import type { RunnableConfig } from "@langchain/core/runnables";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
@@ -180,6 +183,18 @@ export interface SubagentTransformOptions {
    * backends, exactly like the parent's backend selection.
    */
   readonly shellEnv?: Record<string, string>;
+  /**
+   * Filesystem permission rules baked into each compiled sub-agent graph,
+   * inherited from the parent's rules in setup.ts (plan mode's deny-all-writes
+   * today). Required because deepagents' parent-permission inheritance covers
+   * only spec-style sub-agents — pre-built CompiledSubAgents bypass it, so
+   * without this a plan-mode sub-agent could still write (issue #255).
+   *
+   * Must not be combined with `shellEnv`: deepagents rejects permissions on an
+   * execution-capable backend (see the cas-capture-backend.ts header). Plan
+   * mode guarantees that by construction — it is the mode that clears shellEnv.
+   */
+  readonly permissions?: FilesystemPermission[];
 }
 
 // =========================================================================
@@ -525,6 +540,8 @@ export async function compileSubagents(
     readonly modelFactory?: (modelName: string) => Promise<BaseChatModel>;
     /** Shell env for `execute`; see {@link SubagentTransformOptions.shellEnv}. */
     readonly shellEnv?: Record<string, string>;
+    /** Per-graph filesystem rules; see {@link SubagentTransformOptions.permissions}. */
+    readonly permissions?: FilesystemPermission[];
   },
 ): Promise<CompiledSubAgent[]> {
   if (transformed.length === 0) return [];
@@ -560,6 +577,9 @@ export async function compileSubagents(
         tools: spec.tools.length > 0 ? spec.tools : undefined,
         middleware: middleware as unknown[],
         backend,
+        // Enforced inside this graph's own filesystem tools — and inherited by
+        // any spec-style sub-agent deepagents auto-injects one level deeper.
+        ...(opts.permissions ? { permissions: opts.permissions } : {}),
       } as Parameters<typeof createDeepAgent>[0]);
 
       const gatedRunnable = gate.wrapRunnable(
@@ -623,6 +643,7 @@ export async function transformAndCompileSubagents(
     costCap,
     modelFactory,
     shellEnv,
+    permissions,
   } = options;
 
   if (subAgents.length === 0 && !workspaceBackend.rootDir) {
@@ -743,6 +764,7 @@ export async function transformAndCompileSubagents(
     casObserver,
     modelFactory,
     shellEnv,
+    permissions,
   });
 
   if (compiled.length === 0) {

--- a/backend/services/runner/src/activities/execute-deep-agent/subagent-wiring.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/subagent-wiring.ts
@@ -9,11 +9,16 @@
  *   bypassed) — installed only when the parent itself is gated
  *   (`approvalGate` present; absent under auto-approve-all)
  * - Shared cost cap view (parent's budget, no reset on sub-agent start)
+ * - Error hints (issue #255): a thrown tool error becomes a recoverable
+ *   ToolMessage exactly as on the parent. Without it, any tool throw — a
+ *   plan-mode permission denial, an MCP hiccup — propagated out of the
+ *   sub-agent graph and killed the whole delegated task, losing all its
+ *   accumulated work, where the parent's identical error is one failed
+ *   tool round the model adapts to.
  *
  * The sub-agent middleware stack does NOT include:
  * - Graceful stop (parent handles STOP signal propagation)
  * - OTel spans (parent's OTel context propagates automatically)
- * - Error hints (applied at tool level, not sub-agent level)
  *
  * Approval-gate note: the gate is what *creates* the LangGraph `interrupt()`.
  * A sub-agent's interrupt does surface at the parent checkpoint and resumes
@@ -31,6 +36,7 @@ import {
   createApprovalGateMiddleware,
   type ApprovalGateConfig,
 } from "../../middleware/approval-gate.js";
+import { createErrorHintsMiddleware } from "../../middleware/error-hints.js";
 
 const SUB_AGENT_ADVISORY_INTERVAL = 30;
 const SUB_AGENT_MAX_ADVISORIES = 4;
@@ -60,9 +66,11 @@ export interface SubAgentMiddlewareOptions {
  *
  * Returns an ordered array mirroring the parent composition:
  * loop detection → execution budget (periodic) → tool truncation →
- * [approval gate] → cost cap view. The gate sits before the cost-cap view so an
- * approval pause happens before budget accounting, matching the parent order
- * (…→ truncation → graceful-stop → approval gate → cost cap …).
+ * [approval gate] → cost cap view → error hints. The gate sits before the
+ * cost-cap view so an approval pause happens before budget accounting, and
+ * error hints come after the gate — both matching the parent order
+ * (…→ truncation → graceful-stop → approval gate → cost cap → error hints …),
+ * which keeps the gate's HITL interrupt outside the hints' try/catch.
  */
 export function buildSubAgentMiddleware(
   options: SubAgentMiddlewareOptions = {},
@@ -98,6 +106,8 @@ export function buildSubAgentMiddleware(
   if (options.costCap) {
     stack.push(options.costCap.forSubAgent());
   }
+
+  stack.push(createErrorHintsMiddleware());
 
   return stack;
 }

--- a/backend/services/runner/src/shared/plan-mode-permissions.ts
+++ b/backend/services/runner/src/shared/plan-mode-permissions.ts
@@ -1,0 +1,30 @@
+/**
+ * The Plan-mode filesystem permission rules — the enforcement twin of
+ * `plan-mode-prompt.ts` (which carries the instruction half of the contract).
+ *
+ * Plan mode is read-only BY CONSTRUCTION on the native harness: these rules
+ * deny every filesystem write operation at the tool level so
+ * write_file/edit_file cannot mutate the workspace regardless of what the
+ * model was told. Rules are first-match-wins with a permissive default, so a
+ * single deny-all-writes rule is sufficient. (The Cursor harness has no
+ * tool-level lever and enforces plan mode via its prompt prefix instead.)
+ *
+ * Applied in execute-deep-agent/setup.ts to the parent graph AND threaded
+ * into every compiled sub-agent graph: deepagents' parent-permission
+ * inheritance covers only spec-style sub-agents, and ours are pre-built
+ * CompiledSubAgents, so each sub-agent graph must carry the rules itself
+ * (issue #255). Kept as its own side-effect-free module so tests can pin the
+ * production rules without dragging in setup.ts's import graph.
+ *
+ * Invariant: never combine these rules with a shell-capable (sandbox)
+ * backend — deepagents rejects that pairing at graph construction (see the
+ * cas-capture-backend.ts header). Plan mode guarantees it by construction:
+ * it is the mode that clears `shellEnv`, and `shellEnv` is the single switch
+ * for shell capability on both the parent and sub-agent backends.
+ */
+
+import type { FilesystemPermission } from "deepagents";
+
+export const PLAN_MODE_PERMISSIONS: FilesystemPermission[] = [
+  { operations: ["write"], paths: ["/**"], mode: "deny" },
+];


### PR DESCRIPTION
## Summary

Fixes the plan-mode read-only gap for sub-agents ([#255](https://github.com/stigmer/stigmer/issues/255)): the deny-all-writes filesystem permissions were applied to the **parent** graph only, and deepagents' parent-permission inheritance covers only spec-style sub-agents — our pre-built `CompiledSubAgent`s bypass it entirely. A plan-mode sub-agent could therefore still issue `write_file`/`edit_file`, intercepted only by the approval gate rather than denied at the tool level like the parent.

### What changed

- **`shared/plan-mode-permissions.ts` (new)** — `PLAN_MODE_PERMISSIONS` hoisted out of `setup.ts` as the side-effect-free enforcement twin of `plan-mode-prompt.ts`: one source of truth for the parent graph, every sub-agent graph, and the regression proof.
- **`setup.ts`** — threads the rules into sub-agent compilation under `isPlanMode`, mirroring the parent's own conditional spread. Act mode passes nothing (byte-identical behavior).
- **`subagent-transformer.ts`** — `compileSubagents` bakes the rules into each sub-agent's `createDeepAgent` call. Bonus depth-2 coverage for free: any spec-style `general-purpose` sub-agent deepagents auto-injects into a sub-agent's graph (providers outside our anthropic/openai suppression) inherits these rules.
- **`subagent-wiring.ts`** — adds the error-hints middleware to sub-agent stacks (owner-approved in-session). Without it, any thrown tool error — the plan-mode permission denial, an MCP hiccup — propagated out of the sub-agent graph and killed the entire delegated task, where the parent's identical error is one recoverable tool round. Ordered after the approval gate so the HITL interrupt stays outside the hints' try/catch, matching the parent's composition (interrupt propagation re-verified green).

### Regression proof

New `subagent-plan-mode-permissions.test.ts` (real deepagents + LangGraph runtime, scripted model, no LLM/network), compiled through the production `compileSubagents` with **no approval gate** — the denial must come from the rules alone:

- `write_file` and `edit_file` denied with `permission denied for write`; nothing on disk; the CAS observer saw neither mutation (denial fires before any backend).
- `read_file` unaffected (deny rule covers the `write` operation class only).
- Act-mode contrast: identical worker without the rules — the write lands (zero delta outside plan mode).
- Relative-path mutations refused too (by validation, before the rules) — pins that read-only survives the pre-existing path-shape friction discovered during this work and filed as [#429](https://github.com/stigmer/stigmer/issues/429).

## Verification

- New proof file 3/3; all sub-agent suites green (approval propagation, gitignored capture, transformer, tracker, wiring — wiring's stack-shape pins updated for the new middleware).
- Full runner suite in an isolated worktree: 4224 passed; only failures are the 3 pre-existing `node:sqlite` collection failures (oss#257 class, Node 23.1 environment) plus parallel-load timeout flakes — all 6 flaky files re-run serially in isolation: 139/139 green.
- `tsc --noEmit` clean.

Closes #255

Made with [Cursor](https://cursor.com)