### PR TITLE
fix(sdk/react): key SessionViewer narrow-layout collapse on its container, not the viewport

### DIFF
--- a/demos/tours/_shared/SessionView.tsx
+++ b/demos/tours/_shared/SessionView.tsx
@@ -125,11 +125,12 @@ interface SessionViewProps {
  *
  * Two deliberate departures from the shipped viewers, both determinism
  * seams the layout exposes for exactly this host class (DD-006):
- * `responsive={false}` (the embed iframe's viewport sits below `lg`, where
- * the default would hide the conversation on open-panel beats) and no
- * `splitStorageKey` (a persisted pane width would make replays
- * reader-dependent). Everything else enters as props from step data; the
- * root is `inert`, so the depicted page is non-interactive during playback.
+ * `responsive={false}` (the tour canvas is a narrow fixed box, where the
+ * default container-width collapse would hide the conversation on exactly
+ * the open-panel beats the tour is narrating) and no `splitStorageKey` (a
+ * persisted pane width would make replays reader-dependent). Everything
+ * else enters as props from step data; the root is `inert`, so the
+ * depicted page is non-interactive during playback.
  */
 export function SessionView({
   execution,

--- a/sdk/react/src/internal/ResizableSplit.tsx
+++ b/sdk/react/src/internal/ResizableSplit.tsx
@@ -13,11 +13,17 @@ import { cn } from "@stigmer/theme";
 export type ResizablePane = "primary" | "secondary";
 
 /**
- * Which pane (if any) collapses below the `lg` breakpoint, leaving its sibling
- * full-width. Use this to hide the pixel-sized pane on narrow screens — always
- * pair it with {@link ResizableSplitProps.resizablePane} (hide the fixed pane so
- * the visible sibling is the flexing one and fills the row). `"none"` keeps both
+ * Which pane (if any) collapses when the split's own box is narrower than
+ * 48rem, leaving its sibling full-width. Use this to hide the pixel-sized
+ * pane in tight quarters — always pair it with
+ * {@link ResizableSplitProps.resizablePane} (hide the fixed pane so the
+ * visible sibling is the flexing one and fills the row). `"none"` keeps both
  * panes at every width.
+ *
+ * The narrowness check is a CSS container query against the split root —
+ * never a viewport media query — so an embedded dock inside a wide window
+ * collapses exactly like a narrow window does (stigmer/stigmer#301). See
+ * {@link ResizableSplitProps.responsiveCollapse} for the threshold rationale.
  */
 export type ResizableCollapse = "primary" | "secondary" | "none";
 
@@ -52,7 +58,22 @@ export interface ResizableSplitProps {
    * a distinct persisted width per mode.
    */
   readonly storageKey?: string;
-  /** Which pane collapses below the `lg` breakpoint. @default "none" */
+  /**
+   * Which pane collapses when the split's own box is narrower than 48rem
+   * (768px, Tailwind's `--container-3xl`).
+   *
+   * The threshold is fixed and keys on the split root via a CSS container
+   * query. 48rem clears the session layout's content minimums (320px min
+   * chat + drag handle + a usable workspace panel) and approximately
+   * preserves the console's previous viewport-`lg` trigger point, where the
+   * viewer's box is the ~1024px window minus the ~280px sidebar. It is
+   * deliberately not a prop: container-query conditions cannot read CSS
+   * custom properties, so a runtime threshold would need an inline-`<style>`
+   * or ResizeObserver mechanism — heavier than the static utility this is,
+   * with no consumer needing it.
+   *
+   * @default "none"
+   */
   readonly responsiveCollapse?: ResizableCollapse;
   /**
    * Which pane (if any) is collapsed at every width, hiding the drag handle and
@@ -126,7 +147,8 @@ function readInitialWidth(
  *   so the pane always grows toward its own side
  * - Optional `localStorage` persistence via `storageKey`, re-initialized when
  *   the key or resizable side changes (no remount required)
- * - Optional responsive collapse of the pixel pane below `lg`
+ * - Optional responsive collapse of the pixel pane when the split's own box
+ *   is narrow (container query, not viewport — see `responsiveCollapse`)
  * - Styled with `--stgm-*` tokens; no hardcoded colors
  *
  * @example
@@ -293,12 +315,30 @@ export function ResizableSplit({
         : fixedPaneClass;
 
   return (
-    <div ref={containerRef} className={cn("flex min-h-0 flex-1", className)}>
+    <div
+      ref={containerRef}
+      className={cn(
+        "flex min-h-0 flex-1",
+        // The responsive collapse queries the split's OWN width, so the root
+        // must be a CSS container (stigmer/stigmer#301). Applied ONLY while a
+        // collapse is requested: `container-type: inline-size` imposes layout
+        // containment, which re-parents `position: fixed` descendants and
+        // creates a stacking context — the workflow inspector's in-tree
+        // viewport-covering backdrop (InspectorHeader) lives inside a split
+        // pane and must not be captured. The one `responsiveCollapse`
+        // consumer (the session layout) has no in-tree fixed descendants:
+        // its dialogs are native <dialog> (top layer) and its floating UI
+        // portals out.
+        responsiveCollapse !== "none" && "@container/resizable-split",
+        className,
+      )}
+    >
       {/* Primary region (first child, order-stable across flips/collapses) */}
       <div
         className={cn(
           primaryPaneClass,
-          responsiveCollapse === "primary" && "max-lg:hidden",
+          responsiveCollapse === "primary" &&
+            "@max-3xl/resizable-split:hidden",
         )}
         style={
           isPrimaryResizable && !isCollapsed ? { width: panelWidth } : undefined
@@ -329,7 +369,7 @@ export function ResizableSplit({
           "focus-visible:bg-[var(--stgm-primary,#6366f1)] focus-visible:outline-none",
           "active:bg-[var(--stgm-primary,#6366f1)]",
           "transition-colors duration-100",
-          responsiveCollapse !== "none" && "max-lg:hidden",
+          responsiveCollapse !== "none" && "@max-3xl/resizable-split:hidden",
           isCollapsed && "hidden",
         )}
       >
@@ -341,7 +381,8 @@ export function ResizableSplit({
       <div
         className={cn(
           secondaryPaneClass,
-          responsiveCollapse === "secondary" && "max-lg:hidden",
+          responsiveCollapse === "secondary" &&
+            "@max-3xl/resizable-split:hidden",
         )}
         style={
           !isPrimaryResizable && !isCollapsed ? { width: panelWidth } : undefined

--- a/sdk/react/src/internal/__tests__/ResizableSplit.layout.test.tsx
+++ b/sdk/react/src/internal/__tests__/ResizableSplit.layout.test.tsx
@@ -1,0 +1,136 @@
+// Layout-contract regression suite for ResizableSplit's responsive collapse
+// (stigmer/stigmer#301). Runs in a real Chromium via `vitest.a11y.config.ts` —
+// evaluating a CSS container query requires a real layout engine, which
+// happy-dom does not have.
+//
+// The contract under test: `responsiveCollapse` keys on the split's OWN box
+// (a container query), never the browser viewport. The defining scenario is
+// the one the issue reports — a narrow dock inside a WIDE window. A viewport
+// media query can never fire there (the window is wide), so every assertion
+// below that expects a collapse is meaningless under the old `max-lg`
+// implementation and fails against it.
+//
+// Like the provider container suite (#260/DD-019), this renders against the
+// SHIPPED stylesheet (`dist/styles.css`, built by `npm run build:libs`), so
+// the contract is verified on the artifact consumers actually load.
+
+import "../../../dist/styles.css";
+
+import { describe, it, expect, afterEach, beforeAll } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { page } from "@vitest/browser/context";
+import { ResizableSplit } from "../ResizableSplit";
+
+// The harness default viewport (414×896) is narrower than Tailwind's `lg`,
+// where a viewport-keyed collapse would fire too — hiding the very defect
+// this suite exists to catch. Pin a desktop-wide window so the narrow-dock
+// cases can only pass with a container-keyed implementation.
+beforeAll(async () => {
+  await page.viewport(1280, 800);
+});
+
+afterEach(cleanup);
+
+/** The collapse threshold the component documents: 48rem = 768px. */
+const THRESHOLD_PX = 768;
+
+/** Comfortably inside the collapse band — the issue's 360–640px dock class. */
+const NARROW_PX = 500;
+
+/** Comfortably above the threshold, yet far below the Chromium viewport. */
+const WIDE_PX = THRESHOLD_PX + 132;
+
+/**
+ * Render the split docked in a fixed-width wrapper, the embedded-host
+ * arrangement from stigmer/stigmer#301: the wrapper is narrower than the
+ * viewport, so any viewport-keyed rule sees a wide window while the
+ * component's own box is tight.
+ */
+function renderDocked(
+  wrapperWidthPx: number,
+  overrides: Partial<React.ComponentProps<typeof ResizableSplit>> = {},
+) {
+  return render(
+    <div style={{ width: wrapperWidthPx, height: 400, display: "flex" }}>
+      <ResizableSplit
+        resizablePane="primary"
+        responsiveCollapse="primary"
+        primary={<div data-testid="primary">chat</div>}
+        secondary={<div data-testid="secondary">panel</div>}
+        {...overrides}
+      />
+    </div>,
+  );
+}
+
+function paneOf(testId: string): HTMLElement {
+  return screen.getByTestId(testId).parentElement!;
+}
+
+describe("ResizableSplit responsive collapse keys on its container (#301)", () => {
+  it("sanity: the test viewport is wide enough that a viewport-lg query could never fire", () => {
+    // Guards the premise of every case below. If the runner's viewport ever
+    // shrinks below Tailwind's `lg` (1024px), the narrow-dock cases stop
+    // discriminating between container- and viewport-keyed implementations.
+    expect(window.innerWidth).toBeGreaterThanOrEqual(1024);
+  });
+
+  it("collapses the primary pane in a narrow dock inside a wide window", () => {
+    renderDocked(NARROW_PX);
+
+    expect(getComputedStyle(paneOf("primary")).display).toBe("none");
+    // The drag handle hides with the pane...
+    const separator = screen.getByRole("separator", { hidden: true });
+    expect(getComputedStyle(separator).display).toBe("none");
+    // ...so the secondary pane owns the full dock width.
+    expect(paneOf("secondary").getBoundingClientRect().width).toBe(NARROW_PX);
+  });
+
+  it("keeps both panes side-by-side once the dock is wider than the threshold", () => {
+    renderDocked(WIDE_PX);
+
+    const primary = paneOf("primary");
+    const secondary = paneOf("secondary");
+    expect(getComputedStyle(primary).display).not.toBe("none");
+    expect(getComputedStyle(secondary).display).not.toBe("none");
+    // The fixed pane holds its pixel width; the sibling flexes into the rest.
+    expect(primary.getBoundingClientRect().width).toBe(384);
+    expect(secondary.getBoundingClientRect().width).toBeGreaterThan(0);
+  });
+
+  it("collapses the secondary pane when it is the responsive side", () => {
+    renderDocked(NARROW_PX, {
+      resizablePane: "secondary",
+      responsiveCollapse: "secondary",
+    });
+
+    expect(getComputedStyle(paneOf("secondary")).display).toBe("none");
+    expect(paneOf("primary").getBoundingClientRect().width).toBe(NARROW_PX);
+  });
+
+  it('responsiveCollapse="none": never collapses and creates no containment context', () => {
+    const { container } = renderDocked(NARROW_PX, {
+      responsiveCollapse: "none",
+    });
+
+    expect(getComputedStyle(paneOf("primary")).display).not.toBe("none");
+    expect(getComputedStyle(paneOf("secondary")).display).not.toBe("none");
+
+    // The containment invariant: without a collapse to decide, the root must
+    // NOT be a CSS container — `container-type: inline-size` would re-parent
+    // `position: fixed` descendants (the workflow inspector's click-away
+    // backdrop renders in-tree inside a split pane) and add a stacking
+    // context. See the conditional in ResizableSplit.
+    const root = paneOf("primary").parentElement!;
+    expect(getComputedStyle(root).containerType).toBe("normal");
+  });
+
+  it("the collapse-enabled root is an inline-size container named for its query", () => {
+    renderDocked(NARROW_PX);
+
+    const root = screen.getByRole("separator", { hidden: true }).parentElement!;
+    const style = getComputedStyle(root);
+    expect(style.containerType).toBe("inline-size");
+    expect(style.containerName).toBe("resizable-split");
+  });
+});

--- a/sdk/react/src/internal/__tests__/ResizableSplit.test.tsx
+++ b/sdk/react/src/internal/__tests__/ResizableSplit.test.tsx
@@ -72,6 +72,53 @@ describe("ResizableSplit", () => {
     });
   });
 
+  // Class-name pins only; the collapse behavior itself is a container query
+  // that needs a real layout engine, proven by ResizableSplit.layout.test.tsx
+  // (stigmer/stigmer#301).
+  describe("responsiveCollapse", () => {
+    it("marks the root as a named CSS container only while a collapse is requested", () => {
+      const { container, rerender } = render(
+        <ResizableSplit
+          responsiveCollapse="primary"
+          primary={<div data-testid="primary">Primary</div>}
+          secondary={<div data-testid="secondary">Secondary</div>}
+        />,
+      );
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).toContain("@container/resizable-split");
+
+      // Without a collapse to decide, the container marker must be absent —
+      // `container-type` imposes layout containment (re-parents fixed
+      // descendants, adds a stacking context), which the workflow splits'
+      // pane content must never inherit.
+      rerender(
+        <ResizableSplit
+          responsiveCollapse="none"
+          primary={<div data-testid="primary">Primary</div>}
+          secondary={<div data-testid="secondary">Secondary</div>}
+        />,
+      );
+      expect(root.className).not.toContain("@container");
+    });
+
+    it("tags the collapsing pane and the separator with the container-query variant", () => {
+      render(
+        <ResizableSplit
+          responsiveCollapse="primary"
+          primary={<div data-testid="primary">Primary</div>}
+          secondary={<div data-testid="secondary">Secondary</div>}
+        />,
+      );
+      const pane = screen.getByTestId("primary").parentElement as HTMLElement;
+      const separator = screen.getByRole("separator");
+      expect(pane.className).toContain("@max-3xl/resizable-split:hidden");
+      expect(separator.className).toContain("@max-3xl/resizable-split:hidden");
+      const sibling = screen.getByTestId("secondary")
+        .parentElement as HTMLElement;
+      expect(sibling.className).not.toContain("@max-3xl");
+    });
+  });
+
   describe("collapsedPane", () => {
     /** The pane wrapper div for a rendered probe. */
     function paneOf(testId: string): HTMLElement {

--- a/sdk/react/src/session/SessionViewerLayout.tsx
+++ b/sdk/react/src/session/SessionViewerLayout.tsx
@@ -44,15 +44,18 @@ export interface SessionViewerLayoutProps {
    */
   readonly splitStorageKey?: string;
   /**
-   * Whether the conversation pane collapses below the `lg` breakpoint
-   * while the panel is open, leaving the panel full-width — the shipped
-   * console behavior on narrow windows.
+   * Whether the conversation pane collapses while the panel is open and
+   * the layout's own box is narrower than 48rem, leaving the panel
+   * full-width — the shipped console behavior in tight quarters.
    *
-   * Pass `false` in fixed-canvas hosts, where the media query is
-   * meaningless or actively wrong: a documentation embed renders in an
-   * iframe whose viewport is the docs column (below `lg` on most pages),
-   * so the default would hide the conversation on exactly the beats that
-   * open the panel.
+   * The narrowness check is a CSS container query against the layout's
+   * box, never the viewport (stigmer/stigmer#301), so it is equally
+   * correct full-window and docked in a narrow pane of a wide window.
+   *
+   * Pass `false` in hosts that must never trade the conversation for the
+   * panel regardless of available space — e.g. a scripted documentation
+   * tour rendered on a narrow fixed canvas, where the collapse would hide
+   * the conversation on exactly the beats that open the panel.
    *
    * @default true
    */

--- a/sdk/react/src/session/__tests__/SessionViewerLayout.test.tsx
+++ b/sdk/react/src/session/__tests__/SessionViewerLayout.test.tsx
@@ -8,8 +8,8 @@ import { SessionViewerLayout } from "../SessionViewerLayout";
 // The contract under test:
 //   - `panel` is the single source of truth for collapsed state
 //   - the conversation never remounts across an open/close toggle
-//   - `responsive={false}` disables the below-`lg` conversation collapse
-//     (fixed-canvas hosts: docs embeds, video export)
+//   - `responsive={false}` disables the narrow-container conversation
+//     collapse (hosts that must never trade the conversation for the panel)
 //   - no `splitStorageKey` means no localStorage read (deterministic hosts)
 // ---------------------------------------------------------------------------
 
@@ -75,17 +75,24 @@ describe("SessionViewerLayout", () => {
     expect(pane.style.width).toBe("420px");
   });
 
-  it("responsive (default): the open-panel conversation pane collapses below lg", () => {
+  // The collapse classes are container-query variants keyed on the split's
+  // own box, never the viewport (stigmer/stigmer#301). These are class-name
+  // pins only — the real layout behavior (a narrow dock inside a wide window
+  // collapsing) is proven in Chromium by ResizableSplit.layout.test.tsx.
+  it("responsive (default): the open-panel conversation pane collapses in a narrow container", () => {
     const { container } = render(
       <SessionViewerLayout conversation={conversation()} panel={panel()} />,
     );
     const pane = screen.getByTestId("conversation").parentElement!;
-    expect(pane.className).toContain("max-lg:hidden");
-    // The separator hides with it, so the panel is the full row below lg.
-    expect(container.querySelectorAll('[class*="max-lg:hidden"]').length).toBe(2);
+    expect(pane.className).toContain("@max-3xl/resizable-split:hidden");
+    // The separator hides with it, so the panel is the full narrow row.
+    expect(
+      container.querySelectorAll('[class*="@max-3xl/resizable-split:hidden"]')
+        .length,
+    ).toBe(2);
   });
 
-  it("responsive={false}: no below-lg collapse anywhere (fixed-canvas hosts)", () => {
+  it("responsive={false}: no narrow-container collapse anywhere (opt-out hosts)", () => {
     const { container } = render(
       <SessionViewerLayout
         conversation={conversation()}
@@ -93,7 +100,12 @@ describe("SessionViewerLayout", () => {
         responsive={false}
       />,
     );
-    expect(container.querySelector('[class*="max-lg:hidden"]')).toBeNull();
+    expect(
+      container.querySelector('[class*="@max-3xl/resizable-split:hidden"]'),
+    ).toBeNull();
+    // No collapse to decide means no CSS container either (the containment
+    // invariant documented in ResizableSplit).
+    expect(container.querySelector('[class*="@container"]')).toBeNull();
   });
 
   it("reads no localStorage without a splitStorageKey (deterministic hosts)", () => {


### PR DESCRIPTION
## Summary

`SessionViewer`'s deliberate narrow-layout behavior — chat steps aside and the workspace panel takes the full width — triggered on the **browser window** (`max-lg:hidden`, 1024px), not on the viewer's own box. Embedded hosts docking the viewer in a 360–640px pane inside a wide window could never reach it: the fixed chat column (min 320px) and sidebar (min 200px) stayed side-by-side and crushed the editor content to a sliver. The collapse now keys on the split's own box via a CSS container query.

Closes #301

## Context

The SDK's embedding contract is container-honesty (`h-full w-full`, the `[data-stgm-root]` sizing seam) — `ResizableSplit`'s media query was the one place the window leaked in. `SessionViewerLayout` is the only `responsiveCollapse` consumer, so fixing the split fixes `SessionViewer`, `NewSessionViewer`, and every host composing the layout, with zero host wiring changes.

## Changes

- `ResizableSplit`: the split root becomes a named CSS container (`@container/resizable-split`, Tailwind v4 native) **only while a collapse is requested**; the three `max-lg:hidden` sites become `@max-3xl/resizable-split:hidden` (fires when the split's own box is under 48rem / 768px).
- `SessionViewerLayout`: `responsive` prop docs rewritten — the default is now container-correct in docks and iframes; the opt-out remains for hosts that must never trade the conversation for the panel (the docs tours keep `responsive={false}`, comment truthed up in `demos/tours/_shared/SessionView.tsx`).
- New real-browser layout suite `ResizableSplit.layout.test.tsx` (Chromium, renders the shipped `dist/styles.css`): the issue's exact repro — a narrow dock inside a pinned-wide (1280px) viewport. Verified to fail 3/6 against the old implementation.
- Class-name pins updated in `SessionViewerLayout.test.tsx`; new `responsiveCollapse` pins in `ResizableSplit.test.tsx` so the fast suite also guards the conditional container marker.

## Implementation notes

- **Why the container is conditional**: `container-type: inline-size` imposes layout containment — it re-parents `position: fixed` descendants and creates a stacking context. The workflow inspector's click-away backdrop (`InspectorHeader`) is an in-tree viewport-covering `fixed` element inside a split pane; a blanket container would shrink it to pane-covering. Gating on `responsiveCollapse` confines containment to the session layout, whose pane trees were audited clean (dialogs are native `<dialog>`/top-layer; floating UI portals out). The invariant is recorded on the conditional and pinned by tests.
- **Why 48rem**: clears the session layout's content minimums (320px min chat + handle + usable workspace panel) and approximately preserves the shipped console's old trigger point (1024px window − ~280px sidebar ≈ 744px box). Deliberately not a prop: container-query conditions cannot read CSS custom properties, so a runtime threshold would need a ResizeObserver mechanism no consumer wants.

## Breaking changes

- None structural. Behavior realignment: a full-window host with no side chrome at 768–1024px window width previously collapsed the chat and now keeps both panes (that box genuinely fits both). The shipped console's real-world trigger point is approximately unchanged.

## Test plan

- New Chromium layout suite: 6/6 green; fails 3/6 against the old viewport-keyed implementation (discrimination proven).
- Full `sdk/react`: 4340/4340 unit + 59/59 browser-mode; typecheck clean; touched files lint-clean; `verify-esm-node` OK.
- Shipped-artifact + pipeline proof: `dist/styles.css` and the web console's compiled Next.js CSS both contain the `@container resizable-split` rules (`npm run build:libs` + full `next build` green).

## Risks

- Hosts relying on the old viewport behavior in the 768–1024px full-window band see both panes instead of a collapse — strictly more usable in a box that fits both. Rollback is a single-commit revert.

## Checklist

- [x] Docs updated (TSDoc + tours comment)
- [x] Tests added/updated
- [x] Backward compatible (no API change; opt-out prop unchanged)

Made with [Cursor](https://cursor.com)