### PR TITLE
fix(runner): restore STIGMER_LLM_REQUEST_TIMEOUT_MS on every Anthropic path (T06)

### DIFF
--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -600,8 +600,11 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     // Step 9: Construct the LLM model. Resolution to the provider API id
     // happens inside buildChatModel; modelName stays the registry id for
     // pricing, the native-thinking heuristic, and sub-agent inheritance.
-    const requestTimeoutMs =
-      parseInt(process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS ?? "0") || undefined;
+    // Operator input: only a positive integer means "bound the request" —
+    // unset, non-numeric, zero, and negative all normalize to no bound.
+    const parsedTimeoutMs =
+      Number.parseInt(process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS ?? "", 10);
+    const requestTimeoutMs = parsedTimeoutMs > 0 ? parsedTimeoutMs : undefined;
     const { model } = await buildChatModel({
       modelName,
       proxyEndpoint: config.proxyEndpoint ?? undefined,

--- a/backend/services/runner/src/shared/__tests__/bedrock-adapter.test.ts
+++ b/backend/services/runner/src/shared/__tests__/bedrock-adapter.test.ts
@@ -13,6 +13,9 @@
  * Pinned here:
  * - the factory forwards LangChain's `maxRetries: 0` to the client (a
  *   factory that drops it nests SDK retries inside LangChain's own loop),
+ * - the factory forwards the request timeout (clientOptions.timeout ->
+ *   factory options -> SDK constructor; how STIGMER_LLM_REQUEST_TIMEOUT_MS
+ *   bounds this backend),
  * - construction and invocation succeed with NO ANTHROPIC_API_KEY (Bedrock
  *   auth is AWS's, and ChatAnthropic waives the key when createClient is
  *   provided),
@@ -28,7 +31,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
 
 const { bedrockCtorArgs, createRequests } = vi.hoisted(() => ({
-  bedrockCtorArgs: [] as Array<{ maxRetries?: number }>,
+  bedrockCtorArgs: [] as Array<{ maxRetries?: number; timeout?: number }>,
   createRequests: [] as Array<Record<string, unknown>>,
 }));
 
@@ -51,7 +54,7 @@ vi.mock("@anthropic-ai/bedrock-sdk", () => ({
       },
     };
 
-    constructor(opts: { maxRetries?: number }) {
+    constructor(opts: { maxRetries?: number; timeout?: number }) {
       bedrockCtorArgs.push(opts);
       this.maxRetries = opts.maxRetries;
     }
@@ -169,6 +172,22 @@ describe("buildChatModel bedrock adapter", () => {
     await model.invoke([new HumanMessage("hi")]);
 
     expect(createRequests.at(-1)?.max_tokens).toBe(canonicalDefault);
+  });
+
+  it("forwards the request timeout to the SDK client (STIGMER_LLM_REQUEST_TIMEOUT_MS path)", async () => {
+    // The timeout rides clientOptions -> factory options -> SDK constructor.
+    // A factory that drops it silently unbounds the operator's timeout on
+    // this backend (the regression T06 repaired for the public path).
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+      timeoutMs: 5000,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(bedrockCtorArgs).toHaveLength(1);
+    expect(bedrockCtorArgs[0].timeout).toBe(5000);
+    expect(bedrockCtorArgs[0].maxRetries).toBe(0);
   });
 
   it("constructs and invokes with no ANTHROPIC_API_KEY anywhere in the environment", async () => {

--- a/backend/services/runner/src/shared/__tests__/foundry-adapter.test.ts
+++ b/backend/services/runner/src/shared/__tests__/foundry-adapter.test.ts
@@ -13,6 +13,9 @@
  *
  * Pinned here:
  * - the factory forwards LangChain's `maxRetries: 0` to the client,
+ * - the factory forwards the request timeout (clientOptions.timeout ->
+ *   factory options -> SDK constructor; how STIGMER_LLM_REQUEST_TIMEOUT_MS
+ *   bounds this backend),
  * - construction and invocation succeed with NO ANTHROPIC_API_KEY (Foundry
  *   auth is Azure's, and ChatAnthropic waives the key when createClient is
  *   provided),
@@ -35,6 +38,7 @@ import { HumanMessage, AIMessage } from "@langchain/core/messages";
 const { foundryCtorArgs, createRequests, identityCalls } = vi.hoisted(() => ({
   foundryCtorArgs: [] as Array<{
     maxRetries?: number;
+    timeout?: number;
     azureADTokenProvider?: () => Promise<string>;
   }>,
   createRequests: [] as Array<Record<string, unknown>>,
@@ -65,6 +69,7 @@ vi.mock("@anthropic-ai/foundry-sdk", () => ({
 
     constructor(opts: {
       maxRetries?: number;
+      timeout?: number;
       azureADTokenProvider?: () => Promise<string>;
     }) {
       foundryCtorArgs.push(opts);
@@ -230,6 +235,22 @@ describe("buildChatModel foundry adapter", () => {
     await model.invoke([new HumanMessage("hi")]);
 
     expect(createRequests.at(-1)?.max_tokens).toBe(canonicalDefault);
+  });
+
+  it("forwards the request timeout to the SDK client (STIGMER_LLM_REQUEST_TIMEOUT_MS path)", async () => {
+    // The timeout rides clientOptions -> factory options -> SDK constructor.
+    // A factory that drops it silently unbounds the operator's timeout on
+    // this backend (the regression T06 repaired for the public path).
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+      timeoutMs: 5000,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(foundryCtorArgs).toHaveLength(1);
+    expect(foundryCtorArgs[0].timeout).toBe(5000);
+    expect(foundryCtorArgs[0].maxRetries).toBe(0);
   });
 
   it("constructs and invokes with no ANTHROPIC_API_KEY anywhere in the environment", async () => {

--- a/backend/services/runner/src/shared/__tests__/model-client.test.ts
+++ b/backend/services/runner/src/shared/__tests__/model-client.test.ts
@@ -163,6 +163,60 @@ describe("buildChatModel", () => {
     expect(apiModelId).toBe("claude-haiku-4.5");
   });
 
+  // ─── Request timeout (STIGMER_LLM_REQUEST_TIMEOUT_MS) ──────────────────────
+  //
+  // The timeout lives in a different slot per wrapper: ChatOpenAI reads it
+  // as a constructor field; ChatAnthropic only honors clientOptions.timeout.
+  // Putting it in the shared constructor spread was the regression that made
+  // the env var inert on every Anthropic path (T02 finding 2, repaired in
+  // T06). The backend factories' half of the chain is pinned in the
+  // vertex/bedrock/foundry adapter tests.
+
+  describe("request timeout", () => {
+    it("places the OpenAI timeout at the constructor level with maxRetries 0", async () => {
+      mockRegistryResponse([
+        { id: "gpt-4.1", apiModelId: "gpt-4.1", provider: "openai" },
+      ]);
+
+      await buildChatModel({ modelName: "gpt-4.1", timeoutMs: 5000 });
+
+      const args = mockOpenAICtor.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(args).toMatchObject({ timeout: 5000, maxRetries: 0 });
+    });
+
+    it("places the Anthropic timeout in clientOptions, never the inert constructor slot", async () => {
+      mockRegistryResponse([
+        { id: "claude-haiku-4.5", apiModelId: "claude-haiku-4-5-20251001", provider: "anthropic" },
+      ]);
+
+      await buildChatModel({ modelName: "claude-haiku-4.5", timeoutMs: 5000 });
+
+      const args = lastAnthropicArgs();
+      expect(args).toMatchObject({ clientOptions: { timeout: 5000 }, maxRetries: 0 });
+      expect(args).not.toHaveProperty("timeout");
+    });
+
+    it("merges the timeout with the proxy wiring inside one clientOptions block", async () => {
+      mockRegistryResponse([
+        { id: "claude-haiku-4.5", apiModelId: "claude-haiku-4-5-20251001", provider: "anthropic" },
+      ]);
+
+      await buildChatModel({
+        modelName: "claude-haiku-4.5",
+        proxyEndpoint: "https://api.stigmer.ai",
+        stigmerToken: "tok-123",
+        timeoutMs: 5000,
+      });
+
+      expect(lastAnthropicArgs()).toMatchObject({
+        clientOptions: {
+          timeout: 5000,
+          baseURL: "https://api.stigmer.ai/v1/proxy/llm/anthropic",
+        },
+      });
+    });
+  });
+
   // ─── Provider backends (STIGMER_ANTHROPIC_BACKEND) ─────────────────────────
 
   describe("vertex backend", () => {

--- a/backend/services/runner/src/shared/__tests__/vertex-adapter.test.ts
+++ b/backend/services/runner/src/shared/__tests__/vertex-adapter.test.ts
@@ -13,6 +13,9 @@
  * Pinned here:
  * - the factory forwards LangChain's `maxRetries: 0` to the client (a
  *   factory that drops it nests SDK retries inside LangChain's own loop),
+ * - the factory forwards the request timeout (clientOptions.timeout ->
+ *   factory options -> SDK constructor; how STIGMER_LLM_REQUEST_TIMEOUT_MS
+ *   bounds this backend),
  * - construction and invocation succeed with NO ANTHROPIC_API_KEY (Vertex
  *   auth is Google's, and ChatAnthropic waives the key when createClient
  *   is provided),
@@ -25,7 +28,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
 
 const { vertexCtorArgs, createRequests } = vi.hoisted(() => ({
-  vertexCtorArgs: [] as Array<{ maxRetries?: number }>,
+  vertexCtorArgs: [] as Array<{ maxRetries?: number; timeout?: number }>,
   createRequests: [] as Array<Record<string, unknown>>,
 }));
 
@@ -48,7 +51,7 @@ vi.mock("@anthropic-ai/vertex-sdk", () => ({
       },
     };
 
-    constructor(opts: { maxRetries?: number }) {
+    constructor(opts: { maxRetries?: number; timeout?: number }) {
       vertexCtorArgs.push(opts);
       this.maxRetries = opts.maxRetries;
     }
@@ -132,6 +135,22 @@ describe("buildChatModel vertex adapter", () => {
       const vertexModel = new ChatAnthropic({ model: toVertexModelId(canonical), apiKey: "probe" });
       expect(vertexModel.maxTokens, canonical).toBe(publicModel.maxTokens);
     }
+  });
+
+  it("forwards the request timeout to the SDK client (STIGMER_LLM_REQUEST_TIMEOUT_MS path)", async () => {
+    // The timeout rides clientOptions -> factory options -> SDK constructor.
+    // A factory that drops it silently unbounds the operator's timeout on
+    // this backend (the regression T06 repaired for the public path).
+    const { model } = await buildChatModel({
+      modelName: "claude-sonnet-4-6",
+      maxTokens: 256,
+      timeoutMs: 5000,
+    });
+    await model.invoke([new HumanMessage("hi")]);
+
+    expect(vertexCtorArgs).toHaveLength(1);
+    expect(vertexCtorArgs[0].timeout).toBe(5000);
+    expect(vertexCtorArgs[0].maxRetries).toBe(0);
   });
 
   it("constructs and invokes with no ANTHROPIC_API_KEY anywhere in the environment", async () => {

--- a/backend/services/runner/src/shared/model-client.ts
+++ b/backend/services/runner/src/shared/model-client.ts
@@ -100,11 +100,14 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   // ChatAnthropic once per cached client (batch + streaming), so the class
   // is captured here, in async context.
   //
-  // Each factory MUST honor options.maxRetries: LangChain owns retrying and
-  // hands the factory maxRetries: 0 — a factory that drops it nests the
-  // SDK's default 2 retries inside LangChain's retry loop, multiplying
-  // every transient failure. Pinned by vertex-seam.test.ts and
-  // bedrock-seam.test.ts. Prerequisites are re-checked here (not only in
+  // Each factory MUST honor options.maxRetries and options.timeout:
+  // LangChain owns retrying and hands the factory maxRetries: 0 — a factory
+  // that drops it nests the SDK's default 2 retries inside LangChain's
+  // retry loop, multiplying every transient failure — and `timeout` arrives
+  // through the same options object (ChatAnthropic spreads clientOptions
+  // into it), so a factory that drops it silently unbounds
+  // STIGMER_LLM_REQUEST_TIMEOUT_MS on that backend. Pinned by the seam
+  // tests. Prerequisites are re-checked here (not only in
   // the factories' preflight) so paths that construct models without a
   // runner factory still fail at dispatch with the catalog message instead
   // of mid-request. Credentials are read natively by each SDK from its
@@ -112,7 +115,9 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   // the credential chain / AWS_BEARER_TOKEN_BEDROCK; Foundry:
   // ANTHROPIC_FOUNDRY_API_KEY, or the Azure credential chain when no key
   // is set).
-  let backendCreateClient: ((options: { maxRetries?: number }) => unknown) | undefined;
+  let backendCreateClient:
+    | ((options: { maxRetries?: number; timeout?: number }) => unknown)
+    | undefined;
   let wireModelId = apiModelId;
   let maxTokens = opts.maxTokens;
   if (anthropicBackend === "vertex") {
@@ -120,14 +125,14 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     if (prereq !== null) throw new Error(prereq);
     const { AnthropicVertex } = await import("@anthropic-ai/vertex-sdk");
     backendCreateClient = (options) =>
-      new AnthropicVertex({ maxRetries: options.maxRetries });
+      new AnthropicVertex({ maxRetries: options.maxRetries, timeout: options.timeout });
     wireModelId = toVertexModelId(apiModelId);
   } else if (anthropicBackend === "bedrock") {
     const prereq = checkBedrockPrerequisites();
     if (prereq !== null) throw new Error(prereq);
     const { AnthropicBedrock } = await import("@anthropic-ai/bedrock-sdk");
     backendCreateClient = (options) =>
-      new AnthropicBedrock({ maxRetries: options.maxRetries });
+      new AnthropicBedrock({ maxRetries: options.maxRetries, timeout: options.timeout });
     wireModelId = toBedrockModelId(apiModelId);
     if (maxTokens === undefined) {
       // LangChain's per-model maxTokens table prefix-matches the model
@@ -167,6 +172,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     backendCreateClient = (options) =>
       new AnthropicFoundry({
         maxRetries: options.maxRetries,
+        timeout: options.timeout,
         ...(azureADTokenProvider ? { azureADTokenProvider } : {}),
       });
     // Unlike the vertex/bedrock ids, the deployment name needs no maxTokens
@@ -195,8 +201,28 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     temperature: opts.temperature ?? 0,
     apiKey,
     ...(maxTokens ? { maxTokens } : {}),
-    ...(opts.timeoutMs ? { maxRetries: opts.maxRetries ?? 0, timeout: opts.timeoutMs } : {}),
+    ...(opts.timeoutMs ? { maxRetries: opts.maxRetries ?? 0 } : {}),
   };
+
+  // The request timeout lives in a different slot per wrapper: ChatOpenAI
+  // reads `timeout` as a constructor field, but ChatAnthropic ignores it
+  // there — its slot is `clientOptions.timeout`, which the wrapper spreads
+  // into the createClient factory options and (on the default factory) the
+  // SDK constructor. This split is what makes STIGMER_LLM_REQUEST_TIMEOUT_MS
+  // bound every path; putting `timeout` in the shared constructor spread is
+  // the exact regression that made it inert for Anthropic (T02 finding 2).
+  // The `maxRetries` half above stays constructor-level for both wrappers:
+  // that is LangChain's own retry knob, distinct from the SDK-level
+  // maxRetries the factories receive.
+  const anthropicClientOptions = {
+    ...(opts.timeoutMs ? { timeout: opts.timeoutMs } : {}),
+    ...(baseUrl ? { baseURL: baseUrl } : {}),
+    ...(headers ? { defaultHeaders: headers } : {}),
+  };
+  const anthropicClientOptionsField =
+    Object.keys(anthropicClientOptions).length > 0
+      ? { clientOptions: anthropicClientOptions }
+      : {};
 
   // The two SDKs name the transport-override block differently (OpenAI:
   // `configuration`, Anthropic: `clientOptions`) — encapsulating that here is
@@ -205,6 +231,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     ? new ChatOpenAI({
         model: apiModelId,
         ...common,
+        ...(opts.timeoutMs ? { timeout: opts.timeoutMs } : {}),
         ...(baseUrl || headers
           ? {
               configuration: {
@@ -219,22 +246,18 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
         // client moves it from the JSON body into its URL path. The waiver
         // in ChatAnthropic (an API key is not required when createClient is
         // provided) is what lets this construct with no ANTHROPIC_API_KEY.
+        // (Backend mode never has a proxy — see the precedence rule above —
+        // so the clientOptions here carry at most the timeout.)
         new ChatAnthropic({
           model: wireModelId,
           ...common,
+          ...anthropicClientOptionsField,
           createClient: backendCreateClient,
         })
       : new ChatAnthropic({
           model: apiModelId,
           ...common,
-          ...(baseUrl || headers
-            ? {
-                clientOptions: {
-                  ...(baseUrl ? { baseURL: baseUrl } : {}),
-                  ...(headers ? { defaultHeaders: headers } : {}),
-                },
-              }
-            : {}),
+          ...anthropicClientOptionsField,
         });
 
   return { model, provider, apiModelId };

--- a/docs/guides/runners/model-backends.mdx
+++ b/docs/guides/runners/model-backends.mdx
@@ -290,6 +290,20 @@ canonical id to whatever you named the deployment in the portal:
 export STIGMER_FOUNDRY_DEPLOYMENT_MAP="claude-sonnet-4-6=my-sonnet-deployment"
 ```
 
+## Bound each model request with a timeout
+
+Set `STIGMER_LLM_REQUEST_TIMEOUT_MS` to cap how long the runner waits for a
+single model response. The bound applies uniformly to the public provider APIs
+and to every backend on this page:
+
+```bash
+export STIGMER_LLM_REQUEST_TIMEOUT_MS=120000   # fail a stuck request after 2 minutes
+```
+
+Leave it unset to use each SDK's default (10 minutes). Values that are not
+positive integers are ignored. A request that exceeds the bound fails as a
+retryable connection timeout that names the model.
+
 ## Troubleshooting
 
 Every failure names the variable or permission to fix. The common ones:


### PR DESCRIPTION
## Summary

`STIGMER_LLM_REQUEST_TIMEOUT_MS` now actually bounds Anthropic model calls again — public API, Stigmer proxy, and all three provider backends (Vertex, Bedrock, Foundry). The variable had been silently inert on every Anthropic path since per-site model construction was consolidated into `buildChatModel` (T02 finding 2). This closes T06 of the multi-cloud provider-backends project; the cross-backend hardening matrix was audited and every other row was already pinned by T02–T05.

## Context

The 2026-05-25 change introduced the variable and configured the SDK client timeout for BOTH providers (so the offline integration harness can fail keyless LLM calls in 5s instead of ~110s). The `buildChatModel` consolidation later moved `timeout` into a constructor spread shared by both wrappers — a slot `ChatOpenAI` reads but `ChatAnthropic` ignores — unbinding every Anthropic call with no error or warning. This is a regression repair, not new behavior.

## Changes

- `model-client.ts`: `timeout` moves out of the shared constructor spread into each wrapper's real slot — `ChatOpenAI` constructor field (unchanged), `ChatAnthropic` `clientOptions.timeout` (merged with the proxy's baseURL/headers when both apply). The vertex/bedrock/foundry factories forward `options.timeout` exactly as they forward `options.maxRetries`; the factory contract comment now names both fields.
- `setup.ts`: boundary normalization — only a positive integer bounds the request; unset, non-numeric, zero, and negative all mean "no bound" (a negative value previously passed through to the SDK).
- Tests: new "request timeout" describe in `model-client.test.ts` (OpenAI slot, Anthropic slot, proxy merge) and one forwarding pin per adapter test (vertex/bedrock/foundry) through the real lazy `createClient` path.
- Docs: first documentation for the variable — "Bound each model request with a timeout" section in `guides/runners/model-backends.mdx`.

## Implementation notes

- Both fix assumptions were probed against the installed packages before coding: all four SDK constructors honor `timeout`, and `clientOptions.timeout` arrives in the `createClient` factory options alongside the wrapper's hardcoded `maxRetries: 0`.
- The LangChain-level `maxRetries` coupling to `timeoutMs` presence is existing behavior and deliberately untouched.
- `call-llm.ts` never passed `timeoutMs` and deliberately still does not — extending the variable to new call sites is a separate product decision.

## Breaking changes

- None. Deployments that set the variable will start seeing real (retryable, classified `LLM_CONNECTION_TIMEOUT`) timeouts on stuck Anthropic calls — the behavior the variable always promised and the docs now state.

## Test plan

- Full runner suite: 4,299 passed / 0 failed (2 load-induced flakes in untouched areas — `golden-e2e` hook timeout, `skill-resolver` session-dir race — both pass in isolation).
- Typecheck, `check-langchain-deps` green.
- `build:slim` + `verify:slim`: PASS on the rebuilt bundle, 84.1 MB ≤ 120 MB. `verify:dist`: PASS.
- Offline integration suite (the variable's one live consumer — the harness passes `5000` in keyless mode): 76 tests, 2 skipped, exit 0 with the bound now enforced on Anthropic paths.
- Docs: Vale 0 errors, Prettier clean on the edited page, docs-YAML gate green.

## Risks

- Low: the change is confined to the model construction seam and pinned per path. Rollback is a single revert; the variable simply returns to being inert on Anthropic.

## Checklist

- [x] Docs updated
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)
- Offline integration suite (the variable's one live consumer — the harness passes `STIGMER_LLM_REQUEST_TIMEOUT_MS=5000` in keyless mode, now actually enforced on Anthropic paths): **76 passed / 0 failed / 2 skipped, exit 0** against the stigmer-cloud fat JAR; no mock-delay calibration issues surfaced.
- Docs inventory gate: 198 pages OK (prose-only edit, no classification change; `site/yarn.lock` side effect restored).
- An independent full-suite run reproduced green: 4,315 passed / 6 skipped, one unrelated load-induced flake (`capture.test.ts`, passes in isolation 29/29).
