### PR TITLE
test(cli): hold Verb.Validate to the verb/dispatch conformance suite

### DIFF
--- a/client-apps/cli/src/registry/registry.test.ts
+++ b/client-apps/cli/src/registry/registry.test.ts
@@ -4,6 +4,7 @@ import { APPLY_HANDLERS } from "../resources/apply/handlers.js";
 import { DELETE_HANDLERS } from "../resources/delete.js";
 import { GET_BINDINGS } from "../resources/get-bindings.js";
 import { LIST_HANDLERS, SEARCH_KINDS } from "../resources/list.js";
+import { VALIDATE_SCHEMAS } from "../resources/validate.js";
 import { defaultRegistry } from "./registry.js";
 import { Verb } from "./verbs.js";
 
@@ -165,6 +166,12 @@ describe("registry — verb/dispatch conformance", () => {
       label: "list",
       verb: Verb.List,
       wired: new Set([...LIST_HANDLERS.keys(), ...SEARCH_KINDS]),
+      specialCases: new Map(),
+    },
+    {
+      label: "validate",
+      verb: Verb.Validate,
+      wired: new Set(VALIDATE_SCHEMAS.keys()),
       specialCases: new Map(),
     },
     {

--- a/client-apps/cli/src/resources/validate.ts
+++ b/client-apps/cli/src/resources/validate.ts
@@ -13,7 +13,11 @@ import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/a
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
 
-const VALIDATE_SCHEMAS: ReadonlyMap<ApiResourceKind, DescMessage> = new Map<ApiResourceKind, DescMessage>([
+// Exported for the verb/dispatch conformance suite (registry/registry.test.ts),
+// which holds this map and the matrix's Verb.Validate promises to strict
+// bidirectional equality — the stigmer/stigmer#353 drift class. Command code
+// resolves schemas through `schemaForValidate`, never this map directly.
+export const VALIDATE_SCHEMAS: ReadonlyMap<ApiResourceKind, DescMessage> = new Map<ApiResourceKind, DescMessage>([
   [ApiResourceKind.agent, AgentSchema],
   [ApiResourceKind.workflow, WorkflowSchema],
   [ApiResourceKind.mcp_server, McpServerSchema],


### PR DESCRIPTION
## Summary

- The verb/dispatch conformance suite (`client-apps/cli/src/registry/registry.test.ts`) was built so the #353 class — the verb matrix promises a verb, the runtime dispatch throws "not implemented" — fails as a red test instead of a runtime surprise. It pins apply/get/list/delete but **omitted validate**, leaving `VALIDATE_SCHEMAS` the one hand-maintained dispatch table not held to the matrix — the exact shape that drifted before #353's fix.
- Adds the validate lane to the existing `DISPATCH` array (`wired: new Set(VALIDATE_SCHEMAS.keys())`, no special cases — every Validate-promising kind has a schema binding) and exports `VALIDATE_SCHEMAS`, matching how the suite already consumes `DELETE_HANDLERS`, `GET_BINDINGS`, and `LIST_HANDLERS`. `schemaForValidate` stays the runtime accessor.
- Test-only + one export; no behavior change. The lane lands green: all five Validate-promising kinds (agent, workflow, mcp_server, project, datastore) pair exactly with the five schema bindings today. This is a pin, not a fix.

Surfaced while closing #306 (duplicate of #353, fixed by 779b6ad17d9722856d564be05e0315ed4c485fc7).

## Test plan

- [x] `client-apps/cli` full suite: 862/862 across 89 files (conformance suite grows 40 → 42: both lane directions)
- [x] `tsc --noEmit` clean in `client-apps/cli`
- [x] Verified in an isolated worktree off `origin/main` (858a50741)

Made with [Cursor](https://cursor.com)