### PR TITLE
ci(docs): exclude login-gated GCP and Azure Foundry console URLs from link checking

### DIFF
--- a/.github/workflows/ci.docs.yaml
+++ b/.github/workflows/ci.docs.yaml
@@ -23,6 +23,7 @@ on:
       - "sdk/embed/**"
       - ".vale.ini"
       - ".prettierrc"
+      - ".lychee.toml"
       - "vale/**"
   push:
     branches: [main]
@@ -39,6 +40,7 @@ on:
       - "sdk/embed/**"
       - ".vale.ini"
       - ".prettierrc"
+      - ".lychee.toml"
       - "vale/**"
   workflow_dispatch:
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -10,6 +10,8 @@ exclude = [
   "https://portal\\.azure\\.com/",
   "https://console\\.aws\\.amazon\\.com/",
   "https://console\\.anthropic\\.com/",
+  "https://console\\.cloud\\.google\\.com/",
+  "https://ai\\.azure\\.com/",
   "https://docs\\.aws\\.amazon\\.com/cognito/",
   "https://api\\.stigmer\\.ai",
   "http://localhost"

--- a/docs/guides/integrations/oauth-architecture.mdx
+++ b/docs/guides/integrations/oauth-architecture.mdx
@@ -150,14 +150,14 @@ When you click **Sign in to connect**, the backend performs three steps:
    parameter, and the scopes from the OAuthApp. For DCR servers, this step also
    discovers the authorization server and registers a client, then probes the
    built authorization URL server-side before returning it. Some vendors accept
-   any redirect URI at registration but enforce a redirect-host allowlist at
-   the authorization endpoint (Canva, for example, requires public callback
-   hosts to be approved through its MCP waitlist). Without the probe, that
-   rejection would only ever appear as a vendor error page inside the popup —
-   the flow would never learn it failed. A definite rejection (HTTP 400) fails
-   the initiate with an explanation of the deployment's callback host; any
-   other response proceeds normally, so an unreachable or bot-protected
-   authorization endpoint never blocks a working sign-in.
+   any redirect URI at registration but enforce a redirect-host allowlist at the
+   authorization endpoint (Canva, for example, requires public callback hosts to
+   be approved through its MCP waitlist). Without the probe, that rejection
+   would only ever appear as a vendor error page inside the popup — the flow
+   would never learn it failed. A definite rejection (HTTP 400) fails the
+   initiate with an explanation of the deployment's callback host; any other
+   response proceeds normally, so an unreachable or bot-protected authorization
+   endpoint never blocks a working sign-in.
 2. **Authorize** — You approve the request in the vendor's authorization page.
    The vendor redirects back with an authorization code.
 3. **Complete** — The backend exchanges the code for tokens using the PKCE


### PR DESCRIPTION
## Summary

Restores `ci.docs` to green on main, which has been red on every push since ~13:56 UTC — and, it turns out, has been masking a second breakage. Three commits, one purpose:

**1. Exclude login-gated vendor consoles from link checking (the trigger).** Every main push fails with:

```
[302] https://console.cloud.google.com/vertex-ai/model-garden | Rejected status code: 302 Found
```

The link (in `docs/guides/runners/model-backends.mdx`, added in `23bd9f4e4`/T02) passed the checker for four consecutive merges; Google's console changed today to answer unauthenticated requests with a 302-to-sign-in. The link itself is correct — the doc step is literally "open the console and enable models". `.lychee.toml` already maintains a commented exclusion list for exactly this class ("vendor dashboard / console URLs always redirect to a login page"): Azure portal, AWS console, and Anthropic console are in it. This adds the two missing vendor consoles:

- `console.cloud.google.com` — fixes the current failure.
- `ai.azure.com` (Azure AI Foundry portal, linked from the same doc) — same class, currently passing, one Microsoft auth-flow change away from the identical breakage. Added proactively.

**2. Trigger `ci.docs` on `.lychee.toml` changes.** The link checker's own config was not in the workflow's path filters (unlike `.vale.ini` and `.prettierrc`, its other lint configs), so config changes never ran the checker — this PR would not have validated itself. Both path lists now include it.

**3. Prettier `oauth-architecture.mdx`.** The broken-window effect in action: #427 merged this doc unformatted at 12:51 UTC while `ci.docs` was already red, so nothing caught it. Pure line-rewrapping (8 lines), no content change. Without this, `ci.docs` stays red even after the Lychee fix.

## Alternatives considered

- Swapping the doc link to a public docs page: rejected — the console deep link is the right operator UX and matches `register-identity-provider.mdx`, which links the Azure/AWS consoles the same way.
- Accepting 302 globally via `accept`: rejected — genuinely moved/broken links (including internal ones) would then pass silently everywhere.

## Test plan

- [x] Reproduced the Lychee failure locally on main with the exact CI invocation (`lychee --config .lychee.toml --root-dir . docs/`): 1 error, same as CI.
- [x] Re-ran after the change: 0 errors, excluded count 9 → 11 (each new pattern catches exactly its intended URL).
- [x] `make format-docs-check` passes locally after the prettier commit.
- [x] `ci.docs` runs on this PR (the path-filter fix is what triggers it) — Links (Lychee) already green on the first push.