### PR TITLE
test(conformance): pin skill push acceptance of Go-default streaming ZIPs (#336)

### DIFF
--- a/test/conformance/src/suites/skill.conformance.test.ts
+++ b/test/conformance/src/suites/skill.conformance.test.ts
@@ -28,7 +28,7 @@ import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
 import { uniqueName } from "../support/naming";
-import { makeSkillArtifact, zipFiles } from "../support/skills";
+import { makeSkillArtifact, makeStreamingSkillArtifact, zipFiles } from "../support/skills";
 import { createTarget, type TargetProfile } from "../targets";
 
 let target: TargetProfile;
@@ -104,6 +104,23 @@ describe("Skill conformance — push & identity", () => {
 
     expect(fetched.metadata?.id).toBe(pushed.metadata?.id);
     expect(fetched.status?.versionHash).toBe(pushed.status?.versionHash);
+  });
+
+  it("accepts a ZIP with stored streaming entries — Go stdlib zip's default shape (#336)", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("skill");
+
+    // Stored entries with data descriptors: what Go's archive/zip emits by
+    // default, i.e. what a Go SDK integrator pushes unless they hand-tune the
+    // writer. A streaming ZIP parser cannot read this shape; a central-directory
+    // parser can. Both editions must accept it (#336: the cloud edition
+    // rejected it while the OSS server accepted it). fflate's zipSync cannot
+    // emit this shape, which is why no other case in this suite covers it.
+    const pushed = await pushSkill(org, makeStreamingSkillArtifact({ name, description: "go-shaped artifact" }));
+
+    expect(pushed.metadata?.name, "identity derives from frontmatter as for any other shape").toBe(name);
+    expect(pushed.metadata?.slug).toBe(name);
+    expect(pushed.status?.versionHash, "version hash is computed over the raw bytes").toMatch(/^[a-f0-9]{64}$/);
   });
 
   it("isolates skills with the same name across orgs", async () => {

--- a/test/conformance/src/support/skills.ts
+++ b/test/conformance/src/support/skills.ts
@@ -64,3 +64,112 @@ function skillMd(opts: SkillArtifactOptions): string {
 export function makeSkillArtifact(opts: SkillArtifactOptions): Uint8Array {
   return zipFiles({ "SKILL.md": skillMd(opts) });
 }
+
+// Builds a ZIP with *stored streaming entries*: method 0 (stored), general-purpose
+// flag bit 3 set, zeroed sizes in the local file header, and a trailing data
+// descriptor carrying the real CRC/sizes. This is byte-for-byte the default output
+// of Go's standard archive/zip writer (zip.Writer.CreateHeader with Method:
+// zip.Store) — the shape a streaming parser cannot read (a stored entry's payload
+// length is only known from the descriptor *after* the payload) but every
+// central-directory reader can. stigmer#336: the cloud edition's JDK ZipInputStream
+// rejected this shape while the Go server accepted it. fflate's zipSync can only
+// emit descriptor-free entries, which is exactly why no test caught the divergence;
+// this builder exists so the parity stays pinned.
+export function zipFilesStreaming(files: Record<string, Uint8Array | string>): Uint8Array {
+  const chunks: number[] = [];
+  const u16 = (v: number) => chunks.push(v & 0xff, (v >>> 8) & 0xff);
+  const u32 = (v: number) =>
+    chunks.push(v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff);
+
+  interface Written {
+    nameBytes: Uint8Array;
+    content: Uint8Array;
+    crc: number;
+    localHeaderOffset: number;
+  }
+  const written: Written[] = [];
+
+  for (const [name, raw] of Object.entries(files)) {
+    const content = typeof raw === "string" ? strToU8(raw) : raw;
+    const nameBytes = strToU8(name);
+    const entry: Written = { nameBytes, content, crc: crc32(content), localHeaderOffset: chunks.length };
+    written.push(entry);
+
+    // Local file header: flag bit 3 set, CRC/sizes zeroed (deferred to the descriptor).
+    u32(0x04034b50);
+    u16(20); // version needed to extract
+    u16(0x0008); // general-purpose flags: data descriptor follows
+    u16(0); // method: stored
+    u16(0); // mod time
+    u16(0); // mod date
+    u32(0); // crc-32 (deferred)
+    u32(0); // compressed size (deferred)
+    u32(0); // uncompressed size (deferred)
+    u16(nameBytes.length);
+    u16(0); // extra field length
+    chunks.push(...nameBytes);
+
+    chunks.push(...content);
+
+    // Data descriptor with the conventional signature (Go writes it).
+    u32(0x08074b50);
+    u32(entry.crc);
+    u32(content.length); // compressed size (stored = raw)
+    u32(content.length); // uncompressed size
+  }
+
+  const centralDirOffset = chunks.length;
+  for (const entry of written) {
+    // Central directory record: the authoritative CRC and sizes.
+    u32(0x02014b50);
+    u16(20); // version made by
+    u16(20); // version needed to extract
+    u16(0x0008);
+    u16(0); // method: stored
+    u16(0); // mod time
+    u16(0); // mod date
+    u32(entry.crc);
+    u32(entry.content.length); // compressed size
+    u32(entry.content.length); // uncompressed size
+    u16(entry.nameBytes.length);
+    u16(0); // extra field length
+    u16(0); // comment length
+    u16(0); // disk number start
+    u16(0); // internal attributes
+    u32(0); // external attributes
+    u32(entry.localHeaderOffset);
+    chunks.push(...entry.nameBytes);
+  }
+  const centralDirSize = chunks.length - centralDirOffset;
+
+  // End of central directory record.
+  u32(0x06054b50);
+  u16(0); // this disk number
+  u16(0); // disk with central directory
+  u16(written.length); // entries on this disk
+  u16(written.length); // total entries
+  u32(centralDirSize);
+  u32(centralDirOffset);
+  u16(0); // comment length
+
+  return Uint8Array.from(chunks);
+}
+
+// A valid skill artifact in the streaming stored shape above — the Go-SDK-default
+// twin of makeSkillArtifact, for edition-parity acceptance tests.
+export function makeStreamingSkillArtifact(opts: SkillArtifactOptions): Uint8Array {
+  return zipFilesStreaming({ "SKILL.md": skillMd(opts) });
+}
+
+// Standard CRC-32 (IEEE 802.3, the ZIP checksum). Implemented inline because
+// fflate does not export its internal implementation.
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data[i]!;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}


### PR DESCRIPTION
## Summary

Edition-parity pin for [#336](https://github.com/stigmer/stigmer/issues/336): a new conformance case pushes a ZIP with **stored streaming entries** — the default output of Go's standard `archive/zip` writer — and asserts it is accepted with the same derived identity as any other artifact. The OSS server has always accepted this shape; the cloud edition rejected it until [stigmer-cloud#316](https://github.com/stigmer/stigmer-cloud/pull/316).

## Context

The divergence shipped because `support/skills.ts` builds every fixture with fflate's `zipSync`, which cannot emit the streaming shape (stored entries, flag bit 3, sizes in a trailing data descriptor) — so no test on either edition ever exercised it. Streaming parsers cannot read that shape; central-directory parsers can. This PR makes the shape a permanent part of the conformance corpus.

## Changes

- `zipFilesStreaming()` + `makeStreamingSkillArtifact()` in `test/conformance/src/support/skills.ts`: hand-crafted local headers / data descriptors / central directory, byte-for-byte the Go `zip.Writer.CreateHeader` + `Method: zip.Store` shape (inline CRC-32 — fflate exports no public implementation).
- New skill-suite case: "accepts a ZIP with stored streaming entries — Go stdlib zip's default shape (#336)".

## Merge ordering

Merge **after** [stigmer-cloud#316](https://github.com/stigmer/stigmer-cloud/pull/316): OSS CI pins `CONFORMANCE_TARGET=local-go` (green with this case today), but a manual `cloud`-target run would be red until the cloud fix deploys.

## Test plan

- `CONFORMANCE_TARGET=local-go`: skill suite 42/42 (41 existing + this case).
- Conformance package typecheck: zero delta (7 pre-existing errors on pristine main, none in touched files).

Made with [Cursor](https://cursor.com)