### PR TITLE
fix(server): repoint workflow head on rollback applies; pin canonical version identity in conformance

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "tag_version_test.go",
         "validate_spec_step_test.go",
         "validate_spec_test.go",
+        "version_repoint_test.go",
         "workflow_controller_test.go",
     ],
     embed = [":controller"],

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/list_versions.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/list_versions.go
@@ -19,6 +19,7 @@ const (
 	listVersionsDefaultPageSize = 50
 	listVersionsMaxPageSize     = 100
 	listVersionsWorkflowIDKey   = "listVersionsWorkflowId"
+	listVersionsHeadHashKey     = "listVersionsHeadHash"
 )
 
 // ListVersions returns the version history for a workflow, identified by org and slug.
@@ -73,6 +74,11 @@ func (s *resolveWorkflowBySlugStep) Execute(ctx *pipeline.RequestContext[*workfl
 	}
 
 	ctx.Set(listVersionsWorkflowIDKey, wf.Metadata.Id)
+	// The live head's hash decides is_current downstream. Under repoint
+	// semantics (a rollback apply re-activates an archived version,
+	// stigmer/stigmer#341) the current version need not be the
+	// newest-archived row, so recency cannot stand in for currency.
+	ctx.Set(listVersionsHeadHashKey, wf.GetStatus().GetVersionHash())
 	return nil
 }
 
@@ -98,14 +104,24 @@ func (s *loadAndMapWorkflowVersionsStep) Execute(ctx *pipeline.RequestContext[*w
 		return grpclib.InternalError(err, "failed to load workflow version history")
 	}
 
+	// is_current = the entry whose hash matches the live head, not the newest
+	// row: a rollback apply repoints the head at an older archived version
+	// without inserting a new row (stigmer/stigmer#341), so recency and
+	// currency legitimately diverge. Legacy data may hold duplicate-hash rows
+	// (predating the repoint semantics); marking only the first match keeps
+	// exactly-one-current true for them too.
+	headHash, _ := ctx.Get(listVersionsHeadHashKey).(string)
+	currentMarked := false
 	entries := make([]*workflowv1.WorkflowVersionEntry, 0, len(records))
-	for i, rec := range records {
+	for _, rec := range records {
 		var wf workflowv1.Workflow
 		if err := proto.Unmarshal(rec.Data, &wf); err != nil {
 			continue
 		}
+		isCurrent := !currentMarked && headHash != "" && wf.GetStatus().GetVersionHash() == headHash
+		currentMarked = currentMarked || isCurrent
 		// Tag comes from the audit column (source of truth), not the snapshot.
-		entries = append(entries, mapWorkflowToVersionEntry(&wf, i == 0, rec.Tag))
+		entries = append(entries, mapWorkflowToVersionEntry(&wf, isCurrent, rec.Tag))
 	}
 
 	// Pagination

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/version_repoint_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/version_repoint_test.go
@@ -1,0 +1,168 @@
+package workflow
+
+import (
+	"testing"
+
+	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflow/validation"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflowinstance"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestWorkflowVersioning_RollbackApplyRepointsHead pins the content-addressed
+// version identity contract (stigmer/stigmer#341) end-to-end against the real
+// store and validator:
+//
+//   - an identical re-apply registers no new version (the changed-gate);
+//   - a changed spec archives exactly one new version;
+//   - re-applying a PRIOR version's spec repoints the head to the existing
+//     audit row instead of inserting a duplicate — the history stays one row
+//     per content, and listVersions marks the repointed-to entry current even
+//     though it is not the newest-archived row.
+//
+// The rollback arm only became reachable with canonical YAML rendering: before
+// it, hashes never repeated, so re-applying old content minted a fresh hash
+// and a duplicate history entry.
+func TestWorkflowVersioning_RollbackApplyRepointsHead(t *testing.T) {
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer s.Close()
+
+	_, workflowInstanceConn, cleanup := setupInProcessServers(t, s)
+	t.Cleanup(cleanup)
+
+	// The real validator, so the pipeline renders real YAML and real hashes —
+	// version registration is a no-op without them.
+	controller := NewWorkflowController(
+		s, workflowinstance.NewClient(workflowInstanceConn), validation.NewInProcessValidator())
+
+	specWith := func(value string) *workflowv1.WorkflowSpec {
+		taskConfig, err := structpb.NewStruct(map[string]interface{}{
+			"variables": map[string]interface{}{"greeting": value},
+		})
+		if err != nil {
+			t.Fatalf("failed to build task config: %v", err)
+		}
+		return &workflowv1.WorkflowSpec{
+			Description: "version repoint test",
+			Document: &workflowv1.WorkflowDocument{
+				Dsl:       "1.0.0",
+				Namespace: "test",
+				Name:      "version-repoint",
+				Version:   "1.0.0",
+			},
+			Tasks: []*workflowv1.WorkflowTask{{
+				Name:       "setVars",
+				Kind:       workflowv1.WorkflowTaskKind_set_vars,
+				TaskConfig: taskConfig,
+			}},
+		}
+	}
+
+	created, err := controller.Create(contextWithWorkflowKind(), &workflowv1.Workflow{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "Workflow",
+		Metadata:   &apiresource.ApiResourceMetadata{Name: "Version Repoint", Org: "test-org"},
+		Spec:       specWith("a"),
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	hashA := created.GetStatus().GetVersionHash()
+	if hashA == "" {
+		t.Fatal("create must compute a version hash")
+	}
+
+	// Identical re-apply: the changed-gate must not register a version.
+	created.Spec = specWith("a")
+	unchanged, err := controller.Update(contextWithWorkflowKind(), created)
+	if err != nil {
+		t.Fatalf("identical update failed: %v", err)
+	}
+	if got := unchanged.GetStatus().GetVersionHash(); got != hashA {
+		t.Fatalf("identical spec must keep the head hash: got %s, want %s", got, hashA)
+	}
+	assertVersionHistory(t, controller, created.Metadata.Slug, []versionExpectation{
+		{hash: hashA, isCurrent: true},
+	})
+
+	// Changed spec: exactly one new version, head advances.
+	unchanged.Spec = specWith("b")
+	atB, err := controller.Update(contextWithWorkflowKind(), unchanged)
+	if err != nil {
+		t.Fatalf("update to spec B failed: %v", err)
+	}
+	hashB := atB.GetStatus().GetVersionHash()
+	if hashB == hashA {
+		t.Fatal("a changed spec must change the version hash")
+	}
+	assertVersionHistory(t, controller, created.Metadata.Slug, []versionExpectation{
+		{hash: hashB, isCurrent: true},
+		{hash: hashA, isCurrent: false},
+	})
+
+	// Rollback: re-apply spec A. Canonical rendering reproduces hashA, which
+	// is already archived — the head must repoint without a duplicate row.
+	atB.Spec = specWith("a")
+	rolledBack, err := controller.Update(contextWithWorkflowKind(), atB)
+	if err != nil {
+		t.Fatalf("rollback update failed: %v", err)
+	}
+	if got := rolledBack.GetStatus().GetVersionHash(); got != hashA {
+		t.Fatalf("rollback must repoint the head to the prior hash: got %s, want %s", got, hashA)
+	}
+	if got := rolledBack.GetMetadata().GetVersion().GetPreviousVersionId(); got != hashB {
+		t.Fatalf("rollback must chain previous_version_id to the replaced head: got %s, want %s", got, hashB)
+	}
+	// Still two entries — newest-archived first — with current on the OLDER
+	// row: recency and currency legitimately diverge under repoint.
+	assertVersionHistory(t, controller, created.Metadata.Slug, []versionExpectation{
+		{hash: hashB, isCurrent: false},
+		{hash: hashA, isCurrent: true},
+	})
+}
+
+type versionExpectation struct {
+	hash      string
+	isCurrent bool
+}
+
+// assertVersionHistory asserts the exact newest-first version history and that
+// exactly one entry is current.
+func assertVersionHistory(t *testing.T, controller *WorkflowController, slug string, want []versionExpectation) {
+	t.Helper()
+
+	resp, err := controller.ListVersions(contextWithWorkflowKind(), &workflowv1.ListWorkflowVersionsInput{
+		Org:  "test-org",
+		Slug: slug,
+	})
+	if err != nil {
+		t.Fatalf("ListVersions failed: %v", err)
+	}
+	if len(resp.Versions) != len(want) {
+		t.Fatalf("version count = %d, want %d", len(resp.Versions), len(want))
+	}
+
+	currentCount := 0
+	for i, entry := range resp.Versions {
+		if entry.VersionHash != want[i].hash {
+			t.Errorf("versions[%d].version_hash = %s, want %s", i, entry.VersionHash, want[i].hash)
+		}
+		if entry.IsCurrent != want[i].isCurrent {
+			t.Errorf("versions[%d].is_current = %v, want %v", i, entry.IsCurrent, want[i].isCurrent)
+		}
+		if entry.IsCurrent {
+			currentCount++
+		}
+		if entry.ValidatedYaml == "" {
+			t.Errorf("versions[%d] must carry its executable YAML", i)
+		}
+	}
+	if currentCount != 1 {
+		t.Errorf("exactly one version must be current, got %d", currentCount)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/version_steps.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/version_steps.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 
 	"github.com/rs/zerolog/log"
 	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
@@ -214,43 +215,67 @@ func (s *saveVersionAuditStep) Execute(ctx *pipeline.RequestContext[*workflowv1.
 		kind = apiresourcekind.ApiResourceKind_workflow
 	}
 
-	// Archive the snapshot tagless. The tag lives only in the audit tag column
-	// (the source of truth), assigned below through the single-holder primitive.
-	// Snapshot blobs are never the tag's home, so a later tag move never rewrites
-	// this immutable content.
-	if err := s.store.SaveAudit(ctx.Context(), kind, workflowID, wf, versionHash, ""); err != nil {
-		log.Error().
-			Err(err).
+	// Rollback applies repoint, never duplicate (stigmer/stigmer#341): when the
+	// caller re-applies a prior version's spec, the canonical rendering
+	// reproduces that version's hash, so the content is already archived.
+	// Versions are content-addressed identities — one content, one history
+	// entry — so the head simply repoints to the existing row (the hash chain
+	// was already set by populateVersionHashStep) and only the tag assignment
+	// below still runs. Inserting again would give the tag single-holder
+	// UPDATE two targets and make hash lookups ambiguous. An unexpected
+	// lookup failure degrades to archiving anyway: a possible duplicate row
+	// beats a failed apply.
+	var existingSnapshot workflowv1.Workflow
+	lookupErr := s.store.GetAuditByHash(ctx.Context(), kind, workflowID, versionHash, &existingSnapshot)
+	alreadyArchived := lookupErr == nil
+	if lookupErr != nil && !errors.Is(lookupErr, store.ErrAuditNotFound) {
+		log.Warn().
+			Err(lookupErr).
 			Str("workflow_id", workflowID).
 			Str("version_hash", truncateHash(versionHash)).
-			Msg("Failed to save workflow version audit — reverting version hash to maintain audit-resolvability invariant")
+			Msg("Could not check for an existing archived version — archiving anyway")
+	}
 
-		// Revert: clear version hash so the persisted workflow doesn't reference
-		// an audit entry that doesn't exist. The workflow is still created/updated
-		// successfully, but without version tracking for this apply.
-		wf.Status.VersionHash = ""
-		if wf.Metadata != nil && wf.Metadata.Version != nil {
-			wf.Metadata.Version.Id = ""
-		}
-		ctx.SetNewState(wf)
+	if !alreadyArchived {
+		// Archive the snapshot tagless. The tag lives only in the audit tag column
+		// (the source of truth), assigned below through the single-holder primitive.
+		// Snapshot blobs are never the tag's home, so a later tag move never rewrites
+		// this immutable content.
+		if err := s.store.SaveAudit(ctx.Context(), kind, workflowID, wf, versionHash, ""); err != nil {
+			log.Error().
+				Err(err).
+				Str("workflow_id", workflowID).
+				Str("version_hash", truncateHash(versionHash)).
+				Msg("Failed to save workflow version audit — reverting version hash to maintain audit-resolvability invariant")
 
-		// When this step runs after the final persist (create path), flush the
-		// reverted state ourselves — there is no downstream persist to do it.
-		if s.persistOnRevert {
-			if perr := s.store.SaveResource(ctx.Context(), kind, workflowID, wf); perr != nil {
-				log.Error().
-					Err(perr).
-					Str("workflow_id", workflowID).
-					Msg("Failed to re-persist workflow after reverting version hash")
+			// Revert: clear version hash so the persisted workflow doesn't reference
+			// an audit entry that doesn't exist. The workflow is still created/updated
+			// successfully, but without version tracking for this apply.
+			wf.Status.VersionHash = ""
+			if wf.Metadata != nil && wf.Metadata.Version != nil {
+				wf.Metadata.Version.Id = ""
 			}
+			ctx.SetNewState(wf)
+
+			// When this step runs after the final persist (create path), flush the
+			// reverted state ourselves — there is no downstream persist to do it.
+			if s.persistOnRevert {
+				if perr := s.store.SaveResource(ctx.Context(), kind, workflowID, wf); perr != nil {
+					log.Error().
+						Err(perr).
+						Str("workflow_id", workflowID).
+						Msg("Failed to re-persist workflow after reverting version hash")
+				}
+			}
+			return nil
 		}
-		return nil
 	}
 
 	// Assign the requested tag through SetAuditTag — the one primitive shared
 	// with the tagVersion RPC — so apply-time tagging obeys the same
-	// single-holder invariant (a tag names exactly one version). The freshly
-	// archived head becomes the tag's sole holder; any prior holder is cleared.
+	// single-holder invariant (a tag names exactly one version). The head
+	// version (freshly archived or repointed-to) becomes the tag's sole
+	// holder; any prior holder is cleared.
 	if tag != "" {
 		if err := s.store.SetAuditTag(ctx.Context(), kind, workflowID, versionHash, tag); err != nil {
 			log.Error().
@@ -269,11 +294,19 @@ func (s *saveVersionAuditStep) Execute(ctx *pipeline.RequestContext[*workflowv1.
 		}
 	}
 
-	log.Info().
-		Str("workflow_id", workflowID).
-		Str("version_hash", truncateHash(versionHash)).
-		Str("tag", tag).
-		Msg("Archived workflow version to audit history")
+	if alreadyArchived {
+		log.Info().
+			Str("workflow_id", workflowID).
+			Str("version_hash", truncateHash(versionHash)).
+			Str("tag", tag).
+			Msg("Version content already archived — repointed head without a new history row")
+	} else {
+		log.Info().
+			Str("workflow_id", workflowID).
+			Str("version_hash", truncateHash(versionHash)).
+			Str("tag", tag).
+			Msg("Archived workflow version to audit history")
+	}
 
 	return nil
 }

--- a/test/conformance/src/suites/workflow.conformance.test.ts
+++ b/test/conformance/src/suites/workflow.conformance.test.ts
@@ -47,6 +47,7 @@ afterAll(async () => {
 
 interface CreateOptions {
   taskVar?: string;
+  variables?: Record<string, string>;
   tag?: string;
   documentName?: string;
 }
@@ -220,6 +221,55 @@ describe("Workflow conformance — version history", () => {
     const history = await clients.workflowQuery.listVersions({ org, slug: created.metadata!.slug });
     expect(history.versions, "re-applying the same spec must not create a version").toHaveLength(1);
     expect(history.totalCount).toBe(1);
+  });
+
+  it("an idempotent apply is order-agnostic: permuted task-config key order registers no version", async () => {
+    // Protobuf map entry order carries no meaning, and real SDKs vary it (Go
+    // randomizes proto map marshal order per apply). protobuf-es serializes
+    // Struct fields in object insertion order, so these two applies reproduce
+    // that wire variance deliberately — the single-key test above can never
+    // exercise it, which is exactly how stigmer/stigmer#341 shipped: the
+    // cloud engine hashed wire-ordered YAML, so every SDK re-apply registered
+    // a phantom version. Both editions must render canonical (key-sorted)
+    // YAML so version identity is a pure function of the spec.
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("wf");
+
+    const created = await applyWorkflow(org, name, { variables: { alpha: "1", beta: "2", gamma: "3" } });
+    await applyWorkflow(org, name, { variables: { gamma: "3", beta: "2", alpha: "1" } }, false);
+
+    const history = await clients.workflowQuery.listVersions({ org, slug: created.metadata!.slug });
+    expect(history.versions, "map key order on the wire must not affect version identity").toHaveLength(1);
+    expect(history.totalCount).toBe(1);
+  });
+
+  it("re-applying a prior version's spec repoints the head without a duplicate row (A→B→A)", async () => {
+    // Content-addressed identity: one content, one history entry. A rollback
+    // apply reproduces the archived version's hash (canonical rendering), so
+    // the head repoints to the existing row instead of appending a duplicate
+    // — which would give the single-holder tag primitive two targets and
+    // make hash lookups ambiguous. Recency and currency legitimately diverge
+    // here: the newest-archived row is B, the current version is A.
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("wf");
+
+    const vA = await applyWorkflow(org, name, { taskVar: "a" });
+    const vB = await applyWorkflow(org, name, { taskVar: "b" }, false);
+    expect(vB.status?.versionHash).not.toBe(vA.status?.versionHash);
+
+    const rolledBack = await applyWorkflow(org, name, { taskVar: "a" }, false);
+    expect(rolledBack.status?.versionHash, "rollback must repoint the head to the archived version's hash").toBe(
+      vA.status?.versionHash,
+    );
+
+    const history = await clients.workflowQuery.listVersions({ org, slug: vA.metadata!.slug });
+    expect(history.versions, "rollback must not append a duplicate history row").toHaveLength(2);
+    expect(history.totalCount).toBe(2);
+    expect(history.versions[0]?.versionHash, "history stays newest-archived-first").toBe(vB.status?.versionHash);
+
+    const current = history.versions.filter((entry) => entry.isCurrent);
+    expect(current, "exactly one version is current").toHaveLength(1);
+    expect(current[0]?.versionHash, "the repointed-to entry is current").toBe(vA.status?.versionHash);
   });
 
   it("applying a changed spec archives a new version (newest-first, exactly one current)", async () => {

--- a/test/conformance/src/support/workflows.ts
+++ b/test/conformance/src/support/workflows.ts
@@ -28,6 +28,15 @@ export interface WorkflowSpecOptions {
   // YAML and therefore the version hash — used to force a new version, or keep
   // it identical to assert idempotency.
   taskVar?: string;
+  // Full set_vars variables map, taking precedence over taskVar. Its OBJECT
+  // INSERTION ORDER is load-bearing: protobuf-es serializes Struct fields in
+  // that order, so permuting keys between two otherwise-identical applies
+  // reproduces the wire-order variance real SDKs (Go randomizes proto map
+  // marshal order) produce — the lever the order-agnostic idempotency pin
+  // pulls (stigmer/stigmer#341). Use non-integer-like keys: JS objects
+  // re-order integer-like keys numerically, silently neutralizing the
+  // permutation.
+  variables?: Record<string, string>;
   // Blueprint env-var declarations projected into spec.env — the least-privilege
   // key whitelist the execution engine filters the merged environment against.
   // Declarations carry no value (that is the instance/runtime job); see envmerge.
@@ -50,7 +59,7 @@ export function makeWorkflowSpec(opts: WorkflowSpecOptions = {}): MessageInitSha
       {
         name: "setVars",
         kind: WorkflowTaskKind.set_vars,
-        taskConfig: { variables: { greeting: opts.taskVar ?? "hello" } },
+        taskConfig: { variables: opts.variables ?? { greeting: opts.taskVar ?? "hello" } },
         export: { as: "${ . }" },
       },
     ],
@@ -69,7 +78,7 @@ export interface WorkflowOptions extends WorkflowSpecOptions {
 
 // A complete, valid Workflow resource ready to hand to create/apply/update.
 export function makeWorkflow(opts: WorkflowOptions): MessageInitShape<typeof WorkflowSchema> {
-  const { org, name, tag, namespace, documentName, taskVar } = opts;
+  const { org, name, tag, namespace, documentName, taskVar, variables } = opts;
   return {
     apiVersion: WORKFLOW_API_VERSION,
     kind: WORKFLOW_KIND,
@@ -82,6 +91,7 @@ export function makeWorkflow(opts: WorkflowOptions): MessageInitShape<typeof Wor
       namespace: namespace ?? org,
       documentName: documentName ?? name,
       taskVar,
+      variables,
     }),
   };
 }


### PR DESCRIPTION
## Summary

Companion to [stigmer/stigmer-cloud#318](https://github.com/stigmer/stigmer-cloud/pull/318), which fixes [#341](https://github.com/stigmer/stigmer/issues/341) (hosted engine registered a new workflow version on every apply of an identical spec — nondeterministic rendered-YAML key order defeated the version-unchanged check). **Merge the cloud PR first.**

Canonical rendering makes rollback applies (A→B→A) reproduce the archived version's hash for the first time, and the editions disagreed on what that should do (OSS appended a duplicate history row; cloud's unique index made the archive throw and strand the head hash). Owner ruling: **repoint, never duplicate** — versions are content-addressed identities.

- `saveVersionAuditStep`: when the hash is already archived (`GetAuditByHash`), skip the insert; the head repoints (hash chain set upstream) and only the tag moves. Duplicate rows would give the single-holder tag `UPDATE` two targets and make `LIMIT 1` hash lookups ambiguous.
- `list_versions`: `is_current` derives from the live head hash, not row recency — under repoint they legitimately diverge. First-match-only keeps exactly-one-current over legacy duplicate-hash rows.
- Conformance, two new edition-agnostic pins:
  1. **Permuted task-config key order registers no version** — proto map wire order is meaningless and Go SDKs randomize it per marshal; the existing idempotency test's single-key fixture could never vary the wire, which is exactly how #341 shipped.
  2. **A→B→A repoint contract** — two history rows, head back on A, exactly one `is_current` on the repointed-to (older) entry.

## Verification

- New `TestWorkflowVersioning_RollbackApplyRepointsHead` (real SQLite store + real validator): identical re-apply skips, changed spec archives, rollback repoints. **Red without the repoint change** (duplicate third row).
- Conformance workflow suite: 28/28 vs local-go; vs the **pre-fix** cloud JAR exactly the two new pins fail (26/28); 28/28 vs the fixed cloud build.
- Full `stigmer-server` module `go test -race`: green except `TestPauseSignal_UpdatesStatusAndRelays` (workflowexecution/temporal), a flake **reproduced on clean main** with no changes applied — issue to be filed separately.

Refs #341 (closed by the cloud PR).

Made with [Cursor](https://cursor.com)