### PR TITLE
fix(sdk/react): make portals fall back to document.body outside StigmerProvider

### DIFF
--- a/docs/sdk/react/core.mdx
+++ b/docs/sdk/react/core.mdx
@@ -106,14 +106,24 @@ function AgentDetail({ id }: { id: string }) {
 
 Returns the managed portal container for the nearest `StigmerProvider`.
 
-SDK components that use `Popover.Portal`, `Dialog.Portal`,
-`Select.Portal`, or `Menu.Portal` pass the returned element as the
+SDK components that use `Popover.Portal`, `Dialog.Portal`, or
+`Menu.Portal` pass the returned value straight through as the
 `container` prop so that portaled content inherits `--stgm-*` design
 tokens (including dark-mode values).
 
-Returns `null` when called outside a `StigmerProvider`, which makes
-Base UI portals fall back to `document.body`. This keeps components
-functional (though un-themed) when used standalone.
+The return value is deliberately three-state, mirroring Base UI's
+`container` prop semantics so no coalescing is needed at call sites:
+
+- `undefined` — no `StigmerProvider` above. Base UI portals fall
+  back to `document.body`, keeping components functional (though
+  un-themed) when used standalone. Never coerce this to `null`:
+  Base UI treats an explicit `null` as "wait for a container" and
+  renders the popup nowhere.
+- `null` — a `StigmerProvider` exists but its themed portal
+  container has not mounted yet (first paint, SSR). Base UI waits
+  for the container instead of flashing un-themed content into
+  `document.body`, then re-portals once it mounts.
+- an `HTMLElement` — the mounted themed container.
 
 Platform builders who create custom portaled components should use
 this hook to target the same container as the built-in SDK components.
@@ -121,7 +131,7 @@ this hook to target the same container as the built-in SDK components.
 **Signature**
 
 ```tsx
-function useStigmerPortalContainer(): HTMLElement | null
+function useStigmerPortalContainer(): HTMLElement | null | undefined
 ```
 
 ```tsx

--- a/sdk/react/src/__tests__/portal-container.test.tsx
+++ b/sdk/react/src/__tests__/portal-container.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { render, renderHook, screen, cleanup } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import type { Stigmer } from "@stigmer/sdk";
+import { StigmerProvider } from "../provider";
+import { useStigmerPortalContainer } from "../portal-container";
+import { Menu, MenuTrigger, MenuContent, MenuItem } from "../internal/menu";
+
+// Regression tests for stigmer-cloud#271: Base UI treats an EXPLICIT
+// `container={null}` as "wait for a container" and renders the popup
+// NOWHERE; only `undefined` falls back to `document.body`. The hook
+// therefore returns a three-state value (undefined / null / element)
+// that call sites pass straight through — see `useStigmerPortalContainer`
+// for the full contract. These tests pin the contract at its single
+// source plus one real consumer rendered standalone.
+
+beforeAll(() => {
+  // happy-dom lacks ResizeObserver, which Base UI positioners observe.
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+  }
+});
+
+afterEach(cleanup);
+
+// A minimal client: the provider eagerly fetches the model/task-kind
+// registries on mount. Returning a null credential keeps that work
+// non-blocking (it polls for a token) so rendering is synchronous and
+// never touches the network during the test.
+function makeClient(): Stigmer {
+  return {
+    baseUrl: "https://example.test",
+    getAuthCredential: async () => null,
+    fetch: (async () => {
+      throw new Error("network disabled in test");
+    }) as unknown as typeof globalThis.fetch,
+  } as unknown as Stigmer;
+}
+
+describe("useStigmerPortalContainer contract", () => {
+  it("returns undefined — never null — outside a StigmerProvider", () => {
+    const { result } = renderHook(() => useStigmerPortalContainer());
+
+    // The load-bearing distinction: `undefined` makes Base UI portals
+    // fall back to `document.body` (standalone components work);
+    // an explicit `null` makes them render NOWHERE. A default of
+    // `null` is exactly the cloud#271 defect.
+    expect(result.current).toBeUndefined();
+    expect(result.current).not.toBeNull();
+  });
+
+  it("returns the mounted themed portal container inside a StigmerProvider", () => {
+    const { result } = renderHook(() => useStigmerPortalContainer(), {
+      wrapper: ({ children }) => (
+        <StigmerProvider client={makeClient()}>{children}</StigmerProvider>
+      ),
+    });
+
+    // After mount the provider publishes its themed container — the
+    // `data-stgm-portal` element appended to document.body.
+    expect(result.current).toBeInstanceOf(HTMLElement);
+    expect(result.current!.hasAttribute("data-stgm-portal")).toBe(true);
+    expect(document.body.contains(result.current!)).toBe(true);
+  });
+});
+
+describe("standalone portal rendering (no StigmerProvider)", () => {
+  it("opens a menu into document.body instead of rendering it nowhere", async () => {
+    // The internal menu wrapper is a real consumer that passes the
+    // hook's value straight through as `container`. Rendered without
+    // any provider, the popup must reach document.body via Base UI's
+    // `undefined` fallback. Against the pre-fix hook (default `null`)
+    // this popup renders nowhere and the query below times out.
+    const { container } = render(
+      <Menu>
+        <MenuTrigger>Open actions</MenuTrigger>
+        <MenuContent>
+          <MenuItem>Rename</MenuItem>
+        </MenuContent>
+      </Menu>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open actions" }));
+
+    const item = await screen.findByRole("menuitem", { name: "Rename" });
+
+    // Portaled for real: in the document, but NOT inside the render
+    // container — Base UI appended it to document.body.
+    expect(document.body.contains(item)).toBe(true);
+    expect(container.contains(item)).toBe(false);
+  });
+});

--- a/sdk/react/src/agent-instance/__tests__/AgentInstanceList.test.tsx
+++ b/sdk/react/src/agent-instance/__tests__/AgentInstanceList.test.tsx
@@ -3,12 +3,6 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { AgentInstanceList } from "../AgentInstanceList";
 
-// The kebab menu portals its content; without a StigmerProvider the portal
-// container is null and nothing mounts — pin it to document.body.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 // Isolate the row-actions behavior under test from the data, environment,
 // visibility, and permission subsystems (each has its own tests).
 const data = vi.hoisted(() => ({

--- a/sdk/react/src/channel/__tests__/AgentChannelsPanel.test.tsx
+++ b/sdk/react/src/channel/__tests__/AgentChannelsPanel.test.tsx
@@ -12,13 +12,6 @@ vi.mock("../../feedback/toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-// The card actions live in a Base UI menu, whose content is portaled to the
-// SDK portal container. Without a StigmerProvider that container is null and
-// the menu renders nothing — pin it to document.body so the menu mounts.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 beforeAll(() => {
   // happy-dom does not implement the native dialog show/close methods.
   HTMLDialogElement.prototype.showModal = function showModal() {

--- a/sdk/react/src/composer/__tests__/SessionComposer-lockAgent.test.tsx
+++ b/sdk/react/src/composer/__tests__/SessionComposer-lockAgent.test.tsx
@@ -5,12 +5,6 @@ import type { Stigmer } from "@stigmer/sdk";
 import { StigmerContext } from "../../context";
 import { ModelRegistryContext } from "../../models/ModelRegistryContext";
 
-// Without a StigmerProvider the portal container is null, and Base UI's
-// Portal renders nothing — pin it to document.body so the popover mounts.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 // Controllable agent-setup state — lets these tests drive the lock × setup
 // matrix directly instead of exercising the full resolution state machine
 // (which is covered by useAgentSetup's own tests).

--- a/sdk/react/src/composer/__tests__/SessionComposer-serviceTier.test.tsx
+++ b/sdk/react/src/composer/__tests__/SessionComposer-serviceTier.test.tsx
@@ -7,13 +7,8 @@ import { ModelRegistryContext } from "../../models/ModelRegistryContext";
 import type { ModelInfo } from "../../models/registry";
 import { SessionComposer } from "../SessionComposer";
 
-// Portal into document.body so the popover mounts under happy-dom, and shim
-// ResizeObserver for Base UI's positioner (the scheduleCreation.test.tsx
-// pattern).
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
+// Shim ResizeObserver for Base UI's positioner (the
+// scheduleCreation.test.tsx pattern).
 beforeAll(() => {
   if (!("ResizeObserver" in globalThis)) {
     (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =

--- a/sdk/react/src/internal/tooltip.tsx
+++ b/sdk/react/src/internal/tooltip.tsx
@@ -40,12 +40,10 @@ function TooltipContent({
   const portalContainer = useStigmerPortalContainer();
 
   return (
-    // `?? undefined`, never a raw null: Base UI treats an EXPLICIT null
-    // container as "wait for one" and renders the popup nowhere, while
-    // undefined falls back to document.body — the standalone behavior
-    // `useStigmerPortalContainer` documents. Without the coalesce, a
-    // tooltip outside a StigmerProvider opens invisibly.
-    <TooltipPrimitive.Portal container={portalContainer ?? undefined}>
+    // Raw pass-through, no coalescing: the hook's three-state return
+    // (undefined / null / element) maps exactly onto Base UI's
+    // `container` semantics — see `useStigmerPortalContainer`.
+    <TooltipPrimitive.Portal container={portalContainer}>
       <TooltipPrimitive.Positioner
         className="isolate z-50 outline-none"
         side={side}

--- a/sdk/react/src/library/__tests__/VisibilitySelector.test.tsx
+++ b/sdk/react/src/library/__tests__/VisibilitySelector.test.tsx
@@ -17,12 +17,6 @@ import {
   blueprintVisibilityLevels,
 } from "../visibilityLevels";
 
-// Without a StigmerProvider the portal container is null, and Base UI's
-// Portal renders nothing — pin it to document.body so the popover mounts.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 // Base UI's Popover positioner observes its anchor; happy-dom lacks
 // ResizeObserver, so provide a no-op shim.
 beforeAll(() => {

--- a/sdk/react/src/mcp-server/__tests__/McpServerDetailView.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/McpServerDetailView.test.tsx
@@ -30,12 +30,6 @@ import { StigmerContext } from "../../context";
 import { McpServerDetailView } from "../McpServerDetailView";
 import type { UseMcpServerReturn } from "../useMcpServer";
 
-// The kebab menu and dialogs portal their content; without a StigmerProvider
-// the portal container is null — pin it to document.body like sibling tests.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 beforeAll(() => {
   // happy-dom lacks ResizeObserver, which Base UI positioners observe.
   if (!("ResizeObserver" in globalThis)) {

--- a/sdk/react/src/models/__tests__/ModelSelector-serviceTier.test.tsx
+++ b/sdk/react/src/models/__tests__/ModelSelector-serviceTier.test.tsx
@@ -4,13 +4,8 @@ import { ModelSelector } from "../ModelSelector";
 import { ModelRegistryContext } from "../ModelRegistryContext";
 import type { ModelInfo } from "../registry";
 
-// Portal into document.body so the popover mounts under happy-dom, and shim
-// ResizeObserver for Base UI's positioner (the scheduleCreation.test.tsx
-// pattern).
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
+// Shim ResizeObserver for Base UI's positioner (the
+// scheduleCreation.test.tsx pattern).
 beforeAll(() => {
   if (!("ResizeObserver" in globalThis)) {
     (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =

--- a/sdk/react/src/portal-container.ts
+++ b/sdk/react/src/portal-container.ts
@@ -15,24 +15,51 @@ import { createContext, useContext } from "react";
  * `className`-scoped token overrides — even though it lives outside the
  * provider's DOM subtree (where the cascade would otherwise not reach it).
  *
- * Defaults to `null` so components rendered outside a `StigmerProvider`
- * fall back to the browser's default portal target (`document.body`).
+ * Three states, chosen to map EXACTLY onto Base UI's `container` prop
+ * semantics so the value can be passed straight through:
+ *
+ * - `undefined` (the default — no `StigmerProvider` above): Base UI
+ *   falls back to `document.body`, so standalone components stay
+ *   functional (though un-themed).
+ * - `null` (published by `StigmerProvider` during its first paint and
+ *   under SSR, before the portal `<div>` mounts): Base UI treats an
+ *   explicit `null` as "wait for a container" — the popup holds off
+ *   for a frame instead of flashing un-themed into `document.body`,
+ *   then re-portals into the themed container the moment it mounts.
+ * - an `HTMLElement` (the mounted themed container): portaled content
+ *   renders inside it and inherits the `--stgm-*` token scope.
+ *
+ * The default MUST stay `undefined`, never `null`: an explicit `null`
+ * makes Base UI portals render NOWHERE, which breaks every popup for
+ * consumers embedding components outside a provider (stigmer-cloud#271).
  *
  * @internal Consumed by SDK components; not part of the public API.
  */
-export const PortalContainerContext = createContext<HTMLElement | null>(null);
+export const PortalContainerContext = createContext<
+  HTMLElement | null | undefined
+>(undefined);
 
 /**
  * Returns the managed portal container for the nearest `StigmerProvider`.
  *
- * SDK components that use `Popover.Portal`, `Dialog.Portal`,
- * `Select.Portal`, or `Menu.Portal` pass the returned element as the
+ * SDK components that use `Popover.Portal`, `Dialog.Portal`, or
+ * `Menu.Portal` pass the returned value straight through as the
  * `container` prop so that portaled content inherits `--stgm-*` design
  * tokens (including dark-mode values).
  *
- * Returns `null` when called outside a `StigmerProvider`, which makes
- * Base UI portals fall back to `document.body`. This keeps components
- * functional (though un-themed) when used standalone.
+ * The return value is deliberately three-state, mirroring Base UI's
+ * `container` prop semantics so no coalescing is needed at call sites:
+ *
+ * - `undefined` — no `StigmerProvider` above. Base UI portals fall
+ *   back to `document.body`, keeping components functional (though
+ *   un-themed) when used standalone. Never coerce this to `null`:
+ *   Base UI treats an explicit `null` as "wait for a container" and
+ *   renders the popup nowhere.
+ * - `null` — a `StigmerProvider` exists but its themed portal
+ *   container has not mounted yet (first paint, SSR). Base UI waits
+ *   for the container instead of flashing un-themed content into
+ *   `document.body`, then re-portals once it mounts.
+ * - an `HTMLElement` — the mounted themed container.
  *
  * Platform builders who create custom portaled components should use
  * this hook to target the same container as the built-in SDK components.
@@ -58,6 +85,6 @@ export const PortalContainerContext = createContext<HTMLElement | null>(null);
  * }
  * ```
  */
-export function useStigmerPortalContainer(): HTMLElement | null {
+export function useStigmerPortalContainer(): HTMLElement | null | undefined {
   return useContext(PortalContainerContext);
 }

--- a/sdk/react/src/schedule/__tests__/scheduleCreation.test.tsx
+++ b/sdk/react/src/schedule/__tests__/scheduleCreation.test.tsx
@@ -21,13 +21,6 @@ import { CadenceField } from "../CadenceField";
 import { ScheduleForm } from "../ScheduleForm";
 import type { CadencePreset } from "../cadence";
 
-// Without a StigmerProvider the portal container is null, and Base UI's
-// Portal renders nothing — pin it to document.body so the agent-picker
-// popover mounts.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 // Base UI's Popover positioner observes its anchor; happy-dom lacks
 // ResizeObserver, so provide a no-op shim.
 beforeAll(() => {

--- a/sdk/react/src/sharing/__tests__/AgentShareList.test.tsx
+++ b/sdk/react/src/sharing/__tests__/AgentShareList.test.tsx
@@ -14,13 +14,6 @@ vi.mock("../../feedback/toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-// The row actions live in a Base UI menu, whose content is portaled to the
-// SDK portal container. Without a StigmerProvider that container is null and
-// the menu renders nothing — pin it to document.body so the menu mounts.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 beforeAll(() => {
   // happy-dom does not implement the native dialog show/close methods.
   HTMLDialogElement.prototype.showModal = function showModal() {

--- a/sdk/react/src/sidebar/__tests__/SettingsSidebar.test.tsx
+++ b/sdk/react/src/sidebar/__tests__/SettingsSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { createRouterTransport } from "@connectrpc/connect";
@@ -8,10 +8,6 @@ import { OrgProvider } from "../../organization/OrgProvider";
 import { SETTINGS_NAV_GROUPS } from "../../settings/settings-nav";
 import { SettingsSidebar } from "../SettingsSidebar";
 import type { RenderSidebarLink } from "../types";
-
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
 
 beforeAll(() => {
   if (!("ResizeObserver" in globalThis)) {

--- a/sdk/react/src/sidebar/__tests__/WorkspaceSidebar.test.tsx
+++ b/sdk/react/src/sidebar/__tests__/WorkspaceSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { render, screen, cleanup, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { create } from "@bufbuild/protobuf";
@@ -13,13 +13,6 @@ import { OrgProvider } from "../../organization/OrgProvider";
 import { WorkspaceSidebar } from "../WorkspaceSidebar";
 import type { RecentActivityEntry } from "../../activity/types";
 import type { RenderSidebarLink } from "../types";
-
-// Tooltips and the org switcher menu portal their content; without a
-// StigmerProvider the portal container is null — pin it to document.body
-// like sibling tests.
-vi.mock("../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
 
 beforeAll(() => {
   // happy-dom lacks ResizeObserver, which Base UI positioners observe.

--- a/sdk/react/src/workflow/instance/__tests__/WorkflowInstanceList.test.tsx
+++ b/sdk/react/src/workflow/instance/__tests__/WorkflowInstanceList.test.tsx
@@ -3,12 +3,6 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { WorkflowInstanceList } from "../WorkflowInstanceList";
 
-// The kebab menu portals its content; without a StigmerProvider the portal
-// container is null and nothing mounts — pin it to document.body.
-vi.mock("../../../portal-container", () => ({
-  useStigmerPortalContainer: () => document.body,
-}));
-
 // Isolate the row-actions behavior under test from the data, environment,
 // visibility, and permission subsystems (each has its own tests).
 const data = vi.hoisted(() => ({


### PR DESCRIPTION
## Summary

Base UI treats an explicit `container={null}` as "wait for a container" and renders the popup **nowhere**; only `undefined` falls back to `document.body`. `useStigmerPortalContainer()` defaulted to `null`, so all 12 SDK portal sites (menus, popovers, the org-switcher dialog) opened invisibly for consumers embedding components outside a `StigmerProvider`.

## Context

Fixes [stigmer-cloud#271](https://github.com/stigmer/stigmer-cloud/issues/271). The issue sketched a per-wrapper `?? undefined` fix (the shape shipped for the tooltip on 2026-08-08), but that coalesce is subtly wrong *inside* a provider: `StigmerProvider` legitimately publishes `null` during first paint and SSR (the themed portal `<div>` mounts in an effect), and Base UI's "wait for the container" behavior there is desirable — it prevents an un-themed flash into `document.body` and re-portals the moment the themed container mounts (verified in the installed Base UI source; the portal watches its `container` prop). The real defect: two different states — "no provider, ever" and "provider still mounting" — shared the value `null`.

## Changes

- **`portal-container.ts`**: the context is now three-state, mapping exactly onto Base UI's `container` semantics — `undefined` (default; no provider → `document.body`), `null` (provider mounting/SSR → wait for the themed container), element (mounted themed container). The JSDoc is the single authoritative home for the contract (it also feeds the generated docs).
- **Zero call-site edits**: all 12 portal sites already pass the hook's value straight through, which is now correct by construction — including for platform builders following the documented pattern.
- **`internal/tooltip.tsx`**: reverted to raw pass-through; its `?? undefined` workaround traded away the wait-for-themed-container behavior.
- **Removed the 12 identical `vi.mock("../../portal-container")` workarounds** that masked this defect — those suites (139 tests) now exercise the real hook while rendering standalone, doubling as real standalone-portal coverage across the popover and menu families.
- **New `portal-container.test.tsx`**: hook contract pins (undefined outside / themed element inside a provider) plus a standalone menu render pin.
- **`docs/sdk/react/core.mdx`**: regenerated from the corrected JSDoc (documents the three states; drops the phantom `Select.Portal` mention).

## Implementation notes

- Public API note: the hook's return type widens from `HTMLElement | null` to `HTMLElement | null | undefined`. `container={...}` usage keeps compiling everywhere (Base UI's prop accepts the full union); both repos audited — no strict-null comparisons against the hook exist.
- Negative control proven: with the pre-fix hook restored, the new contract test fails (hook returns `null`) and the standalone menu pin fails exactly as filed (trigger renders, popup renders nowhere).

## Breaking changes

- None at runtime. Type-level only: consumers assigning the hook's result to a strictly-typed `HTMLElement | null` variable need to widen it.

## Test plan

- Full `sdk/react` suite: 393 files / 4343 tests green (includes the 12 de-masked suites).
- Real-browser layout suite: 59/59 green (tooltip reveal pins ride the raw pass-through).
- `tsc --noEmit` clean; eslint 0 errors; `make gen-react-sdk-docs-check` green (re-verified after the pre-commit prettier pass).

## Risks

- Low: single-file semantic change, provider behavior byte-identical after mount. Rollback is a one-commit revert.

Closes stigmer/stigmer-cloud#271

Made with [Cursor](https://cursor.com)