### PR TITLE
fix(sdk-react): scope the form-control preflight under .stgm for preflight-less hosts

### DIFF
--- a/sdk/react/src/__tests__/preflight-parity.layout.test.tsx
+++ b/sdk/react/src/__tests__/preflight-parity.layout.test.tsx
@@ -1,0 +1,156 @@
+// Preflight-parity regression suite for form controls (#374).
+//
+// Runs in a real Chromium via `vitest.a11y.config.ts` — the defect under
+// guard is the user agent's OWN default control styling (buttonface
+// background, built-in padding, UA font stack), which only a real browser
+// applies. happy-dom has no UA stylesheet, so it would pass vacuously.
+//
+// The contract: every SDK component is authored against Tailwind's preflight
+// baseline (our consoles run it globally). In a host WITHOUT a preflight —
+// third-party embeds, the packed demo tours — the scoped form-control
+// preflight in `styles.css` must reproduce that baseline under `.stgm`, or
+// every unstyled-by-intent button renders as a grey UA box (the #374
+// screenshots). Like the sibling layout suites (DD-21), this renders against
+// the SHIPPED stylesheet (`dist/styles.css`, rebuilt by `npm run build:css`)
+// and nothing else — exactly what an embed loads.
+//
+// Two directions, both load-bearing:
+// 1. UA defaults neutralized: bare controls show no buttonface box, no UA
+//    padding, no UA font.
+// 2. Utilities still win: the preflight lives in `@layer base`, so `bg-*`
+//    and `p-*` utilities on themed components must beat it. This half is
+//    what fails if the block ever migrates to a layer above `utilities`
+//    (the exact mistake that shipped three times with the border reset —
+//    see styles-border-layer-invariant.test.ts for the host-compiled twin).
+
+import "../../dist/styles.css";
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import type { Stigmer } from "@stigmer/sdk";
+import { StigmerProvider } from "../provider";
+import { Button } from "../button/Button.js";
+import { UNSTYLED_BUTTON } from "../internal/form-primitives.js";
+
+afterEach(cleanup);
+
+// A minimal client (the provider-container suite's idiom): a null credential
+// keeps the provider's registry fetches non-blocking so rendering is
+// synchronous and never touches the network.
+function makeClient(): Stigmer {
+  return {
+    baseUrl: "https://example.test",
+    getAuthCredential: async () => null,
+    fetch: (async () => {
+      throw new Error("network disabled in test");
+    }) as unknown as typeof globalThis.fetch,
+  } as unknown as Stigmer;
+}
+
+/**
+ * Renders `ui` inside the provider, wrapped in a probe `<div>` with a
+ * distinctive font so inheritance is detectable: a control that inherits
+ * (`font: inherit`) computes to Georgia; one still wearing the UA button
+ * font does not.
+ */
+function renderScoped(ui: React.ReactNode): HTMLElement {
+  render(
+    <StigmerProvider client={makeClient()}>
+      <div data-testid="probe" style={{ fontFamily: "Georgia, serif" }}>
+        {ui}
+      </div>
+    </StigmerProvider>,
+  );
+  return document.querySelector('[data-testid="probe"]') as HTMLElement;
+}
+
+function computed(el: Element): CSSStyleDeclaration {
+  return getComputedStyle(el);
+}
+
+const TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+describe("scoped form-control preflight (#374)", () => {
+  describe("UA defaults are neutralized under .stgm", () => {
+    it("a bare button loses the buttonface box, UA padding, and UA font", () => {
+      const probe = renderScoped(<button type="button">bare</button>);
+      const style = computed(probe.querySelector("button")!);
+
+      expect(style.backgroundColor, "UA buttonface background must be cleared").toBe(TRANSPARENT);
+      // Chromium's UA button padding is 1px 6px — all four sides must be 0.
+      expect(
+        [style.paddingTop, style.paddingRight, style.paddingBottom, style.paddingLeft],
+        "UA button padding must be zeroed",
+      ).toEqual(["0px", "0px", "0px", "0px"]);
+      expect(style.fontFamily, "button font must inherit, not the UA stack").toBe(
+        computed(probe).fontFamily,
+      );
+      expect(style.borderTopLeftRadius).toBe("0px");
+    });
+
+    it("an unstyled-by-intent tile button (the #371 shape) renders content-only", () => {
+      // The exact pattern the issue screenshotted: an image tile whose only
+      // classes are UNSTYLED_BUTTON + geometry.
+      const probe = renderScoped(
+        <button type="button" className={`${UNSTYLED_BUTTON} relative block h-14 w-14 rounded-md`}>
+          tile
+        </button>,
+      );
+      const style = computed(probe.querySelector("button")!);
+
+      expect(style.backgroundColor).toBe(TRANSPARENT);
+      expect(style.paddingLeft).toBe("0px");
+      expect(style.cursor, "UNSTYLED_BUTTON supplies the pointer cursor").toBe("pointer");
+      // Geometry utilities keep working on top of the reset.
+      expect(style.width).toBe("56px");
+      expect(style.borderTopLeftRadius).not.toBe("0px");
+    });
+
+    it("bare input, textarea, and select lose UA backgrounds and inherit the font", () => {
+      const probe = renderScoped(
+        <>
+          <input readOnly value="i" />
+          <textarea readOnly value="t" />
+          <select defaultValue="o">
+            <option value="o">o</option>
+          </select>
+        </>,
+      );
+
+      for (const tag of ["input", "textarea", "select"] as const) {
+        const style = computed(probe.querySelector(tag)!);
+        expect(style.backgroundColor, `${tag} UA background must be cleared`).toBe(TRANSPARENT);
+        expect(style.fontFamily, `${tag} font must inherit`).toBe(computed(probe).fontFamily);
+      }
+      expect(
+        computed(probe.querySelector("textarea")!).resize,
+        "textareas resize vertically only (preflight parity)",
+      ).toBe("vertical");
+    });
+  });
+
+  describe("utilities still beat the preflight (the base-vs-utilities invariant, on the shipped artifact)", () => {
+    it("the themed Button keeps its background and padding", () => {
+      const probe = renderScoped(<Button variant="primary">go</Button>);
+      const style = computed(probe.querySelector("button")!);
+
+      // `bg-primary` must survive the preflight's background-color:
+      // transparent — this is the assertion that fails if the form-control
+      // block ever lands in a layer above `utilities`.
+      expect(style.backgroundColor, "bg-primary must win over the preflight").not.toBe(
+        TRANSPARENT,
+      );
+      // size "sm" = px-3 py-1.5 → 12px / 6px.
+      expect(style.paddingLeft, "p-* utilities must win over the preflight").toBe("12px");
+      expect(style.paddingTop).toBe("6px");
+    });
+
+    it("the ghost Button is transparent by design and stays that way", () => {
+      // Ghost sets NO bg-* utility: pre-#374 it silently wore the UA
+      // buttonface grey in embeds. Transparent here proves the preflight is
+      // what ghost was implicitly depending on all along.
+      const probe = renderScoped(<Button variant="ghost">go</Button>);
+      expect(computed(probe.querySelector("button")!).backgroundColor).toBe(TRANSPARENT);
+    });
+  });
+});

--- a/sdk/react/src/__tests__/styles-border-layer-invariant.test.ts
+++ b/sdk/react/src/__tests__/styles-border-layer-invariant.test.ts
@@ -102,4 +102,44 @@ describe("styles.css border-layer invariant (host-compiled)", () => {
       `expected @layer base (#${baseIdx}) to precede @layer utilities (#${utilitiesIdx}); order was [${layerOrder.join(", ")}]`,
     ).toBeLessThan(utilitiesIdx);
   });
+
+  // The form-control preflight (#374) has the same one dangerous failure mode
+  // as the border reset: land it in any layer above `utilities` and it
+  // silently overrides every `bg-*`/`p-*` utility on every button in the SDK.
+  // Same harness, same invariant — pinned separately because the rule is
+  // found by a different fingerprint (background-color on `.stgm button`).
+  it("emits the .stgm form-control preflight in `base`, below the `utilities` layer", async () => {
+    const css = await compileHostContext();
+    const root = postcss.parse(css);
+
+    let controlRule: Rule | null = null;
+    root.walkRules((rule) => {
+      if (!rule.selector.includes(".stgm button")) return;
+      const clearsBackground = rule.some(
+        (decl) =>
+          decl.type === "decl" &&
+          decl.prop === "background-color" &&
+          decl.value.trim() === "transparent",
+      );
+      if (clearsBackground) controlRule = rule;
+    });
+    expect(
+      controlRule,
+      "the .stgm form-control preflight (background-color: transparent on .stgm button) was not found",
+    ).not.toBeNull();
+    expect(
+      enclosingLayer(controlRule!),
+      "the .stgm form-control preflight must live in @layer base (a layer above `utilities` silently overrides every bg-*/p-* utility on every button in the SDK)",
+    ).toBe("base");
+
+    // The block must cover all five control elements, not just button —
+    // an accidental selector trim would silently re-expose the UA defaults
+    // on inputs/textareas in preflight-less hosts.
+    for (const control of ["input", "select", "optgroup", "textarea"]) {
+      expect(
+        controlRule!.selector,
+        `the form-control preflight selector must include .stgm ${control}`,
+      ).toContain(`.stgm ${control}`);
+    }
+  });
 });

--- a/sdk/react/src/attachment/AttachmentChipList.tsx
+++ b/sdk/react/src/attachment/AttachmentChipList.tsx
@@ -225,8 +225,8 @@ function ImageAttachmentChip({
       {/* The whole tile is the preview target. Preview stays enabled while
           `disabled` (that prop gates the mutating remove/retry actions) and
           in every phase: the object URL wraps in-memory bytes, no fetch.
-          UNSTYLED_BUTTON is load-bearing: without it the tile shows the
-          UA's default button box in preflight-less hosts (see the constant). */}
+          UNSTYLED_BUTTON adds the pointer cursor — the image tile carries
+          no other clickability cue. */}
       <button
         type="button"
         onClick={onPreview}
@@ -271,7 +271,7 @@ function ImageAttachmentChip({
           aria-label={`Retry uploading ${entry.file.name}`}
           className={cn(
             UNSTYLED_BUTTON,
-            "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-destructive px-1.5 py-0.5 text-[0.6rem] font-medium leading-none text-destructive-foreground shadow-sm [font-family:inherit] hover:bg-destructive-hover disabled:pointer-events-none",
+            "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-destructive px-1.5 py-0.5 text-[0.6rem] font-medium leading-none text-destructive-foreground shadow-sm hover:bg-destructive-hover disabled:pointer-events-none",
           )}
         >
           Retry
@@ -363,7 +363,7 @@ function RetryButton({
       disabled={disabled}
       className={cn(
         UNSTYLED_BUTTON,
-        "shrink-0 text-[0.6rem] font-medium text-destructive underline [font-family:inherit] hover:text-destructive-muted disabled:pointer-events-none",
+        "shrink-0 text-[0.6rem] font-medium text-destructive underline hover:text-destructive-muted disabled:pointer-events-none",
       )}
       aria-label={`Retry uploading ${filename}`}
     >

--- a/sdk/react/src/attachment/AttachmentImageLightbox.tsx
+++ b/sdk/react/src/attachment/AttachmentImageLightbox.tsx
@@ -101,13 +101,11 @@ export function AttachmentImageLightbox({
             >
               {filename}
             </span>
-            {/* `bg-transparent` neutralizes the UA button box in
-                preflight-less hosts (see UNSTYLED_BUTTON in the chip list). */}
             <button
               type="button"
               onClick={onClose}
               aria-label="Close image preview"
-              className="shrink-0 cursor-pointer rounded bg-transparent p-0.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="shrink-0 cursor-pointer rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <CloseIcon />
             </button>

--- a/sdk/react/src/conversation/ConversationMediaAttachment.tsx
+++ b/sdk/react/src/conversation/ConversationMediaAttachment.tsx
@@ -115,8 +115,8 @@ function MediaImageThumbnail({
 
   return (
     <>
-      {/* UNSTYLED_BUTTON is load-bearing: without it the thumbnail shows
-          the UA's default button box in preflight-less hosts. */}
+      {/* UNSTYLED_BUTTON adds the pointer cursor — the media thumbnail
+          carries no other clickability cue. */}
       <button
         type="button"
         onClick={() => setPreviewOpen(true)}
@@ -201,7 +201,7 @@ function MediaDocumentChip({
           aria-label={`Open ${name}`}
           className={cn(
             UNSTYLED_BUTTON,
-            "flex min-w-0 items-center gap-1.5 rounded-sm text-inherit [font:inherit] hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "flex min-w-0 items-center gap-1.5 rounded-sm hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             isOpening && "opacity-70",
           )}
         >

--- a/sdk/react/src/execution/MessageAttachments.tsx
+++ b/sdk/react/src/execution/MessageAttachments.tsx
@@ -173,9 +173,9 @@ function ImagePreviewChip({
 
   return (
     <span role="listitem" aria-label={name} title={name} className="inline-flex">
-      {/* The whole tile is the preview target. UNSTYLED_BUTTON is
-          load-bearing: without it the tile shows the UA's default button
-          box in preflight-less hosts (see the constant). */}
+      {/* The whole tile is the preview target. UNSTYLED_BUTTON adds the
+          pointer cursor — the image tile carries no other clickability
+          cue. */}
       <button
         type="button"
         onClick={onPreview}
@@ -270,7 +270,7 @@ function DocumentChip({
           aria-label={`Download ${name}`}
           className={cn(
             UNSTYLED_BUTTON,
-            "flex min-w-0 items-center gap-1 rounded-sm text-inherit [font:inherit] hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "flex min-w-0 items-center gap-1 rounded-sm hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             isDownloading && "opacity-70",
           )}
         >

--- a/sdk/react/src/internal/form-primitives.tsx
+++ b/sdk/react/src/internal/form-primitives.tsx
@@ -9,18 +9,20 @@ import { cn } from "@stigmer/theme";
 // ---------------------------------------------------------------------------
 
 /**
- * Neutralizes the UA's default `<button>` styling (buttonface background,
- * padding, default cursor). The SDK's scoped preflight in `styles.css`
- * resets only borders/box-sizing; in the console and desktop app the host's
- * global Tailwind preflight covers the rest, but a preflight-less host
- * (docs tours, third-party embeds) would otherwise render every bare button
- * as a gray UA box. Font is NOT reset here — callers that render text set
- * `[font:inherit]` or explicit text utilities themselves.
+ * Pointer cursor for buttons that are styled entirely by their content
+ * (chips, image tiles, icon-only affordances) — surfaces where nothing else
+ * signals clickability.
  *
- * Applies to buttons that are styled entirely by their content (chips,
- * icon-only affordances), not to the themed button components.
+ * This used to also carry `bg-transparent p-0` as a stopgap for
+ * preflight-less hosts; the scoped form-control preflight in `styles.css`
+ * (#374) now neutralizes the UA button box (background, padding, font) for
+ * every button under `.stgm`, so only the cursor remains. The cursor stays
+ * a per-component choice rather than a preflight rule on purpose: Tailwind's
+ * preflight leaves buttons with the default arrow cursor, and the scoped
+ * preflight mirrors it byte-for-byte so embeds render exactly like the
+ * consoles.
  */
-export const UNSTYLED_BUTTON = "cursor-pointer bg-transparent p-0";
+export const UNSTYLED_BUTTON = "cursor-pointer";
 
 /** Standard text-input styling for the operator consoles. */
 export const INPUT_CLASSES = cn(

--- a/sdk/react/src/styles.css
+++ b/sdk/react/src/styles.css
@@ -147,6 +147,100 @@
     border-style: solid;
     border-color: var(--stgm-border, currentColor);
   }
+
+  /* Scoped form-control preflight (#374). Every SDK component is authored
+     against Tailwind's preflight baseline — our own consoles run it globally,
+     so ghost/outline buttons, icon buttons, and chip actions carry no `bg-*`,
+     `p-*`, or font utilities and silently depend on the host having zeroed
+     the UA's `buttonface` box. A host WITHOUT a global preflight (third-party
+     embeds, the packed demo tours) rendered every such control as a grey UA
+     default box. These rules reproduce, under `.stgm`, the form-control
+     subset of `tailwindcss/preflight.css` — copied VERBATIM, value for
+     value. That byte-parity is load-bearing twice over:
+
+     - In a preflight host the same values already apply globally in this
+       same `base` layer, so the scoped copy is a no-op by construction
+       (the `.stgm`-prefixed selector has higher specificity within `base`,
+       which only matters if the values ever diverge — do not let them).
+     - In a preflight-less host, SDK surfaces render exactly what the
+       components were designed against in the consoles.
+
+     Like the border reset above, these MUST stay in `base`: one layer
+     higher and they silently override every `bg-*`/`p-*` utility on every
+     button in the SDK (the utilities are emitted into `utilities`/`stgm`).
+
+     Deliberately NOT ported from preflight: the universal margin/padding
+     zero and the typography resets. In the documented quickstart the host
+     wraps its whole app in `StigmerProvider`, i.e. inside `.stgm` — those
+     rules would strip a non-Tailwind host's own content styling (paragraph
+     margins, heading sizes). Form controls carry the same bounded,
+     already-accepted trade-off as the border reset above. The margin/
+     padding zero below is preflight's universal rule narrowed to the
+     controls it exists to fix. Normalization rules for input types the SDK
+     never renders (date/time/search chrome, -moz-ui-invalid) are also
+     omitted — add them verbatim if such an input ever ships. */
+  .stgm button,
+  .stgm input,
+  .stgm select,
+  .stgm optgroup,
+  .stgm textarea,
+  .stgm ::file-selector-button {
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+
+  /* Correct the inability to style the border radius in iOS Safari. */
+  .stgm button,
+  .stgm input:where([type="button"], [type="reset"], [type="submit"]),
+  .stgm ::file-selector-button {
+    appearance: button;
+  }
+
+  /* Restore default font weight (the block above inherits it away). */
+  .stgm :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+
+  /* Restore space after button. */
+  .stgm ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+
+  /* Reset the default placeholder opacity in Firefox.
+     (https://github.com/tailwindlabs/tailwindcss/issues/3300) */
+  .stgm ::placeholder {
+    opacity: 1;
+  }
+
+  /* Set the default placeholder color to a semi-transparent version of the
+     current text color in browsers that do not crash when using
+     `color-mix(…)` with `currentcolor`.
+     (https://github.com/tailwindlabs/tailwindcss/issues/17194) */
+  @supports (not (-webkit-appearance: -apple-pay-button)) /* Not Safari */ or
+    (contain-intrinsic-size: 1px) /* Safari 17+ */ {
+    .stgm ::placeholder {
+      color: color-mix(in oklab, currentcolor 50%, transparent);
+    }
+  }
+
+  /* Prevent resizing textareas horizontally by default. */
+  .stgm textarea {
+    resize: vertical;
+  }
+
+  /* Correct the cursor style of increment and decrement buttons in Safari. */
+  .stgm ::-webkit-inner-spin-button,
+  .stgm ::-webkit-outer-spin-button {
+    height: auto;
+  }
 }
 
 @layer stgm {

--- a/sdk/react/src/workspace/FileViewer.tsx
+++ b/sdk/react/src/workspace/FileViewer.tsx
@@ -538,8 +538,8 @@ function ImageFileContent({
       )}
       <div className="flex flex-col items-center gap-2 p-4">
         {url ? (
-          // UNSTYLED_BUTTON is load-bearing: without it the button shows the
-          // UA's default box in preflight-less hosts (see the constant).
+          // UNSTYLED_BUTTON adds the pointer cursor — the image preview
+          // carries no other clickability cue.
           <button
             type="button"
             onClick={() => setLightboxOpen(true)}


### PR DESCRIPTION
## Summary
Extends the SDK's scoped preflight in `sdk/react/src/styles.css` to cover form controls (`button`, `input`, `select`, `optgroup`, `textarea`), mirroring Tailwind v4's own preflight values verbatim under `.stgm`. In hosts without a global Tailwind preflight — third-party embeds and the packed demo tours, exactly the hosts `@stigmer/react` exists for — every unstyled-by-intent button rendered as a grey UA `buttonface` box; ghost/outline `Button` variants and bare inputs had the same class of defect.

## Context
Every SDK component is authored against the preflight-zeroed baseline (our consoles run the full Tailwind preflight globally). The scoped reset only covered box-sizing/borders, so preflight-less hosts got the UA's default control styling. Found via real-Chromium screenshots while verifying #371; the `UNSTYLED_BUTTON` constant was the two-file stopgap, this is the class fix.

## Changes
- `styles.css`: form-control subset of `tailwindcss/preflight.css`, scoped to `.stgm`, in `@layer base` (below `utilities`, same reasoning as the border reset). Byte-parity with stock preflight means it is a no-op in preflight hosts. Deliberately excluded (documented in the stylesheet comment): the universal margin/padding zero and typography resets — in the quickstart pattern the host's whole app sits inside `.stgm`, and those would strip a non-Tailwind host's own content styling.
- `UNSTYLED_BUTTON` shrinks to `cursor-pointer` (its `bg-transparent p-0` halves now come from the preflight); redundant per-button `[font:inherit]`/`text-inherit`/`bg-transparent` workarounds removed at the call sites.
- No `cursor: pointer` in the preflight (owner decision): Tailwind's preflight leaves the arrow cursor, and byte-parity keeps embeds identical to the consoles.

## Test plan
- New `preflight-parity.layout.test.tsx` (real Chromium, shipped `dist/styles.css` only): UA defaults neutralized on bare controls AND utilities still beat the preflight on themed `Button`. **Negative control proven**: 4/5 tests fail against the pre-fix dist (bare button reports the literal `rgb(239, 239, 239)` buttonface).
- `styles-border-layer-invariant.test.ts` extended: the form-control block must land in `@layer base` in the host-compiled cascade (the layer mistake that shipped 3× with borders). **Mutation-checked**: moving the reset to `@layer stgm` reddens both invariants.
- Full browser suite 64/64 (all axe audits pass against the new baseline — no target-size/color-contrast flips), unit suite 4344/4344, `lint` + `typecheck` clean.
- Visual pass on the shipped stylesheet, both color modes, before/after: ghost/outline buttons, attachment tiles, text buttons, lightbox close button all converge to the console baseline; themed primary/destructive buttons pixel-identical.

## Risks
- Any embed relying on the UA defaults inside `.stgm` shifts to the console baseline — that is the fix, by definition. Preflight hosts see zero change (identical values, same layer).
- A host nesting its own UA-default-styled form controls inside `StigmerProvider` loses their UA chrome — the same bounded trade-off the shipped border reset already made.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible for preflight hosts (no-op by construction)
- [x] Docs: no doc claims hosts must supply a preflight (verified) — nothing to update

Closes #374

Made with [Cursor](https://cursor.com)