### PR TITLE
fix(runner): uniquify duplicate attachment filenames with disclosure in both harnesses

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/attachment-resolver.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/attachment-resolver.test.ts
@@ -114,6 +114,59 @@ describe("resolveAttachments", () => {
     expect(readFileSync(join(platformDir, "inputs", "data.csv"), "utf-8")).toBe("a,b,c");
   });
 
+  it("uniquifies duplicate filenames on the storage branch — neither file's bytes are lost (issue #364)", async () => {
+    // Before the fix this branch had no collision check and the second write
+    // silently overwrote the first.
+    const { storage } = makeInMemoryArtifactStorage();
+    await storage.upload("attachments/01AAA/report.pdf", Buffer.from("first bytes"), "application/pdf");
+    await storage.upload("attachments/01BBB/report.pdf", Buffer.from("second bytes"), "application/pdf");
+
+    const result = await resolveAttachments(
+      [
+        makeAttachment({ filename: "report.pdf", storageKey: "attachments/01AAA/report.pdf" }),
+        makeAttachment({ filename: "report.pdf", storageKey: "attachments/01BBB/report.pdf" }),
+      ],
+      options({ storage }),
+    );
+
+    expect(result).toEqual([
+      { filename: "report.pdf", relativePath: ".stigmer/inputs/report.pdf" },
+      {
+        filename: "report-2.pdf",
+        relativePath: ".stigmer/inputs/report-2.pdf",
+        renamedFrom: "report.pdf",
+      },
+    ]);
+    expect(readFileSync(join(platformDir, "inputs", "report.pdf"), "utf-8")).toBe("first bytes");
+    expect(readFileSync(join(platformDir, "inputs", "report-2.pdf"), "utf-8")).toBe("second bytes");
+  });
+
+  it("uniquifies duplicate filenames across the local and storage branches (one shared taken-set)", async () => {
+    const srcPath = join(workspaceDir, "notes.md");
+    writeFileSync(srcPath, "local copy");
+    const { storage } = makeInMemoryArtifactStorage();
+    await storage.upload("attachments/01ABC/notes.md", Buffer.from("uploaded copy"), "text/markdown");
+
+    const result = await resolveAttachments(
+      [
+        makeAttachment({ filename: "notes.md", storageKey: "", localPath: srcPath }),
+        makeAttachment({ filename: "notes.md", storageKey: "attachments/01ABC/notes.md" }),
+      ],
+      options({ storage }),
+    );
+
+    expect(result).toEqual([
+      { filename: "notes.md", relativePath: ".stigmer/inputs/notes.md" },
+      {
+        filename: "notes-2.md",
+        relativePath: ".stigmer/inputs/notes-2.md",
+        renamedFrom: "notes.md",
+      },
+    ]);
+    expect(readFileSync(join(platformDir, "inputs", "notes.md"), "utf-8")).toBe("local copy");
+    expect(readFileSync(join(platformDir, "inputs", "notes-2.md"), "utf-8")).toBe("uploaded copy");
+  });
+
   it("ignores localPath in cloud mode and downloads by storage key", async () => {
     const { storage } = makeInMemoryArtifactStorage();
     await storage.upload("attachments/01ABC/plan.md", Buffer.from("from storage"), "text/markdown");

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
@@ -47,7 +47,7 @@ function input(overrides: Partial<BuildPromptInput>): BuildPromptInput {
     subAgents: [],
     workspaceDirs: ["/tmp/ws"],
     workspaceFileRefs: [],
-    attachmentPaths: [],
+    attachments: [],
     pendingApprovals: [],
     ...overrides,
   };
@@ -269,12 +269,29 @@ describe("attachments on a resumed turn (T04 — the mid-session WhatsApp case)"
 
   it("announces this turn's attachments to a resumed agent (per-execution value, never inherited)", () => {
     const prompt = buildPrompt(
-      input({ ...RESUMED, attachmentPaths: [".stigmer/inputs/lease.pdf"] }),
+      input({ ...RESUMED, attachments: [{ path: ".stigmer/inputs/lease.pdf" }] }),
     );
     expect(prompt).toContain("<input_files>");
     expect(prompt).toContain("`.stigmer/inputs/lease.pdf`");
     // The user message stays last — the section is a prefix.
     expect(prompt.endsWith(USER_MESSAGE)).toBe(true);
+  });
+
+  it("discloses a duplicate-renamed attachment's original name (issue #364)", () => {
+    const prompt = buildPrompt(
+      input({
+        ...RESUMED,
+        attachments: [
+          { path: ".stigmer/inputs/report.pdf" },
+          { path: ".stigmer/inputs/report-2.pdf", renamedFrom: "report.pdf" },
+        ],
+      }),
+    );
+    expect(prompt).toContain(
+      "- `.stigmer/inputs/report-2.pdf` (renamed from duplicate 'report.pdf')",
+    );
+    // The first file keeps a clean entry — no disclosure noise.
+    expect(prompt).toContain("- `.stigmer/inputs/report.pdf`\n");
   });
 
   it("keeps a resumed turn WITHOUT attachments byte-identical to the raw message (regression guard)", () => {
@@ -286,7 +303,7 @@ describe("attachments on a resumed turn (T04 — the mid-session WhatsApp case)"
     const prompt = buildPrompt(
       input({
         ...RESUMED,
-        attachmentPaths: [".stigmer/inputs/photo.jpg"],
+        attachments: [{ path: ".stigmer/inputs/photo.jpg" }],
         conversationCatchup: "User also said hello on the channel.",
       }),
     );
@@ -300,7 +317,7 @@ describe("attachments on a resumed turn (T04 — the mid-session WhatsApp case)"
     const prompt = buildPrompt(
       input({
         ...RESUMED,
-        attachmentPaths: [".stigmer/inputs/a.jpg", ".stigmer/inputs/big.png"],
+        attachments: [{ path: ".stigmer/inputs/a.jpg" }, { path: ".stigmer/inputs/big.png" }],
         vision: {
           inlineFilenames: ["a.jpg"],
           notViewable: [{ path: ".stigmer/inputs/big.png", reason: "too_large" }],
@@ -316,7 +333,7 @@ describe("attachments on a resumed turn (T04 — the mid-session WhatsApp case)"
     const prompt = buildPrompt(
       input({
         resolution: resolution("local", "created_first_execution"),
-        attachmentPaths: [".stigmer/inputs/a.jpg"],
+        attachments: [{ path: ".stigmer/inputs/a.jpg" }],
         vision: { inlineFilenames: ["a.jpg"], notViewable: [] },
       }),
     );
@@ -336,7 +353,7 @@ describe("attachments on a resumed turn (T04 — the mid-session WhatsApp case)"
             message: "Write file: gated.txt",
           }),
         ],
-        attachmentPaths: [".stigmer/inputs/photo.jpg"],
+        attachments: [{ path: ".stigmer/inputs/photo.jpg" }],
         vision: { inlineFilenames: ["photo.jpg"], notViewable: [] },
       }),
     );
@@ -543,7 +560,10 @@ describe("formatImplementPlanSection", () => {
   const PLAN_PATH = ".stigmer/inputs/plan.md";
 
   it("wraps the attached-plan directive when the plan is among the attachments", () => {
-    const section = formatImplementPlanSection(true, [PLAN_PATH, ".stigmer/inputs/data.csv"]);
+    const section = formatImplementPlanSection(true, [
+      { path: PLAN_PATH },
+      { path: ".stigmer/inputs/data.csv" },
+    ]);
 
     expect(section).toBeDefined();
     expect(section!.startsWith("<implement_plan>")).toBe(true);
@@ -553,7 +573,9 @@ describe("formatImplementPlanSection", () => {
   });
 
   it("falls back to the conversation-plan directive when no plan attachment resolved", () => {
-    const section = formatImplementPlanSection(true, [".stigmer/inputs/data.csv"]);
+    const section = formatImplementPlanSection(true, [
+      { path: ".stigmer/inputs/data.csv" },
+    ]);
 
     expect(section).toBeDefined();
     expect(section).not.toContain("plan.md");
@@ -561,12 +583,12 @@ describe("formatImplementPlanSection", () => {
   });
 
   it("returns undefined for an ordinary (non-build) execution", () => {
-    expect(formatImplementPlanSection(false, [PLAN_PATH])).toBeUndefined();
-    expect(formatImplementPlanSection(undefined, [PLAN_PATH])).toBeUndefined();
+    expect(formatImplementPlanSection(false, [{ path: PLAN_PATH }])).toBeUndefined();
+    expect(formatImplementPlanSection(undefined, [{ path: PLAN_PATH }])).toBeUndefined();
   });
 
   it("carries the plan-derived progress-tracking instruction (Tier 3)", () => {
-    const section = formatImplementPlanSection(true, [PLAN_PATH]);
+    const section = formatImplementPlanSection(true, [{ path: PLAN_PATH }]);
 
     expect(section).toContain("to-do list");
     expect(section).toContain("break the plan into");
@@ -577,7 +599,7 @@ describe("formatImplementPlanSection", () => {
       input({
         resolution: resolution("local", "created_first_execution"),
         buildFromPlan: true,
-        attachmentPaths: [PLAN_PATH],
+        attachments: [{ path: PLAN_PATH }],
       }),
     );
 
@@ -593,7 +615,7 @@ describe("formatImplementPlanSection", () => {
       input({
         resolution: resolution("local", "resumed_successfully"),
         buildFromPlan: true,
-        attachmentPaths: [PLAN_PATH],
+        attachments: [{ path: PLAN_PATH }],
       }),
     );
 
@@ -611,7 +633,7 @@ describe("formatImplementPlanSection", () => {
       input({
         resolution: resolution("local", "resumed_successfully"),
         buildFromPlan: false,
-        attachmentPaths: [PLAN_PATH],
+        attachments: [{ path: PLAN_PATH }],
       }),
     );
 

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/prompt-builder-delegation.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/prompt-builder-delegation.test.ts
@@ -70,7 +70,7 @@ describe("buildEnhancedPrompt delegation integration", () => {
     skills: [],
     subAgents: [],
     workspaceFileRefs: [],
-    attachmentPaths: [],
+    attachments: [],
   };
 
   it("includes exploration guidance when a workspace dir is present", () => {

--- a/backend/services/runner/src/activities/execute-cursor/attachment-resolver.ts
+++ b/backend/services/runner/src/activities/execute-cursor/attachment-resolver.ts
@@ -22,6 +22,13 @@
  * directives are built from the RESOLVED paths, so prompt and filesystem can
  * never disagree.
  *
+ * Duplicate filenames are renamed, never overwritten (issue #364): because
+ * placement keys purely on the filename, two attachments with the same name
+ * contend for one path — the later one takes the platform's `stem-2.ext`
+ * rename (shared/attachment-naming.ts, same semantics as the deep-agent
+ * injector and the React composer) and the rename is disclosed in the
+ * prompt's `<input_files>` section via {@link ResolvedAttachment.renamedFrom}.
+ *
  * Error model: fail-hard, matching the native harness's attachment injector.
  * Attachments are explicit user inputs — an execution that silently runs
  * without one produces silently incorrect results (the "plan file wasn't
@@ -33,6 +40,7 @@ import { mkdir, copyFile, readFile, stat, writeFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import type { Attachment } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import type { ArtifactStorage } from "../../shared/artifact-storage.js";
+import { allocateUniqueName } from "../../shared/attachment-naming.js";
 import {
   isVisionCandidate,
   type VisionBudget,
@@ -46,9 +54,16 @@ import { ensureStigmerSymlink, STIGMER_LOCAL_STATE_DIR } from "../../shared/work
 const INPUTS_SUBDIR = "inputs";
 
 export interface ResolvedAttachment {
+  /** The final on-disk basename — after any duplicate rename. */
   filename: string;
   /** Workspace-relative path the agent reads (`.stigmer/inputs/{filename}`). */
   relativePath: string;
+  /**
+   * The attachment's original filename, present only when a duplicate name
+   * was renamed (shared/attachment-naming.ts) — rendered as disclosure in
+   * the prompt's `<input_files>` section.
+   */
+  renamedFrom?: string;
   /** Present when the attachment was accepted into the turn's vision payload. */
   vision?: VisionImage;
   /**
@@ -111,9 +126,13 @@ export async function resolveAttachments(
   // it, but only when the agent has skills).
   await ensureStigmerSymlink(options.primaryWorkspaceDir, platformDir);
 
+  // Placement keys purely on the filename, so this set is the whole
+  // collision domain — sequential resolution means each attachment sees
+  // every name claimed before it (see module doc on duplicate handling).
+  const takenNames = new Set<string>();
   const results: ResolvedAttachment[] = [];
   for (const attachment of attachments) {
-    results.push(await resolveAttachment(attachment, inputsDir, options));
+    results.push(await resolveAttachment(attachment, inputsDir, takenNames, options));
   }
 
   console.log(
@@ -127,11 +146,15 @@ export async function resolveAttachments(
 async function resolveAttachment(
   attachment: Attachment,
   inputsDir: string,
+  takenNames: Set<string>,
   options: AttachmentResolverOptions,
 ): Promise<ResolvedAttachment> {
   // Local-mode fast path: the file is already on this machine's disk.
   if (options.mode === "local" && attachment.localPath) {
-    const filename = safeInputName(attachment.filename || attachment.localPath);
+    const { name: filename, renamedFrom } = allocateUniqueName(
+      safeInputName(attachment.filename || attachment.localPath),
+      takenNames,
+    );
     let vision: VisionOutcome | undefined;
     try {
       vision = await materializeLocalFile(attachment, filename, inputsDir, options.visionBudget);
@@ -145,6 +168,7 @@ async function resolveAttachment(
     return {
       filename,
       relativePath: join(STIGMER_LOCAL_STATE_DIR, INPUTS_SUBDIR, filename),
+      ...(renamedFrom !== undefined ? { renamedFrom } : {}),
       ...visionOutcomeFields(vision),
     };
   }
@@ -164,7 +188,10 @@ async function resolveAttachment(
     );
   }
 
-  const filename = safeInputName(attachment.filename || attachment.storageKey);
+  const { name: filename, renamedFrom } = allocateUniqueName(
+    safeInputName(attachment.filename || attachment.storageKey),
+    takenNames,
+  );
   let content: Buffer;
   try {
     content = await options.storage.download(attachment.storageKey);
@@ -185,6 +212,7 @@ async function resolveAttachment(
   return {
     filename,
     relativePath: join(STIGMER_LOCAL_STATE_DIR, INPUTS_SUBDIR, filename),
+    ...(renamedFrom !== undefined ? { renamedFrom } : {}),
     ...visionOutcomeFields(vision),
   };
 }

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -798,7 +798,10 @@ async function executeCursorInner(
       storage: artifactStorage,
       visionBudget,
     });
-    const attachmentPaths = attachmentResults.map((a) => a.relativePath);
+    const attachmentEntries = attachmentResults.map((a) => ({
+      path: a.relativePath,
+      ...(a.renamedFrom !== undefined ? { renamedFrom: a.renamedFrom } : {}),
+    }));
     // Vision facts, derived once from the single resolution result: the
     // images the model will see inline (in attachment order) and the ones
     // that degraded to path-only, disclosed in the prompt.
@@ -1148,7 +1151,7 @@ async function executeCursorInner(
       subAgents: blueprint.subAgents,
       workspaceDirs: blueprint.workspaceDirs,
       workspaceFileRefs: spec.workspaceFileRefs ?? [],
-      attachmentPaths,
+      attachments: attachmentEntries,
       vision: visionPromptInfo,
       pendingApprovals: adjudicatedApprovals,
       appliedToolCallIds,
@@ -1806,7 +1809,7 @@ async function executeCursorInner(
             subAgents: blueprint.subAgents,
             workspaceDirs: blueprint.workspaceDirs,
             workspaceFileRefs: spec.workspaceFileRefs ?? [],
-            attachmentPaths,
+            attachments: attachmentEntries,
             vision: visionPromptInfo,
             pendingApprovals: adjudicatedApprovals,
             interactionMode,
@@ -2342,7 +2345,11 @@ export interface BuildPromptInput {
   subAgents: import("@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb").SubAgent[];
   workspaceDirs: string[];
   workspaceFileRefs: string[];
-  attachmentPaths: string[];
+  /**
+   * This turn's resolved attachments for the `<input_files>` section —
+   * final paths plus duplicate-rename disclosure (attachment-resolver.ts).
+   */
+  attachments: import("./prompt-builder.js").AttachmentPromptEntry[];
   /**
    * Vision facts for the input-files section (T04): which attachments the
    * model sees inline and which degraded to path-only. PER-TURN like the
@@ -2435,7 +2442,7 @@ export function buildPrompt(input: BuildPromptInput): string {
     subAgents,
     workspaceDirs,
     workspaceFileRefs,
-    attachmentPaths,
+    attachments,
     interactionMode,
     buildFromPlan,
     conversationCatchup,
@@ -2469,9 +2476,9 @@ export function buildPrompt(input: BuildPromptInput): string {
   if (resolution.reason === "resumed_successfully") {
     const prefixes = [
       formatInteractionModePrefix(interactionMode),
-      formatImplementPlanSection(buildFromPlan, attachmentPaths),
-      attachmentPaths.length > 0
-        ? formatInputFiles(attachmentPaths, input.vision)
+      formatImplementPlanSection(buildFromPlan, attachments),
+      attachments.length > 0
+        ? formatInputFiles(attachments, input.vision)
         : undefined,
       conversationCatchup !== undefined
         ? formatConversationCatchupSection(conversationCatchup)
@@ -2494,7 +2501,7 @@ export function buildPrompt(input: BuildPromptInput): string {
     subAgents,
     workspaceDirs,
     workspaceFileRefs,
-    attachmentPaths,
+    attachments,
     vision: input.vision,
     interactionMode,
     buildFromPlan,

--- a/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
@@ -71,6 +71,18 @@ export interface VisionPromptInfo {
   notViewable: NotViewableEntry[];
 }
 
+/**
+ * One resolved attachment as the `<input_files>` section renders it —
+ * the final workspace-relative path plus the duplicate-rename disclosure
+ * (attachment-resolver.ts / shared/attachment-naming.ts).
+ */
+export interface AttachmentPromptEntry {
+  /** Workspace-relative path the agent reads (`.stigmer/inputs/{filename}`). */
+  path: string;
+  /** Original filename, present only when a duplicate name was renamed. */
+  renamedFrom?: string;
+}
+
 export interface EnhancedPromptOptions {
   instructions: string;
   userMessage: string;
@@ -90,7 +102,7 @@ export interface EnhancedPromptOptions {
   subAgents: SubAgent[];
   workspaceDirs: string[];
   workspaceFileRefs: string[];
-  attachmentPaths: string[];
+  attachments: AttachmentPromptEntry[];
   /** Inline/degraded image facts for the input-files section (T04 vision). */
   vision?: VisionPromptInfo;
   interactionMode?: InteractionMode;
@@ -153,7 +165,7 @@ export function buildEnhancedPrompt(options: EnhancedPromptOptions): string {
 
   const implementPlan = formatImplementPlanSection(
     options.buildFromPlan,
-    options.attachmentPaths,
+    options.attachments,
   );
   if (implementPlan) {
     sections.push(implementPlan);
@@ -195,8 +207,8 @@ export function buildEnhancedPrompt(options: EnhancedPromptOptions): string {
     sections.push(formatWorkspaceContext(safeDirs));
   }
 
-  if (options.attachmentPaths.length > 0) {
-    sections.push(formatInputFiles(options.attachmentPaths, options.vision));
+  if (options.attachments.length > 0) {
+    sections.push(formatInputFiles(options.attachments, options.vision));
   }
 
   if (options.workspaceFileRefs.length > 0) {
@@ -479,8 +491,18 @@ export function formatWorkspaceContext(dirs: string[]): string {
   ].join("\n");
 }
 
-export function formatInputFiles(paths: string[], vision?: VisionPromptInfo): string {
-  const entries = paths.map((p) => `- \`${p}\``);
+export function formatInputFiles(
+  attachments: readonly AttachmentPromptEntry[],
+  vision?: VisionPromptInfo,
+): string {
+  // A duplicate-renamed file (attachment-naming.ts) discloses its original
+  // name so the agent can connect "the two report.pdfs" in the user's
+  // message to distinct files on disk.
+  const entries = attachments.map((a) =>
+    a.renamedFrom !== undefined
+      ? `- \`${a.path}\` (renamed from duplicate '${a.renamedFrom}')`
+      : `- \`${a.path}\``,
+  );
   // The vision lines (shared wording, attachment-vision.ts) tell the model
   // which of these files it can already SEE inline versus which degraded to
   // path-only — without them an agent silently ignores a photo the user
@@ -541,14 +563,14 @@ export function formatInteractionModePrefix(
  */
 export function formatImplementPlanSection(
   buildFromPlan: boolean | undefined,
-  attachmentPaths: string[],
+  attachments: readonly AttachmentPromptEntry[],
 ): string | undefined {
   if (!buildFromPlan) {
     return undefined;
   }
 
   const directive = buildImplementPlanDirective(
-    findApprovedPlanPath(attachmentPaths),
+    findApprovedPlanPath(attachments.map((a) => a.path)),
   );
   return ["<implement_plan>", directive, "</implement_plan>"].join("\n");
 }

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
@@ -600,22 +600,95 @@ describe("injectAttachments", () => {
     expect(Buffer.compare(writtenBuffer, binaryContent)).toBe(0);
   });
 
-  it("detects mount path collision before any downloads", async () => {
+  it("uniquifies duplicate default-derived filenames instead of failing (issue #364)", async () => {
+    const contentA = Buffer.from("first");
+    const contentB = Buffer.from("second");
+    const storage = makeMockStorage();
+    await storage.upload("attachments/a/data.csv", contentA);
+    await storage.upload("attachments/b/data.csv", contentB);
+
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [
+        makeAttachment({ filename: "data.csv", storageKey: "attachments/a/data.csv" }),
+        makeAttachment({ filename: "data.csv", storageKey: "attachments/b/data.csv" }),
+      ],
+      storage,
+      isLocalMode: false,
+    });
+
+    // Both files land, both downloads run — the execution is never burned
+    // over a mechanically resolvable name.
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      filename: "data.csv",
+      path: ".stigmer/inputs/data.csv",
+    });
+    expect(result[0].renamedFrom).toBeUndefined();
+    // The rename follows the platform's stem-2.ext semantics and carries the
+    // disclosure payload for the prompt.
+    expect(result[1]).toMatchObject({
+      filename: "data-2.csv",
+      path: ".stigmer/inputs/data-2.csv",
+      renamedFrom: "data.csv",
+    });
+    expect(backend.writeFileBuffer).toHaveBeenCalledWith(
+      ".stigmer/inputs/data.csv", contentA,
+    );
+    expect(backend.writeFileBuffer).toHaveBeenCalledWith(
+      ".stigmer/inputs/data-2.csv", contentB,
+    );
+  });
+
+  it("rejects two attachments explicitly pinning the same mountPath (a user contradiction)", async () => {
     const backend = mockWorkspaceBackend();
     const storage = makeMockStorage();
 
     await expect(injectAttachments({
       backend,
       attachments: [
-        makeAttachment({ filename: "data.csv", storageKey: "key1" }),
-        makeAttachment({ filename: "data.csv", storageKey: "key2" }),
+        makeAttachment({ filename: "a.csv", storageKey: "key1", mountPath: "inputs/data.csv" }),
+        makeAttachment({ filename: "b.csv", storageKey: "key2", mountPath: "inputs/data.csv" }),
       ],
       storage,
       isLocalMode: false,
     })).rejects.toThrow(/collides with/);
 
-    // Verify no downloads were attempted
+    // The contradiction is detected before any downloads
     expect(storage.download).not.toHaveBeenCalled();
+  });
+
+  it("default-derived names dodge an explicit mountPath already inside the inputs prefix", async () => {
+    const storage = makeMockStorage();
+    await storage.upload("attachments/a/pinned", Buffer.from("pinned"));
+    await storage.upload("attachments/b/report.pdf", Buffer.from("derived"));
+
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [
+        // Listed AFTER the default-derived attachment: explicit paths claim
+        // first regardless of order, so the default still dodges.
+        makeAttachment({ filename: "report.pdf", storageKey: "attachments/b/report.pdf" }),
+        makeAttachment({
+          filename: "report.pdf",
+          storageKey: "attachments/a/pinned",
+          mountPath: ".stigmer/inputs/report.pdf",
+        }),
+      ],
+      storage,
+      isLocalMode: false,
+    });
+
+    const byPath = new Map(result.map((f) => [f.path, f]));
+    expect(byPath.get(".stigmer/inputs/report.pdf")?.renamedFrom).toBeUndefined();
+    expect(byPath.get(".stigmer/inputs/report-2.pdf")).toMatchObject({
+      filename: "report-2.pdf",
+      renamedFrom: "report.pdf",
+    });
   });
 
   it("derives filename from storageKey when filename is empty", async () => {
@@ -662,7 +735,7 @@ describe("injectAttachments", () => {
     expect(result[0].path).toBe("workspace/input.csv");
   });
 
-  it("error message includes attachment filename and actionable suggestion", async () => {
+  it("explicit-collision error names both attachments and stays actionable", async () => {
     const backend = mockWorkspaceBackend();
     const storage = makeMockStorage();
 
@@ -670,8 +743,8 @@ describe("injectAttachments", () => {
       await injectAttachments({
         backend,
         attachments: [
-          makeAttachment({ filename: "first.csv" }),
-          makeAttachment({ filename: "first.csv", storageKey: "key2" }),
+          makeAttachment({ filename: "first.csv", mountPath: "inputs/shared.csv" }),
+          makeAttachment({ filename: "second.csv", storageKey: "key2", mountPath: "inputs/shared.csv" }),
         ],
         storage,
         isLocalMode: false,
@@ -680,7 +753,7 @@ describe("injectAttachments", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(AttachmentInjectionError);
       const injErr = err as AttachmentInjectionError;
-      expect(injErr.attachmentFilename).toBe("first.csv");
+      expect(injErr.attachmentFilename).toBe("second.csv");
       expect(injErr.message).toContain("first.csv");
       expect(injErr.message).toContain("mountPath");
     }
@@ -858,6 +931,35 @@ describe("injectAttachments — vision selection", () => {
 
     expect(injected.vision).toBeUndefined();
     expect(injected.visionDegraded).toBe("type_mismatch");
+  });
+
+  it("labels a duplicate-renamed image's vision payload with the on-disk name", async () => {
+    // Coherence pin: the prompt lists the renamed path and the vision
+    // disclosure lists image filenames — if the offer used the original
+    // attachment.filename, the agent would see two images with one
+    // indistinguishable name.
+    const backend = mockWorkspaceBackend();
+    const storage = makeMockStorage();
+    await storage.upload("attachments/a/photo.png", PNG_BYTES);
+    await storage.upload("attachments/b/photo.png", PNG_BYTES);
+
+    const injected = await injectAttachments({
+      backend,
+      attachments: [
+        makeAttachment({ filename: "photo.png", storageKey: "attachments/a/photo.png", contentType: "image/png" }),
+        makeAttachment({ filename: "photo.png", storageKey: "attachments/b/photo.png", contentType: "image/png" }),
+      ],
+      storage,
+      isLocalMode: false,
+      visionBudget: new VisionBudget(DEEP_AGENT_VISION_PROFILE),
+    });
+
+    expect(injected[0].vision?.filename).toBe("photo.png");
+    expect(injected[1]).toMatchObject({
+      filename: "photo-2.png",
+      renamedFrom: "photo.png",
+    });
+    expect(injected[1].vision?.filename).toBe("photo-2.png");
   });
 
   it("never offers an extract archive to the budget — extracted files carry no vision fields", async () => {

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/prompt-builder.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/prompt-builder.test.ts
@@ -142,6 +142,10 @@ describe("buildEnhancedSystemPrompt", () => {
   });
 
   it("includes injected files section with size info", () => {
+    // The section renders the injector's own result type (sizeBytes). A local
+    // structural twin with a `size` field used to live in the prompt builder,
+    // and production wiring silently dropped the size — this pin holds the
+    // real field name so that drift class cannot return.
     const prompt = buildEnhancedSystemPrompt({
       instructions: "Test",
       provisionResults: [],
@@ -150,15 +154,40 @@ describe("buildEnhancedSystemPrompt", () => {
       workspaceFileRefs: [],
       workspaceRoot: "/workspace",
       injectedFiles: [
-        { filename: "data.csv", path: ".stigmer/inputs/data.csv", size: 1024 },
-        { filename: "notes.md", path: ".stigmer/inputs/notes.md", size: null },
+        { filename: "data.csv", path: ".stigmer/inputs/data.csv", sizeBytes: 1024 },
+        { filename: "notes.md", path: ".stigmer/inputs/notes.md", sizeBytes: 12 },
       ],
     });
 
     expect(prompt).toContain("## Input Files");
     expect(prompt).toContain("`.stigmer/inputs/data.csv` (1024 bytes)");
-    expect(prompt).toContain("`.stigmer/inputs/notes.md`");
-    expect(prompt).not.toContain("null");
+    expect(prompt).toContain("`.stigmer/inputs/notes.md` (12 bytes)");
+  });
+
+  it("discloses a duplicate-renamed injected file's original name", () => {
+    const prompt = buildEnhancedSystemPrompt({
+      instructions: "Test",
+      provisionResults: [],
+      containerRoot: "",
+      skillsPromptSection: "",
+      workspaceFileRefs: [],
+      workspaceRoot: "/workspace",
+      injectedFiles: [
+        { filename: "report.pdf", path: ".stigmer/inputs/report.pdf", sizeBytes: 10 },
+        {
+          filename: "report-2.pdf",
+          path: ".stigmer/inputs/report-2.pdf",
+          sizeBytes: 20,
+          renamedFrom: "report.pdf",
+        },
+      ],
+    });
+
+    expect(prompt).toContain(
+      "`.stigmer/inputs/report-2.pdf` (20 bytes) (renamed from duplicate 'report.pdf')",
+    );
+    // The first file keeps a clean entry — no disclosure noise.
+    expect(prompt).toContain("`.stigmer/inputs/report.pdf` (10 bytes)\n");
   });
 
   it("produces a git repo description for git workspace entries", () => {
@@ -361,7 +390,7 @@ describe("buildEnhancedSystemPrompt", () => {
     const planFile = {
       filename: "plan.md",
       path: ".stigmer/inputs/plan.md",
-      size: 1024,
+      sizeBytes: 1024,
     };
 
     it("appends the implement-plan directive pointing at the injected plan", () => {

--- a/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
@@ -12,14 +12,22 @@
  * Error model: fail-hard. Any attachment failure aborts the entire injection
  * and propagates a descriptive error. Attachments are explicit user inputs —
  * running with partial inputs produces silently incorrect results.
+ *
+ * Duplicate names are NOT a failure (issue #364): a default-derived mount
+ * path that collides is renamed with the platform's `stem-2.ext` semantics
+ * (shared/attachment-naming.ts) and the rename is disclosed in the prompt's
+ * Input Files section. Only two attachments EXPLICITLY pinning the same
+ * `mountPath` still abort — that is a user contradiction no rename can
+ * honestly resolve.
  */
 
 import { readFile } from "node:fs/promises";
 import { createInflateRaw } from "node:zlib";
-import { basename, posix } from "node:path";
+import { posix } from "node:path";
 import type { Attachment } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import type { WorkspaceBackend } from "../../shared/workspace/types.js";
 import type { ArtifactStorage } from "../../shared/artifact-storage.js";
+import { allocateUniqueName } from "../../shared/attachment-naming.js";
 import type {
   VisionBudget,
   VisionDegradedReason,
@@ -38,9 +46,17 @@ export { MAX_ZIP_FILES, MAX_ZIP_EXTRACTED_SIZE };
 // ── Types ────────────────────────────────────────────────────────────
 
 export interface InjectedFile {
+  /** The final on-disk basename — after any duplicate rename, so it always
+   * agrees with {@link path} and with the vision payload's image label. */
   readonly filename: string;
   readonly path: string;
   readonly sizeBytes: number;
+  /**
+   * The attachment's original filename, present only when a duplicate name
+   * was renamed (shared/attachment-naming.ts) — rendered as disclosure in
+   * the prompt's Input Files section.
+   */
+  readonly renamedFrom?: string;
   /** Present when the attachment was accepted into the turn's vision payload. */
   readonly vision?: VisionImage;
   /**
@@ -257,7 +273,9 @@ export function validateZipForExtraction(
 /**
  * Download, validate, and inject all attachments into the workspace.
  *
- * Performs mount path collision detection before any downloads begin.
+ * Resolves all mount paths before any downloads begin: duplicate
+ * default-derived names are renamed (never fatal — see module doc), and an
+ * explicit-mountPath contradiction throws before any bytes move.
  * On any failure, throws AttachmentInjectionError with an actionable message.
  */
 export async function injectAttachments(opts: InjectAttachmentsOptions): Promise<InjectedFile[]> {
@@ -273,17 +291,24 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
 
   for (const attachment of attachments) {
     const content = await downloadAttachment(attachment, storage, isLocalMode);
-    const mountPath = mountPaths.get(attachment)!;
+    const { path: mountPath, renamedFrom } = mountPaths.get(attachment)!;
 
     if (attachment.extract) {
       const entries = validateZipForExtraction(content, attachment.filename);
       const extracted = await extractZipToWorkspace(
         content, entries, mountPath, backend,
       );
+      // A renamed mount DIR is visible through every extracted path; the
+      // entries themselves were not renamed, so they carry no renamedFrom
+      // (per-file disclosure would misattribute the rename).
       injectedFiles.push(...extracted);
     } else {
       await backend.writeFileBuffer(mountPath, content);
-      const filename = attachment.filename || basename(mountPath);
+      // The final basename is the canonical filename: after a duplicate
+      // rename the original attachment.filename no longer names the file on
+      // disk, and the vision label must match what the prompt lists or the
+      // agent sees two images with one indistinguishable name.
+      const filename = posix.basename(mountPath);
       // The bytes are already in hand for the workspace write — offer them to
       // the vision budget before they go out of scope (the sniff decides
       // eligibility; the budget owns every size/count rule).
@@ -292,6 +317,7 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
         filename,
         path: mountPath,
         sizeBytes: content.length,
+        ...(renamedFrom !== undefined ? { renamedFrom } : {}),
         ...(vision?.kind === "accepted" ? { vision: vision.image } : {}),
         ...(vision?.kind === "degraded" ? { visionDegraded: vision.reason } : {}),
       });
@@ -307,14 +333,24 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
 
 // ── Internal Helpers ─────────────────────────────────────────────────
 
+interface ResolvedMountPath {
+  readonly path: string;
+  /** Present when a default-derived name was uniquified (issue #364). */
+  readonly renamedFrom?: string;
+}
+
 function resolveMountPaths(
   attachments: readonly Attachment[],
-): Map<Attachment, string> {
-  const result = new Map<Attachment, string>();
+): Map<Attachment, ResolvedMountPath> {
+  const result = new Map<Attachment, ResolvedMountPath>();
   const pathToAttachment = new Map<string, Attachment>();
 
+  // Pass 1: explicit mount paths claim their exact targets first. Two
+  // attachments explicitly pinning the SAME path is a user contradiction no
+  // rename can honestly resolve — keep rejecting with the actionable message.
   for (const attachment of attachments) {
-    const mountPath = resolveMountPath(attachment);
+    if (!attachment.mountPath) continue;
+    const mountPath = resolveExplicitMountPath(attachment);
     const existing = pathToAttachment.get(mountPath);
 
     if (existing) {
@@ -326,35 +362,63 @@ function resolveMountPaths(
     }
 
     pathToAttachment.set(mountPath, attachment);
-    result.set(attachment, mountPath);
+    result.set(attachment, { path: mountPath });
+  }
+
+  // Pass 2: default-derived names (`.stigmer/inputs/{filename}`) uniquify
+  // around everything already taken — other defaults AND explicit paths that
+  // landed inside the inputs prefix — instead of failing the execution
+  // (issue #364). The taken-set is seeded with the basenames the explicit
+  // pass claimed directly under the prefix.
+  const takenNames = new Set<string>();
+  for (const path of pathToAttachment.keys()) {
+    if (path.startsWith(`${DEFAULT_INPUTS_PREFIX}/`)) {
+      const rest = path.slice(DEFAULT_INPUTS_PREFIX.length + 1);
+      if (rest.length > 0 && !rest.includes("/")) takenNames.add(rest);
+    }
+  }
+  for (const attachment of attachments) {
+    if (attachment.mountPath) continue;
+    const { name, renamedFrom } = allocateUniqueName(
+      deriveDefaultFilename(attachment),
+      takenNames,
+    );
+    const path = `${DEFAULT_INPUTS_PREFIX}/${name}`;
+    pathToAttachment.set(path, attachment);
+    result.set(
+      attachment,
+      renamedFrom !== undefined ? { path, renamedFrom } : { path },
+    );
   }
 
   return result;
 }
 
-function resolveMountPath(attachment: Attachment): string {
-  if (attachment.mountPath) {
-    const cleaned = attachment.mountPath.replace(/^\/+/, "");
-    if (cleaned.length === 0) {
-      throw new AttachmentInjectionError(
-        attachment.filename,
-        "mountPath resolves to an empty path after removing leading slashes",
-      );
-    }
-    // A caller-supplied mount path is untrusted. Stripping leading slashes does
-    // not stop `..` segments from climbing out of the workspace root on the
-    // non-`.stigmer/` branch (the `.stigmer/`-routed branch is already guarded
-    // by LocalWorkspaceBackend.resolvePath). Reject any path that normalizes to
-    // an escape before it reaches the backend write.
-    if (escapesRoot(cleaned)) {
-      throw new AttachmentInjectionError(
-        attachment.filename,
-        `mount path '${attachment.mountPath}' escapes the workspace root`,
-      );
-    }
-    return cleaned;
+function resolveExplicitMountPath(attachment: Attachment): string {
+  const cleaned = attachment.mountPath.replace(/^\/+/, "");
+  if (cleaned.length === 0) {
+    throw new AttachmentInjectionError(
+      attachment.filename,
+      "mountPath resolves to an empty path after removing leading slashes",
+    );
   }
+  // A caller-supplied mount path is untrusted. Stripping leading slashes does
+  // not stop `..` segments from climbing out of the workspace root on the
+  // non-`.stigmer/` branch (the `.stigmer/`-routed branch is already guarded
+  // by LocalWorkspaceBackend.resolvePath). Reject any path that normalizes to
+  // an escape before it reaches the backend write.
+  if (escapesRoot(cleaned)) {
+    throw new AttachmentInjectionError(
+      attachment.filename,
+      `mount path '${attachment.mountPath}' escapes the workspace root`,
+    );
+  }
+  return cleaned;
+}
 
+// Derives the single-component filename an attachment without an explicit
+// mountPath materializes under (the name that pass 2 uniquifies).
+function deriveDefaultFilename(attachment: Attachment): string {
   const rawName = attachment.filename || deriveFilename(attachment.storageKey);
   if (!rawName) {
     throw new AttachmentInjectionError(
@@ -373,7 +437,7 @@ function resolveMountPath(attachment: Attachment): string {
     );
   }
 
-  return `${DEFAULT_INPUTS_PREFIX}/${filename}`;
+  return filename;
 }
 
 // escapesRoot reports whether a workspace-relative mount path would climb out

--- a/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
@@ -26,6 +26,7 @@ import {
   buildImplementPlanDirective,
   findApprovedPlanPath,
 } from "../../shared/implement-plan-prompt.js";
+import type { InjectedFile } from "./attachment-injector.js";
 
 const RESPONSE_RULES = `
 
@@ -162,11 +163,10 @@ export interface PromptBuilderInput {
   sessionContext?: string;
 }
 
-export interface InjectedFile {
-  filename: string;
-  path: string;
-  size?: number | null;
-}
+// The prompt renders the injector's own result type — a local structural twin
+// once lived here and silently dropped the size field (`size` vs `sizeBytes`),
+// so the "(N bytes)" annotation never rendered. One type, one truth.
+export type { InjectedFile } from "./attachment-injector.js";
 
 /**
  * Which images ride the user message inline (in send order) and which
@@ -396,7 +396,7 @@ function buildReferencedFilesSection(
 }
 
 function buildInjectedFilesSection(
-  files: InjectedFile[],
+  files: readonly InjectedFile[],
   vision?: VisionPromptInfo,
 ): string {
   let section = "\n\n## Input Files\n\n";
@@ -410,8 +410,15 @@ function buildInjectedFilesSection(
     "Do NOT modify or delete these files.\n\n";
 
   for (const f of files) {
-    const sizeInfo = f.size != null ? ` (${f.size} bytes)` : "";
-    section += `- \`${f.path}\`${sizeInfo}\n`;
+    const sizeInfo = ` (${f.sizeBytes} bytes)`;
+    // A duplicate-renamed file (attachment-naming.ts) discloses its original
+    // name so the agent can connect "the two report.pdfs" in the user's
+    // message to distinct files on disk.
+    const renameInfo =
+      f.renamedFrom !== undefined
+        ? ` (renamed from duplicate '${f.renamedFrom}')`
+        : "";
+    section += `- \`${f.path}\`${sizeInfo}${renameInfo}\n`;
   }
 
   // The vision lines (shared wording, attachment-vision.ts) tell the model

--- a/backend/services/runner/src/shared/__tests__/attachment-naming.test.ts
+++ b/backend/services/runner/src/shared/__tests__/attachment-naming.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { uniquifyFilename, allocateUniqueName } from "../attachment-naming.js";
+import { injectAttachments } from "../../activities/execute-deep-agent/attachment-injector.js";
+import { resolveAttachments } from "../../activities/execute-cursor/attachment-resolver.js";
+import { getPlatformDir } from "../workspace/platform-dir.js";
+import { makeInMemoryArtifactStorage } from "../../__test-utils__/fake-artifact-storage.js";
+import type { WorkspaceBackend } from "../workspace/types.js";
+
+describe("uniquifyFilename", () => {
+  // This table is the byte-for-byte twin of the React SDK suite
+  // (sdk/react/src/attachment/__tests__/attachment-utils.test.ts) — the two
+  // implementations are kept in sync by hand, so their pins must agree.
+  const cases: Array<{
+    scenario: string;
+    name: string;
+    taken: string[];
+    expected: string;
+  }> = [
+    {
+      scenario: "returns the name unchanged when nothing collides",
+      name: "report.pdf",
+      taken: [],
+      expected: "report.pdf",
+    },
+    {
+      scenario: "suffixes -2 before the extension on first collision",
+      name: "report.pdf",
+      taken: ["report.pdf"],
+      expected: "report-2.pdf",
+    },
+    {
+      scenario: "walks past already-taken suffixes",
+      name: "report.pdf",
+      taken: ["report.pdf", "report-2.pdf", "report-3.pdf"],
+      expected: "report-4.pdf",
+    },
+    {
+      scenario: "handles names without an extension",
+      name: "Makefile",
+      taken: ["Makefile"],
+      expected: "Makefile-2",
+    },
+    {
+      scenario: "treats a leading dot as a hidden-file prefix, not an extension",
+      name: ".env",
+      taken: [".env"],
+      expected: ".env-2",
+    },
+    {
+      scenario: "only splits on the last dot of a multi-dot name",
+      name: "backup.tar.gz",
+      taken: ["backup.tar.gz"],
+      expected: "backup.tar-2.gz",
+    },
+  ];
+
+  for (const { scenario, name, taken, expected } of cases) {
+    it(scenario, () => {
+      expect(uniquifyFilename(name, new Set(taken))).toBe(expected);
+    });
+  }
+});
+
+describe("allocateUniqueName", () => {
+  it("claims the allocated name so sequential allocations see each other", () => {
+    const taken = new Set<string>();
+
+    expect(allocateUniqueName("data.csv", taken)).toEqual({ name: "data.csv" });
+    expect(allocateUniqueName("data.csv", taken)).toEqual({
+      name: "data-2.csv",
+      renamedFrom: "data.csv",
+    });
+    expect(allocateUniqueName("data.csv", taken)).toEqual({
+      name: "data-3.csv",
+      renamedFrom: "data.csv",
+    });
+    expect(taken).toEqual(new Set(["data.csv", "data-2.csv", "data-3.csv"]));
+  });
+
+  it("carries no renamedFrom when the name was free (nothing to disclose)", () => {
+    const allocated = allocateUniqueName("report.pdf", new Set());
+    expect(allocated.name).toBe("report.pdf");
+    expect("renamedFrom" in allocated && allocated.renamedFrom !== undefined).toBe(false);
+  });
+});
+
+describe("cross-harness naming parity", () => {
+  // Both harnesses must resolve the same attachment list to the same final
+  // basenames — one platform answer, not two accidental ones (issue #364).
+  let workspaceDir: string;
+  let sessionId: string;
+  let platformDir: string;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "naming-parity-ws-"));
+    sessionId = `parity-session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    platformDir = getPlatformDir(sessionId);
+  });
+
+  afterEach(() => {
+    rmSync(platformDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  function makeAttachment(filename: string, storageKey: string) {
+    return {
+      filename,
+      storageKey,
+      mountPath: "",
+      contentType: "text/plain",
+      extract: false,
+      localPath: "",
+      $typeName: "ai.stigmer.agentic.agentexecution.v1.Attachment" as const,
+      $unknown: undefined,
+    } as any;
+  }
+
+  it("both harnesses produce identical final basenames for the same duplicate-heavy list", async () => {
+    const { storage } = makeInMemoryArtifactStorage();
+    await storage.upload("attachments/01A/data.csv", Buffer.from("a"), "text/plain");
+    await storage.upload("attachments/01B/data.csv", Buffer.from("b"), "text/plain");
+    await storage.upload("attachments/01C/Makefile", Buffer.from("c"), "text/plain");
+    await storage.upload("attachments/01D/Makefile", Buffer.from("d"), "text/plain");
+    const attachments = [
+      makeAttachment("data.csv", "attachments/01A/data.csv"),
+      makeAttachment("data.csv", "attachments/01B/data.csv"),
+      makeAttachment("Makefile", "attachments/01C/Makefile"),
+      makeAttachment("Makefile", "attachments/01D/Makefile"),
+    ];
+
+    const backend = { writeFileBuffer: vi.fn() } as unknown as WorkspaceBackend;
+    const injected = await injectAttachments({
+      backend,
+      attachments,
+      storage,
+      isLocalMode: false,
+    });
+
+    const resolved = await resolveAttachments(attachments, {
+      sessionId,
+      primaryWorkspaceDir: workspaceDir,
+      mode: "cloud",
+      storage,
+    });
+
+    const injectedNames = injected.map((f) => f.filename);
+    const resolvedNames = resolved.map((r) => r.filename);
+    expect(injectedNames).toEqual(["data.csv", "data-2.csv", "Makefile", "Makefile-2"]);
+    expect(resolvedNames).toEqual(injectedNames);
+    expect(injected.map((f) => f.renamedFrom)).toEqual(
+      resolved.map((r) => r.renamedFrom),
+    );
+    // The resolver's files really land under the renamed paths.
+    expect(readFileSync(join(platformDir, "inputs", "data-2.csv"), "utf-8")).toBe("b");
+  });
+});

--- a/backend/services/runner/src/shared/attachment-naming.ts
+++ b/backend/services/runner/src/shared/attachment-naming.ts
@@ -1,0 +1,78 @@
+/**
+ * Naming policy for execution attachments — the single owner of the rule that
+ * resolves duplicate attachment filenames (issue #364).
+ *
+ * Both harnesses materialize attachments into the platform inputs namespace
+ * keyed by filename, so two attachments carrying the same name contend for
+ * one on-disk path. Before this module existed each harness had an accidental
+ * answer: the deep-agent injector failed the whole execution on the collision
+ * and the Cursor resolver silently overwrote the earlier file. The platform
+ * answer is neither — a duplicate is mechanically renamed (`report.pdf`,
+ * `report-2.pdf`, ...) and the rename is disclosed to the agent through the
+ * input-files prompt section, so no execution is ever burned over a
+ * resolvable name and no user file silently vanishes.
+ *
+ * The `stem-2.ext` semantics deliberately mirror the React SDK composer's
+ * client-side rename (sdk/react/src/attachment/attachment-utils.ts,
+ * `uniquifyFilename` — kept in sync by hand, the packages share no
+ * dependency), so a user sees the same rename shape whether the client or the
+ * runner performed it.
+ *
+ * Scope: this module owns NAMES only. What constitutes a collision is the
+ * caller's business — the deep-agent injector keys on full mount paths
+ * (explicit `mountPath` values participate), the Cursor resolver keys on bare
+ * filenames under `inputs/`. Callers that consider a collision a user
+ * contradiction (two attachments explicitly pinning the same mount path)
+ * keep rejecting; only mechanically derived names are renamed.
+ */
+
+/** The outcome of allocating a unique name for one attachment. */
+export interface AllocatedName {
+  /** The final name — unchanged when it was free, `stem-N.ext` otherwise. */
+  readonly name: string;
+  /**
+   * The original requested name, present only when a rename happened — the
+   * disclosure payload the prompt builders render so the agent can still
+   * connect "the two report.pdfs" in the user's message to distinct files.
+   */
+  readonly renamedFrom?: string;
+}
+
+/**
+ * Returns `name` unchanged when it is not in `taken`, otherwise the first
+ * free `stem-2.ext`, `stem-3.ext`, … variant.
+ *
+ * Byte-for-byte twin of the React SDK's `uniquifyFilename`
+ * (sdk/react/src/attachment/attachment-utils.ts) so client-side and
+ * runner-side renames are indistinguishable to the user.
+ */
+export function uniquifyFilename(
+  name: string,
+  taken: ReadonlySet<string>,
+): string {
+  if (!taken.has(name)) return name;
+
+  const dotIndex = name.lastIndexOf(".");
+  // A leading dot (".env") is a hidden-file prefix, not an extension.
+  const stem = dotIndex > 0 ? name.slice(0, dotIndex) : name;
+  const ext = dotIndex > 0 ? name.slice(dotIndex) : "";
+
+  for (let n = 2; ; n++) {
+    const candidate = `${stem}-${n}${ext}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Allocate a unique name against `taken`, claiming the result in the set so
+ * sequential allocations see each other. Returns the disclosure payload
+ * (`renamedFrom`) when the name had to change.
+ */
+export function allocateUniqueName(
+  name: string,
+  taken: Set<string>,
+): AllocatedName {
+  const unique = uniquifyFilename(name, taken);
+  taken.add(unique);
+  return unique === name ? { name: unique } : { name: unique, renamedFrom: name };
+}

--- a/client-apps/cli/src/resources/run/attachments.test.ts
+++ b/client-apps/cli/src/resources/run/attachments.test.ts
@@ -110,4 +110,26 @@ describe("directory zipping", () => {
     writeFileSync(join(empty, ".hidden"), "x"); // only hidden -> nothing attachable
     await expect(processAttachments(uploader, [empty], [])).rejects.toThrow(/no attachable files/);
   });
+
+  it("uniquifies duplicate directory basenames so mount paths never contradict (issue #364)", async () => {
+    // Two dirs named `data` from different parents would otherwise derive the
+    // SAME explicit mount path, which the runner rejects as a contradiction.
+    const dirA = join(dir, "a", "data");
+    const dirB = join(dir, "b", "data");
+    mkdirSync(dirA, { recursive: true });
+    mkdirSync(dirB, { recursive: true });
+    writeFileSync(join(dirA, "one.txt"), "1");
+    writeFileSync(join(dirB, "two.txt"), "2");
+
+    const progress: string[] = [];
+    const result = await processAttachments(uploader, [dirA, dirB], [], (l) => progress.push(l));
+
+    expect(result.attachments).toHaveLength(2);
+    expect(result.attachments[0].filename).toBe("data.zip");
+    expect(result.attachments[0].mountPath).toBe("inputs/data/");
+    expect(result.attachments[1].filename).toBe("data-2.zip");
+    expect(result.attachments[1].mountPath).toBe("inputs/data-2/");
+    // The rename is disclosed to the user on the progress sink.
+    expect(progress.some((l) => l.includes("'data/'") && l.includes("'data-2/'"))).toBe(true);
+  });
 });

--- a/client-apps/cli/src/resources/run/attachments.ts
+++ b/client-apps/cli/src/resources/run/attachments.ts
@@ -55,6 +55,7 @@ export async function processAttachments(
   const workspaceFileRefs: string[] = [];
   if (paths.length === 0) return { attachments, workspaceFileRefs };
 
+  const takenDirNames = new Set<string>();
   for (const path of paths) {
     const rel = matchWorkspaceRoot(path, workspaceRoots);
     if (rel !== null) {
@@ -62,7 +63,7 @@ export async function processAttachments(
       workspaceFileRefs.push(rel);
       continue;
     }
-    attachments.push(await processFile(uploader, path, progress));
+    attachments.push(await processFile(uploader, path, takenDirNames, progress));
   }
 
   return { attachments, workspaceFileRefs };
@@ -90,7 +91,12 @@ function matchWorkspaceRoot(path: string, roots: readonly string[]): string | nu
 
 // Stat the path, then upload a file or zip+upload a directory. Mirrors Go's
 // processFile.
-async function processFile(uploader: AttachmentUploader, path: string, progress?: ProgressSink): Promise<Attachment> {
+async function processFile(
+  uploader: AttachmentUploader,
+  path: string,
+  takenDirNames: Set<string>,
+  progress?: ProgressSink,
+): Promise<Attachment> {
   let stat: ReturnType<typeof statSync>;
   try {
     stat = statSync(path);
@@ -100,7 +106,7 @@ async function processFile(uploader: AttachmentUploader, path: string, progress?
     throw new UsageError(`failed to stat attachment "${path}": ${e.message}`);
   }
 
-  if (stat.isDirectory()) return processDirectory(uploader, path, progress);
+  if (stat.isDirectory()) return processDirectory(uploader, path, takenDirNames, progress);
 
   const absPath = resolve(path);
   const filename = basenameOf(path);
@@ -113,9 +119,29 @@ async function processFile(uploader: AttachmentUploader, path: string, progress?
 
 // Zip a directory (extract=true so the runner unpacks it at mount_path) and
 // upload it as one archive. Mirrors Go's processDirectory.
-async function processDirectory(uploader: AttachmentUploader, path: string, progress?: ProgressSink): Promise<Attachment> {
+async function processDirectory(
+  uploader: AttachmentUploader,
+  path: string,
+  takenDirNames: Set<string>,
+  progress?: ProgressSink,
+): Promise<Attachment> {
   const absPath = resolve(path);
-  const dirname = basenameOf(absPath);
+  // Two same-named directories (`--attach a/data --attach b/data`) would
+  // derive the SAME explicit mount path, which the runner rejects as a user
+  // contradiction (attachment-injector.ts resolveMountPaths). The CLI derives
+  // these names mechanically from basenames, so it owns the rename — the same
+  // principle as the React composer's client-side uniquify (sdk/react
+  // attachment-utils.ts). Duplicate FILE attachments need no CLI handling:
+  // they carry no mountPath, so the runner renames them itself.
+  const requestedName = basenameOf(absPath);
+  const dirname = uniquifyDirName(requestedName, takenDirNames);
+  takenDirNames.add(dirname);
+  if (dirname !== requestedName) {
+    progress?.(
+      `Attaching second '${requestedName}/' as '${dirname}/' (a directory ` +
+        `named '${requestedName}' is already attached)`,
+    );
+  }
 
   const { bytes, fileCount, originalSize } = zipDirectory(absPath, progress);
   const zipSize = bytes.byteLength;
@@ -246,6 +272,19 @@ function formatFileSize(bytes: number): string {
   if (bytes >= MB) return `${(bytes / MB).toFixed(1)} MB`;
   if (bytes >= KB) return `${(bytes / KB).toFixed(1)} KB`;
   return `${bytes} B`;
+}
+
+// Returns `name` unchanged when free, otherwise the first free `name-2`,
+// `name-3`, … variant. Deliberately extension-blind — directory names have no
+// extension semantics ("reports.2024" becomes "reports.2024-2", not
+// "reports-2.2024"), unlike the filename uniquify in the runner and React SDK
+// (shared/attachment-naming.ts / attachment-utils.ts) this mirrors.
+function uniquifyDirName(name: string, taken: ReadonlySet<string>): string {
+  if (!taken.has(name)) return name;
+  for (let n = 2; ; n++) {
+    const candidate = `${name}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
 }
 
 // path.basename, but resilient to trailing slashes (matches Go filepath.Base

--- a/sdk/react/src/attachment/attachment-utils.ts
+++ b/sdk/react/src/attachment/attachment-utils.ts
@@ -117,11 +117,14 @@ export function validateAttachmentSize(file: File): string | null {
  * Returns `name` unchanged when it is not in `taken`, otherwise the first
  * free `stem-2.ext`, `stem-3.ext`, … variant.
  *
- * Duplicate filenames within one turn are not a cosmetic problem:
- * attachments materialize at `.stigmer/inputs/{filename}`, where the
- * deep-agent harness fails the whole execution on a mount-path collision
- * and the Cursor harness silently overwrites the earlier file. A visible
- * rename on the attachment chip is strictly better than either outcome.
+ * Attachments materialize at `.stigmer/inputs/{filename}`, so duplicate
+ * names within one turn contend for one path. The runner resolves that with
+ * this same rename (backend/services/runner/src/shared/attachment-naming.ts,
+ * a byte-for-byte twin kept in sync by hand — the packages share no
+ * dependency), disclosed to the agent in the prompt. Renaming client-side
+ * as well keeps the chip, the uploaded bytes, and the mounted file all
+ * agreeing on one visible name — strictly better UX than a server-side
+ * rename the user only discovers in the transcript.
  */
 export function uniquifyFilename(
   name: string,


### PR DESCRIPTION
## Summary

Closes #364.

Two attachments with the same filename produced a different wrong behavior on each harness: **deep-agent** failed the whole execution on the mount-path collision, and **Cursor** had no collision check and silently overwrote the earlier file. The React composer already renames duplicates client-side, so only CLI / API / channel callers hit this. This PR gives the platform one deliberate answer.

- **New `runner/src/shared/attachment-naming.ts`** — the single owner of the duplicate-name rule, following the `attachment-vision.ts` "one policy module, both harnesses" pattern: `uniquifyFilename` (byte-for-byte twin of the React SDK's `stem-2.ext` rename, cross-referenced both ways) plus `allocateUniqueName` returning the `renamedFrom` disclosure payload.
- **deep-agent injector**: mount-path resolution is two-pass — explicit `mountPath` values claim their exact targets first (two explicit claims on one path keep the actionable `AttachmentInjectionError`; that is a user contradiction no rename can honestly resolve), then default-derived names uniquify around everything taken. The final basename is now the canonical `filename` everywhere, so a renamed image's **vision label matches the on-disk name** (previously two renamed images would have disclosed under one indistinguishable name).
- **Cursor resolver**: a taken-name set threads through both write branches (storage + localPath) — silent overwrite is impossible by construction.
- **Prompt disclosure in both harnesses**: renamed entries render as `` `.stigmer/inputs/report-2.pdf` (renamed from duplicate 'report.pdf') `` so the agent can still connect "the two report.pdfs" in the user's message to distinct files. The Cursor prompt input widened from bare path strings to entries carrying `renamedFrom`.
- **CLI directory mounts**: `processDirectory` derives explicit mount paths mechanically from directory basenames, so `--attach a/data --attach b/data` previously produced exactly the contradiction the runner rejects. The CLI now uniquifies the derived name (plain `-2` suffix — directories have no extension semantics) and reports the rename on its progress line.
- **Latent bug fixed in passing**: the deep-agent prompt-builder kept a local structural twin of `InjectedFile` whose `size` field never matched the injector's `sizeBytes` — TypeScript bridged it silently and the "(N bytes)" annotation in the Input Files section NEVER rendered in production. The twin is deleted; the prompt renders the injector's own type, pinned so the drift class cannot return.

No proto, server, or migration changes; no ops step. Ships in the next OSS release; the cloud sandbox picks it up with the next runner image build (the runner is shared between editions).

## Test plan

- [x] 169 tests green across the six touched runner suites
- [x] **Negative control proven**: against the pre-fix injector/resolver, exactly the six new pins fail (uniquify, explicit-dodge, vision-label coherence, resolver storage-dup, resolver mixed-dup, cross-harness parity)
- [x] New cross-harness parity pin: the same duplicate-heavy attachment list yields identical final basenames from both harnesses
- [x] Full runner suite: 4340 passed; the only failing files are the pre-existing environmental set (node:sqlite trio + one HITL load flake), all green under Node 22
- [x] `verify-dist-boot` PASS (Node 22)
- [x] Full CLI suite 863/863; runner and CLI `tsc --noEmit` clean
- [x] sdk/react attachment suite green (comment-only change there)

Made with [Cursor](https://cursor.com)