### PR TITLE
fix(runner): retry transient checkpoint proxy failures instead of killing the execution

### DIFF
--- a/backend/services/runner/src/shared/__tests__/http-retry.test.ts
+++ b/backend/services/runner/src/shared/__tests__/http-retry.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { isRetryableHttpStatus, isRetryableFetchError } from "../http-retry.js";
+
+// The bounded-backoff loop that consumes these classifiers lives in
+// checkpointer/http-saver.ts (fetchWithRetry) and is exercised by
+// http-saver.test.ts ("retry behavior"). This file covers the classification
+// policy in isolation — the grpc-retry.test.ts twin.
+
+describe("isRetryableHttpStatus", () => {
+  it("returns true for 408 (request timeout)", () => {
+    expect(isRetryableHttpStatus(408)).toBe(true);
+  });
+
+  it("returns true for 429 (throttled)", () => {
+    expect(isRetryableHttpStatus(429)).toBe(true);
+  });
+
+  it.each([500, 502, 503, 504])("returns true for %i", (status) => {
+    expect(isRetryableHttpStatus(status)).toBe(true);
+  });
+
+  // The four deterministic errors CheckpointerProxyController actually emits:
+  // 400 malformed, 403 FGA deny, 404 missing, 413 over the 4 MB cap. Retrying
+  // any of them would repeat the same failure (and 404 carries semantics —
+  // getTuple maps it to "no checkpoint yet").
+  it.each([400, 401, 403, 404, 413])("returns false for deterministic %i", (status) => {
+    expect(isRetryableHttpStatus(status)).toBe(false);
+  });
+
+  it("returns false for success statuses", () => {
+    expect(isRetryableHttpStatus(200)).toBe(false);
+    expect(isRetryableHttpStatus(204)).toBe(false);
+  });
+});
+
+describe("isRetryableFetchError", () => {
+  it("returns true for undici's network-failure shape (TypeError: fetch failed)", () => {
+    const err = new TypeError("fetch failed");
+    (err as TypeError & { cause?: unknown }).cause = new Error("connect ECONNREFUSED");
+    expect(isRetryableFetchError(err)).toBe(true);
+  });
+
+  it("returns true for a bare TypeError (no cause)", () => {
+    expect(isRetryableFetchError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("returns true for AbortSignal.timeout's rejection shape (TimeoutError)", () => {
+    // DOMException with name "TimeoutError" is what AbortSignal.timeout()
+    // produces; construct the real shape rather than a look-alike.
+    const err = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    expect(isRetryableFetchError(err)).toBe(true);
+  });
+
+  it("returns false for a manual abort (AbortError) — the caller cancelled on purpose", () => {
+    const err = new DOMException("This operation was aborted", "AbortError");
+    expect(isRetryableFetchError(err)).toBe(false);
+  });
+
+  it("returns false for a generic Error", () => {
+    expect(isRetryableFetchError(new Error("random"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isRetryableFetchError("boom")).toBe(false);
+    expect(isRetryableFetchError(undefined)).toBe(false);
+  });
+});

--- a/backend/services/runner/src/shared/checkpointer/__tests__/http-saver.test.ts
+++ b/backend/services/runner/src/shared/checkpointer/__tests__/http-saver.test.ts
@@ -29,9 +29,17 @@ async function serializeForProxy(obj: unknown): Promise<{ type: string; binary: 
 describe("HttpCheckpointSaver", () => {
   let saver: HttpCheckpointSaver;
   let fetchSpy: ReturnType<typeof vi.fn>;
+  let recordedDelays: number[];
 
   beforeEach(() => {
-    saver = new HttpCheckpointSaver(PROXY, TOKEN);
+    // delayFn injected so retry-path tests record the backoff schedule
+    // instead of sleeping through it (~7.75 s of real delays otherwise).
+    recordedDelays = [];
+    saver = new HttpCheckpointSaver(PROXY, TOKEN, {
+      delayFn: async (ms) => {
+        recordedDelays.push(ms);
+      },
+    });
     fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
   });
@@ -160,6 +168,193 @@ describe("HttpCheckpointSaver", () => {
       }
       expect(results).toHaveLength(1);
       expect(results[0].config.configurable.checkpoint_id).toBe("cp-list-1");
+    });
+  });
+
+  // The bounded-backoff loop (cloud#188). Classification policy itself is
+  // covered by shared/__tests__/http-retry.test.ts; these cases pin the
+  // loop's behavior at the saver's call sites: transient failures recover,
+  // deterministic failures never retry, budget exhaustion still fails
+  // loudly, and 404 semantics survive unchanged.
+  describe("retry behavior", () => {
+    const ok404 = { status: 404, ok: false, statusText: "Not Found" };
+    const err503 = { status: 503, ok: false, statusText: "Service Unavailable" };
+    const err400 = { status: 400, ok: false, statusText: "Bad Request" };
+    const err401 = { status: 401, ok: false, statusText: "Unauthorized" };
+
+    function makeCheckpoint(): Checkpoint {
+      return {
+        v: 4,
+        id: "cp-retry",
+        ts: new Date().toISOString(),
+        channel_values: {},
+        channel_versions: {},
+        versions_seen: {},
+      };
+    }
+    const md: CheckpointMetadata = { source: "loop", step: 0, parents: {} };
+
+    it("recovers a put from a transient 503", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(err503)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      const result = await saver.put(makeConfig(), makeCheckpoint(), md, {});
+      expect(result.configurable?.checkpoint_id).toBe("cp-retry");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(recordedDelays).toEqual([250]);
+    });
+
+    it("recovers a put from a network-level rejection (undici TypeError)", async () => {
+      fetchSpy
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await expect(saver.put(makeConfig(), makeCheckpoint(), md, {})).resolves.toBeDefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("backs off exponentially across consecutive transient failures", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(err503)
+        .mockResolvedValueOnce(err503)
+        .mockResolvedValueOnce(err503)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await saver.put(makeConfig(), makeCheckpoint(), md, {});
+      expect(recordedDelays).toEqual([250, 500, 1000]);
+    });
+
+    it("fails loudly when the budget is exhausted on a retryable status", async () => {
+      fetchSpy.mockResolvedValue(err503);
+
+      await expect(saver.put(makeConfig(), makeCheckpoint(), md, {}))
+        .rejects.toThrow("Checkpoint PUT failed: 503");
+      // 1 initial attempt + 5 retries (the default budget).
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(recordedDelays).toEqual([250, 500, 1000, 2000, 4000]);
+    });
+
+    it("rethrows the original error when the budget is exhausted on network rejections", async () => {
+      const netErr = new TypeError("fetch failed");
+      fetchSpy.mockRejectedValue(netErr);
+
+      await expect(saver.putWrites(makeConfig(), [["messages", { a: 1 }]], "t1"))
+        .rejects.toBe(netErr);
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it("never retries a deterministic 400", async () => {
+      fetchSpy.mockResolvedValue(err400);
+
+      await expect(saver.put(makeConfig(), makeCheckpoint(), md, {}))
+        .rejects.toThrow("Checkpoint PUT failed: 400");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(recordedDelays).toEqual([]);
+    });
+
+    it("never retries a rejected credential (401)", async () => {
+      fetchSpy.mockResolvedValue(err401);
+
+      await expect(saver.getTuple(makeConfig())).rejects.toThrow("Checkpoint GET failed: 401");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("never retries a manual abort (AbortError)", async () => {
+      const abortErr = new DOMException("This operation was aborted", "AbortError");
+      fetchSpy.mockRejectedValue(abortErr);
+
+      await expect(saver.getTuple(makeConfig())).rejects.toBe(abortErr);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries a hung request aborted by the per-request timeout (TimeoutError)", async () => {
+      fetchSpy
+        .mockRejectedValueOnce(
+          new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+        )
+        .mockResolvedValueOnce(ok404);
+
+      await expect(saver.getTuple(makeConfig())).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("preserves getTuple's 404 semantics without retrying", async () => {
+      fetchSpy.mockResolvedValue(ok404);
+
+      await expect(saver.getTuple(makeConfig())).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves deleteThread's 404 tolerance without retrying", async () => {
+      fetchSpy.mockResolvedValue(ok404);
+
+      await expect(saver.deleteThread("thread-1")).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("bounds every request with an abort signal", async () => {
+      fetchSpy.mockResolvedValue(ok404);
+
+      await saver.getTuple(makeConfig());
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("surfaces a pending-writes read failure instead of silently degrading", async () => {
+      // The checkpoint GET succeeds; the follow-up writes GET fails on every
+      // attempt. Pre-#188 code mapped this to "no pending writes" and
+      // returned a tuple stripped of resume state.
+      const cp = makeCheckpoint();
+      const cpSer = await serializeForProxy(cp);
+      const mdSer = await serializeForProxy(md);
+      const checkpointDoc = {
+        thread_id: "thread-1",
+        checkpoint_ns: "",
+        checkpoint_id: cp.id,
+        type: cpSer.type,
+        checkpoint: cpSer.binary,
+        metadata_type: mdSer.type,
+        metadata: mdSer.binary,
+      };
+      fetchSpy.mockImplementation((url: string) => {
+        if (url.includes("/writes")) return Promise.resolve(err503);
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(checkpointDoc) });
+      });
+
+      await expect(saver.getTuple(makeConfig())).rejects.toThrow(
+        "Checkpoint writes GET failed: 503",
+      );
+    });
+
+    it("recovers the pending-writes read from a transient failure", async () => {
+      const cp = makeCheckpoint();
+      const cpSer = await serializeForProxy(cp);
+      const mdSer = await serializeForProxy(md);
+      const checkpointDoc = {
+        thread_id: "thread-1",
+        checkpoint_ns: "",
+        checkpoint_id: cp.id,
+        type: cpSer.type,
+        checkpoint: cpSer.binary,
+        metadata_type: mdSer.type,
+        metadata: mdSer.binary,
+      };
+      let writesCalls = 0;
+      fetchSpy.mockImplementation((url: string) => {
+        if (url.includes("/writes")) {
+          writesCalls++;
+          return writesCalls === 1
+            ? Promise.resolve(err503)
+            : Promise.resolve({ ok: true, json: () => Promise.resolve({ writes: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(checkpointDoc) });
+      });
+
+      const tuple = await saver.getTuple(makeConfig());
+      expect(tuple?.checkpoint.id).toBe(cp.id);
+      expect(tuple?.pendingWrites).toEqual([]);
+      expect(writesCalls).toBe(2);
     });
   });
 

--- a/backend/services/runner/src/shared/checkpointer/http-saver.ts
+++ b/backend/services/runner/src/shared/checkpointer/http-saver.ts
@@ -13,6 +13,19 @@
  *
  * The Java proxy calls Document.parse(json) which handles $binary
  * natively, and doc.toJson() emits the same format on reads.
+ *
+ * Every request runs through {@link HttpCheckpointSaver.fetchWithRetry}:
+ * bounded exponential backoff on transient failures (classified by
+ * http-retry.ts) with a per-request abort timeout. This loop is the ONLY
+ * retry layer between an agent execution and its checkpoints — the deep
+ * agent activity is deliberately non-retryable at the Temporal level
+ * (maximumAttempts: 1; replaying a whole agent run is not safe), so before
+ * this existed a single dropped request killed the execution
+ * (stigmer/stigmer-cloud#188). Retrying puts is safe by server contract:
+ * CheckpointStore documents putCheckpoint/putWrite as keyed save-or-replace
+ * upserts. Budget exhaustion still fails loudly — checkpoints are not
+ * lossy-tolerable (unlike status updates, see status.ts), and silently
+ * dropping one would corrupt resume state.
  */
 
 import type { RunnableConfig } from "@langchain/core/runnables";
@@ -25,6 +38,8 @@ import {
   type ChannelVersions,
 } from "@langchain/langgraph-checkpoint";
 import type { CheckpointMetadata, PendingWrite } from "@langchain/langgraph-checkpoint";
+import type { RetryOptions } from "../grpc-retry.js";
+import { isRetryableFetchError, isRetryableHttpStatus } from "../http-retry.js";
 
 function encodeB64(data: Uint8Array): string {
   if (typeof Buffer !== "undefined") {
@@ -77,17 +92,104 @@ function configOrg(config: RunnableConfig): string | undefined {
   return config.configurable?.org as string | undefined;
 }
 
+/** Retry policy plus the per-request bound; every field is defaulted. */
+export interface HttpCheckpointSaverOptions extends RetryOptions {
+  /**
+   * Milliseconds before an in-flight request is aborted and the attempt is
+   * classified retryable. Without it a hung connection (the realistic
+   * unplanned-pod-kill symptom) stalls forever and the retry never engages.
+   */
+  readonly requestTimeoutMs?: number;
+}
+
+/**
+ * Default transient-retry policy. Wider than status.ts's DEFAULT_PERSIST_RETRY
+ * (3 retries, ~700 ms) on purpose: a dropped status update is lossy-tolerable,
+ * a dropped checkpoint kills the execution, so the budget here is sized to
+ * span a pod-restart reroute (~7.75 s of delays across 5 retries). Worst case
+ * with every attempt hanging — 6 x 30 s + delays, ~3.7 min — stays well inside
+ * the deep-agent activity's 1 h startToCloseTimeout (no heartbeatTimeout).
+ */
+const DEFAULT_RETRY = {
+  baseDelayMs: 250,
+  backoffFactor: 2,
+  maxRetries: 5,
+  requestTimeoutMs: 30_000,
+} as const;
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class HttpCheckpointSaver extends BaseCheckpointSaver {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
+  private readonly baseDelayMs: number;
+  private readonly backoffFactor: number;
+  private readonly maxRetries: number;
+  private readonly requestTimeoutMs: number;
+  private readonly delay: (ms: number) => Promise<void>;
 
-  constructor(proxyEndpoint: string, authToken: string) {
+  constructor(
+    proxyEndpoint: string,
+    authToken: string,
+    options: HttpCheckpointSaverOptions = {},
+  ) {
     super();
     this.baseUrl = `${proxyEndpoint.replace(/\/+$/, "")}/v1/proxy/checkpoints`;
     this.headers = {
       Authorization: `Bearer ${authToken}`,
       "Content-Type": "application/json",
     };
+    this.baseDelayMs = options.baseDelayMs ?? DEFAULT_RETRY.baseDelayMs;
+    this.backoffFactor = options.backoffFactor ?? DEFAULT_RETRY.backoffFactor;
+    this.maxRetries = options.maxRetries ?? DEFAULT_RETRY.maxRetries;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_RETRY.requestTimeoutMs;
+    this.delay = options.delayFn ?? defaultDelay;
+  }
+
+  /**
+   * `fetch` with bounded exponential backoff on transient failures and a
+   * per-request abort timeout.
+   *
+   * Composition contract: on a non-retryable status — or when the budget is
+   * exhausted on a retryable one — the last `Response` is RETURNED, so every
+   * call site keeps its own `resp.ok` / 404 handling unchanged; this wrapper
+   * changes when a response arrives, never what call sites do with it. It
+   * throws only what `fetch` itself throws: a network-level rejection that is
+   * non-retryable or has exhausted the budget.
+   */
+  private async fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
+    for (let attempt = 0; ; attempt++) {
+      const canRetry = attempt < this.maxRetries;
+      let resp: Response;
+      try {
+        resp = await fetch(url, {
+          ...init,
+          signal: AbortSignal.timeout(this.requestTimeoutMs),
+        });
+      } catch (err) {
+        if (canRetry && isRetryableFetchError(err)) {
+          await this.backOff(attempt, String(err));
+          continue;
+        }
+        throw err;
+      }
+      if (canRetry && isRetryableHttpStatus(resp.status)) {
+        await this.backOff(attempt, `HTTP ${resp.status} ${resp.statusText}`);
+        continue;
+      }
+      return resp;
+    }
+  }
+
+  private async backOff(attempt: number, reason: string): Promise<void> {
+    const delayMs = this.baseDelayMs * Math.pow(this.backoffFactor, attempt);
+    console.warn(
+      `[HttpCheckpointSaver] retryable failure ` +
+      `(attempt ${attempt + 1}/${this.maxRetries + 1}, retry in ${delayMs}ms): ${reason}`,
+    );
+    await this.delay(delayMs);
   }
 
   private async serializeTyped(obj: unknown): Promise<[string, BinaryObj]> {
@@ -113,7 +215,7 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
       params.set("checkpoint_id", checkpointId);
     }
 
-    const resp = await fetch(`${this.baseUrl}/checkpoint?${params}`, {
+    const resp = await this.fetchWithRetry(`${this.baseUrl}/checkpoint?${params}`, {
       headers: this.headers,
     });
     if (resp.status === 404) return undefined;
@@ -143,7 +245,7 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
       params.set("before", beforeId);
     }
 
-    const resp = await fetch(`${this.baseUrl}/checkpoints?${params}`, {
+    const resp = await this.fetchWithRetry(`${this.baseUrl}/checkpoints?${params}`, {
       headers: this.headers,
     });
     if (!resp.ok) {
@@ -183,7 +285,7 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
     const orgId = configOrg(config);
     if (orgId) doc.org_id = orgId;
 
-    const resp = await fetch(`${this.baseUrl}/checkpoint`, {
+    const resp = await this.fetchWithRetry(`${this.baseUrl}/checkpoint`, {
       method: "PUT",
       headers: this.headers,
       body: JSON.stringify(doc),
@@ -203,7 +305,7 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
 
   async deleteThread(threadId: string): Promise<void> {
     const params = new URLSearchParams({ thread_id: threadId });
-    const resp = await fetch(`${this.baseUrl}/thread?${params}`, {
+    const resp = await this.fetchWithRetry(`${this.baseUrl}/thread?${params}`, {
       method: "DELETE",
       headers: this.headers,
     });
@@ -238,7 +340,7 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
       return doc;
     }));
 
-    const resp = await fetch(`${this.baseUrl}/writes`, {
+    const resp = await this.fetchWithRetry(`${this.baseUrl}/writes`, {
       method: "PUT",
       headers: this.headers,
       body: JSON.stringify({ writes: docs }),
@@ -272,7 +374,7 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
       };
     }
 
-    const writesResp = await fetch(
+    const writesResp = await this.fetchWithRetry(
       `${this.baseUrl}/writes?${new URLSearchParams({
         thread_id: threadId,
         checkpoint_ns: checkpointNs,
@@ -280,8 +382,14 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
       })}`,
       { headers: this.headers },
     );
+    // Fail loudly, never degrade: this used to map ANY non-ok response to "no
+    // pending writes", which silently stripped resume state on a transient
+    // 500 — a checkpoint would load without the writes recorded against it.
+    if (!writesResp.ok) {
+      throw new Error(`Checkpoint writes GET failed: ${writesResp.status} ${writesResp.statusText}`);
+    }
     const pendingWrites = await this.parseWrites(
-      writesResp.ok ? (await writesResp.json()) as Record<string, any> : {},
+      (await writesResp.json()) as Record<string, any>,
     );
 
     return {

--- a/backend/services/runner/src/shared/http-retry.ts
+++ b/backend/services/runner/src/shared/http-retry.ts
@@ -1,0 +1,50 @@
+/**
+ * HTTP error classification for side-channel proxy retries.
+ *
+ * The runner reaches stigmer-service's Side-Channel Proxy (`/v1/proxy/...`)
+ * over plain `fetch` from several clients — the checkpoint saver today;
+ * artifact storage, the LLM proxy, and the registry endpoint are candidates
+ * (stigmer/stigmer#468). This module is the one place that answers "is this
+ * HTTP failure worth retrying?", the `fetch` twin of grpc-retry.ts: it holds
+ * the classification policy only, kept small and separately tested. The
+ * bounded-backoff loop that consumes it lives with each client (the
+ * grpc-retry/status.ts split).
+ *
+ * The policy is grounded in what the proxy actually emits, not HTTP folklore.
+ * CheckpointerProxyController returns exactly four deterministic errors —
+ * 400 (malformed document), 403 (FGA deny), 404 (no such checkpoint), and
+ * 413 (the 4 MB cap) — and never a transient status. Transient failures
+ * reach the runner only as 5xx (Spring's error handler, ingress 502-504),
+ * 408/429 (infrastructure between runner and service), or as network-level
+ * fetch rejections. 401/403 stay terminal deliberately: retrying cannot fix
+ * an expired or rejected credential.
+ */
+
+/**
+ * True for HTTP statuses that signal a transient condition worth retrying:
+ * 408 (request timeout), 429 (throttled), and all 5xx. Every other status is
+ * deterministic — the proxy's 4xx errors mean the same request will fail the
+ * same way forever.
+ */
+export function isRetryableHttpStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * True for `fetch` rejections that signal a transient transport condition:
+ *
+ * - `TypeError` — undici's network-failure shape (`fetch failed`, with the
+ *   ECONNREFUSED/ECONNRESET/DNS cause attached). A deterministic TypeError
+ *   (e.g. a malformed URL) also matches, which is accepted: such a bug fails
+ *   every attempt including the first test run, and the bounded budget caps
+ *   the wasted retries at seconds.
+ * - `TimeoutError` — the rejection shape of `AbortSignal.timeout()`, i.e. a
+ *   hung connection whose attempt we bounded ourselves.
+ *
+ * A manual abort (`AbortError`) is deliberately NOT retryable: the caller
+ * cancelled on purpose.
+ */
+export function isRetryableFetchError(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  return err instanceof Error && err.name === "TimeoutError";
+}


### PR DESCRIPTION
## Summary

Fixes [stigmer/stigmer-cloud#188](https://github.com/stigmer/stigmer-cloud/issues/188): every `HttpCheckpointSaver` method was a bare `fetch` that threw on first failure; the throw propagates out of `graph.stream()` and fails the agent execution. The deep-agent activity is deliberately non-retryable at the Temporal level (`maximumAttempts: 1` — replaying a whole agent run is not safe), so this saver is the **only** place in the stack where a transient transport blip can be absorbed. Today it's masked by `maxUnavailable: 0` rolling deploys (the line that forced the Postgres cutover's execution-drain gate); it fires on any unplanned pod restart.

- **New `shared/http-retry.ts`** — HTTP failure classification, the `grpc-retry.ts` twin (policy only, separately tested). Placed in `shared/` because the audit found three more bare `/v1/proxy` fetch clients (`artifact-storage`, `llm-proxy`, `registry-endpoint`) that can adopt it — spawned as #468. Grounded in what the proxy actually emits (`CheckpointerProxyController` produces exactly 400/403/404/413, all deterministic): retryable = network rejections (undici `TypeError: fetch failed`) / 408 / 429 / 5xx / our own timeout aborts; terminal = every other 4xx and manual `AbortError`.
- **`fetchWithRetry` wraps all six call sites** — 5 retries, 250 ms base, x2 backoff (~7.75 s of delays; deliberately wider than `status.ts`'s lossy-tolerant budget — checkpoints are execution-fatal) + `AbortSignal.timeout(30s)` per request so a *hung* connection engages the retry instead of stalling forever. Worst case (~3.7 min, every attempt hanging) sits well inside the activity's 1 h `startToCloseTimeout`.
- **Zero call-site drift by construction**: the wrapper RETURNS the last response on non-retryable/exhausted statuses, so every call site keeps its `resp.ok` / 404 handling byte-for-byte (`getTuple` 404 → `undefined`, `deleteThread` 404 tolerance — both pinned). It throws only what `fetch` itself throws.
- **Budget exhaustion still fails loudly** — checkpoints are not lossy-tolerable; silently dropping one corrupts resume state.
- **Also fixed**: `getTuple`'s pending-writes GET mapped ANY non-ok response to "no pending writes" — a transient 500 silently stripped resume state. Now retried, then loud.

Retrying puts is safe by documented server contract: `CheckpointStore.java` pins `putCheckpoint`/`putWrite` as keyed save-or-replace upserts ("LangGraph retries the whole batch idempotently on failure").

## Test plan

- [x] New `http-retry.test.ts` classification suite (18 tests): real undici/`DOMException` error shapes, not look-alikes.
- [x] `http-saver.test.ts` extended to 21 tests: transient 503/network/timeout recovery, exponential schedule pinned (`delayFn` injected — suite went 7.8 s → 15 ms), exhaustion fails loudly with correct attempt counts, 400/401/manual-abort never retry, 404 semantics unchanged, every request carries an abort signal, pending-writes failure surfaces + recovers.
- [x] **Negative control**: against the pre-fix saver, 9 new tests fail (all recovery/exhaustion/writes-surfacing pins); the 12 that pass are the unchanged-behavior pins — green on both by design.
- [x] Runner typecheck clean; full runner vitest suite run in an isolated worktree (result posted on this PR).

Closes stigmer/stigmer-cloud#188

Made with [Cursor](https://cursor.com)