### PR TITLE
PROBE (do not merge): reproduce #323 ci.frontend failure under Node 22.23.2

### DIFF
--- a/.github/workflows/ci.frontend.yaml
+++ b/.github/workflows/ci.frontend.yaml
@@ -85,7 +85,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # PROBE (throwaway, do not merge): pin the exact Node that broke main on 2026-08-11
+          # to reproduce the happy-dom menu-mount failure for issue #323.
+          node-version: 22.23.2
           cache: npm
 
       - name: Enable Corepack
@@ -120,7 +122,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # PROBE (throwaway, do not merge): pin the exact Node that broke main on 2026-08-11
+          # to reproduce the happy-dom menu-mount failure for issue #323.
+          node-version: 22.23.2
           cache: npm
 
       - name: Enable Corepack
@@ -153,7 +157,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # PROBE (throwaway, do not merge): pin the exact Node that broke main on 2026-08-11
+          # to reproduce the happy-dom menu-mount failure for issue #323.
+          node-version: 22.23.2
           cache: npm
 
       - name: Enable Corepack
@@ -179,7 +185,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # PROBE (throwaway, do not merge): pin the exact Node that broke main on 2026-08-11
+          # to reproduce the happy-dom menu-mount failure for issue #323.
+          node-version: 22.23.2
           cache: npm
 
       - name: Enable Corepack
@@ -204,7 +212,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # PROBE (throwaway, do not merge): pin the exact Node that broke main on 2026-08-11
+          # to reproduce the happy-dom menu-mount failure for issue #323.
+          node-version: 22.23.2
           cache: npm
 
       - name: Enable Corepack


### PR DESCRIPTION
Throwaway probe for #323: main's ci.frontend went red when GitHub's toolcache rolled Node 22.23.1 -> 22.23.2 (setup-node floats on node-version: 22). The failure does not reproduce on macOS under 22.23.2; this PR pins the exact suspect version to reproduce on Linux CI and capture full logs. Will be closed unmerged.

Made with [Cursor](https://cursor.com)