### PR TITLE
fix(store): resolve duplicate-hash audit lookups to the newest row

### DIFF
--- a/backend/libs/go/store/sqlite/store.go
+++ b/backend/libs/go/store/sqlite/store.go
@@ -1310,6 +1310,17 @@ func (s *Store) ListAuditRecords(ctx context.Context, kind apiresourcekind.ApiRe
 
 // GetAuditRecordByHash retrieves a single archived version by exact hash,
 // carrying its authoritative tag from the tag column.
+//
+// Duplicate rows for one (kind, resource_id, version_hash) are legal data,
+// so this lookup must be ordered, not an arbitrary LIMIT 1
+// (stigmer/stigmer-cloud#191): the skill push path archives a re-push of
+// prior content as a fresh row (skill tags are archive-time facts resolved
+// most-recently-archived-wins — see ArchiveCurrentSkillStep), and workflow
+// rows archived before the stigmer/stigmer#341 repoint semantics can hold
+// duplicates too. Duplicates share content but differ in envelope metadata
+// (metadata.version.previous_version_id, audit timestamps, archive-time
+// tag), and the newest row carries the current version chain — so newest
+// wins, matching every other audit read in this file.
 func (s *Store) GetAuditRecordByHash(ctx context.Context, kind apiresourcekind.ApiResourceKind, resourceId, versionHash string) (*store.AuditRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1322,10 +1333,12 @@ func (s *Store) GetAuditRecordByHash(ctx context.Context, kind apiresourcekind.A
 		data []byte
 		tag  sql.NullString
 	)
-	// Query uses idx_audit_hash index for efficient lookup
+	// Query uses idx_audit_hash index and returns most recent by archived_at.
+	// Use id DESC as tiebreaker when timestamps are equal (sub-second inserts).
 	err := s.db.QueryRowContext(ctx,
 		`SELECT data, tag FROM resource_audit
 		 WHERE kind = ? AND resource_id = ? AND version_hash = ?
+		 ORDER BY archived_at DESC, id DESC
 		 LIMIT 1`,
 		kind.String(), resourceId, versionHash).Scan(&data, &tag)
 

--- a/backend/libs/go/store/sqlite/store_test.go
+++ b/backend/libs/go/store/sqlite/store_test.go
@@ -1043,6 +1043,69 @@ func TestStore_GetAuditByHash(t *testing.T) {
 	assert.True(t, errors.Is(err, store.ErrAuditNotFound), "expected ErrAuditNotFound, got: %v", err)
 }
 
+// TestStore_GetAuditByHash_DuplicateHashRowsResolveNewest pins the ordered
+// contract of the hash lookup (stigmer/stigmer-cloud#191): duplicate rows
+// for one (kind, resource_id, version_hash) are legal data — the skill push
+// path archives a re-push of prior content as a fresh row, and legacy
+// workflow rows predating the stigmer/stigmer#341 repoint semantics can
+// hold duplicates — and the lookup must return the NEWEST row (its envelope
+// carries the current version chain and archive-time tag fact), matching
+// the ordering of every other audit read.
+//
+// Negative control: without the ORDER BY, SQLite's idx_audit_hash scan
+// returns the lowest-rowid (oldest) duplicate in practice, so this test
+// fails against the previous unordered query.
+func TestStore_GetAuditByHash_DuplicateHashRowsResolveNewest(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.sqlite")
+	s, err := NewStore(dbPath)
+	require.NoError(t, err)
+	defer s.Close()
+
+	kindNameStr, err := apiresourcelib.GetKindName(apiresourcekind.ApiResourceKind_agent)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	resourceId := "agent-duplicate-hash-test"
+	agent := &agentv1.Agent{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       kindNameStr,
+		Metadata: &apiresource.ApiResourceMetadata{
+			Id:   resourceId,
+			Name: "duplicate-hash-agent",
+		},
+	}
+	err = s.SaveResource(ctx, apiresourcekind.ApiResourceKind_agent, resourceId, agent)
+	require.NoError(t, err)
+
+	// Two archives of the SAME hash with distinguishable envelopes. Both
+	// inserts land within the same datetime('now') second, so this also
+	// exercises the id DESC tiebreaker.
+	sharedHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	agent.Spec = &agentv1.AgentSpec{Description: "first archive of this content"}
+	err = s.SaveAudit(ctx, apiresourcekind.ApiResourceKind_agent, resourceId, agent, sharedHash, "")
+	require.NoError(t, err)
+
+	agent.Spec = &agentv1.AgentSpec{Description: "second archive of this content"}
+	err = s.SaveAudit(ctx, apiresourcekind.ApiResourceKind_agent, resourceId, agent, sharedHash, "re-push-tag")
+	require.NoError(t, err)
+
+	// The unmarshalling adapter returns the newest snapshot...
+	retrieved := &agentv1.Agent{}
+	err = s.GetAuditByHash(ctx, apiresourcekind.ApiResourceKind_agent, resourceId, sharedHash, retrieved)
+	require.NoError(t, err)
+	assert.Equal(t, "second archive of this content", retrieved.Spec.Description,
+		"duplicate-hash lookup must resolve to the newest row")
+
+	// ...and the record variant carries the newest row's authoritative tag column.
+	rec, err := s.GetAuditRecordByHash(ctx, apiresourcekind.ApiResourceKind_agent, resourceId, sharedHash)
+	require.NoError(t, err)
+	assert.Equal(t, "re-push-tag", rec.Tag,
+		"duplicate-hash lookup must carry the newest row's tag column")
+}
+
 func TestStore_GetAuditByTag(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.sqlite")


### PR DESCRIPTION
## Summary

- `GetAuditRecordByHash` was the only unordered `LIMIT 1` among the `resource_audit` reads (`GetLatestAuditHash`, `GetAuditRecordByTag`, and `ListAuditRecords` all order `archived_at DESC, id DESC`). Duplicate rows for one `(kind, resource_id, version_hash)` are **legal data**: the skill push path archives a re-push of prior content (A→B→A) as a fresh row — the archive-time tag-fact model — and workflow rows archived before the stigmer/stigmer#341 repoint semantics can hold duplicates too. On such rows, SQLite picked the returned row arbitrarily (oldest in practice), so `skill@<hash>` resolution and workflow version reads returned a nondeterministic envelope (`previous_version_id` chain, audit timestamps, archive-time tag).
- Adds the sibling ordering to the hash lookup: newest row wins — its envelope carries the current version chain and tag fact. The method comment documents why duplicates are legal and why the ordering is load-bearing, so it doesn't get "simplified" away.
- Deliberately **not** in this PR: any change to the skill push path or new conformance pins on A→B→A skill behavior. Whether skills should converge to the workflow versioning model (repoint + single-holder tags + unique index) is a cross-edition design ruling tracked separately (issues to follow, cross-linked from stigmer/stigmer-cloud#191).

Part of the stigmer/stigmer-cloud#191 residue (the issue's named "unordered LIMIT 1 hash lookup" nondeterminism). The workflow A→B→A half of that issue was fixed by #455 / stigmer-cloud#318.

## Test plan

- [x] New `TestStore_GetAuditByHash_DuplicateHashRowsResolveNewest`: two same-hash rows with distinguishable envelopes → newest returned by both the unmarshalling adapter and the record variant (incl. the `id DESC` sub-second tiebreaker). **Negative control proven**: fails against the unordered query (returns the oldest row), passes with the fix.
- [x] `backend/libs/go/store` full package green under `go test -race`.
- [x] Full `stigmer-server` module green under `go test -race` (50 packages).
- [x] Conformance vs `local-go`: skill suite 42/42, workflow suite 28/28.
- [x] Audited callers: `saveVersionAuditStep` (existence check — order-insensitive), workflow `getVersion`/`tagVersion`/`query`, skill `loadByReference` — all content reads where newest-envelope is the correct row. No test depends on the previous accidental oldest-row behavior.

Made with [Cursor](https://cursor.com)