### PR TITLE
fix(ci): make red on main mean something — pin Node via .nvmrc, format docs drift, self-announcing canary

### DIFF
--- a/.github/workflows/ci.conformance-cloud.yaml
+++ b/.github/workflows/ci.conformance-cloud.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install npm workspace dependencies
         run: npm ci

--- a/.github/workflows/ci.conformance-execution.yaml
+++ b/.github/workflows/ci.conformance-execution.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install npm workspace dependencies
         run: npm ci

--- a/.github/workflows/ci.conformance.yaml
+++ b/.github/workflows/ci.conformance.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install npm workspace dependencies
         run: npm ci

--- a/.github/workflows/ci.crate.yaml
+++ b/.github/workflows/ci.crate.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
 
       # `make gen-ipc-fixtures-check` installs the runner's deps on demand, then
       # regenerates the golden fixtures and fails if either committed copy (the

--- a/.github/workflows/ci.docs.yaml
+++ b/.github/workflows/ci.docs.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack

--- a/.github/workflows/ci.e2e.yaml
+++ b/.github/workflows/ci.e2e.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.frontend.yaml
+++ b/.github/workflows/ci.frontend.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack
@@ -120,7 +120,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack
@@ -153,7 +153,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack
@@ -204,7 +204,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Enable Corepack

--- a/.github/workflows/ci.integration-canary.yaml
+++ b/.github/workflows/ci.integration-canary.yaml
@@ -37,6 +37,8 @@ concurrency:
 permissions:
   contents: read
   checks: write
+  # Lets the notify-failure job file/update the canary-failure issue.
+  issues: write
 
 jobs:
   build-service-jar:
@@ -104,7 +106,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install npm workspace dependencies
         run: npm ci
@@ -150,3 +152,31 @@ jobs:
           name: Canary Test Report
           path: test/integration/.test-output-canary/junit.xml
           reporter: java-junit
+
+  # Scheduled runs have no PR to block, so a red canary is invisible unless it
+  # announces itself — this lane once sat red for 30+ days unnoticed (#323).
+  # One open issue per breakage window: subsequent failures comment on the
+  # existing issue instead of filing duplicates; closing it arms the next one.
+  # Manual dispatches are attended, so only cron failures notify.
+  notify-failure:
+    name: File Canary Failure Issue
+    runs-on: ubuntu-latest
+    needs: [build-service-jar, canary-tests]
+    if: failure() && github.event_name == 'schedule'
+    steps:
+      - name: File or update the canary-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" \
+            --label ci-canary-failure --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" \
+              --body "Nightly provider canary failed again: $run_url"
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --label ci-canary-failure \
+              --title "ci.integration-canary: nightly provider canary is failing" \
+              --body "$(printf 'The scheduled provider canary failed: %s\n\nThis lane asserts only that live provider calls complete (model retirement, proxy breakage, API key expiry). A failure here usually means a provider or credential problem, not a code regression.\n\nThis issue is filed automatically by the notify-failure job; later failures add comments here instead of new issues. Close it once the lane is green again.' "$run_url")"
+          fi

--- a/.github/workflows/ci.integration-canary.yaml
+++ b/.github/workflows/ci.integration-canary.yaml
@@ -144,6 +144,10 @@ jobs:
           path: test/integration/.test-output-canary/
           retention-days: 30
           if-no-files-found: ignore
+          # The output dir is dot-prefixed and upload-artifact@v4 excludes
+          # hidden paths by default — without this the artifact is silently
+          # empty (found on the lane's first real run, #323).
+          include-hidden-files: true
 
       - name: Publish canary test report
         if: always() && hashFiles('test/integration/.test-output-canary/junit.xml') != ''

--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -208,7 +208,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install npm workspace dependencies
         run: npm ci

--- a/.github/workflows/ci.integration-providers.yaml
+++ b/.github/workflows/ci.integration-providers.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Run provider integration tests
         env:

--- a/.github/workflows/ci.runner.yaml
+++ b/.github/workflows/ci.runner.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install npm workspace dependencies
         run: npm ci

--- a/.github/workflows/release.crate.yaml
+++ b/.github/workflows/release.crate.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
 
       # Cargo-native version stamping (analogue of maven versions:set / the python
       # regex). Prebuilt binary so it installs in seconds.

--- a/.github/workflows/release.desktop.yaml
+++ b/.github/workflows/release.desktop.yaml
@@ -225,7 +225,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: ".nvmrc"
           cache: 'npm'
 
       - name: Install Rust stable

--- a/.github/workflows/release.dev.yaml
+++ b/.github/workflows/release.dev.yaml
@@ -211,7 +211,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: ".nvmrc"
           cache: 'npm'
 
       - name: Install dependencies
@@ -246,7 +246,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: ".nvmrc"
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: ".nvmrc"
           cache: 'npm'
 
       - name: Install dependencies
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: ".nvmrc"
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.website.yaml
+++ b/.github/workflows/release.website.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Enable Corepack
         run: corepack enable

--- a/docs/concepts/agents.mdx
+++ b/docs/concepts/agents.mdx
@@ -177,13 +177,12 @@ The assistant is minimal by design. It has no Skills and no MCP server
 references — it's a blank slate. The value of Stigmer appears when you create
 Agents tailored to your domain.
 
-The `stigmer.ai/default-agent: "true"` label is what marks the default, and
-the Agent must be publicly visible to serve as one. To replace the default,
-apply the new labeled Agent first, then remove the label from the old one —
-that removal is the cutover. While both carry the label, the original keeps
-serving: among labeled public Agents, the longest-standing one (lowest ID)
-wins, so the default never changes as a side effect of another Agent gaining
-the label.
+The `stigmer.ai/default-agent: "true"` label is what marks the default, and the
+Agent must be publicly visible to serve as one. To replace the default, apply
+the new labeled Agent first, then remove the label from the old one — that
+removal is the cutover. While both carry the label, the original keeps serving:
+among labeled public Agents, the longest-standing one (lowest ID) wins, so the
+default never changes as a side effect of another Agent gaining the label.
 
 ## Instructions matter
 

--- a/sdk/react/src/channel/__tests__/AgentChannelsPanel.test.tsx
+++ b/sdk/react/src/channel/__tests__/AgentChannelsPanel.test.tsx
@@ -417,7 +417,9 @@ describe("AgentChannelsPanel", () => {
     // bar as viewing its sessions, DD-012). Mutation items stay
     // permission-gated and absent.
     fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
-    expect(screen.getByRole("menuitem", { name: /sessions/i })).toBeTruthy();
+    // The awaited query anchors on the portaled menu's mount (#323) — only
+    // then are the absence assertions below meaningful rather than vacuous.
+    expect(await screen.findByRole("menuitem", { name: /sessions/i })).toBeTruthy();
     expect(screen.queryByRole("menuitem", { name: /tool credentials/i })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: /disconnect/i })).toBeNull();
   });
@@ -440,7 +442,7 @@ describe("AgentChannelsPanel", () => {
     await waitFor(() => expect(screen.getByText("Support Slack")).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
-    fireEvent.click(screen.getByRole("menuitem", { name: /manage access/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /manage access/i }));
 
     // The one canonical dialog opens, and its subtitle names the channel
     // — the scope every grant covers (a participant grant is per

--- a/sdk/react/src/composer/__tests__/SessionComposer-lockAgent.test.tsx
+++ b/sdk/react/src/composer/__tests__/SessionComposer-lockAgent.test.tsx
@@ -79,10 +79,17 @@ function renderComposer(
   );
 }
 
-function openConfigureMenu() {
+/**
+ * Opens the composer's Configure menu and resolves once the portaled menu
+ * content mounts. Menu items render asynchronously in a portal, so a
+ * synchronous item query straight after the click races the mount (the
+ * openRowMenu idiom; see stigmer/stigmer#323).
+ */
+async function openConfigureMenu() {
   fireEvent.click(
     screen.getByRole("button", { name: "Configure agent, tools, and skills" }),
   );
+  await screen.findByRole("menu");
 }
 
 beforeEach(() => {
@@ -92,25 +99,25 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("SessionComposer — lockAgent", () => {
-  it("shows the Agent entry in the Configure menu by default", () => {
+  it("shows the Agent entry in the Configure menu by default", async () => {
     renderComposer();
-    openConfigureMenu();
+    await openConfigureMenu();
 
     expect(screen.getByRole("menuitem", { name: /Agent/ })).toBeTruthy();
   });
 
-  it("hides the Agent entry when locked, leaving other entries intact", () => {
+  it("hides the Agent entry when locked, leaving other entries intact", async () => {
     renderComposer({
       lockAgent: true,
       agentRef: { org: "acme", slug: "support-bot" },
     });
-    openConfigureMenu();
+    await openConfigureMenu();
 
     expect(screen.queryByRole("menuitem", { name: /Agent/ })).toBeNull();
     expect(screen.getByRole("menuitem", { name: /Skills/ })).toBeTruthy();
   });
 
-  it("keeps the Agent entry reachable while a locked agent needs env vars", () => {
+  it("keeps the Agent entry reachable while a locked agent needs env vars", async () => {
     // A pinned agent that requires credentials: resolution is pending and
     // the env form lives in the Configure > Agent panel — lock ≠ unwire.
     mockAgentSetup.state = {
@@ -126,11 +133,11 @@ describe("SessionComposer — lockAgent", () => {
     expect(screen.getByText("Agent needs configuration before use")).toBeTruthy();
 
     // ...and as a (warning-marked) Configure menu entry, despite the lock.
-    openConfigureMenu();
+    await openConfigureMenu();
     expect(screen.getByRole("menuitem", { name: /Agent/ })).toBeTruthy();
   });
 
-  it("removes the Agent entry once the locked agent has resolved", () => {
+  it("removes the Agent entry once the locked agent has resolved", async () => {
     mockAgentSetup.state = { status: "idle" };
     renderComposer({
       lockAgent: true,
@@ -138,7 +145,7 @@ describe("SessionComposer — lockAgent", () => {
     });
 
     expect(screen.queryByText("Agent needs configuration before use")).toBeNull();
-    openConfigureMenu();
+    await openConfigureMenu();
     expect(screen.queryByRole("menuitem", { name: /Agent/ })).toBeNull();
   });
 });

--- a/sdk/react/vitest.setup.ts
+++ b/sdk/react/vitest.setup.ts
@@ -7,10 +7,14 @@ import { configure } from "@testing-library/react";
 // sprinkling per-call timeouts: passing tests are unaffected (waits resolve
 // the moment the element appears); only genuinely failing waits report later.
 //
+// 8s, not less: during the 2026-08-11 merge-rush contention window a menu
+// mount blew the previous 4s allowance on a starved runner (#323) — a wait
+// this generous only delays the report of a real failure, never a pass.
+//
 // Kept below the raised vitest testTimeout (vitest.config.ts) so a failing
 // wait still surfaces the informative testing-library error with a DOM dump,
 // never a bare vitest "test timed out".
-configure({ asyncUtilTimeout: 4000 });
+configure({ asyncUtilTimeout: 8000 });
 
 // No test may reach the real network. Any code path that calls the global
 // fetch unmocked fails immediately, in the right test file, instead of


### PR DESCRIPTION
## Summary

Fixes the three chronically red CI lanes from #323 — each was a different disease:

### ci.docs — formatting drift
PR #458 landed `docs/concepts/agents.mdx` unformatted (merged without waiting on checks). Formatted with the repo's own prose-wrap flags. Verified: `make format-docs-check` green, docs YAML gate green (119 blocks, 0 unclassified).

### ci.frontend — CI toolchain changed with zero commits
The last green run on main resolved Node 22.23.1; the first red run 100 minutes later resolved 22.23.2 — GitHub's toolcache rolled a Node patch mid-day and every `setup-node` site floats on `node-version: 22`. Nothing in the repo changed.

- **Determinism fix**: the repo already pins Node exactly in `.nvmrc` (22.22.1) and CI ignored it. All 23 Node-22 workflow sites now use `node-version-file: ".nvmrc"` — the `go-version-file: go.work` idiom this repo already uses for Go. A toolchain change is now a reviewable diff. The four Node-20 workflows (`ci.seedpack-canary`, `reconcile-homebrew`, `release.dev` one job, `release.mcp-server`) are deliberately untouched: changing release-lane toolchains without cause is not this PR's business, but they carry the same floating-version class.
- **Honest causality note**: a probe PR (#473, throwaway) pinning ci.frontend to 22.23.2 came back GREEN on Linux, so 22.23.2 is not a deterministic break — the red window was toolchain roll + the day's merge-rush runner contention. Two of the three failures were an *unanchored* synchronous menu query; the third blew the 4s async allowance on a starved runner.
- **Test hardening**: the genuinely unanchored portaled-menu queries are now anchored (`openConfigureMenu` resolves on menu mount — the documented `openRowMenu` idiom; plus two `AgentChannelsPanel` sites, one of which was the repeated CI failure). The remaining sync `menuitem` queries all follow an awaited anchor and stay sync by convention. `asyncUtilTimeout` raised 4s → 8s with an incident-citing comment (a longer allowance only delays a real failure's report, never a pass).

### ci.integration-canary — never ran once since creation
The `provider-integration` environment carried **zero secrets**, so every nightly run died at bootstrap before a single test ran. Provisioned `ANTHROPIC_API_KEY` + `CURSOR_API_KEY` from Planton (repo settings, not in-tree). Scheduled lanes have no PR to block, so failures were invisible — the new `notify-failure` job files/updates a `ci-canary-failure`-labeled issue on cron failures (label created).

First real dispatch got past bootstrap and ran all five tests for the first time ever; execution-path failures under diagnosis (30+ days of rot to burn through — tracked in the session record, not blocking this PR's lanes).

## Verification

- sdk/react: full suite 4344/4344 under Node 22.22.1 AND 22.23.2 locally; web 35/35 + desktop 42/42 under 22.23.2; probe PR proves SDK/web/desktop suites green under 22.23.2 on Linux.
- All 16 edited workflow files parse-validated.
- Touched test files re-run green (45 tests).

Made with [Cursor](https://cursor.com)