### PR TITLE
fix(test/integration): fail fast when the unified runner cannot boot

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -113,7 +113,7 @@ ensure-runner-dist:
 # ─── Targets ──────────────────────────────────
 
 .PHONY: test
-test: ensure-service-jar ## Run offline integration tests (no API keys needed)
+test: check-runner-node ensure-service-jar ## Run offline integration tests (no API keys needed)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -132,7 +132,7 @@ test: ensure-service-jar ## Run offline integration tests (no API keys needed)
 		-- -tags integration -timeout 900s -count=1 $(call quarantine_skip_args)
 
 .PHONY: test-providers
-test-providers: ensure-service-jar ## Run provider-backed integration tests (auto-fetches API keys)
+test-providers: check-runner-node ensure-service-jar ## Run provider-backed integration tests (auto-fetches API keys)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -175,7 +175,7 @@ test-providers: ensure-service-jar ## Run provider-backed integration tests (aut
 		-- -tags integration -timeout 900s -count=1 $(call quarantine_skip_args) -run 'TestWorkflow(LlmCall|AgentCall|CursorCall|Architect|Eval|_StructuredOutput)|TestAgentExecution'
 
 .PHONY: test-canary
-test-canary: ensure-service-jar ## Run canary tests (live provider health checks, auto-fetches API keys)
+test-canary: check-runner-node ensure-service-jar ## Run canary tests (live provider health checks, auto-fetches API keys)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -216,7 +216,7 @@ test-canary: ensure-service-jar ## Run canary tests (live provider health checks
 		-- -tags integration -timeout 600s -count=1 -run 'TestCanary_'
 
 .PHONY: test-workflow-architect
-test-workflow-architect: ensure-service-jar ## Run Workflow Architect agent E2E tests (auto-fetches API keys)
+test-workflow-architect: check-runner-node ensure-service-jar ## Run Workflow Architect agent E2E tests (auto-fetches API keys)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -257,7 +257,7 @@ test-workflow-architect: ensure-service-jar ## Run Workflow Architect agent E2E 
 		-- -tags integration -timeout 900s -count=1 $(call quarantine_skip_args) -run 'TestWorkflowArchitect'
 
 .PHONY: test-agent
-test-agent: ensure-service-jar ## Run agent execution integration tests (auto-fetches API keys)
+test-agent: check-runner-node ensure-service-jar ## Run agent execution integration tests (auto-fetches API keys)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -301,7 +301,7 @@ FAILING_OUTPUT_DIR ?= .test-output-failing
 TEST_RUN ?=
 
 .PHONY: test-subset
-test-subset: ensure-service-jar ## Run a subset of integration tests: make test-subset TEST_RUN='TestFoo|TestBar'
+test-subset: check-runner-node ensure-service-jar ## Run a subset of integration tests: make test-subset TEST_RUN='TestFoo|TestBar'
 	@if [ -z "$(TEST_RUN)" ]; then \
 		echo "error: TEST_RUN is required"; \
 		echo "  usage: make test-subset TEST_RUN='TestAgentExecution_Foo|TestAgentExecution_Bar'"; \
@@ -351,7 +351,7 @@ test-subset: ensure-service-jar ## Run a subset of integration tests: make test-
 SDK_OUTPUT_DIR ?= .test-output-sdk
 
 .PHONY: test-sdk
-test-sdk: ensure-service-jar ## Run SDK acceptance smoke tests (Go, TypeScript, Python)
+test-sdk: check-runner-node ensure-service-jar ## Run SDK acceptance smoke tests (Go, TypeScript, Python)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -373,7 +373,7 @@ REPLAY_HISTORY_OUTPUT_DIR ?= ../../backend/services/workflow-runner/test/replay/
 REPLAY_CAPTURE_OUTPUT_DIR ?= .test-output-replay-capture
 
 .PHONY: capture-replay-histories
-capture-replay-histories: ensure-service-jar ## Capture Temporal event histories for replay determinism tests
+capture-replay-histories: check-runner-node ensure-service-jar ## Capture Temporal event histories for replay determinism tests
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -406,9 +406,13 @@ BENCHMARK_RUN_PATTERN ?= TestCostBenchmark
 
 # The unified runner requires node:sqlite (Cursor SDK local state). On a Node
 # without it (e.g. 23.1.0; needs 22.13+/23.4+) the runner prints one error and
-# dies — but the manager still reports ready, so every execution silently times
-# out at 4 minutes. On the benchmark lanes that burns a full paid run before
-# anyone notices, so those lanes assert the capability before spending money.
+# dies, and every runner-dependent test strands in a silent timeout instead of
+# failing fast (oss#307: 6 tests "failed deterministically" for weeks before
+# the Node version was identified). Every lane in this Makefile boots the
+# runner through the suite's TestMain, so every lane gets this guard as its
+# first prerequisite — it turns a multi-hour debugging trap into a two-second
+# actionable error. On the paid benchmark lanes it additionally prevents
+# burning a full run before anyone notices.
 .PHONY: check-runner-node
 check-runner-node:
 	@command -v node >/dev/null 2>&1 || { \
@@ -418,7 +422,8 @@ check-runner-node:
 	}
 	@node -e "require('node:sqlite')" >/dev/null 2>&1 || { \
 		echo "error: Node $$(node --version) lacks node:sqlite — the unified runner will die at startup"; \
-		echo "  and every benchmark execution would time out (~4 min each), wasting the whole run."; \
+		echo "  and every runner-dependent test (or paid benchmark run) would strand in a silent"; \
+		echo "  multi-minute timeout instead of failing (oss#307)."; \
 		echo "  fix: nvm use v22.22.1 (or any Node >= 22.13 / >= 23.4)"; \
 		exit 1; \
 	}
@@ -511,7 +516,7 @@ benchmark-cursor-modes: check-runner-node ensure-service-jar ensure-runner-dist 
 		-- -tags 'integration benchmark' -timeout 1800s -count=1 -run 'TestCostBenchmark_CursorLocalVsCloud'
 
 .PHONY: test-traced
-test-traced: ensure-service-jar ## Run offline integration tests with OTel tracing (Jaeger)
+test-traced: check-runner-node ensure-service-jar ## Run offline integration tests with OTel tracing (Jaeger)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -538,7 +543,7 @@ test-traced: ensure-service-jar ## Run offline integration tests with OTel traci
 # flakes. Quarantine skip is disabled so quarantined tests are also exercised.
 
 .PHONY: test-stress
-test-stress: ensure-service-jar ## Run offline integration tests 3x to detect flakes (no quarantine skip)
+test-stress: check-runner-node ensure-service-jar ## Run offline integration tests 3x to detect flakes (no quarantine skip)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \

--- a/test/integration/harness/BUILD.bazel
+++ b/test/integration/harness/BUILD.bazel
@@ -141,6 +141,7 @@ go_test(
         "benchmark_helpers_test.go",
         "benchmark_stats_test.go",
         "ipc_fixtures_test.go",
+        "unified_runner_test.go",
     ],
     embed = [":harness"],
     deps = [

--- a/test/integration/harness/unified_runner.go
+++ b/test/integration/harness/unified_runner.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -550,20 +551,35 @@ func StartUnifiedRunnerStatic(ctx context.Context, cfg UnifiedRunnerConfig, task
 		return nil, fmt.Errorf("start unified-runner-static: %w", err)
 	}
 
-	// Give Temporal worker time to connect and register.
-	time.Sleep(5 * time.Second)
+	// Race process death against the startup window instead of polling
+	// cmd.ProcessState, which is only populated by Wait() and therefore can
+	// never observe an early exit (the pre-oss#307 check was dead code: a
+	// runner that died at boot — e.g. Node without node:sqlite — was still
+	// reported "started", and every execution then timed out silently). The
+	// Wait goroutine also reaps the child, so a boot-time death no longer
+	// leaves a zombie for the life of the suite.
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
 
-	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+	// Give the Temporal worker time to connect and register; a process that
+	// survives this window is considered started (worker-level readiness is
+	// observed by the tests themselves).
+	select {
+	case waitErr := <-waitCh:
 		logFile.Sync()
+		lastLog := ""
 		if logBytes, readErr := os.ReadFile(logPath); readErr == nil {
-			lines := string(logBytes)
-			if len(lines) > 2000 {
-				lines = lines[len(lines)-2000:]
+			lastLog = string(logBytes)
+			if len(lastLog) > 2000 {
+				lastLog = lastLog[len(lastLog)-2000:]
 			}
-			logger.Error("unified-runner-static exited prematurely", "last_log", lines)
 		}
+		logger.Error("unified-runner-static exited during startup",
+			"wait_err", waitErr, "last_log", lastLog)
 		logFile.Close()
-		return nil, fmt.Errorf("unified-runner-static exited during startup")
+		return nil, fmt.Errorf("unified-runner-static exited during startup (log: %s): %s",
+			logPath, strings.TrimSpace(lastLog))
+	case <-time.After(5 * time.Second):
 	}
 
 	logger.Info("unified-runner-static started", "pid", cmd.Process.Pid, "task_queue", taskQueue)
@@ -583,6 +599,11 @@ func (r *UnifiedRunnerStatic) Stop() error {
 	}
 	r.logger.Info("stopping unified-runner-static")
 	err := r.cmd.Process.Kill()
+	// The startup Wait goroutine reaps the child, so a runner that already
+	// died is not an error worth surfacing to Stop's callers.
+	if errors.Is(err, os.ErrProcessDone) {
+		err = nil
+	}
 	if r.logFile != nil {
 		r.logFile.Close()
 	}

--- a/test/integration/harness/unified_runner_test.go
+++ b/test/integration/harness/unified_runner_test.go
@@ -1,0 +1,89 @@
+package harness
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeRunnerDir builds a minimal runner directory (package.json + dist/main.js)
+// so resolveRunnerCommand launches `node dist/main.js` with the given script
+// body. UNIFIED_RUNNER_DIR points StartUnifiedRunnerStatic at it.
+func fakeRunnerDir(t *testing.T, mainJS string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"fake-runner"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "dist"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dist", "main.js"), []byte(mainJS), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestStartUnifiedRunnerStatic_BootDeathIsAnError pins the oss#307 failure
+// mode: a runner process that dies during startup (e.g. Node without
+// node:sqlite prints one error and exits) must surface as a start error —
+// so the suite degrades to clean skips — instead of being reported
+// "started", which strands every runner-dependent test in a silent timeout.
+//
+// Before the fix this test fails: the old premature-exit check polled
+// cmd.ProcessState after a sleep, which is only populated by Wait() and so
+// never observed the death.
+func TestStartUnifiedRunnerStatic_BootDeathIsAnError(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH")
+	}
+	t.Setenv("UNIFIED_RUNNER_DIR", fakeRunnerDir(t,
+		`console.error("fake runner: fatal boot error (oss#307 pin)"); process.exit(1);`))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	runner, err := StartUnifiedRunnerStatic(context.Background(), UnifiedRunnerConfig{
+		StigmerServiceAddress: "127.0.0.1:1",
+		TemporalAddress:       "127.0.0.1:1",
+		LogDir:                t.TempDir(),
+	}, "pin_boot_death", logger)
+
+	if err == nil {
+		_ = runner.Stop()
+		t.Fatal("StartUnifiedRunnerStatic reported success for a runner that died at boot")
+	}
+	if want := "exited during startup"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not mention %q", err.Error(), want)
+	}
+	// The error must carry the runner's own diagnostic so the operator sees
+	// the actionable cause (for oss#307 that was the node:sqlite message).
+	if want := "fatal boot error"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not surface the runner log tail (%q)", err.Error(), want)
+	}
+}
+
+// TestStartUnifiedRunnerStatic_SurvivingProcessStarts is the control: a
+// process that outlives the startup window starts normally and stops cleanly.
+func TestStartUnifiedRunnerStatic_SurvivingProcessStarts(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH")
+	}
+	t.Setenv("UNIFIED_RUNNER_DIR", fakeRunnerDir(t,
+		`setInterval(() => {}, 1000);`))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	runner, err := StartUnifiedRunnerStatic(context.Background(), UnifiedRunnerConfig{
+		StigmerServiceAddress: "127.0.0.1:1",
+		TemporalAddress:       "127.0.0.1:1",
+		LogDir:                t.TempDir(),
+	}, "pin_survivor", logger)
+	if err != nil {
+		t.Fatalf("StartUnifiedRunnerStatic failed for a healthy process: %v", err)
+	}
+	if err := runner.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Root-causes and closes #307. The filed defects — `TestSDKAcceptance_Python` + 5 `TestWorkflowAgentCall_*` failing deterministically in the offline lane, and `TestWorkflowAgentCall_NonexistentAgent` grinding the gotestsum rerun pass — were never product or test-code defects. They are one **unguarded environment trap**: on a Node without `node:sqlite` (e.g. v23.1.0), the unified runner prints one error and dies at boot, but the harness still reported it "started", so every runner-dependent test stranded in a multi-minute silent timeout while LLM-gated siblings skipped — exactly the filed set. CI never saw it because CI pins Node 22.

The repo already had the guard (`check-runner-node`) — wired only into the paid benchmark lanes — and the harness already *intended* to detect boot death, but that check was dead code.

## What changed

- **`test/integration/Makefile`** — `check-runner-node` is now the first prerequisite of every lane that boots the runner via the suite's TestMain (`test`, `test-providers`, `test-canary`, `test-workflow-architect`, `test-agent`, `test-subset`, `test-sdk`, `capture-replay-histories`, `test-traced`, `test-stress`; the two benchmark lanes already had it). Guard copy + comment truthed: this protects every lane, not just paid runs.
- **`harness/unified_runner.go`** — `StartUnifiedRunnerStatic`'s premature-exit check polled `cmd.ProcessState`, which only `Wait()` populates — it could never fire, and the dead child leaked as a zombie for the life of the suite. It now races a `Wait()` goroutine against the 5s startup window and returns the runner's own log tail in the error; the suite's existing degrade path (`UnifiedRunner = nil` → clean skips with a WARN naming the cause) then does the right thing. `Stop()` tolerates the already-reaped process. (Manager mode was already correct — its IPC ready-handshake fails fast when stdout closes.)
- **`harness/unified_runner_test.go`** (new, registered in BUILD) — pins boot-death-is-an-error (fails against the old code) including the requirement that the error surfaces the runner's own diagnostic, plus the healthy-start control.

## Verification

- **Negative control (Node 23.1.0, pre-fix code)**: reproduced the filed signature 1:1 — Python Tier-2 dead at `EXECUTION_PENDING` (91.8s), `LiveEventsEmitted` 4m timeout, `NonexistentAgent` 90s timeout; rerun pass ground through 23 minutes of per-test infra re-boots (one of which failed under load — the filed "hang" mode). Runner log carried the node:sqlite fatal; runner process was a zombie.
- **CI-parity control (Node 22.22.1, rebuilt runner dist, clean-worktree service JAR from cloud `origin/main`)**: full offline lane — 934 tests, all #307 tests PASS (`NonexistentAgent` 0.47s, Python 3.98s); the only failures are the five `TestArtifact_*` of #447 (separately tracked), matching CI run 31520092974 exactly.
- **Fix proofs**: harness pin red on old code, green on new; `make check-runner-node` passes on Node 22 and fails in ~2s on Node 23.1.0 with the nvm instruction; end-to-end wrong-Node run through the fixed harness now completes in 16s with a clean SKIP and an actionable WARN (was: silent multi-minute failures).
- `gofmt` clean on touched files; `go vet ./harness/` clean; gazelle confirms the BUILD registration.

## Notes for reviewers

- The remaining lane red (5 × `TestArtifact_*`, `FailedPrecondition: source execution not found or carries no org`) is #447 — not touched here.
- `TestSDKAcceptance_TypeScript` silently never runs anywhere (no `tsx` on PATH in CI or locally) — filed separately rather than fixed here.

Closes #307

Made with [Cursor](https://cursor.com)

## Rider

- Removes `test/integration/${SQLITE_DB_PATH}` — a zero-byte file literally named after an unexpanded env var, accidentally committed in `14e1ed042` (2026-05 seedpack sqlite work) and tracked ever since. Spotted while ruling it out as a suspect for this issue.