### PR TITLE
fix(sdk-react): replace native title tooltips with the house tooltip and ban them by lint

### DIFF
--- a/client-apps/desktop/eslint.config.mjs
+++ b/client-apps/desktop/eslint.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig([
     plugins: { stigmer: stigmerPlugin },
     rules: {
       "stigmer/sdk-import-boundaries": "error",
+      "stigmer/no-native-title": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/no-main-tokens-in-sidebar": "warn",
     },

--- a/client-apps/desktop/src/shell/Sidebar.tsx
+++ b/client-apps/desktop/src/shell/Sidebar.tsx
@@ -167,13 +167,17 @@ export function Sidebar() {
  * Pulsing dot shown on a recents row whose execution is still running in the
  * background (its session worker is kept alive by an in-flight activity even
  * though the user navigated away).
+ *
+ * No `title` here: the accessory renders inside the SDK sidebar's recents
+ * rows, whose row-level house tooltip already owns hover — a native title on
+ * the dot would fight it with a second, OS-styled popup. The `aria-label`
+ * carries the name for screen readers.
  */
 function BackgroundRunDot() {
   return (
     <span
       role="status"
       aria-label="Running in background"
-      title="Running in background"
       className="relative mt-1 flex size-2 shrink-0"
     >
       <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary opacity-75" />

--- a/client-apps/web/eslint.config.mjs
+++ b/client-apps/web/eslint.config.mjs
@@ -29,6 +29,7 @@ const eslintConfig = defineConfig([
       ],
       "@typescript-eslint/no-explicit-any": "error",
       "stigmer/no-main-tokens-in-sidebar": "warn",
+      "stigmer/no-native-title": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/sdk-import-boundaries": "error",
     },

--- a/sdk/react/eslint.config.mjs
+++ b/sdk/react/eslint.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig([
     plugins: { stigmer: stigmerPlugin },
     rules: {
       "stigmer/sdk-import-boundaries": "error",
+      "stigmer/no-native-title": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/no-main-tokens-in-sidebar": "warn",
     },

--- a/sdk/react/src/agent-instance/AgentInstanceList.tsx
+++ b/sdk/react/src/agent-instance/AgentInstanceList.tsx
@@ -11,6 +11,7 @@ import { Button } from "../button/Button.js";
 import { useEnvironmentList } from "../environment/useEnvironmentList.js";
 import { ResourceVisibilityControl } from "../library/ResourceVisibilityControl.js";
 import { useCheckPermission } from "../iam-policy/useCheckPermission.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { AgentInstanceEmptyState } from "./AgentInstanceEmptyState.js";
 
 /** Label marking a user's auto-managed personal instance. */
@@ -216,12 +217,10 @@ function InstanceRow({
       <td className="stg:px-4 stg:py-2.5">
         <div className="stg:min-w-0">
           <div className="stg:flex stg:min-w-0 stg:items-center stg:gap-2">
-            <span
-              className="stg:truncate stg:font-medium stg:text-foreground"
-              title={meta?.name || meta?.slug || undefined}
-            >
-              {meta?.name || meta?.slug || "\u2014"}
-            </span>
+            <TruncatedText
+              text={meta?.name || meta?.slug || "\u2014"}
+              className="stg:font-medium stg:text-foreground"
+            />
             {isPersonal && (
               <span
                 className={cn(

--- a/sdk/react/src/api-key/ApiKeyListPanel.tsx
+++ b/sdk/react/src/api-key/ApiKeyListPanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { ApiKey } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/api_pb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useApiKeyList } from "./useApiKeyList.js";
 import { useDeleteApiKey } from "./useDeleteApiKey.js";
 
@@ -242,9 +243,16 @@ function ApiKeyRow({
       {/* Metadata columns */}
       <div className="stg:hidden stg:sm:flex stg:shrink-0 stg:items-center stg:gap-4 stg:text-xs stg:text-muted-foreground">
         {createdAt && (
-          <span title={`Created ${timestampDate(createdAt).toISOString()}`}>
-            {formatShortDate(timestampDate(createdAt))}
-          </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={<time dateTime={timestampDate(createdAt).toISOString()} />}
+            >
+              {formatShortDate(timestampDate(createdAt))}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {`Created ${timestampDate(createdAt).toISOString()}`}
+            </TooltipContent>
+          </Tooltip>
         )}
         <span>
           {neverExpires

--- a/sdk/react/src/attachment/AttachmentChipList.tsx
+++ b/sdk/react/src/attachment/AttachmentChipList.tsx
@@ -7,6 +7,7 @@ import { formatFileSize } from "./attachment-utils.js";
 import { useObjectUrl } from "./useObjectUrl.js";
 import { AttachmentImageLightbox } from "./AttachmentImageLightbox.js";
 import { UNSTYLED_BUTTON } from "../internal/form-primitives.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link AttachmentChipList}. */
 export interface AttachmentChipListProps {
@@ -216,84 +217,92 @@ function ImageAttachmentChip({
   return (
     // The remove badge and retry pill are SIBLINGS of the preview button,
     // absolutely positioned over it — buttons cannot nest inside buttons.
-    <span
-      role="listitem"
-      aria-label={chipAriaLabel(entry)}
-      title={entry.file.name}
-      className="stg:relative stg:inline-flex"
-    >
-      {/* The whole tile is the preview target. Preview stays enabled while
-          `disabled` (that prop gates the mutating remove/retry actions) and
-          in every phase: the object URL wraps in-memory bytes, no fetch.
-          UNSTYLED_BUTTON adds the pointer cursor — the image tile carries
-          no other clickability cue. */}
-      <button
-        type="button"
-        onClick={onPreview}
-        aria-label={`Preview ${entry.file.name}`}
-        className={cn(
-          UNSTYLED_BUTTON,
-          "stg:relative stg:block stg:h-14 stg:w-14 stg:overflow-hidden stg:rounded-md stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-          isError && "stg:ring-1 stg:ring-destructive",
-        )}
-      >
-        {url ? (
-          <img
-            src={url}
-            alt=""
-            aria-hidden="true"
-            onError={() => setLoadFailed(true)}
-            className={cn(
-              "stg:h-full stg:w-full stg:object-cover",
-              (isUploading || isError) && "stg:opacity-50",
-            )}
-          />
-        ) : (
-          // One-frame placeholder until the object-URL effect runs; same
-          // footprint as the image, so no layout shift.
+    <Tooltip>
+      <TooltipTrigger
+        render={
           <span
-            className="stg:block stg:h-full stg:w-full stg:animate-pulse stg:bg-muted"
-            aria-hidden="true"
+            role="listitem"
+            aria-label={chipAriaLabel(entry)}
+            className="stg:relative stg:inline-flex"
           />
-        )}
-        {isUploading && (
-          <span className="stg:absolute stg:inset-0 stg:flex stg:items-center stg:justify-center">
-            <ChipSpinner size={16} />
-          </span>
-        )}
-      </button>
-
-      {isError && (
+        }
+      >
+        {/* The whole tile is the preview target. Preview stays enabled while
+            `disabled` (that prop gates the mutating remove/retry actions) and
+            in every phase: the object URL wraps in-memory bytes, no fetch.
+            UNSTYLED_BUTTON adds the pointer cursor — the image tile carries
+            no other clickability cue. */}
         <button
           type="button"
-          onClick={onRetry}
-          disabled={disabled}
-          aria-label={`Retry uploading ${entry.file.name}`}
+          onClick={onPreview}
+          aria-label={`Preview ${entry.file.name}`}
           className={cn(
             UNSTYLED_BUTTON,
-            "stg:absolute stg:left-1/2 stg:top-1/2 stg:-translate-x-1/2 stg:-translate-y-1/2 stg:rounded-full stg:bg-destructive stg:px-1.5 stg:py-0.5 stg:text-[0.6rem] stg:font-medium stg:leading-none stg:text-destructive-foreground stg:shadow-sm stg:hover:bg-destructive-hover stg:disabled:pointer-events-none",
+            "stg:relative stg:block stg:h-14 stg:w-14 stg:overflow-hidden stg:rounded-md stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+            isError && "stg:ring-1 stg:ring-destructive",
           )}
         >
-          Retry
+          {url ? (
+            <img
+              src={url}
+              alt=""
+              aria-hidden="true"
+              onError={() => setLoadFailed(true)}
+              className={cn(
+                "stg:h-full stg:w-full stg:object-cover",
+                (isUploading || isError) && "stg:opacity-50",
+              )}
+            />
+          ) : (
+            // One-frame placeholder until the object-URL effect runs; same
+            // footprint as the image, so no layout shift.
+            <span
+              className="stg:block stg:h-full stg:w-full stg:animate-pulse stg:bg-muted"
+              aria-hidden="true"
+            />
+          )}
+          {isUploading && (
+            <span className="stg:absolute stg:inset-0 stg:flex stg:items-center stg:justify-center">
+              <ChipSpinner size={16} />
+            </span>
+          )}
         </button>
-      )}
 
-      <button
-        type="button"
-        onClick={onRemove}
-        disabled={disabled}
-        aria-label={`Remove ${entry.file.name}`}
-        className={cn(
-          UNSTYLED_BUTTON,
-          // The established corner-badge geometry (ContextPopover,
-          // ComposerToolbar). Solid bg + border keep it legible over any
-          // image without opacity-modified tokens (Dont-Do #4).
-          "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-4 stg:w-4 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-border stg:bg-background stg:text-muted-foreground stg:shadow-sm stg:hover:text-destructive stg:disabled:pointer-events-none",
+        {isError && (
+          <button
+            type="button"
+            onClick={onRetry}
+            disabled={disabled}
+            aria-label={`Retry uploading ${entry.file.name}`}
+            className={cn(
+              UNSTYLED_BUTTON,
+              "stg:absolute stg:left-1/2 stg:top-1/2 stg:-translate-x-1/2 stg:-translate-y-1/2 stg:rounded-full stg:bg-destructive stg:px-1.5 stg:py-0.5 stg:text-[0.6rem] stg:font-medium stg:leading-none stg:text-destructive-foreground stg:shadow-sm stg:hover:bg-destructive-hover stg:disabled:pointer-events-none",
+            )}
+          >
+            Retry
+          </button>
         )}
-      >
-        <XIcon />
-      </button>
-    </span>
+
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label={`Remove ${entry.file.name}`}
+          className={cn(
+            UNSTYLED_BUTTON,
+            // The established corner-badge geometry (ContextPopover,
+            // ComposerToolbar). Solid bg + border keep it legible over any
+            // image without opacity-modified tokens (Dont-Do #4).
+            "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-4 stg:w-4 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-border stg:bg-background stg:text-muted-foreground stg:shadow-sm stg:hover:text-destructive stg:disabled:pointer-events-none",
+          )}
+        >
+          <XIcon />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="stg:break-all">
+        {entry.file.name}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/attachment/AttachmentImageLightbox.tsx
+++ b/sdk/react/src/attachment/AttachmentImageLightbox.tsx
@@ -95,10 +95,11 @@ export function AttachmentImageLightbox({
       {open && (
         <div className="stg:flex stg:flex-col">
           <div className="stg:flex stg:items-center stg:gap-2 stg:px-3 stg:py-2">
-            <span
-              className="stg:min-w-0 stg:flex-1 stg:truncate stg:text-xs stg:font-semibold stg:text-foreground"
-              title={filename}
-            >
+            {/* No tooltip here: the house tooltip portals OUTSIDE this native
+                showModal() dialog, where the top layer covers it and `inert`
+                disables it. The old title only restated the visible filename
+                (also the image's alt), so it is dropped rather than replaced. */}
+            <span className="stg:min-w-0 stg:flex-1 stg:truncate stg:text-xs stg:font-semibold stg:text-foreground">
               {filename}
             </span>
             <button

--- a/sdk/react/src/attachment/__tests__/AttachmentChipList.test.tsx
+++ b/sdk/react/src/attachment/__tests__/AttachmentChipList.test.tsx
@@ -106,11 +106,12 @@ describe("AttachmentChipList — image miniature", () => {
 
     await waitFor(() => expect(chipImage(container)).toBeTruthy());
 
-    // The tile is the chip — the name lives in the tooltip and accessible
-    // label, never as a text node (file chips, by contrast, keep theirs).
+    // The tile is the chip — the name lives in the house tooltip and
+    // accessible label, never as a text node (file chips, by contrast,
+    // keep theirs) and never a native title (banned, stigmer-cloud#268).
     expect(screen.queryByText("shot.png")).toBeNull();
     const tile = screen.getByRole("listitem", { name: /^shot\.png/ });
-    expect(tile.getAttribute("title")).toBe("shot.png");
+    expect(tile.getAttribute("title")).toBeNull();
     // Remove is an always-visible corner badge, not hover-revealed.
     expect(screen.getByRole("button", { name: "Remove shot.png" })).toBeTruthy();
   });

--- a/sdk/react/src/channel-app/internal.tsx
+++ b/sdk/react/src/channel-app/internal.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { TruncatedText } from "../internal/truncated-text.js";
 
 /**
  * Internal building blocks shared by the channel-app forms and panels.
@@ -74,15 +75,13 @@ export function CopyRow({
     <div className="stg:space-y-1">
       <p className="stg:text-xs stg:font-medium stg:text-foreground">{label}</p>
       <div className="stg:flex stg:items-center stg:gap-1.5">
-        <code
+        <TruncatedText
+          text={value}
           className={cn(
-            "stg:min-w-0 stg:flex-1 stg:truncate stg:rounded-md stg:border stg:border-border stg:bg-muted-subtle",
+            "stg:min-w-0 stg:flex-1 stg:rounded-md stg:border stg:border-border stg:bg-muted-subtle",
             "stg:px-2 stg:py-1.5 stg:font-mono stg:text-[0.65rem] stg:text-foreground",
           )}
-          title={value}
-        >
-          {value}
-        </code>
+        />
         <CopyButton copied={copied} onCopy={copy} copyTargetId={copyTargetId} />
       </div>
     </div>

--- a/sdk/react/src/channel/AgentChannelsPanel.tsx
+++ b/sdk/react/src/channel/AgentChannelsPanel.tsx
@@ -22,6 +22,7 @@ import { useConfirmAction } from "../resource-detail/useConfirmAction.js";
 import { EditResourceYamlDialog } from "../manifest/EditResourceYamlDialog.js";
 import { useDeploymentMode } from "../deployment-mode.js";
 import { CloudFeatureNotice } from "../internal/CloudFeatureNotice.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { ChannelConversationsDialog } from "./ChannelConversationsDialog.js";
 import { ChannelCredentialsDialog } from "./ChannelCredentialsDialog.js";
 import { ChannelTemplatesDialog } from "./ChannelTemplatesDialog.js";
@@ -510,12 +511,10 @@ function ChannelCard({
           <provider.Icon className="stg:size-5 stg:shrink-0 stg:text-foreground" />
           <div className="stg:min-w-0">
             <div className="stg:flex stg:items-center stg:gap-2">
-              <span
-                className="stg:truncate stg:text-sm stg:font-medium stg:text-foreground"
-                title={meta?.name || meta?.slug || undefined}
-              >
-                {meta?.name || meta?.slug || "\u2014"}
-              </span>
+              <TruncatedText
+                text={meta?.name || meta?.slug || "\u2014"}
+                className="stg:text-sm stg:font-medium stg:text-foreground"
+              />
               <InstallStatePill state={installState} />
             </div>
             <p className="stg:mt-0.5 stg:text-xs stg:text-muted-foreground">

--- a/sdk/react/src/channel/ChannelConversationsDialog.tsx
+++ b/sdk/react/src/channel/ChannelConversationsDialog.tsx
@@ -10,6 +10,7 @@ import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_
 import { formatRelativeTime } from "../activity/format-relative-time.js";
 import { Button } from "../button/Button.js";
 import { EmptyState } from "../empty-state/EmptyState.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { channelSessionExternalUserKey } from "../session/channelOrigin.js";
 import { useChannelSessions } from "./useChannelSessions.js";
 
@@ -200,9 +201,10 @@ function ConversationRow({
   const content = (
     <>
       <div className="stg:min-w-0 stg:flex-1">
-        <p className="stg:truncate stg:text-sm stg:text-foreground" title={subject}>
-          {subject}
-        </p>
+        <TruncatedText
+          text={subject}
+          className="stg:block stg:text-sm stg:text-foreground"
+        />
         {externalUser && (
           <p className="stg:mt-0.5 stg:flex stg:items-center stg:gap-1 stg:text-xs stg:text-muted-foreground">
             <User aria-hidden="true" className="stg:size-3" />

--- a/sdk/react/src/channel/ChannelTemplatesDialog.tsx
+++ b/sdk/react/src/channel/ChannelTemplatesDialog.tsx
@@ -9,6 +9,7 @@ import type { ChannelTemplate } from "@stigmer/protos/ai/stigmer/agentic/agentch
 import { Button } from "../button/Button.js";
 import { EmptyState } from "../empty-state/EmptyState.js";
 import { CloudFeatureNotice } from "../internal/CloudFeatureNotice.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { StatusBadge } from "../resource-workbench/components/StatusBadge.js";
 import {
   channelPresentationOf,
@@ -332,12 +333,10 @@ function TemplateRow({ template }: { readonly template: ChannelTemplate }) {
     <li className="stg:rounded-lg stg:border stg:border-border stg:p-3">
       <div className="stg:flex stg:items-start stg:justify-between stg:gap-3">
         <div className="stg:flex stg:min-w-0 stg:flex-wrap stg:items-center stg:gap-x-2 stg:gap-y-1">
-          <span
-            className="stg:truncate stg:text-sm stg:font-medium stg:text-foreground"
-            title={template.name}
-          >
-            {template.name}
-          </span>
+          <TruncatedText
+            text={template.name}
+            className="stg:text-sm stg:font-medium stg:text-foreground"
+          />
           {/* (name, language) is the template's identity — each
               language is approved independently, so it always shows. */}
           <span className="stg:shrink-0 stg:text-xs stg:text-muted-foreground">

--- a/sdk/react/src/composer/ComposerToolbar.tsx
+++ b/sdk/react/src/composer/ComposerToolbar.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../internal/tooltip.js";
 import { ContextPopover } from "./ContextPopover.js";
 import { ConfigureMenu, type ConfigureMenuItem } from "./ConfigureMenu.js";
 import { ModelSelector } from "../models/ModelSelector.js";
@@ -160,101 +166,127 @@ export function ComposerToolbar({
         )}
       </div>
 
-      {/* ---- Right group: Secondary actions (icon-only) + Send ---- */}
+      {/* ---- Right group: Secondary actions (icon-only) + Send ----
 
-      <div className="stg:flex stg:shrink-0 stg:items-center stg:gap-1">
-        {showWorkspace && (
-          onWorkspaceDirectAction
-            ? <button
-                type="button"
-                disabled={disabled}
-                onClick={onWorkspaceDirectAction}
-                title="Workspace"
-                className={cn(
-                  "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
-                  "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
-                  "stg:disabled:pointer-events-none stg:disabled:opacity-50",
-                )}
-                aria-label="Workspace"
-              >
-                <span className="stg:relative">
-                  <WorkspaceIcon />
-                  {workspaceCount > 0 && (
-                    <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
-                      {workspaceCount}
-                    </span>
+          Icon-only actions carry house tooltips (never native `title` —
+          OS-delayed and unreachable from keyboard/touch, dead entirely on
+          disabled controls). Disabled-capable buttons put the trigger on a
+          plain wrapper span: `disabled` adds `pointer-events-none`, so the
+          span, not the button, must own the hover for the tooltip to keep
+          working while disabled. The provider is context-only (no DOM node)
+          and groups the buttons' hover delay. */}
+
+      <TooltipProvider>
+        <div className="stg:flex stg:shrink-0 stg:items-center stg:gap-1">
+          {showWorkspace && (
+            onWorkspaceDirectAction
+              ? <Tooltip>
+                  <TooltipTrigger render={<span className="stg:inline-flex" />}>
+                    <button
+                      type="button"
+                      disabled={disabled}
+                      onClick={onWorkspaceDirectAction}
+                      className={cn(
+                        "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
+                        "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
+                        "stg:disabled:pointer-events-none stg:disabled:opacity-50",
+                      )}
+                      aria-label="Workspace"
+                    >
+                      <span className="stg:relative">
+                        <WorkspaceIcon />
+                        {workspaceCount > 0 && (
+                          <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
+                            {workspaceCount}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Workspace</TooltipContent>
+                </Tooltip>
+              : <ContextPopover
+                  icon={<WorkspaceIcon />}
+                  label="Workspace"
+                  count={workspaceCount}
+                  disabled={disabled}
+                >
+                  {workspaceContent}
+                </ContextPopover>
+          )}
+
+          {showAttach && (
+            <Tooltip>
+              <TooltipTrigger render={<span className="stg:inline-flex" />}>
+                <button
+                  type="button"
+                  disabled={disabled}
+                  onClick={onAttachClick}
+                  className={cn(
+                    "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
+                    "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
+                    "stg:disabled:pointer-events-none stg:disabled:opacity-50",
                   )}
-                </span>
-              </button>
-            : <ContextPopover
-                icon={<WorkspaceIcon />}
-                label="Workspace"
-                count={workspaceCount}
-                disabled={disabled}
-              >
-                {workspaceContent}
-              </ContextPopover>
-        )}
+                  aria-label="Attach files"
+                >
+                  <span className="stg:relative">
+                    <PaperclipIcon />
+                    {attachmentCount > 0 && (
+                      <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
+                        {attachmentCount}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">Attach files</TooltipContent>
+            </Tooltip>
+          )}
 
-        {showAttach && (
-          <button
-            type="button"
+          <ConfigureMenu
+            open={configOpen}
+            onOpenChange={onConfigOpenChange}
+            activePanel={configActivePanel}
+            onActivePanelChange={onConfigActivePanelChange}
+            items={configureItems}
+            renderPanel={renderConfigPanel}
             disabled={disabled}
-            onClick={onAttachClick}
-            title="Attach files"
-            className={cn(
-              "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
-              "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
-              "stg:disabled:pointer-events-none stg:disabled:opacity-50",
-            )}
-            aria-label="Attach files"
-          >
-            <span className="stg:relative">
-              <PaperclipIcon />
-              {attachmentCount > 0 && (
-                <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
-                  {attachmentCount}
-                </span>
-              )}
-            </span>
-          </button>
-        )}
+          />
 
-        <ConfigureMenu
-          open={configOpen}
-          onOpenChange={onConfigOpenChange}
-          activePanel={configActivePanel}
-          onActivePanelChange={onConfigActivePanelChange}
-          items={configureItems}
-          renderPanel={renderConfigPanel}
-          disabled={disabled}
-        />
-
-        {onStop ? (
-          // Circular container (vs. Send's rounded-square) gives the square glyph
-          // a proper home — the canonical stop affordance — and the shape morph
-          // from Send→Stop signals the running state at a glance.
-          <button
-            type="button"
-            onClick={onStop}
-            className="stg:flex stg:h-8 stg:w-8 stg:shrink-0 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:text-primary-foreground stg:transition-colors stg:hover:bg-primary-hover"
-            aria-label="Stop generating"
-            title="Stop"
-          >
-            {isStopping ? <SpinnerIcon /> : <StopIcon />}
-          </button>
-        ) : (
-          <button
-            type="button"
-            disabled={!canSend}
-            onClick={onSend}
-            className="stg:flex stg:h-8 stg:w-8 stg:shrink-0 stg:items-center stg:justify-center stg:rounded-lg stg:bg-primary stg:text-primary-foreground stg:transition-colors stg:hover:bg-primary-hover stg:disabled:pointer-events-none stg:disabled:opacity-40"
-            aria-label="Send message"
-          >
-            {isSubmitting ? <SpinnerIcon /> : <ArrowUpIcon />}
-          </button>
-        )}
-      </div>
+          {onStop ? (
+            // Circular container (vs. Send's rounded-square) gives the square glyph
+            // a proper home — the canonical stop affordance — and the shape morph
+            // from Send→Stop signals the running state at a glance. Always
+            // enabled, so the button itself is the tooltip trigger (keyboard
+            // focus opens it too).
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={onStop}
+                    className="stg:flex stg:h-8 stg:w-8 stg:shrink-0 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:text-primary-foreground stg:transition-colors stg:hover:bg-primary-hover"
+                    aria-label="Stop generating"
+                  />
+                }
+              >
+                {isStopping ? <SpinnerIcon /> : <StopIcon />}
+              </TooltipTrigger>
+              <TooltipContent side="top">Stop</TooltipContent>
+            </Tooltip>
+          ) : (
+            <button
+              type="button"
+              disabled={!canSend}
+              onClick={onSend}
+              className="stg:flex stg:h-8 stg:w-8 stg:shrink-0 stg:items-center stg:justify-center stg:rounded-lg stg:bg-primary stg:text-primary-foreground stg:transition-colors stg:hover:bg-primary-hover stg:disabled:pointer-events-none stg:disabled:opacity-40"
+              aria-label="Send message"
+            >
+              {isSubmitting ? <SpinnerIcon /> : <ArrowUpIcon />}
+            </button>
+          )}
+        </div>
+      </TooltipProvider>
     </div>
   );
 }

--- a/sdk/react/src/composer/ConfigureMenu.tsx
+++ b/sdk/react/src/composer/ConfigureMenu.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@stigmer/theme";
 import { Popover } from "@base-ui/react/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useStigmerPortalContainer } from "../portal-container.js";
 import { ConfigureIcon } from "./icons.js";
 
@@ -71,31 +72,39 @@ export function ConfigureMenu({
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <Popover.Trigger
-        disabled={disabled}
-        title="Configure"
-        className={cn(
-          "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
-          "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
-          "stg:disabled:pointer-events-none stg:disabled:opacity-50",
-        )}
-        aria-label="Configure agent, tools, and skills"
-      >
-        <span className="stg:relative">
-          <ConfigureIcon />
-          {totalCount > 0 && (
-            <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
-              {totalCount}
+      {/* The tooltip trigger is a wrapper span, not the popover trigger
+          itself: `disabled` adds `pointer-events-none` to the button, so
+          only the span keeps hover — the icon's name stays discoverable
+          while the composer is disabled. */}
+      <Tooltip>
+        <TooltipTrigger render={<span className="stg:inline-flex" />}>
+          <Popover.Trigger
+            disabled={disabled}
+            className={cn(
+              "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
+              "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
+              "stg:disabled:pointer-events-none stg:disabled:opacity-50",
+            )}
+            aria-label="Configure agent, tools, and skills"
+          >
+            <span className="stg:relative">
+              <ConfigureIcon />
+              {totalCount > 0 && (
+                <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
+                  {totalCount}
+                </span>
+              )}
+              {hasWarning && totalCount === 0 && (
+                <span
+                  className="stg:absolute stg:-right-0.5 stg:-top-0.5 stg:inline-block stg:h-2 stg:w-2 stg:rounded-full stg:bg-warning"
+                  aria-label="Configuration needed"
+                />
+              )}
             </span>
-          )}
-          {hasWarning && totalCount === 0 && (
-            <span
-              className="stg:absolute stg:-right-0.5 stg:-top-0.5 stg:inline-block stg:h-2 stg:w-2 stg:rounded-full stg:bg-warning"
-              aria-label="Configuration needed"
-            />
-          )}
-        </span>
-      </Popover.Trigger>
+          </Popover.Trigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">Configure</TooltipContent>
+      </Tooltip>
       <Popover.Portal container={portalContainer}>
         <Popover.Positioner sideOffset={8} align="start">
           <Popover.Popup

--- a/sdk/react/src/composer/ContextChip.tsx
+++ b/sdk/react/src/composer/ContextChip.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@stigmer/theme";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { ChipSpinner, XIcon } from "./icons.js";
 
 export interface ChipItem {
@@ -60,9 +61,7 @@ export function ContextChip({
       <span className="stg:text-[0.55rem] stg:font-medium stg:uppercase stg:tracking-wider stg:text-muted-foreground">
         {CHIP_TYPE_LABELS[type]}
       </span>
-      <span className="stg:max-w-[120px] stg:truncate" title={label}>
-        {label}
-      </span>
+      <TruncatedText text={label} className="stg:max-w-[120px]" />
       {detail != null && (
         <span className="stg:shrink-0 stg:text-[0.6rem] stg:font-medium stg:text-muted-foreground">
           {detail}

--- a/sdk/react/src/composer/ContextPopover.tsx
+++ b/sdk/react/src/composer/ContextPopover.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@stigmer/theme";
 import { Popover } from "@base-ui/react/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useStigmerPortalContainer } from "../portal-container.js";
 
 export function ContextPopover({
@@ -23,25 +24,33 @@ export function ContextPopover({
 
   return (
     <Popover.Root open={open} onOpenChange={onOpenChange}>
-      <Popover.Trigger
-        disabled={disabled}
-        title={label}
-        aria-label={label}
-        className={cn(
-          "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
-          "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
-          "stg:disabled:pointer-events-none stg:disabled:opacity-50",
-        )}
-      >
-        <span className="stg:relative">
-          {icon}
-          {count > 0 && (
-            <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
-              {count}
+      {/* The tooltip trigger is a wrapper span, not the popover trigger
+          itself: `disabled` adds `pointer-events-none` to the button, so
+          only the span keeps hover — the icon's name stays discoverable
+          while the composer is disabled. */}
+      <Tooltip>
+        <TooltipTrigger render={<span className="stg:inline-flex" />}>
+          <Popover.Trigger
+            disabled={disabled}
+            aria-label={label}
+            className={cn(
+              "stg:inline-flex stg:h-8 stg:w-8 stg:items-center stg:justify-center stg:rounded-md stg:text-xs stg:transition-colors",
+              "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
+              "stg:disabled:pointer-events-none stg:disabled:opacity-50",
+            )}
+          >
+            <span className="stg:relative">
+              {icon}
+              {count > 0 && (
+                <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:flex stg:h-3.5 stg:min-w-3.5 stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-0.5 stg:text-[0.5rem] stg:font-medium stg:leading-none stg:text-primary-foreground">
+                  {count}
+                </span>
+              )}
             </span>
-          )}
-        </span>
-      </Popover.Trigger>
+          </Popover.Trigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">{label}</TooltipContent>
+      </Tooltip>
       <Popover.Portal container={portalContainer}>
         <Popover.Positioner sideOffset={8} align="start">
           <Popover.Popup

--- a/sdk/react/src/composer/SessionComposer.tsx
+++ b/sdk/react/src/composer/SessionComposer.tsx
@@ -38,6 +38,7 @@ import {
   resolveSystemEnvVarValues,
 } from "../environment/systemEnvVars.js";
 import { useRenderTracer } from "../internal/dev/index.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import {
   AgentIcon,
   McpServerIcon,
@@ -1522,15 +1523,21 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
               Editing message
             </span>
             {onCancelEdit && (
-              <button
-                type="button"
-                onClick={onCancelEdit}
-                aria-label="Cancel editing"
-                title="Cancel editing (Esc)"
-                className="stg:rounded stg:p-0.5 stg:text-muted-foreground stg:transition-colors stg:hover:bg-accent stg:hover:text-foreground stg:focus-visible:outline-none stg:focus-visible:ring-1 stg:focus-visible:ring-ring"
-              >
-                <XIcon />
-              </button>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      onClick={onCancelEdit}
+                      aria-label="Cancel editing"
+                      className="stg:rounded stg:p-0.5 stg:text-muted-foreground stg:transition-colors stg:hover:bg-accent stg:hover:text-foreground stg:focus-visible:outline-none stg:focus-visible:ring-1 stg:focus-visible:ring-ring"
+                    />
+                  }
+                >
+                  <XIcon />
+                </TooltipTrigger>
+                <TooltipContent side="top">Cancel editing (Esc)</TooltipContent>
+              </Tooltip>
             )}
           </div>
         )}

--- a/sdk/react/src/conversation/ConversationMediaAttachment.tsx
+++ b/sdk/react/src/conversation/ConversationMediaAttachment.tsx
@@ -10,6 +10,7 @@ import { AttachmentImageLightbox } from "../attachment/AttachmentImageLightbox.j
 import { formatFileSize } from "../attachment/attachment-utils.js";
 import { UNSTYLED_BUTTON } from "../internal/form-primitives.js";
 import { toError } from "../internal/toError.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { useStigmer } from "../hooks.js";
 import { useConversationMediaUrl } from "./useConversationMediaUrl.js";
 
@@ -191,7 +192,6 @@ function MediaDocumentChip({
   return (
     <div className={className}>
       <span
-        title={name}
         className="stg:inline-flex stg:max-w-[240px] stg:items-center stg:rounded-md stg:bg-muted-subtle stg:px-2 stg:py-1 stg:text-xs stg:text-foreground"
       >
         <button
@@ -206,7 +206,7 @@ function MediaDocumentChip({
           )}
         >
           <FileGlyph />
-          <span className="stg:min-w-0 stg:truncate">{name}</span>
+          <TruncatedText text={name} className="stg:min-w-0" />
           {size !== null && (
             <span className="stg:shrink-0 stg:text-muted-foreground">{size}</span>
           )}

--- a/sdk/react/src/cursor-accounts/MemberCoverageTable.tsx
+++ b/sdk/react/src/cursor-accounts/MemberCoverageTable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/io_pb";
 import type { CursorMemberSpend } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/cursor_account_pb";
 import { Button } from "../button/index.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { StateBadge } from "./badges.js";
 import { formatPoolPercent, formatSpendMicros } from "./cursor-account-format.js";
 import type { CursorAccountCoverage } from "./cursor-account-coverage.js";
@@ -225,9 +226,9 @@ function CoverageGroup({
  * The member-identity cell shared by key rows and gap rows. The email is
  * the row's identity, so it must be fully readable: it wraps onto more
  * lines when the column is narrow (emails are unbroken strings, so they
- * need explicit word-breaking) with a hover tooltip as backup, unlike
- * the other text cells which truncate. The secondary name line stays
- * truncated — it is display sugar, not identity.
+ * need explicit word-breaking), unlike the other text cells which
+ * truncate. The secondary name line stays truncated — it is display
+ * sugar, not identity.
  */
 function MemberCell({
   email,
@@ -238,7 +239,9 @@ function MemberCell({
 }) {
   return (
     <span role="cell" className="stg:min-w-0">
-      <span className="stg:block stg:break-words stg:font-medium stg:text-foreground" title={email}>
+      {/* No tooltip: break-words shows the full email, so a hover hint
+          would only repeat what is already visible. */}
+      <span className="stg:block stg:break-words stg:font-medium stg:text-foreground">
         {email}
       </span>
       {name && (
@@ -273,16 +276,15 @@ function KeyRow({
     <div role="row" className={cn(ROW_GRID, "stg:border-t stg:border-border-muted stg:text-xs")}>
       <MemberCell email={key.boundEmail} />
       <span role="cell" className="stg:min-w-0">
-        <span
-          className="stg:block stg:truncate stg:text-muted-foreground"
-          title={key.cursorKeyName || undefined}
-        >
-          {key.cursorKeyName || "unnamed key"}
-        </span>
+        <TruncatedText
+          text={key.cursorKeyName || "unnamed key"}
+          className="stg:block stg:text-muted-foreground"
+        />
         {key.label && (
-          <span className="stg:block stg:truncate stg:text-[11px] stg:text-muted-foreground" title={key.label}>
-            {key.label}
-          </span>
+          <TruncatedText
+            text={key.label}
+            className="stg:block stg:text-[11px] stg:text-muted-foreground"
+          />
         )}
       </span>
       <SpendCells spend={keyView.spend} />

--- a/sdk/react/src/cursor-accounts/__tests__/CursorAccountsConsole.test.tsx
+++ b/sdk/react/src/cursor-accounts/__tests__/CursorAccountsConsole.test.tsx
@@ -237,10 +237,10 @@ describe("CursorAccountsConsole", () => {
     expect(screen.getByText(/On the team — key held/)).toBeTruthy();
     expect(screen.getByText("zane@scenar.ai")).toBeTruthy();
     expect(screen.getByText("stigmer-prod")).toBeTruthy();
-    // The email is the row's identity: full value always hoverable on
-    // both row kinds (the cell wraps rather than truncates).
-    expect(screen.getByTitle("zane@scenar.ai")).toBeTruthy();
-    expect(screen.getByTitle("uncovered@scenar.ai")).toBeTruthy();
+    // The email is the row's identity: the cell wraps rather than
+    // truncates, so the full value is always visible text on both row
+    // kinds — and never a native title (banned, stigmer-cloud#268).
+    expect(document.querySelector("[title]")).toBeNull();
     expect(screen.getByText("$0.17")).toBeTruthy(); // included, 169342 micro-USD
     expect(screen.getByText("Active")).toBeTruthy();
     // Category 2: on the team, no key — server-joined spend on the gap row.

--- a/sdk/react/src/dashboard/DashboardKPICards.tsx
+++ b/sdk/react/src/dashboard/DashboardKPICards.tsx
@@ -103,11 +103,12 @@ export const DashboardKPICards = memo(function DashboardKPICards({
     <div className={cn("stg:grid stg:gap-3 stg:sm:grid-cols-2 stg:lg:grid-cols-4", className)}>
       {STAT_CARDS.map((card) => {
         const breakdown = card.getBreakdown(summary);
+        // No tooltip on the card: the breakdown is rendered visibly below
+        // the value, so the old title only repeated on-screen text.
         return (
           <div
             key={card.label}
             className="stg:rounded-lg stg:border stg:border-border stg:bg-card stg:px-4 stg:py-3"
-            title={breakdown ?? undefined}
           >
             <p className="stg:text-xs stg:font-medium stg:text-muted-foreground">
               {card.label}

--- a/sdk/react/src/datastore/CollectionRecordsBrowser.tsx
+++ b/sdk/react/src/datastore/CollectionRecordsBrowser.tsx
@@ -14,6 +14,7 @@ import type {
   CollectionDescription,
   RecordEnvelope,
 } from "@stigmer/protos/ai/stigmer/agentic/datastore/v1/record_io_pb";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { ResourceTable } from "../resource-workbench/components/ResourceTable.js";
 import { ConfirmDialog } from "../resource-detail/ConfirmDialog.js";
 import { useConfirmAction } from "../resource-detail/useConfirmAction.js";
@@ -505,18 +506,18 @@ function TypedCell({
   readonly numeric?: boolean;
   readonly mono?: boolean;
 }) {
-  const truncated = value.length > 80 ? `${value.slice(0, 79)}…` : value;
+  // TruncatedText's overflow gating supersedes the old hand-rolled
+  // 80-character slice + conditional title: CSS truncates the cell and the
+  // tooltip opens only when the value is actually clipped.
   return (
-    <span
-      title={value.length > 80 ? value : undefined}
+    <TruncatedText
+      text={value}
       className={cn(
-        "stg:block stg:max-w-xs stg:truncate",
+        "stg:block stg:max-w-xs",
         numeric && "stg:text-right stg:tabular-nums",
         mono && "stg:font-mono",
       )}
-    >
-      {truncated}
-    </span>
+    />
   );
 }
 

--- a/sdk/react/src/environment/EnvironmentVariableEditor.tsx
+++ b/sdk/react/src/environment/EnvironmentVariableEditor.tsx
@@ -12,6 +12,7 @@ import { getUserMessage, type EnvVarInput } from "@stigmer/sdk";
 import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
 import { useStigmer } from "../hooks.js";
 import { toError } from "../internal/toError.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { PermissionGate } from "../iam-policy/PermissionGate.js";
 import { useUpdateEnvironmentVariables } from "./useUpdateEnvironmentVariables.js";
 import { useRemoveEnvironmentVariables } from "./useRemoveEnvironmentVariables.js";
@@ -390,12 +391,22 @@ function VariableRow({
       <div className="stg:group stg:flex stg:items-center stg:gap-3 stg:py-2">
         {/* Key + badge */}
         <div className="stg:flex stg:shrink-0 stg:items-baseline stg:gap-1.5">
-          <span
-            className="stg:font-mono stg:text-xs stg:font-medium stg:text-foreground"
-            title={variable.description || undefined}
-          >
-            {variable.key}
-          </span>
+          {variable.description ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span className="stg:font-mono stg:text-xs stg:font-medium stg:text-foreground" />
+                }
+              >
+                {variable.key}
+              </TooltipTrigger>
+              <TooltipContent side="top">{variable.description}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="stg:font-mono stg:text-xs stg:font-medium stg:text-foreground">
+              {variable.key}
+            </span>
+          )}
           {variable.isSecret && (
             <span className="stg:text-[0.55rem] stg:uppercase stg:tracking-wider stg:text-muted-foreground-subtle">
               secret

--- a/sdk/react/src/execution/ApprovalCard.tsx
+++ b/sdk/react/src/execution/ApprovalCard.tsx
@@ -407,12 +407,10 @@ export function ApprovalCardBody({
       </div>
 
       {/* De-emphasized provenance, trailing the decision it explains. Only the
-          informative reasons reach here (see showGateReason); the full phrase is
-          on hover. */}
+          informative reasons reach here (see showGateReason). */}
       {showGateReason && (
         <p
           className="stg:text-[11px] stg:italic stg:text-muted-foreground"
-          title={gateReason ?? undefined}
           data-cursor-target="approval-gate-reason"
         >
           {gateReason}

--- a/sdk/react/src/execution/ArtifactRowView.tsx
+++ b/sdk/react/src/execution/ArtifactRowView.tsx
@@ -5,6 +5,7 @@
 
 import { cn } from "@stigmer/theme";
 import { FileTypeIcon, FolderTypeIcon } from "../internal/file-icons/index.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import type { ArtifactRowItem } from "./artifact-row-item.js";
 import { formatArtifactSize } from "./artifact-utils.js";
 
@@ -59,54 +60,73 @@ export function ArtifactRowView({
 }: ArtifactRowViewProps) {
   return (
     <li className={cn("stg:group stg:flex stg:items-stretch", className)}>
-      <button
-        type="button"
-        onClick={onOpen}
-        onDoubleClick={onActivate}
-        title={item.tooltip}
-        className={cn(
-          "stg:flex stg:min-w-0 stg:flex-1 stg:items-center stg:gap-2 stg:px-2 stg:py-1 stg:text-left stg:text-xs stg:text-muted-foreground stg:transition-colors",
-          "stg:hover:bg-muted stg:hover:text-foreground",
-          "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
-        )}
-      >
-        <span className="stg:shrink-0 stg:text-muted-foreground">
-          {item.isDirectory ? (
-            <FolderTypeIcon open={false} />
-          ) : (
-            <FileTypeIcon fileName={item.name} />
-          )}
-        </span>
-        <span className="stg:min-w-0 stg:flex-1 stg:truncate stg:text-foreground">
-          {item.name}
-          {item.isDirectory && "/"}
-          {item.subtitlePath && (
-            <span className="stg:ml-1.5 stg:text-[0.65rem] stg:text-muted-foreground">
-              {item.subtitlePath}
-            </span>
-          )}
-        </span>
-        <span className="stg:shrink-0 stg:tabular-nums stg:text-[0.65rem] stg:text-muted-foreground-faint">
-          {formatArtifactSize(item.sizeBytes)}
-        </span>
-      </button>
-      <button
-        type="button"
-        onClick={onDownload}
-        disabled={isDownloading}
-        aria-label={
-          isDownloading ? `Preparing ${item.name}` : `Download ${item.name}`
-        }
-        title={item.isDirectory ? "Download ZIP" : "Download"}
-        className={cn(
-          "stg:flex stg:shrink-0 stg:items-center stg:px-2 stg:text-muted-foreground stg:opacity-0 stg:transition-opacity",
-          "stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
-          "stg:hover:text-foreground stg:disabled:opacity-50",
-          "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
-        )}
-      >
-        <DownloadIcon />
-      </button>
+      {/* The open button is its own tooltip trigger (hover and keyboard focus
+          both reveal the full path); the Download button's trigger is a
+          wrapper span so the hint survives the in-flight `disabled` state
+          (browsers suppress pointer events on disabled form controls, so a
+          disabled button can never open its own tooltip). */}
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={onOpen}
+              onDoubleClick={onActivate}
+              className={cn(
+                "stg:flex stg:min-w-0 stg:flex-1 stg:items-center stg:gap-2 stg:px-2 stg:py-1 stg:text-left stg:text-xs stg:text-muted-foreground stg:transition-colors",
+                "stg:hover:bg-muted stg:hover:text-foreground",
+                "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
+              )}
+            />
+          }
+        >
+          <span className="stg:shrink-0 stg:text-muted-foreground">
+            {item.isDirectory ? (
+              <FolderTypeIcon open={false} />
+            ) : (
+              <FileTypeIcon fileName={item.name} />
+            )}
+          </span>
+          <span className="stg:min-w-0 stg:flex-1 stg:truncate stg:text-foreground">
+            {item.name}
+            {item.isDirectory && "/"}
+            {item.subtitlePath && (
+              <span className="stg:ml-1.5 stg:text-[0.65rem] stg:text-muted-foreground">
+                {item.subtitlePath}
+              </span>
+            )}
+          </span>
+          <span className="stg:shrink-0 stg:tabular-nums stg:text-[0.65rem] stg:text-muted-foreground-faint">
+            {formatArtifactSize(item.sizeBytes)}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="stg:break-all">
+          {item.tooltip}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger render={<span className="stg:flex stg:shrink-0" />}>
+          <button
+            type="button"
+            onClick={onDownload}
+            disabled={isDownloading}
+            aria-label={
+              isDownloading ? `Preparing ${item.name}` : `Download ${item.name}`
+            }
+            className={cn(
+              "stg:flex stg:shrink-0 stg:items-center stg:px-2 stg:text-muted-foreground stg:opacity-0 stg:transition-opacity",
+              "stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
+              "stg:hover:text-foreground stg:disabled:opacity-50",
+              "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
+            )}
+          >
+            <DownloadIcon />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {item.isDirectory ? "Download ZIP" : "Download"}
+        </TooltipContent>
+      </Tooltip>
     </li>
   );
 }

--- a/sdk/react/src/execution/FilePathLink.tsx
+++ b/sdk/react/src/execution/FilePathLink.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useContext, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { FilePathContext } from "./FilePathContext.js";
 import { resolvePathAction, splitDisplayPath } from "./file-path-resolver.js";
 
@@ -18,9 +19,9 @@ export interface FilePathLinkProps {
   readonly path: string;
   /**
    * How much of the directory prefix to show. Defaults to `"hide"` (file name
-   * only); the full path is always available on hover via `title`. Use `"dim"`
-   * where the surrounding directory aids comprehension (diff headers, the
-   * multi-file changes list).
+   * only); the full path is always available on the hover/focus tooltip. Use
+   * `"dim"` where the surrounding directory aids comprehension (diff headers,
+   * the multi-file changes list).
    */
   readonly dirDisplay?: FilePathDirDisplay;
   /** Additional CSS class names for the root element. */
@@ -35,7 +36,7 @@ const COPIED_FEEDBACK_MS = 2000;
  *
  * **Filename-first.** It shows the base name prominently and never clips it;
  * the directory is optional (`dirDisplay`) and dimmed, and the *full* path is
- * always available on hover via `title` (and to screen readers via
+ * always available on the hover/focus tooltip (and to screen readers via
  * `aria-label`). This fixes the prior behaviour, where a single `truncate` on
  * the whole path clipped the file name — the one part that identifies the
  * change — and surfaced only the action verb on hover.
@@ -75,7 +76,6 @@ export function FilePathLink({
   // path. The action verb moves into the aria-label so hover surfaces the path,
   // not "Copy path".
   const fullPath = resolved.action === "copy" ? resolved.value : path;
-  const title = fullPath;
   const ariaLabel = `${resolved.tooltip}: ${fullPath}`;
 
   const handleCopy = useCallback(() => {
@@ -143,32 +143,48 @@ export function FilePathLink({
   // in-app viewer) and only calls `preventDefault` when the handler took it.
   if (resolved.action === "link") {
     return (
-      <a
-        href={resolved.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={handleClick}
-        aria-label={ariaLabel}
-        title={title}
-        className={cn(sharedClasses, "stg:group/fpl")}
-      >
-        {label}
-        <ExternalLinkIcon />
-      </a>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <a
+              href={resolved.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleClick}
+              aria-label={ariaLabel}
+              className={cn(sharedClasses, "stg:group/fpl")}
+            />
+          }
+        >
+          {label}
+          <ExternalLinkIcon />
+        </TooltipTrigger>
+        <TooltipContent side="top" className="stg:break-all">
+          {fullPath}
+        </TooltipContent>
+      </Tooltip>
     );
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      aria-label={ariaLabel}
-      title={title}
-      className={cn(sharedClasses, "stg:group/fpl stg:cursor-pointer")}
-    >
-      {label}
-      {!copied && <CopyIcon />}
-    </button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={handleClick}
+            aria-label={ariaLabel}
+            className={cn(sharedClasses, "stg:group/fpl stg:cursor-pointer")}
+          />
+        }
+      >
+        {label}
+        {!copied && <CopyIcon />}
+      </TooltipTrigger>
+      <TooltipContent side="top" className="stg:break-all">
+        {fullPath}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/execution/McpToolDetail.tsx
+++ b/sdk/react/src/execution/McpToolDetail.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 import { cn } from "@stigmer/theme";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { formatDuration } from "./ToolCallDetail.js";
 import { humanizeToolName } from "./tool-categories.js";
 import {
@@ -301,8 +302,11 @@ function ScalarRow({ label, value }: { label: string; value: string }) {
           </pre>
         </dd>
       ) : (
-        <dd className="stg:min-w-0 stg:truncate stg:font-mono stg:text-foreground" title={value}>
-          {value}
+        <dd className="stg:min-w-0">
+          <TruncatedText
+            text={value}
+            className="stg:block stg:font-mono stg:text-foreground"
+          />
         </dd>
       )}
     </>

--- a/sdk/react/src/execution/MessageAttachments.tsx
+++ b/sdk/react/src/execution/MessageAttachments.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { cn } from "@stigmer/theme";
 import { AttachmentImageLightbox } from "../attachment/AttachmentImageLightbox.js";
 import { UNSTYLED_BUTTON } from "../internal/form-primitives.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { useArtifactDownload } from "./useArtifactDownload.js";
 import { useArtifactDownloadUrl } from "./useArtifactDownloadUrl.js";
 
@@ -172,38 +174,45 @@ function ImagePreviewChip({
   }
 
   return (
-    <span role="listitem" aria-label={name} title={name} className="stg:inline-flex">
-      {/* The whole tile is the preview target. UNSTYLED_BUTTON adds the
-          pointer cursor — the image tile carries no other clickability
-          cue. */}
-      <button
-        type="button"
-        onClick={onPreview}
-        aria-label={`Preview ${name}`}
-        className={cn(
-          UNSTYLED_BUTTON,
-          "stg:relative stg:block stg:h-14 stg:w-14 stg:overflow-hidden stg:rounded-md stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-        )}
+    <Tooltip>
+      <TooltipTrigger
+        render={<span role="listitem" aria-label={name} className="stg:inline-flex" />}
       >
-        {url ? (
-          <img
-            src={url}
-            alt=""
-            aria-hidden="true"
-            loading="lazy"
-            className="stg:h-full stg:w-full stg:object-cover"
-          />
-        ) : (
-          // Pulse placeholder while the presigned URL is minted — pulse
-          // means work is genuinely in flight (contrast ImageGlyphTile).
-          // Same footprint as the image, so no layout shift.
-          <span
-            className="stg:block stg:h-full stg:w-full stg:animate-pulse stg:bg-muted"
-            aria-hidden="true"
-          />
-        )}
-      </button>
-    </span>
+        {/* The whole tile is the preview target. UNSTYLED_BUTTON adds the
+            pointer cursor — the image tile carries no other clickability
+            cue. */}
+        <button
+          type="button"
+          onClick={onPreview}
+          aria-label={`Preview ${name}`}
+          className={cn(
+            UNSTYLED_BUTTON,
+            "stg:relative stg:block stg:h-14 stg:w-14 stg:overflow-hidden stg:rounded-md stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+          )}
+        >
+          {url ? (
+            <img
+              src={url}
+              alt=""
+              aria-hidden="true"
+              loading="lazy"
+              className="stg:h-full stg:w-full stg:object-cover"
+            />
+          ) : (
+            // Pulse placeholder while the presigned URL is minted — pulse
+            // means work is genuinely in flight (contrast ImageGlyphTile).
+            // Same footprint as the image, so no layout shift.
+            <span
+              className="stg:block stg:h-full stg:w-full stg:animate-pulse stg:bg-muted"
+              aria-hidden="true"
+            />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="stg:break-all">
+        {name}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -215,14 +224,22 @@ function ImagePreviewChip({
  */
 function ImageGlyphTile({ name }: { readonly name: string }) {
   return (
-    <span
-      role="listitem"
-      aria-label={name}
-      title={name}
-      className="stg:inline-flex stg:h-14 stg:w-14 stg:items-center stg:justify-center stg:rounded-md stg:bg-muted-subtle"
-    >
-      <ImageGlyph />
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            role="listitem"
+            aria-label={name}
+            className="stg:inline-flex stg:h-14 stg:w-14 stg:items-center stg:justify-center stg:rounded-md stg:bg-muted-subtle"
+          />
+        }
+      >
+        <ImageGlyph />
+      </TooltipTrigger>
+      <TooltipContent side="top" className="stg:break-all">
+        {name}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -251,7 +268,7 @@ function DocumentChip({
   const content = (
     <>
       <FileGlyph />
-      <span className="stg:min-w-0 stg:truncate">{name}</span>
+      <TruncatedText text={name} className="stg:min-w-0" />
     </>
   );
 
@@ -259,7 +276,6 @@ function DocumentChip({
     <span
       role="listitem"
       aria-label={name}
-      title={name}
       className="stg:inline-flex stg:max-w-[200px] stg:items-center stg:rounded-md stg:bg-muted-subtle stg:px-2 stg:py-0.5 stg:text-xs stg:text-foreground"
     >
       {downloadable ? (

--- a/sdk/react/src/execution/MessageEntry.tsx
+++ b/sdk/react/src/execution/MessageEntry.tsx
@@ -19,6 +19,7 @@ import {
 } from "./MessageAttachments.js";
 import { PlanDocumentMessage } from "./PlanDocumentMessage.js";
 import { useRenderTracer } from "../internal/dev/index.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link MessageEntry}. */
 export interface MessageEntryProps {
@@ -192,21 +193,27 @@ function HumanMessage({
       )}
       <p className="stg:text-sm stg:text-foreground stg:whitespace-pre-wrap">{content}</p>
       {onEdit && (
-        <button
-          type="button"
-          onClick={onEdit}
-          aria-label="Edit message"
-          title="Edit"
-          className={cn(
-            "stg:absolute stg:-top-2.5 stg:-right-2.5 stg:inline-flex stg:h-7 stg:w-7 stg:items-center stg:justify-center stg:rounded-full",
-            "stg:border stg:border-border stg:bg-card stg:text-muted-foreground stg:shadow-sm stg:transition",
-            "stg:hover:text-foreground stg:hover:bg-accent-hover",
-            "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
-            "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-          )}
-        >
-          <EditIcon />
-        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={onEdit}
+                aria-label="Edit message"
+                className={cn(
+                  "stg:absolute stg:-top-2.5 stg:-right-2.5 stg:inline-flex stg:h-7 stg:w-7 stg:items-center stg:justify-center stg:rounded-full",
+                  "stg:border stg:border-border stg:bg-card stg:text-muted-foreground stg:shadow-sm stg:transition",
+                  "stg:hover:text-foreground stg:hover:bg-accent-hover",
+                  "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
+                  "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+                )}
+              />
+            }
+          >
+            <EditIcon />
+          </TooltipTrigger>
+          <TooltipContent side="top">Edit</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/sdk/react/src/execution/PlanArtifactCard.tsx
+++ b/sdk/react/src/execution/PlanArtifactCard.tsx
@@ -3,6 +3,7 @@
 import { memo, useState, type ReactNode } from "react";
 import { cn } from "@stigmer/theme";
 import type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { ArtifactPreviewModal } from "./ArtifactPreviewModal.js";
 import { formatArtifactSize } from "./artifact-utils.js";
 import { useArtifactCopy } from "./useArtifactCopy.js";
@@ -184,9 +185,11 @@ const FOCUS_RING =
   "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring stg:focus-visible:rounded-sm";
 
 /**
- * An icon-only secondary action. The accessible name doubles as the hover
- * tooltip (native `title` — the codebase's tooltip pattern), and the padded
- * hit area keeps the target comfortable despite the compact glyph.
+ * An icon-only secondary action. The accessible name doubles as the house
+ * tooltip's content; the trigger is a wrapper span so the hint stays
+ * hoverable while the action is disabled (`pointer-events-none` on the
+ * button would otherwise take the tooltip down with it). The padded hit
+ * area keeps the target comfortable despite the compact glyph.
  */
 function IconAction({
   label,
@@ -200,21 +203,25 @@ function IconAction({
   readonly disabled?: boolean;
 }) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "stg:inline-flex stg:items-center stg:rounded-md stg:p-1.5 stg:text-muted-foreground",
-        "stg:transition-colors stg:hover:bg-muted stg:hover:text-foreground",
-        "stg:disabled:pointer-events-none stg:disabled:opacity-50",
-        FOCUS_RING,
-      )}
-    >
-      {icon}
-    </button>
+    <Tooltip>
+      <TooltipTrigger render={<span className="stg:inline-flex" />}>
+        <button
+          type="button"
+          aria-label={label}
+          onClick={onClick}
+          disabled={disabled}
+          className={cn(
+            "stg:inline-flex stg:items-center stg:rounded-md stg:p-1.5 stg:text-muted-foreground",
+            "stg:transition-colors stg:hover:bg-muted stg:hover:text-foreground",
+            "stg:disabled:pointer-events-none stg:disabled:opacity-50",
+            FOCUS_RING,
+          )}
+        >
+          {icon}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/execution/ToolCallDetail.tsx
+++ b/sdk/react/src/execution/ToolCallDetail.tsx
@@ -312,10 +312,7 @@ function ProvenanceNote({ toolCall }: { toolCall: ToolCall }) {
   if (!provenance) return null;
 
   return (
-    <p
-      className="stg:text-[11px] stg:italic stg:text-muted-foreground"
-      title={provenance}
-    >
+    <p className="stg:text-[11px] stg:italic stg:text-muted-foreground">
       {provenance}
     </p>
   );

--- a/sdk/react/src/execution/ToolCallItem.tsx
+++ b/sdk/react/src/execution/ToolCallItem.tsx
@@ -31,6 +31,7 @@ import type { FileReviewRowState } from "./file-review-status.js";
 import { FilePathLink } from "./FilePathLink.js";
 import { isFileCategory, type ToolCategory } from "./tool-categories.js";
 import { useToolPresentation } from "./tool-presenter.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link ToolCallItem}. */
 export interface ToolCallItemProps {
@@ -307,13 +308,23 @@ export const ToolCallItem = memo(function ToolCallItem({
           />
         ) : (
           displaySubtitle && (
-            <span
-              ref={measuresSubtitle ? subtitleRef : undefined}
-              title={displaySubtitle}
-              className="stg:min-w-0 stg:truncate stg:text-muted-foreground stg:font-mono"
-            >
-              {displaySubtitle}
-            </span>
+            // Not TruncatedText: the span must carry the external measurement
+            // ref (useIsTextTruncated) that the expanded detail reads.
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    ref={measuresSubtitle ? subtitleRef : undefined}
+                    className="stg:min-w-0 stg:truncate stg:text-muted-foreground stg:font-mono"
+                  />
+                }
+              >
+                {displaySubtitle}
+              </TooltipTrigger>
+              <TooltipContent side="top" className="stg:break-all">
+                {displaySubtitle}
+              </TooltipContent>
+            </Tooltip>
           )
         )}
         {!isSubAgent && category !== "shell" && resultSummary && (

--- a/sdk/react/src/execution/WriteBackCard.tsx
+++ b/sdk/react/src/execution/WriteBackCard.tsx
@@ -5,6 +5,8 @@ import type { WorkspaceWriteBack } from "@stigmer/protos/ai/stigmer/agentic/agen
 import { WorkspaceWriteBackPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/writeback_pb";
 import { cn } from "@stigmer/theme";
 import { DiffSummary } from "../version-history/DiffSummary.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import {
   parseDiffStatSummary,
   trailingDiffStatLine,
@@ -73,12 +75,10 @@ export function WriteBackCard({ writeBack, className }: WriteBackCardProps) {
     >
       {/* Header: workspace name + quiet phase caption */}
       <div className="stg:flex stg:items-center stg:gap-2 stg:px-2 stg:py-1">
-        <span
-          className="stg:min-w-0 stg:flex-1 stg:truncate stg:text-xs stg:font-medium stg:text-foreground"
-          title={displayName}
-        >
-          {displayName}
-        </span>
+        <TruncatedText
+          text={displayName}
+          className="stg:min-w-0 stg:flex-1 stg:text-xs stg:font-medium stg:text-foreground"
+        />
         <PhaseCaption
           phase={writeBack.phase}
           pullRequestNumber={writeBack.pullRequestNumber}
@@ -236,16 +236,17 @@ function BranchRow({
 
   return (
     <div className="stg:group stg:flex stg:items-stretch">
-      <div
-        className="stg:flex stg:min-w-0 stg:flex-1 stg:items-center stg:gap-2 stg:px-2 stg:py-1 stg:text-xs"
-        title={baseBranch ? `${branchName} \u2190 ${baseBranch}` : branchName}
-      >
+      {/* The old row title restated "branch ← base", which is already visible
+          text; only the branch name can clip, so it alone carries the
+          overflow-gated tooltip. */}
+      <div className="stg:flex stg:min-w-0 stg:flex-1 stg:items-center stg:gap-2 stg:px-2 stg:py-1 stg:text-xs">
         <span className="stg:shrink-0 stg:text-muted-foreground">
           <GitBranchIcon />
         </span>
-        <span className="stg:min-w-0 stg:truncate stg:font-mono stg:text-foreground">
-          {branchName}
-        </span>
+        <TruncatedText
+          text={branchName}
+          className="stg:min-w-0 stg:font-mono stg:text-foreground"
+        />
         {baseBranch && (
           <span className="stg:shrink-0 stg:font-mono stg:text-muted-foreground-faint">
             {"\u2190 "}
@@ -253,22 +254,30 @@ function BranchRow({
           </span>
         )}
       </div>
-      <button
-        type="button"
-        onClick={handleCopy}
-        aria-label={copied ? "Branch name copied" : `Copy branch name ${branchName}`}
-        title={copied ? "Copied" : "Copy branch name"}
-        className={cn(
-          "stg:flex stg:shrink-0 stg:items-center stg:px-2 stg:text-muted-foreground stg:transition-opacity",
-          copied
-            ? "stg:opacity-100"
-            : "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
-          "stg:hover:text-foreground",
-          "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
-        )}
-      >
-        {copied ? <CheckIcon /> : <CopyIcon />}
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label={copied ? "Branch name copied" : `Copy branch name ${branchName}`}
+              className={cn(
+                "stg:flex stg:shrink-0 stg:items-center stg:px-2 stg:text-muted-foreground stg:transition-opacity",
+                copied
+                  ? "stg:opacity-100"
+                  : "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
+                "stg:hover:text-foreground",
+                "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
+              )}
+            />
+          }
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {copied ? "Copied" : "Copy branch name"}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/sdk/react/src/execution/__tests__/ArtifactRow.test.tsx
+++ b/sdk/react/src/execution/__tests__/ArtifactRow.test.tsx
@@ -132,8 +132,12 @@ describe("ArtifactRow — download", () => {
     });
   });
 
-  it("labels the Download control 'Download ZIP' for a directory", () => {
+  it("renders the directory Download control with no native title", () => {
     renderRow({ artifact: dirArtifact("return-policy") });
-    expect(screen.getByTitle("Download ZIP")).toBeTruthy();
+    // The "Download ZIP" copy moved to the house tooltip (native titles
+    // are banned — stigmer-cloud#268); its reveal is pinned in the
+    // real-browser suite (artifact-row-tooltips.layout.test.tsx).
+    expect(screen.getByLabelText("Download return-policy")).toBeTruthy();
+    expect(document.querySelector("[title]")).toBeNull();
   });
 });

--- a/sdk/react/src/execution/__tests__/ArtifactRowView.test.tsx
+++ b/sdk/react/src/execution/__tests__/ArtifactRowView.test.tsx
@@ -68,11 +68,14 @@ describe("ArtifactRowView — the shared row primitive", () => {
     expect((download as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("renders directory affordances (slash suffix, ZIP download title)", () => {
+  it("renders directory affordances with no native title anywhere", () => {
     renderView({
       item: { ...fileItem, name: "bundle", tooltip: "bundle", isDirectory: true },
     });
     expect(screen.getByText("bundle/")).toBeTruthy();
-    expect(screen.getByTitle("Download ZIP")).toBeTruthy();
+    // The "Download ZIP" copy moved to the house tooltip (native titles
+    // are banned — stigmer-cloud#268); its reveal is pinned in the
+    // real-browser suite (artifact-row-tooltips.layout.test.tsx).
+    expect(document.querySelector("[title]")).toBeNull();
   });
 });

--- a/sdk/react/src/execution/__tests__/FilePathLink.test.tsx
+++ b/sdk/react/src/execution/__tests__/FilePathLink.test.tsx
@@ -46,8 +46,8 @@ describe("FilePathLink filename-first display", () => {
   });
 });
 
-describe("FilePathLink full path on hover", () => {
-  it("puts the absolute local path in the title (not the action verb)", () => {
+describe("FilePathLink full path resolution", () => {
+  it("resolves the absolute local path into the accessible name (hover ride the house tooltip)", () => {
     const entries = [localEntry("my-app", "/Users/dev/my-app")];
     render(
       <FilePathContext.Provider value={{ workspaceEntries: entries }}>
@@ -55,14 +55,18 @@ describe("FilePathLink full path on hover", () => {
       </FilePathContext.Provider>,
     );
     const el = screen.getByRole("button");
-    expect(el.getAttribute("title")).toBe("/Users/dev/my-app/src/main.go");
-    // The action verb moves into the accessible name, with the path.
+    // The resolved path is observable in the accessible name; the visual
+    // hover reveal is the house tooltip (native titles are banned,
+    // stigmer-cloud#268).
     expect(el.getAttribute("aria-label")).toBe("Copy path: /Users/dev/my-app/src/main.go");
+    expect(el.getAttribute("title")).toBeNull();
   });
 
-  it("falls back to the logical path in the title when unresolved", () => {
+  it("falls back to the logical path when unresolved", () => {
     render(<FilePathLink path="src/main.go" />);
-    expect(screen.getByRole("button").getAttribute("title")).toBe("src/main.go");
+    const el = screen.getByRole("button");
+    expect(el.getAttribute("aria-label")).toBe("Copy path: src/main.go");
+    expect(el.getAttribute("title")).toBeNull();
   });
 });
 

--- a/sdk/react/src/execution/__tests__/FileReviewCard.test.tsx
+++ b/sdk/react/src/execution/__tests__/FileReviewCard.test.tsx
@@ -883,7 +883,8 @@ describe("FileReviewCard", () => {
       expect(screen.getByText("a.ts")).toBeTruthy();
       expect(screen.getByText("b.ts")).toBeTruthy();
       expect(screen.getByRole("button", { name: /Copy path: src\/a\.ts/ })).toBeTruthy();
-      expect(screen.getByTitle("src/a.ts")).toBeTruthy();
+      // Full path on hover rides the house tooltip; no native title remains.
+      expect(document.querySelector("[title]")).toBeNull();
     });
 
     it("keeps a single complete file collapsed behind the 'Files' expander", () => {

--- a/sdk/react/src/execution/__tests__/MessageEntry-attachments.test.tsx
+++ b/sdk/react/src/execution/__tests__/MessageEntry-attachments.test.tsx
@@ -135,9 +135,10 @@ describe("MessageEntry attachment rendering", () => {
 
     // The tile is preview-only: no "screenshot.png" text node anywhere…
     expect(screen.queryByText("screenshot.png")).toBeNull();
-    // …but the name stays reachable — tooltip on the listitem, aria on both.
+    // …but the name stays reachable — house tooltip on the tile (native
+    // titles are banned, stigmer-cloud#268), aria on both.
     const tile = screen.getByRole("listitem", { name: "screenshot.png" });
-    expect(tile.getAttribute("title")).toBe("screenshot.png");
+    expect(tile.getAttribute("title")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Preview screenshot.png" }),
     ).toBeTruthy();

--- a/sdk/react/src/execution/__tests__/MessageThread.test.tsx
+++ b/sdk/react/src/execution/__tests__/MessageThread.test.tsx
@@ -365,7 +365,12 @@ describe("MessageThread", () => {
     // shows the folded set's changed file.
     expect(screen.getByText("File changes")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Show" }));
-    expect(screen.getByTitle("src/a.ts")).toBeTruthy();
+    // The changed file renders as a FilePathLink whose accessible name
+    // carries the full path (the hover reveal is the house tooltip now —
+    // native titles are banned, stigmer-cloud#268).
+    expect(
+      screen.getByRole("button", { name: /Copy path: src\/a\.ts/ }),
+    ).toBeTruthy();
     expect(
       document.querySelector('[data-cursor-target="file-review-approve"]'),
     ).toBeNull();

--- a/sdk/react/src/execution/__tests__/artifact-row-tooltips.layout.test.tsx
+++ b/sdk/react/src/execution/__tests__/artifact-row-tooltips.layout.test.tsx
@@ -1,0 +1,115 @@
+// The interactive-trigger tooltip contract from the native-title sweep
+// (stigmer-cloud#268), pinned in a real Chromium on ArtifactRowView. When
+// an enabled control is its own tooltip trigger, keyboard FOCUS opens the
+// hint too — the concrete accessibility gain over the native `title` this
+// replaced, which no keyboard user ever saw. Focus-open is real focus
+// machinery (Base UI opens on focus-visible), so only a real browser can
+// pin it honestly.
+
+import "../../../dist/styles.css";
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { userEvent } from "@vitest/browser/context";
+import { ArtifactRowView } from "../ArtifactRowView.js";
+
+const ITEM = {
+  name: "report.pdf",
+  tooltip: "/workspace/output/report.pdf",
+  subtitlePath: null,
+  sizeBytes: 2048,
+  isDirectory: false,
+};
+
+function renderRow() {
+  const pane = document.createElement("div");
+  pane.className = "stgm";
+  pane.style.width = "320px";
+  document.body.appendChild(pane);
+  render(
+    <ul>
+      <ArtifactRowView
+        item={ITEM}
+        onOpen={() => {}}
+        onDownload={() => {}}
+        isDownloading={false}
+      />
+    </ul>,
+    { container: pane },
+  );
+  return pane;
+}
+
+function portaledText(pane: HTMLElement): string {
+  return Array.from(document.body.children)
+    .filter((node) => node !== pane)
+    .map((node) => node.textContent ?? "")
+    .join(" ");
+}
+
+afterEach(() => {
+  cleanup();
+  document.querySelectorAll(".stgm").forEach((node) => node.remove());
+});
+
+describe("ArtifactRowView tooltips", () => {
+  it("opens the full-path hint on keyboard focus — no pointer required", async () => {
+    const pane = renderRow();
+    expect(pane.querySelector("[title]")).toBeNull();
+
+    // Tab reaches the open button (first focusable in the row); the
+    // tooltip must follow focus per the interactive-trigger pattern.
+    await userEvent.tab();
+    const openButton = Array.from(pane.querySelectorAll("button")).find((el) =>
+      el.textContent?.includes("report.pdf"),
+    );
+    expect(document.activeElement).toBe(openButton);
+
+    await vi.waitFor(
+      () => expect(portaledText(pane)).toContain("/workspace/output/report.pdf"),
+      { timeout: 3000, interval: 50 },
+    );
+  });
+
+  it("keeps the download hint hoverable through the wrapper span", async () => {
+    const pane = renderRow();
+
+    const download = Array.from(pane.querySelectorAll("button")).find(
+      (el) => el.getAttribute("aria-label") === "Download report.pdf",
+    );
+    await userEvent.hover(download!.parentElement!);
+    await vi.waitFor(
+      () => expect(portaledText(pane)).toContain("Download"),
+      { timeout: 3000, interval: 50 },
+    );
+    await userEvent.unhover(download!.parentElement!);
+  });
+
+  it("says 'Download ZIP' for a directory", async () => {
+    const pane = document.createElement("div");
+    pane.className = "stgm";
+    pane.style.width = "320px";
+    document.body.appendChild(pane);
+    render(
+      <ul>
+        <ArtifactRowView
+          item={{ ...ITEM, name: "bundle", tooltip: "bundle", isDirectory: true }}
+          onOpen={() => {}}
+          onDownload={() => {}}
+          isDownloading={false}
+        />
+      </ul>,
+      { container: pane },
+    );
+
+    const download = Array.from(pane.querySelectorAll("button")).find(
+      (el) => el.getAttribute("aria-label") === "Download bundle",
+    );
+    await userEvent.hover(download!.parentElement!);
+    await vi.waitFor(
+      () => expect(portaledText(pane)).toContain("Download ZIP"),
+      { timeout: 3000, interval: 50 },
+    );
+    await userEvent.unhover(download!.parentElement!);
+  });
+});

--- a/sdk/react/src/execution/artifact-row-item.ts
+++ b/sdk/react/src/execution/artifact-row-item.ts
@@ -19,7 +19,7 @@ import type { Artifact } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/ap
 export interface ArtifactRowItem {
   /** Display label (file or directory name). */
   readonly name: string;
-  /** Hover title — the fullest location/name known for the artifact. */
+  /** House-tooltip content — the fullest location/name known for the artifact. */
   readonly tooltip: string;
   /**
    * Disambiguation subtitle rendered after the name when another row shares

--- a/sdk/react/src/file-reference/FileReferenceChipList.tsx
+++ b/sdk/react/src/file-reference/FileReferenceChipList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link FileReferenceChipList}. */
 export interface FileReferenceChipListProps {
@@ -83,24 +84,35 @@ function FileReferenceChip({
   const filename = path.split("/").pop() ?? path;
 
   return (
-    <span
-      role="listitem"
-      aria-label={`Referenced file: ${path}`}
-      title={path}
-      className="stg:inline-flex stg:max-w-[200px] stg:items-center stg:gap-1 stg:rounded-md stg:bg-muted-subtle stg:px-2 stg:py-0.5 stg:text-xs stg:text-foreground"
-    >
-      <FileRefIcon />
-      <span className="stg:truncate">{filename}</span>
-      <button
-        type="button"
-        onClick={onRemove}
-        disabled={disabled}
-        className="stg:ml-0.5 stg:shrink-0 stg:text-muted-foreground stg:hover:text-destructive stg:disabled:pointer-events-none"
-        aria-label={`Remove reference to ${path}`}
+    // The chip shows only the basename; the tooltip restores the full path,
+    // so it is a hover-always hint on the chip, not an overflow-gated
+    // TruncatedText.
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            role="listitem"
+            aria-label={`Referenced file: ${path}`}
+            className="stg:inline-flex stg:max-w-[200px] stg:items-center stg:gap-1 stg:rounded-md stg:bg-muted-subtle stg:px-2 stg:py-0.5 stg:text-xs stg:text-foreground"
+          />
+        }
       >
-        <XIcon />
-      </button>
-    </span>
+        <FileRefIcon />
+        <span className="stg:truncate">{filename}</span>
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={disabled}
+          className="stg:ml-0.5 stg:shrink-0 stg:text-muted-foreground stg:hover:text-destructive stg:disabled:pointer-events-none"
+          aria-label={`Remove reference to ${path}`}
+        >
+          <XIcon />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="stg:break-all">
+        {path}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/file-reference/__tests__/FileReferenceChipList.test.tsx
+++ b/sdk/react/src/file-reference/__tests__/FileReferenceChipList.test.tsx
@@ -80,7 +80,7 @@ describe("FileReferenceChipList", () => {
     expect(list.getAttribute("aria-label")).toBe("Referenced workspace files");
   });
 
-  it("sets title attribute on chip for full path tooltip", () => {
+  it("keeps the chip free of native titles — the full path rides the house tooltip", () => {
     render(
       <FileReferenceChipList
         refs={["src/deeply/nested/file.ts"]}
@@ -89,6 +89,9 @@ describe("FileReferenceChipList", () => {
     );
 
     const item = screen.getByRole("listitem");
-    expect(item.getAttribute("title")).toBe("src/deeply/nested/file.ts");
+    expect(item.getAttribute("title")).toBeNull();
+    // The basename stays visible; the full path is the tooltip's content
+    // (reveal pinned in the real-browser suites).
+    expect(item.textContent).toContain("file.ts");
   });
 });

--- a/sdk/react/src/iam-policy/OrgMembersPanel.tsx
+++ b/sdk/react/src/iam-policy/OrgMembersPanel.tsx
@@ -15,6 +15,7 @@ import {
   iamRoleFromString,
   iamRoleToString,
 } from "@stigmer/sdk";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useResourceAccess } from "./useResourceAccess.js";
 import { usePrincipalsCount } from "./usePrincipalsCount.js";
 import { useWhoAmI } from "./useWhoAmI.js";
@@ -282,26 +283,32 @@ function MemberRow({
 function RoleBadge({ grant }: { grant: RoleGrant }) {
   const roleName = grant.role?.name || grant.role?.code || "Unknown";
   return (
-    <span
-      className={cn(
-        "stg:inline-flex stg:items-center stg:rounded-md stg:border stg:px-2 stg:py-0.5 stg:text-[0.65rem] stg:font-medium",
-        grant.isInherited
-          ? "stg:border-border-muted stg:text-muted-foreground stg:bg-muted-subtle stg:italic"
-          : "stg:border-border stg:bg-muted stg:text-foreground",
-      )}
-      title={
-        grant.isInherited
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "stg:inline-flex stg:items-center stg:rounded-md stg:border stg:px-2 stg:py-0.5 stg:text-[0.65rem] stg:font-medium",
+              grant.isInherited
+                ? "stg:border-border-muted stg:text-muted-foreground stg:bg-muted-subtle stg:italic"
+                : "stg:border-border stg:bg-muted stg:text-foreground",
+            )}
+          />
+        }
+      >
+        {roleName}
+        {grant.isInherited && (
+          <span className="stg:ml-1 stg:text-[0.55rem] stg:text-muted-foreground">
+            (inherited)
+          </span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        {grant.isInherited
           ? `Inherited from ${grant.ownerResource?.kind ?? "parent"}`
-          : `Directly assigned`
-      }
-    >
-      {roleName}
-      {grant.isInherited && (
-        <span className="stg:ml-1 stg:text-[0.55rem] stg:text-muted-foreground">
-          (inherited)
-        </span>
-      )}
-    </span>
+          : `Directly assigned`}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/iam-policy/ProviderBadge.tsx
+++ b/sdk/react/src/iam-policy/ProviderBadge.tsx
@@ -2,6 +2,7 @@
 
 import type { ApiResourceRefView } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/io_pb";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /**
  * The human-readable identity-source label for a principal, or `""` when none
@@ -39,15 +40,21 @@ export function ProviderBadge({ principal, className }: ProviderBadgeProps) {
   }
 
   return (
-    <span
-      className={cn(
-        "stg:inline-flex stg:items-center stg:rounded stg:px-1.5 stg:py-0.5 stg:text-[0.6rem] stg:font-medium",
-        "stg:bg-muted-subtle stg:text-muted-foreground",
-        className,
-      )}
-      title={`Identity provider: ${label}`}
-    >
-      {label}
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "stg:inline-flex stg:items-center stg:rounded stg:px-1.5 stg:py-0.5 stg:text-[0.6rem] stg:font-medium",
+              "stg:bg-muted-subtle stg:text-muted-foreground",
+              className,
+            )}
+          />
+        }
+      >
+        {label}
+      </TooltipTrigger>
+      <TooltipContent side="top">{`Identity provider: ${label}`}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/sdk/react/src/iam-policy/RoleSelector.tsx
+++ b/sdk/react/src/iam-policy/RoleSelector.tsx
@@ -74,7 +74,6 @@ export function RoleSelector({
           return (
             <label
               key={opt.value}
-              title={opt.description}
               className={cn(
                 "stg:inline-flex stg:cursor-pointer stg:flex-col stg:rounded-md stg:border stg:px-3 stg:py-1.5 stg:text-xs stg:transition-colors",
                 isChecked

--- a/sdk/react/src/identity-provider/IdentityProviderListPanel.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderListPanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useIdentityProviderList } from "./useIdentityProviderList.js";
 import { useDeleteIdentityProvider } from "./useDeleteIdentityProvider.js";
 
@@ -246,9 +247,16 @@ function IdpRow({
           </span>
         )}
         {createdAt && (
-          <span title={`Created ${timestampDate(createdAt).toISOString()}`}>
-            {formatShortDate(timestampDate(createdAt))}
-          </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={<time dateTime={timestampDate(createdAt).toISOString()} />}
+            >
+              {formatShortDate(timestampDate(createdAt))}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {`Created ${timestampDate(createdAt).toISOString()}`}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/sdk/react/src/internal/__tests__/truncated-text.layout.test.tsx
+++ b/sdk/react/src/internal/__tests__/truncated-text.layout.test.tsx
@@ -1,0 +1,68 @@
+// TruncatedText's overflow gating in a real Chromium (stigmer-cloud#268).
+// The native `title` idiom this helper replaced fired whether or not the
+// text was actually clipped; the helper opens the house tooltip ONLY when
+// CSS truncation really happened. That distinction is a layout fact —
+// happy-dom reports zero geometry — so only a real browser can pin it.
+
+import "../../../dist/styles.css";
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { userEvent } from "@vitest/browser/context";
+import type { ReactElement } from "react";
+import { TruncatedText } from "../truncated-text.js";
+
+const LONG = "a-very-long-model-identifier/that-cannot-fit-in-eighty-pixels";
+const SHORT = "fits";
+
+/** A themed, hard-sized cell so truncation geometry is real. */
+function renderInCell(ui: ReactElement, width: string) {
+  const cell = document.createElement("div");
+  cell.className = "stgm";
+  cell.style.width = width;
+  cell.style.display = "block";
+  document.body.appendChild(cell);
+  render(ui, { container: cell });
+  return cell;
+}
+
+function portaledText(cell: HTMLElement): string {
+  return Array.from(document.body.children)
+    .filter((node) => node !== cell)
+    .map((node) => node.textContent ?? "")
+    .join(" ");
+}
+
+afterEach(() => {
+  cleanup();
+  document.querySelectorAll(".stgm").forEach((node) => node.remove());
+});
+
+describe("TruncatedText overflow gating", () => {
+  it("reveals the full value on hover when the text is actually clipped", async () => {
+    const cell = renderInCell(<TruncatedText text={LONG} />, "80px");
+    expect(cell.querySelector("[title]")).toBeNull();
+
+    const span = cell.querySelector("span");
+    expect(span!.scrollWidth).toBeGreaterThan(span!.clientWidth);
+
+    await userEvent.hover(span!);
+    await vi.waitFor(
+      () => expect(portaledText(cell)).toContain(LONG),
+      { timeout: 3000, interval: 50 },
+    );
+    await userEvent.unhover(span!);
+  });
+
+  it("stays quiet when nothing is clipped — the tooltip would only repeat the cell", async () => {
+    const cell = renderInCell(<TruncatedText text={SHORT} />, "300px");
+
+    const span = cell.querySelector("span");
+    await userEvent.hover(span!);
+    // Base UI's default open delay is 600ms; wait past it and assert the
+    // portal never produced the tooltip.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(portaledText(cell)).not.toContain(SHORT);
+    await userEvent.unhover(span!);
+  });
+});

--- a/sdk/react/src/internal/__tests__/truncated-text.test.tsx
+++ b/sdk/react/src/internal/__tests__/truncated-text.test.tsx
@@ -1,0 +1,33 @@
+// Fast structural pins for TruncatedText (the native-title sweep's
+// truncation replacement, stigmer-cloud#268). Happy-dom can honestly pin
+// the STRUCTURE — full text in the DOM, zero native titles, zero new tab
+// stops; the overflow-gated REVEAL needs real layout and lives in
+// truncated-text.layout.test.tsx.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { TruncatedText } from "../truncated-text.js";
+
+afterEach(cleanup);
+
+describe("TruncatedText", () => {
+  it("renders the full text in the DOM with no native title and no tab stop", () => {
+    render(<TruncatedText text="models/anthropic/claude-4.6-opus" />);
+
+    // CSS truncation is purely visual: screen readers and selection get
+    // the full value from the DOM, so no sr-only duplicate is needed.
+    const span = screen.getByText("models/anthropic/claude-4.6-opus");
+    expect(span.closest("[title]")).toBeNull();
+    expect(span.closest("[tabindex]")).toBeNull();
+  });
+
+  it("applies stg:truncate by default and yields to a line-clamp class", () => {
+    const { rerender } = render(<TruncatedText text="abc" />);
+    expect(screen.getByText("abc").className).toContain("stg:truncate");
+
+    rerender(<TruncatedText text="abc" className="stg:line-clamp-2" />);
+    const clamped = screen.getByText("abc");
+    expect(clamped.className).toContain("stg:line-clamp-2");
+    expect(clamped.className).not.toContain("stg:truncate");
+  });
+});

--- a/sdk/react/src/internal/truncated-text.tsx
+++ b/sdk/react/src/internal/truncated-text.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip.js";
+
+// ---------------------------------------------------------------------------
+// SDK-internal truncated-text span with an overflow-gated house tooltip.
+//
+// Replaces the `title={fullValue}` idiom on truncated cells (paths, hashes,
+// model ids, …) after the native-title sweep (stigmer/stigmer-cloud#268).
+// Native titles were OS-delayed and fired whether or not the text was
+// actually clipped; this helper opens the house tooltip ONLY when the text
+// truly overflows its box, checked at open time — a non-truncated cell
+// stays tooltip-free.
+//
+// The trigger is a plain, non-focusable span (the StatusHint precedent in
+// ConversationTimelineView): CSS truncation is purely visual, so the full
+// text is already in the DOM for screen readers and selection — the tooltip
+// is a sighted-pointer convenience, and a tab stop per table cell would be
+// noise. Works with or without a `TooltipProvider` in scope (the provider
+// only adds delay grouping); like ./tooltip.tsx, NOT exported from
+// @stigmer/react.
+// ---------------------------------------------------------------------------
+
+interface TruncatedTextProps {
+  /** The full value: rendered inside the span and shown by the tooltip. */
+  readonly text: string;
+  /**
+   * Classes for the truncating span. `stg:truncate` is applied by default;
+   * pass a `stg:line-clamp-*` class instead for multi-line clamping (the
+   * overflow check covers both axes).
+   */
+  readonly className?: string;
+  /** Tooltip placement; truncated cells read best with the default "top". */
+  readonly side?: React.ComponentProps<typeof TooltipContent>["side"];
+}
+
+/** True when CSS actually clipped the element on either axis. */
+function isOverflowing(el: HTMLElement): boolean {
+  return el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+}
+
+export function TruncatedText({ text, className, side = "top" }: TruncatedTextProps) {
+  const spanRef = React.useRef<HTMLSpanElement>(null);
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+    if (nextOpen && spanRef.current && !isOverflowing(spanRef.current)) {
+      return; // Nothing is clipped — the tooltip would only repeat the cell.
+    }
+    setOpen(nextOpen);
+  }, []);
+
+  return (
+    <Tooltip open={open} onOpenChange={handleOpenChange}>
+      <TooltipTrigger
+        render={
+          <span
+            ref={spanRef}
+            className={cn(
+              // A plain inline span can neither truncate (overflow does not
+              // apply to inline boxes) nor be measured (clientWidth is 0 by
+              // spec), so the span defaults to block; cn()'s conflict
+              // resolution lets callers override with their own display
+              // class (inline-block, flex-1 cells, …).
+              "stg:block",
+              className?.match(/(?:^|\s)stg:line-clamp-/) ? undefined : "stg:truncate",
+              className,
+            )}
+          />
+        }
+      >
+        {text}
+      </TooltipTrigger>
+      <TooltipContent side={side} className="stg:break-all">
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/sdk/react/src/invitation/InvitationManager.tsx
+++ b/sdk/react/src/invitation/InvitationManager.tsx
@@ -15,6 +15,7 @@ import { useOrgInvitations } from "./useOrgInvitations.js";
 import { useCreateInvitation } from "./useCreateInvitation.js";
 import { useRevokeInvitation } from "./useRevokeInvitation.js";
 import { InvitationCreatedAlert } from "./InvitationCreatedAlert.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { RoleSelector } from "../iam-policy/RoleSelector.js";
 
 // ---------------------------------------------------------------------------
@@ -465,11 +466,23 @@ function InvitationRow({
 
         {/* Expiry */}
         {expiresAt && (
-          <span className="stg:text-xs stg:text-muted-foreground" title={timestampDate(expiresAt).toISOString()}>
-            {isActive
-              ? formatRelativeExpiry(timestampDate(expiresAt))
-              : formatShortDate(timestampDate(expiresAt))}
-          </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <time
+                  dateTime={timestampDate(expiresAt).toISOString()}
+                  className="stg:text-xs stg:text-muted-foreground"
+                />
+              }
+            >
+              {isActive
+                ? formatRelativeExpiry(timestampDate(expiresAt))
+                : formatShortDate(timestampDate(expiresAt))}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {timestampDate(expiresAt).toISOString()}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/sdk/react/src/library/ScopeToggle.tsx
+++ b/sdk/react/src/library/ScopeToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef } from "react";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import type { ResourceListScope } from "../search/index.js";
 
 /** Props for {@link ScopeToggle}. */
@@ -116,7 +117,7 @@ export function ScopeToggle({
         const isSelected = value === option.value;
         const Icon = option.icon;
 
-        return (
+        const radio = (
           <button
             key={option.value}
             ref={(el) => {
@@ -126,7 +127,6 @@ export function ScopeToggle({
             role="radio"
             aria-checked={isSelected}
             aria-label={option.ariaLabel}
-            title={compact ? option.ariaLabel : undefined}
             tabIndex={isSelected ? 0 : -1}
             disabled={disabled}
             onClick={() => handleSelect(option.value)}
@@ -142,6 +142,18 @@ export function ScopeToggle({
             <Icon className="stg:size-3" />
             {!compact && option.label}
           </button>
+        );
+
+        // Icon-only radios need their name discoverable by sighted users
+        // too: in compact mode each radio is its own tooltip trigger (hover
+        // and roving-tabindex focus both open it). Full mode shows visible
+        // labels, so a tooltip would only repeat them.
+        if (!compact) return radio;
+        return (
+          <Tooltip key={option.value}>
+            <TooltipTrigger render={radio} />
+            <TooltipContent side="top">{option.ariaLabel}</TooltipContent>
+          </Tooltip>
         );
       })}
     </div>

--- a/sdk/react/src/library/VisibilitySelector.tsx
+++ b/sdk/react/src/library/VisibilitySelector.tsx
@@ -5,6 +5,7 @@ import { Popover } from "@base-ui/react/popover";
 import { cn } from "@stigmer/theme";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { useStigmerPortalContainer } from "../portal-container.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { ConfirmDialog } from "../resource-detail/ConfirmDialog.js";
 import { useConfirmAction } from "../resource-detail/useConfirmAction.js";
 import {
@@ -454,20 +455,26 @@ export function VisibilityBadge({
 
   if (onClick) {
     return (
-      <button
-        type="button"
-        onClick={onClick}
-        title="Manage access"
-        aria-label={`${option.label} visibility — manage access`}
-        className={cn(
-          VISIBILITY_CHIP_CLASS,
-          "stg:transition-colors stg:hover:bg-accent-hover stg:hover:text-foreground",
-          "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-          className,
-        )}
-      >
-        {content}
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={onClick}
+              aria-label={`${option.label} visibility — manage access`}
+              className={cn(
+                VISIBILITY_CHIP_CLASS,
+                "stg:transition-colors stg:hover:bg-accent-hover stg:hover:text-foreground",
+                "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+                className,
+              )}
+            />
+          }
+        >
+          {content}
+        </TooltipTrigger>
+        <TooltipContent side="top">Manage access</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/sdk/react/src/mcp-server/McpServerDetailView.tsx
+++ b/sdk/react/src/mcp-server/McpServerDetailView.tsx
@@ -31,6 +31,7 @@ import { useOrgOAuthApp } from "./useOrgOAuthApp.js";
 import { OAuthAppForm } from "./OAuthAppForm.js";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ErrorMessage } from "../error/ErrorMessage.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { EnvVarForm } from "../environment/EnvVarForm.js";
 import type { EnvVarFormVariable } from "../environment/EnvVarForm.js";
 import { VisibilityBadge } from "../library/VisibilitySelector.js";
@@ -1660,13 +1661,18 @@ function renderHeaderValue(value: string): React.ReactNode {
       parts.push(value.slice(lastIndex, match.index));
     }
     parts.push(
-      <span
-        key={match.index}
-        className="stg:inline-flex stg:items-center stg:gap-0.5 stg:rounded stg:bg-primary-subtle stg:px-1 stg:py-px stg:text-[10px] stg:font-medium stg:text-primary"
-        title={`Resolved from environment variable: ${match[1]}`}
-      >
-        {match[0]}
-      </span>,
+      <Tooltip key={match.index}>
+        <TooltipTrigger
+          render={
+            <span className="stg:inline-flex stg:items-center stg:gap-0.5 stg:rounded stg:bg-primary-subtle stg:px-1 stg:py-px stg:text-[10px] stg:font-medium stg:text-primary" />
+          }
+        >
+          {match[0]}
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {`Resolved from environment variable: ${match[1]}`}
+        </TooltipContent>
+      </Tooltip>,
     );
     lastIndex = match.index + match[0].length;
   }

--- a/sdk/react/src/mcp-server/McpToolSelector.tsx
+++ b/sdk/react/src/mcp-server/McpToolSelector.tsx
@@ -6,6 +6,7 @@ import type { DiscoveredTool } from "@stigmer/protos/ai/stigmer/agentic/mcpserve
 import type { ToolApprovalPolicy } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
 import { useScrollShadows } from "../internal/useScrollShadows.js";
 import { ScrollFade } from "../internal/ScrollFade.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link McpToolSelector}. */
 export interface McpToolSelectorProps {
@@ -217,13 +218,17 @@ function ApprovalBadge({ message }: { readonly message: string }) {
   const resolvedTitle = message || "This tool requires approval before execution";
 
   return (
-    <span
-      className="stg:inline-flex stg:shrink-0 stg:items-center stg:gap-0.5 stg:rounded stg:px-1 stg:py-0.5 stg:text-[0.6rem] stg:font-medium stg:leading-none stg:bg-warning/15 stg:text-warning"
-      title={resolvedTitle}
-    >
-      <ShieldIcon />
-      Approval
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className="stg:inline-flex stg:shrink-0 stg:items-center stg:gap-0.5 stg:rounded stg:px-1 stg:py-0.5 stg:text-[0.6rem] stg:font-medium stg:leading-none stg:bg-warning/15 stg:text-warning" />
+        }
+      >
+        <ShieldIcon />
+        Approval
+      </TooltipTrigger>
+      <TooltipContent side="top">{resolvedTitle}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/oauth-app/OAuthAppListPanel.tsx
+++ b/sdk/react/src/oauth-app/OAuthAppListPanel.tsx
@@ -4,6 +4,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useOAuthAppList } from "./useOAuthAppList.js";
 
 // ---------------------------------------------------------------------------
@@ -153,9 +154,16 @@ function OAuthAppRow({
 
       <div className="stg:hidden stg:shrink-0 stg:items-center stg:gap-4 stg:text-xs stg:text-muted-foreground stg:sm:flex">
         {createdAt && (
-          <span title={`Created ${timestampDate(createdAt).toISOString()}`}>
-            {formatShortDate(timestampDate(createdAt))}
-          </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={<time dateTime={timestampDate(createdAt).toISOString()} />}
+            >
+              {formatShortDate(timestampDate(createdAt))}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {`Created ${timestampDate(createdAt).toISOString()}`}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/sdk/react/src/platform-client/PlatformClientListPanel.tsx
+++ b/sdk/react/src/platform-client/PlatformClientListPanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { PlatformClient } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/api_pb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { usePlatformClientList } from "./usePlatformClientList.js";
 import { useDeletePlatformClient } from "./useDeletePlatformClient.js";
 
@@ -239,12 +240,14 @@ function PlatformClientRow({
 
       <div className="stg:hidden stg:sm:flex stg:shrink-0 stg:items-center stg:gap-3 stg:text-xs stg:text-muted-foreground">
         {fingerprint && (
-          <span
-            className="stg:font-mono"
-            title={`Secret fingerprint: ${fingerprint}`}
-          >
-            ••••{fingerprint.slice(-4)}
-          </span>
+          <Tooltip>
+            <TooltipTrigger render={<span className="stg:font-mono" />}>
+              ••••{fingerprint.slice(-4)}
+            </TooltipTrigger>
+            <TooltipContent side="top" className="stg:break-all">
+              {`Secret fingerprint: ${fingerprint}`}
+            </TooltipContent>
+          </Tooltip>
         )}
         <ExpiryBadge spec={spec} />
         {spec?.autoProvisionAccounts && (
@@ -253,9 +256,16 @@ function PlatformClientRow({
           </span>
         )}
         {createdAt && (
-          <span title={`Created ${timestampDate(createdAt).toISOString()}`}>
-            {formatShortDate(timestampDate(createdAt))}
-          </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={<time dateTime={timestampDate(createdAt).toISOString()} />}
+            >
+              {formatShortDate(timestampDate(createdAt))}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {`Created ${timestampDate(createdAt).toISOString()}`}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 
@@ -305,15 +315,22 @@ function ExpiryBadge({ spec }: { spec: PlatformClient["spec"] }) {
     const date = timestampDate(spec.expiresAt);
     const isExpired = date < new Date();
     return (
-      <span
-        className={cn(
-          "stg:text-[0.65rem]",
-          isExpired ? "stg:text-destructive stg:font-medium" : "stg:text-muted-foreground",
-        )}
-        title={`Expires ${date.toISOString()}`}
-      >
-        {isExpired ? "Expired" : `Exp ${formatShortDate(date)}`}
-      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <time
+              dateTime={date.toISOString()}
+              className={cn(
+                "stg:text-[0.65rem]",
+                isExpired ? "stg:text-destructive stg:font-medium" : "stg:text-muted-foreground",
+              )}
+            />
+          }
+        >
+          {isExpired ? "Expired" : `Exp ${formatShortDate(date)}`}
+        </TooltipTrigger>
+        <TooltipContent side="top">{`Expires ${date.toISOString()}`}</TooltipContent>
+      </Tooltip>
     );
   }
   return null;

--- a/sdk/react/src/pricing-governance/ModelCatalogPanel.tsx
+++ b/sdk/react/src/pricing-governance/ModelCatalogPanel.tsx
@@ -8,6 +8,7 @@ import {
   type ModelPricingBaseline,
 } from "@stigmer/protos/ai/stigmer/billing/v1/model_pricing_baseline_pb";
 import { Button } from "../button/index.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { BaselineEditor } from "./BaselineEditor.js";
 import { RetireConfirm } from "./RetireConfirm.js";
 import { OperatorAccessNotice } from "./OperatorAccessNotice.js";
@@ -232,13 +233,16 @@ function CatalogRow({
         className="stg:grid stg:grid-cols-[2fr_1fr_1fr_1fr_1fr_auto] stg:items-center stg:gap-2 stg:px-3 stg:py-2 stg:text-xs"
       >
         <span role="cell" className="stg:min-w-0">
-          <span className="stg:block stg:truncate stg:font-medium stg:text-foreground" title={baseline.modelId}>
+          {/* The display name needs no tooltip: the model id it used to
+              reveal is printed on the line below, which shows its own
+              tooltip when clipped. */}
+          <span className="stg:block stg:truncate stg:font-medium stg:text-foreground">
             {baseline.displayName || baseline.modelId}
           </span>
-          <span className="stg:block stg:truncate stg:text-[11px] stg:text-muted-foreground">
-            {baseline.modelId}
-            {baseline.featured ? " · featured" : ""}
-          </span>
+          <TruncatedText
+            text={`${baseline.modelId}${baseline.featured ? " · featured" : ""}`}
+            className="stg:block stg:text-[11px] stg:text-muted-foreground"
+          />
         </span>
         <span role="cell" className="stg:text-muted-foreground">
           {baseline.harness}

--- a/sdk/react/src/pricing-governance/PricingGovernanceConsole.tsx
+++ b/sdk/react/src/pricing-governance/PricingGovernanceConsole.tsx
@@ -12,6 +12,7 @@ import { ModelGovernanceDetail } from "./ModelGovernanceDetail.js";
 import { OperatorAccessNotice } from "./OperatorAccessNotice.js";
 import { GovernanceBadge, PendingOverrideCard, RateCell } from "./governance-primitives.js";
 import { INPUT_CLASSES } from "../internal/form-primitives.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { ZERO } from "./pricing-format.js";
 import { useDecidePricingOverride } from "./useDecidePricingOverride.js";
 import { useRetireModelPricingBaseline } from "./useRetireModelPricingBaseline.js";
@@ -367,13 +368,16 @@ function ModelRow({
         )}
       >
         <span className="stg:min-w-0">
-          <span className="stg:block stg:truncate stg:font-medium stg:text-foreground" title={baseline.modelId}>
+          {/* The display name needs no tooltip: the model id it used to
+              reveal is printed on the line below, which shows its own
+              tooltip when clipped. */}
+          <span className="stg:block stg:truncate stg:font-medium stg:text-foreground">
             {baseline.displayName || baseline.modelId}
           </span>
-          <span className="stg:block stg:truncate stg:text-[11px] stg:text-muted-foreground">
-            {baseline.modelId}
-            {baseline.featured ? " · featured" : ""}
-          </span>
+          <TruncatedText
+            text={`${baseline.modelId}${baseline.featured ? " · featured" : ""}`}
+            className="stg:block stg:text-[11px] stg:text-muted-foreground"
+          />
         </span>
         <span className="stg:text-muted-foreground">{baseline.harness}</span>
         <RateCell

--- a/sdk/react/src/pricing-governance/PricingGovernancePanel.tsx
+++ b/sdk/react/src/pricing-governance/PricingGovernancePanel.tsx
@@ -5,6 +5,7 @@ import { getUserMessage, isPermissionDenied } from "@stigmer/sdk";
 import type {
   ModelPricingGovernanceEntry,
 } from "@stigmer/protos/ai/stigmer/billing/v1/io_pb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { OperatorAccessNotice } from "./OperatorAccessNotice.js";
 import { GovernanceBadge, PendingOverrideCard, RateCell } from "./governance-primitives.js";
 import { usePricingGovernance } from "./usePricingGovernance.js";
@@ -140,10 +141,18 @@ function GovernanceRow({ entry }: { readonly entry: ModelPricingGovernanceEntry 
   return (
     <div role="row"
          className="stg:grid stg:grid-cols-[2fr_1fr_1fr_1fr_1fr] stg:items-center stg:gap-2 stg:border-b stg:border-border stg:px-3 stg:py-2 stg:text-xs stg:last:border-b-0">
-      <span role="cell" className="stg:truncate stg:font-medium stg:text-foreground"
-            title={entry.modelId}>
-        {entry.displayName || entry.modelId}
-      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span role="cell" className="stg:truncate stg:font-medium stg:text-foreground" />
+          }
+        >
+          {entry.displayName || entry.modelId}
+        </TooltipTrigger>
+        <TooltipContent side="top" className="stg:break-all">
+          {entry.modelId}
+        </TooltipContent>
+      </Tooltip>
       <span role="cell" className="stg:text-muted-foreground">{entry.harness}</span>
       <RateCell
         role="cell"

--- a/sdk/react/src/resource-workbench/components/StatusBadge.tsx
+++ b/sdk/react/src/resource-workbench/components/StatusBadge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
 import type { StatusPhase } from "../types.js";
 
 /** Props for {@link StatusBadge}. */
@@ -69,9 +70,12 @@ export function StatusBadge({
   if (!tooltip) return badge;
 
   return (
-    <span title={tooltip} className="stg:inline-flex">
-      {badge}
-    </span>
+    <Tooltip>
+      <TooltipTrigger render={<span className="stg:inline-flex" />}>
+        {badge}
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/schedule/CadenceField.tsx
+++ b/sdk/react/src/schedule/CadenceField.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId } from "react";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import {
   cadenceToCron,
   describeCadence,
@@ -164,33 +165,43 @@ export function CadenceField({
               // schedule with zero days is not expressible in cron.
               const isLastSelected = isOn && value.days.length === 1;
               return (
-                <button
-                  key={label}
-                  type="button"
-                  aria-pressed={isOn}
-                  aria-label={label}
-                  title={label}
-                  disabled={disabled || isLastSelected}
-                  onClick={() =>
-                    onChange({
-                      ...value,
-                      days: isOn
-                        ? value.days.filter((d) => d !== day)
-                        : [...value.days, day].sort((a, b) => a - b),
-                    })
-                  }
-                  className={cn(
-                    "stg:inline-flex stg:h-7 stg:w-9 stg:items-center stg:justify-center stg:rounded-md stg:border stg:text-xs stg:font-medium stg:transition-colors",
-                    "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-                    "stg:disabled:pointer-events-none",
-                    isOn
-                      ? "stg:border-primary stg:bg-primary stg:text-primary-foreground"
-                      : "stg:border-input stg:bg-background stg:text-muted-foreground stg:hover:text-foreground",
-                    isLastSelected && "stg:opacity-70",
-                  )}
-                >
-                  {label.slice(0, 3)}
-                </button>
+                // The tooltip trigger is a wrapper span so the hint stays
+                // hoverable on the always-disabled last selected day — the
+                // one toggle whose state actually needs explaining.
+                <Tooltip key={label}>
+                  <TooltipTrigger render={<span className="stg:inline-flex" />}>
+                    <button
+                      type="button"
+                      aria-pressed={isOn}
+                      aria-label={label}
+                      disabled={disabled || isLastSelected}
+                      onClick={() =>
+                        onChange({
+                          ...value,
+                          days: isOn
+                            ? value.days.filter((d) => d !== day)
+                            : [...value.days, day].sort((a, b) => a - b),
+                        })
+                      }
+                      className={cn(
+                        "stg:inline-flex stg:h-7 stg:w-9 stg:items-center stg:justify-center stg:rounded-md stg:border stg:text-xs stg:font-medium stg:transition-colors",
+                        "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+                        "stg:disabled:pointer-events-none",
+                        isOn
+                          ? "stg:border-primary stg:bg-primary stg:text-primary-foreground"
+                          : "stg:border-input stg:bg-background stg:text-muted-foreground stg:hover:text-foreground",
+                        isLastSelected && "stg:opacity-70",
+                      )}
+                    >
+                      {label.slice(0, 3)}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    {isLastSelected
+                      ? "A weekly schedule needs at least one day"
+                      : label}
+                  </TooltipContent>
+                </Tooltip>
               );
             })}
           </div>

--- a/sdk/react/src/schedule/ScheduleRunsTable.tsx
+++ b/sdk/react/src/schedule/ScheduleRunsTable.tsx
@@ -11,6 +11,7 @@ import {
 import { formatRelativeTime } from "../activity/format-relative-time.js";
 import { ErrorMessage } from "../error/ErrorMessage.js";
 import { Pagination } from "../internal/Pagination.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useScheduleRuns } from "./useScheduleRuns.js";
 
 /** Props for {@link ScheduleRunsTable}. */
@@ -188,12 +189,17 @@ function RunTableRow({
       <span role="cell" className="stg:hidden stg:text-xs stg:text-muted-foreground stg:sm:block">
         {runOriginLabel(run.origin)}
       </span>
-      <span
-        role="cell"
-        className="stg:text-xs stg:text-muted-foreground"
-        title={fireDate ? fireDate.toLocaleString() : undefined}
-      >
-        {fireDate ? formatRelativeTime(fireDate, now) : "—"}
+      <span role="cell" className="stg:text-xs stg:text-muted-foreground">
+        {fireDate ? (
+          <Tooltip>
+            <TooltipTrigger render={<time dateTime={fireDate.toISOString()} />}>
+              {formatRelativeTime(fireDate, now)}
+            </TooltipTrigger>
+            <TooltipContent side="top">{fireDate.toLocaleString()}</TooltipContent>
+          </Tooltip>
+        ) : (
+          "—"
+        )}
       </span>
       <span
         role="cell"
@@ -313,11 +319,17 @@ function CompactRunRow({
           {runOriginLabel(run.origin)}
         </span>
         <span className="stg:text-xs stg:text-muted-foreground-subtle">·</span>
-        <span
-          className="stg:text-xs stg:text-muted-foreground"
-          title={fireDate ? fireDate.toLocaleString() : undefined}
-        >
-          {fireDate ? formatRelativeTime(fireDate, now) : "—"}
+        <span className="stg:text-xs stg:text-muted-foreground">
+          {fireDate ? (
+            <Tooltip>
+              <TooltipTrigger render={<time dateTime={fireDate.toISOString()} />}>
+                {formatRelativeTime(fireDate, now)}
+              </TooltipTrigger>
+              <TooltipContent side="top">{fireDate.toLocaleString()}</TooltipContent>
+            </Tooltip>
+          ) : (
+            "—"
+          )}
         </span>
       </div>
       {run.reason && (

--- a/sdk/react/src/schedule/__tests__/cadence-tooltips.layout.test.tsx
+++ b/sdk/react/src/schedule/__tests__/cadence-tooltips.layout.test.tsx
@@ -1,0 +1,86 @@
+// The disabled-control tooltip contract from the native-title sweep
+// (stigmer-cloud#268), pinned in a real Chromium on CadenceField's
+// weekday toggles — the sweep's canonical "explanation on a disabled
+// control" site. Browsers suppress pointer events on disabled form
+// controls, so the old native `title` was unreachable by EVERY input
+// method exactly when it mattered (the always-disabled last selected
+// day). The fix hangs the house tooltip off a wrapper span; this suite
+// proves a mouse user really gets the reason while the button is
+// disabled.
+
+import "../../../dist/styles.css";
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { userEvent } from "@vitest/browser/context";
+import { CadenceField } from "../CadenceField.js";
+
+function renderWeekly() {
+  const pane = document.createElement("div");
+  pane.className = "stgm";
+  pane.style.width = "480px";
+  document.body.appendChild(pane);
+  render(
+    <CadenceField
+      value={{ kind: "weekly", days: [1], hour: 9, minute: 0 }}
+      onChange={() => {}}
+    />,
+    { container: pane },
+  );
+  return pane;
+}
+
+afterEach(() => {
+  cleanup();
+  document.querySelectorAll(".stgm").forEach((node) => node.remove());
+});
+
+describe("CadenceField disabled-day tooltip", () => {
+  it("explains the locked last-selected day on hover while the button is disabled", async () => {
+    const pane = renderWeekly();
+    expect(pane.querySelector("[title]")).toBeNull();
+
+    const monday = Array.from(pane.querySelectorAll("button")).find(
+      (el) => el.getAttribute("aria-label") === "Monday",
+    );
+    expect(monday!.disabled).toBe(true);
+
+    // Hover the wrapper span — the disabled button itself receives no
+    // pointer events, which is the entire reason the wrapper exists.
+    const wrapper = monday!.parentElement!;
+    await userEvent.hover(wrapper);
+    await vi.waitFor(
+      () => {
+        const portaled = Array.from(document.body.children)
+          .filter((node) => node !== pane)
+          .map((node) => node.textContent ?? "")
+          .join(" ");
+        expect(portaled).toContain("A weekly schedule needs at least one day");
+      },
+      { timeout: 3000, interval: 50 },
+    );
+    await userEvent.unhover(wrapper);
+  });
+
+  it("names an enabled weekday on hover", async () => {
+    const pane = renderWeekly();
+
+    const tuesday = Array.from(pane.querySelectorAll("button")).find(
+      (el) => el.getAttribute("aria-label") === "Tuesday",
+    );
+    expect(tuesday!.disabled).toBe(false);
+
+    await userEvent.hover(tuesday!.parentElement!);
+    await vi.waitFor(
+      () => {
+        const portaled = Array.from(document.body.children)
+          .filter((node) => node !== pane)
+          .map((node) => node.textContent ?? "")
+          .join(" ");
+        expect(portaled).toContain("Tuesday");
+      },
+      { timeout: 3000, interval: 50 },
+    );
+    await userEvent.unhover(tuesday!.parentElement!);
+  });
+});

--- a/sdk/react/src/session/PlanEditor.tsx
+++ b/sdk/react/src/session/PlanEditor.tsx
@@ -153,17 +153,21 @@ export function PlanEditor({
               onClick={() => setView("edit")}
               label="Edit"
               disabled={!canEdit}
-              title={
-                !canEdit
-                  ? "This plan is too large to edit in place — download it instead."
-                  : undefined
-              }
             />
           )}
         </div>
         <span className="stg:text-[0.65rem] stg:tabular-nums stg:text-muted-foreground-faint">
           {formatArtifactSize(plan.artifact.sizeBytes)}
         </span>
+        {/* The reason the Edit tab is disabled must be visible text: a
+            disabled tab leaves the tab order and drops pointer events, so
+            no hover- or focus-dependent hint can ever reach the user who
+            needs it. */}
+        {activeDraft !== undefined && !canEdit && (
+          <span className="stg:min-w-0 stg:text-[0.65rem] stg:text-muted-foreground">
+            This plan is too large to edit in place — download it instead.
+          </span>
+        )}
 
         <div className="stg:ml-auto stg:flex stg:min-w-0 stg:flex-wrap stg:items-center stg:gap-3">
           {activeDraft?.isEdited && (
@@ -312,13 +316,11 @@ function ViewTab({
   onClick,
   label,
   disabled,
-  title,
 }: {
   readonly active: boolean;
   readonly onClick: () => void;
   readonly label: string;
   readonly disabled?: boolean;
-  readonly title?: string;
 }) {
   return (
     <button
@@ -327,7 +329,6 @@ function ViewTab({
       aria-selected={active}
       onClick={onClick}
       disabled={disabled}
-      title={title}
       className={cn(
         "stg:rounded stg:px-2 stg:py-0.5 stg:text-[0.65rem] stg:font-medium stg:transition-colors",
         "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",

--- a/sdk/react/src/sharing/AgentShareList.tsx
+++ b/sdk/react/src/sharing/AgentShareList.tsx
@@ -15,6 +15,8 @@ import { ActionMenu } from "../action-menu/index.js";
 import { Button } from "../button/Button.js";
 import { EmptyState } from "../empty-state/EmptyState.js";
 import { useCheckPermission } from "../iam-policy/useCheckPermission.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { ConfirmDialog } from "../resource-detail/ConfirmDialog.js";
 import { useConfirmAction } from "../resource-detail/useConfirmAction.js";
 import { useCopyResource } from "../resource-detail/useCopyResource.js";
@@ -311,35 +313,39 @@ function ShareRow({
     >
       <td className="stg:px-4 stg:py-2.5">
         <div className="stg:flex stg:min-w-0 stg:items-center stg:gap-2">
-          <span
-            className="stg:truncate stg:font-medium stg:text-foreground"
-            title={meta?.name || slug || undefined}
-          >
-            {meta?.name || slug || "\u2014"}
-          </span>
+          <TruncatedText
+            text={meta?.name || slug || "\u2014"}
+            className="stg:font-medium stg:text-foreground"
+          />
           {isCrossOrg && (
-            <span
-              className={cn(
-                "stg:inline-flex stg:shrink-0 stg:items-center stg:rounded-md stg:px-1.5 stg:py-0.5",
-                "stg:text-[0.6rem] stg:font-medium stg:uppercase stg:tracking-wide",
-                "stg:bg-muted stg:text-muted-foreground stg:border stg:border-border",
-              )}
-              title={`This share lives in ${org}; the agent lives in ${agent.metadata?.org}`}
-            >
-              Cross-org
-            </span>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    className={cn(
+                      "stg:inline-flex stg:shrink-0 stg:items-center stg:rounded-md stg:px-1.5 stg:py-0.5",
+                      "stg:text-[0.6rem] stg:font-medium stg:uppercase stg:tracking-wide",
+                      "stg:bg-muted stg:text-muted-foreground stg:border stg:border-border",
+                    )}
+                  />
+                }
+              >
+                Cross-org
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {`This share lives in ${org}; the agent lives in ${agent.metadata?.org}`}
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       </td>
 
       <td className="stg:px-4 stg:py-2.5" onClick={(e) => e.stopPropagation()}>
         <div className="stg:flex stg:min-w-0 stg:items-center stg:gap-1.5">
-          <code
-            className="stg:truncate stg:font-mono stg:text-xs stg:text-muted-foreground"
-            title={displayPath}
-          >
-            {displayPath}
-          </code>
+          <TruncatedText
+            text={displayPath}
+            className="stg:font-mono stg:text-xs stg:text-muted-foreground"
+          />
           <button
             type="button"
             onClick={handleCopyLink}

--- a/sdk/react/src/sharing/ShareAgentDialog.tsx
+++ b/sdk/react/src/sharing/ShareAgentDialog.tsx
@@ -27,6 +27,7 @@ import { useBillingAccount } from "../billing/useBillingAccount.js";
 import { formatCreditBalance } from "../billing/format.js";
 import { EnvironmentPicker } from "../environment/EnvironmentPicker.js";
 import { generateSlug } from "../internal/slug.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 import { getFieldError, validateMessage } from "../internal/validate.js";
 import {
   draftFromShare,
@@ -1637,15 +1638,13 @@ function CopyField({
             {value}
           </pre>
         ) : (
-          <code
+          <TruncatedText
+            text={value}
             className={cn(
-              "stg:min-w-0 stg:flex-1 stg:truncate stg:rounded-md stg:border stg:border-border stg:bg-muted-subtle stg:px-2.5 stg:py-1.5",
+              "stg:min-w-0 stg:flex-1 stg:rounded-md stg:border stg:border-border stg:bg-muted-subtle stg:px-2.5 stg:py-1.5",
               "stg:font-mono stg:text-xs stg:text-foreground",
             )}
-            title={value}
-          >
-            {value}
-          </code>
+          />
         )}
         <div className="stg:flex stg:shrink-0 stg:flex-col stg:gap-1.5">
           <button

--- a/sdk/react/src/skill/SkillDetailView.tsx
+++ b/sdk/react/src/skill/SkillDetailView.tsx
@@ -14,6 +14,7 @@ import { ErrorMessage } from "../error/ErrorMessage.js";
 import { VisibilityBadge } from "../library/VisibilitySelector.js";
 import { useManageAccess } from "../access/useManageAccess.js";
 import { MARKDOWN_COMPONENTS, REMARK_PLUGINS, stripFrontmatter } from "../internal/markdown-components.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { ResourceDetailShell } from "../resource-detail/ResourceDetailShell.js";
 import { Section } from "../resource-detail/Section.js";
 import { useDetailTabs } from "../resource-detail/useDetailTabs.js";
@@ -518,12 +519,16 @@ function VersionSection({
             <span className="stg:text-xs stg:font-medium stg:text-muted-foreground">
               Hash
             </span>
-            <code
-              className="stg:font-mono stg:text-xs stg:text-foreground"
-              title={versionHash}
-            >
-              {truncatedHash}
-            </code>
+            <Tooltip>
+              <TooltipTrigger
+                render={<code className="stg:font-mono stg:text-xs stg:text-foreground" />}
+              >
+                {truncatedHash}
+              </TooltipTrigger>
+              <TooltipContent side="top" className="stg:break-all">
+                {versionHash}
+              </TooltipContent>
+            </Tooltip>
           </div>
         )}
 
@@ -567,12 +572,18 @@ function GitProvenanceDisplay({
             </>
           )}
           {truncatedCommit && (
-            <code
-              className="stg:rounded stg:bg-muted stg:px-1 stg:py-0.5 stg:font-mono stg:text-[10px]"
-              title={provenance.commit}
-            >
-              {truncatedCommit}
-            </code>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <code className="stg:rounded stg:bg-muted stg:px-1 stg:py-0.5 stg:font-mono stg:text-[10px]" />
+                }
+              >
+                {truncatedCommit}
+              </TooltipTrigger>
+              <TooltipContent side="top" className="stg:break-all">
+                {provenance.commit}
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/sdk/react/src/version-history/VersionTimelineEntry.tsx
+++ b/sdk/react/src/version-history/VersionTimelineEntry.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import type { VersionTimelineEntryProps } from "./types.js";
 
 /**
@@ -82,12 +83,18 @@ export function VersionTimelineEntry({
       >
         {/* Top line: hash + tag + current badge */}
         <div className="stg:flex stg:items-center stg:gap-2">
-          <code
-            className="stg:shrink-0 stg:rounded stg:bg-muted stg:px-1.5 stg:py-0.5 stg:font-mono stg:text-[11px] stg:font-medium stg:text-foreground"
-            title={entry.id}
-          >
-            {entry.label}
-          </code>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <code className="stg:shrink-0 stg:rounded stg:bg-muted stg:px-1.5 stg:py-0.5 stg:font-mono stg:text-[11px] stg:font-medium stg:text-foreground" />
+              }
+            >
+              {entry.label}
+            </TooltipTrigger>
+            <TooltipContent side="top" className="stg:break-all">
+              {entry.id}
+            </TooltipContent>
+          </Tooltip>
 
           {isCompareSource && (
             <span className="stg:shrink-0 stg:rounded-full stg:bg-primary stg:px-1.5 stg:py-0.5 stg:text-[10px] stg:font-medium stg:text-primary-foreground">
@@ -114,12 +121,14 @@ export function VersionTimelineEntry({
 
         {/* Second line: timestamp + actor */}
         <div className="stg:flex stg:items-center stg:gap-2 stg:text-xs stg:text-muted-foreground">
-          <time
-            dateTime={entry.timestamp.toISOString()}
-            title={entry.timestamp.toLocaleString()}
-          >
-            {formatRelativeTime(entry.timestamp)}
-          </time>
+          <Tooltip>
+            <TooltipTrigger render={<time dateTime={entry.timestamp.toISOString()} />}>
+              {formatRelativeTime(entry.timestamp)}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {entry.timestamp.toLocaleString()}
+            </TooltipContent>
+          </Tooltip>
 
           {entry.actor && (
             <>

--- a/sdk/react/src/workflow/CanvasTransitionEdge.tsx
+++ b/sdk/react/src/workflow/CanvasTransitionEdge.tsx
@@ -10,6 +10,7 @@ import type { EdgeDiffStatus } from "./diff/types.js";
 import { CanvasActionsContext } from "./CanvasActionsContext.js";
 import { TaskPickerPopover } from "./TaskPickerPopover.js";
 import { useWorkflowGraphMode } from "./WorkflowGraphModeContext.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 // ---------------------------------------------------------------------------
 // Execution-state visual mapping (DD-T06-005)
@@ -205,22 +206,28 @@ export const CanvasTransitionEdge = memo(function CanvasTransitionEdge({
           {/* Insert button and picker — design mode only */}
           {isDesignMode && (
             <>
-              <button
-                ref={insertBtnRef}
-                type="button"
-                onClick={handleOpenPicker}
-                className={cn(
-                  "stg:flex stg:h-5 stg:w-5 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
-                  "stg:hover:border-[var(--stgm-primary,#6366f1)] stg:hover:bg-[var(--stgm-primary,#6366f1)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
-                  hovered || selected || pickerOpen ? "stg:scale-100 stg:opacity-100" : "stg:scale-75 stg:opacity-0",
-                )}
-                aria-label="Insert task here"
-                title="Insert task"
-              >
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-                  <path d="M5 2v6M2 5h6" />
-                </svg>
-              </button>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      ref={insertBtnRef}
+                      type="button"
+                      onClick={handleOpenPicker}
+                      className={cn(
+                        "stg:flex stg:h-5 stg:w-5 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
+                        "stg:hover:border-[var(--stgm-primary,#6366f1)] stg:hover:bg-[var(--stgm-primary,#6366f1)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
+                        hovered || selected || pickerOpen ? "stg:scale-100 stg:opacity-100" : "stg:scale-75 stg:opacity-0",
+                      )}
+                      aria-label="Insert task here"
+                    />
+                  }
+                >
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+                    <path d="M5 2v6M2 5h6" />
+                  </svg>
+                </TooltipTrigger>
+                <TooltipContent side="top">Insert task</TooltipContent>
+              </Tooltip>
 
               <TaskPickerPopover
                 open={pickerOpen}

--- a/sdk/react/src/workflow/ExecutionActiveTaskIndicator.tsx
+++ b/sdk/react/src/workflow/ExecutionActiveTaskIndicator.tsx
@@ -4,6 +4,7 @@ import { memo, useEffect, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import type { ActiveTaskInfo } from "./useActiveTaskName.js";
 import { formatDuration } from "./format-utils.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link ExecutionActiveTaskIndicator}. */
 export interface ExecutionActiveTaskIndicatorProps {
@@ -79,70 +80,84 @@ export const ExecutionActiveTaskIndicator = memo(function ExecutionActiveTaskInd
   return (
     <div className={cn("stg:absolute stg:left-3 stg:top-3 stg:z-50 stg:flex stg:items-center stg:gap-2", className)}>
       {/* Main indicator pill */}
-      <button
-        type="button"
-        onClick={onJumpToTask}
-        className={cn(
-          "stg:flex stg:items-center stg:gap-2 stg:rounded-md stg:border stg:px-2.5 stg:py-1.5 stg:text-xs stg:font-medium stg:shadow-sm stg:backdrop-blur-sm stg:transition-colors",
-          isApproval
-            ? "stg:border-[var(--stgm-warning,#f59e0b)]/40 stg:bg-[var(--stgm-warning,#f59e0b)]/10 stg:text-[var(--stgm-foreground,#1a1a2e)] stg:hover:bg-[var(--stgm-warning,#f59e0b)]/20"
-            : "stg:border-[var(--stgm-primary,#6366f1)]/30 stg:bg-[var(--stgm-card,#fff)]/90 stg:text-[var(--stgm-foreground,#1a1a2e)] stg:hover:bg-[var(--stgm-primary,#6366f1)]/10",
-        )}
-        title="Click to center on active task"
-      >
-        {/* Pulsing status dot */}
-        <span
-          className={cn(
-            "stg:inline-block stg:h-2 stg:w-2 stg:rounded-full stg:motion-safe:animate-pulse",
-            isApproval
-              ? "stg:bg-[var(--stgm-warning,#f59e0b)]"
-              : "stg:bg-[var(--stgm-primary,#6366f1)]",
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={onJumpToTask}
+              className={cn(
+                "stg:flex stg:items-center stg:gap-2 stg:rounded-md stg:border stg:px-2.5 stg:py-1.5 stg:text-xs stg:font-medium stg:shadow-sm stg:backdrop-blur-sm stg:transition-colors",
+                isApproval
+                  ? "stg:border-[var(--stgm-warning,#f59e0b)]/40 stg:bg-[var(--stgm-warning,#f59e0b)]/10 stg:text-[var(--stgm-foreground,#1a1a2e)] stg:hover:bg-[var(--stgm-warning,#f59e0b)]/20"
+                  : "stg:border-[var(--stgm-primary,#6366f1)]/30 stg:bg-[var(--stgm-card,#fff)]/90 stg:text-[var(--stgm-foreground,#1a1a2e)] stg:hover:bg-[var(--stgm-primary,#6366f1)]/10",
+              )}
+            />
+          }
+        >
+          {/* Pulsing status dot */}
+          <span
+            className={cn(
+              "stg:inline-block stg:h-2 stg:w-2 stg:rounded-full stg:motion-safe:animate-pulse",
+              isApproval
+                ? "stg:bg-[var(--stgm-warning,#f59e0b)]"
+                : "stg:bg-[var(--stgm-primary,#6366f1)]",
+            )}
+            aria-hidden="true"
+          />
+
+          <span>{statusLabel}</span>
+
+          {elapsedMs > 0 && (
+            <>
+              <span className="stg:text-[var(--stgm-muted-foreground,#737373)]" aria-hidden="true">·</span>
+              <span className="stg:tabular-nums stg:text-[var(--stgm-muted-foreground,#737373)]">
+                {formatDuration(elapsedMs)}
+              </span>
+            </>
           )}
-          aria-hidden="true"
-        />
-
-        <span>{statusLabel}</span>
-
-        {elapsedMs > 0 && (
-          <>
-            <span className="stg:text-[var(--stgm-muted-foreground,#737373)]" aria-hidden="true">·</span>
-            <span className="stg:tabular-nums stg:text-[var(--stgm-muted-foreground,#737373)]">
-              {formatDuration(elapsedMs)}
-            </span>
-          </>
-        )}
-      </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Click to center on active task</TooltipContent>
+      </Tooltip>
 
       {/* Follow toggle */}
-      <button
-        type="button"
-        onClick={onFollowToggle}
-        className={cn(
-          "stg:flex stg:h-7 stg:w-7 stg:items-center stg:justify-center stg:rounded-md stg:border stg:shadow-sm stg:backdrop-blur-sm stg:transition-colors",
-          isFollowing
-            ? "stg:border-[var(--stgm-primary,#6366f1)]/40 stg:bg-[var(--stgm-primary,#6366f1)]/10 stg:text-[var(--stgm-primary,#6366f1)]"
-            : "stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-card,#fff)]/90 stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-foreground,#1a1a2e)]",
-        )}
-        title={isFollowing ? "Following active task (click to stop)" : "Follow active task"}
-        aria-label={isFollowing ? "Stop following active task" : "Follow active task"}
-        aria-pressed={isFollowing}
-      >
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-          {isFollowing ? (
-            // Crosshair icon (following)
-            <>
-              <circle cx="7" cy="7" r="3" stroke="currentColor" strokeWidth="1.5" />
-              <path d="M7 1v2M7 11v2M1 7h2M11 7h2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            </>
-          ) : (
-            // Eye icon (not following)
-            <>
-              <path d="M1.5 7s2.2-3.5 5.5-3.5S12.5 7 12.5 7s-2.2 3.5-5.5 3.5S1.5 7 1.5 7z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
-              <circle cx="7" cy="7" r="1.5" stroke="currentColor" strokeWidth="1.5" />
-            </>
-          )}
-        </svg>
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={onFollowToggle}
+              className={cn(
+                "stg:flex stg:h-7 stg:w-7 stg:items-center stg:justify-center stg:rounded-md stg:border stg:shadow-sm stg:backdrop-blur-sm stg:transition-colors",
+                isFollowing
+                  ? "stg:border-[var(--stgm-primary,#6366f1)]/40 stg:bg-[var(--stgm-primary,#6366f1)]/10 stg:text-[var(--stgm-primary,#6366f1)]"
+                  : "stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-card,#fff)]/90 stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-foreground,#1a1a2e)]",
+              )}
+              aria-label={isFollowing ? "Stop following active task" : "Follow active task"}
+              aria-pressed={isFollowing}
+            />
+          }
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+            {isFollowing ? (
+              // Crosshair icon (following)
+              <>
+                <circle cx="7" cy="7" r="3" stroke="currentColor" strokeWidth="1.5" />
+                <path d="M7 1v2M7 11v2M1 7h2M11 7h2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </>
+            ) : (
+              // Eye icon (not following)
+              <>
+                <path d="M1.5 7s2.2-3.5 5.5-3.5S12.5 7 12.5 7s-2.2 3.5-5.5 3.5S1.5 7 1.5 7z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+                <circle cx="7" cy="7" r="1.5" stroke="currentColor" strokeWidth="1.5" />
+              </>
+            )}
+          </svg>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {isFollowing ? "Following active task (click to stop)" : "Follow active task"}
+        </TooltipContent>
+      </Tooltip>
 
       {/* Screen reader live region */}
       <span

--- a/sdk/react/src/workflow/TaskPickerPopover.tsx
+++ b/sdk/react/src/workflow/TaskPickerPopover.tsx
@@ -308,7 +308,6 @@ function PickerItem({
       role="option"
       aria-selected={isFocused}
       aria-disabled={item.disabled}
-      title={item.disabled ? item.disabledReason : undefined}
       onClick={item.disabled ? undefined : () => onSelect(item.descriptor.kind)}
       className={cn(
         "stg:flex stg:w-full stg:items-start stg:gap-2 stg:rounded stg:px-2 stg:py-1.5 stg:text-left stg:transition-colors",

--- a/sdk/react/src/workflow/WorkflowCanvasEditor.tsx
+++ b/sdk/react/src/workflow/WorkflowCanvasEditor.tsx
@@ -16,6 +16,12 @@ import type { CanvasContextMenuTarget } from "./CanvasContextMenu.js";
 import { TaskPickerPopover } from "./TaskPickerPopover.js";
 import { useCanvasKeyboardShortcuts } from "./useCanvasKeyboardShortcuts.js";
 import { ViewYamlDialog } from "./ViewYamlDialog.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../internal/tooltip.js";
 
 /** Props for {@link WorkflowCanvasEditor}. */
 export interface WorkflowCanvasEditorProps {
@@ -732,41 +738,49 @@ function PaletteToggle({
   onToggle: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className={cn(
-        "stg:absolute stg:left-2 stg:z-10 stg:rounded stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:p-1 stg:shadow-sm",
-        "stg:hover:bg-[var(--stgm-muted,#f5f5f5)] stg:active:bg-[var(--stgm-accent,#e5e5e5)]",
-        collapsed ? "stg:top-2" : "stg:bottom-2",
-      )}
-      aria-label={collapsed ? "Show task palette" : "Hide task palette"}
-      title={collapsed ? "Show task palette" : "Hide task palette"}
-    >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="stg:text-[var(--stgm-foreground,#1a1a2e)]"
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={onToggle}
+            className={cn(
+              "stg:absolute stg:left-2 stg:z-10 stg:rounded stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:p-1 stg:shadow-sm",
+              "stg:hover:bg-[var(--stgm-muted,#f5f5f5)] stg:active:bg-[var(--stgm-accent,#e5e5e5)]",
+              collapsed ? "stg:top-2" : "stg:bottom-2",
+            )}
+            aria-label={collapsed ? "Show task palette" : "Hide task palette"}
+          />
+        }
       >
-        {collapsed ? (
-          <>
-            <rect x="1" y="1" width="5" height="14" rx="1" />
-            <path d="M10 8h5M11 6l2 2-2 2" />
-          </>
-        ) : (
-          <>
-            <rect x="1" y="1" width="5" height="14" rx="1" />
-            <path d="M14 8H9M13 6l-2 2 2 2" />
-          </>
-        )}
-      </svg>
-    </button>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="stg:text-[var(--stgm-foreground,#1a1a2e)]"
+        >
+          {collapsed ? (
+            <>
+              <rect x="1" y="1" width="5" height="14" rx="1" />
+              <path d="M10 8h5M11 6l2 2-2 2" />
+            </>
+          ) : (
+            <>
+              <rect x="1" y="1" width="5" height="14" rx="1" />
+              <path d="M14 8H9M13 6l-2 2 2 2" />
+            </>
+          )}
+        </svg>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        {collapsed ? "Show task palette" : "Hide task palette"}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -802,35 +816,52 @@ function CanvasToolbar({
     "stg:rounded stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:px-2 stg:py-1 stg:text-xs stg:font-medium stg:text-[var(--stgm-foreground,#1a1a2e)] stg:shadow-sm stg:hover:bg-[var(--stgm-muted,#f5f5f5)] stg:active:bg-[var(--stgm-accent,#e5e5e5)] stg:disabled:cursor-not-allowed stg:disabled:opacity-40";
 
   return (
-    <div className="stg:absolute stg:left-2 stg:top-2 stg:z-10 stg:flex stg:items-center stg:gap-1">
-      <button type="button" onClick={onUndo} disabled={!canUndo} className={btnClass} aria-label="Undo" title={`Undo (${TOOLBAR_SHORTCUTS.undo})`}>
-        Undo
-      </button>
-      <button type="button" onClick={onRedo} disabled={!canRedo} className={btnClass} aria-label="Redo" title={`Redo (${TOOLBAR_SHORTCUTS.redo})`}>
-        Redo
-      </button>
-      <div className="stg:mx-1 stg:h-4 stg:w-px stg:bg-[var(--stgm-border,#d4d4d8)]" aria-hidden="true" />
-      <button type="button" onClick={onAutoLayout} className={btnClass} aria-label="Auto-layout" title="Auto-layout">
-        Auto-layout
-      </button>
-      {onSave && (
-        <>
-          <div className="stg:mx-1 stg:h-4 stg:w-px stg:bg-[var(--stgm-border,#d4d4d8)]" aria-hidden="true" />
-          <button
-            type="button"
-            onClick={onSave}
-            disabled={!isDirty || isSaving}
-            className="stg:rounded stg:bg-[var(--stgm-primary,#6366f1)] stg:px-2.5 stg:py-1 stg:text-xs stg:font-medium stg:text-[var(--stgm-primary-foreground,#fff)] stg:shadow-sm stg:hover:opacity-90 stg:disabled:cursor-not-allowed stg:disabled:opacity-40"
-          >
-            {isSaving ? "Saving\u2026" : "Save"}
-          </button>
-        </>
-      )}
-      {isDirty && !onSave && (
-        <span className="stg:ml-1 stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]">
-          Modified
-        </span>
-      )}
-    </div>
+    // Undo/Redo show their keyboard shortcut on the house tooltip; the
+    // trigger is a wrapper span so the shortcut stays discoverable while the
+    // button is disabled (disabled buttons receive no pointer events).
+    // Auto-layout's label is already visible text — no tooltip to add. The
+    // provider is context-only and groups the buttons' hover delay.
+    <TooltipProvider>
+      <div className="stg:absolute stg:left-2 stg:top-2 stg:z-10 stg:flex stg:items-center stg:gap-1">
+        <Tooltip>
+          <TooltipTrigger render={<span className="stg:inline-flex" />}>
+            <button type="button" onClick={onUndo} disabled={!canUndo} className={btnClass} aria-label="Undo">
+              Undo
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{TOOLBAR_SHORTCUTS.undo}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger render={<span className="stg:inline-flex" />}>
+            <button type="button" onClick={onRedo} disabled={!canRedo} className={btnClass} aria-label="Redo">
+              Redo
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{TOOLBAR_SHORTCUTS.redo}</TooltipContent>
+        </Tooltip>
+        <div className="stg:mx-1 stg:h-4 stg:w-px stg:bg-[var(--stgm-border,#d4d4d8)]" aria-hidden="true" />
+        <button type="button" onClick={onAutoLayout} className={btnClass} aria-label="Auto-layout">
+          Auto-layout
+        </button>
+        {onSave && (
+          <>
+            <div className="stg:mx-1 stg:h-4 stg:w-px stg:bg-[var(--stgm-border,#d4d4d8)]" aria-hidden="true" />
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={!isDirty || isSaving}
+              className="stg:rounded stg:bg-[var(--stgm-primary,#6366f1)] stg:px-2.5 stg:py-1 stg:text-xs stg:font-medium stg:text-[var(--stgm-primary-foreground,#fff)] stg:shadow-sm stg:hover:opacity-90 stg:disabled:cursor-not-allowed stg:disabled:opacity-40"
+            >
+              {isSaving ? "Saving\u2026" : "Save"}
+            </button>
+          </>
+        )}
+        {isDirty && !onSave && (
+          <span className="stg:ml-1 stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]">
+            Modified
+          </span>
+        )}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/sdk/react/src/workflow/WorkflowNode.tsx
+++ b/sdk/react/src/workflow/WorkflowNode.tsx
@@ -7,6 +7,7 @@ import type { CanvasTaskNodeData } from "./workflow-graph-conversions.js";
 import { getVisualSpec } from "./task-type-visual-registry.js";
 import { NodeShell, NodeContent, NodeHandles, NodeActions, ExecutionBadge, BranchBadge, DiffBadge } from "./node-shell/index.js";
 import { useWorkflowGraphMode } from "./WorkflowGraphModeContext.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 const NESTED_TASK_KINDS = new Set(["fork", "for_each", "try_catch"]);
 
@@ -67,12 +68,18 @@ export const WorkflowNode = memo(function WorkflowNode({
 
       {/* Validation badge — design mode only */}
       {mode === "design" && errorCount > 0 && (
-        <span
-          className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-4 stg:min-w-4 stg:items-center stg:justify-center stg:rounded-full stg:bg-[var(--stgm-destructive,#ef4444)] stg:px-1 stg:text-[9px] stg:font-bold stg:leading-none stg:text-[var(--stgm-destructive-foreground,#fff)]"
-          title={`${errorCount} validation ${errorCount === 1 ? "error" : "errors"}`}
-        >
-          {errorCount}
-        </span>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span className="stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-4 stg:min-w-4 stg:items-center stg:justify-center stg:rounded-full stg:bg-[var(--stgm-destructive,#ef4444)] stg:px-1 stg:text-[9px] stg:font-bold stg:leading-none stg:text-[var(--stgm-destructive-foreground,#fff)]" />
+            }
+          >
+            {errorCount}
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {`${errorCount} validation ${errorCount === 1 ? "error" : "errors"}`}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Execution badge — execution mode only */}

--- a/sdk/react/src/workflow/WorkflowTaskApprovalSummary.tsx
+++ b/sdk/react/src/workflow/WorkflowTaskApprovalSummary.tsx
@@ -5,6 +5,7 @@ import Markdown from "react-markdown";
 import type { JsonObject } from "@bufbuild/protobuf";
 import { cn } from "@stigmer/theme";
 import { MARKDOWN_COMPONENTS, REMARK_PLUGINS } from "../internal/markdown-components.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { formatDuration, formatTimestamp } from "./format-utils.js";
 import type { TaskOutcome } from "./WorkflowTaskApprovalCard.js";
 import {
@@ -190,27 +191,33 @@ export const WorkflowTaskApprovalSummary = memo(function WorkflowTaskApprovalSum
 /**
  * `by <avatar> Ada Lovelace` — the reviewer's display identity, following
  * the platform's actor pattern (see `WorkflowVersionTimeline`). The email
- * rides as a native tooltip when it is not already the visible label. A
+ * rides on the house tooltip when it is not already the visible label. A
  * label that fell through to the raw identity (legacy records) renders
  * de-emphasized — internal IDs are never presented as if they were names.
  */
 function ReviewerChip({ reviewer }: { readonly reviewer: TaskReviewerView }) {
+  const nameClass = cn(
+    reviewer.isRawId
+      ? "stg:font-mono stg:text-[10px] stg:text-muted-foreground"
+      : "stg:font-medium stg:text-foreground",
+  );
+
   return (
     <span className="stg:flex stg:items-center stg:gap-1">
       by{" "}
       {reviewer.avatar && (
         <img src={reviewer.avatar} alt="" className="stg:size-3.5 stg:rounded-full" />
       )}
-      <span
-        className={cn(
-          reviewer.isRawId
-            ? "stg:font-mono stg:text-[10px] stg:text-muted-foreground"
-            : "stg:font-medium stg:text-foreground",
-        )}
-        title={reviewer.email || undefined}
-      >
-        {reviewer.label}
-      </span>
+      {reviewer.email ? (
+        <Tooltip>
+          <TooltipTrigger render={<span className={nameClass} />}>
+            {reviewer.label}
+          </TooltipTrigger>
+          <TooltipContent side="top">{reviewer.email}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className={nameClass}>{reviewer.label}</span>
+      )}
     </span>
   );
 }

--- a/sdk/react/src/workflow/WorkflowTaskList.tsx
+++ b/sdk/react/src/workflow/WorkflowTaskList.tsx
@@ -141,16 +141,16 @@ function formatKindName(kind: WorkflowTaskKind): string {
  * keep the bundle size minimal (DD-004).
  */
 function TaskKindIcon({
-  iconName,
   className,
 }: {
+  // The icon name is accepted (future per-kind icons) but not surfaced: the
+  // glyph is decorative and the kind label is already visible next to it.
   readonly iconName: string;
   readonly className?: string;
 }) {
   return (
     <span
       className={cn("stg:inline-flex stg:items-center stg:justify-center", className)}
-      title={iconName}
       aria-hidden="true"
     >
       <TaskDotIcon />

--- a/sdk/react/src/workflow/WorkflowVersionBadge.tsx
+++ b/sdk/react/src/workflow/WorkflowVersionBadge.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useCallback, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link WorkflowVersionBadge}. */
 export interface WorkflowVersionBadgeProps {
@@ -56,26 +57,40 @@ export const WorkflowVersionBadge = memo(function WorkflowVersionBadge({
   return (
     <span className={cn("stg:inline-flex stg:items-center stg:gap-1.5", className)}>
       {isCurrent && (
-        <span
-          className="stg:size-2 stg:shrink-0 stg:rounded-full stg:bg-status-ready"
-          aria-label="Current version"
-          title="Current version"
-        />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span
+                className="stg:size-2 stg:shrink-0 stg:rounded-full stg:bg-status-ready"
+                aria-label="Current version"
+              />
+            }
+          />
+          <TooltipContent side="top">Current version</TooltipContent>
+        </Tooltip>
       )}
 
-      <button
-        type="button"
-        onClick={handleCopy}
-        title={copied ? "Copied!" : `Copy full hash: ${versionHash}`}
-        className={cn(
-          "stg:shrink-0 stg:rounded stg:bg-muted stg:px-1.5 stg:py-0.5 stg:font-mono stg:text-[11px] stg:font-medium stg:text-foreground stg:transition-colors",
-          "stg:hover:bg-accent-hover",
-          "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-          copied && "stg:bg-status-ready-subtle stg:text-status-ready",
-        )}
-      >
-        {copied ? "copied" : truncated}
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={handleCopy}
+              className={cn(
+                "stg:shrink-0 stg:rounded stg:bg-muted stg:px-1.5 stg:py-0.5 stg:font-mono stg:text-[11px] stg:font-medium stg:text-foreground stg:transition-colors",
+                "stg:hover:bg-accent-hover",
+                "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+                copied && "stg:bg-status-ready-subtle stg:text-status-ready",
+              )}
+            />
+          }
+        >
+          {copied ? "copied" : truncated}
+        </TooltipTrigger>
+        <TooltipContent side="top" className="stg:break-all">
+          {copied ? "Copied!" : `Copy full hash: ${versionHash}`}
+        </TooltipContent>
+      </Tooltip>
 
       {tag && (
         <span className="stg:shrink-0 stg:rounded-full stg:bg-primary-subtle stg:px-1.5 stg:py-0.5 stg:text-[10px] stg:font-medium stg:text-primary">

--- a/sdk/react/src/workflow/WorkflowVersionTimeline.tsx
+++ b/sdk/react/src/workflow/WorkflowVersionTimeline.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { useWorkflowVersions } from "./useWorkflowVersions.js";
 import { WorkflowVersionBadge } from "./WorkflowVersionBadge.js";
 import type { VersionEntry } from "../version-history/types.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link WorkflowVersionTimeline}. */
 export interface WorkflowVersionTimelineProps {
@@ -169,12 +170,12 @@ function VersionTimelineRow({
 
         {/* Second line: timestamp + actor */}
         <div className="stg:flex stg:items-center stg:gap-2 stg:text-xs stg:text-muted-foreground">
-          <time
-            dateTime={entry.timestamp.toISOString()}
-            title={entry.timestamp.toLocaleString()}
-          >
-            {formatRelativeTime(entry.timestamp)}
-          </time>
+          <Tooltip>
+            <TooltipTrigger render={<time dateTime={entry.timestamp.toISOString()} />}>
+              {formatRelativeTime(entry.timestamp)}
+            </TooltipTrigger>
+            <TooltipContent side="top">{entry.timestamp.toLocaleString()}</TooltipContent>
+          </Tooltip>
 
           {entry.actor && (
             <>

--- a/sdk/react/src/workflow/__tests__/WorkflowTaskApprovalSummary.test.tsx
+++ b/sdk/react/src/workflow/__tests__/WorkflowTaskApprovalSummary.test.tsx
@@ -74,7 +74,9 @@ describe("WorkflowTaskApprovalSummary", () => {
         />,
       );
       const name = screen.getByText("Ada Lovelace");
-      expect(name.getAttribute("title")).toBe("ada@example.com");
+      // The email rides the house tooltip now (native titles are banned,
+      // stigmer-cloud#268); the name span stays title-free.
+      expect(name.getAttribute("title")).toBeNull();
       expect(document.querySelector('img[src="https://example.com/ada.png"]')).toBeTruthy();
       // The raw identity is never shown when a display identity exists.
       expect(screen.queryByText("ida_01abc")).toBeNull();

--- a/sdk/react/src/workflow/__tests__/structured-data-viewer.test.tsx
+++ b/sdk/react/src/workflow/__tests__/structured-data-viewer.test.tsx
@@ -69,8 +69,11 @@ describe("StructuredDataViewer", () => {
     it("does not treat IDs/URLs > 120 chars as prose", () => {
       const longId = "aex_" + "a".repeat(200);
       render(<StructuredDataViewer data={{ execution_id: longId }} />);
-      const element = screen.getByTitle(longId);
-      expect(element).toBeTruthy();
+      // A long ID renders as a truncating value (TruncatedText — the full
+      // string stays in the DOM; native titles are banned), never as a <p>.
+      const element = screen.getByText(longId);
+      expect(element.tagName).not.toBe("P");
+      expect(element.closest("[title]")).toBeNull();
     });
   });
 

--- a/sdk/react/src/workflow/execution-comparison/ExecutionComparisonView.tsx
+++ b/sdk/react/src/workflow/execution-comparison/ExecutionComparisonView.tsx
@@ -6,6 +6,7 @@ import { WorkflowExecutionPhaseBadge } from "../WorkflowExecutionPhaseBadge.js";
 import { useExecutionComparison } from "./useExecutionComparison.js";
 import { ComparisonSummaryCards } from "./ComparisonSummaryCards.js";
 import { TaskComparisonTable } from "./TaskComparisonTable.js";
+import { TruncatedText } from "../../internal/truncated-text.js";
 
 /** Props for {@link ExecutionComparisonView}. */
 export interface ExecutionComparisonViewProps {
@@ -146,9 +147,10 @@ function ExecutionLabel({
         {label}:
       </span>
       <WorkflowExecutionPhaseBadge phase={phase} />
-      <span className="stg:max-w-[10rem] stg:truncate stg:text-xs stg:font-medium stg:text-[var(--stgm-foreground,#1a1a2e)]" title={name}>
-        {name}
-      </span>
+      <TruncatedText
+        text={name}
+        className="stg:max-w-[10rem] stg:text-xs stg:font-medium stg:text-[var(--stgm-foreground,#1a1a2e)]"
+      />
     </div>
   );
 }

--- a/sdk/react/src/workflow/execution-comparison/TaskComparisonTable.tsx
+++ b/sdk/react/src/workflow/execution-comparison/TaskComparisonTable.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { WorkflowTaskStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
 import { formatDuration, formatMicroUsd } from "../format-utils.js";
 import type { TaskComparison, ExecutionComparison } from "./types.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
 
 /** Props for {@link TaskComparisonTable}. */
 export interface TaskComparisonTableProps {
@@ -152,11 +153,17 @@ const TaskRow = memo(function TaskRow({
       <td className="stg:px-3 stg:py-2">
         <div className="stg:flex stg:items-center stg:gap-1.5">
           {isDivergencePoint && (
-            <span
-              className="stg:inline-block stg:h-1.5 stg:w-1.5 stg:rounded-full stg:bg-[var(--stgm-warning,#f59e0b)]"
-              title="First point of divergence"
-              aria-label="Divergence point"
-            />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    className="stg:inline-block stg:h-1.5 stg:w-1.5 stg:rounded-full stg:bg-[var(--stgm-warning,#f59e0b)]"
+                    aria-label="Divergence point"
+                  />
+                }
+              />
+              <TooltipContent side="top">First point of divergence</TooltipContent>
+            </Tooltip>
           )}
           <span className="stg:font-medium stg:text-[var(--stgm-foreground,#1a1a2e)]">
             {task.taskName}

--- a/sdk/react/src/workflow/execution-history/ExecutionHistoryTable.tsx
+++ b/sdk/react/src/workflow/execution-history/ExecutionHistoryTable.tsx
@@ -10,6 +10,8 @@ import {
   type ExecutionSortField,
   type SortDirection,
 } from "./derive-execution-row.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
+import { TruncatedText } from "../../internal/truncated-text.js";
 
 // ---------------------------------------------------------------------------
 // Column definitions
@@ -33,9 +35,10 @@ const COLUMNS: readonly ColumnDef[] = [
     header: "Name",
     sortField: "name",
     cell: (row) => (
-      <span className="stg:font-medium stg:text-foreground stg:truncate stg:max-w-[12rem] stg:inline-block" title={row.name}>
-        {row.name || "\u2014"}
-      </span>
+      <TruncatedText
+        text={row.name || "\u2014"}
+        className="stg:font-medium stg:text-foreground stg:max-w-[12rem] stg:inline-block"
+      />
     ),
     defaultVisible: true,
     minWidth: "8rem",
@@ -54,9 +57,12 @@ const COLUMNS: readonly ColumnDef[] = [
     sortField: "startedAt",
     cell: (row) =>
       row.startedAt ? (
-        <time dateTime={row.startedAt.toISOString()} title={row.startedAt.toLocaleString()}>
-          {formatRelativeTime(row.startedAt)}
-        </time>
+        <Tooltip>
+          <TooltipTrigger render={<time dateTime={row.startedAt.toISOString()} />}>
+            {formatRelativeTime(row.startedAt)}
+          </TooltipTrigger>
+          <TooltipContent side="top">{row.startedAt.toLocaleString()}</TooltipContent>
+        </Tooltip>
       ) : (
         "\u2014"
       ),
@@ -103,9 +109,14 @@ const COLUMNS: readonly ColumnDef[] = [
     sortField: "tasks",
     cell: (row) =>
       row.taskCount > 0 ? (
-        <span title={`${row.completedTaskCount} of ${row.taskCount} tasks finished`}>
-          {row.completedTaskCount}/{row.taskCount}
-        </span>
+        <Tooltip>
+          <TooltipTrigger render={<span />}>
+            {row.completedTaskCount}/{row.taskCount}
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {`${row.completedTaskCount} of ${row.taskCount} tasks finished`}
+          </TooltipContent>
+        </Tooltip>
       ) : (
         "\u2014"
       ),
@@ -122,15 +133,13 @@ const COLUMNS: readonly ColumnDef[] = [
       if (!label) return "\u2014";
       const isFailed = !!row.failedTaskName;
       return (
-        <span
+        <TruncatedText
+          text={label}
           className={cn(
-            "stg:truncate stg:max-w-[10rem] stg:inline-block stg:text-xs",
+            "stg:max-w-[10rem] stg:inline-block stg:text-xs",
             isFailed ? "stg:text-destructive" : "stg:text-muted-foreground",
           )}
-          title={label}
-        >
-          {label}
-        </span>
+        />
       );
     },
     defaultVisible: true,

--- a/sdk/react/src/workflow/inspector/InspectorHeader.tsx
+++ b/sdk/react/src/workflow/inspector/InspectorHeader.tsx
@@ -5,6 +5,8 @@ import { cn } from "@stigmer/theme";
 import type { WorkflowGraphModel } from "../workflow-graph-model.js";
 import { TASK_NAME_PATTERN, TASK_NAME_PATTERN_ERROR } from "../canvas-constants.js";
 import type { InspectorNodeIdentity, InspectorMutations } from "./types.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
+import { TruncatedText } from "../../internal/truncated-text.js";
 
 /** Props for {@link InspectorHeader}. */
 export interface InspectorHeaderProps {
@@ -107,14 +109,20 @@ export const InspectorHeader = memo(function InspectorHeader({
               )}
             </div>
           ) : (
-            <button
-              type="button"
-              onClick={startEditing}
-              className="stg:w-fit stg:max-w-full stg:truncate stg:text-left stg:text-sm stg:font-semibold stg:text-[var(--stgm-foreground,#1a1a2e)] stg:hover:underline"
-              title="Click to rename"
-            >
-              {identity.taskName}
-            </button>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={startEditing}
+                    className="stg:w-fit stg:max-w-full stg:truncate stg:text-left stg:text-sm stg:font-semibold stg:text-[var(--stgm-foreground,#1a1a2e)] stg:hover:underline"
+                  />
+                }
+              >
+                {identity.taskName}
+              </TooltipTrigger>
+              <TooltipContent side="top">Click to rename</TooltipContent>
+            </Tooltip>
           )}
         </div>
 
@@ -155,9 +163,10 @@ export const InspectorHeader = memo(function InspectorHeader({
           {identity.kindString.replace(/_/g, " ")}
         </span>
         {identity.description && (
-          <span className="stg:truncate stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]" title={identity.description}>
-            {identity.description}
-          </span>
+          <TruncatedText
+            text={identity.description}
+            className="stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]"
+          />
         )}
       </div>
     </div>

--- a/sdk/react/src/workflow/inspector/NestedTaskList.tsx
+++ b/sdk/react/src/workflow/inspector/NestedTaskList.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useCallback } from "react";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
 
 /** A nested task entry for display in the inspector. */
 export interface NestedTaskEntry {
@@ -118,17 +119,23 @@ export const NestedTaskList = memo(function NestedTaskList({
 
           {/* Remove button */}
           {editable && onRemove && (
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); onRemove(idx); }}
-              className="stg:shrink-0 stg:opacity-0 stg:group-hover/task:opacity-100 stg:transition-opacity stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-destructive,#ef4444)]"
-              aria-label={`Remove task ${task.name}`}
-              title="Remove"
-            >
-              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-                <path d="M2.5 2.5l5 5M7.5 2.5l-5 5" />
-              </svg>
-            </button>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); onRemove(idx); }}
+                    className="stg:shrink-0 stg:opacity-0 stg:group-hover/task:opacity-100 stg:transition-opacity stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-destructive,#ef4444)]"
+                    aria-label={`Remove task ${task.name}`}
+                  />
+                }
+              >
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+                  <path d="M2.5 2.5l5 5M7.5 2.5l-5 5" />
+                </svg>
+              </TooltipTrigger>
+              <TooltipContent side="top">Remove</TooltipContent>
+            </Tooltip>
           )}
         </div>
       ))}

--- a/sdk/react/src/workflow/inspector/WorkflowSummaryPanel.tsx
+++ b/sdk/react/src/workflow/inspector/WorkflowSummaryPanel.tsx
@@ -6,6 +6,7 @@ import type { WorkflowGraphModel, WorkflowGraphBudget, WorkflowGraphEnvVar } fro
 import { START_NODE_ID, END_NODE_ID } from "../workflow-graph-model.js";
 import { CATEGORY_DISPLAY_NAMES } from "../canvas-constants.js";
 import type { TopologyNodeCategory } from "../useWorkflowTopology.js";
+import { TruncatedText } from "../../internal/truncated-text.js";
 
 /** Props for {@link WorkflowSummaryPanel}. */
 export interface WorkflowSummaryPanelProps {
@@ -201,9 +202,10 @@ function EnvVarsSection({
               <span className="stg:text-[var(--stgm-muted-foreground,#737373)]">optional</span>
             )}
             {env.description && (
-              <span className="stg:truncate stg:text-[var(--stgm-muted-foreground,#737373)]" title={env.description}>
-                {env.description}
-              </span>
+              <TruncatedText
+                text={env.description}
+                className="stg:text-[var(--stgm-muted-foreground,#737373)]"
+              />
             )}
           </div>
         ))}

--- a/sdk/react/src/workflow/inspector/tabs/BranchesTab.tsx
+++ b/sdk/react/src/workflow/inspector/tabs/BranchesTab.tsx
@@ -2,6 +2,11 @@
 
 import { memo, useCallback, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../../../internal/tooltip.js";
 import type { WorkflowGraphNode, WorkflowGraphModel } from "../../workflow-graph-model.js";
 import type { InspectorMutations } from "../types.js";
 
@@ -172,17 +177,23 @@ function SwitchCaseBranches({
                 </div>
 
                 {/* Remove button */}
-                <button
-                  type="button"
-                  onClick={() => handleRemove(caseEntry.name)}
-                  className="stg:shrink-0 stg:opacity-0 stg:group-hover/case:opacity-100 stg:transition-opacity stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-destructive,#ef4444)]"
-                  aria-label={`Remove case ${caseEntry.name}`}
-                  title="Remove case"
-                >
-                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-                    <path d="M3 3l6 6M9 3l-6 6" />
-                  </svg>
-                </button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(caseEntry.name)}
+                        className="stg:shrink-0 stg:opacity-0 stg:group-hover/case:opacity-100 stg:transition-opacity stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-destructive,#ef4444)]"
+                        aria-label={`Remove case ${caseEntry.name}`}
+                      />
+                    }
+                  >
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+                      <path d="M3 3l6 6M9 3l-6 6" />
+                    </svg>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Remove case</TooltipContent>
+                </Tooltip>
               </div>
             );
           })}
@@ -354,32 +365,51 @@ function ForkBranches({
                     className="stg:w-full stg:rounded stg:border stg:border-[var(--stgm-ring,#3b82f6)] stg:bg-[var(--stgm-background,#fff)] stg:px-1 stg:py-0.5 stg:text-[11px] stg:text-[var(--stgm-foreground,#1a1a2e)] stg:outline-none"
                   />
                 ) : (
-                  <span
-                    className="stg:text-[11px] stg:font-medium stg:text-[var(--stgm-foreground,#1a1a2e)] stg:truncate stg:block stg:cursor-text"
-                    onDoubleClick={() => startRename(idx, branch.name)}
-                    title="Double-click to rename"
-                  >
-                    {branch.name}
-                  </span>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <span
+                          className="stg:text-[11px] stg:font-medium stg:text-[var(--stgm-foreground,#1a1a2e)] stg:truncate stg:block stg:cursor-text"
+                          onDoubleClick={() => startRename(idx, branch.name)}
+                        />
+                      }
+                    >
+                      {branch.name}
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      Double-click to rename
+                    </TooltipContent>
+                  </Tooltip>
                 )}
                 <span className="stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]">
                   {branch.taskCount} {branch.taskCount === 1 ? "task" : "tasks"}
                 </span>
               </div>
 
-              {/* Remove — disabled if only 2 branches */}
-              <button
-                type="button"
-                onClick={() => handleRemove(branch.name)}
-                disabled={branches.length <= 2}
-                className="stg:shrink-0 stg:opacity-0 stg:group-hover/branch:opacity-100 stg:transition-opacity stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-destructive,#ef4444)] stg:disabled:opacity-30 stg:disabled:cursor-not-allowed"
-                aria-label={`Remove branch ${branch.name}`}
-                title={branches.length <= 2 ? "Fork requires at least 2 branches" : "Remove branch"}
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-                  <path d="M3 3l6 6M9 3l-6 6" />
-                </svg>
-              </button>
+              {/* Remove — disabled if only 2 branches. The tooltip trigger is
+                  a wrapper span so the "why is this disabled" explanation
+                  stays hoverable (disabled buttons never receive pointer
+                  events). */}
+              <Tooltip>
+                <TooltipTrigger render={<span className="stg:inline-flex stg:shrink-0" />}>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(branch.name)}
+                    disabled={branches.length <= 2}
+                    className="stg:shrink-0 stg:opacity-0 stg:group-hover/branch:opacity-100 stg:transition-opacity stg:text-[var(--stgm-muted-foreground,#737373)] stg:hover:text-[var(--stgm-destructive,#ef4444)] stg:disabled:opacity-30 stg:disabled:cursor-not-allowed"
+                    aria-label={`Remove branch ${branch.name}`}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+                      <path d="M3 3l6 6M9 3l-6 6" />
+                    </svg>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {branches.length <= 2
+                    ? "Fork requires at least 2 branches"
+                    : "Remove branch"}
+                </TooltipContent>
+              </Tooltip>
             </div>
           ))}
         </div>

--- a/sdk/react/src/workflow/instance/WorkflowInstanceList.tsx
+++ b/sdk/react/src/workflow/instance/WorkflowInstanceList.tsx
@@ -12,6 +12,7 @@ import { useEnvironmentList } from "../../environment/useEnvironmentList.js";
 import { ResourceVisibilityControl } from "../../library/ResourceVisibilityControl.js";
 import { useCheckPermission } from "../../iam-policy/useCheckPermission.js";
 import { WorkflowInstanceEmptyState } from "./WorkflowInstanceEmptyState.js";
+import { TruncatedText } from "../../internal/truncated-text.js";
 
 /** Props for {@link WorkflowInstanceList}. */
 export interface WorkflowInstanceListProps {
@@ -206,12 +207,10 @@ function InstanceRow({
     >
       <td className="stg:px-4 stg:py-2.5">
         <div className="stg:min-w-0">
-          <span
-            className="stg:block stg:truncate stg:font-medium stg:text-foreground"
-            title={meta?.name || meta?.slug || undefined}
-          >
-            {meta?.name || meta?.slug || "—"}
-          </span>
+          <TruncatedText
+            text={meta?.name || meta?.slug || "—"}
+            className="stg:block stg:font-medium stg:text-foreground"
+          />
           {instance.spec?.description && (
             <p className="stg:text-[0.65rem] stg:text-muted-foreground stg:truncate">
               {instance.spec.description}

--- a/sdk/react/src/workflow/node-shell/DiffBadge.tsx
+++ b/sdk/react/src/workflow/node-shell/DiffBadge.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import { cn } from "@stigmer/theme";
 import type { NodeDiffStatus } from "../diff/types.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
 
 export interface DiffBadgeProps {
   readonly status: NodeDiffStatus;
@@ -30,17 +31,23 @@ export const DiffBadge = memo(function DiffBadge({
       : icon;
 
   return (
-    <span
-      className={cn(
-        "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:min-w-5 stg:items-center stg:justify-center stg:rounded-full stg:px-1 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
-        className,
-      )}
-      title={label}
-      aria-label={label}
-      data-diff-status={status}
-    >
-      {displayText}
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:min-w-5 stg:items-center stg:justify-center stg:rounded-full stg:px-1 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
+              className,
+            )}
+            aria-label={label}
+            data-diff-status={status}
+          />
+        }
+      >
+        {displayText}
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
   );
 });
 

--- a/sdk/react/src/workflow/node-shell/ExecutionBadge.tsx
+++ b/sdk/react/src/workflow/node-shell/ExecutionBadge.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import { cn } from "@stigmer/theme";
 import type { NodeExecutionStatus } from "../workflow-graph-conversions.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
 
 /** Fork branch completion progress (T06). */
 export interface ForkProgressInfo {
@@ -54,17 +55,23 @@ export const ExecutionBadge = memo(function ExecutionBadge({
   if (status === "waiting_approval" && approvalToolName) {
     const approvalLabel = `Awaiting approval: ${approvalToolName}`;
     return (
-      <span
-        className={cn(
-          "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:items-center stg:gap-0.5 stg:rounded-full stg:px-1.5 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
-          "stg:bg-[var(--stgm-warning,#f59e0b)] stg:text-[var(--stgm-warning-foreground,#fff)]",
-        )}
-        title={approvalLabel}
-        aria-label={approvalLabel}
-      >
-        ✋
-        <span className="stg:max-w-[60px] stg:truncate">{approvalToolName}</span>
-      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              className={cn(
+                "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:items-center stg:gap-0.5 stg:rounded-full stg:px-1.5 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
+                "stg:bg-[var(--stgm-warning,#f59e0b)] stg:text-[var(--stgm-warning-foreground,#fff)]",
+              )}
+              aria-label={approvalLabel}
+            />
+          }
+        >
+          ✋
+          <span className="stg:max-w-[60px] stg:truncate">{approvalToolName}</span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{approvalLabel}</TooltipContent>
+      </Tooltip>
     );
   }
 
@@ -76,17 +83,23 @@ export const ExecutionBadge = memo(function ExecutionBadge({
       : `Agent: ${agentActivity.messagesCount} messages, ${agentActivity.toolCallsCount} tool calls`;
 
     return (
-      <span
-        className={cn(
-          "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:items-center stg:gap-0.5 stg:rounded-full stg:px-1.5 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
-          "stg:bg-[var(--stgm-primary,#6366f1)] stg:text-[var(--stgm-primary-foreground,#fff)]",
-        )}
-        title={agentLabel}
-        aria-label={agentLabel}
-      >
-        {agentActivity.currentToolName ? "🔧" : "💬"}
-        <span className="stg:max-w-[60px] stg:truncate">{displayText}</span>
-      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              className={cn(
+                "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:items-center stg:gap-0.5 stg:rounded-full stg:px-1.5 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
+                "stg:bg-[var(--stgm-primary,#6366f1)] stg:text-[var(--stgm-primary-foreground,#fff)]",
+              )}
+              aria-label={agentLabel}
+            />
+          }
+        >
+          {agentActivity.currentToolName ? "🔧" : "💬"}
+          <span className="stg:max-w-[60px] stg:truncate">{displayText}</span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{agentLabel}</TooltipContent>
+      </Tooltip>
     );
   }
 
@@ -97,36 +110,50 @@ export const ExecutionBadge = memo(function ExecutionBadge({
       : `Fork running, ${forkProgress.completed} of ${forkProgress.total} branches completed`;
 
     return (
-      <span
-        className={cn(
-          "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:min-w-5 stg:items-center stg:justify-center stg:rounded-full stg:px-1.5 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
-          "stg:bg-[var(--stgm-primary,#6366f1)] stg:text-[var(--stgm-primary-foreground,#fff)]",
-        )}
-        title={progressLabel}
-        aria-label={progressLabel}
-      >
-        {forkProgress.completed}/{forkProgress.total}
-        {forkProgress.compete && <span className="stg:ml-0.5">⚡</span>}
-      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              className={cn(
+                "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:min-w-5 stg:items-center stg:justify-center stg:rounded-full stg:px-1.5 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
+                "stg:bg-[var(--stgm-primary,#6366f1)] stg:text-[var(--stgm-primary-foreground,#fff)]",
+              )}
+              aria-label={progressLabel}
+            />
+          }
+        >
+          {forkProgress.completed}/{forkProgress.total}
+          {forkProgress.compete && <span className="stg:ml-0.5">⚡</span>}
+        </TooltipTrigger>
+        <TooltipContent side="top">{progressLabel}</TooltipContent>
+      </Tooltip>
     );
   }
 
   const { icon, label, className } = BADGE_CONFIG[status];
 
   return (
-    <span
-      className={cn(
-        "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:min-w-5 stg:items-center stg:justify-center stg:rounded-full stg:px-1 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
-        className,
-      )}
-      title={label + (attemptNumber && attemptNumber > 1 ? ` (attempt ${attemptNumber})` : "")}
-      aria-label={label}
-    >
-      {icon}
-      {status === "retrying" && attemptNumber != null && attemptNumber > 1 && (
-        <span className="stg:ml-0.5">{attemptNumber}</span>
-      )}
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "stg:absolute stg:-right-1.5 stg:-top-1.5 stg:z-20 stg:flex stg:h-5 stg:min-w-5 stg:items-center stg:justify-center stg:rounded-full stg:px-1 stg:text-[10px] stg:font-semibold stg:leading-none stg:shadow-sm",
+              className,
+            )}
+            aria-label={label}
+          />
+        }
+      >
+        {icon}
+        {status === "retrying" && attemptNumber != null && attemptNumber > 1 && (
+          <span className="stg:ml-0.5">{attemptNumber}</span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        {label + (attemptNumber && attemptNumber > 1 ? ` (attempt ${attemptNumber})` : "")}
+      </TooltipContent>
+    </Tooltip>
   );
 });
 

--- a/sdk/react/src/workflow/node-shell/NodeActions.tsx
+++ b/sdk/react/src/workflow/node-shell/NodeActions.tsx
@@ -9,6 +9,12 @@ import { BranchAddPopover } from "../picker/BranchAddPopover.js";
 import type { BranchAddMode, BranchAddResult } from "../picker/BranchAddPopover.js";
 import type { InsertionContext } from "../picker/insertion-context.js";
 import { TrashIcon, DuplicateIcon, PlusIcon } from "../canvas-icons.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../../internal/tooltip.js";
 
 export interface NodeActionsProps {
   nodeId: string;
@@ -156,70 +162,84 @@ export const NodeActions = memo(function NodeActions({
     <>
       {/* Selection toolbar — auto-shown by React Flow when selected */}
       <NodeToolbar position={Position.Top} offset={8} align="center">
-        <div
-          className="stgm stg:flex stg:items-center stg:gap-0.5 stg:rounded-md stg:border stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-popover,var(--stgm-background,#fff))] stg:p-0.5 stg:shadow-md"
-          role="toolbar"
-          aria-label="Task actions"
-          aria-orientation="horizontal"
-        >
-          <ToolbarButton
-            icon={<DuplicateIcon />}
-            label={`Duplicate task ${taskName}`}
-            title="Duplicate"
-            onClick={handleDuplicate}
-          />
-          <ToolbarButton
-            ref={toolbarAddRef}
-            icon={<PlusIcon />}
-            label={`Add task after ${taskName}`}
-            title="Add task after"
-            onClick={handleToolbarAddClick}
-          />
-          <div className="stg:mx-0.5 stg:h-4 stg:w-px stg:bg-[var(--stgm-border,#e5e5e5)]" aria-hidden="true" />
-          <ToolbarButton
-            icon={<TrashIcon />}
-            label={`Delete task ${taskName}`}
-            title="Delete"
-            onClick={handleDelete}
-            destructive
-          />
-        </div>
+        <TooltipProvider>
+          <div
+            className="stgm stg:flex stg:items-center stg:gap-0.5 stg:rounded-md stg:border stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-popover,var(--stgm-background,#fff))] stg:p-0.5 stg:shadow-md"
+            role="toolbar"
+            aria-label="Task actions"
+            aria-orientation="horizontal"
+          >
+            <ToolbarButton
+              icon={<DuplicateIcon />}
+              label={`Duplicate task ${taskName}`}
+              tooltip="Duplicate"
+              onClick={handleDuplicate}
+            />
+            <ToolbarButton
+              ref={toolbarAddRef}
+              icon={<PlusIcon />}
+              label={`Add task after ${taskName}`}
+              tooltip="Add task after"
+              onClick={handleToolbarAddClick}
+            />
+            <div className="stg:mx-0.5 stg:h-4 stg:w-px stg:bg-[var(--stgm-border,#e5e5e5)]" aria-hidden="true" />
+            <ToolbarButton
+              icon={<TrashIcon />}
+              label={`Delete task ${taskName}`}
+              tooltip="Delete"
+              onClick={handleDelete}
+              destructive
+            />
+          </div>
+        </TooltipProvider>
       </NodeToolbar>
 
       {/* Delete button — revealed on hover via CSS group */}
-      <button
-        type="button"
-        onClick={handleDelete}
-        className={cn(
-          "stg:absolute stg:-right-2 stg:-top-2 stg:z-10 stg:flex stg:h-5 stg:w-5 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
-          "stg:hover:border-[var(--stgm-destructive,#ef4444)] stg:hover:bg-[var(--stgm-destructive,#ef4444)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
-          "stg:scale-75 stg:opacity-0 stg:group-hover:scale-100 stg:group-hover:opacity-100",
-        )}
-        aria-label={`Delete task ${taskName}`}
-        title="Delete task"
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-          <path d="M2 3h6M3.5 3V2.5a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5V3M4 4.5v2.5M6 4.5v2.5M3 3l.5 5h3l.5-5" />
-        </svg>
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={handleDelete}
+              className={cn(
+                "stg:absolute stg:-right-2 stg:-top-2 stg:z-10 stg:flex stg:h-5 stg:w-5 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
+                "stg:hover:border-[var(--stgm-destructive,#ef4444)] stg:hover:bg-[var(--stgm-destructive,#ef4444)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
+                "stg:scale-75 stg:opacity-0 stg:group-hover:scale-100 stg:group-hover:opacity-100",
+              )}
+              aria-label={`Delete task ${taskName}`}
+            />
+          }
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+            <path d="M2 3h6M3.5 3V2.5a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5V3M4 4.5v2.5M6 4.5v2.5M3 3l.5 5h3l.5-5" />
+          </svg>
+        </TooltipTrigger>
+        <TooltipContent side="top">Delete task</TooltipContent>
+      </Tooltip>
 
       {/* Add successor button — revealed on hover via CSS group */}
-      <button
-        ref={hoverAddRef}
-        type="button"
-        onClick={handleHoverAddClick}
-        className={cn(
-          "stg:absolute stg:-bottom-3 stg:left-1/2 stg:z-10 stg:flex stg:h-5 stg:w-5 stg:-translate-x-1/2 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
-          "stg:hover:border-[var(--stgm-primary,#6366f1)] stg:hover:bg-[var(--stgm-primary,#6366f1)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
-          "stg:scale-75 stg:opacity-0 stg:group-hover:scale-100 stg:group-hover:opacity-100",
-        )}
-        aria-label={`Add task after ${taskName}`}
-        title="Add task"
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-          <path d="M5 2v6M2 5h6" />
-        </svg>
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              ref={hoverAddRef}
+              type="button"
+              onClick={handleHoverAddClick}
+              className={cn(
+                "stg:absolute stg:-bottom-3 stg:left-1/2 stg:z-10 stg:flex stg:h-5 stg:w-5 stg:-translate-x-1/2 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
+                "stg:hover:border-[var(--stgm-primary,#6366f1)] stg:hover:bg-[var(--stgm-primary,#6366f1)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
+                "stg:scale-75 stg:opacity-0 stg:group-hover:scale-100 stg:group-hover:opacity-100",
+              )}
+              aria-label={`Add task after ${taskName}`}
+            />
+          }
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+            <path d="M5 2v6M2 5h6" />
+          </svg>
+        </TooltipTrigger>
+        <TooltipContent side="top">Add task</TooltipContent>
+      </Tooltip>
 
       <TaskPickerPopover
         open={pickerOpen}
@@ -233,32 +253,38 @@ export const NodeActions = memo(function NodeActions({
 
       {branchMode && (
         <>
-          <button
-            ref={branchAddRef}
-            type="button"
-            onClick={() => setBranchPopoverOpen(true)}
-            className={cn(
-              "stg:absolute stg:-bottom-3 stg:left-1/2 stg:z-10 stg:flex stg:h-5 stg:-translate-x-1/2 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:px-2 stg:text-[9px] stg:font-medium stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
-              "stg:hover:border-[var(--stgm-primary,#6366f1)] stg:hover:bg-[var(--stgm-primary,#6366f1)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
-              "stg:scale-75 stg:opacity-0 stg:group-hover:scale-100 stg:group-hover:opacity-100",
-            )}
-            aria-label={
-              branchMode === "switch-case"
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  ref={branchAddRef}
+                  type="button"
+                  onClick={() => setBranchPopoverOpen(true)}
+                  className={cn(
+                    "stg:absolute stg:-bottom-3 stg:left-1/2 stg:z-10 stg:flex stg:h-5 stg:-translate-x-1/2 stg:items-center stg:justify-center stg:rounded-full stg:border stg:border-[var(--stgm-border-prominent,#d4d4d8)] stg:bg-[var(--stgm-card,var(--stgm-background,#fff))] stg:px-2 stg:text-[9px] stg:font-medium stg:text-[var(--stgm-muted-foreground,#737373)] stg:shadow-sm stg:transition-all",
+                    "stg:hover:border-[var(--stgm-primary,#6366f1)] stg:hover:bg-[var(--stgm-primary,#6366f1)] stg:hover:text-[var(--stgm-primary-foreground,#fff)]",
+                    "stg:scale-75 stg:opacity-0 stg:group-hover:scale-100 stg:group-hover:opacity-100",
+                  )}
+                  aria-label={
+                    branchMode === "switch-case"
+                      ? "Add case"
+                      : branchMode === "fork-branch"
+                        ? "Add branch"
+                        : "Add catch"
+                  }
+                />
+              }
+            >
+              +
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {branchMode === "switch-case"
                 ? "Add case"
                 : branchMode === "fork-branch"
                   ? "Add branch"
-                  : "Add catch"
-            }
-            title={
-              branchMode === "switch-case"
-                ? "Add case"
-                : branchMode === "fork-branch"
-                  ? "Add branch"
-                  : "Add catch"
-            }
-          >
-            +
-          </button>
+                  : "Add catch"}
+            </TooltipContent>
+          </Tooltip>
 
           <BranchAddPopover
             open={branchPopoverOpen}
@@ -290,25 +316,33 @@ const TOOLBAR_BTN_DESTRUCTIVE_CLASS = cn(
 
 interface ToolbarButtonProps {
   icon: React.ReactNode;
+  /** Full accessible name (e.g. "Duplicate task fetch-data"). */
   label: string;
-  title: string;
+  /** Short action name shown on the house tooltip. */
+  tooltip: string;
   onClick: () => void;
   destructive?: boolean;
 }
 
 const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
-  function ToolbarButton({ icon, label, title, onClick, destructive }, ref) {
+  function ToolbarButton({ icon, label, tooltip, onClick, destructive }, ref) {
     return (
-      <button
-        ref={ref}
-        type="button"
-        onClick={onClick}
-        className={destructive ? TOOLBAR_BTN_DESTRUCTIVE_CLASS : TOOLBAR_BTN_CLASS}
-        aria-label={label}
-        title={title}
-      >
-        {icon}
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              ref={ref}
+              type="button"
+              onClick={onClick}
+              className={destructive ? TOOLBAR_BTN_DESTRUCTIVE_CLASS : TOOLBAR_BTN_CLASS}
+              aria-label={label}
+            />
+          }
+        >
+          {icon}
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltip}</TooltipContent>
+      </Tooltip>
     );
   },
 );

--- a/sdk/react/src/workflow/task-detail/StructuredDataViewer.tsx
+++ b/sdk/react/src/workflow/task-detail/StructuredDataViewer.tsx
@@ -9,6 +9,7 @@ import {
   humanizeArgKey,
   isScalar,
 } from "../../execution/tool-rendering-primitives.js";
+import { TruncatedText } from "../../internal/truncated-text.js";
 
 /**
  * Threshold (in characters) above which a string value is rendered
@@ -148,14 +149,15 @@ function ScalarEntry({
             typeof value === "boolean" && "stg:font-medium",
             (value === null || value === undefined) && "stg:text-muted-foreground",
           )}
-          title={strValue}
         >
           {strValue.includes("\n") ? (
+            // Multiline values wrap fully in the <pre> — nothing is clipped,
+            // so no tooltip is needed.
             <pre className="stg:whitespace-pre-wrap stg:break-words stg:rounded stg:border stg:border-border stg:bg-muted-subtle stg:px-2 stg:py-1 stg:font-mono stg:text-foreground">
               {strValue}
             </pre>
           ) : (
-            <span className="stg:block stg:truncate">{strValue}</span>
+            <TruncatedText text={strValue} className="stg:block" />
           )}
         </dd>
       )}

--- a/sdk/react/src/workspace/EditorTabs.tsx
+++ b/sdk/react/src/workspace/EditorTabs.tsx
@@ -3,6 +3,12 @@
 import { useCallback, type KeyboardEvent, type MouseEvent } from "react";
 import { cn } from "@stigmer/theme";
 import { editorKey, type OpenEditor } from "../internal/store/index.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../internal/tooltip.js";
 
 /**
  * Deterministic, space-free DOM id for a tab, built from an instance-scoped
@@ -73,94 +79,105 @@ export function EditorTabs({
   );
 
   return (
-    <div
-      role="tablist"
-      aria-label="Open editors"
-      aria-orientation="horizontal"
-      className={cn(
-        "stg:flex stg:shrink-0 stg:items-stretch stg:overflow-x-auto stg:border-b stg:border-border",
-        className,
-      )}
-    >
-      {editors.map((editor, index) => {
-        const key = editorKey(editor.entryId, editor.path);
-        const isActive = key === activeKey;
-        const lastSlash = editor.path.lastIndexOf("/");
-        const basename =
-          lastSlash >= 0 ? editor.path.slice(lastSlash + 1) : editor.path;
+    <TooltipProvider>
+      <div
+        role="tablist"
+        aria-label="Open editors"
+        aria-orientation="horizontal"
+        className={cn(
+          "stg:flex stg:shrink-0 stg:items-stretch stg:overflow-x-auto stg:border-b stg:border-border",
+          className,
+        )}
+      >
+        {editors.map((editor, index) => {
+          const key = editorKey(editor.entryId, editor.path);
+          const isActive = key === activeKey;
+          const lastSlash = editor.path.lastIndexOf("/");
+          const basename =
+            lastSlash >= 0 ? editor.path.slice(lastSlash + 1) : editor.path;
 
-        const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-          if (e.key === "ArrowRight") {
-            e.preventDefault();
-            move(index, 1);
-          } else if (e.key === "ArrowLeft") {
-            e.preventDefault();
-            move(index, -1);
-          } else if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onActivate(editor.entryId, editor.path);
-          } else if (e.key === "Delete" || e.key === "Backspace") {
-            e.preventDefault();
-            onClose(editor.entryId, editor.path);
-          }
-        };
+          const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+            if (e.key === "ArrowRight") {
+              e.preventDefault();
+              move(index, 1);
+            } else if (e.key === "ArrowLeft") {
+              e.preventDefault();
+              move(index, -1);
+            } else if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onActivate(editor.entryId, editor.path);
+            } else if (e.key === "Delete" || e.key === "Backspace") {
+              e.preventDefault();
+              onClose(editor.entryId, editor.path);
+            }
+          };
 
-        const handleAuxClick = (e: MouseEvent<HTMLDivElement>) => {
-          // Middle click closes, matching browser/editor tab conventions.
-          if (e.button === 1) {
-            e.preventDefault();
-            onClose(editor.entryId, editor.path);
-          }
-        };
+          const handleAuxClick = (e: MouseEvent<HTMLDivElement>) => {
+            // Middle click closes, matching browser/editor tab conventions.
+            if (e.button === 1) {
+              e.preventDefault();
+              onClose(editor.entryId, editor.path);
+            }
+          };
 
-        return (
-          <div
-            key={key}
-            role="tab"
-            id={tabIdPrefix ? editorTabDomId(tabIdPrefix, key) : undefined}
-            aria-selected={isActive}
-            aria-controls={panelId}
-            tabIndex={isActive ? 0 : -1}
-            title={editor.path}
-            onClick={() => onActivate(editor.entryId, editor.path)}
-            onDoubleClick={() => onPin(editor.entryId, editor.path)}
-            onAuxClick={handleAuxClick}
-            onKeyDown={handleKeyDown}
-            className={cn(
-              "stg:group stg:flex stg:max-w-[12rem] stg:shrink-0 stg:cursor-pointer stg:items-center stg:gap-1.5 stg:border-r stg:border-border stg:px-3 stg:py-1.5 stg:text-xs stg:transition-colors",
-              "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
-              isActive
-                ? "stg:bg-background stg:text-foreground"
-                : "stg:bg-muted-faint stg:text-muted-foreground stg:hover:bg-muted stg:hover:text-foreground",
-            )}
-          >
-            <span className={cn("stg:truncate", editor.preview && "stg:italic")}>
-              {basename}
-            </span>
-            {/* The visual close "X" is a presentational mouse affordance, NOT a
-                nested interactive control: a `<button>` inside `role="tab"` would
-                violate WCAG 4.1.2 (axe `nested-interactive`). Assistive tech and
-                keyboard users close the focused tab via Delete/Backspace (handled
-                above), so `aria-hidden` here removes the redundant nested control
-                without losing the close action for anyone. */}
-            <span
-              aria-hidden="true"
-              title={`Close ${basename}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onClose(editor.entryId, editor.path);
-              }}
-              className={cn(
-                "stg:shrink-0 stg:cursor-pointer stg:rounded stg:p-0.5 stg:text-muted-foreground stg:transition-opacity stg:hover:bg-accent-hover stg:hover:text-foreground",
-                isActive ? "stg:opacity-100" : "stg:opacity-0 stg:group-hover:opacity-100",
-              )}
-            >
-              <CloseIcon />
-            </span>
-          </div>
-        );
-      })}
-    </div>
+          return (
+            <Tooltip key={key}>
+              <TooltipTrigger
+                render={
+                  <div
+                    role="tab"
+                    id={tabIdPrefix ? editorTabDomId(tabIdPrefix, key) : undefined}
+                    aria-selected={isActive}
+                    aria-controls={panelId}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => onActivate(editor.entryId, editor.path)}
+                    onDoubleClick={() => onPin(editor.entryId, editor.path)}
+                    onAuxClick={handleAuxClick}
+                    onKeyDown={handleKeyDown}
+                    className={cn(
+                      "stg:group stg:flex stg:max-w-[12rem] stg:shrink-0 stg:cursor-pointer stg:items-center stg:gap-1.5 stg:border-r stg:border-border stg:px-3 stg:py-1.5 stg:text-xs stg:transition-colors",
+                      "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
+                      isActive
+                        ? "stg:bg-background stg:text-foreground"
+                        : "stg:bg-muted-faint stg:text-muted-foreground stg:hover:bg-muted stg:hover:text-foreground",
+                    )}
+                  />
+                }
+              >
+                <span className={cn("stg:truncate", editor.preview && "stg:italic")}>
+                  {basename}
+                </span>
+                {/* The visual close "X" is a presentational mouse affordance, NOT a
+                    nested interactive control: a `<button>` inside `role="tab"` would
+                    violate WCAG 4.1.2 (axe `nested-interactive`). Assistive tech and
+                    keyboard users close the focused tab via Delete/Backspace (handled
+                    above), so `aria-hidden` here removes the redundant nested control
+                    without losing the close action for anyone. It carries no tooltip
+                    of its own: it sits inside the tab's tooltip trigger, so a nested
+                    trigger would pop two tooltips at once, and its old title only
+                    restated the visible basename. */}
+                <span
+                  aria-hidden="true"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose(editor.entryId, editor.path);
+                  }}
+                  className={cn(
+                    "stg:shrink-0 stg:cursor-pointer stg:rounded stg:p-0.5 stg:text-muted-foreground stg:transition-opacity stg:hover:bg-accent-hover stg:hover:text-foreground",
+                    isActive ? "stg:opacity-100" : "stg:opacity-0 stg:group-hover:opacity-100",
+                  )}
+                >
+                  <CloseIcon />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="stg:break-all">
+                {editor.path}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
   );
 }
 

--- a/sdk/react/src/workspace/ExplorerTree.tsx
+++ b/sdk/react/src/workspace/ExplorerTree.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { cn } from "@stigmer/theme";
 import { FileTreeNode } from "../internal/file-tree/index.js";
 import type { SelectedWorkspaceFile } from "../internal/store/index.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useWorkspaceFiles } from "./useWorkspaceFiles.js";
 import type { WorkspaceEntry } from "./useWorkspaceEntries.js";
 import type { WorkspaceFileLister } from "./WorkspaceFileLister.js";
@@ -91,38 +92,54 @@ function ExplorerRoot({
   return (
     <div className="stg:flex stg:flex-col">
       <div className="stg:group/root stg:flex stg:items-stretch">
-        <button
-          type="button"
-          onClick={() => setExpanded((prev) => !prev)}
-          aria-expanded={expanded}
-          className={cn(
-            "stg:flex stg:min-w-0 stg:flex-1 stg:items-center stg:gap-1.5 stg:px-1.5 stg:py-1 stg:text-left stg:text-[0.7rem] stg:font-semibold stg:uppercase stg:tracking-wide stg:text-foreground stg:transition-colors stg:hover:bg-accent-hover",
-            "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
-          )}
-          title={entry.type === "local" ? entry.localPath : entry.gitUrl}
-        >
-          <span
-            aria-hidden="true"
-            className="stg:text-[10px] stg:text-muted-foreground-subtle"
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => setExpanded((prev) => !prev)}
+                aria-expanded={expanded}
+                className={cn(
+                  "stg:flex stg:min-w-0 stg:flex-1 stg:items-center stg:gap-1.5 stg:px-1.5 stg:py-1 stg:text-left stg:text-[0.7rem] stg:font-semibold stg:uppercase stg:tracking-wide stg:text-foreground stg:transition-colors stg:hover:bg-accent-hover",
+                  "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
+                )}
+              />
+            }
           >
-            {expanded ? "▼" : "▶"}
-          </span>
-          <span className="stg:truncate">{entry.name}</span>
-        </button>
+            <span
+              aria-hidden="true"
+              className="stg:text-[10px] stg:text-muted-foreground-subtle"
+            >
+              {expanded ? "▼" : "▶"}
+            </span>
+            <span className="stg:truncate">{entry.name}</span>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="stg:break-all">
+            {entry.type === "local" ? entry.localPath : entry.gitUrl}
+          </TooltipContent>
+        </Tooltip>
         {onRemove && (
-          <button
-            type="button"
-            onClick={() => onRemove(entry.id)}
-            aria-label={`Remove ${entry.name} from workspace`}
-            title={`Remove ${entry.name} from workspace`}
-            className={cn(
-              "stg:shrink-0 stg:px-1.5 stg:text-muted-foreground stg:opacity-0 stg:transition-opacity",
-              "stg:group-hover/root:opacity-100 stg:focus-visible:opacity-100",
-              "stg:hover:text-destructive stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
-            )}
-          >
-            <RemoveIcon />
-          </button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={() => onRemove(entry.id)}
+                  aria-label={`Remove ${entry.name} from workspace`}
+                  className={cn(
+                    "stg:shrink-0 stg:px-1.5 stg:text-muted-foreground stg:opacity-0 stg:transition-opacity",
+                    "stg:group-hover/root:opacity-100 stg:focus-visible:opacity-100",
+                    "stg:hover:text-destructive stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
+                  )}
+                />
+              }
+            >
+              <RemoveIcon />
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {`Remove ${entry.name} from workspace`}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/sdk/react/src/workspace/FileViewer.tsx
+++ b/sdk/react/src/workspace/FileViewer.tsx
@@ -22,6 +22,7 @@ import { ArtifactContentRenderer } from "../execution/ArtifactContentRenderer.js
 import { FileChangeDiff } from "../execution/FileChangesView.js";
 import { useFileChangeContent } from "../execution/useFileChangeContent.js";
 import { UNSTYLED_BUTTON } from "../internal/form-primitives.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import type { RevealTarget } from "../internal/useRevealLine.js";
 import type { SelectedWorkspaceFile } from "../internal/store/workspace-file-selection-store.js";
 import { useWorkspaceFileContent } from "./useWorkspaceFileContent.js";
@@ -660,9 +661,16 @@ function ViewerHeader({
     <div className="stg:flex stg:items-center stg:gap-2 stg:border-b stg:border-border stg:px-3 stg:py-2">
       <FileIcon />
       <div className="stg:flex stg:min-w-0 stg:flex-1 stg:items-baseline stg:gap-1.5">
-        <span className="stg:truncate stg:text-xs stg:font-semibold stg:text-foreground" title={dir ? `${dir}/${basename}` : basename}>
-          {basename}
-        </span>
+        <Tooltip>
+          <TooltipTrigger
+            render={<span className="stg:truncate stg:text-xs stg:font-semibold stg:text-foreground" />}
+          >
+            {basename}
+          </TooltipTrigger>
+          <TooltipContent side="top" className="stg:break-all">
+            {dir ? `${dir}/${basename}` : basename}
+          </TooltipContent>
+        </Tooltip>
         {dir && (
           <span className="stg:truncate stg:text-[0.65rem] stg:text-muted-foreground">{dir}</span>
         )}

--- a/sdk/react/src/workspace/PanelChip.tsx
+++ b/sdk/react/src/workspace/PanelChip.tsx
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef } from "react";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 /** Props for {@link PanelChip}. */
 export interface PanelChipProps {
@@ -50,29 +51,37 @@ export function PanelChip({ isOpen, onToggle, badgeCount }: PanelChipProps) {
   }, [isOpen]);
 
   return (
-    <button
-      ref={buttonRef}
-      type="button"
-      onClick={onToggle}
-      aria-expanded={isOpen}
-      aria-label={isOpen ? "Hide panel" : "Show panel"}
-      title={isOpen ? "Hide panel" : "Show panel"}
-      className={cn(
-        "stg:flex stg:items-center stg:gap-1.5 stg:rounded-md stg:border stg:border-border stg:bg-card stg:px-1.5 stg:py-1",
-        "stg:text-muted-foreground stg:transition-colors stg:hover:bg-muted stg:hover:text-foreground",
-        "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-      )}
-    >
-      {showCount && (
-        <span
-          aria-label={`${badgeCount} new items`}
-          className="stg:inline-flex stg:min-w-[1rem] stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-1 stg:py-px stg:text-[10px] stg:font-medium stg:leading-none stg:text-primary-foreground"
-        >
-          {badgeCount}
-        </span>
-      )}
-      <PanelIcon open={isOpen} />
-    </button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            ref={buttonRef}
+            type="button"
+            onClick={onToggle}
+            aria-expanded={isOpen}
+            aria-label={isOpen ? "Hide panel" : "Show panel"}
+            className={cn(
+              "stg:flex stg:items-center stg:gap-1.5 stg:rounded-md stg:border stg:border-border stg:bg-card stg:px-1.5 stg:py-1",
+              "stg:text-muted-foreground stg:transition-colors stg:hover:bg-muted stg:hover:text-foreground",
+              "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+            )}
+          />
+        }
+      >
+        {showCount && (
+          <span
+            aria-label={`${badgeCount} new items`}
+            className="stg:inline-flex stg:min-w-[1rem] stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-1 stg:py-px stg:text-[10px] stg:font-medium stg:leading-none stg:text-primary-foreground"
+          >
+            {badgeCount}
+          </span>
+        )}
+        <PanelIcon open={isOpen} />
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        {isOpen ? "Hide panel" : "Show panel"}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/sdk/react/src/workspace/WorkspaceEditor.tsx
+++ b/sdk/react/src/workspace/WorkspaceEditor.tsx
@@ -7,6 +7,7 @@ import type { UseGitHubConnectionReturn } from "../github/useGitHubConnection.js
 import { GitHubRepoPicker } from "../github/GitHubRepoPicker.js";
 import { useScrollShadows } from "../internal/useScrollShadows.js";
 import { ScrollFade } from "../internal/ScrollFade.js";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 
 type ActivePanel = "github" | null;
 
@@ -202,15 +203,26 @@ export function WorkspaceEditor({
                     <FolderIcon />
                   </span>
                 )}
-                <span
-                  className={cn(
-                    "stg:min-w-0 stg:flex-1 stg:truncate stg:text-foreground",
-                    entry.type === "local" && "stg:[direction:rtl] stg:text-left",
-                  )}
-                  title={entry.name}
-                >
-                  <bdi>{entry.name}</bdi>
-                </span>
+                {/* Not TruncatedText: the <bdi> + rtl-direction pair keeps the
+                    tail of a long local path visible, which a plain text span
+                    cannot reproduce. */}
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <span
+                        className={cn(
+                          "stg:min-w-0 stg:flex-1 stg:truncate stg:text-foreground",
+                          entry.type === "local" && "stg:[direction:rtl] stg:text-left",
+                        )}
+                      />
+                    }
+                  >
+                    <bdi>{entry.name}</bdi>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="stg:break-all">
+                    {entry.name}
+                  </TooltipContent>
+                </Tooltip>
                 <button
                   type="button"
                   onClick={() => workspace.remove(entry.id)}

--- a/sdk/react/src/workspace/WorkspaceSummary.tsx
+++ b/sdk/react/src/workspace/WorkspaceSummary.tsx
@@ -3,6 +3,8 @@
 import type { WorkspaceEntry } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import type { WorkspaceSource } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import { cn } from "@stigmer/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { TruncatedText } from "../internal/truncated-text.js";
 
 /** Props for {@link WorkspaceSummary}. */
 export interface WorkspaceSummaryProps {
@@ -67,25 +69,32 @@ function SourceLabel({ source }: { source?: WorkspaceSource }) {
     const short = url
       .replace(/^https?:\/\//, "")
       .replace(/\.git$/, "");
+    // The cell shows the shortened form but the tooltip restores the full
+    // URL (protocol and .git suffix), so this is a hover-always hint, not an
+    // overflow-gated TruncatedText.
     return (
-      <span
-        className="stg:ml-5 stg:block stg:truncate stg:text-muted-foreground"
-        title={url}
-      >
-        {short}
-      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="stg:ml-5 stg:block stg:truncate stg:text-muted-foreground" />
+          }
+        >
+          {short}
+        </TooltipTrigger>
+        <TooltipContent side="top" className="stg:break-all">
+          {url}
+        </TooltipContent>
+      </Tooltip>
     );
   }
 
   if (source.source.case === "localPath") {
     const path = source.source.value.path;
     return (
-      <span
-        className="stg:ml-5 stg:block stg:truncate stg:font-mono stg:text-muted-foreground"
-        title={path}
-      >
-        {path}
-      </span>
+      <TruncatedText
+        text={path}
+        className="stg:ml-5 stg:block stg:font-mono stg:text-muted-foreground"
+      />
     );
   }
 

--- a/sdk/react/src/workspace/WorkspaceSurface.tsx
+++ b/sdk/react/src/workspace/WorkspaceSurface.tsx
@@ -12,6 +12,12 @@ import { cn } from "@stigmer/theme";
 import type { FileChange } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 import { ResizableSplit } from "../internal/ResizableSplit.js";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../internal/tooltip.js";
+import {
   editorKey,
   type OpenEditor,
   type OpenFileOptions,
@@ -371,50 +377,57 @@ function ActivityRail({
   );
 
   return (
-    <div
-      role="radiogroup"
-      aria-label="Workspace view"
-      aria-orientation="vertical"
-      className="stg:flex stg:w-11 stg:shrink-0 stg:flex-col stg:items-center stg:gap-1 stg:border-r stg:border-border stg:bg-muted-faint stg:py-2"
-    >
-      {items.map((item, index) => {
-        const isSelected = view === item.id;
-        const showBadge = item.badge != null && item.badge > 0;
-        return (
-          <button
-            key={item.id}
-            ref={(el) => {
-              buttonRefs.current[index] = el;
-            }}
-            type="button"
-            role="radio"
-            aria-checked={isSelected}
-            aria-label={showBadge ? `${item.label} (${item.badge})` : item.label}
-            title={item.label}
-            tabIndex={isSelected ? 0 : -1}
-            onClick={() => onViewChange(item.id)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
-            className={cn(
-              "stg:relative stg:flex stg:h-9 stg:w-9 stg:items-center stg:justify-center stg:rounded-md stg:transition-colors",
-              "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-              isSelected
-                ? "stg:bg-accent stg:text-foreground"
-                : "stg:text-muted-foreground stg:hover:bg-accent-hover stg:hover:text-foreground",
-            )}
-          >
-            {item.icon}
-            {showBadge && (
-              <span
-                aria-hidden="true"
-                className="stg:absolute stg:-right-0.5 stg:-top-0.5 stg:inline-flex stg:min-w-[0.875rem] stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-1 stg:py-px stg:text-[9px] stg:font-medium stg:leading-none stg:text-primary-foreground"
+    <TooltipProvider>
+      <div
+        role="radiogroup"
+        aria-label="Workspace view"
+        aria-orientation="vertical"
+        className="stg:flex stg:w-11 stg:shrink-0 stg:flex-col stg:items-center stg:gap-1 stg:border-r stg:border-border stg:bg-muted-faint stg:py-2"
+      >
+        {items.map((item, index) => {
+          const isSelected = view === item.id;
+          const showBadge = item.badge != null && item.badge > 0;
+          return (
+            <Tooltip key={item.id}>
+              <TooltipTrigger
+                render={
+                  <button
+                    ref={(el) => {
+                      buttonRefs.current[index] = el;
+                    }}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    aria-label={showBadge ? `${item.label} (${item.badge})` : item.label}
+                    tabIndex={isSelected ? 0 : -1}
+                    onClick={() => onViewChange(item.id)}
+                    onKeyDown={(e) => handleKeyDown(e, index)}
+                    className={cn(
+                      "stg:relative stg:flex stg:h-9 stg:w-9 stg:items-center stg:justify-center stg:rounded-md stg:transition-colors",
+                      "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+                      isSelected
+                        ? "stg:bg-accent stg:text-foreground"
+                        : "stg:text-muted-foreground stg:hover:bg-accent-hover stg:hover:text-foreground",
+                    )}
+                  />
+                }
               >
-                {item.badge}
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </div>
+                {item.icon}
+                {showBadge && (
+                  <span
+                    aria-hidden="true"
+                    className="stg:absolute stg:-right-0.5 stg:-top-0.5 stg:inline-flex stg:min-w-[0.875rem] stg:items-center stg:justify-center stg:rounded-full stg:bg-primary stg:px-1 stg:py-px stg:text-[9px] stg:font-medium stg:leading-none stg:text-primary-foreground"
+                  >
+                    {item.badge}
+                  </span>
+                )}
+              </TooltipTrigger>
+              <TooltipContent side="right">{item.label}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
   );
 }
 
@@ -684,15 +697,21 @@ function EditorArea({
           the session viewer floats its top-right controls (host
           `headerActions` and the panel chip) over this region. */}
       <div className="stg:flex stg:shrink-0 stg:items-stretch stg:border-b stg:border-border stg:pr-24">
-        <button
-          type="button"
-          onClick={onCollapse}
-          aria-label="Back to chat"
-          title="Back to chat"
-          className="stg:flex stg:shrink-0 stg:items-center stg:border-r stg:border-border stg:px-2 stg:text-muted-foreground stg:transition-colors stg:hover:bg-accent-hover stg:hover:text-foreground stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring"
-        >
-          <ChevronLeftIcon />
-        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={onCollapse}
+                aria-label="Back to chat"
+                className="stg:flex stg:shrink-0 stg:items-center stg:border-r stg:border-border stg:px-2 stg:text-muted-foreground stg:transition-colors stg:hover:bg-accent-hover stg:hover:text-foreground stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring"
+              />
+            }
+          >
+            <ChevronLeftIcon />
+          </TooltipTrigger>
+          <TooltipContent side="top">Back to chat</TooltipContent>
+        </Tooltip>
         {editors.length > 0 && (
           <EditorTabs
             editors={editors}
@@ -800,15 +819,21 @@ function Breadcrumbs({
         })}
       </nav>
       {onRefresh && (
-        <button
-          type="button"
-          onClick={onRefresh}
-          aria-label="Reload file"
-          title="Reload file"
-          className="stg:shrink-0 stg:rounded stg:p-0.5 stg:text-muted-foreground stg:transition-colors stg:hover:text-foreground stg:focus-visible:outline-none stg:focus-visible:ring-1 stg:focus-visible:ring-ring"
-        >
-          <RefreshIcon />
-        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={onRefresh}
+                aria-label="Reload file"
+                className="stg:shrink-0 stg:rounded stg:p-0.5 stg:text-muted-foreground stg:transition-colors stg:hover:text-foreground stg:focus-visible:outline-none stg:focus-visible:ring-1 stg:focus-visible:ring-ring"
+              />
+            }
+          >
+            <RefreshIcon />
+          </TooltipTrigger>
+          <TooltipContent side="top">Reload file</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/sdk/react/src/workspace/__tests__/EditorTabs.test.tsx
+++ b/sdk/react/src/workspace/__tests__/EditorTabs.test.tsx
@@ -70,8 +70,11 @@ describe("EditorTabs", () => {
   it("closes a tab via its close affordance (presentational, aria-hidden)", () => {
     const { onClose } = renderTabs();
     // The close "X" is a presentational span (not a nested button) to satisfy
-    // WCAG 4.1.2; it is addressable by its title.
-    fireEvent.click(screen.getByTitle("Close a.ts"));
+    // WCAG 4.1.2, and carries no native title (banned, stigmer-cloud#268) —
+    // it is the tab's only aria-hidden child.
+    const tab = screen.getByRole("tab", { name: "a.ts" });
+    const closeX = tab.querySelector('[aria-hidden="true"]');
+    fireEvent.click(closeX!);
     expect(onClose).toHaveBeenCalledWith("e1", "src/a.ts");
   });
 

--- a/sdk/react/src/workspace/__tests__/WorkspaceSurface.test.tsx
+++ b/sdk/react/src/workspace/__tests__/WorkspaceSurface.test.tsx
@@ -204,13 +204,16 @@ const changesView = {
 describe("WorkspaceSurface extraViews", () => {
   it("renders injected views in the rail after the built-ins", () => {
     renderSurface({ extraViews: [configView, changesView] });
+    // Rail names live in accessible labels (hover rides the house tooltip;
+    // native titles are banned, stigmer-cloud#268).
     const radios = screen.getAllByRole("radio");
-    expect(radios.map((r) => r.getAttribute("title"))).toEqual([
+    expect(radios.map((r) => r.getAttribute("aria-label"))).toEqual([
       "Explorer",
       "Search",
       "Config",
-      "Changes",
+      "Changes (3)", // the badge count folds into the accessible name
     ]);
+    expect(radios.every((r) => r.getAttribute("title") === null)).toBe(true);
   });
 
   it("shows a count badge on a rail view and folds it into the accessible name", () => {

--- a/tools/eslint-plugin-stigmer/index.js
+++ b/tools/eslint-plugin-stigmer/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const noMainTokensInSidebar = require("./rules/no-main-tokens-in-sidebar");
+const noNativeTitle = require("./rules/no-native-title");
 const noTokenOpacityModifiers = require("./rules/no-token-opacity-modifiers");
 const sdkImportBoundaries = require("./rules/sdk-import-boundaries");
 
@@ -11,6 +12,7 @@ const plugin = {
   },
   rules: {
     "no-main-tokens-in-sidebar": noMainTokensInSidebar,
+    "no-native-title": noNativeTitle,
     "no-token-opacity-modifiers": noTokenOpacityModifiers,
     "sdk-import-boundaries": sdkImportBoundaries,
   },

--- a/tools/eslint-plugin-stigmer/rules/no-native-title.js
+++ b/tools/eslint-plugin-stigmer/rules/no-native-title.js
@@ -1,0 +1,87 @@
+"use strict";
+
+// Native `title` attributes are below the product's quality bar as tooltips:
+// they are OS-delayed, imprecise hover targets, not keyboard-accessible, and
+// invisible on touch. On disabled controls they are unreachable by EVERY
+// input method (`disabled` removes the control from the tab order and the
+// house button styles add `pointer-events-none`), so the user who most needs
+// the explanation can never see it (stigmer/stigmer-cloud#268).
+//
+// The rule flags `title` on anything that renders it into the DOM:
+//   - lowercase JSX elements (`<button title=…>`), and
+//   - components known to forward arbitrary props onto their DOM element:
+//     the SDK `Button` (spreads `...rest`) and Base UI-style trigger
+//     components (`Popover.Trigger`, `TooltipTrigger`, …), matched by a
+//     `Trigger` name suffix.
+//
+// Custom components where `title` is a rendered-text prop (Section,
+// EmptyState, DialogHeader, …) are deliberately NOT flagged — those render
+// visible headings, not native tooltips.
+
+const FORWARDING_COMPONENT_NAMES = new Set(["Button"]);
+const FORWARDING_NAME_SUFFIX = /Trigger$/;
+
+/**
+ * Resolves whether the JSX element owning this attribute renders the
+ * attribute into the DOM (host element or a known prop-forwarding
+ * component). Returns the printable element name when it does.
+ */
+function domRenderingElementName(openingElement) {
+  const nameNode = openingElement.name;
+
+  if (nameNode.type === "JSXIdentifier") {
+    const name = nameNode.name;
+    if (/^[a-z]/.test(name)) return name;
+    if (FORWARDING_COMPONENT_NAMES.has(name)) return name;
+    if (FORWARDING_NAME_SUFFIX.test(name)) return name;
+    return null;
+  }
+
+  // <Popover.Trigger title=…> — Base UI triggers forward props to the DOM.
+  if (
+    nameNode.type === "JSXMemberExpression" &&
+    nameNode.property.type === "JSXIdentifier" &&
+    FORWARDING_NAME_SUFFIX.test(nameNode.property.name)
+  ) {
+    return `${nameNode.object.name ?? ""}.${nameNode.property.name}`;
+  }
+
+  return null;
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow native `title` attributes — OS-delayed, keyboard- and touch-inaccessible tooltips, fully unreachable on disabled controls",
+    },
+    messages: {
+      nativeTitle:
+        "Native `title` on <{{ element }}> is an OS-delayed tooltip that keyboard and touch users never see" +
+        " (and on a disabled control, nobody sees). Use the house tooltip (internal/tooltip.tsx)," +
+        " TruncatedText (internal/truncated-text.tsx) for truncated values, or visible text for" +
+        " a disabled control's explanation.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.type !== "JSXIdentifier" || node.name.name !== "title") {
+          return;
+        }
+
+        const element = domRenderingElementName(node.parent);
+        if (element === null) return;
+
+        context.report({
+          node,
+          messageId: "nativeTitle",
+          data: { element },
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Kills the native-`title` tooltip class across `@stigmer/react` (118 sites, ~100 files) and the desktop console, replacing each site with the pattern it deserves, and adds an error-level `stigmer/no-native-title` eslint rule so the ~119th can never ship.

Native titles are OS-delayed, imprecise hover targets, invisible on touch, unreachable by keyboard — and on disabled controls (which drop pointer events and leave the tab order) unreachable by **every** input method, precisely where the explanation matters most (the filed a11y defect).

## What changed

**Patterns applied per site class** (model: the conversations F-18 sweep, `e1bdeca4a`):
- **Interactive enabled controls** (toolbars, tabs, links, icon buttons): the control itself is the tooltip trigger — keyboard focus now opens the hint, a real gain over native titles. (`WorkspaceSidebar` recents-row precedent.)
- **Non-interactive badges/glyphs/timestamps**: non-focusable span triggers, `sr-only` names kept, zero new tab stops (`StatusHint` precedent). Absolute dates render as semantic `<time dateTime>` triggers.
- **Disabled-capable buttons**: the trigger is a wrapper span, so the hint survives `disabled` (browsers suppress pointer events on disabled form controls). The always-disabled last weekday in `CadenceField` finally explains itself ("A weekly schedule needs at least one day").
- **Truncated values** (paths, hashes, model ids): new internal `TruncatedText` — an overflow-**gated** house tooltip that opens only when the text is actually clipped (native titles fired always; `CollectionRecordsBrowser`'s hand-rolled 80-char check is superseded).
- **Visible text** where the message explains why a control is disabled (`PlanEditor`'s too-large-to-edit hint; `TaskPickerPopover` already rendered its reason visibly).
- **Deletions** where the title only duplicated adjacent visible text — each with an in-code rationale (incl. `AttachmentImageLightbox`, where a portaled tooltip physically cannot render above a native `showModal()` top layer).

**Lint rule**: `stigmer/no-native-title` (error) registered in `sdk/react` and both client apps; flags `title` on DOM elements and title-forwarding components (`Button`, `*Trigger`). Negative control: 118 real errors pre-sweep, 0 after.

**Client-app fix**: desktop `BackgroundRunDot` dropped its native title (it renders inside the SDK sidebar rows' house tooltip — the two fought on hover).

## Test plan

- [x] Full unit suite: 4360/4360 (title-asserting tests upgraded to accessible-name / no-title pins)
- [x] Real-Chromium browser suite: 77/77, including three new pins — `TruncatedText` overflow gating (opens when clipped, stays quiet when not), disabled-day reveal through the wrapper span, keyboard-focus-opens on `ArtifactRowView`
- [x] `tsc --noEmit` clean; eslint 0 errors in sdk/react + web + desktop; `lint:prefix` OK; `verify-esm-node` 9/9 packages
- [ ] Post-merge: visual smoke of composer toolbar / canvas toolbar / recents in the deployed console

Fixes stigmer/stigmer-cloud#268

Made with [Cursor](https://cursor.com)