### PR TITLE
fix(runner): fail the test suite fast on Nodes without node:sqlite and tighten the engines floor

### DIFF
--- a/backend/services/runner/package.json
+++ b/backend/services/runner/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "engines": {
-    "node": ">=22.13"
+    "node": "^22.13.0 || >=23.4.0"
   },
   "bin": {
     "stigmer-runner": "./dist/main.js"

--- a/backend/services/runner/src/__test-utils__/__tests__/vitest-global-setup.test.ts
+++ b/backend/services/runner/src/__test-utils__/__tests__/vitest-global-setup.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Suite-gate tests (oss#257).
+ *
+ * The gate is what turns "three sqlite-importing files die at collection
+ * with a raw ERR_UNKNOWN_BUILTIN_MODULE" into one immediate, actionable
+ * failure. Both arms are pinned around an injected preflight (the
+ * preflightNodeRuntime idiom), so the failure arm is testable on a
+ * supported Node. The preflight MESSAGE contract itself is pinned in
+ * __tests__/preflight.test.ts — here we pin only what the gate adds: the
+ * throw/pass behavior and the test-context fix hint.
+ */
+
+import { describe, expect, it } from "vitest";
+import { assertNodeCanRunSuite } from "../vitest-global-setup.js";
+
+describe("assertNodeCanRunSuite", () => {
+  it("returns cleanly when the preflight passes", () => {
+    expect(() => assertNodeCanRunSuite(() => null)).not.toThrow();
+  });
+
+  it("throws the preflight diagnosis verbatim when it fails", () => {
+    // The diagnosis must arrive unwrapped — it is the single source of what
+    // is wrong (found version, missing capability, both floors).
+    expect(() => assertNodeCanRunSuite(() => "diagnosis from preflight")).toThrow(
+      /diagnosis from preflight/,
+    );
+  });
+
+  it("appends the test-context fix hint", () => {
+    // Both escape hatches: the repo's pinned Node, and the experimental flag
+    // for Nodes where the builtin is flag-gated.
+    expect(() => assertNodeCanRunSuite(() => "boom")).toThrow(/\.nvmrc/);
+    expect(() => assertNodeCanRunSuite(() => "boom")).toThrow(
+      /--experimental-sqlite/,
+    );
+  });
+});

--- a/backend/services/runner/src/__test-utils__/vitest-global-setup.ts
+++ b/backend/services/runner/src/__test-utils__/vitest-global-setup.ts
@@ -1,0 +1,50 @@
+/**
+ * Vitest globalSetup: refuse to run the suite on a Node that cannot run the
+ * runner.
+ *
+ * Why this exists: the durable checkpointer imports Node's built-in
+ * `node:sqlite` at module load time, so on a Node without it (below 22.13,
+ * or 23.0–23.3 — the 23.x line only gained it unflagged in 23.4) the
+ * sqlite-importing test files die at COLLECTION with a raw
+ * `ERR_UNKNOWN_BUILTIN_MODULE` while the rest of the suite grinds on
+ * (oss#257). globalSetup runs once in the main process before any file is
+ * collected, so the whole run fails immediately with the same actionable
+ * message the runner itself prints at boot (src/preflight.ts).
+ *
+ * Deliberately fails the WHOLE suite rather than skipping the sqlite tests:
+ * a Node that cannot load `node:sqlite` cannot run the runner at all, and a
+ * green-with-skips suite on such a Node would be a false signal. The gate is
+ * a capability probe, not a version check — on Nodes where the builtin is
+ * flag-gated (22.5–22.12, 23.0–23.3), `NODE_OPTIONS=--experimental-sqlite`
+ * satisfies the probe and the suite runs (vitest workers inherit
+ * NODE_OPTIONS, so the flag reaches every fork).
+ *
+ * Lives in src/__test-utils__/ so `tsc --noEmit` covers it (the dev tsconfig
+ * only includes src/) while tsconfig.build.json's exclusion keeps it out of
+ * dist/.
+ */
+
+import { preflightNodeRuntime } from "../preflight.js";
+
+/**
+ * Throw an actionable error when this Node cannot run the runner (and hence
+ * its test suite). The preflight message is reused verbatim — single source
+ * of the diagnosis, contract pinned by __tests__/preflight.test.ts — with a
+ * test-context fix hint appended (the check-runner-node Makefile idiom).
+ */
+export function assertNodeCanRunSuite(
+  preflight: () => string | null = preflightNodeRuntime,
+): void {
+  const failure = preflight();
+  if (failure === null) return;
+  throw new Error(
+    `${failure}\n` +
+      `  fix: nvm use (the repo's .nvmrc pins a supported Node), or on a Node\n` +
+      `  where node:sqlite is flag-gated (22.5-22.12, 23.0-23.3) run the suite\n` +
+      `  with NODE_OPTIONS=--experimental-sqlite.`,
+  );
+}
+
+export default function globalSetup(): void {
+  assertNodeCanRunSuite();
+}

--- a/backend/services/runner/src/__tests__/preflight.test.ts
+++ b/backend/services/runner/src/__tests__/preflight.test.ts
@@ -11,6 +11,7 @@
  *   the desktop Run dialog via the IPC handshake.
  */
 
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isNodeSqliteAvailable,
@@ -41,6 +42,20 @@ describe("preflightNodeRuntime", () => {
     // itself run under a Node without node:sqlite (e.g. 23.0–23.3), in which
     // case BOTH sides must report unsupported.
     expect(preflightNodeRuntime() === null).toBe(isNodeSqliteAvailable());
+  });
+
+  it("package.json engines matches the floors this preflight documents", () => {
+    // The published engines range and the preflight message describe the same
+    // two floors (node:sqlite is unflagged from 22.13 in the 22.x line and
+    // only from 23.4 after that). engines is the only one of the two that a
+    // future edit can silently loosen — `>=22.13` once re-admitted the
+    // 23.0–23.3 gap (oss#257) — so pin it byte-for-byte to the range that
+    // excludes that gap. If the floors genuinely move, update the preflight
+    // message, this pin, and package.json together.
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { engines: { node: string } };
+    expect(pkg.engines.node).toBe("^22.13.0 || >=23.4.0");
   });
 });
 

--- a/backend/services/runner/vitest.config.ts
+++ b/backend/services/runner/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
+    // Fail fast (before collection) on a Node that cannot run the runner —
+    // without this, the sqlite-importing files die mid-collection with a raw
+    // ERR_UNKNOWN_BUILTIN_MODULE (oss#257). See the setup file's header.
+    globalSetup: ["./src/__test-utils__/vitest-global-setup.ts"],
     // Several suites drive REAL bash/git subprocesses (the approval hook, the git
     // snapshot/restore capture). Under full file-parallelism these legitimately
     // exceed the 5s default when the CPU is saturated, so give subprocess tests


### PR DESCRIPTION
## Summary

Closes the two remnants of #257 that later sessions had not already covered (the runner boot preflight shipped with the oss#307 fix; the CI Node pin shipped with oss#323):

- **Fail-fast test-suite gate**: a new vitest `globalSetup` (`src/__test-utils__/vitest-global-setup.ts`) reuses `preflightNodeRuntime()` from `src/preflight.ts` and refuses to run the suite on a Node without `node:sqlite` — one immediate, actionable error (diagnosis verbatim from the preflight, plus a `fix:` hint naming `.nvmrc` and `NODE_OPTIONS=--experimental-sqlite`) instead of three files dying mid-collection with a raw `ERR_UNKNOWN_BUILTIN_MODULE` while the rest of the suite grinds on. Every suite entry point (`npm test`, `make test-runner`, `ci.runner.yaml`) funnels through the one config, so one gate covers them all.
- **Honest `engines.node`**: `>=22.13` → `"^22.13.0 || >=23.4.0"`. The old range admitted Node 23.0–23.3, which lack `node:sqlite` unflagged — the exact gap behind oss#307. A drift pin in `preflight.test.ts` ties the range byte-for-byte to the preflight's documented floors so it cannot silently re-loosen.

**Design choice — fail the whole suite, don't skip the sqlite tests**: a Node that cannot load `node:sqlite` cannot run the runner at all; a green-with-skips suite there would be a false signal. The gate is a capability probe, not a version check: on flag-gated Nodes (22.5–22.12, 23.0–23.3) `NODE_OPTIONS=--experimental-sqlite` satisfies it and the suite runs (workers inherit `NODE_OPTIONS`).

**Consumer-visible effect, stated deliberately**: `@stigmer/runner` is a published npm package, so the tightened range ships to consumers. npm/pnpm warn only; **yarn hard-blocks install on Node 23.0–23.3** (it enforces engines by default) — the correct outcome, since that Node today installs fine and then fails later and worse, at boot, via the preflight.

Considered and rejected: tightening the CLI's engines (the CLI itself runs fine on 23.0–23.3; its runner-launch path already probes with an actionable error and a `STIGMER_NODE_BIN` escape hatch), and `.npmrc engine-strict` (hard-fails installs for any engines mismatch — too blunt for this class).

## Verification

- **Positive**: full suite on Node 22.22.1 (the `.nvmrc` pin): **4414 passed / 6 skipped / 0 failed, exit 0** (one unhandled `onTaskUpdate` reporter-RPC timeout of the documented load-flake class; did not affect the result). `tsc --noEmit` clean on both tsconfigs.
- **Negative control, on the issue's real repro environment**: suite run under Node **v23.1.0** (sqlite-less) exits **1** with the single gate error — the raw `ERR_UNKNOWN_BUILTIN_MODULE` no longer appears anywhere in the output.
- **Escape hatch proven**: same Node 23.1.0 with `NODE_OPTIONS=--experimental-sqlite` passes the gate; preflight + gate suites 10/10 green there (includes the new drift pin and both gate arms, which are pinned around an injected probe).

Closes #257

Made with [Cursor](https://cursor.com)