### PR TITLE
fix(runner): rebuild full turn context when a fresh agent replaces a lost Cursor HITL resume

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
@@ -14,7 +14,7 @@ import { ApprovalAction, InteractionMode } from "@stigmer/protos/ai/stigmer/agen
 import { PendingApprovalSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
 import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 
-import { buildPrompt, isHitlReinvocation } from "../index.js";
+import { appendStructuredOutputDirective, buildPrompt, isHitlReinvocation, primarySendCarriesImages } from "../index.js";
 import type { BuildPromptInput } from "../index.js";
 import { buildReinvocationPrompt, formatInteractionModePrefix, formatImplementPlanSection, formatToolApprovalProtocol, buildToolApprovalRuleFile } from "../prompt-builder.js";
 import { PLAN_MODE_DIRECTIVE } from "../../../shared/plan-mode-prompt.js";
@@ -255,7 +255,7 @@ describe("buildPrompt", () => {
   });
 });
 
-describe("isHitlReinvocation (the single discriminator for message-accompanied payloads)", () => {
+describe("isHitlReinvocation (paired with resolution.reason at every consumer — issue #366)", () => {
   it("is false with no decisions and false with an empty map", () => {
     expect(isHitlReinvocation(undefined)).toBe(false);
     expect(isHitlReinvocation(new Map())).toBe(false);
@@ -265,6 +265,115 @@ describe("isHitlReinvocation (the single discriminator for message-accompanied p
     expect(
       isHitlReinvocation(new Map([["tc-1", ApprovalAction.APPROVE]])),
     ).toBe(true);
+  });
+});
+
+describe("HITL recovery — fresh agent mid-HITL (issue #366)", () => {
+  const decisions = () =>
+    new Map<string, ApprovalAction>([["tool-call-1", ApprovalAction.APPROVE]]);
+  const approvals = () => [
+    create(PendingApprovalSchema, {
+      toolCallId: "tool-call-1",
+      toolName: "Write",
+      message: "Write file: gated.txt",
+    }),
+  ];
+  const recoveryInput = (overrides: Partial<BuildPromptInput> = {}) =>
+    input({
+      resolution: resolution("local", "created_after_resume_failure"),
+      approvalDecisions: decisions(),
+      pendingApprovals: approvals(),
+      ...overrides,
+    });
+
+  it("keeps the resumed-HITL prompt byte-identical to the bare reinvocation prompt (regression guard)", () => {
+    const prompt = buildPrompt(
+      input({
+        resolution: resolution("local", "resumed_successfully"),
+        approvalDecisions: decisions(),
+        pendingApprovals: approvals(),
+      }),
+    );
+    expect(prompt).toBe(buildReinvocationPrompt(approvals(), decisions()));
+  });
+
+  it("rebuilds full context for a fresh agent mid-HITL: instructions, the ORIGINAL user message, the state-loss disclosure, and the decisions", () => {
+    const prompt = buildPrompt(recoveryInput());
+    // The pre-fix failure mode: bare decisions with no story.
+    expect(prompt).not.toBe(buildReinvocationPrompt(approvals(), decisions()));
+    expect(prompt).toContain("<agent_instructions>");
+    expect(prompt).toContain("<tool_approval_protocol>");
+    expect(prompt).toContain(`<user_request>\n${USER_MESSAGE}\n</user_request>`);
+    expect(prompt).toContain("<turn_recovery>");
+    expect(prompt).toContain("Write file: gated.txt");
+    expect(prompt).toContain("APPROVED");
+    // The opaque tool-call id must not leak into the prompt (reinvocation rule).
+    expect(prompt).not.toContain("tool-call-1");
+  });
+
+  it("orders the recovery chronologically: request, then the recovered work, then the decisions, ending on the continue directive", () => {
+    const prompt = buildPrompt(
+      recoveryInput({ turnRecoveryDigest: "Tool: Write file: draft.txt — completed" }),
+    );
+    const requestIdx = prompt.indexOf("<user_request>");
+    const recoveryIdx = prompt.indexOf("<turn_recovery>");
+    const decisionsIdx = prompt.indexOf("APPROVED");
+    expect(requestIdx).toBeGreaterThan(-1);
+    expect(recoveryIdx).toBeGreaterThan(requestIdx);
+    expect(decisionsIdx).toBeGreaterThan(recoveryIdx);
+    expect(prompt).toContain("Tool: Write file: draft.txt — completed");
+    expect(prompt.trimEnd().endsWith("do not ask the user for permission in prose.")).toBe(true);
+  });
+
+  it("discloses the state loss even with NO transcript — otherwise the decisions read as reactions to proposals this agent never made", () => {
+    const prompt = buildPrompt(recoveryInput({ turnRecoveryDigest: undefined }));
+    expect(prompt).toContain("<turn_recovery>");
+    expect(prompt).toContain("no transcript of your progress is available");
+  });
+
+  it("preserves already-applied semantics: exact-applied writes are described as done, not as work to redo", () => {
+    const prompt = buildPrompt(
+      recoveryInput({ appliedToolCallIds: new Set(["tool-call-1"]) }),
+    );
+    expect(prompt).toContain("ALREADY applied");
+    expect(prompt).not.toContain("Carry them out now");
+  });
+
+  it("carries the session-standing context a first turn would get — the replacement agent inherits the whole story, not just the blueprint", () => {
+    const prompt = buildPrompt(
+      recoveryInput({ contextBridge: "User: earlier thread\nAssistant: earlier reply" }),
+    );
+    expect(prompt).toContain("<previous_conversation_context>");
+    expect(prompt).toContain("User: earlier thread");
+  });
+
+  it("selects the recovery shape for ANY non-resumed reason — decisions-only is safe only when native context is guaranteed", () => {
+    // created_first_execution + decisions cannot happen in practice
+    // (decisions are reconstructed from a persisted transcript, which
+    // implies a prior invocation) — but if it ever did, the bare decisions
+    // prompt would reproduce the #366 amnesia. Fail safe.
+    const prompt = buildPrompt(
+      recoveryInput({ resolution: resolution("local", "created_first_execution") }),
+    );
+    expect(prompt).toContain("<turn_recovery>");
+    expect(prompt).toContain("<agent_instructions>");
+  });
+
+  it("primary send skips images ONLY for a resumed HITL agent (which holds them natively); every fresh agent gets the re-delivery", () => {
+    expect(primarySendCarriesImages(decisions(), "resumed_successfully")).toBe(false);
+    // The #366 vision corollary: fresh agent mid-HITL after a
+    // resolution-time resume failure.
+    expect(primarySendCarriesImages(decisions(), "created_after_resume_failure")).toBe(true);
+    // Non-HITL turns always carry the message's images, resumed or not.
+    expect(primarySendCarriesImages(undefined, "resumed_successfully")).toBe(true);
+    expect(primarySendCarriesImages(undefined, "created_first_execution")).toBe(true);
+  });
+
+  it("the structured-output directive is a pure append shared by the primary and recovery sends — absent schema, absent suffix", () => {
+    expect(appendStructuredOutputDirective("base", undefined)).toBe("base");
+    const withSchema = appendStructuredOutputDirective("base", { type: "object" });
+    expect(withSchema.startsWith("base\n\n---\nCRITICAL OUTPUT REQUIREMENT:")).toBe(true);
+    expect(withSchema).toContain('"type": "object"');
   });
 });
 

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/turn-recovery.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/turn-recovery.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the turn-recovery digest (issue #366).
+ *
+ * The digest is the replacement agent's only account of the work its lost
+ * predecessor did, so these pins cover the three doctrine properties it
+ * inherits from the DD-013 bridge composer — bounded lines, drop-oldest
+ * budget enforcement with disclosure, never-throw — plus the rendering
+ * contract per message/tool-call kind.
+ */
+
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import {
+  AgentMessageSchema,
+  ToolCallSchema,
+  type AgentMessage,
+  type ToolCall,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { MessageType, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import { composeTurnRecoveryDigest, formatTurnRecoveryText } from "../turn-recovery.js";
+
+function aiMessage(content: string, toolCalls: ToolCall[] = []): AgentMessage {
+  return create(AgentMessageSchema, { type: MessageType.MESSAGE_AI, content, toolCalls });
+}
+
+type ToolCallFields = Partial<
+  Pick<ToolCall, "name" | "argsPreview" | "approvalMessage" | "status" | "error">
+>;
+
+function toolCall(overrides: ToolCallFields): ToolCall {
+  return create(ToolCallSchema, {
+    id: "tc-1",
+    name: "Shell",
+    status: ToolCallStatus.TOOL_CALL_COMPLETED,
+    ...overrides,
+  });
+}
+
+describe("composeTurnRecoveryDigest", () => {
+  it("renders assistant text and tool calls oldest-first", () => {
+    const digest = composeTurnRecoveryDigest([
+      aiMessage("Let me check the config first.", [
+        toolCall({ name: "Read", argsPreview: '{"path":"config.yaml"}' }),
+      ]),
+      aiMessage("The port is wrong — fixing it."),
+    ]);
+    expect(digest).toBe(
+      [
+        "Assistant: Let me check the config first.",
+        'Tool: Read({"path":"config.yaml"}) — completed',
+        "Assistant: The port is wrong — fixing it.",
+      ].join("\n"),
+    );
+  });
+
+  it("prefers the resolved approval message for a tool line — the same description the user approved against", () => {
+    const digest = composeTurnRecoveryDigest([
+      aiMessage("", [
+        toolCall({
+          approvalMessage: "Write file: gated.txt",
+          argsPreview: '{"path":"gated.txt","content":"..."}',
+          status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+        }),
+      ]),
+    ]);
+    expect(digest).toBe("Tool: Write file: gated.txt — paused for user approval");
+  });
+
+  it("maps each terminal status honestly and treats in-flight calls as interrupted", () => {
+    const digest = composeTurnRecoveryDigest([
+      aiMessage("", [
+        toolCall({ name: "A", status: ToolCallStatus.TOOL_CALL_COMPLETED }),
+        toolCall({ name: "B", status: ToolCallStatus.TOOL_CALL_FAILED, error: "exit 1" }),
+        toolCall({ name: "C", status: ToolCallStatus.TOOL_CALL_FAILED }),
+        toolCall({ name: "D", status: ToolCallStatus.TOOL_CALL_SKIPPED }),
+        toolCall({ name: "E", status: ToolCallStatus.TOOL_CALL_RUNNING }),
+        toolCall({ name: "F", status: ToolCallStatus.TOOL_CALL_PENDING }),
+      ]),
+    ]);
+    expect(digest).toBe(
+      [
+        "Tool: A — completed",
+        "Tool: B — failed: exit 1",
+        "Tool: C — failed",
+        "Tool: D — skipped",
+        "Tool: E — interrupted before it finished",
+        "Tool: F — interrupted before it finished",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps system notices but skips human messages (already in <user_request>), thinking, and blanks", () => {
+    const digest = composeTurnRecoveryDigest([
+      create(AgentMessageSchema, { type: MessageType.MESSAGE_HUMAN, content: "Fix the build" }),
+      create(AgentMessageSchema, { type: MessageType.MESSAGE_SYSTEM, content: "Budget warning: 80% used" }),
+      create(AgentMessageSchema, { type: MessageType.MESSAGE_THINKING, content: "hmm, maybe the lockfile" }),
+      aiMessage("   "),
+    ]);
+    expect(digest).toBe("System: Budget warning: 80% used");
+  });
+
+  it("returns undefined when nothing renders", () => {
+    expect(composeTurnRecoveryDigest([])).toBeUndefined();
+    expect(
+      composeTurnRecoveryDigest([
+        create(AgentMessageSchema, { type: MessageType.MESSAGE_HUMAN, content: "only the request" }),
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("truncates a long assistant line at the per-line budget with an ellipsis", () => {
+    const digest = composeTurnRecoveryDigest([aiMessage("x".repeat(1000))]);
+    expect(digest).toBe(`Assistant: ${"x".repeat(400)}\u2026`);
+  });
+
+  it("drops the OLDEST lines when over the whole-digest budget and discloses the omission", () => {
+    // 30 lines of ~311 chars each (~9.6k total) against the 4000-char budget:
+    // the newest lines must survive, the oldest go, and the notice leads.
+    const messages = Array.from({ length: 30 }, (_, i) =>
+      aiMessage(`step ${String(i).padStart(2, "0")} ${"y".repeat(300)}`),
+    );
+    const digest = composeTurnRecoveryDigest(messages);
+    expect(digest).toBeDefined();
+    expect(digest!.length).toBeLessThanOrEqual(4000);
+    const lines = digest!.split("\n");
+    expect(lines[0]).toBe("[\u2026 earlier activity in this turn omitted for length]");
+    // Recency wins: the last line is the newest entry, the first entries are gone.
+    expect(lines[lines.length - 1]).toContain("step 29");
+    expect(digest).not.toContain("step 00");
+  });
+
+  it("never throws — a malformed message degrades to no digest, not a failed recovery", () => {
+    // Force the internal iteration to blow up: content getter that throws.
+    const poison = new Proxy(aiMessage("ok"), {
+      get(target, prop, receiver) {
+        if (prop === "content") throw new Error("corrupt row");
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    expect(composeTurnRecoveryDigest([poison as AgentMessage])).toBeUndefined();
+  });
+});
+
+describe("formatTurnRecoveryText", () => {
+  it("frames a digest with the work-already-done preamble", () => {
+    const text = formatTurnRecoveryText("Assistant: did things");
+    expect(text).toContain("session holding that conversation was lost");
+    expect(text).toContain("do not start the task over");
+    expect(text.endsWith("Assistant: did things")).toBe(true);
+  });
+
+  it("still discloses the state loss when there is no transcript — without it the appended decisions would read as reactions to proposals this agent never made", () => {
+    for (const empty of [undefined, "", "   "]) {
+      const text = formatTurnRecoveryText(empty);
+      expect(text).toContain("session holding that conversation was lost");
+      expect(text).toContain("no transcript of your progress is available");
+    }
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -41,7 +41,7 @@ import type { Config } from "../../config.js";
 import { StigmerClient } from "../../client/stigmer-client.js";
 import { describeExecutionError } from "../../shared/model-error.js";
 import { resolveAgentWithTransportRecovery } from "./session-lifecycle.js";
-import type { AgentResolution, CreateAgentOptions, CreateCloudAgentOptions } from "./session-lifecycle.js";
+import type { AgentResolution, AgentResolutionReason, CreateAgentOptions, CreateCloudAgentOptions } from "./session-lifecycle.js";
 import { CursorMode } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
 import { determineCursorMode, isCloudMode } from "./cursor-mode.js";
 import { MessageAccumulator, cancelInProgressSubAgentProtos, collapseRedundantToolCallTwins } from "./message-translator.js";
@@ -92,7 +92,8 @@ import { buildCursorSubAgentDefinitions } from "./subagent-config.js";
 import { resolveSkills } from "./skill-resolver.js";
 import { removeStigmerSymlink } from "../../shared/workspace/stigmer-link.js";
 import { resolveAttachments } from "./attachment-resolver.js";
-import { buildEnhancedPrompt, buildReinvocationPrompt, formatConversationCatchupSection, formatInputFiles, formatInteractionModePrefix, formatImplementPlanSection } from "./prompt-builder.js";
+import { buildEnhancedPrompt, buildHitlRecoveryPrompt, buildReinvocationPrompt, formatConversationCatchupSection, formatInputFiles, formatInteractionModePrefix, formatImplementPlanSection } from "./prompt-builder.js";
+import { composeTurnRecoveryDigest } from "./turn-recovery.js";
 import { installHitlGate, removeHitlGate } from "./workspace-setup.js";
 import { ensureHitlDir } from "../../shared/workspace/platform-dir.js";
 import {
@@ -1161,28 +1162,43 @@ async function executeCursorInner(
       senderIdentity: readSenderIdentity(blueprint.sessionSpec.metadata),
       sessionContext: readSessionContext(blueprint.sessionSpec.metadata),
       conversationCatchup: readConversationCatchup(spec.conversationCatchup),
+      // The turn's recorded transcript, seeded from the persisted execution
+      // on a reinvocation (Phase 3). Consumed only by the HITL-recovery
+      // shape — reached from HERE when the stored handle failed to resume
+      // at resolution time (issue #366 crossing 2).
+      turnRecoveryDigest: isReinvocation
+        ? composeTurnRecoveryDigest(status.messages)
+        : undefined,
     });
 
-    // Phase 10a: Inject structured output instruction for Cursor harness
-    let effectivePrompt = prompt;
-    if (structuredOutputSchema) {
-      const schemaStr = JSON.stringify(structuredOutputSchema, null, 2);
-      effectivePrompt += `\n\n---\nCRITICAL OUTPUT REQUIREMENT:\nYour final response MUST be a single valid JSON object (no markdown, no commentary, no code fences) that matches this schema:\n${schemaStr}\n\nRespond with ONLY the JSON object. Nothing else.`;
-    }
+    // Phase 10a: Inject the structured output instruction for the Cursor
+    // harness. A per-turn directive, so like buildFromPlan it must ride every
+    // prompt this turn sends — the primary AND the poisoned-handle recovery
+    // rebuild (the transport retry re-sends effectivePrompt and inherits it).
+    const withStructuredOutputDirective = (basePrompt: string): string =>
+      appendStructuredOutputDirective(basePrompt, structuredOutputSchema);
+    const effectivePrompt = withStructuredOutputDirective(prompt);
 
     // Phase 10a1: The turn's vision payload. The invariant is "images
-    // accompany the user's turn message — where the message goes, they go":
-    // every send that delivers this turn's message carries them (the primary
-    // send and both fresh-agent recovery retries, whose empty conversations
-    // genuinely need the re-send), while a HITL re-invocation — whose prompt
-    // carries no user message and whose resumed agent already holds the
-    // images in its native conversation — carries none. Computed ONCE here so
-    // all send sites agree by construction.
-    const turnImages = isHitlReinvocation(approvalDecisions)
-      ? []
-      : toCursorImages(visionImages);
-    const toSendMessage = (sendPrompt: string): string | SDKUserMessage =>
-      turnImages.length > 0 ? { text: sendPrompt, images: turnImages } : sendPrompt;
+    // accompany the user's turn message, wherever the conversation does not
+    // already hold them" (primarySendCarriesImages): the ONLY send that
+    // skips them is a HITL re-invocation of a successfully RESUMED agent,
+    // whose native conversation carries the images from the original send.
+    // Every send that starts an empty conversation re-delivers them — the
+    // ordinary first/fresh-agent primary send, the HITL primary send after a
+    // resolution-time resume failure, and both mid-send recovery retries
+    // (which always run on a fresh agent, so their sites pass turnImages
+    // unconditionally). Attachments re-resolve on every invocation
+    // (Phase 5b), so the bytes are in hand even on a re-invocation.
+    const turnImages = toCursorImages(visionImages);
+    const primarySendImages = primarySendCarriesImages(approvalDecisions, resolution.reason)
+      ? turnImages
+      : [];
+    const toSendMessage = (
+      sendPrompt: string,
+      images: { data: string; mimeType: string }[],
+    ): string | SDKUserMessage =>
+      images.length > 0 ? { text: sendPrompt, images } : sendPrompt;
 
     // Phase 10a2: Log Stigmer preamble size for context trimming diagnostics
     const promptChars = effectivePrompt.length;
@@ -1298,7 +1314,7 @@ async function executeCursorInner(
     // The stall watchdog is armed inside consumeCursorTurnStream (it needs the
     // run to cancel), stored on turnState.stallWatchdog so this shared onDelta can
     // reset it and the activity's finally can stop it as a backstop.
-    const run = await resolution.agent.send(toSendMessage(effectivePrompt), {
+    const run = await resolution.agent.send(toSendMessage(effectivePrompt, primarySendImages), {
       onDelta: (event) => {
         if (!turnFirstEventEmitted) {
           turnFirstEventEmitted = true;
@@ -1669,10 +1685,11 @@ async function executeCursorInner(
       // poisoned-handle path leaked the fresh agent — it closed the stale one.)
       resolution = { ...resolution, agent: freshAgent, agentId: freshAgent.agentId, isNew: true };
       turnState.streamErrorMessage = undefined;
-      // The retry carries the turn's images too (same toSendMessage): the
-      // fresh agent's conversation is empty, so skipping them here would
-      // silently lose the user's photo on a recovered turn.
-      const retryRun = await freshAgent.send(toSendMessage(retryPrompt), {
+      // The retry always carries the turn's full image payload — never the
+      // primary send's HITL-trimmed set: the fresh agent's conversation is
+      // empty, so skipping them here would silently lose the user's photo on
+      // a recovered turn (issue #366's vision corollary).
+      const retryRun = await freshAgent.send(toSendMessage(retryPrompt, turnImages), {
         onDelta: makeCursorTurnOnDelta(onDeltaDeps),
       });
       await consumeCursorTurnStream(retryRun, streamDeps);
@@ -1812,6 +1829,10 @@ async function executeCursorInner(
             attachments: attachmentEntries,
             vision: visionPromptInfo,
             pendingApprovals: adjudicatedApprovals,
+            // Without the applied set, the HITL-recovery prompt would tell
+            // the fresh agent to carry out writes the runner already
+            // exact-applied (the primary call at Phase 10 passes it too).
+            appliedToolCallIds,
             interactionMode,
             // buildFromPlan was silently dropped here until T03 Sitting 3 —
             // a build turn that hit handle recovery lost its directive. The
@@ -1822,6 +1843,10 @@ async function executeCursorInner(
             senderIdentity: readSenderIdentity(blueprint.sessionSpec.metadata),
             sessionContext: readSessionContext(blueprint.sessionSpec.metadata),
             conversationCatchup: readConversationCatchup(spec.conversationCatchup),
+            // Composed fresh (not reused from Phase 10): the failed primary
+            // stream may have appended partial work onto status.messages,
+            // and the replacement agent should know about that too.
+            turnRecoveryDigest: composeTurnRecoveryDigest(status.messages),
           });
 
           console.log(
@@ -1837,7 +1862,14 @@ async function executeCursorInner(
             console.warn("Failed to update session with fresh agentId (non-fatal):", updateErr);
           }
 
-          const outcome = await runRecoveryStream(freshAgent, freshPrompt);
+          // Same per-turn directive rule as buildFromPlan above: a
+          // structured-output turn keeps its output contract on the rebuilt
+          // prompt (the transport retry re-sends effectivePrompt and
+          // inherits it without help).
+          const outcome = await runRecoveryStream(
+            freshAgent,
+            withStructuredOutputDirective(freshPrompt),
+          );
           if (!outcome.proceeded) {
             if (outcome.terminal.kind === "return") return slimStatus(status);
             throw new CancelledFailure(outcome.terminal.message);
@@ -2400,6 +2432,15 @@ export interface BuildPromptInput {
    * usually blank.
    */
   conversationCatchup?: string;
+  /**
+   * The turn's recorded transcript rendered as digest lines
+   * (turn-recovery.ts), composed from `status.messages` at the call site.
+   * Consumed ONLY by the HITL-recovery shape — a fresh agent that replaced
+   * a lost one mid-HITL needs the story of the work it no longer remembers
+   * (issue #366); every other shape either has native context or no prior
+   * work to tell.
+   */
+  turnRecoveryDigest?: string;
 }
 
 /**
@@ -2411,25 +2452,66 @@ export interface BuildPromptInput {
  * volume, or cloud server-side state) — there is no separate continuation
  * store. The prompt therefore depends only on how the agent was resolved:
  *
- * 1. HITL reinvocation        -> buildReinvocationPrompt (approval decisions;
- *                                 the resumed agent's native context carries
- *                                 the prior conversation)
- * 2. resumed_successfully      -> raw userMessage (native context carries it)
- * 3. first execution / fresh   -> buildEnhancedPrompt (full instructions +
+ * 1. HITL reinvocation,        -> buildReinvocationPrompt (approval decisions
+ *    resumed agent                 only; the resumed agent's native context
+ *                                  carries the prior conversation)
+ * 2. HITL reinvocation,        -> buildHitlRecoveryPrompt (full context +
+ *    fresh agent after            the turn's recorded transcript + decisions;
+ *    resume failure               the replacement agent's conversation is
+ *                                 empty, and both fresh-agent crossings —
+ *                                 resolution-time resume failure and mid-send
+ *                                 poisoned-handle recovery — land here by
+ *                                 keying on the reason, issue #366)
+ * 3. resumed_successfully      -> raw userMessage (native context carries it)
+ * 4. first execution / fresh   -> buildEnhancedPrompt (full instructions +
  *    agent after resume failure   skills; no prior conversation to inherit)
  */
 /**
  * Whether this activity invocation is a HITL re-invocation — the turn resumes
  * an agent purely to convey approval decisions, carrying NO user message.
- * The single discriminator for everything that must ride with the user's
- * message and nothing else: the reinvocation prompt shape (below) and the
- * vision payload (images accompany the message; a resumed agent already holds
- * them in its native conversation).
+ * Discriminates the two surfaces that depend on the agent already holding
+ * this turn's content natively — the prompt shape (below) and the primary
+ * send's vision payload — but never alone: both pair it with
+ * `resolution.reason`, because a FRESH agent mid-HITL holds nothing and
+ * needs the full re-delivery (issue #366).
  */
 export function isHitlReinvocation(
   approvalDecisions: Map<string, ApprovalAction> | undefined,
 ): approvalDecisions is Map<string, ApprovalAction> {
   return approvalDecisions !== undefined && approvalDecisions.size > 0;
+}
+
+/**
+ * Whether the PRIMARY send delivers the turn's vision payload. The invariant
+ * is "images accompany the user's turn message, wherever the conversation
+ * does not already hold them" — so the only send that skips them is a HITL
+ * re-invocation of a successfully RESUMED agent, whose native conversation
+ * carries the images from the original send. A fresh agent mid-HITL
+ * (resolution-time resume failure — issue #366's vision corollary) holds
+ * nothing and needs the re-delivery. The mid-send recovery retries always
+ * run on a fresh agent, so their send sites carry the payload
+ * unconditionally rather than consulting this.
+ */
+export function primarySendCarriesImages(
+  approvalDecisions: Map<string, ApprovalAction> | undefined,
+  reason: AgentResolutionReason,
+): boolean {
+  return !(isHitlReinvocation(approvalDecisions) && reason === "resumed_successfully");
+}
+
+/**
+ * Append the structured-output contract to a prompt when the execution
+ * requests one. A per-turn directive (the buildFromPlan rule): it must ride
+ * every prompt this turn sends — the primary send AND the poisoned-handle
+ * recovery rebuild, which previously lost it (issue #366 ride-along).
+ */
+export function appendStructuredOutputDirective(
+  basePrompt: string,
+  schema: Record<string, unknown> | undefined,
+): string {
+  if (!schema) return basePrompt;
+  const schemaStr = JSON.stringify(schema, null, 2);
+  return basePrompt + `\n\n---\nCRITICAL OUTPUT REQUIREMENT:\nYour final response MUST be a single valid JSON object (no markdown, no commentary, no code fences) that matches this schema:\n${schemaStr}\n\nRespond with ONLY the JSON object. Nothing else.`;
 }
 
 export function buildPrompt(input: BuildPromptInput): string {
@@ -2448,10 +2530,44 @@ export function buildPrompt(input: BuildPromptInput): string {
     conversationCatchup,
   } = input;
 
-  // HITL reinvocation: the agent is resumed, so its native context carries the
-  // prior conversation; the reinvocation prompt conveys the approval decisions
-  // (and which approved writes the runner already exact-applied).
+  // HITL reinvocation: the decisions-only prompt is correct ONLY while the
+  // agent's native context still carries the prior conversation — which only
+  // resumed_successfully guarantees. Any other reason means a fresh agent
+  // mid-HITL (in practice created_after_resume_failure: the stored handle
+  // failed to resume, or a poisoned handle was replaced mid-send), which
+  // gets the full recovery shape instead — enhanced context + the turn's
+  // recorded transcript + the same decisions — because the bare decisions on
+  // an empty conversation strand the agent with instructions and no story,
+  // and the session inherits that amnesia permanently (issue #366).
   if (isHitlReinvocation(approvalDecisions)) {
+    if (resolution.reason !== "resumed_successfully") {
+      return buildHitlRecoveryPrompt(
+        {
+          instructions,
+          userMessage,
+          skills,
+          datastoreUsages: input.datastoreUsages ?? [],
+          channelMessaging: input.channelMessaging ?? [],
+          subAgents,
+          workspaceDirs,
+          workspaceFileRefs,
+          attachments,
+          vision: input.vision,
+          interactionMode,
+          buildFromPlan,
+          contextBridge: input.contextBridge,
+          senderIdentity: input.senderIdentity,
+          sessionContext: input.sessionContext,
+          conversationCatchup,
+        },
+        {
+          turnDigest: input.turnRecoveryDigest,
+          pendingApprovals: input.pendingApprovals,
+          approvalDecisions,
+          appliedToolCallIds: input.appliedToolCallIds,
+        },
+      );
+    }
     return buildReinvocationPrompt(
       input.pendingApprovals,
       approvalDecisions,

--- a/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
@@ -36,6 +36,7 @@ import {
   visionDisclosureLines,
   type NotViewableEntry,
 } from "../../shared/attachment-vision.js";
+import { formatTurnRecoveryText } from "./turn-recovery.js";
 import { PLAN_MODE_DIRECTIVE } from "../../shared/plan-mode-prompt.js";
 import {
   buildImplementPlanDirective,
@@ -336,6 +337,56 @@ export function buildReinvocationPrompt(
   );
 
   return parts.join("\n\n");
+}
+
+/**
+ * Build the prompt for a fresh agent that replaced a lost one MID-HITL —
+ * the stored handle failed to resume when the approval landed, or the
+ * resumed handle proved poisoned mid-send (issue #366, both crossings).
+ *
+ * A resumed agent gets {@link buildReinvocationPrompt} alone because its
+ * native conversation carries everything else. A replacement agent's
+ * conversation is EMPTY, so the bare decisions prompt would strand it with
+ * instructions and no story — and, because recovery repoints the session at
+ * the new agent, every later turn would inherit that amnesia. This prompt
+ * rebuilds the whole story in chronological-narrative order:
+ *
+ * 1. the full enhanced prompt (blueprint, standing context, protocol, and
+ *    the turn's ORIGINAL user message as `<user_request>`),
+ * 2. `<turn_recovery>` — the state-loss disclosure plus the recorded
+ *    transcript of the turn so far (turn-recovery.ts; rendered even with no
+ *    transcript, since without the disclosure the decisions below would read
+ *    as reactions to proposals this agent never made),
+ * 3. the reinvocation decisions verbatim — already-applied / approved /
+ *    skipped semantics byte-identical to the resumed path, ending on its
+ *    "continue the task" directive.
+ *
+ * Appending past `<user_request>` is the chronology speaking (request →
+ * work done → decisions → continue), the same shape as the activity-level
+ * structured-output suffix.
+ */
+export function buildHitlRecoveryPrompt(
+  options: EnhancedPromptOptions,
+  recovery: {
+    turnDigest: string | undefined;
+    pendingApprovals: PendingApproval[];
+    approvalDecisions: Map<string, ApprovalAction>;
+    appliedToolCallIds?: ReadonlySet<string>;
+  },
+): string {
+  return [
+    buildEnhancedPrompt(options),
+    formatTurnRecoverySection(recovery.turnDigest),
+    buildReinvocationPrompt(
+      recovery.pendingApprovals,
+      recovery.approvalDecisions,
+      recovery.appliedToolCallIds,
+    ),
+  ].join("\n\n---\n\n");
+}
+
+export function formatTurnRecoverySection(digest: string | undefined): string {
+  return `<turn_recovery>\n${formatTurnRecoveryText(digest)}\n</turn_recovery>`;
 }
 
 /**

--- a/backend/services/runner/src/activities/execute-cursor/turn-recovery.ts
+++ b/backend/services/runner/src/activities/execute-cursor/turn-recovery.ts
@@ -1,0 +1,208 @@
+/**
+ * Turn-recovery digest: the platform's recorded transcript of the current
+ * turn, rendered as prompt context for a fresh agent that replaced one whose
+ * conversation state was lost mid-turn (issue #366).
+ *
+ * A HITL-paused turn can lose its agent two ways — the stored handle fails
+ * to resume when the approval lands, or the resumed handle turns out to be
+ * poisoned mid-send. Either way the replacement agent starts with an EMPTY
+ * conversation, so the approval decisions alone read as instructions with no
+ * story: the agent no longer knows what it was doing. This module rebuilds
+ * that story from `status.messages` — the persisted execution transcript
+ * seeded on every re-invocation — which is the platform's durable record of
+ * the turn AND exactly what the user watched happen (introspecting the dead
+ * agent's own conversation is best-effort at most; the handle is the thing
+ * that failed).
+ *
+ * Doctrine (mirrors `ChannelRolloverBridgeComposer`, cloud DD-013 — the
+ * platform's reference for conversation digests):
+ * - Content here, presentation framing separate: {@link composeTurnRecoveryDigest}
+ *   emits bare `Assistant:` / `Tool:` / `System:` lines;
+ *   {@link formatTurnRecoveryText} adds the behavioral preamble; the prompt
+ *   builder wraps the section tag (the context-bridge / conversation-catchup
+ *   split).
+ * - Oldest-first reading order; over budget, the OLDEST lines drop first
+ *   (recency wins) and the drop is disclosed.
+ * - Best-effort by contract: composition never throws — a failed digest
+ *   degrades to recovery-without-transcript, never a failed recovery.
+ *
+ * Scope: the CURRENT turn only. Prior turns live in other execution records
+ * and are not recoverable runner-side (that is the rollover bridge's domain,
+ * composed cloud-side); the enhanced prompt's standing-context sections carry
+ * whatever the session already had.
+ */
+
+import type { AgentMessage, ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { MessageType, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+/** Per-line text budget; longer texts are cut with an ellipsis (DD-013 twin). */
+const MAX_LINE_CHARS = 400;
+
+/**
+ * Args-preview budget inside a tool line — the `describeApproval` precedent
+ * (prompt-builder.ts), so tool renderings are bounded the same way on both
+ * surfaces that describe them.
+ */
+const MAX_ARGS_CHARS = 200;
+
+/**
+ * Whole-digest budget (DD-013 twin). Enforced by dropping the OLDEST lines
+ * first — recency wins, matching how a human skims their own recent work
+ * before continuing it.
+ */
+const MAX_DIGEST_CHARS = 4000;
+
+const ELLIPSIS = "\u2026";
+
+/** Disclosed in place of the dropped prefix so the record never lies by omission. */
+const OMISSION_NOTICE = `[${ELLIPSIS} earlier activity in this turn omitted for length]`;
+
+/**
+ * How the transcript is introduced to the model. Establishes the three facts
+ * the replacement agent must hold: the work below is its OWN (continue, don't
+ * restart), completed actions are DONE (don't redo them), and the workspace —
+ * not this summary — is the source of truth for exact current state.
+ */
+const TURN_RECOVERY_PREAMBLE =
+  "You had already started working on the user's request above, but the " +
+  "session holding that conversation was lost, so you do not remember it. " +
+  "Below is the platform's recorded transcript of your progress in this " +
+  "turn, oldest first. Treat it as work YOU already did: do not start the " +
+  "task over, do not redo actions shown as completed, and check the " +
+  "workspace's current state where exact details matter.";
+
+/**
+ * Fallback framing when the turn produced no renderable transcript (or
+ * composition failed): the state-loss disclosure still matters — without it,
+ * the appended approval decisions read as reactions to proposals this agent
+ * never made.
+ */
+const TURN_RECOVERY_NO_TRANSCRIPT =
+  "You had already started working on the user's request above, but the " +
+  "session holding that conversation was lost, so you do not remember it " +
+  "and no transcript of your progress is available. Check the workspace's " +
+  "current state to see what you already did before continuing.";
+
+/**
+ * Render the turn's persisted transcript as bare digest lines, or undefined
+ * when there is nothing worth carrying. Never throws.
+ *
+ * Human messages are skipped — the turn's user message is already rendered
+ * in the enhanced prompt's `<user_request>`, and duplicating it here would
+ * dilute the budget. Thinking content is skipped as model-internal (the
+ * replacement agent forms its own). System notices are kept: platform
+ * messages like budget warnings or degradation notices are turn context the
+ * agent acted under.
+ */
+export function composeTurnRecoveryDigest(
+  messages: readonly AgentMessage[],
+): string | undefined {
+  try {
+    const lines: string[] = [];
+    for (const message of messages) {
+      lines.push(...messageLines(message));
+    }
+    if (lines.length === 0) return undefined;
+
+    // Oldest-first; drop from the FRONT when over budget so the newest work
+    // always survives, and disclose the drop (DD-013 enforcement shape). The
+    // notice participates in the budget so the result never overshoots.
+    let first = 0;
+    while (first < lines.length && totalLength(lines, first) > MAX_DIGEST_CHARS) {
+      first++;
+    }
+    if (first >= lines.length) {
+      // Degenerate case: even the newest line alone busts the budget (it is
+      // already line-truncated, so this would take a pathological budget/line
+      // ratio) — keep that one line rather than rendering nothing.
+      first = lines.length - 1;
+    }
+    const kept = lines.slice(first);
+    if (first > 0) kept.unshift(OMISSION_NOTICE);
+    return kept.join("\n");
+  } catch (err) {
+    console.warn("Turn-recovery digest composition failed — recovering without a transcript:", err);
+    return undefined;
+  }
+}
+
+/**
+ * The framed recovery body (preamble + digest), ready for section wrapping.
+ * Accepts an absent digest: the state-loss disclosure is load-bearing even
+ * when there is no transcript to show (see {@link TURN_RECOVERY_NO_TRANSCRIPT}).
+ */
+export function formatTurnRecoveryText(digest: string | undefined): string {
+  if (digest === undefined || digest.trim() === "") {
+    return TURN_RECOVERY_NO_TRANSCRIPT;
+  }
+  return `${TURN_RECOVERY_PREAMBLE}\n\n${digest.trim()}`;
+}
+
+/** The digest lines one transcript message contributes (possibly none). */
+function messageLines(message: AgentMessage): string[] {
+  const lines: string[] = [];
+  const text = message.content.trim();
+  switch (message.type) {
+    case MessageType.MESSAGE_AI:
+      if (text) lines.push(`Assistant: ${truncate(text, MAX_LINE_CHARS)}`);
+      // Tool calls ride AI messages (message.proto contract); render them
+      // even when the surrounding text is blank.
+      for (const toolCall of message.toolCalls) {
+        lines.push(toolCallLine(toolCall));
+      }
+      return lines;
+    case MessageType.MESSAGE_SYSTEM:
+      if (text) lines.push(`System: ${truncate(text, MAX_LINE_CHARS)}`);
+      return lines;
+    default:
+      // Human (already in <user_request>), thinking (model-internal), tool
+      // results (each ToolCall line already carries its outcome), unknown.
+      return lines;
+  }
+}
+
+/**
+ * One bounded line per tool call: what was attempted and how it ended.
+ * Prefers the resolved approval message where one exists — the same
+ * human-meaningful description the user approved against
+ * (the `describeApproval` convention).
+ */
+function toolCallLine(toolCall: ToolCall): string {
+  const action = toolCall.approvalMessage
+    ? toolCall.approvalMessage
+    : toolCall.argsPreview
+      ? `${toolCall.name}(${truncate(toolCall.argsPreview, MAX_ARGS_CHARS)})`
+      : toolCall.name;
+  return `Tool: ${truncate(action, MAX_LINE_CHARS)} — ${outcome(toolCall)}`;
+}
+
+function outcome(toolCall: ToolCall): string {
+  switch (toolCall.status) {
+    case ToolCallStatus.TOOL_CALL_COMPLETED:
+      return "completed";
+    case ToolCallStatus.TOOL_CALL_FAILED:
+      return toolCall.error
+        ? `failed: ${truncate(toolCall.error, MAX_ARGS_CHARS)}`
+        : "failed";
+    case ToolCallStatus.TOOL_CALL_WAITING_APPROVAL:
+      return "paused for user approval";
+    case ToolCallStatus.TOOL_CALL_SKIPPED:
+      return "skipped";
+    default:
+      // PENDING / RUNNING / unknown: in flight when the session was lost.
+      return "interrupted before it finished";
+  }
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}${ELLIPSIS}`;
+}
+
+/** Joined length of lines[first..] plus the omission notice when one would render. */
+function totalLength(lines: readonly string[], first: number): number {
+  let total = first > 0 ? OMISSION_NOTICE.length + 1 : 0;
+  for (let i = first; i < lines.length; i++) {
+    total += lines[i].length + 1;
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary

Closes #366.

When a HITL-paused Cursor turn came back with the user's approval and a **fresh agent** had to stand in for the lost one, that agent received only the bare approval-decisions prompt — no instructions, no user request, no record of the turn's work. And because recovery repoints `sessionSpec.harnessStateId` at the replacement, every later turn resumed the amnesiac: the damage was session-permanent, not one bad turn.

The issue described the mid-send poisoned-handle double failure. Planning found a **second, single-failure crossing** it missed: `resolveAgent` returns `created_after_resume_failure` at resolution time when the stored handle cannot resume — plausible whenever an approval lands long after the pause. Both crossings flowed through the same `buildPrompt` HITL early-return, which never consulted `resolution.reason`.

### The fix

- **`buildPrompt`**: the decisions-only shape now requires `resumed_successfully` — the only case whose native context makes it safe. Any fresh agent mid-HITL gets **`buildHitlRecoveryPrompt`**: the full enhanced prompt (blueprint, standing context, the turn's ORIGINAL user message), a new `<turn_recovery>` section, then the decisions text byte-identical to the resumed path. Keying on the reason inside `buildPrompt` covers both crossings with one branch (pinned).
- **`turn-recovery.ts` (new)**: renders the turn's persisted transcript (`status.messages` — the platform's durable record, and exactly what the user watched) as a bounded digest following the DD-013 bridge-composer doctrine: bare `Assistant:`/`Tool:`/`System:` lines, oldest-first, drop-oldest-first at the 400/4000-char budgets with the omission disclosed, never-throw (a failed digest degrades to recovery-without-transcript, never a failed recovery). The state-loss disclosure renders even with no transcript, so the decisions never read as reactions to proposals the agent never made.

### Three sibling drops on the same path, fixed in-PR

- **`appliedToolCallIds`** never reached the recovery prompt — exact-applied writes would have been described as work to redo.
- **Vision**: the turn's images were dropped for every fresh agent in a HITL turn (computed once, send-site-blind). Corrected invariant: images accompany the turn's message wherever the conversation does not already hold them (`primarySendCarriesImages`); recovery sends carry them unconditionally.
- **Structured output**: the recovery rebuild lost the output contract (only the primary and transport-retry prompts had it). Extracted `appendStructuredOutputDirective`, shared by both sends.

### Verified non-issues

- The transport-timeout retry is unreachable on HITL turns (`reason !== "resumed_successfully"` gate).
- Exact-apply and approval grants are workspace/hook-level and agent-agnostic — approved actions flow correctly for the fresh agent; the prompt layer was the only broken piece.
- The deep-agent harness has **no twin**: a lost checkpointer at HITL resume falls back to the turn's original user message by design (replay degradation, never bare-decisions amnesia).

## Test plan

- [x] New `turn-recovery.test.ts` (10): rendering contract per message/tool kind, per-line + whole-digest budgets, drop-oldest disclosure, never-throw via poisoned Proxy.
- [x] `build-prompt.test.ts` +9 pins: recovery shape (instructions + original message + digest + decisions), chronological ordering ending on the continue directive, **byte-identical resumed-HITL regression guard**, already-applied semantics, no-transcript disclosure, fail-safe for any non-resumed reason, `primarySendCarriesImages` / `appendStructuredOutputDirective` rules.
- [x] Full execute-cursor suite: 43 files / 717 tests green.
- [x] Full runner suite: all failures attributed — known node:sqlite pair on local Node v23.1.0 (13/13 under `--experimental-sqlite`; CI pins Node 22 via `.nvmrc`) + 8 load-flake files 162/162 green in isolation.
- [x] `tsc --noEmit` clean.

Made with [Cursor](https://cursor.com)