### PR TITLE
fix(sdk/react): invoke the Tailwind CLI via node, not npx — Windows spawn dies silently

### DIFF
--- a/sdk/react/scripts/build-styles.ts
+++ b/sdk/react/scripts/build-styles.ts
@@ -24,6 +24,7 @@
 
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import postcss from "postcss";
@@ -32,11 +33,20 @@ import { scopeUnprefixedSelectors } from "./lib/scope-unprefixed.js";
 const sdkRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const distFile = join(sdkRoot, "dist", "styles.css");
 
+// Invoke the Tailwind CLI's JS entry with the current Node binary rather than
+// `npx`: on Windows `npx` is a `.cmd` shim that Node refuses to spawn without
+// a shell (CVE-2024-27980 hardening), which killed release builds silently.
+const require = createRequire(import.meta.url);
+const cliPkgPath = require.resolve("@tailwindcss/cli/package.json");
+const cliPkg = require(cliPkgPath) as { bin: { tailwindcss: string } };
+const tailwindCli = join(dirname(cliPkgPath), cliPkg.bin.tailwindcss);
+
 const cli = spawnSync(
-  "npx",
-  ["tailwindcss", "-i", "src/styles.css", "-o", "dist/styles.css", "--minify"],
+  process.execPath,
+  [tailwindCli, "-i", "src/styles.css", "-o", "dist/styles.css", "--minify"],
   { cwd: sdkRoot, stdio: "inherit" },
 );
+if (cli.error) throw cli.error;
 if (cli.status !== 0) process.exit(cli.status ?? 1);
 
 const root = postcss.parse(readFileSync(distFile, "utf8"));


### PR DESCRIPTION
## Summary
Makes `sdk/react/scripts/build-styles.ts` invoke the Tailwind CLI's JS entry point directly with the current Node binary instead of shelling out to `npx`, so the stylesheet build works on Windows.

## Context
The v3.11.0 tag release ([run 31564122055](https://github.com/stigmer/stigmer/actions/runs/31564122055)) failed on the Windows build, twice, with no diagnostics: `tsc` passed, then the step exited 1 in silence. Root cause: on Windows `npx` is a `.cmd` shim, and Node refuses to spawn `.cmd`/`.bat` files without a shell (CVE-2024-27980 hardening). `spawnSync("npx", ...)` therefore fails before launching anything, leaving `cli.status` null, and the script exited via `process.exit(null ?? 1)` without ever surfacing `cli.error`. The script is new since #471, so this tag was the first release build to hit it (main pushes skip the build matrix entirely).

## Changes
- Resolve `@tailwindcss/cli`'s bin script via `createRequire` + its `package.json` `bin` field and run it with `process.execPath` — no shell, no platform-specific shims, works identically on all three OSes.
- Throw `cli.error` when the spawn itself fails, so a launch failure can never again exit silently.

## Breaking changes
- None. The produced `dist/styles.css` is unchanged; only how the Tailwind CLI is launched differs.

## Test plan
- `npm run build -w @stigmer/react` passes locally (macOS) and writes `dist/styles.css`.
- `npx vitest run src/__tests__/styles-dist-isolation.test.ts` — 4/4 pass, so the output contract holds.
- Windows verification happens on the next tag release, which is the only place the build matrix runs.

## Risks
- Low: if `@tailwindcss/cli` restructures its `bin` field the resolution breaks, but that now fails loudly instead of silently.

Made with [Cursor](https://cursor.com)