### PR TITLE
fix(server): create pipelines now honor defaults_to_org_visibility

### DIFF
--- a/backend/libs/go/grpc/request/pipeline/steps/defaults.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/defaults.go
@@ -30,8 +30,23 @@ import (
 //     - updated_at (timestamp)
 //     - event (ApiResourceEventType.created)
 //     - Both spec_audit and status_audit are set identically for create operations
+//  6. Set metadata.visibility to the kind's default when the client left it
+//     unspecified, so consumers never have to treat UNSPECIFIED as an implicit
+//     level. The default is config-driven via the kind's proto VisibilityConfig
+//     (apiresource.DefaultVisibilityFor): blueprint kinds flagged
+//     defaults_to_org_visibility (agent, skill, workflow, mcp_server) get
+//     visibility_org — blueprints are shared org assets, and a private default
+//     would silently hide every new blueprint from the author's teammates once
+//     visibility enforcement is real; private is an explicit opt-in. Every
+//     other kind gets visibility_private. This mirrors the cloud edition,
+//     where CreateOperationBuildNewStateStepV2 composes
+//     CreateOperationSetDefaultVisibilityStepV2 for every kind's create; the
+//     cross-edition contract is pinned by TestVisibilityCreateDefaults
+//     (test/integration, exercises the Java service) and the per-kind create
+//     pins in test/conformance (exercise both editions).
 //
-// The step is idempotent - if ID is already set, it will not override it.
+// The step is idempotent - if ID is already set, it will not override it;
+// an explicitly provided visibility is never overwritten.
 //
 // The api_resource_kind is extracted from request context (injected by interceptor).
 //
@@ -100,6 +115,18 @@ func (s *BuildNewStateStep[T]) Execute(ctx *pipeline.RequestContext[T]) error {
 		if err := setAuditFieldsReflect(resource, "created"); err != nil {
 			return fmt.Errorf("failed to set audit fields: %w", err)
 		}
+	}
+
+	// 6. Default metadata.visibility from the kind's proto config when the
+	// client left it unspecified (blueprints -> visibility_org, everything
+	// else -> visibility_private; see the step doc for the full contract).
+	if metadata.Visibility == commonspb.ApiResourceVisibility_api_resource_visibility_unspecified {
+		kind := apiresourceinterceptor.GetApiResourceKind(ctx.Context())
+		visibility, err := apiresource.DefaultVisibilityFor(kind)
+		if err != nil {
+			return fmt.Errorf("failed to resolve default visibility from kind: %w", err)
+		}
+		metadata.Visibility = visibility
 	}
 
 	return nil

--- a/backend/libs/go/grpc/request/pipeline/steps/defaults_test.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/defaults_test.go
@@ -157,6 +157,77 @@ func TestBuildNewStateStep_DifferentKinds(t *testing.T) {
 	}
 }
 
+// TestBuildNewStateStep_DefaultVisibility pins the create-time visibility
+// default: blueprint kinds flagged defaults_to_org_visibility persist
+// visibility_org, every other kind persists visibility_private — never the
+// proto zero value. This is the OSS half of the cross-edition contract
+// asserted end-to-end by TestVisibilityCreateDefaults (test/integration,
+// Java service) and the per-kind create pins in test/conformance.
+//
+// The agent proto is reused across kinds deliberately (the same trick as
+// TestBuildNewStateStep_DifferentKinds): the step is generic and visibility
+// lives on the shared ApiResourceMetadata, so only the kind in context
+// matters.
+func TestBuildNewStateStep_DefaultVisibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     apiresourcekind.ApiResourceKind
+		expected apiresource.ApiResourceVisibility
+	}{
+		{"agent (blueprint) defaults to org", apiresourcekind.ApiResourceKind_agent, apiresource.ApiResourceVisibility_visibility_org},
+		{"workflow (blueprint) defaults to org", apiresourcekind.ApiResourceKind_workflow, apiresource.ApiResourceVisibility_visibility_org},
+		{"mcp_server (blueprint) defaults to org", apiresourcekind.ApiResourceKind_mcp_server, apiresource.ApiResourceVisibility_visibility_org},
+		{"agent_instance (non-blueprint) defaults to private", apiresourcekind.ApiResourceKind_agent_instance, apiresource.ApiResourceVisibility_visibility_private},
+		{"session (non-blueprint) defaults to private", apiresourcekind.ApiResourceKind_session, apiresource.ApiResourceVisibility_visibility_private},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &agentv1.Agent{
+				Metadata: &apiresource.ApiResourceMetadata{
+					Name: "Test",
+				},
+			}
+
+			step := NewBuildNewStateStep[*agentv1.Agent]()
+			ctx := pipeline.NewRequestContext(contextWithKind(tt.kind), agent)
+			ctx.SetNewState(agent)
+
+			if err := step.Execute(ctx); err != nil {
+				t.Fatalf("Expected success, got error: %v", err)
+			}
+
+			if agent.Metadata.Visibility != tt.expected {
+				t.Errorf("Expected visibility %v, got %v", tt.expected, agent.Metadata.Visibility)
+			}
+		})
+	}
+}
+
+// TestBuildNewStateStep_ExplicitVisibilityPreserved pins that the default is
+// strictly an unspecified-only fill: a client-chosen level is never
+// overwritten, even when it differs from the kind's default.
+func TestBuildNewStateStep_ExplicitVisibilityPreserved(t *testing.T) {
+	agent := &agentv1.Agent{
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name:       "Test",
+			Visibility: apiresource.ApiResourceVisibility_visibility_public,
+		},
+	}
+
+	step := NewBuildNewStateStep[*agentv1.Agent]()
+	ctx := pipeline.NewRequestContext(contextWithKind(apiresourcekind.ApiResourceKind_agent), agent)
+	ctx.SetNewState(agent)
+
+	if err := step.Execute(ctx); err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	if agent.Metadata.Visibility != apiresource.ApiResourceVisibility_visibility_public {
+		t.Errorf("Expected explicit visibility_public to be preserved, got %v", agent.Metadata.Visibility)
+	}
+}
+
 func TestBuildNewStateStep_MultipleResources(t *testing.T) {
 	// Create multiple agents and ensure they get different IDs
 	ids := make(map[string]bool)

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/create.go
@@ -27,7 +27,7 @@ const (
 // 1. ValidateFieldConstraints - Validate proto field constraints using buf validate
 // 2. ResolveSlug - Generate slug from metadata.name
 // 3. CheckDuplicate - Verify no duplicate exists
-// 4. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+// 4. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 5. NormalizeReferences - Resolve empty org in cross-references (skill_refs, mcp_server_usages, etc.)
 // 6. MergeMcpServerEnvSpecs - Merge env_spec entries from referenced MCP servers into agent
 // 7. Persist - Save agent to repository

--- a/backend/services/stigmer-server/pkg/domain/agentchannel/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentchannel/controller/create.go
@@ -20,7 +20,7 @@ import (
 //     default — channels are N-per-agent, see ResolveChannelDefaults)
 //  4. CheckDuplicate - Org+slug uniqueness
 //  5. BuildNewState - Set ID (ach_ prefix), clear client-provided status,
-//     audit fields
+//     audit fields, default visibility
 //  6. InitInstallState - status.install_state = pending_install; after
 //     BuildNewState so the status wipe cannot erase it
 //  7. NormalizeReferences - Make references absolute (fill org)

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
@@ -52,7 +52,7 @@ const autoCreatedSessionSubject = "Auto-created session"
 //     reference must be resolved by this point (see step doc for why this is an
 //     invariant, not input validation)
 //  4. ResolveSlug - Generate slug from metadata.name
-//  5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+//  5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 //  6. NormalizeReferences - Resolve cross-references (slugs to IDs)
 //  7. EnsureEngineAvailable - Fail fast with Unavailable if the agent execution engine is not connected (before the first side effect)
 //  8. CreateDefaultInstanceIfNeeded - Create default agent instance if missing

--- a/backend/services/stigmer-server/pkg/domain/agentshare/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentshare/controller/create.go
@@ -21,7 +21,7 @@ import (
 //     defaults step already set it)
 //  4. CheckDuplicate - Org+slug uniqueness; with the agent-slug default
 //     this structurally caps shares at one canonical link per agent per org
-//  5. BuildNewState - Set ID (ash_ prefix), clear status, audit fields
+//  5. BuildNewState - Set ID (ash_ prefix), clear status, audit fields, default visibility
 //  6. StampAgentPin - Write status.agent_id (the rebind guard) from the
 //     agent loaded in step 2; after BuildNewState so the wipe of
 //     client-provided status cannot erase it

--- a/backend/services/stigmer-server/pkg/domain/channelapp/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/channelapp/controller/create.go
@@ -17,7 +17,8 @@ import (
 //  3. CheckDuplicate - no duplicate by slug within the org
 //  4. EncryptChannelAppSecrets - AES-256-GCM encrypt both secrets;
 //     the redaction marker is refused on create
-//  5. BuildNewState - generate id (chapp_{ulid}), clear status, set audit
+//  5. BuildNewState - generate id (chapp_{ulid}), clear status, set audit,
+//     default visibility
 //  6. Persist - save to the store
 //
 // The returned ChannelApp has both secret fields redacted.

--- a/backend/services/stigmer-server/pkg/domain/datastore/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/datastore/controller/create.go
@@ -20,7 +20,7 @@ import (
 //  4. ValidateSpec       - cross-field domain validation (names, roles,
 //     defaults, timezone, constraint references, CEL compilation)
 //  5. EnforceOrgQuota    - max datastores per org
-//  6. BuildNewState      - ID (dst_<ulid>), audit fields
+//  6. BuildNewState      - ID (dst_<ulid>), audit fields, default visibility
 //  7. Persist            - save resource
 //  8. SchemaSync         - GATING: materialize tables/indexes, seed-once,
 //     write sync report to status (rejection rolls the create back)

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
@@ -17,7 +17,7 @@ import (
 // 2. ResolveSlug - Generate slug from metadata.name
 // 3. CheckDuplicate - Verify no duplicate exists (slug-level)
 // 4. EnforcePersonalEnvUniqueness - At most one personal env per org
-// 5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+// 5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 6. PreserveRedactedSecrets - Reject secret sentinels (redaction marker, enc:v<N>: prefix)
 // 7. Persist - Save environment to repository
 // 8. IndexSearch - Update search index

--- a/backend/services/stigmer-server/pkg/domain/executioncontext/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/executioncontext/controller/create.go
@@ -21,7 +21,7 @@ import (
 // 1. ValidateProto - Validate proto field constraints (including owner_scope restriction)
 // 2. ResolveSlug - Generate slug from metadata.name
 // 3. CheckDuplicate - Verify no duplicate exists by slug
-// 4. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+// 4. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 5. Persist - Save execution context to repository
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/create.go
@@ -19,7 +19,7 @@ import (
 //     - docker.image is required with min length 1
 //  2. ResolveSlug - Generate slug from metadata.name
 //  3. CheckDuplicate - Verify no duplicate exists by slug
-//  4. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+//  4. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 //  5. Persist - Save MCP server to repository
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:

--- a/backend/services/stigmer-server/pkg/domain/oauthapp/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/oauthapp/controller/create.go
@@ -19,7 +19,7 @@ import (
 //     - client_id, client_secret, authorization_url, token_url are required
 //  3. CheckDuplicate - Verify no duplicate exists by slug (within org)
 //  4. EncryptClientSecret - AES-256-GCM encrypt client_secret before persist
-//  5. BuildNewState - Generate ID (oap_{ulid}), clear status, set audit fields
+//  5. BuildNewState - Generate ID (oap_{ulid}), clear status, set audit fields, default visibility
 //  6. Persist - Save OAuthApp to repository
 //
 // The returned OAuthApp has client_secret replaced with ***REDACTED***.

--- a/backend/services/stigmer-server/pkg/domain/organization/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/organization/controller/create.go
@@ -20,7 +20,7 @@ import (
 //  3. CheckDuplicate - Reject a duplicate slug, checked GLOBALLY by id
 //     (organizations use slug as id; see step 5). Mirrors cloud's
 //     OrganizationCreateHandler.CheckDuplicate.
-//  4. BuildNewState - Mint a throwaway org_<ulid>, clear status, set audit fields
+//  4. BuildNewState - Mint a throwaway org_<ulid>, clear status, set audit fields, default visibility
 //  5. CopySlugToId - Overwrite the id with the slug (the id == slug exception),
 //     mirroring cloud's OrganizationCreateHandler.CopySlugToId
 //  6. Persist - Save organization to repository

--- a/backend/services/stigmer-server/pkg/domain/project/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/project/controller/create.go
@@ -16,7 +16,7 @@ import (
 //     (api_version, kind, metadata required)
 //  2. ResolveSlug - Generates URL-safe slug from metadata.name
 //  3. CheckDuplicate - Verifies no duplicate exists by slug within org
-//  4. BuildNewState - Generates ID (prj-{ulid}), clears status, sets audit fields
+//  4. BuildNewState - Generates ID (prj-{ulid}), clears status, sets audit fields, defaults visibility
 //  5. Persist - Saves project to repository
 //
 // Unlike Agent, Project has no custom steps (no default instance creation).

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/create.go
@@ -20,7 +20,7 @@ import (
 //     default — schedules are N-per-agent, see ResolveScheduleDefaults)
 //  4. CheckDuplicate - Org+slug uniqueness
 //  5. BuildNewState - Set ID (sch_ prefix), clear client-provided status,
-//     audit fields. The status wipe is the contract: status is
+//     audit fields, default visibility. The status wipe is the contract: status is
 //     platform-owned and starts empty — no client may seed firing
 //     observations.
 //  6. NormalizeReferences - Make references absolute (fill org)

--- a/backend/services/stigmer-server/pkg/domain/session/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/create.go
@@ -29,7 +29,7 @@ import (
 //  2. ValidateFieldConstraints - Validate proto field constraints using buf validate
 //  3. ResolveSlug - Generate slug from metadata.name
 //  4. CheckDuplicate - Verify no duplicate exists
-//  5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+//  5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 //  6. NormalizeReferences - Resolve cross-references (slugs to IDs)
 //  7. Persist - Save session to repository
 //  8. IndexSearch - Update search index

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/create.go
@@ -28,7 +28,7 @@ const (
 // 2. ValidateWorkflowSpec - Validate workflow spec in-process (Layer 2: proto → CNCF YAML + structural checks - SSOT)
 // 3. ResolveSlug - Generate slug from metadata.name
 // 4. CheckDuplicate - Verify no duplicate exists
-// 5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+// 5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 6. Persist - Save workflow to repository
 // 7. CreateDefaultInstance - Create default workflow instance
 // 8. UpdateWorkflowStatusWithDefaultInstance - Update workflow status with default_instance_id

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create.go
@@ -36,7 +36,7 @@ const (
 // 4. EnsureEngineAvailable - Fail fast with Unavailable if the workflow engine is not connected (before any side effect)
 // 5. CreateDefaultInstanceIfNeeded - Auto-create default instance if workflow_id is used
 // 6. CheckDuplicate - Verify no duplicate exists
-// 7. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+// 7. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 8. SetInitialPhase - Set execution phase to PENDING
 // 9. Persist - Save execution to repository
 // 10. StartWorkflow - Start Temporal workflow

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/create.go
@@ -27,7 +27,7 @@ const (
 // 3. LoadParentWorkflow - Load and validate workflow template exists
 // 4. ValidateSameOrgBusinessRule - Verify same-org for org-scoped instances
 // 5. CheckDuplicate - Verify no duplicate exists
-// 6. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event)
+// 6. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 7. Persist - Save workflow instance to repository
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:

--- a/test/conformance/src/suites/agent.conformance.test.ts
+++ b/test/conformance/src/suites/agent.conformance.test.ts
@@ -9,6 +9,7 @@
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import { Code } from "@connectrpc/connect";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
@@ -56,6 +57,9 @@ describe("Agent conformance — CRUD & identity", () => {
     expect(created.spec?.description).toBe("code reviewer");
     expect(created.status?.audit?.specAudit?.event).toBe("created");
     expect(created.status?.defaultInstanceId, "create provisions a default instance").toMatch(/^ain_[0-9a-z]+$/);
+    // Agent is a blueprint kind (defaults_to_org_visibility), so an
+    // unspecified visibility defaults to org; private is an explicit opt-in.
+    expect(created.metadata?.visibility, "visibility defaults to org (blueprint default)").toBe(ApiResourceVisibility.visibility_org);
   });
 
   it("creates an agent without a spec (spec is optional at the proto level)", async () => {

--- a/test/conformance/src/suites/environment.conformance.test.ts
+++ b/test/conformance/src/suites/environment.conformance.test.ts
@@ -22,6 +22,7 @@
 import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
 import { Code } from "@connectrpc/connect";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
@@ -81,6 +82,9 @@ describe("Environment conformance — CRUD & identity", () => {
     expect(created.spec?.description).toBe("staging config");
     expect(created.spec?.data?.PLAIN_KEY?.value).toBe("plain-value");
     expect(created.status?.audit?.specAudit?.event).toBe("created");
+    // Environment is NOT a blueprint kind, so an unspecified visibility
+    // defaults to private — explicitly persisted, never the proto zero value.
+    expect(created.metadata?.visibility, "visibility defaults to private (non-blueprint default)").toBe(ApiResourceVisibility.visibility_private);
   });
 
   it("get round-trips the created resource (ignoring server-set fields)", async () => {

--- a/test/conformance/src/suites/mcpserver.conformance.test.ts
+++ b/test/conformance/src/suites/mcpserver.conformance.test.ts
@@ -12,6 +12,7 @@
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { Code } from "@connectrpc/connect";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
@@ -58,6 +59,9 @@ describe("McpServer conformance — CRUD & identity", () => {
     expect(created.spec?.description).toBe("github operations");
     expect(created.spec?.serverType.case).toBe("stdio");
     expect(created.status?.audit?.specAudit?.event).toBe("created");
+    // McpServer is a blueprint kind (defaults_to_org_visibility), so an
+    // unspecified visibility defaults to org; private is an explicit opt-in.
+    expect(created.metadata?.visibility, "visibility defaults to org (blueprint default)").toBe(ApiResourceVisibility.visibility_org);
   });
 
   it("get round-trips the created resource (ignoring server-set fields)", async () => {

--- a/test/conformance/src/suites/workflow.conformance.test.ts
+++ b/test/conformance/src/suites/workflow.conformance.test.ts
@@ -18,6 +18,7 @@ import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/a
 import { ValidationState } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/serverless/validation_pb";
 import { Code } from "@connectrpc/connect";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
@@ -84,6 +85,9 @@ describe("Workflow conformance — CRUD & identity", () => {
     expect(created.status?.audit?.specAudit?.event).toBe("created");
     expect(created.status?.versionHash, "create computes a content version hash").toMatch(/^[a-f0-9]{64}$/);
     expect(created.status?.defaultInstanceId, "create provisions a default instance").toMatch(/^win_[0-9a-z]+$/);
+    // Workflow is a blueprint kind (defaults_to_org_visibility), so an
+    // unspecified visibility defaults to org; private is an explicit opt-in.
+    expect(created.metadata?.visibility, "visibility defaults to org (blueprint default)").toBe(ApiResourceVisibility.visibility_org);
   });
 
   it("get round-trips the created resource (ignoring server-set fields)", async () => {


### PR DESCRIPTION
## Summary

- `BuildNewStateStep` (the shared create-pipeline step behind every OSS create) now defaults `metadata.visibility` when the client leaves it unspecified: blueprint kinds flagged `defaults_to_org_visibility` (agent, skill, workflow, mcp_server) persist `visibility_org`; every other kind persists `visibility_private` — never the proto zero value.
- This mirrors the cloud edition exactly: `CreateOperationBuildNewStateStepV2` composes `CreateOperationSetDefaultVisibilityStepV2` for **every** kind's create, so the fix lands in the shared step rather than being wired into the three blueprint pipelines individually (one step better than the issue's proposed shape — new kinds inherit the default automatically and the "some kind forgot the default" class is closed). Both editions derive the default from the same proto kind config via `apiresource.DefaultVisibilityFor`.
- Skill push is untouched — it already defaults correctly via the same primitive in its bespoke pipeline.
- The ~20 per-pipeline `BuildNewState` doc comments gain the new operation so no inline doc goes stale.

## Behavior notes

- **Web console (OSS)**: a newly created agent/workflow/mcp_server now shows an "Organization" visibility badge instead of "Private". This is a correction — OSS enforces no access gating, and the proto contract has always declared org as the blueprint default. `VisibilitySelector` already renders a current-but-not-offered level legibly (no SDK change needed).
- **Legacy rows**: resources persisted with `0` stay as-is — no migration; every read site branches only on `visibility_public`, and the update path preserves visibility on omit.
- `Apply` delegates to `Create`, so manifest-driven creates and seedpack applies are covered.

## Tests

- Unit: `TestBuildNewStateStep_DefaultVisibility` (blueprints → org, non-blueprints → private) + `TestBuildNewStateStep_ExplicitVisibilityPreserved`; proven red against the pre-fix step.
- Conformance: create-time visibility pins in the agent, workflow, and mcpserver suites (org default) + environment (private default, explicitly persisted). These are the only cross-edition create-default coverage the Go server gets — the integration suite's `TestVisibilityCreateDefaults` exercises the Java service only. Proven red against the pre-fix server (persisted `0`); the cloud lane is green by construction (cloud already defaults).

## Verification

- `go test -race`: full `stigmer-server` module green; `backend/libs/go` module green.
- Conformance vs local-go: agent + workflow + mcpserver + environment suites, 100/100.
- `go vet` / `gofmt -s`: no new findings (the `schedule/temporal` vet failure and the listed gofmt drift exist identically on `origin/main`).

## Spawned

- #489 — the validation twin: cloud rejects unsupported visibility levels at create (`ValidateVisibilityStep`) and on updateVisibility; OSS validates neither. Kept out of this PR because cloud itself separates defaulting from validation.

Closes #227

Made with [Cursor](https://cursor.com)