### PR TITLE
fix(docs): inventory gate requires a "why" for any non-keep fate

### DIFF
--- a/docs/_inventory/classification.yaml
+++ b/docs/_inventory/classification.yaml
@@ -17,7 +17,9 @@
 #             are the substrate of every page, not a medium. `still` and
 #             `screenshot-journey` are Scenar-rendered `<Still>`s (see
 #             docs/STYLE.md "Stills") — never hand-captured screenshots.
-#   why       Rationale for a non-"none" medium (required by the gate).
+#   why       Rationale, required by the gate for a non-"none" medium (why
+#             that centerpiece) and for a non-"keep" fate (why the page
+#             doesn't survive as-is) — one sentence each when both apply.
 #   embeds    Per-embed fate map for embeds the page renders TODAY, keyed by
 #             ScenarEmbed id or legacy <Demo*> component name:
 #               keep    — survives as-is
@@ -657,6 +659,10 @@ pages:
       Stigmer Cloud's prepaid credit model — how a call is priced, how
       executions reserve and release credits, and what reduces spend.
     medium: none
+    why:
+      Split because one page mixes the credit-model explanation with
+      pricing and spend-reduction mechanics that belong nearer the billing
+      guides; the concept survives, the operational halves move out.
 
   # ── CLI ────────────────────────────────────────────────────────────────
   cli:

--- a/site/src/lib/__tests__/docs-inventory.test.ts
+++ b/site/src/lib/__tests__/docs-inventory.test.ts
@@ -113,10 +113,39 @@ describe("parseClassification", () => {
     expect(text).toContain('pages["bad"]: diataxis');
     expect(text).toContain('pages["bad"]: teaches');
     expect(text).toContain('pages["bad"]: medium');
-    expect(text).toContain('pages["needs-why"]: a non-"none" medium requires');
+    expect(text).toContain(
+      'pages["needs-why"]: a non-"none" medium and a non-"keep" fate each require',
+    );
     expect(text).toContain('pages["bad-embed"]: embeds["some-tour"]');
     expect(text).toContain('cohorts["no-slash"]: cohort prefixes must end with "/"');
     expect(text).toContain('cohorts["no-slash"]: generator');
+    // "bad" has an invalid fate AND an invalid medium — each already has
+    // its own error, so the why requirement must not pile on a third.
+    expect(errors.filter((message) => message.includes('"why"'))).toHaveLength(1);
+  });
+
+  it('requires a "why" for any non-"keep" fate, independent of medium', () => {
+    // The oss#315 hole: keying why on medium alone let a destructive plan
+    // (fate: split, medium: none) rest with no reason on the record.
+    const { errors } = parseClassification(
+      yamlOf({
+        pages: {
+          "silent-split": entry({ fate: "split" }),
+          "silent-move": entry({ fate: "move:concepts/elsewhere" }),
+          "explained-merge": entry({
+            fate: "merge:concepts/agents",
+            why: "Duplicates the agents page, section for section.",
+          }),
+          "plain-keep": entry(),
+        },
+        cohorts: {},
+      }),
+    );
+    const text = errors.join("\n");
+    expect(text).toContain('pages["silent-split"]');
+    expect(text).toContain('pages["silent-move"]');
+    expect(text).not.toContain('pages["explained-merge"]');
+    expect(text).not.toContain('pages["plain-keep"]');
   });
 
   it("rejects malformed YAML and non-mapping documents with one clear error", () => {

--- a/site/src/lib/docs-inventory.ts
+++ b/site/src/lib/docs-inventory.ts
@@ -73,7 +73,13 @@ export interface PageClassification {
   /** One sentence: what the reader walks away knowing or having done. */
   teaches: string;
   medium: Medium;
-  /** Rationale for the medium choice. Required when medium is not "none". */
+  /**
+   * Rationale for the decisions that need one: a non-"none" medium (why
+   * that centerpiece), a non-"keep" fate (why the page doesn't survive
+   * as-is), or both in one sentence each when both apply. Destructive
+   * plans with no reason on the record are exactly what the gate exists
+   * to prevent.
+   */
   why?: string;
   /**
    * Per-embed fate map, keyed by ScenarEmbed id (e.g. "quickstart-tour")
@@ -158,8 +164,19 @@ export function parseClassification(raw: string): {
       }
       if (!(MEDIUMS as readonly unknown[]).includes(medium)) {
         errors.push(`${where}: medium must be one of ${MEDIUMS.join(" | ")}`);
-      } else if (medium !== "none" && (typeof why !== "string" || why.trim() === "")) {
-        errors.push(`${where}: a non-"none" medium requires a "why" rationale`);
+      }
+      // `why` is demanded by two independent decisions, each considered
+      // only when its field is itself valid (an invalid fate or medium
+      // already has its own error above — no cascading noise). Keying the
+      // fate trigger on medium (the pre-2026-08 shape) let a destructive
+      // plan rest with no reason on the record (oss#315).
+      const mediumNeedsWhy =
+        (MEDIUMS as readonly unknown[]).includes(medium) && medium !== "none";
+      const fateNeedsWhy = typeof fate === "string" && isValidFate(fate) && fate !== "keep";
+      if ((mediumNeedsWhy || fateNeedsWhy) && (typeof why !== "string" || why.trim() === "")) {
+        errors.push(
+          `${where}: a non-"none" medium and a non-"keep" fate each require a "why" rationale`,
+        );
       }
       if (embeds !== undefined) {
         if (!isRecord(embeds)) {


### PR DESCRIPTION
## Summary

Closes #315.

The docs inventory gate keyed its `why` requirement on the medium alone (`medium !== "none"`), so a page could record a **destructive plan with no reason on the record** — `concepts/billing` carried `fate: split` with `medium: none` and no rationale, the only such entry among the record's 4 splits.

- **Gate** (`site/src/lib/docs-inventory.ts`): `why` is now demanded by two independent triggers — a valid non-`"none"` medium, or a valid non-`"keep"` fate (`split` / `archive` / `delete` / `move:` / `merge:`). Each trigger is gated on its own field's validity, so an invalid fate or medium (which already carries its own error) never cascades a bogus why-error — preserving the parser's collect-every-problem contract.
- **Record self-documentation** (`docs/_inventory/classification.yaml` header + the `why?` doc comment on `PageClassification`): both stated the old medium-only rule and would have lied after the gate change; updated in the same commit.
- **Backfill**: `concepts/billing` gets its split rationale (mixes the credit-model explanation with pricing/spend mechanics that belong nearer the billing guides). Rationale only — the split's target shape stays with the docs-revamp project's pending "fate: split target shapes" work.

## Verification

- `make -C site check-docs-inventory` green against the real record (198 pages OK).
- Negative control: the gate run against the pre-backfill record fails naming exactly `pages["concepts/billing"]`.
- Site unit suite 138/138 (19/19 in the touched file, incl. new pins: non-keep fate without `why` rejected; `keep`+`none` without `why` stays legal; `move:`/`merge:` covered; no cascade onto invalid-fate entries).
- `tsc --noEmit` output byte-identical to untouched HEAD (pre-existing generated-artifact errors only; none in touched files).

## Deploy

CI-infra class fix — effective on main immediately; no `status: to-be-deployed`.

Made with [Cursor](https://cursor.com)