### PR TITLE
test(server/workflowexecution): deflake Temporal test-env panic, unskip 3 tests

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows/invoke_workflow_impl_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows/invoke_workflow_impl_test.go
@@ -2,6 +2,7 @@ package workflows
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
@@ -10,67 +11,121 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
 
+// childWorkflowName mirrors the child workflow name the orchestrator starts
+// (executeChildWorkflow in invoke_workflow_impl.go).
+const childWorkflowName = "stigmer/workflow/execute-from-execution"
+
 // Stub activity functions for registration. The Temporal test env requires
 // actual Go functions registered under the correct names so that
-// workflow.ExecuteActivity / workflow.ExecuteLocalActivity calls can be matched.
+// workflow.ExecuteActivity / workflow.ExecuteLocalActivity calls can be
+// matched.
 func stubUpdateWfExecStatus(_ string, _ *workflowexecutionv1.WorkflowExecutionStatus) error {
 	return nil
 }
 func stubDeleteWfExecContext(_ string) error { return nil }
 
-// stubChildWorkflow is a stand-in for the TS child workflow
-// "stigmer/workflow/execute-from-execution".
-func stubChildWorkflow(_ workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
-	return nil
-}
-
-// stubLegacyActivity is a stand-in for the old ExecuteWorkflow activity.
+// stubLegacyActivity is a stand-in for the old ExecuteWorkflow activity
+// (the version-0 path).
 func stubLegacyActivity(_ *activities.InvokeWorkflowExecutionWorkflowInput) (*workflowexecutionv1.WorkflowExecutionStatus, error) {
 	return nil, nil
 }
 
-// registerWfExecCommonMocks sets up the activity/workflow mocks that every test needs.
-func registerWfExecCommonMocks(env *testsuite.TestWorkflowEnvironment) {
+// childWorkflowFn is the signature of the TS child workflow stand-in
+// ("stigmer/workflow/execute-from-execution").
+type childWorkflowFn func(workflow.Context, *activities.InvokeWorkflowExecutionWorkflowInput) error
+
+// childCompleting completes immediately with success.
+func childCompleting(_ workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
+	return nil
+}
+
+// childFailingWith returns a child that fails with the given message.
+func childFailingWith(msg string) childWorkflowFn {
+	return func(_ workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
+		return fmt.Errorf("%s", msg)
+	}
+}
+
+// ecDeleteRecorder counts DeleteExecutionContext calls so tests can assert the
+// EC cleanup actually ran. Capturing at registration is mandatory: testify
+// matches the FIRST registered expectation for an activity, so a later
+// per-test OnActivity override would silently never run (the same recorder
+// idiom as the agentexecution twin's persistedStatuses).
+type ecDeleteRecorder struct {
+	count int
+}
+
+// registerWfExecCommonMocks registers the activities every test needs and
+// registers `child` as a REAL child workflow implementation under the
+// production child workflow name. Returns a recorder of EC delete calls.
+//
+// Real children (instead of env.OnWorkflow mocks) buy two things: the test
+// env delivers parent→child SignalExternalWorkflow calls DIRECTLY to running
+// children — an OnSignalExternalWorkflow mock is never consulted for them —
+// so relay tests can assert actual delivery; and a child that consumes its
+// relays before returning serializes the whole signal chain ahead of parent
+// completion, which keeps the parent-close-policy sweep (the orchestrator
+// sets PARENT_CLOSE_POLICY_REQUEST_CANCEL) away from half-torn-down state.
+//
+// CRITICAL: every external stimulus (SignalWorkflow, CancelWorkflow) must be
+// scheduled through runWhenChildStarts, never RegisterDelayedCallback at
+// delay 0 — see that helper for the SDK startup race it closes (stigmer#457).
+func registerWfExecCommonMocks(env *testsuite.TestWorkflowEnvironment, child childWorkflowFn) *ecDeleteRecorder {
 	env.RegisterActivityWithOptions(stubUpdateWfExecStatus, activity.RegisterOptions{
 		Name: activities.UpdateWorkflowExecutionStatusActivityName,
 	})
 	env.RegisterActivityWithOptions(stubDeleteWfExecContext, activity.RegisterOptions{
 		Name: ecactivities.DeleteExecutionContextActivityName,
 	})
-	env.RegisterWorkflowWithOptions(stubChildWorkflow, workflow.RegisterOptions{
-		Name: "stigmer/workflow/execute-from-execution",
+	env.RegisterWorkflowWithOptions(child, workflow.RegisterOptions{
+		Name: childWorkflowName,
 	})
 	env.RegisterActivityWithOptions(stubLegacyActivity, activity.RegisterOptions{
 		Name: activities.ExecuteWorkflowActivityName,
 	})
 
+	recorder := &ecDeleteRecorder{}
 	env.OnActivity(stubDeleteWfExecContext, mock.Anything).
-		Return(nil).Maybe()
+		Return(func(_ string) error {
+			recorder.count++
+			return nil
+		}).Maybe()
+	return recorder
+}
 
-	// Allow SignalExternalWorkflow calls (signal relay to child) to succeed
-	env.OnSignalExternalWorkflow(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(nil).Maybe()
-
-	// Allow RequestCancelExternalWorkflow (for parent close policy propagation)
-	env.OnRequestCancelExternalWorkflow(mock.Anything, mock.Anything, mock.Anything).
-		Return(nil).Maybe()
+// runWhenChildStarts schedules f to run once the child workflow has actually
+// begun executing — i.e. after its signal and cancel handlers are registered.
+//
+// This gate is what makes the signal/cancel tests deterministic, and it is
+// the fix for the stigmer#457 flake. ExecuteChildWorkflow registers the child
+// in the env's workflow map synchronously, but the child's startup runs on a
+// SEPARATE goroutine. A stimulus scheduled with RegisterDelayedCallback at
+// delay 0 races that goroutine; when it wins, the env delivers the signal (or
+// the parent-close REQUEST_CANCEL sweep after the resulting panic) to a child
+// env whose handlers are still nil, and the SDK nil-calls them (v1.43.1
+// internal_workflow_testsuite.go:2537→:2519; code unchanged on SDK master as
+// of v1.47.0). The child-started listener fires inside the child's first
+// workflow task, strictly after handler registration, so stimuli enqueued
+// from it can always be received.
+func runWhenChildStarts(env *testsuite.TestWorkflowEnvironment, f func()) {
+	env.SetOnChildWorkflowStartedListener(func(_ *workflow.Info, _ workflow.Context, _ converter.EncodedValues) {
+		f()
+	})
 }
 
 func TestChildWorkflow_CompletesSuccessfully(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
+	ecDeletes := registerWfExecCommonMocks(env, childCompleting)
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.Anything).
 		Return(nil).Maybe()
-
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(nil)
 
 	input := &activities.InvokeWorkflowExecutionWorkflowInput{
 		ExecutionID:        "exec-success-1",
@@ -83,8 +138,7 @@ func TestChildWorkflow_CompletesSuccessfully(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
-
-	// Verify EC cleanup was called
+	require.Equal(t, 1, ecDeletes.count, "success path must clean up the ExecutionContext")
 	env.AssertExpectations(t)
 }
 
@@ -92,10 +146,7 @@ func TestChildWorkflow_FailureUpdatesStatus(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
-
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(fmt.Errorf("child workflow exploded"))
+	registerWfExecCommonMocks(env, childFailingWith("child workflow exploded"))
 
 	// Expect status update to FAILED
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
@@ -116,30 +167,71 @@ func TestChildWorkflow_FailureUpdatesStatus(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
+// TestChildWorkflow_CancellationCleanup verifies the external-cancel path end
+// to end: the child is cancelled with the parent, and handleCancellation
+// persists the quiet CANCELLED status and deletes the ExecutionContext.
+//
+// Previously skipped for the test-env panic that runWhenChildStarts closes;
+// cancelling only after the child has started lets the full path run.
 func TestChildWorkflow_CancellationCleanup(t *testing.T) {
-	// Skipped: Temporal's test env panics on ParentClosePolicy REQUEST_CANCEL
-	// when the child workflow's dispatcher is already closed. This path is
-	// validated by integration tests with a real Temporal server.
-	t.Skip("requires real Temporal server — test env does not support REQUEST_CANCEL on closed child dispatchers")
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	// The child blocks until cancellation reaches it through the parent's
+	// context, standing in for a long TS runner execution.
+	childBlocking := func(ctx workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
+		return workflow.Await(ctx, func() bool { return false })
+	}
+	ecDeletes := registerWfExecCommonMocks(env, childBlocking)
+
+	// The cleanup must persist CANCELLED with NO error (the quiet-cancelled
+	// contract, stigmer#282).
+	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
+		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_CANCELLED &&
+			status.GetError() == ""
+	})).Return(nil).Once()
+
+	runWhenChildStarts(env, func() {
+		env.CancelWorkflow()
+	})
+
+	input := &activities.InvokeWorkflowExecutionWorkflowInput{
+		ExecutionID:        "exec-cancel-cleanup-1",
+		WorkflowInstanceID: "wi-1",
+		WorkflowID:         "wf-1",
+		OrgID:              "org-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeWorkflowExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError(), "external cancellation surfaces as a workflow error")
+	require.Equal(t, 1, ecDeletes.count, "cancellation cleanup must delete the ExecutionContext")
+	env.AssertExpectations(t)
 }
 
 func TestPauseSignal_UpdatesStatusAndRelays(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
+	// The child completes only after the relayed pause signal reaches it:
+	// the relay is asserted for real (the test's name), and the pause chain
+	// (status update + relay) is serialized ahead of parent completion.
+	var relayedReason string
+	childAwaitingPause := func(ctx workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
+		workflow.GetSignalChannel(ctx, SignalPause).Receive(ctx, &relayedReason)
+		return nil
+	}
+	registerWfExecCommonMocks(env, childAwaitingPause)
 
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(nil)
-
-	// Expect PAUSED status update (registered before the catch-all so it matches first)
+	// Expect PAUSED status update
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
 		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_PAUSED
 	})).Return(nil).Once()
 
-	env.RegisterDelayedCallback(func() {
+	runWhenChildStarts(env, func() {
 		env.SignalWorkflow(SignalPause, "user requested pause")
-	}, 0)
+	})
 
 	input := &activities.InvokeWorkflowExecutionWorkflowInput{
 		ExecutionID:        "exec-pause-1",
@@ -152,26 +244,102 @@ func TestPauseSignal_UpdatesStatusAndRelays(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, "user requested pause", relayedReason,
+		"the pause reason must be relayed to the child verbatim")
 	env.AssertExpectations(t)
 }
 
+// TestResumeSignal_UpdatesStatusAndRelays pins the pause→resume chain: each
+// signal updates the persisted status (PAUSED, then IN_PROGRESS) and is
+// relayed to the child in arrival order — the ordering the Selector in
+// startSignalHandlers exists to guarantee.
+//
+// Previously skipped for the test-env panic that runWhenChildStarts closes.
 func TestResumeSignal_UpdatesStatusAndRelays(t *testing.T) {
-	// Skipped: after the resume signal the orchestrator workflow runs to
-	// completion, at which point Temporal's test env fires
-	// ParentClosePolicy REQUEST_CANCEL on the child workflow whose dispatcher
-	// is already closed, causing a nil pointer panic inside
-	// RequestCancelExternalWorkflow. This is the same test-env limitation that
-	// TestRelaySignal_ForwardsToChild and TestChildWorkflow_CancellationCleanup
-	// are skipped for. The resume status update and signal relay are validated
-	// by integration tests against a real Temporal server.
-	t.Skip("requires real Temporal server — test env panics on REQUEST_CANCEL of a completed child after resume")
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	// The child completes only after BOTH relays arrive, in order. A resume
+	// relay overtaking its pause relay would leave the child blocked on the
+	// pause channel and fail the test at the env timeout.
+	var relayedReason string
+	resumeRelayed := false
+	childAwaitingPauseThenResume := func(ctx workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
+		workflow.GetSignalChannel(ctx, SignalPause).Receive(ctx, &relayedReason)
+		workflow.GetSignalChannel(ctx, SignalResume).Receive(ctx, nil)
+		resumeRelayed = true
+		return nil
+	}
+	registerWfExecCommonMocks(env, childAwaitingPauseThenResume)
+
+	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
+		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_PAUSED
+	})).Return(nil).Once()
+	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
+		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_IN_PROGRESS
+	})).Return(nil).Once()
+
+	runWhenChildStarts(env, func() {
+		env.SignalWorkflow(SignalPause, "user requested pause")
+		env.SignalWorkflow(SignalResume, nil)
+	})
+
+	input := &activities.InvokeWorkflowExecutionWorkflowInput{
+		ExecutionID:        "exec-resume-1",
+		WorkflowInstanceID: "wi-1",
+		WorkflowID:         "wf-1",
+		OrgID:              "org-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeWorkflowExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, "user requested pause", relayedReason)
+	require.True(t, resumeRelayed, "the resume signal must be relayed to the child after the pause")
+	env.AssertExpectations(t)
 }
 
+// TestRelaySignal_ForwardsToChild pins the generic relay lane used by
+// signal-receiving tasks (human_input, listen): a relaySignal sent to the
+// orchestrator is forwarded to the child under its task-specific signal name
+// with the payload intact.
+//
+// Previously skipped for the test-env panic that runWhenChildStarts closes.
 func TestRelaySignal_ForwardsToChild(t *testing.T) {
-	// Skipped: Temporal's test env panics when handleParentClosePolicy fires
-	// RequestCancelExternalWorkflow on a child whose dispatcher is already closed.
-	// The relay signal forwarding is validated by integration tests.
-	t.Skip("requires real Temporal server — test env does not support signal relay with REQUEST_CANCEL child close policy")
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+
+	const taskSignalName = "human-input-task-1"
+
+	var forwardedPayload string
+	childAwaitingTaskSignal := func(ctx workflow.Context, _ *activities.InvokeWorkflowExecutionWorkflowInput) error {
+		workflow.GetSignalChannel(ctx, taskSignalName).Receive(ctx, &forwardedPayload)
+		return nil
+	}
+	registerWfExecCommonMocks(env, childAwaitingTaskSignal)
+
+	runWhenChildStarts(env, func() {
+		env.SignalWorkflow("relaySignal", RelaySignalPayload{
+			SignalName: taskSignalName,
+			Payload:    "approved",
+		})
+	})
+
+	input := &activities.InvokeWorkflowExecutionWorkflowInput{
+		ExecutionID:        "exec-relay-1",
+		WorkflowInstanceID: "wi-1",
+		WorkflowID:         "wf-1",
+		OrgID:              "org-1",
+	}
+
+	env.ExecuteWorkflow((&InvokeWorkflowExecutionWorkflowImpl{}).Run, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, "approved", forwardedPayload,
+		"the relay payload must be forwarded to the child's task signal channel verbatim")
+	env.AssertExpectations(t)
 }
 
 // TestChildWorkflow_FailureReachesTerminalState verifies that when the child
@@ -183,10 +351,7 @@ func TestChildWorkflow_FailureReachesTerminalState(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
-
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(fmt.Errorf("child failed: task 'deploy' exited with code 1"))
+	registerWfExecCommonMocks(env, childFailingWith("child failed: task 'deploy' exited with code 1"))
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
 		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_FAILED
@@ -216,10 +381,7 @@ func TestChildWorkflow_CleanupOnFailure(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
-
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(fmt.Errorf("child failed for cleanup test"))
+	ecDeletes := registerWfExecCommonMocks(env, childFailingWith("child failed for cleanup test"))
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
 		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_FAILED
@@ -235,29 +397,24 @@ func TestChildWorkflow_CleanupOnFailure(t *testing.T) {
 	env.ExecuteWorkflow((&InvokeWorkflowExecutionWorkflowImpl{}).Run, input)
 
 	require.True(t, env.IsWorkflowCompleted())
-	// The common mock has DeleteExecutionContext with Maybe(). If it was NOT
-	// called, AssertExpectations would still pass. Instead, verify workflow
-	// completed with error (which exercises the full failure path including
-	// cleanup) and the status update was called.
 	require.Error(t, env.GetWorkflowError())
+	require.Equal(t, 1, ecDeletes.count, "failure path must clean up the ExecutionContext")
 	env.AssertExpectations(t)
 }
 
 // TestChildWorkflow_FailureStatusContainsError verifies that the FAILED
-// status update includes a meaningful error message from the child workflow.
+// status update includes the child workflow's own error message, not just a
+// generic wrapper.
 func TestChildWorkflow_FailureStatusContainsError(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
-
 	childErrMsg := "YAML parse error: invalid task 'deploy' configuration"
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(fmt.Errorf("child failed: %s", childErrMsg))
+	registerWfExecCommonMocks(env, childFailingWith("child failed: "+childErrMsg))
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.MatchedBy(func(status *workflowexecutionv1.WorkflowExecutionStatus) bool {
 		return status.GetPhase() == workflowexecutionv1.ExecutionPhase_EXECUTION_FAILED &&
-			status.GetError() != "" // Error message must be populated
+			strings.Contains(status.GetError(), childErrMsg)
 	})).Return(nil).Once()
 
 	input := &activities.InvokeWorkflowExecutionWorkflowInput{
@@ -274,20 +431,16 @@ func TestChildWorkflow_FailureStatusContainsError(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-// TestChildWorkflow_SuccessDeletesEC verifies that EC delete is called
-// on the success path (covered by the common mock's Maybe() + workflow
-// completion — the activity was dispatched in the workflow logs).
+// TestChildWorkflow_SuccessDeletesEC verifies that EC delete is called on the
+// success path.
 func TestChildWorkflow_SuccessDeletesEC(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
+	ecDeletes := registerWfExecCommonMocks(env, childCompleting)
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.Anything).
 		Return(nil).Maybe()
-
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(nil)
 
 	input := &activities.InvokeWorkflowExecutionWorkflowInput{
 		ExecutionID:        "exec-success-ec-1",
@@ -300,29 +453,27 @@ func TestChildWorkflow_SuccessDeletesEC(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, ecDeletes.count, "success path must delete the ExecutionContext exactly once")
 	env.AssertExpectations(t)
 }
 
 // TestChildWorkflow_RecoveryModeAccepted verifies that the orchestrator
-// workflow completes successfully when the input carries RecoveryMode: true.
-// The orchestrator passes input to the child as-is (line 190 of
-// invoke_workflow_impl.go: ExecuteChildWorkflow(childCtx, ..., input)),
-// so structural correctness ensures the flag reaches the TS child.
-//
-// The Temporal test framework's mock layer intercepts child workflow calls
-// without executing the registered function body, so we verify acceptance
-// rather than capture the forwarded input.
+// forwards the input — including RecoveryMode: true — to the child workflow
+// unchanged. The real child captures its input, so the flag's arrival is
+// asserted directly.
 func TestChildWorkflow_RecoveryModeAccepted(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
+	var childInput *activities.InvokeWorkflowExecutionWorkflowInput
+	childCapturingInput := func(_ workflow.Context, in *activities.InvokeWorkflowExecutionWorkflowInput) error {
+		childInput = in
+		return nil
+	}
+	registerWfExecCommonMocks(env, childCapturingInput)
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.Anything).
 		Return(nil).Maybe()
-
-	env.OnWorkflow(stubChildWorkflow, mock.Anything, mock.Anything).
-		Return(nil)
 
 	input := &activities.InvokeWorkflowExecutionWorkflowInput{
 		ExecutionID:        "exec-recovery-1",
@@ -337,6 +488,9 @@ func TestChildWorkflow_RecoveryModeAccepted(t *testing.T) {
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError(),
 		"orchestrator must complete without error when RecoveryMode is true")
+	require.NotNil(t, childInput, "the child workflow must receive the forwarded input")
+	require.True(t, childInput.RecoveryMode,
+		"RecoveryMode must reach the child workflow unchanged")
 
 	env.AssertExpectations(t)
 }
@@ -347,17 +501,16 @@ func TestChildWorkflow_RecoveryModeAccepted(t *testing.T) {
 // regression that reintroduces a "Workflow execution cancelled" error
 // sentinel would make clients render a user-initiated stop as a failure.
 //
-// The full cancel path (external cancel → handleCancellation) cannot run in
-// the test env — ParentClosePolicy REQUEST_CANCEL panics on a closed child
-// dispatcher (see the skipped TestChildWorkflow_CancellationCleanup) — so
-// this exercises updateStatusOnCancellation directly via a wrapper workflow,
-// the same pattern TestVersioning_V0FallsBackToActivity uses. The cancel
-// path itself is validated by integration tests against a real server.
+// The full external-cancel path is covered by
+// TestChildWorkflow_CancellationCleanup; this exercises
+// updateStatusOnCancellation in isolation via a wrapper workflow (the same
+// pattern TestVersioning_V0FallsBackToActivity uses) so the contract stays
+// pinned even if the end-to-end test's shape changes.
 func TestCancellationStatusIsQuiet(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
+	registerWfExecCommonMocks(env, childCompleting)
 
 	// The mock only matches a CANCELLED status carrying no error; a sentinel
 	// regression would leave the activity unmatched and fail the assertion.
@@ -384,7 +537,7 @@ func TestVersioning_V0FallsBackToActivity(t *testing.T) {
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
 
-	registerWfExecCommonMocks(env)
+	registerWfExecCommonMocks(env, childCompleting)
 
 	env.OnActivity(stubUpdateWfExecStatus, mock.Anything, mock.Anything).
 		Return(nil).Maybe()


### PR DESCRIPTION
## Summary

Fixes the nondeterministic SIGSEGV in `TestPauseSignal_UpdatesStatusAndRelays` (a flaky gate that poisoned every full-module `go test -race` run) and resurrects the three tests that had been skipped for the same test-env panic. Test-only change; no production code touched.

## Context

The panic reproduced on clean main (`-race -count=100`, ~1-2% per repetition). Instrumenting the SDK showed a **stacked failure inside the Temporal test environment**, not a defect in the orchestrator:

1. `ExecuteChildWorkflow` registers the child in the env's workflow map **synchronously**, but the child's startup (which wires its signal/cancel handlers and workflow definition) runs on a **separate goroutine**.
2. A stimulus scheduled with `RegisterDelayedCallback(..., 0)` races that goroutine. When it wins, the env delivers the signal to a child whose `signalHandler` is still nil — a nil-function call that panics the parent workflow.
3. The parent then panic-completes, and its `PARENT_CLOSE_POLICY_REQUEST_CANCEL` sweep fires at the never-started child, nil-calling `workflowCancelHandler` (`internal_workflow_testsuite.go:2537` → `:2519` in v1.43.1) — the SIGSEGV in the issue.

The code at the panic site is byte-identical through current SDK master (v1.47.0), so an SDK upgrade does not help. The old test only passed most of the time because its pause path runs a wall-clock local activity that usually gave the child's start goroutine time to run — scheduling luck, not a guarantee.

## Changes

- New `runWhenChildStarts` helper: every external stimulus (signal, cancel) is gated on `SetOnChildWorkflowStartedListener`, which fires inside the child's first workflow task, strictly after its handlers are registered. This closes the startup race deterministically.
- Child workflows are now **real registered stubs** chosen per test instead of `env.OnWorkflow` mocks. The test env delivers parent→child signals directly to running children (the old `OnSignalExternalWorkflow(...).Maybe()` mock was never consulted for them), so the tests now assert **actual relay delivery** — previously the "AndRelays" half of the pause test's name verified nothing.
- Resurrected all three tests skipped for this exact panic: `TestResumeSignal_UpdatesStatusAndRelays` (pins the Selector's pause→resume ordering guarantee), `TestRelaySignal_ForwardsToChild` (pins the human_input/listen relay lane with payload fidelity), `TestChildWorkflow_CancellationCleanup` (pins the full external-cancel path: quiet CANCELLED status + EC delete). **Zero skipped tests remain in the file.**
- Assertion upgrades: relay payloads asserted verbatim; `RecoveryMode` arrival now asserted inside the child (the old mock layer made this impossible, as its comment lamented); EC cleanup counted via a recorder (the old `Maybe()` could never fail) on success, failure, and cancel paths; the FAILED status must now *contain the child's error message*, not just be non-empty.

## Implementation notes

- The recorder idiom (`ecDeleteRecorder`) mirrors the agentexecution twin's `persistedStatuses`: testify matches the first registered expectation, so capture-at-registration is the only reliable way to assert on an activity the common helper must also permit.
- The corrected mechanism supersedes the initial hypothesis (mocked-vs-real child): the true axis is *started vs not-yet-started* when a stimulus arrives. Real children are still load-bearing — for honest relay assertions and completion ordering — but the deterministic fix is the started-listener gate.

## Breaking changes

- None (test-only).

## Test plan

- Negative control: panic reproduced on clean main at `-race -count=100` with the exact trace from the issue before the fix.
- All four signal/cancel tests green at `-race -count=1000` each (4,000 executions; the old pause test failed ~1-2% per rep, the relay shape failed near-always).
- Full package green at `-race -count=30`; full `stigmer-server` module green under `go test -race ./...`.
- `go vet` and `gofmt` clean.

## Risks

- None beyond test semantics; rollback is reverting one test file. The upstream SDK race still exists — worth filing on temporalio/sdk-go (nil-handler delivery to a registered-but-unstarted child).

Closes #457

Made with [Cursor](https://cursor.com)