### PR TITLE
fix(test/e2e): repair comparison spec running-execution test and add typecheck gate

### DIFF
--- a/.github/workflows/ci.frontend.yaml
+++ b/.github/workflows/ci.frontend.yaml
@@ -22,6 +22,10 @@ on:
       # Scenar tours consume the @stigmer/* workspace source; an SDK change
       # can break them (and vice versa), so tour changes gate here too.
       - "demos/**"
+      # E2E specs typecheck against @stigmer/sdk + @stigmer/protos workspace
+      # source — the same coupling as demos (see cloud#275: spec/helper
+      # drift rode to main because nothing typechecked test/e2e).
+      - "test/e2e/**"
       - "client-apps/web/**"
       - "client-apps/desktop/**"
       - "client-apps/cli/**"
@@ -46,6 +50,7 @@ on:
       - "sdk/ink/**"
       - "sdk/embed/**"
       - "demos/**"
+      - "test/e2e/**"
       - "client-apps/web/**"
       - "client-apps/desktop/**"
       - "client-apps/cli/**"
@@ -224,6 +229,13 @@ jobs:
       # (bundles are only packed by release.website.yaml).
       - name: Typecheck Scenar tours
         run: npm run typecheck -w @stigmer/demos
+
+      # Same coupling as the tours: e2e specs typecheck against @stigmer/sdk
+      # + @stigmer/protos workspace source, and no other lane typechecks
+      # test/e2e (the interactive Playwright project never runs in CI), so
+      # spec/helper drift is invisible without this step (cloud#275).
+      - name: Typecheck e2e specs
+        run: npm run typecheck -w @stigmer/e2e
 
       # Determinism (DD-006), timeline shape, and docs embed-id resolution.
       # Also wired in ci.docs.yaml: this workflow doesn't trigger on docs/**,

--- a/Makefile
+++ b/Makefile
@@ -677,7 +677,7 @@ test-e2e-approval: ## Run the deterministic HITL approval E2E (mock LLM, serial,
 #      toolchain/directory so they never write to the same files:
 #        check-go    — go vet/test/build + buf lint + go binaries
 #        check-node  — npm typecheck/lint/build/test (web, react, sdk, desktop TS,
-#                      runner) + tsdoc + dep hygiene
+#                      runner, e2e specs) + tsdoc + dep hygiene
 #        check-site  — vale, prettier --check, site lint/typecheck/build,
 #                      demo validation, link check (all under docs/ + site/)
 #        check-rust  — desktop cargo check + runner-host crate
@@ -725,11 +725,15 @@ check-go: ## check bucket: Go vet/test/build + buf lint + binaries
 	@mkdir -p bin
 	cd backend/services/stigmer-server && go build -o ../../../bin/stigmer-server ./cmd/server
 
-check-node: ## check bucket: npm typecheck/lint/build/test (web, react, sdk, desktop, runner, demos)
+check-node: ## check bucket: npm typecheck/lint/build/test (web, react, sdk, desktop, runner, demos, e2e)
 	npm run typecheck -w @stigmer/sdk
 	npm run lint -w @stigmer/react
 	npm run typecheck -w @stigmer/react
 	npm run typecheck -w @stigmer/demos
+	# E2E specs typecheck against @stigmer/sdk + @stigmer/protos workspace
+	# source; this catches spec/helper drift that nothing else runs
+	# (the interactive Playwright project has no CI lane — cloud#275).
+	npm run typecheck -w @stigmer/e2e
 	node scripts/verify-scenar-tours.mjs
 	npm run lint -w client-apps/web
 	npm run typecheck -w desktop

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -7,7 +7,8 @@
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "test:interactive": "playwright test --project=interactive",
-    "report": "playwright show-report"
+    "report": "playwright show-report",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -13,7 +13,9 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * - **interactive**: tests that require the full backend stack (stigmer-server,
  *   Temporal, unified runner). Create real resources via API, verify they render
- *   correctly, and exercise complete user flows. Run via `make test-e2e-interactive`.
+ *   correctly, and exercise complete user flows. No Makefile target — run
+ *   `npm run test:interactive` in test/e2e (global-setup boots the stack
+ *   when nothing is listening on the API port).
  *
  * - **interactive-approval**: the HITL approval/disclosure flow, made
  *   deterministic by a mock LLM proxy wired into the runner (opt-in via

--- a/test/e2e/tests/interactive/workflow-execution-comparison.spec.ts
+++ b/test/e2e/tests/interactive/workflow-execution-comparison.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../../fixtures";
-import { createTestWorkflowExecution } from "../../fixtures/seed-helpers";
+import {
+  createTestWaitWorkflow,
+  createTestWorkflowExecution,
+} from "../../fixtures/seed-helpers";
 import {
   navigateToExecution,
   waitForPhaseBadge,
@@ -32,22 +35,33 @@ test.describe("Workflow execution comparison", () => {
   test("Compare button is hidden on running execution", async ({
     page,
     stigmerClient,
-    testWorkflow,
   }) => {
+    // A bespoke wait workflow (not the shared testWaitWorkflow fixture): the
+    // running-window clock starts at API create, BEFORE navigation, and a
+    // cold dev-server compile of the execution route can exceed the
+    // fixture's 10s default — the execution would complete before the
+    // header renders. 30s matches this spec's sibling tolerances.
+    const waitWorkflow = await createTestWaitWorkflow(stigmerClient, {
+      waitDurationSeconds: 30,
+    });
     const execution = await createTestWorkflowExecution(
       stigmerClient,
-      testWorkflow.id,
-      { waitForCompletion: false },
+      waitWorkflow.id,
     );
 
     try {
       await navigateToExecution(page, execution.id);
       await assertNoErrorBoundary(page);
 
+      // Anchor on the non-terminal badge first so the hidden-assertion
+      // below cannot pass vacuously on an unrendered header.
+      await waitForPhaseBadge(page, "Running", { timeout: 15_000 });
+
       const compareButton = page.getByRole("button", { name: /Compare with/ });
-      await expect(compareButton).toBeHidden({ timeout: 5_000 });
+      await expect(compareButton).toBeHidden();
     } finally {
       await execution.cleanup();
+      await waitWorkflow.cleanup();
     }
   });
 


### PR DESCRIPTION
## Summary

- **Fixes the e2e typecheck break on main** (stigmer/stigmer-cloud#275): `workflow-execution-comparison.spec.ts` passed a `waitForCompletion` option that `createTestWorkflowExecution` never had — spec and phantom option were born together in `b44d3ffde`; the helper never waits. Beyond the type error the test was racy: the `set_vars` fixture completes in milliseconds, so the execution could be terminal by page load and "hidden on running execution" would flake.
- **Repairs the test to honor its intent**: a bespoke 30s wait workflow via the existing `createTestWaitWorkflow(..., { waitDurationSeconds: 30 })` option (the running window must survive a cold dev-server route compile; the shared fixture's 10s default can't be raised without breaking `workflow-run-flow`'s pause/resume timing), anchored on `waitForPhaseBadge(page, "Running")` — the `workflow-run-flow.spec.ts` house pattern — so the hidden-assertion cannot pass vacuously on an unrendered header. The UI rule being pinned is real: `WorkflowExecutionHeader` shows Compare only for `TERMINAL_PHASES`.
- **Closes the drift class**: `test/e2e` was the only TS workspace package with no `typecheck` script and no CI lane typechecking it. Adds the standard script, wires it into the Makefile `check-node` bucket and `ci.frontend.yaml`'s verify job with `test/e2e/**` trigger paths (the demos precedent — same `@stigmer/*` workspace-source coupling, so an SDK type change breaking e2e specs now gates too).
- Corrects a stale `playwright.config.ts` docstring pointing at a nonexistent `make test-e2e-interactive` target.

## Verification

- `npm run typecheck -w @stigmer/e2e` green on this branch; negative control: red with exactly the one TS2353 against the pre-fix spec.
- `npx playwright test --project=interactive --list`: all 99 tests in 17 files load.
- `ci.frontend.yaml` parses (js-yaml).
- **Live run blocked by a pre-existing suite-wide breakage** (owner-approved scope call): every workflow-seeding interactive fixture fails `InvalidArgument` on clean main because seed-helper task names (`step-one`, `blocking-wait`, ...) violate the task-name pattern added in `10f12f891` (2026-05-17) — the interactive suite has been silently dead for ~3 months (it runs in no CI lane, the same visibility gap this PR's gate addresses at the type level). Filed and classified as #501. The full stack itself boots cleanly (Temporal + stigmer-server + unified runner under Node 22.22.1 + web).

Closes stigmer/stigmer-cloud#275

Made with [Cursor](https://cursor.com)