### PR TITLE
fix(runner): bound side-channel proxy fetches with retry and per-request timeouts

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/model-pricing.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/model-pricing.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import {
+  getPricingTable,
+  _resetPricingCache,
+  DEFAULT_PRICING,
+} from "../model-pricing-data.js";
 
 /**
  * Verifies the cursor-runner display estimate resolves Cursor speed variants
@@ -108,5 +113,61 @@ describe("getCursorModelPricing — speed variant resolution", () => {
   it("getCursorModelPricingForVariant('fast') falls back to base rates when unpriced", () => {
     const p = getCursorModelPricingForVariant("claude-opus-4-6", "fast");
     expect(p.inputPricePerMillion).toBe(5.0);
+  });
+});
+
+describe("getPricingTable failure caching (#468)", () => {
+  beforeEach(() => {
+    _resetPricingCache();
+  });
+
+  afterEach(() => {
+    _resetPricingCache();
+    vi.useRealTimers();
+  });
+
+  it("retries after the short failure TTL instead of pinning DEFAULT_PRICING for an hour", async () => {
+    // The model-registry.ts failure-cache policy, applied here: wrong default
+    // rates for cost tracking must not persist a full success TTL.
+    vi.useFakeTimers();
+    const registryResponse = () =>
+      new Response(
+        JSON.stringify({
+          models: [
+            {
+              id: "composer-2.5",
+              displayName: "Composer 2.5",
+              provider: "cursor",
+              harness: "cursor",
+              costTier: "economy",
+              pricing: {
+                inputPricePerMillion: 0.5,
+                outputPricePerMillion: 2.5,
+                cacheWritePricePerMillion: 0,
+                cacheReadPricePerMillion: 0.2,
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const fetchSpy = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(registryResponse());
+    vi.stubGlobal("fetch", fetchSpy);
+
+    // First call fails and degrades to the default table.
+    expect((await getPricingTable())[0]).toBe(DEFAULT_PRICING);
+
+    // Within the failure TTL the fallback stays cached (no refetch).
+    vi.advanceTimersByTime(30_000);
+    expect((await getPricingTable())[0]).toBe(DEFAULT_PRICING);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Past the failure TTL the registry is refetched and real rates recover.
+    vi.advanceTimersByTime(31_000);
+    expect((await getPricingTable())[0]?.model).toBe("composer-2.5");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/services/runner/src/activities/execute-cursor/model-pricing-data.ts
+++ b/backend/services/runner/src/activities/execute-cursor/model-pricing-data.ts
@@ -8,7 +8,12 @@
  * endpoint is unreachable.
  */
 
-import { resolveModelRegistryUrl, buildRegistryHeaders } from "../../shared/registry-endpoint.js";
+import {
+  resolveModelRegistryUrl,
+  buildRegistryHeaders,
+  REGISTRY_RETRY_POLICY,
+} from "../../shared/registry-endpoint.js";
+import { fetchWithRetry } from "../../shared/http-retry.js";
 
 /** Per-million rates for a speed/mode variant (e.g. "fast") of a base model. */
 export interface CursorVariantPricing {
@@ -53,6 +58,10 @@ interface RegistryEntry {
 }
 
 const CACHE_TTL_MS = 3_600_000; // 1 hour
+// Failed fetches are cached much shorter than successes (the model-registry.ts
+// policy): a transient failure must not pin DEFAULT_PRICING — wrong rates for
+// cost tracking — for a full hour.
+const FAILURE_CACHE_TTL_MS = 60_000;
 
 const DEFAULT_PRICING: CursorModelPricing = {
   model: "unknown",
@@ -104,7 +113,11 @@ function parseVariants(
 }
 
 async function fetchFromApi(): Promise<readonly CursorModelPricing[]> {
-  const res = await fetch(resolveModelRegistryUrl(), { headers: buildRegistryHeaders() });
+  const res = await fetchWithRetry(
+    resolveModelRegistryUrl(),
+    { headers: buildRegistryHeaders() },
+    REGISTRY_RETRY_POLICY,
+  );
   if (!res.ok) throw new Error(`Model registry fetch failed: ${res.status}`);
   const data: unknown = await res.json();
   const table = parsePricingTable(data);
@@ -138,7 +151,7 @@ export async function getPricingTable(): Promise<readonly CursorModelPricing[]> 
         `Failed to fetch model registry from API, using default pricing: ${err}`,
       );
       const fallback = [DEFAULT_PRICING];
-      cache = { data: fallback, expiresAt: Date.now() + CACHE_TTL_MS };
+      cache = { data: fallback, expiresAt: Date.now() + FAILURE_CACHE_TTL_MS };
       return fallback;
     })
     .finally(() => {
@@ -146,6 +159,12 @@ export async function getPricingTable(): Promise<readonly CursorModelPricing[]> 
     });
 
   return inflightFetch;
+}
+
+/** Exposed for testing — resets the in-memory cache. */
+export function _resetPricingCache(): void {
+  cache = null;
+  inflightFetch = null;
 }
 
 export { DEFAULT_PRICING };

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -635,17 +635,14 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     // Step 9: Construct the LLM model. Resolution to the provider API id
     // happens inside buildChatModel; modelName stays the registry id for
     // pricing, the native-thinking heuristic, and sub-agent inheritance.
-    // Operator input: only a positive integer means "bound the request" —
-    // unset, non-numeric, zero, and negative all normalize to no bound.
-    const parsedTimeoutMs =
-      Number.parseInt(process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS ?? "", 10);
-    const requestTimeoutMs = parsedTimeoutMs > 0 ? parsedTimeoutMs : undefined;
+    // The operator's STIGMER_LLM_REQUEST_TIMEOUT_MS bound is applied inside
+    // buildChatModel (#468) — the sub-agent modelFactory below silently
+    // dropped it when each caller parsed the env itself.
     const { model } = await buildChatModel({
       modelName,
       proxyEndpoint: config.proxyEndpoint ?? undefined,
       stigmerToken: config.stigmerToken ?? undefined,
       headerScope: { executionId },
-      timeoutMs: requestTimeoutMs,
     });
     timing.mark("build_model");
 

--- a/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
+++ b/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
@@ -294,7 +294,13 @@ describe("ProxyArtifactStorage", () => {
       return new Response("server error", { status: 500 });
     }) as typeof fetch;
 
-    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    // 500 is retryable, so this persistent failure exhausts the budget —
+    // delayFn injected to skip the real ~7.75 s of backoff (#468). The
+    // degrade contract under test (budget exhaustion still throws the
+    // caller-visible error) is unchanged.
+    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok", {
+      delayFn: async () => {},
+    });
     await expect(
       storage.upload("key", Buffer.from("x")),
     ).rejects.toThrow("Presigned upload failed (HTTP 500)");
@@ -411,10 +417,147 @@ describe("ProxyArtifactStorage", () => {
 
   it("exists throws on an unexpected object status (a fault, not an existence answer)", async () => {
     mockProxyFetch(() => new Response("boom", { status: 500 }));
-    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    // Persistent 500 exhausts the retry budget; delayFn skips the real
+    // backoff (#468). The fault-not-an-answer contract is unchanged.
+    const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok", {
+      delayFn: async () => {},
+    });
     await expect(storage.exists("key")).rejects.toThrow(
       /Artifact existence check failed \(HTTP 500\) for key 'key'/,
     );
+  });
+
+  // The bounded-backoff adoption (stigmer/stigmer#468). Classification policy
+  // is covered by shared/__tests__/http-retry.test.ts; these cases pin the
+  // loop's behavior at this client's call sites: transient failures recover
+  // (each of these fails on pre-#468 code, which threw on the first error),
+  // deterministic failures never retry, and a hung request is aborted at the
+  // per-request bound instead of stalling forever.
+  describe("retry behavior (#468)", () => {
+    let recordedDelays: number[];
+
+    beforeEach(() => {
+      recordedDelays = [];
+    });
+
+    function makeStorage() {
+      return new ProxyArtifactStorage("https://proxy.example.com", "tok", {
+        delayFn: async (ms) => {
+          recordedDelays.push(ms);
+        },
+      });
+    }
+
+    it("upload recovers from a transient presign failure", async () => {
+      let presignCalls = 0;
+      const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("presigned-upload-url")) {
+          presignCalls++;
+          if (presignCalls === 1) {
+            return new Response("bad gateway", { status: 502 });
+          }
+          return new Response(JSON.stringify({ url: "https://r2.example.com/put" }), { status: 200 });
+        }
+        return new Response("", { status: 200 });
+      });
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      const key = await makeStorage().upload("artifacts/e/f.txt", Buffer.from("x"));
+
+      expect(key).toBe("artifacts/e/f.txt");
+      expect(presignCalls).toBe(2);
+      expect(recordedDelays).toEqual([250]);
+    });
+
+    it("upload recovers from a transient R2 PUT failure, re-sending identical bytes", async () => {
+      const putBodies: string[] = [];
+      let putCalls = 0;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("presigned-upload-url")) {
+          return new Response(JSON.stringify({ url: "https://r2.example.com/put" }), { status: 200 });
+        }
+        putCalls++;
+        putBodies.push(String(init?.body));
+        if (putCalls === 1) {
+          return new Response("unavailable", { status: 503 });
+        }
+        return new Response("", { status: 200 });
+      }) as typeof fetch;
+
+      await makeStorage().upload("k", Buffer.from("same-bytes"));
+
+      expect(putCalls).toBe(2);
+      expect(putBodies[0]).toBe(putBodies[1]);
+      expect(recordedDelays).toEqual([250]);
+    });
+
+    it("download recovers from a transient network failure on the R2 GET", async () => {
+      let getCalls = 0;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("presigned-download-url")) {
+          return new Response(JSON.stringify({ url: "https://r2.example.com/dl" }), { status: 200 });
+        }
+        getCalls++;
+        if (getCalls === 1) {
+          // undici's network-failure shape (retryable).
+          throw new TypeError("fetch failed");
+        }
+        return new Response(Buffer.from("payload"), { status: 200 });
+      }) as typeof fetch;
+
+      const got = await makeStorage().download("k");
+
+      expect(got.toString()).toBe("payload");
+      expect(getCalls).toBe(2);
+      expect(recordedDelays).toEqual([250]);
+    });
+
+    it("never retries a deterministic presign refusal (403)", async () => {
+      const fetchSpy = vi.fn(async () => new Response("forbidden", { status: 403 }));
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await expect(makeStorage().upload("k", Buffer.from("x"))).rejects.toThrow(
+        "Failed to get presigned upload URL (HTTP 403)",
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(recordedDelays).toEqual([]);
+    });
+
+    it("aborts a hung request at the per-request bound and retries it", async () => {
+      let calls = 0;
+      globalThis.fetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        calls++;
+        if (calls === 1) {
+          // Hang until the AbortSignal.timeout fires, then reject the way
+          // undici does — proving the bound converts a stall into a
+          // retryable attempt instead of waiting forever.
+          return new Promise<Response>((_, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(init.signal!.reason as Error),
+            );
+          });
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ url: "https://r2.example.com/dl" }), { status: 200 }),
+        );
+      }) as typeof fetch;
+
+      const storage = new ProxyArtifactStorage("https://proxy.example.com", "tok", {
+        requestTimeoutMs: 20,
+        delayFn: async (ms) => {
+          recordedDelays.push(ms);
+        },
+      });
+
+      const url = await storage.getDownloadUrl("k");
+
+      expect(url).toBe("https://r2.example.com/dl");
+      expect(calls).toBe(2);
+      expect(recordedDelays).toEqual([250]);
+    });
   });
 });
 

--- a/backend/services/runner/src/shared/__tests__/http-retry.test.ts
+++ b/backend/services/runner/src/shared/__tests__/http-retry.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { isRetryableHttpStatus, isRetryableFetchError } from "../http-retry.js";
 
-// The bounded-backoff loop that consumes these classifiers lives in
-// checkpointer/http-saver.ts (fetchWithRetry) and is exercised by
-// http-saver.test.ts ("retry behavior"). This file covers the classification
-// policy in isolation — the grpc-retry.test.ts twin.
+// The shared bounded-backoff loop (fetchWithRetry, same module) is exercised
+// through its consumers' suites — http-saver.test.ts ("retry behavior"),
+// artifact-storage.test.ts, registry-fetch tests — which pin the loop's
+// behavior at real call sites rather than in the abstract. This file covers
+// the classification policy in isolation — the grpc-retry.test.ts twin.
 
 describe("isRetryableHttpStatus", () => {
   it("returns true for 408 (request timeout)", () => {

--- a/backend/services/runner/src/shared/__tests__/model-client.test.ts
+++ b/backend/services/runner/src/shared/__tests__/model-client.test.ts
@@ -56,6 +56,7 @@ describe("buildChatModel", () => {
     delete process.env.STIGMER_ANTHROPIC_BACKEND;
     delete process.env.STIGMER_OPENAI_BACKEND;
     delete process.env.CLOUD_ML_REGION;
+    delete process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS;
   });
 
   afterEach(() => {
@@ -215,6 +216,51 @@ describe("buildChatModel", () => {
         },
       });
     });
+
+    // The env default resolves INSIDE buildChatModel (#468): before this,
+    // each caller parsed STIGMER_LLM_REQUEST_TIMEOUT_MS itself, and every
+    // caller except the deep-agent main path — including its own sub-agent
+    // modelFactory — dropped the bound.
+    it("defaults to STIGMER_LLM_REQUEST_TIMEOUT_MS when the caller passes no timeout", async () => {
+      process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS = "7000";
+      mockRegistryResponse([
+        { id: "claude-haiku-4.5", apiModelId: "claude-haiku-4-5-20251001", provider: "anthropic" },
+      ]);
+
+      await buildChatModel({ modelName: "claude-haiku-4.5" });
+
+      expect(lastAnthropicArgs()).toMatchObject({
+        clientOptions: { timeout: 7000 },
+        maxRetries: 0,
+      });
+    });
+
+    it("lets an explicit caller timeout win over the env default", async () => {
+      process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS = "7000";
+      mockRegistryResponse([
+        { id: "claude-haiku-4.5", apiModelId: "claude-haiku-4-5-20251001", provider: "anthropic" },
+      ]);
+
+      await buildChatModel({ modelName: "claude-haiku-4.5", timeoutMs: 5000 });
+
+      expect(lastAnthropicArgs()).toMatchObject({ clientOptions: { timeout: 5000 } });
+    });
+
+    it.each(["0", "-1", "not-a-number", ""])(
+      "normalizes a non-positive env value (%j) to no bound",
+      async (envValue) => {
+        process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS = envValue;
+        mockRegistryResponse([
+          { id: "claude-haiku-4.5", apiModelId: "claude-haiku-4-5-20251001", provider: "anthropic" },
+        ]);
+
+        await buildChatModel({ modelName: "claude-haiku-4.5" });
+
+        const args = lastAnthropicArgs();
+        expect(args).not.toHaveProperty("clientOptions");
+        expect(args).not.toHaveProperty("maxRetries");
+      },
+    );
   });
 
   // ─── Provider backends (STIGMER_ANTHROPIC_BACKEND) ─────────────────────────

--- a/backend/services/runner/src/shared/__tests__/model-pricing.test.ts
+++ b/backend/services/runner/src/shared/__tests__/model-pricing.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { computeLlmCostMicros, computeTurnCost, getModelPricing, resolveModelId, ensureLoaded } from "../model-pricing.js";
-import type { ModelPricing } from "../model-pricing-data.js";
+import {
+  getPricingTable,
+  _resetPricingCache,
+  DEFAULT_PRICING,
+  type ModelPricing,
+} from "../model-pricing-data.js";
 
 describe("computeLlmCostMicros", () => {
   it("falls back to DEFAULT_PRICING when registry is not loaded", () => {
@@ -81,5 +86,60 @@ describe("getModelPricing", () => {
   it("overrides model field in fallback pricing", () => {
     const pricing = getModelPricing("custom-model");
     expect(pricing.model).toBe("custom-model");
+  });
+});
+
+describe("getPricingTable failure caching (#468)", () => {
+  beforeEach(() => {
+    _resetPricingCache();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    _resetPricingCache();
+    vi.useRealTimers();
+  });
+
+  const registryResponse = () =>
+    new Response(
+      JSON.stringify({
+        models: [
+          {
+            id: "claude-sonnet-4-6",
+            displayName: "Claude Sonnet",
+            costTier: "standard",
+            pricing: {
+              inputPricePerMillion: 3.0,
+              outputPricePerMillion: 15.0,
+              cacheWritePricePerMillion: 3.75,
+              cacheReadPricePerMillion: 0.3,
+            },
+          },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  it("retries after the short failure TTL instead of pinning DEFAULT_PRICING for an hour", async () => {
+    // The model-registry.ts failure-cache policy, applied here: wrong default
+    // rates for cost tracking must not persist a full success TTL.
+    vi.useFakeTimers();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(registryResponse());
+
+    // First call fails and degrades to the default table.
+    expect((await getPricingTable())[0]).toBe(DEFAULT_PRICING);
+
+    // Within the failure TTL the fallback stays cached (no refetch).
+    vi.advanceTimersByTime(30_000);
+    expect((await getPricingTable())[0]).toBe(DEFAULT_PRICING);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Past the failure TTL the registry is refetched and real rates recover.
+    vi.advanceTimersByTime(31_000);
+    expect((await getPricingTable())[0]?.model).toBe("claude-sonnet-4-6");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/services/runner/src/shared/__tests__/model-registry.test.ts
+++ b/backend/services/runner/src/shared/__tests__/model-registry.test.ts
@@ -223,6 +223,28 @@ describe("resolveToApiModelId", () => {
     expect(result).toBe("claude-haiku-4.5");
   });
 
+  it("recovers from a transient network failure without engaging the failure cache (#468)", async () => {
+    // undici's retryable shape (TypeError) — the shared bounded-backoff loop
+    // absorbs it, so resolution succeeds on the SAME call and the 60 s
+    // degraded window never opens. Pre-#468 code failed the fetch outright.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            models: [
+              { id: "claude-haiku-4.5", apiModelId: "claude-haiku-4-5-20251001", provider: "anthropic", costTier: "economy", harness: "native" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    expect(await resolveToApiModelId("claude-haiku-4.5")).toBe("claude-haiku-4-5-20251001");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("retries after the short failure TTL instead of caching the failure for an hour", async () => {
     vi.useFakeTimers();
     const fetchSpy = vi

--- a/backend/services/runner/src/shared/artifact-storage.ts
+++ b/backend/services/runner/src/shared/artifact-storage.ts
@@ -13,6 +13,11 @@
  * The runner never holds R2/S3 credentials — in cloud mode it calls the proxy
  * to obtain a presigned upload URL, then PUTs content over plain HTTPS.
  *
+ * Every proxy-backend request rides the shared bounded-backoff loop
+ * (http-retry.ts) with a per-request abort timeout, so a momentary
+ * stigmer-service interruption is retried and a hung connection cannot
+ * stall an agent turn unboundedly (stigmer/stigmer#468).
+ *
  * DD-6: No direct R2 backend. Local + Proxy only.
  */
 
@@ -20,6 +25,8 @@ import { mkdir, writeFile, readFile, access, rm } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import type { Config } from "../config.js";
+import type { RetryOptions } from "./grpc-retry.js";
+import { fetchWithRetry, type FetchRetryPolicy } from "./http-retry.js";
 
 // ── Interface ────────────────────────────────────────────────────────
 
@@ -117,13 +124,64 @@ export class LocalArtifactStorage implements ArtifactStorage {
 
 // ── Proxy Backend ────────────────────────────────────────────────────
 
+/** Retry policy plus the two per-request bounds; every field is defaulted. */
+export interface ProxyArtifactStorageOptions extends RetryOptions {
+  /** Bound for proxy presign calls and the 1-byte exists probe. Default 30 s. */
+  readonly requestTimeoutMs?: number;
+  /**
+   * Bound for the presigned R2 PUT/GET, which move whole artifact payloads
+   * (claim-check offloads, tool outputs, file-review captures — MB scale).
+   * Deliberately wider than requestTimeoutMs so a legitimate slow transfer
+   * is never aborted by a bound sized for JSON round-trips. Default 120 s.
+   */
+  readonly transferTimeoutMs?: number;
+}
+
+/**
+ * Default transient-retry policy (stigmer/stigmer#468): the checkpointer's
+ * budget — sized to span a pod-restart reroute, ~7.75 s of delays across
+ * 5 retries. Retrying is safe at every site: the presign POSTs are
+ * idempotent mints, the PUT re-sends identical bytes to the same key (a
+ * keyed overwrite), and the GETs are reads.
+ */
+const DEFAULT_RETRY = {
+  baseDelayMs: 250,
+  backoffFactor: 2,
+  maxRetries: 5,
+  requestTimeoutMs: 30_000,
+  transferTimeoutMs: 120_000,
+} as const;
+
 export class ProxyArtifactStorage implements ArtifactStorage {
   private readonly baseUrl: string;
   private readonly authTokenSource: ProxyAuthTokenSource;
+  /** Governs the proxy presign calls and the exists probe. */
+  private readonly requestPolicy: FetchRetryPolicy;
+  /** Governs the presigned R2 transfers; same budget, wider timeout. */
+  private readonly transferPolicy: FetchRetryPolicy;
 
-  constructor(proxyEndpoint: string, authToken: ProxyAuthTokenSource) {
+  constructor(
+    proxyEndpoint: string,
+    authToken: ProxyAuthTokenSource,
+    options: ProxyArtifactStorageOptions = {},
+  ) {
     this.baseUrl = `${proxyEndpoint.replace(/\/+$/, "")}/v1/proxy/artifacts`;
     this.authTokenSource = authToken;
+    const shared = {
+      label: "ProxyArtifactStorage",
+      baseDelayMs: options.baseDelayMs ?? DEFAULT_RETRY.baseDelayMs,
+      backoffFactor: options.backoffFactor ?? DEFAULT_RETRY.backoffFactor,
+      maxRetries: options.maxRetries ?? DEFAULT_RETRY.maxRetries,
+      delayFn: options.delayFn,
+    };
+    this.requestPolicy = {
+      ...shared,
+      requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_RETRY.requestTimeoutMs,
+    };
+    this.transferPolicy = {
+      ...shared,
+      requestTimeoutMs: options.transferTimeoutMs ?? DEFAULT_RETRY.transferTimeoutMs,
+    };
   }
 
   /**
@@ -141,14 +199,14 @@ export class ProxyArtifactStorage implements ArtifactStorage {
   async upload(key: string, content: Buffer, contentType?: string): Promise<string> {
     const ct = contentType ?? "application/octet-stream";
 
-    const presignResp = await fetch(`${this.baseUrl}/presigned-upload-url`, {
+    const presignResp = await fetchWithRetry(`${this.baseUrl}/presigned-upload-url`, {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${this.authToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ key, content_type: ct }),
-    });
+    }, this.requestPolicy);
     if (!presignResp.ok) {
       throw new Error(
         `Failed to get presigned upload URL (HTTP ${presignResp.status}): ` +
@@ -180,11 +238,14 @@ export class ProxyArtifactStorage implements ArtifactStorage {
       uploadHeaders["Content-Type"] = ct;
     }
 
-    const putResp = await fetch(data.url, {
+    // Retrying the PUT alone (not the presign+PUT pair) is deliberate: the
+    // retry budget's few seconds of delays sit far inside presign validity,
+    // and re-sending the same Buffer to the same key is a keyed overwrite.
+    const putResp = await fetchWithRetry(data.url, {
       method: "PUT",
       headers: uploadHeaders,
       body: content,
-    });
+    }, this.transferPolicy);
     if (!putResp.ok) {
       throw new Error(
         `Presigned upload failed (HTTP ${putResp.status}): ` +
@@ -196,14 +257,14 @@ export class ProxyArtifactStorage implements ArtifactStorage {
   }
 
   async getDownloadUrl(key: string): Promise<string> {
-    const resp = await fetch(`${this.baseUrl}/presigned-download-url`, {
+    const resp = await fetchWithRetry(`${this.baseUrl}/presigned-download-url`, {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${this.authToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ key }),
-    });
+    }, this.requestPolicy);
     if (!resp.ok) {
       throw new Error(
         `Failed to get presigned download URL (HTTP ${resp.status}): ` +
@@ -216,7 +277,7 @@ export class ProxyArtifactStorage implements ArtifactStorage {
 
   async download(key: string): Promise<Buffer> {
     const url = await this.getDownloadUrl(key);
-    const resp = await fetch(url);
+    const resp = await fetchWithRetry(url, undefined, this.transferPolicy);
     if (!resp.ok) {
       throw new Error(
         `Artifact download failed (HTTP ${resp.status}) for key '${key}': ` +
@@ -242,7 +303,11 @@ export class ProxyArtifactStorage implements ArtifactStorage {
       // addressed CAS blob dedup) then re-uploads, which is idempotent.
       return false;
     }
-    const resp = await fetch(url, { headers: { Range: "bytes=0-0" } });
+    const resp = await fetchWithRetry(
+      url,
+      { headers: { Range: "bytes=0-0" } },
+      this.requestPolicy,
+    );
     await resp.arrayBuffer().catch(() => undefined); // drain the <=1-byte body
     if (resp.status === 404) return false;
     if (resp.status === 200 || resp.status === 206 || resp.status === 416) return true;

--- a/backend/services/runner/src/shared/checkpointer/http-saver.ts
+++ b/backend/services/runner/src/shared/checkpointer/http-saver.ts
@@ -14,9 +14,9 @@
  * The Java proxy calls Document.parse(json) which handles $binary
  * natively, and doc.toJson() emits the same format on reads.
  *
- * Every request runs through {@link HttpCheckpointSaver.fetchWithRetry}:
- * bounded exponential backoff on transient failures (classified by
- * http-retry.ts) with a per-request abort timeout. This loop is the ONLY
+ * Every request runs through the shared bounded-backoff loop
+ * (http-retry.ts's fetchWithRetry, with this saver's policy: transient
+ * classification + a per-request abort timeout). That loop is the ONLY
  * retry layer between an agent execution and its checkpoints — the deep
  * agent activity is deliberately non-retryable at the Temporal level
  * (maximumAttempts: 1; replaying a whole agent run is not safe), so before
@@ -39,7 +39,7 @@ import {
 } from "@langchain/langgraph-checkpoint";
 import type { CheckpointMetadata, PendingWrite } from "@langchain/langgraph-checkpoint";
 import type { RetryOptions } from "../grpc-retry.js";
-import { isRetryableFetchError, isRetryableHttpStatus } from "../http-retry.js";
+import { fetchWithRetry, type FetchRetryPolicy } from "../http-retry.js";
 
 function encodeB64(data: Uint8Array): string {
   if (typeof Buffer !== "undefined") {
@@ -117,18 +117,10 @@ const DEFAULT_RETRY = {
   requestTimeoutMs: 30_000,
 } as const;
 
-function defaultDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export class HttpCheckpointSaver extends BaseCheckpointSaver {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
-  private readonly baseDelayMs: number;
-  private readonly backoffFactor: number;
-  private readonly maxRetries: number;
-  private readonly requestTimeoutMs: number;
-  private readonly delay: (ms: number) => Promise<void>;
+  private readonly retryPolicy: FetchRetryPolicy;
 
   constructor(
     proxyEndpoint: string,
@@ -141,55 +133,18 @@ export class HttpCheckpointSaver extends BaseCheckpointSaver {
       Authorization: `Bearer ${authToken}`,
       "Content-Type": "application/json",
     };
-    this.baseDelayMs = options.baseDelayMs ?? DEFAULT_RETRY.baseDelayMs;
-    this.backoffFactor = options.backoffFactor ?? DEFAULT_RETRY.backoffFactor;
-    this.maxRetries = options.maxRetries ?? DEFAULT_RETRY.maxRetries;
-    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_RETRY.requestTimeoutMs;
-    this.delay = options.delayFn ?? defaultDelay;
+    this.retryPolicy = {
+      label: "HttpCheckpointSaver",
+      baseDelayMs: options.baseDelayMs ?? DEFAULT_RETRY.baseDelayMs,
+      backoffFactor: options.backoffFactor ?? DEFAULT_RETRY.backoffFactor,
+      maxRetries: options.maxRetries ?? DEFAULT_RETRY.maxRetries,
+      requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_RETRY.requestTimeoutMs,
+      delayFn: options.delayFn,
+    };
   }
 
-  /**
-   * `fetch` with bounded exponential backoff on transient failures and a
-   * per-request abort timeout.
-   *
-   * Composition contract: on a non-retryable status — or when the budget is
-   * exhausted on a retryable one — the last `Response` is RETURNED, so every
-   * call site keeps its own `resp.ok` / 404 handling unchanged; this wrapper
-   * changes when a response arrives, never what call sites do with it. It
-   * throws only what `fetch` itself throws: a network-level rejection that is
-   * non-retryable or has exhausted the budget.
-   */
-  private async fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
-    for (let attempt = 0; ; attempt++) {
-      const canRetry = attempt < this.maxRetries;
-      let resp: Response;
-      try {
-        resp = await fetch(url, {
-          ...init,
-          signal: AbortSignal.timeout(this.requestTimeoutMs),
-        });
-      } catch (err) {
-        if (canRetry && isRetryableFetchError(err)) {
-          await this.backOff(attempt, String(err));
-          continue;
-        }
-        throw err;
-      }
-      if (canRetry && isRetryableHttpStatus(resp.status)) {
-        await this.backOff(attempt, `HTTP ${resp.status} ${resp.statusText}`);
-        continue;
-      }
-      return resp;
-    }
-  }
-
-  private async backOff(attempt: number, reason: string): Promise<void> {
-    const delayMs = this.baseDelayMs * Math.pow(this.backoffFactor, attempt);
-    console.warn(
-      `[HttpCheckpointSaver] retryable failure ` +
-      `(attempt ${attempt + 1}/${this.maxRetries + 1}, retry in ${delayMs}ms): ${reason}`,
-    );
-    await this.delay(delayMs);
+  private fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
+    return fetchWithRetry(url, init, this.retryPolicy);
   }
 
   private async serializeTyped(obj: unknown): Promise<[string, BinaryObj]> {

--- a/backend/services/runner/src/shared/grpc-retry.ts
+++ b/backend/services/runner/src/shared/grpc-retry.ts
@@ -6,7 +6,11 @@
  * `updateStatus` should back off and retry (transient transport errors) or
  * fail fast (deterministic errors). This module is intentionally just the
  * classification policy + its options type, kept small and separately tested;
- * the persist loop that consumes it lives with the rest of the persist logic.
+ * the persist loop that consumes it lives with the rest of the persist logic
+ * in status.ts — a single consumer whose loop is interwoven with persist
+ * semantics. (The HTTP twin, http-retry.ts, diverged there deliberately: with
+ * three fetch clients needing a byte-identical loop it hosts the shared
+ * fetchWithRetry too — see its module doc.)
  */
 
 import { ConnectError, Code } from "@connectrpc/connect";

--- a/backend/services/runner/src/shared/http-retry.ts
+++ b/backend/services/runner/src/shared/http-retry.ts
@@ -1,14 +1,17 @@
 /**
- * HTTP error classification for side-channel proxy retries.
+ * HTTP error classification AND the shared bounded-backoff loop for
+ * side-channel proxy retries.
  *
  * The runner reaches stigmer-service's Side-Channel Proxy (`/v1/proxy/...`)
- * over plain `fetch` from several clients — the checkpoint saver today;
- * artifact storage, the LLM proxy, and the registry endpoint are candidates
- * (stigmer/stigmer#468). This module is the one place that answers "is this
- * HTTP failure worth retrying?", the `fetch` twin of grpc-retry.ts: it holds
- * the classification policy only, kept small and separately tested. The
- * bounded-backoff loop that consumes it lives with each client (the
- * grpc-retry/status.ts split).
+ * over plain `fetch` from several clients: the checkpoint saver, artifact
+ * storage, and the model-registry fetches (stigmer/stigmer#468). This module
+ * is the one place that answers "is this HTTP failure worth retrying?" — the
+ * `fetch` twin of grpc-retry.ts — and, since #468, also owns the
+ * {@link fetchWithRetry} loop those clients share. That is a deliberate
+ * divergence from grpc-retry.ts's policy-only split: the gRPC side has a
+ * single consumer whose loop is interwoven with persist-specific logic
+ * (status.ts), while the HTTP side grew three consumers needing a
+ * byte-identical loop — per-client copies were the drift risk, not the seam.
  *
  * The policy is grounded in what the proxy actually emits, not HTTP folklore.
  * CheckpointerProxyController returns exactly four deterministic errors —
@@ -17,7 +20,10 @@
  * reach the runner only as 5xx (Spring's error handler, ingress 502-504),
  * 408/429 (infrastructure between runner and service), or as network-level
  * fetch rejections. 401/403 stay terminal deliberately: retrying cannot fix
- * an expired or rejected credential.
+ * an expired or rejected credential. The same classification holds for the
+ * presigned R2 URLs artifact storage talks to: their deterministic failures
+ * (403 expired signature, 404 missing object) are 4xx, their transient ones
+ * are 5xx/network.
  */
 
 /**
@@ -47,4 +53,87 @@ export function isRetryableHttpStatus(status: number): boolean {
 export function isRetryableFetchError(err: unknown): boolean {
   if (err instanceof TypeError) return true;
   return err instanceof Error && err.name === "TimeoutError";
+}
+
+/**
+ * A fully-resolved retry policy for {@link fetchWithRetry}. Every field is
+ * required on purpose: defaults differ per client (the checkpointer and the
+ * presign endpoints run 30 s requests, artifact transfers 120 s, registry
+ * fetches 10 s), so each client resolves its own defaults once and this
+ * module never guesses.
+ */
+export interface FetchRetryPolicy {
+  /** Client name for retry logs, e.g. "HttpCheckpointSaver". */
+  readonly label: string;
+  /** Delay before the first retry (ms); doubles per attempt via the factor. */
+  readonly baseDelayMs: number;
+  readonly backoffFactor: number;
+  /** Retry attempts after the initial one. */
+  readonly maxRetries: number;
+  /**
+   * Milliseconds before an in-flight request is aborted and the attempt is
+   * classified retryable. Without it a hung connection (the realistic
+   * unplanned-pod-kill symptom) stalls forever and the retry never engages.
+   */
+  readonly requestTimeoutMs: number;
+  /** Injectable delay for tests; defaults to a real setTimeout sleep. */
+  readonly delayFn?: (ms: number) => Promise<void>;
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * `fetch` with bounded exponential backoff on transient failures and a
+ * per-request abort timeout.
+ *
+ * Composition contract: on a non-retryable status — or when the budget is
+ * exhausted on a retryable one — the last `Response` is RETURNED, so every
+ * call site keeps its own `resp.ok` / 404 handling unchanged; this wrapper
+ * changes when a response arrives, never what call sites do with it. It
+ * throws only what `fetch` itself throws: a network-level rejection that is
+ * non-retryable or has exhausted the budget.
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit | undefined,
+  policy: FetchRetryPolicy,
+): Promise<Response> {
+  const delay = policy.delayFn ?? defaultDelay;
+  for (let attempt = 0; ; attempt++) {
+    const canRetry = attempt < policy.maxRetries;
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(policy.requestTimeoutMs),
+      });
+    } catch (err) {
+      if (canRetry && isRetryableFetchError(err)) {
+        await backOff(policy, delay, attempt, String(err));
+        continue;
+      }
+      throw err;
+    }
+    if (canRetry && isRetryableHttpStatus(resp.status)) {
+      await backOff(policy, delay, attempt, `HTTP ${resp.status} ${resp.statusText}`);
+      continue;
+    }
+    return resp;
+  }
+}
+
+async function backOff(
+  policy: FetchRetryPolicy,
+  delay: (ms: number) => Promise<void>,
+  attempt: number,
+  reason: string,
+): Promise<void> {
+  const delayMs = policy.baseDelayMs * Math.pow(policy.backoffFactor, attempt);
+  console.warn(
+    `[${policy.label}] retryable failure ` +
+    `(attempt ${attempt + 1}/${policy.maxRetries + 1}, retry in ${delayMs}ms): ${reason}`,
+  );
+  await delay(delayMs);
 }

--- a/backend/services/runner/src/shared/model-client.ts
+++ b/backend/services/runner/src/shared/model-client.ts
@@ -55,8 +55,25 @@ export interface BuildChatModelOptions {
    * stays the caller's decision to avoid silently changing behavior.
    */
   readonly maxTokens?: number;
+  /**
+   * Per-request bound. When omitted, defaults to the operator's
+   * STIGMER_LLM_REQUEST_TIMEOUT_MS — resolved HERE, not per caller, so no
+   * call site can drop the bound by forgetting to plumb it (the sub-agent
+   * factory did exactly that; stigmer/stigmer#468). An explicit value wins.
+   */
   readonly timeoutMs?: number;
   readonly maxRetries?: number;
+}
+
+/**
+ * The operator's request-timeout bound. Only a positive integer means
+ * "bound the request" — unset, non-numeric, zero, and negative all
+ * normalize to no bound. Deployment-static env, read here the same way
+ * provider API keys are.
+ */
+function resolveDefaultTimeoutMs(): number | undefined {
+  const parsed = Number.parseInt(process.env.STIGMER_LLM_REQUEST_TIMEOUT_MS ?? "", 10);
+  return parsed > 0 ? parsed : undefined;
 }
 
 export interface BuiltChatModel {
@@ -82,6 +99,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   const resolved = await resolveToApiModelId(opts.modelName);
   const provider = inferProvider(resolved);
   const apiModelId = stripProviderPrefix(resolved);
+  const timeoutMs = opts.timeoutMs ?? resolveDefaultTimeoutMs();
 
   // Backend precedence by construction: a proxied call never consults the
   // backend var — the proxy owns provider routing (the factories' preflight
@@ -201,7 +219,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     temperature: opts.temperature ?? 0,
     apiKey,
     ...(maxTokens ? { maxTokens } : {}),
-    ...(opts.timeoutMs ? { maxRetries: opts.maxRetries ?? 0 } : {}),
+    ...(timeoutMs ? { maxRetries: opts.maxRetries ?? 0 } : {}),
   };
 
   // The request timeout lives in a different slot per wrapper: ChatOpenAI
@@ -215,7 +233,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   // that is LangChain's own retry knob, distinct from the SDK-level
   // maxRetries the factories receive.
   const anthropicClientOptions = {
-    ...(opts.timeoutMs ? { timeout: opts.timeoutMs } : {}),
+    ...(timeoutMs ? { timeout: timeoutMs } : {}),
     ...(baseUrl ? { baseURL: baseUrl } : {}),
     ...(headers ? { defaultHeaders: headers } : {}),
   };
@@ -231,7 +249,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     ? new ChatOpenAI({
         model: apiModelId,
         ...common,
-        ...(opts.timeoutMs ? { timeout: opts.timeoutMs } : {}),
+        ...(timeoutMs ? { timeout: timeoutMs } : {}),
         ...(baseUrl || headers
           ? {
               configuration: {

--- a/backend/services/runner/src/shared/model-pricing-data.ts
+++ b/backend/services/runner/src/shared/model-pricing-data.ts
@@ -30,9 +30,18 @@ interface RegistryEntry {
   };
 }
 
-import { resolveModelRegistryUrl, buildRegistryHeaders } from "./registry-endpoint.js";
+import {
+  resolveModelRegistryUrl,
+  buildRegistryHeaders,
+  REGISTRY_RETRY_POLICY,
+} from "./registry-endpoint.js";
+import { fetchWithRetry } from "./http-retry.js";
 
 const CACHE_TTL_MS = 3_600_000;
+// Failed fetches are cached much shorter than successes (the model-registry.ts
+// policy): a transient failure must not pin DEFAULT_PRICING — wrong rates for
+// cost tracking — for a full hour.
+const FAILURE_CACHE_TTL_MS = 60_000;
 
 export const DEFAULT_PRICING: ModelPricing = {
   model: "unknown",
@@ -66,7 +75,11 @@ function parsePricingTable(json: unknown): ModelPricing[] {
 }
 
 async function fetchFromApi(): Promise<readonly ModelPricing[]> {
-  const res = await fetch(resolveModelRegistryUrl(), { headers: buildRegistryHeaders() });
+  const res = await fetchWithRetry(
+    resolveModelRegistryUrl(),
+    { headers: buildRegistryHeaders() },
+    REGISTRY_RETRY_POLICY,
+  );
   if (!res.ok) throw new Error(`Model registry fetch failed: ${res.status}`);
   const data: unknown = await res.json();
   const table = parsePricingTable(data);
@@ -93,7 +106,7 @@ export async function getPricingTable(): Promise<readonly ModelPricing[]> {
         `Failed to fetch model registry, using default pricing: ${err}`,
       );
       const fallback = [DEFAULT_PRICING];
-      cache = { data: fallback, expiresAt: Date.now() + CACHE_TTL_MS };
+      cache = { data: fallback, expiresAt: Date.now() + FAILURE_CACHE_TTL_MS };
       return fallback;
     })
     .finally(() => {
@@ -101,4 +114,10 @@ export async function getPricingTable(): Promise<readonly ModelPricing[]> {
     });
 
   return inflightFetch;
+}
+
+/** Exposed for testing — resets the in-memory cache. */
+export function _resetPricingCache(): void {
+  cache = null;
+  inflightFetch = null;
 }

--- a/backend/services/runner/src/shared/model-registry.ts
+++ b/backend/services/runner/src/shared/model-registry.ts
@@ -10,7 +10,12 @@
  * (getModelVisionCapability).
  */
 
-import { resolveModelRegistryUrl, buildRegistryHeaders } from "./registry-endpoint.js";
+import {
+  resolveModelRegistryUrl,
+  buildRegistryHeaders,
+  REGISTRY_RETRY_POLICY,
+} from "./registry-endpoint.js";
+import { fetchWithRetry } from "./http-retry.js";
 
 const CACHE_TTL_MS = 3_600_000;
 // Failed fetches are cached much shorter than successes: a transient failure
@@ -68,7 +73,7 @@ function parseVisionCapability(capabilities: unknown): boolean | undefined {
 
 async function fetchRegistry(): Promise<readonly RegistryModel[]> {
   const url = resolveModelRegistryUrl();
-  const res = await fetch(url, { headers: buildRegistryHeaders() });
+  const res = await fetchWithRetry(url, { headers: buildRegistryHeaders() }, REGISTRY_RETRY_POLICY);
   if (!res.ok) throw new Error(`Model registry fetch failed: ${res.status}`);
   const data: unknown = await res.json();
   return parseRegistry(data);

--- a/backend/services/runner/src/shared/registry-endpoint.ts
+++ b/backend/services/runner/src/shared/registry-endpoint.ts
@@ -20,9 +20,36 @@
  */
 
 import { normalizeEndpoint } from "../config.js";
+import type { FetchRetryPolicy } from "./http-retry.js";
 
 /** Default local stigmer-server origin — mirrors config.ts's local-mode default. */
 const DEFAULT_LOCAL_BACKEND = "http://localhost:7234";
+
+/**
+ * Shared retry policy for the three registry fetch clients (model-registry.ts
+ * and both model-pricing-data.ts modules) — stigmer/stigmer#468.
+ *
+ * The timeout is the load-bearing half: each consumer deduplicates callers
+ * through a single in-flight promise, so one hung fetch strands every
+ * concurrent caller behind it — model-registry.ts's sits in front of every
+ * LLM client build. 10 s (not the checkpointer's 30 s) because the response
+ * is a small JSON document and the callers degrade gracefully; what they must
+ * never do is wait forever.
+ *
+ * The retry half matters because the degrade is not free: a failed registry
+ * fetch is cached (60 s empty registry → unresolved model ids that 404 at the
+ * provider; pricing falls back to defaults), so a budget spanning a
+ * pod-restart reroute converts that poisoned window into ~1.75 s of backoff.
+ * Worst case fully bounded: ~31 s of cold-cache stall when the control plane
+ * is genuinely down, versus an infinite hang before #468.
+ */
+export const REGISTRY_RETRY_POLICY: FetchRetryPolicy = {
+  label: "registry-endpoint",
+  baseDelayMs: 250,
+  backoffFactor: 2,
+  maxRetries: 3,
+  requestTimeoutMs: 10_000,
+};
 
 /**
  * Resolve the base URL (origin, no path) for model-registry and pricing


### PR DESCRIPTION
## Summary

Fixes the class stigmer/stigmer#468 names: after the cloud#188 checkpoint-saver fix, the runner still had bare `fetch` clients on the Side-Channel Proxy with no retry and no per-request timeout — a momentary stigmer-service interruption failed them on first error, and a hung connection stalled them unboundedly.

**Investigation corrected the issue's premise on two of its three named clients** (details in each section):

### 1. Shared loop extraction (`shared/http-retry.ts`)

`HttpCheckpointSaver.fetchWithRetry` is extracted as `fetchWithRetry(url, init, policy)` — same composition contract (non-retryable / budget-exhausted statuses are *returned* so call sites keep their own `resp.ok` handling; throws only what fetch throws). This is a deliberate, recorded divergence from `grpc-retry.ts`'s policy-only split: the gRPC side has one consumer whose loop is interwoven with persist logic; the HTTP side now has three consumers needing a byte-identical loop. Both module docs record the reasoning. The saver's 21 existing tests pass **unmodified**.

### 2. `artifact-storage.ts` — as filed

All 5 `ProxyArtifactStorage` fetch sites adopt the loop: presign POSTs + the exists probe at 30s/5-retry (checkpointer parity), presigned R2 PUT/GET at 120s (payload-scale transfers, incl. claim-check offloads). Retry is safe at every site: no streaming bodies, PUT re-sends identical bytes to the same key. Constructor gains an *optional* options param (`HttpCheckpointSaverOptions` idiom) — production call sites unchanged.

### 3. Registry fetches — the issue named the wrong module

`registry-endpoint.ts` has no fetch; its three consumers do (`model-registry.ts`, both `model-pricing-data.ts`). All three adopt a shared 10s/3-retry policy (`REGISTRY_RETRY_POLICY`). The timeout is load-bearing: each module deduplicates callers through one in-flight promise, so a single hung fetch stranded **every** concurrent model construction. Cache/degrade semantics stay byte-identical.

### 4. LLM arm — no bare fetch exists; the real gap was plumbing

LLM calls ride the LangChain/SDK clients, which own retry/timeout (`STIGMER_LLM_REQUEST_TIMEOUT_MS`, seam-tested). But only the deep-agent main path passed `timeoutMs` — `call-llm`, `classify-tool-approvals`, `extract-structured-output`, **and the deep-agent's own sub-agent `modelFactory`** dropped the bound. The env default now resolves *inside* `buildChatModel` (explicit caller value wins; non-positive/unset normalizes to no bound, unchanged). Env unset = zero behavior change anywhere.

### 5. Ride-along (owner-ruled in planning): pricing failure-cache TTL

Both pricing modules cached the fetch-failure fallback (`DEFAULT_PRICING` — wrong rates for cost tracking) for the full 1-hour success TTL. They now use the 60s failure TTL that `model-registry.ts` records for exactly this reason.

## Test plan

- [x] New retry-behavior suites per client (recorded-delay idiom): transient recovery on presign/PUT/R2-GET (each fails on pre-#468 code), deterministic 4xx never retried, hung request aborted at the bound and retried
- [x] `buildChatModel` env-default pins: env set + caller omits → bound applies with `maxRetries: 0`; explicit caller wins; `0`/`-1`/garbage/unset → no bound (today's shape)
- [x] Failure-TTL pins in both pricing modules (fake-timer idiom from the model-registry twin test)
- [x] `HttpCheckpointSaver` suite green **unmodified** (refactor-safety pin)
- [x] Full runner gate: `npm run typecheck` clean + **4447 passed / 6 pre-existing skips** (`vitest run`, Node 22.22.1)

Closes #468

Made with [Cursor](https://cursor.com)