### PR TITLE
fix(runner): lead detail-free cursor fallback errors with user-facing copy

### DIFF
--- a/backend/services/runner/src/activities/__tests__/error-classifier.test.ts
+++ b/backend/services/runner/src/activities/__tests__/error-classifier.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { synthesizeError, formatClassifiedError, shouldRetryWithFreshAgent } from "../execute-cursor/error-classifier.js";
+import {
+  synthesizeError,
+  formatClassifiedError,
+  shouldRetryWithFreshAgent,
+  DETAIL_FREE_FALLBACK_USER_PREFIX,
+  TRANSPORT_TIMEOUT_USER_PREFIX,
+} from "../execute-cursor/error-classifier.js";
 
 describe("synthesizeError", () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -213,7 +219,7 @@ describe("synthesizeError", () => {
 
     expect(result.category).toBe("unknown");
     expect(result.source).toBe("fallback");
-    expect(result.message).toContain("no detail from SDK");
+    expect(result.message).toContain(DETAIL_FREE_FALLBACK_USER_PREFIX);
     expect(result.message).toContain("claude-sonnet-4");
   });
 
@@ -259,6 +265,92 @@ describe("synthesizeError", () => {
     expect(result.message).toContain("Model=claude-sonnet-4");
     expect(result.message).toContain("mode=local");
     expect(result.message).toContain("agentId=agent-123");
+  });
+
+  // The exact prod shape from oss#492: the Composer 2.5 capacity incident
+  // rejected every run with a bare { status: "error" } — all five detail
+  // channels empty, fresh agent (the poisoned-handle retry produces this
+  // same shape with isResumedHandle: false). End users read this message
+  // verbatim in embedded surfaces, so it must lead with actionable copy,
+  // keep the diagnostic parenthetical for operators, and be retryable
+  // (provider capacity is transient).
+  it("detail-free failure on a fresh agent leads with user-facing copy and is retryable (oss#492)", () => {
+    const result = synthesizeError({
+      sdkError: undefined,
+      sdkResultFields: undefined,
+      streamErrorMessage: undefined,
+      capturedRejection: undefined,
+      conversationErrorText: undefined,
+      isResumedHandle: false,
+      fallbackContext: { model: "composer-2.5", mode: "local", agentId: "agent-abc" },
+    });
+
+    expect(result.category).toBe("unknown");
+    expect(result.source).toBe("fallback");
+    expect(result.retryable).toBe(true);
+    expect(result.message.startsWith(DETAIL_FREE_FALLBACK_USER_PREFIX)).toBe(true);
+    // Diagnostic context survives for operators (and the env integration
+    // test's Model= matcher).
+    expect(result.message).toContain("Model=composer-2.5");
+    expect(result.message).toContain("mode=local");
+    expect(result.message).toContain("agentId=agent-abc");
+  });
+
+  // sdk-react's isInterruptedError reframes any error containing the phrase
+  // "retry or resume" as a neutral resumable notice instead of a failure
+  // alert. A capacity failure must render as a failure — guard the copy
+  // (formatted end-to-end, tail included) against ever matching that regex.
+  it("user-facing fallback copy never trips the sdk-react interrupted-error reframe", () => {
+    const interruptedReframe = /\[StallTimeoutError\]|execution interrupted|retry or resume/i;
+    for (const prefix of [DETAIL_FREE_FALLBACK_USER_PREFIX, TRANSPORT_TIMEOUT_USER_PREFIX]) {
+      expect(prefix).not.toMatch(interruptedReframe);
+    }
+    const formatted = formatClassifiedError(synthesizeError({
+      sdkResultFields: undefined,
+      streamErrorMessage: undefined,
+      capturedRejection: undefined,
+      isResumedHandle: false,
+      fallbackContext,
+    }));
+    expect(formatted).not.toMatch(interruptedReframe);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Transport-timeout heuristic (0 messages, ~default SDK timeout)
+  // ---------------------------------------------------------------------------
+
+  it("classifies a 0-message ~30s failure as retryable network with user-facing copy", () => {
+    const result = synthesizeError({
+      sdkResultFields: undefined,
+      streamErrorMessage: undefined,
+      capturedRejection: undefined,
+      isResumedHandle: false,
+      fallbackContext,
+      durationMs: 30012,
+      messageCount: 0,
+    });
+
+    expect(result.category).toBe("network");
+    expect(result.source).toBe("fallback");
+    expect(result.retryable).toBe(true);
+    expect(result.message.startsWith(TRANSPORT_TIMEOUT_USER_PREFIX)).toBe(true);
+    expect(result.message).toContain("30012ms");
+    expect(result.message).toContain("Model=claude-sonnet-4");
+  });
+
+  it("does not apply the transport heuristic outside the default-timeout window", () => {
+    const result = synthesizeError({
+      sdkResultFields: undefined,
+      streamErrorMessage: undefined,
+      capturedRejection: undefined,
+      isResumedHandle: false,
+      fallbackContext,
+      durationMs: 120000,
+      messageCount: 0,
+    });
+
+    expect(result.category).toBe("unknown");
+    expect(result.message.startsWith(DETAIL_FREE_FALLBACK_USER_PREFIX)).toBe(true);
   });
 
   // ---------------------------------------------------------------------------

--- a/backend/services/runner/src/activities/execute-cursor/error-classifier.ts
+++ b/backend/services/runner/src/activities/execute-cursor/error-classifier.ts
@@ -131,6 +131,29 @@ function extractFromCandidate(v: unknown): RunErrorSources | undefined {
   return text.length > 0 ? { sdkError: undefined, sdkResultFields: text } : undefined;
 }
 
+/**
+ * Stable lead sentence of the detail-free fallback error (all five detail
+ * channels empty — empirically the shape of Cursor-side capacity rejections,
+ * oss#492). This is what end users read in embedded surfaces, so it must be
+ * actionable product copy, not a diagnostic; the diagnostic context follows
+ * in a parenthetical. Mirrors the COST_LIMIT_ERROR_PREFIX convention: a
+ * consumer that needs to recognize this failure can match on the prefix.
+ * Do not reword without checking consumers, and NEVER include the phrase
+ * "retry or resume" — sdk-react's isInterruptedError (MessageThread.tsx)
+ * reframes any error containing it as a neutral resumable notice instead of
+ * a failure alert.
+ */
+export const DETAIL_FREE_FALLBACK_USER_PREFIX =
+  "The model may be temporarily overloaded — please retry, or switch to a different model.";
+
+/**
+ * Stable lead sentence of the transport-timeout fallback error (0 messages,
+ * ~30s duration — the SDK's default timeout with no stream established).
+ * Same user-facing rules as DETAIL_FREE_FALLBACK_USER_PREFIX above.
+ */
+export const TRANSPORT_TIMEOUT_USER_PREFIX =
+  "The connection to the model could not be established — please retry.";
+
 const AUTH_PATTERNS = [
   "unauthenticated", "unauthorized", "401", "forbidden",
   "permission_denied", "invalid api key", "not logged in",
@@ -317,7 +340,10 @@ function classifyFromSources(opts: SynthesizeErrorOpts): ClassifiedError {
     const { model, mode, agentId } = opts.fallbackContext;
     return {
       category: "network",
-      message: `Transport timeout (${opts.durationMs}ms, 0 messages received). Model=${model}, mode=${mode}, agentId=${agentId}`,
+      message:
+        `${TRANSPORT_TIMEOUT_USER_PREFIX} ` +
+        `(Transport timeout: ${opts.durationMs}ms, 0 messages received. ` +
+        `Model=${model}, mode=${mode}, agentId=${agentId})`,
       retryable: true,
       source: "fallback",
     };
@@ -332,11 +358,22 @@ function classifyFromSources(opts: SynthesizeErrorOpts): ClassifiedError {
     };
   }
 
+  // The honest last resort: every detail channel was empty. Observed in prod
+  // only during provider capacity incidents (oss#492: Composer 2.5 degradation
+  // — the SDK rejection that carries ERROR_RESOURCE_EXHAUSTED in Cursor's IDE
+  // arrives here detail-free), so the copy leads with the capacity hypothesis
+  // hedged ("may be"), and retryable is true: the observed cause is transient
+  // by nature, and nothing gates a recovery loop on unknown+retryable. The
+  // parenthetical keeps the exact Model=/mode=/agentId= tokens for log-grep
+  // continuity and the env integration test's matcher.
   const { model, mode, agentId } = opts.fallbackContext;
   return {
     category: "unknown",
-    message: `Cursor run failed (no detail from SDK). Model=${model}, mode=${mode}, agentId=${agentId}`,
-    retryable: false,
+    message:
+      `${DETAIL_FREE_FALLBACK_USER_PREFIX} ` +
+      `(No error detail from the Cursor SDK. ` +
+      `Model=${model}, mode=${mode}, agentId=${agentId})`,
+    retryable: true,
     source: "fallback",
   };
 }


### PR DESCRIPTION
## Summary

During the 2026-08-11 Composer 2.5 capacity incident, every run through the cursor harness died with a bare `status: "error"` — all five classifier detail channels empty — and the classifier's honest last-resort fallback (`Cursor run failed (no detail from SDK). Model=… [category=unknown, source=fallback, retryable=false]`) streamed verbatim into an embedded end-user chat (issue #492).

- **`unknown` + `fallback` arm** (all detail channels empty — empirically the shape of Cursor-side capacity rejections) now leads with user-facing copy: *"The model may be temporarily overloaded — please retry, or switch to a different model."* The diagnostic follows as a parenthetical, preserving the exact `Model=`/`mode=`/`agentId=` tokens for log greps and the env integration test's matcher, and the `[category=…, source=…, retryable=…]` tail is unchanged for operator attribution.
- **`retryable: true`** for that arm: the observed cause (provider capacity) is transient by nature. Verified no recovery path gates on `unknown`+retryable (`shouldRetryWithFreshAgent` is category-based; the transport retry requires `category === "network"`), so this cannot create a retry loop — it only stops clients rendering a dead end during a minutes-long capacity wave.
- **Sibling transport-timeout arm** gets the same user-first treatment ("The connection to the model could not be established — please retry.") — it is the same defect one arm up: a detail-free failure whose developer-grade string reached users when transport recovery failed.
- Both leads are exported as documented stable-prefix constants (mirroring the `COST_LIMIT_ERROR_PREFIX` convention), with the recorded constraint that the copy must never contain the phrase "retry or resume" — sdk-react's `isInterruptedError` would reframe the failure as a neutral resumable notice.

Consumer audit: nothing pattern-matches the old strings (workflow-engine structured task errors read `ApplicationFailure.type`, not the message; cloud's Java workflow test uses the string as an arbitrary stub; the env integration test matches `Model=`, preserved). The `agent-stale` fallback message is deliberately untouched: the per-turn recovery latch guarantees poisoned-handle recovery consumes it before it can reach `status.error`.

Deliberately out of scope: a structured user-message/diagnostic split on `AgentExecutionStatus` (cross-repo proto change; the single-string-with-machine-tail pattern is the established contract carrier per `shared/model-error.ts`).

## Test plan

- [x] `error-classifier` suites: 66/66 pass, including 4 new tests (exact prod shape pinned: all channels empty + fresh agent → user copy leads, retryable; `isInterruptedError` phrase-trap guard; first-ever coverage of the transport-timeout arm's message and its window boundary)
- [x] Full runner unit suite: 4435 passed (one pre-existing flake — Temporal ephemeral-server download race — passes in isolation)
- [x] `tsc --noEmit` clean

Closes #492

Made with [Cursor](https://cursor.com)