### PR TITLE
fix(server): keep internal error causes off the gRPC wire

### DIFF
--- a/backend/libs/go/grpc/errors_test.go
+++ b/backend/libs/go/grpc/errors_test.go
@@ -1,0 +1,149 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// TestInternalError_WireMessageIsSanitized pins the information-disclosure
+// contract from stigmer/stigmer#478: the status description — the part gRPC
+// sends to clients — carries ONLY the static public message, never the
+// underlying cause (which can hold storage-engine detail or filesystem
+// paths, and reaches unauthenticated visitors on anonymous surfaces such as
+// getSharedProfile).
+func TestInternalError_WireMessageIsSanitized(t *testing.T) {
+	cause := errors.New("bbolt: /var/lib/stigmer/store.db corrupted")
+	err := InternalError(cause, "failed to list agent share resources")
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatal("expected InternalError to resolve to a gRPC status")
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("code = %s, want Internal", st.Code())
+	}
+	if st.Message() != "failed to list agent share resources" {
+		t.Errorf("wire message = %q, want only the public message", st.Message())
+	}
+	if strings.Contains(st.Message(), "bbolt") || strings.Contains(st.Message(), "/var/lib") {
+		t.Errorf("wire message must not carry the cause, got %q", st.Message())
+	}
+}
+
+// TestInternalError_CauseStaysReachableServerSide verifies the other half of
+// the contract: sanitization must not lose the cause for server-side code.
+// errors.Is sees through the wrapper, and Error() renders the full
+// "message: cause" form that the transport logging interceptors record.
+func TestInternalError_CauseStaysReachableServerSide(t *testing.T) {
+	cause := errors.New("bbolt: page 42 checksum mismatch")
+	err := InternalError(cause, "failed to load resource")
+
+	if !errors.Is(err, cause) {
+		t.Error("errors.Is must reach the cause through the sanitized wrapper")
+	}
+	if got := err.Error(); !strings.Contains(got, "failed to load resource") || !strings.Contains(got, "bbolt") {
+		t.Errorf("Error() = %q, want message and cause together for server logs", got)
+	}
+}
+
+// TestInternalError_WireLevelNegativeControl proves the sanitization on the
+// real wire: a full grpc-go round trip over the in-process bufconn transport,
+// through the standard interceptor chain, must deliver the client only the
+// public message. This pins grpc-go's status serialization (GRPCStatus
+// resolution) against future library upgrades — the negative control for
+// stigmer/stigmer#478.
+func TestInternalError_WireLevelNegativeControl(t *testing.T) {
+	cause := errors.New("bbolt: /var/lib/stigmer/store.db corrupted")
+	failingInterceptor := func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		return nil, InternalError(cause, "failed to list agent share resources")
+	}
+
+	server := NewServer(WithInProcess(), WithUnaryInterceptor(failingInterceptor))
+	if err := server.StartInProcess(); err != nil {
+		t.Fatalf("failed to start in-process server: %v", err)
+	}
+	defer server.Stop()
+
+	conn, err := server.NewInProcessConnection(context.Background())
+	if err != nil {
+		t.Fatalf("failed to create in-process connection: %v", err)
+	}
+	defer conn.Close()
+
+	_, err = healthpb.NewHealthClient(conn).Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err == nil {
+		t.Fatal("expected the injected internal error to reach the client")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a gRPC status from the client-observed error, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("client-observed code = %s, want Internal", st.Code())
+	}
+	if st.Message() != "failed to list agent share resources" {
+		t.Errorf("client-observed message = %q, want only the public message", st.Message())
+	}
+	if strings.Contains(st.Message(), "bbolt") || strings.Contains(st.Message(), "/var/lib") {
+		t.Errorf("client must never see the cause, got %q", st.Message())
+	}
+}
+
+// TestLoggingUnaryInterceptor_CauseInLogNotOnWire verifies the split the
+// sanitization depends on: the transport boundary log line carries the full
+// operator detail (via err.Error()) while the status returned to the
+// transport stays sanitized. If the interceptor ever regresses to logging
+// st.Message(), this fails — operators would silently lose every internal
+// cause.
+func TestLoggingUnaryInterceptor_CauseInLogNotOnWire(t *testing.T) {
+	var buf bytes.Buffer
+	origLogger := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() { log.Logger = origLogger })
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, InternalError(
+			errors.New("bbolt: page 42 checksum mismatch"),
+			"failed to list agent share resources",
+		)
+	}
+
+	_, err := loggingUnaryInterceptor(
+		context.Background(),
+		nil,
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		handler,
+	)
+	if err == nil {
+		t.Fatal("expected the handler error to propagate")
+	}
+
+	st, _ := status.FromError(err)
+	if strings.Contains(st.Message(), "bbolt") {
+		t.Errorf("returned status must stay sanitized, got %q", st.Message())
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "bbolt: page 42 checksum mismatch") {
+		t.Errorf("boundary log must preserve the cause for operators, got %q", logged)
+	}
+	if !strings.Contains(logged, "failed to list agent share resources") {
+		t.Errorf("boundary log must carry the public message too, got %q", logged)
+	}
+}

--- a/backend/libs/go/grpc/request/pipeline/error.go
+++ b/backend/libs/go/grpc/request/pipeline/error.go
@@ -28,6 +28,14 @@ func (e *PipelineError) Unwrap() error {
 	return e.Err
 }
 
+// internalFallbackMessage is the wire description for a step that returned a
+// plain (un-statused) error. It is deliberately generic: the real error text
+// can carry storage-engine detail, filesystem paths, or other internals, and
+// the status description is client-visible — on an anonymous surface that is
+// information disclosure (stigmer/stigmer#478). The step name and cause stay
+// in Error(), which the transport logging interceptors record server-side.
+const internalFallbackMessage = "internal server error"
+
 // GRPCStatus lets the transport recover the step's intended gRPC code. A step
 // that returns a typed status (AlreadyExists, InvalidArgument, FailedPrecondition,
 // NotFound) has it preserved verbatim; any un-statused error becomes Internal
@@ -40,11 +48,18 @@ func (e *PipelineError) Unwrap() error {
 // directly also strips the "pipeline step X failed:" prefix from the wire
 // message on typed errors, giving clients the clean domain message; the step
 // name is still retained in server logs and in Error() for debugging.
+//
+// The un-statused arm carries only internalFallbackMessage on the wire —
+// never e.Error(), whose step name and raw cause are internals a client (and
+// on anonymous surfaces, an unauthenticated visitor) must not see. Steps that
+// want a meaningful client-visible message for an internal failure return
+// grpclib.InternalError(err, "failed to <do thing>"), whose sanitized status
+// the typed arm preserves.
 func (e *PipelineError) GRPCStatus() *status.Status {
 	if st, ok := status.FromError(e.Err); ok {
 		return st
 	}
-	return status.New(codes.Internal, e.Error())
+	return status.New(codes.Internal, internalFallbackMessage)
 }
 
 // StepError creates a new PipelineError wrapping the given error.

--- a/backend/libs/go/grpc/request/pipeline/error_test.go
+++ b/backend/libs/go/grpc/request/pipeline/error_test.go
@@ -2,8 +2,10 @@ package pipeline
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -101,6 +103,11 @@ func TestPipelineError_GRPCStatus(t *testing.T) {
 			inner:    errors.New("resource metadata is nil"),
 			wantCode: codes.Internal,
 		},
+		{
+			name:     "grpclib.InternalError keeps Internal through the wrapper",
+			inner:    grpclib.InternalError(errors.New("bbolt: file corrupted"), "failed to list resources"),
+			wantCode: codes.Internal,
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +123,58 @@ func TestPipelineError_GRPCStatus(t *testing.T) {
 				t.Error("wrapped pipeline error must never surface as codes.Unknown")
 			}
 		})
+	}
+}
+
+// TestPipelineError_GRPCStatus_NakedErrorMessageIsSanitized pins the
+// information-disclosure contract from stigmer/stigmer#478: a step that
+// returns a plain (un-statused) error must reach the client as the generic
+// fallback copy — never the step name, never the raw cause. Both stay
+// available in Error() for the transport boundary log.
+func TestPipelineError_GRPCStatus_NakedErrorMessageIsSanitized(t *testing.T) {
+	inner := errors.New("bbolt: /var/lib/stigmer/store.db corrupted")
+	wrapped := StepError("LoadShareForProfile", inner)
+
+	st, ok := status.FromError(wrapped)
+	if !ok {
+		t.Fatal("expected a gRPC status from the wrapped error")
+	}
+	if st.Message() != internalFallbackMessage {
+		t.Errorf("wire message = %q, want the generic fallback %q", st.Message(), internalFallbackMessage)
+	}
+	if strings.Contains(st.Message(), "bbolt") || strings.Contains(st.Message(), "LoadShareForProfile") {
+		t.Errorf("wire message must carry neither the cause nor the step name, got %q", st.Message())
+	}
+
+	// The operator-facing form keeps both.
+	if got := wrapped.Error(); !strings.Contains(got, "LoadShareForProfile") || !strings.Contains(got, "bbolt") {
+		t.Errorf("Error() = %q, want step name and cause preserved for server logs", got)
+	}
+}
+
+// TestPipelineError_GRPCStatus_InternalErrorMessageSurvives verifies that a
+// step returning grpclib.InternalError reaches the client with exactly the
+// sanitized public message — the pipeline wrapper neither re-leaks the cause
+// nor degrades the message to the generic fallback.
+func TestPipelineError_GRPCStatus_InternalErrorMessageSurvives(t *testing.T) {
+	inner := grpclib.InternalError(
+		errors.New("bbolt: /var/lib/stigmer/store.db corrupted"),
+		"failed to list agent share resources",
+	)
+	wrapped := StepError("LoadShareForProfile", inner)
+
+	st, ok := status.FromError(wrapped)
+	if !ok {
+		t.Fatal("expected a gRPC status from the wrapped error")
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("code = %s, want Internal", st.Code())
+	}
+	if st.Message() != "failed to list agent share resources" {
+		t.Errorf("wire message = %q, want the sanitized public message", st.Message())
+	}
+	if strings.Contains(st.Message(), "bbolt") {
+		t.Errorf("wire message must not carry the cause, got %q", st.Message())
 	}
 }
 

--- a/backend/libs/go/grpc/server.go
+++ b/backend/libs/go/grpc/server.go
@@ -311,11 +311,15 @@ func loggingUnaryInterceptor(
 			logMsg = "gRPC call failed"
 		}
 
+		// Log err.Error(), not st.Message(): sanitized errors (InternalError,
+		// the PipelineError fallback) deliberately keep the cause OUT of the
+		// wire-visible status message — this boundary log line is where the
+		// full detail is preserved for operators.
 		logEvent.
 			Str("method", info.FullMethod).
 			Dur("duration_ms", duration).
 			Str("code", st.Code().String()).
-			Str("error", st.Message()).
+			Str("error", err.Error()).
 			Msg(logMsg)
 	} else {
 		// Health probes are high-frequency infrastructure traffic; log their
@@ -376,11 +380,14 @@ func loggingStreamInterceptor(
 			logMsg = "gRPC stream call failed"
 		}
 
+		// err.Error() rather than st.Message() — same rationale as the unary
+		// interceptor: sanitized errors keep the cause off the wire, and this
+		// log line is the operator's copy of it.
 		logEvent.
 			Str("method", info.FullMethod).
 			Dur("duration_ms", duration).
 			Str("code", st.Code().String()).
-			Str("error", st.Message()).
+			Str("error", err.Error()).
 			Msg(logMsg)
 	} else {
 		// Health Watch is a long-lived probe stream; log its completion at
@@ -398,7 +405,14 @@ func loggingStreamInterceptor(
 	return err
 }
 
-// WrapError wraps an error with an appropriate gRPC status code
+// WrapError wraps an error with an appropriate gRPC status code.
+//
+// The underlying error is embedded in the wire-visible description, so this
+// is only for codes whose causes are client-appropriate (NotFound,
+// FailedPrecondition, and similar caller-actionable refusals). Never use it
+// with codes.Internal: internal causes are server internals and must stay off
+// the wire — use InternalError, which sanitizes the description while keeping
+// the cause for server logs (stigmer/stigmer#478).
 func WrapError(err error, code codes.Code, message string) error {
 	if err == nil {
 		return nil
@@ -419,9 +433,51 @@ func InvalidArgumentError(format string, args ...interface{}) error {
 	return status.Errorf(codes.InvalidArgument, format, args...)
 }
 
-// InternalError returns a gRPC INTERNAL error
+// InternalError returns a gRPC INTERNAL error whose wire-visible description
+// is ONLY the static message. The underlying cause never crosses the wire: an
+// internal failure's raw text can carry storage-engine detail or filesystem
+// paths, and the description is client-visible — on an anonymous surface such
+// as getSharedProfile that is information disclosure to an unauthenticated
+// visitor (stigmer/stigmer#478, the OSS twin of stigmer-cloud#242).
+//
+// The cause is not lost: it stays reachable via errors.Is/errors.As/Unwrap,
+// and Error() renders "message: cause" — which the transport logging
+// interceptors record server-side. Callers therefore keep writing
+// InternalError(err, "failed to <do thing>") exactly as before; the split
+// between operator-visible detail and client-visible copy happens here.
 func InternalError(err error, message string) error {
-	return status.Errorf(codes.Internal, "%s: %v", message, err)
+	return &internalError{cause: err, message: message}
+}
+
+// internalError is the sanitized-status error type behind InternalError. It
+// follows the same contract as pipeline.PipelineError: GRPCStatus() decides
+// the wire representation (implemented explicitly so status.FromError hits
+// its fast path instead of depending on grpc-go's chain-walking), while
+// Error() keeps the full detail for server logs.
+type internalError struct {
+	cause   error
+	message string
+}
+
+// Error renders the operator-facing form, message and cause together. This is
+// what the transport logging interceptors record; it must never be sent to
+// clients.
+func (e *internalError) Error() string {
+	return fmt.Sprintf("%s: %v", e.message, e.cause)
+}
+
+// Unwrap exposes the cause so errors.Is and errors.As see through the
+// sanitization.
+func (e *internalError) Unwrap() error {
+	return e.cause
+}
+
+// GRPCStatus is the wire representation: codes.Internal with only the static
+// public message. grpc-go resolves it via status.FromError, including when
+// this error is wrapped further (e.g. by pipeline.StepError), so the
+// sanitized description survives to the client verbatim.
+func (e *internalError) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.message)
 }
 
 // AlreadyExistsError returns a gRPC ALREADY_EXISTS error

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/get_default.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/get_default.go
@@ -69,8 +69,9 @@ func (s *loadDefaultAgentStep) Execute(ctx *pipeline.RequestContext[*agentv1.Get
 			"Default agent exists but is not visibility_public")
 	case err != nil:
 		// Store/decode failure — an internal fault, not "no default agent".
+		// InternalError keeps the cause off the wire (stigmer/stigmer#478).
 		log.Error().Err(err).Msg("Failed to resolve platform default agent")
-		return grpclib.WrapError(err, codes.Internal, "failed to resolve the platform default agent")
+		return grpclib.InternalError(err, "failed to resolve the platform default agent")
 	}
 
 	log.Info().

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
@@ -175,8 +175,9 @@ func (s *resolveDefaultAgentStep) Execute(ctx *pipeline.RequestContext[*agentexe
 		)
 	case err != nil:
 		// Store/decode failure — an internal fault, not "no default agent".
+		// InternalError keeps the cause off the wire (stigmer/stigmer#478).
 		log.Error().Err(err).Msg("Failed to resolve platform default agent")
-		return grpclib.WrapError(err, codes.Internal, "failed to resolve the platform default agent")
+		return grpclib.InternalError(err, "failed to resolve the platform default agent")
 	}
 
 	resolvedID := defaultAgent.GetMetadata().GetId()

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/get_artifact_content.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/get_artifact_content.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	apiresourcekind "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/filereview"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -125,7 +126,7 @@ func (c *AgentExecutionController) GetArtifactContent(
 			Str("execution_id", req.ExecutionId).
 			Str("storage_key", req.StorageKey).
 			Msg("Failed to download artifact content")
-		return nil, status.Errorf(codes.Internal, "failed to read artifact content: %v", err)
+		return nil, grpclib.InternalError(err, "failed to read artifact content")
 	}
 
 	// Serve-time integrity check for CAS blobs. A CAS blob key encodes its own

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/get_artifact_download_url.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/get_artifact_download_url.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	apiresourcekind "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -126,7 +127,7 @@ func (c *AgentExecutionController) GetArtifactDownloadUrl(ctx context.Context, r
 			Str("execution_id", req.ExecutionId).
 			Str("storage_key", req.StorageKey).
 			Msg("Failed to generate presigned URL for artifact")
-		return nil, status.Errorf(codes.Internal, "failed to generate download URL: %v", err)
+		return nil, grpclib.InternalError(err, "failed to generate download URL")
 	}
 
 	log.Info().

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/upload_attachment.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/upload_attachment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rs/zerolog/log"
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -94,7 +95,7 @@ func (c *AgentExecutionController) UploadAttachment(ctx context.Context, req *ag
 			Err(err).
 			Str("storage_key", storageKey).
 			Msg("Failed to upload attachment to storage")
-		return nil, status.Errorf(codes.Internal, "failed to upload attachment: %v", err)
+		return nil, grpclib.InternalError(err, "failed to upload attachment")
 	}
 
 	log.Info().

--- a/backend/services/stigmer-server/pkg/domain/agentshare/controller/agentshare_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentshare/controller/agentshare_test.go
@@ -2,6 +2,7 @@ package agentshare
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -140,6 +141,72 @@ func createTestShare(t *testing.T, tc *testControllers, agent *agentv1.Agent, en
 		t.Fatalf("share Create failed: %v", err)
 	}
 	return created
+}
+
+// failingListStore delegates to the real store but fails ListResources for
+// one kind — the smallest fault injection that reaches the anonymous
+// resolution path's store dependency.
+type failingListStore struct {
+	store.Store
+	failKind apiresourcekind.ApiResourceKind
+	cause    error
+}
+
+func (s *failingListStore) ListResources(
+	ctx context.Context,
+	kind apiresourcekind.ApiResourceKind,
+) ([][]byte, error) {
+	if kind == s.failKind {
+		return nil, s.cause
+	}
+	return s.Store.ListResources(ctx, kind)
+}
+
+// TestGetSharedProfile_StoreFailureLeaksNoInternals pins stigmer/stigmer#478
+// on the exact surface the issue names: getSharedProfile is the OSS server's
+// only anonymous (is_public) RPC, and a store-level failure there used to
+// format the raw underlying error — storage-engine detail, filesystem paths —
+// into the wire-visible status description. The anonymous visitor must see
+// only the static public message; the cause stays reachable server-side for
+// the transport boundary log.
+func TestGetSharedProfile_StoreFailureLeaksNoInternals(t *testing.T) {
+	tc := newTestControllers(t)
+	agent := createTestAgent(t, tc, "Leak Probe Agent")
+	createTestShare(t, tc, agent, true)
+
+	cause := errors.New("bbolt: /var/lib/stigmer/store.db corrupted")
+	broken := NewAgentShareController(&failingListStore{
+		Store:    tc.store,
+		failKind: apiresourcekind.ApiResourceKind_agent_share,
+		cause:    cause,
+	})
+
+	_, err := broken.GetSharedProfile(shareCtx(), &agentsharev1.GetSharedProfileRequest{
+		Org:  "test-org",
+		Slug: agent.GetMetadata().GetSlug(),
+	})
+	if err == nil {
+		t.Fatal("expected the injected store failure to surface")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a gRPC status, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("code = %s, want Internal", st.Code())
+	}
+	if st.Message() != "failed to list agent share resources" {
+		t.Errorf("wire message = %q, want only the public message", st.Message())
+	}
+	if strings.Contains(st.Message(), "bbolt") || strings.Contains(st.Message(), "/var/lib") {
+		t.Errorf("anonymous visitors must never see store internals, got %q", st.Message())
+	}
+
+	// Sanitization must not lose the cause for server-side code and logs.
+	if !errors.Is(err, cause) {
+		t.Error("the cause must stay reachable through the sanitized error chain")
+	}
 }
 
 func TestAgentShareController_Create(t *testing.T) {

--- a/backend/services/stigmer-server/pkg/domain/artifact/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/artifact/controller/create.go
@@ -11,6 +11,7 @@ import (
 	artifactv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/artifact/v1"
 	apiresource "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	storelib "github.com/stigmer/stigmer/backend/libs/go/store"
 	"google.golang.org/grpc/codes"
@@ -77,7 +78,7 @@ func (c *ArtifactController) Create(ctx context.Context, input *artifactv1.Creat
 
 	if err := c.artifactStorage.Upload(ctx, contentHash, content, spec.GetContentType()); err != nil {
 		log.Error().Err(err).Str("content_hash", contentHash).Msg("Failed to upload artifact blob")
-		return nil, status.Errorf(codes.Internal, "failed to upload artifact content: %v", err)
+		return nil, grpclib.InternalError(err, "failed to upload artifact content")
 	}
 
 	// --- Derive org from producing execution ---
@@ -114,7 +115,7 @@ func (c *ArtifactController) Create(ctx context.Context, input *artifactv1.Creat
 
 	if err := c.store.SaveResource(ctx, apiresourcekind.ApiResourceKind_artifact, artifactID, artifact); err != nil {
 		log.Error().Err(err).Str("artifact_id", artifactID).Msg("Failed to persist artifact metadata")
-		return nil, status.Errorf(codes.Internal, "failed to persist artifact: %v", err)
+		return nil, grpclib.InternalError(err, "failed to persist artifact")
 	}
 
 	log.Info().

--- a/backend/services/stigmer-server/pkg/domain/artifact/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/artifact/controller/delete.go
@@ -7,6 +7,7 @@ import (
 	artifactv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/artifact/v1"
 	apiresource "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -45,7 +46,7 @@ func (c *ArtifactController) Delete(ctx context.Context, id *apiresource.ApiReso
 
 	if err := c.store.SaveResource(ctx, apiresourcekind.ApiResourceKind_artifact, resourceID, artifact); err != nil {
 		log.Error().Err(err).Str("artifact_id", resourceID).Msg("Failed to persist artifact deletion")
-		return nil, status.Errorf(codes.Internal, "failed to persist artifact deletion: %v", err)
+		return nil, grpclib.InternalError(err, "failed to persist artifact deletion")
 	}
 
 	log.Info().

--- a/backend/services/stigmer-server/pkg/domain/artifact/controller/get_content.go
+++ b/backend/services/stigmer-server/pkg/domain/artifact/controller/get_content.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	artifactv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/artifact/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -75,7 +76,7 @@ func (c *ArtifactController) GetContent(ctx context.Context, req *artifactv1.Get
 			Str("artifact_id", artifactID).
 			Str("content_hash", contentHash).
 			Msg("Failed to download artifact content")
-		return nil, status.Errorf(codes.Internal, "failed to read artifact content: %v", err)
+		return nil, grpclib.InternalError(err, "failed to read artifact content")
 	}
 
 	totalSize := int64(len(data))

--- a/backend/services/stigmer-server/pkg/domain/artifact/controller/get_download_url.go
+++ b/backend/services/stigmer-server/pkg/domain/artifact/controller/get_download_url.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	artifactv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/artifact/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -65,7 +66,7 @@ func (c *ArtifactController) GetDownloadUrl(ctx context.Context, id *artifactv1.
 			Str("artifact_id", resourceID).
 			Str("content_hash", contentHash).
 			Msg("Failed to generate download URL for artifact")
-		return nil, status.Errorf(codes.Internal, "failed to generate download URL: %v", err)
+		return nil, grpclib.InternalError(err, "failed to generate download URL")
 	}
 
 	ttlSeconds := int32(downloadURLExpiration.Seconds())

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/connect.go
@@ -562,6 +562,12 @@ func (c *McpServerController) executeConnectWorkflow(
 			return nil, grpclib.UnavailableError(
 				"connect service temporarily unavailable for MCP server '%s'", mcpServerID)
 		default:
+			// Deliberate exception to the "internal causes stay off the wire"
+			// rule (stigmer/stigmer#478): the cause here is the runner's own
+			// CLASSIFIED, user-facing connect-failure text (see the runner's
+			// error classification and buildConnectFailureMessage below), not
+			// raw server internals. Connect failures are user-debugged
+			// configuration problems — the classified cause is the product.
 			return nil, status.Error(codes.Internal,
 				buildConnectFailureMessage(mcpServer, err.Error()))
 		}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/disconnect_oauth.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/disconnect_oauth.go
@@ -6,8 +6,6 @@ import (
 	"github.com/rs/zerolog/log"
 	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // DisconnectOAuth tears down a user's OAuth connection for an MCP server.
@@ -43,7 +41,7 @@ func (c *McpServerController) DisconnectOAuth(
 	// OSS mode: single user, empty identity_account_id.
 	grant, err := c.oauthGrantStore.Find(ctx, "", resourceID, org)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to look up OAuth grant: %v", err)
+		return nil, grpclib.InternalError(err, "failed to look up OAuth grant")
 	}
 
 	if grant == nil {
@@ -65,7 +63,7 @@ func (c *McpServerController) DisconnectOAuth(
 	}
 
 	if err := c.oauthGrantStore.Delete(ctx, "", resourceID, org); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete OAuth grant: %v", err)
+		return nil, grpclib.InternalError(err, "failed to delete OAuth grant")
 	}
 
 	log.Info().

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/get_oauth_grant_status.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/get_oauth_grant_status.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -44,7 +45,7 @@ func (c *McpServerController) GetOAuthGrantStatus(
 
 	grant, err := c.oauthGrantStore.Find(ctx, "", input.GetResourceId(), input.GetOrg())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to look up OAuth grant: %v", err)
+		return nil, grpclib.InternalError(err, "failed to look up OAuth grant")
 	}
 
 	if grant == nil {

--- a/backend/services/stigmer-server/pkg/domain/session/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/create.go
@@ -122,8 +122,9 @@ func (s *resolveDefaultAgentInstanceStep) Execute(ctx *pipeline.RequestContext[*
 		)
 	case err != nil:
 		// Store/decode failure — an internal fault, not "no default agent".
+		// InternalError keeps the cause off the wire (stigmer/stigmer#478).
 		log.Error().Err(err).Msg("Failed to resolve platform default agent")
-		return grpclib.WrapError(err, codes.Internal, "failed to resolve the platform default agent")
+		return grpclib.InternalError(err, "failed to resolve the platform default agent")
 	}
 
 	agentID := defaultAgent.GetMetadata().GetId()

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/get_artifact.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/get_artifact.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	skillv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/skill/v1"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/skill/storage"
@@ -82,7 +83,7 @@ func (s *loadArtifactStep) Execute(ctx *pipeline.RequestContext[*skillv1.GetArti
 		if strings.Contains(err.Error(), "not found") {
 			return status.Errorf(codes.NotFound, "skill artifact not found: %s", storageKey)
 		}
-		return status.Errorf(codes.Internal, "failed to load skill artifact: %v", err)
+		return grpclib.InternalError(err, "failed to load skill artifact")
 	}
 
 	// Store artifact bytes in context for the handler to retrieve

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/push_from_execution_artifact.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/push_from_execution_artifact.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	skillv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/skill/v1"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -68,7 +69,7 @@ func (c *SkillController) PushFromExecutionArtifact(
 			Str("execution_id", req.ExecutionId).
 			Str("storage_key", req.StorageKey).
 			Msg("Failed to download execution artifact")
-		return nil, status.Errorf(codes.Internal, "failed to download execution artifact: %v", err)
+		return nil, grpclib.InternalError(err, "failed to download execution artifact")
 	}
 
 	pushReq := &skillv1.PushSkillRequest{

--- a/backend/services/stigmer-server/pkg/query/search/controller/search_controller.go
+++ b/backend/services/stigmer-server/pkg/query/search/controller/search_controller.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	searchv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/search/v1"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/handler"
 )
 
@@ -96,8 +97,10 @@ func toGRPCError(err error) error {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	// Default to internal error
-	return status.Error(codes.Internal, err.Error())
+	// Default to internal error. The handler error's raw text is server
+	// internals and must stay off the wire (stigmer/stigmer#478); the call
+	// site has already logged the full error.
+	return grpclib.InternalError(err, "search failed")
 }
 
 // contains checks if s contains any of the substrings.


### PR DESCRIPTION
## Summary

Closes #478 — `grpclib.InternalError` formatted the raw underlying error into the gRPC status description, which crosses the wire verbatim. On `getSharedProfile` — the OSS server's only anonymous `is_public` surface (the hosted chat share page) — a store-level failure would hand storage-engine detail and possibly filesystem paths to an unauthenticated visitor. The OSS twin of stigmer-cloud#242, in a much smaller body.

## What changed

**Commit 1 — the fix (both arms of the leak):**

- `InternalError` is now a sanitized-status error type following the existing `PipelineError` `GRPCStatus()` idiom: only the static public message crosses the wire; `Error()`/`Unwrap()` keep the full `message: cause` for server-side code. All ~100 call sites are fixed with no signature change.
- **Second arm the issue missed**: `PipelineError.GRPCStatus()`'s naked-error fallback put `"pipeline step X failed: <raw cause>"` — internal step name AND cause — on the wire for any step returning a plain error, through every pipeline-based RPC including the anonymous one. It now returns generic copy (`"internal server error"`); step name + cause stay in `Error()`.
- Both transport logging interceptors record `err.Error()` instead of `st.Message()`, so the boundary log line carries strictly **more** detail than before (step name + public message + cause) while the wire carries strictly less. Operators lose nothing.
- The three `WrapError(err, codes.Internal, …)` call sites route through `InternalError`; `WrapError`'s doc now forbids Internal.

**Commit 2 — consistency sweep:** the 14 direct `status.Errorf(codes.Internal, "…: %v", err)` constructions (worst: search sent `err.Error()` verbatim as the whole description) now route through `grpclib.InternalError`, keeping each site's static message. The OSS server registers no auth interceptor (single-user local posture), so on a port-exposed deployment *every* handler's Internal errors are credential-free reachable — after this sweep the sanitizing helper is the only way an Internal status is built. Deliberate exemption with anchoring comment: mcpserver connect's failure copy, whose "cause" is the runner's classified, user-facing text by design.

## Proof

- Unit pins on the helper (wire message, `errors.Is` reachability, `Error()` contract).
- **Wire-level negative control**: full grpc-go round trip over bufconn through the standard interceptor chain — client observes only the public message; pins grpc-go's `GRPCStatus` resolution against future upgrades.
- Failing-store test on the anonymous `getSharedProfile` path (the issue's exact surface).
- Pipeline fallback pins (naked-error arm message; `InternalError` survives `StepError` wrapping verbatim).
- Interceptor log test: cause present in the boundary log, absent from the returned status.

## Test plan

- [x] `go test -race ./...` green in `backend/libs/go` and `backend/services/stigmer-server`
- [x] Server binary builds; `go mod tidy` no-op; vet clean apart from the pre-existing #426 copylocks failure on clean main (not touched here)
- [x] Audited: no Go test pins Internal message content; TS SDK `getUserMessage` displays but never parses descriptions; all status consumers branch on codes only

## Client-visible behavior change

Clients previously receiving `"failed to X: <raw cause>"` on Internal failures now receive `"failed to X"`. Self-hosters find the cause in the server log (same boundary log line, now with more detail). End users see clean copy instead of raw engine spew.

Made with [Cursor](https://cursor.com)