### PR TITLE
test(integration): seed shared-pool CursorAccount for proxied cursor tests

### DIFF
--- a/.github/workflows/ci.integration-canary.yaml
+++ b/.github/workflows/ci.integration-canary.yaml
@@ -14,7 +14,14 @@
 #
 # Cost: under $0.05 per run.
 #
-# Secrets: ANTHROPIC_API_KEY and CURSOR_API_KEY from "provider-integration".
+# Secrets (from the "provider-integration" environment):
+#   ANTHROPIC_API_KEY — platform LLM proxy upstream key
+#   CURSOR_API_KEY    — user-scoped Cursor key (the shared-pool member key)
+#   CURSOR_ADMIN_KEY  — Cursor team Admin API key; the suite's boot-time
+#                       shared-pool CursorAccount seed live-validates it
+#                       (DD-008: DB-resident accounts are the only Cursor
+#                       credential source — without the seed every proxied
+#                       Cursor call 503s)
 # =============================================================================
 
 name: ci.integration-canary
@@ -134,6 +141,7 @@ jobs:
           STIGMER_SERVICE_JAR: ${{ github.workspace }}/.artifacts/stigmer_service_fatjar.jar
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CURSOR_ADMIN_KEY: ${{ secrets.CURSOR_ADMIN_KEY }}
         run: make test-integration-canary
 
       - name: Upload canary test results

--- a/test/integration-session-routing/Makefile
+++ b/test/integration-session-routing/Makefile
@@ -92,8 +92,17 @@ test: ensure-service-jar ensure-runner-built ## Run offline session routing test
 
 # ─── Provider-Backed Tests (Tier 3) ─────────────────────────────────────────
 
+# Fetch a Planton secret's value (the test/integration/Makefile idiom): the
+# CLI renders a decorated box, so the value is extracted from the "Value"
+# line, ANSI-stripped. Empty result means "fetch failed" — callers skip.
+# The previous `planton service secrets get-value` syntax is obsolete and
+# silently captured the CLI error text as the key.
+define planton_get_secret
+planton secret get $(1) --env prod --org stigmer 2>/dev/null | awk '{ gsub(/\033\[[0-9;]*m/, "") } /^[[:space:]]*Value[[:space:]]+/ { sub(/^[[:space:]]*Value[[:space:]]+/, ""); gsub(/[[:space:]]+$$/, ""); print; exit }'
+endef
+
 .PHONY: test-providers
-test-providers: ensure-service-jar ensure-runner-built ## Run provider-backed session routing E2E tests (auto-fetches CURSOR_API_KEY)
+test-providers: ensure-service-jar ensure-runner-built ## Run provider-backed session routing E2E tests (auto-fetches Cursor keys)
 	@command -v gotestsum >/dev/null 2>&1 || { \
 		echo "error: gotestsum not found"; \
 		echo "  install: go install gotest.tools/gotestsum@latest"; \
@@ -101,16 +110,19 @@ test-providers: ensure-service-jar ensure-runner-built ## Run provider-backed se
 	}
 	@mkdir -p $(PROVIDER_OUTPUT_DIR)
 	@CURSOR_KEY=$${CURSOR_API_KEY:-}; \
-	if [ -z "$$CURSOR_KEY" ]; then \
-		if command -v planton >/dev/null 2>&1; then \
-			echo "Fetching CURSOR_API_KEY from Planton..."; \
-			CURSOR_KEY=$$(planton service secrets get-value --org stigmer --group cursor --name prod.api-key 2>&1 || true); \
-			if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — E2E tests will be skipped"; fi; \
-		else \
-			echo "warning: CURSOR_API_KEY not set and planton CLI not found — E2E tests will be skipped"; \
-		fi; \
+	if [ -z "$$CURSOR_KEY" ] && command -v planton >/dev/null 2>&1; then \
+		echo "Fetching CURSOR_API_KEY from Planton..."; \
+		CURSOR_KEY=$$($(call planton_get_secret,cursor) || true); \
+		if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — E2E tests will be skipped"; fi; \
+	fi; \
+	CURSOR_ADMIN=$${CURSOR_ADMIN_KEY:-}; \
+	if [ -z "$$CURSOR_ADMIN" ] && command -v planton >/dev/null 2>&1; then \
+		echo "Fetching CURSOR_ADMIN_KEY from Planton..."; \
+		CURSOR_ADMIN=$$($(call planton_get_secret,cursor-admin) || true); \
+		if [ -n "$$CURSOR_ADMIN" ]; then echo "CURSOR_ADMIN_KEY fetched"; else echo "CURSOR_ADMIN_KEY not available — E2E tests will be skipped (shared-pool seed needs it)"; fi; \
 	fi; \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath $(PROVIDER_OUTPUT_DIR)) gotestsum \
 		--junitfile $(PROVIDER_OUTPUT_DIR)/junit.xml \

--- a/test/integration-session-routing/e2e_provider_test.go
+++ b/test/integration-session-routing/e2e_provider_test.go
@@ -18,8 +18,14 @@ import (
 
 func requireCursorKey(t *testing.T) {
 	t.Helper()
+	// Same credential pair the suite-boot SeedSharedPoolCursorAccount
+	// needs: without both, the proxy's shared pool is empty and every
+	// cursor call 503s.
 	if cursorKey == "" {
 		t.Skip("CURSOR_API_KEY not set — skipping provider-backed E2E test")
+	}
+	if cursorAdminKey == "" {
+		t.Skip("CURSOR_ADMIN_KEY not set — skipping provider-backed E2E test (the shared-pool CursorAccount seed needs the team admin key)")
 	}
 }
 

--- a/test/integration-session-routing/suite_test.go
+++ b/test/integration-session-routing/suite_test.go
@@ -21,6 +21,7 @@ var (
 	temporalClient client.Client
 	suiteLogger    *slog.Logger
 	cursorKey      string
+	cursorAdminKey string
 )
 
 func TestMain(m *testing.M) {
@@ -57,6 +58,7 @@ func TestMain(m *testing.M) {
 	logDir := testHarness.LogDir()
 
 	cursorKey = os.Getenv("CURSOR_API_KEY")
+	cursorAdminKey = os.Getenv("CURSOR_ADMIN_KEY")
 
 	svcCfg := harness.ServiceConfig{
 		JarPath:         jarPath,
@@ -70,7 +72,6 @@ func TestMain(m *testing.M) {
 		TemporalAddress: testHarness.Temporal.Address(),
 		VaultAddr:       testHarness.OpenBao.Addr,
 		VaultToken:      testHarness.OpenBao.RootToken,
-		CursorAPIKey:    cursorKey,
 		LogDir:          logDir,
 
 		// Session routing: all activities dispatch to session:{id} queues.
@@ -137,10 +138,22 @@ func TestMain(m *testing.M) {
 		suiteLogger.Info("default agent seeded")
 	}
 
+	// Cursor credentials are DB-resident CursorAccounts (DD-008) — without
+	// this seed every proxied Cursor call 503s on an empty shared pool
+	// (requireCursorKey skips the E2E tests when either key is absent).
+	if cursorKey != "" && cursorAdminKey != "" {
+		if err := harness.SeedSharedPoolCursorAccount(ctx, grpcConn, cursorAdminKey, cursorKey); err != nil {
+			suiteLogger.Warn("failed to seed shared-pool cursor account — cursor E2E tests will fail at key selection", "error", err)
+		} else {
+			suiteLogger.Info("shared-pool cursor account seeded")
+		}
+	}
+
 	suiteLogger.Info("session routing suite ready",
 		"grpc_address", svc.GRPCAddress(),
 		"activity_routing", "session",
 		"cursor_key_available", cursorKey != "",
+		"cursor_admin_key_available", cursorAdminKey != "",
 		"log_dir", logDir,
 	)
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -51,15 +51,33 @@ RERUN_FLAGS = \
 
 # ─── Planton Secret Fetch ────────────────────
 # Fetch a Planton secret's value for use as an API key. Secrets are
-# environment-scoped to `prod` (slugs: anthropic, cursor). The CLI renders a
-# decorated box even with `-o plain`, so we extract the value from the "Value"
-# line (stripping any ANSI). On failure (not logged in / not found) stdout has
-# no "Value" line, so the result is empty — which callers treat as "fetch
-# failed". Replaces the obsolete `planton service secrets get-value
-# --group/--name` syntax, which silently captured the CLI error text as the key.
+# environment-scoped to `prod` (slugs: anthropic, cursor, cursor-admin). The
+# CLI renders a decorated box even with `-o plain`, so we extract the value
+# from the "Value" line (stripping any ANSI). On failure (not logged in / not
+# found) stdout has no "Value" line, so the result is empty — which callers
+# treat as "fetch failed". Replaces the obsolete `planton service secrets
+# get-value --group/--name` syntax, which silently captured the CLI error
+# text as the key.
 #   Usage in a recipe: KEY=$$($(call planton_get_secret,<slug>))
 define planton_get_secret
 planton secret get $(1) --env prod --org stigmer 2>/dev/null | awk '{ gsub(/\033\[[0-9;]*m/, "") } /^[[:space:]]*Value[[:space:]]+/ { sub(/^[[:space:]]*Value[[:space:]]+/, ""); gsub(/[[:space:]]+$$/, ""); print; exit }'
+endef
+
+# Best-effort fetch of the Cursor team Admin API key (CURSOR_ADMIN_KEY). The
+# suite's boot-time shared-pool CursorAccount seed needs it alongside the
+# user-scoped CURSOR_API_KEY (DD-008: DB-resident CursorAccounts are the only
+# Cursor credential source; the seed's upsert live-validates the admin key).
+# Optional like the cursor key: when absent, cursor tests skip honestly via
+# RequireCursorPrereqs. Recipes that HARD-require cursor add their own
+# emptiness check after expanding this.
+#   Usage in a recipe (inside the same shell chain): $(call fetch_cursor_admin_key)
+define fetch_cursor_admin_key
+CURSOR_ADMIN=$${CURSOR_ADMIN_KEY:-}; \
+if [ -z "$$CURSOR_ADMIN" ] && command -v planton >/dev/null 2>&1; then \
+	echo "Fetching CURSOR_ADMIN_KEY from Planton..."; \
+	CURSOR_ADMIN=$$($(call planton_get_secret,cursor-admin) || true); \
+	if [ -n "$$CURSOR_ADMIN" ]; then echo "CURSOR_ADMIN_KEY fetched"; else echo "CURSOR_ADMIN_KEY not available — cursor tests will be skipped (shared-pool seed needs it)"; fi; \
+fi
 endef
 
 # Guarantees the service JAR reflects current stigmer-cloud sources. When the
@@ -161,8 +179,10 @@ test-providers: check-runner-node ensure-service-jar ## Run provider-backed inte
 		CURSOR_KEY=$$($(call planton_get_secret,cursor) || true); \
 		if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — cursor tests will be skipped"; fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
 	ANTHROPIC_API_KEY=$$ANTHROPIC_KEY \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath $(PROVIDER_OUTPUT_DIR)) gotestsum \
 		--junitfile $(PROVIDER_OUTPUT_DIR)/junit.xml \
@@ -204,8 +224,10 @@ test-canary: check-runner-node ensure-service-jar ## Run canary tests (live prov
 		CURSOR_KEY=$$($(call planton_get_secret,cursor) || true); \
 		if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — cursor canary will be skipped"; fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
 	ANTHROPIC_API_KEY=$$ANTHROPIC_KEY \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath .test-output-canary) gotestsum \
 		--junitfile .test-output-canary/junit.xml \
@@ -243,8 +265,10 @@ test-workflow-architect: check-runner-node ensure-service-jar ## Run Workflow Ar
 		CURSOR_KEY=$$($(call planton_get_secret,cursor) || true); \
 		if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — cursor subtests will be skipped"; fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
 	ANTHROPIC_API_KEY=$$ANTHROPIC_KEY \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath .test-output-architect) gotestsum \
 		--junitfile .test-output-architect/junit.xml \
@@ -284,8 +308,10 @@ test-agent: check-runner-node ensure-service-jar ## Run agent execution integrat
 		CURSOR_KEY=$$($(call planton_get_secret,cursor) || true); \
 		if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — cursor subtests will be skipped"; fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
 	ANTHROPIC_API_KEY=$$ANTHROPIC_KEY \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath $(AGENT_OUTPUT_DIR)) gotestsum \
 		--junitfile $(AGENT_OUTPUT_DIR)/junit.xml \
@@ -333,9 +359,11 @@ test-subset: check-runner-node ensure-service-jar ## Run a subset of integration
 		CURSOR_KEY=$$($(call planton_get_secret,cursor) || true); \
 		if [ -n "$$CURSOR_KEY" ]; then echo "CURSOR_API_KEY fetched"; else echo "CURSOR_API_KEY not available — cursor subtests will be skipped"; fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
 	echo "Running tests matching: $(TEST_RUN)"; \
 	ANTHROPIC_API_KEY=$$ANTHROPIC_KEY \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath $(FAILING_OUTPUT_DIR)) gotestsum \
 		--junitfile $(FAILING_OUTPUT_DIR)/junit.xml \
@@ -465,9 +493,15 @@ benchmark-cost: check-runner-node ensure-service-jar ensure-runner-dist ## Run c
 			exit 1; \
 		fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
+	if [ -z "$$CURSOR_ADMIN" ]; then \
+		echo "error: CURSOR_ADMIN_KEY required — the shared-pool CursorAccount seed needs the team admin key"; \
+		exit 1; \
+	fi; \
 	echo "Running cost benchmarks (native vs cursor)..."; \
 	ANTHROPIC_API_KEY=$$ANTHROPIC_KEY \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath $(BENCHMARK_OUTPUT_DIR)) gotestsum \
 		--junitfile $(BENCHMARK_OUTPUT_DIR)/junit.xml \
@@ -503,8 +537,14 @@ benchmark-cursor-modes: check-runner-node ensure-service-jar ensure-runner-dist 
 			exit 1; \
 		fi; \
 	fi; \
+	$(call fetch_cursor_admin_key); \
+	if [ -z "$$CURSOR_ADMIN" ]; then \
+		echo "error: CURSOR_ADMIN_KEY required — the shared-pool CursorAccount seed needs the team admin key"; \
+		exit 1; \
+	fi; \
 	echo "Running cursor mode benchmarks (local vs cloud)..."; \
 	CURSOR_API_KEY=$$CURSOR_KEY \
+	CURSOR_ADMIN_KEY=$$CURSOR_ADMIN \
 	STIGMER_CURSOR_CLOUD_MODE_ENABLED=true \
 	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
 	INTEGRATION_TEST_OUTPUT_DIR=$(abspath $(CURSOR_MODE_OUTPUT_DIR)) gotestsum \

--- a/test/integration/canary_test.go
+++ b/test/integration/canary_test.go
@@ -42,8 +42,14 @@ func requireCanaryAnthropicPrereqs(t *testing.T) {
 func requireCanaryCursorPrereqs(t *testing.T) {
 	t.Helper()
 	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+	// Same credential pair the suite-boot SeedSharedPoolCursorAccount
+	// needs: without both, the proxy's shared pool is empty and every
+	// cursor call 503s (see RequireCursorPrereqs).
 	if os.Getenv("CURSOR_API_KEY") == "" {
 		t.Skip("CURSOR_API_KEY not set — skipping cursor canary test")
+	}
+	if os.Getenv("CURSOR_ADMIN_KEY") == "" {
+		t.Skip("CURSOR_ADMIN_KEY not set — skipping cursor canary test (the shared-pool CursorAccount seed needs the team admin key)")
 	}
 }
 

--- a/test/integration/harness/cursor_pool_seeder.go
+++ b/test/integration/harness/cursor_pool_seeder.go
@@ -1,0 +1,58 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+
+	cursoraccountv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/platform/cursoraccount/v1"
+	"google.golang.org/grpc"
+)
+
+// SeedSharedPoolCursorAccount provisions the shared-pool CursorAccount the
+// cloud proxy's key selection requires — since the DD-008 amendment removed
+// the STIGMER_PROXY_CURSOR_API_KEY env fallback, DB-resident CursorAccount
+// records are the ONLY Cursor credential source, and an empty pool REJECTs
+// every proxied Cursor call with a 503. Without this seed, no cursor-harness
+// execution can succeed in the suite (oss#482).
+//
+// It goes through the real operator RPCs rather than the repository so the
+// suite exercises the production provisioning path, including both LIVE
+// Cursor API validations:
+//   - upsertCursorAccount proves adminAPIKey against GET /teams/members
+//     (team Admin API key — a different credential class from memberAPIKey);
+//   - addCursorMemberKey proves memberAPIKey against GET /v1/me and binds
+//     its owning member (user-scoped keys only; admin keys are rejected).
+//
+// An enabled account with no org assignment IS the shared pool, and a
+// freshly added enabled key is immediately routable (no sync needed:
+// CursorKeyRoutability reads a missing roster snapshot as eligible).
+//
+// conn must authenticate as a principal holding can_manage_cursor_accounts
+// on platform:stigmer — the suite's tokenless owner qualifies via the
+// `operator` tuple written by SeedBaseFGATuples.
+func SeedSharedPoolCursorAccount(ctx context.Context, conn grpc.ClientConnInterface, adminAPIKey, memberAPIKey string) error {
+	client := cursoraccountv1.NewCursorAccountCommandControllerClient(conn)
+
+	account, err := client.UpsertCursorAccount(ctx, &cursoraccountv1.UpsertCursorAccountInput{
+		Account: &cursoraccountv1.CursorAccount{
+			DisplayName: "integration-harness shared pool",
+			AdminApiKey: adminAPIKey,
+			Enabled:     true,
+			// OrgIds stays empty: org assignment would make this a
+			// DEDICATED account serving only that org.
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("upsertCursorAccount: %w", err)
+	}
+
+	if _, err := client.AddCursorMemberKey(ctx, &cursoraccountv1.AddCursorMemberKeyInput{
+		AccountId: account.GetAccountId(),
+		ApiKey:    memberAPIKey,
+		Label:     "integration-harness pool key",
+	}); err != nil {
+		return fmt.Errorf("addCursorMemberKey: %w", err)
+	}
+
+	return nil
+}

--- a/test/integration/harness/harness_config.go
+++ b/test/integration/harness/harness_config.go
@@ -52,9 +52,13 @@ func RequireNativePrereqs(t *testing.T, th *TestHarness) {
 }
 
 // RequireCursorPrereqs skips the test if the unified runner is not available
-// or if the Cursor API key is absent. Every cursor harness test dispatches
-// an agent execution through the Cursor proxy, which requires an upstream key.
-// Without it, executions fail immediately with HTTP 502 from the proxy.
+// or if either Cursor credential is absent. Every cursor harness test
+// dispatches through the Cursor proxy, whose key selection serves ONLY from
+// the DB-resident shared pool (DD-008) — seeded at suite boot by
+// SeedSharedPoolCursorAccount, which needs BOTH keys: the admin key to
+// create the account (live-validated against Cursor's Admin API) and the
+// user-scoped key as the pool member key. Without the seed, every proxied
+// Cursor call fails with a pool-exhausted 503.
 func RequireCursorPrereqs(t *testing.T, th *TestHarness) {
 	t.Helper()
 	if th.UnifiedRunner == nil {
@@ -62,6 +66,9 @@ func RequireCursorPrereqs(t *testing.T, th *TestHarness) {
 	}
 	if os.Getenv("CURSOR_API_KEY") == "" {
 		t.Skip("CURSOR_API_KEY not set — skipping cursor harness test (requires Cursor proxy)")
+	}
+	if os.Getenv("CURSOR_ADMIN_KEY") == "" {
+		t.Skip("CURSOR_ADMIN_KEY not set — skipping cursor harness test (the shared-pool CursorAccount seed needs the team admin key)")
 	}
 }
 

--- a/test/integration/harness/service.go
+++ b/test/integration/harness/service.go
@@ -76,12 +76,12 @@ type ServiceConfig struct {
 	// AnthropicAPIKey is passed to the Java service as the LLM proxy's
 	// upstream Anthropic key. When set, the proxy can forward runner
 	// LLM calls to Anthropic and record per-call usage for billing.
+	//
+	// There is deliberately no Cursor counterpart: the DD-008 amendment
+	// removed the STIGMER_PROXY_CURSOR_API_KEY env path from the Cursor
+	// proxy — Cursor credentials are DB-resident CursorAccounts, seeded
+	// through the operator RPCs (SeedSharedPoolCursorAccount).
 	AnthropicAPIKey string
-
-	// CursorAPIKey is passed to the Java service as the Cursor proxy's
-	// upstream API key. When set, the CursorProxyController can forward
-	// cursor-runner requests to Cursor's API and record per-call usage.
-	CursorAPIKey string
 
 	// OpenFGA configuration. When all three are set, the Java service
 	// uses a real OpenFGA instance for authorization instead of the
@@ -592,12 +592,6 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 	if cfg.AnthropicAPIKey != "" {
 		env = append(env,
 			fmt.Sprintf("STIGMER_PROXY_ANTHROPIC_API_KEY=%s", cfg.AnthropicAPIKey),
-		)
-	}
-
-	if cfg.CursorAPIKey != "" {
-		env = append(env,
-			fmt.Sprintf("STIGMER_PROXY_CURSOR_API_KEY=%s", cfg.CursorAPIKey),
 		)
 	}
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -69,6 +69,7 @@ func TestMain(m *testing.M) {
 	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
 
 	cursorKey := os.Getenv("CURSOR_API_KEY")
+	cursorAdminKey := os.Getenv("CURSOR_ADMIN_KEY")
 
 	mockWhatsAppGraph = harness.StartMockWhatsAppGraph()
 	defer mockWhatsAppGraph.Close()
@@ -79,7 +80,6 @@ func TestMain(m *testing.M) {
 		RedisPort:            testHarness.Redis.Port,
 		TemporalAddress:      testHarness.Temporal.Address(),
 		AnthropicAPIKey:      anthropicKey,
-		CursorAPIKey:         cursorKey,
 		WhatsAppGraphBaseURL: mockWhatsAppGraph.BaseURL(),
 		LogDir:               logDir,
 	}
@@ -211,6 +211,19 @@ func TestMain(m *testing.M) {
 		suiteLogger.Warn("failed to seed default agent — tests requiring a default agent may fail", "error", err)
 	} else {
 		suiteLogger.Info("default agent seeded")
+	}
+
+	// Cursor credentials are DB-resident CursorAccounts (DD-008) — without
+	// this seed every proxied Cursor call 503s on an empty shared pool.
+	// Both keys are required: the seed's upsert live-validates the admin
+	// key against Cursor's Admin API (RequireCursorPrereqs skips cursor
+	// tests when either is absent).
+	if cursorKey != "" && cursorAdminKey != "" {
+		if err := harness.SeedSharedPoolCursorAccount(ctx, grpcConn, cursorAdminKey, cursorKey); err != nil {
+			suiteLogger.Warn("failed to seed shared-pool cursor account — cursor harness tests will fail at key selection", "error", err)
+		} else {
+			suiteLogger.Info("shared-pool cursor account seeded")
+		}
 	}
 
 	mcpBinary, mcpErr := harness.BuildTestMcpServer(cfg.OutputDir)


### PR DESCRIPTION
## Summary

Makes the integration-canary lane's Cursor arm green again (issue #482) by seeding a shared-pool `CursorAccount` at suite boot through the real platform operator RPCs. Also heals every other proxied cursor test in the repo (agent-execution harness table, cost benchmarks, session-routing E2E) — all broken by the same root cause.

## Context

oss#482 framed the canary failures as "provider keys never reach the execution path". Investigation split that into two different failures:

- **Cursor (fixed here)**: stigmer-cloud's DD-008 amendment (`2e3283a2a`, 2026-07-23) removed the `STIGMER_PROXY_CURSOR_API_KEY` env path — DB-resident `CursorAccount` records are now the ONLY Cursor credential source. The harness still exported the dead env var and seeded no account, so key selection rejected every proxied cursor call with the pool-exhausted 503.
- **Anthropic (ops, not code)**: the `STIGMER_PROXY_ANTHROPIC_API_KEY` path is alive; the `STIGMER_PLATFORM_MODEL_CAPACITY` 503 is the proxy's rewrite of Anthropic rejecting the platform key — verified live as `PLATFORM_BILLING` ("credit balance is too low"). The account needs funding; details on the issue.

The runner's direct-key mode was never removed (it remains the self-hosted path, selected by omitting `STIGMER_PROXY_ENDPOINT`); the suite deliberately runs the production proxy topology, and keeps doing so.

## Changes

- **`test/integration/harness/cursor_pool_seeder.go`** (new): `SeedSharedPoolCursorAccount` — `upsertCursorAccount` (team admin key, live-validated against Cursor's `GET /teams/members`) + `addCursorMemberKey` (user-scoped key, live-validated via `GET /v1/me`), through the real operator RPCs so the suite exercises the production provisioning path. Auth rides the existing `operator` tuple on `platform:stigmer` seeded by `SeedBaseFGATuples`.
- Wired into both TestMains (`test/integration`, `test/integration-session-routing`) behind the `CURSOR_API_KEY` + `CURSOR_ADMIN_KEY` pair, warn-and-continue like the sibling seeders.
- **Honest skip guards**: `RequireCursorPrereqs` (shared), the canary guard, and session-routing's `requireCursorKey` now also require `CURSOR_ADMIN_KEY`, naming the missing secret.
- **Secret plumbing**: `CURSOR_ADMIN_KEY` fetch (Planton slug `cursor-admin`) added to all seven cursor-fetching make targets via a shared `fetch_cursor_admin_key` macro (mandatory at the two benchmark targets that already hard-require cursor); `ci.integration-canary.yaml` passes the new `provider-integration` environment secret (already provisioned).
- **Dead config removed**: `ServiceConfig.CursorAPIKey` + the `STIGMER_PROXY_CURSOR_API_KEY` export (dead since DD-008; the field's doc comment now records why there is no Cursor counterpart).
- In passing: session-routing's provider Makefile still used the obsolete `planton service secrets get-value` syntax (captures CLI error text as the key, the exact failure the main Makefile's comment documents) — fixed to the current fetch idiom.

## Test plan

All runs against a clean-`origin/main` stigmer-cloud JAR (`117b9889d`), FGA enabled, Node 22.22.1:

- **Negative control** (deliberately invalid admin key): seed rejected live by Cursor (`Admin key rejected by Cursor — HTTP 401: Invalid Team API Key`, warn-and-continue held), and `TestCanary_CursorAgentCompletes` failed fast (2.13s) with the issue's exact signature — `exchange_user_api_key → proxy status=503`, "No shared-pool Cursor account has a usable execution key". The seed is the differentiator.
- **Positive**: `TestCanary_CursorAgentCompletes` **pass** (12.23s inside the full `make test-integration-canary` lane; 43.8s standalone) — live end-to-end: seed → pool selection → key exchange → Cursor execution → COMPLETED.
- Full `make test-integration-canary` with all three keys Planton-fetched through the new macro: 11 tests, 7 skipped (MCP-canary gated + HTTP), 3 failures = exactly the three Anthropic-path tests (unfunded platform account, expected until the ops step on #482 lands).
- All four test modules compile (`go build -tags integration`), `go vet` clean, gofmt clean on touched files, all seven modified make targets parse (`make -n`).

## Risks

- Cursor-gated tests now require a second secret; without it they **skip with an explanatory message** (previous behavior with one key was a guaranteed 503 failure). Benchmarks hard-fail with a clear error instead of burning a boot to fail later.
- The canary lane stays red until the Anthropic platform account is funded — deliberately NOT auto-closing #482 (its `ci-canary-failure` label makes the nightly notify job comment there; close only when the lane is green).

Refs #482

Made with [Cursor](https://cursor.com)