### PR TITLE
fix(runner): deny all runner credentials to agent shell commands

### DIFF
--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/shell-env.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/shell-env.test.ts
@@ -1,22 +1,36 @@
 import { describe, it, expect } from "vitest";
 import { buildShellEnv, SHELL_ENV_DENYLIST } from "../shell-env.js";
+import { RUNNER_CREDENTIAL_ENV_KEYS } from "../../../shared/runner-credential-keys.js";
 
 describe("buildShellEnv", () => {
-  it("strips runner-internal credentials from the base env", () => {
-    const base = {
-      PATH: "/usr/bin",
-      HOME: "/home/runner",
-      STIGMER_RUNNER_HITL_SECRET: "secret",
-      CURSOR_API_KEY: "cursor-key",
-      STIGMER_TOKEN: "stigmer-token",
-    };
+  it("strips every runner credential from the base env", () => {
+    // Plant a value for every name in the source-of-truth list, so a key
+    // added to runner-credential-keys.ts is covered here automatically.
+    const base: NodeJS.ProcessEnv = { PATH: "/usr/bin", HOME: "/home/runner" };
+    for (const key of RUNNER_CREDENTIAL_ENV_KEYS) {
+      base[key] = `leaked-${key}`;
+    }
 
     const env = buildShellEnv({}, base);
 
     expect(env.PATH).toBe("/usr/bin");
     expect(env.HOME).toBe("/home/runner");
-    for (const key of SHELL_ENV_DENYLIST) {
-      expect(env[key]).toBeUndefined();
+    for (const key of RUNNER_CREDENTIAL_ENV_KEYS) {
+      expect(env[key], `runner credential '${key}' must not reach the shell env`).toBeUndefined();
+    }
+  });
+
+  it("denies the full credential list, not just the original three (issue #385)", () => {
+    // Pins the five names #385 added. The parameterized test above would
+    // pass even if the list regressed to three; this one cannot.
+    for (const key of [
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+      "STIGMER_AUTH_TOKEN",
+      "ANTHROPIC_FOUNDRY_API_KEY",
+      "AWS_BEARER_TOKEN_BEDROCK",
+    ]) {
+      expect(SHELL_ENV_DENYLIST, `'${key}' must be in the shell denylist`).toContain(key);
     }
   });
 

--- a/backend/services/runner/src/activities/execute-deep-agent/shell-env.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/shell-env.ts
@@ -6,15 +6,14 @@
  * never once at process start.
  */
 
-/** Runner-internal keys that must never reach agent shell commands. */
-export const SHELL_ENV_DENYLIST: readonly string[] = [
-  // Derives HITL approval fingerprints — an agent that reads this could forge receipts.
-  "STIGMER_RUNNER_HITL_SECRET",
-  // Cursor harness credential; shell commands do not need direct Cursor API access.
-  "CURSOR_API_KEY",
-  // Stigmer control-plane auth; shell commands use ExecutionContext overlay instead.
-  "STIGMER_TOKEN",
-];
+import { RUNNER_CREDENTIAL_ENV_KEYS } from "../../shared/runner-credential-keys.js";
+
+/**
+ * Runner-internal keys that must never reach agent shell commands: every
+ * credential the runner holds for its own outbound calls (issue #385). The
+ * names — and the rule for adding one — live in runner-credential-keys.ts.
+ */
+export const SHELL_ENV_DENYLIST: readonly string[] = RUNNER_CREDENTIAL_ENV_KEYS;
 
 /**
  * Build the environment map passed to deepagents' LocalShellBackend.

--- a/backend/services/runner/src/shared/__tests__/mcp-manager.test.ts
+++ b/backend/services/runner/src/shared/__tests__/mcp-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import type { Connection } from "@langchain/mcp-adapters";
 import { connectMcpServers, toMcpClientConfig } from "../mcp-manager.js";
+import { RUNNER_CREDENTIAL_ENV_KEYS } from "../runner-credential-keys.js";
 import type { ResolvedMcpServer } from "../mcp-resolver.js";
 
 // The adapter client is mocked ONLY for the connectMcpServers tests below
@@ -112,25 +113,15 @@ describe("toMcpClientConfig", () => {
   });
 });
 
-// Runner-internal credentials that must never reach an MCP stdio subprocess
-// (oss#256). Names mirror what the runner actually reads: config.ts,
-// fingerprint-secret.ts, model-client.ts, registry-endpoint.ts.
-const RUNNER_CREDENTIAL_KEYS = [
-  "STIGMER_RUNNER_HITL_SECRET",
-  "STIGMER_TOKEN",
-  "STIGMER_AUTH_TOKEN",
-  "CURSOR_API_KEY",
-  "ANTHROPIC_API_KEY",
-  "OPENAI_API_KEY",
-] as const;
-
 describe("toMcpClientConfig — stdio env isolation (oss#256)", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
   it("gives a stdio server with no declared env none of the runner's variables", () => {
-    for (const key of RUNNER_CREDENTIAL_KEYS) {
+    // The canaries are the runner's real credential names (oss#385's single
+    // source of truth), so a key added there is automatically covered here.
+    for (const key of RUNNER_CREDENTIAL_ENV_KEYS) {
       vi.stubEnv(key, `leaked-${key}`);
     }
     vi.stubEnv("STIGMER_TEST_LEAK_SENTINEL", "canary");

--- a/backend/services/runner/src/shared/mcp-manager.ts
+++ b/backend/services/runner/src/shared/mcp-manager.ts
@@ -18,10 +18,10 @@
  * (HOME, LOGNAME, PATH, SHELL, TERM, USER — getDefaultEnvironment in
  * @modelcontextprotocol/sdk, merged under whatever we pass). The
  * runner's own process env is never passed: it carries runner-internal
- * credentials (STIGMER_TOKEN, STIGMER_RUNNER_HITL_SECRET,
- * CURSOR_API_KEY, LLM provider keys) that no third-party MCP subprocess
- * may see. A declared-empty env and an undeclared env are deliberately
- * equivalent — both yield the SDK base environment.
+ * credentials (enumerated in runner-credential-keys.ts) that no
+ * third-party MCP subprocess may see. A declared-empty env and an
+ * undeclared env are deliberately equivalent — both yield the SDK base
+ * environment.
  *
  * The Cursor execution path does NOT use this manager — it passes MCP
  * configs directly to the Cursor SDK via toCursorMcpConfig(). This

--- a/backend/services/runner/src/shared/runner-credential-keys.ts
+++ b/backend/services/runner/src/shared/runner-credential-keys.ts
@@ -1,0 +1,46 @@
+/**
+ * Env var names of the runner's own credentials — the single source of truth
+ * for every surface that isolates agent-spawned processes from the runner's
+ * process env (issue #385).
+ *
+ * Inclusion rule: a name belongs here iff the runner reads it from its own
+ * `process.env` to authenticate the runner's own outbound calls. User-supplied
+ * credentials resolved from ExecutionContext (e.g. GITHUB_TOKEN, read only
+ * from mergedEnvVars) must NEVER be listed — the ExecutionContext overlay is
+ * their sanctioned delivery channel, and denying them here would break it.
+ *
+ * Consumers:
+ * - shell-env.ts: SHELL_ENV_DENYLIST for the native harness `execute` tool.
+ * - mcp-manager.test.ts: leak-tripwire canaries for MCP stdio subprocesses
+ *   (that path passes NO runner env by construction; the test plants these
+ *   names to prove none leak through).
+ *
+ * Ambient cloud-SDK chain vars (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+ * GOOGLE_APPLICATION_CREDENTIALS, ...) are deliberately absent: they are
+ * dual-use on local runners (operators expect agent shells to keep their
+ * ambient aws/gcloud auth), and on a local backend the shell can read the
+ * credential files off disk regardless (owner ruling on #385).
+ */
+export const RUNNER_CREDENTIAL_ENV_KEYS: readonly string[] = [
+  // Derives HITL approval fingerprints (fingerprint-secret.ts) — an agent
+  // that reads this could forge approval receipts.
+  "STIGMER_RUNNER_HITL_SECRET",
+  // Stigmer control-plane auth (config.ts; rotated at runtime by
+  // runner-manager.ts). Executions receive theirs via ExecutionContext.
+  "STIGMER_TOKEN",
+  // Fallback bearer token for model-registry/pricing fetches when
+  // STIGMER_TOKEN is unset (registry-endpoint.ts).
+  "STIGMER_AUTH_TOKEN",
+  // Cursor harness credential (config.ts) — agent-spawned processes never
+  // need direct Cursor API access.
+  "CURSOR_API_KEY",
+  // Direct-mode Anthropic key for the native harness (model-client.ts).
+  "ANTHROPIC_API_KEY",
+  // Direct-mode OpenAI key for the native harness (model-client.ts).
+  "OPENAI_API_KEY",
+  // Azure AI Foundry backend key (model-client.ts).
+  "ANTHROPIC_FOUNDRY_API_KEY",
+  // Bedrock backend bearer credential, read by the AWS SDK's chain
+  // (llm-backend.ts documents it as a supported auth path).
+  "AWS_BEARER_TOKEN_BEDROCK",
+];


### PR DESCRIPTION
## Summary

Closes #385.

`SHELL_ENV_DENYLIST` stripped only three keys (`STIGMER_RUNNER_HITL_SECRET`, `CURSOR_API_KEY`, `STIGMER_TOKEN`) from the env handed to the native harness's `execute` shell tool, so agent shell commands could read the operator's LLM provider credentials. The issue named three missing keys; a full audit of every `process.env` read in the runner found five: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `STIGMER_AUTH_TOKEN` (the issue's three), plus `ANTHROPIC_FOUNDRY_API_KEY` and `AWS_BEARER_TOKEN_BEDROCK` (same class, found in audit — owner ruled them in).

## Changes

- **New `shared/runner-credential-keys.ts`** — `RUNNER_CREDENTIAL_ENV_KEYS`, the single source of truth for the runner's own credential env names, with the inclusion rule documented: denied = credentials the runner reads from its own `process.env` to authenticate its own calls; user-supplied ExecutionContext credentials (e.g. `GITHUB_TOKEN`, read only from `mergedEnvVars`) are never listed — the overlay is their sanctioned channel.
- **`shell-env.ts`** — `SHELL_ENV_DENYLIST` now derives from the shared constant (8 names, up from 3). `buildShellEnv` semantics unchanged: ExecutionContext overlay still wins, so deliberately-granted credentials keep flowing.
- **`mcp-manager.test.ts`** — the oss#256 stdio-isolation tripwire now imports the shared constant instead of hand-copying the names, so a key added there is automatically covered by the MCP leak test too. The `mcp-manager.ts` header prose (the third hand-maintained copy of these names) now references the constant as well.
- **`shell-env.test.ts`** — parameterized over the constant (every listed key must be stripped) plus a regression pin that the five #385 names are present in the denylist.

## Out of scope, tracked elsewhere

- Denylist→allowlist flip: flagged by the issue; the decision point is #384 (workflow `run` task env contract).
- Ambient cloud-SDK chain vars (`AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`, ...): owner-ruled out — dual-use on local runners, and a local shell can read the credential files off disk regardless.
- The same exposure through cursor-agent's inherited env: filed as #508.

## Verification

- Runner typecheck clean.
- Touched suites: 18/18 (shell-env 5, mcp-manager 13).
- Full runner gate: 4452 passed / 6 pre-existing skips, 0 failures (one vitest worker IPC-timeout flake on the first run, gone on rerun with zero test failures).

## Risk

Contained: the only behavior change is five env names disappearing from agent shell commands. The one conceivable regression — an agent silently relying on the operator's provider key in shell — is precisely the exposure being closed; the sanctioned path (declare the credential in an Environment) is unaffected.

Made with [Cursor](https://cursor.com)