### PR TITLE
fix(runner): define the catchup digest's send-status annotations in the model-facing preamble

### DIFF
--- a/backend/services/runner/src/shared/__tests__/conversation-catchup.test.ts
+++ b/backend/services/runner/src/shared/__tests__/conversation-catchup.test.ts
@@ -55,6 +55,18 @@ describe("formatConversationCatchupText", () => {
     expect(framed).toContain("Continue from the customer's newest message.");
   });
 
+  it("defines the send-status annotations — undelivered words are not settled history (cloud#347)", () => {
+    // The cloud composer marks lines the customer never got or may not
+    // have gotten yet; the preamble must define both annotations and
+    // carve them out of the don't-re-answer contract, or the agent would
+    // silently abandon whatever a failed teammate reply meant to convey.
+    expect(framed).toContain("(not delivered)");
+    expect(framed).toContain("never reached the customer");
+    expect(framed).toContain("(sending)");
+    expect(framed).toContain("still on their way");
+    expect(framed).toContain("weigh that when deciding what still needs saying");
+  });
+
   it("asserts no takeover — a digest can exist with no human handoff at all (the A15/A20 honesty bar)", () => {
     // The preamble may DESCRIBE what the digest can contain ("may include"),
     // but must never state that a handoff happened on THIS conversation: a

--- a/backend/services/runner/src/shared/conversation-catchup.ts
+++ b/backend/services/runner/src/shared/conversation-catchup.ts
@@ -1,8 +1,11 @@
 /**
  * Conversation catchup (cloud channel-conversations DD-006): what happened on
  * a live channel conversation that the agent has not seen — customer messages
- * handled by a human teammate, the teammate's replies, platform notices the
- * customer received, notes, and the agent's own earlier escalations.
+ * handled by a human teammate, the teammate's replies, platform notices,
+ * notes, and the agent's own earlier escalations. Since cloud#347 a line
+ * whose send is known-undelivered carries a `(not delivered)` speaker
+ * annotation and an in-flight one carries `(sending)` — the digest no longer
+ * implies every public-lane line reached the customer.
  *
  * The cloud composes the CONTENT (bare `Customer:` / `Teammate:` / `System:` /
  * `You escalated:` / `Note:` lines, oldest first) on the execution spec's
@@ -29,16 +32,26 @@ import type { ConversationCatchup } from "@stigmer/protos/ai/stigmer/agentic/age
  * drift between them. Deliberately takeover-neutral: a digest can exist with
  * no human handoff at all (a failed turn's re-composed window), so the
  * preamble asserts only what is always true (the A15/A20 honesty bar).
+ *
+ * The send-status annotations (cloud#347) get an explicit exception from the
+ * don't-re-answer contract: a `(not delivered)` teammate reply is words the
+ * customer never got, so treating it as settled history would silently
+ * abandon whatever it was meant to convey. The preamble defines the
+ * annotations — the DD-013 split puts model-facing meaning here, while the
+ * cloud composer owns which lines earn them.
  */
 const CONVERSATION_CATCHUP_PREAMBLE =
   "Below is activity from this conversation that you have not seen — " +
   "oldest first. It may include customer messages that were handled by a " +
-  "human teammate, the teammate's own replies, notices the customer " +
-  "received, internal notes, and escalations you raised earlier. Treat it " +
+  "human teammate, the teammate's own replies, notices sent to the " +
+  "customer, internal notes, and escalations you raised earlier. Treat it " +
   "as conversation history you already know: do not answer or re-answer " +
   "these messages, do not repeat or summarize them back, and do not " +
-  "mention any handoff unless asked. Continue from the customer's newest " +
-  "message.";
+  "mention any handoff unless asked. One exception: lines marked " +
+  "(not delivered) never reached the customer, and lines marked (sending) " +
+  "were still on their way when this summary was built — the customer may " +
+  "not have seen those words, so weigh that when deciding what still needs " +
+  "saying. Continue from the customer's newest message.";
 
 /**
  * Read the catchup digest from an execution spec's `conversation_catchup`.


### PR DESCRIPTION
## Summary
Paired with stigmer-cloud [PR #351](https://github.com/stigmer/stigmer-cloud/pull/351) (cloud#347): the catchup digest now annotates undelivered/in-flight sends with `(not delivered)` / `(sending)`. The runner's preamble — the model-facing framing of that digest — is amended to define both annotations and carve them out of the don't-re-answer contract.

## Context
The preamble asserted the digest is history the customer received and instructed the model to never re-answer or repeat it. For a `(not delivered)` teammate reply that instruction would suppress exactly the corrective action the annotation enables — the customer never got those words, and the agent may need to convey their substance. Per the DD-013 content/presentation split, defining what the annotations mean to the model belongs here; which lines earn them belongs to the cloud composer.

## Changes
- `CONVERSATION_CATCHUP_PREAMBLE`: one exception clause defining `(not delivered)` (never reached the customer) and `(sending)` (still on their way at compose time), with "weigh that when deciding what still needs saying"; "notices the customer received" softened to "notices sent to the customer".
- Module doc updated; new test pinning the annotation-definition contract.

## Breaking changes
- None. The preamble stays takeover-neutral (existing pins unchanged). Either PR of the pair is independently safe to land in either order — an older runner renders the annotations as plain digest text, a newer preamble with an un-annotated digest describes marks that simply never appear.

## Test plan
- `tsc --noEmit` clean; full runner Vitest suite 4452 passed / 6 skipped (includes the new preamble-contract pin).

## Risks
- Low: prompt-copy change in one shared module, both harnesses inherit it. Rollback is a revert.

Ref: https://github.com/stigmer/stigmer-cloud/issues/347

Made with [Cursor](https://cursor.com)