### PR TITLE
fix(runner): stop workflow run tasks from inheriting the runner process env

### DIFF
--- a/backend/services/runner/src/activities/__tests__/run-command.test.ts
+++ b/backend/services/runner/src/activities/__tests__/run-command.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Env contract tests for the workflow `run` task (oss#384).
+ *
+ * These spawn REAL subprocesses through the RunShell / RunScript
+ * activities and inspect the environment the child actually received —
+ * the leak-reproduction style established by the #256 fix (PR #383).
+ * Subprocess output is env variable NAMES only, never values.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRunCommandActivities } from "../run-command.js";
+import { buildRunEnv, RUN_ENV_BASE_KEYS } from "../run-env.js";
+import { RuntimePlaceholderResolutionError } from "../../workflow-engine/resolve.js";
+
+/**
+ * Credentials planted into the runner process env before each test.
+ * Includes a name outside every known denylist to prove the contract
+ * is declare-to-receive, not deny-known-names.
+ */
+const PLANTED_SENTINELS: Record<string, string> = {
+  STIGMER_RUNNER_HITL_SECRET: "sentinel-hitl",
+  STIGMER_TOKEN: "sentinel-token",
+  CURSOR_API_KEY: "sentinel-cursor",
+  ANTHROPIC_API_KEY: "sentinel-anthropic",
+  OPERATOR_PRIVATE_CREDENTIAL: "sentinel-arbitrary",
+};
+
+const PRINT_ENV_KEYS_SHELL = `node -p 'JSON.stringify(Object.keys(process.env))'`;
+const PRINT_ENV_KEYS_SCRIPT = `console.log(JSON.stringify(Object.keys(process.env)))`;
+
+const activities = createRunCommandActivities();
+
+async function childEnvKeysViaShell(
+  environment?: Record<string, string>,
+  runtimeEnv: Record<string, unknown> = {},
+): Promise<string[]> {
+  const stdout = await activities.RunShell({
+    mode: "shell",
+    command: PRINT_ENV_KEYS_SHELL,
+    environment,
+    runtimeEnv,
+  });
+  return JSON.parse(String(stdout)) as string[];
+}
+
+async function childEnvKeysViaScript(
+  environment?: Record<string, string>,
+  runtimeEnv: Record<string, unknown> = {},
+): Promise<string[]> {
+  const stdout = await activities.RunScript({
+    mode: "script",
+    language: "js",
+    code: PRINT_ENV_KEYS_SCRIPT,
+    environment,
+    runtimeEnv,
+  });
+  return JSON.parse(String(stdout)) as string[];
+}
+
+describe("run task env contract (oss#384)", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const [key, value] of Object.entries(PLANTED_SENTINELS)) {
+      saved[key] = process.env[key];
+      process.env[key] = value;
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(PLANTED_SENTINELS)) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  describe("RunShell", () => {
+    it("does not leak runner process credentials to the child", async () => {
+      const keys = await childEnvKeysViaShell();
+
+      for (const sentinel of Object.keys(PLANTED_SENTINELS)) {
+        expect(keys, `runner credential "${sentinel}" leaked to shell child`)
+          .not.toContain(sentinel);
+      }
+    });
+
+    it("provides the minimal base env and the declared overlay", async () => {
+      const keys = await childEnvKeysViaShell({ DECLARED_VAR: "value" });
+
+      for (const base of RUN_ENV_BASE_KEYS) {
+        if (process.env[base] !== undefined) {
+          expect(keys, `base key "${base}" missing from shell child`).toContain(base);
+        }
+      }
+      expect(keys).toContain("DECLARED_VAR");
+    });
+
+    it("resolves ${.secrets.KEY} placeholders in declared values just-in-time", async () => {
+      const stdout = await activities.RunShell({
+        mode: "shell",
+        command: `node -p 'process.env.API_KEY'`,
+        environment: { API_KEY: "${.secrets.TEST_API_KEY}" },
+        runtimeEnv: { TEST_API_KEY: "resolved-secret-value" },
+      });
+
+      expect(stdout).toBe("resolved-secret-value");
+    });
+
+    it("fails non-retryably, naming the variable, when a placeholder key is missing", async () => {
+      await expect(
+        activities.RunShell({
+          mode: "shell",
+          command: "true",
+          environment: { API_KEY: "${.secrets.NOT_PROVIDED}" },
+          runtimeEnv: {},
+        }),
+      ).rejects.toMatchObject({
+        nonRetryable: true,
+        type: "RUN_ENV_UNRESOLVED_PLACEHOLDER",
+        message: expect.stringContaining("NOT_PROVIDED"),
+      });
+    });
+  });
+
+  describe("RunScript", () => {
+    it("does not leak runner process credentials to the child", async () => {
+      const keys = await childEnvKeysViaScript();
+
+      for (const sentinel of Object.keys(PLANTED_SENTINELS)) {
+        expect(keys, `runner credential "${sentinel}" leaked to script child`)
+          .not.toContain(sentinel);
+      }
+    });
+
+    it("provides the minimal base env and the declared overlay", async () => {
+      const keys = await childEnvKeysViaScript({ DECLARED_VAR: "value" });
+
+      for (const base of RUN_ENV_BASE_KEYS) {
+        if (process.env[base] !== undefined) {
+          expect(keys, `base key "${base}" missing from script child`).toContain(base);
+        }
+      }
+      expect(keys).toContain("DECLARED_VAR");
+    });
+
+    it("resolves ${.env_vars.KEY} placeholders in declared values just-in-time", async () => {
+      const stdout = await activities.RunScript({
+        mode: "script",
+        language: "js",
+        code: "console.log(process.env.REGION)",
+        environment: { REGION: "${.env_vars.DEPLOY_REGION}" },
+        runtimeEnv: { DEPLOY_REGION: "us-east-1" },
+      });
+
+      expect(stdout).toBe("us-east-1");
+    });
+  });
+});
+
+describe("buildRunEnv", () => {
+  it("copies only the base keys present in the runner env", () => {
+    const base = {
+      PATH: "/usr/bin",
+      HOME: "/home/runner",
+      TERM: "xterm",
+    };
+
+    const env = buildRunEnv(undefined, {}, base);
+
+    expect(env).toEqual({ PATH: "/usr/bin", HOME: "/home/runner", TERM: "xterm" });
+  });
+
+  it("never copies undeclared runner variables — the oss#384 tripwire", () => {
+    // Guards against a future reintroduction of `{ ...process.env }`:
+    // credentials must be structurally absent, whatever their names.
+    const base = {
+      PATH: "/usr/bin",
+      STIGMER_RUNNER_HITL_SECRET: "secret",
+      ANY_FUTURE_CREDENTIAL: "secret",
+    };
+
+    const env = buildRunEnv({ DECLARED: "yes" }, {}, base);
+
+    expect(Object.keys(env).sort()).toEqual(["DECLARED", "PATH"]);
+  });
+
+  it("lets a declared variable override a base variable", () => {
+    const base = { PATH: "/usr/bin" };
+
+    const env = buildRunEnv({ PATH: "/custom/bin" }, {}, base);
+
+    expect(env.PATH).toBe("/custom/bin");
+  });
+
+  it("passes non-placeholder declared values through untouched", () => {
+    const env = buildRunEnv(
+      { LITERAL: "plain-value", TEMPLATED: "prefix-${.secrets.KEY}-suffix" },
+      { KEY: "mid" },
+      {},
+    );
+
+    expect(env.LITERAL).toBe("plain-value");
+    expect(env.TEMPLATED).toBe("prefix-mid-suffix");
+  });
+
+  it("throws a named error for a missing placeholder key", () => {
+    expect(() =>
+      buildRunEnv({ API_KEY: "${.secrets.MISSING}" }, {}, {}),
+    ).toThrowError(RuntimePlaceholderResolutionError);
+
+    try {
+      buildRunEnv({ API_KEY: "${.secrets.MISSING}" }, {}, {});
+    } catch (err) {
+      expect((err as RuntimePlaceholderResolutionError).variableName).toBe("MISSING");
+      expect((err as Error).message).toContain('environment "API_KEY"');
+    }
+  });
+});

--- a/backend/services/runner/src/activities/run-command.ts
+++ b/backend/services/runner/src/activities/run-command.ts
@@ -5,8 +5,11 @@
  * - RunScript: writes inline code to a temp file, executes via node/python
  * - RunShell: executes a shell command directly
  *
- * Both resolve runtime placeholders (JIT secrets) before execution
- * and capture stdout as the activity result.
+ * The child environment follows the declare-to-receive contract in
+ * run-env.ts: a minimal base plus the task's declared `environment`,
+ * with runtime placeholders (JIT secrets) resolved here in the activity
+ * so secret values never enter Temporal history. Both activities capture
+ * stdout as the activity result.
  */
 
 import { execFile, exec } from "node:child_process";
@@ -16,7 +19,9 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { ApplicationFailure } from "@temporalio/activity";
 import type { RunCommandConfig } from "../workflow-engine/types.js";
+import { RuntimePlaceholderResolutionError } from "../workflow-engine/resolve.js";
 import { startHeartbeat } from "../shared/heartbeat.js";
+import { buildRunEnv } from "./run-env.js";
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -49,7 +54,7 @@ async function runScriptImpl(config: RunCommandConfig): Promise<unknown> {
 
   const language = config.language!;
   const code = config.code!;
-  const env = buildEnv(config.environment);
+  const env = buildTaskEnv(config);
 
   const ext = language === "js" ? ".js" : ".py";
   const interpreter = language === "js" ? "node" : "python3";
@@ -94,7 +99,7 @@ async function runShellImpl(config: RunCommandConfig): Promise<unknown> {
   const fullCommand = args.length > 0
     ? `${command} ${args.join(" ")}`
     : command;
-  const env = buildEnv(config.environment);
+  const env = buildTaskEnv(config);
 
   try {
     const { stdout } = await execAsync(fullCommand, {
@@ -116,16 +121,24 @@ async function runShellImpl(config: RunCommandConfig): Promise<unknown> {
   }
 }
 
-function buildEnv(
-  taskEnv?: Record<string, string>,
-): Record<string, string | undefined> {
-  const base = { ...process.env };
-  if (taskEnv) {
-    for (const [k, v] of Object.entries(taskEnv)) {
-      base[k] = v;
+/**
+ * Build the child env per the run-env.ts contract, translating a missing
+ * placeholder key into a non-retryable failure — retrying cannot conjure
+ * a variable the workflow's runtime env does not have.
+ */
+function buildTaskEnv(config: RunCommandConfig): Record<string, string> {
+  try {
+    return buildRunEnv(config.environment, config.runtimeEnv);
+  } catch (err: unknown) {
+    if (err instanceof RuntimePlaceholderResolutionError) {
+      throw ApplicationFailure.nonRetryable(
+        err.message,
+        "RUN_ENV_UNRESOLVED_PLACEHOLDER",
+        { variable: err.variableName },
+      );
     }
+    throw err;
   }
-  return base;
 }
 
 function buildArgsList(args: unknown): string[] {

--- a/backend/services/runner/src/activities/run-env.ts
+++ b/backend/services/runner/src/activities/run-env.ts
@@ -1,0 +1,79 @@
+/**
+ * Environment contract for the workflow `run` task (shell and script modes).
+ *
+ * Declare-to-receive, the same rule the stdio MCP contract adopted after
+ * #256 (PR #383): the child process sees ONLY
+ *
+ *   1. a minimal base copied from the runner process
+ *      ({@link RUN_ENV_BASE_KEYS} — the six variables the MCP SDK pins),
+ *   2. the task's declared `environment` map, with `${.secrets.KEY}` /
+ *      `${.env_vars.KEY}` placeholders resolved just-in-time from the
+ *      workflow's runtime env. Resolution happens here in the activity,
+ *      never in the deterministic workflow phase, so secret values stay
+ *      out of Temporal history.
+ *
+ * Runner credentials (STIGMER_TOKEN, the HITL secret, provider keys) are
+ * structurally absent rather than denylisted — a workflow-authored
+ * `printenv` cannot read what was never passed (oss#384). A missing
+ * placeholder key fails loudly: running a command with a silently-empty
+ * credential produces cryptic downstream failures.
+ *
+ * Placeholders resolve only in declared environment VALUES, never in
+ * `command` / `code` strings — argv is visible to `ps` on the host, so
+ * the environment is the sanctioned channel for secrets.
+ */
+
+import { resolveRuntimePlaceholdersStrict } from "../workflow-engine/resolve.js";
+
+/**
+ * Base variables copied from the runner process when present — the same
+ * six the MCP SDK provides to stdio servers, so "undeclared subprocess
+ * environment" has one platform-wide answer. `PATH` keeps interpreters
+ * and tools findable; the rest keep shells and language runtimes sane.
+ */
+export const RUN_ENV_BASE_KEYS: readonly string[] = [
+  "HOME",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "USER",
+];
+
+/**
+ * Build the environment for a run task's child process: minimal base +
+ * declared overlay with strict placeholder resolution (declared wins on
+ * conflict with the base).
+ *
+ * @throws RuntimePlaceholderResolutionError when a declared value
+ *   references a runtime key that does not exist.
+ */
+export function buildRunEnv(
+  declaredEnv: Readonly<Record<string, string>> | undefined,
+  runtimeEnv: Readonly<Record<string, unknown>>,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const key of RUN_ENV_BASE_KEYS) {
+    const value = baseEnv[key];
+    if (value !== undefined) env[key] = value;
+  }
+
+  if (!declaredEnv || Object.keys(declaredEnv).length === 0) {
+    // The only case whose behavior changed in oss#384 (previously the
+    // child inherited the full runner env) — leave a trace for operators.
+    console.log("run task declares no environment — child receives the minimal base env only");
+    return env;
+  }
+
+  for (const [key, value] of Object.entries(declaredEnv)) {
+    env[key] = resolveRuntimePlaceholdersStrict(
+      value,
+      runtimeEnv,
+      `environment "${key}"`,
+    );
+  }
+
+  return env;
+}

--- a/backend/services/runner/src/workflow-engine/resolve.ts
+++ b/backend/services/runner/src/workflow-engine/resolve.ts
@@ -158,6 +158,9 @@ function parsePath(path: string): (string | number)[] {
 
 const RUNTIME_PLACEHOLDER_RE = /\$\{\.(secrets|env_vars)\.\w+\}/;
 
+/** Substitution form of {@link RUNTIME_PLACEHOLDER_RE} (global, capturing). */
+const RUNTIME_PLACEHOLDER_SUB_RE = /\$\{\.(secrets|env_vars)\.(\w+)\}/g;
+
 /**
  * Checks whether a string contains a runtime placeholder that should
  * NOT be evaluated in the workflow (deterministic) phase. These are
@@ -172,7 +175,9 @@ export function isRuntimePlaceholder(value: string): boolean {
 
 /**
  * Resolves runtime placeholders (`${.secrets.KEY}`, `${.env_vars.KEY}`)
- * in a string using values from the runtime environment map.
+ * in a string using values from the runtime environment map. Missing
+ * keys resolve to `""` — callers that must fail loudly instead use
+ * {@link resolveRuntimePlaceholdersStrict}.
  *
  * This runs in activities only — never in the workflow sandbox.
  */
@@ -181,10 +186,51 @@ export function resolveRuntimePlaceholders(
   runtimeEnv: Record<string, unknown>,
 ): string {
   return value.replace(
-    /\$\{\.(secrets|env_vars)\.(\w+)\}/g,
+    RUNTIME_PLACEHOLDER_SUB_RE,
     (_match, _ns: string, key: string) => {
       const resolved = runtimeEnv[key];
       return resolved !== undefined ? String(resolved) : "";
+    },
+  );
+}
+
+/** Thrown by {@link resolveRuntimePlaceholdersStrict} for a missing key. */
+export class RuntimePlaceholderResolutionError extends Error {
+  constructor(
+    public readonly variableName: string,
+    public readonly context?: string,
+  ) {
+    const where = context ? ` in ${context}` : "";
+    super(
+      `Unresolved runtime placeholder for "${variableName}"${where}: ` +
+        `variable is not present in the workflow's runtime environment`,
+    );
+    this.name = "RuntimePlaceholderResolutionError";
+  }
+}
+
+/**
+ * Strict variant of {@link resolveRuntimePlaceholders}: a placeholder
+ * whose key is missing from the runtime environment throws instead of
+ * resolving to `""` — a silently-empty credential produces cryptic
+ * downstream failures, so declared-value consumers (the run task's env
+ * contract) fail fast with the variable named.
+ *
+ * This runs in activities only — never in the workflow sandbox.
+ */
+export function resolveRuntimePlaceholdersStrict(
+  value: string,
+  runtimeEnv: Record<string, unknown>,
+  context?: string,
+): string {
+  return value.replace(
+    RUNTIME_PLACEHOLDER_SUB_RE,
+    (_match, _ns: string, key: string) => {
+      const resolved = runtimeEnv[key];
+      if (resolved === undefined) {
+        throw new RuntimePlaceholderResolutionError(key, context);
+      }
+      return String(resolved);
     },
   );
 }

--- a/docs/concepts/environments.mdx
+++ b/docs/concepts/environments.mdx
@@ -146,15 +146,17 @@ When an Agent runs, Stigmer merges the Environments attached to its Agent
 Instance into a single **ExecutionContext**. That merged map is what the runner
 uses at execution time. Different surfaces see different slices of it:
 
-| Surface                                            | What the Agent sees                                                                                                                                                                                                                   |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Shell commands** (native harness `execute` tool) | The runner's own process variables, minus runner-internal credentials, with ExecutionContext values overlaid on top. Overlay wins when a name exists in both.                                                                         |
-| **MCP stdio servers**                              | Only variables declared in the MCP server's `env` map, taken from ExecutionContext, plus a minimal base set (`PATH`, `HOME`, and similar). A server that declares nothing gets only that base set — never the runner's own variables. |
+| Surface                                              | What the Agent sees                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Shell commands** (native harness `execute` tool)   | The runner's own process variables, minus runner-internal credentials, with ExecutionContext values overlaid on top. Overlay wins when a name exists in both.                                                                                                                                                                        |
+| **MCP stdio servers**                                | Only variables declared in the MCP server's `env` map, taken from ExecutionContext, plus a minimal base set (`PATH`, `HOME`, and similar). A server that declares nothing gets only that base set — never the runner's own variables.                                                                                                |
+| **Workflow `run` tasks** (`run.shell`, `run.script`) | Only variables declared in the task's `environment` map, plus the same minimal base set. Declared values may reference `${.secrets.KEY}` / `${.env_vars.KEY}` — resolved at execution time; a missing key fails the task with a clear error. A task that declares nothing gets only the base set — never the runner's own variables. |
 
-Shell commands inherit `PATH` and other host settings from the runner so local
-CLIs work, while ExecutionContext supplies API keys and service URLs your Agent
-declares. Secrets marked `is_secret: true` are still redacted in logs and the UI
-regardless of which surface consumes them.
+Agent shell commands inherit `PATH` and other host settings from the runner so
+local CLIs work, while ExecutionContext supplies API keys and service URLs your
+Agent declares. Workflow `run` tasks follow the stricter declare-to-receive rule
+in the table above. Secrets marked `is_secret: true` are still redacted in logs
+and the UI regardless of which surface consumes them.
 
 ## What's next
 


### PR DESCRIPTION
## Summary

The workflow `run` task (shell and script modes) spawned its child with the runner's **full process environment** underneath the task's declared env — any workflow-authored command (`run: shell: command: printenv`) could read `STIGMER_TOKEN`, `STIGMER_RUNNER_HITL_SECRET` (the key deriving HITL approval fingerprints), `CURSOR_API_KEY`, and the operator's LLM provider keys. Same leak class as #248 (agent shell) and #256 (MCP stdio), through a third channel.

## Context

`buildEnv()` in `run-command.ts` started from `{ ...process.env }`. The issue asked for a deliberate env-contract ruling; the owner chose **declare-to-receive** (the post-#256 MCP stdio rule) over the agent-shell denylist — denylists go stale (#385 is currently extending one), structural absence cannot.

A second gap surfaced during planning: the run activity's header claimed "Both resolve runtime placeholders (JIT secrets) before execution", but nothing did — `config.runtimeEnv` arrived and was dropped, so `${.secrets.KEY}` in a declared env value passed through as literal text. Under declared-only that resolution is the *only* path for a secret to reach a run task, so it ships here (owner-ruled), completing the two-phase pattern (`resolve.ts`: sandbox-side jq, activity-side JIT secrets never in Temporal history) that every sibling call task already implements.

## Changes

- **`activities/run-env.ts` (new)** — the run task's env contract, mirroring `shell-env.ts`'s module shape: exported `RUN_ENV_BASE_KEYS` (the six variables the MCP SDK pins: `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) + `buildRunEnv()` (base + declared overlay, strict placeholder resolution on declared values). One-line notice log when a task declares nothing — the only case whose behavior changed silently.
- **`workflow-engine/resolve.ts`** — adds `resolveRuntimePlaceholdersStrict` + `RuntimePlaceholderResolutionError` beside the lenient resolver (which `emit-event` keeps using, unchanged). A missing key throws naming the variable instead of resolving to `""` — a silently-empty credential produces cryptic downstream failures; the docs already promise fail-fast.
- **`activities/run-command.ts`** — `buildEnv()` replaced by the contract; unresolved placeholders surface as non-retryable `ApplicationFailure` (`RUN_ENV_UNRESOLVED_PLACEHOLDER`); stale header rewritten. Placeholders resolve in declared env **values** only, never `command`/`code` strings — argv is visible to `ps`; env is the sanctioned channel.
- **`docs/concepts/environments.mdx`** — the per-surface env-contract table gains the workflow run-task row.

## Test plan

- New `run-command.test.ts` (12 tests): leak reproduction spawns **real subprocesses** through `RunShell`/`RunScript` with planted sentinel credentials (including a name outside every known denylist) and inspects env variable *names* — observed failing pre-fix (`STIGMER_RUNNER_HITL_SECRET` leaked to both children, 115+ vars). Post-fix: sentinels absent, base + declared overlay present, `${.secrets.*}`/`${.env_vars.*}` resolve JIT, missing key fails naming the variable, and a tripwire guards against `{ ...process.env }` reintroduction.
- Full runner suite: 4463 passed, typecheck clean. Docs: Vale, Prettier, and the docs-YAML gate pass.

## Breaking changes

- A workflow whose `run.shell`/`run.script` task silently relied on inherited runner env now sees only the six-variable base plus its declared `environment`. No seedpack workflow, integration test, or example does; the remedy is declaring what the task needs (same stance as #383).

## Risks

- Low: contract is opt-in-visible (declared env), interpreters stay findable via inherited `PATH`, and the change is confined to the run task's activity. Rollback is reverting one commit.

Closes #384

Made with [Cursor](https://cursor.com)