### PR TITLE
test(sdk/react): gate menu opens on trigger wiring to kill the kebab-menu flake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2918,6 +2918,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3757,6 +3758,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3779,6 +3781,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3801,6 +3804,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3817,6 +3821,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3833,6 +3838,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3849,6 +3855,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3865,6 +3872,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3881,6 +3889,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3897,6 +3906,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3913,6 +3923,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3929,6 +3940,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3945,6 +3957,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3961,6 +3974,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3983,6 +3997,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4005,6 +4020,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4027,6 +4043,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4049,6 +4066,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4071,6 +4089,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4093,6 +4112,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4115,6 +4135,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4137,6 +4158,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4156,6 +4178,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4175,6 +4198,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4194,6 +4218,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16906,6 +16931,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -21065,6 +21091,7 @@
         "@tailwindcss/postcss": "^4",
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@typescript-eslint/parser": "^8.57.0",
         "@vitest/browser": "^3.2.4",
         "@xyflow/react": "^12.10.2",

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -160,6 +160,7 @@
     "@tailwindcss/postcss": "^4",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/browser": "^3.2.4",
     "@xyflow/react": "^12.10.2",

--- a/sdk/react/src/__tests__/helpers/open-menu.ts
+++ b/sdk/react/src/__tests__/helpers/open-menu.ts
@@ -1,0 +1,88 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * Open a Base UI floating-trigger popup (action menu, dropdown) the way a
+ * real pointer does, and fail with the exact stage that died.
+ *
+ * WHY THIS EXISTS (oss#483): Base UI commits a trigger's interactive props
+ * (open handlers, `aria-expanded`) one store-notification cycle AFTER the
+ * button first appears in the DOM. A test that clicks immediately after
+ * render can hit that window — the click lands on a not-yet-wired button
+ * and the open is never attempted. Invisible at human speed, the window
+ * widens under CI load into intermittent "menu never opened" timeouts
+ * (~5% per attempt under CPU starvation; mechanism pinned by probing
+ * `aria-expanded` synchronously after the click: `null`, with the menu
+ * root's `onOpenChange` never firing). The readiness stage below closes
+ * the race by construction; the pointer-fidelity click keeps the test on
+ * the open path real users exercise.
+ *
+ * Failure semantics: each stage throws a named error, so a CI log
+ * pinpoints WHICH link broke (trigger never wired / open never happened /
+ * items never rendered) instead of an opaque 8s query timeout. There are
+ * deliberately NO retries: a helper that re-clicks would mask genuine
+ * open-path regressions in the SDK.
+ *
+ * Caveat: `userEvent` deadlocks under `vi.useFakeTimers()` unless
+ * configured with `advanceTimers` — don't call this helper from
+ * fake-timer tests (none of the menu suites use them today).
+ *
+ * Not a `.test` file and inside `__tests__` deliberately: vitest does not
+ * collect it, and the build/typedoc excludes keep it out of the published
+ * package.
+ */
+export async function openMenu(trigger: HTMLElement): Promise<void> {
+  await openFloatingTrigger(trigger, "menuitem");
+}
+
+/**
+ * Trigger-generic core: Base UI selects/comboboxes share the same wiring
+ * lifecycle and the same latent race (their popup items are `option`
+ * instead of `menuitem`). Widen to an exported `openSelect` if that family
+ * ever needs it — do not fork the stages.
+ */
+async function openFloatingTrigger(
+  trigger: HTMLElement,
+  itemRole: "menuitem" | "option",
+): Promise<void> {
+  // Stage 1 — trigger wiring. `aria-expanded` arrives in the same props
+  // merge as the open handlers, so its presence is the observable signal
+  // that the button is actually clickable-as-a-trigger.
+  await waitFor(() => {
+    if (!trigger.hasAttribute("aria-expanded")) {
+      throw new Error(
+        `openMenu stage "trigger-wiring": trigger is rendered but Base UI ` +
+          `has not attached its interactive props yet (no aria-expanded). ` +
+          `Trigger: ${describeTrigger(trigger)}`,
+      );
+    }
+  });
+
+  // Stage 2 — the click, with full pointer + focus fidelity (pointerdown,
+  // mousedown, focus, pointerup, mouseup, click) so the primary
+  // mousedown-open path is exercised, not the bare-click fallback.
+  await userEvent.click(trigger);
+
+  // Stage 3 — the open must register on the trigger itself.
+  await waitFor(() => {
+    if (trigger.getAttribute("aria-expanded") !== "true") {
+      throw new Error(
+        `openMenu stage "open": the click was dispatched but the trigger ` +
+          `never reported open (aria-expanded=` +
+          `${JSON.stringify(trigger.getAttribute("aria-expanded"))}). ` +
+          `Trigger: ${describeTrigger(trigger)}`,
+      );
+    }
+  });
+
+  // Stage 4 — items must be queryable. findAllByRole (not waitFor) so a
+  // timeout here still produces testing-library's DOM dump.
+  await screen.findAllByRole(itemRole);
+}
+
+function describeTrigger(trigger: HTMLElement): string {
+  const label = trigger.getAttribute("aria-label") ?? trigger.textContent;
+  return `<${trigger.tagName.toLowerCase()} aria-label=${JSON.stringify(
+    label,
+  )} connected=${trigger.isConnected}>`;
+}

--- a/sdk/react/src/__tests__/portal-container.test.tsx
+++ b/sdk/react/src/__tests__/portal-container.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { render, renderHook, screen, cleanup } from "@testing-library/react";
-import { fireEvent } from "@testing-library/react";
 import type { Stigmer } from "@stigmer/sdk";
 import { StigmerProvider } from "../provider";
 import { useStigmerPortalContainer } from "../portal-container";
 import { Menu, MenuTrigger, MenuContent, MenuItem } from "../internal/menu";
+import { openMenu } from "./helpers/open-menu";
 
 // Regression tests for stigmer-cloud#271: Base UI treats an EXPLICIT
 // `container={null}` as "wait for a container" and renders the popup
@@ -85,9 +85,9 @@ describe("standalone portal rendering (no StigmerProvider)", () => {
       </Menu>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open actions" }));
+    await openMenu(screen.getByRole("button", { name: "Open actions" }));
 
-    const item = await screen.findByRole("menuitem", { name: "Rename" });
+    const item = screen.getByRole("menuitem", { name: "Rename" });
 
     // Portaled for real: in the document, but NOT inside the render
     // container — Base UI appended it to document.body.

--- a/sdk/react/src/agent-instance/__tests__/AgentInstanceList.test.tsx
+++ b/sdk/react/src/agent-instance/__tests__/AgentInstanceList.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { openMenu } from "../../__tests__/helpers/open-menu";
 import { AgentInstanceList } from "../AgentInstanceList";
 
 // Isolate the row-actions behavior under test from the data, environment,
@@ -79,7 +80,7 @@ describe("AgentInstanceList row actions", () => {
 
     // No always-visible action buttons; the row shows a single kebab.
     expect(screen.queryByRole("button", { name: "Start session" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
 
     expect(
       await screen.findByRole("menuitem", { name: "Start session" }),
@@ -100,7 +101,7 @@ describe("AgentInstanceList row actions", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Start session" }));
 
     expect(onStart).toHaveBeenCalledTimes(1);
@@ -120,7 +121,7 @@ describe("AgentInstanceList row actions", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
 
     expect(onDelete).toHaveBeenCalledWith(inst);
@@ -138,7 +139,7 @@ describe("AgentInstanceList row actions", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
     expect(
       await screen.findByRole("menuitem", { name: "Start session" }),
     ).toBeTruthy();

--- a/sdk/react/src/channel/__tests__/AgentChannelsPanel.test.tsx
+++ b/sdk/react/src/channel/__tests__/AgentChannelsPanel.test.tsx
@@ -5,6 +5,7 @@ import type { AgentChannelInput } from "@stigmer/sdk";
 import { StigmerContext } from "../../context";
 import { FetchCacheContext } from "../../internal/FetchCacheProvider";
 import { DeploymentModeContext } from "../../deployment-mode";
+import { openMenu } from "../../__tests__/helpers/open-menu";
 import { AgentChannelsPanel } from "../AgentChannelsPanel";
 
 // Toasts are visual feedback owned by the feedback module; keep them inert.
@@ -272,7 +273,7 @@ describe("AgentChannelsPanel", () => {
     );
 
     await waitFor(() => expect(screen.getByText("Support Slack")).toBeTruthy());
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Disconnect" }));
 
     // The confirmation explains teardown vs pause before anything happens.
@@ -409,14 +410,18 @@ describe("AgentChannelsPanel", () => {
     await waitFor(() => expect(screen.getByText("Support Slack")).toBeTruthy());
     await waitFor(() => expect(checkMyPermission).toHaveBeenCalled());
 
-    expect(screen.queryByRole("switch")).toBeNull();
+    // The panel renders mutation affordances optimistic-visible and hides
+    // them when the denial lands. "Mock was called" precedes "denial
+    // rendered", so wait for the state this test is actually about instead
+    // of racing the re-render (flaked under CPU contention, ~1/20).
+    await waitFor(() => expect(screen.queryByRole("switch")).toBeNull());
     expect(screen.queryByRole("button", { name: /connect to slack/i })).toBeNull();
 
     // The card menu still renders: Sessions is a viewer-level action
     // (everyone who sees the card holds can_view on the channel — the same
     // bar as viewing its sessions, DD-012). Mutation items stay
     // permission-gated and absent.
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
     // The awaited query anchors on the portaled menu's mount (#323) — only
     // then are the absence assertions below meaningful rather than vacuous.
     expect(await screen.findByRole("menuitem", { name: /sessions/i })).toBeTruthy();
@@ -441,7 +446,7 @@ describe("AgentChannelsPanel", () => {
     );
     await waitFor(() => expect(screen.getByText("Support Slack")).toBeTruthy());
 
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
     fireEvent.click(await screen.findByRole("menuitem", { name: /manage access/i }));
 
     // The one canonical dialog opens, and its subtitle names the channel
@@ -501,7 +506,7 @@ describe("AgentChannelsPanel", () => {
     );
 
     await waitFor(() => expect(screen.getByText("Support Slack")).toBeTruthy());
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
     fireEvent.click(
       await screen.findByRole("menuitem", { name: "Tool credentials" }),
     );
@@ -629,7 +634,7 @@ describe("AgentChannelsPanel", () => {
     await waitFor(() =>
       expect(screen.getByText("Support WhatsApp")).toBeTruthy(),
     );
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Disconnect" }));
 
     // WhatsApp credentials live on the shared ChannelApp and survive the
@@ -652,7 +657,7 @@ describe("AgentChannelsPanel", () => {
     await waitFor(() =>
       expect(screen.getByText("Support WhatsApp")).toBeTruthy(),
     );
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Templates" }));
 
     expect(
@@ -676,7 +681,7 @@ describe("AgentChannelsPanel", () => {
     );
 
     await waitFor(() => expect(screen.getByText("Support Slack")).toBeTruthy());
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
 
     // Slack has no template concept: hidden, not disabled — a disabled
     // item would imply the capability might one day exist there.
@@ -704,7 +709,7 @@ describe("AgentChannelsPanel", () => {
       expect(screen.getByText("Support WhatsApp")).toBeTruthy(),
     );
     await waitFor(() => expect(checkMyPermission).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: /actions for/i }));
+    await openMenu(screen.getByRole("button", { name: /actions for/i }));
 
     expect(
       await screen.findByRole("menuitem", { name: /sessions/i }),

--- a/sdk/react/src/composer/__tests__/SessionComposer-lockAgent.test.tsx
+++ b/sdk/react/src/composer/__tests__/SessionComposer-lockAgent.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { Stigmer } from "@stigmer/sdk";
 import { StigmerContext } from "../../context";
+import { openMenu } from "../../__tests__/helpers/open-menu";
 import { ModelRegistryContext } from "../../models/ModelRegistryContext";
 
 // Controllable agent-setup state — lets these tests drive the lock × setup
@@ -79,17 +80,11 @@ function renderComposer(
   );
 }
 
-/**
- * Opens the composer's Configure menu and resolves once the portaled menu
- * content mounts. Menu items render asynchronously in a portal, so a
- * synchronous item query straight after the click races the mount (the
- * openRowMenu idiom; see stigmer/stigmer#323).
- */
+/** Opens the composer's Configure menu via the shared readiness-gated helper. */
 async function openConfigureMenu() {
-  fireEvent.click(
+  await openMenu(
     screen.getByRole("button", { name: "Configure agent, tools, and skills" }),
   );
-  await screen.findByRole("menu");
 }
 
 beforeEach(() => {

--- a/sdk/react/src/sharing/__tests__/AgentShareList.test.tsx
+++ b/sdk/react/src/sharing/__tests__/AgentShareList.test.tsx
@@ -7,6 +7,7 @@ import type { AgentShareInput } from "@stigmer/sdk";
 import { StigmerContext } from "../../context";
 import { FetchCacheContext } from "../../internal/FetchCacheProvider";
 import { DeploymentModeContext } from "../../deployment-mode";
+import { openMenu } from "../../__tests__/helpers/open-menu";
 import { AgentShareList } from "../AgentShareList";
 
 // Toasts are visual feedback owned by the feedback module; keep them inert.
@@ -173,8 +174,7 @@ async function openRowMenu(rowName?: string) {
   const scope = rowName
     ? within(screen.getByText(rowName).closest("tr")!)
     : screen;
-  fireEvent.click(scope.getByRole("button", { name: /^Actions for/ }));
-  await screen.findByRole("menuitem", { name: "Edit" });
+  await openMenu(scope.getByRole("button", { name: /^Actions for/ }));
 }
 
 describe("AgentShareList", () => {
@@ -442,8 +442,8 @@ describe("AgentShareList", () => {
       });
       await renderList(client);
 
-      fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
-      expect(await screen.findByRole("menuitem", { name: "Delete" })).toBeTruthy();
+      await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
+      expect(screen.getByRole("menuitem", { name: "Delete" })).toBeTruthy();
       expect(screen.queryByRole("menuitem", { name: "Edit" })).toBeNull();
       expect(screen.queryByRole("menuitem", { name: "Pause" })).toBeNull();
       expect(screen.queryByRole("menuitem", { name: "Reset link" })).toBeNull();

--- a/sdk/react/src/workflow/instance/__tests__/WorkflowInstanceList.test.tsx
+++ b/sdk/react/src/workflow/instance/__tests__/WorkflowInstanceList.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { openMenu } from "../../../__tests__/helpers/open-menu";
 import { WorkflowInstanceList } from "../WorkflowInstanceList";
 
 // Isolate the row-actions behavior under test from the data, environment,
@@ -78,7 +79,7 @@ describe("WorkflowInstanceList row actions", () => {
 
     // No always-visible action buttons; the row shows a single kebab.
     expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
 
     expect(await screen.findByRole("menuitem", { name: "Run" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Delete" })).toBeTruthy();
@@ -97,7 +98,7 @@ describe("WorkflowInstanceList row actions", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Run" }));
 
     expect(onRun).toHaveBeenCalledTimes(1);
@@ -117,7 +118,7 @@ describe("WorkflowInstanceList row actions", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
 
     expect(onDelete).toHaveBeenCalledWith(inst);
@@ -135,7 +136,7 @@ describe("WorkflowInstanceList row actions", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /^Actions for/ }));
+    await openMenu(screen.getByRole("button", { name: /^Actions for/ }));
     expect(await screen.findByRole("menuitem", { name: "Run" })).toBeTruthy();
     expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
   });


### PR DESCRIPTION
## Summary
Kills the intermittent "kebab menu never opens" CI failure ([oss#483](https://github.com/stigmer/stigmer/issues/483)) at its now-pinned root cause: tests were clicking Base UI menu triggers inside a window where the button is rendered but Base UI has not yet committed its interactive props (open handlers, `aria-expanded`). A new shared test helper gates the click on trigger wiring, drives it with full pointer+focus fidelity, and reports failures stage-by-stage; all six menu-opening test files converge on it.

## Context
The flake poisoned `ci.frontend` in busy CI windows (~50–100% failure rate 16:47–19:30Z on 2026-08-11; another specimen on main the morning of this fix, run 31572085104). The issue's mechanism guess (floating-ui ignore-click guards eating the keyboard-click fallback) was **disproven**: in `@base-ui/react@1.3.0`, a bare `click` with no preceding pointer event opens synchronously.

The real mechanism, pinned by local repro + instrumentation:
- Repro: 60x loop of unmodified `AgentShareList.test.tsx` under CPU contention (24 busy-loop burners, Node 22.22.1) → **3/60 failures**, exact CI shape, across three different tests.
- Instrumented runs (Menu-root `onOpenChange` log + synchronous post-click `aria-expanded` probe) caught 4 failing samples, all identical: at click time the trigger had **no `aria-expanded` attribute at all** (`expandedSync: null`) and `onOpenChange` never fired (`openLog: []`); the same DOM node was fully wired moments later. Base UI commits trigger props one store-notification cycle after the button first renders; CPU starvation widens that window past the test's click.
- Also disproven en route (deterministic probes): stale document dismiss-listeners after a close cycle (only a harmless `selectionchange` survives cleanup) and stale close-path timers/rAF (replaying them before the next click does not block the open).

Not a product defect: the window is microseconds at human speed and self-heals; only synthetic tests that click immediately after render can lose the race.

## Changes
- **New shared helper `sdk/react/src/__tests__/helpers/open-menu.ts`** (`openMenu(trigger)`): stage 1 waits for trigger wiring (`aria-expanded` present — it arrives in the same props merge as the open handlers); stage 2 clicks via `userEvent.click` (full pointerdown→mousedown→focus→pointerup→mouseup→click, exercising the primary mousedown-open path); stage 3 waits for `aria-expanded="true"`; stage 4 anchors on menu items via `findAllByRole` (keeps testing-library's DOM dump on timeout). Each stage throws a named error so future CI failures pinpoint the broken link instead of an opaque 8s timeout. Deliberately **no retries** — a re-clicking helper would mask genuine open-path regressions. Core is trigger-generic (`menuitem`/`option`) so the Base UI select/combobox family can converge later without redesign.
- **All six menu-opening test files migrated**: `AgentShareList`, `AgentChannelsPanel` (8 sites), `AgentInstanceList` (4), `WorkflowInstanceList` (4), `portal-container`, `SessionComposer-lockAgent`. The cloud#271 portal pin keeps its discriminating power (against the pre-fix hook, stage 4 still fails as the pin requires).
- **Ride-along, same disease family**: `AgentChannelsPanel > "hides mutation affordances"` asserted the serving switch's absence right after observing the permission mock was *called*, racing the denial's re-render (panel renders optimistic-visible first) — flaked 1/20 under this PR's load harness. Now waits for the state the test is about.
- **Dependency hygiene**: `@testing-library/user-event` was imported by ~10 test files but declared in no package.json (phantom dependency riding on hoisting) — now declared in `sdk/react` devDependencies. Lockfile picks up the entry plus a handful of `"dev": true` flags npm recomputed for already-present optional packages.

## Implementation notes
- Driver choice was spiked, not assumed: bare `fireEvent.click`, `userEvent.click`, and an explicit fireEvent pointer sequence all open a *wired* trigger reliably under happy-dom (25x each under contention). `userEvent` won on fidelity: it also moves focus the way a real browser does (`fireEvent.click` leaves `document.activeElement` on `body` — a state Base UI's focus manager never sees in production). Caveat documented in the helper: `userEvent` deadlocks under `vi.useFakeTimers()` without `advanceTimers`; no menu suite uses fake timers today.
- Helper placement follows the existing convention for shared, build-excluded, non-collected test helpers (`src/__tests__/helpers/compile-sdk-styles.ts`, `src/internal/__tests__/fake-timer-slices.ts`).

## Breaking changes
- None (test files + one devDependency declaration; nothing ships to users).

## Test plan
- **Negative control**: unmodified main, 60x under CPU contention → 3 failures with the exact CI shape; instrumented variant → 3 more, all carrying the mechanism signature.
- **Fix proof**: helper-migrated `AgentShareList` → **0/100 failures** under the identical contention profile; all six migrated files → 1/20 (the unrelated `AgentChannelsPanel` permission race, fixed in this PR) then **0/20** after.
- Full `sdk/react` suite: **4365/4365 green**; `npm run lint` (eslint + prefix-classnames) clean.

## Risks
- Test-only; zero shipped-code changes. If a genuine menu-open regression ever lands, the helper fails loudly at a named stage rather than masking it.

Closes #483

Made with [Cursor](https://cursor.com)