### PR TITLE
fix(backend/session): resolve execution-target immutability through dispatch's deployment default

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/config.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/config.go
@@ -2,6 +2,8 @@ package temporal
 
 import (
 	"os"
+
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
 )
 
 // Activity routing mode constants. These control how the dispatch function
@@ -61,6 +63,27 @@ type Config struct {
 	// "local" (default): client's runner polls the queue.
 	// "cloud": server provisions a sandbox.
 	DefaultExecutionTarget string
+}
+
+// ResolveExecutionTarget resolves a session's execution_target value to its
+// effective target: EXECUTION_TARGET_UNSPECIFIED becomes the configured
+// DefaultExecutionTarget (LOCAL on OSS/self-hosted, CLOUD on the managed
+// cloud service); explicit values pass through unchanged.
+//
+// This is the single definition of the resolution rule — dispatch
+// (ResolveActivityTaskQueue) and policy enforcement (e.g. the session
+// update pipeline's execution-target immutability step) must both use it
+// rather than re-deriving the default, so they can never disagree about
+// where an execution runs. Mirrors the cloud edition's
+// AgentExecutionTemporalConfig.resolveExecutionTarget.
+func (c *Config) ResolveExecutionTarget(target sessionv1.ExecutionTarget) sessionv1.ExecutionTarget {
+	if target != sessionv1.ExecutionTarget_EXECUTION_TARGET_UNSPECIFIED {
+		return target
+	}
+	if c.DefaultExecutionTarget == DefaultExecutionTargetCloud {
+		return sessionv1.ExecutionTarget_EXECUTION_TARGET_CLOUD
+	}
+	return sessionv1.ExecutionTarget_EXECUTION_TARGET_LOCAL
 }
 
 // NewConfig creates a new Config with values from environment variables or defaults.

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/dispatch.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/dispatch.go
@@ -98,7 +98,7 @@ func ResolveActivityTaskQueue(ctx context.Context, s store.Store, sessionID stri
 		}
 	}
 
-	resolvedTarget := resolveExecutionTarget(executionTarget, cfg)
+	resolvedTarget := cfg.ResolveExecutionTarget(executionTarget)
 	taskQueue := resolveTaskQueue(sessionID, cfg)
 
 	log.Info().
@@ -113,17 +113,6 @@ func ResolveActivityTaskQueue(ctx context.Context, s store.Store, sessionID stri
 		Harness:         harness,
 		ExecutionTarget: resolvedTarget,
 	}, nil
-}
-
-// resolveExecutionTarget resolves UNSPECIFIED to the configured default.
-func resolveExecutionTarget(target sessionv1.ExecutionTarget, cfg *Config) sessionv1.ExecutionTarget {
-	if target != sessionv1.ExecutionTarget_EXECUTION_TARGET_UNSPECIFIED {
-		return target
-	}
-	if cfg.DefaultExecutionTarget == DefaultExecutionTargetCloud {
-		return sessionv1.ExecutionTarget_EXECUTION_TARGET_CLOUD
-	}
-	return sessionv1.ExecutionTarget_EXECUTION_TARGET_LOCAL
 }
 
 // resolveTaskQueue derives the task queue name based on routing mode and session ID.

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/dispatch_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/dispatch_test.go
@@ -295,9 +295,9 @@ func TestResolveExecutionTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveExecutionTarget(tt.target, tt.cfg)
+			got := tt.cfg.ResolveExecutionTarget(tt.target)
 			if got != tt.want {
-				t.Errorf("resolveExecutionTarget(%v) = %v, want %v", tt.target, got, tt.want)
+				t.Errorf("Config.ResolveExecutionTarget(%v) = %v, want %v", tt.target, got, tt.want)
 			}
 		})
 	}

--- a/backend/services/stigmer-server/pkg/domain/session/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//backend/libs/go/grpc/request/pipeline/steps",
         "//backend/libs/go/store",
         "//backend/services/stigmer-server/pkg/domain/agent/defaultagent",
+        "//backend/services/stigmer-server/pkg/domain/agentexecution/temporal",
         "//backend/services/stigmer-server/pkg/domain/session/controller/steps",
         "//backend/services/stigmer-server/pkg/downstream/agent",
         "//backend/services/stigmer-server/pkg/downstream/agentinstance",
@@ -51,6 +52,7 @@ go_test(
         "record_harness_state_history_test.go",
         "session_controller_test.go",
         "update_subject_test.go",
+        "validate_execution_target_immutability_test.go",
     ],
     embed = [":controller"],
     deps = [
@@ -63,6 +65,7 @@ go_test(
         "//backend/libs/go/grpc/request/pipeline/steps",
         "//backend/libs/go/store",
         "//backend/libs/go/store/sqlite",
+        "//backend/services/stigmer-server/pkg/domain/agentexecution/temporal",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",

--- a/backend/services/stigmer-server/pkg/domain/session/controller/session_controller.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/session_controller.go
@@ -3,6 +3,7 @@ package session
 import (
 	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	agentexecutiontemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/agent"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/agentinstance"
 )
@@ -12,6 +13,7 @@ type SessionController struct {
 	sessionv1.UnimplementedSessionCommandControllerServer
 	sessionv1.UnimplementedSessionQueryControllerServer
 	store               store.Store
+	temporalConfig      *agentexecutiontemporal.Config
 	agentClient         *agent.Client
 	agentInstanceClient *agentinstance.Client
 }
@@ -20,9 +22,13 @@ type SessionController struct {
 //
 // Parameters:
 //   - store: Store for persistence
-func NewSessionController(store store.Store) *SessionController {
+//   - temporalConfig: agent execution temporal config; the update pipeline's
+//     execution-target immutability step resolves UNSPECIFIED through the same
+//     deployment default dispatch uses (oss#397)
+func NewSessionController(store store.Store, temporalConfig *agentexecutiontemporal.Config) *SessionController {
 	return &SessionController{
-		store: store,
+		store:          store,
+		temporalConfig: temporalConfig,
 	}
 }
 

--- a/backend/services/stigmer-server/pkg/domain/session/controller/session_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/session_controller_test.go
@@ -10,6 +10,7 @@ import (
 	apiresourceinterceptor "github.com/stigmer/stigmer/backend/libs/go/grpc/interceptors/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	agentexecutiontemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal"
 )
 
 // contextWithSessionKind creates a context with the session resource kind injected
@@ -18,7 +19,10 @@ func contextWithSessionKind() context.Context {
 	return context.WithValue(context.Background(), apiresourceinterceptor.ApiResourceKindKey, apiresourcekind.ApiResourceKind_session)
 }
 
-// setupTestController creates a test controller with necessary dependencies
+// setupTestController creates a test controller with necessary dependencies.
+// The temporal config pins the OSS deployment default (UNSPECIFIED → LOCAL);
+// the two-default resolution matrix is covered by the focused step test in
+// validate_execution_target_immutability_test.go.
 func setupTestController(t *testing.T) (*SessionController, store.Store) {
 	// Create temporary SQLite store
 	store, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
@@ -26,7 +30,9 @@ func setupTestController(t *testing.T) (*SessionController, store.Store) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
-	controller := NewSessionController(store)
+	controller := NewSessionController(store, &agentexecutiontemporal.Config{
+		DefaultExecutionTarget: agentexecutiontemporal.DefaultExecutionTargetLocal,
+	})
 
 	return controller, store
 }

--- a/backend/services/stigmer-server/pkg/domain/session/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/update.go
@@ -43,7 +43,7 @@ func (c *SessionController) buildUpdatePipeline() *pipeline.Pipeline[*sessionv1.
 		AddStep(steps.NewResolveSlugStep[*sessionv1.Session]()).                                       // 2. Resolve slug
 		AddStep(steps.NewLoadExistingStep[*sessionv1.Session](c.store)).                               // 3. Load existing session
 		AddStep(NewValidateHarnessImmutabilityStep()).                                                 // 4. Reject harness change after first execution
-		AddStep(NewValidateExecutionTargetImmutabilityStep()).                                         // 5. Reject execution_target change after first execution
+		AddStep(NewValidateExecutionTargetImmutabilityStep(c.temporalConfig)).                         // 5. Reject execution_target change after first execution
 		AddStep(steps.NewBuildUpdateStateStep[*sessionv1.Session]()).                                  // 6. Build updated state
 		AddStep(NewRecordHarnessStateHistoryStep()).                                                   // 7. Server-owned harness_state_id_history append
 		AddStep(steps.NewPersistStep[*sessionv1.Session](c.store)).                                    // 8. Persist session

--- a/backend/services/stigmer-server/pkg/domain/session/controller/validate_execution_target_immutability.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/validate_execution_target_immutability.go
@@ -5,6 +5,7 @@ import (
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	agentexecutiontemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal"
 )
 
 // ValidateExecutionTargetImmutabilityStep rejects session updates that attempt
@@ -14,12 +15,25 @@ import (
 // A session running on a client's embedded runner (LOCAL) has local filesystem
 // state; switching to CLOUD mid-session would lose that state, and vice versa.
 //
+// UNSPECIFIED is compared by what dispatch would actually do with it: both the
+// existing and the input target are resolved through the same deployment
+// default dispatch uses (Config.ResolveExecutionTarget — LOCAL on OSS, CLOUD
+// on hosted deployments), so "no effective change" and "no dispatch change"
+// are the same predicate on every deployment. Hardcoding UNSPECIFIED to a
+// fixed target here would refuse round-trips that change nothing on
+// cloud-defaulting deployments and wave through updates that really do move
+// the session (oss#397).
+//
 // Uses the same sentinel as harness immutability: harness_state_id is non-empty
 // after the first execution completes.
-type ValidateExecutionTargetImmutabilityStep struct{}
+type ValidateExecutionTargetImmutabilityStep struct {
+	temporalConfig *agentexecutiontemporal.Config
+}
 
-func NewValidateExecutionTargetImmutabilityStep() *ValidateExecutionTargetImmutabilityStep {
-	return &ValidateExecutionTargetImmutabilityStep{}
+func NewValidateExecutionTargetImmutabilityStep(
+	temporalConfig *agentexecutiontemporal.Config,
+) *ValidateExecutionTargetImmutabilityStep {
+	return &ValidateExecutionTargetImmutabilityStep{temporalConfig: temporalConfig}
 }
 
 func (s *ValidateExecutionTargetImmutabilityStep) Name() string {
@@ -53,22 +67,15 @@ func (s *ValidateExecutionTargetImmutabilityStep) Execute(ctx *pipeline.RequestC
 		return nil
 	}
 
-	existingTarget := existingSpec.GetExecutionTarget()
-	inputTarget := inputSpec.GetExecutionTarget()
-
-	// Treat UNSPECIFIED as equivalent — it is resolved at dispatch time,
-	// so UNSPECIFIED→LOCAL and LOCAL→UNSPECIFIED are not meaningful changes.
-	if existingTarget == sessionv1.ExecutionTarget_EXECUTION_TARGET_UNSPECIFIED {
-		existingTarget = sessionv1.ExecutionTarget_EXECUTION_TARGET_LOCAL
-	}
-	if inputTarget == sessionv1.ExecutionTarget_EXECUTION_TARGET_UNSPECIFIED {
-		inputTarget = sessionv1.ExecutionTarget_EXECUTION_TARGET_LOCAL
-	}
+	existingTarget := s.temporalConfig.ResolveExecutionTarget(existingSpec.GetExecutionTarget())
+	inputTarget := s.temporalConfig.ResolveExecutionTarget(inputSpec.GetExecutionTarget())
 
 	if inputTarget != existingTarget {
 		return grpclib.FailedPreconditionError(
-			"session execution_target cannot be changed after the first execution — " +
-				"workspace state may not be portable between local and cloud environments")
+			"session execution_target cannot be changed after the first execution (%s → %s; "+
+				"unset resolves to the deployment default, %s) — "+
+				"workspace state may not be portable between local and cloud environments",
+			existingTarget, inputTarget, s.temporalConfig.DefaultExecutionTarget)
 	}
 
 	return nil

--- a/backend/services/stigmer-server/pkg/domain/session/controller/validate_execution_target_immutability_test.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/validate_execution_target_immutability_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	agentexecutiontemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal"
+)
+
+// The immutability predicate must match dispatch: UNSPECIFIED resolves to the
+// deployment default (Config.ResolveExecutionTarget), not to a fixed target.
+// A hardcoded UNSPECIFIED→LOCAL mapping refused no-op round-trips on
+// cloud-defaulting deployments and waved through real target changes (oss#397).
+func TestValidateExecutionTargetImmutabilityStep_DeploymentDefaultMatrix(t *testing.T) {
+	const (
+		unspecified = sessionv1.ExecutionTarget_EXECUTION_TARGET_UNSPECIFIED
+		local       = sessionv1.ExecutionTarget_EXECUTION_TARGET_LOCAL
+		cloud       = sessionv1.ExecutionTarget_EXECUTION_TARGET_CLOUD
+	)
+
+	localDefault := &agentexecutiontemporal.Config{
+		DefaultExecutionTarget: agentexecutiontemporal.DefaultExecutionTargetLocal,
+	}
+	cloudDefault := &agentexecutiontemporal.Config{
+		DefaultExecutionTarget: agentexecutiontemporal.DefaultExecutionTargetCloud,
+	}
+
+	tests := []struct {
+		name     string
+		cfg      *agentexecutiontemporal.Config
+		existing sessionv1.ExecutionTarget
+		input    sessionv1.ExecutionTarget
+		wantErr  bool
+	}{
+		// Cloud-default deployment: UNSPECIFIED means CLOUD.
+		{"cloud default: UNSPECIFIED→CLOUD is a no-op round-trip", cloudDefault, unspecified, cloud, false},
+		{"cloud default: CLOUD→UNSPECIFIED is a no-op", cloudDefault, cloud, unspecified, false},
+		{"cloud default: UNSPECIFIED→LOCAL is a real change", cloudDefault, unspecified, local, true},
+		{"cloud default: LOCAL→UNSPECIFIED would move dispatch to CLOUD", cloudDefault, local, unspecified, true},
+		{"cloud default: LOCAL→CLOUD is a real change", cloudDefault, local, cloud, true},
+		{"cloud default: CLOUD→CLOUD is a no-op", cloudDefault, cloud, cloud, false},
+
+		// Local-default deployment (OSS): UNSPECIFIED means LOCAL —
+		// the pre-fix behavior, pinned unchanged.
+		{"local default: UNSPECIFIED→LOCAL is a no-op", localDefault, unspecified, local, false},
+		{"local default: LOCAL→UNSPECIFIED is a no-op", localDefault, local, unspecified, false},
+		{"local default: UNSPECIFIED→CLOUD is a real change", localDefault, unspecified, cloud, true},
+		{"local default: CLOUD→UNSPECIFIED would move dispatch to LOCAL", localDefault, cloud, unspecified, true},
+		{"local default: LOCAL→CLOUD is a real change", localDefault, local, cloud, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := &sessionv1.Session{
+				Spec: &sessionv1.SessionSpec{
+					// Non-empty: the session has executed, immutability applies.
+					HarnessStateId:  "thread-xyz",
+					ExecutionTarget: tt.existing,
+				},
+			}
+			input := &sessionv1.Session{
+				Spec: &sessionv1.SessionSpec{
+					HarnessStateId:  "thread-xyz",
+					ExecutionTarget: tt.input,
+				},
+			}
+
+			ctx := pipeline.NewRequestContext(context.Background(), input)
+			ctx.Set(steps.ExistingResourceKey, existing)
+
+			err := NewValidateExecutionTargetImmutabilityStep(tt.cfg).Execute(ctx)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected refusal for %v → %v with default %q, got nil",
+					tt.existing, tt.input, tt.cfg.DefaultExecutionTarget)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no-op acceptance for %v → %v with default %q, got: %v",
+					tt.existing, tt.input, tt.cfg.DefaultExecutionTarget, err)
+			}
+		})
+	}
+}
+
+// Before the first execution (empty harness_state_id) the target is freely
+// mutable regardless of deployment default.
+func TestValidateExecutionTargetImmutabilityStep_MutableBeforeFirstExecution(t *testing.T) {
+	cfg := &agentexecutiontemporal.Config{
+		DefaultExecutionTarget: agentexecutiontemporal.DefaultExecutionTargetCloud,
+	}
+
+	existing := &sessionv1.Session{
+		Spec: &sessionv1.SessionSpec{
+			ExecutionTarget: sessionv1.ExecutionTarget_EXECUTION_TARGET_CLOUD,
+		},
+	}
+	input := &sessionv1.Session{
+		Spec: &sessionv1.SessionSpec{
+			ExecutionTarget: sessionv1.ExecutionTarget_EXECUTION_TARGET_LOCAL,
+		},
+	}
+
+	ctx := pipeline.NewRequestContext(context.Background(), input)
+	ctx.Set(steps.ExistingResourceKey, existing)
+
+	if err := NewValidateExecutionTargetImmutabilityStep(cfg).Execute(ctx); err != nil {
+		t.Errorf("expected target change to be allowed before first execution, got: %v", err)
+	}
+}

--- a/backend/services/stigmer-server/pkg/server/server.go
+++ b/backend/services/stigmer-server/pkg/server/server.go
@@ -247,8 +247,10 @@ func Run() error {
 
 	log.Info().Msg("Registered AgentInstance controllers")
 
-	// Create and register Session controller
-	sessionController := sessioncontroller.NewSessionController(store)
+	// Create and register Session controller. The temporal config drives the
+	// update pipeline's execution-target immutability check: UNSPECIFIED is
+	// resolved through the same deployment default dispatch uses (oss#397).
+	sessionController := sessioncontroller.NewSessionController(store, agentExecutionTemporalConfig)
 	sessionv1.RegisterSessionCommandControllerServer(grpcServer, sessionController)
 	sessionv1.RegisterSessionQueryControllerServer(grpcServer, sessionController)
 


### PR DESCRIPTION
## Summary

The session update pipeline's execution-target immutability step hardcoded `EXECUTION_TARGET_UNSPECIFIED` → `LOCAL`, while dispatch resolves UNSPECIFIED through the deployment's configured default (LOCAL on OSS, CLOUD on hosted). On a cloud-defaulting deployment, a client that round-trips a session and writes back the now-known effective value `CLOUD` was refused for a "change" that never happened — and the inverse (`LOCAL → UNSPECIFIED`, a real dispatch change) was waved through. The step now resolves both targets through the same deployment-default lookup dispatch uses, so "no effective change" and "no dispatch change" are the same predicate on every deployment.

## Context

Filed as #397 from the oss#394 session. `BuildUpdateStateStep` performs full spec replacement, so an update carrying UNSPECIFIED genuinely persists it and genuinely changes what dispatch does later — the comparison must resolve through the deployment default, not a fixed value.

## Changes

- `agentexecution/temporal`: promoted the private `resolveExecutionTarget` in `dispatch.go` to an exported method `Config.ResolveExecutionTarget` — the single definition of the resolution rule (mirrors the cloud edition's `AgentExecutionTemporalConfig.resolveExecutionTarget`). Dispatch now calls the method.
- `session/controller`: `ValidateExecutionTargetImmutabilityStep` takes the temporal `*Config` and resolves both existing and input targets through it before comparing; `SessionController`/`NewSessionController` carry the config; `server.go` passes the already-constructed `agentExecutionTemporalConfig`.
- Refusal message now names the resolved transition and the deployment default (e.g. `EXECUTION_TARGET_LOCAL → EXECUTION_TARGET_CLOUD; unset resolves to the deployment default, cloud`), so the newly-refused clear-to-unset case is self-explanatory.
- Tests: new `validate_execution_target_immutability_test.go` pins the full two-default matrix (11 cases) plus the mutable-before-first-execution guard; existing controller tests pinned on the OSS local default; dispatch resolver tests renamed to the method.

## Implementation notes

- Behavioral tightening (deliberate): on a cloud-default deployment, clearing an explicit LOCAL to unset after the first execution is now refused — under full spec replacement it would move future dispatch to CLOUD, exactly the change this step exists to prevent.
- The `workflowexecution/temporal` resolver with its separate `STIGMER_WORKFLOW_DEFAULT_EXECUTION_TARGET` knob is intentionally untouched: workflow executions and agent sessions are independently defaultable.
- Paired cloud PR applies the same predicate to the hosted service's `SessionUpdateHandler`.

## Breaking changes

- None for OSS deployments (local default preserves the previous equivalence exactly).

## Test plan

- `go test ./backend/services/stigmer-server/pkg/domain/session/... ./backend/services/stigmer-server/pkg/domain/agentexecution/...` — all pass
- `go build ./cmd/server`, `make tidy`, `gofmt`, `go vet` on touched packages — clean
- `bazel run //:gazelle` — only the session controller BUILD dep added (pre-existing drift in unrelated BUILD files left untouched)

## Risks

- Low: validation-step change with the full resolution matrix pinned; rollback is a straight revert.

Closes #397

Made with [Cursor](https://cursor.com)