### PR TITLE
feat(backend/stigmer-server): add decode-only Temporal payload decryption codec

### DIFF
--- a/backend/services/stigmer-server/pkg/config/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/config/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/config",
     visibility = ["//visibility:public"],
-    deps = ["//backend/services/stigmer-server/pkg/domain/artifact/storage"],
+    deps = [
+        "//backend/services/stigmer-server/pkg/domain/artifact/storage",
+        "//backend/services/stigmer-server/pkg/encryption/payloadcodec",
+    ],
 )

--- a/backend/services/stigmer-server/pkg/config/config.go
+++ b/backend/services/stigmer-server/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	artifactstorage "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/artifact/storage"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption/payloadcodec"
 )
 
 // defaultGitHubOAuthClientID and defaultGitHubOAuthClientSecret are the
@@ -57,6 +58,12 @@ type Config struct {
 	// Override via STIGMER_OAUTH_REDIRECT_URI. When empty, OAuth Connect
 	// for MCP servers is unavailable.
 	OAuthRedirectURI string
+
+	// PayloadEncryption holds the Temporal payload-decryption keys
+	// (STIGMER_PAYLOAD_ENCRYPTION_KEY(_ID) + optional secondary pair —
+	// the same env vars the TS runner reads). Nil when encryption is not
+	// configured; the decode-only codec is then not installed.
+	PayloadEncryption *payloadcodec.Config
 }
 
 // LoadConfig loads configuration from environment variables
@@ -123,6 +130,15 @@ func LoadConfig() (*Config, error) {
 			return nil, fmt.Errorf("invalid R2 configuration: %w", err)
 		}
 	}
+
+	// A present-but-malformed payload encryption key fails the boot:
+	// the operator intended runner history to be encrypted, and without
+	// the decode codec every runner payload read would fail at runtime.
+	payloadEncryption, err := payloadcodec.LoadConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	config.PayloadEncryption = payloadEncryption
 
 	return config, nil
 }

--- a/backend/services/stigmer-server/pkg/encryption/payloadcodec/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/encryption/payloadcodec/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "payloadcodec",
+    srcs = [
+        "codec.go",
+        "config.go",
+    ],
+    importpath = "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption/payloadcodec",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_temporal_go_api//common/v1:common",
+        "@io_temporal_go_sdk//converter",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "payloadcodec_test",
+    srcs = [
+        "codec_test.go",
+        "config_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":payloadcodec"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@io_temporal_go_api//common/v1:common",
+        "@org_golang_google_protobuf//proto",
+    ],
+)

--- a/backend/services/stigmer-server/pkg/encryption/payloadcodec/codec.go
+++ b/backend/services/stigmer-server/pkg/encryption/payloadcodec/codec.go
@@ -1,0 +1,169 @@
+// Package payloadcodec implements the decode-only Go half of the Stigmer
+// Temporal payload-encryption contract (stigmer-cloud#227, stigmer#398).
+//
+// The TS runner encrypts every payload its workers hand to Temporal with an
+// AES-256-GCM PayloadCodec (backend/services/runner/src/encryption/). The
+// server never encrypts — its own histories (orchestrator workflows, signals,
+// memos) stay plaintext and UI-readable — but it MUST be able to decode
+// runner-produced payloads: the agent-execution workflow reads
+// ExecuteDeepAgent/ExecuteCursor/EnsureThread activity results, and the MCP
+// connect controller reads the connect workflow result on the client. With
+// runner encryption enabled and no codec here, every agent execution and MCP
+// connect fails on decode.
+//
+// Envelope (cross-SDK contract — byte-compatible with the TS codec and the
+// Java decode-only codec in stigmer-cloud's temporal-starter, pinned by the
+// conformance fixture in testdata/, a byte-for-byte copy of the one the TS
+// and Java tests decrypt):
+//
+//	metadata: encoding          = "binary/encrypted"
+//	          encryption-key-id = <key id that encrypted this payload>
+//	data:     iv (12 bytes) ‖ AES-256-GCM(ciphertext ‖ tag (16 bytes))
+//
+// The plaintext is the serialized ORIGINAL Payload proto (metadata AND data),
+// so decode restores the payload exactly — including its original encoding —
+// with no side channel.
+//
+// Decode passes through payloads it did not encrypt: plaintext payloads from
+// the server's own workers and pre-rollout in-flight histories keep working
+// with zero migration. Everything else fails closed — unknown key id, missing
+// key id, truncation, and GCM auth failure all error rather than surfacing
+// bogus payloads.
+//
+// Two standing constraints this codec creates for server code:
+//   - ApplicationFailure DETAILS from runner activities/workflows are
+//     codec-encoded payloads. No Go code reads failure details today; any
+//     future reader works only through a client carrying this codec.
+//   - The same goes for workflow QUERY responses served by runner workers
+//     (listen tasks can register query handlers); nothing queries them today.
+package payloadcodec
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	encodingMetadataKey    = "encoding"
+	encryptedEncodingValue = "binary/encrypted"
+	keyIDMetadataKey       = "encryption-key-id"
+
+	// AES-GCM parameters shared with the TS and Java implementations.
+	ivBytes      = 12
+	authTagBytes = 16
+)
+
+// DecryptionCodec is a decode-only Temporal PayloadCodec: Encode is the
+// identity (the server writes plaintext), Decode decrypts runner-produced
+// payloads. Safe for concurrent use.
+type DecryptionCodec struct {
+	// Accepted decryption keys by key id — the runner's primary key plus,
+	// during rotation windows, its predecessor.
+	aeadByKeyID map[string]cipher.AEAD
+}
+
+var _ converter.PayloadCodec = (*DecryptionCodec)(nil)
+
+// NewDecryptionCodec builds the codec from a loaded config (see
+// LoadConfigFromEnv, which validates key material at boot).
+func NewDecryptionCodec(cfg *Config) (*DecryptionCodec, error) {
+	keys := []Key{cfg.Primary}
+	if cfg.Secondary != nil {
+		keys = append(keys, *cfg.Secondary)
+	}
+
+	aeadByKeyID := make(map[string]cipher.AEAD, len(keys))
+	for _, k := range keys {
+		block, err := aes.NewCipher(k.Material)
+		if err != nil {
+			return nil, fmt.Errorf("payload encryption key %q is invalid: %w", k.ID, err)
+		}
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return nil, fmt.Errorf("payload encryption key %q is invalid: %w", k.ID, err)
+		}
+		aeadByKeyID[k.ID] = gcm
+	}
+	return &DecryptionCodec{aeadByKeyID: aeadByKeyID}, nil
+}
+
+// NewDataConverter wraps Temporal's default data converter with the
+// decode-only codec. Install it on client.Options.DataConverter — the client
+// is the single choke point that covers all workers AND client-side reads
+// (e.g. WorkflowRun.Get on the MCP connect workflow result).
+func NewDataConverter(cfg *Config) (converter.DataConverter, error) {
+	codec, err := NewDecryptionCodec(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codec), nil
+}
+
+// Encode is the identity: the server never encrypts its own payloads, so
+// orchestrator histories stay plaintext and readable in the Temporal UI.
+func (c *DecryptionCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	return payloads, nil
+}
+
+// Decode decrypts encrypted payloads and passes everything else through.
+func (c *DecryptionCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	out := make([]*commonpb.Payload, len(payloads))
+	for i, p := range payloads {
+		decoded, err := c.decodePayload(p)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = decoded
+	}
+	return out, nil
+}
+
+func (c *DecryptionCodec) decodePayload(payload *commonpb.Payload) (*commonpb.Payload, error) {
+	if !isEncryptedPayload(payload) {
+		return payload, nil
+	}
+
+	keyIDBytes, ok := payload.GetMetadata()[keyIDMetadataKey]
+	if !ok || len(keyIDBytes) == 0 {
+		return nil, fmt.Errorf(
+			"encrypted payload is missing its %s metadata — refusing to decode", keyIDMetadataKey)
+	}
+	keyID := string(keyIDBytes)
+	aead, ok := c.aeadByKeyID[keyID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"encrypted payload uses unknown key id %q — configure it as the primary or "+
+				"secondary payload encryption key (rotation window?)", keyID)
+	}
+
+	data := payload.GetData()
+	if len(data) < ivBytes+authTagBytes {
+		return nil, fmt.Errorf(
+			"encrypted payload under key id %q is truncated (%d bytes)", keyID, len(data))
+	}
+
+	// GCM auth failure means tampered ciphertext or a key that does not
+	// match its advertised id. Never surface partially decrypted bytes.
+	plaintext, err := aead.Open(nil, data[:ivBytes], data[ivBytes:], nil)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to decrypt payload under key id %q — ciphertext is corrupt or the "+
+				"configured key does not match", keyID)
+	}
+
+	original := &commonpb.Payload{}
+	if err := proto.Unmarshal(plaintext, original); err != nil {
+		return nil, fmt.Errorf(
+			"decrypted payload under key id %q is not a valid Payload proto: %w", keyID, err)
+	}
+	return original, nil
+}
+
+func isEncryptedPayload(payload *commonpb.Payload) bool {
+	return string(payload.GetMetadata()[encodingMetadataKey]) == encryptedEncodingValue
+}

--- a/backend/services/stigmer-server/pkg/encryption/payloadcodec/codec_test.go
+++ b/backend/services/stigmer-server/pkg/encryption/payloadcodec/codec_test.go
@@ -1,0 +1,214 @@
+package payloadcodec
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func testKey(t *testing.T, seed byte) []byte {
+	t.Helper()
+	key := make([]byte, aes256KeyBytes)
+	for i := range key {
+		key[i] = seed
+	}
+	return key
+}
+
+func testCodec(t *testing.T, cfg *Config) *DecryptionCodec {
+	t.Helper()
+	codec, err := NewDecryptionCodec(cfg)
+	require.NoError(t, err)
+	return codec
+}
+
+func plaintextPayload(data string) *commonpb.Payload {
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{encodingMetadataKey: []byte("json/plain")},
+		Data:     []byte(data),
+	}
+}
+
+// encryptForTest mirrors the TS runner's encode: the serialized original
+// Payload proto sealed as iv ‖ AES-256-GCM(ciphertext ‖ tag), with the
+// envelope metadata. Kept test-only — this package must never grow a
+// production encrypt path (decode-only is the design).
+func encryptForTest(t *testing.T, original *commonpb.Payload, key []byte, keyID string) *commonpb.Payload {
+	t.Helper()
+
+	serialized, err := proto.Marshal(original)
+	require.NoError(t, err)
+
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+
+	iv := make([]byte, ivBytes)
+	_, err = rand.Read(iv)
+	require.NoError(t, err)
+
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{
+			encodingMetadataKey: []byte(encryptedEncodingValue),
+			keyIDMetadataKey:    []byte(keyID),
+		},
+		Data: append(append([]byte{}, iv...), gcm.Seal(nil, iv, serialized, nil)...),
+	}
+}
+
+func TestDecodeRoundTrip(t *testing.T) {
+	key := testKey(t, 0x11)
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: key}})
+
+	original := plaintextPayload(`{"secret":"value"}`)
+	encrypted := encryptForTest(t, original, key, "k1")
+
+	decoded, err := codec.Decode([]*commonpb.Payload{encrypted})
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	require.True(t, proto.Equal(original, decoded[0]),
+		"decode must restore the original payload exactly, metadata included")
+}
+
+func TestDecodePassesThroughPlaintext(t *testing.T) {
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: testKey(t, 0x11)}})
+
+	// Plaintext payloads (the server's own histories, pre-rollout in-flight
+	// executions) must survive decode untouched — the zero-migration property.
+	payload := plaintextPayload(`{"plain":"data"}`)
+	decoded, err := codec.Decode([]*commonpb.Payload{payload})
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	require.Same(t, payload, decoded[0])
+}
+
+func TestEncodeIsIdentity(t *testing.T) {
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: testKey(t, 0x11)}})
+
+	payloads := []*commonpb.Payload{plaintextPayload(`{"a":1}`), plaintextPayload(`{"b":2}`)}
+	encoded, err := codec.Encode(payloads)
+	require.NoError(t, err)
+	require.Equal(t, payloads, encoded)
+}
+
+func TestDecodeWithSecondaryKeyDuringRotation(t *testing.T) {
+	oldKey := testKey(t, 0x22)
+	codec := testCodec(t, &Config{
+		Primary:   Key{ID: "k2", Material: testKey(t, 0x11)},
+		Secondary: &Key{ID: "k1", Material: oldKey},
+	})
+
+	original := plaintextPayload(`{"secret":"pre-rotation"}`)
+	encrypted := encryptForTest(t, original, oldKey, "k1")
+
+	decoded, err := codec.Decode([]*commonpb.Payload{encrypted})
+	require.NoError(t, err)
+	require.True(t, proto.Equal(original, decoded[0]))
+}
+
+func TestDecodeFailsClosedOnUnknownKeyID(t *testing.T) {
+	key := testKey(t, 0x11)
+	codec := testCodec(t, &Config{Primary: Key{ID: "known", Material: key}})
+
+	encrypted := encryptForTest(t, plaintextPayload(`{}`), key, "unknown")
+	_, err := codec.Decode([]*commonpb.Payload{encrypted})
+	require.ErrorContains(t, err, `unknown key id "unknown"`)
+}
+
+func TestDecodeFailsClosedOnMissingKeyID(t *testing.T) {
+	key := testKey(t, 0x11)
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: key}})
+
+	encrypted := encryptForTest(t, plaintextPayload(`{}`), key, "k1")
+	delete(encrypted.Metadata, keyIDMetadataKey)
+
+	_, err := codec.Decode([]*commonpb.Payload{encrypted})
+	require.ErrorContains(t, err, "missing its encryption-key-id metadata")
+}
+
+func TestDecodeFailsClosedOnTruncatedData(t *testing.T) {
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: testKey(t, 0x11)}})
+
+	truncated := &commonpb.Payload{
+		Metadata: map[string][]byte{
+			encodingMetadataKey: []byte(encryptedEncodingValue),
+			keyIDMetadataKey:    []byte("k1"),
+		},
+		Data: make([]byte, ivBytes+authTagBytes-1),
+	}
+	_, err := codec.Decode([]*commonpb.Payload{truncated})
+	require.ErrorContains(t, err, "truncated")
+}
+
+func TestDecodeFailsClosedOnTamperedCiphertext(t *testing.T) {
+	key := testKey(t, 0x11)
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: key}})
+
+	encrypted := encryptForTest(t, plaintextPayload(`{"secret":"value"}`), key, "k1")
+	encrypted.Data[len(encrypted.Data)/2] ^= 0xff
+
+	_, err := codec.Decode([]*commonpb.Payload{encrypted})
+	require.ErrorContains(t, err, "ciphertext is corrupt or the configured key does not match")
+}
+
+func TestDecodeFailsClosedOnWrongKeyForAdvertisedID(t *testing.T) {
+	codec := testCodec(t, &Config{Primary: Key{ID: "k1", Material: testKey(t, 0x33)}})
+
+	// Encrypted under a DIFFERENT key that advertises the same id.
+	encrypted := encryptForTest(t, plaintextPayload(`{}`), testKey(t, 0x44), "k1")
+	_, err := codec.Decode([]*commonpb.Payload{encrypted})
+	require.ErrorContains(t, err, "ciphertext is corrupt or the configured key does not match")
+}
+
+// conformanceFixture mirrors the committed cross-language fixture's shape.
+// The file is a byte-for-byte copy of the TS runner's
+// __tests__/fixtures/encrypted-payload-fixture.json (also copied into
+// stigmer-cloud's temporal-starter test resources) — the three
+// implementations decrypt the SAME bytes, so envelope drift fails CI on
+// whichever side drifted.
+type conformanceFixture struct {
+	KeyID     string `json:"keyId"`
+	KeyBase64 string `json:"keyBase64"`
+	Encrypted struct {
+		MetadataBase64 map[string]string `json:"metadataBase64"`
+		DataBase64     string            `json:"dataBase64"`
+	} `json:"encrypted"`
+	Original struct {
+		DataJSON string `json:"dataJson"`
+	} `json:"original"`
+}
+
+func TestCrossLanguageConformanceFixture(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "encrypted-payload-fixture.json"))
+	require.NoError(t, err)
+	var fixture conformanceFixture
+	require.NoError(t, json.Unmarshal(raw, &fixture))
+
+	key, err := base64.StdEncoding.DecodeString(fixture.KeyBase64)
+	require.NoError(t, err)
+	codec := testCodec(t, &Config{Primary: Key{ID: fixture.KeyID, Material: key}})
+
+	metadata := make(map[string][]byte, len(fixture.Encrypted.MetadataBase64))
+	for k, v := range fixture.Encrypted.MetadataBase64 {
+		metadata[k], err = base64.StdEncoding.DecodeString(v)
+		require.NoError(t, err)
+	}
+	data, err := base64.StdEncoding.DecodeString(fixture.Encrypted.DataBase64)
+	require.NoError(t, err)
+
+	decoded, err := codec.Decode([]*commonpb.Payload{{Metadata: metadata, Data: data}})
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	require.Equal(t, "json/plain", string(decoded[0].GetMetadata()[encodingMetadataKey]))
+	require.JSONEq(t, fixture.Original.DataJSON, string(decoded[0].GetData()))
+}

--- a/backend/services/stigmer-server/pkg/encryption/payloadcodec/config.go
+++ b/backend/services/stigmer-server/pkg/encryption/payloadcodec/config.go
@@ -1,0 +1,88 @@
+package payloadcodec
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+// Env var names are deliberately IDENTICAL to what the TS runner and the
+// Java service read (DD-003): a self-hosted deployment sets one key pair for
+// both processes, so the two consumers cannot rotate apart.
+const (
+	keyEnv            = "STIGMER_PAYLOAD_ENCRYPTION_KEY"
+	keyIDEnv          = "STIGMER_PAYLOAD_ENCRYPTION_KEY_ID"
+	secondaryKeyEnv   = "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY"
+	secondaryKeyIDEnv = "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID"
+
+	aes256KeyBytes = 32
+)
+
+// Key is one accepted decryption key.
+type Key struct {
+	// ID is the value payloads carry in their encryption-key-id metadata.
+	ID string
+	// Material is the raw 32-byte AES-256 key (validated at load).
+	Material []byte
+}
+
+// Config holds the accepted decryption keys.
+type Config struct {
+	// Primary is the key the runner currently encrypts with.
+	Primary Key
+	// Secondary is the previous key, accepted during rotation windows.
+	Secondary *Key
+}
+
+// LoadConfigFromEnv returns the payload-encryption config, or (nil, nil)
+// when encryption is not configured (the codec is then simply not
+// installed — the enabled-iff-configured pattern the runner uses).
+//
+// A present-but-malformed key, or a key without its id, is an error: an
+// operator who set the key intended runner history to be encrypted, and the
+// server would otherwise fail on the first runner payload it reads. Key
+// misconfiguration must stop the boot, not surface later as decode errors.
+func LoadConfigFromEnv() (*Config, error) {
+	rawKey := os.Getenv(keyEnv)
+	if rawKey == "" {
+		return nil, nil
+	}
+
+	primary, err := loadKey(rawKey, keyEnv, keyIDEnv)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &Config{Primary: *primary}
+
+	if rawSecondary := os.Getenv(secondaryKeyEnv); rawSecondary != "" {
+		secondary, err := loadKey(rawSecondary, secondaryKeyEnv, secondaryKeyIDEnv)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Secondary = secondary
+	}
+	return cfg, nil
+}
+
+func loadKey(rawBase64, keyEnvName, keyIDEnvName string) (*Key, error) {
+	// An explicit id is required (no default): during rotation two keys
+	// coexist, and payloads must name which one encrypted them.
+	keyID := os.Getenv(keyIDEnvName)
+	if keyID == "" {
+		return nil, fmt.Errorf(
+			"payload encryption misconfigured: %s is required when %s is set",
+			keyIDEnvName, keyEnvName)
+	}
+
+	material, err := base64.StdEncoding.DecodeString(rawBase64)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"payload encryption misconfigured: %s is not valid base64", keyEnvName)
+	}
+	if len(material) != aes256KeyBytes {
+		return nil, fmt.Errorf(
+			"payload encryption misconfigured: %s must decode to %d bytes (AES-256), got %d",
+			keyEnvName, aes256KeyBytes, len(material))
+	}
+	return &Key{ID: keyID, Material: material}, nil
+}

--- a/backend/services/stigmer-server/pkg/encryption/payloadcodec/config_test.go
+++ b/backend/services/stigmer-server/pkg/encryption/payloadcodec/config_test.go
@@ -1,0 +1,95 @@
+package payloadcodec
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validKeyBase64(seed byte) string {
+	key := make([]byte, aes256KeyBytes)
+	for i := range key {
+		key[i] = seed
+	}
+	return base64.StdEncoding.EncodeToString(key)
+}
+
+func clearEncryptionEnv(t *testing.T) {
+	t.Helper()
+	// t.Setenv registers cleanup AND marks the test as non-parallel, which
+	// matters here: these tests mutate process-global env.
+	for _, name := range []string{keyEnv, keyIDEnv, secondaryKeyEnv, secondaryKeyIDEnv} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestLoadConfigReturnsNilWhenUnset(t *testing.T) {
+	clearEncryptionEnv(t)
+
+	cfg, err := LoadConfigFromEnv()
+	require.NoError(t, err)
+	require.Nil(t, cfg, "encryption must be off when no key is configured")
+}
+
+func TestLoadConfigPrimaryOnly(t *testing.T) {
+	clearEncryptionEnv(t)
+	t.Setenv(keyEnv, validKeyBase64(0x11))
+	t.Setenv(keyIDEnv, "key-2026-08")
+
+	cfg, err := LoadConfigFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, "key-2026-08", cfg.Primary.ID)
+	require.Len(t, cfg.Primary.Material, aes256KeyBytes)
+	require.Nil(t, cfg.Secondary)
+}
+
+func TestLoadConfigWithSecondary(t *testing.T) {
+	clearEncryptionEnv(t)
+	t.Setenv(keyEnv, validKeyBase64(0x11))
+	t.Setenv(keyIDEnv, "key-new")
+	t.Setenv(secondaryKeyEnv, validKeyBase64(0x22))
+	t.Setenv(secondaryKeyIDEnv, "key-old")
+
+	cfg, err := LoadConfigFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, "key-new", cfg.Primary.ID)
+	require.NotNil(t, cfg.Secondary)
+	require.Equal(t, "key-old", cfg.Secondary.ID)
+}
+
+func TestLoadConfigFailsWithoutKeyID(t *testing.T) {
+	clearEncryptionEnv(t)
+	t.Setenv(keyEnv, validKeyBase64(0x11))
+
+	_, err := LoadConfigFromEnv()
+	require.ErrorContains(t, err, "STIGMER_PAYLOAD_ENCRYPTION_KEY_ID is required")
+}
+
+func TestLoadConfigFailsOnInvalidBase64(t *testing.T) {
+	clearEncryptionEnv(t)
+	t.Setenv(keyEnv, "not-valid-base64!!!")
+	t.Setenv(keyIDEnv, "key-1")
+
+	_, err := LoadConfigFromEnv()
+	require.ErrorContains(t, err, "is not valid base64")
+}
+
+func TestLoadConfigFailsOnWrongKeyLength(t *testing.T) {
+	clearEncryptionEnv(t)
+	t.Setenv(keyEnv, base64.StdEncoding.EncodeToString([]byte("too-short")))
+	t.Setenv(keyIDEnv, "key-1")
+
+	_, err := LoadConfigFromEnv()
+	require.ErrorContains(t, err, "must decode to 32 bytes (AES-256)")
+}
+
+func TestLoadConfigFailsWhenSecondaryMissingItsID(t *testing.T) {
+	clearEncryptionEnv(t)
+	t.Setenv(keyEnv, validKeyBase64(0x11))
+	t.Setenv(keyIDEnv, "key-new")
+	t.Setenv(secondaryKeyEnv, validKeyBase64(0x22))
+
+	_, err := LoadConfigFromEnv()
+	require.ErrorContains(t, err, "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID is required")
+}

--- a/backend/services/stigmer-server/pkg/encryption/payloadcodec/testdata/encrypted-payload-fixture.json
+++ b/backend/services/stigmer-server/pkg/encryption/payloadcodec/testdata/encrypted-payload-fixture.json
@@ -1,0 +1,15 @@
+{
+  "description": "Cross-language conformance fixture for the Temporal payload-encryption envelope (stigmer-cloud#227). data = iv(12) || AES-256-GCM ciphertext || tag(16); plaintext is the serialized original Payload proto. The TS codec (stigmer OSS runner) and the Java decode-only codec (stigmer-cloud temporal-starter) must both decrypt this to original.dataJson with encoding json/plain. The key is TEST-ONLY. Do not regenerate without moving both implementations in lockstep.",
+  "keyId": "conformance-2026-08-11",
+  "keyBase64": "LwN0jDzOwm0aPH8lyRRqsTMali/7RAgKKB9CY6psNFw=",
+  "encrypted": {
+    "metadataBase64": {
+      "encoding": "YmluYXJ5L2VuY3J5cHRlZA==",
+      "encryption-key-id": "Y29uZm9ybWFuY2UtMjAyNi0wOC0xMQ=="
+    },
+    "dataBase64": "CzL44tAoZwoawET5ApaDKGLYcJO2P8eTPS4hZnoEOUvZ7jkD5mkCnD9krgY9etYWO+06y779i8xRCs7QrnOKo5xo74HtlY0bwxYjr2dOra9TGRbtv3PlrW+DcfmEFAQ3Efem"
+  },
+  "original": {
+    "dataJson": "{\"secret\":\"cross-language-conformance-value\"}"
+  }
+}

--- a/backend/services/stigmer-server/pkg/server/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/server/BUILD.bazel
@@ -86,6 +86,7 @@ go_library(
         "//backend/services/stigmer-server/pkg/downstream/workflow",
         "//backend/services/stigmer-server/pkg/downstream/workflowinstance",
         "//backend/services/stigmer-server/pkg/encryption",
+        "//backend/services/stigmer-server/pkg/encryption/payloadcodec",
         "//backend/services/stigmer-server/pkg/query/search/controller",
         "//backend/services/stigmer-server/pkg/query/search/extractor",
         "//backend/services/stigmer-server/pkg/query/search/handler",

--- a/backend/services/stigmer-server/pkg/server/temporal_manager.go
+++ b/backend/services/stigmer-server/pkg/server/temporal_manager.go
@@ -18,6 +18,7 @@ import (
 	workflowexecutiontemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal"
 	workflowexecutionactivities "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/activities"
 	workflowexecutionworkflows "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption/payloadcodec"
 	"go.temporal.io/sdk/client"
 	temporallog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/worker"
@@ -361,11 +362,26 @@ func (tm *TemporalManager) calculateBackoff() time.Duration {
 
 // dialTemporal creates a new Temporal client connection
 func (tm *TemporalManager) dialTemporal(ctx context.Context) (client.Client, error) {
-	return client.Dial(client.Options{
+	opts := client.Options{
 		HostPort:  tm.cfg.TemporalHostPort,
 		Namespace: tm.namespace,
 		Logger:    temporallog.NewStructuredLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
-	})
+	}
+
+	// When payload encryption is configured, install the decode-only codec
+	// on the client — the single choke point that covers every worker AND
+	// client-side reads of runner-produced payloads (agent-execution
+	// activity results, the MCP connect workflow result). The server's own
+	// payloads stay plaintext (encode is the identity).
+	if tm.cfg.PayloadEncryption != nil {
+		dataConverter, err := payloadcodec.NewDataConverter(tm.cfg.PayloadEncryption)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build payload decryption data converter: %w", err)
+		}
+		opts.DataConverter = dataConverter
+	}
+
+	return client.Dial(opts)
 }
 
 // restartWorkers stops old workers and starts new ones with the new client

--- a/docs/guides/runners/meta.json
+++ b/docs/guides/runners/meta.json
@@ -1,4 +1,11 @@
 {
   "title": "Runner guides",
-  "pages": ["overview", "embedding", "ipc-protocol", "cursor-harness", "model-backends"]
+  "pages": [
+    "overview",
+    "embedding",
+    "ipc-protocol",
+    "cursor-harness",
+    "model-backends",
+    "payload-encryption"
+  ]
 }

--- a/docs/guides/runners/payload-encryption.mdx
+++ b/docs/guides/runners/payload-encryption.mdx
@@ -1,0 +1,88 @@
+---
+title: Encrypt Temporal payloads at rest
+description:
+  Opt-in AES-256-GCM encryption for every Temporal payload the runner produces,
+  so decrypted workflow secrets never rest in Temporal history or appear in the
+  Temporal UI. Two environment variables on the runner and the server.
+---
+
+Workflow and agent executions move data through Temporal: activity inputs and
+results, expression markers, workflow results. Without encryption, that data —
+including execution-context secrets a workflow interpolates into task configs —
+rests in durable Temporal history, readable by anyone with access to the
+Temporal UI or database.
+
+Payload encryption closes the whole class at the codec layer: the runner
+encrypts **every payload its workers hand to Temporal** with AES-256-GCM before
+it leaves the process, and decrypts on the way back in. The Stigmer server
+carries a **decode-only** twin of the codec, so it can read runner results
+(agent activity results, MCP connect results) while its own orchestration
+history stays plaintext and UI-readable.
+
+Encryption is off by default and enabled by configuration alone — no code or
+workflow changes.
+
+## Enable it
+
+Generate a 32-byte key and give it an id:
+
+```bash
+openssl rand -base64 32
+```
+
+Set the **same two variables on both processes** — the stigmer-server and the
+runner:
+
+```bash
+STIGMER_PAYLOAD_ENCRYPTION_KEY="<base64 key>"
+STIGMER_PAYLOAD_ENCRYPTION_KEY_ID="key-2026-08"
+```
+
+The key id is stamped on every encrypted payload so rotation can tell keys
+apart; it is required whenever the key is set. A malformed key — or a key
+without its id — fails the boot on both sides. Misconfiguration never degrades
+to silent plaintext.
+
+<Callout type="warn">
+  Both processes need the key. The server holds it to *decode* runner results —
+  with the key set only on the runner, every agent execution and MCP connect
+  fails on the server's first read. Upgrade both to a release that ships the
+  server-side codec, then set the key on both together.
+</Callout>
+
+Existing in-flight executions are unaffected: decode passes through payloads
+that were never encrypted, so pre-rollout histories and the server's own
+plaintext payloads keep working with zero migration.
+
+## Rotate keys
+
+Payloads name the key that encrypted them, so rotation is a two-key window:
+
+1. Set the new key as primary and demote the old pair to
+   `STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY` /
+   `STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID` on both processes, then
+   restart. New payloads are written under the new key; histories written under
+   the old key stay readable.
+2. Once executions started before the rotation have drained, drop the secondary
+   pair.
+
+## What stays plaintext
+
+The codec encrypts what the **runner** produces. By design, these stay readable
+without a key:
+
+- **Server-side history** — orchestrator workflow inputs, signals sent by the
+  server (approvals, pause/resume), memos, and search attributes.
+- **Workflow completion results** on the execution path — the runner completes
+  the cross-language child workflow with a data-less (void) result; outputs
+  reach you through the event log instead.
+- **Failure messages and stack traces** — Temporal stores these outside
+  payloads, so errors stay debuggable in the UI.
+- **Event signals sent by `emit` tasks** — the emit task's delivery client is
+  deliberately not encrypted: it is the one direct runner-to-runner channel, and
+  its targets cannot be assumed to hold the sender's key. Treat event payloads
+  as boundary-crossing messages, not secret carriers.
+
+Encrypted payloads appear as opaque `binary/encrypted` blobs in the Temporal UI.
+Decoding them in the UI would require a Temporal codec server, which Stigmer
+does not ship today.


### PR DESCRIPTION
## Summary

First half of #398 (the OSS arm): a decode-only Temporal `PayloadCodec` for the Go server so self-hosted deployments can enable the runner's payload-encryption codec that shipped with stigmer-cloud#227, plus the opt-in docs.

This is load-bearing, not future-proofing: the Go agent-execution workflow decodes `ExecuteDeepAgent`/`ExecuteCursor`/`EnsureThread` activity results from the runner queue, and the MCP connect controller decodes the connect workflow result client-side (`run.Get`). With runner encryption on and no server codec, every OSS agent execution and MCP connect fails on decode.

## What changed

- **`pkg/encryption/payloadcodec`** — decode-only codec implementing the pinned cross-SDK envelope (metadata `encoding: binary/encrypted` + `encryption-key-id`; data `iv(12) ‖ AES-256-GCM(ciphertext ‖ tag(16))` over the serialized original Payload proto):
  - `Encode` is the identity — the server's own histories stay plaintext and Temporal-UI-readable.
  - `Decode` passes through payloads it did not encrypt (zero-migration for in-flight histories and server-produced payloads) and fails closed on missing key id, unknown key id, truncation, and GCM auth failure.
- **Config** — the same `STIGMER_PAYLOAD_ENCRYPTION_KEY(_ID)` / `_SECONDARY_KEY(_ID)` env vars the TS runner and the cloud Java service read (one key pair per deployment, consumers cannot rotate apart). A present-but-malformed key, or a key without its id, fails the boot — misconfiguration never degrades to silent plaintext.
- **Wiring** — `dialTemporal` installs the codec via `client.Options.DataConverter`. That is the single production `client.Dial` in the codebase, so one change covers all three workers, reconnection, and client-side reads.
- **Docs** — new `docs/guides/runners/payload-encryption.mdx` (+ nav): enablement, upgrade ordering (server must carry the codec before the runner key is set), rotation via the secondary pair, and what stays plaintext — including the `emit` task's delivery boundary, which is deliberately unencrypted (it is the platform's only direct runner-to-runner channel; encrypting it conflicts with the per-runner keys #398's second half introduces — follow-up: #517).

## Verification

- `go test -race ./pkg/encryption/...` and `bazel test //backend/services/stigmer-server/pkg/encryption/payloadcodec:payloadcodec_test` — green.
- **Cross-language conformance**: the Go test decrypts a byte-for-byte copy of the committed TS fixture (`encrypted-payload-fixture.json`) — the third implementation pinned to the same envelope bytes; drift on any side fails that side's CI.
- Fail-closed arms covered: unknown key id, missing key id, truncation, tampered ciphertext, wrong key behind an advertised id; config boot failures (missing id, bad base64, wrong length).
- `go build ./...`, `go vet` + `gofmt` + `go mod tidy` clean on touched packages; docs pass Vale (0 errors), Prettier, and the docs-YAML gate.
- Note: `bazel build //backend/services/stigmer-server/pkg/server:server` currently fails on **pristine main** due to an unrelated missing dep in `pkg/query/search/controller` (a parallel session has the fix in flight); the Go toolchain build of the same code is clean.

Part of #398 — the second half (per-runner persistent keys for desktop runners on cloud Temporal) follows in paired PRs; this PR does not close the issue.

Made with [Cursor](https://cursor.com)