### PR TITLE
fix(site): repair demo visibility suite and mock provider registry fetches

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -12,6 +12,10 @@
 /coverage
 /e2e/screenshots/
 /e2e/demos/demo-manifest.json
+# Demo screenshot baselines are per-machine (self-baselined on first
+# run, regenerated via test:demos:update-snapshots); no CI consumes
+# them, so committing the PNGs would only churn the repo.
+/e2e/demos/*-snapshots/
 /playwright-report/
 /test-results/
 

--- a/site/.scenar/providers.tsx
+++ b/site/.scenar/providers.tsx
@@ -25,7 +25,15 @@ export function PreviewProviders({ children }: PreviewProvidersProps) {
       baseUrl: "/",
       useBinaryFormat: false,
     });
-    return new Stigmer({ baseUrl: "/", customTransport: transport });
+    // The fake apiKey matters: without a credential, the provider's
+    // registry hooks poll for a token every 500ms for 10 seconds on
+    // every demo mount before their first fetch. With it, the fetches
+    // fire immediately into the MSW fixtures.
+    return new Stigmer({
+      baseUrl: "/",
+      apiKey: "scenar-preview",
+      customTransport: transport,
+    });
   }, []);
 
   return <StigmerProvider client={client}>{children}</StigmerProvider>;

--- a/site/e2e/demos/demo-visibility.spec.ts
+++ b/site/e2e/demos/demo-visibility.spec.ts
@@ -2,26 +2,34 @@
  * Targeted visibility contract tests for demo scenarios.
  *
  * Reads the auto-generated demo-manifest.json and filters for entries
- * with a visibilityContract (originating from co-located visibility.json
- * files in each scenario directory). For each:
+ * with a visibilityContract (auto-derived from scenario scroll/cursor
+ * interactions by validate-demos.ts, merged with co-located
+ * visibility.json overrides). For each:
  *
  * 1. Navigates to the docs page with accelerated playback.
  * 2. Starts playback by clicking the poster play button.
- * 3. At each contracted step (detected via data-demo-step), waits for
- *    mid-step interactions to settle, then asserts that declared target
- *    elements are visible inside the demo's scroll container.
- * 4. For steps with cursorMustAlign, verifies the cursor overlay is
- *    positioned within tolerance of the target element's center.
- * 5. Takes a visual regression screenshot at each contracted step.
+ * 3. At each contracted step (detected via data-demo-step), polls the
+ *    contract's requirements until each is observed satisfied, or the
+ *    step ends. A contract means "this step shows the viewer this
+ *    content at some point" — NOT "at a fixed instant". Scenarios
+ *    deliberately schedule scrolls partway through a step (narrate the
+ *    top, then scroll), so requirements become true at different
+ *    moments within the step; each only has to be observed once.
+ * 4. For steps with cursorMustAlign, the same polling verifies the
+ *    cursor overlay reaches the target element's center. Auto-derived
+ *    cursor requirements (cursorTarget) are presence-tolerant: skipped
+ *    when the target never mounts during the step, strict when it does.
+ * 5. Once the contract is satisfied, takes a visual regression
+ *    screenshot after the scroll geometry stabilizes.
  *
  * Visibility checks use page.evaluate with getBoundingClientRect
  * inside the page context. This avoids Playwright's known issues
  * with CSS `zoom` property (#21192, #7642). Checks require full
  * containment (target fully inside container), not just intersection.
  *
- * This suite complements demo.spec.ts (which auto-checks all scroll
- * targets) by additionally verifying specific cursor targets and
- * capturing screenshot baselines for visual regression.
+ * This suite is the single home for demo visibility assertions;
+ * demo.spec.ts is pure playback smoke (every demo plays to completion
+ * without JS errors).
  */
 
 import * as fs from "fs";
@@ -37,6 +45,15 @@ interface StepAssertion {
   scrollContainer?: string;
   cursorMustAlign?: string;
   mustBeCentered?: string;
+  /**
+   * Auto-derived cursor requirement — presence-tolerant. Cursor
+   * targets mount through async fixture round-trips and can
+   * legitimately miss a short step at accelerated playback (the
+   * Cursor component itself retries briefly, then gives up). If the
+   * target never mounts during the step the requirement is skipped;
+   * if it mounts, containment and cursor alignment are asserted.
+   */
+  cursorTarget?: string;
 }
 
 interface ManifestEntry {
@@ -75,12 +92,11 @@ const fixtures = loadFixtures();
 const TEST_SPEED = 2;
 
 /**
- * Time to wait after a step transition for mid-step interactions
- * to fire and smooth scroll to settle. At 2x speed, most interactions
- * fire within the first 50-55% of step duration (~1-2s) and scroll
- * animations are constant (~300-500ms).
+ * Interval between requirement polls within a contracted step.
+ * Scroll animations run ~300-500ms and steps last seconds, so 150ms
+ * sampling cannot miss a satisfied state.
  */
-const INTERACTION_SETTLE_MS = 1_500;
+const POLL_INTERVAL_MS = 150;
 
 /**
  * Maximum wall-clock time for a demo to reach a target step at 2x.
@@ -88,6 +104,22 @@ const INTERACTION_SETTLE_MS = 1_500;
  * late steps. 120s covers the worst case.
  */
 const STEP_TIMEOUT_MS = 120_000;
+
+/**
+ * Hard cap on polling within a single step. Steps normally end (and
+ * end the poll loop) on their own; this cap only matters for the
+ * final step of a scenario, which never transitions away.
+ */
+const CONTRACT_SATISFY_TIMEOUT_MS = 30_000;
+
+/**
+ * Wait after a cursorMustAlign requirement is satisfied before taking
+ * the step screenshot. Alignment can be observed the moment the
+ * cursor lands, but the click ripple fires CLICK_DELAY_MS (450ms)
+ * after arrival and animates for another 450ms — capturing mid-ripple
+ * is nondeterministic. This covers the full ripple with margin.
+ */
+const CURSOR_RIPPLE_SETTLE_MS = 1_200;
 
 /**
  * Sub-pixel tolerance for containment checks. CSS zoom produces
@@ -110,11 +142,214 @@ const CURSOR_ALIGNMENT_TOLERANCE_PX = 25;
  */
 const CENTERING_THRESHOLD = 0.2;
 
+// ---------------------------------------------------------------------------
+// In-page requirement evaluation
+// ---------------------------------------------------------------------------
+
 /**
- * Extra wait time after the interaction settle delay for the cursor
- * spring animation to reach its target before checking alignment.
+ * One poll's verdict for a single contract requirement, produced
+ * inside the page. `detail` carries the last-observed geometry so a
+ * never-satisfied requirement fails with actionable numbers.
+ * `present` reports whether the requirement's element was in the DOM
+ * this poll — presence-tolerant requirements are skipped (not failed)
+ * when their element was never present during the whole step.
  */
-const CURSOR_SETTLE_MS = 600;
+interface RequirementVerdict {
+  satisfied: boolean;
+  detail: string;
+  present?: boolean;
+}
+
+/** Serializable inputs for the in-page requirement evaluation. */
+interface RequirementProbe {
+  targets: string[];
+  scrollSelector: string;
+  mustBeCentered?: string;
+  cursorMustAlign?: string;
+  /** Presence-tolerant cursor requirement (see StepAssertion). */
+  cursorTarget?: string;
+  containmentTolerance: number;
+  centeringThreshold: number;
+  cursorTolerance: number;
+}
+
+/**
+ * Evaluated inside the page: check every contract requirement once
+ * and report per-requirement verdicts plus the scroll position (used
+ * by the caller to detect when scrolling has settled).
+ *
+ * Keyed by requirement name: `target:<id>`, `centered:<id>`,
+ * `cursor:<id>`, `cursor-opt:<id>`.
+ */
+function evaluateRequirements(
+  container: Element,
+  probe: RequirementProbe,
+): {
+  verdicts: Record<string, RequirementVerdict>;
+  scrollTop: number;
+  scrollHeight: number;
+} {
+  const verdicts: Record<string, RequirementVerdict> = {};
+
+  const scrollParent = container.querySelector(probe.scrollSelector);
+  const ref = scrollParent ?? container;
+  const refRect = ref.getBoundingClientRect();
+
+  const findTarget = (targetId: string): Element | null =>
+    container.querySelector(`[data-scroll-target="${targetId}"]`) ??
+    container.querySelector(`[data-cursor-target="${targetId}"]`);
+
+  const containment = (
+    target: Element,
+  ): { contained: boolean; detail: string } => {
+    const t = target.getBoundingClientRect();
+    const tol = probe.containmentTolerance;
+    const contained =
+      t.top >= refRect.top - tol &&
+      t.bottom <= refRect.bottom + tol &&
+      t.left >= refRect.left - tol &&
+      t.right <= refRect.right + tol;
+    return {
+      contained,
+      detail: contained
+        ? "contained"
+        : `target ${Math.round(t.top)}..${Math.round(t.bottom)} vs ` +
+          `container ${Math.round(refRect.top)}..${Math.round(refRect.bottom)}`,
+    };
+  };
+
+  // The Cursor overlay is deliberately a SIBLING of the demo
+  // container ([data-demo-step] is the ScenarioPlayer root), not a
+  // descendant: both are direct children of DemoViewport's inner
+  // zoomed div, which is also the cursor's positioning parent and
+  // the `containerRef` its coordinates are computed against.
+  const cursorAlignment = (
+    target: Element,
+  ): { aligned: boolean; detail: string } => {
+    const viewport = container.parentElement;
+    const cursor = viewport?.querySelector(
+      ":scope > .pointer-events-none.absolute.z-50",
+    ) as HTMLElement | null;
+    if (!viewport || !cursor) {
+      return { aligned: false, detail: "cursor overlay not found" };
+    }
+
+    const transform = getComputedStyle(cursor).transform;
+    if (!transform || transform === "none") {
+      return { aligned: false, detail: "cursor has no transform" };
+    }
+
+    // Mirror @scenar/core's computeCursorPosition: the cursor
+    // transform is in the viewport's pre-zoom CSS space; rects are
+    // post-zoom viewport coordinates. Divide by the effective zoom
+    // to compare like with like.
+    const matrix = new DOMMatrix(transform);
+    const tRect = target.getBoundingClientRect();
+    const vRect = viewport.getBoundingClientRect();
+    const zoom = vRect.width / viewport.offsetWidth || 1;
+    const targetCenterX = (tRect.left - vRect.left + tRect.width / 2) / zoom;
+    const targetCenterY = (tRect.top - vRect.top + tRect.height / 2) / zoom;
+    const dx = Math.abs(matrix.m41 - targetCenterX);
+    const dy = Math.abs(matrix.m42 - targetCenterY);
+    return {
+      aligned: dx <= probe.cursorTolerance && dy <= probe.cursorTolerance,
+      detail: `cursor ${Math.round(dx)}px/${Math.round(dy)}px from ` +
+        `target center (tolerance ${probe.cursorTolerance}px)`,
+    };
+  };
+
+  for (const targetId of probe.targets) {
+    const target = findTarget(targetId);
+    if (!target) {
+      verdicts[`target:${targetId}`] = {
+        satisfied: false,
+        detail: "not found in DOM",
+      };
+      continue;
+    }
+    const { contained, detail } = containment(target);
+    verdicts[`target:${targetId}`] = { satisfied: contained, detail };
+  }
+
+  if (probe.mustBeCentered) {
+    const target =
+      container.querySelector(
+        `[data-scroll-target="${probe.mustBeCentered}"]`,
+      ) ??
+      container.querySelector(
+        `[data-cursor-target="${probe.mustBeCentered}"]`,
+      );
+
+    if (!target) {
+      verdicts[`centered:${probe.mustBeCentered}`] = {
+        satisfied: false,
+        detail: "not found in DOM",
+      };
+    } else {
+      const cr = container.getBoundingClientRect();
+      const tr = target.getBoundingClientRect();
+      const offset = Math.abs(
+        (tr.top + tr.bottom) / 2 - (cr.top + cr.bottom) / 2,
+      );
+      const maxOffset = cr.height * probe.centeringThreshold;
+      verdicts[`centered:${probe.mustBeCentered}`] = {
+        satisfied: offset <= maxOffset,
+        detail: `${Math.round(offset)}px from vertical center ` +
+          `(max ${Math.round(maxOffset)}px)`,
+      };
+    }
+  }
+
+  if (probe.cursorMustAlign) {
+    const target = findTarget(probe.cursorMustAlign);
+    if (!target) {
+      verdicts[`cursor:${probe.cursorMustAlign}`] = {
+        satisfied: false,
+        detail: "target not found",
+      };
+    } else {
+      const { aligned, detail } = cursorAlignment(target);
+      verdicts[`cursor:${probe.cursorMustAlign}`] = {
+        satisfied: aligned,
+        detail,
+      };
+    }
+  }
+
+  if (probe.cursorTarget) {
+    // Presence-tolerant: report `present` so the caller can skip the
+    // requirement if the target never mounts during the step. When
+    // present, both containment and cursor alignment must hold.
+    const target = findTarget(probe.cursorTarget);
+    if (!target) {
+      verdicts[`cursor-opt:${probe.cursorTarget}`] = {
+        satisfied: false,
+        present: false,
+        detail: "target never mounted during the step",
+      };
+    } else {
+      const { contained, detail: containDetail } = containment(target);
+      const { aligned, detail: alignDetail } = cursorAlignment(target);
+      verdicts[`cursor-opt:${probe.cursorTarget}`] = {
+        satisfied: contained && aligned,
+        present: true,
+        detail: contained ? alignDetail : containDetail,
+      };
+    }
+  }
+
+  // Exact (unrounded) values: the screenshot stability check compares
+  // consecutive samples for identity, and a smooth scroll's ease-out
+  // tail creeps by fractions of a pixel per interval — rounding would
+  // declare it settled while it is still moving. scrollHeight changes
+  // when async fixture content is still streaming into the view.
+  const sc = container.querySelector(probe.scrollSelector);
+  return {
+    verdicts,
+    scrollTop: sc ? sc.scrollTop : 0,
+    scrollHeight: sc ? sc.scrollHeight : 0,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -214,171 +449,133 @@ for (const fixture of fixtures) {
             containerIdx: demoIdx,
             targetStep: step.stepIndex,
           },
-          { timeout: STEP_TIMEOUT_MS, polling: 200 },
+          // Poll fast: arriving late eats into the window in which
+          // this step's requirements can be observed.
+          { timeout: STEP_TIMEOUT_MS, polling: 50 },
         );
 
-        await page.waitForTimeout(INTERACTION_SETTLE_MS);
-
-        const currentStepAfterSettle = Number(
+        // The demo may already have advanced past this contracted step
+        // (short steps at accelerated playback). Nothing to assert then.
+        const stepOnArrival = Number(
           await demoContainer.getAttribute("data-demo-step") ?? "-1",
         );
-        if (currentStepAfterSettle !== step.stepIndex) {
+        if (stepOnArrival !== step.stepIndex) {
           continue;
         }
 
-        const scrollSelector =
-          step.scrollContainer ?? "[data-scroll-container]";
+        const probe: RequirementProbe = {
+          targets: step.targets,
+          scrollSelector: step.scrollContainer ?? "[data-scroll-container]",
+          mustBeCentered: step.mustBeCentered,
+          cursorMustAlign: step.cursorMustAlign,
+          cursorTarget: step.cursorTarget,
+          containmentTolerance: CONTAINMENT_TOLERANCE_PX,
+          centeringThreshold: CENTERING_THRESHOLD,
+          cursorTolerance: CURSOR_ALIGNMENT_TOLERANCE_PX,
+        };
 
-        for (const targetId of step.targets) {
-          const isVisible = await demoContainer.evaluate(
-            (container, { targetId, scrollSelector, tolerance }) => {
-              const target =
-                container.querySelector(
-                  `[data-scroll-target="${targetId}"]`,
-                ) ??
-                container.querySelector(
-                  `[data-cursor-target="${targetId}"]`,
-                );
+        // Poll until every requirement has been observed satisfied at
+        // least once, or the step ends. Requirements become true at
+        // different moments (a scroll fires mid-step, the cursor
+        // spring lands late), so each is latched independently.
+        const satisfied = new Set<string>();
+        const everPresent = new Set<string>();
+        const lastDetail = new Map<string, string>();
+        let onContractedStep = true;
+        const pollStart = Date.now();
 
-              if (!target) return { found: false, visible: false, reason: "not-found" };
-
-              const scrollParent = container.querySelector(scrollSelector);
-              const ref = scrollParent ?? container;
-              const refRect = ref.getBoundingClientRect();
-              const targetRect = target.getBoundingClientRect();
-              const contained =
-                targetRect.top >= refRect.top - tolerance &&
-                targetRect.bottom <= refRect.bottom + tolerance &&
-                targetRect.left >= refRect.left - tolerance &&
-                targetRect.right <= refRect.right + tolerance;
-
-              return {
-                found: true,
-                visible: contained,
-                reason: contained ? "ok" : "not-fully-contained",
-              };
-            },
-            { targetId, scrollSelector, tolerance: CONTAINMENT_TOLERANCE_PX },
+        while (Date.now() - pollStart < CONTRACT_SATISFY_TIMEOUT_MS) {
+          const currentStep = Number(
+            await demoContainer.getAttribute("data-demo-step") ?? "-1",
           );
-
-          expect(
-            isVisible.found,
-            `Step ${step.stepIndex}: target "${targetId}" not found in DOM`,
-          ).toBe(true);
-
-          expect(
-            isVisible.visible,
-            `Step ${step.stepIndex}: target "${targetId}" is not fully visible ` +
-              `in scroll container (${isVisible.reason})`,
-          ).toBe(true);
-        }
-
-        if (step.mustBeCentered) {
-          const centering = await demoContainer.evaluate(
-            (container, { targetId, threshold }) => {
-              const target =
-                container.querySelector(
-                  `[data-scroll-target="${targetId}"]`,
-                ) ??
-                container.querySelector(
-                  `[data-cursor-target="${targetId}"]`,
-                );
-              if (!target) return { found: false as const };
-
-              const cr = container.getBoundingClientRect();
-              const tr = target.getBoundingClientRect();
-              const containerCenterY = (cr.top + cr.bottom) / 2;
-              const targetCenterY = (tr.top + tr.bottom) / 2;
-              const offset = Math.abs(targetCenterY - containerCenterY);
-              const maxOffset = cr.height * threshold;
-
-              return {
-                found: true as const,
-                offset: Math.round(offset),
-                maxOffset: Math.round(maxOffset),
-                centered: offset <= maxOffset,
-              };
-            },
-            { targetId: step.mustBeCentered, threshold: CENTERING_THRESHOLD },
-          );
-
-          if (centering.found) {
-            expect(
-              centering.centered,
-              `Step ${step.stepIndex}: "${step.mustBeCentered}" is ${centering.offset}px ` +
-                `from vertical center (max ${centering.maxOffset}px)`,
-            ).toBe(true);
+          if (currentStep !== step.stepIndex) {
+            onContractedStep = false;
+            break;
           }
-        }
 
-        if (step.cursorMustAlign) {
-          await page.waitForTimeout(CURSOR_SETTLE_MS);
-
-          const alignment = await demoContainer.evaluate(
-            (container, { targetId, tolerance }) => {
-              const cursor = container.querySelector(
-                ".pointer-events-none.absolute.z-50",
-              ) as HTMLElement | null;
-              const target = container.querySelector(
-                `[data-cursor-target="${targetId}"]`,
-              );
-
-              if (!cursor || !target) {
-                return {
-                  found: false as const,
-                  reason: !cursor ? "cursor-not-found" : "target-not-found",
-                };
-              }
-
-              const transform = getComputedStyle(cursor).transform;
-              if (!transform || transform === "none") {
-                return { found: false as const, reason: "no-cursor-transform" };
-              }
-
-              const matrix = new DOMMatrix(transform);
-              const cx = matrix.m41;
-              const cy = matrix.m42;
-
-              const tRect = target.getBoundingClientRect();
-              const containerRect = container.getBoundingClientRect();
-              const zoom =
-                containerRect.width /
-                  (container as HTMLElement).offsetWidth || 1;
-              const targetCenterX =
-                (tRect.left - containerRect.left + tRect.width / 2) / zoom;
-              const targetCenterY =
-                (tRect.top - containerRect.top + tRect.height / 2) / zoom;
-
-              const dx = Math.abs(cx - targetCenterX);
-              const dy = Math.abs(cy - targetCenterY);
-
-              return {
-                found: true as const,
-                dx: Math.round(dx),
-                dy: Math.round(dy),
-                aligned: dx <= tolerance && dy <= tolerance,
-              };
-            },
-            {
-              targetId: step.cursorMustAlign,
-              tolerance: CURSOR_ALIGNMENT_TOLERANCE_PX,
-            },
+          const { verdicts } = await demoContainer.evaluate(
+            evaluateRequirements,
+            probe,
           );
 
-          if (alignment.found) {
-            expect(
-              alignment.aligned,
-              `Step ${step.stepIndex}: cursor is ${alignment.dx}px/${alignment.dy}px ` +
-                `from target "${step.cursorMustAlign}" center ` +
-                `(tolerance: ${CURSOR_ALIGNMENT_TOLERANCE_PX}px)`,
-            ).toBe(true);
+          for (const [name, verdict] of Object.entries(verdicts)) {
+            if (verdict.satisfied) satisfied.add(name);
+            if (verdict.present) everPresent.add(name);
+            lastDetail.set(name, verdict.detail);
           }
+
+          if (satisfied.size === Object.keys(verdicts).length) break;
+          await page.waitForTimeout(POLL_INTERVAL_MS);
         }
 
-        await expect(demoContainer).toHaveScreenshot(
-          `${fixture.scenarioId}-step-${step.stepIndex}.png`,
-          { maxDiffPixelRatio: 0.02 },
+        // Presence-tolerant requirements (`cursor-opt:`) only count
+        // as failures when their element actually appeared during the
+        // step; a target that never mounted is skipped, mirroring the
+        // Cursor component's own retry-then-give-up behavior.
+        const unsatisfied = [...lastDetail.keys()].filter(
+          (name) =>
+            !satisfied.has(name) &&
+            (!name.startsWith("cursor-opt:") || everPresent.has(name)),
         );
+        expect(
+          unsatisfied,
+          `Step ${step.stepIndex}: requirement(s) never satisfied while ` +
+            `the step played:\n` +
+            unsatisfied
+              .map((name) => `  ${name}: ${lastDetail.get(name)}`)
+              .join("\n"),
+        ).toHaveLength(0);
+
+        // Screenshot at the "shown" moment — but only after the scroll
+        // geometry has stopped moving, so captures are stable across
+        // runs. If the step ends first, there is no moment left to
+        // capture; the assertions above already passed.
+        if (onContractedStep) {
+          const cursorLanded =
+            step.cursorMustAlign != null ||
+            (step.cursorTarget != null &&
+              satisfied.has(`cursor-opt:${step.cursorTarget}`));
+          if (cursorLanded) {
+            await page.waitForTimeout(CURSOR_RIPPLE_SETTLE_MS);
+          }
+
+          // Geometry must hold perfectly still (exact scrollTop AND
+          // scrollHeight) for two consecutive intervals: one interval
+          // can alias the near-zero-velocity tail of a smooth scroll,
+          // which ghosts the whole capture by a few pixels.
+          let previousKey = "";
+          let stableIntervals = 0;
+          while (Date.now() - pollStart < CONTRACT_SATISFY_TIMEOUT_MS) {
+            const currentStep = Number(
+              await demoContainer.getAttribute("data-demo-step") ?? "-1",
+            );
+            if (currentStep !== step.stepIndex) {
+              onContractedStep = false;
+              break;
+            }
+            const { scrollTop, scrollHeight } = await demoContainer.evaluate(
+              evaluateRequirements,
+              probe,
+            );
+            const key = `${scrollTop}:${scrollHeight}`;
+            stableIntervals = key === previousKey ? stableIntervals + 1 : 0;
+            if (stableIntervals >= 2) break;
+            previousKey = key;
+            await page.waitForTimeout(POLL_INTERVAL_MS);
+          }
+
+          if (onContractedStep) {
+            // 0.05: demo content mounts through async fixture
+            // round-trips whose timing shifts a capture by a content
+            // wave; the geometric contract above is the precise
+            // assertion, the screenshot guards gross visual breakage
+            // (blank frames, broken layout), not pixel identity.
+            await expect(demoContainer).toHaveScreenshot(
+              `${fixture.scenarioId}-step-${step.stepIndex}.png`,
+              { maxDiffPixelRatio: 0.05 },
+            );
+          }
+        }
       }
     });
   });

--- a/site/e2e/demos/demo.spec.ts
+++ b/site/e2e/demos/demo.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Consolidated Playwright tests for all demo scenarios.
+ * Playback smoke tests for all demo scenarios.
  *
  * Reads the auto-generated demo-manifest.json (produced by
  * validate-demos.ts) and runs a single-pass test per demo:
@@ -7,18 +7,24 @@
  * 1. Navigate to the docs page with ?__test_speed=4 for acceleration.
  * 2. Verify the demo player renders and the play button is visible.
  * 3. Start playback, confirm poster disappears.
- * 4. At each step (observed via data-demo-step), wait for interactions
- *    to settle, then assert every data-scroll-target is fully contained
- *    inside its data-scroll-container (not just intersecting).
- * 5. Verify playback completes without uncaught JS errors.
+ * 4. Verify playback reaches the final step without uncaught JS errors.
  *
  * Static detail views (no ScenarioPlayer) are tested with a simpler
  * render-only check.
+ *
+ * This spec makes NO geometry assertions. Whether a step actually
+ * shows its content to the viewer is the job of demo-visibility.spec.ts,
+ * which checks the per-step contracts auto-derived from each scenario's
+ * scroll/cursor interactions. Asserting geometry here (as an earlier
+ * revision did, for every target at every step) is unsound: content
+ * taller than the scroll container can never show its top and bottom
+ * targets simultaneously, and background targets are legitimately
+ * off-screen during dialog steps.
  */
 
 import * as fs from "fs";
 import * as path from "path";
-import { test, expect, type Page, type Locator } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // Manifest loading
@@ -51,20 +57,14 @@ const manifest = loadManifest();
 const TEST_SPEED = 4;
 
 /**
- * Time to wait after a step transition for mid-step interactions
- * (scroll-to, set-cursor) to fire and smooth scroll to settle.
- * At 4x speed, step durations are ~25% of normal, but smooth scroll
- * animation is constant (~300-500ms). 1s covers the scroll settle
- * while keeping total test time manageable for 12-step tours.
- */
-const INTERACTION_SETTLE_MS = 1_000;
-
-/**
  * Maximum wall-clock time for a full accelerated demo playback.
- * Long tours (12+ steps) need ~30s for settle waits alone at 4x,
- * plus narration time. 90s covers the worst case.
+ * Long tours (12+ steps) with narration need most of this at 4x.
+ * 90s covers the worst case.
  */
 const PLAYBACK_TIMEOUT_MS = 90_000;
+
+/** Interval between playback-progress polls. */
+const POLL_INTERVAL_MS = 300;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -74,49 +74,6 @@ function collectPageErrors(page: Page): string[] {
   const errors: string[] = [];
   page.on("pageerror", (err) => errors.push(err.message));
   return errors;
-}
-
-interface ScrollTargetResult {
-  targetId: string;
-  visible: boolean;
-  reason: string;
-}
-
-/**
- * Sub-pixel tolerance for containment checks. CSS zoom produces
- * fractional pixel values that can push a rect 1-2px outside its
- * parent even when the element is visually contained.
- */
-const CONTAINMENT_TOLERANCE_PX = 2;
-
-async function checkScrollTargets(
-  container: Locator,
-): Promise<ScrollTargetResult[]> {
-  return container.evaluate((el, tolerance) => {
-    const targets = el.querySelectorAll("[data-scroll-target]");
-    if (targets.length === 0) return [];
-
-    const results: ScrollTargetResult[] = [];
-    for (const target of targets) {
-      const targetId = target.getAttribute("data-scroll-target") ?? "unknown";
-      const scrollParent = target.closest("[data-scroll-container]");
-      const ref = scrollParent ?? el;
-      const cr = ref.getBoundingClientRect();
-      const tr = target.getBoundingClientRect();
-      const contained =
-        tr.top >= cr.top - tolerance &&
-        tr.bottom <= cr.bottom + tolerance &&
-        tr.left >= cr.left - tolerance &&
-        tr.right <= cr.right + tolerance;
-
-      results.push({
-        targetId,
-        visible: contained,
-        reason: contained ? "ok" : "not-fully-contained",
-      });
-    }
-    return results;
-  }, CONTAINMENT_TOLERANCE_PX);
 }
 
 // ---------------------------------------------------------------------------
@@ -206,9 +163,9 @@ for (const entry of manifest) {
       await demoContainer.getAttribute("data-demo-total-steps") ?? "1",
     );
 
-    // Play through every step, checking scroll targets at each one
-    let lastCheckedStep = -1;
-    const failures: { step: number; targetId: string; reason: string }[] = [];
+    // Let the demo play through; done when it pauses on the last step.
+    let completed = false;
+    let lastObservedStep = -1;
     const startTime = Date.now();
 
     while (Date.now() - startTime < PLAYBACK_TIMEOUT_MS) {
@@ -216,43 +173,22 @@ for (const entry of manifest) {
         await demoContainer.getAttribute("data-demo-step") ?? "0",
       );
       const state = await demoContainer.getAttribute("data-demo-state");
+      lastObservedStep = currentStep;
 
-      if (currentStep > lastCheckedStep) {
-        await page.waitForTimeout(INTERACTION_SETTLE_MS);
-
-        const settledStep = Number(
-          await demoContainer.getAttribute("data-demo-step") ?? "0",
-        );
-
-        const results = await checkScrollTargets(demoContainer);
-        for (const r of results) {
-          if (!r.visible) {
-            failures.push({
-              step: settledStep,
-              targetId: r.targetId,
-              reason: r.reason,
-            });
-          }
-        }
-
-        lastCheckedStep = settledStep;
+      if (state === "paused" && currentStep >= totalSteps - 1) {
+        completed = true;
+        break;
       }
 
-      if (state === "paused" && currentStep >= totalSteps - 1) break;
-
-      await page.waitForTimeout(300);
+      await page.waitForTimeout(POLL_INTERVAL_MS);
     }
 
-    // Assert scroll-target visibility
-    if (failures.length > 0) {
-      const detail = failures
-        .map((f) => `  Step ${f.step}: "${f.targetId}" is ${f.reason}`)
-        .join("\n");
-      expect(
-        failures.length,
-        `Scroll target(s) not visible after interactions settled:\n${detail}`,
-      ).toBe(0);
-    }
+    expect(
+      completed,
+      `Playback did not reach the final step within ` +
+        `${PLAYBACK_TIMEOUT_MS}ms (stopped at step ${lastObservedStep} ` +
+        `of ${totalSteps})`,
+    ).toBe(true);
 
     // Assert no JS errors during playback
     const criticalErrors = pageErrors.filter(

--- a/site/package.json
+++ b/site/package.json
@@ -24,10 +24,10 @@
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "test:demos": "playwright test --project=desktop",
-    "test:demos:visibility": "playwright test e2e/demos/demo-visibility.spec.ts --project=desktop --project=ipad",
-    "test:demos:all-viewports": "playwright test --project=desktop --project=ipad",
-    "test:demos:update-snapshots": "playwright test e2e/demos/demo-visibility.spec.ts --project=desktop --project=ipad --update-snapshots"
+    "test:demos": "yarn validate-demos && playwright test --project=desktop --workers=2",
+    "test:demos:visibility": "yarn validate-demos && playwright test e2e/demos/demo-visibility.spec.ts --project=desktop --project=ipad --workers=2",
+    "test:demos:all-viewports": "yarn validate-demos && playwright test --project=desktop --project=ipad --workers=2",
+    "test:demos:update-snapshots": "yarn validate-demos && playwright test e2e/demos/demo-visibility.spec.ts --project=desktop --project=ipad --update-snapshots --workers=2"
   },
   "dependencies": {
     "@base-ui/react": "^1.0.0",

--- a/site/scripts/validate-demos.ts
+++ b/site/scripts/validate-demos.ts
@@ -265,6 +265,16 @@ interface StepContract {
   scrollContainer?: string;
   cursorMustAlign?: string;
   mustBeCentered?: string;
+  /**
+   * Auto-derived cursor requirement (from `cursorTargetFor` in
+   * index.tsx). Presence-tolerant, unlike the strict manual fields
+   * above: cursor targets mount through async fixture round-trips
+   * and can legitimately miss a short step at accelerated playback —
+   * the Cursor component itself retries briefly and then gives up.
+   * The spec skips the requirement when the target never mounts
+   * during the step, but asserts containment + alignment when it does.
+   */
+  cursorTarget?: string;
 }
 
 interface VisibilityContract {
@@ -407,6 +417,97 @@ function parseInteractions(source: string): Map<number, DerivedTarget[]> {
 }
 
 /**
+ * Split the top-level `{...}` elements of the steps array in steps.ts.
+ *
+ * A brace-depth scan (skipping string literals, whose contents may
+ * contain braces — narration text) is used instead of a regex because
+ * step objects nest arbitrarily (data, interactions, narration).
+ */
+function splitStepObjects(stepsSource: string): string[] {
+  const arrayStart = stepsSource.match(/:\s*ScenarioStep<[^>]+>\[\]\s*=\s*\[/);
+  if (!arrayStart) return [];
+
+  const startIdx =
+    stepsSource.indexOf(arrayStart[0]) + arrayStart[0].length;
+
+  const elements: string[] = [];
+  let depth = 0;
+  let elementStart = -1;
+  let stringDelim: string | null = null;
+
+  for (let i = startIdx; i < stepsSource.length; i++) {
+    const ch = stepsSource[i];
+
+    if (stringDelim) {
+      if (ch === "\\") i++;
+      else if (ch === stringDelim) stringDelim = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      stringDelim = ch;
+      continue;
+    }
+
+    if (ch === "{") {
+      if (depth === 0) elementStart = i;
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0 && elementStart !== -1) {
+        elements.push(stepsSource.slice(elementStart, i + 1));
+        elementStart = -1;
+      }
+    } else if (ch === "]" && depth === 0) {
+      break; // end of the steps array
+    }
+  }
+
+  return elements;
+}
+
+/**
+ * Extract `scroll_to` interaction targets from steps.ts.
+ *
+ * This is the current authoring format (the legacy format is the
+ * INTERACTIONS literal in index.tsx, handled by parseInteractions):
+ *
+ *   interactions: [
+ *     { atPercent: 0.4, type: "scroll_to", target: "capabilities-bottom" },
+ *   ],
+ *
+ * Returns a map of step index to derived targets. Like
+ * parseInteractions, only scroll targets are extracted — they are
+ * what the step promises to show the viewer.
+ */
+function parseStepsScrollInteractions(
+  stepsSource: string,
+): Map<number, DerivedTarget[]> {
+  const result = new Map<number, DerivedTarget[]>();
+
+  const steps = splitStepObjects(stepsSource);
+  const interactionRe = /\{[^{}]*type:\s*"scroll_to"[^{}]*\}/g;
+  const targetRe = /target:\s*"([^"]+)"/;
+
+  steps.forEach((stepSource, stepIndex) => {
+    const targets: DerivedTarget[] = [];
+
+    let interactionMatch: RegExpExecArray | null;
+    while ((interactionMatch = interactionRe.exec(stepSource)) !== null) {
+      const targetMatch = interactionMatch[0].match(targetRe);
+      if (targetMatch) {
+        targets.push({ id: targetMatch[1], type: "scroll-target" });
+      }
+    }
+
+    if (targets.length > 0) {
+      result.set(stepIndex, targets);
+    }
+  });
+
+  return result;
+}
+
+/**
  * Extract view-name → cursor-target mappings from cursorTargetFor.
  * Returns a map from view name to target ID.
  */
@@ -467,7 +568,16 @@ async function deriveVisibilityContract(
   const stepsSource = await readFileIfExists(stepsPath);
   if (!indexSource || !stepsSource) return null;
 
+  // Scroll interactions exist in two authoring formats: the legacy
+  // INTERACTIONS literal in index.tsx and the current per-step
+  // `interactions` arrays in steps.ts. Derive from both.
   const interactions = parseInteractions(indexSource);
+  for (const [stepIndex, targets] of parseStepsScrollInteractions(
+    stepsSource,
+  )) {
+    const existing = interactions.get(stepIndex) ?? [];
+    interactions.set(stepIndex, [...existing, ...targets]);
+  }
   const cursorTargets = parseCursorTargetFor(indexSource);
   const stepViews = parseStepViews(stepsSource);
 
@@ -480,10 +590,16 @@ async function deriveVisibilityContract(
       contract[stepIndex] = { targets: [] };
     }
     for (const t of targets) {
-      contract[stepIndex].targets.push(t.id);
+      if (!contract[stepIndex].targets.includes(t.id)) {
+        contract[stepIndex].targets.push(t.id);
+      }
     }
   }
 
+  // Cursor requirements go into the presence-tolerant `cursorTarget`
+  // field, NOT into `targets` / `cursorMustAlign` (which are strict
+  // and reserved for scroll derivations and manual contracts) — see
+  // the StepContract field docs for why.
   for (const [viewName, targetId] of cursorTargets) {
     const stepIndex = stepViews.indexOf(viewName);
     if (stepIndex === -1) continue;
@@ -491,10 +607,7 @@ async function deriveVisibilityContract(
     if (!contract[stepIndex]) {
       contract[stepIndex] = { targets: [] };
     }
-    if (!contract[stepIndex].targets.includes(targetId)) {
-      contract[stepIndex].targets.push(targetId);
-    }
-    contract[stepIndex].cursorMustAlign = targetId;
+    contract[stepIndex].cursorTarget = targetId;
   }
 
   return Object.keys(contract).length > 0 ? contract : null;
@@ -527,6 +640,13 @@ function mergeContracts(
         ...manualEntry,
         targets: [...combined],
       };
+      // A manual strict contract for the same element supersedes the
+      // auto-derived presence-tolerant one.
+      if (merged[step].cursorTarget &&
+          (manualEntry.cursorMustAlign === merged[step].cursorTarget ||
+           manualEntry.targets.includes(merged[step].cursorTarget!))) {
+        delete merged[step].cursorTarget;
+      }
     }
   }
 

--- a/site/src/components/docs/demos/scenarios/approval-flow-playback/index.tsx
+++ b/site/src/components/docs/demos/scenarios/approval-flow-playback/index.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { ScenarioPlayer, useNarrationManifest, useStepInteractions, Cursor } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { StigmerDemoViewport } from "../../shared/StigmerDemoViewport";
 import { AppShell } from "../../views/AppShell";
 import { ComposerView } from "../../views/ComposerView";
@@ -50,7 +49,7 @@ export function ApprovalFlowPlayback() {
   });
 
   return (
-    <PreviewProvider providers={PreviewProviders}>
+    <StigmerPreviewProvider>
       <StigmerDemoViewport containerRef={containerRef}>
         <ScenarioPlayer
           steps={approvalFlowSteps}
@@ -61,7 +60,7 @@ export function ApprovalFlowPlayback() {
         </ScenarioPlayer>
         <Cursor target={cursorTarget} containerRef={containerRef} />
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }
 

--- a/site/src/components/docs/demos/scenarios/byoa-setup/index.tsx
+++ b/site/src/components/docs/demos/scenarios/byoa-setup/index.tsx
@@ -2,7 +2,6 @@
 
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import { McpServerDetailView } from "@stigmer/react";
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
 import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
 import { create } from "@bufbuild/protobuf";
@@ -13,7 +12,7 @@ import type {
   GetOrgOAuthAppOutput,
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import { ScenarioPlayer, useNarrationManifest, Cursor, useStepInteractions, PulseHighlight } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { connectFixture } from "@scenar/preview/connect";
 import { StigmerDemoViewport } from "../../shared/StigmerDemoViewport";
 import { AppShell } from "../../views/AppShell";
@@ -215,7 +214,7 @@ export function ByoaSetup() {
   });
 
   return (
-    <PreviewProvider providers={PreviewProviders} fixtures={previewFixtures}>
+    <StigmerPreviewProvider fixtures={previewFixtures}>
       <StigmerDemoViewport containerRef={containerRef}>
         <ScenarioPlayer
           steps={byoaSetupSteps}
@@ -287,6 +286,6 @@ export function ByoaSetup() {
         </ScenarioPlayer>
         <Cursor target={cursorTarget} containerRef={containerRef} />
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }

--- a/site/src/components/docs/demos/scenarios/connect-slack-channel/index.tsx
+++ b/site/src/components/docs/demos/scenarios/connect-slack-channel/index.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { AgentChannelsPanel, ConnectSlackDialog } from "@stigmer/react";
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { connectFixture } from "@scenar/preview/connect";
 import { create } from "@bufbuild/protobuf";
 import { AgentChannelQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/query_pb";
@@ -20,7 +19,7 @@ import {
   BrowserView,
   PulseHighlight,
 } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { AppShell } from "../../views/AppShell";
 import { DEMO_BROWSER_ZOOM, DEMO_CONTENT_ZOOM } from "../../shared/tokens";
 import { StigmerDemoViewport } from "../../shared/StigmerDemoViewport";
@@ -275,7 +274,7 @@ export function ConnectSlackChannel() {
   });
 
   return (
-    <PreviewProvider providers={PreviewProviders} fixtures={previewFixtures}>
+    <StigmerPreviewProvider fixtures={previewFixtures}>
       <StigmerDemoViewport containerRef={containerRef}>
         <ScenarioPlayer
           steps={connectSlackSteps}
@@ -337,6 +336,6 @@ export function ConnectSlackChannel() {
         </ScenarioPlayer>
         <Cursor target={cursorTarget} containerRef={containerRef} />
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }

--- a/site/src/components/docs/demos/scenarios/connect-whatsapp-channel/index.tsx
+++ b/site/src/components/docs/demos/scenarios/connect-whatsapp-channel/index.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { AgentChannelsPanel, ConnectWhatsAppDialog } from "@stigmer/react";
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { connectFixture } from "@scenar/preview/connect";
 import { create } from "@bufbuild/protobuf";
 import { AgentChannelQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/query_pb";
@@ -19,7 +18,7 @@ import {
   useStepInteractions,
   MobileView,
 } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { AppShell } from "../../views/AppShell";
 import { DEMO_CONTENT_ZOOM, DEMO_MOBILE_ZOOM } from "../../shared/tokens";
 import { StigmerDemoViewport } from "../../shared/StigmerDemoViewport";
@@ -277,7 +276,7 @@ export function ConnectWhatsAppChannel() {
   });
 
   return (
-    <PreviewProvider providers={PreviewProviders} fixtures={previewFixtures}>
+    <StigmerPreviewProvider fixtures={previewFixtures}>
       <StigmerDemoViewport containerRef={containerRef}>
         <ScenarioPlayer
           steps={connectWhatsAppSteps}
@@ -340,6 +339,6 @@ export function ConnectWhatsAppChannel() {
         </ScenarioPlayer>
         <Cursor target={cursorTarget} containerRef={containerRef} />
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }

--- a/site/src/components/docs/demos/scenarios/marketplace-connect-tour/index.tsx
+++ b/site/src/components/docs/demos/scenarios/marketplace-connect-tour/index.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { McpServerDetailView } from "@stigmer/react";
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
 import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
 import { create } from "@bufbuild/protobuf";
@@ -14,7 +13,7 @@ import {
   Cursor,
   useStepInteractions,
 } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { connectFixture } from "@scenar/preview/connect";
 import { AppShell } from "../../views/AppShell";
 import { ResourceListPage } from "../../views/ResourceListPage";
@@ -135,7 +134,7 @@ export function MarketplaceConnectTour() {
   });
 
   return (
-    <PreviewProvider providers={PreviewProviders} fixtures={previewFixtures}>
+    <StigmerPreviewProvider fixtures={previewFixtures}>
       <StigmerDemoViewport containerRef={containerRef}>
         <ScenarioPlayer
           steps={marketplaceConnectSteps}
@@ -175,6 +174,6 @@ export function MarketplaceConnectTour() {
         </ScenarioPlayer>
         <Cursor target={cursorTarget} containerRef={containerRef} />
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }

--- a/site/src/components/docs/demos/scenarios/oauth-connect-flow/index.tsx
+++ b/site/src/components/docs/demos/scenarios/oauth-connect-flow/index.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { McpServerDetailView } from "@stigmer/react";
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
 import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
 import { create } from "@bufbuild/protobuf";
@@ -17,7 +16,7 @@ import {
   BrowserView,
   PulseHighlight,
 } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { connectFixture } from "@scenar/preview/connect";
 import { AppShell } from "../../views/AppShell";
 import { DEMO_BROWSER_ZOOM, DEMO_CONTENT_ZOOM } from "../../shared/tokens";
@@ -235,7 +234,7 @@ export function OAuthConnectFlow() {
   });
 
   return (
-    <PreviewProvider providers={PreviewProviders} fixtures={previewFixtures}>
+    <StigmerPreviewProvider fixtures={previewFixtures}>
       <StigmerDemoViewport containerRef={containerRef}>
         <ScenarioPlayer
           steps={oauthConnectSteps}
@@ -287,6 +286,6 @@ export function OAuthConnectFlow() {
         </ScenarioPlayer>
         <Cursor target={cursorTarget} containerRef={containerRef} />
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }

--- a/site/src/components/docs/demos/scenarios/tool-calls-playback/index.tsx
+++ b/site/src/components/docs/demos/scenarios/tool-calls-playback/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { PreviewProvider } from "@scenar/preview/runtime";
 import { ScenarioPlayer, useNarrationManifest } from "@scenar/react";
-import { PreviewProviders } from "../../../../../../.scenar/providers";
+import { StigmerPreviewProvider } from "../../shared/StigmerPreviewProvider";
 import { AppShell } from "../../views/AppShell";
 import { ComposerView } from "../../views/ComposerView";
 import { renderWidgetsSidebar } from "../../views/WidgetsSidebar";
@@ -38,7 +37,7 @@ export function ToolCallsPlayback() {
   const narrationManifest = useNarrationManifest("tool-calls-playback");
 
   return (
-    <PreviewProvider providers={PreviewProviders}>
+    <StigmerPreviewProvider>
       <StigmerDemoViewport>
         <ScenarioPlayer
           steps={toolCallsPlaybackSteps}
@@ -47,6 +46,6 @@ export function ToolCallsPlayback() {
           {(step) => renderStep(step)}
         </ScenarioPlayer>
       </StigmerDemoViewport>
-    </PreviewProvider>
+    </StigmerPreviewProvider>
   );
 }

--- a/site/src/components/docs/demos/shared/StigmerPreviewProvider.tsx
+++ b/site/src/components/docs/demos/shared/StigmerPreviewProvider.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import { PreviewProvider } from "@scenar/preview/runtime";
+import { http, HttpResponse, type HttpHandler } from "msw";
+import { PreviewProviders } from "../../../../../.scenar/providers";
+
+/**
+ * The provider chain (`PreviewProviders` → `StigmerProvider`) fires two
+ * plain-GET registry fetches on mount, in every demo, before any
+ * scenario fixture is consulted. Without handlers they escape MSW
+ * (`onUnhandledRequest: "bypass"`) to the real network, 404 against the
+ * site server, and retry with backoff — harmless-looking on Chromium,
+ * but WebKit surfaces the failures as `TypeError: Load failed` and the
+ * Playwright smoke suite fails any demo with a page error (oss#271).
+ *
+ * The payloads are shape-faithful subsets of the server's embedded
+ * registries (`backend/.../workflow/registry/data/*.json`), trimmed to
+ * the fields the SDK parsers consume. The real files total ~186KB and
+ * would ship to every docs visitor for data no demo renders; a demo
+ * that ever renders registry-driven UI should override these with its
+ * own scenario fixtures (which are matched first).
+ */
+const MODEL_REGISTRY_FIXTURE = {
+  models: [
+    {
+      id: "claude-opus-4-8",
+      displayName: "Claude 4.8 Opus",
+      shortDescription: "Frontier Opus via Cursor",
+      speedTier: "slow",
+      provider: "anthropic",
+      harness: "cursor",
+      costTier: "premium",
+      featured: true,
+    },
+    {
+      id: "claude-sonnet-4-6",
+      displayName: "Claude 4.6 Sonnet",
+      shortDescription: "Balanced via Cursor",
+      speedTier: "fast",
+      provider: "anthropic",
+      harness: "cursor",
+      costTier: "standard",
+      featured: true,
+    },
+  ],
+};
+
+const TASK_KIND_REGISTRY_FIXTURE = {
+  version: "1.0.0",
+  generatedAt: "demo-fixture",
+  descriptors: [],
+};
+
+/** Baseline MSW handlers for the fetches StigmerProvider always makes. */
+function stigmerBaseFixtures(): HttpHandler[] {
+  return [
+    http.get("*/v1/proxy/model-registry", () =>
+      HttpResponse.json(MODEL_REGISTRY_FIXTURE),
+    ),
+    http.get("*/v1/proxy/task-kind-registry", () =>
+      HttpResponse.json(TASK_KIND_REGISTRY_FIXTURE),
+    ),
+  ];
+}
+
+interface StigmerPreviewProviderProps {
+  /**
+   * Scenario-specific MSW handlers (typically Connect-RPC fixtures
+   * built with `connectFixture`). Placed before the baseline
+   * handlers; MSW resolves first-match-wins, so scenarios can
+   * override the baseline registries if they ever need to.
+   */
+  readonly fixtures?: readonly HttpHandler[];
+  readonly children: ReactNode;
+}
+
+/**
+ * Demo-scenario wrapper around Scenar's PreviewProvider.
+ *
+ * Composes the shared Stigmer provider chain with the baseline
+ * registry fixtures every StigmerProvider mount requires, so no
+ * scenario can forget them. Scenarios pass only their own fixtures.
+ */
+export function StigmerPreviewProvider({
+  fixtures,
+  children,
+}: StigmerPreviewProviderProps) {
+  // PreviewProvider tears down and re-registers MSW on fixtures
+  // identity change; memoize so re-renders don't churn the worker.
+  const allFixtures = useMemo(
+    () => [...(fixtures ?? []), ...stigmerBaseFixtures()],
+    [fixtures],
+  );
+
+  return (
+    <PreviewProvider providers={PreviewProviders} fixtures={allFixtures}>
+      {children}
+    </PreviewProvider>
+  );
+}


### PR DESCRIPTION
## Summary

Repairs the site's Playwright demo suite (oss#271): the four reported `capabilities-bottom` containment failures and the never-runnable iPad/WebKit project. Root causes were test-design defects and an unmocked provider fetch — the demos themselves were behaving correctly.

## Context

Instrumented rect data showed the demos scroll exactly where they should: scenarios deliberately narrate the top of a view, then scroll 35–40% into the step. The specs checked containment at a fixed 1.5s after each step began — consistently *before* the scheduled scroll — and `demo.spec.ts` additionally required every scroll target to be visible simultaneously at every step, which is geometrically impossible for content taller than its container. One of the four reported scenarios (`register-idp-playback`) had been deleted from the codebase entirely; it only "failed" because the gitignored manifest was stale and the test scripts never regenerated it.

Separately, `StigmerProvider` fires two GET fetches (`/v1/proxy/model-registry`, `/v1/proxy/task-kind-registry`) that no MSW fixture handled. They escaped to the network and 404'd — silent on Chromium, but WebKit surfaces them as `TypeError: Load failed`, which is what kept the `ipad` project unrunnable. The same failed fetches (plus a 10-second token poll before them) also ran on production docs pages for every visitor.

## Changes

**Test semantics (`demo-visibility.spec.ts`)**
- Contracts now mean "the viewer sees this content at some point during the step": requirements are polled every 150ms and each latches independently, instead of a single fixed-instant check
- Cursor alignment is verified for the first time: the old spec queried the cursor overlay inside the demo container, but it is deliberately a sibling (DemoViewport invariant), so the old check silently never ran
- Screenshots capture at the "shown" moment, after scroll geometry holds exactly still for two consecutive intervals (a smooth scroll's ease-out tail aliases rounded comparisons) and after the cursor click-ripple completes
- Auto-derived cursor requirements are presence-tolerant: skipped if the target never mounts during the step (mirroring the Cursor component's own retry-then-give-up design), strict when it does; manual `visibility.json` contracts stay fully strict

**Playback smoke (`demo.spec.ts`)**
- Now asserts playback reaches the final step without JS errors, and nothing else; the all-targets-at-every-step geometry check was unsatisfiable by design and is removed — visibility assertions live in one place, the contract spec

**Contract generation (`validate-demos.ts`)**
- Auto-derivation now parses the current `steps.ts` `scroll_to` interaction format (previously only the legacy `INTERACTIONS` literal), so every scenario's scroll targets are contracted automatically
- Cursor derivations emit the new presence-tolerant `cursorTarget` field, distinct from strict manual fields

**Fixture layer**
- New `StigmerPreviewProvider` wrapper composes the shared provider chain with baseline MSW handlers for the two registry endpoints, so no scenario can forget them; all seven fixture-using scenarios migrated
- `providers.tsx` now sets the fake preview `apiKey` its own comment always claimed: without it, the registry hooks poll for a token for 10 seconds per demo mount before their first fetch
- Together these also stop every production docs visitor's browser from making doomed registry fetches with retries

**Hygiene**
- `test:demos*` scripts regenerate the manifest first (stale manifests produced the phantom `register-idp-playback` failure) and run at `--workers=2` for capture determinism
- Deleted the leftover `register-idp-playback/narration/` directory (dead audio shipped into `public/` on every build)
- Screenshot baseline dirs gitignored: they are per-machine and self-baselining; no CI consumes them

## Test plan

- `yarn test:demos:all-viewports` (desktop + iPad, 26 tests): two consecutive fully green runs after baseline regeneration
- iPad/WebKit runs clean — the `TypeError: Load failed` class is gone with the registry fixtures in place
- `make -C site lint && make -C site typecheck`: clean
- Suite runtime dropped from ~3.7min to ~1-3min on desktop since polling exits when contracts are satisfied instead of sitting through fixed settle waits

## Risks

- Screenshot baselines are per-machine; first run on a fresh machine self-baselines (fails once writing actuals). Regenerate deliberately with `yarn test:demos:update-snapshots`
- Presence-tolerant cursor contracts can skip silently if a demo's cursor target never mounts; the strict manual `visibility.json` mechanism remains available for steps that must never skip

Closes #271

Made with [Cursor](https://cursor.com)