### PR TITLE
fix(sdk-react): retry bare discovery in McpServerPicker after an OAuth discovery-leg failure

### DIFF
--- a/sdk/react/src/mcp-server/McpServerConfigPanel.tsx
+++ b/sdk/react/src/mcp-server/McpServerConfigPanel.tsx
@@ -14,7 +14,10 @@ import {
   type EnvVarFormSubmitOptions,
 } from "../environment/EnvVarForm.js";
 import { McpToolSelector } from "./McpToolSelector.js";
-import type { OAuthConnectPhase } from "./useMcpServerOAuthConnect.js";
+import {
+  getOAuthConnectErrorMessage,
+  type OAuthConnectPhase,
+} from "./useMcpServerOAuthConnect.js";
 
 // ---------------------------------------------------------------------------
 // Credential sub-props
@@ -93,8 +96,27 @@ export interface McpServerOAuthSignInProps {
   readonly onClearDisconnectError?: () => void;
   /** Error from the most recent failed OAuth attempt, or `null`. */
   readonly error: Error | null;
+  /**
+   * The OAuth flow phase in which {@link error} was thrown, or `null`.
+   *
+   * Threading it lets the panel compose error copy through
+   * `getOAuthConnectErrorMessage`: a `"connecting"`-phase failure means
+   * sign-in SUCCEEDED and only the chained tool discovery failed —
+   * without this, the raw RPC error reads as a failed sign-in
+   * (stigmer/stigmer#418).
+   */
+  readonly failedPhase?: OAuthConnectPhase | null;
   /** Clear the OAuth error state. */
   readonly onClearError: () => void;
+  /**
+   * `true` when the user is signed in but the server has no discovered
+   * tools — the "signed in — tools not discovered yet" state
+   * (stigmer/stigmer#229/#418). The action button reads "Discover tools"
+   * and `onSignIn` is expected to run bare discovery instead of the
+   * OAuth popup. The caller owns that branch; this prop only drives
+   * presentation.
+   */
+  readonly isOAuthStranded?: boolean;
   /**
    * `true` when the platform's OAuth app is pending vendor approval.
    * Disables the sign-in button and shows an informational message.
@@ -331,6 +353,8 @@ export function McpServerConfigPanel({
           disconnectError={oauthSignIn.disconnectError}
           onClearDisconnectError={oauthSignIn.onClearDisconnectError}
           error={oauthSignIn.error}
+          failedPhase={oauthSignIn.failedPhase}
+          isOAuthStranded={oauthSignIn.isOAuthStranded}
           onClearError={oauthSignIn.onClearError}
           isVendorApprovalPending={oauthSignIn.isVendorApprovalPending}
           isVendorApprovalBlocked={oauthSignIn.isVendorApprovalBlocked}
@@ -451,6 +475,8 @@ function InlineOAuthSignIn({
   disconnectError,
   onClearDisconnectError,
   error,
+  failedPhase,
+  isOAuthStranded,
   onClearError,
   isVendorApprovalPending,
   isVendorApprovalBlocked,
@@ -472,6 +498,8 @@ function InlineOAuthSignIn({
   readonly disconnectError?: Error | null;
   readonly onClearDisconnectError?: () => void;
   readonly error: Error | null;
+  readonly failedPhase?: OAuthConnectPhase | null;
+  readonly isOAuthStranded?: boolean;
   readonly onClearError: () => void;
   readonly isVendorApprovalPending?: boolean;
   readonly isVendorApprovalBlocked?: boolean;
@@ -494,17 +522,28 @@ function InlineOAuthSignIn({
     phase === "completing" ||
     phase === "connecting";
 
-  const signInDisabled = isBusy || (!!blocked && !isOrgOAuthApp);
+  // Stranded ("signed in — tools not discovered yet", stigmer/stigmer#418):
+  // the action is bare tool discovery, which needs no OAuth app — so the
+  // vendor-approval block must not gate it.
+  const stranded = !!isOAuthStranded;
+
+  const signInDisabled = isBusy || (!!blocked && !isOrgOAuthApp && !stranded);
   const anyBusy = isBusy || !!isDisconnecting || !!isRemovingOrgApp;
 
   const needsReAuth =
     connectionHealth === OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED;
 
-  const status = inlineHealthProps(
-    connectionHealth,
-    isConnected,
-    !!isVendorApprovalPending && !isOrgOAuthApp,
-  );
+  const status = stranded
+    ? {
+        textClass: "stg:text-amber-600 stg:dark:text-amber-400",
+        dotClass: "stg:bg-amber-500",
+        label: "Signed in \u2014 tools not discovered yet",
+      }
+    : inlineHealthProps(
+        connectionHealth,
+        isConnected,
+        !!isVendorApprovalPending && !isOrgOAuthApp,
+      );
 
   const showDisconnectLink =
     isConnected && onDisconnect && !anyBusy && disconnectPhase === "idle";
@@ -668,7 +707,7 @@ function InlineOAuthSignIn({
           disabled={signInDisabled}
           className={cn(
             "stg:inline-flex stg:items-center stg:gap-1 stg:rounded stg:px-2 stg:py-0.5 stg:text-[0.65rem] stg:font-medium",
-            isConnected && !needsReAuth
+            isConnected && !needsReAuth && !stranded
               ? "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover"
               : "stg:bg-primary stg:text-primary-foreground stg:hover:bg-primary-hover",
             "stg:disabled:pointer-events-none stg:disabled:opacity-50",
@@ -676,6 +715,8 @@ function InlineOAuthSignIn({
         >
           {isBusy ? (
             <InlineSpinner />
+          ) : stranded ? (
+            "Discover tools"
           ) : isOrgOAuthApp && !isConnected ? (
             "Sign in with your app"
           ) : isConnected && !needsReAuth ? (
@@ -728,7 +769,12 @@ function InlineOAuthSignIn({
 
       {error && (
         <div className="stg:flex stg:items-start stg:gap-1.5 stg:text-[0.65rem] stg:text-destructive" role="alert">
-          <span className="stg:flex-1">{getUserMessage(error)}</span>
+          {/* Phase-aware copy: a "connecting"-phase failure means sign-in
+              succeeded and only tool discovery failed — the raw RPC message
+              alone reads as a failed sign-in (stigmer/stigmer#418). */}
+          <span className="stg:flex-1">
+            {getOAuthConnectErrorMessage(error, failedPhase ?? null)}
+          </span>
           <div className="stg:flex stg:shrink-0 stg:items-center stg:gap-1.5">
             {isRetryableError(error) && (
               <button

--- a/sdk/react/src/mcp-server/McpServerPicker.tsx
+++ b/sdk/react/src/mcp-server/McpServerPicker.tsx
@@ -13,6 +13,7 @@ import { cn } from "@stigmer/theme";
 import type { EnvVarInput, McpServerUsageInput, ResourceRef } from "@stigmer/sdk";
 import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OAuthConnectionHealth } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
 import type { EnvVarFormSubmitOptions } from "../environment/EnvVarForm.js";
 import { useMcpServerSearch } from "./useMcpServerSearch.js";
@@ -20,6 +21,7 @@ import { useScrollShadows } from "../internal/useScrollShadows.js";
 import { ScrollFade } from "../internal/ScrollFade.js";
 import { McpServerConfigPanel } from "./McpServerConfigPanel.js";
 import type { McpServerSetupEntry } from "./mcpServerSetupReducer.js";
+import { useMcpServerConnect } from "./useMcpServerConnect.js";
 import { useMcpServerOAuthConnect } from "./useMcpServerOAuthConnect.js";
 import { ScopeToggle } from "../library/ScopeToggle.js";
 import type { ResourceListScope } from "../search/index.js";
@@ -269,6 +271,17 @@ export function McpServerPicker({
   const { results, isLoading, error, query, setQuery } =
     useMcpServerSearch(org, { scope: activeScope });
   const oauth = useMcpServerOAuthConnect();
+  // Bare tool-discovery `connect`, used when sign-in already succeeded and
+  // only the chained discovery leg failed — relaunching the OAuth popup
+  // would burn a consent round for nothing (stigmer/stigmer#418).
+  const discovery = useMcpServerConnect();
+  // The oauth/discovery hooks are single instances shared by every server
+  // in the picker, so their error/phase/failedPhase signals are only
+  // meaningful for the server an attempt was started for. Without this
+  // key, server A's discovery failure would render under server B's
+  // configure view — and worse, make B's sign-in click retry discovery
+  // for a grant B never had.
+  const [oauthAttemptKey, setOauthAttemptKey] = useState<string | null>(null);
 
   const [focusIndex, setFocusIndex] = useState(-1);
   const [view, setView] = useState<PickerView>(() =>
@@ -431,25 +444,101 @@ export function McpServerPicker({
       (oauthStatus?.vendorApprovalStatus === VendorApprovalStatus.PENDING ||
         oauthStatus?.vendorApprovalStatus === VendorApprovalStatus.REJECTED);
 
+    // System env vars are only injected when the server declares them —
+    // the dialog and detail view pass these on every OAuth chain and
+    // bare connect; the picker must too.
+    const declaredEnvKeys = Object.keys(entry.mcpServer.spec?.env ?? {});
+
+    // Scope the shared hooks' signals to the server they belong to.
+    const isOwnOAuthAttempt = oauthAttemptKey === view.serverKey;
+    const oauthError = isOwnOAuthAttempt ? oauth.error : null;
+    const oauthFailedPhase = isOwnOAuthAttempt ? oauth.failedPhase : null;
+    const discoveryError = isOwnOAuthAttempt ? discovery.error : null;
+
+    // "Signed in — tools not discovered yet" (the stigmer/stigmer#229
+    // two-act persistence gap, picker arm: stigmer/stigmer#418). Two
+    // signals, mirroring the detail view:
+    // - In-flow: the OAuth chain broke in its "connecting" phase, so
+    //   sign-in succeeded and only discovery failed — the entry's own
+    //   data is still stale at this point.
+    // - Server truth: the entry resolved ready off a usable grant with
+    //   nothing discovered. Survives popover close/reopen, where the
+    //   in-flow signal dies with the hook. Token-expired grants are
+    //   excluded — re-auth, not discovery, is their next step.
+    const isDiscoveryRetry = oauthFailedPhase === "connecting";
+    const grantUsable =
+      entry.oauthConnectionHealth ===
+        OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY ||
+      entry.oauthConnectionHealth ===
+        OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE;
+    const isOAuthStranded =
+      isDiscoveryRetry ||
+      (hasOAuth &&
+        entry.status === "ready" &&
+        grantUsable &&
+        entry.discoveredTools.length === 0);
+
     const oauthSignInProps =
       hasOAuth && !isManualOverride
         ? {
             onSignIn: async () => {
               if (!entry.mcpServer.metadata?.id) return;
+              const serverId = entry.mcpServer.metadata.id;
+              const connectOrg = activeOrg ?? org;
+              setOauthAttemptKey(view.serverKey);
+
+              if (isOAuthStranded) {
+                // Sign-in already succeeded — the grant is stored
+                // server-side. Retry bare discovery; never relaunch the
+                // popup (stigmer/stigmer#418).
+                try {
+                  await discovery.connect(
+                    serverId,
+                    connectOrg,
+                    undefined,
+                    declaredEnvKeys,
+                  );
+                  // Discovery succeeded — retire the chain's stale
+                  // failure and re-evaluate the entry so it resolves
+                  // ready with the discovered tools.
+                  oauth.clearError();
+                  setup.onServerAdded(ref);
+                } catch {
+                  // error state managed by the discovery hook
+                }
+                return;
+              }
+
               try {
-                await oauth.startOAuth(
-                  entry.mcpServer.metadata.id,
-                  activeOrg ?? org,
-                );
+                await oauth.startOAuth(serverId, connectOrg, declaredEnvKeys);
                 setup.onServerAdded(ref);
               } catch {
                 // error state managed by oauth hook
               }
             },
-            phase: oauth.phase,
+            // oauth.phase stays unscoped on purpose: it disables every
+            // server's sign-in button while a popup flow is in flight,
+            // preventing two concurrent flows over the same hook.
+            phase:
+              discovery.isConnecting && isOwnOAuthAttempt
+                ? ("connecting" as const)
+                : oauth.phase,
             isConnected: !oauthTokenMissing,
-            error: oauth.error,
-            onClearError: oauth.clearError,
+            connectionHealth: entry.oauthConnectionHealth,
+            error: oauthError ?? discoveryError,
+            // A bare-discovery failure is by definition a discovery-leg
+            // failure — keep the honest "signed in, but discovery
+            // failed" copy for it.
+            failedPhase: oauthError
+              ? oauthFailedPhase
+              : discoveryError
+                ? ("connecting" as const)
+                : null,
+            isOAuthStranded,
+            onClearError: () => {
+              oauth.clearError();
+              discovery.clearError();
+            },
             isVendorApprovalPending,
             isVendorApprovalBlocked,
             vendorApprovalDocsUrl: oauthStatus?.vendorApprovalDocsUrl || null,
@@ -757,6 +846,7 @@ function SetupServerRow({
               "stg:text-warning stg:hover:bg-warning/10",
               "stg:disabled:pointer-events-none stg:disabled:opacity-50",
             )}
+            aria-label={`Configure ${slug}`}
           >
             Configure
           </button>
@@ -778,6 +868,7 @@ function SetupServerRow({
               "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
               "stg:disabled:pointer-events-none stg:disabled:opacity-50",
             )}
+            aria-label={`Configure ${slug}`}
           >
             {entry.discoveredTools.length > 0 && (
               <span>

--- a/sdk/react/src/mcp-server/__tests__/McpServerPicker.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/McpServerPicker.test.tsx
@@ -1,0 +1,504 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { useEffect, useRef, type ReactNode } from "react";
+import { create } from "@bufbuild/protobuf";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { Stigmer } from "@stigmer/sdk";
+import type { ResourceRef } from "@stigmer/sdk";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import {
+  OAuthConnectionHealth,
+  GetOAuthGrantStatusOutputSchema,
+  InitiateOAuthConnectOutputSchema,
+  CompleteOAuthConnectOutputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import {
+  McpServerSpecSchema,
+  McpServerAuthSchema,
+  HttpServerConfigSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import {
+  McpServerStatusSchema,
+  DiscoveredCapabilitiesSchema,
+  DiscoveredToolSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { EnvVarDeclarationSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { samples } from "../../test/samples";
+import { StigmerContext } from "../../context";
+import { McpServerPicker } from "../McpServerPicker";
+import { useMcpServerSetup } from "../useMcpServerSetup";
+import * as oauthPopup from "../../internal/oauthPopup.js";
+
+// The popup machinery is window-dependent (window.open, postMessage,
+// BroadcastChannel); these tests drive the RPC chain, so replace it with
+// a deterministic callback handshake. The `openOAuthPopup` call count is
+// the load-bearing assertion of this suite: a discovery-leg retry must
+// NEVER reopen the popup (stigmer/stigmer#418).
+vi.mock("../../internal/oauthPopup.js", () => ({
+  openOAuthPopup: vi.fn(() => ({ location: { href: "" }, closed: false })),
+  popupBlockedError: vi.fn(
+    () => new Error("Popup was blocked by the browser."),
+  ),
+  waitForOAuthCallback: vi.fn(async () => ({
+    code: "auth-code",
+    state: "state-1",
+  })),
+  closeOAuthPopup: vi.fn(),
+  OAUTH_CALLBACK_MESSAGE_TYPE: "stigmer:oauth:callback",
+  OAUTH_BROADCAST_CHANNEL: "stigmer:oauth:broadcast",
+}));
+
+const openOAuthPopupMock = vi.mocked(oauthPopup.openOAuthPopup);
+
+beforeAll(() => {
+  // happy-dom lacks ResizeObserver, which the scroll-shadow machinery
+  // observes.
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const ORG = "acme";
+const SLUG = "order-management-api";
+const SERVER_NAME = "Order Management API";
+
+function serverRef(slug = SLUG): ResourceRef {
+  return { org: ORG, slug, kind: ApiResourceKind.mcp_server };
+}
+
+/**
+ * An OAuth-only server before any discovery: one declared env var that is
+ * also the OAuth target, no discovered capabilities.
+ */
+function buildOAuthServer(o?: { name?: string; slug?: string; id?: string }): McpServer {
+  const server = samples.mcpServer({
+    name: o?.name ?? SERVER_NAME,
+    org: ORG,
+    slug: o?.slug ?? SLUG,
+    id: o?.id ?? "mcp-00000000-0000-0000-0000-00000000041a",
+  });
+  server.spec = create(McpServerSpecSchema, {
+    description: "REST API for order lookup and return processing.",
+    serverType: {
+      case: "http",
+      value: create(HttpServerConfigSchema, { url: "https://api.acme.com/mcp" }),
+    },
+    env: {
+      API_TOKEN: create(EnvVarDeclarationSchema, {
+        isSecret: true,
+        description: "OAuth access token",
+      }),
+    },
+    auth: create(McpServerAuthSchema, {
+      targetEnvVar: "API_TOKEN",
+      oauthOnly: true,
+    }),
+  });
+  return server;
+}
+
+/** The same server after a successful discovery: three tools. */
+function buildDiscoveredServer(): McpServer {
+  const server = buildOAuthServer();
+  server.status = create(McpServerStatusSchema, {
+    discoveredCapabilities: create(DiscoveredCapabilitiesSchema, {
+      tools: [
+        create(DiscoveredToolSchema, { name: "get_order" }),
+        create(DiscoveredToolSchema, { name: "list_orders" }),
+        create(DiscoveredToolSchema, { name: "process_return" }),
+      ],
+    }),
+  });
+  return server;
+}
+
+function grantStatusOutput(
+  connected: boolean,
+  health: OAuthConnectionHealth,
+) {
+  return create(GetOAuthGrantStatusOutputSchema, {
+    connected,
+    connectionHealth: health,
+    targetEnvVar: connected ? "API_TOKEN" : "",
+    authMethod: connected ? "mcp_oauth" : "",
+  });
+}
+
+/**
+ * Composes the picker with a real `useMcpServerSetup`, wired exactly the
+ * way `SessionComposer` wires it. The given refs are added once on mount.
+ */
+function PickerHarness({ refs }: { readonly refs: readonly ResourceRef[] }) {
+  const setup = useMcpServerSetup(ORG);
+  const addedRef = useRef(false);
+  const { addServer } = setup;
+  useEffect(() => {
+    if (addedRef.current) return;
+    addedRef.current = true;
+    for (const ref of refs) void addServer(ref);
+  }, [refs, addServer]);
+
+  return (
+    <McpServerPicker
+      org={ORG}
+      setup={{
+        entries: setup.entries,
+        onServerAdded: (ref) => void setup.addServer(ref),
+        onServerRemoved: setup.removeServer,
+        onSubmitEnvVars: (ref, values, opts) =>
+          void setup.submitEnvVars(ref, values, opts),
+        onEnabledToolsChange: setup.setEnabledTools,
+      }}
+    />
+  );
+}
+
+/**
+ * Mounts the harness against a real Connect router transport. RPCs a test
+ * does not register fall through to Connect's `unimplemented`, which the
+ * SDK hooks degrade from (search list and personal-environment lookups
+ * are irrelevant here and stay unregistered).
+ */
+function renderPicker(
+  register: Parameters<typeof createRouterTransport>[0],
+  refs: readonly ResourceRef[] = [serverRef()],
+) {
+  const client = new Stigmer({
+    baseUrl: "/",
+    getAccessToken: () => "test-token",
+    customTransport: createRouterTransport(register),
+  });
+  return render(
+    <StigmerContext.Provider value={client}>
+      <PickerHarness refs={refs} />
+    </StigmerContext.Provider>,
+  );
+}
+
+async function drillIntoConfigure(buttonName: RegExp) {
+  const configure = await screen.findByRole("button", { name: buttonName });
+  fireEvent.click(configure);
+}
+
+describe("McpServerPicker — discovery-leg failure (in-flow arm)", () => {
+  function registerFailingDiscovery() {
+    // Mutable fixture state: the grant flips to connected at token
+    // exchange (the two-act persistence contract), and discovery starts
+    // failing, then succeeds once `discoveryFails` is cleared.
+    const state = {
+      server: buildOAuthServer(),
+      grantConnected: false,
+      discoveryFails: true,
+    };
+    const connectSpy = vi.fn(() => {
+      if (state.discoveryFails) {
+        throw new ConnectError("discovery workflow failed", Code.Internal);
+      }
+      state.server = buildDiscoveredServer();
+      return state.server;
+    });
+
+    const register: Parameters<typeof createRouterTransport>[0] = (
+      router,
+    ) => {
+      router.service(McpServerQueryController, {
+        getByReference: () => state.server,
+        getOAuthGrantStatus: () =>
+          grantStatusOutput(
+            state.grantConnected,
+            state.grantConnected
+              ? OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY
+              : OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT,
+          ),
+      });
+      router.service(McpServerCommandController, {
+        initiateOAuthConnect: () =>
+          create(InitiateOAuthConnectOutputSchema, {
+            authorizationUrl: "https://vendor.example/authorize",
+            state: "state-1",
+          }),
+        completeOAuthConnect: () => {
+          state.grantConnected = true;
+          return create(CompleteOAuthConnectOutputSchema, { connected: true });
+        },
+        connect: connectSpy,
+      });
+    };
+
+    return { state, connectSpy, register };
+  }
+
+  async function signInAndFailDiscovery() {
+    await drillIntoConfigure(new RegExp(`Configure ${SLUG}`));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: `Sign in with ${SERVER_NAME}`,
+      }),
+    );
+    // Honest copy: the sign-in succeeded, only the discovery leg broke.
+    await screen.findByText(
+      /Signed in successfully, but tool discovery failed/,
+    );
+  }
+
+  it("renders the honest copy, stranded status, and a Discover tools action", async () => {
+    const { register } = registerFailingDiscovery();
+    renderPicker(register);
+
+    await signInAndFailDiscovery();
+
+    expect(
+      screen.getByText("Signed in — tools not discovered yet"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Discover tools" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: `Sign in with ${SERVER_NAME}` }),
+    ).toBeNull();
+  });
+
+  it("retries with a bare connect and never reopens the popup", async () => {
+    const { state, connectSpy, register } = registerFailingDiscovery();
+    renderPicker(register);
+
+    await signInAndFailDiscovery();
+    expect(openOAuthPopupMock).toHaveBeenCalledTimes(1);
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+
+    state.discoveryFails = false;
+    fireEvent.click(screen.getByRole("button", { name: "Discover tools" }));
+
+    // Discovery succeeded → the entry re-resolves ready with real tools;
+    // the stranded state and its affordance retire themselves.
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Signed in — tools not discovered yet"),
+      ).toBeNull(),
+    );
+    await screen.findByText("process_return");
+    expect(
+      screen.queryByRole("button", { name: "Discover tools" }),
+    ).toBeNull();
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+    expect(openOAuthPopupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a failing bare retry honest and popup-free", async () => {
+    const { connectSpy, register } = registerFailingDiscovery();
+    renderPicker(register);
+
+    await signInAndFailDiscovery();
+    fireEvent.click(screen.getByRole("button", { name: "Discover tools" }));
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalledTimes(2));
+    // Still stranded, still honest, still no second popup.
+    await screen.findByText(
+      /Signed in successfully, but tool discovery failed/,
+    );
+    expect(
+      screen.getByRole("button", { name: "Discover tools" }),
+    ).toBeTruthy();
+    expect(openOAuthPopupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes a non-discovery failure back through the OAuth popup", async () => {
+    renderPicker((router) => {
+      router.service(McpServerQueryController, {
+        getByReference: () => buildOAuthServer(),
+        getOAuthGrantStatus: () =>
+          grantStatusOutput(
+            false,
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT,
+          ),
+      });
+      router.service(McpServerCommandController, {
+        initiateOAuthConnect: () =>
+          create(InitiateOAuthConnectOutputSchema, {
+            authorizationUrl: "https://vendor.example/authorize",
+            state: "state-1",
+          }),
+        completeOAuthConnect: () => {
+          throw new ConnectError("token exchange failed", Code.Unavailable);
+        },
+      });
+    });
+
+    await drillIntoConfigure(new RegExp(`Configure ${SLUG}`));
+    const signIn = await screen.findByRole("button", {
+      name: `Sign in with ${SERVER_NAME}`,
+    });
+
+    fireEvent.click(signIn);
+    await screen.findByText(/token exchange failed/);
+    // Sign-in itself failed — no "signed in successfully" framing, and the
+    // action remains a full OAuth relaunch.
+    expect(
+      screen.queryByText(/Signed in successfully/),
+    ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: `Sign in with ${SERVER_NAME}` }),
+    );
+    await waitFor(() => expect(openOAuthPopupMock).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("McpServerPicker — stranded server truth (reopen/re-add arm)", () => {
+  it("offers Discover tools for a usable grant with zero discovered tools", async () => {
+    let server = buildOAuthServer();
+    const connectSpy = vi.fn(() => {
+      server = buildDiscoveredServer();
+      return server;
+    });
+
+    renderPicker((router) => {
+      router.service(McpServerQueryController, {
+        getByReference: () => server,
+        getOAuthGrantStatus: () =>
+          grantStatusOutput(
+            true,
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY,
+          ),
+      });
+      router.service(McpServerCommandController, { connect: connectSpy });
+    });
+
+    // Grant exists → the entry resolves ready, but with nothing discovered.
+    await drillIntoConfigure(new RegExp(`Configure ${SLUG}`));
+
+    await screen.findByText("Signed in — tools not discovered yet");
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Discover tools" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Signed in — tools not discovered yet"),
+      ).toBeNull(),
+    );
+    await screen.findByText("process_return");
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(openOAuthPopupMock).not.toHaveBeenCalled();
+  });
+
+  it("offers re-auth, not discovery, for an expired grant", async () => {
+    renderPicker((router) => {
+      router.service(McpServerQueryController, {
+        getByReference: () => buildOAuthServer(),
+        getOAuthGrantStatus: () =>
+          grantStatusOutput(
+            true,
+            OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED,
+          ),
+      });
+    });
+
+    await drillIntoConfigure(new RegExp(`Configure ${SLUG}`));
+
+    await screen.findByRole("button", { name: "Sign in to reconnect" });
+    expect(screen.queryByRole("button", { name: "Discover tools" })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sign in to reconnect" }),
+    );
+    await waitFor(() => expect(openOAuthPopupMock).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("McpServerPicker — cross-server scoping", () => {
+  it("keeps server A's discovery failure out of server B's configure view", async () => {
+    const SLUG_B = "billing-api";
+    const NAME_B = "Billing API";
+    const serverA = buildOAuthServer();
+    const serverB = buildOAuthServer({
+      name: NAME_B,
+      slug: SLUG_B,
+      id: "mcp-00000000-0000-0000-0000-00000000041b",
+    });
+    let grantConnectedA = false;
+    const connectSpy = vi.fn(() => {
+      throw new ConnectError("discovery workflow failed", Code.Internal);
+    });
+
+    renderPicker(
+      (router) => {
+        router.service(McpServerQueryController, {
+          getByReference: (input) =>
+            input.slug === SLUG_B ? serverB : serverA,
+          getOAuthGrantStatus: (input) =>
+            grantStatusOutput(
+              input.resourceId === serverA.metadata!.id && grantConnectedA,
+              input.resourceId === serverA.metadata!.id && grantConnectedA
+                ? OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY
+                : OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT,
+            ),
+        });
+        router.service(McpServerCommandController, {
+          initiateOAuthConnect: () =>
+            create(InitiateOAuthConnectOutputSchema, {
+              authorizationUrl: "https://vendor.example/authorize",
+              state: "state-1",
+            }),
+          completeOAuthConnect: () => {
+            grantConnectedA = true;
+            return create(CompleteOAuthConnectOutputSchema, {
+              connected: true,
+            });
+          },
+          connect: connectSpy,
+        });
+      },
+      [serverRef(), serverRef(SLUG_B)],
+    );
+
+    // Server A: sign in, discovery fails.
+    await drillIntoConfigure(new RegExp(`Configure ${SLUG}$`));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: `Sign in with ${SERVER_NAME}`,
+      }),
+    );
+    await screen.findByText(
+      /Signed in successfully, but tool discovery failed/,
+    );
+    expect(openOAuthPopupMock).toHaveBeenCalledTimes(1);
+
+    // Back to the list, drill into server B.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Back to MCP server list" }),
+    );
+    await drillIntoConfigure(new RegExp(`Configure ${SLUG_B}`));
+
+    // B must not inherit A's failure: no honest-copy banner, no stranded
+    // affordance — a fresh sign-in action.
+    await screen.findByRole("button", { name: `Sign in with ${NAME_B}` });
+    expect(screen.queryByText(/Signed in successfully/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Discover tools" })).toBeNull();
+
+    // And B's sign-in goes through the popup — proving it did not take
+    // A's bare-discovery retry branch.
+    fireEvent.click(
+      screen.getByRole("button", { name: `Sign in with ${NAME_B}` }),
+    );
+    await waitFor(() => expect(openOAuthPopupMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/sdk/react/src/mcp-server/mcpServerSetupReducer.ts
+++ b/sdk/react/src/mcp-server/mcpServerSetupReducer.ts
@@ -1,5 +1,6 @@
 import type { ResourceRef } from "@stigmer/sdk";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { OAuthConnectionHealth } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import type { DiscoveredTool } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
 import type { ToolApprovalPolicy } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
 import type { EnvVarFormVariable } from "../environment/EnvVarForm.js";
@@ -61,6 +62,8 @@ export type McpServerSetupPhase =
       readonly discoveredTools: DiscoveredTool[];
       /** Per-tool approval policies from the server spec. */
       readonly toolApprovals: ToolApprovalPolicy[];
+      /** OAuth grant health at resolve time — full doc on the `ready` variant. */
+      readonly oauthConnectionHealth?: OAuthConnectionHealth;
     }
   | {
       /** Environment variables are being persisted or the instance is being provisioned. */
@@ -73,6 +76,8 @@ export type McpServerSetupPhase =
       readonly discoveredTools: DiscoveredTool[];
       /** Per-tool approval policies from the server spec. */
       readonly toolApprovals: ToolApprovalPolicy[];
+      /** OAuth grant health at resolve time — full doc on the `ready` variant. */
+      readonly oauthConnectionHealth?: OAuthConnectionHealth;
     }
   | {
       /** The server is fully configured and ready for session creation. */
@@ -85,6 +90,15 @@ export type McpServerSetupPhase =
       readonly toolApprovals: ToolApprovalPolicy[];
       /** Tool names enabled for this session, after user selection. */
       readonly enabledTools: string[];
+      /**
+       * OAuth grant health at resolve time, from the grant-status lookup
+       * `addServer` performs for OAuth-declaring servers. `undefined` when
+       * no lookup ran (server has no OAuth declaration) or the lookup
+       * failed. Consumers use it to distinguish "signed in but tools never
+       * discovered" (offer bare discovery, stigmer/stigmer#418) from
+       * "token expired" (offer re-auth) without another RPC.
+       */
+      readonly oauthConnectionHealth?: OAuthConnectionHealth;
     };
 
 /**
@@ -145,6 +159,8 @@ export type McpServerSetupAction =
       readonly discoveredTools: DiscoveredTool[];
       /** Per-tool approval policies from the server spec. */
       readonly toolApprovals: ToolApprovalPolicy[];
+      /** OAuth grant health at resolve time, when a lookup ran. */
+      readonly oauthConnectionHealth?: OAuthConnectionHealth;
     }
   | {
       /** Server resolved and is ready (no env vars needed). */
@@ -159,6 +175,8 @@ export type McpServerSetupAction =
       readonly toolApprovals: ToolApprovalPolicy[];
       /** Tool names enabled for this session. */
       readonly enabledTools: string[];
+      /** OAuth grant health at resolve time, when a lookup ran. */
+      readonly oauthConnectionHealth?: OAuthConnectionHealth;
     }
   | {
       /** Re-evaluate missing variables after pool values arrive. */
@@ -254,6 +272,7 @@ export function mcpServerSetupReducer(
           missingVariables: action.missingVariables,
           discoveredTools: action.discoveredTools,
           toolApprovals: action.toolApprovals,
+          oauthConnectionHealth: action.oauthConnectionHealth,
           error: null,
         },
       };
@@ -270,6 +289,7 @@ export function mcpServerSetupReducer(
           discoveredTools: action.discoveredTools,
           toolApprovals: action.toolApprovals,
           enabledTools: action.enabledTools,
+          oauthConnectionHealth: action.oauthConnectionHealth,
           error: null,
         },
       };
@@ -288,6 +308,7 @@ export function mcpServerSetupReducer(
             discoveredTools: entry.discoveredTools,
             toolApprovals: entry.toolApprovals,
             enabledTools: action.enabledTools,
+            oauthConnectionHealth: entry.oauthConnectionHealth,
             error: null,
           },
         };
@@ -313,6 +334,7 @@ export function mcpServerSetupReducer(
           missingVariables: entry.missingVariables,
           discoveredTools: entry.discoveredTools,
           toolApprovals: entry.toolApprovals,
+          oauthConnectionHealth: entry.oauthConnectionHealth,
           error: null,
         },
       };
@@ -329,6 +351,7 @@ export function mcpServerSetupReducer(
           discoveredTools: entry.discoveredTools,
           toolApprovals: entry.toolApprovals,
           enabledTools: action.enabledTools,
+          oauthConnectionHealth: entry.oauthConnectionHealth,
           error: null,
         },
       };
@@ -345,6 +368,7 @@ export function mcpServerSetupReducer(
           missingVariables: entry.missingVariables,
           discoveredTools: entry.discoveredTools,
           toolApprovals: entry.toolApprovals,
+          oauthConnectionHealth: entry.oauthConnectionHealth,
           error: action.error,
         },
       };

--- a/sdk/react/src/mcp-server/useMcpServerSetup.ts
+++ b/sdk/react/src/mcp-server/useMcpServerSetup.ts
@@ -5,6 +5,7 @@ import type { EnvVarInput, McpServerUsageInput, ResourceRef } from "@stigmer/sdk
 import { create } from "@bufbuild/protobuf";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { GetOAuthGrantStatusInputSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import type { OAuthConnectionHealth } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import type { DiscoveredTool } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { useStigmer } from "../hooks.js";
@@ -287,6 +288,11 @@ export function useMcpServerSetup(
           Object.keys(personalEnv.environment?.spec?.data ?? {}),
         );
 
+        // Carried onto the entry so consumers can tell a healthy grant
+        // that merely lacks tool discovery (offer bare discovery,
+        // stigmer/stigmer#418) apart from an expired one (offer re-auth).
+        let oauthConnectionHealth: OAuthConnectionHealth | undefined;
+
         const auth = mcpServer.spec?.auth;
         if (auth?.targetEnvVar && mcpServer.metadata?.id) {
           try {
@@ -296,6 +302,7 @@ export function useMcpServerSetup(
                 org,
               }),
             );
+            oauthConnectionHealth = grantStatus.connectionHealth;
             if (grantStatus.connected) {
               existingKeys.add(auth.targetEnvVar);
             }
@@ -319,6 +326,7 @@ export function useMcpServerSetup(
               mcpServer,
               discoveredTools,
             ),
+            oauthConnectionHealth,
           });
           return;
         }
@@ -330,6 +338,7 @@ export function useMcpServerSetup(
           missingVariables: requiredMissing,
           discoveredTools,
           toolApprovals,
+          oauthConnectionHealth,
         });
       } catch (err) {
         dispatch({ type: "SET_ERROR", key, error: toError(err) });


### PR DESCRIPTION
## Summary

The picker arm of the oss#229 two-act persistence defect (the deliberately deferred half of #417): in session setup, after a sign-in-succeeded-but-discovery-failed OAuth chain, `McpServerPicker` rendered the raw RPC error as if sign-in had failed and relaunched the OAuth popup on retry — even though the grant was already stored server-side. Worse, closing and reopening the picker resolved the server **ready with zero tools**, silently attaching it to the session in exactly the dishonest state oss#229 existed to kill.

Closes #418

## What changed (all in `@stigmer/react` — web + desktop parity automatic)

- **Retry semantics**: the sign-in action branches on two signals, mirroring the detail view's #417 shape:
  - *In-flow*: `useMcpServerOAuthConnect.failedPhase === "connecting"` (sign-in succeeded, only discovery failed).
  - *Server truth*: usable grant (healthy / expired-but-refreshable) + zero discovered tools — survives popover close/reopen, self-heals when discovery lands.

  When either is up, the button reads **"Discover tools"** and runs a bare `connect` via `useMcpServerConnect` — never the popup. On success the entry re-resolves ready with the real tools. Token-expired grants are excluded: they get "Sign in to reconnect" (re-auth), not a doomed discovery.
- **Honest copy**: `InlineOAuthSignIn` composes errors through `getOAuthConnectErrorMessage` ("Signed in successfully, but tool discovery failed: …") and shows the #417 stranded status ("Signed in — tools not discovered yet"). `McpServerOAuthSignInProps` gains additive optional `failedPhase` / `isOAuthStranded`.
- **Entry-level grant health**: setup entries carry `oauthConnectionHealth` from the grant-status lookup `addServer` already makes (zero extra RPC), which also finally wires the panel's existing "Token expired" / "Re-auth needed" states in the picker.
- **Cross-server scoping**: the picker's single OAuth hook instance served every server, so server A's discovery failure bled into server B's configure view — and would have made B's sign-in take A's bare-discovery branch. Signals are now scoped to the server the attempt was started for.
- **Divergence fix**: the picker's `startOAuth` call now passes `declaredEnvKeys` (system env vars), matching the dialog and detail view.
- A11y: the per-server drill-in buttons gain `aria-label="Configure <slug>"` (the ready-row button had no accessible name at zero tools).

## Verification

- New `McpServerPicker.test.tsx` (7 tests) pins: honest copy + stranded status + "Discover tools" after a discovery-leg failure; retry issues bare `connect` and **never reopens the popup**; failing retries stay honest and popup-free; non-discovery failures still relaunch the popup; the reopen/re-add stranded arm; token-expired exclusion; cross-server scoping. **Fails 7/7 on pre-fix code, passes 7/7 with the fix.**
- Full `sdk/react` suite: 4373/4373 across 397 files. `tsc --noEmit`, `eslint` + classname-prefix check, `verify-esm-node.mjs` all clean.

## Coordination note

The parallel oss#412 session may touch `McpServerConfigPanel.tsx`'s vendor-approval copy in `InlineOAuthSignIn` (no branch pushed yet as of this PR). This PR's panel diff was kept minimal; whichever lands second should re-check that region.

Made with [Cursor](https://cursor.com)