### PR TITLE
fix(runner): sanitize unicode-invalid regex patterns in MCP tool schemas

### DIFF
--- a/backend/services/runner/src/shared/__tests__/mcp-manager.test.ts
+++ b/backend/services/runner/src/shared/__tests__/mcp-manager.test.ts
@@ -240,3 +240,52 @@ describe("connectMcpServers — enabled_tools enforcement (issue #350)", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("ghost"));
   });
 });
+
+describe("connectMcpServers — schema sanitization (issue #420)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockMcpClient.toolMap = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("drops unicode-invalid regex patterns from every discovered tool's schema and warns per tool", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const toxic = {
+      name: "toxic",
+      schema: {
+        type: "object",
+        // PayPal's issue-#420 shape: legal plain regex, invalid under /u.
+        properties: { url: { type: "string", pattern: "^https\\:\\/\\/" } },
+      },
+    } as any;
+    const clean = {
+      name: "clean",
+      schema: {
+        type: "object",
+        properties: { id: { type: "string", pattern: "^[a-z]+$" } },
+      },
+    } as any;
+    mockMcpClient.toolMap = { paypal: [toxic, clean] };
+
+    const result = await connectMcpServers([
+      makeServer({ slug: "paypal", connectionType: "http", url: "https://mcp.example.com/mcp" }),
+    ]);
+
+    // Sanitization happens on the discovered tool objects themselves, so
+    // every downstream consumer (model binding, approval gate, sub-agent
+    // filter) sees the sanitized schema.
+    expect(result.serverToolMap.paypal[0].schema).toEqual({
+      type: "object",
+      properties: { url: { type: "string" } },
+    });
+    expect(result.serverToolMap.paypal[1].schema).toEqual(clean.schema);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Server 'paypal' tool 'toxic'"),
+    );
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/mcp-schema-sanitizer.test.ts
+++ b/backend/services/runner/src/shared/__tests__/mcp-schema-sanitizer.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import { loadMcpTools } from "@langchain/mcp-adapters";
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { sanitizeSchemaPatterns } from "../mcp-schema-sanitizer.js";
+
+// PayPal's real-world specimen from issue #420: legal as a plain ECMAScript
+// regex (Annex B identity escapes), invalid under the /u flag.
+const TOXIC_PATTERN = "^https\\:\\/\\/";
+
+describe("sanitizeSchemaPatterns — walker semantics", () => {
+  it("drops a unicode-invalid pattern and reports it", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        url: { type: "string", pattern: TOXIC_PATTERN },
+      },
+    };
+
+    const dropped = sanitizeSchemaPatterns(schema);
+
+    expect(schema.properties.url).toEqual({ type: "string" });
+    expect(dropped).toEqual([
+      {
+        location: "/properties/url/pattern",
+        pattern: TOXIC_PATTERN,
+        compilesWithoutUnicodeFlag: true,
+      },
+    ]);
+  });
+
+  it("flags patterns that are broken outright (invalid without /u too)", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string", pattern: "(unclosed" } },
+    };
+
+    const dropped = sanitizeSchemaPatterns(schema);
+
+    expect(schema.properties.name).toEqual({ type: "string" });
+    expect(dropped[0].compilesWithoutUnicodeFlag).toBe(false);
+  });
+
+  it("leaves clean schemas byte-identical", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        url: { type: "string", pattern: "^https://" },
+        tags: { type: "array", items: { type: "string", pattern: "^[a-z]+$" } },
+      },
+      patternProperties: { "^x-": { type: "string" } },
+      additionalProperties: false,
+      required: ["url"],
+    };
+    const before = JSON.parse(JSON.stringify(schema));
+
+    expect(sanitizeSchemaPatterns(schema)).toEqual([]);
+    expect(schema).toEqual(before);
+  });
+
+  it("never touches a property literally named 'pattern'", () => {
+    // 'pattern' as a property NAME is data, not a keyword — but the pattern
+    // KEYWORD on that property's own schema is still sanitized.
+    const schema = {
+      type: "object",
+      properties: {
+        pattern: { type: "string", pattern: TOXIC_PATTERN },
+      },
+    };
+
+    const dropped = sanitizeSchemaPatterns(schema);
+
+    expect(Object.keys(schema.properties)).toEqual(["pattern"]);
+    expect(schema.properties.pattern).toEqual({ type: "string" });
+    expect(dropped[0].location).toBe("/properties/pattern/pattern");
+  });
+
+  it("leaves a non-string pattern value alone", () => {
+    const schema = { type: "object", properties: { n: { pattern: 123 } } };
+    expect(sanitizeSchemaPatterns(schema)).toEqual([]);
+    expect((schema.properties.n as { pattern: unknown }).pattern).toBe(123);
+  });
+
+  it("reaches nested schema positions", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        choice: {
+          anyOf: [
+            { type: "string", pattern: TOXIC_PATTERN },
+            { type: "number" },
+          ],
+        },
+        tuple: {
+          type: "array",
+          items: [{ type: "string", pattern: TOXIC_PATTERN }],
+        },
+        names: { propertyNames: { pattern: TOXIC_PATTERN } },
+      },
+      $defs: {
+        link: { type: "string", pattern: TOXIC_PATTERN },
+      },
+      dependencies: {
+        // Array form is dependentRequired (names, not schemas) — untouched.
+        a: ["b"],
+        c: { properties: { d: { type: "string", pattern: TOXIC_PATTERN } } },
+      },
+    };
+
+    const dropped = sanitizeSchemaPatterns(schema);
+
+    expect(dropped.map((d) => d.location).sort()).toEqual([
+      "/$defs/link/pattern",
+      "/dependencies/c/properties/d/pattern",
+      "/properties/choice/anyOf/0/pattern",
+      "/properties/names/propertyNames/pattern",
+      "/properties/tuple/items/0/pattern",
+    ]);
+    expect(schema.dependencies.a).toEqual(["b"]);
+  });
+
+  it("terminates on a cyclic schema graph", () => {
+    const node: Record<string, unknown> = {
+      type: "object",
+      properties: { url: { type: "string", pattern: TOXIC_PATTERN } },
+    };
+    node.not = node;
+
+    const dropped = sanitizeSchemaPatterns(node);
+    expect(dropped).toHaveLength(1);
+  });
+
+  it("ignores non-object input", () => {
+    expect(sanitizeSchemaPatterns(undefined)).toEqual([]);
+    expect(sanitizeSchemaPatterns("pattern")).toEqual([]);
+    expect(sanitizeSchemaPatterns([{ pattern: TOXIC_PATTERN }])).toEqual([]);
+  });
+});
+
+describe("sanitizeSchemaPatterns — never-tighten invariant (patternProperties)", () => {
+  // Slash-free /u-invalid key so the expected report location needs no
+  // JSON-pointer escaping (the walker escapes `/` in map keys as `~1`).
+  const TOXIC_KEY = "^x\\:";
+
+  it("drops a broken patternProperties key and relaxes restrictive additionalProperties", () => {
+    const schema = {
+      type: "object",
+      patternProperties: {
+        [TOXIC_KEY]: { type: "string" },
+        "^clean-": { type: "number" },
+      },
+      additionalProperties: false,
+    };
+
+    const dropped = sanitizeSchemaPatterns(schema);
+
+    expect(dropped).toEqual([
+      {
+        location: `/patternProperties/${TOXIC_KEY}`,
+        pattern: TOXIC_KEY,
+        compilesWithoutUnicodeFlag: true,
+      },
+    ]);
+    expect(schema.patternProperties).toEqual({ "^clean-": { type: "number" } });
+    // Keys the dropped pattern used to match would fall through to
+    // additionalProperties: false and be falsely REJECTED — the relaxation
+    // is what keeps sanitization strictly loosening.
+    expect("additionalProperties" in schema).toBe(false);
+  });
+
+  it("removes an emptied patternProperties and relaxes a restrictive subschema additionalProperties", () => {
+    const schema = {
+      type: "object",
+      patternProperties: { [TOXIC_KEY]: { type: "string" } },
+      additionalProperties: { type: "number" },
+      unevaluatedProperties: false,
+    };
+
+    sanitizeSchemaPatterns(schema);
+
+    expect("patternProperties" in schema).toBe(false);
+    expect("additionalProperties" in schema).toBe(false);
+    expect("unevaluatedProperties" in schema).toBe(false);
+  });
+
+  it("keeps additionalProperties when no patternProperties entry was dropped", () => {
+    const schema = {
+      type: "object",
+      patternProperties: { "^clean-": { type: "string" } },
+      additionalProperties: false,
+    };
+
+    sanitizeSchemaPatterns(schema);
+
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("proves the loosened schema through the real validator: previously matched keys stay accepted", async () => {
+    // End-to-end through @langchain/core's own validation path (the exact
+    // consumer that compiles patterns with /u): after sanitization, an input
+    // whose key only the dropped pattern used to match must validate — not
+    // fall through to additionalProperties: false.
+    const schema = {
+      type: "object" as const,
+      patternProperties: { "^x\\:": { type: "string" as const } },
+      additionalProperties: false,
+    };
+    sanitizeSchemaPatterns(schema);
+
+    // Default generics: the JSON-schema constructor arm types invoke input
+    // as ToolCall otherwise, rejecting the pattern-shaped key at compile time.
+    const tool: DynamicStructuredTool = new DynamicStructuredTool({
+      name: "probe",
+      description: "d",
+      schema,
+      func: async () => "ok",
+    });
+
+    await expect(tool.invoke({ "x:key": "value" })).resolves.toBe("ok");
+  });
+});
+
+describe("sanitizeSchemaPatterns — issue #420 regression pin", () => {
+  // The issue's exact repro: a tool loaded through the real adapter with the
+  // PayPal pattern shape loads fine but fails EVERY invocation with
+  // "SyntaxError: Invalid regular expression: /^https\:\/\//u".
+  const toxicTool = {
+    name: "toxic",
+    description: "d",
+    inputSchema: {
+      type: "object",
+      properties: { url: { type: "string", pattern: TOXIC_PATTERN } },
+    },
+  };
+  const fakeClient = {
+    listTools: async () => ({ tools: [toxicTool] }),
+    callTool: async () => ({ content: [{ type: "text", text: "called" }] }),
+  };
+
+  it("negative control: without sanitization the tool is uncallable (the defect)", async () => {
+    const tools = await loadMcpTools("srv", fakeClient as never, {
+      throwOnLoadError: true,
+    });
+
+    await expect(tools[0].invoke({ url: "https://x.com" })).rejects.toThrow(
+      /Invalid regular expression/,
+    );
+  });
+
+  it("after sanitization the same tool invokes successfully", async () => {
+    const tools = await loadMcpTools("srv", fakeClient as never, {
+      throwOnLoadError: true,
+    });
+
+    const dropped = sanitizeSchemaPatterns(tools[0].schema);
+
+    expect(dropped).toEqual([
+      {
+        location: "/properties/url/pattern",
+        pattern: TOXIC_PATTERN,
+        compilesWithoutUnicodeFlag: true,
+      },
+    ]);
+    await expect(tools[0].invoke({ url: "https://x.com" })).resolves.toBe(
+      "called",
+    );
+  });
+});

--- a/backend/services/runner/src/shared/mcp-manager.ts
+++ b/backend/services/runner/src/shared/mcp-manager.ts
@@ -4,6 +4,10 @@
  * Wraps @langchain/mcp-adapters MultiServerMCPClient with:
  * - Conversion from ResolvedMcpServer[] to the SDK's Connection config
  * - Proper async cleanup via close()
+ * - Input-schema sanitization of unicode-invalid regex patterns
+ *   (issue #420; semantics in shared/mcp-schema-sanitizer.ts) — a vendor
+ *   pattern that cannot compile under the /u flag must not leave its tool
+ *   permanently uncallable
  * - Tool filtering by each server's effective enabled_tools allow-list
  *   (issue #350; semantics in shared/mcp-enabled-tools.ts) — the model only
  *   ever sees the tools the agent's manifest enables
@@ -35,6 +39,7 @@ import type { Connection } from "@langchain/mcp-adapters";
 import type { DynamicStructuredTool } from "@langchain/core/tools";
 import type { ResolvedMcpServer } from "./mcp-resolver.js";
 import { filterToolsByEnabledTools } from "./mcp-enabled-tools.js";
+import { sanitizeSchemaPatterns } from "./mcp-schema-sanitizer.js";
 
 /**
  * Convert harness-agnostic ResolvedMcpServer[] into the
@@ -99,6 +104,32 @@ export async function connectMcpServers(
 
   const client = new MultiServerMCPClient(connectionConfig);
   const discoveredToolMap = await client.initializeConnections();
+
+  // Drop unicode-invalid regex patterns from every discovered tool's input
+  // schema BEFORE anything downstream holds a reference (issue #420):
+  // @langchain/core re-validates against tool.schema on every invocation,
+  // so one vendor pattern that cannot compile under the /u flag would
+  // otherwise make its tool permanently uncallable. Semantics and the
+  // loosen-never-tighten invariant live in shared/mcp-schema-sanitizer.ts.
+  for (const [slug, discovered] of Object.entries(discoveredToolMap)) {
+    for (const tool of discovered) {
+      const droppedPatterns = sanitizeSchemaPatterns(tool.schema);
+      if (droppedPatterns.length > 0) {
+        console.warn(
+          `[MCP] Server '${slug}' tool '${tool.name}': dropped ` +
+          `${droppedPatterns.length} regex pattern(s) that cannot compile ` +
+          `under the unicode flag — the tool stays callable, the server ` +
+          `still validates its own inputs (issue #420): ` +
+          droppedPatterns
+            .map((d) =>
+              `${d.location} ${JSON.stringify(d.pattern)}` +
+              (d.compilesWithoutUnicodeFlag ? "" : " (invalid without /u too)"),
+            )
+            .join(", "),
+        );
+      }
+    }
+  }
 
   // Enforce each server's effective enabled_tools allow-list (issue #350)
   // HERE, before anything downstream sees the tools: the parent tool list,

--- a/backend/services/runner/src/shared/mcp-schema-sanitizer.ts
+++ b/backend/services/runner/src/shared/mcp-schema-sanitizer.ts
@@ -1,0 +1,224 @@
+/**
+ * Unicode-flag regex sanitization for MCP tool input schemas (issue #420).
+ *
+ * Why this exists: real-world MCP servers ship JSON-schema `pattern` values
+ * that are legal as plain ECMAScript regexes but invalid under the unicode
+ * flag (PayPal's `^https\:\/\/` — `\:` is an invalid escape under /u).
+ * @langchain/core validates tool input on EVERY call with
+ * @cfworker/json-schema, which compiles patterns via `new RegExp(p, "u")`
+ * at exactly two uncaught sites: the `pattern` keyword and each
+ * `patternProperties` key. One bad vendor pattern therefore makes the tool
+ * permanently uncallable on the deep-agent path — every invocation dies
+ * with a cryptic SyntaxError before the tool is ever reached. (The third
+ * /u compile site, `format: "regex"`, validates instance values inside a
+ * try/catch and fails gracefully — not a crash surface.)
+ *
+ * The fix: at the deep-agent connect funnel (mcp-manager.ts
+ * connectMcpServers), drop every pattern that cannot compile under /u.
+ * Dropping is deliberate — rewriting to a /u-safe equivalent would need an
+ * Annex-B-aware regex transpiler, disproportionate machinery for what is
+ * best-effort client-side validation; the MCP server still validates its
+ * own inputs server-side. This mirrors the loosening posture of
+ * @langchain/mcp-adapters' own schema pipeline (dereferenceJsonSchema →
+ * simplifyJsonSchemaForLLM), which already normalizes schemas for this
+ * exact validator.
+ *
+ * THE INVARIANT: sanitization may only ever LOOSEN validation, never
+ * tighten it. Dropping a `patternProperties` entry naively would violate
+ * this — @cfworker marks pattern-matched keys as "evaluated" and routes
+ * unevaluated keys into the `additionalProperties` / `unevaluatedProperties`
+ * checks, so under `additionalProperties: false` the drop would flip a
+ * crash into a false REJECTION of valid inputs. Whenever a
+ * `patternProperties` entry is dropped, any restrictive
+ * `additionalProperties` / `unevaluatedProperties` at that schema level is
+ * therefore relaxed too.
+ *
+ * Scope: this sanitizer serves the EXECUTION path only. Discovery
+ * (activities/discover-mcp-server.ts) persists tool schemas verbatim from
+ * listTools — deliberately: the stored schema is the vendor's truth for
+ * display, and discovery never invokes tools, so it cannot hit the crash.
+ * Do not "extend" sanitization there.
+ */
+
+/** One dropped regex constraint, for the caller's log line. */
+export interface DroppedPattern {
+  /** JSON-pointer-style path of the dropped constraint within the schema. */
+  location: string;
+  /** The pattern source that failed to compile under the unicode flag. */
+  pattern: string;
+  /**
+   * True when the pattern compiles WITHOUT the /u flag — vendor sloppiness
+   * (Annex B legacy syntax), the oss#420 class. False means the regex is
+   * broken outright; either way validation could only crash, so both drop.
+   */
+  compilesWithoutUnicodeFlag: boolean;
+}
+
+/** Keywords whose value is a single subschema. */
+const SINGLE_SCHEMA_KEYWORDS = [
+  "additionalProperties",
+  "unevaluatedProperties",
+  "propertyNames",
+  "items",
+  "additionalItems",
+  "unevaluatedItems",
+  "contains",
+  "not",
+  "if",
+  "then",
+  "else",
+] as const;
+
+/** Keywords whose value is an array of subschemas. */
+const SCHEMA_ARRAY_KEYWORDS = ["anyOf", "allOf", "oneOf", "prefixItems"] as const;
+
+/** Keywords whose value is an object mapping names to subschemas. */
+const SCHEMA_MAP_KEYWORDS = [
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+  "$defs",
+  "definitions",
+] as const;
+
+function compilesUnderUnicodeFlag(pattern: string): boolean {
+  try {
+    new RegExp(pattern, "u");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compilesWithoutUnicodeFlag(pattern: string): boolean {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** JSON-pointer token escaping (RFC 6901): `~` → `~0`, `/` → `~1`. */
+function pointerToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+/**
+ * Drop unicode-invalid regex patterns from a JSON schema, in place.
+ *
+ * Walks only schema positions (the recursion set is @cfworker's own
+ * validated-keyword list), so a property literally NAMED "pattern" under
+ * `properties` is never touched. The walker handles composition keywords
+ * (anyOf/allOf/oneOf/not/if-then-else) even though the adapter's
+ * simplifyJsonSchemaForLLM currently strips them, and carries a visited-set
+ * cycle guard even though the adapter's $ref inlining currently guarantees
+ * an acyclic result — correctness here must not depend on another
+ * package's internals holding across dependency bumps.
+ *
+ * Returns the dropped constraints (empty for clean schemas — the common
+ * case, which this walk leaves byte-identical).
+ */
+export function sanitizeSchemaPatterns(schema: unknown): DroppedPattern[] {
+  const dropped: DroppedPattern[] = [];
+  if (!isPlainObject(schema)) return dropped;
+  walkSchema(schema, "", dropped, new Set());
+  return dropped;
+}
+
+function recordDrop(dropped: DroppedPattern[], location: string, pattern: string): void {
+  dropped.push({
+    location,
+    pattern,
+    compilesWithoutUnicodeFlag: compilesWithoutUnicodeFlag(pattern),
+  });
+}
+
+function walkSchema(
+  node: Record<string, unknown>,
+  path: string,
+  dropped: DroppedPattern[],
+  seen: Set<object>,
+): void {
+  if (seen.has(node)) return;
+  seen.add(node);
+
+  if (typeof node.pattern === "string" && !compilesUnderUnicodeFlag(node.pattern)) {
+    recordDrop(dropped, `${path}/pattern`, node.pattern);
+    delete node.pattern;
+  }
+
+  if (isPlainObject(node.patternProperties)) {
+    const patternProperties = node.patternProperties;
+    let droppedEntry = false;
+    for (const key of Object.keys(patternProperties)) {
+      if (compilesUnderUnicodeFlag(key)) continue;
+      recordDrop(dropped, `${path}/patternProperties/${pointerToken(key)}`, key);
+      delete patternProperties[key];
+      droppedEntry = true;
+    }
+    if (droppedEntry) {
+      // Never-tighten: keys the dropped pattern used to match would now
+      // fall through to these checks and could be falsely rejected.
+      if (node.additionalProperties !== undefined && node.additionalProperties !== true) {
+        delete node.additionalProperties;
+      }
+      if (node.unevaluatedProperties !== undefined && node.unevaluatedProperties !== true) {
+        delete node.unevaluatedProperties;
+      }
+      if (Object.keys(patternProperties).length === 0) {
+        delete node.patternProperties;
+      }
+    }
+  }
+
+  for (const keyword of SINGLE_SCHEMA_KEYWORDS) {
+    const value = node[keyword];
+    if (isPlainObject(value)) {
+      walkSchema(value, `${path}/${keyword}`, dropped, seen);
+    }
+  }
+
+  for (const keyword of SCHEMA_ARRAY_KEYWORDS) {
+    const value = node[keyword];
+    if (!Array.isArray(value)) continue;
+    value.forEach((entry, index) => {
+      if (isPlainObject(entry)) {
+        walkSchema(entry, `${path}/${keyword}/${index}`, dropped, seen);
+      }
+    });
+  }
+
+  for (const keyword of SCHEMA_MAP_KEYWORDS) {
+    const value = node[keyword];
+    if (!isPlainObject(value)) continue;
+    for (const [name, entry] of Object.entries(value)) {
+      if (isPlainObject(entry)) {
+        walkSchema(entry, `${path}/${keyword}/${pointerToken(name)}`, dropped, seen);
+      }
+    }
+  }
+
+  // Draft-07 `items` tuple form and `dependencies` schema form — both
+  // keywords are dual-shaped, so the typed loops above miss these arms.
+  if (Array.isArray(node.items)) {
+    node.items.forEach((entry, index) => {
+      if (isPlainObject(entry)) {
+        walkSchema(entry, `${path}/items/${index}`, dropped, seen);
+      }
+    });
+  }
+  if (isPlainObject(node.dependencies)) {
+    for (const [name, entry] of Object.entries(node.dependencies)) {
+      // Array-valued entries are dependentRequired (property names, not
+      // schemas) — only schema-valued entries are walked.
+      if (isPlainObject(entry)) {
+        walkSchema(entry, `${path}/dependencies/${pointerToken(name)}`, dropped, seen);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

MCP tools whose JSON schema carries a `pattern` that is a legal plain ECMAScript regex but invalid under the unicode flag (PayPal's `^https\:\/\/` — `\:` is an invalid escape under `/u`) fail **every** invocation on the deep-agent path with a cryptic `SyntaxError`. This PR adds a sanitization seam at the deep-agent MCP connect funnel that drops such patterns, making the tool callable instead of permanently broken.

## Context

`@langchain/core` validates tool input on every call with `@cfworker/json-schema`, which compiles regex patterns via `new RegExp(pattern, "u")` at exactly two uncaught sites: the `pattern` keyword and each `patternProperties` key. Real-world MCP servers routinely ship non-unicode-safe patterns, and we don't control vendor schemas. Full analysis and repro in #420 (spawned from the #231/PR #419 investigation).

Scope: deep-agent executions only. Discovery persists tool schemas verbatim from raw `listTools()` (the vendor's truth, and it never invokes tools), and the Cursor harness passes raw MCP configs to the Cursor SDK — both unaffected.

## Changes

- New `backend/services/runner/src/shared/mcp-schema-sanitizer.ts`: a schema-position-aware walker that deletes any `pattern` / `patternProperties` key failing `new RegExp(p, "u")`, returning a drop report for logging. Walks only schema positions (a property literally *named* `pattern` is never touched), handles composition keywords and both dual-shaped keywords (`items` tuple form, `dependencies` schema form), and carries a visited-set cycle guard.
- `connectMcpServers` (`mcp-manager.ts`) sanitizes every discovered tool's schema right after `initializeConnections()`, before anything downstream holds a reference — the model-facing tool list, the approval gate, and the sub-agent filter all see the sanitized schema. One `[MCP]` warn line per affected tool.

## Implementation notes

- **Drop, don't rewrite.** A semantically-equivalent `/u`-safe rewrite needs an Annex-B-aware regex transpiler — disproportionate for best-effort client-side validation; the MCP server still validates its own inputs. This mirrors the loosening posture of `@langchain/mcp-adapters`' own schema pipeline (`dereferenceJsonSchema` → `simplifyJsonSchemaForLLM`), which already normalizes schemas for this exact validator.
- **Never-tighten invariant.** `@cfworker` marks `patternProperties`-matched keys as evaluated and routes unevaluated keys into `additionalProperties`/`unevaluatedProperties`; dropping an entry naively would flip a crash into a false rejection under `additionalProperties: false`. Dropping a `patternProperties` entry therefore also relaxes restrictive `additionalProperties`/`unevaluatedProperties` at that level. Sanitization only ever loosens.
- Zero new dependencies.
- Upstream follow-up: filing an issue against `@langchain/mcp-adapters` (the natural home, next to its existing cfworker-compat normalization), noting the `@cfworker/json-schema` fallback-compile alternative.

## Breaking changes

- None. Tools with clean schemas pass through byte-identical.

## Test plan

- 14 new sanitizer tests: walker semantics (nested positions, tuple `items`, `dependencies`, cycle guard, property-named-`pattern` protection), never-tighten invariant proven through `@langchain/core`'s real validation path, and the issue's exact repro as a regression pin — including the negative control (unsanitized tool rejects with `Invalid regular expression`; sanitized tool invokes successfully) through the real `loadMcpTools`.
- New `connectMcpServers` wiring test: discovered tools' schemas sanitized in place, per-tool warn emitted, clean sibling untouched.
- Full runner gate green: `npm run typecheck` clean, 4481 tests passed (267 files).

## Risks

- Validation for affected tools is slightly looser than the vendor intended (the dropped constraint) — strictly better than the status quo, where the tool cannot be called at all. Rollback: revert the sanitize loop in `connectMcpServers`.

Closes #420

Made with [Cursor](https://cursor.com)