### PR TITLE
fix(backend/stigmer-server): use proto.Clone in runstarter test fake

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/schedule/temporal/runstarter_test.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/temporal/runstarter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // fakeExecutionCreator records the create request and answers with a
@@ -36,14 +37,16 @@ func (f *fakeExecutionCreator) Create(ctx context.Context, execution *agentexecu
 	}
 	response := f.response
 	if response == nil {
-		clone := *execution
+		// proto.Clone, never a struct copy: proto messages carry an
+		// internal mutex, so copying trips vet's copylocks.
+		clone := proto.Clone(execution).(*agentexecutionv1.AgentExecution)
 		clone.Metadata = &apiresource.ApiResourceMetadata{
 			Id:   "aex_01CREATED",
 			Org:  execution.GetMetadata().GetOrg(),
 			Name: execution.GetMetadata().GetName(),
 			Slug: execution.GetMetadata().GetName(),
 		}
-		response = &clone
+		response = clone
 	}
 	if f.persistOnCreate != nil {
 		if err := f.persistOnCreate.SaveResource(ctx,


### PR DESCRIPTION
## Summary

`make lint` (go vet) has been red on clean `main`: the schedule runstarter test's fake execution creator struct-copies a proto message (`clone := *execution` in `pkg/domain/schedule/temporal/runstarter_test.go`). Proto messages carry an internal mutex (`protoimpl.MessageState` → `sync.Mutex`), so the copy trips vet's `copylocks` check — and a red gate on clean HEAD poisons verification for every session (the cloud#201/cloud#272 failure class).

This replaces the struct copy with the codebase's established `proto.Clone(x).(*T)` idiom (the same pattern the sibling schedule controller tests and production code use, e.g. `workflowexecution/temporal/activities/update_status_impl.go`), with a one-line why-comment at the site. The deep copy is also more faithful mimicry for the fake: a real pipeline never returns a message that aliases the caller's spec.

No new test: vet itself is the regression pin — this PR exists to turn that pin green.

Closes #426

## Verification

- `go vet ./...` in `backend/services/stigmer-server`: 0 diagnostics (was 1 — this was the only vet diagnostic across all six `GO_MODULES` that `make lint` vets, individually confirmed)
- `go test ./pkg/domain/schedule/...`: green (controller + temporal)
- Full `make lint`: green end to end (Go vet × 6 modules, gofmt, apis lint, sdk/react/web typecheck+lint, site lint+typecheck)
- Built and verified in an isolated worktree cut from `origin/main` tip `841fc87f4`

## Notes

While verifying, the full `make lint`'s mutating `gofmt -s -w .` surfaced pre-existing gofmt drift in 11 unrelated files on clean main — deliberately NOT included here (kept scoped to #426); reported separately to the owner.

Made with [Cursor](https://cursor.com)