### PR TITLE
fix(runner): normalize workspace-relative paths before plan-mode permission rules

### DIFF
--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/plan-mode-path-normalization.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/plan-mode-path-normalization.test.ts
@@ -1,0 +1,174 @@
+/**
+ * End-to-end proof (real deepagents + LangGraph runtime, no LLM/network) that
+ * a plan-mode PARENT graph accepts workspace-relative paths (issue #429).
+ *
+ * Before the fix, deepagents' permission enforcement canonicalized every
+ * filesystem tool-call path BEFORE any rule ran and refused non-absolute
+ * shapes, so on a rule-bearing graph a workspace-relative call — reads
+ * included — died with `path must be absolute` instead of just working. The
+ * path-normalization middleware (middleware/path-normalization.ts) rewrites
+ * relative paths to workspace-absolute at our seam, before enforcement sees
+ * them.
+ *
+ * The graph here is composed exactly the way setup.ts composes the parent:
+ * the PRODUCTION buildMiddlewareStack (pathNormalization present, the
+ * rule-bearing shape) + the CAS capture backend + the PRODUCTION
+ * PLAN_MODE_PERMISSIONS constant. These tests are also the empirical proof
+ * that langchain's wrapToolCall seam delivers rewritten args to the tool —
+ * if it did not, the relative read below could never succeed.
+ *
+ * The sub-agent twin of this contract is pinned in
+ * subagent-plan-mode-permissions.test.ts (issue #255 wiring).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, writeFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HumanMessage, ToolMessage, type BaseMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+import { createDeepAgent } from "deepagents";
+
+import { PLAN_MODE_PERMISSIONS } from "../../../shared/plan-mode-permissions.js";
+import { buildMiddlewareStack } from "../../../middleware/index.js";
+import { createCasCaptureBackend } from "../cas-capture-backend.js";
+import { CasCaptureObserver } from "../cas-capture-observer.js";
+import { ScriptedModel, type ScriptSelector } from "../__test-utils__/scripted-model.js";
+
+const SEEDED_CONTENT = "PLAN_MODE_README_TOKEN: hello from the seeded file";
+
+describe("plan-mode parent path normalization (issue #429)", () => {
+  let root: string;
+  let observer: CasCaptureObserver;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "plan-path-"));
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src/notes.md"), SEEDED_CONTENT);
+    observer = new CasCaptureObserver({ rootDir: root, isIgnored: async () => true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /**
+   * Build a parent graph the way setup.ts does in plan mode: the production
+   * middleware stack with pathNormalization set (derived, like the graph's
+   * permissions, from the plan-mode rules), a filesystem-only CAS capture
+   * backend (no shellEnv — plan mode clears it), and PLAN_MODE_PERMISSIONS
+   * on the graph.
+   */
+  async function buildPlanModeParent(script: ScriptSelector) {
+    const { middleware } = buildMiddlewareStack({
+      approvalGate: null,
+      pathNormalization: { rootDir: root },
+    });
+    const backend = await createCasCaptureBackend({ rootDir: root, observer });
+    return createDeepAgent({
+      model: new ScriptedModel(script),
+      checkpointer: new MemorySaver() as never,
+      backend,
+      middleware: middleware as never[],
+      permissions: PLAN_MODE_PERMISSIONS,
+    } as Parameters<typeof createDeepAgent>[0]);
+  }
+
+  function toolResultById(messages: BaseMessage[], toolCallId: string): string {
+    const match = messages.find(
+      (m): m is ToolMessage => m instanceof ToolMessage && m.tool_call_id === toolCallId,
+    );
+    expect(match, `expected a tool result for call '${toolCallId}'`).toBeDefined();
+    return typeof match!.content === "string" ? match!.content : JSON.stringify(match!.content);
+  }
+
+  async function invokeOnce(script: ScriptSelector, threadId: string) {
+    const agent = await buildPlanModeParent(script);
+    return (await agent.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: threadId }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+  }
+
+  it("a prompt-compliant relative read succeeds on the first tool round", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "read_file", args: { file_path: "src/notes.md" }, id: "c_read_rel" },
+        ],
+        done: "done",
+      }),
+      "t_read_rel",
+    );
+
+    const readResult = toolResultById(result.messages, "c_read_rel");
+    expect(readResult).toContain("PLAN_MODE_README_TOKEN");
+    expect(readResult).not.toMatch(/path must be absolute/i);
+    expect(readResult).not.toMatch(/permission denied/i);
+  });
+
+  it("a relative write is refused by the RULES — permission denied, not a path-shape error", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "write_file", args: { file_path: "src/out.txt", content: "x" }, id: "c_write_rel" },
+        ],
+        done: "done",
+      }),
+      "t_write_rel",
+    );
+
+    // The deny-all-writes rule fires on the normalized path — the honest
+    // plan-mode refusal the model can reason about, instead of the
+    // pre-fix validation error that taught it to abandon relative paths.
+    expect(toolResultById(result.messages, "c_write_rel")).toMatch(/permission denied for write/i);
+    expect(toolResultById(result.messages, "c_write_rel")).not.toMatch(/path must be absolute/i);
+    await expect(access(join(root, "src/out.txt"))).rejects.toThrow();
+    expect(observer.before.size).toBe(0);
+  });
+
+  it("an escaping relative read is still refused — normalization grants no new reachability", async () => {
+    // Outside the root, reachable only if `..` were naively joined away.
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "read_file", args: { file_path: "../escape.txt" }, id: "c_read_escape" },
+        ],
+        done: "done",
+      }),
+      "t_read_escape",
+    );
+
+    // Left raw by the middleware, refused by upstream validation exactly as
+    // before the fix.
+    expect(toolResultById(result.messages, "c_read_escape")).toMatch(/must not contain|path must be absolute/i);
+  });
+
+  it("absolute in-workspace paths keep working unchanged", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "read_file", args: { file_path: join(root, "src/notes.md") }, id: "c_read_abs" },
+        ],
+        done: "done",
+      }),
+      "t_read_abs",
+    );
+
+    expect(toolResultById(result.messages, "c_read_abs")).toContain("PLAN_MODE_README_TOKEN");
+  });
+
+  it("relative ls flows through normalization to list the workspace directory", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [{ name: "ls", args: { path: "src" }, id: "c_ls_rel" }],
+        done: "done",
+      }),
+      "t_ls_rel",
+    );
+
+    const lsResult = toolResultById(result.messages, "c_ls_rel");
+    expect(lsResult).toContain("notes.md");
+    expect(lsResult).not.toMatch(/path must be absolute/i);
+  });
+});

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-plan-mode-permissions.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-plan-mode-permissions.test.ts
@@ -83,12 +83,10 @@ describe("plan-mode sub-agent filesystem permissions (issue #255)", () => {
     // One turn, three tool calls: both mutation tools must be denied by the
     // permission rules; the read must pass through untouched (the deny rule
     // covers the `write` operation class only).
-    // Real absolute workspace paths, as production models use (the prompt's
-    // file tree is absolute, and the tools' contract says absolute). With
-    // permission rules present this is also the only shape that reaches the
-    // rules at all: enforcePermission's canonicalization refuses relative
-    // paths with a validation error before any rule or backend runs — a
-    // different denial, but still nothing written.
+    // Absolute workspace paths — the canonical shape after enforcement
+    // canonicalization, and what the single-workspace prompt's prose (the
+    // absolute rootDir) steers models toward. The workspace-relative shape
+    // is pinned separately below (issue #429).
     const script: ScriptSelector = () => ({
       toolCalls: [
         { name: "write_file", args: { file_path: join(root, "dist/out.txt"), content: "new file" }, id: "c_write" },
@@ -143,19 +141,20 @@ describe("plan-mode sub-agent filesystem permissions (issue #255)", () => {
     expect(observer.before.size).toBe(1);
   });
 
-  it("relative-path mutations are refused too — by validation, before the rules", async () => {
-    // The native prompt steers models to workspace-relative paths, but
-    // deepagents' permission canonicalization accepts only absolute ones, so
-    // with rules present a relative-path call fails validation before any
-    // rule (or backend) runs. Read-only still holds — nothing is written —
-    // but the model sees "path must be absolute", not "permission denied",
-    // and prompt-compliant relative READS degrade the same way. That
-    // relative-vs-absolute friction is a pre-existing parent-plan-mode
-    // behavior, tracked as issue #429; this pins that the sub-agent's
-    // read-only contract survives it.
+  it("relative-path writes are refused by the RULES, and relative reads flow (issue #429)", async () => {
+    // The multi-workspace prompt mandates workspace-relative paths, and
+    // models routinely choose them in single-workspace sessions too. Before
+    // the #429 fix, deepagents' permission canonicalization refused the
+    // shape outright — every relative call, reads included, died with
+    // "path must be absolute" before any rule ran. compileSubagents now
+    // derives a path-normalization shim from the same `permissions` it
+    // bakes into the graph, so the relative shape reaches the rules in
+    // canonical form: writes get the honest plan-mode denial, reads just
+    // work. Read-only-by-construction (issue #255) holds throughout.
     const script: ScriptSelector = () => ({
       toolCalls: [
         { name: "write_file", args: { file_path: "dist/out.txt", content: "new file" }, id: "c_write_rel" },
+        { name: "read_file", args: { file_path: "notes.md" }, id: "c_read_rel" },
       ],
       done: "worker done",
     });
@@ -166,8 +165,14 @@ describe("plan-mode sub-agent filesystem permissions (issue #255)", () => {
       { configurable: { thread_id: "t3" }, recursionLimit: 50 },
     )) as { messages: BaseMessage[] };
 
-    expect(toolResultById(result.messages, "c_write_rel")).toMatch(/path must be absolute/i);
+    const writeResult = toolResultById(result.messages, "c_write_rel");
+    expect(writeResult).toMatch(/permission denied for write/i);
+    expect(writeResult).not.toMatch(/path must be absolute/i);
     await expect(access(join(root, "dist/out.txt"))).rejects.toThrow();
     expect(observer.before.size).toBe(0);
+
+    const readResult = toolResultById(result.messages, "c_read_rel");
+    expect(readResult).toContain("PLAN_MODE_README_TOKEN");
+    expect(readResult).not.toMatch(/path must be absolute/i);
   });
 });

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -652,6 +652,12 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     const execConfig = execution.spec!.executionConfig;
     const isPlanMode = execConfig?.interactionMode === InteractionMode.PLAN;
     const shellEnv = isPlanMode ? undefined : buildShellEnv(envResult.mergedEnvVars);
+    // Plan mode's filesystem permission rules, hoisted once: the parent graph,
+    // every sub-agent graph, AND the path-normalization middleware (issue #429)
+    // all derive from this single value, so a rule-bearing graph can never miss
+    // the shim that keeps prompt-compliant relative paths from dying in rule
+    // validation (`path must be absolute`).
+    const planModePermissions = isPlanMode ? PLAN_MODE_PERMISSIONS : undefined;
 
     const toolServerMap = new Map<string, string>();
     if (mcpConnection) {
@@ -757,6 +763,9 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       } : null,
       otelSpans: { toolServerMap },
       approvalGate: approvalGateConfig,
+      pathNormalization: planModePermissions
+        ? { rootDir: workspaceBackend.rootDir }
+        : null,
     });
     timing.mark("build_middleware");
 
@@ -820,7 +829,9 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
         // Plan mode's deny-all-writes rule, mirrored onto every sub-agent graph
         // (issue #255) — pre-built CompiledSubAgents never inherit the parent's
         // permissions, so read-only-by-construction must be baked in here.
-        ...(isPlanMode ? { permissions: PLAN_MODE_PERMISSIONS } : {}),
+        // compileSubagents derives each sub-agent's path-normalization shim
+        // from this same value (issue #429).
+        ...(planModePermissions ? { permissions: planModePermissions } : {}),
       });
       timing.mark("compile_subagents");
     }
@@ -854,7 +865,7 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       middleware: middleware as any,
       subagents: compiledSubagents ?? undefined,
       ...(responseFormat ? { responseFormat } : {}),
-      ...(isPlanMode ? { permissions: PLAN_MODE_PERMISSIONS } : {}),
+      ...(planModePermissions ? { permissions: planModePermissions } : {}),
     } as Parameters<typeof createDeepAgent>[0]);
 
     // Step 11: Prepare invocation input and config. The conversation catchup

--- a/backend/services/runner/src/activities/execute-deep-agent/subagent-transformer.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/subagent-transformer.ts
@@ -554,11 +554,17 @@ export async function compileSubagents(
       // Structural coupling (DD-19): a sub-agent gate flows gitignored writes into
       // CAS iff a CAS observer backs that sub-agent's filesystem backend. Deriving
       // both from the same `casObserver` makes "unobserved unreviewable bytes"
-      // impossible by construction.
+      // impossible by construction. Same idiom for path normalization
+      // (issue #429): derived from the same `permissions` baked into the graph
+      // below, so a rule-bearing graph always carries the shim that keeps
+      // prompt-compliant relative paths from dying in rule validation.
       const middleware = buildSubAgentMiddleware({
         costCap: opts.costCap,
         approvalGate: opts.approvalGate,
         captureIgnored: !!opts.casObserver,
+        ...(opts.permissions?.length
+          ? { pathNormalization: { rootDir: opts.workspaceRootDir } }
+          : {}),
       });
 
       const modelName = spec.model ?? opts.parentModelName;

--- a/backend/services/runner/src/activities/execute-deep-agent/subagent-wiring.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/subagent-wiring.ts
@@ -2,6 +2,12 @@
  * Sub-agent middleware composition for ExecuteDeepAgent.
  *
  * Each sub-agent gets its own middleware stack with:
+ * - Path normalization (issue #429), FIRST and only on permission-rule-
+ *   bearing graphs (plan mode) — workspace-relative paths are rewritten to
+ *   workspace-absolute before deepagents' permission validation refuses
+ *   them, exactly as on the parent. `compileSubagents` derives it from the
+ *   same `permissions` option it bakes into the graph, keeping the rules
+ *   and their normalization shim coupled.
  * - Fresh loop detection (independent cycle tracking)
  * - Fresh tool truncation (same limits as parent)
  * - Periodic execution budget (interval=30, max=4 advisories)
@@ -27,8 +33,13 @@
  * the live HITL bypass this wiring closes.
  */
 
-import type { StigmerMiddleware, ToolTruncationConfig } from "../../middleware/types.js";
+import type {
+  StigmerMiddleware,
+  ToolTruncationConfig,
+  PathNormalizationConfig,
+} from "../../middleware/types.js";
 import type { CostCapMiddleware } from "../../middleware/index.js";
+import { createPathNormalizationMiddleware } from "../../middleware/path-normalization.js";
 import { createLoopDetectionMiddleware } from "../../middleware/loop-detection.js";
 import { createToolTruncationMiddleware } from "../../middleware/tool-truncation.js";
 import { createExecutionBudgetMiddleware } from "../../middleware/execution-budget.js";
@@ -59,14 +70,22 @@ export interface SubAgentMiddlewareOptions {
    * unobserved backend would apply unreviewable bytes.
    */
   readonly captureIgnored?: boolean;
+  /**
+   * Workspace-relative path normalization (issue #429). Present iff this
+   * sub-agent's graph carries filesystem permission rules — the caller
+   * derives it from the same `permissions` value it bakes into the graph.
+   */
+  readonly pathNormalization?: PathNormalizationConfig;
 }
 
 /**
  * Build the middleware stack for a single sub-agent.
  *
  * Returns an ordered array mirroring the parent composition:
- * loop detection → execution budget (periodic) → tool truncation →
- * [approval gate] → cost cap view → error hints. The gate sits before the
+ * [path normalization] → loop detection → execution budget (periodic) →
+ * tool truncation → [approval gate] → cost cap view → error hints.
+ * Normalization is outermost so everything downstream observes canonical
+ * workspace-absolute paths (matching the parent). The gate sits before the
  * cost-cap view so an approval pause happens before budget accounting, and
  * error hints come after the gate — both matching the parent order
  * (…→ truncation → graceful-stop → approval gate → cost cap → error hints …),
@@ -76,6 +95,10 @@ export function buildSubAgentMiddleware(
   options: SubAgentMiddlewareOptions = {},
 ): StigmerMiddleware[] {
   const stack: StigmerMiddleware[] = [];
+
+  if (options.pathNormalization) {
+    stack.push(createPathNormalizationMiddleware(options.pathNormalization));
+  }
 
   stack.push(createLoopDetectionMiddleware({ enabled: true }));
 

--- a/backend/services/runner/src/middleware/__tests__/path-normalization.test.ts
+++ b/backend/services/runner/src/middleware/__tests__/path-normalization.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolMessage } from "@langchain/core/messages";
+import {
+  createPathNormalizationMiddleware,
+  normalizeWorkspacePathArg,
+} from "../path-normalization.js";
+import type { ToolCallRequest } from "../types.js";
+
+const ROOT = "/workspace/session-1/repo";
+
+function makeRequest(
+  name: string,
+  args: Record<string, unknown>,
+): ToolCallRequest {
+  return {
+    toolCall: { id: "tc_1", name, args },
+    tool: undefined,
+    state: { messages: [] },
+    runtime: {},
+  };
+}
+
+/** Run the middleware and return the args the inner handler observed. */
+async function argsSeenByHandler(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const mw = createPathNormalizationMiddleware({ rootDir: ROOT });
+  const handler = vi.fn(async (req: ToolCallRequest) => {
+    return new ToolMessage({ content: "ok", tool_call_id: req.toolCall.id, name });
+  });
+  await mw.wrapToolCall!(makeRequest(name, args), handler);
+  expect(handler).toHaveBeenCalledTimes(1);
+  return handler.mock.calls[0][0].toolCall.args;
+}
+
+describe("normalizeWorkspacePathArg", () => {
+  it("maps a workspace-relative path to its rootDir-joined absolute form", () => {
+    expect(normalizeWorkspacePathArg("src/main.py", ROOT)).toBe(`${ROOT}/src/main.py`);
+  });
+
+  it("strips a leading ./ before joining", () => {
+    expect(normalizeWorkspacePathArg("./notes.md", ROOT)).toBe(`${ROOT}/notes.md`);
+  });
+
+  it("handles multi-workspace entry-relative paths", () => {
+    expect(normalizeWorkspacePathArg("entry-1/src/main.py", ROOT)).toBe(
+      `${ROOT}/entry-1/src/main.py`,
+    );
+  });
+
+  it("resolves interior .. segments that stay inside the root", () => {
+    expect(normalizeWorkspacePathArg("src/../notes.md", ROOT)).toBe(`${ROOT}/notes.md`);
+  });
+
+  it("leaves absolute paths untouched", () => {
+    expect(normalizeWorkspacePathArg("/etc/hosts", ROOT)).toBeUndefined();
+    expect(normalizeWorkspacePathArg(`${ROOT}/src/main.py`, ROOT)).toBeUndefined();
+    expect(normalizeWorkspacePathArg("/", ROOT)).toBeUndefined();
+  });
+
+  it("refuses to rewrite relatives that escape the workspace root", () => {
+    // A naive join would resolve `..` away and hand upstream validation a
+    // clean out-of-root absolute path — an out-of-root read that today's
+    // validation refuses. The guard keeps the refusal.
+    expect(normalizeWorkspacePathArg("../sibling/secret.txt", ROOT)).toBeUndefined();
+    expect(normalizeWorkspacePathArg("src/../../escape.txt", ROOT)).toBeUndefined();
+  });
+
+  it("leaves ~-carrying paths untouched (upstream refuses them either way)", () => {
+    expect(normalizeWorkspacePathArg("~/notes.md", ROOT)).toBeUndefined();
+    expect(normalizeWorkspacePathArg("docs/~/x.md", ROOT)).toBeUndefined();
+  });
+
+  it("leaves the empty string untouched", () => {
+    expect(normalizeWorkspacePathArg("", ROOT)).toBeUndefined();
+  });
+});
+
+describe("createPathNormalizationMiddleware", () => {
+  it("rewrites file_path on the file tools", async () => {
+    for (const tool of ["read_file", "write_file", "edit_file"]) {
+      const args = await argsSeenByHandler(tool, {
+        file_path: "src/main.py",
+        content: "x",
+      });
+      expect(args.file_path).toBe(`${ROOT}/src/main.py`);
+      // Sibling args ride along untouched.
+      expect(args.content).toBe("x");
+    }
+  });
+
+  it("rewrites the base path on ls/glob/grep", async () => {
+    for (const tool of ["ls", "glob", "grep"]) {
+      const args = await argsSeenByHandler(tool, { path: "src", pattern: "**/*.py" });
+      expect(args.path).toBe(`${ROOT}/src`);
+      // The pattern is never a path — byte-untouched.
+      expect(args.pattern).toBe("**/*.py");
+    }
+  });
+
+  it("passes absolute paths through byte-untouched", async () => {
+    const args = await argsSeenByHandler("read_file", { file_path: "/etc/hosts" });
+    expect(args.file_path).toBe("/etc/hosts");
+  });
+
+  it("leaves an omitted base path (backend default) alone", async () => {
+    const args = await argsSeenByHandler("ls", {});
+    expect(args.path).toBeUndefined();
+  });
+
+  it("never touches tools outside the built-in filesystem set", async () => {
+    // An MCP tool could plausibly carry a same-named arg with different
+    // semantics; only the six built-in names are rewritten.
+    const args = await argsSeenByHandler("vendor_upload", { file_path: "src/main.py" });
+    expect(args.file_path).toBe("src/main.py");
+  });
+
+  it("leaves non-string path args for the tool's own input validation", async () => {
+    const args = await argsSeenByHandler("read_file", { file_path: 42 });
+    expect(args.file_path).toBe(42);
+  });
+
+  it("preserves the original request identity fields on rewrite", async () => {
+    const mw = createPathNormalizationMiddleware({ rootDir: ROOT });
+    const handler = vi.fn(async (req: ToolCallRequest) => {
+      return new ToolMessage({ content: "ok", tool_call_id: req.toolCall.id, name: req.toolCall.name });
+    });
+    const original = makeRequest("read_file", { file_path: "notes.md" });
+    await mw.wrapToolCall!(original, handler);
+
+    const seen = handler.mock.calls[0][0];
+    expect(seen.toolCall.id).toBe("tc_1");
+    expect(seen.toolCall.name).toBe("read_file");
+    expect(seen.state).toBe(original.state);
+    expect(seen.runtime).toBe(original.runtime);
+    // The original request is never mutated in place.
+    expect(original.toolCall.args.file_path).toBe("notes.md");
+  });
+});

--- a/backend/services/runner/src/middleware/index.ts
+++ b/backend/services/runner/src/middleware/index.ts
@@ -4,6 +4,9 @@
  * Assembles the ordered middleware array from a MiddlewareStackConfig.
  * The composition order matches the Python create_deep_agent injection:
  *
+ *   0. Path normalization (conditional: only on permission-rule-bearing
+ *      graphs — FIRST, so every downstream middleware observes canonical
+ *      workspace-absolute paths)
  *   1. Loop detection (always)
  *   2. Execution budget (always)
  *   3. Tool truncation (always)
@@ -15,6 +18,7 @@
 
 import type { StigmerMiddleware, MiddlewareStackConfig } from "./types.js";
 import type { GracefulStopMiddleware } from "./graceful-stop.js";
+import { createPathNormalizationMiddleware } from "./path-normalization.js";
 import { createLoopDetectionMiddleware } from "./loop-detection.js";
 import { createExecutionBudgetMiddleware } from "./execution-budget.js";
 import { createToolTruncationMiddleware } from "./tool-truncation.js";
@@ -38,6 +42,10 @@ export function buildMiddlewareStack(
   config: MiddlewareStackConfig = {},
 ): MiddlewareStackResult {
   const stack: StigmerMiddleware[] = [];
+
+  if (config.pathNormalization) {
+    stack.push(createPathNormalizationMiddleware(config.pathNormalization));
+  }
 
   stack.push(createLoopDetectionMiddleware(config.loopDetection));
 

--- a/backend/services/runner/src/middleware/path-normalization.ts
+++ b/backend/services/runner/src/middleware/path-normalization.ts
@@ -1,0 +1,125 @@
+/**
+ * Workspace-relative path normalization for permission-rule-bearing graphs
+ * (issue #429).
+ *
+ * deepagents' permission enforcement canonicalizes tool-call paths BEFORE any
+ * rule or backend runs, and its validation refuses non-absolute paths — on
+ * EVERY filesystem tool call once a graph carries any permission rules, reads
+ * included. Plan mode is the only rule-bearing production configuration
+ * (shared/plan-mode-permissions.ts), so there a workspace-relative path —
+ * the shape the multi-workspace prompt explicitly mandates, and one models
+ * routinely choose in single-workspace sessions — fails with
+ * `path must be absolute` instead of just working, burning tool rounds until
+ * the model adapts by switching to absolute paths.
+ *
+ * This middleware repairs the contract at our own seam: it rewrites
+ * workspace-relative paths on the deepagents built-in filesystem tools to
+ * workspace-absolute before the tool (and therefore enforcement) runs. The
+ * write-deny rule then fires as designed and reads succeed on the first try.
+ * Rule-less (act-mode) graphs never install it — the legacy backend already
+ * resolves relative paths under the workspace root, so act mode keeps a
+ * byte-zero delta.
+ *
+ * Invariant — nothing becomes newly reachable: only paths whose resolution
+ * stays INSIDE the workspace root are rewritten. Escaping relatives (`../x`)
+ * and `~`-carrying paths are left raw so today's validation refusal keeps
+ * speaking (a naive join would resolve `..` away and smuggle an out-of-root
+ * read past validation), and absolute paths pass through byte-untouched.
+ * The middleware converts false errors into correct behavior — never a
+ * refusal into an allowance the rules didn't decide.
+ *
+ * Tool matching is by bare built-in name, the house doctrine (an MCP server
+ * is not expected to shadow a built-in name — see shared/tool-kind.ts); the
+ * rewrite touches only the tool's path-bearing argument, never glob/grep
+ * patterns. Install FIRST in the stack so every downstream middleware
+ * (approval gate, error hints, otel spans) observes canonical paths.
+ */
+
+import { isAbsolute, relative } from "node:path";
+import { resolveWorkspacePath } from "../shared/file-change.js";
+import type { StigmerMiddleware } from "./types.js";
+
+/**
+ * The path-bearing argument of each deepagents built-in filesystem tool.
+ * `ls`/`glob`/`grep` take a base directory `path` (defaulting to "/" when
+ * omitted — absolute, so untouched here); the file tools take `file_path`.
+ * Confirmed against the installed deepagents' tool definitions.
+ */
+const PATH_ARG_BY_TOOL: ReadonlyMap<string, string> = new Map([
+  ["ls", "path"],
+  ["glob", "path"],
+  ["grep", "path"],
+  ["read_file", "file_path"],
+  ["write_file", "file_path"],
+  ["edit_file", "file_path"],
+]);
+
+export interface PathNormalizationConfig {
+  /** The workspace root the graph's filesystem backend resolves against. */
+  readonly rootDir: string;
+}
+
+/**
+ * Rewrite `raw` to its workspace-absolute form, or return undefined when the
+ * value must be left untouched (absolute already, `~`-carrying, or escaping
+ * the workspace root). Exported for direct unit testing of the mapping table.
+ */
+export function normalizeWorkspacePathArg(
+  raw: string,
+  rootDir: string,
+): string | undefined {
+  if (raw.length === 0 || isAbsolute(raw)) return undefined;
+  // Upstream validation refuses `~` segments even in absolute paths, so a
+  // rewrite could not make such a call succeed — leave the raw shape (and
+  // therefore the honest refusal) intact.
+  if (raw.split("/").includes("~")) return undefined;
+
+  const { absolutePath } = resolveWorkspacePath(raw, rootDir, false);
+
+  // No-new-reachability guard: `join` inside the resolver normalizes `..`
+  // segments away, so an escaping relative would otherwise pass upstream
+  // validation as a clean out-of-root absolute path. Today that shape is
+  // refused; keep it that way.
+  const rel = relative(rootDir, absolutePath);
+  if (rel.startsWith("..") || isAbsolute(rel)) return undefined;
+
+  return absolutePath;
+}
+
+/**
+ * Create middleware that normalizes workspace-relative paths on the built-in
+ * filesystem tools before permission enforcement sees them.
+ *
+ * Installed only on graphs that carry filesystem permission rules — derive
+ * the install condition from the same expression that supplies the rules
+ * (setup.ts / compileSubagents) so the rules and their normalization shim
+ * cannot drift apart.
+ */
+export function createPathNormalizationMiddleware(
+  config: PathNormalizationConfig,
+): StigmerMiddleware {
+  const { rootDir } = config;
+
+  return {
+    name: "PathNormalizationMiddleware",
+
+    wrapToolCall(request, handler) {
+      const argKey = PATH_ARG_BY_TOOL.get(request.toolCall.name);
+      if (!argKey) return handler(request);
+
+      const raw = request.toolCall.args[argKey];
+      if (typeof raw !== "string") return handler(request);
+
+      const normalized = normalizeWorkspacePathArg(raw, rootDir);
+      if (normalized === undefined) return handler(request);
+
+      return handler({
+        ...request,
+        toolCall: {
+          ...request.toolCall,
+          args: { ...request.toolCall.args, [argKey]: normalized },
+        },
+      });
+    },
+  };
+}

--- a/backend/services/runner/src/middleware/types.ts
+++ b/backend/services/runner/src/middleware/types.ts
@@ -100,6 +100,11 @@ export interface OtelSpansConfig {
 import type { ApprovalGateConfig } from "./approval-gate.js";
 export type { ApprovalGateConfig };
 
+// Same idiom as ApprovalGateConfig above: the normalization middleware
+// consumes it, this module re-exports it for stack-config assembly.
+import type { PathNormalizationConfig } from "./path-normalization.js";
+export type { PathNormalizationConfig };
+
 /**
  * Top-level configuration for buildMiddlewareStack().
  * All sections are optional — the factory applies sensible defaults.
@@ -111,4 +116,10 @@ export interface MiddlewareStackConfig {
   readonly costCap?: CostCapConfig | null;
   readonly otelSpans?: Partial<OtelSpansConfig>;
   readonly approvalGate?: ApprovalGateConfig | null;
+  /**
+   * Workspace-relative path normalization (issue #429). Set iff the graph
+   * carries filesystem permission rules — derive from the same expression
+   * that supplies the rules so the two cannot drift apart.
+   */
+  readonly pathNormalization?: PathNormalizationConfig | null;
 }

--- a/backend/services/runner/src/shared/plan-mode-permissions.ts
+++ b/backend/services/runner/src/shared/plan-mode-permissions.ts
@@ -16,6 +16,13 @@
  * (issue #255). Kept as its own side-effect-free module so tests can pin the
  * production rules without dragging in setup.ts's import graph.
  *
+ * Rules travel with a companion: every graph that carries them also installs
+ * the path-normalization middleware (middleware/path-normalization.ts,
+ * issue #429), because deepagents' rule validation refuses workspace-relative
+ * paths outright — without the shim, prompt-compliant relative READS die in
+ * validation instead of just working. Both are derived from the same
+ * expression at each composition site so they cannot drift apart.
+ *
  * Invariant: never combine these rules with a shell-capable (sandbox)
  * backend — deepagents rejects that pairing at graph construction (see the
  * cas-capture-backend.ts header). Plan mode guarantees it by construction:


### PR DESCRIPTION
## Summary

Fixes #429: in plan mode — the only production configuration that carries filesystem permission rules — every workspace-relative filesystem tool call failed with a cryptic `path must be absolute` error, **reads included**, because deepagents' permission enforcement canonicalizes paths before any rule runs and refuses non-absolute shapes. Every plan turn burned failed tool rounds until the model adapted by switching to absolute paths, contradicting the multi-workspace prompt's explicit relative-path mandate.

### Design: normalize-before-enforcement at our middleware seam

Of the issue's three proposed directions, this lands **normalization in our own seam** (the issue's "smallest blast radius" option):

- New `PathNormalizationMiddleware` (`middleware/path-normalization.ts`): a `wrapToolCall` middleware — arg override through the tool-call chain is a documented first-class langchain capability — that rewrites workspace-relative paths on the six built-in filesystem tools (`ls`/`glob`/`grep`: `path`; `read_file`/`write_file`/`edit_file`: `file_path`) to workspace-absolute before enforcement sees them. The write-deny rule then fires as designed (`permission denied`, a refusal the model can reason about) and reads succeed on the first try.
- **Installed first in the stack, on rule-bearing graphs only**, derived from the same expression that threads `PLAN_MODE_PERMISSIONS` at both composition sites (parent `buildMiddlewareStack` config in `setup.ts`, and `compileSubagents` → `buildSubAgentMiddleware`) — the rules and their shim cannot drift apart. Act mode keeps a **byte-zero delta**.
- Path mapping reuses the house resolver (`resolveWorkspacePath`, `shared/file-change.ts`).
- **No-new-reachability invariant**: only paths whose resolution stays inside the workspace root are rewritten. Escaping relatives (`../x`) and `~`-carrying paths stay raw so today's validation refusal keeps speaking (a naive join would resolve `..` away and smuggle an out-of-root read past validation); absolute paths pass through byte-untouched.

### Deliberate non-goals (recorded on the issue)

- The **virtualMode** direction was rejected: it changes path display, CAS observer keying, and prompt wording platform-wide for a plan-mode-only defect.
- The **upstream fix** (deepagents' `enforcePermission` doc/code mismatch — its doc claims unparsable paths are skipped; the code throws) is necessary but insufficient — skipping relative paths would silently bypass the write-deny rule. Filed upstream as a courtesy, not blocked on.
- The pre-existing **absolute-path rootDir escape** (legacy backend passes absolute paths through as literal OS paths) is out of scope; spawned as its own issue.

### Tests (red-first proven)

- 15 unit tests on the middleware (mapping table, escape guard, tool/arg targeting, request immutability).
- New `plan-mode-path-normalization.test.ts`: parent graph composed exactly as `setup.ts` composes it (production `buildMiddlewareStack` + CAS backend + production `PLAN_MODE_PERMISSIONS`), real deepagents/LangGraph runtime, no LLM — relative read succeeds first round; relative write refused **by the rules**; escaping relative still refused; absolute unchanged; relative `ls` lists.
- `subagent-plan-mode-permissions.test.ts` pin rewritten: relative writes now refused by the rules and relative reads flow; the #255 read-only-by-construction contract holds throughout. Stale comment about the prompt's path contract corrected.
- Red-first: with only the two composition points reverted, the 4 behavior pins fail with the exact pre-fix `path must be absolute` signature; the invariant pins pass on both sides (they pin unchanged behavior).

## Test plan

- [x] Runner typecheck clean
- [x] Full runner suite: 4508 passed, 0 failed
- [x] Red-first proof on all new/changed behavior pins

Closes #429

Made with [Cursor](https://cursor.com)