### PR TITLE
fix(runner): route emit-task signal delivery through the server's SendSignal lane

### DIFF
--- a/backend/services/runner/package-lock.json
+++ b/backend/services/runner/package-lock.json
@@ -32,7 +32,6 @@
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
         "@temporalio/activity": "^1.11.0",
-        "@temporalio/client": "^1.11.0",
         "@temporalio/common": "^1.11.0",
         "@temporalio/interceptors-opentelemetry": "~1.16.0",
         "@temporalio/proto": "^1.11.0",

--- a/backend/services/runner/package.json
+++ b/backend/services/runner/package.json
@@ -92,7 +92,6 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@stigmer/protos": "file:../../../apis/stubs/ts",
     "@temporalio/activity": "^1.11.0",
-    "@temporalio/client": "^1.11.0",
     "@temporalio/common": "^1.11.0",
     "@temporalio/interceptors-opentelemetry": "~1.16.0",
     "@temporalio/proto": "^1.11.0",

--- a/backend/services/runner/src/activities/emit-event.ts
+++ b/backend/services/runner/src/activities/emit-event.ts
@@ -9,12 +9,24 @@
  *
  * Supported delivery targets:
  * - webhook: HTTP POST with Content-Type: application/cloudevents+json
- * - signal:  Temporal signal to another running workflow's listen task
+ * - signal:  signal to another workflow execution's listen task, routed
+ *            through the server's SendSignal lane
+ *
+ * Signal delivery is deliberately server-mediated (oss#517): a direct
+ * Temporal client here would bypass the authorization boundary (any
+ * workflow could signal any workflow id in the namespace) and is
+ * structurally incompatible with payload encryption — emit→listen is
+ * the platform's only runner-to-runner channel, and under per-identity
+ * runner keys a sender-encrypted signal fails closed at a receiver
+ * holding a different key. The server re-produces the payload, so each
+ * side's codec passes it through.
  *
  * CloudEvents spec: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md
  */
 
 import { randomUUID } from "node:crypto";
+import type { JsonObject } from "@bufbuild/protobuf";
+import { StigmerClient } from "../client/stigmer-client.js";
 import { loadConfig } from "../config.js";
 import { resolveRuntimePlaceholders } from "../workflow-engine/resolve.js";
 
@@ -24,7 +36,9 @@ export interface WebhookDeliveryTarget {
 }
 
 export interface SignalDeliveryTarget {
-  readonly workflow_id: string;
+  /** Target workflow execution id ("wfx_..."), as returned by run/create. */
+  readonly execution_id: string;
+  /** Signal name matching the target's listen task event id (verbatim). */
   readonly signal_name: string;
 }
 
@@ -53,6 +67,11 @@ export interface EmitEventResult {
 }
 
 const WEBHOOK_TIMEOUT_MS = 30_000;
+
+// Delivery is best-effort by contract, so no single target may consume the
+// CallFunction activity's whole 5m startToClose budget. Same bound as the
+// webhook arm.
+const SIGNAL_TIMEOUT_MS = 30_000;
 
 function buildEnvelope(
   config: EmitEventConfig,
@@ -120,33 +139,53 @@ async function deliverWebhook(
   }
 }
 
+function buildClient(): StigmerClient {
+  const config = loadConfig();
+  return new StigmerClient({
+    endpoint: config.stigmerBackendEndpoint,
+    token: config.stigmerToken,
+  });
+}
+
 async function deliverSignal(
   envelope: Record<string, unknown>,
   target: SignalDeliveryTarget,
+  client: StigmerClient,
 ): Promise<DeliveryError | null> {
+  // Refuse the pre-oss#517 field by name: direct-addressing raw Temporal
+  // workflow ids is exactly the capability server mediation removes.
+  const legacyWorkflowId = (target as { workflow_id?: unknown }).workflow_id;
+  if (!target.execution_id) {
+    const reason = legacyWorkflowId
+      ? "signal delivery addresses workflow executions by 'execution_id' (\"wfx_...\"); 'workflow_id' is not supported"
+      : "signal delivery requires 'execution_id'";
+    return {
+      target: `signal:${String(legacyWorkflowId ?? "")}/${target.signal_name ?? ""}`,
+      error: reason,
+    };
+  }
+  if (!target.signal_name) {
+    return {
+      target: `signal:${target.execution_id}/`,
+      error: "signal delivery requires 'signal_name'",
+    };
+  }
+
   try {
-    const { Connection, Client } = await import("@temporalio/client");
-
-    // Resolve Temporal coordinates through the central config layer rather than
-    // reading env directly: signal delivery must dial the SAME cluster/namespace
-    // the worker connected with. config.ts is the single source of truth for the
-    // canonical TEMPORAL_SERVICE_ADDRESS / TEMPORAL_NAMESPACE resolution — reading
-    // env here would diverge (and previously dialed localhost via a stale name).
-    const config = loadConfig();
-    const temporalAddress = config.temporalAddress;
-    const temporalNamespace = config.temporalNamespace;
-
-    const connection = await Connection.connect({ address: temporalAddress });
-    const client = new Client({ connection, namespace: temporalNamespace });
-
-    const handle = client.workflow.getHandle(target.workflow_id);
-    await handle.signal(target.signal_name, envelope);
-
+    await client.sendWorkflowSignal(
+      target.execution_id,
+      target.signal_name,
+      envelope as JsonObject,
+      { timeoutMs: SIGNAL_TIMEOUT_MS },
+    );
     return null;
   } catch (err) {
+    // Server refusals arrive as ConnectErrors whose messages carry the code
+    // (e.g. [not_found], [failed_precondition] for terminal executions) —
+    // surfaced verbatim in delivery_errors, same contract as the webhook arm.
     const message = err instanceof Error ? err.message : String(err);
     return {
-      target: `signal:${target.workflow_id}/${target.signal_name}`,
+      target: `signal:${target.execution_id}/${target.signal_name}`,
       error: message,
     };
   }
@@ -173,13 +212,18 @@ export async function emitEventAction(
   const errors: DeliveryError[] = [];
   const env = runtimeEnv ?? {};
 
+  // One client serves all signal targets of this emit; constructed lazily so
+  // webhook-only emits never pay for a gRPC transport.
+  let client: StigmerClient | undefined;
+
   for (const target of config.delivery) {
     let err: DeliveryError | null = null;
 
     if ("webhook" in target) {
       err = await deliverWebhook(envelope, target.webhook, env);
     } else if ("signal" in target) {
-      err = await deliverSignal(envelope, target.signal);
+      client ??= buildClient();
+      err = await deliverSignal(envelope, target.signal, client);
     }
 
     if (err) {

--- a/backend/services/runner/src/client/__tests__/stigmer-client.test.ts
+++ b/backend/services/runner/src/client/__tests__/stigmer-client.test.ts
@@ -432,6 +432,54 @@ describe("StigmerClient", () => {
     });
   });
 
+  describe("sendWorkflowSignal", () => {
+    function clientWithWorkflowCommand() {
+      const client = new StigmerClient({ endpoint: "http://localhost", token: null });
+      const sendSignal = vi.fn().mockResolvedValue({});
+      // Reach into the private generated client: the mocked createClient()
+      // returned {}, so install the method it would have provided.
+      (client as any).workflowExecutionCommand = { sendSignal };
+      return { client, rpc: sendSignal };
+    }
+
+    it("builds SendSignalInput with execution addressing and the payload verbatim", async () => {
+      const { client, rpc } = clientWithWorkflowCommand();
+      const payload = { type: "approval.granted", data: { ok: true } };
+
+      await client.sendWorkflowSignal("wfx_1", "approval_resolved", payload);
+
+      const input = rpc.mock.calls[0]![0];
+      expect(input.executionId).toBe("wfx_1");
+      expect(input.signalName).toBe("approval_resolved");
+      expect(input.payload).toEqual(payload);
+    });
+
+    it("sends no idempotency key (oss#442: failed-delivery claims are never released)", async () => {
+      const { client, rpc } = clientWithWorkflowCommand();
+
+      await client.sendWorkflowSignal("wfx_1", "ping", undefined);
+
+      const input = rpc.mock.calls[0]![0];
+      expect(input.idempotencyKey).toBe("");
+    });
+
+    it("passes the per-call timeout through to the RPC", async () => {
+      const { client, rpc } = clientWithWorkflowCommand();
+
+      await client.sendWorkflowSignal("wfx_1", "ping", undefined, { timeoutMs: 30_000 });
+
+      expect(rpc).toHaveBeenCalledWith(expect.anything(), { timeoutMs: 30_000 });
+    });
+
+    it("passes an undefined timeout when no options are supplied", async () => {
+      const { client, rpc } = clientWithWorkflowCommand();
+
+      await client.sendWorkflowSignal("wfx_1", "ping", undefined);
+
+      expect(rpc).toHaveBeenCalledWith(expect.anything(), { timeoutMs: undefined });
+    });
+  });
+
   describe("updateToken", () => {
     it("does not affect tokenRef-based resolution", async () => {
       const ref: TokenRef = { current: "from-ref" };

--- a/backend/services/runner/src/client/stigmer-client.ts
+++ b/backend/services/runner/src/client/stigmer-client.ts
@@ -44,7 +44,8 @@ import type { UpdateStatusResponse } from "@stigmer/protos/ai/stigmer/agentic/ag
 import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
 import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
 import type { WorkflowExecution, WorkflowExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
-import { WorkflowExecutionUpdateStatusInputSchema, GetEventLogRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { WorkflowExecutionUpdateStatusInputSchema, GetEventLogRequestSchema, SendSignalInputSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type { JsonObject } from "@bufbuild/protobuf";
 import { WorkflowQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/query_pb";
 import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import { WorkflowInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/query_pb";
@@ -587,6 +588,36 @@ export class StigmerClient {
       pendingUpdateChildAgentExecutionId: options?.pendingUpdateChildAgentExecutionId ?? "",
     });
     return this.workflowExecutionCommand.updateStatus(input);
+  }
+
+  /**
+   * Deliver a named signal to another workflow execution through the
+   * server's SendSignal lane (validate → phase gate → relay via the
+   * outer orchestrator). This is the ONLY sanctioned path for
+   * runner-originated signals: a direct Temporal client would bypass
+   * both the authorization boundary and the payload-encryption design
+   * (per-identity runner keys make sender-side encryption fail closed
+   * at receivers holding a different key — see oss#517).
+   *
+   * Deliberately sends no idempotency_key: the server's dedupe claim is
+   * not released when delivery fails (oss#442), so a key here would
+   * poison the exact retry it exists to protect — and emit envelope ids
+   * regenerate per activity attempt anyway. Revisit once oss#442 lands.
+   */
+  async sendWorkflowSignal(
+    executionId: string,
+    signalName: string,
+    payload: JsonObject | undefined,
+    options?: { timeoutMs?: number },
+  ): Promise<WorkflowExecution> {
+    const input = create(SendSignalInputSchema, {
+      executionId,
+      signalName,
+      payload,
+    });
+    return this.workflowExecutionCommand.sendSignal(input, {
+      timeoutMs: options?.timeoutMs,
+    });
   }
 
   async getWorkflowExecution(executionId: string): Promise<WorkflowExecution> {

--- a/backend/services/runner/src/runner-manager.ts
+++ b/backend/services/runner/src/runner-manager.ts
@@ -293,8 +293,10 @@ export async function createStigmerRunnerManager(
   // Resolve the runner bootstrap after the http2 patch is in place (discovery
   // dials the control plane through connect-node). An explicit address wins;
   // otherwise a token triggers control-plane discovery; otherwise localhost.
-  // Must happen before createAllActivities so runtime activities that dial
-  // Temporal (e.g. emit-event) see the resolved address too.
+  // Must happen before createAllActivities so the activities' Config carries
+  // the resolved coordinates. Only the worker connection dials Temporal — no
+  // activity does (emit-event, the last one, now routes signals through the
+  // server's SendSignal lane; see oss#517).
   const bootstrap = await resolveRunnerBootstrap({
     explicitAddress: options.temporalAddress,
     explicitNamespace: options.temporalNamespace,

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -237,8 +237,9 @@ export async function createStigmerRunner(
   // Resolve Temporal coordinates after the http2 patch is in place (discovery
   // dials the control plane through connect-node). Explicit address wins;
   // otherwise a token triggers control-plane discovery; otherwise localhost.
-  // Activities that dial Temporal at runtime (e.g. emit-event) read
-  // config.temporalAddress, so this must precede their creation.
+  // Only the worker connection consumes these coordinates — no activity dials
+  // Temporal directly (emit-event, the last one, now routes signals through
+  // the server's SendSignal lane; see oss#517).
   //
   // The static runner brings its own already-proxy-valid token (harness/CLI),
   // so it does not consume the minted runner token from the bootstrap response;

--- a/backend/services/runner/src/workflow-engine/__tests__/tasks/emit-event.test.ts
+++ b/backend/services/runner/src/workflow-engine/__tests__/tasks/emit-event.test.ts
@@ -1,32 +1,34 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { emitEventAction, type EmitEventConfig } from "../../../activities/emit-event.js";
+import { emitEventAction, type EmitEventConfig, type SignalDeliveryTarget } from "../../../activities/emit-event.js";
 
-// ─── Temporal signal-delivery mocks ──────────────────────────────────────────
-// deliverSignal dynamically imports @temporalio/client and resolves the cluster
-// coordinates through loadConfig(). We mock both so the signal path is testable
-// without a live Temporal server, and so we can assert which address it dials.
-const mockConnect = vi.fn(async (_opts: { address: string }) => ({}));
-const mockSignal = vi.fn(async () => undefined);
-const mockGetHandle = vi.fn((_id: string) => ({ signal: mockSignal }));
-const mockClientCtor = vi.fn((_opts: { connection: unknown; namespace: string }) => ({
-  workflow: { getHandle: mockGetHandle },
+// ─── Server-mediated signal-delivery mocks ───────────────────────────────────
+// deliverSignal routes through StigmerClient.sendWorkflowSignal (the server's
+// SendSignal lane — oss#517). We mock the client so the signal path is testable
+// without a live server, and so we can assert the addressing, the bounded call
+// timeout, and the best-effort delivery_errors contract.
+const mockSendWorkflowSignal = vi.fn(async (
+  _executionId: string,
+  _signalName: string,
+  _payload: unknown,
+  _options?: { timeoutMs?: number },
+) => ({}));
+const mockClientCtor = vi.fn((_opts: { endpoint: string; token?: string | null }) => ({
+  sendWorkflowSignal: mockSendWorkflowSignal,
 }));
 
-vi.mock("@temporalio/client", () => ({
-  Connection: { connect: (opts: { address: string }) => mockConnect(opts) },
-  Client: vi.fn().mockImplementation((opts: { connection: unknown; namespace: string }) =>
-    mockClientCtor(opts),
+vi.mock("../../../client/stigmer-client.js", () => ({
+  StigmerClient: vi.fn().mockImplementation(
+    (opts: { endpoint: string; token?: string | null }) => mockClientCtor(opts),
   ),
 }));
 
-// Mutable so each test can vary what config.ts resolves. Mirrors the real
-// resolution where temporalAddress comes from TEMPORAL_SERVICE_ADDRESS.
-let mockTemporalAddress = "localhost:7233";
-let mockTemporalNamespace = "default";
+// Mutable so each test can vary what config.ts resolves. deliverSignal builds
+// its client from the canonical stigmerBackendEndpoint resolution.
+let mockBackendEndpoint = "http://localhost:7234";
 vi.mock("../../../config.js", () => ({
   loadConfig: () => ({
-    temporalAddress: mockTemporalAddress,
-    temporalNamespace: mockTemporalNamespace,
+    stigmerBackendEndpoint: mockBackendEndpoint,
+    stigmerToken: null,
   }),
 }));
 
@@ -260,63 +262,139 @@ describe("emitEventAction", () => {
     });
   });
 
-  describe("signal delivery (Temporal coordinates from config)", () => {
+  describe("signal delivery (server-mediated SendSignal lane)", () => {
     beforeEach(() => {
-      mockConnect.mockClear();
-      mockSignal.mockClear();
-      mockGetHandle.mockClear();
+      mockSendWorkflowSignal.mockClear();
       mockClientCtor.mockClear();
-      mockSignal.mockResolvedValue(undefined);
-      mockTemporalAddress = "localhost:7233";
-      mockTemporalNamespace = "default";
+      mockSendWorkflowSignal.mockResolvedValue({});
+      mockBackendEndpoint = "http://localhost:7234";
     });
 
-    it("dials the Temporal address resolved by config, not a hardcoded localhost", async () => {
-      // Regression for F1: deliverSignal previously read process.env.TEMPORAL_ADDRESS
-      // and fell back to localhost — diverging from the canonical
-      // TEMPORAL_SERVICE_ADDRESS the worker uses. It now goes through loadConfig().
-      mockTemporalAddress = "stigmer-temporal-frontend:7233";
-      mockTemporalNamespace = "stigmer-prod";
+    it("routes through the server resolved by config, addressed by execution_id", async () => {
+      mockBackendEndpoint = "https://api.stigmer.example.com";
 
       const config: EmitEventConfig = {
         event: { type: "approval.granted" },
         delivery: [
-          { signal: { workflow_id: "wf-abc", signal_name: "approvalResolved" } },
+          { signal: { execution_id: "wfx_01ABC", signal_name: "approval_resolved" } },
         ],
       };
 
       const result = await emitEventAction(config, "exec-1");
 
-      expect(mockConnect).toHaveBeenCalledWith({ address: "stigmer-temporal-frontend:7233" });
       expect(mockClientCtor).toHaveBeenCalledWith(
-        expect.objectContaining({ namespace: "stigmer-prod" }),
+        expect.objectContaining({ endpoint: "https://api.stigmer.example.com" }),
       );
-      expect(mockGetHandle).toHaveBeenCalledWith("wf-abc");
-      expect(mockSignal).toHaveBeenCalledTimes(1);
-      const [signalName, envelope] = mockSignal.mock.calls[0] as unknown as [
-        string,
-        Record<string, unknown>,
-      ];
-      expect(signalName).toBe("approvalResolved");
+      expect(mockSendWorkflowSignal).toHaveBeenCalledTimes(1);
+      const [executionId, signalName, envelope, options] =
+        mockSendWorkflowSignal.mock.calls[0] as unknown as [
+          string,
+          string,
+          Record<string, unknown>,
+          { timeoutMs?: number },
+        ];
+      expect(executionId).toBe("wfx_01ABC");
+      expect(signalName).toBe("approval_resolved");
       expect(envelope.type).toBe("approval.granted");
+      expect(envelope.specversion).toBe("1.0");
       expect(result.delivery_errors).toBeUndefined();
+      // Best-effort delivery must never consume the activity's 5m budget.
+      expect(options).toEqual({ timeoutMs: 30_000 });
     });
 
-    it("keeps signal delivery best-effort: failures are collected, not thrown", async () => {
-      mockSignal.mockRejectedValueOnce(new Error("temporal unavailable"));
+    it("keeps signal delivery best-effort: server refusals are collected, not thrown", async () => {
+      mockSendWorkflowSignal.mockRejectedValueOnce(
+        new Error("[failed_precondition] cannot send signal to execution in phase EXECUTION_COMPLETED"),
+      );
 
       const config: EmitEventConfig = {
         event: { type: "test" },
         delivery: [
-          { signal: { workflow_id: "wf-down", signal_name: "ping" } },
+          { signal: { execution_id: "wfx_done", signal_name: "ping" } },
         ],
       };
 
       const result = await emitEventAction(config, "exec-1");
 
       expect(result.delivery_errors).toHaveLength(1);
-      expect((result.delivery_errors as any)[0].target).toBe("signal:wf-down/ping");
-      expect((result.delivery_errors as any)[0].error).toContain("temporal unavailable");
+      expect((result.delivery_errors as any)[0].target).toBe("signal:wfx_done/ping");
+      expect((result.delivery_errors as any)[0].error).toContain("failed_precondition");
+    });
+
+    it("refuses the pre-oss#517 workflow_id field by name, without calling the server", async () => {
+      const config: EmitEventConfig = {
+        event: { type: "test" },
+        delivery: [
+          {
+            signal: {
+              workflow_id: "workflow-exec-wfx_01ABC",
+              signal_name: "ping",
+            } as unknown as SignalDeliveryTarget,
+          },
+        ],
+      };
+
+      const result = await emitEventAction(config, "exec-1");
+
+      expect(mockSendWorkflowSignal).not.toHaveBeenCalled();
+      expect(result.delivery_errors).toHaveLength(1);
+      expect((result.delivery_errors as any)[0].error).toContain("'execution_id'");
+      expect((result.delivery_errors as any)[0].error).toContain("'workflow_id' is not supported");
+    });
+
+    it("refuses a signal target missing signal_name", async () => {
+      const config: EmitEventConfig = {
+        event: { type: "test" },
+        delivery: [
+          {
+            signal: {
+              execution_id: "wfx_01ABC",
+            } as unknown as SignalDeliveryTarget,
+          },
+        ],
+      };
+
+      const result = await emitEventAction(config, "exec-1");
+
+      expect(mockSendWorkflowSignal).not.toHaveBeenCalled();
+      expect(result.delivery_errors).toHaveLength(1);
+      expect((result.delivery_errors as any)[0].error).toContain("'signal_name'");
+    });
+
+    it("reuses one client across multiple signal targets", async () => {
+      const config: EmitEventConfig = {
+        event: { type: "fanout" },
+        delivery: [
+          { signal: { execution_id: "wfx_a", signal_name: "sig_a" } },
+          { signal: { execution_id: "wfx_b", signal_name: "sig_b" } },
+        ],
+      };
+
+      const result = await emitEventAction(config, "exec-1");
+
+      expect(mockClientCtor).toHaveBeenCalledTimes(1);
+      expect(mockSendWorkflowSignal).toHaveBeenCalledTimes(2);
+      expect(result.delivery_errors).toBeUndefined();
+    });
+
+    it("constructs no client for webhook-only delivery", async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(() =>
+        Promise.resolve(new Response(null, { status: 200 })),
+      ) as any;
+
+      try {
+        const config: EmitEventConfig = {
+          event: { type: "test" },
+          delivery: [{ webhook: { url: "https://events.example.com" } }],
+        };
+
+        await emitEventAction(config, "exec-1");
+
+        expect(mockClientCtor).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 });

--- a/docs/guides/runners/payload-encryption.mdx
+++ b/docs/guides/runners/payload-encryption.mdx
@@ -78,10 +78,13 @@ without a key:
   reach you through the event log instead.
 - **Failure messages and stack traces** — Temporal stores these outside
   payloads, so errors stay debuggable in the UI.
-- **Event signals sent by `emit` tasks** — the emit task's delivery client is
-  deliberately not encrypted: it is the one direct runner-to-runner channel, and
-  its targets cannot be assumed to hold the sender's key. Treat event payloads
-  as boundary-crossing messages, not secret carriers.
+- **Event signals sent by `emit` tasks** — emit delivery is routed through the
+  server's `SendSignal` lane (the runner holds no Temporal client of its own),
+  so the signal payload is server-produced and follows the server-side
+  plaintext-by-design rule above, exactly like approval signals. Sender-side
+  encryption was rejected deliberately: emit→listen crosses runner boundaries,
+  and a receiver cannot be assumed to hold the sender's key. Treat event
+  payloads as boundary-crossing messages, not secret carriers.
 
 Encrypted payloads appear as opaque `binary/encrypted` blobs in the Temporal UI.
 Decoding them in the UI would require a Temporal codec server, which Stigmer


### PR DESCRIPTION
## Summary

- **What broke**: the emit task's `deliverSignal` (`backend/services/runner/src/activities/emit-event.ts`) constructed its own ad-hoc `@temporalio/client` Client **without payload codecs** and signaled raw Temporal workflow ids directly — the one runner-produced payload class outside the payload-encryption boundary after cloud#227/#398, and an authorization hole (any workflow could signal any workflow id in the namespace).
- **The fix**: emit signal delivery now routes through the server's existing `SendSignal` lane via a new typed `StigmerClient.sendWorkflowSignal` wrapper — validation, phase gate (PENDING/IN_PROGRESS), dedupe, and orchestrator-relayed delivery to the target's listen task, addressed by `execution_id` ("wfx_…") only. The server re-produces the payload, so cross-runner delivery works under per-identity encryption keys (sender-side encryption was rejected during #398: it fails closed at receivers holding a different key).
- **Structurally enforced**: `@temporalio/client` leaves the runner's direct dependencies entirely — no activity dials Temporal; only the worker connection does. Stale bootstrap-ordering comments that existed for emit's sake are rewritten.

## Design rulings (owner, 2026-08-12)

- **Plaintext posture accepted**: the server codec is decode-only by design, so the relayed payload rests plaintext in history — same class as approval signals. The payload-encryption guide's "What stays plaintext" section is updated honestly.
- **`execution_id` only, no legacy arm**: the `delivery` block is unreachable from production authoring (`EmitEventTaskConfig` has no `delivery` field; strict protojson rejects it at apply; the runner-executed CNCF YAML is converter-generated, event-only) — so the old `workflow_id` field had zero users. A `workflow_id` input now gets an honest `delivery_errors` refusal naming `execution_id`. The missing authoring surface is #530.
- **No idempotency key**: the SendSignal dedupe claim is never released on delivery failure (#442) — a key would poison the retry it exists to protect; emit envelope ids also regenerate per activity attempt.
- **Bounded delivery**: the RPC carries a 30s per-call timeout (the webhook arm's bound) so best-effort delivery can never consume the CallFunction activity's 5m budget.

## Changes

- `src/client/stigmer-client.ts`: new `sendWorkflowSignal(executionId, signalName, payload, {timeoutMs})` wrapper on the already-wired `workflowExecutionCommand` stub.
- `src/activities/emit-event.ts`: `SignalDeliveryTarget` is `{execution_id, signal_name}`; `deliverSignal` calls the server; RPC refusals (`not_found`, phase-gate `failed_precondition`, `already_exists`, cloud `permission_denied`) map into `delivery_errors`; the best-effort contract is unchanged; one lazily-built client serves all signal targets.
- `src/runner.ts`, `src/runner-manager.ts`: bootstrap comments no longer claim activities dial Temporal.
- `package.json` + lockfile: `@temporalio/client` removed from direct dependencies.
- `docs/guides/runners/payload-encryption.mdx`: emit boundary rewritten (server-mediated, plaintext-by-design signal lane).
- Tests: emit signal-delivery block rewritten against the mocked `StigmerClient` (execution-id addressing, 30s bound, refusal arms, error mapping, client reuse, webhook-only constructs no client); 4 new `sendWorkflowSignal` wrapper tests including the empty-idempotency-key pin.

## Verification

- Runner gate: `npm run typecheck` clean + full vitest suite **4516 passed / 269 files** (includes golden-e2e) on the pinned Node 22.22.1.
- Docs gates: `check-docs-yaml` green (119 blocks / 69 files), `lint-docs` 0 errors, changed file passes Prettier. Pre-existing red: `make format-docs-check` fails on untouched `docs/vocabulary.md` on clean main — filed as #531.
- The server lane needs zero changes and keeps its live integration coverage (`test/integration/workflow_listen_test.go`: SendSignal → relaySignal → listen unblocks). A true emit→listen e2e is impossible until the authoring surface exists — owned by #530.

Closes #517

Made with [Cursor](https://cursor.com)