### PR TITLE
fix(server): encrypt environment secrets at rest and redact every read response

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/agentexecution_controller.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/agentexecution_controller.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal"
 	artifactstorage "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/artifact/storage"
+	envresolution "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/resolution"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/agent"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/agentinstance"
@@ -23,6 +24,7 @@ type AgentExecutionController struct {
 	agentInstanceClient    *agentinstance.Client
 	sessionClient          *session.Client
 	environmentClient      *environment.Client
+	environmentResolution  *envresolution.RuntimeResolutionService
 	executionContextClient *executioncontext.Client
 	workflowCreator        *temporal.InvokeAgentExecutionWorkflowCreator
 	temporalConfig         *temporal.Config
@@ -72,6 +74,13 @@ func (c *AgentExecutionController) SetClients(
 	c.sessionClient = sessionClient
 	c.environmentClient = environmentClient
 	c.executionContextClient = executionContextClient
+}
+
+// SetEnvironmentResolution sets the environment runtime-resolution service —
+// the decrypt-for-execution path the execution-context builder uses to
+// resolve environment_refs (the RPC surface redacts secret values, oss#405).
+func (c *AgentExecutionController) SetEnvironmentResolution(svc *envresolution.RuntimeResolutionService) {
+	c.environmentResolution = svc
 }
 
 // SetWorkflowCreator sets the Temporal workflow creator dependency

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create_execution_context_step.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create_execution_context_step.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	envresolution "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/resolution"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
 	scheduletemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/schedule/temporal"
 	workflowconverter "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflow/converter"
@@ -51,30 +52,34 @@ import (
 //   - Path B (session_id on the execution): sessionClient.Get -> Session.agent_instance_id -> agentInstanceClient.Get -> agentClient.Get
 //
 // Merge priority (lowest to highest):
-//  1. AgentInstance.environment_refs resolved via environmentClient (in order)
+//  1. AgentInstance.environment_refs resolved via the environment
+//     RuntimeResolutionService (in order; secret values decrypted — the
+//     RPC surface redacts them, oss#405)
 //  2. AgentExecution.spec.runtime_env (execution-time overrides; empty on
 //     recover — consumed into the original EC and cleared before persist)
 type executionContextBuilder struct {
-	agentClient         *agent.Client
-	agentInstanceClient *agentinstance.Client
-	sessionClient       *session.Client
-	environmentClient   *environment.Client
-	executionCtxClient  *executioncontext.Client
-	store               store.Store
-	oauthGrantStore     *oauth.OAuthGrantStore
-	managedEnvService   *oauth.ManagedEnvironmentService
+	agentClient           *agent.Client
+	agentInstanceClient   *agentinstance.Client
+	sessionClient         *session.Client
+	environmentClient     *environment.Client
+	environmentResolution *envresolution.RuntimeResolutionService
+	executionCtxClient    *executioncontext.Client
+	store                 store.Store
+	oauthGrantStore       *oauth.OAuthGrantStore
+	managedEnvService     *oauth.ManagedEnvironmentService
 }
 
 func (c *AgentExecutionController) newExecutionContextBuilder() *executionContextBuilder {
 	return &executionContextBuilder{
-		agentClient:         c.agentClient,
-		agentInstanceClient: c.agentInstanceClient,
-		sessionClient:       c.sessionClient,
-		environmentClient:   c.environmentClient,
-		executionCtxClient:  c.executionContextClient,
-		store:               c.store,
-		oauthGrantStore:     c.oauthGrantStore,
-		managedEnvService:   c.managedEnvService,
+		agentClient:           c.agentClient,
+		agentInstanceClient:   c.agentInstanceClient,
+		sessionClient:         c.sessionClient,
+		environmentClient:     c.environmentClient,
+		environmentResolution: c.environmentResolution,
+		executionCtxClient:    c.executionContextClient,
+		store:                 c.store,
+		oauthGrantStore:       c.oauthGrantStore,
+		managedEnvService:     c.managedEnvService,
 	}
 }
 
@@ -944,7 +949,10 @@ func (b *executionContextBuilder) resolveEnvironments(
 
 	environments := make([]*environmentv1.Environment, 0, len(refs))
 	for _, ref := range refs {
-		env, err := b.environmentClient.GetByReference(ctx, ref)
+		// Runtime resolution, not the GetByReference RPC: the RPC surface
+		// redacts secret values (oss#405); this internal path returns them
+		// decrypted for the execution-context merge.
+		env, err := b.environmentResolution.ResolveByReference(ctx, ref)
 		if err != nil {
 			return nil, fmt.Errorf("resolve environment ref (org=%s, slug=%s): %w",
 				ref.GetOrg(), ref.GetSlug(), err)

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/create.go
@@ -19,8 +19,9 @@ import (
 // 4. EnforcePersonalEnvUniqueness - At most one personal env per org
 // 5. BuildNewState - Generate ID, clear status, set audit fields (timestamps, actors, event), default visibility
 // 6. PreserveRedactedSecrets - Reject secret sentinels (redaction marker, enc:v<N>: prefix)
-// 7. Persist - Save environment to repository
-// 8. IndexSearch - Update search index
+// 7. EncryptSecretValues - Encrypt is_secret values at rest (sentinels → encrypt ordering)
+// 8. Persist - Save environment to repository
+// 9. IndexSearch - Update search index
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:
 // - Authorize step (no multi-tenant auth in OSS)
@@ -36,7 +37,12 @@ func (c *EnvironmentController) Create(ctx context.Context, environment *environ
 		return nil, err
 	}
 
-	return reqCtx.NewState(), nil
+	// Redact AFTER persist: the store keeps ciphertext, the response
+	// carries markers (never ciphertext — clients cannot round-trip it
+	// past the enc: prefix guard, and it is server-internal by design).
+	created := reqCtx.NewState()
+	domainSteps.RedactEnvironmentSecrets(created)
+	return created, nil
 }
 
 // buildCreatePipeline constructs the pipeline for environment creation
@@ -50,7 +56,8 @@ func (c *EnvironmentController) buildCreatePipeline() *pipeline.Pipeline[*enviro
 		AddStep(domainSteps.NewEnforcePersonalUniquenessStep(c.store)).                                            // 4. At most one personal env per org
 		AddStep(steps.NewBuildNewStateStep[*environmentv1.Environment]()).                                         // 5. Build new state
 		AddStep(domainSteps.NewPreserveRedactedSecretsStep()).                                                     // 6. Reject secret sentinels (no existing resource: marker and enc: prefix both refused)
-		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                        // 7. Persist environment
-		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 8. Update search index
+		AddStep(domainSteps.NewEncryptSecretValuesStep(c.secretService)).                                          // 7. Encrypt is_secret values (must follow the sentinel guard)
+		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                        // 8. Persist environment
+		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 9. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/delete.go
@@ -8,6 +8,7 @@ import (
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
 )
 
 // Delete deletes an environment by ID using the pipeline pattern.
@@ -43,7 +44,9 @@ func (c *EnvironmentController) Delete(ctx context.Context, input *apiresource.A
 		return nil, grpclib.InternalError(nil, "deleted environment not found in context")
 	}
 
-	return deletedEnvironment.(*environmentv1.Environment), nil
+	deleted := deletedEnvironment.(*environmentv1.Environment)
+	envsteps.RedactEnvironmentSecrets(deleted)
+	return deleted, nil
 }
 
 // buildDeletePipeline constructs the pipeline for delete operations

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/environment_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/environment_controller_test.go
@@ -109,12 +109,25 @@ func TestEnvironmentController_Create(t *testing.T) {
 			t.Error("Expected AWS_REGION to not be secret")
 		}
 
-		if created.Spec.Data["AWS_ACCESS_KEY_ID"].Value != "AKIA1234567890ABCDEF" {
-			t.Errorf("Expected AWS_ACCESS_KEY_ID 'AKIA1234567890ABCDEF', got '%s'", created.Spec.Data["AWS_ACCESS_KEY_ID"].Value)
+		// Secret values are redacted in every response (oss#405); the
+		// stored value is verified via getSecretValue below.
+		if created.Spec.Data["AWS_ACCESS_KEY_ID"].Value != envsteps.RedactedMarker {
+			t.Errorf("Expected AWS_ACCESS_KEY_ID to be redacted, got '%s'", created.Spec.Data["AWS_ACCESS_KEY_ID"].Value)
 		}
 
 		if !created.Spec.Data["AWS_ACCESS_KEY_ID"].IsSecret {
 			t.Error("Expected AWS_ACCESS_KEY_ID to be secret")
+		}
+
+		revealed, err := controller.GetSecretValue(contextWithEnvironmentKind(), &environmentv1.EnvironmentSecretValueInput{
+			EnvironmentId: created.Metadata.Id,
+			Key:           "AWS_ACCESS_KEY_ID",
+		})
+		if err != nil {
+			t.Fatalf("GetSecretValue failed: %v", err)
+		}
+		if revealed.GetValue() != "AKIA1234567890ABCDEF" {
+			t.Errorf("Expected getSecretValue to reveal 'AKIA1234567890ABCDEF', got '%s'", revealed.GetValue())
 		}
 	})
 
@@ -297,9 +310,21 @@ func TestEnvironmentController_SecretSentinels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marker update failed: %v", err)
 		}
-		if updated.Spec.Data["API_KEY"].GetValue() != "original-secret" {
-			t.Errorf("marker must preserve the stored secret, got %q",
+		// The response is redacted (oss#405); preservation is verified
+		// through the reveal path.
+		if updated.Spec.Data["API_KEY"].GetValue() != envsteps.RedactedMarker {
+			t.Errorf("update response must redact the secret, got %q",
 				updated.Spec.Data["API_KEY"].GetValue())
+		}
+		revealed, err := controller.GetSecretValue(ctx, &environmentv1.EnvironmentSecretValueInput{
+			EnvironmentId: created.GetMetadata().GetId(),
+			Key:           "API_KEY",
+		})
+		if err != nil {
+			t.Fatalf("GetSecretValue failed: %v", err)
+		}
+		if revealed.GetValue() != "original-secret" {
+			t.Errorf("marker must preserve the stored secret, got %q", revealed.GetValue())
 		}
 	})
 
@@ -498,8 +523,9 @@ func TestEnvironmentController_Update(t *testing.T) {
 			t.Errorf("Expected KEY1 'value1', got '%s'", updated.Spec.Data["KEY1"].Value)
 		}
 
-		if updated.Spec.Data["KEY2"].Value != "value2" {
-			t.Errorf("Expected KEY2 'value2', got '%s'", updated.Spec.Data["KEY2"].Value)
+		// KEY2 is secret, so the response redacts it (oss#405).
+		if updated.Spec.Data["KEY2"].Value != envsteps.RedactedMarker {
+			t.Errorf("Expected KEY2 to be redacted, got '%s'", updated.Spec.Data["KEY2"].Value)
 		}
 
 		if !updated.Spec.Data["KEY2"].IsSecret {
@@ -539,12 +565,25 @@ func TestEnvironmentController_Update(t *testing.T) {
 			t.Fatalf("Update failed: %v", err)
 		}
 
-		if updated.Spec.Data["API_KEY"].Value != "new-key" {
-			t.Errorf("Expected API_KEY 'new-key', got '%s'", updated.Spec.Data["API_KEY"].Value)
+		// The response redacts the secret (oss#405); the new value is
+		// verified through the reveal path.
+		if updated.Spec.Data["API_KEY"].Value != envsteps.RedactedMarker {
+			t.Errorf("Expected API_KEY to be redacted, got '%s'", updated.Spec.Data["API_KEY"].Value)
 		}
 
 		if !updated.Spec.Data["API_KEY"].IsSecret {
 			t.Error("Expected API_KEY to remain secret")
+		}
+
+		revealed, err := controller.GetSecretValue(contextWithEnvironmentKind(), &environmentv1.EnvironmentSecretValueInput{
+			EnvironmentId: created.Metadata.Id,
+			Key:           "API_KEY",
+		})
+		if err != nil {
+			t.Fatalf("GetSecretValue failed: %v", err)
+		}
+		if revealed.GetValue() != "new-key" {
+			t.Errorf("Expected getSecretValue to reveal 'new-key', got '%s'", revealed.GetValue())
 		}
 	})
 
@@ -708,8 +747,10 @@ func TestEnvironmentController_Delete(t *testing.T) {
 			t.Fatalf("Delete failed: %v", err)
 		}
 
-		if deleted.Spec.Data["SECRET_KEY"].Value != "secret-value" {
-			t.Errorf("Expected SECRET_KEY 'secret-value', got '%s'", deleted.Spec.Data["SECRET_KEY"].Value)
+		// The delete response redacts secrets like every other response
+		// (oss#405) — the audit-trail return must not be a reveal path.
+		if deleted.Spec.Data["SECRET_KEY"].Value != envsteps.RedactedMarker {
+			t.Errorf("Expected SECRET_KEY to be redacted, got '%s'", deleted.Spec.Data["SECRET_KEY"].Value)
 		}
 
 		if !deleted.Spec.Data["SECRET_KEY"].IsSecret {

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/environment_encryption_test.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/environment_encryption_test.go
@@ -1,0 +1,318 @@
+package environment
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvironmentEncryptionAtRest pins the oss#405 contract with a REAL
+// encryption key: every is_secret value rests as enc:v1: ciphertext, every
+// response redacts it, getSecretValue is the only reveal path, and the
+// marker round-trip never double-encrypts. The keyless twin of this harness
+// (setupTestController) pins the disabled-encryption pass-through in
+// TestEnvironmentEncryptionDisabledStoresPlaintext below.
+
+const testEncryptionKey = "0123456789abcdef0123456789abcdef" // 32 bytes
+
+// setupKeyedTestController builds a controller whose SecretService holds a
+// real AES-256 key — the production configuration (the OSS key
+// auto-generates via NewSecretServiceFromEnv).
+func setupKeyedTestController(t *testing.T) (*EnvironmentController, store.Store, *encryption.SecretService) {
+	t.Helper()
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	require.NoError(t, err, "store should initialize")
+
+	secretService, err := encryption.NewSecretService([]byte(testEncryptionKey))
+	require.NoError(t, err, "keyed secret service should initialize")
+
+	return NewEnvironmentController(s, secretService), s, secretService
+}
+
+// loadStored reads the persisted environment straight from the store,
+// bypassing every RPC boundary — the at-rest truth.
+func loadStored(t *testing.T, s store.Store, id string) *environmentv1.Environment {
+	t.Helper()
+	stored := &environmentv1.Environment{}
+	require.NoError(t, s.GetResource(context.Background(),
+		apiresourcekind.ApiResourceKind_environment, id, stored))
+	return stored
+}
+
+func newSecretEnv(name string) *environmentv1.Environment {
+	return &environmentv1.Environment{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "Environment",
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name: name,
+			Org:  "test-org",
+		},
+		Spec: &environmentv1.EnvironmentSpec{
+			Data: map[string]*environmentv1.EnvironmentValue{
+				"API_TOKEN":  {Value: "s3cr3t-token", IsSecret: true, Description: "a token"},
+				"PLAIN_HOST": {Value: "example.com", IsSecret: false},
+			},
+		},
+	}
+}
+
+func TestEnvironmentEncryptionAtRest_Create(t *testing.T) {
+	controller, s, secretService := setupKeyedTestController(t)
+	defer s.Close()
+	ctx := contextWithEnvironmentKind()
+
+	created, err := controller.Create(ctx, newSecretEnv("Keyed Create"))
+	require.NoError(t, err)
+
+	stored := loadStored(t, s, created.GetMetadata().GetId())
+	storedSecret := stored.GetSpec().GetData()["API_TOKEN"].GetValue()
+	assert.True(t, strings.HasPrefix(storedSecret, encryption.EncryptedPrefix),
+		"secret must rest as enc:v1: ciphertext, got %q", storedSecret)
+	decrypted, err := secretService.Decrypt(storedSecret)
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t-token", decrypted, "ciphertext must decrypt to the original")
+
+	assert.Equal(t, "example.com", stored.GetSpec().GetData()["PLAIN_HOST"].GetValue(),
+		"non-secret values must rest plaintext")
+
+	// The description survives encryption in place.
+	assert.Equal(t, "a token", stored.GetSpec().GetData()["API_TOKEN"].GetDescription())
+}
+
+func TestEnvironmentEncryptionAtRest_UpdateVariables(t *testing.T) {
+	controller, s, secretService := setupKeyedTestController(t)
+	defer s.Close()
+	ctx := contextWithEnvironmentKind()
+
+	created, err := controller.Create(ctx, newSecretEnv("Keyed Merge"))
+	require.NoError(t, err)
+
+	// The vendor OAuth token path (ManagedEnvironmentService.UpdateSecrets)
+	// rides this exact RPC — the oss#405 headline exposure.
+	updated, err := controller.UpdateVariables(ctx, &environmentv1.UpdateEnvironmentVariablesRequest{
+		EnvironmentId: created.GetMetadata().GetId(),
+		Variables: map[string]*environmentv1.EnvironmentValue{
+			"OAUTH_ACCESS_TOKEN": {Value: "vendor-access-token", IsSecret: true, Description: "vendor token"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, envsteps.RedactedMarker, updated.GetSpec().GetData()["OAUTH_ACCESS_TOKEN"].GetValue(),
+		"updateVariables response must redact the merged secret")
+
+	stored := loadStored(t, s, created.GetMetadata().GetId())
+	storedToken := stored.GetSpec().GetData()["OAUTH_ACCESS_TOKEN"].GetValue()
+	assert.True(t, strings.HasPrefix(storedToken, encryption.EncryptedPrefix),
+		"merged secret must rest encrypted, got %q", storedToken)
+	decrypted, err := secretService.Decrypt(storedToken)
+	require.NoError(t, err)
+	assert.Equal(t, "vendor-access-token", decrypted)
+	assert.Equal(t, "vendor token", stored.GetSpec().GetData()["OAUTH_ACCESS_TOKEN"].GetDescription(),
+		"encryption must preserve the description")
+
+	revealed, err := controller.GetSecretValue(ctx, &environmentv1.EnvironmentSecretValueInput{
+		EnvironmentId: created.GetMetadata().GetId(),
+		Key:           "OAUTH_ACCESS_TOKEN",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "vendor-access-token", revealed.GetValue(),
+		"getSecretValue must round-trip the encrypted value")
+}
+
+// TestEnvironmentEncryption_MarkerRoundTripNeverDoubleEncrypts pins the
+// sentinels→encrypt ordering: an update carrying the redaction marker
+// restores the STORED ciphertext, and the encrypt step's idempotent
+// pass-through must leave it untouched — after the round-trip the value
+// still decrypts to the original in one pass.
+func TestEnvironmentEncryption_MarkerRoundTripNeverDoubleEncrypts(t *testing.T) {
+	controller, s, secretService := setupKeyedTestController(t)
+	defer s.Close()
+	ctx := contextWithEnvironmentKind()
+
+	created, err := controller.Create(ctx, newSecretEnv("Keyed Marker Roundtrip"))
+	require.NoError(t, err)
+	ciphertextBefore := loadStored(t, s, created.GetMetadata().GetId()).GetSpec().GetData()["API_TOKEN"].GetValue()
+
+	// The client round-trip: Get (redacted) → edit something else → Update.
+	fetched, err := controller.Get(ctx, &apiresource.ApiResourceId{Value: created.GetMetadata().GetId()})
+	require.NoError(t, err)
+	require.Equal(t, envsteps.RedactedMarker, fetched.GetSpec().GetData()["API_TOKEN"].GetValue())
+	fetched.Spec.Description = "edited elsewhere"
+
+	_, err = controller.Update(ctx, fetched)
+	require.NoError(t, err)
+
+	ciphertextAfter := loadStored(t, s, created.GetMetadata().GetId()).GetSpec().GetData()["API_TOKEN"].GetValue()
+	assert.Equal(t, ciphertextBefore, ciphertextAfter,
+		"the marker round-trip must preserve the stored ciphertext byte-for-byte")
+
+	decrypted, err := secretService.Decrypt(ciphertextAfter)
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t-token", decrypted, "one decrypt pass must recover the original — no double encryption")
+}
+
+// TestEnvironmentRedaction_AllResponseBoundaries table-drives the oss#405
+// response contract across every Environment-returning RPC (apply inherits
+// via create/update delegation): the secret comes back as the marker with
+// is_secret preserved, the non-secret value comes back verbatim. The
+// channelapp every-arm tripwire, applied to RPC boundaries.
+func TestEnvironmentRedaction_AllResponseBoundaries(t *testing.T) {
+	ctx := contextWithEnvironmentKind()
+
+	cases := []struct {
+		rpc  string
+		call func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment
+	}{
+		{"create", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			return created
+		}},
+		{"get", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			env, err := c.Get(ctx, &apiresource.ApiResourceId{Value: created.GetMetadata().GetId()})
+			require.NoError(t, err)
+			return env
+		}},
+		{"getByReference", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			env, err := c.GetByReference(ctx, &apiresource.ApiResourceReference{
+				Kind: apiresourcekind.ApiResourceKind_environment,
+				Org:  "test-org",
+				Slug: created.GetMetadata().GetSlug(),
+			})
+			require.NoError(t, err)
+			return env
+		}},
+		{"list", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			list, err := c.List(ctx, &environmentv1.ListEnvironmentsRequest{Org: "test-org"})
+			require.NoError(t, err)
+			for _, item := range list.GetItems() {
+				if item.GetMetadata().GetId() == created.GetMetadata().GetId() {
+					return item
+				}
+			}
+			t.Fatal("created environment missing from list")
+			return nil
+		}},
+		{"update", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			fetched, err := c.Get(ctx, &apiresource.ApiResourceId{Value: created.GetMetadata().GetId()})
+			require.NoError(t, err)
+			fetched.Spec.Description = "updated"
+			env, err := c.Update(ctx, fetched)
+			require.NoError(t, err)
+			return env
+		}},
+		{"updateVariables", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			env, err := c.UpdateVariables(ctx, &environmentv1.UpdateEnvironmentVariablesRequest{
+				EnvironmentId: created.GetMetadata().GetId(),
+				Variables: map[string]*environmentv1.EnvironmentValue{
+					"EXTRA": {Value: "extra-value", IsSecret: false},
+				},
+			})
+			require.NoError(t, err)
+			return env
+		}},
+		{"removeVariables", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			env, err := c.RemoveVariables(ctx, &environmentv1.RemoveEnvironmentVariablesRequest{
+				EnvironmentId: created.GetMetadata().GetId(),
+				Keys:          []string{"PLAIN_HOST"},
+			})
+			require.NoError(t, err)
+			// PLAIN_HOST is gone in this response; only assert the secret.
+			assert.Equal(t, envsteps.RedactedMarker, env.GetSpec().GetData()["API_TOKEN"].GetValue(),
+				"removeVariables response must redact secrets")
+			return nil // non-secret arm not applicable
+		}},
+		{"updateVisibility", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			env, err := c.UpdateVisibility(ctx, &apiresource.UpdateVisibilityInput{
+				ResourceId: created.GetMetadata().GetId(),
+				Visibility: apiresource.ApiResourceVisibility_visibility_org,
+			})
+			require.NoError(t, err)
+			return env
+		}},
+		{"delete", func(t *testing.T, c *EnvironmentController, created *environmentv1.Environment) *environmentv1.Environment {
+			env, err := c.Delete(ctx, &apiresource.ApiResourceDeleteInput{ResourceId: created.GetMetadata().GetId()})
+			require.NoError(t, err)
+			return env
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.rpc, func(t *testing.T) {
+			controller, s, _ := setupKeyedTestController(t)
+			defer s.Close()
+
+			created, err := controller.Create(ctx, newSecretEnv("Boundary "+tc.rpc))
+			require.NoError(t, err)
+
+			env := tc.call(t, controller, created)
+			if env == nil {
+				return
+			}
+			secret := env.GetSpec().GetData()["API_TOKEN"]
+			require.NotNil(t, secret, "%s response must carry the secret entry", tc.rpc)
+			assert.Equal(t, envsteps.RedactedMarker, secret.GetValue(),
+				"%s response must redact the secret value", tc.rpc)
+			assert.True(t, secret.GetIsSecret(), "%s must preserve is_secret", tc.rpc)
+			assert.Equal(t, "example.com", env.GetSpec().GetData()["PLAIN_HOST"].GetValue(),
+				"%s must return non-secret values verbatim", tc.rpc)
+		})
+	}
+}
+
+// TestEnvironmentRedaction_IsResponseOnly pins that redaction mutates only
+// the response copy: repeated reads keep redacting, and the reveal path
+// keeps decrypting — the marker never leaks into the store.
+func TestEnvironmentRedaction_IsResponseOnly(t *testing.T) {
+	controller, s, _ := setupKeyedTestController(t)
+	defer s.Close()
+	ctx := contextWithEnvironmentKind()
+
+	created, err := controller.Create(ctx, newSecretEnv("Response Only"))
+	require.NoError(t, err)
+	id := created.GetMetadata().GetId()
+
+	for i := 0; i < 2; i++ {
+		fetched, err := controller.Get(ctx, &apiresource.ApiResourceId{Value: id})
+		require.NoError(t, err)
+		assert.Equal(t, envsteps.RedactedMarker, fetched.GetSpec().GetData()["API_TOKEN"].GetValue())
+	}
+
+	revealed, err := controller.GetSecretValue(ctx, &environmentv1.EnvironmentSecretValueInput{
+		EnvironmentId: id, Key: "API_TOKEN",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t-token", revealed.GetValue(),
+		"reveal must still decrypt after redacted reads — redaction never reaches the store")
+
+	stored := loadStored(t, s, id)
+	assert.True(t, strings.HasPrefix(stored.GetSpec().GetData()["API_TOKEN"].GetValue(), encryption.EncryptedPrefix),
+		"the store must hold ciphertext, never the marker")
+}
+
+// TestEnvironmentEncryptionDisabledStoresPlaintext pins the WARN-and-pass-
+// through convention (oss#394): with no key configured, secrets rest
+// plaintext — but responses still redact (redaction is not gated on
+// encryption).
+func TestEnvironmentEncryptionDisabledStoresPlaintext(t *testing.T) {
+	controller, s := setupTestController(t) // keyless harness
+	defer s.Close()
+	ctx := contextWithEnvironmentKind()
+
+	created, err := controller.Create(ctx, newSecretEnv("Keyless Create"))
+	require.NoError(t, err)
+
+	stored := loadStored(t, s, created.GetMetadata().GetId())
+	assert.Equal(t, "s3cr3t-token", stored.GetSpec().GetData()["API_TOKEN"].GetValue(),
+		"keyless deployments pass secrets through to the store as plaintext")
+
+	assert.Equal(t, envsteps.RedactedMarker, created.GetSpec().GetData()["API_TOKEN"].GetValue(),
+		"responses redact even when encryption is disabled")
+}

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/get.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/get.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
 )
 
 // Get retrieves an environment by ID using the pipeline framework
@@ -26,7 +27,8 @@ import (
 // - SendResponse step (handler returns directly)
 //
 // The loaded environment is stored in context with key "targetResource" and
-// returned by the handler.
+// returned by the handler with secret values redacted (both editions redact
+// on read since oss#405 — getSecretValue is the reveal path).
 func (c *EnvironmentController) Get(ctx context.Context, id *apiresource.ApiResourceId) (*environmentv1.Environment, error) {
 	reqCtx := pipeline.NewRequestContext(ctx, id)
 
@@ -38,6 +40,7 @@ func (c *EnvironmentController) Get(ctx context.Context, id *apiresource.ApiReso
 
 	// Retrieve loaded environment from context
 	environment := reqCtx.Get(steps.TargetResourceKey).(*environmentv1.Environment)
+	envsteps.RedactEnvironmentSecrets(environment)
 	return environment, nil
 }
 

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/get_by_reference.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/get_by_reference.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
 )
 
 // GetByReference retrieves an environment by ApiResourceReference (slug-based lookup) using the pipeline framework
@@ -30,7 +31,8 @@ import (
 // - Slug is matched against metadata.name (slug is normalized name)
 //
 // The loaded environment is stored in context with key "targetResource" and
-// returned by the handler.
+// returned by the handler with secret values redacted (both editions redact
+// on read since oss#405 — getSecretValue is the reveal path).
 func (c *EnvironmentController) GetByReference(ctx context.Context, ref *apiresource.ApiResourceReference) (*environmentv1.Environment, error) {
 	reqCtx := pipeline.NewRequestContext(ctx, ref)
 
@@ -42,6 +44,7 @@ func (c *EnvironmentController) GetByReference(ctx context.Context, ref *apireso
 
 	// Retrieve loaded environment from context
 	environment := reqCtx.Get(steps.TargetResourceKey).(*environmentv1.Environment)
+	envsteps.RedactEnvironmentSecrets(environment)
 	return environment, nil
 }
 

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/list.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -25,7 +26,9 @@ const listResultKey = "listResult"
 // Note: Unlike Stigmer Cloud, OSS excludes:
 // - Authorization filtering (no multi-user auth — returns all matching environments)
 // - Pagination (returns all matching results)
-// - Secret redaction (OSS is single-user local; Get/GetByReference also return plaintext)
+//
+// Secret values are redacted in every item (oss#405 — both editions redact
+// on read; getSecretValue is the reveal path).
 func (c *EnvironmentController) List(ctx context.Context, req *environmentv1.ListEnvironmentsRequest) (*environmentv1.EnvironmentList, error) {
 	reqCtx := pipeline.NewRequestContext(ctx, req)
 
@@ -101,6 +104,7 @@ func (s *listByOrgAndLabelsStep) Execute(ctx *pipeline.RequestContext[*environme
 			continue
 		}
 
+		envsteps.RedactEnvironmentSecrets(env)
 		environments = append(environments, env)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/remove_variables.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/remove_variables.go
@@ -24,7 +24,9 @@ func (c *EnvironmentController) RemoveVariables(ctx context.Context, req *enviro
 		return nil, err
 	}
 
-	return reqCtx.Get(envsteps.UpdatedEnvironmentKey).(*environmentv1.Environment), nil
+	updated := reqCtx.Get(envsteps.UpdatedEnvironmentKey).(*environmentv1.Environment)
+	envsteps.RedactEnvironmentSecrets(updated)
+	return updated, nil
 }
 
 func (c *EnvironmentController) buildRemoveVariablesPipeline() *pipeline.Pipeline[*environmentv1.RemoveEnvironmentVariablesRequest] {

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/encrypt_secret_values.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/encrypt_secret_values.go
@@ -1,0 +1,97 @@
+package steps
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+)
+
+// encryptSecretValuesStep encrypts every is_secret value in spec.data before
+// persistence — the OSS mirror of the cloud edition's EncryptSecretValues
+// step, closing oss#405 (environment secrets rested plaintext while oauthapp
+// and channelapp secrets were encrypted in the same store).
+//
+// Ordering contract (the cloud "sentinels → encrypt" doc): this step MUST run
+// after PreserveRedactedSecrets, which handles the two client sentinels —
+// the ***REDACTED*** marker (restored to stored ciphertext) and forged
+// enc:v<N>: input (rejected). By the time this step runs, every secret value
+// is either fresh client plaintext (encrypt it) or marker-restored stored
+// ciphertext (Encrypt's idempotent pass-through leaves it unchanged, so a
+// round-tripped secret is never double-encrypted).
+//
+// When encryption is disabled (no key — effectively test-only, the OSS key
+// auto-generates via NewSecretServiceFromEnv) values pass through plaintext
+// with one WARN per request, the oss#394 convention shared with oauthapp and
+// channelapp.
+//
+// Non-secret values are never touched: getSecretValue and the runtime
+// resolution path gate decryption on is_secret, so encrypting a non-secret
+// value would strand it as unreadable ciphertext.
+type encryptSecretValuesStep struct {
+	secretService *encryption.SecretService
+}
+
+func NewEncryptSecretValuesStep(secretService *encryption.SecretService) *encryptSecretValuesStep {
+	return &encryptSecretValuesStep{secretService: secretService}
+}
+
+func (s *encryptSecretValuesStep) Name() string {
+	return "EncryptSecretValues"
+}
+
+func (s *encryptSecretValuesStep) Execute(ctx *pipeline.RequestContext[*environmentv1.Environment]) error {
+	env := ctx.NewState()
+	if env == nil || env.GetSpec() == nil || len(env.GetSpec().GetData()) == 0 {
+		return nil
+	}
+
+	if !s.secretService.IsEnabled() {
+		if hasNonEmptySecret(env.GetSpec().GetData()) {
+			log.Warn().
+				Str("environment_id", env.GetMetadata().GetId()).
+				Msg("Encryption disabled: environment secret values will be stored in plaintext")
+		}
+		return nil
+	}
+
+	encryptedCount := 0
+	for key, val := range env.Spec.Data {
+		if !val.GetIsSecret() || val.GetValue() == "" {
+			continue
+		}
+
+		encrypted, err := s.secretService.Encrypt(val.GetValue())
+		if err != nil {
+			return grpclib.InternalError(err, fmt.Sprintf("failed to encrypt secret value for variable '%s'", key))
+		}
+		if encrypted != val.GetValue() {
+			val.Value = encrypted
+			encryptedCount++
+		}
+	}
+
+	if encryptedCount > 0 {
+		log.Debug().
+			Int("encryptedCount", encryptedCount).
+			Str("environment_id", env.GetMetadata().GetId()).
+			Msg("Encrypted secret values before persistence")
+	}
+
+	return nil
+}
+
+// hasNonEmptySecret reports whether any entry would have been encrypted —
+// keeps the disabled-encryption WARN honest (no warning for secret-free
+// environments).
+func hasNonEmptySecret(data map[string]*environmentv1.EnvironmentValue) bool {
+	for _, val := range data {
+		if val.GetIsSecret() && val.GetValue() != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/merge_variables_and_persist.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/merge_variables_and_persist.go
@@ -23,14 +23,22 @@ const UpdatedEnvironmentKey = "updatedEnvironment"
 // environment's spec.data and persists the result. Keys in the request
 // overwrite existing keys; keys not in the request are preserved.
 //
+// Incoming is_secret values are encrypted before assignment (oss#405) —
+// this step is its own write boundary (sentinel guard, merge, and persist
+// all live here), so it carries its own encrypt call rather than a separate
+// pipeline step. Same ordering contract as create/update: sentinels first,
+// then encrypt. This is the path OAuth-managed vendor tokens take
+// (ManagedEnvironmentService.UpdateSecrets), so they rest encrypted too.
+//
 // Requires LoadEnvironmentByIDStep to have run first (reads from TargetResourceKey).
 // Stores the modified environment under UpdatedEnvironmentKey.
 type mergeVariablesAndPersistStep struct {
-	store store.Store
+	store         store.Store
+	secretService *encryption.SecretService
 }
 
-func NewMergeVariablesAndPersistStep(store store.Store) *mergeVariablesAndPersistStep {
-	return &mergeVariablesAndPersistStep{store: store}
+func NewMergeVariablesAndPersistStep(store store.Store, secretService *encryption.SecretService) *mergeVariablesAndPersistStep {
+	return &mergeVariablesAndPersistStep{store: store, secretService: secretService}
 }
 
 func (s *mergeVariablesAndPersistStep) Name() string {
@@ -67,6 +75,23 @@ func (s *mergeVariablesAndPersistStep) Execute(ctx *pipeline.RequestContext[*env
 			return grpclib.InvalidArgumentError(
 				"variable '%s' must be plaintext — values carrying the 'enc:' "+
 					"encryption prefix are not accepted from clients", key)
+		}
+		if val.GetIsSecret() && val.GetValue() != "" {
+			if !s.secretService.IsEnabled() {
+				log.Warn().Str("key", key).
+					Msg("Encryption disabled: environment secret value will be stored in plaintext")
+			} else {
+				encrypted, err := s.secretService.Encrypt(val.GetValue())
+				if err != nil {
+					return grpclib.InternalError(err,
+						fmt.Sprintf("failed to encrypt secret value for variable '%s'", key))
+				}
+				val = &environmentv1.EnvironmentValue{
+					Value:       encrypted,
+					IsSecret:    true,
+					Description: val.GetDescription(),
+				}
+			}
 		}
 		env.Spec.Data[key] = val
 	}

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/redact_secret_values.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/redact_secret_values.go
@@ -1,0 +1,36 @@
+package steps
+
+import (
+	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
+)
+
+// RedactEnvironmentSecrets replaces every non-empty is_secret value with
+// RedactedMarker on the given environment — called at every controller
+// boundary that returns an Environment (get, getByReference, list, create,
+// update, updateVariables, removeVariables, updateVisibility, delete; apply
+// inherits via delegation). The RedactChannelApp / oauthapp shape, and the
+// OSS mirror of the cloud edition's RedactSecretValues step.
+//
+// getSecretValue is the sanctioned single-key reveal path and stays
+// unredacted. Server-internal consumers that need real values (execution
+// context builds) go through the environment RuntimeResolutionService, not
+// the RPC surface.
+//
+// is_secret and description are preserved so clients know a hidden value
+// exists; empty secret declarations stay empty (a marker would falsely
+// signal a stored value). Sending the marker back on update means "keep the
+// existing secret" — preserveRedactedSecretsStep completes the round-trip.
+//
+// Mutates in place: callers hold either a fresh store unmarshal (reads) or
+// the already-persisted new state (writes), so the redaction never reaches
+// the store. Runs strictly AFTER Persist on write paths.
+func RedactEnvironmentSecrets(env *environmentv1.Environment) {
+	if env == nil || env.GetSpec() == nil {
+		return
+	}
+	for _, val := range env.Spec.Data {
+		if val.GetIsSecret() && val.GetValue() != "" {
+			val.Value = RedactedMarker
+		}
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/update.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/update.go
@@ -17,7 +17,11 @@ import (
 // 2. ResolveSlug - Generate slug from metadata.name
 // 3. LoadExisting - Load existing environment from repository by ID
 // 4. BuildUpdateState - Merge spec, preserve IDs, update timestamps, clear computed fields
-// 5. Persist - Save updated environment to repository
+// 5. PreserveRedactedSecrets - Restore marker-carrying secrets, reject enc:v<N>: input
+// 6. EncryptSecretValues - Encrypt is_secret values at rest (marker-restored ciphertext passes through unchanged)
+// 7. NormalizeReferences - Normalize cross-references
+// 8. Persist - Save updated environment to repository
+// 9. IndexSearch - Update search index
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:
 // - Authorize step (no multi-tenant auth in OSS)
@@ -32,7 +36,12 @@ func (c *EnvironmentController) Update(ctx context.Context, environment *environ
 		return nil, err
 	}
 
-	return reqCtx.NewState(), nil
+	// Redact AFTER persist: the store keeps ciphertext, the response
+	// carries markers (the round-trip contract: sending a marker back
+	// preserves the stored secret).
+	updated := reqCtx.NewState()
+	envsteps.RedactEnvironmentSecrets(updated)
+	return updated, nil
 }
 
 // buildUpdatePipeline constructs the pipeline for environment update
@@ -45,8 +54,9 @@ func (c *EnvironmentController) buildUpdatePipeline() *pipeline.Pipeline[*enviro
 		AddStep(steps.NewLoadExistingStep[*environmentv1.Environment](c.store)).                                   // 3. Load existing environment
 		AddStep(steps.NewBuildUpdateStateStep[*environmentv1.Environment]()).                                      // 4. Build updated state
 		AddStep(envsteps.NewPreserveRedactedSecretsStep()).                                                        // 5. Preserve secrets when redaction marker sent back
-		AddStep(steps.NewNormalizeReferencesStep[*environmentv1.Environment]()).                                   // 6. Normalize cross-references
-		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                        // 6. Persist environment
-		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 7. Update search index
+		AddStep(envsteps.NewEncryptSecretValuesStep(c.secretService)).                                             // 6. Encrypt is_secret values (must follow the sentinel guard)
+		AddStep(steps.NewNormalizeReferencesStep[*environmentv1.Environment]()).                                   // 7. Normalize cross-references
+		AddStep(steps.NewPersistStep[*environmentv1.Environment](c.store)).                                        // 8. Persist environment
+		AddStep(steps.NewIndexSearchStep[*environmentv1.Environment](c.store, &extractor.EnvironmentExtractor{})). // 9. Update search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/update_variables.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/update_variables.go
@@ -15,9 +15,10 @@ import (
 // inherent in the full-resource Update RPC.
 //
 // Pipeline:
-// 1. ValidateProto    — validate environment_id and variables via buf constraints
-// 2. LoadByEnvID      — load the existing environment from store
-// 3. MergeAndPersist  — merge request variables into spec.data, update audit, persist
+//  1. ValidateProto    — validate environment_id and variables via buf constraints
+//  2. LoadByEnvID      — load the existing environment from store
+//  3. MergeAndPersist  — merge request variables into spec.data (encrypting
+//     is_secret values), update audit, persist
 func (c *EnvironmentController) UpdateVariables(ctx context.Context, req *environmentv1.UpdateEnvironmentVariablesRequest) (*environmentv1.Environment, error) {
 	reqCtx := pipeline.NewRequestContext(ctx, req)
 
@@ -26,13 +27,15 @@ func (c *EnvironmentController) UpdateVariables(ctx context.Context, req *enviro
 		return nil, err
 	}
 
-	return reqCtx.Get(envsteps.UpdatedEnvironmentKey).(*environmentv1.Environment), nil
+	updated := reqCtx.Get(envsteps.UpdatedEnvironmentKey).(*environmentv1.Environment)
+	envsteps.RedactEnvironmentSecrets(updated)
+	return updated, nil
 }
 
 func (c *EnvironmentController) buildUpdateVariablesPipeline() *pipeline.Pipeline[*environmentv1.UpdateEnvironmentVariablesRequest] {
 	return pipeline.NewPipeline[*environmentv1.UpdateEnvironmentVariablesRequest]("environment-update-variables").
 		AddStep(steps.NewValidateProtoStep[*environmentv1.UpdateEnvironmentVariablesRequest]()).
 		AddStep(envsteps.NewLoadEnvironmentByIDStep[*environmentv1.UpdateEnvironmentVariablesRequest](c.store)).
-		AddStep(envsteps.NewMergeVariablesAndPersistStep(c.store)).
+		AddStep(envsteps.NewMergeVariablesAndPersistStep(c.store, c.secretService)).
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/update_visibility.go
@@ -46,6 +46,7 @@ func (c *EnvironmentController) UpdateVisibility(
 	}
 
 	env := reqCtx.Get(updateVisibilityEnvironmentKey).(*environmentv1.Environment)
+	envsteps.RedactEnvironmentSecrets(env)
 	return env, nil
 }
 

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/update_visibility_test.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/update_visibility_test.go
@@ -7,6 +7,7 @@ import (
 	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	envsteps "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller/steps"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -45,12 +46,22 @@ func TestEnvironmentController_UpdateVisibility_PrivateToOrg(t *testing.T) {
 		created.GetMetadata().GetVisibility(),
 		"environments must not default to org visibility - sharing is an explicit opt-in")
 
+	// Snapshot the STORED value before the visibility update — the response
+	// is redacted (oss#405), so the response value cannot serve as the
+	// spec-data-untouched baseline.
+	storedBefore := &environmentv1.Environment{}
+	require.NoError(t, s.GetResource(context.Background(),
+		apiresourcekind.ApiResourceKind_environment, created.GetMetadata().GetId(), storedBefore))
+
 	updated, err := controller.UpdateVisibility(contextWithEnvironmentKind(), &apiresource.UpdateVisibilityInput{
 		ResourceId: created.GetMetadata().GetId(),
 		Visibility: apiresource.ApiResourceVisibility_visibility_org,
 	})
 	require.NoError(t, err, "private -> org should succeed")
 	assert.Equal(t, apiresource.ApiResourceVisibility_visibility_org, updated.GetMetadata().GetVisibility())
+	// Responses never carry stored secret ciphertext or plaintext.
+	assert.Equal(t, envsteps.RedactedMarker, updated.GetSpec().GetData()["API_KEY"].GetValue(),
+		"updateVisibility response must redact secrets")
 
 	// Verify persistence, not just the response.
 	stored := &environmentv1.Environment{}
@@ -58,7 +69,7 @@ func TestEnvironmentController_UpdateVisibility_PrivateToOrg(t *testing.T) {
 		apiresourcekind.ApiResourceKind_environment, created.GetMetadata().GetId(), stored))
 	assert.Equal(t, apiresource.ApiResourceVisibility_visibility_org, stored.GetMetadata().GetVisibility(),
 		"org visibility must be persisted")
-	assert.Equal(t, created.GetSpec().GetData()["API_KEY"].GetValue(), stored.GetSpec().GetData()["API_KEY"].GetValue(),
+	assert.Equal(t, storedBefore.GetSpec().GetData()["API_KEY"].GetValue(), stored.GetSpec().GetData()["API_KEY"].GetValue(),
 		"visibility update must not touch spec data")
 }
 

--- a/backend/services/stigmer-server/pkg/domain/environment/resolution/runtime_resolution.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/resolution/runtime_resolution.go
@@ -1,0 +1,134 @@
+// Package resolution provides server-side resolution of environments for
+// executions — the OSS twin of the cloud edition's
+// EnvironmentRuntimeResolutionService.
+//
+// Runtime resolution and human reveal are two distinct operations: the
+// environment RPC surface redacts secret values in every response (oss#405,
+// getSecretValue being the single-key reveal path), while an execution needs
+// the full map decrypted. This service is the sanctioned internal path for
+// the latter. It deliberately does not ride the gRPC surface: the RPC
+// responses are redacted by design, and this single-user edition has no
+// caller identity that could gate an "unredacted" RPC variant.
+//
+// Called cross-domain by the execution-context builders (agentexecution,
+// workflowexecution) — a deliberate, documented boundary crossing in the
+// style of the cloud edition's EnvironmentMergeService dependency. The OSS
+// edition omits the cloud's OrgSharedEnvironmentPolicy gate: single-user,
+// no trust boundary to enforce.
+//
+// Returned values are PLAINTEXT, for execution-context builds only. Never
+// surface them in an API response, log, or error message.
+package resolution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
+	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+)
+
+// RuntimeResolutionService resolves environments with secret values
+// decrypted, for merging into an ExecutionContext.
+type RuntimeResolutionService struct {
+	store         store.Store
+	secretService *encryption.SecretService
+}
+
+func NewRuntimeResolutionService(
+	s store.Store,
+	secretService *encryption.SecretService,
+) *RuntimeResolutionService {
+	return &RuntimeResolutionService{store: s, secretService: secretService}
+}
+
+// ResolveByReference loads the referenced environment and decrypts its
+// is_secret values in place on the freshly-unmarshalled copy (the store is
+// never touched). Lookup semantics match the GetByReference RPC exactly —
+// same slug+org matching (steps.FindResourceBySlug) and the same org
+// requirement for this org-scoped kind — so a ref that resolves through the
+// RPC surface resolves identically here, and vice versa.
+//
+// Error doctrine (the cloud service's, expressed in this edition's error
+// taxonomy):
+//   - Undecryptable ciphertext (tampered/truncated/wrong-key) is scoped to
+//     one value: WARN and drop that key, matching the cloud's per-key skip.
+//   - encryption.ErrEncryptionDisabled propagates: the stored ciphertext may
+//     be perfectly valid (key file lost), and skipping it would start the
+//     execution silently missing a credential — a confusing downstream
+//     failure instead of a clear one here.
+//
+// An unresolvable reference returns NotFound, same as the RPC path — the
+// execution-context builders treat that as an authoring error that fails
+// the create (never a silent run without credentials).
+func (s *RuntimeResolutionService) ResolveByReference(
+	ctx context.Context,
+	ref *apiresourcepb.ApiResourceReference,
+) (*environmentv1.Environment, error) {
+	if ref == nil || ref.GetSlug() == "" {
+		return nil, grpclib.InvalidArgumentError("environment reference with slug is required")
+	}
+	if kind := ref.GetKind(); kind != 0 && kind != apiresourcekind.ApiResourceKind_environment {
+		return nil, grpclib.InvalidArgumentError(
+			"kind mismatch: expected environment, got %s", kind.String())
+	}
+	if err := steps.RequireOrgForReference(apiresourcekind.ApiResourceKind_environment, ref.GetOrg()); err != nil {
+		return nil, err
+	}
+
+	env, found, err := steps.FindResourceBySlug[*environmentv1.Environment](
+		ctx, s.store, apiresourcekind.ApiResourceKind_environment, ref.GetSlug(), ref.GetOrg(),
+	)
+	if err != nil {
+		return nil, grpclib.InternalError(err, "failed to look up environment for runtime resolution")
+	}
+	if !found {
+		return nil, grpclib.NotFoundError("environment", ref.GetSlug())
+	}
+
+	if err := s.decryptSecretValues(env); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+// decryptSecretValues walks spec.data and decrypts every encrypted is_secret
+// value. Plaintext legacy rows pass through Decrypt unchanged, so pre-oss#405
+// stores resolve without migration.
+func (s *RuntimeResolutionService) decryptSecretValues(env *environmentv1.Environment) error {
+	data := env.GetSpec().GetData()
+	if len(data) == 0 {
+		return nil
+	}
+
+	environmentID := env.GetMetadata().GetId()
+	for key, val := range data {
+		if !val.GetIsSecret() || !s.secretService.IsEncrypted(val.GetValue()) {
+			continue
+		}
+
+		decrypted, err := s.secretService.Decrypt(val.GetValue())
+		if err != nil {
+			if errors.Is(err, encryption.ErrEncryptionDisabled) {
+				return grpclib.InternalError(err, fmt.Sprintf(
+					"environment %s holds encrypted secret '%s' but no encryption key is configured",
+					environmentID, key))
+			}
+			log.Warn().Err(err).
+				Str("key", key).
+				Str("environment_id", environmentID).
+				Msg("Undecryptable ciphertext in environment — dropping this value from runtime resolution")
+			delete(env.Spec.Data, key)
+			continue
+		}
+		val.Value = decrypted
+	}
+	return nil
+}

--- a/backend/services/stigmer-server/pkg/domain/environment/resolution/runtime_resolution_test.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/resolution/runtime_resolution_test.go
@@ -1,0 +1,206 @@
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
+	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const testKey = "0123456789abcdef0123456789abcdef" // 32 bytes
+
+func newTestStore(t *testing.T) store.Store {
+	t.Helper()
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func keyedService(t *testing.T, s store.Store) (*RuntimeResolutionService, *encryption.SecretService) {
+	t.Helper()
+	secretService, err := encryption.NewSecretService([]byte(testKey))
+	require.NoError(t, err)
+	return NewRuntimeResolutionService(s, secretService), secretService
+}
+
+// seedEnvironment persists an environment directly (no controller pipeline)
+// so tests control the exact at-rest bytes — encrypted, plaintext-legacy,
+// or corrupt.
+func seedEnvironment(t *testing.T, s store.Store, slug string, data map[string]*environmentv1.EnvironmentValue) {
+	t.Helper()
+	env := &environmentv1.Environment{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "Environment",
+		Metadata: &apiresourcepb.ApiResourceMetadata{
+			Id:   "env_" + slug,
+			Name: slug,
+			Slug: slug,
+			Org:  "test-org",
+		},
+		Spec: &environmentv1.EnvironmentSpec{Data: data},
+	}
+	require.NoError(t, s.SaveResource(context.Background(),
+		apiresourcekind.ApiResourceKind_environment, env.GetMetadata().GetId(), env))
+}
+
+func envRef(slug string) *apiresourcepb.ApiResourceReference {
+	return &apiresourcepb.ApiResourceReference{
+		Kind: apiresourcekind.ApiResourceKind_environment,
+		Org:  "test-org",
+		Slug: slug,
+	}
+}
+
+func TestResolveByReference_DecryptsSecrets(t *testing.T) {
+	s := newTestStore(t)
+	svc, secretService := keyedService(t, s)
+
+	ciphertext, err := secretService.Encrypt("real-secret")
+	require.NoError(t, err)
+	seedEnvironment(t, s, "keyed-env", map[string]*environmentv1.EnvironmentValue{
+		"API_TOKEN":  {Value: ciphertext, IsSecret: true, Description: "a token"},
+		"PLAIN_HOST": {Value: "example.com", IsSecret: false},
+	})
+
+	resolved, err := svc.ResolveByReference(context.Background(), envRef("keyed-env"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "real-secret", resolved.GetSpec().GetData()["API_TOKEN"].GetValue(),
+		"secret must resolve decrypted for the execution-context merge")
+	assert.True(t, resolved.GetSpec().GetData()["API_TOKEN"].GetIsSecret(),
+		"is_secret must survive resolution (EC merge propagates it)")
+	assert.Equal(t, "example.com", resolved.GetSpec().GetData()["PLAIN_HOST"].GetValue(),
+		"non-secret values pass through untouched")
+}
+
+func TestResolveByReference_LegacyPlaintextPassesThrough(t *testing.T) {
+	s := newTestStore(t)
+	svc, _ := keyedService(t, s)
+
+	// A pre-oss#405 row: is_secret but stored plaintext. Resolution must
+	// hand it through unchanged — zero-migration contract.
+	seedEnvironment(t, s, "legacy-env", map[string]*environmentv1.EnvironmentValue{
+		"OLD_SECRET": {Value: "stored-before-encryption", IsSecret: true},
+	})
+
+	resolved, err := svc.ResolveByReference(context.Background(), envRef("legacy-env"))
+	require.NoError(t, err)
+	assert.Equal(t, "stored-before-encryption", resolved.GetSpec().GetData()["OLD_SECRET"].GetValue())
+}
+
+func TestResolveByReference_DropsUndecryptableValuePerKey(t *testing.T) {
+	s := newTestStore(t)
+	svc, secretService := keyedService(t, s)
+
+	good, err := secretService.Encrypt("good-secret")
+	require.NoError(t, err)
+	seedEnvironment(t, s, "corrupt-env", map[string]*environmentv1.EnvironmentValue{
+		"GOOD_KEY": {Value: good, IsSecret: true},
+		// Ciphertext-shaped but not valid base64 payload — tampered data.
+		"BAD_KEY": {Value: "enc:v1:!!!not-base64!!!", IsSecret: true},
+	})
+
+	resolved, err := svc.ResolveByReference(context.Background(), envRef("corrupt-env"))
+	require.NoError(t, err, "a single corrupt value must not fail the whole resolution")
+
+	assert.Equal(t, "good-secret", resolved.GetSpec().GetData()["GOOD_KEY"].GetValue())
+	_, present := resolved.GetSpec().GetData()["BAD_KEY"]
+	assert.False(t, present, "the undecryptable key must be dropped, not passed through as ciphertext")
+}
+
+func TestResolveByReference_FailsLoudWhenKeyMissingForCiphertext(t *testing.T) {
+	s := newTestStore(t)
+
+	// Encrypt with a real key, then resolve with a keyless service — the
+	// "key file lost" scenario. Silently skipping would start executions
+	// missing credentials; the resolution must fail loud instead.
+	keyedSecrets, err := encryption.NewSecretService([]byte(testKey))
+	require.NoError(t, err)
+	ciphertext, err := keyedSecrets.Encrypt("unreachable-secret")
+	require.NoError(t, err)
+	seedEnvironment(t, s, "stranded-env", map[string]*environmentv1.EnvironmentValue{
+		"API_TOKEN": {Value: ciphertext, IsSecret: true},
+	})
+
+	keyless, err := encryption.NewSecretService(nil)
+	require.NoError(t, err)
+	svc := NewRuntimeResolutionService(s, keyless)
+
+	_, err = svc.ResolveByReference(context.Background(), envRef("stranded-env"))
+	require.Error(t, err, "ciphertext without a key must fail resolution")
+	assert.Contains(t, err.Error(), "no encryption key is configured")
+}
+
+func TestResolveByReference_LookupSemanticsMatchTheRpcPath(t *testing.T) {
+	s := newTestStore(t)
+	svc, _ := keyedService(t, s)
+
+	seedEnvironment(t, s, "lookup-env", map[string]*environmentv1.EnvironmentValue{
+		"K": {Value: "v", IsSecret: false},
+	})
+
+	t.Run("unknown slug is NotFound", func(t *testing.T) {
+		_, err := svc.ResolveByReference(context.Background(), envRef("no-such-env"))
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("wrong org is NotFound", func(t *testing.T) {
+		ref := envRef("lookup-env")
+		ref.Org = "other-org"
+		_, err := svc.ResolveByReference(context.Background(), ref)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("missing org is InvalidArgument (org-scoped kind)", func(t *testing.T) {
+		ref := envRef("lookup-env")
+		ref.Org = ""
+		_, err := svc.ResolveByReference(context.Background(), ref)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("kind mismatch is InvalidArgument", func(t *testing.T) {
+		ref := envRef("lookup-env")
+		ref.Kind = apiresourcekind.ApiResourceKind_agent
+		_, err := svc.ResolveByReference(context.Background(), ref)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("missing slug is InvalidArgument", func(t *testing.T) {
+		ref := envRef("")
+		_, err := svc.ResolveByReference(context.Background(), ref)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+}
+
+// TestResolveByReference_DoesNotMutateTheStore pins that decryption happens
+// on the freshly-unmarshalled copy: after a resolve, the at-rest bytes are
+// still ciphertext.
+func TestResolveByReference_DoesNotMutateTheStore(t *testing.T) {
+	s := newTestStore(t)
+	svc, secretService := keyedService(t, s)
+
+	ciphertext, err := secretService.Encrypt("stay-encrypted")
+	require.NoError(t, err)
+	seedEnvironment(t, s, "immutable-env", map[string]*environmentv1.EnvironmentValue{
+		"API_TOKEN": {Value: ciphertext, IsSecret: true},
+	})
+
+	_, err = svc.ResolveByReference(context.Background(), envRef("immutable-env"))
+	require.NoError(t, err)
+
+	stored := &environmentv1.Environment{}
+	require.NoError(t, s.GetResource(context.Background(),
+		apiresourcekind.ApiResourceKind_environment, "env_immutable-env", stored))
+	assert.Equal(t, ciphertext, stored.GetSpec().GetData()["API_TOKEN"].GetValue(),
+		"resolution must never write plaintext back to the store")
+}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/managed_env.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/oauth/managed_env.go
@@ -92,9 +92,9 @@ func (s *ManagedEnvironmentService) DeleteManagedEnvironment(
 
 // UpdateSecrets writes secret variables into a managed environment.
 // Values must be plaintext (never enc:v<N>:-prefixed — the environment
-// pipeline rejects ciphertext-shaped input, oss#395) and are stored as
-// passed: the OSS environment pipeline does not encrypt at write time
-// (at-rest encryption for environment values is tracked separately).
+// pipeline rejects ciphertext-shaped input, oss#395); the environment
+// pipeline encrypts is_secret values at rest (oss#405), so vendor OAuth
+// tokens stored through here rest as enc:v1: ciphertext.
 func (s *ManagedEnvironmentService) UpdateSecrets(
 	ctx context.Context,
 	environmentID string,

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create_execution_context_step.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create_execution_context_step.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/envmerge"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
-	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/environment"
+	envresolution "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/resolution"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/executioncontext"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflowinstance"
 )
@@ -27,12 +27,14 @@ import (
 //   - store.GetResource(workflow_id) -> Workflow.env_spec (follows WE controller's "same service" store-access pattern)
 //
 // Merge priority (lowest to highest):
-//  1. WorkflowInstance.env_refs resolved via environmentClient (in order)
+//  1. WorkflowInstance.env_refs resolved via the environment
+//     RuntimeResolutionService (in order; secret values decrypted — the
+//     RPC surface redacts them, oss#405)
 //  2. WorkflowExecution.spec.runtime_env (execution-time overrides)
 type createExecutionContextStep struct {
 	store                  store.Store
 	workflowInstanceClient *workflowinstance.Client
-	environmentClient      *environment.Client
+	environmentResolution  *envresolution.RuntimeResolutionService
 	executionCtxClient     *executioncontext.Client
 }
 
@@ -40,7 +42,7 @@ func (c *WorkflowExecutionController) newCreateExecutionContextStep() *createExe
 	return &createExecutionContextStep{
 		store:                  c.store,
 		workflowInstanceClient: c.workflowInstanceClient,
-		environmentClient:      c.environmentClient,
+		environmentResolution:  c.environmentResolution,
 		executionCtxClient:     c.executionContextClient,
 	}
 }
@@ -54,10 +56,10 @@ func (s *createExecutionContextStep) Execute(ctx *pipeline.RequestContext[*workf
 	executionID := execution.GetMetadata().GetId()
 	executionOrg := execution.GetMetadata().GetOrg()
 
-	if s.workflowInstanceClient == nil || s.environmentClient == nil || s.executionCtxClient == nil {
+	if s.workflowInstanceClient == nil || s.environmentResolution == nil || s.executionCtxClient == nil {
 		log.Warn().
 			Str("execution_id", executionID).
-			Msg("ExecutionContext clients not available, skipping execution context creation")
+			Msg("ExecutionContext dependencies not available, skipping execution context creation")
 		return nil
 	}
 
@@ -196,7 +198,10 @@ func (s *createExecutionContextStep) resolveEnvironments(
 
 	environments := make([]*environmentv1.Environment, 0, len(refs))
 	for _, ref := range refs {
-		env, err := s.environmentClient.GetByReference(ctx.Context(), ref)
+		// Runtime resolution, not the GetByReference RPC: the RPC surface
+		// redacts secret values (oss#405); this internal path returns them
+		// decrypted for the execution-context merge.
+		env, err := s.environmentResolution.ResolveByReference(ctx.Context(), ref)
 		if err != nil {
 			return nil, fmt.Errorf("resolve environment ref (org=%s, slug=%s): %w",
 				ref.GetOrg(), ref.GetSlug(), err)

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/recover.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/recover.go
@@ -86,7 +86,7 @@ func (c *WorkflowExecutionController) buildRecoverPipeline() *pipeline.Pipeline[
 		AddStep(NewValidateRecoverableStep[*workflowexecutionv1.RecoverWorkflowExecutionInput]()).
 		AddStep(NewTerminateExistingWorkflowStep[*workflowexecutionv1.RecoverWorkflowExecutionInput](c.temporalClient)).
 		AddStep(newRecreateExecutionContextStep(
-			c.store, c.workflowInstanceClient, c.environmentClient, c.executionContextClient,
+			c.store, c.workflowInstanceClient, c.environmentResolution, c.executionContextClient,
 		)).
 		AddStep(NewStartFreshWorkflowStep[*workflowexecutionv1.RecoverWorkflowExecutionInput](
 			c.workflowCreator, c.temporalConfig,

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/recreate_execution_context_step.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/recreate_execution_context_step.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/envmerge"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
-	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/environment"
+	envresolution "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/resolution"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/executioncontext"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflowinstance"
 )
@@ -34,20 +34,20 @@ import (
 type recreateExecutionContextStep struct {
 	store                  store.Store
 	workflowInstanceClient *workflowinstance.Client
-	environmentClient      *environment.Client
+	environmentResolution  *envresolution.RuntimeResolutionService
 	executionCtxClient     *executioncontext.Client
 }
 
 func newRecreateExecutionContextStep(
 	s store.Store,
 	wiClient *workflowinstance.Client,
-	envClient *environment.Client,
+	envResolution *envresolution.RuntimeResolutionService,
 	ecClient *executioncontext.Client,
 ) *recreateExecutionContextStep {
 	return &recreateExecutionContextStep{
 		store:                  s,
 		workflowInstanceClient: wiClient,
-		environmentClient:      envClient,
+		environmentResolution:  envResolution,
 		executionCtxClient:     ecClient,
 	}
 }
@@ -61,8 +61,8 @@ func (s *recreateExecutionContextStep) Execute(ctx *pipeline.RequestContext[*wor
 		return nil
 	}
 
-	if s.workflowInstanceClient == nil || s.environmentClient == nil || s.executionCtxClient == nil {
-		log.Warn().Msg("ExecutionContext clients not available, skipping EC recreation during recovery")
+	if s.workflowInstanceClient == nil || s.environmentResolution == nil || s.executionCtxClient == nil {
+		log.Warn().Msg("ExecutionContext dependencies not available, skipping EC recreation during recovery")
 		return nil
 	}
 
@@ -199,7 +199,10 @@ func (s *recreateExecutionContextStep) resolveEnvironments(
 
 	environments := make([]*environmentv1.Environment, 0, len(refs))
 	for _, ref := range refs {
-		env, err := s.environmentClient.GetByReference(ctx.Context(), ref)
+		// Runtime resolution, not the GetByReference RPC: the RPC surface
+		// redacts secret values (oss#405); this internal path returns them
+		// decrypted for the execution-context merge.
+		env, err := s.environmentResolution.ResolveByReference(ctx.Context(), ref)
 		if err != nil {
 			return nil, fmt.Errorf("resolve environment ref (org=%s, slug=%s): %w",
 				ref.GetOrg(), ref.GetSlug(), err)

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/workflowexecution_controller.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/workflowexecution_controller.go
@@ -3,10 +3,10 @@ package workflowexecution
 import (
 	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	envresolution "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/resolution"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/dedupe"
 	wftemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows"
-	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/environment"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/executioncontext"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflowinstance"
 	"go.temporal.io/sdk/client"
@@ -41,7 +41,7 @@ type WorkflowExecutionController struct {
 	workflowexecutionv1.UnimplementedWorkflowExecutionQueryControllerServer
 	store                            store.Store
 	workflowInstanceClient           *workflowinstance.Client
-	environmentClient                *environment.Client
+	environmentResolution            *envresolution.RuntimeResolutionService
 	executionContextClient           *executioncontext.Client
 	workflowCreator                  *workflows.InvokeWorkflowExecutionWorkflowCreator
 	streamBroker                     *StreamBroker
@@ -75,13 +75,16 @@ func (c *WorkflowExecutionController) SetWorkflowInstanceClient(client *workflow
 	c.workflowInstanceClient = client
 }
 
-// SetEnvironmentAndExecutionContextClients sets the clients needed for ExecutionContext creation
-// during the create pipeline. These are injected after the in-process gRPC server starts.
-func (c *WorkflowExecutionController) SetEnvironmentAndExecutionContextClients(
-	envClient *environment.Client,
+// SetExecutionContextDependencies sets the dependencies needed for
+// ExecutionContext creation during the create and recover pipelines: the
+// environment runtime-resolution service (the decrypt-for-execution path —
+// the environment RPC surface redacts secret values, oss#405) and the
+// in-process ExecutionContext client (injected after the gRPC server starts).
+func (c *WorkflowExecutionController) SetExecutionContextDependencies(
+	envResolution *envresolution.RuntimeResolutionService,
 	ecClient *executioncontext.Client,
 ) {
-	c.environmentClient = envClient
+	c.environmentResolution = envResolution
 	c.executionContextClient = ecClient
 }
 

--- a/backend/services/stigmer-server/pkg/server/server.go
+++ b/backend/services/stigmer-server/pkg/server/server.go
@@ -50,6 +50,7 @@ import (
 	datastorecontroller "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/datastore/controller"
 	datastorerecordstore "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/datastore/recordstore"
 	environmentcontroller "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/controller"
+	environmentresolution "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/environment/resolution"
 	executioncontextcontroller "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/executioncontext/controller"
 	mcpservercontroller "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/controller"
 	mcpserveroauth "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
@@ -606,7 +607,14 @@ func Run() error {
 	workflowController.SetWorkflowInstanceClient(workflowInstanceClient)
 	workflowInstanceController.SetWorkflowClient(workflowClient)
 	workflowExecutionController.SetWorkflowInstanceClient(workflowInstanceClient)
-	workflowExecutionController.SetEnvironmentAndExecutionContextClients(environmentClient, executionContextClient)
+
+	// Environment runtime resolution: the internal decrypt-for-execution
+	// path the execution-context builders use for environment_refs. The
+	// environment RPC surface redacts secret values (oss#405), so EC builds
+	// must not read through it.
+	environmentResolution := environmentresolution.NewRuntimeResolutionService(store, secretService)
+	agentExecutionController.SetEnvironmentResolution(environmentResolution)
+	workflowExecutionController.SetExecutionContextDependencies(environmentResolution, executionContextClient)
 
 	// Inject workflow creators (nil-safe, controllers handle gracefully)
 	workflowExecutionController.SetWorkflowCreator(workflowExecutionWorkflowCreator)

--- a/test/conformance/src/suites-execution/envmerge.conformance.test.ts
+++ b/test/conformance/src/suites-execution/envmerge.conformance.test.ts
@@ -28,9 +28,14 @@
 // the workflow path, a held mock-LLM turn for the agent path. Neither the read
 // nor the assertions depend on the run reaching any particular phase.
 //
-// Secret values follow the same contract as ExecutionContext/Environment: the
-// is_secret flag is edition-agnostic; the value is plaintext on OSS and redacted
-// on cloud, gated by the secretRedaction capability.
+// Secret values follow the ExecutionContext read contract (NOT Environment's,
+// which is edition-converged since stigmer#405): the merged value is observed
+// through EC getByExecutionId, so it is plaintext on OSS and redacted on
+// cloud, gated by the executionContextSecretRedaction capability. The
+// is_secret flag is edition-agnostic. Note the merge itself DECRYPTS
+// environment secrets on OSS (RuntimeResolutionService) — this suite is the
+// end-to-end proof that encrypted-at-rest environment values reach executions
+// as plaintext.
 import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ConformanceClients } from "../harness/clients";
@@ -229,7 +234,7 @@ describe("envmerge conformance — Workflow precedence", () => {
     );
   });
 
-  it("a secret value survives the merge with is_secret preserved (value gated by secretRedaction)", async () => {
+  it("a secret value survives the merge with is_secret preserved (value gated by executionContextSecretRedaction)", async () => {
     const { org } = await target.provisionTenancy();
     const secretValue = "env-secret-value";
     const { data } = await runWorkflowMerge(org, {
@@ -243,10 +248,13 @@ describe("envmerge conformance — Workflow precedence", () => {
     expect(secretEntry?.isSecret, "is_secret is preserved through the merge in both editions").toBe(true);
     expect(data.PLAIN_KEY?.value, "plaintext values are never redacted").toBe("plain-value");
 
-    if (target.capabilities.secretRedaction) {
+    if (target.capabilities.executionContextSecretRedaction) {
       expect(secretEntry?.value, "redacting targets must not return the plaintext secret").not.toBe(secretValue);
       return;
     }
+    // OSS EC reads are plaintext — and the value being the ORIGINAL secret
+    // (not enc:v1: ciphertext) proves the merge decrypted the encrypted-at-
+    // rest environment value via RuntimeResolutionService (stigmer#405).
     expect(secretEntry?.value, "OSS returns the merged secret value in plaintext").toBe(secretValue);
   });
 

--- a/test/conformance/src/suites/environment.conformance.test.ts
+++ b/test/conformance/src/suites/environment.conformance.test.ts
@@ -8,13 +8,12 @@
 // incremental variable management (updateVariables/removeVariables), single-key
 // secret reveal (getSecretValue), and spec-first negative paths.
 //
-// Secret handling is the domain's defining concern and is edition-divergent:
-//   - get / list / getByReference return the secret VALUE in plaintext on OSS
-//     (single-user/local) but redact it on cloud. This is gated by the
-//     secretRedaction capability — the is_secret flag itself is edition-agnostic.
+// Secret handling is the domain's defining concern and is edition-CONVERGED
+// since stigmer#405 (OSS encrypts at rest and redacts on read, matching cloud):
+//   - Every Environment-returning RPC redacts secret values to the
+//     ***REDACTED*** marker in both editions; the is_secret flag is preserved.
 //   - getSecretValue is the explicit "reveal" endpoint: it returns the unredacted
-//     value in BOTH editions by design (cloud gates it behind can_read_secrets),
-//     so its value assertion is NOT gated.
+//     value in BOTH editions by design (cloud gates it behind can_read_secrets).
 //
 // The shared create steps return typed gRPC codes on every target:
 // duplicate-create -> AlreadyExists (CheckDuplicateStep) and missing-name ->
@@ -196,7 +195,11 @@ describe("Environment conformance — CRUD & identity", () => {
 });
 
 describe("Environment conformance — secrets", () => {
-  it("read RPCs return the secret value per the secretRedaction capability; is_secret is always preserved", async () => {
+  it("read RPCs redact the secret value in both editions; is_secret is always preserved", async () => {
+    // Edition-converged since stigmer#405: OSS encrypts at rest and redacts
+    // on read exactly like cloud, so the former secretRedaction capability
+    // branch is gone — the plaintext secret never leaks on a plain read
+    // anywhere.
     const { org } = await target.provisionTenancy();
     const secretValue = "s3cr3t-token-value";
     const created = await createEnvironment(org, uniqueName("env"), {
@@ -209,20 +212,9 @@ describe("Environment conformance — secrets", () => {
     const fetched = await clients.environmentQuery.get({ value: created.metadata!.id });
     const secretEntry = fetched.spec?.data?.API_TOKEN;
 
-    // The is_secret flag is part of the cross-edition contract regardless of value handling.
     expect(secretEntry?.isSecret, "is_secret is preserved on read in both editions").toBe(true);
     expect(fetched.spec?.data?.PLAIN_HOST?.value, "plaintext values are never redacted").toBe("example.com");
-
-    if (target.capabilities.secretRedaction) {
-      // Cloud redacts the secret value on get/list/getByReference. The exact
-      // redaction representation is the cloud target's to assert; here we pin the
-      // edition-agnostic guarantee: the plaintext secret never leaks on a plain read.
-      expect(secretEntry?.value, "redacting targets must not return the plaintext secret").not.toBe(secretValue);
-      return;
-    }
-
-    // Local OSS is single-user and returns the secret value in plaintext.
-    expect(secretEntry?.value, "OSS returns the secret value in plaintext").toBe(secretValue);
+    expect(secretEntry?.value, "read RPCs must never return the plaintext secret").toBe(REDACTED_MARKER);
   });
 
   it("getSecretValue reveals the unredacted secret value (both editions)", async () => {

--- a/test/conformance/src/suites/executioncontext.conformance.test.ts
+++ b/test/conformance/src/suites/executioncontext.conformance.test.ts
@@ -17,9 +17,12 @@
 // live execution and is covered by the execution-lifecycle session. Here we test
 // the resource's own API contract by creating contexts directly.
 //
-// Secret value handling mirrors Environment: get/getByReference/getByExecutionId
-// return the value in plaintext on OSS and redact it on cloud (gated by
-// secretRedaction); the is_secret flag is edition-agnostic.
+// Secret value handling DIVERGES from Environment (which is edition-converged
+// since stigmer#405): EC get/getByReference/getByExecutionId return the value
+// in plaintext on OSS (its runner reads the EC through these RPCs) and redact
+// it on cloud (gated by executionContextSecretRedaction); the is_secret flag
+// is edition-agnostic. OSS convergence is tracked by the stigmer#405 spawned
+// EC-at-rest issue.
 import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
 import { Code } from "@connectrpc/connect";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
@@ -199,7 +202,7 @@ describe("ExecutionContext conformance — apply (create-or-fail)", () => {
 });
 
 describe("ExecutionContext conformance — secrets", () => {
-  it("read returns the secret value per the secretRedaction capability; is_secret is always preserved", async () => {
+  it("read returns the secret value per the executionContextSecretRedaction capability; is_secret is always preserved", async () => {
     const { org } = await target.provisionTenancy();
     const secretValue = "runtime-secret-value";
     const created = await createExecutionContext(org, uniqueName("ectx"), {
@@ -215,7 +218,7 @@ describe("ExecutionContext conformance — secrets", () => {
     expect(secretEntry?.isSecret, "is_secret is preserved on read in both editions").toBe(true);
     expect(fetched.spec?.data?.AWS_REGION?.value, "plaintext values are never redacted").toBe("us-east-1");
 
-    if (target.capabilities.secretRedaction) {
+    if (target.capabilities.executionContextSecretRedaction) {
       expect(secretEntry?.value, "redacting targets must not return the plaintext secret").not.toBe(secretValue);
       return;
     }
@@ -249,7 +252,7 @@ describe("ExecutionContext conformance — secrets", () => {
     expect(secretEntry?.isSecret, "is_secret is preserved on read in both editions").toBe(true);
     expect(fetched.spec?.data?.AWS_REGION?.value, "plaintext values are never redacted").toBe("us-east-1");
 
-    if (target.capabilities.secretRedaction) {
+    if (target.capabilities.executionContextSecretRedaction) {
       expect(secretEntry?.value, "redacting targets must not return the plaintext secret to a user token").not.toBe(
         secretValue,
       );

--- a/test/conformance/src/support/environments.ts
+++ b/test/conformance/src/support/environments.ts
@@ -3,8 +3,9 @@
 //
 // Environment is a flat (non-versioned) platform resource whose spec.data holds
 // configuration and secret values keyed by name. Each EnvironmentValue carries
-// an is_secret flag; in OSS the value round-trips in plaintext, in cloud it is
-// redacted on read (gated by the secretRedaction capability).
+// an is_secret flag; secret values are redacted on read in BOTH editions
+// (edition-converged since stigmer#405 — OSS encrypts at rest and redacts
+// exactly like cloud; getSecretValue is the reveal path).
 //
 // The canonical builder is deliberately SECRET-FREE: a plain-only environment
 // keeps the create-vs-get parity check edition-stable (secret values would

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -39,7 +39,7 @@ export class CloudTarget implements TargetProfile {
     externalOrgLookup: true,
     organizationEnumeration: false,
     versionTagging: true,
-    secretRedaction: true,
+    executionContextSecretRedaction: true,
     workflowChildApprovalForwarding: true,
     // The hermetic cloud env boots Temporal and the Java service runs the
     // schedule clock (T04 slice 2) — triggers fire for real.

--- a/test/conformance/src/targets/local-go-execution.ts
+++ b/test/conformance/src/targets/local-go-execution.ts
@@ -37,7 +37,7 @@ export class LocalGoExecutionTarget implements TargetProfile {
     externalOrgLookup: false,
     organizationEnumeration: true,
     versionTagging: false,
-    secretRedaction: false,
+    executionContextSecretRedaction: false,
     // The engine runs here, but the child-approval signal sender is cloud-only,
     // so a gated agent_call child never surfaces its gate to the parent workflow
     // (DD-012). The forwarder's reachable negatives still run unconditionally.

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -18,7 +18,7 @@ export class LocalGoTarget implements TargetProfile {
     externalOrgLookup: false,
     organizationEnumeration: true,
     versionTagging: true,
-    secretRedaction: false,
+    executionContextSecretRedaction: false,
     workflowChildApprovalForwarding: false,
     // No Temporal behind this target at all — schedules cannot fire.
     scheduleFiring: false,

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -28,13 +28,20 @@ export interface CapabilityFlags {
   // Unimplemented) — version tags are instead set at apply time via
   // metadata.version.tag and resolved through getByReference.
   versionTagging: boolean;
-  // Secret values (EnvironmentValue/ExecutionValue with is_secret=true) are
-  // redacted on read. False for local OSS, which is single-user/local and
-  // returns secret values in plaintext on get/list/getByReference/getSecretValue
-  // (encryption is implemented but never invoked by the write pipelines). True
-  // for cloud, which encrypts at rest and redacts on read. The is_secret flag
-  // itself is edition-agnostic; only the value handling differs.
-  secretRedaction: boolean;
+  // ExecutionContext secret values (ExecutionValue with is_secret=true) are
+  // redacted on EC read RPCs. True for cloud, which encrypts EC values at rest,
+  // redacts user-class reads, and decrypts only for scope-bound runner
+  // credentials (ResolveExecutionContextValuesForCaller). False for local OSS,
+  // whose runner reads the EC through the plain get/getByExecutionId RPCs — EC
+  // redaction there would break execution until the runner-scoped resolve lane
+  // is ported (tracked as the stigmer#405 spawned EC-at-rest issue; flipping
+  // this flag is that port's finish line).
+  //
+  // NOTE the scope: this gates the ExecutionContext surface ONLY. Environment
+  // secret handling is edition-CONVERGED since stigmer#405 (both editions
+  // encrypt at rest and redact every Environment-returning RPC), so it needs
+  // no capability — the environment suite asserts redaction unconditionally.
+  executionContextSecretRedaction: boolean;
   // A child agent's tool-approval gate surfaces at the parent WorkflowExecution
   // (status.pending_approvals carries the child_agent_execution_id) so that
   // WorkflowExecution.submitApproval can forward the decision to the child.


### PR DESCRIPTION
Closes #405

## Summary

The OSS Go server never encrypted environment secret values at write time: `SecretService` was wired into `EnvironmentController` but its only call site was decrypt-on-read behind `getSecretValue`, so every `is_secret` value — including the long-lived vendor OAuth access/refresh tokens the MCP connect flow stores in managed environments — rested plaintext in the local store, while oauthapp and channelapp secrets were encrypted in the same store with the same service. Owner-ruled fix: encrypt at write AND redact secret values in read responses (the cloud posture), retiring the OSS plaintext-read divergence.

## What changed

**Encrypt at write (3 pipelines)** — new `encryptSecretValuesStep` (the cloud `EncryptSecretValues` twin) after the `PreserveRedactedSecrets` sentinel guard in create and update; `mergeVariablesAndPersistStep` encrypts inside the merge loop (its own write boundary — this is the path vendor OAuth tokens take via `ManagedEnvironmentService.UpdateSecrets`). Marker-restored stored ciphertext survives untouched (`Encrypt` is idempotent — pinned byte-for-byte by test). Keyless deployments keep the oss#394 WARN-and-pass-through convention. Decrypt-on-read passes legacy plaintext rows through, so there is **no migration** in either direction.

**Redact every Environment-returning response (9 RPCs)** — exported `RedactEnvironmentSecrets` called at each controller boundary after pipeline execution (`get`, `getByReference`, `list`, `create`, `update`, `updateVariables`, `removeVariables`, `updateVisibility`, `delete`; `apply` inherits via delegation) — the `RedactChannelApp`/oauthapp idiom, applied a third time. Secrets return as `***REDACTED***` with `is_secret` and `description` preserved; the existing marker round-trip makes client read-modify-write work unchanged; `getSecretValue` stays the reveal path. The React SDK's reveal flow and the MCP connect/personal-env injectors already read through `getSecretValue` — verified unaffected.

**Runtime resolution seam for executions** — new `environment/resolution.RuntimeResolutionService` (the OSS twin of cloud's `EnvironmentRuntimeResolutionService`): the documented internal decrypt-for-execution path. All three execution-context resolution sites (agentexecution builder serving create+recover, workflowexecution create and recreate) switch from `GetByReference` to it, so ExecutionContexts keep receiving plaintext env values. Lookup semantics reuse the shared `FindResourceBySlug`/`RequireOrgForReference` helpers — identical to the RPC path. Error doctrine copied from cloud: per-key WARN-and-drop for corrupt ciphertext, fail-loud on `ErrEncryptionDisabled` (key file lost must not start executions silently missing credentials). The workflowexecution domain drops its environment client entirely.

**Conformance: capability split** — the old `secretRedaction` flag conflated two surfaces. Environment redaction is now edition-CONVERGED and asserted unconditionally (the OSS plaintext arm removed); the flag is renamed `executionContextSecretRedaction` and scoped to the EC read surface only (cloud true, OSS false — the OSS runner reads ECs through plain get RPCs until the runner-scoped resolve lane is ported; documented in the flag with the follow-up pointer).

## Design notes

- Ordering contract everywhere: sentinels → encrypt (the cloud step-ordering doc); redaction strictly after persist, mutating only the response copy — pinned by a test that proves the store never holds the marker.
- The T06 org-sharing integration test's standing assertion that `updateVisibility` responses redact (FGA-gated, previously latent for OSS) now holds unconditionally.
- Residual, spawned as a follow-up issue: the ExecutionContext itself still rests plaintext for the duration of each run; the cloud parity port (`EncryptExecutionContextValues` / `RedactExecutionContextValues` / `ResolveExecutionContextValuesForCaller`) is a second full surface and deliberately out of scope here.

## Verification

- `go vet` + `gofmt -s` clean across all Go modules; server binary builds.
- Full stigmer-server test suite green, including 7 new keyed-harness encryption tests (at-rest ciphertext, marker round-trip/no-double-encrypt, all-9-boundary redaction table, response-only redaction, keyless pass-through) and 7 new runtime-resolution tests (decrypt, legacy pass-through, per-key corrupt drop, fail-loud on missing key, RPC-identical lookup semantics, store immutability).
- Conformance: environment suite 36/36 and executioncontext suite 23/23 pass end-to-end against the live local Go server; conformance TypeScript typecheck clean (pre-existing unrelated errors aside).
- Not verified here: the cloud target conformance run (CI) and the execution-target envmerge suite (requires the engine harness; it is the end-to-end proof that encrypted-at-rest values reach executions decrypted — its OSS plaintext-EC assertion now doubles as the decrypt-seam check).

Made with [Cursor](https://cursor.com)