### PR TITLE
fix(build): docs gates run the pinned prettier, not whatever npx finds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,17 @@ GO_MODULES := \
 
 RUNNER_DIR := backend/services/runner
 
+# Prettier renders formatting VERDICTS (format-docs-check, the gen-*-docs-check
+# freshness gates), so it must always run at the version package-lock.json pins.
+# Bare `npx prettier` is nondeterministic: when no node_modules exists on the
+# directory walk-up path (a fresh worktree outside this checkout, a machine
+# that never ran `npm install`), npx silently downloads the LATEST release —
+# and prettier releases change markdown formatting, so the same bytes pass on
+# one machine and fail on another (oss#531). Invoke the installed binary
+# directly, and fail loudly when it is missing instead of letting npx guess.
+PRETTIER := node_modules/.bin/prettier
+PRETTIER_GUARD := test -x $(PRETTIER) || { echo "error: $(PRETTIER) not found — run 'npm install' at the repo root (prettier must run at the version package-lock.json pins)"; exit 1; }
+
 .DEFAULT_GOAL := help
 
 # ─── Help ─────────────────────────────────────
@@ -134,7 +145,8 @@ gen-task-docs: ## Generate per-task reference docs from schemas
 	go run ./tools/codegen/generator --comprehensive --target=task-docs \
 		--schema-dir tools/codegen/schemas --output-dir docs/guides/workflows/task-types \
 		--meta-dir apis/ai/stigmer/agentic/workflow/v1/tasks/meta --apis-dir apis
-	npx prettier --write --prose-wrap always docs/guides/workflows/task-types/*.mdx
+	@$(PRETTIER_GUARD)
+	$(PRETTIER) --write --prose-wrap always docs/guides/workflows/task-types/*.mdx
 
 gen-task-registry: ## Generate task-kind-registry.json + JSON Schemas and sync into the backend embed
 	go run ./tools/codegen/generator --comprehensive --target=task-registry \
@@ -215,11 +227,12 @@ gen-proto-sdk-docs-check: ## Verify proto SDK docs are up to date (CI)
 	echo "✓ Proto SDK docs are up to date"
 
 gen-task-docs-check: ## Verify task docs are up to date (CI)
+	@$(PRETTIER_GUARD)
 	@tmpdir=$$(mktemp -d) && \
 	go run ./tools/codegen/generator --comprehensive --target=task-docs \
 		--schema-dir tools/codegen/schemas --output-dir "$$tmpdir" \
 		--meta-dir apis/ai/stigmer/agentic/workflow/v1/tasks/meta --apis-dir apis && \
-	npx prettier --write --prose-wrap always --config .prettierrc --ignore-path /dev/null "$$tmpdir"/*.mdx > /dev/null 2>&1; \
+	$(PRETTIER) --write --prose-wrap always --config .prettierrc --ignore-path /dev/null "$$tmpdir"/*.mdx > /dev/null 2>&1; \
 	rc=0; \
 	for f in "$$tmpdir"/*; do \
 		if ! diff -q "$$f" "docs/guides/workflows/task-types/$$(basename $$f)" > /dev/null 2>&1; then \
@@ -281,14 +294,16 @@ gen-theme-docs-check: ## Verify theme token docs are up to date (CI)
 
 gen-cli-docs: ## Generate CLI reference docs from the TypeScript command tree
 	cd client-apps/cli && npx tsx scripts/gen-cli-docs.ts --output ../../docs/cli/commands/
-	npx prettier --write --prose-wrap always docs/cli/commands/
+	@$(PRETTIER_GUARD)
+	$(PRETTIER) --write --prose-wrap always docs/cli/commands/
 
 gen-cli-docs-check: ## Verify CLI docs are up to date (CI)
+	@$(PRETTIER_GUARD)
 	@tmpdir=$$(mktemp -d) && \
 	(cd client-apps/cli && npx tsx scripts/gen-cli-docs.ts --output "$$tmpdir") && \
 	for f in "$$tmpdir"/*; do \
 		bn=$$(basename "$$f"); \
-		npx prettier --stdin-filepath "docs/cli/commands/$$bn" < "$$f" > "$$f.fmt" 2>/dev/null && mv "$$f.fmt" "$$f"; \
+		$(PRETTIER) --stdin-filepath "docs/cli/commands/$$bn" < "$$f" > "$$f.fmt" 2>/dev/null && mv "$$f.fmt" "$$f"; \
 	done; \
 	rc=0; \
 	for f in "$$tmpdir"/*; do \
@@ -757,7 +772,8 @@ check-node: ## check bucket: npm typecheck/lint/build/test (web, react, sdk, des
 check-site: ## check bucket: docs lint/format/links + site lint/typecheck/test/build + demo validation
 	@vale sync 2>/dev/null
 	@vale $(DOCS_SOURCES)
-	@npx prettier --check --prose-wrap always $(DOCS_SOURCES)
+	@$(PRETTIER_GUARD)
+	@$(PRETTIER) --check --prose-wrap always $(DOCS_SOURCES)
 	$(MAKE) check-docs-yaml
 	$(MAKE) check-docs-inventory
 	$(MAKE) -C site lint
@@ -801,10 +817,12 @@ lint-docs-audit: ## Audit docs with Vale (non-blocking report)
 	-@vale $(DOCS_SOURCES)
 
 format-docs: ## Format documentation with Prettier
-	@npx prettier --write --prose-wrap always $(DOCS_SOURCES)
+	@$(PRETTIER_GUARD)
+	@$(PRETTIER) --write --prose-wrap always $(DOCS_SOURCES)
 
 format-docs-check: ## Check documentation formatting (CI, no writes)
-	@npx prettier --check --prose-wrap always $(DOCS_SOURCES)
+	@$(PRETTIER_GUARD)
+	@$(PRETTIER) --check --prose-wrap always $(DOCS_SOURCES)
 
 check-docs-yaml: ## Validate every docs YAML block against the proto contracts (CI)
 	@go run ./tools/codegen/generator --comprehensive --target=docs-yaml-check --docs-dir docs


### PR DESCRIPTION
## Summary
Makes every Prettier-based docs gate deterministic: all six `npx prettier` call sites in the Makefile now invoke the repo-installed `node_modules/.bin/prettier` directly, behind a guard that fails loudly with an install message when the binary is missing. No docs files change.

## Context
#531 reported `make format-docs-check` red on clean main (`docs/vocabulary.md`). The investigation corrected the premise: the file **passes** under the pinned Prettier 3.8.1 (`package-lock.json`), and CI is green because it runs `npm ci` first. The red verdict comes from bare `npx prettier` being nondeterministic — when no `node_modules` exists on the directory walk-up path (a fresh worktree outside the checkout, a machine that never ran `npm install`), npx **silently downloads the latest release** (3.9.6 today), which formats markdown list-item continuations differently than 3.8.1. Same bytes, two verdicts, depending on where the gate runs. Reformatting the file per the issue's suggested command would have flipped the failure onto CI and every installed checkout — the two versions disagree on the same constructs, so no file state satisfies both.

## Changes
- New `PRETTIER` variable (`node_modules/.bin/prettier`) + `PRETTIER_GUARD` (loud, actionable failure when missing), defined once with a comment recording the oss#531 mechanism.
- All six call sites converted: `format-docs`, `format-docs-check`, the inline check in `check-site`, and the generator paths in `gen-task-docs`, `gen-task-docs-check`, `gen-cli-docs`, `gen-cli-docs-check`. The generator write paths could previously rewrite committed docs with the wrong version in a fresh worktree.
- Bonus defect closed: `gen-task-docs-check`/`gen-cli-docs-check` silence prettier's stderr, so a wrong/missing prettier surfaced as a false "docs are stale — run make gen-..." error. The guard makes the real cause loud.

## Implementation notes
- `npx --no-install` was evaluated and rejected: it resolves from npx's download cache (verified: returned 3.9.6, exit 0, in a bare directory), so it is still nondeterministic. Direct binary invocation has no resolution logic to reason about.
- All six sites run with cwd = repo root (verified — the `cd client-apps/cli` in `gen-cli-docs-check` is a closed subshell), so one resolution form serves all.
- The Makefile is the complete fix surface: package.json's lint-staged entry and client-apps/web's npm scripts use bare `prettier`, which npm/lint-staged resolve from the local install by construction.
- Strictness note: worktrees nested under the checkout previously borrowed the parent's `node_modules` via npx walk-up; they now require their own `npm install`. That is deliberate — the binary run is the one belonging to the tree's own lockfile.
- Deliberately out of scope: upgrading Prettier to 3.9.x (separate decision, repo-wide reformat), other bare-`npx` tools (`tsx`, `scenar`, `playwright` — different consequence profile), pre-merge CI coverage (#477).

## Breaking changes
- None (CI already installs before running these targets).

## Test plan
- Red-first: on a clean `origin/main` worktree in /tmp (no upward `node_modules`), `make format-docs-check` reproduced the exact #531 failure (`[warn] docs/vocabulary.md`, npx resolved 3.9.6); the same commit in an installed context is green (3.8.1).
- Post-fix, no install: gate fails loudly with the install message in both worktree layouts — never fetches, never renders a verdict with a foreign toolchain.
- Post-fix, after `npm ci`: `make format-docs-check` green; `make format-docs` reports all 118 docs files unchanged (committed tree is byte-stable under the pinned toolchain — proving no docs edits belong in this PR); `make gen-task-docs-check` and `make gen-cli-docs-check` green (after `npm run build:libs`, as CI does).

## Risks
- Low: Makefile-only, CI behavior unchanged. Rollback is reverting one commit.

Closes #531

Made with [Cursor](https://cursor.com)