### PR TITLE
test(integration): anchor artifact fixtures to real source executions

### DIFF
--- a/test/integration/artifact_test.go
+++ b/test/integration/artifact_test.go
@@ -12,11 +12,38 @@ import (
 
 	artifactv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/artifact/v1"
 	apiresource "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/test/integration/harness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// newSourceExecution deploys a trivial workflow and creates one execution for
+// it, returning the execution's id for use as an artifact source.
+//
+// Artifact fixtures need REAL executions: artifact authorization anchors to
+// the source execution's org — the service resolves spec.source against the
+// store at create time and rejects unresolvable references with
+// FailedPrecondition (stigmer-cloud PR #295; pinned by
+// TestArtifact_Create_UnresolvableSourceRejected), and ListByExecution
+// authorizes can_view against the parent execution named in the request. A
+// fabricated wex_* id cannot work anywhere in this suite.
+//
+// The execution record is persisted and org-stamped by the create RPC itself,
+// so no phase wait — and no unified runner — is needed before artifacts can
+// anchor to it.
+func newSourceExecution(t *testing.T, ctx context.Context, deployer *harness.FixtureDeployer, workflowName string) string {
+	t.Helper()
+
+	wf, err := fastWorkflow(workflowName)
+	require.NoError(t, err, "build source workflow fixture")
+
+	_, execution, err := deployer.DeployAndExecute(ctx, wf, "artifact source execution")
+	require.NoError(t, err, "deploy and execute source workflow")
+
+	return execution.GetMetadata().GetId()
+}
 
 func TestArtifact_CreateAndGet(t *testing.T) {
 	require.NotNil(t, grpcConn)
@@ -24,8 +51,14 @@ func TestArtifact_CreateAndGet(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	clients := harness.NewClients(grpcConn)
+	deployer := harness.NewFixtureDeployer(clients, "artifact-create", suiteLogger)
+	defer deployer.Cleanup(ctx)
+
 	commandClient := artifactv1.NewArtifactCommandControllerClient(grpcConn)
 	queryClient := artifactv1.NewArtifactQueryControllerClient(grpcConn)
+
+	sourceExecutionID := newSourceExecution(t, ctx, deployer, "integration-test-artifact-create")
 
 	content := []byte(`{"analysis": "test result", "score": 42}`)
 	hash := sha256.Sum256(content)
@@ -36,7 +69,7 @@ func TestArtifact_CreateAndGet(t *testing.T) {
 			ContentType: "application/json",
 			DisplayName: "analysis output",
 			Source: &artifactv1.ArtifactSource{
-				WorkflowExecutionId: "wex_integ_test_1",
+				WorkflowExecutionId: sourceExecutionID,
 				TaskName:            "analyze",
 			},
 		},
@@ -68,11 +101,18 @@ func TestArtifact_ListByWorkflowExecution(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	clients := harness.NewClients(grpcConn)
+	deployer := harness.NewFixtureDeployer(clients, "artifact-list", suiteLogger)
+	defer deployer.Cleanup(ctx)
+
 	commandClient := artifactv1.NewArtifactCommandControllerClient(grpcConn)
 	queryClient := artifactv1.NewArtifactQueryControllerClient(grpcConn)
 
-	wexA := "wex_integ_list_A_" + t.Name()
-	wexB := "wex_integ_list_B_" + t.Name()
+	// Two distinct source executions: list-by-A must not see B's artifact.
+	// Execution ids are server-minted ULIDs, so the count assertion below
+	// cannot collide with artifacts from other tests.
+	wexA := newSourceExecution(t, ctx, deployer, "integration-test-artifact-list-a")
+	wexB := newSourceExecution(t, ctx, deployer, "integration-test-artifact-list-b")
 
 	for i, wex := range []string{wexA, wexA, wexB} {
 		_, err := commandClient.Create(ctx, &artifactv1.CreateArtifactInput{
@@ -100,14 +140,20 @@ func TestArtifact_GetDownloadUrl_LocalStorage(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	clients := harness.NewClients(grpcConn)
+	deployer := harness.NewFixtureDeployer(clients, "artifact-dl", suiteLogger)
+	defer deployer.Cleanup(ctx)
+
 	commandClient := artifactv1.NewArtifactCommandControllerClient(grpcConn)
 	queryClient := artifactv1.NewArtifactQueryControllerClient(grpcConn)
+
+	sourceExecutionID := newSourceExecution(t, ctx, deployer, "integration-test-artifact-dl")
 
 	created, err := commandClient.Create(ctx, &artifactv1.CreateArtifactInput{
 		Spec: &artifactv1.ArtifactSpec{
 			ContentType: "text/plain",
 			DisplayName: "downloadable file",
-			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: "wex_dl_test"},
+			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: sourceExecutionID},
 		},
 		Content: []byte("downloadable content"),
 	})
@@ -127,14 +173,20 @@ func TestArtifact_Delete_SoftDelete(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	clients := harness.NewClients(grpcConn)
+	deployer := harness.NewFixtureDeployer(clients, "artifact-del", suiteLogger)
+	defer deployer.Cleanup(ctx)
+
 	commandClient := artifactv1.NewArtifactCommandControllerClient(grpcConn)
 	queryClient := artifactv1.NewArtifactQueryControllerClient(grpcConn)
+
+	sourceExecutionID := newSourceExecution(t, ctx, deployer, "integration-test-artifact-del")
 
 	created, err := commandClient.Create(ctx, &artifactv1.CreateArtifactInput{
 		Spec: &artifactv1.ArtifactSpec{
 			ContentType: "text/plain",
 			DisplayName: "ephemeral",
-			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: "wex_del_test"},
+			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: sourceExecutionID},
 		},
 		Content: []byte("will be deleted"),
 	})
@@ -163,7 +215,16 @@ func TestArtifact_ContentHashDedup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	clients := harness.NewClients(grpcConn)
+	deployer := harness.NewFixtureDeployer(clients, "artifact-dedup", suiteLogger)
+	defer deployer.Cleanup(ctx)
+
 	commandClient := artifactv1.NewArtifactCommandControllerClient(grpcConn)
+
+	// One source execution for both creates: the claim under test is
+	// "same content, distinct artifacts, same hash" — the source is not
+	// part of the dedup key.
+	sourceExecutionID := newSourceExecution(t, ctx, deployer, "integration-test-artifact-dedup")
 
 	content := []byte(`{"dedup": "test"}`)
 
@@ -171,7 +232,7 @@ func TestArtifact_ContentHashDedup(t *testing.T) {
 		Spec: &artifactv1.ArtifactSpec{
 			ContentType: "application/json",
 			DisplayName: "first",
-			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: "wex_dedup_1"},
+			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: sourceExecutionID},
 		},
 		Content: content,
 	})
@@ -181,7 +242,7 @@ func TestArtifact_ContentHashDedup(t *testing.T) {
 		Spec: &artifactv1.ArtifactSpec{
 			ContentType: "application/json",
 			DisplayName: "second",
-			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: "wex_dedup_2"},
+			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: sourceExecutionID},
 		},
 		Content: content,
 	})
@@ -191,6 +252,33 @@ func TestArtifact_ContentHashDedup(t *testing.T) {
 		"different artifacts should have different IDs")
 	assert.Equal(t, a1.GetStatus().GetContentHash(), a2.GetStatus().GetContentHash(),
 		"same content should produce the same content hash")
+}
+
+// TestArtifact_Create_UnresolvableSourceRejected pins the enforcement that
+// broke this suite when it landed service-side (stigmer-cloud PR #295 /
+// oss#447): artifact create anchors authorization to the source execution's
+// org, so a source that resolves to no persisted execution must be rejected
+// with FailedPrecondition instead of minting an unanchored artifact.
+func TestArtifact_Create_UnresolvableSourceRejected(t *testing.T) {
+	require.NotNil(t, grpcConn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	commandClient := artifactv1.NewArtifactCommandControllerClient(grpcConn)
+
+	_, err := commandClient.Create(ctx, &artifactv1.CreateArtifactInput{
+		Spec: &artifactv1.ArtifactSpec{
+			ContentType: "text/plain",
+			DisplayName: "orphan",
+			Source:      &artifactv1.ArtifactSource{WorkflowExecutionId: "wex_never_persisted"},
+		},
+		Content: []byte("content with no anchoring execution"),
+	})
+	require.Error(t, err, "create with an unresolvable source execution must be rejected")
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
 }
 
 func TestArtifact_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

The five `TestArtifact_*` Core-suite tests fabricated `wex_*` source-execution ids, and the service now (correctly) refuses to create an artifact whose source execution cannot be resolved to an org — `ci.integration-offline` has been red on every main push since 2026-08-11. This anchors the fixtures to real, org-stamped workflow executions and pins the enforcement contract from the consumer side.

## Context

stigmer-cloud PR #295 anchored artifact authorization to the source execution: create resolves `spec.source` against the store (org stamping + FGA tuples), and `ListByExecution` authorizes `can_view` on the parent execution named in the request. Fabricated ids can no longer work anywhere in this suite — the enforcement is intentional and stays; the fixtures comply. Suite-wide audit confirmed `artifact_test.go` was the only file fabricating source-execution references.

NOTE: reproducing this red also surfaced stigmer/stigmer-cloud#378 (service cannot boot on cloud main — Temporal activity-type collision, fixed in stigmer/stigmer-cloud#379). `ci.integration-offline` builds the service JAR from cloud main, so it returns green only once BOTH that fix and this one land.

## Changes

- NEW `newSourceExecution` fixture helper: deploys a trivial `fastWorkflow` and creates one execution via the existing `FixtureDeployer`, returning its real id. No phase wait and no runner dependency — the execution record is persisted and org-stamped by the create RPC itself (the green run below executed with the unified runner down).
- The five tests reference real execution ids; `TestArtifact_ListByWorkflowExecution` uses two distinct executions (isolation via server-minted ULIDs), `TestArtifact_ContentHashDedup` shares one (the source is not part of the dedup key).
- NEW `TestArtifact_Create_UnresolvableSourceRejected`: pins that an unresolvable source is rejected with `FailedPrecondition` — the exact contract whose cloud-side arrival broke this suite silently.

## Test plan

- Red-first: pre-fix suite against a fixed-boot JAR built from cloud main reproduces the issue's exact signature — 5 failures × 3 runs, all `FailedPrecondition: source execution not found or carries no org`.
- Post-fix: `DONE 10 tests in 20.352s`, zero failures, first pass (5 rewired + new pin + `TestArtifact_NotFound`); `go vet` clean, `gofmt` clean.
- Post-merge: confirm the next `ci.integration-offline` main run is green (requires stigmer/stigmer-cloud#379 merged first).

## Risks

- None to production code — test-only change. The fixtures add two RPCs per test (~0.3–0.8s each measured).

Closes #447

Made with [Cursor](https://cursor.com)