### PR TITLE
fix(backend/pipeline): preserve creation audit in SetAuditFieldsForUpdate

### DIFF
--- a/backend/libs/go/grpc/request/pipeline/steps/build_update_state.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/build_update_state.go
@@ -6,7 +6,6 @@ import (
 	commonspb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -204,96 +203,24 @@ func copyStatusFromExisting[T proto.Message](merged, existing T) error {
 //
 // The status field is created if it doesn't exist.
 func updateAuditFieldsReflect[T proto.Message](resource T, existing T) error {
-	// Get or create status field using proto reflection
-	statusMsg := getOrCreateStatusField(resource)
-	if statusMsg == nil {
-		// Resource doesn't have a status field - this is OK for some resource types
-		return nil
-	}
-
-	// Get current timestamp
 	now := timestamppb.Now()
+	actor := currentAuditActor()
 
-	// Build audit actor
-	// TODO: Get actual caller information from auth context when auth is implemented
-	// For now, use system/local placeholder
-	actor := &commonspb.ApiResourceAuditActor{
-		Id:     "system",
-		Avatar: "",
-	}
+	// Extract the existing resource's spec_audit creation identity to
+	// carry it forward (nil when the existing resource had no audit —
+	// updatedAuditInfo falls back to the current actor/time).
+	existingCreatedBy, existingCreatedAt := creationAuditOf(existing, "spec_audit")
 
-	// Extract existing audit info to preserve created_by and created_at for spec_audit
-	var existingCreatedBy *commonspb.ApiResourceAuditActor
-	var existingCreatedAt *timestamppb.Timestamp
-
-	// Try to get existing audit info using proto reflection
-	existingStatusMsg := getStatusField(existing)
-	if existingStatusMsg != nil {
-		existingAuditField := existingStatusMsg.Descriptor().Fields().ByName("audit")
-		if existingAuditField != nil && existingStatusMsg.Has(existingAuditField) {
-			existingAuditMsg := existingStatusMsg.Get(existingAuditField).Message()
-
-			// Get spec_audit
-			specAuditField := existingAuditMsg.Descriptor().Fields().ByName("spec_audit")
-			if specAuditField != nil && existingAuditMsg.Has(specAuditField) {
-				specAuditMsg := existingAuditMsg.Get(specAuditField).Message()
-
-				// Get created_by
-				createdByField := specAuditMsg.Descriptor().Fields().ByName("created_by")
-				if createdByField != nil && specAuditMsg.Has(createdByField) {
-					existingCreatedBy = &commonspb.ApiResourceAuditActor{}
-					proto.Merge(existingCreatedBy, specAuditMsg.Get(createdByField).Message().Interface())
-				}
-
-				// Get created_at
-				createdAtField := specAuditMsg.Descriptor().Fields().ByName("created_at")
-				if createdAtField != nil && specAuditMsg.Has(createdAtField) {
-					existingCreatedAt = &timestamppb.Timestamp{}
-					proto.Merge(existingCreatedAt, specAuditMsg.Get(createdAtField).Message().Interface())
-				}
-			}
-		}
-	}
-
-	// Fallback to current actor/time if existing audit not found
-	if existingCreatedBy == nil {
-		existingCreatedBy = actor
-	}
-	if existingCreatedAt == nil {
-		existingCreatedAt = now
-	}
-
-	// Build spec_audit - preserve created info, update updated info
-	specAuditInfo := &commonspb.ApiResourceAuditInfo{
-		CreatedBy: existingCreatedBy,
-		CreatedAt: existingCreatedAt,
-		UpdatedBy: actor,
-		UpdatedAt: now,
-		Event:     "updated",
-	}
-
-	// Build status_audit - status was reset, so both created and updated are current
-	statusAuditInfo := &commonspb.ApiResourceAuditInfo{
-		CreatedBy: actor,
-		CreatedAt: now,
-		UpdatedBy: actor,
-		UpdatedAt: now,
-		Event:     "updated",
-	}
-
-	// Build complete audit
-	audit := &commonspb.ApiResourceAudit{
-		SpecAudit:   specAuditInfo,
-		StatusAudit: statusAuditInfo,
-	}
-
-	// Set audit field using proto reflection
-	auditField := statusMsg.Descriptor().Fields().ByName("audit")
-	if auditField == nil {
-		// Status doesn't have an audit field - this is ok, not all resources may have audit
-		return nil
-	}
-
-	statusMsg.Set(auditField, protoreflect.ValueOfMessage(audit.ProtoReflect()))
-	return nil
+	return setAuditReflect(resource, &commonspb.ApiResourceAudit{
+		// spec_audit - preserve created info, update updated info
+		SpecAudit: updatedAuditInfo(existingCreatedBy, existingCreatedAt, actor, now),
+		// status_audit - status was reset, so both created and updated are current
+		StatusAudit: &commonspb.ApiResourceAuditInfo{
+			CreatedBy: actor,
+			CreatedAt: now,
+			UpdatedBy: actor,
+			UpdatedAt: now,
+			Event:     "updated",
+		},
+	})
 }

--- a/backend/libs/go/grpc/request/pipeline/steps/defaults.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/defaults.go
@@ -112,7 +112,7 @@ func (s *BuildNewStateStep[T]) Execute(ctx *pipeline.RequestContext[T]) error {
 
 	// 5. Set audit fields in status using proto reflection
 	if hasStatusField(resource) {
-		if err := setAuditFieldsReflect(resource, "created"); err != nil {
+		if err := SetAuditFieldsForCreate(resource); err != nil {
 			return fmt.Errorf("failed to set audit fields: %w", err)
 		}
 	}
@@ -174,77 +174,152 @@ func clearStatusFieldReflect(resource proto.Message) error {
 // - event to "created"
 //
 // Both spec_audit and status_audit are set identically for new resources.
+// The status field is created if it doesn't exist; resources without a
+// status field (or without an audit field within it) are a no-op.
+//
 // This function is exported so custom steps can use it for audit field management.
 func SetAuditFieldsForCreate(resource proto.Message) error {
-	return setAuditFieldsReflect(resource, "created")
-}
-
-// SetAuditFieldsForUpdate sets audit fields for an updated resource
-//
-// This preserves created_by and created_at from the existing resource (must be set prior),
-// and updates updated_by and updated_at to current values.
-//
-// This function is exported so custom steps can use it for audit field management.
-func SetAuditFieldsForUpdate(resource proto.Message) error {
-	return setAuditFieldsReflect(resource, "updated")
-}
-
-// setAuditFieldsReflect sets the audit information in the status field using proto reflection
-//
-// For create operations (event="created"):
-// - Both spec_audit and status_audit are set identically
-// - created_by and updated_by are the same actor
-// - created_at and updated_at are the same timestamp
-//
-// For update operations (event="updated"):
-// - spec_audit and status_audit are set with current actor/timestamp
-//
-// This function uses proto reflection to set the audit field generically.
-// The status field is created if it doesn't exist.
-func setAuditFieldsReflect(resource proto.Message, event string) error {
-	// Get or create status field using proto reflection
-	statusMsg := getOrCreateStatusField(resource)
-	if statusMsg == nil {
-		// Resource doesn't have a status field - this is OK for some resource types
-		return nil
-	}
-
-	// Get current timestamp
 	now := timestamppb.Now()
+	actor := currentAuditActor()
 
-	// Build audit actor
-	// TODO: Get actual caller information from auth context when auth is implemented
-	// For now, use system/local placeholder
-	actor := &commonspb.ApiResourceAuditActor{
-		Id:     "system",
-		Avatar: "",
-	}
-
-	// Build audit info
 	auditInfo := &commonspb.ApiResourceAuditInfo{
 		CreatedBy: actor,
 		CreatedAt: now,
 		UpdatedBy: actor,
 		UpdatedAt: now,
-		Event:     event,
+		Event:     "created",
 	}
 
-	// Build complete audit with both spec_audit and status_audit
-	audit := &commonspb.ApiResourceAudit{
+	return setAuditReflect(resource, &commonspb.ApiResourceAudit{
 		SpecAudit:   auditInfo,
 		StatusAudit: auditInfo,
+	})
+}
+
+// SetAuditFieldsForUpdate sets audit fields for an updated resource
+//
+// This preserves created_by and created_at from the resource's own current
+// audit — in both spec_audit and status_audit — and stamps updated_by and
+// updated_at with the current actor/time (event "updated"). Callers hand
+// this the loaded resource they mutated in place (or one that carries the
+// existing audit copied onto it, as skill push does), so the resource
+// itself is the source of creation truth. A resource with no prior audit
+// falls back to the current actor/time for the creation fields, the same
+// fallback BuildUpdateStateStep uses.
+//
+// Unlike BuildUpdateStateStep's updateAuditFieldsReflect — which resets
+// status_audit because the update pipeline rebuilds status from the
+// request — this helper preserves status_audit's creation identity too:
+// its callers are targeted mutations (visibility flips, skill push,
+// schedule stamps, soft deletes) that never reset status.
+//
+// This function is exported so custom steps can use it for audit field management.
+func SetAuditFieldsForUpdate(resource proto.Message) error {
+	now := timestamppb.Now()
+	actor := currentAuditActor()
+
+	specCreatedBy, specCreatedAt := creationAuditOf(resource, "spec_audit")
+	statusCreatedBy, statusCreatedAt := creationAuditOf(resource, "status_audit")
+
+	return setAuditReflect(resource, &commonspb.ApiResourceAudit{
+		SpecAudit:   updatedAuditInfo(specCreatedBy, specCreatedAt, actor, now),
+		StatusAudit: updatedAuditInfo(statusCreatedBy, statusCreatedAt, actor, now),
+	})
+}
+
+// currentAuditActor returns the actor to stamp on audit fields.
+//
+// TODO: Get actual caller information from auth context when auth is implemented
+// For now, use system/local placeholder
+func currentAuditActor() *commonspb.ApiResourceAuditActor {
+	return &commonspb.ApiResourceAuditActor{
+		Id:     "system",
+		Avatar: "",
+	}
+}
+
+// updatedAuditInfo builds the post-update audit info: preserved creation
+// identity (falling back to the updating actor/time when the resource had
+// none) and a fresh update stamp.
+func updatedAuditInfo(
+	createdBy *commonspb.ApiResourceAuditActor,
+	createdAt *timestamppb.Timestamp,
+	actor *commonspb.ApiResourceAuditActor,
+	now *timestamppb.Timestamp,
+) *commonspb.ApiResourceAuditInfo {
+	if createdBy == nil {
+		createdBy = actor
+	}
+	if createdAt == nil {
+		createdAt = now
+	}
+	return &commonspb.ApiResourceAuditInfo{
+		CreatedBy: createdBy,
+		CreatedAt: createdAt,
+		UpdatedBy: actor,
+		UpdatedAt: now,
+		Event:     "updated",
+	}
+}
+
+// creationAuditOf extracts created_by and created_at from the named audit
+// slot ("spec_audit" or "status_audit") of a resource's status.audit,
+// using proto reflection. Returns deep copies so the values survive the
+// audit field being overwritten. Either return may be nil when the
+// resource, its status, the audit, the slot, or the individual field is
+// absent — callers decide the fallback.
+func creationAuditOf(
+	resource proto.Message,
+	auditSlot protoreflect.Name,
+) (*commonspb.ApiResourceAuditActor, *timestamppb.Timestamp) {
+	statusMsg := getStatusField(resource)
+	if statusMsg == nil {
+		return nil, nil
 	}
 
-	// Use proto reflection to set audit field
 	auditField := statusMsg.Descriptor().Fields().ByName("audit")
-	if auditField == nil {
-		// Status doesn't have an audit field - this is ok for some resource types
+	if auditField == nil || !statusMsg.Has(auditField) {
+		return nil, nil
+	}
+	auditMsg := statusMsg.Get(auditField).Message()
+
+	slotField := auditMsg.Descriptor().Fields().ByName(auditSlot)
+	if slotField == nil || !auditMsg.Has(slotField) {
+		return nil, nil
+	}
+	slotMsg := auditMsg.Get(slotField).Message()
+
+	var createdBy *commonspb.ApiResourceAuditActor
+	var createdAt *timestamppb.Timestamp
+
+	if f := slotMsg.Descriptor().Fields().ByName("created_by"); f != nil && slotMsg.Has(f) {
+		createdBy = &commonspb.ApiResourceAuditActor{}
+		proto.Merge(createdBy, slotMsg.Get(f).Message().Interface())
+	}
+	if f := slotMsg.Descriptor().Fields().ByName("created_at"); f != nil && slotMsg.Has(f) {
+		createdAt = &timestamppb.Timestamp{}
+		proto.Merge(createdAt, slotMsg.Get(f).Message().Interface())
+	}
+
+	return createdBy, createdAt
+}
+
+// setAuditReflect writes the audit block onto the resource's status via
+// proto reflection, creating the status field if needed. Resources
+// without a status field, or whose status has no audit field, are a
+// no-op — that is OK for some resource types.
+func setAuditReflect(resource proto.Message, audit *commonspb.ApiResourceAudit) error {
+	statusMsg := getOrCreateStatusField(resource)
+	if statusMsg == nil {
 		return nil
 	}
 
-	// Set the audit field
-	statusMsg.Set(auditField, protoreflect.ValueOfMessage(audit.ProtoReflect()))
+	auditField := statusMsg.Descriptor().Fields().ByName("audit")
+	if auditField == nil {
+		return nil
+	}
 
+	statusMsg.Set(auditField, protoreflect.ValueOfMessage(audit.ProtoReflect()))
 	return nil
 }
 

--- a/backend/libs/go/grpc/request/pipeline/steps/defaults_test.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/defaults_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	apiresourceinterceptor "github.com/stigmer/stigmer/backend/libs/go/grpc/interceptors/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Helper function to create a context with api_resource_kind injected
@@ -321,5 +324,153 @@ func TestGenerateID_Uniqueness(t *testing.T) {
 	// Should have 100 unique IDs
 	if len(ids) != 100 {
 		t.Errorf("Expected 100 unique IDs, got %d", len(ids))
+	}
+}
+
+// TestSetAuditFieldsForUpdate_PreservesCreationAudit is the regression pin
+// for stigmer/stigmer#453: the helper used to rebuild the whole audit
+// block, resetting created_by/created_at to system/now on every call —
+// silently destroying the true creation record at all 14 call sites
+// (visibility flips, skill push, schedule stamps, artifact soft-delete,
+// share-link rotate) and reordering every created_at-sorted list.
+//
+// The pinned contract: created_by/created_at survive EXACTLY (full proto
+// equality, per audit slot — spec_audit and status_audit each keep their
+// own), updated_by/updated_at are stamped fresh, event flips to "updated".
+func TestSetAuditFieldsForUpdate_PreservesCreationAudit(t *testing.T) {
+	// Distinct creation identities per slot prove per-slot extraction —
+	// a fix that copied spec_audit's values into status_audit would fail.
+	specCreatedBy := &apiresource.ApiResourceAuditActor{Id: "user-alice"}
+	specCreatedAt := timestamppb.New(time.Date(2024, 3, 15, 10, 30, 0, 123456789, time.UTC))
+	statusCreatedBy := &apiresource.ApiResourceAuditActor{Id: "user-bob"}
+	statusCreatedAt := timestamppb.New(time.Date(2024, 6, 1, 8, 0, 0, 987654321, time.UTC))
+	staleUpdatedAt := timestamppb.New(time.Date(2024, 7, 4, 12, 0, 0, 0, time.UTC))
+
+	agent := &agentv1.Agent{
+		Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
+		Status: &agentv1.AgentStatus{
+			Audit: &apiresource.ApiResourceAudit{
+				SpecAudit: &apiresource.ApiResourceAuditInfo{
+					CreatedBy: specCreatedBy,
+					CreatedAt: specCreatedAt,
+					UpdatedBy: specCreatedBy,
+					UpdatedAt: staleUpdatedAt,
+					Event:     "created",
+				},
+				StatusAudit: &apiresource.ApiResourceAuditInfo{
+					CreatedBy: statusCreatedBy,
+					CreatedAt: statusCreatedAt,
+					UpdatedBy: statusCreatedBy,
+					UpdatedAt: staleUpdatedAt,
+					Event:     "created",
+				},
+			},
+		},
+	}
+
+	before := time.Now()
+	if err := SetAuditFieldsForUpdate(agent); err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	audit := agent.GetStatus().GetAudit()
+	if audit == nil || audit.SpecAudit == nil || audit.StatusAudit == nil {
+		t.Fatalf("Expected both audit slots to be set, got %v", audit)
+	}
+
+	// Creation identity preserved exactly, per slot.
+	if !proto.Equal(audit.SpecAudit.CreatedBy, specCreatedBy) {
+		t.Errorf("spec_audit.created_by not preserved: want %v, got %v", specCreatedBy, audit.SpecAudit.CreatedBy)
+	}
+	if !proto.Equal(audit.SpecAudit.CreatedAt, specCreatedAt) {
+		t.Errorf("spec_audit.created_at not preserved: want %v, got %v", specCreatedAt, audit.SpecAudit.CreatedAt)
+	}
+	if !proto.Equal(audit.StatusAudit.CreatedBy, statusCreatedBy) {
+		t.Errorf("status_audit.created_by not preserved: want %v, got %v", statusCreatedBy, audit.StatusAudit.CreatedBy)
+	}
+	if !proto.Equal(audit.StatusAudit.CreatedAt, statusCreatedAt) {
+		t.Errorf("status_audit.created_at not preserved: want %v, got %v", statusCreatedAt, audit.StatusAudit.CreatedAt)
+	}
+
+	// Update stamp is fresh on both slots.
+	for slot, info := range map[string]*apiresource.ApiResourceAuditInfo{
+		"spec_audit":   audit.SpecAudit,
+		"status_audit": audit.StatusAudit,
+	} {
+		if info.UpdatedAt.AsTime().Before(before) {
+			t.Errorf("%s.updated_at not stamped fresh: got %v, want >= %v", slot, info.UpdatedAt.AsTime(), before)
+		}
+		if info.UpdatedBy.GetId() != "system" {
+			t.Errorf("%s.updated_by not stamped: want system, got %q", slot, info.UpdatedBy.GetId())
+		}
+		if info.Event != "updated" {
+			t.Errorf("%s.event: want updated, got %q", slot, info.Event)
+		}
+	}
+}
+
+// TestSetAuditFieldsForUpdate_NoPriorAudit pins the first-write fallback:
+// a resource with no existing audit gets creation fields backfilled with
+// the current actor/time — the same fallback BuildUpdateStateStep uses —
+// instead of nil creation fields or an error.
+func TestSetAuditFieldsForUpdate_NoPriorAudit(t *testing.T) {
+	agent := &agentv1.Agent{
+		Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
+		Status:   &agentv1.AgentStatus{},
+	}
+
+	if err := SetAuditFieldsForUpdate(agent); err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	audit := agent.GetStatus().GetAudit()
+	if audit == nil || audit.SpecAudit == nil || audit.StatusAudit == nil {
+		t.Fatalf("Expected both audit slots to be set, got %v", audit)
+	}
+
+	for slot, info := range map[string]*apiresource.ApiResourceAuditInfo{
+		"spec_audit":   audit.SpecAudit,
+		"status_audit": audit.StatusAudit,
+	} {
+		if info.CreatedAt == nil || info.CreatedBy == nil {
+			t.Fatalf("%s: expected creation fallback to be filled, got created_by=%v created_at=%v", slot, info.CreatedBy, info.CreatedAt)
+		}
+		// The fallback backfills creation with the same stamp as the update.
+		if !proto.Equal(info.CreatedAt, info.UpdatedAt) {
+			t.Errorf("%s: fallback created_at should equal updated_at, got %v vs %v", slot, info.CreatedAt, info.UpdatedAt)
+		}
+		if info.CreatedBy.GetId() != "system" {
+			t.Errorf("%s: fallback created_by should be system, got %q", slot, info.CreatedBy.GetId())
+		}
+		if info.Event != "updated" {
+			t.Errorf("%s.event: want updated, got %q", slot, info.Event)
+		}
+	}
+}
+
+// TestSetAuditFieldsForCreate pins the create stamp: both audit slots set
+// identically, created == updated, event "created".
+func TestSetAuditFieldsForCreate(t *testing.T) {
+	agent := &agentv1.Agent{
+		Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
+		Status:   &agentv1.AgentStatus{},
+	}
+
+	if err := SetAuditFieldsForCreate(agent); err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	audit := agent.GetStatus().GetAudit()
+	if audit == nil || audit.SpecAudit == nil || audit.StatusAudit == nil {
+		t.Fatalf("Expected both audit slots to be set, got %v", audit)
+	}
+	if !proto.Equal(audit.SpecAudit, audit.StatusAudit) {
+		t.Errorf("Expected spec_audit and status_audit to be identical on create, got %v vs %v", audit.SpecAudit, audit.StatusAudit)
+	}
+	if !proto.Equal(audit.SpecAudit.CreatedAt, audit.SpecAudit.UpdatedAt) {
+		t.Errorf("Expected created_at == updated_at on create, got %v vs %v", audit.SpecAudit.CreatedAt, audit.SpecAudit.UpdatedAt)
+	}
+	if audit.SpecAudit.Event != "created" {
+		t.Errorf("Expected event=created, got %q", audit.SpecAudit.Event)
 	}
 }

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/agent_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/agent_controller_test.go
@@ -466,6 +466,77 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 	})
 }
 
+// TestAgentController_UpdateVisibility_PreservesCreationAudit pins the
+// call-site half of the stigmer/stigmer#453 fix: a visibility flip must
+// not rewrite spec_audit.created_by/created_at (before the fix,
+// steps.SetAuditFieldsForUpdate rebuilt the whole audit block, resetting
+// creation to system/now — which also reordered every created_at-sorted
+// list). The steps package pins the helper contract; this test proves the
+// preservation survives the full update-visibility pipeline.
+func TestAgentController_UpdateVisibility_PreservesCreationAudit(t *testing.T) {
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer s.Close()
+	controller := NewAgentController(s, nil)
+
+	created, err := controller.Create(contextWithAgentKind(), &agentv1.Agent{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "Agent",
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name: "Audit Pin Agent",
+			Org:  "test-org",
+		},
+		Spec: &agentv1.AgentSpec{
+			Instructions: "You are an agent pinning audit preservation.",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	originalSpecAudit := created.GetStatus().GetAudit().GetSpecAudit()
+	if originalSpecAudit.GetCreatedAt() == nil || originalSpecAudit.GetCreatedBy() == nil {
+		t.Fatalf("precondition: create should stamp spec_audit creation, got %v", originalSpecAudit)
+	}
+
+	updated, err := controller.UpdateVisibility(contextWithAgentKind(), &apiresource.UpdateVisibilityInput{
+		ResourceId: created.Metadata.Id,
+		Visibility: apiresource.ApiResourceVisibility_visibility_private,
+	})
+	if err != nil {
+		t.Fatalf("UpdateVisibility failed: %v", err)
+	}
+
+	if updated.Metadata.Visibility != apiresource.ApiResourceVisibility_visibility_private {
+		t.Errorf("Expected visibility_private, got %v", updated.Metadata.Visibility)
+	}
+
+	specAudit := updated.GetStatus().GetAudit().GetSpecAudit()
+	if !proto.Equal(specAudit.GetCreatedAt(), originalSpecAudit.GetCreatedAt()) {
+		t.Errorf("spec_audit.created_at destroyed by visibility flip: want %v, got %v",
+			originalSpecAudit.GetCreatedAt(), specAudit.GetCreatedAt())
+	}
+	if !proto.Equal(specAudit.GetCreatedBy(), originalSpecAudit.GetCreatedBy()) {
+		t.Errorf("spec_audit.created_by destroyed by visibility flip: want %v, got %v",
+			originalSpecAudit.GetCreatedBy(), specAudit.GetCreatedBy())
+	}
+	if specAudit.GetEvent() != "updated" {
+		t.Errorf("spec_audit.event: want updated, got %q", specAudit.GetEvent())
+	}
+
+	// The persisted row must agree with the response.
+	persisted := &agentv1.Agent{}
+	if err := s.GetResource(context.Background(), apiresourcekind.ApiResourceKind_agent, created.Metadata.Id, persisted); err != nil {
+		t.Fatalf("failed to reload agent: %v", err)
+	}
+	if !proto.Equal(persisted.GetStatus().GetAudit().GetSpecAudit().GetCreatedAt(), originalSpecAudit.GetCreatedAt()) {
+		t.Errorf("persisted spec_audit.created_at destroyed: want %v, got %v",
+			originalSpecAudit.GetCreatedAt(), persisted.GetStatus().GetAudit().GetSpecAudit().GetCreatedAt())
+	}
+}
+
 func TestAgentController_MergeMcpServerEnvSpecs(t *testing.T) {
 	store, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
 	if err != nil {

--- a/backend/services/stigmer-server/pkg/domain/agent/defaultagent/defaultagent.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/defaultagent/defaultagent.go
@@ -33,11 +33,13 @@
 //     agent deterministically capture the platform-wide default.
 //     Incumbent-wins keeps the seeded default serving until an operator
 //     explicitly removes its label — that removal is the rotation cutover.
-//   - Creation time: spec_audit.created_at is not operationally immutable —
-//     steps.SetAuditFieldsForUpdate resets it on every visibility update,
-//     skill push, and schedule trigger (stigmer/stigmer#453), so a
-//     visibility flip on the incumbent mid-rotation would silently flip the
-//     default. metadata.id never changes for the life of the row and is
+//   - Creation time: spec_audit.created_at is not trustworthy as an
+//     ordering key. When this resolver was designed,
+//     steps.SetAuditFieldsForUpdate reset it on every visibility update,
+//     skill push, and schedule trigger (stigmer/stigmer#453, since fixed);
+//     rows written before that fix may still carry rewritten timestamps,
+//     and audit metadata remains operationally mutable in a way identity
+//     is not. metadata.id never changes for the life of the row and is
 //     time-ordered for server-generated ULIDs.
 package defaultagent
 

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/push_test.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/push_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestPush_CreateNew_Success verifies that Push creates a new skill
@@ -286,14 +287,10 @@ func TestPush_Update_PreservesId(t *testing.T) {
 }
 
 // TestPush_Update_PreservesCreatedAt verifies that updating a skill
-// preserves the original created_at timestamp.
-//
-// NOTE: setAuditFieldsReflect currently rebuilds the entire AuditInfo on
-// every call (including created_at). The copy-then-overwrite in
-// PopulateSkillFieldsStep does not yet preserve created_at across the
-// SetAuditFieldsForUpdate call. This test verifies the intent; once the
-// production code is fixed, the assertion can be tightened to compare
-// full Timestamp equality instead of seconds-only.
+// preserves the original created_at/created_by exactly (the
+// stigmer/stigmer#453 regression pin at the push call site: the
+// SetAuditFieldsForUpdate helper used to rebuild the whole audit block,
+// resetting creation to system/now on every push).
 func TestPush_Update_PreservesCreatedAt(t *testing.T) {
 	controller, store := setupTestController(t)
 	defer store.Close()
@@ -308,6 +305,7 @@ func TestPush_Update_PreservesCreatedAt(t *testing.T) {
 	result1, err := controller.Push(contextWithSkillKind(), req1)
 	require.NoError(t, err)
 	originalCreatedAt := result1.Status.Audit.SpecAudit.CreatedAt
+	originalCreatedBy := result1.Status.Audit.SpecAudit.CreatedBy
 
 	// Wait a moment to ensure timestamps differ
 	time.Sleep(1100 * time.Millisecond)
@@ -326,6 +324,19 @@ func TestPush_Update_PreservesCreatedAt(t *testing.T) {
 	require.NotNil(t, result2.Status.Audit)
 	require.NotNil(t, result2.Status.Audit.SpecAudit)
 	require.NotNil(t, result2.Status.Audit.SpecAudit.CreatedAt)
+
+	// Creation identity survives the update exactly — full Timestamp
+	// equality, not seconds-only.
+	assert.True(t,
+		proto.Equal(result2.Status.Audit.SpecAudit.CreatedAt, originalCreatedAt),
+		"created_at should be preserved exactly across an update: want %v, got %v",
+		originalCreatedAt, result2.Status.Audit.SpecAudit.CreatedAt,
+	)
+	assert.True(t,
+		proto.Equal(result2.Status.Audit.SpecAudit.CreatedBy, originalCreatedBy),
+		"created_by should be preserved exactly across an update: want %v, got %v",
+		originalCreatedBy, result2.Status.Audit.SpecAudit.CreatedBy,
+	)
 
 	// Verify updated_at is later than the original created_at
 	assert.Greater(t,


### PR DESCRIPTION
## Summary
`steps.SetAuditFieldsForUpdate` now does what its contract has always claimed: it preserves `created_by`/`created_at` and stamps only `updated_by`/`updated_at`. Previously it rebuilt the whole audit block with `system`/now on every call, silently destroying the true creation record at all 14 call sites.

## Context
Filed as #453 (spawned by the oss#356 session). Beyond audit cosmetics, `spec_audit.created_at` is the sort key for at least nine list endpoints (session, environment, datastore, schedule, agentshare, agentinstance, channelapp, oauthapp, agentchannel) — so a visibility flip or share-link rotate silently reordered those user-facing lists as if the resource were just created. The oss#356 default-agent resolver had to reject `created_at` as an ordering key because of exactly this bug.

## Changes
- `backend/libs/go/grpc/request/pipeline/steps/defaults.go`: `SetAuditFieldsForUpdate` extracts the resource's own creation identity per audit slot (`spec_audit` AND `status_audit` — its callers are targeted mutations that never reset status) and carries it forward; `updated_*` stamped fresh, event `"updated"`. First-write fallback (no prior audit → actor/now) matches `BuildUpdateStateStep`. The extraction lives in a shared `creationAuditOf` helper; `setAuditFieldsReflect`'s now-unreachable "updated" branch is gone (`SetAuditFieldsForCreate` owns the create stamp directly).
- `backend/libs/go/grpc/request/pipeline/steps/build_update_state.go`: `updateAuditFieldsReflect` adopts the shared helpers — ~30 inlined reflection lines deleted, behavior byte-identical (spec_audit preserved from `existing`, status_audit reset per its documented "status was reset" semantics).
- Regression pins at three layers, each verified to FAIL against the old implementation:
  - `defaults_test.go`: helper contract — per-slot exact preservation (distinct creation identities per slot prove per-slot extraction), fresh update stamp, first-write fallback, create stamp.
  - `agent_controller_test.go`: visibility flip preserves creation audit end-to-end through the pipeline, response and persisted row.
  - `push_test.go`: `TestPush_Update_PreservesCreatedAt` gains the exact-Timestamp-equality teeth its own comment asked for (it previously never asserted preservation at all).
- `defaultagent.go`: package doc's created-at-rejection rationale moved to past tense — the key stays rejected (pre-fix rows may carry rewritten timestamps; `metadata.id` is structurally immutable).

## Implementation notes
- The fix sources preservation from the resource's own audit — every call site (verified individually) hands the helper the loaded row mutated in place, or one with the existing audit explicitly copied onto it (skill push). No signature change, no call-site edits.
- Cross-edition check: the cloud never rebuilds audit blocks — every handler preserves and surgically stamps. This fix joins that principle. The finer granularity divergence (cloud bumps only the audit slot matching the change class; OSS stamps both `updated_*` — true before and after this fix) is deliberately out of scope and filed as a follow-up.
- No conformance-suite pin exists on audit fields; no cross-edition contract changes.
- Historical rows are not repaired — the original timestamps were overwritten and are unrecoverable.

## Breaking changes
- None. `updated_*` stamping behavior is byte-identical to before; only the destroyed creation fields change.

## Test plan
- `backend/libs/go`: full module suite green (8 packages).
- `backend/services/stigmer-server`: full module suite green (52 packages).
- All three new/tightened pins verified red against the pre-fix implementation, green with the fix.
- `go vet` clean on both modules, `gofmt -s` clean on session files, `go mod tidy` no-op, server binary builds.

## Risks
- Low: single-helper behavior change, three-layer pins, full suites green. Rollback is a revert.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible
- [x] Docs (package doc comments) updated

Closes #453

Made with [Cursor](https://cursor.com)