### PR TITLE
test(conformance): pin deterministic default-agent resolution (incumbent-wins)

### DIFF
--- a/test/conformance/src/suites/agent.conformance.test.ts
+++ b/test/conformance/src/suites/agent.conformance.test.ts
@@ -238,6 +238,69 @@ describe("Agent conformance — negative paths", () => {
   });
 });
 
+describe("Agent conformance — platform default resolution", () => {
+  const DEFAULT_AGENT_LABEL = "stigmer.ai/default-agent";
+
+  // Creates a getDefault candidate: an agent carrying the platform default
+  // label, flipped public via updateVisibility (agents create org-visible —
+  // the blueprint default — and public is an explicit opt-in, the same lane
+  // the skill suite pins). The label assert gives a crisp failure if an
+  // edition ever strips labels at create, instead of an opaque NotFound later.
+  //
+  // NOTE: label writes ride the currently-unguarded stigmer.ai/* namespace
+  // (stigmer-cloud#320 tracks guarding it at write boundaries); when a guard
+  // lands, this helper must switch to a platform-privileged caller.
+  async function createDefaultCandidate(org: string) {
+    const agent = await clients.agentCommand.create(
+      makeAgent({ org, name: uniqueName("default-cand"), labels: { [DEFAULT_AGENT_LABEL]: "true" } }),
+    );
+    fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+    expect(agent.metadata?.labels?.[DEFAULT_AGENT_LABEL], "the default-agent label survives create").toBe("true");
+
+    const updated = await clients.agentCommand.updateVisibility({
+      resourceId: agent.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+    expect(updated.metadata?.visibility).toBe(ApiResourceVisibility.visibility_public);
+    return agent;
+  }
+
+  it("getDefault resolves the incumbent (first-created) when several public agents carry the label", async () => {
+    const { org } = await target.provisionTenancy();
+
+    // Two labeled public agents is the normal mid-rotation state: the new
+    // default is applied before the old one is retired. The shared contract —
+    // pinned resolver-side on both editions (OSS pkg/domain/agent/defaultagent,
+    // stigmer#356 / PR #458; cloud PostgresAgentRepo.findDefault,
+    // stigmer-cloud#319) — is incumbent-wins: the lowest metadata.id (server
+    // ids are time-ordered ULIDs, so the first-created) keeps serving until
+    // its label is removed. Label removal is the explicit rotation cutover.
+    const incumbent = await createDefaultCandidate(org);
+    const rotatedIn = await createDefaultCandidate(org);
+
+    const resolved = await clients.agentQuery.getDefault({ org });
+
+    // Two-step assert: first that the winner is one of THIS test's candidates
+    // (a foreign winner means the environment carries a pre-existing default
+    // agent — a broken precondition, reported distinctly), then that it is
+    // specifically the incumbent (the determinism contract under test).
+    expect(
+      [incumbent.metadata!.id, rotatedIn.metadata!.id],
+      "getDefault resolved an agent this test did not create — the environment already carries a default agent",
+    ).toContain(resolved.metadata?.id);
+    expect(resolved.metadata?.id, "the incumbent (lowest id) must win").toBe(incumbent.metadata!.id);
+
+    // getDefault is PLATFORM-global state and the deferred cleanup is
+    // best-effort by design — not enough to stand between this test and a
+    // leaked platform-wide default. Delete both candidates here and prove the
+    // no-default state is restored (also what the negative-path pin and the
+    // session suite's no-default case rely on).
+    await clients.agentCommand.delete({ value: rotatedIn.metadata!.id });
+    await clients.agentCommand.delete({ value: incumbent.metadata!.id });
+    await expectGrpcCode(() => clients.agentQuery.getDefault({ org }), Code.NotFound, "getDefault after cleanup");
+  });
+});
+
 describe("Agent conformance — McpServer references", () => {
   it("accepts an agent referencing an existing McpServer and normalizes the reference org", async () => {
     const { org } = await target.provisionTenancy();

--- a/test/conformance/src/support/agents.ts
+++ b/test/conformance/src/support/agents.ts
@@ -81,15 +81,19 @@ export function makeAgentSpec(opts: AgentSpecOptions = {}): MessageInitShape<typ
 export interface AgentOptions extends AgentSpecOptions {
   org: string;
   name: string;
+  // Metadata labels, passed through verbatim — label semantics live server-side.
+  // The suite's one consumer today is the platform default-agent label
+  // (stigmer.ai/default-agent) behind the getDefault determinism pin.
+  labels?: Record<string, string>;
 }
 
 // A complete, valid Agent resource ready to hand to create/apply/update.
 export function makeAgent(opts: AgentOptions): MessageInitShape<typeof AgentSchema> {
-  const { org, name, description, instructions, mcpServerRefs, mcpServerUsages, env } = opts;
+  const { org, name, labels, description, instructions, mcpServerRefs, mcpServerUsages, env } = opts;
   return {
     apiVersion: AGENT_API_VERSION,
     kind: AGENT_KIND,
-    metadata: { name, org },
+    metadata: { name, org, ...(labels !== undefined ? { labels } : {}) },
     spec: makeAgentSpec({ description, instructions, mcpServerRefs, mcpServerUsages, env }),
   };
 }


### PR DESCRIPTION
## Summary

Adds the shared cross-edition determinism pin for `getDefault` that [PR #458](https://github.com/stigmer/stigmer/pull/458) deliberately left out of the conformance suite (a pin then would have reddened the cloud gate before the cloud twin landed). The cloud twin is [stigmer-cloud PR #382](https://github.com/stigmer/stigmer-cloud/pull/382) (fixes [stigmer-cloud#319](https://github.com/stigmer/stigmer-cloud/issues/319)).

**Merge order**: after stigmer-cloud PR #382 — that ordering is the entire reason this pin was deferred out of #458.

## Context

With several public agents carrying `stigmer.ai/default-agent=true` (the normal mid-rotation state), both editions now resolve the platform default identically: **incumbent-wins** — the lowest `metadata.id` (first-created; server ids are time-ordered ULIDs) keeps serving until its label is removed. Each edition pins this resolver-side (OSS `pkg/domain/agent/defaultagent` permutation suite; cloud `AgentRepoCustomQueryContractTest` both-orders case). This pin asserts it through the public API, identically against both targets.

## Changes

- `support/agents.ts`: `makeAgent` accepts optional `metadata.labels` (passed through verbatim; first consumer is this pin).
- `agent.conformance.test.ts`: new `platform default resolution` describe — two labeled agents created org-visible then flipped public via `updateVisibility` (the skill suite's precedented lane); asserts the winner is one of the test's own candidates (a foreign winner means the environment carries a pre-existing default — reported distinctly), then that it is the incumbent. Cleanup is belt-and-braces: `getDefault` is platform-global and `FixtureTracker` is best-effort by design, so the test deletes both candidates in its own body and proves the no-default state is restored (`getDefault` → NotFound), with the deferred deletes as backstop.

## Implementation notes

- **No cloud-side negative control, deliberately**: the pin creates the incumbent first and server-assigned ids cannot be permuted through the API, so an unfixed cloud would likely return the incumbent coincidentally via heap order (#458 documented the identical nuance for SQLite). Red-first evidence lives at the layer that CAN permute insertion order: the cloud adapter contract test, proven red in stigmer-cloud PR #382.
- Label writes ride the currently-unguarded `stigmer.ai/*` namespace (stigmer-cloud#320); when a write-boundary guard lands, the helper must switch to a platform-privileged caller (noted in a comment at the helper).

## Test plan

- Local Go target: agent suite 20/20; full Class A run 231/231 across 12 suites (shared `makeAgent` change breaks nothing).
- Cloud target (hermetic env, service JAR built from the stigmer-cloud PR #382 branch merged with current cloud main): agent + session suites 45/45, including this pin — also proving live that labels survive create and the org-owner caller may flip an agent public under cloud FGA.
- Typecheck: the six pre-existing `tsc --noEmit` errors on clean main (mcp-server, sdk/typescript, one execution suite) are unchanged; zero new errors from this change (verified by stash/compare).

## Risks

- Test-only change. The one shared-fixture edit (`makeAgent` labels) is additive and optional.

Refs stigmer-cloud#319, #458.

Made with [Cursor](https://cursor.com)