### PR TITLE
fix(sdk/java): reject unsupported config values, never silent toString

### DIFF
--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/AgentExecutionInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/AgentExecutionInput.java
@@ -580,7 +580,7 @@ public final class AgentExecutionInput {
                 builder.setInteractionMode(this.interactionMode);
             }
             if (this.structuredOutputSchema != null) {
-                builder.setStructuredOutputSchema(ProtoConvert.mapToStruct(this.structuredOutputSchema));
+                builder.setStructuredOutputSchema(ProtoConvert.mapToStruct(this.structuredOutputSchema, "structuredOutputSchema"));
             }
             builder.setBuildFromPlan(this.buildFromPlan);
             if (this.approvalMode != null) {

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/DatastoreInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/DatastoreInput.java
@@ -457,7 +457,7 @@ public final class DatastoreInput {
             }
             builder.setRequired(this.required);
             if (this.default_ != null) {
-                builder.setDefault(ProtoConvert.objectToValue(this.default_));
+                builder.setDefault(ProtoConvert.objectToValue(this.default_, "default_"));
             }
             if (this.enumValues != null) {
                 builder.addAllEnumValues(this.enumValues);
@@ -557,7 +557,7 @@ public final class DatastoreInput {
                 builder.setField(this.field);
             }
             if (this.equals_ != null) {
-                builder.setEquals(ProtoConvert.objectToValue(this.equals_));
+                builder.setEquals(ProtoConvert.objectToValue(this.equals_, "equals_"));
             }
             return builder.build();
         }

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/ProtoConvert.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/ProtoConvert.java
@@ -5,23 +5,48 @@ package ai.stigmer.sdk.gen;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
+import io.grpc.Status;
 
+// Struct/Value conversion for the generated Input types.
+//
+// objectToValue accepts only values with an exact protobuf Struct
+// representation: String, Number, Boolean, String-keyed Map, Iterable,
+// array, and null. Anything else used to be silently coerced to its
+// String.valueOf — a POJO in a task config arrived on the wire as
+// "com.example.Outcome@1a2b3c4d" with no failure until a human
+// inspected the degraded resource (stigmer/stigmer#448; the Go twin of
+// the class was #342). Unsupported values now throw StigmerException
+// with INVALID_ARGUMENT naming the offending field path and type: a
+// value the SDK refuses client-side surfaces exactly like a value the
+// server would have refused.
+//
+// No lossy guessing: enums, java.time types, and POJOs are refused
+// rather than coerced — callers convert explicitly (e.g. name() for an
+// enum, toString() for an Instant). A JSON dependency for POJO
+// normalization was deliberately rejected to keep the published SDK
+// dependency-free; see #448 for the contract discussion.
 final class ProtoConvert {
     private ProtoConvert() {}
 
-    static Struct mapToStruct(java.util.Map<String, Object> map) {
+    static Struct mapToStruct(java.util.Map<?, ?> map, String path) {
         if (map == null) {
             return Struct.getDefaultInstance();
         }
         Struct.Builder builder = Struct.newBuilder();
-        for (java.util.Map.Entry<String, Object> entry : map.entrySet()) {
-            builder.putFields(entry.getKey(), objectToValue(entry.getValue()));
+        for (java.util.Map.Entry<?, ?> entry : map.entrySet()) {
+            Object key = entry.getKey();
+            if (!(key instanceof String)) {
+                throw invalidValue(path, "map key "
+                    + (key == null ? "null" : "of type " + key.getClass().getName())
+                    + " (Struct keys must be String)");
+            }
+            builder.putFields((String) key,
+                objectToValue(entry.getValue(), path + "[\"" + key + "\"]"));
         }
         return builder.build();
     }
 
-    @SuppressWarnings("unchecked")
-    static Value objectToValue(Object obj) {
+    static Value objectToValue(Object obj, String path) {
         if (obj == null) {
             return Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
         }
@@ -36,16 +61,37 @@ final class ProtoConvert {
         }
         if (obj instanceof java.util.Map) {
             return Value.newBuilder().setStructValue(
-                mapToStruct((java.util.Map<String, Object>) obj)).build();
+                mapToStruct((java.util.Map<?, ?>) obj, path)).build();
         }
         if (obj instanceof Iterable) {
             com.google.protobuf.ListValue.Builder list = com.google.protobuf.ListValue.newBuilder();
+            int idx = 0;
             for (Object item : (Iterable<?>) obj) {
-                list.addValues(objectToValue(item));
+                list.addValues(objectToValue(item, path + "[" + idx + "]"));
+                idx++;
             }
             return Value.newBuilder().setListValue(list.build()).build();
         }
-        return Value.newBuilder().setStringValue(String.valueOf(obj)).build();
+        if (obj.getClass().isArray()) {
+            com.google.protobuf.ListValue.Builder list = com.google.protobuf.ListValue.newBuilder();
+            int length = java.lang.reflect.Array.getLength(obj);
+            for (int idx = 0; idx < length; idx++) {
+                list.addValues(objectToValue(
+                    java.lang.reflect.Array.get(obj, idx), path + "[" + idx + "]"));
+            }
+            return Value.newBuilder().setListValue(list.build()).build();
+        }
+        throw invalidValue(path, "value of type " + obj.getClass().getName()
+            + " (pass a Map, Iterable, array, String, Number, Boolean, or null;"
+            + " convert other types explicitly, e.g. name() for an enum or"
+            + " toString() for a timestamp)");
+    }
+
+    private static StigmerException invalidValue(String path, String detail) {
+        return new StigmerException(
+            ErrorCode.INVALID_ARGUMENT,
+            path + ": unsupported " + detail,
+            Status.Code.INVALID_ARGUMENT);
     }
 }
 

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/WorkflowInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/WorkflowInput.java
@@ -207,7 +207,7 @@ public final class WorkflowInput {
                 builder.setKind(this.kind);
             }
             if (this.taskConfig != null) {
-                builder.setTaskConfig(ProtoConvert.mapToStruct(this.taskConfig));
+                builder.setTaskConfig(ProtoConvert.mapToStruct(this.taskConfig, "taskConfig"));
             }
             if (this.export != null) {
                 builder.setExport(this.export.toProto());

--- a/sdk/java/src/test/java/ai/stigmer/sdk/gen/InputConversionTest.java
+++ b/sdk/java/src/test/java/ai/stigmer/sdk/gen/InputConversionTest.java
@@ -1,0 +1,222 @@
+package ai.stigmer.sdk.gen;
+
+import ai.stigmer.agentic.datastore.v1.FieldDeclaration;
+import ai.stigmer.agentic.workflow.v1.Workflow;
+import ai.stigmer.agentic.workflow.v1.WorkflowTask;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Wire-shape pins for the generated Input struct/value conversion
+ * (stigmer/stigmer#448).
+ *
+ * <p>Every test here calls only {@code toProto()} entry points, whose
+ * signatures are identical before and after the #448 emitter fix — so this
+ * file compiles against BOTH generations and serves as the red-first
+ * negative control: against the pre-fix generated code the array cases
+ * produce a garbage StringValue ({@code "[Ljava.lang.String;@..."}), the
+ * unsupported-type cases return normally instead of throwing, and the
+ * non-String-key case dies with a raw ClassCastException.
+ */
+class InputConversionTest {
+
+    /** A value type the Struct conversion cannot represent faithfully. */
+    private static final class Outcome {
+        @Override
+        public String toString() {
+            return "Outcome{approved}";
+        }
+    }
+
+    private enum Mode { FAST }
+
+    private static WorkflowTask taskProtoWithConfig(java.util.Map<String, Object> config) {
+        return WorkflowInput.WorkflowTaskInput.builder()
+            .name("t1")
+            .taskConfig(config)
+            .build()
+            .toProto();
+    }
+
+    // ------------------------------------------------------------------
+    // Normalization: arrays become ListValue (they are not Iterable, so
+    // the pre-fix code coerced them to String.valueOf garbage).
+    // ------------------------------------------------------------------
+
+    @Test
+    void taskConfig_stringArray_convertsToListValue() {
+        WorkflowTask task = taskProtoWithConfig(java.util.Map.of("tags", new String[] {"a", "b"}));
+
+        Value tags = task.getTaskConfig().getFieldsOrThrow("tags");
+        assertEquals(Value.KindCase.LIST_VALUE, tags.getKindCase());
+        assertEquals(2, tags.getListValue().getValuesCount());
+        assertEquals("a", tags.getListValue().getValues(0).getStringValue());
+        assertEquals("b", tags.getListValue().getValues(1).getStringValue());
+    }
+
+    @Test
+    void taskConfig_primitiveIntArray_convertsToListValue() {
+        WorkflowTask task = taskProtoWithConfig(java.util.Map.of("counts", new int[] {1, 2, 3}));
+
+        Value counts = task.getTaskConfig().getFieldsOrThrow("counts");
+        assertEquals(Value.KindCase.LIST_VALUE, counts.getKindCase());
+        assertEquals(3, counts.getListValue().getValuesCount());
+        assertEquals(2.0, counts.getListValue().getValues(1).getNumberValue());
+    }
+
+    // ------------------------------------------------------------------
+    // Refusal: unsupported types throw the SDK's structured error naming
+    // the offending field path — never a silent toString on the wire.
+    // ------------------------------------------------------------------
+
+    @Test
+    void taskConfig_pojo_throwsInvalidArgumentNamingPath() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> taskProtoWithConfig(java.util.Map.of("outcome", new Outcome())));
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertTrue(e.getMessage().contains("taskConfig[\"outcome\"]"),
+            "message should name the field path, got: " + e.getMessage());
+        assertTrue(e.getMessage().contains(Outcome.class.getName()),
+            "message should name the offending type, got: " + e.getMessage());
+    }
+
+    @Test
+    void taskConfig_enum_throwsInvalidArgument() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> taskProtoWithConfig(java.util.Map.of("mode", Mode.FAST)));
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertTrue(e.getMessage().contains("taskConfig[\"mode\"]"));
+    }
+
+    @Test
+    void taskConfig_instant_throwsInvalidArgument() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> taskProtoWithConfig(java.util.Map.of("at", java.time.Instant.EPOCH)));
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertTrue(e.getMessage().contains("taskConfig[\"at\"]"));
+    }
+
+    @Test
+    void taskConfig_pojoDeepInsideListsAndMaps_errorNamesFullPath() {
+        java.util.Map<String, Object> config = java.util.Map.of(
+            "steps", java.util.List.of(java.util.Map.of("bad", new Outcome())));
+
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> taskProtoWithConfig(config));
+
+        assertTrue(e.getMessage().contains("taskConfig[\"steps\"][0][\"bad\"]"),
+            "message should compose the nested path, got: " + e.getMessage());
+    }
+
+    @Test
+    void taskConfig_nonStringMapKey_throwsInvalidArgumentNotClassCast() {
+        java.util.Map<Object, Object> raw = new java.util.HashMap<>();
+        raw.put(42, "x");
+        @SuppressWarnings("unchecked") // what type erasure lets callers do
+        java.util.Map<String, Object> smuggled = (java.util.Map<String, Object>) (java.util.Map<?, ?>) raw;
+
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> taskProtoWithConfig(java.util.Map.of("nested", smuggled)));
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertTrue(e.getMessage().contains("taskConfig[\"nested\"]"));
+        assertTrue(e.getMessage().contains("Integer"),
+            "message should name the offending key type, got: " + e.getMessage());
+    }
+
+    // ------------------------------------------------------------------
+    // Compatibility: every value that converted correctly before the fix
+    // converts to the byte-identical Struct after it.
+    // ------------------------------------------------------------------
+
+    @Test
+    void taskConfig_recognizedValues_convertUnchanged() {
+        java.util.Map<String, Object> nested = new java.util.HashMap<>();
+        nested.put("inner", "v");
+        java.util.Map<String, Object> config = new java.util.HashMap<>();
+        config.put("str", "hello");
+        config.put("num", 1.5);
+        config.put("flag", true);
+        config.put("none", null);
+        config.put("obj", nested);
+        config.put("list", java.util.List.of("x", 2));
+
+        Struct got = taskProtoWithConfig(config).getTaskConfig();
+
+        Struct want = Struct.newBuilder()
+            .putFields("str", Value.newBuilder().setStringValue("hello").build())
+            .putFields("num", Value.newBuilder().setNumberValue(1.5).build())
+            .putFields("flag", Value.newBuilder().setBoolValue(true).build())
+            .putFields("none", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+            .putFields("obj", Value.newBuilder().setStructValue(Struct.newBuilder()
+                .putFields("inner", Value.newBuilder().setStringValue("v").build())).build())
+            .putFields("list", Value.newBuilder().setListValue(ListValue.newBuilder()
+                .addValues(Value.newBuilder().setStringValue("x"))
+                .addValues(Value.newBuilder().setNumberValue(2))).build())
+            .build();
+        assertEquals(want, got);
+    }
+
+    // ------------------------------------------------------------------
+    // Value-kind fields (DatastoreInput field defaults) take the same
+    // contract through objectToValue with the builder field as the path.
+    // ------------------------------------------------------------------
+
+    @Test
+    void datastoreFieldDefault_array_convertsToListValue() {
+        FieldDeclaration decl = DatastoreInput.FieldDeclarationInput.builder()
+            .name("scores")
+            .default_(new int[] {7, 9})
+            .build()
+            .toProto();
+
+        assertEquals(Value.KindCase.LIST_VALUE, decl.getDefault().getKindCase());
+        assertEquals(7.0, decl.getDefault().getListValue().getValues(0).getNumberValue());
+    }
+
+    @Test
+    void datastoreFieldDefault_pojo_throwsNamingBuilderField() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> DatastoreInput.FieldDeclarationInput.builder()
+                .name("outcome")
+                .default_(new Outcome())
+                .build()
+                .toProto());
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertTrue(e.getMessage().contains("default_"),
+            "message should name the builder field, got: " + e.getMessage());
+    }
+
+    // ------------------------------------------------------------------
+    // End-to-end: the contract holds through the real WorkflowInput entry
+    // point, not just the nested task type.
+    // ------------------------------------------------------------------
+
+    @Test
+    void workflowInput_endToEnd_arrayInTaskConfigReachesWireAsList() {
+        Workflow proto = WorkflowInput.builder()
+            .name("wf")
+            .org("acme")
+            .tasks(java.util.List.of(
+                WorkflowInput.WorkflowTaskInput.builder()
+                    .name("t1")
+                    .taskConfig(java.util.Map.of("tags", new String[] {"a"}))
+                    .build()))
+            .build()
+            .toProto();
+
+        Value tags = proto.getSpec().getTasks(0).getTaskConfig().getFieldsOrThrow("tags");
+        assertEquals(Value.KindCase.LIST_VALUE, tags.getKindCase());
+    }
+}

--- a/sdk/java/src/test/java/ai/stigmer/sdk/gen/ProtoConvertTest.java
+++ b/sdk/java/src/test/java/ai/stigmer/sdk/gen/ProtoConvertTest.java
@@ -1,0 +1,112 @@
+package ai.stigmer.sdk.gen;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct contract pins for {@link ProtoConvert} (stigmer/stigmer#448).
+ *
+ * <p>{@link InputConversionTest} pins the same contract through the
+ * generated toProto() entry points (and is the red-first negative control
+ * against the pre-fix generated code); this file pins the converter's own
+ * edges: null handling, Number subtypes, nested arrays, empty containers,
+ * and exact path composition.
+ */
+class ProtoConvertTest {
+
+    private static final class Opaque {
+    }
+
+    @Test
+    void mapToStruct_nullMap_returnsDefaultInstance() {
+        assertEquals(Struct.getDefaultInstance(), ProtoConvert.mapToStruct(null, "cfg"));
+    }
+
+    @Test
+    void objectToValue_numberSubtypes_allConvertAsDouble() {
+        assertEquals(3.0, ProtoConvert.objectToValue(3L, "n").getNumberValue());
+        assertEquals(2.5, ProtoConvert.objectToValue(2.5f, "n").getNumberValue());
+        assertEquals(7.0, ProtoConvert.objectToValue((short) 7, "n").getNumberValue());
+        assertEquals(1.0, ProtoConvert.objectToValue(java.math.BigDecimal.ONE, "n").getNumberValue());
+    }
+
+    @Test
+    void objectToValue_null_convertsToNullValue() {
+        assertEquals(Value.KindCase.NULL_VALUE, ProtoConvert.objectToValue(null, "v").getKindCase());
+    }
+
+    @Test
+    void objectToValue_emptyArray_convertsToEmptyList() {
+        Value v = ProtoConvert.objectToValue(new String[0], "v");
+        assertEquals(Value.KindCase.LIST_VALUE, v.getKindCase());
+        assertEquals(0, v.getListValue().getValuesCount());
+    }
+
+    @Test
+    void objectToValue_arrayOfMaps_convertsElementsAsStructs() {
+        Value v = ProtoConvert.objectToValue(
+            new Object[] {java.util.Map.of("k", "v")}, "rows");
+        assertEquals("v", v.getListValue().getValues(0)
+            .getStructValue().getFieldsOrThrow("k").getStringValue());
+    }
+
+    @Test
+    void objectToValue_pojoInsideArray_errorNamesElementIndex() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> ProtoConvert.objectToValue(new Object[] {"ok", new Opaque()}, "items"));
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertEquals(io.grpc.Status.Code.INVALID_ARGUMENT, e.getGrpcCode());
+        assertTrue(e.getMessage().startsWith("items[1]: "),
+            "message should locate the element, got: " + e.getMessage());
+    }
+
+    @Test
+    void objectToValue_pojoInsideIterable_errorNamesElementIndex() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> ProtoConvert.objectToValue(java.util.List.of(new Opaque()), "items"));
+
+        assertTrue(e.getMessage().startsWith("items[0]: "));
+    }
+
+    @Test
+    void mapToStruct_pojoValue_errorNamesKeyPath() {
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> ProtoConvert.mapToStruct(java.util.Map.of("outer",
+                java.util.Map.of("inner", new Opaque())), "cfg"));
+
+        assertTrue(e.getMessage().startsWith("cfg[\"outer\"][\"inner\"]: "),
+            "message should compose the nested key path, got: " + e.getMessage());
+        assertTrue(e.getMessage().contains(Opaque.class.getName()));
+    }
+
+    @Test
+    void mapToStruct_nullKey_throwsInvalidArgument() {
+        java.util.Map<Object, Object> map = new java.util.HashMap<>();
+        map.put(null, "x");
+
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> ProtoConvert.mapToStruct(map, "cfg"));
+
+        assertEquals(ErrorCode.INVALID_ARGUMENT, e.getCode());
+        assertTrue(e.getMessage().contains("map key null"),
+            "message should name the null key, got: " + e.getMessage());
+    }
+
+    @Test
+    void mapToStruct_integerKey_throwsInvalidArgumentNamingKeyType() {
+        java.util.Map<Object, Object> map = new java.util.HashMap<>();
+        map.put(42, "x");
+
+        StigmerException e = assertThrows(StigmerException.class,
+            () -> ProtoConvert.mapToStruct(map, "cfg"));
+
+        assertTrue(e.getMessage().contains("java.lang.Integer"),
+            "message should name the key type, got: " + e.getMessage());
+    }
+}

--- a/tools/codegen/generator/conversion_test.go
+++ b/tools/codegen/generator/conversion_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -1586,5 +1588,99 @@ func TestEmitNestedToProto(t *testing.T) {
 
 		mustContain(t, got, `func (i *ExportInput) toProto() (*workflowv1.Export, error)`)
 		mustContain(t, got, `func (i *FlowControlInput) toProto() (*workflowv1.FlowControl, error)`)
+	})
+}
+
+// ============================================================================
+// Part C: sdk_client_java.go — Java SDK Conversion Generation
+// ============================================================================
+
+// ============================================================================
+// C1: TestGenerateJavaProtoConvert
+// ============================================================================
+
+func TestGenerateJavaProtoConvert_RefusesInsteadOfCoercing(t *testing.T) {
+	dir := t.TempDir()
+	if err := generateJavaProtoConvert(dir); err != nil {
+		t.Fatalf("generateJavaProtoConvert: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "ProtoConvert.java"))
+	if err != nil {
+		t.Fatalf("read emitted ProtoConvert.java: %v", err)
+	}
+	got := string(data)
+
+	// The silent String.valueOf fallthrough put a POJO's toString on the
+	// wire ("com.example.Outcome@1a2b3c4d") with no failure until a human
+	// inspected the degraded resource (stigmer/stigmer#448, the Java twin
+	// of #342's silent-drop class). The coercion expression must never be
+	// emitted again (the class comment may still NAME String.valueOf when
+	// telling the story, so the pin targets the code shape).
+	mustNotContain(t, got, `setStringValue(String.valueOf(obj))`)
+
+	// Unsupported values surface as the SDK's structured error — a value
+	// the SDK refuses client-side looks exactly like a value the server
+	// would have refused.
+	mustContain(t, got, `throw invalidValue`)
+	mustContain(t, got, `ErrorCode.INVALID_ARGUMENT`)
+
+	// Arrays are not Iterable — without an explicit arm, String[] takes
+	// the fallthrough. They convert faithfully to ListValue.
+	mustContain(t, got, `obj.getClass().isArray()`)
+	mustContain(t, got, `java.lang.reflect.Array.getLength(obj)`)
+
+	// Struct keys must be String; a non-String key smuggled through type
+	// erasure gets the structured error, not a bare ClassCastException.
+	mustContain(t, got, `Struct keys must be String`)
+}
+
+// ============================================================================
+// C2: TestEmitJavaToProtoField — struct/value call sites thread the field path
+// ============================================================================
+
+func TestEmitJavaToProtoField_StructAndValueThreadFieldPath(t *testing.T) {
+	// The builder field name rides into the conversion as the error-path
+	// root, so a refusal names exactly the field the caller set (e.g.
+	// `taskConfig["outcome"]: unsupported value of type ...`).
+	t.Run("spec_struct_field", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitJavaToProtoField(&buf,
+			field("TaskConfig", "taskConfig", "task_config", TypeSpec{Kind: "struct"}),
+			map[string]*TypeSchema{}, "workflowv1", "        ")
+		got := buf.String()
+
+		mustContain(t, got, `spec.setTaskConfig(ProtoConvert.mapToStruct(this.taskConfig, "taskConfig"));`)
+	})
+
+	t.Run("spec_value_field_reserved_word", func(t *testing.T) {
+		// javaCamel suffixes Java reserved words ("default" -> "default_");
+		// the path must match the builder method the caller actually used.
+		var buf bytes.Buffer
+		emitJavaToProtoField(&buf,
+			field("Default", "default", "default", TypeSpec{Kind: "value"}),
+			map[string]*TypeSchema{}, "datastorev1", "        ")
+		got := buf.String()
+
+		mustContain(t, got, `spec.setDefault(ProtoConvert.objectToValue(this.default_, "default_"));`)
+	})
+
+	t.Run("nested_struct_field", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitJavaNestedToProtoField(&buf,
+			field("TaskConfig", "taskConfig", "task_config", TypeSpec{Kind: "struct"}),
+			map[string]*TypeSchema{}, "workflowv1", "            ")
+		got := buf.String()
+
+		mustContain(t, got, `builder.setTaskConfig(ProtoConvert.mapToStruct(this.taskConfig, "taskConfig"));`)
+	})
+
+	t.Run("nested_value_field", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitJavaNestedToProtoField(&buf,
+			field("Equals", "equals", "equals", TypeSpec{Kind: "value"}),
+			map[string]*TypeSchema{}, "datastorev1", "            ")
+		got := buf.String()
+
+		mustContain(t, got, `builder.setEquals(ProtoConvert.objectToValue(this.equals_, "equals_"));`)
 	})
 }

--- a/tools/codegen/generator/sdk_client_java.go
+++ b/tools/codegen/generator/sdk_client_java.go
@@ -910,24 +910,49 @@ func generateJavaProtoConvert(outputDir string) error {
 	imports.add("com.google.protobuf.NullValue")
 	imports.add("com.google.protobuf.Struct")
 	imports.add("com.google.protobuf.Value")
+	imports.add("io.grpc.Status")
 
 	var body bytes.Buffer
-	body.WriteString(`final class ProtoConvert {
+	body.WriteString(`// Struct/Value conversion for the generated Input types.
+//
+// objectToValue accepts only values with an exact protobuf Struct
+// representation: String, Number, Boolean, String-keyed Map, Iterable,
+// array, and null. Anything else used to be silently coerced to its
+// String.valueOf — a POJO in a task config arrived on the wire as
+// "com.example.Outcome@1a2b3c4d" with no failure until a human
+// inspected the degraded resource (stigmer/stigmer#448; the Go twin of
+// the class was #342). Unsupported values now throw StigmerException
+// with INVALID_ARGUMENT naming the offending field path and type: a
+// value the SDK refuses client-side surfaces exactly like a value the
+// server would have refused.
+//
+// No lossy guessing: enums, java.time types, and POJOs are refused
+// rather than coerced — callers convert explicitly (e.g. name() for an
+// enum, toString() for an Instant). A JSON dependency for POJO
+// normalization was deliberately rejected to keep the published SDK
+// dependency-free; see #448 for the contract discussion.
+final class ProtoConvert {
     private ProtoConvert() {}
 
-    static Struct mapToStruct(java.util.Map<String, Object> map) {
+    static Struct mapToStruct(java.util.Map<?, ?> map, String path) {
         if (map == null) {
             return Struct.getDefaultInstance();
         }
         Struct.Builder builder = Struct.newBuilder();
-        for (java.util.Map.Entry<String, Object> entry : map.entrySet()) {
-            builder.putFields(entry.getKey(), objectToValue(entry.getValue()));
+        for (java.util.Map.Entry<?, ?> entry : map.entrySet()) {
+            Object key = entry.getKey();
+            if (!(key instanceof String)) {
+                throw invalidValue(path, "map key "
+                    + (key == null ? "null" : "of type " + key.getClass().getName())
+                    + " (Struct keys must be String)");
+            }
+            builder.putFields((String) key,
+                objectToValue(entry.getValue(), path + "[\"" + key + "\"]"));
         }
         return builder.build();
     }
 
-    @SuppressWarnings("unchecked")
-    static Value objectToValue(Object obj) {
+    static Value objectToValue(Object obj, String path) {
         if (obj == null) {
             return Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
         }
@@ -942,16 +967,37 @@ func generateJavaProtoConvert(outputDir string) error {
         }
         if (obj instanceof java.util.Map) {
             return Value.newBuilder().setStructValue(
-                mapToStruct((java.util.Map<String, Object>) obj)).build();
+                mapToStruct((java.util.Map<?, ?>) obj, path)).build();
         }
         if (obj instanceof Iterable) {
             com.google.protobuf.ListValue.Builder list = com.google.protobuf.ListValue.newBuilder();
+            int idx = 0;
             for (Object item : (Iterable<?>) obj) {
-                list.addValues(objectToValue(item));
+                list.addValues(objectToValue(item, path + "[" + idx + "]"));
+                idx++;
             }
             return Value.newBuilder().setListValue(list.build()).build();
         }
-        return Value.newBuilder().setStringValue(String.valueOf(obj)).build();
+        if (obj.getClass().isArray()) {
+            com.google.protobuf.ListValue.Builder list = com.google.protobuf.ListValue.newBuilder();
+            int length = java.lang.reflect.Array.getLength(obj);
+            for (int idx = 0; idx < length; idx++) {
+                list.addValues(objectToValue(
+                    java.lang.reflect.Array.get(obj, idx), path + "[" + idx + "]"));
+            }
+            return Value.newBuilder().setListValue(list.build()).build();
+        }
+        throw invalidValue(path, "value of type " + obj.getClass().getName()
+            + " (pass a Map, Iterable, array, String, Number, Boolean, or null;"
+            + " convert other types explicitly, e.g. name() for an enum or"
+            + " toString() for a timestamp)");
+    }
+
+    private static StigmerException invalidValue(String path, String detail) {
+        return new StigmerException(
+            ErrorCode.INVALID_ARGUMENT,
+            path + ": unsupported " + detail,
+            Status.Code.INVALID_ARGUMENT);
     }
 }
 `)
@@ -1570,12 +1616,12 @@ func emitJavaToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[string]
 
 	case f.Type.Kind == "struct":
 		fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
-		fmt.Fprintf(buf, "%s    spec.%s(ProtoConvert.mapToStruct(this.%s));\n", indent, javaSetterName(f.ProtoField), fieldName)
+		fmt.Fprintf(buf, "%s    spec.%s(ProtoConvert.mapToStruct(this.%s, %q));\n", indent, javaSetterName(f.ProtoField), fieldName, fieldName)
 		fmt.Fprintf(buf, "%s}\n", indent)
 
 	case f.Type.Kind == "value":
 		fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
-		fmt.Fprintf(buf, "%s    spec.%s(ProtoConvert.objectToValue(this.%s));\n", indent, javaSetterName(f.ProtoField), fieldName)
+		fmt.Fprintf(buf, "%s    spec.%s(ProtoConvert.objectToValue(this.%s, %q));\n", indent, javaSetterName(f.ProtoField), fieldName, fieldName)
 		fmt.Fprintf(buf, "%s}\n", indent)
 
 	case f.Type.Kind == "string" && f.Type.EnumType != "":
@@ -1724,12 +1770,12 @@ func emitJavaNestedToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[s
 
 	case f.Type.Kind == "struct":
 		fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
-		fmt.Fprintf(buf, "%s    builder.%s(ProtoConvert.mapToStruct(this.%s));\n", indent, javaSetterName(f.ProtoField), fieldName)
+		fmt.Fprintf(buf, "%s    builder.%s(ProtoConvert.mapToStruct(this.%s, %q));\n", indent, javaSetterName(f.ProtoField), fieldName, fieldName)
 		fmt.Fprintf(buf, "%s}\n", indent)
 
 	case f.Type.Kind == "value":
 		fmt.Fprintf(buf, "%sif (this.%s != null) {\n", indent, fieldName)
-		fmt.Fprintf(buf, "%s    builder.%s(ProtoConvert.objectToValue(this.%s));\n", indent, javaSetterName(f.ProtoField), fieldName)
+		fmt.Fprintf(buf, "%s    builder.%s(ProtoConvert.objectToValue(this.%s, %q));\n", indent, javaSetterName(f.ProtoField), fieldName, fieldName)
 		fmt.Fprintf(buf, "%s}\n", indent)
 
 	case f.Type.Kind == "message" && f.Type.MessageType == "ApiResourceReference":


### PR DESCRIPTION
## Summary

Fixes the Java SDK half of the cross-edition silent-corruption class (#342's Go twin): `ProtoConvert.objectToValue` fell through every unrecognized type to `String.valueOf`, so a POJO, enum, `Instant`, or array (arrays are not `Iterable` — `String[]` hits this trivially) in a task config, structured-output schema, or datastore field default arrived on the wire as its `toString` (`"[Ljava.lang.String;@1a2b3c4d"`), with no failure until a human inspected the degraded resource at runtime.

The fix is in the **emitter** (`generateJavaProtoConvert` + the four struct/value call-site emission points in `tools/codegen/generator/sdk_client_java.go`); the checked-in `ProtoConvert.java` and the three Input files are its regenerated output.

## The new contract (ports #342's normalize-then-error shape)

- **Arrays normalize faithfully**: object and primitive arrays become `ListValue` (via `java.lang.reflect.Array`, matching the existing `Iterable` arm).
- **Everything else refuses loudly**: `StigmerException` with `ErrorCode.INVALID_ARGUMENT`, naming the exact field path and offending type — `taskConfig["steps"][0]["bad"]: unsupported value of type com.example.Outcome (...)`. A value the SDK refuses client-side surfaces exactly like a server-side rejection (`StigmerException` is unchecked, so no generated signatures change).
- **Non-String map keys** (reachable via type erasure) get the same structured error instead of a bare context-free `ClassCastException`.
- **Deliberate divergence from Go, no new dependency**: Go normalizes POJOs through a JSON round-trip because `encoding/json` is stdlib. Java has no stdlib JSON, and adding Jackson to a published SDK to enable lossy guessing (enum→`name()`? `Instant`→ISO?) is exactly the "SDK decided for you" class this kills. Callers convert explicitly; POJO acceptance stays additive if ever wanted.

Everything that converted correctly before converts byte-identically after (pinned by an exact-Struct-equality test).

## Verification

- **Red-first negative control**: `InputConversionTest` calls only the unchanged `toProto()` entry points, so it compiles against both generations — against the pre-fix generated code all 10 conversion pins fail in the predicted modes (garbage `STRING_VALUE`, nothing thrown, raw `ClassCastException`); after regen all pass.
- `ProtoConvertTest` pins the converter's edges directly (null map, Number subtypes, empty/nested arrays, exact path composition, null/Integer keys).
- **Generator-level pins** (first Java section in `conversion_test.go`, Part C): the emitted converter must never contain the `setStringValue(String.valueOf(obj))` coercion shape again, and the struct/value call sites must thread the builder field name (including reserved-word fields `default_`/`equals_`).
- `make -C sdk/java codegen-verify` green (regen + compile + full suite, 40 tests); regen idempotent (three consecutive regens, identical tree); `make check-java` green; `go test ./tools/codegen/generator` green; `gofmt`/`go vet` clean.

## Observed, deliberately not touched

The emitter's timestamp arm (`java.time.Instant.parse`) throws a raw `DateTimeParseException` — loud but unstructured. Not part of this silent-corruption class; can be its own follow-up if wanted.

Closes #448

Made with [Cursor](https://cursor.com)