### PR TITLE
fix(cli): accept canonical proto kind names — oauth_app now resolves

### DIFF
--- a/client-apps/cli/src/registry/aliases.test.ts
+++ b/client-apps/cli/src/registry/aliases.test.ts
@@ -7,7 +7,7 @@ function normalized(aliases: string[]): Set<string> {
 
 describe("generateAliases", () => {
   it("derives the full McpServer alias set", () => {
-    const found = normalized(generateAliases("McpServer", "MCP Server", "mcp"));
+    const found = normalized(generateAliases("McpServer", "MCP Server", "mcp", "mcp_server"));
     for (const exp of [
       "mcpserver",
       "mcp-server",
@@ -23,22 +23,45 @@ describe("generateAliases", () => {
   });
 
   it("derives the Agent alias set", () => {
-    const found = normalized(generateAliases("Agent", "Agent", "agt"));
+    const found = normalized(generateAliases("Agent", "Agent", "agt", "agent"));
     for (const exp of ["agent", "agt", "agents", "agts"]) {
       expect(found).toContain(exp);
     }
   });
 
   it("derives the Workflow alias set", () => {
-    const found = normalized(generateAliases("Workflow", "Workflow", "wfl"));
+    const found = normalized(generateAliases("Workflow", "Workflow", "wfl", "workflow"));
     for (const exp of ["workflow", "wfl", "workflows", "wfls"]) {
+      expect(found).toContain(exp);
+    }
+  });
+
+  it("derives the OAuthApp alias set including the canonical proto name", () => {
+    // "OAuthApp" is the only kind whose PascalCase name has consecutive
+    // capitals, so its split-derived forms (o-auth-app) diverge from the proto
+    // enum name (oauth_app). Both families must be accepted: the canonical
+    // spellings via protoName (stigmer/stigmer#470), and the historical
+    // split-derived spellings for backward compatibility.
+    const found = normalized(generateAliases("OAuthApp", "OAuth App", "oapp", "oauth_app"));
+    for (const exp of [
+      "oauth_app",
+      "oauth-app",
+      "oauth_apps",
+      "oauth-apps",
+      "oauthapp",
+      "oauthapps",
+      "o_auth_app",
+      "o-auth-app",
+      "oapp",
+      "oapps",
+    ]) {
       expect(found).toContain(exp);
     }
   });
 
   it("does not let a multi-word display name steal the parent's name", () => {
     // "Agent Instance" must NOT register "agent" (that belongs to Agent).
-    const found = normalized(generateAliases("AgentInstance", "Agent Instance", "ain"));
+    const found = normalized(generateAliases("AgentInstance", "Agent Instance", "ain", "agent_instance"));
     expect(found).not.toContain("agent");
     expect(found).toContain("agentinstance");
     expect(found).toContain("agent-instance");
@@ -46,7 +69,8 @@ describe("generateAliases", () => {
   });
 
   it("produces no duplicate normalized aliases", () => {
-    const aliases = generateAliases("Agent", "Agent", "agent");
+    // "agent" as protoName re-derives already-added forms — dedupe must hold.
+    const aliases = generateAliases("Agent", "Agent", "agent", "agent");
     const lower = aliases.map(normalizeAlias);
     expect(new Set(lower).size).toBe(lower.length);
   });

--- a/client-apps/cli/src/registry/aliases.ts
+++ b/client-apps/cli/src/registry/aliases.ts
@@ -1,8 +1,9 @@
-// Algorithmic alias generation — a faithful port of the Go types.GenerateAliases
-// family. Aliases are *derived* from proto kind metadata (name/display_name/
-// id_prefix), never hardcoded, so a new resource kind picks up its full set of
-// accepted spellings automatically. Keeping the algorithm byte-for-byte
-// identical to Go guarantees both CLIs accept exactly the same inputs.
+// Algorithmic alias generation. Aliases are *derived* from proto kind metadata
+// (name/display_name/id_prefix/proto enum name), never hardcoded, so a new
+// resource kind picks up its full set of accepted spellings automatically.
+// The algorithm was ported from the Go CLI's types.GenerateAliases; the Go CLI
+// was removed in the TypeScript migration (stigmer/stigmer#203), so this is the
+// only alias implementation.
 
 /**
  * Generate every accepted input form for a resource kind.
@@ -10,9 +11,11 @@
  * From name "McpServer":      "mcpserver", "mcp-server", "mcp_server", "McpServer"
  * From displayName "MCP Server": "mcp" / "MCP"
  * From idPrefix "mcp":         "mcp"
+ * From protoName "mcp_server": usually re-derives the forms above; for
+ *                              "OAuthApp" it contributes "oauth_app"/"oauth-app"
  * Plus the plural of every form above.
  */
-export function generateAliases(name: string, displayName: string, idPrefix: string): string[] {
+export function generateAliases(name: string, displayName: string, idPrefix: string, protoName: string): string[] {
   const seen = new Set<string>();
   const aliases: string[] = [];
 
@@ -30,6 +33,16 @@ export function generateAliases(name: string, displayName: string, idPrefix: str
   add(toKebabCase(name)); // "mcp-server"
   add(toSnakeCase(name)); // "mcp_server"
   add(name); // "McpServer"
+
+  // From the proto enum value name: "mcp_server". For most kinds this re-derives
+  // the snake/kebab forms above, but it is the only source that knows the true
+  // word boundaries when the PascalCase name has consecutive capitals — no split
+  // of "OAuthApp" can recover "oauth_app", because "OAuth" being one word is
+  // recorded only in the proto. Feeding it in makes "the canonical kind name
+  // always resolves" structural instead of an accident of PascalCase spelling
+  // (stigmer/stigmer#470).
+  add(protoName); // "oauth_app"
+  add(protoName.replaceAll("_", "-")); // "oauth-app"
 
   // From display_name: single-word names contribute lower/upper forms; for
   // multi-word names only the first word is added, and only when it does not

--- a/client-apps/cli/src/registry/metadata.ts
+++ b/client-apps/cli/src/registry/metadata.ts
@@ -44,10 +44,12 @@ export const KIND_META: ReadonlyMap<ApiResourceKind, KindMeta> = new Map([
 ]);
 
 // Kinds that are user-facing in the CLI and therefore registered as addressable
-// types. Mirrors Go's `cliRelevantKinds`. Note: agent_execution is intentionally
-// excluded — it is driven through its dedicated AgentExecutionQueryController
-// RPCs as a command special-case, not the generic verb dispatch, even though it
-// carries kind metadata above and a verb-support entry below.
+// types. (Inherited from the Go CLI's `cliRelevantKinds`, removed in the
+// TypeScript migration — stigmer/stigmer#203.) Note: agent_execution is
+// intentionally excluded — it is driven through its dedicated
+// AgentExecutionQueryController RPCs as a command special-case, not the generic
+// verb dispatch, even though it carries kind metadata above and a verb-support
+// entry below.
 export const CLI_RELEVANT_KINDS: readonly ApiResourceKind[] = [
   ApiResourceKind.organization,
   ApiResourceKind.agent,

--- a/client-apps/cli/src/registry/registry.test.ts
+++ b/client-apps/cli/src/registry/registry.test.ts
@@ -5,6 +5,7 @@ import { DELETE_HANDLERS } from "../resources/delete.js";
 import { GET_BINDINGS } from "../resources/get-bindings.js";
 import { LIST_HANDLERS, SEARCH_KINDS } from "../resources/list.js";
 import { VALIDATE_SCHEMAS } from "../resources/validate.js";
+import { normalizeAlias } from "./aliases.js";
 import { defaultRegistry } from "./registry.js";
 import { Verb } from "./verbs.js";
 
@@ -24,6 +25,14 @@ describe("registry — alias resolution", () => {
     ["wfl", ApiResourceKind.workflow],
     ["org", ApiResourceKind.organization],
     ["oapp", ApiResourceKind.oauth_app],
+    // The canonical proto enum name and its kebab/plural companions
+    // (stigmer/stigmer#470) plus the historical split-derived spellings,
+    // which must keep working.
+    ["oauth_app", ApiResourceKind.oauth_app],
+    ["oauth-app", ApiResourceKind.oauth_app],
+    ["oauth_apps", ApiResourceKind.oauth_app],
+    ["o_auth_app", ApiResourceKind.oauth_app],
+    ["o-auth-app", ApiResourceKind.oauth_app],
     ["agentchannel", ApiResourceKind.agent_channel],
     ["agent-channel", ApiResourceKind.agent_channel],
     ["agent_channel", ApiResourceKind.agent_channel],
@@ -119,6 +128,45 @@ describe("registry — completeness", () => {
     }
   });
 
+  // The canonical proto enum name is the spelling a proto-literate user is most
+  // likely to type; it must resolve for EVERY kind by construction, not by
+  // accident of PascalCase spelling. OAuthApp was the counterexample
+  // (stigmer/stigmer#470): its split-derived aliases (o_auth_app) diverged from
+  // the proto name (oauth_app), so only it failed.
+  it("resolves every registered kind's canonical proto enum name (snake and kebab)", () => {
+    for (const info of registry.all()) {
+      const protoName = ApiResourceKind[info.kind];
+      expect(
+        registry.getByAlias(protoName)?.kind,
+        `canonical proto name '${protoName}' must resolve to its own kind`,
+      ).toBe(info.kind);
+      const kebab = protoName.replaceAll("_", "-");
+      expect(
+        registry.getByAlias(kebab)?.kind,
+        `kebab form '${kebab}' of the canonical proto name must resolve to its own kind`,
+      ).toBe(info.kind);
+    }
+  });
+
+  // buildRegistry's byAlias.set is last-wins: a collision between two kinds'
+  // alias sets would silently shadow the earlier kind. The one collision found
+  // by hand ("Agent Instance" nearly stealing "agent") is prevented inside
+  // generateAliases; this pin makes the whole class a red test instead of a
+  // hand-check as future kinds (and their derived forms) are added.
+  it("no two kinds share an alias (silent last-wins shadowing guard)", () => {
+    const claimedBy = new Map<string, string>();
+    for (const info of registry.all()) {
+      for (const alias of info.aliases) {
+        const key = normalizeAlias(alias);
+        const owner = claimedBy.get(key);
+        expect(
+          owner === undefined || owner === info.name,
+          `alias '${key}' is claimed by both ${owner} and ${info.name} — the later registration silently wins`,
+        ).toBe(true);
+        claimedBy.set(key, info.name);
+      }
+    }
+  });
 });
 
 // The verb matrix is a PROMISE (`list types` prints it; the command layer

--- a/client-apps/cli/src/registry/registry.ts
+++ b/client-apps/cli/src/registry/registry.ts
@@ -1,7 +1,8 @@
 // The type registry: the single source of truth that maps user-facing resource
 // identifiers (aliases, YAML kinds) to proto kinds and their supported verbs.
 // Built once from the declarative kind-metadata table with aliases derived
-// algorithmically — a structural mirror of Go's types.Registry.
+// algorithmically. (Structure inherited from the Go CLI's types.Registry,
+// removed in the TypeScript migration — stigmer/stigmer#203.)
 
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { generateAliases, normalizeAlias } from "./aliases.js";
@@ -60,7 +61,10 @@ function buildTypeInfo(kind: ApiResourceKind): TypeInfo | undefined {
     idPrefix: meta.idPrefix,
     singular,
     plural: singular.endsWith("s") ? singular : `${singular}s`,
-    aliases: generateAliases(meta.name, meta.displayName, meta.idPrefix),
+    // ApiResourceKind[kind] reverse-maps to the proto enum value name (e.g.
+    // "oauth_app") — the canonical spelling, taken from the enum itself so it
+    // can never drift from the proto.
+    aliases: generateAliases(meta.name, meta.displayName, meta.idPrefix, ApiResourceKind[kind]),
     supportedVerbs: verbsForKind(kind),
   };
 }


### PR DESCRIPTION
## Summary

`stigmer list oauth_app` — the kind's own canonical proto enum name — failed with `unknown resource type`. Alias derivation now feeds the proto enum value name into the accepted-spellings set, so every registered kind's canonical name (snake and kebab, plus plurals) resolves by construction.

## Context

`generateAliases` derives spellings by splitting the PascalCase name before every capital, so `OAuthApp` (the only registered kind with consecutive capitals) derived `o_auth_app`/`o-auth-app` but never `oauth_app`/`oauth-app`. No PascalCase heuristic can fix this — "OAuth" being one word is recorded only in the proto enum name, so the enum name itself is the only correct source.

**Premise correction to the issue:** #470 says "affects BOTH CLIs — fix as twins." That was stale: the Go CLI (`types.GenerateAliases`) was deleted in the TypeScript migration (#203, 2026-06-15), and `client-apps/cli/src/registry/aliases.ts` is the only alias implementation at HEAD. Its header comment still claimed live Go byte-parity — the same stale premise that misled the issue — and is corrected here.

## Changes

- `aliases.ts`: `generateAliases` takes a `protoName` parameter and adds it (plus its kebab form, plus plurals via the existing loop) to the derived set. For every kind except OAuthApp these dedupe into no-ops.
- `registry.ts`: `buildTypeInfo` passes `ApiResourceKind[kind]` — the enum reverse-mapping is byte-identical to the proto value name (verified: protobuf-es does not strip prefixes), so the canonical spelling can never drift from the proto.
- Truthed the three stale Go-lineage comments (`aliases.ts`, `registry.ts`, `metadata.ts`) that referenced the deleted Go CLI as if alive.
- Tests: OAuthApp alias-set case pinning both the canonical spellings and the historical split-derived ones (backward compat); a structural pin that EVERY registered kind's canonical proto name (snake + kebab) resolves; a new cross-kind alias-collision guard (`byAlias.set` is silent last-wins — the "Agent Instance"/"agent" collision was previously prevented only inside `generateAliases`; now any future collision is a red test).

## Implementation notes

- Additive-only by design: mutating the case-splitter to be acronym-aware was rejected — it cannot recover `oauth_app` (the boundary is unknowable from PascalCase) and would *remove* currently-accepted spellings.
- `generateAliases` is package-internal (the published surface of `@stigmer/cli` exports only `buildProgram`/`VERSION`), so the signature change breaks no external consumer.

## Breaking changes

- None. Strictly more inputs accepted; all previous spellings still resolve (pinned by tests). `list types -o json|yaml` alias lists grow by the canonical forms.

## Test plan

- CLI suite: 89 files / 873 tests green (includes the new pins).
- `npm run typecheck -w @stigmer/cli` clean; `make gen-cli-docs-check` green.
- Offline smoke: `list types -o json` shows `oauth_app`/`oauth-app` in OAuthApp's aliases; `stigmer list oauth_app` now resolves the type and correctly reports `OAuth App does not support 'list'` (the deliberate #354 verb narrowing) instead of `unknown resource type`.

## Risks

- Low: blast radius is one function and one call site; behavior is only-add with dedupe. Rollback is a revert.

Closes #470

Spawned during this session: #545 (same consecutive-capitals class in Go's `apiresource.GetKindEnum` — latent, zero callers).

Made with [Cursor](https://cursor.com)