### PR TITLE
fix(test/integration): fail fast on default-agent seed failures; resurrect hidden-dir CI artifact uploads

### DIFF
--- a/.github/workflows/ci.conformance-cloud.yaml
+++ b/.github/workflows/ci.conformance-cloud.yaml
@@ -177,3 +177,7 @@ jobs:
           path: test/integration/.test-output/logs/
           retention-days: 14
           if-no-files-found: ignore
+          # The output dir is dot-prefixed and upload-artifact@v4 excludes
+          # hidden paths by default — without this the artifact is silently
+          # empty (the #323 class, swept in oss#541).
+          include-hidden-files: true

--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -278,6 +278,12 @@ jobs:
 
       # ── Artifacts & report ───────────────────────────────────────────────
 
+      # include-hidden-files: the suite output dirs are dot-named
+      # (.test-output-*), and upload-artifact@v4 excludes hidden paths by
+      # default — without the flag this step silently uploads nothing
+      # (if-no-files-found: ignore), which left oss#541's only red run with
+      # no service log to diagnose from. Canary hit the same class in #323;
+      # this sweep propagates its fix to every sibling lane.
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -286,6 +292,7 @@ jobs:
           path: ${{ matrix.output }}/
           retention-days: 30
           if-no-files-found: ignore
+          include-hidden-files: true
 
       - name: Upload trace bundles
         if: failure() && matrix.suite == 'integration' && hashFiles('test/integration/.test-output/traces/*.json') != ''
@@ -294,6 +301,7 @@ jobs:
           name: integration-trace-bundles
           path: test/integration/.test-output/traces/
           retention-days: 30
+          include-hidden-files: true
 
       - name: Publish test report
         if: always() && hashFiles(format('{0}/junit.xml', matrix.output)) != ''

--- a/.github/workflows/ci.integration-providers.yaml
+++ b/.github/workflows/ci.integration-providers.yaml
@@ -143,6 +143,9 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # include-hidden-files: the dot-named output dirs are excluded by
+      # upload-artifact@v4's default, which silently uploads nothing
+      # (the #323 class, swept in oss#541).
       - name: Upload provider test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -150,6 +153,7 @@ jobs:
           name: provider-integration-results
           path: test/integration/.test-output-providers/
           retention-days: 30
+          include-hidden-files: true
 
       - name: Upload session routing provider results
         if: always()
@@ -159,6 +163,7 @@ jobs:
           path: test/integration-session-routing/.test-output-session-routing-providers/
           retention-days: 30
           if-no-files-found: ignore
+          include-hidden-files: true
 
       - name: Publish provider test report
         if: always() && hashFiles('test/integration/.test-output-providers/junit.xml') != ''

--- a/.github/workflows/ci.integration-stress.yaml
+++ b/.github/workflows/ci.integration-stress.yaml
@@ -148,6 +148,10 @@ jobs:
           name: stress-test-results
           path: test/integration/.test-output-stress/
           retention-days: 30
+          # The output dir is dot-prefixed and upload-artifact@v4 excludes
+          # hidden paths by default — without this the artifact is silently
+          # empty (the #323 class, swept in oss#541).
+          include-hidden-files: true
 
       - name: Publish test report
         if: always() && hashFiles('test/integration/.test-output-stress/junit.xml') != ''

--- a/test/integration-offline/suite_test.go
+++ b/test/integration-offline/suite_test.go
@@ -120,11 +120,16 @@ func TestMain(m *testing.M) {
 		suiteLogger.Warn("failed to provision test billing account — some tests may fail", "error", err)
 	}
 
+	// A failed seed is fatal, not degraded: a half-seeded default agent fails
+	// every session-dependent test with a misleading PERMISSION_DENIED
+	// instead of the one real error here (oss#541).
 	if err := harness.SeedDefaultAgent(ctx, grpcConn); err != nil {
-		suiteLogger.Warn("failed to seed default agent", "error", err)
-	} else {
-		suiteLogger.Info("default agent seeded")
+		suiteLogger.Error("failed to seed default agent — aborting suite", "error", err)
+		grpcConn.Close()
+		testHarness.Stop(ctx)
+		os.Exit(1)
 	}
+	suiteLogger.Info("default agent seeded")
 
 	mcpBinary, mcpErr := harness.BuildTestMcpServer(cfg.OutputDir)
 	if mcpErr != nil {

--- a/test/integration-session-routing/suite_test.go
+++ b/test/integration-session-routing/suite_test.go
@@ -132,11 +132,17 @@ func TestMain(m *testing.M) {
 		suiteLogger.Warn("failed to provision test billing account", "error", err)
 	}
 
+	// A failed seed is fatal, not degraded: a half-seeded default agent fails
+	// every session-dependent test with a misleading PERMISSION_DENIED
+	// instead of the one real error here (oss#541).
 	if err := harness.SeedDefaultAgent(ctx, grpcConn); err != nil {
-		suiteLogger.Warn("failed to seed default agent", "error", err)
-	} else {
-		suiteLogger.Info("default agent seeded")
+		suiteLogger.Error("failed to seed default agent — aborting suite", "error", err)
+		temporalClient.Close()
+		grpcConn.Close()
+		testHarness.Stop(ctx)
+		os.Exit(1)
 	}
+	suiteLogger.Info("default agent seeded")
 
 	// Cursor credentials are DB-resident CursorAccounts (DD-008) — without
 	// this seed every proxied Cursor call 503s on an empty shared pool

--- a/test/integration/harness/BUILD.bazel
+++ b/test/integration/harness/BUILD.bazel
@@ -142,11 +142,13 @@ go_test(
     srcs = [
         "benchmark_helpers_test.go",
         "benchmark_stats_test.go",
+        "fixture_seed_test.go",
         "ipc_fixtures_test.go",
         "unified_runner_test.go",
     ],
     embed = [":harness"],
     deps = [
+        "//apis/stubs/go/ai/stigmer/agentic/agent/v1:agent",
         "//apis/stubs/go/ai/stigmer/agentic/agentexecution/v1:agentexecution",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/test/integration/harness/failure_diagnostics.go
+++ b/test/integration/harness/failure_diagnostics.go
@@ -97,11 +97,18 @@ func (h *TestHarness) snapshotServiceLogs(t *testing.T, bundleDir string) {
 	}
 }
 
-// sanitizeLabel makes a test name safe to use as a directory name. Go subtest
-// names contain "/" and spaces, which would otherwise create nested or
-// awkwardly-named directories.
+// sanitizeLabel makes a label safe to use as a file or directory name. Go
+// subtest names contain "/" and spaces (nested or awkward directories), and
+// Temporal task queues contain ":" — which actions/upload-artifact rejects
+// outright (NTFS-invalid), so one colon-named log used to fail a whole
+// suite's artifact upload. The remaining characters cover the rest of the
+// upload-artifact deny list.
 func sanitizeLabel(label string) string {
-	replacer := strings.NewReplacer("/", "_", " ", "_")
+	replacer := strings.NewReplacer(
+		"/", "_", " ", "_", ":", "_",
+		"\"", "_", "<", "_", ">", "_", "|", "_", "*", "_", "?", "_",
+		"\r", "_", "\n", "_",
+	)
 	return replacer.Replace(label)
 }
 

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
@@ -240,12 +241,41 @@ func (f *FixtureDeployer) Cleanup(ctx context.Context) {
 	f.created = nil
 }
 
+const (
+	// seedDefaultAgentAttempts bounds the apply retries in SeedDefaultAgent.
+	// The seed runs right after service boot, where one-off transients
+	// (connection churn, FGA warm-up) are most likely.
+	seedDefaultAgentAttempts = 3
+	seedDefaultAgentBackoff  = time.Second
+)
+
 // SeedDefaultAgent creates the system default "assistant" agent in test-org
 // via the Agent Apply RPC. This agent is required by tests that create sessions
 // without specifying an explicit agent.
+//
+// The seed is load-bearing for every session-dependent test in a suite, and a
+// half-seeded agent is worse than no agent: AgentCreateHandler has no rollback,
+// so a mid-pipeline failure leaves the agent row and its default-agent label
+// persisted without FGA tuples or a default instance. findDefault keeps
+// serving that agent, and every session create is then denied trying to
+// lazily recreate the instance (oss#541; service-side contract tracked in
+// stigmer-cloud#385). Two consequences here:
+//
+//   - Transient failures are retried a bounded number of times, because a
+//     failed first apply can poison the rest of the run.
+//   - Success is verified against the response, not the RPC status: a re-apply
+//     after a partial failure routes to update and "succeeds" while the agent
+//     is still missing its default instance, so the status alone can lie.
+//
+// Callers must treat a returned error as fatal for the suite.
 func SeedDefaultAgent(ctx context.Context, conn grpc.ClientConnInterface) error {
-	clients := NewClients(conn)
-	_, err := clients.AgentCommand.Apply(ctx, &agentv1.Agent{
+	return seedDefaultAgent(ctx, NewClients(conn).AgentCommand, seedDefaultAgentBackoff)
+}
+
+// seedDefaultAgent is the client-injectable core of SeedDefaultAgent; the
+// backoff grows linearly per attempt (tests pass ~0 to avoid real sleeps).
+func seedDefaultAgent(ctx context.Context, agents agentv1.AgentCommandControllerClient, backoff time.Duration) error {
+	agent := &agentv1.Agent{
 		ApiVersion: TestAPIVersion,
 		Kind:       "Agent",
 		Metadata: &apiresource.ApiResourceMetadata{
@@ -261,8 +291,35 @@ func SeedDefaultAgent(ctx context.Context, conn grpc.ClientConnInterface) error 
 			Description:  "General-purpose AI assistant.",
 			Instructions: "You are a general-purpose AI assistant.",
 		},
-	})
-	return err
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= seedDefaultAgentAttempts; attempt++ {
+		if attempt > 1 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("seed default agent: %w (last attempt error: %v)", ctx.Err(), lastErr)
+			case <-time.After(time.Duration(attempt-1) * backoff):
+			}
+		}
+
+		applied, err := agents.Apply(ctx, agent)
+		if err != nil {
+			lastErr = fmt.Errorf("apply default agent (attempt %d/%d): %w", attempt, seedDefaultAgentAttempts, err)
+			continue
+		}
+		if applied.GetStatus().GetDefaultInstanceId() == "" {
+			// Retrying cannot heal this state (re-apply routes to update, which
+			// converges nothing) — report it precisely instead of looping.
+			return fmt.Errorf(
+				"default agent %s applied but has no default instance bound — "+
+					"half-created state from an earlier failed create; every session "+
+					"create against it will be denied (oss#541, stigmer-cloud#385)",
+				applied.GetMetadata().GetId())
+		}
+		return nil
+	}
+	return lastErr
 }
 
 // ProvisionTestBillingAccount creates a billing account for the given org

--- a/test/integration/harness/fixture_seed_test.go
+++ b/test/integration/harness/fixture_seed_test.go
@@ -1,0 +1,100 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// Unit tests for the SeedDefaultAgent retry/verify contract (oss#541). No
+// service is started — the AgentCommand client is scripted per attempt, the
+// seam seedDefaultAgent exists for. The load-bearing pins:
+//
+//   - an apply that "succeeds" without binding a default instance is an
+//     error, because that half-created agent denies every session create
+//     in the run (retrying routes to update and converges nothing;
+//     service-side contract tracked in stigmer-cloud#385);
+//   - a transient apply failure is retried instead of poisoning the run.
+
+// scriptedAgentCommand returns one scripted result per Apply call and
+// panics via the embedded nil interface if any other RPC is touched.
+type scriptedAgentCommand struct {
+	agentv1.AgentCommandControllerClient
+	t       testing.TB
+	results []scriptedApply
+	calls   int
+}
+
+type scriptedApply struct {
+	agent *agentv1.Agent
+	err   error
+}
+
+func (s *scriptedAgentCommand) Apply(ctx context.Context, in *agentv1.Agent, opts ...grpc.CallOption) (*agentv1.Agent, error) {
+	require.Less(s.t, s.calls, len(s.results), "Apply called more times than scripted")
+	res := s.results[s.calls]
+	s.calls++
+	return res.agent, res.err
+}
+
+func healthyAgent() *agentv1.Agent {
+	return &agentv1.Agent{Status: &agentv1.AgentStatus{DefaultInstanceId: "agi-default-1"}}
+}
+
+func halfCreatedAgent() *agentv1.Agent {
+	// The oss#541 shape: the apply response carries the persisted agent but
+	// status.default_instance_id was never bound.
+	return &agentv1.Agent{Status: &agentv1.AgentStatus{}}
+}
+
+func TestSeedDefaultAgent_HealthyApplySeedsFirstTry(t *testing.T) {
+	client := &scriptedAgentCommand{t: t, results: []scriptedApply{{agent: healthyAgent()}}}
+
+	err := seedDefaultAgent(context.Background(), client, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.calls)
+}
+
+func TestSeedDefaultAgent_HalfCreatedAgentIsAnError(t *testing.T) {
+	client := &scriptedAgentCommand{t: t, results: []scriptedApply{{agent: halfCreatedAgent()}}}
+
+	err := seedDefaultAgent(context.Background(), client, 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no default instance bound")
+	// No retry: a repeated apply routes to update and cannot heal this state.
+	assert.Equal(t, 1, client.calls)
+}
+
+func TestSeedDefaultAgent_RetriesTransientFailure(t *testing.T) {
+	client := &scriptedAgentCommand{t: t, results: []scriptedApply{
+		{err: errors.New("connection refused")},
+		{agent: healthyAgent()},
+	}}
+
+	err := seedDefaultAgent(context.Background(), client, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestSeedDefaultAgent_GivesUpAfterBoundedAttempts(t *testing.T) {
+	transient := errors.New("connection refused")
+	client := &scriptedAgentCommand{t: t, results: []scriptedApply{
+		{err: transient}, {err: transient}, {err: transient},
+	}}
+
+	err := seedDefaultAgent(context.Background(), client, 0)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, transient)
+	assert.Equal(t, seedDefaultAgentAttempts, client.calls)
+	assert.True(t, strings.Contains(err.Error(), "attempt 3/3"), "error should carry the final attempt count: %v", err)
+}

--- a/test/integration/harness/unified_runner.go
+++ b/test/integration/harness/unified_runner.go
@@ -525,7 +525,9 @@ func StartUnifiedRunnerStatic(ctx context.Context, cfg UnifiedRunnerConfig, task
 			return nil, fmt.Errorf("create log dir: %w", mkErr)
 		}
 	}
-	logPath := filepath.Join(logDir, fmt.Sprintf("unified-runner-static-%s.log", taskQueue))
+	// sanitizeLabel: task queues are colon-namespaced (session:ses_<id>) and a
+	// colon in the filename fails the whole suite's CI artifact upload.
+	logPath := filepath.Join(logDir, fmt.Sprintf("unified-runner-static-%s.log", sanitizeLabel(taskQueue)))
 	logFile, err := os.Create(logPath)
 	if err != nil {
 		return nil, fmt.Errorf("create log file: %w", err)

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -207,11 +207,16 @@ func TestMain(m *testing.M) {
 	// Billing policies are seeded by the Java service itself at startup
 	// (BillingPolicySeeder); usage-record uniqueness is enforced by the
 	// Flyway DDL, so no manual index creation remains.
+	//
+	// A failed seed is fatal, not degraded: a half-seeded default agent fails
+	// every session-dependent test with a misleading PERMISSION_DENIED
+	// instead of the one real error here (oss#541).
 	if err := harness.SeedDefaultAgent(ctx, grpcConn); err != nil {
-		suiteLogger.Warn("failed to seed default agent — tests requiring a default agent may fail", "error", err)
-	} else {
-		suiteLogger.Info("default agent seeded")
+		suiteLogger.Error("failed to seed default agent — aborting suite", "error", err)
+		testHarness.Stop(ctx)
+		os.Exit(1)
 	}
+	suiteLogger.Info("default agent seeded")
 
 	// Cursor credentials are DB-resident CursorAccounts (DD-008) — without
 	// this seed every proxied Cursor call 503s on an empty shared pool.


### PR DESCRIPTION
## Summary

Fixes the masking chain behind the oss#541 session-routing red: one transient failure during `SeedDefaultAgent` left a half-created default agent (row + `stigmer.ai/default-agent` label persisted, no FGA tuples, no default instance — the poison state now tracked service-side in stigmer/stigmer-cloud#385), the suite continued on a WARN, and all 10 tests died with a misleading `Internal`-wrapped `PERMISSION_DENIED`. The run's artifacts were empty, so the real seed-time error was unrecoverable.

- **`SeedDefaultAgent` hardening**: bounded retry (3 attempts, linear backoff) for boot-adjacent transients, plus post-condition verification against the apply **response** — a re-apply after a partial failure routes to update and "succeeds" while the agent is still instance-less, so the RPC status alone can lie. A detected half-created agent errors immediately with a precise message instead of poisoning the run.
- **Fail-fast seeding**: all three seeding suites (Core, deterministic-offline, session-routing) now abort on a failed seed, mirroring each suite's established fatal idiom (the `SeedBaseFGATuples` shape) — one loud, real error instead of N misleading ones.
- **Resurrect the CI artifact lane**: `actions/upload-artifact@v4` excludes hidden paths by default and every suite output dir is dot-named (`.test-output-*`) — the declared test-results uploads have silently uploaded **nothing on any run, green or red** (verified across runs). `ci.integration-canary` fixed this for itself in #323; this propagates `include-hidden-files: true` to every sibling lane (offline, providers, stress, conformance-cloud), so the next transient leaves service logs behind.

The status-fidelity twin (stop flattening the nested denial to `INTERNAL` at both lazy default-instance sites) lands cloud-side in stigmer/stigmer-cloud#390.

Evidence for the diagnosis (full green→red window analysis, exonerations, and the single-red-run/bracketing-greens proof) is recorded on the issue.

Closes #541

## Test plan

- [x] New `TestSeedDefaultAgent_*` scripted-client pins (4), each behavioral pin proven red against the pre-fix helper (`HalfCreatedAgentIsAnError`, `RetriesTransientFailure`, `GivesUpAfterBoundedAttempts` fail on old code; healthy path passes on both)
- [x] `go vet -tags integration` + `gofmt` clean across all three touched suite modules
- [x] `actionlint` clean on the five touched workflows (one pre-existing SC2129 style note in an untouched stress-lane script)
- [x] Pre-existing `//test/integration/harness:harness_test` Bazel failure (`TestIPCFixtures_*` missing generated fixture in sandbox) reproduced identically on clean main — not introduced here
- [ ] Watch `ci.integration-offline` on this PR: suites green + test-results artifacts actually uploaded

Made with [Cursor](https://cursor.com)
