### PR TITLE
fix(test/integration): make the TS SDK acceptance smoke actually run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "client-apps/desktop",
         "tools/eslint-plugin-stigmer",
         "test/conformance",
-        "test/e2e"
+        "test/e2e",
+        "test/integration/testdata/sdk-smoke-ts"
       ],
       "devDependencies": {
         "@tailwindcss/cli": "^4.2.1",
@@ -2918,6 +2919,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3757,6 +3759,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3779,6 +3782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3801,6 +3805,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3817,6 +3822,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3833,6 +3839,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3849,6 +3856,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3865,6 +3873,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3881,6 +3890,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3897,6 +3907,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3913,6 +3924,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3929,6 +3941,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3945,6 +3958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3961,6 +3975,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3983,6 +3998,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4005,6 +4021,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4027,6 +4044,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4049,6 +4067,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4071,6 +4090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4093,6 +4113,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4115,6 +4136,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4137,6 +4159,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4156,6 +4179,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4175,6 +4199,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4194,6 +4219,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16906,12 +16932,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18040,6 +18068,10 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/sdk-smoke-ts": {
+      "resolved": "test/integration/testdata/sdk-smoke-ts",
+      "link": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -21275,6 +21307,15 @@
         "@axe-core/playwright": "^4.10.3",
         "@playwright/test": "^1.52.0",
         "typescript": "^5.8.0"
+      }
+    },
+    "test/integration/testdata/sdk-smoke-ts": {
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0",
+        "@stigmer/protos": "*",
+        "@stigmer/sdk": "*"
       }
     },
     "tools/eslint-plugin-stigmer": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "client-apps/desktop",
     "tools/eslint-plugin-stigmer",
     "test/conformance",
-    "test/e2e"
+    "test/e2e",
+    "test/integration/testdata/sdk-smoke-ts"
   ],
   "scripts": {
     "prepare": "husky || true",

--- a/test/integration/harness/mcp_helpers.go
+++ b/test/integration/harness/mcp_helpers.go
@@ -154,16 +154,12 @@ type StigmerMcpLaunch struct {
 // The server connects to the Stigmer backend via gRPC and exposes the
 // workflow-related MCP tools (get_task_kind_registry, validate_workflow_yaml, …).
 func ResolveStigmerMcpLaunch() (StigmerMcpLaunch, error) {
-	_, thisFile, _, _ := runtime.Caller(0)
-	// test/integration/harness/mcp_helpers.go → repo root is three levels up.
-	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
-
-	tsxBin := filepath.Join(repoRoot, "node_modules", ".bin", "tsx")
-	entry := filepath.Join(repoRoot, "mcp-server", "src", "cli", "mcp-server-stigmer.ts")
-
-	if _, err := os.Stat(tsxBin); err != nil {
-		return StigmerMcpLaunch{}, fmt.Errorf("workspace tsx not found at %s (run `npm install` at the repo root): %w", tsxBin, err)
+	tsxBin, err := ResolveWorkspaceTsx()
+	if err != nil {
+		return StigmerMcpLaunch{}, err
 	}
+
+	entry := filepath.Join(MonorepoRoot(), "mcp-server", "src", "cli", "mcp-server-stigmer.ts")
 	if _, err := os.Stat(entry); err != nil {
 		return StigmerMcpLaunch{}, fmt.Errorf("mcp-server entry not found at %s: %w", entry, err)
 	}

--- a/test/integration/harness/npm_workspace.go
+++ b/test/integration/harness/npm_workspace.go
@@ -1,0 +1,36 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// MonorepoRoot returns the absolute path of the stigmer monorepo checkout
+// this harness is compiled from. Derived from this source file's own location
+// so it is independent of the test process's working directory.
+func MonorepoRoot() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	// test/integration/harness/npm_workspace.go → repo root is three levels up.
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+}
+
+// ResolveWorkspaceTsx returns the monorepo's own tsx binary
+// (<repoRoot>/node_modules/.bin/tsx, installed by `npm install` at the repo
+// root from the version package-lock.json pins).
+//
+// PATH is deliberately not consulted. A globally-installed tsx of arbitrary
+// version silently running test entrypoints is the same nondeterminism class
+// as bare `npx prettier` (oss#531): the same bytes pass on one machine and
+// fail on another. It was also the original failure mode of the TypeScript
+// SDK acceptance test (oss#481), which gated on PATH and therefore silently
+// skipped everywhere, indefinitely. Workspace binary or a loud, actionable
+// error — nothing in between.
+func ResolveWorkspaceTsx() (string, error) {
+	tsxBin := filepath.Join(MonorepoRoot(), "node_modules", ".bin", "tsx")
+	if _, err := os.Stat(tsxBin); err != nil {
+		return "", fmt.Errorf("workspace tsx not found at %s (run `npm install` at the repo root): %w", tsxBin, err)
+	}
+	return tsxBin, nil
+}

--- a/test/integration/sdk_acceptance_test.go
+++ b/test/integration/sdk_acceptance_test.go
@@ -33,9 +33,10 @@ func TestSDKAcceptance_TypeScript(t *testing.T) {
 	require.NotNil(t, testHarness, "test harness must be initialized")
 	require.NotNil(t, testHarness.Service, "Java service must be running")
 
-	if _, err := exec.LookPath("tsx"); err != nil {
-		t.Skip("tsx not on PATH — skipping TypeScript SDK acceptance test")
-	}
+	// No skip path: this test silently skipped everywhere for months behind a
+	// PATH lookup (oss#481), so missing prerequisites now fail loudly with the
+	// command that fixes them (the check-runner-node philosophy).
+	tsxBin := requireTsSmokePrereqs(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
@@ -44,7 +45,6 @@ func TestSDKAcceptance_TypeScript(t *testing.T) {
 	harness.RequireServiceHealthy(t, ctx, clients)
 
 	scriptDir := filepath.Join(testdataDir(), "sdk-smoke-ts")
-	requireNpmInstall(t, ctx, scriptDir)
 
 	addr := testHarness.Service.GRPCAddress()
 	workflowRunnerAvailable := "false"
@@ -52,7 +52,7 @@ func TestSDKAcceptance_TypeScript(t *testing.T) {
 		workflowRunnerAvailable = "true"
 	}
 
-	result, err := runSmokeScript(t, ctx, scriptDir, "tsx", []string{"smoke.ts"},
+	result, err := runSmokeScript(t, ctx, scriptDir, tsxBin, []string{"smoke.ts"},
 		"STIGMER_GRPC_ADDRESS", addr,
 		"STIGMER_WORKFLOW_RUNNER_AVAILABLE", workflowRunnerAvailable,
 	)
@@ -133,29 +133,40 @@ func testdataDir() string {
 	return filepath.Join("testdata")
 }
 
-// requireNpmInstall runs npm install in the given directory if node_modules
-// doesn't exist or package.json is newer.
-func requireNpmInstall(t *testing.T, ctx context.Context, dir string) {
+// requireTsSmokePrereqs verifies the TypeScript smoke script can actually run
+// and returns the workspace tsx binary to run it with. The smoke's deps are
+// provided by the root npm workspace (sdk-smoke-ts is a workspace member), so
+// there is deliberately no install-on-demand here: `npm install` inside a
+// workspace member directory prunes the root-hoisted packages (the
+// test-e2e-approval footgun documented in the root Makefile), and a standalone
+// install would fetch the *published* @stigmer/sdk instead of the working tree.
+func requireTsSmokePrereqs(t *testing.T) string {
 	t.Helper()
-	nodeModules := filepath.Join(dir, "node_modules")
-	pkgJSON := filepath.Join(dir, "package.json")
 
-	needsInstall := true
-	if nmInfo, err := os.Stat(nodeModules); err == nil {
-		if pkgInfo, err := os.Stat(pkgJSON); err == nil {
-			needsInstall = pkgInfo.ModTime().After(nmInfo.ModTime())
-		}
+	tsxBin, err := harness.ResolveWorkspaceTsx()
+	require.NoError(t, err, "TypeScript SDK smoke prerequisites missing")
+
+	repoRoot := harness.MonorepoRoot()
+
+	// The sdk-smoke-ts workspace link only exists when the root install ran
+	// against a manifest that lists it as a member — this catches a stale
+	// root node_modules from before the smoke joined the workspace, which a
+	// tsx-only check would miss.
+	smokeLink := filepath.Join(repoRoot, "node_modules", "sdk-smoke-ts")
+	if _, err := os.Stat(smokeLink); err != nil {
+		require.FailNow(t, "TypeScript SDK smoke deps not installed",
+			"workspace link not found at %s — run `npm install` at the repo root", smokeLink)
 	}
 
-	if !needsInstall {
-		return
+	// @stigmer/protos exports only dist/ (no dev/src split, unlike
+	// @stigmer/sdk), so the smoke needs the stubs built.
+	protosDist := filepath.Join(repoRoot, "apis", "stubs", "ts", "dist")
+	if _, err := os.Stat(protosDist); err != nil {
+		require.FailNow(t, "TypeScript proto stubs not built",
+			"dist not found at %s — run `make build-ts-stubs` at the repo root", protosDist)
 	}
 
-	t.Log("running npm install for TypeScript SDK smoke test...")
-	cmd := exec.CommandContext(ctx, "npm", "install", "--no-audit", "--no-fund")
-	cmd.Dir = dir
-	cmd.Stderr = os.Stderr
-	require.NoError(t, cmd.Run(), "npm install must succeed in %s", dir)
+	return tsxBin
 }
 
 // requirePythonVenv creates a virtualenv and installs the stigmer SDK

--- a/test/integration/testdata/sdk-smoke-ts/package.json
+++ b/test/integration/testdata/sdk-smoke-ts/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@stigmer/sdk": "workspace:*",
-    "@stigmer/protos": "workspace:*",
+    "@stigmer/sdk": "*",
+    "@stigmer/protos": "*",
     "@bufbuild/protobuf": "^2.0.0",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0"

--- a/test/integration/testdata/sdk-smoke-ts/smoke.ts
+++ b/test/integration/testdata/sdk-smoke-ts/smoke.ts
@@ -41,9 +41,10 @@ async function main(): Promise<void> {
   const workflowRunnerAvailable =
     process.env.STIGMER_WORKFLOW_RUNNER_AVAILABLE === "true";
 
+  // connect-node v2's gRPC transport is HTTP/2-only; the v1-era httpVersion
+  // option no longer exists.
   const transport = createGrpcTransport({
     baseUrl: `http://${addr}`,
-    httpVersion: "2",
   });
 
   const stigmer = new Stigmer({


### PR DESCRIPTION
## Summary
`TestSDKAcceptance_TypeScript` has silently skipped everywhere — CI and dev machines alike — since it was written. This PR makes it actually run: the smoke's dependencies become installable via workspace membership, tsx resolves from the repo's own `node_modules`, and missing prerequisites now fail loudly instead of skipping.

## Context
The test gated on `exec.LookPath("tsx")`, and tsx (a root-workspace devDependency) is never on PATH, so the TS SDK acceptance smoke never once ran in the gate (verified in CI run 31520093974 and locally) — a TS SDK regression would ship silently while the Python/Go twins run. The skip was also masking a second break: the smoke's `package.json` declared `workspace:*` deps but the directory was not a workspace member, and `requireNpmInstall` ran a standalone `npm install` there, which fails by construction. The script had never been installed, typechecked, or executed.

## Changes
- **Workspace membership**: `test/integration/testdata/sdk-smoke-ts` joins the root `workspaces` with the `"*"` dep ranges every other member uses (`test/conformance`, `test/e2e`, …), so the CI Core job's existing root `npm ci` provides its deps linked to local source. Lockfile regenerated (42-line diff, no hoisting ripple).
- **`harness.ResolveWorkspaceTsx()`** (new `npm_workspace.go`): resolves `<repoRoot>/node_modules/.bin/tsx` with an actionable error; extracted from `ResolveStigmerMcpLaunch`, which now calls it. Deliberately no PATH fallback — an arbitrary-version global tsx silently running test entrypoints is the same nondeterminism class as bare `npx prettier` (oss#531).
- **No skip path**: the test fails with the fixing command when prerequisites are missing — workspace tsx, the `node_modules/sdk-smoke-ts` workspace link (catches a stale root install from before this branch), and the `@stigmer/protos` dist (its exports are dist-only).
- **`requireNpmInstall` deleted**: `npm install` inside a workspace member dir prunes root-hoisted packages (the `test-e2e-approval` footgun documented in the root Makefile), and a standalone install would fetch the *published* `@stigmer/sdk` instead of the working tree.
- **`smoke.ts`**: dropped the v1-era `httpVersion` option removed in `@connectrpc/connect-node` v2 (latent API drift caught by the script's first-ever typecheck).

## Implementation notes
- Zero CI workflow changes: the Core job already runs `npm ci` at root and builds `@stigmer/protos`.
- Release blast radius checked: `publish-libs.mjs` / `verify-esm-node.mjs` enumerate an explicit `PACKAGES` list, so the new (private) member cannot leak into npm publishing.

## Breaking changes
- None. Dev machines that never ran `npm install` at the repo root will now see an actionable failure instead of a silent skip on this one test — by design.

## Test plan
- **Red**: unfixed test code on this branch's deps → `SKIP TestSDKAcceptance_TypeScript (0.00s)` (the lie, reproduced locally).
- **Loud**: fixed code with the workspace link hidden → `FAIL` with "workspace link not found … run `npm install` at the repo root".
- **Green**: `make test-sdk` under Node 22.22.1 against a clean cloud-main JAR → `PASS TestSDKAcceptance_TypeScript (10.22s)` — tier 1 (Agent CRUD) and tier 2 (workflow execution, unified runner up) both executed for the first time ever — plus the Python twin green.
- `go vet`/`go build` (GOWORK=off, CI parity) clean; `npm ci --dry-run` confirms lock/manifest consistency; smoke typechecks clean.

## Risks
- Low. The CI Core leg on this PR is the authoritative proof: `TestSDKAcceptance_TypeScript` must appear as PASS (not SKIP) in the junit report. Rollback is a revert.

Closes #481

Made with [Cursor](https://cursor.com)