### PR TITLE
feat(runner): expose attachment download URLs to agent context

### DIFF
--- a/backend/services/runner/src/__test-utils__/fake-artifact-storage.ts
+++ b/backend/services/runner/src/__test-utils__/fake-artifact-storage.ts
@@ -25,12 +25,20 @@ import type { ArtifactStorage } from "../shared/artifact-storage.js";
 
 /** An {@link ArtifactStorage} whose methods are `vi.fn` spies over a shared Map. */
 export type InMemoryArtifactStorage = {
-  [K in keyof ArtifactStorage]: ReturnType<typeof vi.fn>;
+  [K in keyof ArtifactStorage as ArtifactStorage[K] extends (...args: never[]) => unknown
+    ? K
+    : never]: ReturnType<typeof vi.fn>;
 } & ArtifactStorage;
 
 export interface InMemoryArtifactStorageOptions {
   /** Prefix for the URLs `getDownloadUrl` returns. Defaults to `mem://`. */
   readonly urlBase?: string;
+  /**
+   * The URL kind the double self-describes as (attachment-download-urls.ts).
+   * Defaults to "presigned" — the backend whose URLs the hand-off story is
+   * built for; tests exercising the local-serve wording pass "local-serve".
+   */
+  readonly downloadUrlKind?: ArtifactStorage["downloadUrlKind"];
 }
 
 export interface InMemoryArtifactStorageHandle {
@@ -55,6 +63,7 @@ export function makeInMemoryArtifactStorage(
   const blobs = new Map<string, Buffer>();
 
   const storage = {
+    downloadUrlKind: opts.downloadUrlKind ?? "presigned",
     upload: vi.fn(async (key: string, content: Buffer, _contentType?: string) => {
       blobs.set(key, Buffer.from(content));
       return key;

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/attachment-resolver.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/attachment-resolver.test.ts
@@ -78,7 +78,11 @@ describe("resolveAttachments", () => {
     const result = await resolveAttachments([makeAttachment()], options({ storage }));
 
     expect(result).toEqual([
-      { filename: "plan.md", relativePath: ".stigmer/inputs/plan.md" },
+      {
+        filename: "plan.md",
+        relativePath: ".stigmer/inputs/plan.md",
+        downloadUrl: "mem://attachments/01ABC/plan.md",
+      },
     ]);
     expect(readFileSync(join(platformDir, "inputs", "plan.md"), "utf-8")).toBe("# The Plan");
   });
@@ -130,11 +134,16 @@ describe("resolveAttachments", () => {
     );
 
     expect(result).toEqual([
-      { filename: "report.pdf", relativePath: ".stigmer/inputs/report.pdf" },
+      {
+        filename: "report.pdf",
+        relativePath: ".stigmer/inputs/report.pdf",
+        downloadUrl: "mem://attachments/01AAA/report.pdf",
+      },
       {
         filename: "report-2.pdf",
         relativePath: ".stigmer/inputs/report-2.pdf",
         renamedFrom: "report.pdf",
+        downloadUrl: "mem://attachments/01BBB/report.pdf",
       },
     ]);
     expect(readFileSync(join(platformDir, "inputs", "report.pdf"), "utf-8")).toBe("first bytes");
@@ -155,12 +164,15 @@ describe("resolveAttachments", () => {
       options({ storage }),
     );
 
+    // The key-less local file lists no URL; the storage twin does — the
+    // per-file split the prompt renders.
     expect(result).toEqual([
       { filename: "notes.md", relativePath: ".stigmer/inputs/notes.md" },
       {
         filename: "notes-2.md",
         relativePath: ".stigmer/inputs/notes-2.md",
         renamedFrom: "notes.md",
+        downloadUrl: "mem://attachments/01ABC/notes.md",
       },
     ]);
     expect(readFileSync(join(platformDir, "inputs", "notes.md"), "utf-8")).toBe("local copy");
@@ -225,7 +237,11 @@ describe("resolveAttachments", () => {
     );
 
     expect(result).toEqual([
-      { filename: "evil.md", relativePath: ".stigmer/inputs/evil.md" },
+      {
+        filename: "evil.md",
+        relativePath: ".stigmer/inputs/evil.md",
+        downloadUrl: "mem://attachments/01ABC/x",
+      },
     ]);
     expect(readFileSync(join(platformDir, "inputs", "evil.md"), "utf-8")).toBe("contained");
     // Nothing escaped two levels up (where `../../evil.md` would have landed).
@@ -245,6 +261,50 @@ describe("resolveAttachments", () => {
       { filename: "evil.txt", relativePath: ".stigmer/inputs/evil.txt" },
     ]);
     expect(readFileSync(join(platformDir, "inputs", "evil.txt"), "utf-8")).toBe("local-contained");
+  });
+
+  // ── Download-URL hand-off (issue #532) ───────────────────────────────────
+  // The URL is strictly additive (shared/attachment-download-urls.ts): every
+  // case below also asserts the file materialized exactly as it would
+  // without one.
+
+  describe("download-URL minting during resolution", () => {
+    it("degrades to no URL when the mint fails — file still materialized, turn proceeds", async () => {
+      const { storage } = makeInMemoryArtifactStorage();
+      await storage.upload("attachments/01ABC/plan.md", Buffer.from("# The Plan"), "text/markdown");
+      storage.getDownloadUrl.mockRejectedValueOnce(new Error("presign endpoint unreachable"));
+
+      const result = await resolveAttachments([makeAttachment()], options({ storage }));
+
+      expect(result).toEqual([
+        { filename: "plan.md", relativePath: ".stigmer/inputs/plan.md" },
+      ]);
+      expect(readFileSync(join(platformDir, "inputs", "plan.md"), "utf-8")).toBe("# The Plan");
+    });
+
+    it("mints a URL on the localPath fast path when an uploaded copy also exists", async () => {
+      // The fast path skips storage for the BYTES; the mint rule is
+      // branch-independent, so the uploaded copy still backs the URL.
+      const srcPath = join(workspaceDir, "src.csv");
+      writeFileSync(srcPath, "a,b,c");
+      const { storage } = makeInMemoryArtifactStorage();
+
+      const result = await resolveAttachments(
+        [makeAttachment({ filename: "data.csv", storageKey: "attachments/01ABC/data.csv", localPath: srcPath })],
+        options({ storage }),
+      );
+
+      expect(result).toEqual([
+        {
+          filename: "data.csv",
+          relativePath: ".stigmer/inputs/data.csv",
+          downloadUrl: "mem://attachments/01ABC/data.csv",
+        },
+      ]);
+      // Bytes came off local disk, not storage — the fast path is intact.
+      expect(storage.download).not.toHaveBeenCalled();
+      expect(readFileSync(join(platformDir, "inputs", "data.csv"), "utf-8")).toBe("a,b,c");
+    });
   });
 
   // ── Vision selection (T04) ────────────────────────────────────────────────

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
@@ -454,6 +454,68 @@ describe("attachments on a resumed turn (T04 — the mid-session WhatsApp case)"
     expect(prompt).toContain("Attached inline and visible to you, in order: 1. a.jpg");
   });
 
+  it("lists a minted download URL beside its file with the presigned hand-off line (issue #532)", () => {
+    const prompt = buildPrompt(
+      input({
+        ...RESUMED,
+        attachments: [
+          { path: ".stigmer/inputs/lease.pdf", downloadUrl: "https://r2.example/lease?sig=abc" },
+          { path: ".stigmer/inputs/notes.md" },
+        ],
+        downloadUrlKind: "presigned",
+      }),
+    );
+    expect(prompt).toContain(
+      "- `.stigmer/inputs/lease.pdf` — download URL: https://r2.example/lease?sig=abc",
+    );
+    // The URL-less file keeps a clean entry.
+    expect(prompt).toContain("- `.stigmer/inputs/notes.md`\n");
+    expect(prompt).toContain("These URLs are time-limited");
+  });
+
+  it("words a local-serve URL honestly — reachable only from this machine", () => {
+    const prompt = buildPrompt(
+      input({
+        ...RESUMED,
+        attachments: [
+          { path: ".stigmer/inputs/lease.pdf", downloadUrl: "http://localhost:7235/attachments/01A/lease.pdf" },
+        ],
+        downloadUrlKind: "local-serve",
+      }),
+    );
+    expect(prompt).toContain("download URL: http://localhost:7235/attachments/01A/lease.pdf");
+    expect(prompt).toContain("reachable only from this machine");
+    expect(prompt).not.toContain("time-limited");
+  });
+
+  it("renders no hand-off line when no listed file carries a URL (kind alone is not enough)", () => {
+    const prompt = buildPrompt(
+      input({
+        ...RESUMED,
+        attachments: [{ path: ".stigmer/inputs/local-only.csv" }],
+        downloadUrlKind: "presigned",
+      }),
+    );
+    expect(prompt).toContain("<input_files>");
+    expect(prompt).not.toContain("download URL");
+    expect(prompt).not.toContain("time-limited");
+  });
+
+  it("renders the download URL inside the enhanced first-turn prompt too", () => {
+    const prompt = buildPrompt(
+      input({
+        resolution: resolution("local", "created_first_execution"),
+        attachments: [
+          { path: ".stigmer/inputs/lease.pdf", downloadUrl: "https://r2.example/lease?sig=abc" },
+        ],
+        downloadUrlKind: "presigned",
+      }),
+    );
+    expect(prompt).toContain("<input_files>");
+    expect(prompt).toContain("download URL: https://r2.example/lease?sig=abc");
+    expect(prompt).toContain("These URLs are time-limited");
+  });
+
   it("a HITL re-invocation carries no input-files section — its prompt has no user message at all", () => {
     const prompt = buildPrompt(
       input({

--- a/backend/services/runner/src/activities/execute-cursor/attachment-resolver.ts
+++ b/backend/services/runner/src/activities/execute-cursor/attachment-resolver.ts
@@ -40,6 +40,7 @@ import { mkdir, copyFile, readFile, stat, writeFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import type { Attachment } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import type { ArtifactStorage } from "../../shared/artifact-storage.js";
+import { mintAttachmentDownloadUrl } from "../../shared/attachment-download-urls.js";
 import { allocateUniqueName } from "../../shared/attachment-naming.js";
 import {
   isVisionCandidate,
@@ -73,6 +74,17 @@ export interface ResolvedAttachment {
    * Attachments that were never image-shaped carry neither field.
    */
   visionDegraded?: VisionDegradedReason;
+  /**
+   * A download URL for the attachment's stored object, listed in the prompt's
+   * `<input_files>` section so the agent can hand the file to a tool whose
+   * backend cannot read the sandbox filesystem (issue #532). Minted whenever
+   * the attachment has a `storageKey` and a usable storage — including on the
+   * localPath fast path when an uploaded copy also exists. Absent when there
+   * is nothing to mint or the mint failed (non-fatal — the policy, the
+   * degrade log, and the prompt wording all live in
+   * shared/attachment-download-urls.ts).
+   */
+  downloadUrl?: string;
 }
 
 export interface AttachmentResolverOptions {
@@ -165,11 +177,18 @@ async function resolveAttachment(
         `${err instanceof Error ? err.message : String(err)}`,
       );
     }
+    // The fast path skips storage for the BYTES, but an uploaded copy (an
+    // attachment carrying both localPath and storageKey) still supports the
+    // URL hand-off — the mint rule is branch-independent.
+    const downloadUrl = await mintAttachmentDownloadUrl(
+      options.storage, attachment.storageKey, filename,
+    );
     return {
       filename,
       relativePath: join(STIGMER_LOCAL_STATE_DIR, INPUTS_SUBDIR, filename),
       ...(renamedFrom !== undefined ? { renamedFrom } : {}),
       ...visionOutcomeFields(vision),
+      ...(downloadUrl !== undefined ? { downloadUrl } : {}),
     };
   }
 
@@ -209,11 +228,16 @@ async function resolveAttachment(
   // no pre-filter needed on this branch).
   const vision = options.visionBudget?.offer(filename, attachment.contentType, content);
 
+  const downloadUrl = await mintAttachmentDownloadUrl(
+    options.storage, attachment.storageKey, filename,
+  );
+
   return {
     filename,
     relativePath: join(STIGMER_LOCAL_STATE_DIR, INPUTS_SUBDIR, filename),
     ...(renamedFrom !== undefined ? { renamedFrom } : {}),
     ...visionOutcomeFields(vision),
+    ...(downloadUrl !== undefined ? { downloadUrl } : {}),
   };
 }
 

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -802,6 +802,7 @@ async function executeCursorInner(
     const attachmentEntries = attachmentResults.map((a) => ({
       path: a.relativePath,
       ...(a.renamedFrom !== undefined ? { renamedFrom: a.renamedFrom } : {}),
+      ...(a.downloadUrl !== undefined ? { downloadUrl: a.downloadUrl } : {}),
     }));
     // Vision facts, derived once from the single resolution result: the
     // images the model will see inline (in attachment order) and the ones
@@ -1154,6 +1155,7 @@ async function executeCursorInner(
       workspaceFileRefs: spec.workspaceFileRefs ?? [],
       attachments: attachmentEntries,
       vision: visionPromptInfo,
+      downloadUrlKind: artifactStorage?.downloadUrlKind,
       pendingApprovals: adjudicatedApprovals,
       appliedToolCallIds,
       interactionMode,
@@ -1828,6 +1830,7 @@ async function executeCursorInner(
             workspaceFileRefs: spec.workspaceFileRefs ?? [],
             attachments: attachmentEntries,
             vision: visionPromptInfo,
+            downloadUrlKind: artifactStorage?.downloadUrlKind,
             pendingApprovals: adjudicatedApprovals,
             // Without the applied set, the HITL-recovery prompt would tell
             // the fresh agent to carry out writes the runner already
@@ -2388,6 +2391,12 @@ export interface BuildPromptInput {
    * catchup — it rides both the enhanced prompt and a resumed turn's prefix.
    */
   vision?: import("./prompt-builder.js").VisionPromptInfo;
+  /**
+   * What kind of URL the turn's storage backend mints (issue #532) — keys
+   * the input-files hand-off wording. Sourced from the resolved
+   * artifactStorage's self-description; absent when no storage resolved.
+   */
+  downloadUrlKind?: import("../../shared/attachment-download-urls.js").DownloadUrlKind;
   pendingApprovals: import("@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb").PendingApproval[];
   /**
    * Approved whole-file writes the runner already applied itself (exact-apply).
@@ -2553,6 +2562,7 @@ export function buildPrompt(input: BuildPromptInput): string {
           workspaceFileRefs,
           attachments,
           vision: input.vision,
+          downloadUrlKind: input.downloadUrlKind,
           interactionMode,
           buildFromPlan,
           contextBridge: input.contextBridge,
@@ -2594,7 +2604,7 @@ export function buildPrompt(input: BuildPromptInput): string {
       formatInteractionModePrefix(interactionMode),
       formatImplementPlanSection(buildFromPlan, attachments),
       attachments.length > 0
-        ? formatInputFiles(attachments, input.vision)
+        ? formatInputFiles(attachments, input.vision, input.downloadUrlKind)
         : undefined,
       conversationCatchup !== undefined
         ? formatConversationCatchupSection(conversationCatchup)
@@ -2619,6 +2629,7 @@ export function buildPrompt(input: BuildPromptInput): string {
     workspaceFileRefs,
     attachments,
     vision: input.vision,
+    downloadUrlKind: input.downloadUrlKind,
     interactionMode,
     buildFromPlan,
     contextBridge: input.contextBridge,

--- a/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
@@ -36,6 +36,10 @@ import {
   visionDisclosureLines,
   type NotViewableEntry,
 } from "../../shared/attachment-vision.js";
+import {
+  downloadUrlDisclosureLine,
+  type DownloadUrlKind,
+} from "../../shared/attachment-download-urls.js";
 import { formatTurnRecoveryText } from "./turn-recovery.js";
 import { PLAN_MODE_DIRECTIVE } from "../../shared/plan-mode-prompt.js";
 import {
@@ -82,6 +86,12 @@ export interface AttachmentPromptEntry {
   path: string;
   /** Original filename, present only when a duplicate name was renamed. */
   renamedFrom?: string;
+  /**
+   * Download URL for the attachment's stored object, when one was minted
+   * (shared/attachment-download-urls.ts) — rendered beside the path so the
+   * agent can hand the file to tools that cannot read this filesystem.
+   */
+  downloadUrl?: string;
 }
 
 export interface EnhancedPromptOptions {
@@ -109,6 +119,12 @@ export interface EnhancedPromptOptions {
   attachments: AttachmentPromptEntry[];
   /** Inline/degraded image facts for the input-files section (T04 vision). */
   vision?: VisionPromptInfo;
+  /**
+   * What kind of URL the turn's storage backend mints — keys the input-files
+   * section's hand-off wording (attachment-download-urls.ts). One turn-level
+   * fact: all attachments ride the one configured storage.
+   */
+  downloadUrlKind?: DownloadUrlKind;
   interactionMode?: InteractionMode;
   /**
    * The execution is a Build-from-plan turn (spec.execution_config
@@ -212,7 +228,7 @@ export function buildEnhancedPrompt(options: EnhancedPromptOptions): string {
   }
 
   if (options.attachments.length > 0) {
-    sections.push(formatInputFiles(options.attachments, options.vision));
+    sections.push(formatInputFiles(options.attachments, options.vision, options.downloadUrlKind));
   }
 
   if (options.workspaceFileRefs.length > 0) {
@@ -548,15 +564,28 @@ export function formatWorkspaceContext(dirs: string[]): string {
 export function formatInputFiles(
   attachments: readonly AttachmentPromptEntry[],
   vision?: VisionPromptInfo,
+  downloadUrlKind?: DownloadUrlKind,
 ): string {
   // A duplicate-renamed file (attachment-naming.ts) discloses its original
   // name so the agent can connect "the two report.pdfs" in the user's
-  // message to distinct files on disk.
-  const entries = attachments.map((a) =>
-    a.renamedFrom !== undefined
-      ? `- \`${a.path}\` (renamed from duplicate '${a.renamedFrom}')`
-      : `- \`${a.path}\``,
-  );
+  // message to distinct files on disk. A file with a minted download URL
+  // (attachment-download-urls.ts) lists it beside the path for the remote
+  // hand-off story.
+  const entries = attachments.map((a) => {
+    const rename =
+      a.renamedFrom !== undefined
+        ? ` (renamed from duplicate '${a.renamedFrom}')`
+        : "";
+    const url = a.downloadUrl !== undefined ? ` — download URL: ${a.downloadUrl}` : "";
+    return `- \`${a.path}\`${rename}${url}`;
+  });
+  // The URL hand-off line (shared wording, attachment-download-urls.ts)
+  // renders only when some listed file actually carries a URL — its wording
+  // keys on what kind of URL the storage backend mints.
+  const urlDisclosure =
+    downloadUrlKind !== undefined && attachments.some((a) => a.downloadUrl !== undefined)
+      ? [downloadUrlDisclosureLine(downloadUrlKind)]
+      : [];
   // The vision lines (shared wording, attachment-vision.ts) tell the model
   // which of these files it can already SEE inline versus which degraded to
   // path-only — without them an agent silently ignores a photo the user
@@ -568,6 +597,7 @@ export function formatInputFiles(
     "<input_files>",
     "The following files have been provided as inputs. Read them when relevant to the task:",
     ...entries,
+    ...urlDisclosure,
     ...disclosure,
     "</input_files>",
   ].join("\n");

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
@@ -1014,3 +1014,108 @@ describe("injectAttachments — vision selection", () => {
     expect(injected[1].visionDegraded).toBe("budget_exhausted");
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+// injectAttachments — download-URL hand-off (issue #532)
+// ═══════════════════════════════════════════════════════════════════════
+// The URL is strictly additive (shared/attachment-download-urls.ts): every
+// case also asserts the file injected exactly as it would without one.
+
+describe("injectAttachments — download-URL hand-off", () => {
+  it("mints a URL for a storage-key attachment", async () => {
+    const content = Buffer.from("cloud data");
+    const storage = makeMockStorage();
+    await storage.upload("attachments/xyz/data.csv", content);
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [makeAttachment({ filename: "data.csv", storageKey: "attachments/xyz/data.csv" })],
+      storage,
+      isLocalMode: false,
+    });
+
+    expect(result[0]).toMatchObject({
+      path: ".stigmer/inputs/data.csv",
+      downloadUrl: "mem://attachments/xyz/data.csv",
+    });
+  });
+
+  it("mints a URL for an explicit-mountPath attachment (the rule ignores mount location)", async () => {
+    const storage = makeMockStorage();
+    await storage.upload("attachments/xyz/config.yaml", Buffer.from("a: 1"));
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [makeAttachment({
+        filename: "config.yaml",
+        storageKey: "attachments/xyz/config.yaml",
+        mountPath: "config/app.yaml",
+      })],
+      storage,
+      isLocalMode: false,
+    });
+
+    expect(result[0]).toMatchObject({
+      path: "config/app.yaml",
+      downloadUrl: "mem://attachments/xyz/config.yaml",
+    });
+  });
+
+  it("carries no URL on extracted ZIP entries — the stored object is the ZIP, not any listed file", async () => {
+    const zip = makeZip({ "src/a.txt": "alpha", "src/b.txt": "beta" });
+    const storage = makeMockStorage();
+    await storage.upload("attachments/xyz/code.zip", zip);
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [makeAttachment({
+        filename: "code.zip",
+        storageKey: "attachments/xyz/code.zip",
+        extract: true,
+      })],
+      storage,
+      isLocalMode: false,
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    for (const file of result) {
+      expect(file.downloadUrl).toBeUndefined();
+    }
+  });
+
+  it("carries no URL for a key-less local file", async () => {
+    const localFile = join(tmpdir(), `injector-url-${Date.now()}.txt`);
+    await writeFile(localFile, "local only");
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [makeAttachment({ filename: "local.txt", storageKey: "", localPath: localFile })],
+      storage: makeMockStorage(),
+      isLocalMode: true,
+    });
+
+    expect(result[0].downloadUrl).toBeUndefined();
+  });
+
+  it("degrades to no URL when the mint fails — file still injected, no throw", async () => {
+    const content = Buffer.from("cloud data");
+    const storage = makeMockStorage();
+    await storage.upload("attachments/xyz/data.csv", content);
+    storage.getDownloadUrl.mockRejectedValueOnce(new Error("presign endpoint unreachable"));
+    const backend = mockWorkspaceBackend();
+
+    const result = await injectAttachments({
+      backend,
+      attachments: [makeAttachment({ filename: "data.csv", storageKey: "attachments/xyz/data.csv" })],
+      storage,
+      isLocalMode: false,
+    });
+
+    expect(result[0].downloadUrl).toBeUndefined();
+    expect(backend.writeFileBuffer).toHaveBeenCalledWith(".stigmer/inputs/data.csv", content);
+  });
+});

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/prompt-builder.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/prompt-builder.test.ts
@@ -190,6 +190,77 @@ describe("buildEnhancedSystemPrompt", () => {
     expect(prompt).toContain("`.stigmer/inputs/report.pdf` (10 bytes)\n");
   });
 
+  it("lists a minted download URL beside its file with the presigned hand-off line (issue #532)", () => {
+    const prompt = buildEnhancedSystemPrompt({
+      instructions: "Test",
+      provisionResults: [],
+      containerRoot: "",
+      skillsPromptSection: "",
+      workspaceFileRefs: [],
+      workspaceRoot: "/workspace",
+      injectedFiles: [
+        {
+          filename: "lease.pdf",
+          path: ".stigmer/inputs/lease.pdf",
+          sizeBytes: 2048,
+          downloadUrl: "https://r2.example/lease?sig=abc",
+        },
+        { filename: "notes.md", path: ".stigmer/inputs/notes.md", sizeBytes: 12 },
+      ],
+      downloadUrlKind: "presigned",
+    });
+
+    expect(prompt).toContain(
+      "`.stigmer/inputs/lease.pdf` (2048 bytes) — download URL: https://r2.example/lease?sig=abc",
+    );
+    // The URL-less file keeps a clean entry.
+    expect(prompt).toContain("`.stigmer/inputs/notes.md` (12 bytes)\n");
+    expect(prompt).toContain("These URLs are time-limited");
+  });
+
+  it("words a local-serve URL honestly — reachable only from this machine", () => {
+    const prompt = buildEnhancedSystemPrompt({
+      instructions: "Test",
+      provisionResults: [],
+      containerRoot: "",
+      skillsPromptSection: "",
+      workspaceFileRefs: [],
+      workspaceRoot: "/workspace",
+      injectedFiles: [
+        {
+          filename: "lease.pdf",
+          path: ".stigmer/inputs/lease.pdf",
+          sizeBytes: 2048,
+          downloadUrl: "http://localhost:7235/attachments/01A/lease.pdf",
+        },
+      ],
+      downloadUrlKind: "local-serve",
+    });
+
+    expect(prompt).toContain("download URL: http://localhost:7235/attachments/01A/lease.pdf");
+    expect(prompt).toContain("reachable only from this machine");
+    expect(prompt).not.toContain("time-limited");
+  });
+
+  it("renders no hand-off line when no listed file carries a URL (kind alone is not enough)", () => {
+    const prompt = buildEnhancedSystemPrompt({
+      instructions: "Test",
+      provisionResults: [],
+      containerRoot: "",
+      skillsPromptSection: "",
+      workspaceFileRefs: [],
+      workspaceRoot: "/workspace",
+      injectedFiles: [
+        { filename: "local.csv", path: ".stigmer/inputs/local.csv", sizeBytes: 5 },
+      ],
+      downloadUrlKind: "presigned",
+    });
+
+    expect(prompt).toContain("## Input Files");
+    expect(prompt).not.toContain("download URL");
+    expect(prompt).not.toContain("time-limited");
+  });
+
   it("produces a git repo description for git workspace entries", () => {
     const prompt = buildEnhancedSystemPrompt({
       instructions: "Test",

--- a/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
@@ -27,6 +27,7 @@ import { posix } from "node:path";
 import type { Attachment } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import type { WorkspaceBackend } from "../../shared/workspace/types.js";
 import type { ArtifactStorage } from "../../shared/artifact-storage.js";
+import { mintAttachmentDownloadUrl } from "../../shared/attachment-download-urls.js";
 import { allocateUniqueName } from "../../shared/attachment-naming.js";
 import type {
   VisionBudget,
@@ -66,6 +67,17 @@ export interface InjectedFile {
    * Attachments that were never image-shaped carry neither field.
    */
   readonly visionDegraded?: VisionDegradedReason;
+  /**
+   * A download URL for the attachment's stored object, listed in the system
+   * prompt's Input Files section so the agent can hand the file to a tool
+   * whose backend cannot read the sandbox filesystem (issue #532). Minted
+   * whenever the attachment has a `storageKey` and a usable storage; never
+   * present on extracted ZIP entries (no attachment-level object). Absent
+   * when there is nothing to mint or the mint failed (non-fatal — policy,
+   * degrade log, and prompt wording live in
+   * shared/attachment-download-urls.ts).
+   */
+  readonly downloadUrl?: string;
 }
 
 export interface InjectAttachmentsOptions {
@@ -300,7 +312,10 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
       );
       // A renamed mount DIR is visible through every extracted path; the
       // entries themselves were not renamed, so they carry no renamedFrom
-      // (per-file disclosure would misattribute the rename).
+      // (per-file disclosure would misattribute the rename). Extracted
+      // entries also carry no downloadUrl: the stored object is the ZIP, not
+      // any listed file, and a URL to bytes that differ from the listing
+      // would be a false promise.
       injectedFiles.push(...extracted);
     } else {
       await backend.writeFileBuffer(mountPath, content);
@@ -313,6 +328,9 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
       // the vision budget before they go out of scope (the sniff decides
       // eligibility; the budget owns every size/count rule).
       const vision = visionBudget?.offer(filename, attachment.contentType, content);
+      const downloadUrl = await mintAttachmentDownloadUrl(
+        storage, attachment.storageKey, filename,
+      );
       injectedFiles.push({
         filename,
         path: mountPath,
@@ -320,6 +338,7 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
         ...(renamedFrom !== undefined ? { renamedFrom } : {}),
         ...(vision?.kind === "accepted" ? { vision: vision.image } : {}),
         ...(vision?.kind === "degraded" ? { visionDegraded: vision.reason } : {}),
+        ...(downloadUrl !== undefined ? { downloadUrl } : {}),
       });
     }
   }

--- a/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
@@ -21,6 +21,10 @@ import {
   visionDisclosureLines,
   type NotViewableEntry,
 } from "../../shared/attachment-vision.js";
+import {
+  downloadUrlDisclosureLine,
+  type DownloadUrlKind,
+} from "../../shared/attachment-download-urls.js";
 import { PLAN_MODE_DIRECTIVE } from "../../shared/plan-mode-prompt.js";
 import {
   buildImplementPlanDirective,
@@ -123,6 +127,12 @@ export interface PromptBuilderInput {
    */
   vision?: VisionPromptInfo;
   /**
+   * What kind of URL the turn's storage backend mints (issue #532) — keys
+   * the Input Files section's hand-off wording (attachment-download-urls.ts).
+   * One turn-level fact: all attachments ride the one configured storage.
+   */
+  downloadUrlKind?: DownloadUrlKind;
+  /**
    * The execution's interaction mode. PLAN appends the shared plan-mode
    * directive so the model knows the turn's deliverable is a plan document.
    * Tool-level write enforcement is separate (see setup.ts permissions) —
@@ -220,7 +230,9 @@ export function buildEnhancedSystemPrompt(input: PromptBuilderInput): string {
   }
 
   if (input.injectedFiles.length > 0) {
-    prompt += buildInjectedFilesSection(input.injectedFiles, input.vision);
+    prompt += buildInjectedFilesSection(
+      input.injectedFiles, input.vision, input.downloadUrlKind,
+    );
   }
 
   if (input.senderIdentity) {
@@ -401,6 +413,7 @@ function buildReferencedFilesSection(
 function buildInjectedFilesSection(
   files: readonly InjectedFile[],
   vision?: VisionPromptInfo,
+  downloadUrlKind?: DownloadUrlKind,
 ): string {
   let section = "\n\n## Input Files\n\n";
   section +=
@@ -416,12 +429,23 @@ function buildInjectedFilesSection(
     const sizeInfo = ` (${f.sizeBytes} bytes)`;
     // A duplicate-renamed file (attachment-naming.ts) discloses its original
     // name so the agent can connect "the two report.pdfs" in the user's
-    // message to distinct files on disk.
+    // message to distinct files on disk. A file with a minted download URL
+    // (attachment-download-urls.ts) lists it beside the path for the remote
+    // hand-off story.
     const renameInfo =
       f.renamedFrom !== undefined
         ? ` (renamed from duplicate '${f.renamedFrom}')`
         : "";
-    section += `- \`${f.path}\`${sizeInfo}${renameInfo}\n`;
+    const urlInfo =
+      f.downloadUrl !== undefined ? ` — download URL: ${f.downloadUrl}` : "";
+    section += `- \`${f.path}\`${sizeInfo}${renameInfo}${urlInfo}\n`;
+  }
+
+  // The URL hand-off line (shared wording, attachment-download-urls.ts)
+  // renders only when some listed file actually carries a URL — its wording
+  // keys on what kind of URL the storage backend mints.
+  if (downloadUrlKind !== undefined && files.some((f) => f.downloadUrl !== undefined)) {
+    section += "\n" + downloadUrlDisclosureLine(downloadUrlKind) + "\n";
   }
 
   // The vision lines (shared wording, attachment-vision.ts) tell the model

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -625,6 +625,7 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       workspaceRoot: workspaceBackend.rootDir,
       injectedFiles,
       vision: visionPromptInfo,
+      downloadUrlKind: artifactStorage?.downloadUrlKind,
       interactionMode: execution.spec!.executionConfig?.interactionMode,
       buildFromPlan: execution.spec!.executionConfig?.buildFromPlan,
       contextBridge: readContextBridge(session.spec!.metadata),

--- a/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
+++ b/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
@@ -49,6 +49,10 @@ describe("LocalArtifactStorage", () => {
     expect(url).toBe("http://localhost:7235/artifacts/file.txt");
   });
 
+  it("self-describes its URLs as local-serve (loopback reach, no expiry — issue #532)", () => {
+    expect(storage.downloadUrlKind).toBe("local-serve");
+  });
+
   it("returns true for existing keys", async () => {
     const key = "artifacts/exec-1/file.bin";
     await storage.upload(key, Buffer.from("data"));
@@ -165,6 +169,11 @@ describe("ProxyArtifactStorage", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it("self-describes its URLs as presigned (time-limited, remotely fetchable — issue #532)", () => {
+    const s = new ProxyArtifactStorage("https://proxy.example.com", "tok");
+    expect(s.downloadUrlKind).toBe("presigned");
   });
 
   it("uploads via presigned URL flow", async () => {

--- a/backend/services/runner/src/shared/__tests__/attachment-download-urls.test.ts
+++ b/backend/services/runner/src/shared/__tests__/attachment-download-urls.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the attachment download-URL hand-off policy (issue #532):
+ * the branch-independent mint rule, the non-fatal degrade, and the
+ * per-kind disclosure wording both harnesses embed.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  mintAttachmentDownloadUrl,
+  downloadUrlDisclosureLine,
+} from "../attachment-download-urls.js";
+import { makeInMemoryArtifactStorage } from "../../__test-utils__/fake-artifact-storage.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("mintAttachmentDownloadUrl", () => {
+  it("mints a URL for a storage key", async () => {
+    const { storage } = makeInMemoryArtifactStorage();
+
+    const url = await mintAttachmentDownloadUrl(storage, "attachments/01A/lease.pdf", "lease.pdf");
+
+    expect(url).toBe("mem://attachments/01A/lease.pdf");
+  });
+
+  it("returns undefined when the attachment has no storage key", async () => {
+    const { storage } = makeInMemoryArtifactStorage();
+
+    const url = await mintAttachmentDownloadUrl(storage, "", "local.csv");
+
+    expect(url).toBeUndefined();
+    expect(storage.getDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when no storage is available", async () => {
+    const url = await mintAttachmentDownloadUrl(undefined, "attachments/01A/lease.pdf", "lease.pdf");
+
+    expect(url).toBeUndefined();
+  });
+
+  it("degrades to undefined on a mint failure and logs the degrade (never throws)", async () => {
+    const { storage } = makeInMemoryArtifactStorage();
+    storage.getDownloadUrl.mockRejectedValueOnce(new Error("presign endpoint unreachable"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const url = await mintAttachmentDownloadUrl(storage, "attachments/01A/lease.pdf", "lease.pdf");
+
+    expect(url).toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("lease.pdf");
+  });
+});
+
+describe("downloadUrlDisclosureLine", () => {
+  it("promises time-limited single-object access for presigned URLs", () => {
+    const line = downloadUrlDisclosureLine("presigned");
+
+    expect(line).toContain("time-limited");
+    expect(line).toContain("single file");
+    expect(line).not.toContain("this machine");
+  });
+
+  it("is honest about local-serve reach — same machine only, no expiry claim", () => {
+    const line = downloadUrlDisclosureLine("local-serve");
+
+    expect(line).toContain("reachable only from this machine");
+    expect(line).not.toContain("time-limited");
+  });
+});

--- a/backend/services/runner/src/shared/artifact-storage.ts
+++ b/backend/services/runner/src/shared/artifact-storage.ts
@@ -31,6 +31,15 @@ import { fetchWithRetry, type FetchRetryPolicy } from "./http-retry.js";
 // ── Interface ────────────────────────────────────────────────────────
 
 export interface ArtifactStorage {
+  /**
+   * What kind of URL {@link getDownloadUrl} mints — self-described by the
+   * backend so consumers (the attachment hand-off prompt wording,
+   * attachment-download-urls.ts) can never disagree with the storage actually
+   * in use. "presigned": time-limited, single-object, remotely fetchable.
+   * "local-serve": the stigmer-server's unauthenticated loopback serve URL,
+   * reachable only from this machine.
+   */
+  readonly downloadUrlKind: "presigned" | "local-serve";
   upload(key: string, content: Buffer, contentType?: string): Promise<string>;
   getDownloadUrl(key: string): Promise<string>;
   /**
@@ -52,6 +61,7 @@ export type ArtifactStorageType = "local" | "proxy";
 // ── Local Backend ────────────────────────────────────────────────────
 
 export class LocalArtifactStorage implements ArtifactStorage {
+  readonly downloadUrlKind = "local-serve" as const;
   private readonly basePath: string;
   private readonly serveUrlBase: string;
 
@@ -153,6 +163,7 @@ const DEFAULT_RETRY = {
 } as const;
 
 export class ProxyArtifactStorage implements ArtifactStorage {
+  readonly downloadUrlKind = "presigned" as const;
   private readonly baseUrl: string;
   private readonly authTokenSource: ProxyAuthTokenSource;
   /** Governs the proxy presign calls and the exists probe. */

--- a/backend/services/runner/src/shared/attachment-download-urls.ts
+++ b/backend/services/runner/src/shared/attachment-download-urls.ts
@@ -1,0 +1,98 @@
+/**
+ * Download-URL hand-off for execution attachments (issue #532) — the single
+ * owner of the mint policy and the prompt wording that lets an agent pass an
+ * attachment to a tool whose backend cannot read the sandbox filesystem.
+ *
+ * Both harnesses (Cursor and deep-agent) materialize attachments to disk and
+ * list the workspace paths in their input-files prompt section; that story is
+ * unchanged and this module never touches it. What this module adds is the
+ * *remote hand-off* story: a per-attachment download URL, minted from the
+ * artifact storage the runner already downloads through, surfaced beside the
+ * path so the model can quote a short URL string in a tool-call argument
+ * instead of the impossible alternative (base64 through the model caps out in
+ * the tens of KB; real attachments run 2–8 MB).
+ *
+ * Mint rule: any attachment with a `storageKey` and a usable storage gets a
+ * URL, regardless of which branch materialized the bytes — this covers the
+ * local-mode fast path when an uploaded copy also exists. Attachments with no
+ * storage key (pure CLI-local files) and extracted ZIP entries (no
+ * attachment-level object) get no URL, and their listing is unchanged.
+ *
+ * Failure is non-fatal and silent in the prompt: the file IS materialized —
+ * only the remote hand-off affordance is absent — so a presign hiccup must
+ * not abort a turn the way a missing input does (the resolver/injector
+ * fail-hard doctrine covers inputs, not affordances). This mirrors how vision
+ * delivery degrades without killing materialization. The degrade is logged;
+ * the URL value itself is never logged (a presigned URL in the log pipeline
+ * would outlive its purpose).
+ *
+ * What the URL actually is depends on the storage backend, and the prompt
+ * must not overpromise: proxy storage mints genuinely presigned, time-limited,
+ * single-object URLs a remote service can fetch; local storage returns the
+ * stigmer-server's loopback serve URL, which only same-machine tools can
+ * reach. The backend self-describes via {@link ArtifactStorage.downloadUrlKind}
+ * and {@link downloadUrlDisclosureLine} words each kind honestly.
+ */
+
+import type { ArtifactStorage } from "./artifact-storage.js";
+
+/**
+ * What kind of URL a storage backend's `getDownloadUrl` mints. A property of
+ * the backend, not of the runner's execution mode: storage follows transport
+ * (see loadArtifactStorageConfig), so a local desktop runner on a cloud proxy
+ * mints real presigned URLs.
+ */
+export type DownloadUrlKind = "presigned" | "local-serve";
+
+/**
+ * Mint a download URL for one attachment, or `undefined` when there is
+ * nothing to mint (no key / no storage) or the mint fails (logged, non-fatal
+ * — see module doc). The caller spreads the result into its per-attachment
+ * record with the conditional-spread convention, so an unminted URL leaves no
+ * field behind.
+ */
+export async function mintAttachmentDownloadUrl(
+  storage: ArtifactStorage | undefined,
+  storageKey: string,
+  filename: string,
+): Promise<string | undefined> {
+  if (!storageKey || !storage) return undefined;
+  try {
+    return await storage.getDownloadUrl(storageKey);
+  } catch (err) {
+    console.warn(
+      `[attachment-download-urls] could not mint a download URL for ` +
+      `'${filename}' (key: ${storageKey}) — the file is materialized and the ` +
+      `turn proceeds without one: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * The shared hand-off wording both harnesses embed into their input-files
+ * prompt section when at least one listed file carries a download URL (each
+ * wraps it in its own section framing). Kept here so the two prompts never
+ * drift apart in what they promise the agent.
+ *
+ * Each kind is worded to its real capability. "Time-limited" is deliberately
+ * unquantified: the presign TTL belongs to the serving side (the cloud
+ * proxy's constant today) and hardcoding it here would silently drift.
+ */
+export function downloadUrlDisclosureLine(kind: DownloadUrlKind): string {
+  switch (kind) {
+    case "presigned":
+      return (
+        "Where a file lists a download URL, you can pass that URL to tools " +
+        "whose backends cannot read this workspace's filesystem (e.g. remote " +
+        "services) — the tool fetches the file's contents itself. These URLs " +
+        "are time-limited and each grants access to its single file only."
+      );
+    case "local-serve":
+      return (
+        "Where a file lists a download URL, it is served by the local Stigmer " +
+        "server and is reachable only from this machine — tools running on " +
+        "this machine can fetch it, but remote services cannot."
+      );
+  }
+}


### PR DESCRIPTION
## Summary
Agents can now hand attached files to tools whose backends cannot read the sandbox filesystem (remote MCP servers). During attachment materialization the runner mints a per-attachment download URL from the artifact storage it already downloads through, and both harnesses list it in the agent context beside the existing sandbox path — the model quotes a short URL string in a tool-call argument and the tool's backend fetches the bytes itself.

## Context
An execution attachment today materializes only into the sandbox at `.stigmer/inputs/`; a remote MCP server (no shared filesystem) could receive file bytes only as base64 written by the model into a tool-call argument — a practical ceiling in the tens of KB, while real attachments run 2–8 MB. The presign machinery already existed (proxy-mode `download()` mints a presigned URL per attachment and discards it) — this was a hand-off gap, not new infrastructure.

Closes #532

## Changes
- New `shared/attachment-download-urls.ts` — single owner of the mint policy (`mintAttachmentDownloadUrl`, non-fatal degrade) and the per-kind prompt wording (`downloadUrlDisclosureLine`), following the `attachment-vision.ts` cross-harness parity pattern
- `ArtifactStorage` gains a self-describing `downloadUrlKind` (`"presigned"` for proxy, `"local-serve"` for local) so the prompt wording can never disagree with the backend actually in use — the discriminator is deliberately NOT the runner's execution mode, since storage follows transport (a local desktop runner on a cloud proxy mints real presigned URLs)
- Cursor harness: `resolveAttachment` mints per the branch-independent rule (`storageKey` + usable storage, including the localPath fast path when an uploaded copy exists); `ResolvedAttachment.downloadUrl` threads through `attachmentEntries` into `formatInputFiles`, riding the enhanced prompt, the resumed-turn prefix, and the HITL-recovery rebuild
- Deep-agent harness: `injectAttachments` mints on the non-extract branch (extracted ZIP entries carry no URL — the stored object is the ZIP, not any listed file); rendered in `buildInjectedFilesSection`
- Disclosure wording is honest per kind: presigned URLs are described as time-limited and single-object (unquantified — the TTL belongs to the serving side); local-serve URLs as reachable only from this machine
- Canonical in-memory storage double gains the new field; no other implementer exists

## Implementation notes
- URL-mint failure is non-fatal (log + omit): the input file IS materialized, only the hand-off affordance is absent — the vision-degrade precedent, not a violation of the resolver's fail-hard doctrine (which covers inputs)
- The URL value is never logged; only presence/degrade is
- Security posture: `getArtifactDownloadUrl` already hands 7-day presigned URLs for spec attachment keys to anyone with `can_view` on the execution — the same audience that reads the transcript where these URLs now appear. Same object scope, shorter lifetime (proxy presign TTL). Always-on, no gating flag (owner decision on the issue's open question)
- Attachments are per-turn, so every turn's listing carries freshly minted URLs; only prior turns' history can hold stale ones, which the time-limited wording covers

## Breaking changes
- None

## Test plan
- New: `shared/__tests__/attachment-download-urls.test.ts` (mint rule, degrade, wording)
- Extended: resolver (mint, degrade-with-file-intact, localPath-with-key), injector (mint, mountPath, ZIP-extract exclusion, key-less local, degrade), both prompt builders (per-file URL line, per-kind disclosure, no-URL-no-line), storage backends self-describe their kind
- Full runner gate green: `tsc --noEmit` clean, vitest 270 files / 4544 tests passed

## Risks
- Additive only: agents without storage-backed attachments see no change; revert is a clean single-commit rollback

## Checklist
- [x] Tests added/updated
- [x] Backward compatible
- [ ] Docs updated (no doc surface describes the input-files section contents)

Made with [Cursor](https://cursor.com)