### PR TITLE
fix(server): enrich McpServer status.oauth_status at read time for SDK parity

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/enrich_oauth_status.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/enrich_oauth_status.go
@@ -1,0 +1,96 @@
+package mcpserver
+
+import (
+	"github.com/rs/zerolog/log"
+	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
+	oauthappv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/oauthapp/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"google.golang.org/protobuf/proto"
+)
+
+// enrichOAuthStatusStep populates status.oauth_status on a loaded McpServer
+// from the OAuthApp its spec.auth.oauth_app_ref points to, mirroring the
+// cloud's McpServerVendorApprovalEnricher so the shared SDK's
+// vendor-approval-blocked UI (VendorApprovalBlockedNotice) renders
+// identically on both editions (stigmer/stigmer#523). Without it, an OSS
+// user's first hint that OAuth sign-in is vendor-blocked is the initiate
+// RPC's refusal — after they click.
+//
+// Semantics shared with the cloud enricher:
+//   - Servers without an oauth_app_ref (DCR or manual-token) are untouched.
+//   - A missing OAuthApp skips enrichment (the initiate path owns refusing).
+//   - oauth_status is set only when there is something to gate on: a
+//     non-default vendor_approval_status or a docs URL. Its very presence is
+//     the signal the SDK keys on, so "nothing to report" means absent.
+//   - The fields are response-only, per the OAuthStatus proto contract.
+//     Nothing here persists: get pipelines don't save, and the write
+//     pipelines clear client-sent status (BuildNewState/BuildUpdateState),
+//     so a round-tripped enriched read cannot leak into the store.
+//
+// One deliberate divergence from cloud: a store failure during the lookup
+// degrades to an unenriched response (WARN) instead of failing the read.
+// Enrichment is advisory — the initiate RPC's vendor refusal remains the
+// enforcement boundary — and an advisory lookup must not take down the
+// primary read path.
+//
+// The step is generic over the pipeline input type because it serves both
+// read pipelines (get takes an ApiResourceId, getByReference an
+// ApiResourceReference); it only touches the already-loaded target resource.
+type enrichOAuthStatusStep[T proto.Message] struct {
+	store store.Store
+}
+
+func newEnrichOAuthStatusStep[T proto.Message](s store.Store) *enrichOAuthStatusStep[T] {
+	return &enrichOAuthStatusStep[T]{store: s}
+}
+
+func (s *enrichOAuthStatusStep[T]) Name() string {
+	return "EnrichOAuthStatus"
+}
+
+func (s *enrichOAuthStatusStep[T]) Execute(ctx *pipeline.RequestContext[T]) error {
+	mcpServer, ok := ctx.Get(steps.TargetResourceKey).(*mcpserverv1.McpServer)
+	if !ok {
+		return nil
+	}
+
+	ref := mcpServer.GetSpec().GetAuth().GetOauthAppRef()
+	if ref.GetSlug() == "" {
+		return nil
+	}
+
+	oauthApp, err := resolveOAuthAppByRef(ctx.Context(), s.store, ref)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("mcp_server_id", mcpServer.GetMetadata().GetId()).
+			Str("oauth_app_slug", ref.GetSlug()).
+			Msg("OAuthApp lookup failed; returning MCP server without oauth_status enrichment")
+		return nil
+	}
+	if oauthApp == nil {
+		log.Debug().
+			Str("mcp_server_id", mcpServer.GetMetadata().GetId()).
+			Str("oauth_app_slug", ref.GetSlug()).
+			Msg("OAuthApp not found for ref; skipping oauth_status enrichment")
+		return nil
+	}
+
+	approvalStatus := oauthApp.GetSpec().GetVendorApprovalStatus()
+	docsURL := oauthApp.GetSpec().GetVendorApprovalDocsUrl()
+	if approvalStatus == oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_UNSPECIFIED &&
+		docsURL == "" {
+		return nil
+	}
+
+	if mcpServer.Status == nil {
+		mcpServer.Status = &mcpserverv1.McpServerStatus{}
+	}
+	mcpServer.Status.OauthStatus = &mcpserverv1.OAuthStatus{
+		VendorApprovalStatus:  approvalStatus,
+		VendorApprovalDocsUrl: docsURL,
+	}
+
+	return nil
+}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/enrich_oauth_status_test.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/enrich_oauth_status_test.go
@@ -1,0 +1,310 @@
+package mcpserver
+
+// Pins the read-time oauth_status enrichment (stigmer/stigmer#523): get and
+// getByReference copy vendor_approval_status/vendor_approval_docs_url from
+// the referenced OAuthApp onto status.oauth_status, byte-mirroring the
+// cloud's McpServerVendorApprovalEnricher semantics so the shared SDK's
+// blocked-state UI (useMcpServerCredentials.isVendorApprovalBlocked) behaves
+// identically on both editions. No cloud test pins the enricher, so this
+// table is the executable spec of the shared contract — change it only in
+// lockstep with the Java side.
+
+import (
+	"context"
+	"testing"
+
+	mcpserverv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	oauthappv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/oauthapp/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	enrichTestOAuthAppSlug = "enrich-vendor-app"
+	enrichTestDocsURL      = "https://docs.example.com/byoa-setup"
+)
+
+// saveEnrichmentOAuthApp stores an OAuthApp fixture the enrichment tests
+// reference by slug, carrying the given vendor approval state.
+func saveEnrichmentOAuthApp(
+	t *testing.T,
+	s store.Store,
+	approval oauthappv1.VendorApprovalStatus,
+	docsURL string,
+) {
+	t.Helper()
+
+	app := &oauthappv1.OAuthApp{
+		Metadata: &apiresource.ApiResourceMetadata{
+			Id:   "oauthapp-enrich-test",
+			Name: "Enrich Vendor App",
+			Slug: enrichTestOAuthAppSlug,
+			Org:  "test-org",
+		},
+		Spec: &oauthappv1.OAuthAppSpec{
+			Provider:              "EnrichVendor",
+			ClientId:              "client-enrich",
+			AuthorizationUrl:      "https://vendor.example.com/oauth/authorize",
+			TokenUrl:              "https://vendor.example.com/oauth/token",
+			VendorApprovalStatus:  approval,
+			VendorApprovalDocsUrl: docsURL,
+		},
+	}
+	if err := s.SaveResource(context.Background(), apiresourcekind.ApiResourceKind_oauth_app, app.GetMetadata().GetId(), app); err != nil {
+		t.Fatalf("failed to save oauth app fixture: %v", err)
+	}
+}
+
+// saveEnrichmentMcpServer stores an McpServer fixture with the given auth
+// block, bypassing the create pipeline so the test controls metadata exactly.
+func saveEnrichmentMcpServer(
+	t *testing.T,
+	s store.Store,
+	auth *mcpserverv1.McpServerAuth,
+) *mcpserverv1.McpServer {
+	t.Helper()
+
+	mcpServer := createTestMcpServer("enrich-test-server")
+	mcpServer.Metadata.Id = "mcpserver-enrich-test"
+	mcpServer.Metadata.Slug = "enrich-test-server"
+	mcpServer.Spec.Auth = auth
+	if err := s.SaveResource(context.Background(), apiresourcekind.ApiResourceKind_mcp_server, mcpServer.GetMetadata().GetId(), mcpServer); err != nil {
+		t.Fatalf("failed to save mcp server fixture: %v", err)
+	}
+	return mcpServer
+}
+
+// vendorOAuthAuthBlock returns an auth block referencing the test OAuthApp.
+func vendorOAuthAuthBlock(slug string) *mcpserverv1.McpServerAuth {
+	return &mcpserverv1.McpServerAuth{
+		OauthAppRef:  &apiresource.ApiResourceReference{Slug: slug},
+		TargetEnvVar: "VENDOR_TOKEN",
+	}
+}
+
+func TestGetEnrichesOAuthStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		// nil means "do not save an OAuthApp fixture"
+		approval *oauthappv1.VendorApprovalStatus
+		docsURL  string
+		auth     *mcpserverv1.McpServerAuth
+
+		wantEnriched bool
+		wantStatus   oauthappv1.VendorApprovalStatus
+		wantDocsURL  string
+	}{
+		{
+			name:         "pending approval populates status and docs url",
+			approval:     approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING),
+			docsURL:      enrichTestDocsURL,
+			auth:         vendorOAuthAuthBlock(enrichTestOAuthAppSlug),
+			wantEnriched: true,
+			wantStatus:   oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING,
+			wantDocsURL:  enrichTestDocsURL,
+		},
+		{
+			name:         "rejected approval populates status without docs url",
+			approval:     approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_REJECTED),
+			docsURL:      "",
+			auth:         vendorOAuthAuthBlock(enrichTestOAuthAppSlug),
+			wantEnriched: true,
+			wantStatus:   oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_REJECTED,
+			wantDocsURL:  "",
+		},
+		{
+			name:         "approved status is still reported",
+			approval:     approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_APPROVED),
+			docsURL:      enrichTestDocsURL,
+			auth:         vendorOAuthAuthBlock(enrichTestOAuthAppSlug),
+			wantEnriched: true,
+			wantStatus:   oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_APPROVED,
+			wantDocsURL:  enrichTestDocsURL,
+		},
+		{
+			name:         "unspecified status with docs url is reported",
+			approval:     approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_UNSPECIFIED),
+			docsURL:      enrichTestDocsURL,
+			auth:         vendorOAuthAuthBlock(enrichTestOAuthAppSlug),
+			wantEnriched: true,
+			wantStatus:   oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_UNSPECIFIED,
+			wantDocsURL:  enrichTestDocsURL,
+		},
+		{
+			name:         "unspecified status with no docs url leaves oauth_status absent",
+			approval:     approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_UNSPECIFIED),
+			docsURL:      "",
+			auth:         vendorOAuthAuthBlock(enrichTestOAuthAppSlug),
+			wantEnriched: false,
+		},
+		{
+			name:         "server without auth block is untouched",
+			approval:     approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING),
+			docsURL:      enrichTestDocsURL,
+			auth:         nil,
+			wantEnriched: false,
+		},
+		{
+			name:     "DCR server (auth without oauth_app_ref) is untouched",
+			approval: approvalPtr(oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING),
+			docsURL:  enrichTestDocsURL,
+			auth: &mcpserverv1.McpServerAuth{
+				TargetEnvVar: "DCR_TOKEN",
+			},
+			wantEnriched: false,
+		},
+		{
+			name:         "ref to missing oauth app is untouched",
+			approval:     nil,
+			auth:         vendorOAuthAuthBlock("no-such-app"),
+			wantEnriched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, s := setupTestController(t)
+			if tt.approval != nil {
+				saveEnrichmentOAuthApp(t, s, *tt.approval, tt.docsURL)
+			}
+			saved := saveEnrichmentMcpServer(t, s, tt.auth)
+
+			got, err := controller.Get(contextWithMcpServerKind(), &apiresource.ApiResourceId{Value: saved.GetMetadata().GetId()})
+			if err != nil {
+				t.Fatalf("Get failed: %v", err)
+			}
+
+			assertOAuthStatus(t, got, tt.wantEnriched, tt.wantStatus, tt.wantDocsURL)
+		})
+	}
+}
+
+func TestGetByReferenceEnrichesOAuthStatus(t *testing.T) {
+	controller, s := setupTestController(t)
+	saveEnrichmentOAuthApp(t, s, oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING, enrichTestDocsURL)
+	saved := saveEnrichmentMcpServer(t, s, vendorOAuthAuthBlock(enrichTestOAuthAppSlug))
+
+	got, err := controller.GetByReference(contextWithMcpServerKind(), &apiresource.ApiResourceReference{
+		Slug: saved.GetMetadata().GetSlug(),
+		Org:  saved.GetMetadata().GetOrg(),
+	})
+	if err != nil {
+		t.Fatalf("GetByReference failed: %v", err)
+	}
+
+	assertOAuthStatus(t, got,
+		true,
+		oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING,
+		enrichTestDocsURL,
+	)
+}
+
+// TestEnrichmentIsResponseOnly pins the OAuthStatus proto contract that the
+// enriched fields are never persisted: after an enriched read, the stored
+// McpServer must still carry no oauth_status.
+func TestEnrichmentIsResponseOnly(t *testing.T) {
+	controller, s := setupTestController(t)
+	saveEnrichmentOAuthApp(t, s, oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING, enrichTestDocsURL)
+	saved := saveEnrichmentMcpServer(t, s, vendorOAuthAuthBlock(enrichTestOAuthAppSlug))
+
+	got, err := controller.Get(contextWithMcpServerKind(), &apiresource.ApiResourceId{Value: saved.GetMetadata().GetId()})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.GetStatus().GetOauthStatus() == nil {
+		t.Fatal("expected the Get response to be enriched")
+	}
+
+	stored := &mcpserverv1.McpServer{}
+	if err := s.GetResource(context.Background(), apiresourcekind.ApiResourceKind_mcp_server, saved.GetMetadata().GetId(), stored); err != nil {
+		t.Fatalf("failed to reload stored mcp server: %v", err)
+	}
+	if stored.GetStatus().GetOauthStatus() != nil {
+		t.Errorf("oauth_status leaked into the store: %v", stored.GetStatus().GetOauthStatus())
+	}
+}
+
+// TestInitiateAndEnrichmentResolveSameApp pins that the enricher and the
+// initiate path share one OAuthApp resolution (resolveOAuthAppByRef): a ref
+// carrying an org must resolve to that org's app for both.
+func TestInitiateAndEnrichmentResolveSameApp(t *testing.T) {
+	controller, s := setupTestController(t)
+
+	// Two apps share a slug across orgs; the ref pins org "org-b".
+	for _, fixture := range []struct {
+		id, org  string
+		approval oauthappv1.VendorApprovalStatus
+	}{
+		{"oauthapp-org-a", "org-a", oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_APPROVED},
+		{"oauthapp-org-b", "org-b", oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING},
+	} {
+		app := &oauthappv1.OAuthApp{
+			Metadata: &apiresource.ApiResourceMetadata{
+				Id:   fixture.id,
+				Name: "Shared Slug App",
+				Slug: "shared-slug",
+				Org:  fixture.org,
+			},
+			Spec: &oauthappv1.OAuthAppSpec{
+				Provider:             "SharedVendor",
+				ClientId:             "client-" + fixture.org,
+				AuthorizationUrl:     "https://vendor.example.com/oauth/authorize",
+				TokenUrl:             "https://vendor.example.com/oauth/token",
+				VendorApprovalStatus: fixture.approval,
+			},
+		}
+		if err := s.SaveResource(context.Background(), apiresourcekind.ApiResourceKind_oauth_app, app.GetMetadata().GetId(), app); err != nil {
+			t.Fatalf("failed to save oauth app fixture: %v", err)
+		}
+	}
+
+	saved := saveEnrichmentMcpServer(t, s, &mcpserverv1.McpServerAuth{
+		OauthAppRef: &apiresource.ApiResourceReference{
+			Slug: "shared-slug",
+			Org:  "org-b",
+		},
+		TargetEnvVar: "VENDOR_TOKEN",
+	})
+
+	got, err := controller.Get(contextWithMcpServerKind(), &apiresource.ApiResourceId{Value: saved.GetMetadata().GetId()})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	assertOAuthStatus(t, got,
+		true,
+		oauthappv1.VendorApprovalStatus_VENDOR_APPROVAL_STATUS_PENDING,
+		"",
+	)
+}
+
+func approvalPtr(v oauthappv1.VendorApprovalStatus) *oauthappv1.VendorApprovalStatus {
+	return &v
+}
+
+func assertOAuthStatus(
+	t *testing.T,
+	got *mcpserverv1.McpServer,
+	wantEnriched bool,
+	wantStatus oauthappv1.VendorApprovalStatus,
+	wantDocsURL string,
+) {
+	t.Helper()
+
+	oauthStatus := got.GetStatus().GetOauthStatus()
+	if !wantEnriched {
+		if oauthStatus != nil {
+			t.Errorf("expected oauth_status to be absent, got %v", oauthStatus)
+		}
+		return
+	}
+
+	want := &mcpserverv1.OAuthStatus{
+		VendorApprovalStatus:  wantStatus,
+		VendorApprovalDocsUrl: wantDocsURL,
+	}
+	if !proto.Equal(oauthStatus, want) {
+		t.Errorf("oauth_status mismatch:\n  got:  %v\n  want: %v", oauthStatus, want)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/get.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/get.go
@@ -14,6 +14,8 @@ import (
 // Pipeline Steps:
 //  1. ValidateProto - Validate input ApiResourceId (ensures value is not empty)
 //  2. LoadTarget - Load MCP server from repository by ID, returns NotFound if missing
+//  3. EnrichOAuthStatus - Populate response-only status.oauth_status from the
+//     referenced OAuthApp (cloud parity, stigmer/stigmer#523)
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:
 //   - Authorize step (no multi-tenant auth in OSS)
@@ -43,5 +45,6 @@ func (c *McpServerController) buildGetPipeline() *pipeline.Pipeline[*apiresource
 	return pipeline.NewPipeline[*apiresource.ApiResourceId]("mcpserver-get").
 		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceId]()).                             // 1. Validate input
 		AddStep(steps.NewLoadTargetStep[*apiresource.ApiResourceId, *mcpserverv1.McpServer](c.store)). // 2. Load by ID
+		AddStep(newEnrichOAuthStatusStep[*apiresource.ApiResourceId](c.store)).                        // 3. Enrich oauth_status
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/get_by_reference.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/get_by_reference.go
@@ -15,6 +15,8 @@ import (
 // Pipeline Steps:
 //  1. ValidateProto - Validate input ApiResourceReference
 //  2. LoadByReference - Load MCP server by slug (with optional org filtering)
+//  3. EnrichOAuthStatus - Populate response-only status.oauth_status from the
+//     referenced OAuthApp (cloud parity, stigmer/stigmer#523)
 //
 // Note: Compared to Stigmer Cloud, OSS excludes:
 //   - Authorize step (no multi-tenant auth in OSS)
@@ -50,7 +52,8 @@ func (c *McpServerController) GetByReference(ctx context.Context, ref *apiresour
 // by the apiresource interceptor and injected into request context.
 func (c *McpServerController) buildGetByReferencePipeline() *pipeline.Pipeline[*apiresource.ApiResourceReference] {
 	return pipeline.NewPipeline[*apiresource.ApiResourceReference]("mcpserver-get-by-reference").
-		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceReference]()). // 1. Validate input
-		AddStep(steps.NewLoadByReferenceStep[*mcpserverv1.McpServer](c.store)).   // 2. Load by slug
+		AddStep(steps.NewValidateProtoStep[*apiresource.ApiResourceReference]()).      // 1. Validate input
+		AddStep(steps.NewLoadByReferenceStep[*mcpserverv1.McpServer](c.store)).        // 2. Load by slug
+		AddStep(newEnrichOAuthStatusStep[*apiresource.ApiResourceReference](c.store)). // 3. Enrich oauth_status
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_oauth_connect.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_oauth_connect.go
@@ -15,7 +15,6 @@ import (
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/mcpserver/oauth"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
-	"google.golang.org/protobuf/proto"
 )
 
 // InitiateOAuthConnect starts the OAuth authorization flow for an MCP server.
@@ -247,24 +246,10 @@ func (c *McpServerController) initiateVendorOAuth(
 ) (*initiateResult, error) {
 	ref := mcpServer.GetSpec().GetAuth().GetOauthAppRef()
 
-	oauthApps, err := c.store.ListResources(ctx, apiresourcekind.ApiResourceKind_oauth_app)
+	oauthApp, err := resolveOAuthAppByRef(ctx, c.store, ref)
 	if err != nil {
 		return nil, grpclib.InternalError(err, "failed to list oauth apps")
 	}
-
-	var oauthApp *oauthappv1.OAuthApp
-	for _, data := range oauthApps {
-		app := &oauthappv1.OAuthApp{}
-		if err := proto.Unmarshal(data, app); err != nil {
-			continue
-		}
-		if app.GetMetadata().GetSlug() == ref.GetSlug() &&
-			(ref.GetOrg() == "" || app.GetMetadata().GetOrg() == ref.GetOrg()) {
-			oauthApp = app
-			break
-		}
-	}
-
 	if oauthApp == nil {
 		return nil, grpclib.NotFoundError("oauth_app", ref.GetSlug())
 	}

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_vendor_refusal_test.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/initiate_vendor_refusal_test.go
@@ -5,9 +5,11 @@ package mcpserver
 // actually work. oauth_only endpoints reject static tokens, so the refusal
 // must steer those users to BYOA, never to manual token entry.
 //
-// This is the primary UX for the blocked state on OSS: the server does not
-// enrich status.oauth_status, so no client-side notice pre-empts the click —
-// the user sees exactly this message.
+// This refusal is the enforcement boundary for the blocked state. Since
+// stigmer/stigmer#523 the read pipelines also enrich status.oauth_status
+// (see enrich_oauth_status.go), so the SDK's blocked notice normally
+// pre-empts the click — this message remains the backstop for clients that
+// initiate anyway (stale reads, non-SDK callers).
 
 import (
 	"context"

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/oauth_app_resolution.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/oauth_app_resolution.go
@@ -1,0 +1,46 @@
+package mcpserver
+
+import (
+	"context"
+
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	apiresourcekind "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	oauthappv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/oauthapp/v1"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"google.golang.org/protobuf/proto"
+)
+
+// resolveOAuthAppByRef resolves the OAuthApp an McpServer's
+// spec.auth.oauth_app_ref points to: matched by slug, with org as an
+// additional filter only when the ref carries one. OSS has a flat OAuthApp
+// store — there is no org-override resolution chain like the cloud's
+// OAuthAppResolutionService, so the ref IS the whole resolution.
+//
+// Both the OAuth initiate path and the read-path oauth_status enricher must
+// select the same OAuthApp for a given ref, so they share this one lookup.
+//
+// Returns (nil, nil) when no stored OAuthApp matches; callers own the
+// severity of that outcome (initiate refuses NOT_FOUND, the enricher skips).
+func resolveOAuthAppByRef(
+	ctx context.Context,
+	s store.Store,
+	ref *apiresource.ApiResourceReference,
+) (*oauthappv1.OAuthApp, error) {
+	oauthApps, err := s.ListResources(ctx, apiresourcekind.ApiResourceKind_oauth_app)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, data := range oauthApps {
+		app := &oauthappv1.OAuthApp{}
+		if err := proto.Unmarshal(data, app); err != nil {
+			continue
+		}
+		if app.GetMetadata().GetSlug() == ref.GetSlug() &&
+			(ref.GetOrg() == "" || app.GetMetadata().GetOrg() == ref.GetOrg()) {
+			return app, nil
+		}
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

The OSS Go server never populated `McpServer.status.oauth_status`, so the shared SDK's vendor-approval-blocked UI (`VendorApprovalBlockedNotice`, keyed on `useMcpServerCredentials.isVendorApprovalBlocked`) was hosted-only — on OSS the user's first hint that OAuth sign-in is blocked was the initiate RPC's refusal, after the click. This PR mirrors the cloud's `McpServerVendorApprovalEnricher` into the OSS read pipelines; the SDK's blocked-state UI (notice, docs link, BYOA steer, across all four connect surfaces) now lights up on OSS with zero client changes.

## Context

The `OAuthStatus` proto contract already promises this edition-neutrally ("populated by the backend enricher at query time... computed fresh on every get/getByReference response"), and all the data lives in the OSS store: the full OAuthApp domain exists, and `initiateVendorOAuth` already resolves the referenced OAuthApp to refuse blocked sign-ins. The gap was only that reads returned the stored proto verbatim.

Closes #523

## Changes

- New `enrichOAuthStatusStep` (generic over pipeline input) appended to both McpServer read pipelines (`get`, `getByReference`), copying `vendor_approval_status` + `vendor_approval_docs_url` from the referenced OAuthApp onto `status.oauth_status`, with the cloud enricher's exact skip semantics (no ref / missing app / nothing-to-gate-on → `oauth_status` stays absent).
- Extracted `resolveOAuthAppByRef` — the OAuthApp-by-ref lookup previously inlined in `initiateVendorOAuth` — so the refusal path and the enrichment path share one resolution and cannot drift.
- Truthed the comments this change invalidates: the `initiate_vendor_refusal_test.go` header (the refusal is now the enforcement backstop, no longer the primary UX) and both get handlers' pipeline-step docs.

## Implementation notes

- **Scope**: only the two fields the cloud enricher actually populates. The proto also promises `effective_oauth_source`/`effective_oauth_app_id`, but no code on either edition sets them — filed as stigmer-cloud#401 rather than having OSS populate fields cloud doesn't.
- **Deliberate divergence, flagged in the step's doc comment**: a store failure during enrichment degrades to an unenriched response (WARN) instead of failing the read. Enrichment is advisory; the initiate refusal remains the enforcement boundary.
- **Never persisted**: get pipelines don't save, and the write pipelines clear client-sent status (`BuildNewState`/`BuildUpdateState`), so a round-tripped enriched read cannot leak into the store — pinned by `TestEnrichmentIsResponseOnly`.

## Test plan

- New table-driven tests (11 cases): PENDING/REJECTED/APPROVED populated, UNSPECIFIED+docs populated, UNSPECIFIED+no-docs absent, no-auth/DCR/missing-app untouched, `GetByReference` parity, response-only pin, shared-resolution pin (org-scoped ref disambiguates same-slug apps). No cloud test pins the Java enricher, so this table is the executable spec of the shared semantics.
- Gates: `go vet ./...` clean, `gofmt -s -l` clean on touched files, full mcpserver domain suite green, server binary builds, `go mod tidy` no-op.
- Pre-existing, untouched: `oauth_preflight_test.go` is unformatted on clean main (noted since the #412 session).

## Risks

- Low: additive response-only field; every skip path returns the resource unchanged. Rollback is reverting one commit.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible (additive response enrichment; proto contract already promised it)
- [ ] Docs updated (not needed — behavior now matches the documented proto contract)

Made with [Cursor](https://cursor.com)