### PR TITLE
ci(workflows): roll the notify-failure pattern to every unattended lane

### DIFF
--- a/.github/workflows/ci.conformance-cloud.yaml
+++ b/.github/workflows/ci.conformance-cloud.yaml
@@ -181,3 +181,23 @@ jobs:
           # hidden paths by default — without this the artifact is silently
           # empty (the #323 class, swept in oss#541).
           include-hidden-files: true
+
+  # PR and push failures are attended; the nightly cron is not — and the cron
+  # is this lane's load-bearing trigger (path filters cannot see stigmer-cloud
+  # merges), so a silent red here means cross-edition drift ships unnoticed
+  # (#477). Shared file-or-comment mechanics live in notify-failure.yaml.
+  notify-failure:
+    name: File Conformance Failure Issue
+    needs: [build-service-jar, conformance-cloud]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: ci-conformance-cloud-failure
+      title: "ci.conformance-cloud: nightly cross-edition conformance is failing"
+      body-context: >-
+        The nightly run is the only trigger that sees stigmer-cloud merges
+        (path filters in this repo cannot), so a failure here usually means
+        cloud-side behavioral drift against the shared conformance contract —
+        or a stigmer-cloud main that no longer builds.

--- a/.github/workflows/ci.e2e.yaml
+++ b/.github/workflows/ci.e2e.yaml
@@ -93,8 +93,24 @@ jobs:
           path: test/e2e/playwright-report/
           retention-days: 30
 
-      - name: Notify on failure
-        if: failure() && github.event_name != 'workflow_dispatch'
-        run: |
-          echo "::error::E2E smoke tests failed against ${{ inputs.base_url || 'https://app.stigmer.ai' }}"
-          echo "This indicates a deployment regression. Check the Playwright report for details."
+  # Post-deploy (workflow_run) and cron runs are both unattended — a red run
+  # notifies nobody unless it announces itself (#477). Manual dispatches are
+  # attended, so they never notify. Shared file-or-comment mechanics live in
+  # notify-failure.yaml; a skipped e2e-smoke (triggering deploy failed) does
+  # not count as failure() and files nothing.
+  notify-failure:
+    name: File E2E Failure Issue
+    needs: e2e-smoke
+    if: failure() && github.event_name != 'workflow_dispatch'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: ci-e2e-failure
+      title: "ci.e2e: E2E smoke against the deployed console is failing"
+      body-context: >-
+        This lane runs Playwright smoke tests against the deployed web console
+        (after each deploy and on a weekday cron). A failure here usually means
+        a deployment regression: a broken API contract, a missing environment
+        variable, or a build issue that only manifests in production — start
+        with the uploaded Playwright report.

--- a/.github/workflows/ci.integration-canary.yaml
+++ b/.github/workflows/ci.integration-canary.yaml
@@ -44,8 +44,6 @@ concurrency:
 permissions:
   contents: read
   checks: write
-  # Lets the notify-failure job file/update the canary-failure issue.
-  issues: write
 
 jobs:
   build-service-jar:
@@ -167,28 +165,19 @@ jobs:
 
   # Scheduled runs have no PR to block, so a red canary is invisible unless it
   # announces itself — this lane once sat red for 30+ days unnoticed (#323).
-  # One open issue per breakage window: subsequent failures comment on the
-  # existing issue instead of filing duplicates; closing it arms the next one.
-  # Manual dispatches are attended, so only cron failures notify.
+  # Manual dispatches are attended, so only cron failures notify. Shared
+  # file-or-comment mechanics live in notify-failure.yaml (#477).
   notify-failure:
     name: File Canary Failure Issue
-    runs-on: ubuntu-latest
     needs: [build-service-jar, canary-tests]
     if: failure() && github.event_name == 'schedule'
-    steps:
-      - name: File or update the canary-failure issue
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          existing=$(gh issue list --repo "${{ github.repository }}" \
-            --label ci-canary-failure --state open --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "${{ github.repository }}" \
-              --body "Nightly provider canary failed again: $run_url"
-          else
-            gh issue create --repo "${{ github.repository }}" \
-              --label ci-canary-failure \
-              --title "ci.integration-canary: nightly provider canary is failing" \
-              --body "$(printf 'The scheduled provider canary failed: %s\n\nThis lane asserts only that live provider calls complete (model retirement, proxy breakage, API key expiry). A failure here usually means a provider or credential problem, not a code regression.\n\nThis issue is filed automatically by the notify-failure job; later failures add comments here instead of new issues. Close it once the lane is green again.' "$run_url")"
-          fi
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: ci-canary-failure
+      title: "ci.integration-canary: nightly provider canary is failing"
+      body-context: >-
+        This lane asserts only that live provider calls complete (model
+        retirement, proxy breakage, API key expiry). A failure here usually
+        means a provider or credential problem, not a code regression.

--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -317,3 +317,22 @@ jobs:
           name: ${{ matrix.report }}
           path: ${{ matrix.output }}/junit.xml
           reporter: java-junit
+
+  # PR and push failures are attended surfaces; the weekly cron is not (#477).
+  # failure() is true if any matrix leg failed. Shared file-or-comment
+  # mechanics live in notify-failure.yaml.
+  notify-failure:
+    name: File Offline-Suite Failure Issue
+    needs: [build-service-jar, integration-tests]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: ci-integration-offline-failure
+      title: "ci.integration-offline: weekly offline integration run is failing"
+      body-context: >-
+        The weekly cron runs all five offline suites against stigmer-cloud@main.
+        PR and push runs of this lane are attended, so this issue tracks cron
+        failures only — often cloud-side drift landing between OSS merges (see
+        the cross-repo coupling contract in the workflow header).

--- a/.github/workflows/ci.integration-stress.yaml
+++ b/.github/workflows/ci.integration-stress.yaml
@@ -160,3 +160,22 @@ jobs:
           name: Stress Test Report
           path: test/integration/.test-output-stress/junit.xml
           reporter: java-junit
+
+  # Scheduled runs are unattended and this lane blocks no merges, so a red
+  # week is invisible without an announcement (#477). Shared file-or-comment
+  # mechanics live in notify-failure.yaml.
+  notify-failure:
+    name: File Stress Failure Issue
+    needs: [build-service-jar, stress-tests]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: ci-integration-stress-failure
+      title: "ci.integration-stress: weekly stress/flake-detection run is failing"
+      body-context: >-
+        This lane is advisory flake detection: it reruns the offline
+        integration suite three times with quarantine skip disabled. A failure
+        means timing-dependent flakes (or still-flaky quarantined tests) were
+        found — it never blocks merges, but it should not sit red unexamined.

--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -1,9 +1,15 @@
-name: CI / Seedpack Canary Tests
+# Live-tests marketplace MCP servers: transport reachability plus canary calls
+# with real vendor credentials fetched from Planton at run time.
+
+name: ci.seedpack-canary
 
 on:
   schedule:
     - cron: '0 2 * * 1-5'  # Weekdays at 2am UTC
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   seedpack-canary:
@@ -36,3 +42,21 @@ jobs:
         run: make test-seedpack-canary
         env:
           STIGMER_MCP_CANARY: "true"
+
+  # Scheduled runs are unattended; manual dispatches are watched (#477).
+  # Shared file-or-comment mechanics live in notify-failure.yaml.
+  notify-failure:
+    name: File Seedpack Canary Failure Issue
+    needs: seedpack-canary
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: ci-seedpack-canary-failure
+      title: "ci.seedpack-canary: seedpack MCP canary is failing"
+      body-context: >-
+        This lane live-tests marketplace MCP servers (transport reachability
+        plus canary calls with real credentials fetched from Planton). A
+        failure here usually means a vendor API change, an expired canary
+        credential, or a seedpack manifest that no longer matches the vendor.

--- a/.github/workflows/notify-failure.yaml
+++ b/.github/workflows/notify-failure.yaml
@@ -1,0 +1,80 @@
+# =============================================================================
+# Notify on Unattended Failure (reusable)
+# =============================================================================
+# Unattended runs (cron schedules, post-deploy workflow_run chains) block no PR,
+# so a red run notifies nobody — ci.integration-canary once sat red for 30+
+# days before anyone noticed (#323). PR #476 shipped the fix shape for that one
+# lane; this reusable workflow is the single definition every unattended lane
+# consumes (#477), so the copies cannot drift.
+#
+# Semantics — one open issue per breakage window, per lane:
+#   - `label` is the dedupe key. If an open issue carries it, the failure adds
+#     a comment there; otherwise a fresh issue is filed with `title` and
+#     `body-context`. Closing the issue arms the next window.
+#   - Each lane owns a distinct label so breakage windows stay per-lane even
+#     when one root cause reds several lanes at once.
+#
+# Caller contract (see ci.integration-canary.yaml for the canonical example):
+#   notify-failure:
+#     needs: [<every job in the workflow>]
+#     if: failure() && github.event_name == 'schedule'   # unattended only —
+#     permissions:                                       # dispatches are watched
+#       issues: write
+#     uses: ./.github/workflows/notify-failure.yaml
+#     with: { label: ..., title: ..., body-context: ... }
+#
+# The job runs in the caller's run context: github.workflow / run_id resolve to
+# the failing run, and GITHUB_TOKEN flows from the caller job's permissions.
+# Inputs are freeform strings, so they reach the script via env — never inline
+# ${{ }} interpolation inside run (script-injection hardening).
+# =============================================================================
+
+name: notify-failure
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: >-
+          Per-lane issue label (must already exist in the repo — gh issue
+          create fails on unknown labels). The dedupe key: one open issue with
+          this label tracks the current breakage window.
+        required: true
+        type: string
+      title:
+        description: Title for a newly filed failure issue.
+        required: true
+        type: string
+      body-context:
+        description: >-
+          Lane-specific paragraph for the issue body explaining what a failure
+          here usually means and where to start looking.
+        required: true
+        type: string
+
+jobs:
+  notify:
+    name: File Failure Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: File or update the failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+          LABEL: ${{ inputs.label }}
+          TITLE: ${{ inputs.title }}
+          BODY_CONTEXT: ${{ inputs.body-context }}
+        run: |
+          existing=$(gh issue list --repo "$REPO" \
+            --label "$LABEL" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "$WORKFLOW failed again: $RUN_URL"
+          else
+            gh issue create --repo "$REPO" \
+              --label "$LABEL" \
+              --title "$TITLE" \
+              --body "$(printf 'An unattended run of %s failed: %s\n\n%s\n\nThis issue is filed automatically by the notify-failure job; later failures add comments here instead of new issues. Close it once the lane is green again.' "$WORKFLOW" "$RUN_URL" "$BODY_CONTEXT")"
+          fi

--- a/.github/workflows/reconcile-homebrew.yaml
+++ b/.github/workflows/reconcile-homebrew.yaml
@@ -141,3 +141,21 @@ jobs:
           git add Formula/stigmer.rb
           git commit -m "Update stigmer to ${TARGET}"
           git push
+
+  # Scheduled runs are unattended; manual dispatches are watched (#477).
+  # Shared file-or-comment mechanics live in notify-failure.yaml.
+  notify-failure:
+    name: File Homebrew Reconcile Failure Issue
+    needs: reconcile
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yaml
+    with:
+      label: reconcile-homebrew-failure
+      title: "reconcile-homebrew: daily Homebrew tap reconciliation is failing"
+      body-context: >-
+        This job bumps stigmer/homebrew-tap to the aged npm latest of
+        @stigmer/cli; while it is red, brew users may be stuck on an old
+        version. Usual suspects: npm registry metadata changes, an expired
+        HOMEBREW_TAP_TOKEN, or drift in the formula template.


### PR DESCRIPTION
## Summary

Extracts the live-proven `notify-failure` job from `ci.integration-canary` ([PR #476](https://github.com/stigmer/stigmer/pull/476)) into a reusable `workflow_call` workflow and wires it into every unattended lane — six cron lanes plus the canary itself — each with its own per-lane failure label so breakage windows stay per-lane.

## Context

Unattended runs (cron schedules, post-deploy `workflow_run` chains) block no PR, so a red run notifies nobody: `ci.integration-canary` sat red for 30+ days before anyone noticed (#323). Issue #477 asks for the canary's file-or-comment pattern on the five remaining cron lanes, with the notify job extracted so the copies can't drift.

**Scope addition found during the design pass:** a sweep of every `cron:` trigger found a seventh scheduled lane the issue's list missed — `ci.conformance-cloud` (nightly). Its cron is load-bearing (path filters in this repo cannot see stigmer-cloud merges, so the nightly run is the only thing that catches cross-edition drift), which makes a silent red there exactly the class this issue exists to kill. It joins the rollout under the issue's title ("no failure notification on **any** cron lane"). `mirror-test-images` was checked too: push/dispatch only, correctly out of scope.

## Changes

- **New `.github/workflows/notify-failure.yaml`** — the repo's first reusable (`workflow_call`) workflow: inputs `label` (per-lane dedupe key), `title`, `body-context`. One open issue per breakage window: comment if an open labeled issue exists, else file fresh; closing it arms the next window. Header comment documents the pattern and the caller contract.
- **`ci.integration-canary`** — inline job migrated to the shared workflow, byte-equivalent semantics, label `ci-canary-failure` unchanged (no open window at migration time — verified). `issues: write` moved from workflow level to the notify job, where it's used.
- **`ci.e2e`** — notifies on both `schedule` and `workflow_run` failures (owner ruling: post-deploy runs are equally unattended); the dead `::error` echo step is deleted. Label `ci-e2e-failure`.
- **`ci.conformance-cloud`** — schedule-only notify (PR/push are attended). Label `ci-conformance-cloud-failure`.
- **`ci.integration-offline`** — schedule-only notify; `failure()` catches any matrix leg. Label `ci-integration-offline-failure`.
- **`ci.integration-stress`** — schedule-only notify; body notes the lane is advisory flake detection. Label `ci-integration-stress-failure`.
- **`ci.seedpack-canary`** — schedule-only notify, label `ci-seedpack-canary-failure`; ride-alongs while touching the file: explicit `permissions: contents: read` block (it had none) and display name normalized to `ci.seedpack-canary` (nothing references the old name — no `workflow_run` consumers, no branch-protection contexts).
- **`reconcile-homebrew`** — schedule-only notify. Label `reconcile-homebrew-failure`.
- **Labels** — the six new per-lane labels are already created in the repo (styled after `ci-canary-failure`), since `gh issue create --label` fails on unknown labels.

## Implementation notes

- Freeform string inputs reach the script via `env`, never inline `${{ }}` interpolation inside `run` — script-injection hardening the verbatim copy would have lacked (the canary only interpolated trusted `github.*` values).
- The follow-up comment uses `github.workflow` ("<workflow> failed again"), so the shared job stays lane-agnostic; inside a reusable workflow these contexts resolve to the caller's run.
- Each caller keeps its own job-level `if` (unattended-trigger predicates differ per lane) and grants `permissions: issues: write` at the job level, overriding the lanes' workflow-level `contents: read`.
- The notifier deliberately has no API-retry machinery: a failed notify job is itself a visible red job, and the canary shipped without it.

## Breaking changes

- None.

## Test plan

- `actionlint` across all eight touched workflows: zero new findings (the two shellcheck style/info notes it reports exist identically on `main` in scripts this PR does not touch).
- Live dry-run of the script **extracted verbatim from the shipped YAML** against a scratch label on this repo, proving all three arms: fresh window files an issue; open window receives a comment; closed window re-arms and files fresh. An injection-probe body (backticks, `$(...)`, quotes) rendered character-for-character. All test issues hard-deleted and the scratch label removed.
- Observed during the dry-run: back-to-back runs seconds apart can double-file because `gh issue list` rides GitHub's eventually-consistent search index. At production cadence (daily/weekly crons, minutes-apart deploys at worst) the window is irrelevant; noted here for honesty.
- Honest limit: the `schedule`-triggered path itself cannot be exercised pre-merge; confidence rests on byte-equivalence with the canary's live-fired logic plus the dry-run above.

## Risks

- Low: notify jobs only run on `failure()` of unattended triggers and touch nothing but the issues API. Rollback is deleting the notify jobs; the lanes themselves are untouched.

Closes #477

Made with [Cursor](https://cursor.com)