### PR TITLE
fix(runner): scope plan-mode file reads to the session workspace

### DIFF
--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/plan-mode-path-normalization.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/plan-mode-path-normalization.test.ts
@@ -1,19 +1,23 @@
 /**
  * End-to-end proof (real deepagents + LangGraph runtime, no LLM/network) that
- * a plan-mode PARENT graph accepts workspace-relative paths (issue #429).
+ * a plan-mode PARENT graph accepts workspace-relative paths (issue #429) and
+ * scopes reads to the workspace (issue #528).
  *
- * Before the fix, deepagents' permission enforcement canonicalized every
+ * Before the #429 fix, deepagents' permission enforcement canonicalized every
  * filesystem tool-call path BEFORE any rule ran and refused non-absolute
  * shapes, so on a rule-bearing graph a workspace-relative call — reads
  * included — died with `path must be absolute` instead of just working. The
  * path-normalization middleware (middleware/path-normalization.ts) rewrites
  * relative paths to workspace-absolute at our seam, before enforcement sees
- * them.
+ * them. #528 then made the workspace the READ boundary (owner ruling): the
+ * rules deny out-of-root reads, the middleware fills the ls/glob/grep
+ * omitted-path case (whose schema default is the OS root), and the
+ * `.stigmer` symlink keeps platform-dir reads in-root as path strings.
  *
  * The graph here is composed exactly the way setup.ts composes the parent:
  * the PRODUCTION buildMiddlewareStack (pathNormalization present, the
  * rule-bearing shape) + the CAS capture backend + the PRODUCTION
- * PLAN_MODE_PERMISSIONS constant. These tests are also the empirical proof
+ * buildPlanModePermissions rules. These tests are also the empirical proof
  * that langchain's wrapToolCall seam delivers rewritten args to the tool —
  * if it did not, the relative read below could never succeed.
  *
@@ -22,20 +26,56 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, rm, readFile, writeFile, access } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, readFile, writeFile, access, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HumanMessage, ToolMessage, type BaseMessage } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";
 import { createDeepAgent } from "deepagents";
 
-import { PLAN_MODE_PERMISSIONS } from "../../../shared/plan-mode-permissions.js";
+import { buildPlanModePermissions } from "../../../shared/plan-mode-permissions.js";
 import { buildMiddlewareStack } from "../../../middleware/index.js";
 import { createCasCaptureBackend } from "../cas-capture-backend.js";
 import { CasCaptureObserver } from "../cas-capture-observer.js";
 import { ScriptedModel, type ScriptSelector } from "../__test-utils__/scripted-model.js";
 
 const SEEDED_CONTENT = "PLAN_MODE_README_TOKEN: hello from the seeded file";
+const OUTSIDE_CONTENT = "OUT_OF_ROOT_SECRET_TOKEN: must never cross the boundary";
+const PLATFORM_CONTENT = "PLATFORM_SKILL_TOKEN: reached through the .stigmer symlink";
+
+/**
+ * Build a plan-mode parent graph the way setup.ts does: the production
+ * middleware stack with pathNormalization set (derived, like the graph's
+ * permissions, from the plan-mode rules), a filesystem-only CAS capture
+ * backend (no shellEnv — plan mode clears it), and the production
+ * buildPlanModePermissions rules on the graph.
+ */
+async function buildPlanModeParent(
+  root: string,
+  observer: CasCaptureObserver,
+  script: ScriptSelector,
+) {
+  const { middleware } = buildMiddlewareStack({
+    approvalGate: null,
+    pathNormalization: { rootDir: root },
+  });
+  const backend = await createCasCaptureBackend({ rootDir: root, observer });
+  return createDeepAgent({
+    model: new ScriptedModel(script),
+    checkpointer: new MemorySaver() as never,
+    backend,
+    middleware: middleware as never[],
+    permissions: buildPlanModePermissions(root),
+  } as Parameters<typeof createDeepAgent>[0]);
+}
+
+function toolResultById(messages: BaseMessage[], toolCallId: string): string {
+  const match = messages.find(
+    (m): m is ToolMessage => m instanceof ToolMessage && m.tool_call_id === toolCallId,
+  );
+  expect(match, `expected a tool result for call '${toolCallId}'`).toBeDefined();
+  return typeof match!.content === "string" ? match!.content : JSON.stringify(match!.content);
+}
 
 describe("plan-mode parent path normalization (issue #429)", () => {
   let root: string;
@@ -52,38 +92,8 @@ describe("plan-mode parent path normalization (issue #429)", () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  /**
-   * Build a parent graph the way setup.ts does in plan mode: the production
-   * middleware stack with pathNormalization set (derived, like the graph's
-   * permissions, from the plan-mode rules), a filesystem-only CAS capture
-   * backend (no shellEnv — plan mode clears it), and PLAN_MODE_PERMISSIONS
-   * on the graph.
-   */
-  async function buildPlanModeParent(script: ScriptSelector) {
-    const { middleware } = buildMiddlewareStack({
-      approvalGate: null,
-      pathNormalization: { rootDir: root },
-    });
-    const backend = await createCasCaptureBackend({ rootDir: root, observer });
-    return createDeepAgent({
-      model: new ScriptedModel(script),
-      checkpointer: new MemorySaver() as never,
-      backend,
-      middleware: middleware as never[],
-      permissions: PLAN_MODE_PERMISSIONS,
-    } as Parameters<typeof createDeepAgent>[0]);
-  }
-
-  function toolResultById(messages: BaseMessage[], toolCallId: string): string {
-    const match = messages.find(
-      (m): m is ToolMessage => m instanceof ToolMessage && m.tool_call_id === toolCallId,
-    );
-    expect(match, `expected a tool result for call '${toolCallId}'`).toBeDefined();
-    return typeof match!.content === "string" ? match!.content : JSON.stringify(match!.content);
-  }
-
   async function invokeOnce(script: ScriptSelector, threadId: string) {
-    const agent = await buildPlanModeParent(script);
+    const agent = await buildPlanModeParent(root, observer, script);
     return (await agent.invoke(
       { messages: [new HumanMessage({ content: "go" })] },
       { configurable: { thread_id: threadId }, recursionLimit: 50 },
@@ -170,5 +180,204 @@ describe("plan-mode parent path normalization (issue #429)", () => {
     const lsResult = toolResultById(result.messages, "c_ls_rel");
     expect(lsResult).toContain("notes.md");
     expect(lsResult).not.toMatch(/path must be absolute/i);
+  });
+});
+
+describe("plan-mode workspace read boundary (issue #528)", () => {
+  let root: string;
+  let outside: string;
+  let platform: string;
+  let observer: CasCaptureObserver;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "plan-bound-"));
+    outside = await mkdtemp(join(tmpdir(), "plan-outside-"));
+    platform = await mkdtemp(join(tmpdir(), "plan-platform-"));
+
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src/notes.md"), SEEDED_CONTENT);
+    await writeFile(join(outside, "secret.txt"), OUTSIDE_CONTENT);
+
+    // The production shape from shared/workspace/stigmer-link.ts: the
+    // platform dir lives OUTSIDE the workspace, reached through an in-root
+    // symlink — its path STRINGS are in-root, which is what the rules match.
+    await mkdir(join(platform, "skills"), { recursive: true });
+    await writeFile(join(platform, "skills/guide.md"), PLATFORM_CONTENT);
+    await symlink(platform, join(root, ".stigmer"));
+
+    observer = new CasCaptureObserver({ rootDir: root, isIgnored: async () => true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+    await rm(platform, { recursive: true, force: true });
+  });
+
+  async function invokeOnce(script: ScriptSelector, threadId: string) {
+    const agent = await buildPlanModeParent(root, observer, script);
+    return (await agent.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: threadId }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+  }
+
+  it("denies an out-of-root absolute read — the exposure #429 deliberately preserved is closed", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "read_file", args: { file_path: join(outside, "secret.txt") }, id: "c_read_out" },
+        ],
+        done: "done",
+      }),
+      "t_read_out",
+    );
+
+    const readResult = toolResultById(result.messages, "c_read_out");
+    expect(readResult).toMatch(/permission denied for read/i);
+    expect(readResult).not.toContain("OUT_OF_ROOT_SECRET_TOKEN");
+  });
+
+  it("lists the workspace root itself — {root}/** admits the root, not just its subtree", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [{ name: "ls", args: { path: root }, id: "c_ls_root" }],
+        done: "done",
+      }),
+      "t_ls_root",
+    );
+
+    const lsResult = toolResultById(result.messages, "c_ls_root");
+    expect(lsResult).toContain("src");
+    expect(lsResult).not.toMatch(/permission denied/i);
+  });
+
+  it("reads platform-dir material through the .stigmer symlink — in-root strings, out-of-root bytes", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "read_file", args: { file_path: join(root, ".stigmer/skills/guide.md") }, id: "c_read_skill" },
+        ],
+        done: "done",
+      }),
+      "t_read_skill",
+    );
+
+    const readResult = toolResultById(result.messages, "c_read_skill");
+    expect(readResult).toContain("PLATFORM_SKILL_TOKEN");
+    expect(readResult).not.toMatch(/permission denied/i);
+  });
+
+  it("a bare ls (no path argument) lists the workspace, not the OS root", async () => {
+    // The tool's schema default is "/" — the OS root — applied inside the
+    // tool, after the middleware seam. The middleware fills the omission
+    // with the workspace root, so the model's first listing just works.
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [{ name: "ls", args: {}, id: "c_ls_bare" }],
+        done: "done",
+      }),
+      "t_ls_bare",
+    );
+
+    const lsResult = toolResultById(result.messages, "c_ls_bare");
+    expect(lsResult).toContain("src");
+    expect(lsResult).not.toMatch(/permission denied/i);
+  });
+
+  it("a bare grep (no path argument) searches the workspace, not the whole filesystem", async () => {
+    // Pre-#528, a bare grep recursively scanned the ENTIRE OS filesystem
+    // (schema default "/" + the legacy backend's literal pass-through).
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "grep", args: { pattern: "PLAN_MODE_README_TOKEN" }, id: "c_grep_bare" },
+        ],
+        done: "done",
+      }),
+      "t_grep_bare",
+    );
+
+    const grepResult = toolResultById(result.messages, "c_grep_bare");
+    expect(grepResult).toContain("notes.md");
+    expect(grepResult).not.toMatch(/permission denied/i);
+  });
+
+  it("an explicit ls of '/' is denied honestly — not silently redirected to the workspace", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [{ name: "ls", args: { path: "/" }, id: "c_ls_slash" }],
+        done: "done",
+      }),
+      "t_ls_slash",
+    );
+
+    expect(toolResultById(result.messages, "c_ls_slash")).toMatch(
+      /permission denied for read on \//i,
+    );
+  });
+
+  it("writes stay denied everywhere — the read-allow rule admits reads only", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "write_file", args: { file_path: join(root, "src/out.txt"), content: "x" }, id: "c_write_in" },
+        ],
+        done: "done",
+      }),
+      "t_write_in",
+    );
+
+    expect(toolResultById(result.messages, "c_write_in")).toMatch(/permission denied for write/i);
+    await expect(access(join(root, "src/out.txt"))).rejects.toThrow();
+  });
+});
+
+describe("plan-mode read boundary with a glob-special workspace root (issue #528)", () => {
+  // Desktop localPath workspaces use the user's real project directory AS
+  // the root — names like "My (work) [v2]" are legal there. This suite pins
+  // escapeGlobLiteral against deepagents' real matcher end-to-end: without
+  // escaping, the read-allow rule would silently never match and every
+  // plan-mode read in such a workspace would be denied.
+  let base: string;
+  let root: string;
+  let observer: CasCaptureObserver;
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), "plan-glob-"));
+    root = join(base, "My (work) [v2]");
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src/notes.md"), SEEDED_CONTENT);
+    observer = new CasCaptureObserver({ rootDir: root, isIgnored: async () => true });
+  });
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  async function invokeOnce(script: ScriptSelector, threadId: string) {
+    const agent = await buildPlanModeParent(root, observer, script);
+    return (await agent.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: threadId }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+  }
+
+  it("in-root reads work, absolute and relative alike; out-of-root reads stay denied", async () => {
+    const result = await invokeOnce(
+      () => ({
+        toolCalls: [
+          { name: "read_file", args: { file_path: join(root, "src/notes.md") }, id: "c_abs" },
+          { name: "read_file", args: { file_path: "src/notes.md" }, id: "c_rel" },
+          { name: "read_file", args: { file_path: "/etc/hosts" }, id: "c_out" },
+        ],
+        done: "done",
+      }),
+      "t_glob_root",
+    );
+
+    expect(toolResultById(result.messages, "c_abs")).toContain("PLAN_MODE_README_TOKEN");
+    expect(toolResultById(result.messages, "c_rel")).toContain("PLAN_MODE_README_TOKEN");
+    expect(toolResultById(result.messages, "c_out")).toMatch(/permission denied for read/i);
   });
 });

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/prompt-builder.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/prompt-builder.test.ts
@@ -422,14 +422,19 @@ describe("buildEnhancedSystemPrompt", () => {
       injectedFiles: [],
     };
 
-    it("appends the shared plan-mode directive as the final section", () => {
+    it("appends the shared plan-mode directive plus the native-only read-boundary line as the final section", () => {
       const prompt = buildEnhancedSystemPrompt({
         ...base,
         interactionMode: InteractionMode.PLAN,
       });
 
       expect(prompt).toContain("## Plan mode");
-      expect(prompt.endsWith(PLAN_MODE_DIRECTIVE)).toBe(true);
+      expect(prompt).toContain(PLAN_MODE_DIRECTIVE);
+      // The read boundary (issue #528) is enforced only on the native
+      // harness, so its sentence rides OUTSIDE the shared directive — after
+      // it, still in the plan-mode section.
+      expect(prompt.endsWith("paths outside it are refused.")).toBe(true);
+      expect(PLAN_MODE_DIRECTIVE).not.toContain("File reads are limited");
     });
 
     it("omits the directive for Agent mode", () => {

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-plan-mode-permissions.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/subagent-plan-mode-permissions.test.ts
@@ -13,8 +13,8 @@
  * rules (act mode) the same write flows — this change is a plan-mode-only
  * delta.
  *
- * The rule under test is the PRODUCTION constant from
- * shared/plan-mode-permissions.ts (the same one setup.ts applies to both
+ * The rules under test are the PRODUCTION buildPlanModePermissions output
+ * from shared/plan-mode-permissions.ts (the same setup.ts applies to both
  * graph sites), not a test copy, so a change to the plan-mode permission set
  * re-proves sub-agent coverage automatically.
  */
@@ -25,7 +25,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HumanMessage, ToolMessage, type BaseMessage } from "@langchain/core/messages";
 
-import { PLAN_MODE_PERMISSIONS } from "../../../shared/plan-mode-permissions.js";
+import { buildPlanModePermissions } from "../../../shared/plan-mode-permissions.js";
 import { CasCaptureObserver } from "../cas-capture-observer.js";
 import { compileSubagents } from "../subagent-transformer.js";
 import { ScriptedModel, type ScriptSelector } from "../__test-utils__/scripted-model.js";
@@ -64,7 +64,7 @@ describe("plan-mode sub-agent filesystem permissions (issue #255)", () => {
         workspaceRootDir: root,
         casObserver: observer,
         modelFactory: async () => new ScriptedModel(script),
-        ...(planMode ? { permissions: PLAN_MODE_PERMISSIONS } : {}),
+        ...(planMode ? { permissions: buildPlanModePermissions(root) } : {}),
       },
     );
     expect(compiled).toHaveLength(1);
@@ -174,5 +174,36 @@ describe("plan-mode sub-agent filesystem permissions (issue #255)", () => {
     const readResult = toolResultById(result.messages, "c_read_rel");
     expect(readResult).toContain("PLAN_MODE_README_TOKEN");
     expect(readResult).not.toMatch(/path must be absolute/i);
+  });
+
+  it("scopes sub-agent reads to the workspace and fills the bare-ls default (issue #528)", async () => {
+    // The read boundary must hold on SUB-AGENT graphs too — they carry their
+    // own rules (issue #255) and their own normalization shim (#429), so a
+    // parent-only fix would leave sub-agents reading anywhere. One turn,
+    // three calls: out-of-root read denied, in-root read flows, bare ls
+    // (whose schema default is the OS root) lists the workspace.
+    const script: ScriptSelector = () => ({
+      toolCalls: [
+        { name: "read_file", args: { file_path: "/etc/hosts" }, id: "c_read_out" },
+        { name: "read_file", args: { file_path: join(root, "notes.md") }, id: "c_read_in" },
+        { name: "ls", args: {}, id: "c_ls_bare" },
+      ],
+      done: "worker done",
+    });
+
+    const worker = await compileWorker(script, true);
+    const result = (await worker.runnable.invoke(
+      { messages: [new HumanMessage({ content: "go" })] },
+      { configurable: { thread_id: "t4" }, recursionLimit: 50 },
+    )) as { messages: BaseMessage[] };
+
+    const outResult = toolResultById(result.messages, "c_read_out");
+    expect(outResult).toMatch(/permission denied for read/i);
+
+    expect(toolResultById(result.messages, "c_read_in")).toContain("PLAN_MODE_README_TOKEN");
+
+    const lsResult = toolResultById(result.messages, "c_ls_bare");
+    expect(lsResult).toContain("notes.md");
+    expect(lsResult).not.toMatch(/permission denied/i);
   });
 });

--- a/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/prompt-builder.ts
@@ -251,7 +251,17 @@ export function buildEnhancedSystemPrompt(input: PromptBuilderInput): string {
   // reads. (PLAN and build_from_plan are mutually exclusive in practice —
   // the build turn is always an Agent-mode execution.)
   if (input.interactionMode === InteractionMode.PLAN) {
-    prompt += "\n\n## Plan mode\n\n" + PLAN_MODE_DIRECTIVE;
+    // The read-boundary sentence is native-harness-only, appended OUTSIDE the
+    // shared directive: PLAN_MODE_DIRECTIVE also serves the Cursor harness,
+    // which has no tool-level read boundary — there the sentence would be
+    // false. Here it is enforced fact (shared/plan-mode-permissions.ts,
+    // issue #528), stated so the model doesn't burn rounds probing paths the
+    // rules will refuse.
+    prompt +=
+      "\n\n## Plan mode\n\n" +
+      PLAN_MODE_DIRECTIVE +
+      "\n- File reads are limited to your workspace (including its " +
+      "`.stigmer/` directory); paths outside it are refused.";
   }
 
   if (input.buildFromPlan) {

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -52,7 +52,7 @@ import { LocalWorkspaceBackend } from "../../shared/workspace/local-backend.js";
 import type { WorkspaceBackend, ProvisionResult } from "../../shared/workspace/types.js";
 import { createCasCaptureBackend } from "./cas-capture-backend.js";
 import { buildShellEnv } from "./shell-env.js";
-import { PLAN_MODE_PERMISSIONS } from "../../shared/plan-mode-permissions.js";
+import { buildPlanModePermissions } from "../../shared/plan-mode-permissions.js";
 import { CasCaptureObserver } from "./cas-capture-observer.js";
 import { isGitWorkTree, isPathCapturable } from "../../shared/filereview/git-substrate.js";
 import { deriveCaptureMode } from "../../shared/filereview/capture.js";
@@ -598,8 +598,12 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     // every sub-agent graph, AND the path-normalization middleware (issue #429)
     // all derive from this single value, so a rule-bearing graph can never miss
     // the shim that keeps prompt-compliant relative paths from dying in rule
-    // validation (`path must be absolute`).
-    const planModePermissions = isPlanMode ? PLAN_MODE_PERMISSIONS : undefined;
+    // validation (`path must be absolute`). Built from the same rootDir the
+    // backends and the shim resolve against, so the workspace read boundary
+    // (issue #528) and the paths it must admit agree by construction.
+    const planModePermissions = isPlanMode
+      ? buildPlanModePermissions(workspaceBackend.rootDir)
+      : undefined;
 
     const toolServerMap = new Map<string, string>();
     if (mcpConnection) {

--- a/backend/services/runner/src/middleware/__tests__/path-normalization.test.ts
+++ b/backend/services/runner/src/middleware/__tests__/path-normalization.test.ts
@@ -104,9 +104,35 @@ describe("createPathNormalizationMiddleware", () => {
     expect(args.file_path).toBe("/etc/hosts");
   });
 
-  it("leaves an omitted base path (backend default) alone", async () => {
-    const args = await argsSeenByHandler("ls", {});
-    expect(args.path).toBeUndefined();
+  it("supplies the workspace root when the base path is omitted on ls/glob/grep", async () => {
+    // Deliberate reversal of the original #429 pin ("leaves an omitted base
+    // path alone"): the tools' schema default is "/" — the OS ROOT under the
+    // legacy backend — applied inside the tool AFTER this seam, so under the
+    // #528 workspace read boundary an untouched omission would deny the bare
+    // first listing. The middleware fills the omission with the root it
+    // already knows.
+    for (const tool of ["ls", "glob", "grep"]) {
+      const args = await argsSeenByHandler(tool, { pattern: "TOKEN" });
+      expect(args.path).toBe(ROOT);
+      expect(args.pattern).toBe("TOKEN");
+    }
+  });
+
+  it("does not fill an omitted file_path on the file tools", async () => {
+    // An absent file_path is a genuine model error — the tool's own input
+    // validation gives the better message than any path this seam could invent.
+    const args = await argsSeenByHandler("read_file", {});
+    expect(args.file_path).toBeUndefined();
+  });
+
+  it("leaves an explicit '/' untouched on the dir tools — the rules answer it honestly", async () => {
+    // The model asked for the OS root; under plan mode's read boundary the
+    // honest answer is the rules' denial, not silently substituted workspace
+    // contents (the #429 never-convert-a-refusal-into-an-allowance doctrine).
+    for (const tool of ["ls", "glob", "grep"]) {
+      const args = await argsSeenByHandler(tool, { path: "/" });
+      expect(args.path).toBe("/");
+    }
   });
 
   it("never touches tools outside the built-in filesystem set", async () => {

--- a/backend/services/runner/src/middleware/path-normalization.ts
+++ b/backend/services/runner/src/middleware/path-normalization.ts
@@ -1,6 +1,6 @@
 /**
  * Workspace-relative path normalization for permission-rule-bearing graphs
- * (issue #429).
+ * (issues #429, #528).
  *
  * deepagents' permission enforcement canonicalizes tool-call paths BEFORE any
  * rule or backend runs, and its validation refuses non-absolute paths — on
@@ -20,13 +20,26 @@
  * resolves relative paths under the workspace root, so act mode keeps a
  * byte-zero delta.
  *
+ * It also supplies the workspace root when `ls`/`glob`/`grep` are called
+ * with NO path argument (issue #528). Those tools' schema default is "/" —
+ * the OS ROOT under the legacy backend — and the default is applied inside
+ * the tool, after this seam, so under the workspace read boundary a bare
+ * first `ls` would otherwise die with `permission denied for read on /`
+ * (the same first-turn degradation class #429 fixed). An EXPLICIT "/" is
+ * deliberately NOT rewritten: the model asked for the OS root, and the
+ * honest answer under plan mode's read boundary is the rules' denial —
+ * silently substituting workspace contents would be an answer to a
+ * different question.
+ *
  * Invariant — nothing becomes newly reachable: only paths whose resolution
  * stays INSIDE the workspace root are rewritten. Escaping relatives (`../x`)
  * and `~`-carrying paths are left raw so today's validation refusal keeps
  * speaking (a naive join would resolve `..` away and smuggle an out-of-root
  * read past validation), and absolute paths pass through byte-untouched.
  * The middleware converts false errors into correct behavior — never a
- * refusal into an allowance the rules didn't decide.
+ * refusal into an allowance the rules didn't decide. (The absent-path
+ * injection honors the same line: it narrows the tool's own OS-root default
+ * to the workspace, granting nothing the rules would refuse.)
  *
  * Tool matching is by bare built-in name, the house doctrine (an MCP server
  * is not expected to shadow a built-in name — see shared/tool-kind.ts); the
@@ -41,9 +54,8 @@ import type { StigmerMiddleware } from "./types.js";
 
 /**
  * The path-bearing argument of each deepagents built-in filesystem tool.
- * `ls`/`glob`/`grep` take a base directory `path` (defaulting to "/" when
- * omitted — absolute, so untouched here); the file tools take `file_path`.
- * Confirmed against the installed deepagents' tool definitions.
+ * `ls`/`glob`/`grep` take a base directory `path`; the file tools take
+ * `file_path`. Confirmed against the installed deepagents' tool definitions.
  */
 const PATH_ARG_BY_TOOL: ReadonlyMap<string, string> = new Map([
   ["ls", "path"],
@@ -53,6 +65,15 @@ const PATH_ARG_BY_TOOL: ReadonlyMap<string, string> = new Map([
   ["write_file", "file_path"],
   ["edit_file", "file_path"],
 ]);
+
+/**
+ * The tools whose path argument is optional with an OS-root ("/") schema
+ * default. When the model omits it, this middleware supplies the workspace
+ * root instead (issue #528). The file tools are deliberately excluded: an
+ * absent `file_path` is a genuine model error, and the tool's own input
+ * validation gives the better message.
+ */
+const DIR_DEFAULTING_TOOLS: ReadonlySet<string> = new Set(["ls", "glob", "grep"]);
 
 export interface PathNormalizationConfig {
   /** The workspace root the graph's filesystem backend resolves against. */
@@ -108,6 +129,22 @@ export function createPathNormalizationMiddleware(
       if (!argKey) return handler(request);
 
       const raw = request.toolCall.args[argKey];
+
+      // Absent base directory on ls/glob/grep: the middleware sees the
+      // model's raw args, BEFORE the tool's zod parse applies the "/"
+      // (OS root) schema default — so the omission must be filled here,
+      // where the workspace root is known. An explicit "/" is not this
+      // case and flows through to an honest rule denial (header doctrine).
+      if (raw == null && DIR_DEFAULTING_TOOLS.has(request.toolCall.name)) {
+        return handler({
+          ...request,
+          toolCall: {
+            ...request.toolCall,
+            args: { ...request.toolCall.args, [argKey]: rootDir },
+          },
+        });
+      }
+
       if (typeof raw !== "string") return handler(request);
 
       const normalized = normalizeWorkspacePathArg(raw, rootDir);

--- a/backend/services/runner/src/shared/__tests__/plan-mode-permissions.test.ts
+++ b/backend/services/runner/src/shared/__tests__/plan-mode-permissions.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit pins for the plan-mode rule builder (issue #528).
+ *
+ * The rule ORDER and SHAPE are the security boundary: deepagents evaluates
+ * first-match-wins with a permissive default, so the workspace read-allow
+ * must precede the read-deny, and the deny patterns must be the match-all
+ * "/**". These tests pin the built value; the boundary's end-to-end
+ * behavior (including matcher semantics for escaped roots and symlinked
+ * platform paths) is pinned against the real deepagents runtime in
+ * execute-deep-agent/__tests__/plan-mode-path-normalization.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildPlanModePermissions,
+  escapeGlobLiteral,
+} from "../plan-mode-permissions.js";
+
+describe("buildPlanModePermissions", () => {
+  it("builds the policy in enforcement order: workspace read-allow, then read-deny, then write-deny", () => {
+    expect(buildPlanModePermissions("/ws/session-1/repo")).toEqual([
+      { operations: ["read"], paths: ["/ws/session-1/repo/**"] },
+      { operations: ["read"], paths: ["/**"], mode: "deny" },
+      { operations: ["write"], paths: ["/**"], mode: "deny" },
+    ]);
+  });
+
+  it("canonicalizes the root before building the pattern", () => {
+    // Enforcement canonicalizes incoming paths (no trailing separator,
+    // collapsed slashes) before matching — a pattern built from a raw
+    // trailing-slash root would silently match nothing.
+    const [allow] = buildPlanModePermissions("/ws//session-1/repo/");
+    expect(allow.paths).toEqual(["/ws/session-1/repo/**"]);
+  });
+
+  it("glob-escapes the root so special characters match literally", () => {
+    const [allow] = buildPlanModePermissions("/Users/x/My (work) [v2]");
+    expect(allow.paths).toEqual(["/Users/x/My \\(work\\) \\[v2\\]/**"]);
+  });
+});
+
+describe("escapeGlobLiteral", () => {
+  it("escapes every micromatch metacharacter", () => {
+    expect(escapeGlobLiteral("a*b?c(d)e[f]g{h}i!j+k@l")).toBe(
+      "a\\*b\\?c\\(d\\)e\\[f\\]g\\{h\\}i\\!j\\+k\\@l",
+    );
+  });
+
+  it("escapes backslashes themselves", () => {
+    expect(escapeGlobLiteral("a\\b")).toBe("a\\\\b");
+  });
+
+  it("leaves plain path characters alone", () => {
+    expect(escapeGlobLiteral("/ws/session-1/repo.dir")).toBe(
+      "/ws/session-1/repo.dir",
+    );
+  });
+});

--- a/backend/services/runner/src/shared/plan-mode-permissions.ts
+++ b/backend/services/runner/src/shared/plan-mode-permissions.ts
@@ -2,12 +2,26 @@
  * The Plan-mode filesystem permission rules — the enforcement twin of
  * `plan-mode-prompt.ts` (which carries the instruction half of the contract).
  *
- * Plan mode is read-only BY CONSTRUCTION on the native harness: these rules
- * deny every filesystem write operation at the tool level so
- * write_file/edit_file cannot mutate the workspace regardless of what the
- * model was told. Rules are first-match-wins with a permissive default, so a
- * single deny-all-writes rule is sufficient. (The Cursor harness has no
- * tool-level lever and enforces plan mode via its prompt prefix instead.)
+ * Plan mode is contained BY CONSTRUCTION on the native harness: these rules
+ * deny every filesystem write everywhere AND scope reads to the session
+ * workspace (issue #528 — owner ruling: the workspace is plan mode's read
+ * boundary on cloud and desktop runners alike). Without the read boundary,
+ * model-provided absolute paths reached anywhere the process account could
+ * read — the pod filesystem (including /proc/self/environ) on cloud runners,
+ * the user's whole home directory on desktop — while plan mode still carries
+ * exfiltration-capable tools (web_fetch, MCP). Rules are first-match-wins
+ * with a permissive default (deepagents' decidePathAccess), so order is
+ * load-bearing: the workspace read-allow must precede the read-deny.
+ *
+ * The workspace-root pattern is matched as a STRING against the raw tool-call
+ * path (micromatch, dot:true), before the backend touches disk. That is
+ * exactly why the legitimate out-of-workspace reads keep working: skills,
+ * attachments, and the approved plan live in the platform dir but are
+ * addressed through the `{workspace}/.stigmer` symlink (see
+ * shared/workspace/stigmer-link.ts), so their path strings are in-root even
+ * though the bytes are not. The same holds for multi-workspace local entries
+ * (`{workspace}/{name}` symlinks). A realpath-based boundary would break
+ * both; do not "harden" this into one.
  *
  * Applied in execute-deep-agent/setup.ts to the parent graph AND threaded
  * into every compiled sub-agent graph: deepagents' parent-permission
@@ -18,9 +32,9 @@
  *
  * Rules travel with a companion: every graph that carries them also installs
  * the path-normalization middleware (middleware/path-normalization.ts,
- * issue #429), because deepagents' rule validation refuses workspace-relative
- * paths outright — without the shim, prompt-compliant relative READS die in
- * validation instead of just working. Both are derived from the same
+ * issues #429/#528), because deepagents' rule validation refuses
+ * workspace-relative paths outright and its `ls`/`glob`/`grep` schema default
+ * of "/" would deny the bare first listing. Both are derived from the same
  * expression at each composition site so they cannot drift apart.
  *
  * Invariant: never combine these rules with a shell-capable (sandbox)
@@ -30,8 +44,41 @@
  * for shell capability on both the parent and sub-agent backends.
  */
 
+import { resolve } from "node:path";
 import type { FilesystemPermission } from "deepagents";
 
-export const PLAN_MODE_PERMISSIONS: FilesystemPermission[] = [
-  { operations: ["write"], paths: ["/**"], mode: "deny" },
-];
+/**
+ * Backslash-escape every character micromatch/picomatch treats as glob
+ * syntax, so the result matches the input literally. micromatch exports no
+ * escape API of its own, and this is correctness, not caution: an unescaped
+ * `(` in a desktop project path would make the workspace read-allow rule
+ * silently never match — bricking every plan-mode read for that workspace.
+ * Semantics are pinned end-to-end through deepagents' own matcher by the
+ * special-character workspace suite in plan-mode-path-normalization.test.ts.
+ */
+export function escapeGlobLiteral(literal: string): string {
+  return literal.replace(/[\\*?()[\]{}!+@]/g, "\\$&");
+}
+
+/**
+ * Build the plan-mode rule set for a graph whose filesystem backend is
+ * rooted at `workspaceRootDir`. The three rules read as the policy:
+ * reads allowed in the workspace, reads denied everywhere else, writes
+ * denied everywhere.
+ *
+ * `{root}/**` matches the root itself as well as its subtree (verified
+ * against the installed micromatch), so one allow pattern suffices. The
+ * root is `path.resolve`d first because enforcement canonicalizes incoming
+ * paths (collapsed slashes, no trailing separator) before matching — a
+ * trailing slash in the pattern would silently match nothing.
+ */
+export function buildPlanModePermissions(
+  workspaceRootDir: string,
+): FilesystemPermission[] {
+  const canonicalRoot = resolve(workspaceRootDir);
+  return [
+    { operations: ["read"], paths: [`${escapeGlobLiteral(canonicalRoot)}/**`] },
+    { operations: ["read"], paths: ["/**"], mode: "deny" },
+    { operations: ["write"], paths: ["/**"], mode: "deny" },
+  ];
+}

--- a/docs/concepts/harnesses.mdx
+++ b/docs/concepts/harnesses.mdx
@@ -37,7 +37,8 @@ specifying a Harness, it uses native.
 - Shell command execution on local Workspaces through the `execute` tool.
   Commands run on the host machine attached to the runner, and every command
   goes through the same approval gate as other mutating tools. Plan mode
-  (read-only Sessions) does not expose shell execution.
+  (read-only Sessions) does not expose shell execution, and its file reads are
+  scoped to the Session's Workspace — the Agent cannot read paths outside it.
 - Built-in web retrieval through the `web_fetch` tool — every native Session can
   fetch a public URL and read it as Markdown, with no MCP server to configure.
   The tool is read-only and never prompts for approval; on managed cloud runners


### PR DESCRIPTION
## Summary

Makes the session workspace plan mode's READ boundary on the native harness (owner ruling on #528). Writes were already denied everywhere; reads via model-provided absolute paths previously reached anywhere the process account could read — the pod filesystem (including `/proc/self/environ`) on cloud runners, the user's whole home directory on desktop — while plan mode still carries exfiltration-capable tools (`web_fetch`, MCP).

## Context

Spawned from #429 (PR #527), whose fix deliberately preserved this boundary under its no-new-reachability invariant, pending a design ruling. The ruling: plan-mode reads are workspace-scoped on cloud and desktop alike, and the `ls`/`glob`/`grep` omitted-path case (schema default `/` — the OS root under the legacy backend) is filled with the workspace root so the model's first listing just works. An EXPLICIT `ls /` is deliberately NOT redirected — it gets the rules' honest denial (#429's never-convert-a-refusal-into-an-allowance doctrine).

Worse than the issue text: pre-fix, a bare `grep` in plan mode recursively scanned the ENTIRE OS filesystem (schema default `/` + legacy `resolvePath` pass-through). This closes that too.

## Changes

- `shared/plan-mode-permissions.ts`: the static write-deny const becomes `buildPlanModePermissions(rootDir)` — three rules reading as the policy: reads allowed in the workspace, reads denied elsewhere, writes denied everywhere. Includes `escapeGlobLiteral` (micromatch exports no escape API; an unescaped `(` in a desktop project path would silently brick every plan-mode read for that workspace).
- `middleware/path-normalization.ts`: fills the OMITTED base path on `ls`/`glob`/`grep` with the workspace root (the middleware sees pre-schema args, so the tool's OS-root default never reaches enforcement). Explicit paths — including `/` — pass through untouched.
- `execute-deep-agent/setup.ts`: the hoisted plan-mode permissions value is now built from the same `workspaceBackend.rootDir` the backends and shim resolve against, so the boundary and the paths it must admit agree by construction (parent + sub-agents, the #255/#429 pattern unchanged).
- `execute-deep-agent/prompt-builder.ts`: one native-only read-boundary sentence appended OUTSIDE the shared `PLAN_MODE_DIRECTIVE` (which also serves the Cursor harness, where no tool-level read boundary exists — the sentence would be false there).
- `docs/concepts/harnesses.mdx`: user-facing sentence stating the boundary.

## Implementation notes

- The boundary matches path STRINGS before any disk access. Legitimate out-of-workspace reads (skills, attachments, approved plan) keep working because they are addressed through the in-root `{workspace}/.stigmer` symlink; multi-workspace local entries work the same way. A realpath-based boundary would break both — verified that deepagents' `ls`/`glob`/`grep` never realpath their results (string-join only), so the post-filters cannot silently empty symlinked listings.
- Verified live against the installed micromatch: `/**` matches `/` (explicit `ls /` / `grep /` deny cleanly pre-scan — no whole-disk walk) and `{root}/**` matches `{root}` itself (one allow pattern suffices).
- `virtualMode` re-examined and rejected again (per #429): platform-wide path-display/CAS-keying/prompt blast radius for a plan-mode-only boundary, and it would break the symlink mechanisms above.
- `web_fetch` cannot read around the boundary: the URL guard rejects every non-http(s) scheme on both postures. MCP tools remain outside this boundary (user-configured servers can expose FS access) — out of scope here.
- Known trade-off: a model that resolves the `.stigmer` symlink and reads by real path is denied (prompts only advertise the in-root form; the deny names the path, recovery is one round).

## Breaking changes

- None for act mode (byte-zero delta — rules exist only on plan-mode graphs). Plan-mode sessions that relied on reading outside the workspace will now see `permission denied for read on <path>` — the intended behavior change.

## Test plan

- Red-first: with the pre-#528 rules restored, exactly the 4 new boundary pins fail (out-of-root reads succeed where they must not) while every allowance and #429 pin stays green.
- New end-to-end pins (real deepagents + LangGraph runtime, production middleware/backend/rules): out-of-root absolute read denied; workspace root itself listable; `.stigmer` symlink read flows; bare `ls`/`grep` (no path arg) hit the workspace; explicit `ls /` denied honestly; write-deny unchanged; sub-agent twin pins (#255 wiring); a glob-special workspace root (`My (work) [v2]`) pins `escapeGlobLiteral` through the real matcher end-to-end.
- Unit pins: rule order/shape, trailing-slash canonicalization, metacharacter escaping, absent-arg injection (and non-injection for file tools / explicit `/`).
- Full runner gate: typecheck clean; 4532 passed / 6 skipped; the only 2 failures (`discover-mcp-server.test.ts` heartbeat timeouts) reproduce on CLEAN stashed main in this environment — pre-existing, unrelated (MCP discovery activity; likely network-restricted sandbox).
- Docs gates: `lint-docs` 0 errors, `format-docs-check` clean, `check-docs-yaml` green.

## Risks

- Prompt-side: models occasionally passing explicit `path: "/"` (the tool description says "default: /") burn one denied round before recovering with the workspace root — deliberate, honest-deny by design.
- Rollback: revert this PR; the rules collapse back to write-deny-only.

Closes #528

Made with [Cursor](https://cursor.com)