### PR TITLE
fix(test/e2e): revive the interactive workflow suite — compliant task names, stdio drain, editor-canvas scoping

### DIFF
--- a/test/e2e/fixtures/seed-helpers.ts
+++ b/test/e2e/fixtures/seed-helpers.ts
@@ -121,9 +121,12 @@ export async function createTestWorkflow(
   const name = opts?.name ?? `e2e-wf-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const org = opts?.org ?? DEFAULT_ORG;
 
+  // Task names must match WorkflowTask.name's proto constraint
+  // (^[a-zA-Z_][a-zA-Z0-9_]*$) — snake_case, never hyphenated like the
+  // resource names above. The server rejects the whole apply otherwise.
   const tasks = opts?.tasks ?? [
-    { name: "step-one", variables: { greeting: "hello-from-e2e" } },
-    { name: "step-two", variables: { farewell: "goodbye-from-e2e" } },
+    { name: "step_one", variables: { greeting: "hello-from-e2e" } },
+    { name: "step_two", variables: { farewell: "goodbye-from-e2e" } },
   ];
 
   const workflow = await client.workflow.apply({
@@ -187,14 +190,16 @@ export async function createTestWaitWorkflow(
       name,
       version: "1.0.0",
     },
+    // Task names: snake_case per WorkflowTask.name's proto constraint
+    // (see createTestWorkflow above).
     tasks: [
       {
-        name: "blocking-wait",
+        name: "blocking_wait",
         kind: WorkflowTaskKind.wait,
         taskConfig: { duration: { seconds: waitSeconds } },
       },
       {
-        name: "final-step",
+        name: "final_step",
         kind: WorkflowTaskKind.set_vars,
         taskConfig: { variables: { completed: "true" } },
         export: { as: "${ . }" },

--- a/test/e2e/fixtures/server-manager.ts
+++ b/test/e2e/fixtures/server-manager.ts
@@ -86,6 +86,21 @@ async function waitForPort(
   );
 }
 
+/**
+ * Keeps a child's piped stdout/stderr flowing when nothing consumes them.
+ *
+ * A `stdio: "pipe"` stream with no reader backpressures once the OS pipe
+ * buffer (~64KB) fills, and the child then blocks mid-write — the Go
+ * server wedged exactly this way partway into every suite run, hanging
+ * all subsequent RPCs (#501; it logs every request, far outpacing the
+ * buffer). `resume()` switches the streams to flowing mode and discards
+ * the data; diag mode's file tees also drain, so this stays a no-op there.
+ */
+function drainStdio(proc: ChildProcess): void {
+  proc.stdout?.resume();
+  proc.stderr?.resume();
+}
+
 function waitForOutput(
   proc: ChildProcess,
   pattern: RegExp,
@@ -192,6 +207,7 @@ export async function startBackendStack(opts: {
   if (!temporal.pid) {
     throw new Error("Failed to spawn Temporal dev server. Is `temporal` CLI on PATH?");
   }
+  drainStdio(temporal);
 
   await waitForPort(temporalPort, "127.0.0.1", 15_000, 250);
   console.log(`[e2e] Temporal ready (pid: ${temporal.pid})`);
@@ -231,6 +247,7 @@ export async function startBackendStack(opts: {
     temporal.kill();
     throw new Error(`Failed to spawn stigmer-server at ${serverBin}. Build with: make build`);
   }
+  drainStdio(server);
 
   await waitForPort(apiPort, "127.0.0.1", 30_000, 500);
   console.log(`[e2e] stigmer-server ready (pid: ${server.pid})`);

--- a/test/e2e/helpers/workflow-canvas.ts
+++ b/test/e2e/helpers/workflow-canvas.ts
@@ -1,6 +1,21 @@
 import type { Page, Locator } from "@playwright/test";
 
 /**
+ * Returns a locator for the visual editor's React Flow canvas.
+ *
+ * The workflow detail page mounts TWO React Flow canvases — a read-only
+ * one in the Overview tabpanel and the editable one in the Editor
+ * tabpanel — so a bare `.react-flow` locator is a strict-mode violation.
+ * All canvas helpers must resolve inside this scope, otherwise they can
+ * silently match the Overview canvas.
+ */
+export function getEditorCanvas(page: Page): Locator {
+  return page
+    .getByRole("tabpanel", { name: "Editor" })
+    .locator(".react-flow");
+}
+
+/**
  * Navigates to a workflow's visual editor canvas.
  *
  * 1. Goes to the workflow detail page
@@ -26,7 +41,7 @@ export async function navigateToVisualEditor(
     await visualTab.click();
   }
 
-  await page.locator(".react-flow").waitFor({ timeout: 15_000 });
+  await getEditorCanvas(page).waitFor({ timeout: 15_000 });
 }
 
 /**
@@ -36,14 +51,14 @@ export async function navigateToVisualEditor(
  * `"{DisplayName} node {taskName}, {shape} shape"`.
  */
 export function getCanvasNode(page: Page, taskName: string): Locator {
-  return page.locator(`[aria-label*="node ${taskName}"]`);
+  return getEditorCanvas(page).locator(`[aria-label*="node ${taskName}"]`);
 }
 
 /**
  * Returns a locator for a canvas node by its `data-task-kind` attribute.
  */
 export function getCanvasNodeByKind(page: Page, kindString: string): Locator {
-  return page.locator(`[data-task-kind="${kindString}"]`);
+  return getEditorCanvas(page).locator(`[data-task-kind="${kindString}"]`);
 }
 
 /**

--- a/test/e2e/tests/functional/version-history.spec.ts
+++ b/test/e2e/tests/functional/version-history.spec.ts
@@ -31,7 +31,7 @@ test.describe("Version history timeline", () => {
       ...baseInput,
       tasks: [
         {
-          name: "step-one",
+          name: "step_one",
           kind: WorkflowTaskKind.set_vars,
           taskConfig: { variables: { greeting: "v1" } },
           export: { as: "${ . }" },
@@ -46,7 +46,7 @@ test.describe("Version history timeline", () => {
         ...baseInput,
         tasks: [
           {
-            name: "step-one",
+            name: "step_one",
             kind: WorkflowTaskKind.set_vars,
             taskConfig: { variables: { greeting: "v2-changed" } },
             export: { as: "${ . }" },
@@ -89,7 +89,7 @@ test.describe("Version history timeline", () => {
       document: { dsl: "1.0.0", namespace: org, name, version: "1.0.0" },
       tasks: [
         {
-          name: "only-step",
+          name: "only_step",
           kind: WorkflowTaskKind.set_vars,
           taskConfig: { variables: { value: "constant" } },
           export: { as: "${ . }" },

--- a/test/e2e/tests/interactive/workflow-execution-flow.spec.ts
+++ b/test/e2e/tests/interactive/workflow-execution-flow.spec.ts
@@ -70,8 +70,8 @@ test.describe("Workflow execution flow", () => {
 
       await waitForPhaseBadge(page, "Completed", { timeout: 30_000 });
 
-      await expect(page.getByText("step-one")).toBeVisible();
-      await expect(page.getByText("step-two")).toBeVisible();
+      await expect(page.getByText("step_one")).toBeVisible();
+      await expect(page.getByText("step_two")).toBeVisible();
     } finally {
       await execution.cleanup();
     }

--- a/test/e2e/tests/interactive/workflow-node-shapes.spec.ts
+++ b/test/e2e/tests/interactive/workflow-node-shapes.spec.ts
@@ -4,6 +4,7 @@ import {
   navigateToVisualEditor,
   getCanvasNode,
   getCanvasNodeByKind,
+  getEditorCanvas,
   getNodeVisualClass,
 } from "../../helpers/workflow-canvas";
 
@@ -19,7 +20,9 @@ test.describe("Workflow node visual classes (T01)", () => {
     );
     await assertNoErrorBoundary(page);
 
-    const nodesWithVisualClass = page.locator("[data-visual-class]");
+    // Scoped: the Overview tabpanel mounts a second canvas whose nodes
+    // would inflate a page-wide count.
+    const nodesWithVisualClass = getEditorCanvas(page).locator("[data-visual-class]");
     await expect(nodesWithVisualClass.first()).toBeVisible({ timeout: 10_000 });
 
     const count = await nodesWithVisualClass.count();
@@ -106,7 +109,7 @@ test.describe("Workflow node visual classes (T01)", () => {
       testMultiKindWorkflow.slug,
     );
 
-    const startNode = page.locator(
+    const startNode = getEditorCanvas(page).locator(
       '[data-task-kind="workflow_task_kind_unspecified"][data-visual-class="terminal-pill"]',
     );
     await expect(startNode.first()).toBeVisible({ timeout: 10_000 });

--- a/test/e2e/tests/interactive/workflow-run-flow.spec.ts
+++ b/test/e2e/tests/interactive/workflow-run-flow.spec.ts
@@ -70,7 +70,7 @@ test.describe("Workflow execution via Run button", () => {
     await expect(timeline).toBeVisible();
     await verifyTimelineHasEvents(page, 1);
 
-    await expect(page.getByText("step-one")).toBeVisible();
+    await expect(page.getByText("step_one")).toBeVisible();
   });
 
   test("pause a running execution then resume to completion", async ({

--- a/test/e2e/tests/interactive/workflow-task-insertion.spec.ts
+++ b/test/e2e/tests/interactive/workflow-task-insertion.spec.ts
@@ -3,6 +3,7 @@ import { assertNoErrorBoundary } from "../../helpers/navigation";
 import {
   navigateToVisualEditor,
   getCanvasNode,
+  getEditorCanvas,
 } from "../../helpers/workflow-canvas";
 
 test.describe("Workflow task insertion (T08)", () => {
@@ -23,8 +24,9 @@ test.describe("Workflow task insertion (T08)", () => {
     );
     await expect(edgePlusButton.first()).toBeAttached({ timeout: 10_000 });
 
-    // Hover to reveal the plus button
-    const firstEdge = page.locator(".react-flow__edge").first();
+    // Hover to reveal the plus button (scoped: the Overview tabpanel
+    // mounts a second canvas whose edges must not be matched)
+    const firstEdge = getEditorCanvas(page).locator(".react-flow__edge").first();
     await firstEdge.hover();
 
     // Click the plus button
@@ -205,17 +207,19 @@ test.describe("Workflow task insertion (T08)", () => {
     );
     await assertNoErrorBoundary(page);
 
-    // Count edges before insertion
-    const edgesBefore = await page.locator(".react-flow__edge").count();
+    // Count edges before insertion (scoped: the Overview tabpanel mounts
+    // a second canvas whose edges would inflate a page-wide count)
+    const canvas = getEditorCanvas(page);
+    const edgesBefore = await canvas.locator(".react-flow__edge").count();
 
     // Find the last task node (connected to __end__)
-    const endNode = page.locator('[data-id="__end__"]');
+    const endNode = canvas.locator('[data-id="__end__"]');
     await expect(endNode).toBeAttached({ timeout: 10_000 });
 
     // Find a node connected to end by selecting it and using toolbar add
     // After inserting, the new node should be between the source and __end__
     // Verify edge count increased (splice creates 2 new edges, removes 1)
-    const nodeBeforeEnd = page
+    const nodeBeforeEnd = canvas
       .locator("[data-task-kind]")
       .last();
     await nodeBeforeEnd.click();
@@ -235,7 +239,7 @@ test.describe("Workflow task insertion (T08)", () => {
         await firstOption.click();
 
         // Verify new node was created
-        const edgesAfter = await page.locator(".react-flow__edge").count();
+        const edgesAfter = await canvas.locator(".react-flow__edge").count();
         expect(edgesAfter).toBeGreaterThanOrEqual(edgesBefore);
       }
     }


### PR DESCRIPTION
## Summary

Revives the interactive e2e suite, runtime-dead since 2026-05-17. The live run surfaced two additional suite-killers beyond the one #501 reported; all three fixes are test-infra-only:

1. **Task-name pattern (the reported bug)** — seed helpers created tasks named `step-one`/`step-two`/`blocking-wait`/`final-step` (and `version-history.spec.ts` seeded `step-one`/`only-step` inline), which the server rejects since `10f12f891` added the `^[a-zA-Z_][a-zA-Z0-9_]*$` constraint to `WorkflowTask.name`. Renamed to snake_case in the helpers and every referencing assertion, with a guard comment pointing at the proto constraint.

2. **Stdio backpressure deadlock (discovered)** — `server-manager.ts` spawns Temporal and stigmer-server with piped stdout/stderr that nothing ever reads. After ~64KB of log output (the server writes ~727KB per suite run), the OS pipe fills and the Go server blocks mid-log-write, hanging every subsequent RPC — with the names fixed, 74+ tests still timed out in fixture setup because of this. `drainStdio()` (stream `resume()`) keeps both children flowing; diag-mode file tees already drain and are unaffected.

3. **Dual-canvas strict-mode violations (discovered)** — the workflow detail page now mounts two React Flow canvases (Overview + Editor tabpanels), so bare `.react-flow` locators throw strict-mode violations and page-wide node/edge counts silently include the wrong canvas. New `getEditorCanvas()` scopes all canvas helpers and the direct locators in `workflow-node-shapes` / `workflow-task-insertion`.

## Verification

- `npm run typecheck -w @stigmer/e2e` green.
- Full `--project=interactive workflow-*` run at **default parallelism through the suite's own global-setup** (fresh stack: Temporal + stigmer-server + unified runner, Node 22.22.1): **zero fixture-setup timeouts** (previously 74+), 33 passed / 6 skipped / 52 failed in 2.2 min.
- The never-executed `workflow-execution-comparison.spec.ts` passes **5/5**.
- `version-history` functional spec passes **3/3**.

## Remaining failures are tracked, not hidden

The 52 remaining failures are spec drift against UI redesigns that happened while the suite was dead — the execution page moved to Thread/Graph tabs (specs assert the old always-visible graph, "Execution timeline" list, inspector, waterfall) and editor affordances changed ("Insert task here" / "Add task after"). Each needs a product-intent decision, tracked in a follow-up issue rather than rushed here.

Closes #501

Made with [Cursor](https://cursor.com)