### PR TITLE
fix(build): add PR #560's mcpserver controller files to BUILD.bazel srcs

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/BUILD.bazel
@@ -9,11 +9,13 @@ go_library(
         "create.go",
         "delete.go",
         "disconnect_oauth.go",
+        "enrich_oauth_status.go",
         "get.go",
         "get_by_reference.go",
         "get_oauth_grant_status.go",
         "initiate_oauth_connect.go",
         "mcpserver_controller.go",
+        "oauth_app_resolution.go",
         "update.go",
         "update_visibility.go",
     ],
@@ -54,6 +56,7 @@ go_test(
     name = "controller_test",
     srcs = [
         "connect_test.go",
+        "enrich_oauth_status_test.go",
         "initiate_vendor_refusal_test.go",
         "mcpserver_controller_test.go",
         "oauth_connect_secrets_test.go",
@@ -74,5 +77,6 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
     ],
 )


### PR DESCRIPTION
## Summary

- [#560](https://github.com/stigmer/stigmer/pull/560) added `enrich_oauth_status.go`, `oauth_app_resolution.go`, and `enrich_oauth_status_test.go` but did not register them in the package's `BUILD.bazel`, so **every bazel build of the mcpserver controller on main currently fails** (`undefined: newEnrichOAuthStatusStep` from `get.go` / `get_by_reference.go` / `initiate_oauth_connect.go`).
- This is the gazelle-generated repair — srcs/test-srcs registration plus the `protobuf//proto` test dep. No code changes.

Found by the oss#556 session's gazelle run; shipped stand-alone so the fix isn't coupled to unrelated work.

## Test plan

- [x] Reproduced the failure on clean `main` (`bazel build //backend/services/stigmer-server/pkg/domain/mcpserver/controller:controller` fails)
- [x] With this change: build succeeds and `:controller_test` passes

Made with [Cursor](https://cursor.com)