### PR TITLE
fix(apiresource): GetKindEnum resolves kinds via canonical kind_meta.name lookup — OAuthApp was unresolvable

### DIFF
--- a/backend/libs/go/apiresource/BUILD.bazel
+++ b/backend/libs/go/apiresource/BUILD.bazel
@@ -21,5 +21,6 @@ go_test(
         "//apis/stubs/go/ai/stigmer/agentic/agent/v1:agent",
         "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/backend/libs/go/apiresource/metadata.go
+++ b/backend/libs/go/apiresource/metadata.go
@@ -2,6 +2,8 @@ package apiresource
 
 import (
 	"fmt"
+	"strings"
+	"sync"
 
 	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
@@ -11,6 +13,14 @@ import (
 
 // GetKindEnum returns the ApiResourceKind enum value for a given proto message.
 // It extracts the kind from the message's "kind" field and maps it to the enum.
+//
+// Resolution goes through the kind_meta.name each enum value declares in the
+// proto — the only source that knows a kind's true word boundaries — rather
+// than re-deriving the enum name from PascalCase, which cannot recover
+// "oauth_app" from "OAuthApp" (stigmer/stigmer#545). Matching is canonical
+// (case-insensitive, underscores ignored); this mirrors Cloud's
+// ApiResourceKindExtractor.extract so both editions resolve the same kind
+// strings from the same proto metadata.
 //
 // Example:
 //
@@ -33,15 +43,50 @@ func GetKindEnum(msg proto.Message) (apiresourcekind.ApiResourceKind, error) {
 		return apiresourcekind.ApiResourceKind_api_resource_kind_unknown, fmt.Errorf("kind field is empty")
 	}
 
-	// Map the kind string to enum value
-	// The enum value names are snake_case versions of the kind names
-	// e.g., "Agent" -> "agent", "AgentInstance" -> "agent_instance"
-	enumValue, ok := apiresourcekind.ApiResourceKind_value[toSnakeCase(kindValue)]
+	kind, ok := kindsByCanonicalName()[canonicalKindName(kindValue)]
 	if !ok {
 		return apiresourcekind.ApiResourceKind_api_resource_kind_unknown, fmt.Errorf("unknown kind: %s", kindValue)
 	}
 
-	return apiresourcekind.ApiResourceKind(enumValue), nil
+	return kind, nil
+}
+
+// canonicalKindName normalizes a kind name so different spellings compare
+// equal: "OAuthApp", "oauth_app" and "OAUTHAPP" all canonicalize to
+// "oauthapp". Twin of the canonical() helper in Cloud's
+// ApiResourceKindExtractor — the two must stay in sync so both editions
+// accept and reject the same spellings.
+func canonicalKindName(s string) string {
+	return strings.ReplaceAll(strings.ToLower(s), "_", "")
+}
+
+var (
+	kindsByCanonicalNameOnce sync.Once
+	kindsByCanonicalNameMap  map[string]apiresourcekind.ApiResourceKind
+)
+
+// kindsByCanonicalName lazily builds the canonical kind_meta.name → enum
+// lookup by walking the ApiResourceKind enum values through proto reflection.
+// Values without kind_meta (only the unknown zero value) are skipped. The
+// proto is the single source of truth, so a newly added kind is resolvable
+// with no code change here; TestGetKindEnumResolvesEveryDeclaredKind pins
+// that property.
+func kindsByCanonicalName() map[string]apiresourcekind.ApiResourceKind {
+	kindsByCanonicalNameOnce.Do(func() {
+		values := apiresourcekind.ApiResourceKind(0).Descriptor().Values()
+		m := make(map[string]apiresourcekind.ApiResourceKind, values.Len())
+		for i := 0; i < values.Len(); i++ {
+			valueDesc := values.Get(i)
+			opts := valueDesc.Options()
+			if opts == nil || !proto.HasExtension(opts, apiresourcekind.E_KindMeta) {
+				continue
+			}
+			meta := proto.GetExtension(opts, apiresourcekind.E_KindMeta).(*apiresourcekind.ApiResourceKindMeta)
+			m[canonicalKindName(meta.GetName())] = apiresourcekind.ApiResourceKind(valueDesc.Number())
+		}
+		kindsByCanonicalNameMap = m
+	})
+	return kindsByCanonicalNameMap
 }
 
 // GetKindMeta returns the ApiResourceKindMeta for a given ApiResourceKind enum value.
@@ -196,32 +241,4 @@ func SupportedVisibilityLevels(kind apiresourcekind.ApiResourceKind) (string, er
 		levels += ", " + apiresourcepb.ApiResourceVisibility_visibility_platform.String()
 	}
 	return levels, nil
-}
-
-// toSnakeCase converts a PascalCase string to snake_case.
-// This is used to map kind names (e.g., "Agent", "AgentInstance") to enum value names.
-//
-// Examples:
-//   - "Agent" -> "agent"
-//   - "AgentInstance" -> "agent_instance"
-//   - "WorkflowExecution" -> "workflow_execution"
-func toSnakeCase(s string) string {
-	if s == "" {
-		return s
-	}
-
-	var result []rune
-	for i, r := range s {
-		// If uppercase and not the first character, add underscore before it
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			result = append(result, '_')
-		}
-		// Convert to lowercase
-		if r >= 'A' && r <= 'Z' {
-			result = append(result, r+32) // Convert to lowercase
-		} else {
-			result = append(result, r)
-		}
-	}
-	return string(result)
 }

--- a/backend/libs/go/apiresource/metadata_test.go
+++ b/backend/libs/go/apiresource/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
 	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestGetKindEnum(t *testing.T) {
@@ -21,6 +22,28 @@ func TestGetKindEnum(t *testing.T) {
 				Kind: "Agent",
 			},
 			expected: apiresourcekind.ApiResourceKind_agent,
+			wantErr:  false,
+		},
+		{
+			// The oss#545 repro: OAuthApp is the only kind whose PascalCase
+			// name has consecutive capitals — no character-class split can
+			// recover "oauth_app" because "OAuth" being one word is recorded
+			// only in the proto's kind_meta.
+			name: "kind with consecutive capitals (OAuthApp)",
+			msg: &agentv1.Agent{
+				Kind: "OAuthApp",
+			},
+			expected: apiresourcekind.ApiResourceKind_oauth_app,
+			wantErr:  false,
+		},
+		{
+			// Cloud's ApiResourceKindExtractor.extract accepts snake_case
+			// spellings; both editions must resolve the same inputs.
+			name: "snake_case spelling resolves (cloud parity)",
+			msg: &agentv1.Agent{
+				Kind: "oauth_app",
+			},
+			expected: apiresourcekind.ApiResourceKind_oauth_app,
 			wantErr:  false,
 		},
 		{
@@ -259,26 +282,61 @@ func TestSupportedVisibilityLevels(t *testing.T) {
 	}
 }
 
-func TestToSnakeCase(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"Agent", "agent"},
-		{"AgentInstance", "agent_instance"},
-		{"WorkflowExecution", "workflow_execution"},
-		{"IAMPolicy", "i_a_m_policy"},
-		{"", ""},
-		{"a", "a"},
-		{"AB", "a_b"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := toSnakeCase(tt.input)
-			if got != tt.expected {
-				t.Errorf("toSnakeCase(%q) = %q, want %q", tt.input, got, tt.expected)
+// TestGetKindEnumResolvesEveryDeclaredKind pins the structural guarantee that
+// motivated the kind_meta lookup (stigmer/stigmer#545): every kind the proto
+// declares resolves through GetKindEnum, by construction. A future kind with
+// unusual capitalization cannot regress silently — this test picks it up from
+// the proto with no code change.
+func TestGetKindEnumResolvesEveryDeclaredKind(t *testing.T) {
+	values := apiresourcekind.ApiResourceKind(0).Descriptor().Values()
+	checked := 0
+	for i := 0; i < values.Len(); i++ {
+		valueDesc := values.Get(i)
+		opts := valueDesc.Options()
+		if opts == nil || !proto.HasExtension(opts, apiresourcekind.E_KindMeta) {
+			// Only the unknown zero value carries no kind_meta.
+			if valueDesc.Number() != 0 {
+				t.Errorf("enum value %s (%d) has no kind_meta — every real kind must declare one", valueDesc.Name(), valueDesc.Number())
 			}
-		})
+			continue
+		}
+		meta := proto.GetExtension(opts, apiresourcekind.E_KindMeta).(*apiresourcekind.ApiResourceKindMeta)
+		want := apiresourcekind.ApiResourceKind(valueDesc.Number())
+
+		got, err := GetKindEnum(&agentv1.Agent{Kind: meta.GetName()})
+		if err != nil {
+			t.Errorf("GetKindEnum(kind=%q) failed for declared kind %s: %v", meta.GetName(), valueDesc.Name(), err)
+			continue
+		}
+		if got != want {
+			t.Errorf("GetKindEnum(kind=%q) = %v, want %v", meta.GetName(), got, want)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no enum values carried kind_meta — the reflection walk is broken")
+	}
+}
+
+// TestKindMetaNamesAreCanonicallyUnique pins the lookup's correctness
+// precondition: no two kinds may share a canonical name. This guards the
+// cross-edition contract, not just this package — Cloud's
+// ApiResourceKindExtractor compares with the same canonicalization, so a
+// collision would make kind resolution ambiguous on both editions.
+func TestKindMetaNamesAreCanonicallyUnique(t *testing.T) {
+	values := apiresourcekind.ApiResourceKind(0).Descriptor().Values()
+	seen := make(map[string]string)
+	for i := 0; i < values.Len(); i++ {
+		valueDesc := values.Get(i)
+		opts := valueDesc.Options()
+		if opts == nil || !proto.HasExtension(opts, apiresourcekind.E_KindMeta) {
+			continue
+		}
+		meta := proto.GetExtension(opts, apiresourcekind.E_KindMeta).(*apiresourcekind.ApiResourceKindMeta)
+		key := canonicalKindName(meta.GetName())
+		if prior, dup := seen[key]; dup {
+			t.Errorf("kinds %q and %q canonicalize to the same name %q — kind resolution is ambiguous in both editions", prior, meta.GetName(), key)
+		}
+		seen[key] = meta.GetName()
 	}
 }


### PR DESCRIPTION
## Summary

`GetKindEnum` mapped a message's `kind` field to the `ApiResourceKind` enum by re-deriving the enum value name with a local `toSnakeCase` that inserts an underscore before *every* capital. For `OAuthApp` — the only kind whose PascalCase name has consecutive capitals — that yields `o_auth_app`, which does not exist in the enum, so the function returned `unknown kind: OAuthApp`. Same defect class as #470 (CLI alias derivation), different site.

## What changed

- **Resolution now goes through the proto's own declaration.** A lazily-built (`sync.Once`) map keyed by canonical `kind_meta.name` — built by walking the `ApiResourceKind` enum values through proto reflection — replaces the PascalCase re-derivation. The proto is the single source of truth: a newly added kind resolves with no code change here.
- **Canonical matching (case-insensitive, underscores ignored) mirrors Cloud.** Cloud's `ApiResourceKindExtractor.extract` resolves with exactly this tolerance; both editions now accept and reject the same spellings by construction. Matching is also a strict superset of the old code's acceptance (which incidentally accepted already-snake_case input), so nothing that resolved before stops resolving.
- **`toSnakeCase` is deleted**, along with `TestToSnakeCase`, which pinned the defect as expected behavior (`{"IAMPolicy", "i_a_m_policy"}` was an asserted-pass case).

## Tests

- Red-first repro: `Kind: "OAuthApp"` case added to `TestGetKindEnum` — verified failing (`unknown kind: OAuthApp`) on unmodified code — plus a snake_case cloud-parity case.
- `TestGetKindEnumResolvesEveryDeclaredKind`: every enum value carrying `kind_meta` resolves back to itself — a future kind with unusual capitalization cannot regress silently.
- `TestKindMetaNamesAreCanonicallyUnique`: no two kinds share a canonical name — guards the cross-edition contract (a collision would make Cloud's extractor ambiguous too).

## Verification

- `go test -race ./apiresource/...` — all green (repro case proven red before the fix)
- `bazel test //backend/libs/go/apiresource:apiresource_test` — PASSED
- `go mod tidy` (no-op), `go vet`, `gofmt -s` — clean

## Impact

Latent — `GetKindEnum` has zero production callers today and `oauth_app` is a cloud_only kind. This fixes the exported library contract before its first real caller inherits the confusing error, and removes a cross-edition resolution divergence.

Closes #545

Made with [Cursor](https://cursor.com)