### PR TITLE
fix(runner): parse ZIP central directory instead of scanning payloads for data-descriptor signatures

### DIFF
--- a/backend/services/runner/src/__test-utils__/zip-fixtures.ts
+++ b/backend/services/runner/src/__test-utils__/zip-fixtures.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared ZIP fixture builder for runner unit tests.
+ *
+ * Emits complete, real-shaped archives — local file headers (optionally
+ * streaming-style, the Go stdlib writer's default), payloads, central
+ * directory, and EOCD — because that is the only shape that can reach the
+ * runner: both editions' skill push gates validate artifacts with
+ * central-directory-based readers (see zip-extract.ts's module doc and
+ * design record 017). Earlier fixtures emitted local headers only, a
+ * shape no real ZIP writer produces, and were coupled to the old parser's
+ * front-to-back walk.
+ *
+ * Mirrors the conformance suite's `zipFilesStreaming()`
+ * (test/conformance/src/support/skills.ts) so unit fixtures and
+ * cross-edition fixtures share one shape.
+ *
+ * Lives in src/__test-utils__/ so `tsc --noEmit` covers it while
+ * tsconfig.build.json keeps it out of dist/.
+ */
+
+import { deflateRawSync } from "node:zlib";
+
+export interface ZipFixtureFile {
+  name: string;
+  content: string;
+  /** Compression method for the entry. Defaults to stored. */
+  method?: "stored" | "deflated";
+  /**
+   * Emit the entry the way Go's archive/zip does by default: general-purpose
+   * flag bit 3 set, zeroed sizes in the local header, and a trailing data
+   * descriptor (with the conventional signature) carrying the real values.
+   */
+  streaming?: boolean;
+}
+
+export interface ZipFixtureOptions {
+  /** Trailing archive comment appended after the EOCD record. */
+  comment?: string;
+  /**
+   * Drop the central directory and EOCD, leaving only local headers and
+   * payloads. No real ZIP writer produces this shape — it models a download
+   * truncated before the archive's index.
+   */
+  omitCentralDirectory?: boolean;
+}
+
+/** Build a ZIP archive from path + content pairs. */
+export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): Uint8Array {
+  const bytes: number[] = [];
+  const u16 = (v: number) => bytes.push(v & 0xff, (v >>> 8) & 0xff);
+  const u32 = (v: number) =>
+    bytes.push(v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff);
+  const raw = (b: Uint8Array) => bytes.push(...b);
+
+  interface WrittenEntry {
+    nameBytes: Uint8Array;
+    payload: Uint8Array;
+    uncompressedLength: number;
+    crc: number;
+    flags: number;
+    method: number;
+    localHeaderOffset: number;
+  }
+  const written: WrittenEntry[] = [];
+
+  for (const file of files) {
+    const contentBytes = new TextEncoder().encode(file.content);
+    const deflated = file.method === "deflated";
+    const payload = deflated ? new Uint8Array(deflateRawSync(contentBytes)) : contentBytes;
+    const entry: WrittenEntry = {
+      nameBytes: new TextEncoder().encode(file.name),
+      payload,
+      uncompressedLength: contentBytes.length,
+      crc: crc32(contentBytes),
+      flags: file.streaming ? 0x0008 : 0,
+      method: deflated ? 8 : 0,
+      localHeaderOffset: bytes.length,
+    };
+    written.push(entry);
+
+    u32(0x04034b50); // local file header signature
+    u16(20); // version needed to extract
+    u16(entry.flags);
+    u16(entry.method);
+    u16(0); // mod time
+    u16(0); // mod date
+    u32(file.streaming ? 0 : entry.crc);
+    u32(file.streaming ? 0 : payload.length);
+    u32(file.streaming ? 0 : entry.uncompressedLength);
+    u16(entry.nameBytes.length);
+    u16(0); // extra field length
+    raw(entry.nameBytes);
+    raw(payload);
+
+    if (file.streaming) {
+      u32(0x08074b50); // data descriptor signature (Go writes it)
+      u32(entry.crc);
+      u32(payload.length);
+      u32(entry.uncompressedLength);
+    }
+  }
+
+  if (options?.omitCentralDirectory) {
+    return new Uint8Array(bytes);
+  }
+
+  const centralDirectoryOffset = bytes.length;
+  for (const entry of written) {
+    u32(0x02014b50); // central directory record signature
+    u16(20); // version made by
+    u16(20); // version needed to extract
+    u16(entry.flags);
+    u16(entry.method);
+    u16(0); // mod time
+    u16(0); // mod date
+    u32(entry.crc);
+    u32(entry.payload.length);
+    u32(entry.uncompressedLength);
+    u16(entry.nameBytes.length);
+    u16(0); // extra field length
+    u16(0); // comment length
+    u16(0); // disk number start
+    u16(0); // internal attributes
+    u32(0); // external attributes
+    u32(entry.localHeaderOffset);
+    raw(entry.nameBytes);
+  }
+  const centralDirectorySize = bytes.length - centralDirectoryOffset;
+
+  const commentBytes = new TextEncoder().encode(options?.comment ?? "");
+  u32(0x06054b50); // EOCD signature
+  u16(0); // disk number
+  u16(0); // disk with central directory
+  u16(written.length); // entries on this disk
+  u16(written.length); // total entries
+  u32(centralDirectorySize);
+  u32(centralDirectoryOffset);
+  u16(commentBytes.length);
+  raw(commentBytes);
+
+  return new Uint8Array(bytes);
+}
+
+// Standard CRC-32 (IEEE 802.3, the ZIP checksum) — same inline shape as the
+// conformance suite's helper.
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data[i]!;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
@@ -3,51 +3,12 @@ import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveSkills } from "../skill-resolver.js";
+import { buildZip } from "../../../__test-utils__/zip-fixtures.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
 function makeTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
-}
-
-/**
- * Build a minimal stored (method 0) ZIP archive for testing.
- */
-function buildStoredZip(files: { name: string; content: string }[]): Uint8Array {
-  const parts: Uint8Array[] = [];
-
-  for (const file of files) {
-    const nameBytes = new TextEncoder().encode(file.name);
-    const contentBytes = new TextEncoder().encode(file.content);
-    const isDir = file.name.endsWith("/");
-
-    const header = new ArrayBuffer(30);
-    const view = new DataView(header);
-    view.setUint32(0, 0x04034b50, true);
-    view.setUint16(4, 20, true);
-    view.setUint16(6, 0, true);
-    view.setUint16(8, 0, true);
-    view.setUint16(10, 0, true);
-    view.setUint16(12, 0, true);
-    view.setUint32(14, 0, true);
-    view.setUint32(18, isDir ? 0 : contentBytes.length, true);
-    view.setUint32(22, isDir ? 0 : contentBytes.length, true);
-    view.setUint16(26, nameBytes.length, true);
-    view.setUint16(28, 0, true);
-
-    parts.push(new Uint8Array(header));
-    parts.push(nameBytes);
-    if (!isDir) parts.push(contentBytes);
-  }
-
-  const totalLength = parts.reduce((sum, p) => sum + p.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const part of parts) {
-    result.set(part, offset);
-    offset += part.length;
-  }
-  return result;
 }
 
 function makeSkillProto(overrides: {
@@ -141,7 +102,7 @@ describe("resolveSkills — artifact extraction", () => {
     const skillMd = "# Garden Design Makeover\n\nSee [references/database-schema.md](references/database-schema.md)";
     const schemaContent = "# Database Schema\n\nTable definitions here.";
 
-    const artifact = buildStoredZip([
+    const artifact = buildZip([
       { name: "SKILL.md", content: skillMd },
       { name: "references/", content: "" },
       { name: "references/database-schema.md", content: schemaContent },
@@ -232,7 +193,7 @@ describe("resolveSkills — artifact extraction", () => {
     const specContent = "# Authoritative SKILL.md from spec";
     const zipContent = "# Stale SKILL.md from ZIP";
 
-    const artifact = buildStoredZip([
+    const artifact = buildZip([
       { name: "SKILL.md", content: zipContent },
       { name: "references/data.md", content: "data" },
     ]);

--- a/backend/services/runner/src/shared/__tests__/zip-extract.test.ts
+++ b/backend/services/runner/src/shared/__tests__/zip-extract.test.ts
@@ -1,89 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { deflateRawSync } from "node:zlib";
 import { extractZipFileEntries } from "../zip-extract.js";
-
-// ─── Helpers ─────────────────────────────────────────────────────────────
-
-/**
- * Build a minimal valid ZIP archive from an array of { name, content } entries.
- * Uses stored (method 0) compression for simplicity. Produces local file
- * headers only (no central directory) — sufficient for our parser.
- */
-function buildStoredZip(files: { name: string; content: string }[]): Uint8Array {
-  const parts: Uint8Array[] = [];
-
-  for (const file of files) {
-    const nameBytes = new TextEncoder().encode(file.name);
-    const contentBytes = new TextEncoder().encode(file.content);
-    const isDir = file.name.endsWith("/");
-
-    // Local file header: 30 bytes
-    const header = new ArrayBuffer(30);
-    const view = new DataView(header);
-    view.setUint32(0, 0x04034b50, true);  // signature
-    view.setUint16(4, 20, true);           // version needed
-    view.setUint16(6, 0, true);            // general purpose flags
-    view.setUint16(8, 0, true);            // compression method (stored)
-    view.setUint16(10, 0, true);           // last mod time
-    view.setUint16(12, 0, true);           // last mod date
-    view.setUint32(14, 0, true);           // crc-32 (unused for our purposes)
-    view.setUint32(18, isDir ? 0 : contentBytes.length, true); // compressed size
-    view.setUint32(22, isDir ? 0 : contentBytes.length, true); // uncompressed size
-    view.setUint16(26, nameBytes.length, true);  // file name length
-    view.setUint16(28, 0, true);           // extra field length
-
-    parts.push(new Uint8Array(header));
-    parts.push(nameBytes);
-    if (!isDir) {
-      parts.push(contentBytes);
-    }
-  }
-
-  const totalLength = parts.reduce((sum, p) => sum + p.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const part of parts) {
-    result.set(part, offset);
-    offset += part.length;
-  }
-  return result;
-}
-
-/**
- * Build a ZIP archive with a single deflated (method 8) entry.
- */
-function buildDeflatedZip(name: string, content: string): Uint8Array {
-  const nameBytes = new TextEncoder().encode(name);
-  const contentBytes = new TextEncoder().encode(content);
-  const compressed = deflateRawSync(contentBytes);
-
-  const header = new ArrayBuffer(30);
-  const view = new DataView(header);
-  view.setUint32(0, 0x04034b50, true);
-  view.setUint16(4, 20, true);
-  view.setUint16(6, 0, true);
-  view.setUint16(8, 8, true);            // deflated
-  view.setUint16(10, 0, true);
-  view.setUint16(12, 0, true);
-  view.setUint32(14, 0, true);
-  view.setUint32(18, compressed.length, true);
-  view.setUint32(22, contentBytes.length, true);
-  view.setUint16(26, nameBytes.length, true);
-  view.setUint16(28, 0, true);
-
-  const totalLength = 30 + nameBytes.length + compressed.length;
-  const result = new Uint8Array(totalLength);
-  result.set(new Uint8Array(header), 0);
-  result.set(nameBytes, 30);
-  result.set(new Uint8Array(compressed.buffer, compressed.byteOffset, compressed.length), 30 + nameBytes.length);
-  return result;
-}
+import { buildZip } from "../../__test-utils__/zip-fixtures.js";
 
 // ─── extractZipFileEntries ───────────────────────────────────────────────
 
 describe("extractZipFileEntries", () => {
   it("extracts stored files from a ZIP archive", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "SKILL.md", content: "# My Skill" },
       { name: "references/schema.md", content: "# Schema\n\nTable definitions." },
     ]);
@@ -96,7 +19,7 @@ describe("extractZipFileEntries", () => {
 
   it("extracts deflated files", async () => {
     const content = "This content is compressed with deflate.";
-    const zip = buildDeflatedZip("notes.txt", content);
+    const zip = buildZip([{ name: "notes.txt", content, method: "deflated" }]);
 
     const entries = await extractZipFileEntries(zip);
     expect(entries).toHaveLength(1);
@@ -104,7 +27,7 @@ describe("extractZipFileEntries", () => {
   });
 
   it("skips directory entries", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "references/", content: "" },
       { name: "references/data.md", content: "data" },
     ]);
@@ -115,7 +38,7 @@ describe("extractZipFileEntries", () => {
   });
 
   it("excludes files by basename", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "SKILL.md", content: "# Skill" },
       { name: "references/schema.md", content: "# Schema" },
       { name: "scripts/run.py", content: "print('hi')" },
@@ -127,7 +50,7 @@ describe("extractZipFileEntries", () => {
   });
 
   it("excludes files by full path", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "a.md", content: "a" },
       { name: "nested/a.md", content: "nested" },
     ]);
@@ -138,7 +61,7 @@ describe("extractZipFileEntries", () => {
   });
 
   it("excludes entries matching basename even when nested", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "SKILL.md", content: "root" },
       { name: "sub/SKILL.md", content: "sub" },
       { name: "data.md", content: "data" },
@@ -166,7 +89,7 @@ describe("extractZipFileEntries", () => {
   });
 
   it("handles multiple files with nested directories", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "SKILL.md", content: "# Skill" },
       { name: "references/", content: "" },
       { name: "references/database-schema.md", content: "# Schema" },
@@ -184,7 +107,7 @@ describe("extractZipFileEntries", () => {
   });
 
   it("returns all entries when no exclude option is provided", async () => {
-    const zip = buildStoredZip([
+    const zip = buildZip([
       { name: "a.txt", content: "aaa" },
       { name: "b.txt", content: "bbb" },
     ]);
@@ -194,11 +117,105 @@ describe("extractZipFileEntries", () => {
   });
 
   it("returns all entries when exclude list is empty", async () => {
-    const zip = buildStoredZip([
-      { name: "a.txt", content: "aaa" },
-    ]);
+    const zip = buildZip([{ name: "a.txt", content: "aaa" }]);
 
     const entries = await extractZipFileEntries(zip, { exclude: [] });
     expect(entries).toHaveLength(1);
+  });
+
+  // ── Streaming entries (issue #450) ─────────────────────────────────────
+
+  it("extracts Go-default streaming archives (deflated, data descriptors)", async () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: "# Streamed Skill", method: "deflated", streaming: true },
+      { name: "references/notes.md", content: "streamed notes", method: "deflated", streaming: true },
+    ]);
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([
+      { path: "SKILL.md", content: "# Streamed Skill" },
+      { path: "references/notes.md", content: "streamed notes" },
+    ]);
+  });
+
+  it("extracts a stored streaming entry whose payload embeds the data-descriptor signature", async () => {
+    // The four bytes of the descriptor signature (0x08074b50, little-endian
+    // "PK\x07\x08") planted mid-content, followed by twelve bytes a
+    // descriptor-scanning parser would misread as CRC and sizes. The old
+    // local-header walk truncated this entry at the planted signature and
+    // desynchronized everything after it — the exact defect of issue #450.
+    const poisoned = "before PK\u0007\u0008AAAABBBBCCCC after — full content survives";
+    const zip = buildZip([
+      { name: "poison.md", content: poisoned, streaming: true },
+      { name: "after.md", content: "the entry after the poisoned one" },
+    ]);
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([
+      { path: "poison.md", content: poisoned },
+      { path: "after.md", content: "the entry after the poisoned one" },
+    ]);
+  });
+
+  it("uses central-directory sizes when local header sizes are zeroed", async () => {
+    const content = "sizes live only in the central directory";
+    const zip = buildZip([{ name: "cd-sizes.txt", content, streaming: true }]);
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([{ path: "cd-sizes.txt", content }]);
+  });
+
+  // ── Central directory edge cases ───────────────────────────────────────
+
+  it("locates the EOCD behind a trailing archive comment", async () => {
+    const zip = buildZip([{ name: "a.txt", content: "aaa" }], {
+      comment: "release archive — built by tooling",
+    });
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([{ path: "a.txt", content: "aaa" }]);
+  });
+
+  it("is not fooled by EOCD signature bytes inside the archive comment", async () => {
+    // "PK\x05\x06" inside the comment is a decoy EOCD; validation must
+    // reject it (its "fields" are comment text) and keep scanning backward
+    // to the real record.
+    const zip = buildZip([{ name: "a.txt", content: "aaa" }], {
+      comment: "decoy: PK\u0005\u0006 not a real record",
+    });
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([{ path: "a.txt", content: "aaa" }]);
+  });
+
+  it("returns empty array when the central directory is missing", async () => {
+    // Local headers and payloads only — a download truncated before the
+    // archive's index. The parser must not fall back to guessing from
+    // local headers (design record 017).
+    const zip = buildZip(
+      [
+        { name: "a.txt", content: "aaa" },
+        { name: "b.txt", content: "bbb" },
+      ],
+      { omitCentralDirectory: true },
+    );
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([]);
+  });
+
+  it("returns empty array for an archive with entries but a truncated tail", async () => {
+    const zip = buildZip([{ name: "a.txt", content: "aaa" }]);
+    const truncated = zip.subarray(0, zip.length - 10); // clips into the EOCD
+
+    const entries = await extractZipFileEntries(truncated);
+    expect(entries).toEqual([]);
+  });
+
+  it("extracts an empty archive (EOCD only) as no entries", async () => {
+    const zip = buildZip([]);
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toEqual([]);
   });
 });

--- a/backend/services/runner/src/shared/zip-extract.ts
+++ b/backend/services/runner/src/shared/zip-extract.ts
@@ -1,10 +1,33 @@
 /**
  * Minimal, dependency-free ZIP archive parser.
  *
- * Handles the local file header format, supporting stored (method 0) and
- * deflated (method 8) entries. Returns parsed entries as path + content
- * pairs — consumers bring their own write mechanism (WorkspaceBackend,
- * node:fs, etc.).
+ * Parsing is *central-directory-based*: entries are enumerated from the
+ * archive's end-of-central-directory record (EOCD) and central directory —
+ * the format's authoritative index — never by walking local file headers
+ * front-to-back. This is a correctness decision, not a style choice
+ * (issue #450): local headers of streaming entries (general-purpose flag
+ * bit 3) carry zeroed sizes, and the only local-only way to recover them
+ * is scanning the payload for the data-descriptor signature — which
+ * silently truncates any stored entry whose *content* happens to contain
+ * those four bytes, and desynchronizes every entry after it. The central
+ * directory always carries the real sizes, and this parser always holds
+ * the complete archive bytes, so nothing a local-header walk could offer
+ * is needed.
+ *
+ * Input without a readable central directory is not given a second
+ * chance on purpose: every artifact reaching the runner was validated at
+ * push by a central-directory-based reader on both editions (OSS:
+ * `safearchive/zip` in stigmer-server's skill storage; cloud:
+ * commons-compress `ZipFile` in SkillArtifactExtractor), so a missing
+ * EOCD here can only mean a truncated or corrupted download — and the
+ * honest result for that is the documented empty return, not a guess.
+ *
+ * ZIP64 is deliberately unsupported: the push gates cap artifacts at
+ * 100MB / 10,000 files, far below every ZIP64 threshold.
+ *
+ * Handles stored (method 0) and deflated (method 8) entries. Returns
+ * parsed entries as path + content pairs — consumers bring their own
+ * write mechanism (WorkspaceBackend, node:fs, etc.).
  *
  * Extracted from skill-writer.ts so both the deep-agent and Cursor
  * harnesses can share the same ZIP parsing logic without coupling to
@@ -29,18 +52,26 @@ export interface ZipFileEntry {
  * entries whose filename (basename or full path) matches any excluded name.
  *
  * Returns an empty array for empty, truncated, or non-ZIP input rather
- * than throwing — callers treat missing artifacts as non-fatal.
+ * than throwing — callers treat missing artifacts as non-fatal. Errors
+ * while *decompressing* a structurally valid entry (corrupt deflate
+ * stream, unsupported compression method) do propagate: at that point
+ * the archive's structure vouched for the entry, and silently dropping
+ * it would be the exact corruption this module exists to prevent.
  */
 export async function extractZipFileEntries(
   zipBytes: Uint8Array,
   options?: { exclude?: readonly string[] },
 ): Promise<ZipFileEntry[]> {
-  if (zipBytes.length < 4) return [];
+  if (zipBytes.length < EOCD_MIN_SIZE) return [];
 
   let entries: ZipEntry[];
   try {
     entries = parseZipEntries(zipBytes);
-  } catch {
+  } catch (err) {
+    console.warn(
+      "[zip-extract] archive has no readable central directory " +
+      `(truncated or corrupt download?): ${err instanceof Error ? err.message : String(err)}`,
+    );
     return [];
   }
 
@@ -58,14 +89,31 @@ export async function extractZipFileEntries(
   return results;
 }
 
-// ─── Internals ───────────────────────────────────────────────────────────
+// ─── Structural parsing (central directory) ──────────────────────────────
+//
+// This layer is deliberately policy-free — it maps bytes to entry records
+// (name, method, payload slice) and nothing else — so a future consumer
+// with different policy (e.g. the attachment injector's fail-hard,
+// security-validated extraction) can lift it without dragging along the
+// skill-specific text decoding above.
+
+const LOCAL_FILE_HEADER_SIG = 0x04034b50;
+const CENTRAL_DIRECTORY_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+
+/** Fixed size of the EOCD record, excluding the variable-length comment. */
+const EOCD_MIN_SIZE = 22;
+/** The archive comment length is a u16, so the EOCD sits within the last 64KB + 22 bytes. */
+const EOCD_MAX_COMMENT = 0xffff;
+
+const LOCAL_HEADER_SIZE = 30;
+const CD_RECORD_SIZE = 46;
 
 interface ZipEntry {
   name: string;
   isDirectory: boolean;
   compressedData: Uint8Array;
   compressionMethod: number;
-  uncompressedSize: number;
 }
 
 function isExcluded(name: string, excludeSet: ReadonlySet<string>): boolean {
@@ -76,102 +124,117 @@ function isExcluded(name: string, excludeSet: ReadonlySet<string>): boolean {
   return excludeSet.has(basename);
 }
 
+/**
+ * Enumerate the archive's entries from its central directory.
+ *
+ * Throws on any structural defect (no valid EOCD, a central directory or
+ * local header record that doesn't parse, a payload slice that runs past
+ * the end of the buffer) — the caller translates that into the module's
+ * non-fatal empty return.
+ */
 function parseZipEntries(data: Uint8Array): ZipEntry[] {
-  const entries: ZipEntry[] = [];
   const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  let offset = 0;
+  const eocd = findEndOfCentralDirectory(data, view);
 
-  while (offset < data.length - 4) {
-    const signature = view.getUint32(offset, true);
-    if (signature !== 0x04034b50) break; // Local file header signature
+  const entries: ZipEntry[] = [];
+  let offset = eocd.centralDirectoryOffset;
 
-    const generalFlags = view.getUint16(offset + 6, true);
-    const hasDataDescriptor = (generalFlags & 0x08) !== 0;
-    const compressionMethod = view.getUint16(offset + 8, true);
-    let compressedSize = view.getUint32(offset + 18, true);
-    let uncompressedSize = view.getUint32(offset + 22, true);
-    const fileNameLength = view.getUint16(offset + 26, true);
-    const extraFieldLength = view.getUint16(offset + 28, true);
-
-    const fileNameStart = offset + 30;
-    const fileName = new TextDecoder().decode(
-      data.subarray(fileNameStart, fileNameStart + fileNameLength),
-    );
-
-    const dataStart = fileNameStart + fileNameLength + extraFieldLength;
-
-    if (hasDataDescriptor && compressedSize === 0) {
-      const sizes = findDataDescriptor(data, view, dataStart, compressionMethod);
-      compressedSize = sizes.compressedSize;
-      uncompressedSize = sizes.uncompressedSize;
+  for (let i = 0; i < eocd.entryCount; i++) {
+    if (offset + CD_RECORD_SIZE > data.length || view.getUint32(offset, true) !== CENTRAL_DIRECTORY_SIG) {
+      throw new Error(`invalid central directory record at offset ${offset}`);
     }
 
-    const compressedData = data.subarray(dataStart, dataStart + compressedSize);
+    const compressionMethod = view.getUint16(offset + 10, true);
+    const compressedSize = view.getUint32(offset + 20, true);
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraFieldLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const localHeaderOffset = view.getUint32(offset + 42, true);
+
+    const fileName = new TextDecoder().decode(
+      data.subarray(offset + CD_RECORD_SIZE, offset + CD_RECORD_SIZE + fileNameLength),
+    );
+
+    // The local header is consulted for one thing only: the payload start.
+    // Its name/extra field lengths can legitimately differ from the central
+    // directory's (streaming writers pad the extra field), so the offset
+    // cannot be derived from CD fields alone.
+    const dataStart = payloadStart(data, view, localHeaderOffset, fileName);
+    if (dataStart + compressedSize > data.length) {
+      throw new Error(`entry "${fileName}" payload runs past end of archive`);
+    }
 
     entries.push({
       name: fileName,
       isDirectory: fileName.endsWith("/"),
-      compressedData,
+      compressedData: data.subarray(dataStart, dataStart + compressedSize),
       compressionMethod,
-      uncompressedSize,
     });
 
-    let nextOffset = dataStart + compressedSize;
-    if (hasDataDescriptor) {
-      if (nextOffset + 4 <= data.length && view.getUint32(nextOffset, true) === 0x08074b50) {
-        nextOffset += 16; // signature(4) + crc(4) + compressedSize(4) + uncompressedSize(4)
-      } else {
-        nextOffset += 12; // crc(4) + compressedSize(4) + uncompressedSize(4)
-      }
-    }
-    offset = nextOffset;
+    offset += CD_RECORD_SIZE + fileNameLength + extraFieldLength + commentLength;
   }
 
   return entries;
 }
 
+interface EndOfCentralDirectory {
+  centralDirectoryOffset: number;
+  entryCount: number;
+}
+
 /**
- * Scan forward from dataStart to find the data descriptor that contains
- * the actual compressed and uncompressed sizes. Looks for either the
- * optional signature 0x08074b50 or falls back to scanning the central
- * directory for the matching entry.
+ * Locate and validate the end-of-central-directory record.
+ *
+ * Scans backward from the end of the archive across the maximum comment
+ * span. A signature match alone is not trusted (the four bytes can occur
+ * inside a trailing comment): the record must also point at an offset
+ * that actually holds a central directory record, or be a genuinely
+ * empty archive.
  */
-function findDataDescriptor(
+function findEndOfCentralDirectory(data: Uint8Array, view: DataView): EndOfCentralDirectory {
+  const scanFloor = Math.max(0, data.length - EOCD_MIN_SIZE - EOCD_MAX_COMMENT);
+
+  for (let pos = data.length - EOCD_MIN_SIZE; pos >= scanFloor; pos--) {
+    if (view.getUint32(pos, true) !== EOCD_SIG) continue;
+
+    const entryCount = view.getUint16(pos + 10, true);
+    const centralDirectorySize = view.getUint32(pos + 12, true);
+    const centralDirectoryOffset = view.getUint32(pos + 16, true);
+
+    const directoryEndsAtRecord = centralDirectoryOffset + centralDirectorySize <= pos;
+    const directoryLooksReal =
+      entryCount === 0 ||
+      (centralDirectoryOffset + 4 <= data.length &&
+        view.getUint32(centralDirectoryOffset, true) === CENTRAL_DIRECTORY_SIG);
+
+    if (directoryEndsAtRecord && directoryLooksReal) {
+      return { centralDirectoryOffset, entryCount };
+    }
+  }
+
+  throw new Error("no end-of-central-directory record found");
+}
+
+/** Resolve where an entry's payload begins, from its local file header. */
+function payloadStart(
   data: Uint8Array,
   view: DataView,
-  dataStart: number,
-  _compressionMethod: number,
-): { compressedSize: number; uncompressedSize: number } {
-  for (let pos = dataStart; pos < data.length - 16; pos++) {
-    const sig = view.getUint32(pos, true);
-    if (sig === 0x08074b50) {
-      return {
-        compressedSize: view.getUint32(pos + 8, true),
-        uncompressedSize: view.getUint32(pos + 12, true),
-      };
-    }
-    if (sig === 0x04034b50 || sig === 0x02014b50) {
-      const descStart = pos - 12;
-      if (descStart >= dataStart) {
-        return {
-          compressedSize: view.getUint32(descStart + 4, true),
-          uncompressedSize: view.getUint32(descStart + 8, true),
-        };
-      }
-      break;
-    }
+  localHeaderOffset: number,
+  fileName: string,
+): number {
+  if (
+    localHeaderOffset + LOCAL_HEADER_SIZE > data.length ||
+    view.getUint32(localHeaderOffset, true) !== LOCAL_FILE_HEADER_SIG
+  ) {
+    throw new Error(`entry "${fileName}" has no local file header at offset ${localHeaderOffset}`);
   }
-  for (let pos = dataStart; pos < data.length - 4; pos++) {
-    const sig = view.getUint32(pos, true);
-    if (sig === 0x04034b50 || sig === 0x02014b50 || sig === 0x08074b50) {
-      const compressedSize = sig === 0x08074b50
-        ? view.getUint32(pos + 8, true)
-        : pos - dataStart;
-      return { compressedSize, uncompressedSize: 0 };
-    }
-  }
-  return { compressedSize: data.length - dataStart, uncompressedSize: 0 };
+
+  const localNameLength = view.getUint16(localHeaderOffset + 26, true);
+  const localExtraLength = view.getUint16(localHeaderOffset + 28, true);
+  return localHeaderOffset + LOCAL_HEADER_SIZE + localNameLength + localExtraLength;
 }
+
+// ─── Decompression ───────────────────────────────────────────────────────
 
 async function decompressEntry(entry: ZipEntry): Promise<string> {
   if (entry.compressionMethod === 0) {


### PR DESCRIPTION
## Summary

Closes #450.

The runner's dependency-free ZIP parser (`backend/services/runner/src/shared/zip-extract.ts`, skill artifact extraction for both the deep-agent and Cursor harnesses) walked local file headers front-to-back and recovered streaming-entry sizes by **scanning the payload for the data-descriptor signature** — silently truncating any stored entry whose content contains those four bytes (`PK\x07\x08`) and desynchronizing every entry after it. A routine shape since stigmer-cloud#316 made Go-default streaming archives flow at push.

Entries are now enumerated from the **central directory** — the archive's authoritative index:

- EOCD located by backward scan across the maximum comment span, with candidate validation (a signature match must point at a real CD record, so decoy bytes inside a trailing comment can't select a bogus record).
- CD records supply authoritative names, methods, sizes, and local-header offsets; local headers are consulted only to resolve payload starts (their name/extra lengths can legitimately differ).
- The structural layer (EOCD locate + CD walk → entry records) is kept policy-free and separable from the skill policy layer (text decode, exclusions, non-fatal posture) so #567 can lift it.

## Design ruling (DD-017): no local-header fallback

The issue suggested keeping the old walk as a fallback for truncated input; the design pass disproved the premise. Both editions' push gates validate every artifact with central-directory-based readers before storage (OSS: `safearchive/zip` in `zip_extractor.go`; cloud post-#316: commons-compress `ZipFile` in `SkillArtifactExtractor`), so **an artifact without a central directory cannot reach runner extraction**. A CD-less input is by construction a truncated/corrupt download, and the honest result is the module's documented non-fatal empty return (now with a WARN) — not a best-effort parse that preserves the silent-corruption class this PR deletes. `findDataDescriptor` and the local-header walk are gone entirely. Decompression errors on structurally valid entries keep propagating (contract boundary unchanged).

## Tests

- Fixtures upgraded to emit **complete, real-shaped archives** (local headers, optional streaming descriptors, central directory, EOCD) via a shared builder (`src/__test-utils__/zip-fixtures.ts`, mirroring the conformance suite's `zipFilesStreaming()`); also de-duplicates `skill-resolver.test.ts`'s private CD-less copy. All 13 pre-existing behavioral assertions kept unchanged.
- New coverage: the poison-payload pinning case (stored streaming entry embedding `PK\x07\x08` + a following entry — the exact #450 defect), Go-default streaming archives, trailing-comment EOCD, decoy EOCD bytes in the comment, CD-authoritative sizes, CD-less/truncated input → empty, empty archive.
- **Red-green proven**: 3 of the new cases fail on the old parser; 20/20 pass on the new.

## Verification

- `npm run typecheck` clean; `make build-runner` clean.
- Targeted suites: zip-extract + skill-resolver + all of `src/shared/` — 1172/1172 green.
- Full runner suite: 4518 passed / 7 failed — the 7 are load-dependent vitest worker RPC timeouts (`Timeout calling "onTaskUpdate"`) unrelated to this change: every one of them passes load-matched on this branch, and the failing set differs run to run on this machine.

## Spawned

#567 — the sibling-parser audit found `attachment-injector.ts` carries a second local-header ZIP walk (untrusted-upload boundary, fail-hard model) with silent manifest truncation on stored streaming entries and outright rejection of Go-default archives; confirmed by runtime repro, deliberately not folded in here (different trust boundary + error model).

Made with [Cursor](https://cursor.com)