### PR TITLE
fix(skill): pin root-only SKILL.md and add a repackaging hint (#452)

### DIFF
--- a/apis/ai/stigmer/agentic/skill/docs/publishing-skills.md
+++ b/apis/ai/stigmer/agentic/skill/docs/publishing-skills.md
@@ -6,6 +6,8 @@ How to push skill artifacts to the platform — from the CLI directly, from a re
 
 Publishing a skill means pushing a packaged artifact to the platform so agents can reference and use it. The platform stores the artifact, extracts the skill metadata from `SKILL.md`, computes a SHA-256 version hash, and records git provenance if available.
 
+The artifact ZIP must carry `SKILL.md` at the **archive root** — zip the skill folder's *contents*, not the folder itself. Both editions reject a nested `SKILL.md` (e.g. `my-skill/SKILL.md`) at push time, because the runner extracts entry paths verbatim when materializing the skill: a nested layout would place `references/` and `scripts/` files where the skill's own instructions can never find them. The CLI and SDK packaging paths below produce the correct layout automatically; this only matters when building artifact bytes yourself and calling `push` directly.
+
 There are three paths to publishing a skill:
 
 | Path | Use When |

--- a/backend/services/stigmer-server/pkg/domain/skill/storage/zip_extractor.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/storage/zip_extractor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/google/safearchive/zip"
 )
@@ -100,11 +101,15 @@ func validateZipContent(reader *zip.Reader) error {
 
 	var totalUncompressedSize uint64
 	hasSkillMd := false
+	hasNestedSkillMd := false
 
 	for _, file := range reader.File {
-		// Check for SKILL.md
+		// SKILL.md must be at the archive root. Nested occurrences are tracked
+		// only to make the rejection actionable (see below).
 		if file.Name == "SKILL.md" {
 			hasSkillMd = true
+		} else if strings.HasSuffix(file.Name, "/SKILL.md") {
+			hasNestedSkillMd = true
 		}
 
 		// Validate filename characters (prevent null bytes, control characters)
@@ -131,8 +136,16 @@ func validateZipContent(reader *zip.Reader) error {
 		}
 	}
 
-	// Ensure SKILL.md exists
+	// Ensure SKILL.md exists at the archive root. A nested-only SKILL.md is
+	// the "zipped the folder instead of its contents" mistake: the runner
+	// extracts entry paths verbatim when materializing a skill, so accepting
+	// nested placement would land every supporting file one directory too
+	// deep and break the skill silently at runtime (stigmer#452). The hint
+	// teaches the fix; its text is byte-identical to the cloud edition's.
 	if !hasSkillMd {
+		if hasNestedSkillMd {
+			return fmt.Errorf("SKILL.md must be at the archive root — zip the skill folder's contents, not the folder itself")
+		}
 		return fmt.Errorf("SKILL.md not found in ZIP archive")
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/skill/storage/zip_extractor_test.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/storage/zip_extractor_test.go
@@ -145,6 +145,40 @@ func TestExtractSkillMd_NoSkillMd(t *testing.T) {
 	assert.Contains(t, err.Error(), "SKILL.md not found")
 }
 
+// TestExtractSkillMd_NestedOnlySkillMd verifies that a SKILL.md nested under a
+// directory — the "zipped the folder instead of its contents" mistake — is
+// rejected with a hint that says how to repackage (stigmer#452). The runner
+// extracts entry paths verbatim, so accepting nested placement would produce a
+// skill whose supporting files never resolve at runtime.
+func TestExtractSkillMd_NestedOnlySkillMd(t *testing.T) {
+	skillContent := ValidSkillContent("nested-skill", "# Nested Skill")
+	zipData := CreateTestZipWithFiles(map[string][]byte{
+		"my-skill/SKILL.md":          []byte(skillContent),
+		"my-skill/references/api.md": []byte("# API notes"),
+	})
+
+	_, err := ExtractSkillMd(zipData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SKILL.md must be at the archive root",
+		"nested-only SKILL.md should get the repackaging hint, not the generic not-found")
+}
+
+// TestExtractSkillMd_RootSkillMdWinsOverNested verifies that a stray nested
+// SKILL.md (e.g. vendored from another skill) neither shadows the root file
+// nor triggers the nested-only rejection.
+func TestExtractSkillMd_RootSkillMdWinsOverNested(t *testing.T) {
+	rootContent := ValidSkillContent("root-skill", "# Root Skill")
+	zipData := CreateTestZipWithFiles(map[string][]byte{
+		"SKILL.md":        []byte(rootContent),
+		"vendor/SKILL.md": []byte(ValidSkillContent("vendored", "# Vendored")),
+	})
+
+	result, err := ExtractSkillMd(zipData)
+	require.NoError(t, err)
+	assert.Equal(t, rootContent, result.Content)
+	assert.Equal(t, "root-skill", result.Name)
+}
+
 // TestExtractSkillMd_EmptySkillMd verifies that ZIPs with empty SKILL.md
 // files are rejected.
 func TestExtractSkillMd_EmptySkillMd(t *testing.T) {

--- a/test/conformance/src/suites/skill.conformance.test.ts
+++ b/test/conformance/src/suites/skill.conformance.test.ts
@@ -123,6 +123,25 @@ describe("Skill conformance — push & identity", () => {
     expect(pushed.status?.versionHash, "version hash is computed over the raw bytes").toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("resolves the root SKILL.md when a stray nested one also exists (#452)", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("skill");
+
+    // Root-only is the contract: a nested SKILL.md (e.g. vendored from another
+    // skill) must neither shadow the root file nor trip the nested-only
+    // rejection. The frontmatter name proves which file won.
+    const pushed = await pushSkill(
+      org,
+      zipFiles({
+        "SKILL.md": `---\nname: ${name}\n---\n# root skill`,
+        "vendor/SKILL.md": "---\nname: vendored-skill\n---\n# vendored",
+      }),
+    );
+
+    expect(pushed.metadata?.name, "identity must derive from the ROOT SKILL.md").toBe(name);
+    expect(pushed.metadata?.slug).toBe(name);
+  });
+
   it("isolates skills with the same name across orgs", async () => {
     const a = await target.provisionTenancy();
     const b = await target.provisionTenancy();
@@ -183,6 +202,27 @@ describe("Skill conformance — push validation negatives", () => {
       () => clients.skillCommand.push({ org, artifact: zipFiles({ "README.md": "# not a skill file" }) }),
       Code.InvalidArgument,
       "push zip missing SKILL.md",
+    );
+  });
+
+  it("rejects a SKILL.md nested under a directory (InvalidArgument, #452)", async () => {
+    const { org } = await target.provisionTenancy();
+    // "Zipped the folder instead of its contents" — the most common archiving
+    // mistake. The cloud edition used to accept this shape while OSS rejected
+    // it (#452); acceptance was the bug: runners extract entry paths verbatim,
+    // so a nested skill's references/ and scripts/ never resolve at runtime.
+    // Both editions must reject it at push, where the mistake is fixable.
+    await expectGrpcCode(
+      () =>
+        clients.skillCommand.push({
+          org,
+          artifact: zipFiles({
+            "my-skill/SKILL.md": "---\nname: nested-skill\n---\n# body",
+            "my-skill/references/api.md": "# api notes",
+          }),
+        }),
+      Code.InvalidArgument,
+      "push zip with nested-only SKILL.md",
     );
   });
 


### PR DESCRIPTION
## Summary

The OSS half of #452 (skill push: editions disagree on nested SKILL.md). **Owner ruling: root-only on both editions** — the cloud's nested acceptance was the defect, because runners re-extract artifact ZIPs verbatim, so a "zipped the folder" skill pushes fine but its `references/` and `scripts/` never resolve at runtime. The cloud tighten is [stigmer-cloud#403](https://github.com/stigmer/stigmer-cloud/pull/403).

OSS behavior was already root-only; this PR closes the remaining gaps:

- **Actionable error** (`zip_extractor.go`): a nested-only `SKILL.md` now gets *"SKILL.md must be at the archive root — zip the skill folder's contents, not the folder itself"* (byte-identical to cloud's new message) instead of the generic not-found. No-SKILL.md-anywhere keeps its long-standing message.
- **Conformance pins** (the #336 lesson — unpinned edition behavior drifts): nested-only archive rejected with `InvalidArgument`; root `SKILL.md` wins regardless of stray nested entries. Red-first proven: the rejection pin fails against the unpatched cloud JAR.
- **Docs contract** (`publishing-skills.md`): states the root-layout requirement for raw-SDK integrators — the only population that can produce nested archives (the CLI always zips directory contents).

## Merge order

[stigmer-cloud#403](https://github.com/stigmer/stigmer-cloud/pull/403) merges FIRST, then this — the nightly cloud-conformance lane must not see the pin before the cloud fix (the #336/#449 precedent).

## Verification

- Skill domain Go tests, `gofmt`, `go vet` — clean
- Skill conformance: 44/44 vs `local-go` (server built from this HEAD); 44/44 vs the patched cloud JAR (hermetic env, real OpenFGA); red run vs unpatched cloud JAR fails exactly the new pin
- Pre-existing (untouched, noted per verify rule): `tsc --noEmit` in the conformance package reports 4 errors in `mcp-server`/`sdk/typescript`/`agentexecution.conformance.test.ts` on clean main

Closes #452

Made with [Cursor](https://cursor.com)