### PR TITLE
fix(runner): attachment injector parses ZIPs from the central directory and enforces declared sizes

### DIFF
--- a/backend/services/runner/src/__test-utils__/zip-fixtures.ts
+++ b/backend/services/runner/src/__test-utils__/zip-fixtures.ts
@@ -22,7 +22,8 @@ import { deflateRawSync } from "node:zlib";
 
 export interface ZipFixtureFile {
   name: string;
-  content: string;
+  /** Text content is UTF-8 encoded; pass bytes directly for binary payloads. */
+  content: string | Uint8Array;
   /** Compression method for the entry. Defaults to stored. */
   method?: "stored" | "deflated";
   /**
@@ -31,6 +32,14 @@ export interface ZipFixtureFile {
    * descriptor (with the conventional signature) carrying the real values.
    */
   streaming?: boolean;
+  /**
+   * Lie about the entry's uncompressed size everywhere the writer would
+   * declare it (local header, data descriptor, central directory). Models a
+   * crafted archive whose declarations disagree with its actual payload —
+   * the input class the attachment injector's declared-size enforcement
+   * exists to reject (issue #567).
+   */
+  declaredUncompressedSize?: number;
 }
 
 export interface ZipFixtureOptions {
@@ -46,16 +55,12 @@ export interface ZipFixtureOptions {
 
 /** Build a ZIP archive from path + content pairs. */
 export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): Uint8Array {
-  const bytes: number[] = [];
-  const u16 = (v: number) => bytes.push(v & 0xff, (v >>> 8) & 0xff);
-  const u32 = (v: number) =>
-    bytes.push(v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff);
-  const raw = (b: Uint8Array) => bytes.push(...b);
+  const out = new ByteWriter();
 
   interface WrittenEntry {
     nameBytes: Uint8Array;
     payload: Uint8Array;
-    uncompressedLength: number;
+    declaredUncompressed: number;
     crc: number;
     flags: number;
     method: number;
@@ -64,92 +69,138 @@ export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): 
   const written: WrittenEntry[] = [];
 
   for (const file of files) {
-    const contentBytes = new TextEncoder().encode(file.content);
+    const contentBytes =
+      typeof file.content === "string" ? new TextEncoder().encode(file.content) : file.content;
     const deflated = file.method === "deflated";
     const payload = deflated ? new Uint8Array(deflateRawSync(contentBytes)) : contentBytes;
     const entry: WrittenEntry = {
       nameBytes: new TextEncoder().encode(file.name),
       payload,
-      uncompressedLength: contentBytes.length,
+      declaredUncompressed: file.declaredUncompressedSize ?? contentBytes.length,
       crc: crc32(contentBytes),
       flags: file.streaming ? 0x0008 : 0,
       method: deflated ? 8 : 0,
-      localHeaderOffset: bytes.length,
+      localHeaderOffset: out.length,
     };
     written.push(entry);
 
-    u32(0x04034b50); // local file header signature
-    u16(20); // version needed to extract
-    u16(entry.flags);
-    u16(entry.method);
-    u16(0); // mod time
-    u16(0); // mod date
-    u32(file.streaming ? 0 : entry.crc);
-    u32(file.streaming ? 0 : payload.length);
-    u32(file.streaming ? 0 : entry.uncompressedLength);
-    u16(entry.nameBytes.length);
-    u16(0); // extra field length
-    raw(entry.nameBytes);
-    raw(payload);
+    out.u32(0x04034b50); // local file header signature
+    out.u16(20); // version needed to extract
+    out.u16(entry.flags);
+    out.u16(entry.method);
+    out.u16(0); // mod time
+    out.u16(0); // mod date
+    out.u32(file.streaming ? 0 : entry.crc);
+    out.u32(file.streaming ? 0 : payload.length);
+    out.u32(file.streaming ? 0 : entry.declaredUncompressed);
+    out.u16(entry.nameBytes.length);
+    out.u16(0); // extra field length
+    out.raw(entry.nameBytes);
+    out.raw(payload);
 
     if (file.streaming) {
-      u32(0x08074b50); // data descriptor signature (Go writes it)
-      u32(entry.crc);
-      u32(payload.length);
-      u32(entry.uncompressedLength);
+      out.u32(0x08074b50); // data descriptor signature (Go writes it)
+      out.u32(entry.crc);
+      out.u32(payload.length);
+      out.u32(entry.declaredUncompressed);
     }
   }
 
   if (options?.omitCentralDirectory) {
-    return new Uint8Array(bytes);
+    return out.toUint8Array();
   }
 
-  const centralDirectoryOffset = bytes.length;
+  const centralDirectoryOffset = out.length;
   for (const entry of written) {
-    u32(0x02014b50); // central directory record signature
-    u16(20); // version made by
-    u16(20); // version needed to extract
-    u16(entry.flags);
-    u16(entry.method);
-    u16(0); // mod time
-    u16(0); // mod date
-    u32(entry.crc);
-    u32(entry.payload.length);
-    u32(entry.uncompressedLength);
-    u16(entry.nameBytes.length);
-    u16(0); // extra field length
-    u16(0); // comment length
-    u16(0); // disk number start
-    u16(0); // internal attributes
-    u32(0); // external attributes
-    u32(entry.localHeaderOffset);
-    raw(entry.nameBytes);
+    out.u32(0x02014b50); // central directory record signature
+    out.u16(20); // version made by
+    out.u16(20); // version needed to extract
+    out.u16(entry.flags);
+    out.u16(entry.method);
+    out.u16(0); // mod time
+    out.u16(0); // mod date
+    out.u32(entry.crc);
+    out.u32(entry.payload.length);
+    out.u32(entry.declaredUncompressed);
+    out.u16(entry.nameBytes.length);
+    out.u16(0); // extra field length
+    out.u16(0); // comment length
+    out.u16(0); // disk number start
+    out.u16(0); // internal attributes
+    out.u32(0); // external attributes
+    out.u32(entry.localHeaderOffset);
+    out.raw(entry.nameBytes);
   }
-  const centralDirectorySize = bytes.length - centralDirectoryOffset;
+  const centralDirectorySize = out.length - centralDirectoryOffset;
 
   const commentBytes = new TextEncoder().encode(options?.comment ?? "");
-  u32(0x06054b50); // EOCD signature
-  u16(0); // disk number
-  u16(0); // disk with central directory
-  u16(written.length); // entries on this disk
-  u16(written.length); // total entries
-  u32(centralDirectorySize);
-  u32(centralDirectoryOffset);
-  u16(commentBytes.length);
-  raw(commentBytes);
+  out.u32(0x06054b50); // EOCD signature
+  out.u16(0); // disk number
+  out.u16(0); // disk with central directory
+  out.u16(written.length); // entries on this disk
+  out.u16(written.length); // total entries
+  out.u32(centralDirectorySize);
+  out.u32(centralDirectoryOffset);
+  out.u16(commentBytes.length);
+  out.raw(commentBytes);
 
-  return new Uint8Array(bytes);
+  return out.toUint8Array();
 }
 
-// Standard CRC-32 (IEEE 802.3, the ZIP checksum) — same inline shape as the
-// conformance suite's helper.
+// Chunked assembly instead of a number[]-per-byte accumulator: fixtures at
+// the injector's 100 MB zip-bomb limit are built from payload-sized chunks,
+// which a per-byte spread-push cannot survive (argument-count overflow).
+class ByteWriter {
+  private readonly chunks: Uint8Array[] = [];
+  private size = 0;
+
+  get length(): number {
+    return this.size;
+  }
+
+  u16(v: number): void {
+    this.raw(new Uint8Array([v & 0xff, (v >>> 8) & 0xff]));
+  }
+
+  u32(v: number): void {
+    this.raw(new Uint8Array([v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff]));
+  }
+
+  raw(b: Uint8Array): void {
+    this.chunks.push(b);
+    this.size += b.length;
+  }
+
+  toUint8Array(): Uint8Array {
+    const result = new Uint8Array(this.size);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return result;
+  }
+}
+
+// Standard CRC-32 (IEEE 802.3, the ZIP checksum), table-driven so fixtures
+// at the injector's 100 MB limit stay cheap to build. Semantically identical
+// to the conformance suite's inline bit-loop helper.
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let bit = 0; bit < 8; bit++) {
+      c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
+    }
+    table[n] = c;
+  }
+  return table;
+})();
+
 function crc32(data: Uint8Array): number {
   let crc = 0xffffffff;
   for (let i = 0; i < data.length; i++) {
-    crc ^= data[i]!;
-    for (let bit = 0; bit < 8; bit++) {
-      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
-    }
+    crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ data[i]!) & 0xff]!;
   }
   return (crc ^ 0xffffffff) >>> 0;
 }

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { deflateRawSync } from "node:zlib";
 import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -15,130 +14,42 @@ import {
 } from "../attachment-injector.js";
 import { mockWorkspaceBackend } from "../../../__test-utils__/mock-workspace.js";
 import { makeInMemoryArtifactStorage } from "../../../__test-utils__/fake-artifact-storage.js";
+import { buildZip, type ZipFixtureFile } from "../../../__test-utils__/zip-fixtures.js";
 import {
   DEEP_AGENT_VISION_PROFILE,
   VisionBudget,
 } from "../../../shared/attachment-vision.js";
 
 // ── ZIP Construction Helpers ─────────────────────────────────────────
+//
+// All archives come from the shared real-shape builder (zip-fixtures.ts):
+// local headers, payloads, central directory, EOCD — the only shape real
+// ZIP writers produce and the shape central-directory parsing requires.
+// The record-form helpers below keep ordinary call sites terse; tests that
+// need streaming or declared-size shapes call buildZip directly.
 
 function makeZip(entries: Record<string, string | Buffer>): Buffer {
-  const parts: Buffer[] = [];
-  const centralDir: Buffer[] = [];
-  let offset = 0;
-
-  for (const [name, content] of Object.entries(entries)) {
-    const nameBytes = Buffer.from(name, "utf-8");
-    const contentBytes = typeof content === "string" ? Buffer.from(content, "utf-8") : content;
-    const compressed = deflateRawSync(contentBytes);
-
-    // Local file header
-    const header = Buffer.alloc(30);
-    header.writeUInt32LE(0x04034b50, 0); // signature
-    header.writeUInt16LE(20, 4);          // version needed
-    header.writeUInt16LE(0, 6);           // flags
-    header.writeUInt16LE(8, 8);           // compression: deflate
-    header.writeUInt16LE(0, 10);          // mod time
-    header.writeUInt16LE(0, 12);          // mod date
-    header.writeUInt32LE(0, 14);          // crc32 (skip for tests)
-    header.writeUInt32LE(compressed.length, 18);  // compressed size
-    header.writeUInt32LE(contentBytes.length, 22); // uncompressed size
-    header.writeUInt16LE(nameBytes.length, 26);    // filename length
-    header.writeUInt16LE(0, 28);                   // extra field length
-
-    parts.push(header, nameBytes, compressed);
-
-    // Central directory entry
-    const cdEntry = Buffer.alloc(46);
-    cdEntry.writeUInt32LE(0x02014b50, 0);
-    cdEntry.writeUInt16LE(20, 4);
-    cdEntry.writeUInt16LE(20, 6);
-    cdEntry.writeUInt16LE(0, 8);
-    cdEntry.writeUInt16LE(8, 10);
-    cdEntry.writeUInt16LE(0, 12);
-    cdEntry.writeUInt16LE(0, 14);
-    cdEntry.writeUInt32LE(0, 16);
-    cdEntry.writeUInt32LE(compressed.length, 20);
-    cdEntry.writeUInt32LE(contentBytes.length, 24);
-    cdEntry.writeUInt16LE(nameBytes.length, 28);
-    cdEntry.writeUInt16LE(0, 30);
-    cdEntry.writeUInt16LE(0, 32);
-    cdEntry.writeUInt16LE(0, 34);
-    cdEntry.writeUInt16LE(0, 36);
-    cdEntry.writeUInt32LE(0, 38);
-    cdEntry.writeUInt32LE(offset, 42);
-    centralDir.push(cdEntry, nameBytes);
-
-    offset += header.length + nameBytes.length + compressed.length;
-  }
-
-  // End of central directory
-  const eocd = Buffer.alloc(22);
-  const cdSize = centralDir.reduce((s, b) => s + b.length, 0);
-  eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(0, 4);
-  eocd.writeUInt16LE(0, 6);
-  eocd.writeUInt16LE(Object.keys(entries).length, 8);
-  eocd.writeUInt16LE(Object.keys(entries).length, 10);
-  eocd.writeUInt32LE(cdSize, 12);
-  eocd.writeUInt32LE(offset, 16);
-  eocd.writeUInt16LE(0, 20);
-
-  return Buffer.concat([...parts, ...centralDir, eocd]);
+  return makeZipWith(entries, { method: "deflated" });
 }
 
 function makeStoredZip(entries: Record<string, Buffer>): Buffer {
-  const parts: Buffer[] = [];
-  let offset = 0;
+  return makeZipWith(entries, { method: "stored" });
+}
 
-  for (const [name, content] of Object.entries(entries)) {
-    const nameBytes = Buffer.from(name, "utf-8");
-
-    const header = Buffer.alloc(30);
-    header.writeUInt32LE(0x04034b50, 0);
-    header.writeUInt16LE(20, 4);
-    header.writeUInt16LE(0, 6);
-    header.writeUInt16LE(0, 8);  // stored (no compression)
-    header.writeUInt32LE(content.length, 18);
-    header.writeUInt32LE(content.length, 22);
-    header.writeUInt16LE(nameBytes.length, 26);
-    header.writeUInt16LE(0, 28);
-
-    parts.push(header, nameBytes, content);
-    offset += header.length + nameBytes.length + content.length;
-  }
-
-  // Minimal EOCD
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(Object.keys(entries).length, 8);
-  eocd.writeUInt16LE(Object.keys(entries).length, 10);
-  eocd.writeUInt32LE(0, 12);
-  eocd.writeUInt32LE(offset, 16);
-
-  return Buffer.concat([...parts, eocd]);
+function makeZipWith(
+  entries: Record<string, string | Buffer>,
+  shape: Pick<ZipFixtureFile, "method" | "streaming">,
+): Buffer {
+  const files: ZipFixtureFile[] = Object.entries(entries).map(([name, content]) => ({
+    name,
+    content: typeof content === "string" ? content : new Uint8Array(content),
+    ...shape,
+  }));
+  return Buffer.from(buildZip(files));
 }
 
 function makeDirectoryOnlyZip(): Buffer {
-  const name = "empty_dir/";
-  const nameBytes = Buffer.from(name, "utf-8");
-
-  const header = Buffer.alloc(30);
-  header.writeUInt32LE(0x04034b50, 0);
-  header.writeUInt16LE(20, 4);
-  header.writeUInt16LE(0, 6);
-  header.writeUInt16LE(0, 8);
-  header.writeUInt32LE(0, 18);
-  header.writeUInt32LE(0, 22);
-  header.writeUInt16LE(nameBytes.length, 26);
-  header.writeUInt16LE(0, 28);
-
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(1, 8);
-  eocd.writeUInt16LE(1, 10);
-
-  return Buffer.concat([header, nameBytes, eocd]);
+  return Buffer.from(buildZip([{ name: "empty_dir/", content: "" }]));
 }
 
 function makeAttachment(overrides: Partial<{
@@ -251,22 +162,7 @@ describe("validateZipForExtraction", () => {
   });
 
   it("rejects null bytes in filenames", () => {
-    const nameWithNull = "file\x00.txt";
-    const nameBytes = Buffer.from(nameWithNull, "utf-8");
-    const content = Buffer.from("test");
-    const compressed = deflateRawSync(content);
-
-    const header = Buffer.alloc(30);
-    header.writeUInt32LE(0x04034b50, 0);
-    header.writeUInt16LE(20, 4);
-    header.writeUInt16LE(0, 6);
-    header.writeUInt16LE(8, 8);
-    header.writeUInt32LE(compressed.length, 18);
-    header.writeUInt32LE(content.length, 22);
-    header.writeUInt16LE(nameBytes.length, 26);
-    header.writeUInt16LE(0, 28);
-
-    const zip = Buffer.concat([header, nameBytes, compressed]);
+    const zip = makeZip({ "file\u0000.txt": "test" });
     expect(() => validateZipForExtraction(zip, "null.zip"))
       .toThrow(/null bytes/);
   });
@@ -302,6 +198,149 @@ describe("validateZipForExtraction", () => {
     const zip = makeStoredZip(entries);
     const result = validateZipForExtraction(zip, "ok.zip");
     expect(result).toHaveLength(MAX_ZIP_FILES);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Central-directory parsing (issue #567)
+// ═══════════════════════════════════════════════════════════════════════
+// The archive shapes the old local-header walk corrupted or rejected:
+// stored streaming entries (silent manifest truncation) and Go-default
+// deflated streaming entries (rejected outright). Sizes come from the
+// central directory — the format's authoritative index — and structural
+// failures are fail-hard, unlike the skill-artifact reader's non-fatal
+// empty return: nothing upstream vouches for an attachment.
+
+describe("validateZipForExtraction — central-directory parsing (issue #567)", () => {
+  it("validates every entry of a stored streaming archive (no silent truncation)", () => {
+    // Method 0 + flag bit 3 + zeroed local sizes: the old walk admitted the
+    // first entry with size 0, landed mid-payload, and quietly dropped the
+    // rest of the manifest.
+    const zip = Buffer.from(buildZip([
+      { name: "first.txt", content: "first file content", streaming: true },
+      { name: "second.txt", content: "second file content", streaming: true },
+    ]));
+
+    const result = validateZipForExtraction(zip, "streamed.zip");
+    expect(result.map((e) => e.relativePath)).toEqual(["first.txt", "second.txt"]);
+    expect(result.map((e) => e.uncompressedSize)).toEqual([
+      "first file content".length,
+      "second file content".length,
+    ]);
+  });
+
+  it("accepts a Go-default archive (deflated streaming entries)", () => {
+    const zip = Buffer.from(buildZip([
+      { name: "main.go", content: "package main", method: "deflated", streaming: true },
+      { name: "go.mod", content: "module example", method: "deflated", streaming: true },
+    ]));
+
+    const result = validateZipForExtraction(zip, "go-built.zip");
+    expect(result.map((e) => e.relativePath)).toEqual(["go.mod", "main.go"]);
+  });
+
+  it("rejects an archive with no central directory (fail-hard, unlike skill extraction)", () => {
+    const zip = Buffer.from(buildZip(
+      [{ name: "a.txt", content: "aaa" }],
+      { omitCentralDirectory: true },
+    ));
+
+    expect(() => validateZipForExtraction(zip, "truncated.zip"))
+      .toThrow(AttachmentValidationError);
+    expect(() => validateZipForExtraction(zip, "truncated.zip"))
+      .toThrow(/not a valid ZIP archive/);
+  });
+
+  it("rejects duplicate entry paths (a contradictory manifest)", () => {
+    const zip = Buffer.from(buildZip([
+      { name: "dup.txt", content: "one" },
+      { name: "dup.txt", content: "two" },
+    ]));
+
+    expect(() => validateZipForExtraction(zip, "dup.zip"))
+      .toThrow(/duplicate entry/);
+  });
+
+  it("locates the central directory behind a trailing archive comment", () => {
+    const zip = Buffer.from(buildZip(
+      [{ name: "a.txt", content: "aaa" }],
+      { comment: "release archive — built by tooling" },
+    ));
+
+    const result = validateZipForExtraction(zip, "commented.zip");
+    expect(result.map((e) => e.relativePath)).toEqual(["a.txt"]);
+  });
+});
+
+describe("injectAttachments — central-directory extraction (issue #567)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "attachment-cd-"));
+  });
+
+  async function extractArchive(zip: Uint8Array) {
+    const localFile = join(tempDir, "archive.zip");
+    await writeFile(localFile, zip);
+    const backend = mockWorkspaceBackend();
+    const result = await injectAttachments({
+      backend,
+      attachments: [makeAttachment({
+        filename: "archive.zip",
+        mountPath: ".stigmer/inputs/archive",
+        extract: true,
+        localPath: localFile,
+      })],
+      storage: makeMockStorage(),
+      isLocalMode: true,
+    });
+    return { backend, result };
+  }
+
+  it("extracts a stored streaming archive completely, contents intact", async () => {
+    const { backend, result } = await extractArchive(buildZip([
+      { name: "first.txt", content: "first file content", streaming: true },
+      { name: "second.txt", content: "second file content", streaming: true },
+    ]));
+
+    expect(result.map((f) => f.path).sort()).toEqual([
+      ".stigmer/inputs/archive/first.txt",
+      ".stigmer/inputs/archive/second.txt",
+    ]);
+    expect(backend.writeFileBuffer).toHaveBeenCalledWith(
+      ".stigmer/inputs/archive/first.txt", Buffer.from("first file content"),
+    );
+    expect(backend.writeFileBuffer).toHaveBeenCalledWith(
+      ".stigmer/inputs/archive/second.txt", Buffer.from("second file content"),
+    );
+  });
+
+  it("extracts a Go-default deflated streaming archive", async () => {
+    const { backend, result } = await extractArchive(buildZip([
+      { name: "src/main.go", content: "package main\n", method: "deflated", streaming: true },
+    ]));
+
+    expect(result).toHaveLength(1);
+    expect(backend.writeFileBuffer).toHaveBeenCalledWith(
+      ".stigmer/inputs/archive/src/main.go", Buffer.from("package main\n"),
+    );
+  });
+
+  it("aborts when an entry inflates past its declared size (crafted archive)", async () => {
+    await expect(extractArchive(buildZip([
+      {
+        name: "bomb.txt",
+        content: "x".repeat(4096),
+        method: "deflated",
+        declaredUncompressedSize: 16,
+      },
+    ]))).rejects.toThrow(AttachmentValidationError);
+  });
+
+  it("aborts when a stored entry's payload disagrees with its declared size", async () => {
+    await expect(extractArchive(buildZip([
+      { name: "short.txt", content: "eleven byte", declaredUncompressedSize: 4096 },
+    ]))).rejects.toThrow(/declare/);
   });
 });
 

--- a/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
@@ -5,13 +5,23 @@
  * validates ZIP archives with security guards, and writes files into the
  * workspace via the platform mount namespace (.stigmer/inputs/).
  *
- * Security model: attachments are untrusted user uploads. All ZIP content
- * is validated for path traversal, zip bombs, and format integrity before
- * any extraction occurs.
+ * Security model: attachments are untrusted user uploads. ZIP archives are
+ * parsed from the central directory — the format's authoritative index —
+ * via the shared structural layer (shared/zip-structure.ts; issue #567,
+ * which killed this module's local-header walk: it silently truncated
+ * stored streaming entries and rejected Go-default archives outright).
+ * Every entry is validated for path traversal, zip bombs, and format
+ * integrity BEFORE any extraction occurs, and because the central
+ * directory's sizes are declarations an attacker controls, decompression
+ * re-enforces them: an entry whose actual output disagrees with its
+ * declared size aborts the injection.
  *
  * Error model: fail-hard. Any attachment failure aborts the entire injection
  * and propagates a descriptive error. Attachments are explicit user inputs —
- * running with partial inputs produces silently incorrect results.
+ * running with partial inputs produces silently incorrect results. This is
+ * deliberately the OPPOSITE policy from the skill-artifact reader
+ * (shared/zip-extract.ts, non-fatal empty return): skill artifacts were
+ * structurally vouched for by the push gates, attachments never are.
  *
  * Duplicate names are NOT a failure (issue #364): a default-derived mount
  * path that collides is renamed with the platform's `stem-2.ext` semantics
@@ -34,13 +44,17 @@ import type {
   VisionDegradedReason,
   VisionImage,
 } from "../../shared/attachment-vision.js";
+import {
+  EOCD_MIN_SIZE,
+  parseZipStructure,
+  type ZipStructuralEntry,
+} from "../../shared/zip-structure.js";
 
 // ── Constants ────────────────────────────────────────────────────────
 
 const MAX_ZIP_FILES = 1000;
 const MAX_ZIP_EXTRACTED_SIZE = 100 * 1024 * 1024; // 100 MB
 const DEFAULT_INPUTS_PREFIX = ".stigmer/inputs";
-const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 
 export { MAX_ZIP_FILES, MAX_ZIP_EXTRACTED_SIZE };
 
@@ -132,126 +146,117 @@ export class AttachmentValidationError extends Error {
   }
 }
 
-// ── ZIP Validation (pure function) ───────────────────────────────────
+// ── ZIP Validation (pure functions) ──────────────────────────────────
 
 /**
  * Validate a ZIP archive for safe extraction. Returns the manifest of
  * file entries (directories excluded) if the archive passes all checks.
  *
  * Security checks enforced:
- * 1. Valid ZIP format (local file header signature present)
+ * 1. Valid ZIP format (readable central directory; fail-hard, see module doc)
  * 2. No absolute paths (entries starting with / or \)
  * 3. No path traversal (.. components)
  * 4. No null bytes in filenames
- * 5. Non-empty archive (at least one file entry)
- * 6. File count within limits (max 1000)
- * 7. Total uncompressed size within limits (max 100 MB)
+ * 5. No duplicate entry paths (a contradictory manifest)
+ * 6. Only supported compression methods (stored, deflate) — checked here
+ *    so an unsupported entry can never abort extraction after earlier
+ *    entries were already written
+ * 7. Non-empty archive (at least one file entry)
+ * 8. File count within limits (max 1000)
+ * 9. Total declared uncompressed size within limits (max 100 MB) —
+ *    declarations are re-enforced against actual output at decompression
  */
 export function validateZipForExtraction(
   zipData: Buffer,
   sourceFilename: string,
 ): ZipEntryInfo[] {
-  if (zipData.length < 4) {
+  return parseAndValidateZip(zipData, sourceFilename).map(
+    ({ relativePath, uncompressedSize }) => ({ relativePath, uncompressedSize }),
+  );
+}
+
+/**
+ * A validated file entry, still carrying its payload slice. Validation and
+ * extraction share these records — parsing happens exactly once, so "the
+ * manifest promised a file extraction cannot find" is unrepresentable
+ * (the old two-walker design silently skipped such entries).
+ */
+interface ValidatedZipEntry extends ZipEntryInfo {
+  readonly compressionMethod: number;
+  readonly compressedData: Uint8Array;
+}
+
+function parseAndValidateZip(
+  zipData: Buffer,
+  sourceFilename: string,
+): ValidatedZipEntry[] {
+  if (zipData.length < EOCD_MIN_SIZE) {
     throw new AttachmentValidationError(
       sourceFilename,
       "not a valid ZIP archive (file too small)",
     );
   }
 
-  const view = new DataView(zipData.buffer, zipData.byteOffset, zipData.byteLength);
-  const firstSignature = view.getUint32(0, true);
-
-  if (firstSignature !== ZIP_LOCAL_FILE_HEADER_SIGNATURE) {
+  let structural: ZipStructuralEntry[];
+  try {
+    structural = parseZipStructure(zipData);
+  } catch (err) {
     throw new AttachmentValidationError(
       sourceFilename,
-      "not a valid ZIP archive (invalid header signature)",
+      `not a valid ZIP archive (${err instanceof Error ? err.message : String(err)})`,
     );
   }
 
-  const entries: ZipEntryInfo[] = [];
+  const entries: ValidatedZipEntry[] = [];
+  const seenPaths = new Set<string>();
   let totalUncompressed = 0;
-  let offset = 0;
 
-  while (offset < zipData.length - 4) {
-    const signature = view.getUint32(offset, true);
-    if (signature !== ZIP_LOCAL_FILE_HEADER_SIGNATURE) break;
-
-    if (offset + 30 > zipData.length) {
+  for (const entry of structural) {
+    if (entry.name.includes("\u0000")) {
       throw new AttachmentValidationError(
         sourceFilename,
-        "not a valid ZIP archive (truncated local file header)",
+        "contains a filename with null bytes and cannot be safely extracted",
       );
     }
 
-    const compressionMethod = view.getUint16(offset + 8, true);
-    const compressedSize = view.getUint32(offset + 18, true);
-    const uncompressedSize = view.getUint32(offset + 22, true);
-    const fileNameLength = view.getUint16(offset + 26, true);
-    const extraFieldLength = view.getUint16(offset + 28, true);
+    if (entry.isDirectory) continue;
 
-    const fileNameStart = offset + 30;
-    const fileNameEnd = fileNameStart + fileNameLength;
-
-    if (fileNameEnd > zipData.length) {
+    if (entry.name.startsWith("/") || entry.name.startsWith("\\")) {
       throw new AttachmentValidationError(
         sourceFilename,
-        "not a valid ZIP archive (truncated filename)",
+        `contains an absolute path entry and cannot be safely extracted: ${entry.name}`,
       );
     }
 
-    const fileNameBytes = zipData.subarray(fileNameStart, fileNameEnd);
-
-    for (let i = 0; i < fileNameBytes.length; i++) {
-      if (fileNameBytes[i] === 0x00) {
-        throw new AttachmentValidationError(
-          sourceFilename,
-          "contains a filename with null bytes and cannot be safely extracted",
-        );
-      }
+    if (hasPathTraversal(entry.name)) {
+      throw new AttachmentValidationError(
+        sourceFilename,
+        `contains a path traversal entry and cannot be safely extracted: ${entry.name}`,
+      );
     }
 
-    const fileName = new TextDecoder().decode(fileNameBytes);
+    if (seenPaths.has(entry.name)) {
+      throw new AttachmentValidationError(
+        sourceFilename,
+        `contains duplicate entry '${entry.name}' and cannot be safely extracted`,
+      );
+    }
+    seenPaths.add(entry.name);
 
-    const isDirectory = fileName.endsWith("/");
-
-    if (!isDirectory) {
-      if (fileName.startsWith("/") || fileName.startsWith("\\")) {
-        throw new AttachmentValidationError(
-          sourceFilename,
-          `contains an absolute path entry and cannot be safely extracted: ${fileName}`,
-        );
-      }
-
-      if (hasPathTraversal(fileName)) {
-        throw new AttachmentValidationError(
-          sourceFilename,
-          `contains a path traversal entry and cannot be safely extracted: ${fileName}`,
-        );
-      }
-
-      entries.push({ relativePath: fileName, uncompressedSize });
-      totalUncompressed += uncompressedSize;
+    if (entry.compressionMethod !== 0 && entry.compressionMethod !== 8) {
+      throw new AttachmentValidationError(
+        sourceFilename,
+        `entry '${entry.name}' uses unsupported compression method ${entry.compressionMethod}`,
+      );
     }
 
-    const dataStart = fileNameStart + fileNameLength + extraFieldLength;
-
-    // Handle data descriptor (bit 3 of general purpose flag)
-    const generalFlags = view.getUint16(offset + 6, true);
-    let dataSize = compressedSize;
-
-    if ((generalFlags & 0x08) !== 0 && compressedSize === 0) {
-      // Data descriptor follows compressed data — scan for next header
-      // This is a simplified approach; for untrusted inputs we require
-      // sizes in the local header. Reject archives that use streaming.
-      if (!isDirectory && compressionMethod !== 0) {
-        throw new AttachmentValidationError(
-          sourceFilename,
-          "uses streaming (data descriptors without sizes) which is not supported for security validation",
-        );
-      }
-    }
-
-    offset = dataStart + dataSize;
+    entries.push({
+      relativePath: entry.name,
+      uncompressedSize: entry.uncompressedSize,
+      compressionMethod: entry.compressionMethod,
+      compressedData: entry.compressedData,
+    });
+    totalUncompressed += entry.uncompressedSize;
   }
 
   if (entries.length === 0) {
@@ -306,9 +311,9 @@ export async function injectAttachments(opts: InjectAttachmentsOptions): Promise
     const { path: mountPath, renamedFrom } = mountPaths.get(attachment)!;
 
     if (attachment.extract) {
-      const entries = validateZipForExtraction(content, attachment.filename);
+      const entries = parseAndValidateZip(content, attachment.filename);
       const extracted = await extractZipToWorkspace(
-        content, entries, mountPath, backend,
+        entries, mountPath, backend, attachment.filename,
       );
       // A renamed mount DIR is visible through every extracted path; the
       // entries themselves were not renamed, so they carry no renamedFrom
@@ -524,20 +529,16 @@ async function downloadAttachment(
 }
 
 async function extractZipToWorkspace(
-  zipData: Buffer,
-  entries: readonly ZipEntryInfo[],
+  entries: readonly ValidatedZipEntry[],
   mountDir: string,
   backend: WorkspaceBackend,
+  sourceFilename: string,
 ): Promise<InjectedFile[]> {
   const cleanMountDir = mountDir.replace(/\/+$/, "");
   const injected: InjectedFile[] = [];
-  const parsedEntries = parseZipFileData(zipData);
 
   for (const entry of entries) {
-    const fileData = parsedEntries.get(entry.relativePath);
-    if (!fileData) continue;
-
-    const content = await decompressEntry(fileData);
+    const content = await decompressEntry(entry, sourceFilename);
     const targetPath = `${cleanMountDir}/${entry.relativePath}`;
 
     await backend.writeFileBuffer(targetPath, content);
@@ -551,63 +552,66 @@ async function extractZipToWorkspace(
   return injected;
 }
 
-interface RawZipEntry {
-  compressedData: Buffer;
-  compressionMethod: number;
-}
+/**
+ * Decompress a validated entry, enforcing its declared uncompressed size.
+ *
+ * The size cap in parseAndValidateZip budgets *declared* sizes, which the
+ * archive author controls — a crafted archive can declare 1 KB and inflate
+ * to gigabytes. Enforcement is therefore two-sided and fail-hard: inflation
+ * aborts the moment output exceeds the declaration, and an undershoot (or a
+ * stored payload whose length disagrees) fails too, because a manifest that
+ * misdescribes its own contents is exactly the corrupt-input class this
+ * module must never extract from.
+ */
+async function decompressEntry(
+  entry: ValidatedZipEntry,
+  sourceFilename: string,
+): Promise<Buffer> {
+  const declared = entry.uncompressedSize;
 
-function parseZipFileData(zipData: Buffer): Map<string, RawZipEntry> {
-  const result = new Map<string, RawZipEntry>();
-  const view = new DataView(zipData.buffer, zipData.byteOffset, zipData.byteLength);
-  let offset = 0;
-
-  while (offset < zipData.length - 4) {
-    const signature = view.getUint32(offset, true);
-    if (signature !== ZIP_LOCAL_FILE_HEADER_SIGNATURE) break;
-
-    const compressionMethod = view.getUint16(offset + 8, true);
-    const compressedSize = view.getUint32(offset + 18, true);
-    const fileNameLength = view.getUint16(offset + 26, true);
-    const extraFieldLength = view.getUint16(offset + 28, true);
-
-    const fileNameStart = offset + 30;
-    const fileName = new TextDecoder().decode(
-      zipData.subarray(fileNameStart, fileNameStart + fileNameLength),
-    );
-
-    const dataStart = fileNameStart + fileNameLength + extraFieldLength;
-    const compressedData = zipData.subarray(dataStart, dataStart + compressedSize);
-
-    if (!fileName.endsWith("/")) {
-      result.set(fileName, {
-        compressedData: Buffer.from(compressedData),
-        compressionMethod,
-      });
-    }
-
-    offset = dataStart + compressedSize;
-  }
-
-  return result;
-}
-
-async function decompressEntry(entry: RawZipEntry): Promise<Buffer> {
   if (entry.compressionMethod === 0) {
-    return entry.compressedData;
+    if (entry.compressedData.length !== declared) {
+      throw new AttachmentValidationError(
+        sourceFilename,
+        `entry '${entry.relativePath}' payload is ${entry.compressedData.length} bytes ` +
+        `but the archive declares ${declared} — corrupt or crafted archive`,
+      );
+    }
+    return Buffer.from(entry.compressedData);
   }
 
-  if (entry.compressionMethod === 8) {
-    return new Promise<Buffer>((resolve, reject) => {
-      const inflate = createInflateRaw();
-      const chunks: Buffer[] = [];
-      inflate.on("data", (chunk: Buffer) => chunks.push(chunk));
-      inflate.on("end", () => resolve(Buffer.concat(chunks)));
-      inflate.on("error", reject);
-      inflate.end(entry.compressedData);
+  // Deflate — the only other method parseAndValidateZip admits.
+  return new Promise<Buffer>((resolve, reject) => {
+    const inflate = createInflateRaw();
+    const chunks: Buffer[] = [];
+    let produced = 0;
+    inflate.on("data", (chunk: Buffer) => {
+      produced += chunk.length;
+      if (produced > declared) {
+        inflate.destroy();
+        reject(new AttachmentValidationError(
+          sourceFilename,
+          `entry '${entry.relativePath}' decompresses past its declared size of ` +
+          `${declared} bytes — corrupt or crafted archive`,
+        ));
+        return;
+      }
+      chunks.push(chunk);
     });
-  }
-
-  throw new Error(`Unsupported ZIP compression method: ${entry.compressionMethod}`);
+    inflate.on("end", () => {
+      if (produced !== declared) {
+        reject(new AttachmentValidationError(
+          sourceFilename,
+          `entry '${entry.relativePath}' decompressed to ${produced} bytes ` +
+          `but the archive declares ${declared} — corrupt or crafted archive`,
+        ));
+        return;
+      }
+      resolve(Buffer.concat(chunks));
+    });
+    inflate.on("error", reject);
+    inflate.end(Buffer.from(entry.compressedData));
+  });
 }
 
 function hasPathTraversal(filePath: string): boolean {

--- a/backend/services/runner/src/shared/zip-extract.ts
+++ b/backend/services/runner/src/shared/zip-extract.ts
@@ -1,18 +1,10 @@
 /**
- * Minimal, dependency-free ZIP archive parser.
+ * Skill-artifact ZIP extraction: text-decoded entries with non-fatal
+ * structural failure.
  *
- * Parsing is *central-directory-based*: entries are enumerated from the
- * archive's end-of-central-directory record (EOCD) and central directory —
- * the format's authoritative index — never by walking local file headers
- * front-to-back. This is a correctness decision, not a style choice
- * (issue #450): local headers of streaming entries (general-purpose flag
- * bit 3) carry zeroed sizes, and the only local-only way to recover them
- * is scanning the payload for the data-descriptor signature — which
- * silently truncates any stored entry whose *content* happens to contain
- * those four bytes, and desynchronizes every entry after it. The central
- * directory always carries the real sizes, and this parser always holds
- * the complete archive bytes, so nothing a local-header walk could offer
- * is needed.
+ * Structural parsing lives in zip-structure.ts (central-directory-based —
+ * see that module's doc for why local-header walks are never acceptable,
+ * issue #450). This module owns the skill-artifact *policy* on top of it:
  *
  * Input without a readable central directory is not given a second
  * chance on purpose: every artifact reaching the runner was validated at
@@ -21,9 +13,8 @@
  * commons-compress `ZipFile` in SkillArtifactExtractor), so a missing
  * EOCD here can only mean a truncated or corrupted download — and the
  * honest result for that is the documented empty return, not a guess.
- *
- * ZIP64 is deliberately unsupported: the push gates cap artifacts at
- * 100MB / 10,000 files, far below every ZIP64 threshold.
+ * (The attachment injector consumes the same structural layer under the
+ * opposite policy — fail-hard — because its input is untrusted.)
  *
  * Handles stored (method 0) and deflated (method 8) entries. Returns
  * parsed entries as path + content pairs — consumers bring their own
@@ -35,6 +26,7 @@
  */
 
 import { createInflateRaw } from "node:zlib";
+import { EOCD_MIN_SIZE, parseZipStructure, type ZipStructuralEntry } from "./zip-structure.js";
 
 // ─── Public API ──────────────────────────────────────────────────────────
 
@@ -64,9 +56,9 @@ export async function extractZipFileEntries(
 ): Promise<ZipFileEntry[]> {
   if (zipBytes.length < EOCD_MIN_SIZE) return [];
 
-  let entries: ZipEntry[];
+  let entries: ZipStructuralEntry[];
   try {
-    entries = parseZipEntries(zipBytes);
+    entries = parseZipStructure(zipBytes);
   } catch (err) {
     console.warn(
       "[zip-extract] archive has no readable central directory " +
@@ -89,33 +81,6 @@ export async function extractZipFileEntries(
   return results;
 }
 
-// ─── Structural parsing (central directory) ──────────────────────────────
-//
-// This layer is deliberately policy-free — it maps bytes to entry records
-// (name, method, payload slice) and nothing else — so a future consumer
-// with different policy (e.g. the attachment injector's fail-hard,
-// security-validated extraction) can lift it without dragging along the
-// skill-specific text decoding above.
-
-const LOCAL_FILE_HEADER_SIG = 0x04034b50;
-const CENTRAL_DIRECTORY_SIG = 0x02014b50;
-const EOCD_SIG = 0x06054b50;
-
-/** Fixed size of the EOCD record, excluding the variable-length comment. */
-const EOCD_MIN_SIZE = 22;
-/** The archive comment length is a u16, so the EOCD sits within the last 64KB + 22 bytes. */
-const EOCD_MAX_COMMENT = 0xffff;
-
-const LOCAL_HEADER_SIZE = 30;
-const CD_RECORD_SIZE = 46;
-
-interface ZipEntry {
-  name: string;
-  isDirectory: boolean;
-  compressedData: Uint8Array;
-  compressionMethod: number;
-}
-
 function isExcluded(name: string, excludeSet: ReadonlySet<string>): boolean {
   if (excludeSet.size === 0) return false;
   if (excludeSet.has(name)) return true;
@@ -124,119 +89,9 @@ function isExcluded(name: string, excludeSet: ReadonlySet<string>): boolean {
   return excludeSet.has(basename);
 }
 
-/**
- * Enumerate the archive's entries from its central directory.
- *
- * Throws on any structural defect (no valid EOCD, a central directory or
- * local header record that doesn't parse, a payload slice that runs past
- * the end of the buffer) — the caller translates that into the module's
- * non-fatal empty return.
- */
-function parseZipEntries(data: Uint8Array): ZipEntry[] {
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  const eocd = findEndOfCentralDirectory(data, view);
-
-  const entries: ZipEntry[] = [];
-  let offset = eocd.centralDirectoryOffset;
-
-  for (let i = 0; i < eocd.entryCount; i++) {
-    if (offset + CD_RECORD_SIZE > data.length || view.getUint32(offset, true) !== CENTRAL_DIRECTORY_SIG) {
-      throw new Error(`invalid central directory record at offset ${offset}`);
-    }
-
-    const compressionMethod = view.getUint16(offset + 10, true);
-    const compressedSize = view.getUint32(offset + 20, true);
-    const fileNameLength = view.getUint16(offset + 28, true);
-    const extraFieldLength = view.getUint16(offset + 30, true);
-    const commentLength = view.getUint16(offset + 32, true);
-    const localHeaderOffset = view.getUint32(offset + 42, true);
-
-    const fileName = new TextDecoder().decode(
-      data.subarray(offset + CD_RECORD_SIZE, offset + CD_RECORD_SIZE + fileNameLength),
-    );
-
-    // The local header is consulted for one thing only: the payload start.
-    // Its name/extra field lengths can legitimately differ from the central
-    // directory's (streaming writers pad the extra field), so the offset
-    // cannot be derived from CD fields alone.
-    const dataStart = payloadStart(data, view, localHeaderOffset, fileName);
-    if (dataStart + compressedSize > data.length) {
-      throw new Error(`entry "${fileName}" payload runs past end of archive`);
-    }
-
-    entries.push({
-      name: fileName,
-      isDirectory: fileName.endsWith("/"),
-      compressedData: data.subarray(dataStart, dataStart + compressedSize),
-      compressionMethod,
-    });
-
-    offset += CD_RECORD_SIZE + fileNameLength + extraFieldLength + commentLength;
-  }
-
-  return entries;
-}
-
-interface EndOfCentralDirectory {
-  centralDirectoryOffset: number;
-  entryCount: number;
-}
-
-/**
- * Locate and validate the end-of-central-directory record.
- *
- * Scans backward from the end of the archive across the maximum comment
- * span. A signature match alone is not trusted (the four bytes can occur
- * inside a trailing comment): the record must also point at an offset
- * that actually holds a central directory record, or be a genuinely
- * empty archive.
- */
-function findEndOfCentralDirectory(data: Uint8Array, view: DataView): EndOfCentralDirectory {
-  const scanFloor = Math.max(0, data.length - EOCD_MIN_SIZE - EOCD_MAX_COMMENT);
-
-  for (let pos = data.length - EOCD_MIN_SIZE; pos >= scanFloor; pos--) {
-    if (view.getUint32(pos, true) !== EOCD_SIG) continue;
-
-    const entryCount = view.getUint16(pos + 10, true);
-    const centralDirectorySize = view.getUint32(pos + 12, true);
-    const centralDirectoryOffset = view.getUint32(pos + 16, true);
-
-    const directoryEndsAtRecord = centralDirectoryOffset + centralDirectorySize <= pos;
-    const directoryLooksReal =
-      entryCount === 0 ||
-      (centralDirectoryOffset + 4 <= data.length &&
-        view.getUint32(centralDirectoryOffset, true) === CENTRAL_DIRECTORY_SIG);
-
-    if (directoryEndsAtRecord && directoryLooksReal) {
-      return { centralDirectoryOffset, entryCount };
-    }
-  }
-
-  throw new Error("no end-of-central-directory record found");
-}
-
-/** Resolve where an entry's payload begins, from its local file header. */
-function payloadStart(
-  data: Uint8Array,
-  view: DataView,
-  localHeaderOffset: number,
-  fileName: string,
-): number {
-  if (
-    localHeaderOffset + LOCAL_HEADER_SIZE > data.length ||
-    view.getUint32(localHeaderOffset, true) !== LOCAL_FILE_HEADER_SIG
-  ) {
-    throw new Error(`entry "${fileName}" has no local file header at offset ${localHeaderOffset}`);
-  }
-
-  const localNameLength = view.getUint16(localHeaderOffset + 26, true);
-  const localExtraLength = view.getUint16(localHeaderOffset + 28, true);
-  return localHeaderOffset + LOCAL_HEADER_SIZE + localNameLength + localExtraLength;
-}
-
 // ─── Decompression ───────────────────────────────────────────────────────
 
-async function decompressEntry(entry: ZipEntry): Promise<string> {
+async function decompressEntry(entry: ZipStructuralEntry): Promise<string> {
   if (entry.compressionMethod === 0) {
     return new TextDecoder().decode(entry.compressedData);
   }

--- a/backend/services/runner/src/shared/zip-structure.ts
+++ b/backend/services/runner/src/shared/zip-structure.ts
@@ -1,0 +1,181 @@
+/**
+ * Policy-free structural ZIP parsing: end-of-central-directory (EOCD)
+ * location plus central-directory walk, producing one record per entry.
+ *
+ * Parsing is *central-directory-based* — never a front-to-back walk of
+ * local file headers. This is a correctness decision, not a style choice
+ * (issues #450 and #567): local headers of streaming entries
+ * (general-purpose flag bit 3) carry zeroed sizes, and the only
+ * local-only way to recover them is scanning the payload for the
+ * data-descriptor signature — which silently truncates any stored entry
+ * whose *content* happens to contain those four bytes, and
+ * desynchronizes every entry after it. The central directory always
+ * carries the real sizes, and every consumer here holds the complete
+ * archive bytes, so nothing a local-header walk could offer is needed.
+ *
+ * This layer maps bytes to entry records and nothing else. Policy — what
+ * a structural failure means, which entries are acceptable, how payloads
+ * are decoded — belongs to the consumers, and they differ on purpose:
+ *
+ *   - shared/zip-extract.ts (skill artifacts): structural failure is
+ *     NON-FATAL — both editions' push gates validated every artifact
+ *     with a central-directory-based reader before storage, so a defect
+ *     here can only be a truncated or corrupted download.
+ *   - execute-deep-agent/attachment-injector.ts (user attachments):
+ *     structural failure is FAIL-HARD — the input is an untrusted
+ *     upload and nothing upstream vouched for it.
+ *
+ * ZIP64 is deliberately unsupported: both consumers cap input far below
+ * every ZIP64 threshold (skill push gates: 100MB / 10,000 files;
+ * attachment uploads: 10MB).
+ *
+ * Throws plain `Error`s on structural defects (no valid EOCD, a central
+ * directory or local header record that does not parse, a payload slice
+ * that runs past the end of the buffer); consumers translate those into
+ * their own error models.
+ */
+
+// ─── Entry records ───────────────────────────────────────────────────────
+
+export interface ZipStructuralEntry {
+  /** Entry path exactly as recorded in the central directory. */
+  readonly name: string;
+  readonly isDirectory: boolean;
+  readonly compressionMethod: number;
+  /**
+   * The central directory's declared uncompressed size — authoritative for
+   * pre-extraction accounting (e.g. ZIP-bomb budgeting), but still a
+   * *declaration*: a consumer that distrusts its input must enforce it
+   * against the actual decompressed output.
+   */
+  readonly uncompressedSize: number;
+  /** The entry's raw payload slice (a view, not a copy) of the archive buffer. */
+  readonly compressedData: Uint8Array;
+}
+
+// ─── Format constants ────────────────────────────────────────────────────
+
+const LOCAL_FILE_HEADER_SIG = 0x04034b50;
+const CENTRAL_DIRECTORY_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+
+/** Fixed size of the EOCD record, excluding the variable-length comment. */
+export const EOCD_MIN_SIZE = 22;
+/** The archive comment length is a u16, so the EOCD sits within the last 64KB + 22 bytes. */
+const EOCD_MAX_COMMENT = 0xffff;
+
+const LOCAL_HEADER_SIZE = 30;
+const CD_RECORD_SIZE = 46;
+
+// ─── Parsing ─────────────────────────────────────────────────────────────
+
+/**
+ * Enumerate the archive's entries from its central directory.
+ *
+ * Throws on any structural defect: no valid EOCD, a central directory or
+ * local header record that doesn't parse, or a payload slice that runs
+ * past the end of the buffer.
+ */
+export function parseZipStructure(data: Uint8Array): ZipStructuralEntry[] {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const eocd = findEndOfCentralDirectory(data, view);
+
+  const entries: ZipStructuralEntry[] = [];
+  let offset = eocd.centralDirectoryOffset;
+
+  for (let i = 0; i < eocd.entryCount; i++) {
+    if (offset + CD_RECORD_SIZE > data.length || view.getUint32(offset, true) !== CENTRAL_DIRECTORY_SIG) {
+      throw new Error(`invalid central directory record at offset ${offset}`);
+    }
+
+    const compressionMethod = view.getUint16(offset + 10, true);
+    const compressedSize = view.getUint32(offset + 20, true);
+    const uncompressedSize = view.getUint32(offset + 24, true);
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraFieldLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const localHeaderOffset = view.getUint32(offset + 42, true);
+
+    const fileName = new TextDecoder().decode(
+      data.subarray(offset + CD_RECORD_SIZE, offset + CD_RECORD_SIZE + fileNameLength),
+    );
+
+    // The local header is consulted for one thing only: the payload start.
+    // Its name/extra field lengths can legitimately differ from the central
+    // directory's (streaming writers pad the extra field), so the offset
+    // cannot be derived from CD fields alone.
+    const dataStart = payloadStart(data, view, localHeaderOffset, fileName);
+    if (dataStart + compressedSize > data.length) {
+      throw new Error(`entry "${fileName}" payload runs past end of archive`);
+    }
+
+    entries.push({
+      name: fileName,
+      isDirectory: fileName.endsWith("/"),
+      compressionMethod,
+      uncompressedSize,
+      compressedData: data.subarray(dataStart, dataStart + compressedSize),
+    });
+
+    offset += CD_RECORD_SIZE + fileNameLength + extraFieldLength + commentLength;
+  }
+
+  return entries;
+}
+
+interface EndOfCentralDirectory {
+  centralDirectoryOffset: number;
+  entryCount: number;
+}
+
+/**
+ * Locate and validate the end-of-central-directory record.
+ *
+ * Scans backward from the end of the archive across the maximum comment
+ * span. A signature match alone is not trusted (the four bytes can occur
+ * inside a trailing comment): the record must also point at an offset
+ * that actually holds a central directory record, or be a genuinely
+ * empty archive.
+ */
+function findEndOfCentralDirectory(data: Uint8Array, view: DataView): EndOfCentralDirectory {
+  const scanFloor = Math.max(0, data.length - EOCD_MIN_SIZE - EOCD_MAX_COMMENT);
+
+  for (let pos = data.length - EOCD_MIN_SIZE; pos >= scanFloor; pos--) {
+    if (view.getUint32(pos, true) !== EOCD_SIG) continue;
+
+    const entryCount = view.getUint16(pos + 10, true);
+    const centralDirectorySize = view.getUint32(pos + 12, true);
+    const centralDirectoryOffset = view.getUint32(pos + 16, true);
+
+    const directoryEndsAtRecord = centralDirectoryOffset + centralDirectorySize <= pos;
+    const directoryLooksReal =
+      entryCount === 0 ||
+      (centralDirectoryOffset + 4 <= data.length &&
+        view.getUint32(centralDirectoryOffset, true) === CENTRAL_DIRECTORY_SIG);
+
+    if (directoryEndsAtRecord && directoryLooksReal) {
+      return { centralDirectoryOffset, entryCount };
+    }
+  }
+
+  throw new Error("no end-of-central-directory record found");
+}
+
+/** Resolve where an entry's payload begins, from its local file header. */
+function payloadStart(
+  data: Uint8Array,
+  view: DataView,
+  localHeaderOffset: number,
+  fileName: string,
+): number {
+  if (
+    localHeaderOffset + LOCAL_HEADER_SIZE > data.length ||
+    view.getUint32(localHeaderOffset, true) !== LOCAL_FILE_HEADER_SIG
+  ) {
+    throw new Error(`entry "${fileName}" has no local file header at offset ${localHeaderOffset}`);
+  }
+
+  const localNameLength = view.getUint16(localHeaderOffset + 26, true);
+  const localExtraLength = view.getUint16(localHeaderOffset + 28, true);
+  return localHeaderOffset + LOCAL_HEADER_SIZE + localNameLength + localExtraLength;
+}


### PR DESCRIPTION
## Summary

Fixes the deep-agent attachment injector's hand-rolled local-header ZIP walk — the second of the two parsers found by #450's sibling audit, this one at the **untrusted-upload boundary** with a documented fail-hard error model it violated three ways:

- **Silent manifest truncation**: a stored streaming entry (method 0, flag bit 3, zeroed local sizes) validated with size 0 and desynchronized the walk into a quiet `break` — a two-file archive extracted ONE empty file, no error.
- **Go-default archives rejected**: any deflated-streaming archive (Go stdlib's default shape, the same shape both editions' skill push accepts) failed validation outright.
- **Validate/extract divergence swallowed**: validation and extraction were two independent walkers, and extraction silently `continue`d past any validated entry its own map lacked.

## Design

One parser, two policies — the layering PR #577 deliberately prepared (design record 017):

- New **`shared/zip-structure.ts`**: the policy-free structural layer (EOCD locate with decoy-resistant validation, central-directory walk → entry records), lifted verbatim from `zip-extract.ts` plus the CD-declared `uncompressedSize` the injector's ZIP-bomb budget needs.
- **`zip-extract.ts`** keeps its public API and skill-artifact policy (non-fatal empty return — push gates vouched for structure) and consumes the shared layer. Its test suite passes untouched.
- **`attachment-injector.ts`** parses **once**: an internal parse-and-validate step produces payload-carrying records, runs the security policy over them (path traversal, null bytes, absolute paths, limits — plus new duplicate-path and unsupported-method rejection), and hands the *same records* to extraction, making the silent-skip state unrepresentable. Structural failure throws `AttachmentValidationError` — fail-hard, the opposite of zip-extract, because nothing upstream vouches for an attachment.
- **Declared-size enforcement** (owner-ruled scope addition): the ZIP-bomb budget counts attacker-controlled declarations, so decompression re-enforces them — inflation aborts the moment output passes the declared size, and any mismatch (short, long, or a stored payload disagreeing) fails hard.

Test fixtures migrate to the shared real-shape builder (`__test-utils__/zip-fixtures.ts`), which gains binary content support and a per-file declared-size override; the old local `makeStoredZip`/`makeDirectoryOnlyZip` emitted CD-less shapes no real ZIP writer produces.

## Verification

- **Red-first**: the 8 new cases fail on the old parser (silent truncation, Go-default rejection, CD-less acceptance, duplicate paths, both lying-size shapes, both extraction paths); all 50 migrated pre-existing assertions stayed green on the old parser.
- **Green**: injector suite 58/58; `zip-extract.test.ts` 20/20 untouched (proves the structural move changed nothing for skill artifacts); full runner suite 4551 passed / 6 skipped; `tsc --noEmit` clean.

Closes #567


Made with [Cursor](https://cursor.com)