### PR TITLE
fix(sdk-react): derive the MCP-server org-override signal client-side — OAuthStatus fields 3-4 are never server-populated

### DIFF
--- a/apis/ai/stigmer/agentic/mcpserver/v1/status.proto
+++ b/apis/ai/stigmer/agentic/mcpserver/v1/status.proto
@@ -55,9 +55,9 @@ message McpServerStatus {
   repeated ToolApprovalPolicy tool_approvals = 4;
 
   // OAuth-related enrichment state, populated at query time by the backend.
-  // Contains vendor approval status (resolved from the referenced OAuthApp)
-  // and BYOA resolution chain results (which OAuthApp is effective for the
-  // caller's org context). None of these fields are persisted.
+  // Carries the vendor approval status resolved from the referenced OAuthApp
+  // (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+  // None of these fields are persisted.
   OAuthStatus oauth_status = 5;
 
   // Standard audit information (created_at, updated_at, created_by, etc.)
@@ -148,10 +148,17 @@ message DiscoveredResourceTemplate {
 }
 
 // OAuthAppSource identifies where the effective OAuth app for an MCP server
-// was resolved from. Populated at query time by the backend enricher to tell
-// the frontend which credential source is active for the current org context.
+// was resolved from.
 //
-// Used in OAuthStatus.effective_oauth_source (read-only, not persisted).
+// The resolution chain is the same one the OAuth connect flow evaluates:
+//   1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
+//   2. McpServerAuth.oauth_app_ref → PLATFORM
+//   3. Neither exists → NONE
+//
+// Resolved CLIENT-SIDE by the shared SDK from the getOrgOAuthApp RPC: the
+// resolution is per (server, caller's active org), and the caller's active
+// org is client-side context the read RPCs never carry, so no backend can
+// compute it at enrichment time (see OAuthStatus fields 3-4).
 enum OAuthAppSource {
   // Default / unset. The resolution chain has not been evaluated yet.
   OAUTH_APP_SOURCE_UNSPECIFIED = 0;
@@ -170,17 +177,24 @@ enum OAuthAppSource {
 // OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
 //
 // @internal
-// All fields are read-only, populated by the backend enricher at query time.
-// None are persisted on the McpServer document — they are computed fresh on
-// every get/getByReference response.
+// All fields are read-only and never persisted on the McpServer document.
 //
-// Two categories of enrichment:
-// 1. Vendor approval (fields 1-2): Resolved from the referenced OAuthApp
-//    resource. Tells the frontend whether the sign-in button should be
-//    enabled and provides a BYOA documentation link when approval is pending.
-// 2. BYOA resolution (fields 3-4): Computed from the OAuth app resolution
-//    chain. Tells the frontend which credential source is active for the
-//    caller's org context and its OAuthApp ID.
+// Two categories, with different production stories:
+// 1. Vendor approval (fields 1-2): populated by the backend enricher on
+//    every get/getByReference response, resolved from the referenced
+//    OAuthApp. Tells the frontend whether the platform sign-in flow is
+//    gated and provides a BYOA documentation link when approval is pending.
+// 2. BYOA resolution (fields 3-4): NEVER POPULATED, by any edition. The
+//    resolution is per (server, caller's active org), and the caller's
+//    active org is client-side context the read RPCs never carry — get has
+//    no org, and getByReference's org is the server's OWNING org (the
+//    lookup key), which differs from the caller's org when browsing another
+//    org's public server. Resolving against the owning org would misreport
+//    exactly the cross-org marketplace flow BYOA exists for. The shared SDK
+//    instead derives the signal client-side from the getOrgOAuthApp RPC,
+//    keyed on the same org the connect flow uses. The fields are retained
+//    for wire compatibility and as the home of this contract note; a future
+//    server-side active-org mechanism could legitimately populate them.
 message OAuthStatus {
   // Vendor marketplace/app-review approval status for this MCP server's
   // OAuth app. Resolved from the referenced OAuthApp at query time.
@@ -194,14 +208,13 @@ message OAuthStatus {
   // Empty when the OAuthApp has no documentation link or is already approved.
   string vendor_approval_docs_url = 2;
 
-  // Where the effective OAuth app was resolved from for the caller's org.
-  // Computed from the resolution chain:
-  //   1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-  //   2. McpServerAuth.oauth_app_ref → PLATFORM
-  //   3. Neither exists → NONE
+  // NEVER POPULATED (see the message comment): the caller's active org is
+  // client-side context, so no backend can evaluate the resolution chain at
+  // read time. The shared SDK derives this value client-side from the
+  // getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
   OAuthAppSource effective_oauth_source = 3;
 
-  // System-generated ID (metadata.id) of the OAuthApp that the resolution
-  // chain selected. Empty when effective_oauth_source is NONE.
+  // NEVER POPULATED (see the message comment). The override's OAuthApp ID
+  // is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
   string effective_oauth_app_id = 4;
 }

--- a/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1/status.pb.go
+++ b/apis/stubs/go/ai/stigmer/agentic/mcpserver/v1/status.pb.go
@@ -85,10 +85,17 @@ func (ValidationState) EnumDescriptor() ([]byte, []int) {
 }
 
 // OAuthAppSource identifies where the effective OAuth app for an MCP server
-// was resolved from. Populated at query time by the backend enricher to tell
-// the frontend which credential source is active for the current org context.
+// was resolved from.
 //
-// Used in OAuthStatus.effective_oauth_source (read-only, not persisted).
+// The resolution chain is the same one the OAuth connect flow evaluates:
+//  1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
+//  2. McpServerAuth.oauth_app_ref → PLATFORM
+//  3. Neither exists → NONE
+//
+// Resolved CLIENT-SIDE by the shared SDK from the getOrgOAuthApp RPC: the
+// resolution is per (server, caller's active org), and the caller's active
+// org is client-side context the read RPCs never carry, so no backend can
+// compute it at enrichment time (see OAuthStatus fields 3-4).
 type OAuthAppSource int32
 
 const (
@@ -190,9 +197,9 @@ type McpServerStatus struct {
 	// 4. AgentExecution.auto_approve_all - Runtime bypass
 	ToolApprovals []*ToolApprovalPolicy `protobuf:"bytes,4,rep,name=tool_approvals,json=toolApprovals,proto3" json:"tool_approvals,omitempty"`
 	// OAuth-related enrichment state, populated at query time by the backend.
-	// Contains vendor approval status (resolved from the referenced OAuthApp)
-	// and BYOA resolution chain results (which OAuthApp is effective for the
-	// caller's org context). None of these fields are persisted.
+	// Carries the vendor approval status resolved from the referenced OAuthApp
+	// (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+	// None of these fields are persisted.
 	OauthStatus *OAuthStatus `protobuf:"bytes,5,opt,name=oauth_status,json=oauthStatus,proto3" json:"oauth_status,omitempty"`
 	// Standard audit information (created_at, updated_at, created_by, etc.)
 	Audit         *apiresource.ApiResourceAudit `protobuf:"bytes,99,opt,name=audit,proto3" json:"audit,omitempty"`
@@ -502,17 +509,24 @@ func (x *DiscoveredResourceTemplate) GetMimeType() string {
 // OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
 //
 // @internal
-// All fields are read-only, populated by the backend enricher at query time.
-// None are persisted on the McpServer document — they are computed fresh on
-// every get/getByReference response.
+// All fields are read-only and never persisted on the McpServer document.
 //
-// Two categories of enrichment:
-//  1. Vendor approval (fields 1-2): Resolved from the referenced OAuthApp
-//     resource. Tells the frontend whether the sign-in button should be
-//     enabled and provides a BYOA documentation link when approval is pending.
-//  2. BYOA resolution (fields 3-4): Computed from the OAuth app resolution
-//     chain. Tells the frontend which credential source is active for the
-//     caller's org context and its OAuthApp ID.
+// Two categories, with different production stories:
+//  1. Vendor approval (fields 1-2): populated by the backend enricher on
+//     every get/getByReference response, resolved from the referenced
+//     OAuthApp. Tells the frontend whether the platform sign-in flow is
+//     gated and provides a BYOA documentation link when approval is pending.
+//  2. BYOA resolution (fields 3-4): NEVER POPULATED, by any edition. The
+//     resolution is per (server, caller's active org), and the caller's
+//     active org is client-side context the read RPCs never carry — get has
+//     no org, and getByReference's org is the server's OWNING org (the
+//     lookup key), which differs from the caller's org when browsing another
+//     org's public server. Resolving against the owning org would misreport
+//     exactly the cross-org marketplace flow BYOA exists for. The shared SDK
+//     instead derives the signal client-side from the getOrgOAuthApp RPC,
+//     keyed on the same org the connect flow uses. The fields are retained
+//     for wire compatibility and as the home of this contract note; a future
+//     server-side active-org mechanism could legitimately populate them.
 type OAuthStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Vendor marketplace/app-review approval status for this MCP server's
@@ -525,14 +539,13 @@ type OAuthStatus struct {
 	// Resolved from the referenced OAuthApp at query time.
 	// Empty when the OAuthApp has no documentation link or is already approved.
 	VendorApprovalDocsUrl string `protobuf:"bytes,2,opt,name=vendor_approval_docs_url,json=vendorApprovalDocsUrl,proto3" json:"vendor_approval_docs_url,omitempty"`
-	// Where the effective OAuth app was resolved from for the caller's org.
-	// Computed from the resolution chain:
-	//  1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-	//  2. McpServerAuth.oauth_app_ref → PLATFORM
-	//  3. Neither exists → NONE
+	// NEVER POPULATED (see the message comment): the caller's active org is
+	// client-side context, so no backend can evaluate the resolution chain at
+	// read time. The shared SDK derives this value client-side from the
+	// getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
 	EffectiveOauthSource OAuthAppSource `protobuf:"varint,3,opt,name=effective_oauth_source,json=effectiveOauthSource,proto3,enum=ai.stigmer.agentic.mcpserver.v1.OAuthAppSource" json:"effective_oauth_source,omitempty"`
-	// System-generated ID (metadata.id) of the OAuthApp that the resolution
-	// chain selected. Empty when effective_oauth_source is NONE.
+	// NEVER POPULATED (see the message comment). The override's OAuthApp ID
+	// is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
 	EffectiveOauthAppId string `protobuf:"bytes,4,opt,name=effective_oauth_app_id,json=effectiveOauthAppId,proto3" json:"effective_oauth_app_id,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/McpServerStatus.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/McpServerStatus.java
@@ -318,9 +318,9 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -333,9 +333,9 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -348,9 +348,9 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1811,9 +1811,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1825,9 +1825,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1843,9 +1843,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1866,9 +1866,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1887,9 +1887,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1915,9 +1915,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1935,9 +1935,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1950,9 +1950,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -1968,9 +1968,9 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * OAuth-related enrichment state, populated at query time by the backend.
-     * Contains vendor approval status (resolved from the referenced OAuthApp)
-     * and BYOA resolution chain results (which OAuthApp is effective for the
-     * caller's org context). None of these fields are persisted.
+     * Carries the vendor approval status resolved from the referenced OAuthApp
+     * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+     * None of these fields are persisted.
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/McpServerStatusOrBuilder.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/McpServerStatusOrBuilder.java
@@ -195,9 +195,9 @@ public interface McpServerStatusOrBuilder extends
   /**
    * <pre>
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -207,9 +207,9 @@ public interface McpServerStatusOrBuilder extends
   /**
    * <pre>
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>
@@ -219,9 +219,9 @@ public interface McpServerStatusOrBuilder extends
   /**
    * <pre>
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5 [json_name = "oauthStatus"];</code>

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/OAuthAppSource.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/OAuthAppSource.java
@@ -8,10 +8,17 @@ package ai.stigmer.agentic.mcpserver.v1;
 /**
  * <pre>
  * OAuthAppSource identifies where the effective OAuth app for an MCP server
- * was resolved from. Populated at query time by the backend enricher to tell
- * the frontend which credential source is active for the current org context.
+ * was resolved from.
  *
- * Used in OAuthStatus.effective_oauth_source (read-only, not persisted).
+ * The resolution chain is the same one the OAuth connect flow evaluates:
+ * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
+ * 2. McpServerAuth.oauth_app_ref → PLATFORM
+ * 3. Neither exists → NONE
+ *
+ * Resolved CLIENT-SIDE by the shared SDK from the getOrgOAuthApp RPC: the
+ * resolution is per (server, caller's active org), and the caller's active
+ * org is client-side context the read RPCs never carry, so no backend can
+ * compute it at enrichment time (see OAuthStatus fields 3-4).
  * </pre>
  *
  * Protobuf enum {@code ai.stigmer.agentic.mcpserver.v1.OAuthAppSource}

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/OAuthStatus.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/OAuthStatus.java
@@ -10,17 +10,24 @@ package ai.stigmer.agentic.mcpserver.v1;
  * OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
  *
  * &#64;internal
- * All fields are read-only, populated by the backend enricher at query time.
- * None are persisted on the McpServer document — they are computed fresh on
- * every get/getByReference response.
+ * All fields are read-only and never persisted on the McpServer document.
  *
- * Two categories of enrichment:
- * 1. Vendor approval (fields 1-2): Resolved from the referenced OAuthApp
- * resource. Tells the frontend whether the sign-in button should be
- * enabled and provides a BYOA documentation link when approval is pending.
- * 2. BYOA resolution (fields 3-4): Computed from the OAuth app resolution
- * chain. Tells the frontend which credential source is active for the
- * caller's org context and its OAuthApp ID.
+ * Two categories, with different production stories:
+ * 1. Vendor approval (fields 1-2): populated by the backend enricher on
+ * every get/getByReference response, resolved from the referenced
+ * OAuthApp. Tells the frontend whether the platform sign-in flow is
+ * gated and provides a BYOA documentation link when approval is pending.
+ * 2. BYOA resolution (fields 3-4): NEVER POPULATED, by any edition. The
+ * resolution is per (server, caller's active org), and the caller's
+ * active org is client-side context the read RPCs never carry — get has
+ * no org, and getByReference's org is the server's OWNING org (the
+ * lookup key), which differs from the caller's org when browsing another
+ * org's public server. Resolving against the owning org would misreport
+ * exactly the cross-org marketplace flow BYOA exists for. The shared SDK
+ * instead derives the signal client-side from the getOrgOAuthApp RPC,
+ * keyed on the same org the connect flow uses. The fields are retained
+ * for wire compatibility and as the home of this contract note; a future
+ * server-side active-org mechanism could legitimately populate them.
  * </pre>
  *
  * Protobuf type {@code ai.stigmer.agentic.mcpserver.v1.OAuthStatus}
@@ -158,11 +165,10 @@ private static final long serialVersionUID = 0L;
   private int effectiveOauthSource_ = 0;
   /**
    * <pre>
-   * Where the effective OAuth app was resolved from for the caller's org.
-   * Computed from the resolution chain:
-   * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-   * 2. McpServerAuth.oauth_app_ref → PLATFORM
-   * 3. Neither exists → NONE
+   * NEVER POPULATED (see the message comment): the caller's active org is
+   * client-side context, so no backend can evaluate the resolution chain at
+   * read time. The shared SDK derives this value client-side from the
+   * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -173,11 +179,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Where the effective OAuth app was resolved from for the caller's org.
-   * Computed from the resolution chain:
-   * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-   * 2. McpServerAuth.oauth_app_ref → PLATFORM
-   * 3. Neither exists → NONE
+   * NEVER POPULATED (see the message comment): the caller's active org is
+   * client-side context, so no backend can evaluate the resolution chain at
+   * read time. The shared SDK derives this value client-side from the
+   * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -193,8 +198,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object effectiveOauthAppId_ = "";
   /**
    * <pre>
-   * System-generated ID (metadata.id) of the OAuthApp that the resolution
-   * chain selected. Empty when effective_oauth_source is NONE.
+   * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+   * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
    * </pre>
    *
    * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -215,8 +220,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * System-generated ID (metadata.id) of the OAuthApp that the resolution
-   * chain selected. Empty when effective_oauth_source is NONE.
+   * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+   * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
    * </pre>
    *
    * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -428,17 +433,24 @@ private static final long serialVersionUID = 0L;
    * OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
    *
    * &#64;internal
-   * All fields are read-only, populated by the backend enricher at query time.
-   * None are persisted on the McpServer document — they are computed fresh on
-   * every get/getByReference response.
+   * All fields are read-only and never persisted on the McpServer document.
    *
-   * Two categories of enrichment:
-   * 1. Vendor approval (fields 1-2): Resolved from the referenced OAuthApp
-   * resource. Tells the frontend whether the sign-in button should be
-   * enabled and provides a BYOA documentation link when approval is pending.
-   * 2. BYOA resolution (fields 3-4): Computed from the OAuth app resolution
-   * chain. Tells the frontend which credential source is active for the
-   * caller's org context and its OAuthApp ID.
+   * Two categories, with different production stories:
+   * 1. Vendor approval (fields 1-2): populated by the backend enricher on
+   * every get/getByReference response, resolved from the referenced
+   * OAuthApp. Tells the frontend whether the platform sign-in flow is
+   * gated and provides a BYOA documentation link when approval is pending.
+   * 2. BYOA resolution (fields 3-4): NEVER POPULATED, by any edition. The
+   * resolution is per (server, caller's active org), and the caller's
+   * active org is client-side context the read RPCs never carry — get has
+   * no org, and getByReference's org is the server's OWNING org (the
+   * lookup key), which differs from the caller's org when browsing another
+   * org's public server. Resolving against the owning org would misreport
+   * exactly the cross-org marketplace flow BYOA exists for. The shared SDK
+   * instead derives the signal client-side from the getOrgOAuthApp RPC,
+   * keyed on the same org the connect flow uses. The fields are retained
+   * for wire compatibility and as the home of this contract note; a future
+   * server-side active-org mechanism could legitimately populate them.
    * </pre>
    *
    * Protobuf type {@code ai.stigmer.agentic.mcpserver.v1.OAuthStatus}
@@ -813,11 +825,10 @@ private static final long serialVersionUID = 0L;
     private int effectiveOauthSource_ = 0;
     /**
      * <pre>
-     * Where the effective OAuth app was resolved from for the caller's org.
-     * Computed from the resolution chain:
-     * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-     * 2. McpServerAuth.oauth_app_ref → PLATFORM
-     * 3. Neither exists → NONE
+     * NEVER POPULATED (see the message comment): the caller's active org is
+     * client-side context, so no backend can evaluate the resolution chain at
+     * read time. The shared SDK derives this value client-side from the
+     * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -828,11 +839,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Where the effective OAuth app was resolved from for the caller's org.
-     * Computed from the resolution chain:
-     * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-     * 2. McpServerAuth.oauth_app_ref → PLATFORM
-     * 3. Neither exists → NONE
+     * NEVER POPULATED (see the message comment): the caller's active org is
+     * client-side context, so no backend can evaluate the resolution chain at
+     * read time. The shared SDK derives this value client-side from the
+     * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -848,11 +858,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Where the effective OAuth app was resolved from for the caller's org.
-     * Computed from the resolution chain:
-     * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-     * 2. McpServerAuth.oauth_app_ref → PLATFORM
-     * 3. Neither exists → NONE
+     * NEVER POPULATED (see the message comment): the caller's active org is
+     * client-side context, so no backend can evaluate the resolution chain at
+     * read time. The shared SDK derives this value client-side from the
+     * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -865,11 +874,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Where the effective OAuth app was resolved from for the caller's org.
-     * Computed from the resolution chain:
-     * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-     * 2. McpServerAuth.oauth_app_ref → PLATFORM
-     * 3. Neither exists → NONE
+     * NEVER POPULATED (see the message comment): the caller's active org is
+     * client-side context, so no backend can evaluate the resolution chain at
+     * read time. The shared SDK derives this value client-side from the
+     * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -885,11 +893,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Where the effective OAuth app was resolved from for the caller's org.
-     * Computed from the resolution chain:
-     * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-     * 2. McpServerAuth.oauth_app_ref → PLATFORM
-     * 3. Neither exists → NONE
+     * NEVER POPULATED (see the message comment): the caller's active org is
+     * client-side context, so no backend can evaluate the resolution chain at
+     * read time. The shared SDK derives this value client-side from the
+     * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
      * </pre>
      *
      * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -905,8 +912,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object effectiveOauthAppId_ = "";
     /**
      * <pre>
-     * System-generated ID (metadata.id) of the OAuthApp that the resolution
-     * chain selected. Empty when effective_oauth_source is NONE.
+     * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+     * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
      * </pre>
      *
      * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -926,8 +933,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * System-generated ID (metadata.id) of the OAuthApp that the resolution
-     * chain selected. Empty when effective_oauth_source is NONE.
+     * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+     * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
      * </pre>
      *
      * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -948,8 +955,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * System-generated ID (metadata.id) of the OAuthApp that the resolution
-     * chain selected. Empty when effective_oauth_source is NONE.
+     * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+     * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
      * </pre>
      *
      * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -966,8 +973,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * System-generated ID (metadata.id) of the OAuthApp that the resolution
-     * chain selected. Empty when effective_oauth_source is NONE.
+     * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+     * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
      * </pre>
      *
      * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -981,8 +988,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * System-generated ID (metadata.id) of the OAuthApp that the resolution
-     * chain selected. Empty when effective_oauth_source is NONE.
+     * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+     * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
      * </pre>
      *
      * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>

--- a/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/OAuthStatusOrBuilder.java
+++ b/apis/stubs/java/src/main/java/ai/stigmer/agentic/mcpserver/v1/OAuthStatusOrBuilder.java
@@ -63,11 +63,10 @@ public interface OAuthStatusOrBuilder extends
 
   /**
    * <pre>
-   * Where the effective OAuth app was resolved from for the caller's org.
-   * Computed from the resolution chain:
-   * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-   * 2. McpServerAuth.oauth_app_ref → PLATFORM
-   * 3. Neither exists → NONE
+   * NEVER POPULATED (see the message comment): the caller's active org is
+   * client-side context, so no backend can evaluate the resolution chain at
+   * read time. The shared SDK derives this value client-side from the
+   * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -76,11 +75,10 @@ public interface OAuthStatusOrBuilder extends
   int getEffectiveOauthSourceValue();
   /**
    * <pre>
-   * Where the effective OAuth app was resolved from for the caller's org.
-   * Computed from the resolution chain:
-   * 1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-   * 2. McpServerAuth.oauth_app_ref → PLATFORM
-   * 3. Neither exists → NONE
+   * NEVER POPULATED (see the message comment): the caller's active org is
+   * client-side context, so no backend can evaluate the resolution chain at
+   * read time. The shared SDK derives this value client-side from the
+   * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
    * </pre>
    *
    * <code>.ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3 [json_name = "effectiveOauthSource"];</code>
@@ -90,8 +88,8 @@ public interface OAuthStatusOrBuilder extends
 
   /**
    * <pre>
-   * System-generated ID (metadata.id) of the OAuthApp that the resolution
-   * chain selected. Empty when effective_oauth_source is NONE.
+   * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+   * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
    * </pre>
    *
    * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>
@@ -100,8 +98,8 @@ public interface OAuthStatusOrBuilder extends
   java.lang.String getEffectiveOauthAppId();
   /**
    * <pre>
-   * System-generated ID (metadata.id) of the OAuthApp that the resolution
-   * chain selected. Empty when effective_oauth_source is NONE.
+   * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+   * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
    * </pre>
    *
    * <code>string effective_oauth_app_id = 4 [json_name = "effectiveOauthAppId"];</code>

--- a/apis/stubs/ts/ai/stigmer/agentic/mcpserver/v1/status_pb.ts
+++ b/apis/stubs/ts/ai/stigmer/agentic/mcpserver/v1/status_pb.ts
@@ -88,9 +88,9 @@ export type McpServerStatus = Message<"ai.stigmer.agentic.mcpserver.v1.McpServer
 
   /**
    * OAuth-related enrichment state, populated at query time by the backend.
-   * Contains vendor approval status (resolved from the referenced OAuthApp)
-   * and BYOA resolution chain results (which OAuthApp is effective for the
-   * caller's org context). None of these fields are persisted.
+   * Carries the vendor approval status resolved from the referenced OAuthApp
+   * (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+   * None of these fields are persisted.
    *
    * @generated from field: ai.stigmer.agentic.mcpserver.v1.OAuthStatus oauth_status = 5;
    */
@@ -253,17 +253,24 @@ export const DiscoveredResourceTemplateSchema: GenMessage<DiscoveredResourceTemp
  * OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
  *
  * @internal
- * All fields are read-only, populated by the backend enricher at query time.
- * None are persisted on the McpServer document — they are computed fresh on
- * every get/getByReference response.
+ * All fields are read-only and never persisted on the McpServer document.
  *
- * Two categories of enrichment:
- * 1. Vendor approval (fields 1-2): Resolved from the referenced OAuthApp
- *    resource. Tells the frontend whether the sign-in button should be
- *    enabled and provides a BYOA documentation link when approval is pending.
- * 2. BYOA resolution (fields 3-4): Computed from the OAuth app resolution
- *    chain. Tells the frontend which credential source is active for the
- *    caller's org context and its OAuthApp ID.
+ * Two categories, with different production stories:
+ * 1. Vendor approval (fields 1-2): populated by the backend enricher on
+ *    every get/getByReference response, resolved from the referenced
+ *    OAuthApp. Tells the frontend whether the platform sign-in flow is
+ *    gated and provides a BYOA documentation link when approval is pending.
+ * 2. BYOA resolution (fields 3-4): NEVER POPULATED, by any edition. The
+ *    resolution is per (server, caller's active org), and the caller's
+ *    active org is client-side context the read RPCs never carry — get has
+ *    no org, and getByReference's org is the server's OWNING org (the
+ *    lookup key), which differs from the caller's org when browsing another
+ *    org's public server. Resolving against the owning org would misreport
+ *    exactly the cross-org marketplace flow BYOA exists for. The shared SDK
+ *    instead derives the signal client-side from the getOrgOAuthApp RPC,
+ *    keyed on the same org the connect flow uses. The fields are retained
+ *    for wire compatibility and as the home of this contract note; a future
+ *    server-side active-org mechanism could legitimately populate them.
  *
  * @generated from message ai.stigmer.agentic.mcpserver.v1.OAuthStatus
  */
@@ -289,19 +296,18 @@ export type OAuthStatus = Message<"ai.stigmer.agentic.mcpserver.v1.OAuthStatus">
   vendorApprovalDocsUrl: string;
 
   /**
-   * Where the effective OAuth app was resolved from for the caller's org.
-   * Computed from the resolution chain:
-   *   1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-   *   2. McpServerAuth.oauth_app_ref → PLATFORM
-   *   3. Neither exists → NONE
+   * NEVER POPULATED (see the message comment): the caller's active org is
+   * client-side context, so no backend can evaluate the resolution chain at
+   * read time. The shared SDK derives this value client-side from the
+   * getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
    *
    * @generated from field: ai.stigmer.agentic.mcpserver.v1.OAuthAppSource effective_oauth_source = 3;
    */
   effectiveOauthSource: OAuthAppSource;
 
   /**
-   * System-generated ID (metadata.id) of the OAuthApp that the resolution
-   * chain selected. Empty when effective_oauth_source is NONE.
+   * NEVER POPULATED (see the message comment). The override's OAuthApp ID
+   * is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
    *
    * @generated from field: string effective_oauth_app_id = 4;
    */
@@ -357,10 +363,17 @@ export const ValidationStateSchema: GenEnum<ValidationState> = /*@__PURE__*/
 
 /**
  * OAuthAppSource identifies where the effective OAuth app for an MCP server
- * was resolved from. Populated at query time by the backend enricher to tell
- * the frontend which credential source is active for the current org context.
+ * was resolved from.
  *
- * Used in OAuthStatus.effective_oauth_source (read-only, not persisted).
+ * The resolution chain is the same one the OAuth connect flow evaluates:
+ *   1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
+ *   2. McpServerAuth.oauth_app_ref → PLATFORM
+ *   3. Neither exists → NONE
+ *
+ * Resolved CLIENT-SIDE by the shared SDK from the getOrgOAuthApp RPC: the
+ * resolution is per (server, caller's active org), and the caller's active
+ * org is client-side context the read RPCs never carry, so no backend can
+ * compute it at enrichment time (see OAuthStatus fields 3-4).
  *
  * @generated from enum ai.stigmer.agentic.mcpserver.v1.OAuthAppSource
  */

--- a/docs/sdk/react/mcp-server.mdx
+++ b/docs/sdk/react/mcp-server.mdx
@@ -266,6 +266,15 @@ active grant. The OAuth variable is excluded from `missingVariables`
 form. Additional non-OAuth vars still appear in `missingVariables`
 (mixed mode).
 
+**Org-override-aware**: for vendor-OAuth servers with an
+`oauth_app_ref`, the hook also composes `useOrgOAuthApp` to
+resolve which OAuth app the connect flow will use for `org`
+(`effectiveOAuthSource` / `isOrgOAuthApp` / `canBringOwnApp`).
+The `org` parameter must therefore be the caller's ACTIVE org — the
+org credentials are stored in and the org whose BYOA override
+applies — not necessarily the org that owns the MCP server (they
+differ when browsing another org's public server).
+
 Unlike [`useMcpServerSetup`](#usemcpserversetup) which manages multi-server setup
 for session creation, this hook is scoped to a single server and
 always persists to the personal environment (no one-time option).
@@ -294,11 +303,11 @@ function useMcpServerCredentials(org: string | null, mcpServer: McpServer | null
     canBringOwnApp: { type: "boolean", description: "`true` when the BYOA option is relevant for this server: the server uses vendor OAuth (`authMode === \"oauth\"` with an `oauth_app_ref`), no org override is currently active, AND the backend supports the org-override surface at all.  The last condition is an edition capability, confirmed by probing `getOrgOAuthApp` (see useOrgOAuthApp): the surface is hosted-only, so on OSS deployments — where the submit could only answer UNIMPLEMENTED — this stays `false` and no BYOA affordance renders (stigmer/stigmer#558).  When `true`, the UI should offer \"Use your own OAuth app\" as either a primary action (when vendor approval is blocked) or a secondary link (when vendor approval is granted)." },
     canDisconnect: { type: "boolean", description: "`true` when the user can disconnect (i.e., an OAuth grant exists). Always `false` when `authMode` is `\"manual\"` or no grant is present." },
     connectionHealth: { type: "OAuthConnectionHealth", description: "Health of the OAuth connection for this server.  Provides a four-state signal beyond the binary `isOAuthConnected`: healthy, expired-but-refreshable, expired (re-auth needed), or no grant. `UNSPECIFIED` when `authMode` is `\"manual\"` or the status has not been fetched yet." },
-    effectiveOAuthSource: { type: "OAuthAppSource", description: "Where the effective OAuth app was resolved from for the caller's org.  Enriched at query time by the backend — no additional RPC needed. `UNSPECIFIED` when `authMode` is `\"manual\"` or enrichment has not been performed yet." },
+    effectiveOAuthSource: { type: "OAuthAppSource", description: "Where the effective OAuth app is resolved from for the caller's org — the same source the connect flow will use.  Resolved client-side from the `getOrgOAuthApp` RPC keyed on this hook's `org` parameter. It cannot come from the fetched McpServer: the caller's active org is client-side context the read RPCs never carry, so `status.oauth_status` fields 3-4 are never populated by any backend (see the OAuthStatus proto).  `UNSPECIFIED` when `authMode` is `\"manual\"` or while the override lookup has not yet resolved." },
     error: { type: "Error | null", description: "Error from the personal environment or grant status fetch, or `null`." },
     isLoading: { type: "boolean", description: "`true` while the personal environment or grant status is being fetched." },
     isOAuthConnected: { type: "boolean", description: "`true` when the user has an active OAuth grant for this server. Derived from the `getOAuthGrantStatus` API, not from personal environment key presence. Always `false` when `authMode` is `\"manual\"`." },
-    isOrgOAuthApp: { type: "boolean", description: "`true` when an org-level BYOA override is active for this server. Derived from `effectiveOAuthSource === OAUTH_APP_SOURCE_ORG_OVERRIDE`." },
+    isOrgOAuthApp: { type: "boolean", description: "`true` when an org-level BYOA override is active for this server and org. Derived from the `getOrgOAuthApp` lookup." },
     isReady: { type: "boolean", description: "`true` when all required (non-optional) credentials are available — both OAuth-managed and manual variables. For OAuth servers this means the OAuth grant is connected AND any additional required manual vars are present in the personal environment.  Servers whose env vars are all optional are always ready." },
     isSaving: { type: "boolean", description: "`true` while a save operation is in flight." },
     isVendorApprovalBlocked: { type: "boolean", description: "`true` when the platform OAuth app's vendor approval is PENDING or REJECTED — i.e., the platform sign-in flow is blocked. Covers both statuses since the user-facing behavior is the same: sign-in is disabled and BYOA / manual entry are the available alternatives.  See also isVendorApprovalPending which only checks PENDING." },

--- a/docs/sdk/resources/mcp-server.mdx
+++ b/docs/sdk/resources/mcp-server.mdx
@@ -1281,8 +1281,8 @@ OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
   type={{
     vendorApprovalStatus: { type: "VendorApprovalStatus", description: "Vendor marketplace/app-review approval status for this MCP server's OAuth app.", typeDescriptionLink: "#vendorapprovalstatus" },
     vendorApprovalDocsUrl: { type: "string", description: "Documentation URL for users who want to bring their own OAuth app credentials while the platform's OAuth app is pending vendor approval." },
-    effectiveOauthSource: { type: "OAuthAppSource", description: "Where the effective OAuth app was resolved from for the caller's org.", typeDescriptionLink: "#oauthappsource" },
-    effectiveOauthAppId: { type: "string", description: "System-generated ID (metadata.id) of the OAuthApp that the resolution chain selected." },
+    effectiveOauthSource: { type: "OAuthAppSource", description: "NEVER POPULATED (see the message comment): the caller's active org is client-side context, so no backend can evaluate the resolution chain at read time.", typeDescriptionLink: "#oauthappsource" },
+    effectiveOauthAppId: { type: "string", description: "NEVER POPULATED (see the message comment)." },
   }}
 />
 

--- a/sdk/go/proto/ai/stigmer/agentic/mcpserver/v1/status.pb.go
+++ b/sdk/go/proto/ai/stigmer/agentic/mcpserver/v1/status.pb.go
@@ -85,10 +85,17 @@ func (ValidationState) EnumDescriptor() ([]byte, []int) {
 }
 
 // OAuthAppSource identifies where the effective OAuth app for an MCP server
-// was resolved from. Populated at query time by the backend enricher to tell
-// the frontend which credential source is active for the current org context.
+// was resolved from.
 //
-// Used in OAuthStatus.effective_oauth_source (read-only, not persisted).
+// The resolution chain is the same one the OAuth connect flow evaluates:
+//  1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
+//  2. McpServerAuth.oauth_app_ref → PLATFORM
+//  3. Neither exists → NONE
+//
+// Resolved CLIENT-SIDE by the shared SDK from the getOrgOAuthApp RPC: the
+// resolution is per (server, caller's active org), and the caller's active
+// org is client-side context the read RPCs never carry, so no backend can
+// compute it at enrichment time (see OAuthStatus fields 3-4).
 type OAuthAppSource int32
 
 const (
@@ -190,9 +197,9 @@ type McpServerStatus struct {
 	// 4. AgentExecution.auto_approve_all - Runtime bypass
 	ToolApprovals []*ToolApprovalPolicy `protobuf:"bytes,4,rep,name=tool_approvals,json=toolApprovals,proto3" json:"tool_approvals,omitempty"`
 	// OAuth-related enrichment state, populated at query time by the backend.
-	// Contains vendor approval status (resolved from the referenced OAuthApp)
-	// and BYOA resolution chain results (which OAuthApp is effective for the
-	// caller's org context). None of these fields are persisted.
+	// Carries the vendor approval status resolved from the referenced OAuthApp
+	// (fields 1-2; fields 3-4 are never populated — see OAuthStatus).
+	// None of these fields are persisted.
 	OauthStatus *OAuthStatus `protobuf:"bytes,5,opt,name=oauth_status,json=oauthStatus,proto3" json:"oauth_status,omitempty"`
 	// Standard audit information (created_at, updated_at, created_by, etc.)
 	Audit         *apiresource.ApiResourceAudit `protobuf:"bytes,99,opt,name=audit,proto3" json:"audit,omitempty"`
@@ -502,17 +509,24 @@ func (x *DiscoveredResourceTemplate) GetMimeType() string {
 // OAuthStatus holds system-derived OAuth enrichment state for an MCP server.
 //
 // @internal
-// All fields are read-only, populated by the backend enricher at query time.
-// None are persisted on the McpServer document — they are computed fresh on
-// every get/getByReference response.
+// All fields are read-only and never persisted on the McpServer document.
 //
-// Two categories of enrichment:
-//  1. Vendor approval (fields 1-2): Resolved from the referenced OAuthApp
-//     resource. Tells the frontend whether the sign-in button should be
-//     enabled and provides a BYOA documentation link when approval is pending.
-//  2. BYOA resolution (fields 3-4): Computed from the OAuth app resolution
-//     chain. Tells the frontend which credential source is active for the
-//     caller's org context and its OAuthApp ID.
+// Two categories, with different production stories:
+//  1. Vendor approval (fields 1-2): populated by the backend enricher on
+//     every get/getByReference response, resolved from the referenced
+//     OAuthApp. Tells the frontend whether the platform sign-in flow is
+//     gated and provides a BYOA documentation link when approval is pending.
+//  2. BYOA resolution (fields 3-4): NEVER POPULATED, by any edition. The
+//     resolution is per (server, caller's active org), and the caller's
+//     active org is client-side context the read RPCs never carry — get has
+//     no org, and getByReference's org is the server's OWNING org (the
+//     lookup key), which differs from the caller's org when browsing another
+//     org's public server. Resolving against the owning org would misreport
+//     exactly the cross-org marketplace flow BYOA exists for. The shared SDK
+//     instead derives the signal client-side from the getOrgOAuthApp RPC,
+//     keyed on the same org the connect flow uses. The fields are retained
+//     for wire compatibility and as the home of this contract note; a future
+//     server-side active-org mechanism could legitimately populate them.
 type OAuthStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Vendor marketplace/app-review approval status for this MCP server's
@@ -525,14 +539,13 @@ type OAuthStatus struct {
 	// Resolved from the referenced OAuthApp at query time.
 	// Empty when the OAuthApp has no documentation link or is already approved.
 	VendorApprovalDocsUrl string `protobuf:"bytes,2,opt,name=vendor_approval_docs_url,json=vendorApprovalDocsUrl,proto3" json:"vendor_approval_docs_url,omitempty"`
-	// Where the effective OAuth app was resolved from for the caller's org.
-	// Computed from the resolution chain:
-	//  1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE
-	//  2. McpServerAuth.oauth_app_ref → PLATFORM
-	//  3. Neither exists → NONE
+	// NEVER POPULATED (see the message comment): the caller's active org is
+	// client-side context, so no backend can evaluate the resolution chain at
+	// read time. The shared SDK derives this value client-side from the
+	// getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).
 	EffectiveOauthSource OAuthAppSource `protobuf:"varint,3,opt,name=effective_oauth_source,json=effectiveOauthSource,proto3,enum=ai.stigmer.agentic.mcpserver.v1.OAuthAppSource" json:"effective_oauth_source,omitempty"`
-	// System-generated ID (metadata.id) of the OAuthApp that the resolution
-	// chain selected. Empty when effective_oauth_source is NONE.
+	// NEVER POPULATED (see the message comment). The override's OAuthApp ID
+	// is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).
 	EffectiveOauthAppId string `protobuf:"bytes,4,opt,name=effective_oauth_app_id,json=effectiveOauthAppId,proto3" json:"effective_oauth_app_id,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache

--- a/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
+++ b/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
@@ -344,6 +344,7 @@ function ConnectDialogContent({
           onSignIn={handleOAuthSignIn}
           isVendorApprovalBlocked={creds.isVendorApprovalBlocked}
           isVendorApprovalPending={creds.isVendorApprovalPending}
+          isOrgOAuthApp={creds.isOrgOAuthApp}
           manualEntrySupported={creds.manualEntrySupported}
           canBringOwnApp={creds.canBringOwnApp}
           vendorApprovalDocsUrl={creds.vendorApprovalDocsUrl}
@@ -459,6 +460,7 @@ function OAuthSection({
   onSignIn,
   isVendorApprovalBlocked,
   isVendorApprovalPending,
+  isOrgOAuthApp,
   manualEntrySupported,
   canBringOwnApp,
   vendorApprovalDocsUrl,
@@ -471,6 +473,14 @@ function OAuthSection({
   readonly onSignIn: () => void;
   readonly isVendorApprovalBlocked: boolean;
   readonly isVendorApprovalPending: boolean;
+  /**
+   * `true` when the org's own BYOA OAuth app is the effective one. The
+   * vendor-approval block describes the PLATFORM app, so it neither
+   * disables sign-in nor warrants the blocked notice when the org's own
+   * app is what sign-in will use (the caller-side org-override gate the
+   * notice's contract expects).
+   */
+  readonly isOrgOAuthApp: boolean;
   readonly manualEntrySupported: boolean;
   readonly canBringOwnApp: boolean;
   readonly vendorApprovalDocsUrl: string | null;
@@ -502,7 +512,9 @@ function OAuthSection({
       <button
         type="button"
         onClick={onSignIn}
-        disabled={disabled || isInProgress || isVendorApprovalBlocked}
+        disabled={
+          disabled || isInProgress || (isVendorApprovalBlocked && !isOrgOAuthApp)
+        }
         className={cn(
           "stg:inline-flex stg:w-full stg:items-center stg:justify-center stg:gap-2 stg:rounded-md stg:px-4 stg:py-2 stg:text-sm stg:font-medium",
           "stg:bg-primary stg:text-primary-foreground",
@@ -512,17 +524,23 @@ function OAuthSection({
         )}
       >
         {isInProgress && <LoadingSpinner size="sm" />}
-        {isInProgress ? (phaseLabel[phase] ?? "Connecting...") : "Sign in with OAuth"}
+        {isInProgress
+          ? (phaseLabel[phase] ?? "Connecting...")
+          : isOrgOAuthApp
+            ? "Sign in with your app"
+            : "Sign in with OAuth"}
       </button>
-      <VendorApprovalBlockedNotice
-        blocked={isVendorApprovalBlocked}
-        pending={isVendorApprovalPending}
-        manualEntrySupported={manualEntrySupported}
-        canBringOwnApp={canBringOwnApp}
-        docsUrl={vendorApprovalDocsUrl}
-        onBringOwnApp={onOpenDetails}
-        className="stg:rounded-md stg:border stg:border-amber-500/20"
-      />
+      {!isOrgOAuthApp && (
+        <VendorApprovalBlockedNotice
+          blocked={isVendorApprovalBlocked}
+          pending={isVendorApprovalPending}
+          manualEntrySupported={manualEntrySupported}
+          canBringOwnApp={canBringOwnApp}
+          docsUrl={vendorApprovalDocsUrl}
+          onBringOwnApp={onOpenDetails}
+          className="stg:rounded-md stg:border stg:border-amber-500/20"
+        />
+      )}
       {onSwitchToManual && (
         <button
           type="button"

--- a/sdk/react/src/mcp-server/__tests__/VendorApprovalBlocked.surfaces.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/VendorApprovalBlocked.surfaces.test.tsx
@@ -17,7 +17,6 @@ import {
 import {
   McpServerStatusSchema,
   OAuthStatusSchema,
-  OAuthAppSource,
   ValidationState,
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
 import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
@@ -56,8 +55,11 @@ const DOCS_URL = "https://vendor.example.com/oauth-docs";
 
 /**
  * An oauth_only vendor-OAuth server whose platform OAuth app is blocked.
- * `withAppRef` controls the BYOA arm: with a ref and a platform-sourced
- * effective app, `canBringOwnApp` is true.
+ * `withAppRef` controls the BYOA arm: with a ref and no org override,
+ * `canBringOwnApp` is true. The org-override state itself comes from the
+ * `getOrgOAuthApp` transport handler (client-side derivation,
+ * stigmer-cloud#401) — status.oauth_status carries only the
+ * vendor-approval fields, matching what backends actually populate.
  */
 function buildBlockedOAuthOnlyServer(options: {
   status: VendorApprovalStatus;
@@ -89,7 +91,6 @@ function buildBlockedOAuthOnlyServer(options: {
     oauthStatus: create(OAuthStatusSchema, {
       vendorApprovalStatus: options.status,
       vendorApprovalDocsUrl: DOCS_URL,
-      effectiveOauthSource: OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
     }),
   });
   return server;
@@ -212,6 +213,48 @@ describe("McpServerConnectDialog — oauth_only + vendor-blocked", () => {
     });
     expect(docs.getAttribute("href")).toBe(DOCS_URL);
   });
+
+  it("enables sign-in with the org's own app when a BYOA override is active", async () => {
+    // The platform app is still vendor-blocked, but the org brought its
+    // own approved app — the block describes an app sign-in won't use
+    // (stigmer-cloud#401). Before the client-side derivation this state
+    // was a dead end: disabled button AND no way forward.
+    renderWithTransport(
+      <McpServerConnectDialog
+        org={ORG}
+        slug={SLUG}
+        open
+        onClose={() => {}}
+      />,
+      (router) => {
+        router.service(McpServerQueryController, {
+          getByReference: () =>
+            buildBlockedOAuthOnlyServer({
+              status: VendorApprovalStatus.PENDING,
+              withAppRef: true,
+            }),
+          getOAuthGrantStatus: noGrant,
+          getOrgOAuthApp: () =>
+            create(GetOrgOAuthAppOutputSchema, {
+              hasOverride: true,
+              oauthAppId: "oauthapp_01acme",
+              clientId: "acme-client-id",
+            }),
+        });
+      },
+    );
+
+    const signIn = await screen.findByRole("button", {
+      name: "Sign in with your app",
+    });
+    expect((signIn as HTMLButtonElement).disabled).toBe(false);
+    // The blocked notice describes the platform app — suppressed while
+    // the org's own app is the effective one.
+    expect(screen.queryByText(/awaiting vendor approval/)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Use your own OAuth app" }),
+    ).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -265,6 +308,47 @@ describe("McpServerDetailView — oauth_only + vendor-blocked", () => {
     // The byoa-setup docs tour targets this marker; it must survive the
     // extraction into the shared notice.
     expect(cta.getAttribute("data-cursor-target")).toBe("byoa-cta-button");
+  });
+
+  it("enables 'Sign in with your app' when the org's BYOA override is active", async () => {
+    // The vendor block gates the PLATFORM app; with the org's own app
+    // effective, sign-in must be enabled and the BYOA CTA retired
+    // (stigmer-cloud#401 — the signal these gates key on never fired).
+    renderWithTransport(
+      <McpServerDetailView
+        org={ORG}
+        slug={SLUG}
+        mcpServerState={loadedState(
+          buildBlockedOAuthOnlyServer({
+            status: VendorApprovalStatus.PENDING,
+            withAppRef: true,
+          }),
+        )}
+      />,
+      (router) => {
+        router.service(McpServerQueryController, {
+          getOAuthGrantStatus: noGrant,
+          getOrgOAuthApp: () =>
+            create(GetOrgOAuthAppOutputSchema, {
+              hasOverride: true,
+              oauthAppId: "oauthapp_01acme",
+              clientId: "acme-client-id",
+            }),
+        });
+      },
+    );
+
+    const signIn = await screen.findByRole("button", {
+      name: "Sign in with your app",
+    });
+    expect((signIn as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByText("Using your OAuth app")).toBeTruthy();
+    // The blocked banner and BYOA offer describe the platform app —
+    // both retire while the override is active.
+    expect(screen.queryByText(/awaiting vendor approval/)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Use your own OAuth app" }),
+    ).toBeNull();
   });
 });
 

--- a/sdk/react/src/mcp-server/__tests__/useMcpServerCredentials.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/useMcpServerCredentials.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { create } from "@bufbuild/protobuf";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { Stigmer } from "@stigmer/sdk";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import {
+  GetOAuthGrantStatusOutputSchema,
+  GetOrgOAuthAppOutputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
+import { EnvironmentListSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import {
+  McpServerSpecSchema,
+  McpServerAuthSchema,
+  HttpServerConfigSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import { OAuthAppSource } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { samples } from "../../test/samples";
+import { StigmerContext } from "../../context";
+import { useMcpServerCredentials } from "../useMcpServerCredentials";
+
+/**
+ * Pins the client-side derivation of the org-override signal
+ * (stigmer-cloud#401): `effectiveOAuthSource` / `isOrgOAuthApp` /
+ * `canBringOwnApp` are resolved from the `getOrgOAuthApp` RPC keyed on
+ * the hook's `org` parameter — NOT from `status.oauth_status` fields 3-4,
+ * which no backend populates (the caller's active org is client-side
+ * context the read RPCs never carry; see the OAuthStatus proto).
+ */
+
+afterEach(cleanup);
+
+const ORG = "acme";
+
+function buildServer(options: { withAuth: boolean; withAppRef: boolean }): McpServer {
+  const server = samples.mcpServer({ name: "Vendor CRM", org: ORG, slug: "vendor-crm" });
+  server.spec = create(McpServerSpecSchema, {
+    serverType: {
+      case: "http",
+      value: create(HttpServerConfigSchema, { url: "https://mcp.vendor.example.com" }),
+    },
+    ...(options.withAuth
+      ? {
+          auth: create(McpServerAuthSchema, {
+            targetEnvVar: "VENDOR_ACCESS_TOKEN",
+            ...(options.withAppRef
+              ? {
+                  oauthAppRef: {
+                    org: "stigmer",
+                    kind: ApiResourceKind.oauth_app,
+                    slug: "vendor-oauth",
+                  },
+                }
+              : {}),
+          }),
+        }
+      : {}),
+  });
+  return server;
+}
+
+/** Baseline handlers so personal-env and grant-status fetches stay healthy. */
+function baselineHandlers() {
+  return {
+    mcpServer: {
+      getOAuthGrantStatus: () =>
+        create(GetOAuthGrantStatusOutputSchema, { connected: false }),
+    },
+    environment: {
+      list: () => create(EnvironmentListSchema, { items: [] }),
+    },
+  };
+}
+
+function renderCredentials(
+  server: McpServer | null,
+  org: string | null,
+  register: Parameters<typeof createRouterTransport>[0],
+) {
+  const client = new Stigmer({
+    baseUrl: "/",
+    getAccessToken: () => "test-token",
+    customTransport: createRouterTransport(register),
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <StigmerContext.Provider value={client}>{children}</StigmerContext.Provider>
+  );
+  return renderHook(() => useMcpServerCredentials(org, server), { wrapper });
+}
+
+describe("useMcpServerCredentials — org-override derivation", () => {
+  it("reports ORG_OVERRIDE when the org has a BYOA override", async () => {
+    const base = baselineHandlers();
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: true }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp: () =>
+            create(GetOrgOAuthAppOutputSchema, {
+              hasOverride: true,
+              oauthAppId: "oauthapp_01acme",
+              clientId: "acme-client-id",
+            }),
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isOrgOAuthApp).toBe(true);
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_ORG_OVERRIDE,
+    );
+    expect(result.current.canBringOwnApp).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports PLATFORM when no override exists for the org", async () => {
+    const base = baselineHandlers();
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: true }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp: () =>
+            create(GetOrgOAuthAppOutputSchema, { hasOverride: false }),
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isOrgOAuthApp).toBe(false);
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
+    );
+    expect(result.current.canBringOwnApp).toBe(true);
+  });
+
+  it("degrades to no-override with BYOA hidden when the backend does not implement the RPC (OSS)", async () => {
+    // getOrgOAuthApp deliberately NOT registered: the router transport
+    // answers UNIMPLEMENTED — exactly what the OSS server returns for the
+    // hosted-only org-override surface (stigmer/stigmer#558). No override
+    // can exist on that edition, so PLATFORM with no error is the truthful
+    // source — and canBringOwnApp stays false (the #558 capability gate:
+    // offering BYOA where the submit could only fail is a dead end).
+    const base = baselineHandlers();
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: true }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, base.mcpServer);
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isOrgOAuthApp).toBe(false);
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
+    );
+    expect(result.current.canBringOwnApp).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports NONE without firing the RPC when the server has no oauth_app_ref", async () => {
+    const base = baselineHandlers();
+    const getOrgOAuthApp = vi.fn(() =>
+      create(GetOrgOAuthAppOutputSchema, { hasOverride: true }),
+    );
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: false }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp,
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_NONE,
+    );
+    expect(result.current.isOrgOAuthApp).toBe(false);
+    expect(result.current.canBringOwnApp).toBe(false);
+    expect(getOrgOAuthApp).not.toHaveBeenCalled();
+  });
+
+  it("stays UNSPECIFIED without firing the RPC on a manual server", async () => {
+    const base = baselineHandlers();
+    const getOrgOAuthApp = vi.fn(() =>
+      create(GetOrgOAuthAppOutputSchema, { hasOverride: true }),
+    );
+    const { result } = renderCredentials(
+      buildServer({ withAuth: false, withAppRef: false }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp,
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.authMode).toBe("manual");
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_UNSPECIFIED,
+    );
+    expect(getOrgOAuthApp).not.toHaveBeenCalled();
+  });
+
+  it("reports UNSPECIFIED and surfaces the error when the lookup genuinely fails", async () => {
+    const base = baselineHandlers();
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: true }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp: () => {
+            throw new ConnectError("store unavailable", Code.Internal);
+          },
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    // Unknown is not PLATFORM: guessing would hide a real override.
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_UNSPECIFIED,
+    );
+    expect(result.current.isOrgOAuthApp).toBe(false);
+    // An errored probe never confirmed the surface exists — BYOA hides.
+    expect(result.current.canBringOwnApp).toBe(false);
+  });
+
+  it("reports UNSPECIFIED without firing the RPC when org is null", async () => {
+    const base = baselineHandlers();
+    const getOrgOAuthApp = vi.fn(() =>
+      create(GetOrgOAuthAppOutputSchema, { hasOverride: true }),
+    );
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: true }),
+      null,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp,
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.effectiveOAuthSource).toBe(
+      OAuthAppSource.OAUTH_APP_SOURCE_UNSPECIFIED,
+    );
+    expect(getOrgOAuthApp).not.toHaveBeenCalled();
+  });
+
+  it("refetch() re-resolves the override (BYOA set/remove flows update live)", async () => {
+    const base = baselineHandlers();
+    let hasOverride = false;
+    const { result } = renderCredentials(
+      buildServer({ withAuth: true, withAppRef: true }),
+      ORG,
+      (router) => {
+        router.service(McpServerQueryController, {
+          ...base.mcpServer,
+          getOrgOAuthApp: () =>
+            create(GetOrgOAuthAppOutputSchema, { hasOverride }),
+        });
+        router.service(EnvironmentQueryController, base.environment);
+      },
+    );
+
+    await waitFor(() =>
+      expect(result.current.effectiveOAuthSource).toBe(
+        OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
+      ),
+    );
+
+    hasOverride = true;
+    result.current.refetch();
+
+    await waitFor(() =>
+      expect(result.current.effectiveOAuthSource).toBe(
+        OAuthAppSource.OAUTH_APP_SOURCE_ORG_OVERRIDE,
+      ),
+    );
+    expect(result.current.isOrgOAuthApp).toBe(true);
+  });
+});

--- a/sdk/react/src/mcp-server/useMcpServerCredentials.ts
+++ b/sdk/react/src/mcp-server/useMcpServerCredentials.ts
@@ -94,9 +94,15 @@ export interface UseMcpServerCredentialsReturn {
    * Servers whose env vars are all optional are always ready.
    */
   readonly isReady: boolean;
-  /** `true` while the personal environment or grant status is being fetched. */
+  /**
+   * `true` while the personal environment, grant status, or org-override
+   * lookup is being fetched.
+   */
   readonly isLoading: boolean;
-  /** Error from the personal environment or grant status fetch, or `null`. */
+  /**
+   * Error from the personal environment, grant status, or org-override
+   * fetch, or `null`.
+   */
   readonly error: Error | null;
   /**
    * Save the provided credentials to the user's personal environment.
@@ -132,16 +138,22 @@ export interface UseMcpServerCredentialsReturn {
    */
   readonly isVendorApprovalBlocked: boolean;
   /**
-   * Where the effective OAuth app was resolved from for the caller's org.
+   * Where the effective OAuth app is resolved from for the caller's org
+   * — the same source the connect flow will use.
    *
-   * Enriched at query time by the backend — no additional RPC needed.
-   * `UNSPECIFIED` when `authMode` is `"manual"` or enrichment has not
-   * been performed yet.
+   * Resolved client-side from the `getOrgOAuthApp` RPC keyed on this
+   * hook's `org` parameter. It cannot come from the fetched McpServer:
+   * the caller's active org is client-side context the read RPCs never
+   * carry, so `status.oauth_status` fields 3-4 are never populated by
+   * any backend (see the OAuthStatus proto).
+   *
+   * `UNSPECIFIED` when `authMode` is `"manual"` or while the override
+   * lookup has not yet resolved.
    */
   readonly effectiveOAuthSource: OAuthAppSource;
   /**
-   * `true` when an org-level BYOA override is active for this server.
-   * Derived from `effectiveOAuthSource === OAUTH_APP_SOURCE_ORG_OVERRIDE`.
+   * `true` when an org-level BYOA override is active for this server
+   * and org. Derived from the `getOrgOAuthApp` lookup.
    */
   readonly isOrgOAuthApp: boolean;
   /**
@@ -208,6 +220,15 @@ export interface UseMcpServerCredentialsReturn {
  * — it is acquired via {@link useMcpServerOAuthConnect}, not a manual
  * form. Additional non-OAuth vars still appear in `missingVariables`
  * (mixed mode).
+ *
+ * **Org-override-aware**: for vendor-OAuth servers with an
+ * `oauth_app_ref`, the hook also composes {@link useOrgOAuthApp} to
+ * resolve which OAuth app the connect flow will use for `org`
+ * (`effectiveOAuthSource` / `isOrgOAuthApp` / `canBringOwnApp`).
+ * The `org` parameter must therefore be the caller's ACTIVE org — the
+ * org credentials are stored in and the org whose BYOA override
+ * applies — not necessarily the org that owns the MCP server (they
+ * differ when browsing another org's public server).
  *
  * Unlike {@link useMcpServerSetup} which manages multi-server setup
  * for session creation, this hook is scoped to a single server and
@@ -289,29 +310,51 @@ export function useMcpServerCredentials(
       oauthStatus?.vendorApprovalStatus === VendorApprovalStatus.REJECTED);
   const vendorApprovalDocsUrl = oauthStatus?.vendorApprovalDocsUrl || null;
 
-  const effectiveOAuthSource =
-    oauthStatus?.effectiveOauthSource ??
-    OAuthAppSource.OAUTH_APP_SOURCE_UNSPECIFIED;
-  const isOrgOAuthApp =
-    effectiveOAuthSource === OAuthAppSource.OAUTH_APP_SOURCE_ORG_OVERRIDE;
   const hasOAuthAppRef = Boolean(auth?.oauthAppRef?.slug);
 
-  // Capability probe for the hosted-only org-override surface — fetches
-  // only for the exact population that could render a BYOA affordance.
-  // Mutation state on this instance is unused; the probe shares its fetch
-  // with any sibling useOrgOAuthApp instance through the fetch cache.
-  const orgOverrideProbe = useOrgOAuthApp(
+  // Org-override lookup, two duties in one fetch (shared cross-mount via
+  // the hook's fetch cache):
+  //  1. Capability probe (`isSupported`) — the org-override surface is
+  //     hosted-only, so BYOA affordances must hide on OSS (#558).
+  //  2. The override signal (`hasOverride`) — which OAuthApp the connect
+  //     flow will actually use for this org. Resolved client-side because
+  //     the caller's active org is client-side context the read RPCs never
+  //     carry (get has no org; getByReference's org is the server's OWNING
+  //     org, which differs from the caller's org when browsing another
+  //     org's public server), so the fetched McpServer cannot answer this
+  //     (stigmer-cloud#401).
+  // Scoped to vendor-OAuth servers with a platform app ref — the only
+  // shape an override can exist for — so manual/DCR servers pay no RPC.
+  const orgOverride = useOrgOAuthApp(
     authMode === "oauth" && hasOAuthAppRef
       ? (mcpServer?.metadata?.id ?? null)
       : null,
-    authMode === "oauth" && hasOAuthAppRef ? org : null,
+    org,
   );
 
+  const isOrgOAuthApp = orgOverride.hasOverride;
+  // While the lookup is in flight, failed, or unposable (an app ref exists
+  // but no org to resolve an override for), the override state is unknown —
+  // report UNSPECIFIED rather than guessing PLATFORM, matching the
+  // documented "not yet resolved" contract. UNSUPPORTED is not unknown:
+  // on OSS the platform-ref app is truthfully the effective source.
+  const overrideUnknown =
+    orgOverride.isLoading ||
+    orgOverride.error !== null ||
+    (hasOAuthAppRef && !org);
+  const effectiveOAuthSource =
+    authMode !== "oauth" || overrideUnknown
+      ? OAuthAppSource.OAUTH_APP_SOURCE_UNSPECIFIED
+      : isOrgOAuthApp
+        ? OAuthAppSource.OAUTH_APP_SOURCE_ORG_OVERRIDE
+        : hasOAuthAppRef
+          ? OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM
+          : OAuthAppSource.OAUTH_APP_SOURCE_NONE;
   const canBringOwnApp =
     authMode === "oauth" &&
     hasOAuthAppRef &&
     !isOrgOAuthApp &&
-    orgOverrideProbe.isSupported;
+    orgOverride.isSupported;
 
   const grantStatus = useOAuthGrantStatus(
     authMode === "oauth" ? (mcpServer?.metadata?.id ?? null) : null,
@@ -362,7 +405,8 @@ export function useMcpServerCredentials(
   const refetch = useCallback(() => {
     personalEnv.refetch();
     grantStatus.refetch();
-  }, [personalEnv, grantStatus]);
+    orgOverride.refetch();
+  }, [personalEnv, grantStatus, orgOverride]);
 
   return {
     authMode,
@@ -381,8 +425,9 @@ export function useMcpServerCredentials(
     manualEntrySupported,
     missingVariables,
     isReady,
-    isLoading: personalEnv.isLoading || grantStatus.isLoading,
-    error: personalEnv.error ?? grantStatus.error,
+    isLoading:
+      personalEnv.isLoading || grantStatus.isLoading || orgOverride.isLoading,
+    error: personalEnv.error ?? grantStatus.error ?? orgOverride.error,
     saveCredentials,
     isSaving: personalEnv.isMutating,
     refetch,

--- a/site/src/components/docs/demos/scenarios/byoa-setup/steps.ts
+++ b/site/src/components/docs/demos/scenarios/byoa-setup/steps.ts
@@ -23,7 +23,6 @@ import {
   DiscoveredCapabilitiesSchema,
   DiscoveredToolSchema,
   OAuthStatusSchema,
-  OAuthAppSource,
   ValidationState,
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
 import {
@@ -92,13 +91,15 @@ function buildSlackBase(): McpServer {
     }),
   });
 
+  // The org-override signal (effectiveOAuthSource / isOrgOAuthApp) is
+  // client-derived from the mocked getOrgOAuthApp responses (the per-step
+  // orgApp fixtures below) — status.oauth_status carries only the
+  // vendor-approval fields, matching what backends actually populate.
   server.status = create(McpServerStatusSchema, {
     validationState: ValidationState.valid,
     oauthStatus: create(OAuthStatusSchema, {
       vendorApprovalStatus: VendorApprovalStatus.PENDING,
       vendorApprovalDocsUrl: "https://api.slack.com/authentication/oauth-v2",
-      effectiveOauthSource: OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
-      effectiveOauthAppId: "oauthapp_slack_platform",
     }),
   });
 
@@ -112,8 +113,6 @@ function buildSlackOrgApp(): McpServer {
     validationState: ValidationState.valid,
     oauthStatus: create(OAuthStatusSchema, {
       vendorApprovalStatus: VendorApprovalStatus.APPROVED,
-      effectiveOauthSource: OAuthAppSource.OAUTH_APP_SOURCE_ORG_OVERRIDE,
-      effectiveOauthAppId: "oauthapp_acme_slack",
     }),
   });
 
@@ -165,8 +164,6 @@ function buildSlackConnected(): McpServer {
     ],
     oauthStatus: create(OAuthStatusSchema, {
       vendorApprovalStatus: VendorApprovalStatus.APPROVED,
-      effectiveOauthSource: OAuthAppSource.OAUTH_APP_SOURCE_ORG_OVERRIDE,
-      effectiveOauthAppId: "oauthapp_acme_slack",
     }),
   });
 

--- a/site/src/components/docs/demos/scenarios/oauth-connect-flow/steps.ts
+++ b/site/src/components/docs/demos/scenarios/oauth-connect-flow/steps.ts
@@ -21,8 +21,6 @@ import {
   McpServerStatusSchema,
   DiscoveredCapabilitiesSchema,
   DiscoveredToolSchema,
-  OAuthStatusSchema,
-  OAuthAppSource,
   ValidationState,
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
 import {
@@ -89,12 +87,12 @@ function buildGitHubBase(): McpServer {
     }),
   });
 
+  // No oauth_status block: the platform app is approved, so a real backend
+  // leaves it absent (presence signals a vendor gate). The PLATFORM source
+  // is client-derived from spec.auth.oauth_app_ref plus the mocked
+  // getOrgOAuthApp (NO_ORG_OVERRIDE) response.
   server.status = create(McpServerStatusSchema, {
     validationState: ValidationState.valid,
-    oauthStatus: create(OAuthStatusSchema, {
-      effectiveOauthSource: OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
-      effectiveOauthAppId: "oauthapp_github_platform",
-    }),
   });
 
   return server;
@@ -153,10 +151,6 @@ function buildGitHubConnected(): McpServer {
         message: "Push files to {{args.repo}} on {{args.branch}}",
       }),
     ],
-    oauthStatus: create(OAuthStatusSchema, {
-      effectiveOauthSource: OAuthAppSource.OAUTH_APP_SOURCE_PLATFORM,
-      effectiveOauthAppId: "oauthapp_github_platform",
-    }),
   });
 
   return server;

--- a/tools/codegen/schemas/services/mcpserver.json
+++ b/tools/codegen/schemas/services/mcpserver.json
@@ -1082,7 +1082,7 @@
     },
     {
       "name": "OAuthAppSource",
-      "description": "OAuthAppSource identifies where the effective OAuth app for an MCP server\n was resolved from. Populated at query time by the backend enricher to tell\n the frontend which credential source is active for the current org context.\n\n Used in OAuthStatus.effective_oauth_source (read-only, not persisted).",
+      "description": "OAuthAppSource identifies where the effective OAuth app for an MCP server\n was resolved from.\n\n The resolution chain is the same one the OAuth connect flow evaluates:\n   1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE\n   2. McpServerAuth.oauth_app_ref → PLATFORM\n   3. Neither exists → NONE\n\n Resolved CLIENT-SIDE by the shared SDK from the getOrgOAuthApp RPC: the\n resolution is per (server, caller's active org), and the caller's active\n org is client-side context the read RPCs never carry, so no backend can\n compute it at enrichment time (see OAuthStatus fields 3-4).",
       "protoType": "ai.stigmer.agentic.mcpserver.v1.OAuthAppSource",
       "values": [
         {
@@ -1168,7 +1168,7 @@
           "kind": "message",
           "messageType": "OAuthStatus"
         },
-        "description": "OAuth-related enrichment state, populated at query time by the backend.\n Contains vendor approval status (resolved from the referenced OAuthApp)\n and BYOA resolution chain results (which OAuthApp is effective for the\n caller's org context). None of these fields are persisted.",
+        "description": "OAuth-related enrichment state, populated at query time by the backend.\n Carries the vendor approval status resolved from the referenced OAuthApp\n (fields 1-2; fields 3-4 are never populated — see OAuthStatus).\n None of these fields are persisted.",
         "required": false
       },
       {
@@ -1500,7 +1500,7 @@
               "OAUTH_APP_SOURCE_NONE"
             ]
           },
-          "description": "Where the effective OAuth app was resolved from for the caller's org.\n Computed from the resolution chain:\n   1. OAuthAppOverride for (resource_id, resource_kind, org_id) → ORG_OVERRIDE\n   2. McpServerAuth.oauth_app_ref → PLATFORM\n   3. Neither exists → NONE",
+          "description": "NEVER POPULATED (see the message comment): the caller's active org is\n client-side context, so no backend can evaluate the resolution chain at\n read time. The shared SDK derives this value client-side from the\n getOrgOAuthApp RPC (useMcpServerCredentials.effectiveOAuthSource).",
           "required": false
         },
         {
@@ -1510,7 +1510,7 @@
           "type": {
             "kind": "string"
           },
-          "description": "System-generated ID (metadata.id) of the OAuthApp that the resolution\n chain selected. Empty when effective_oauth_source is NONE.",
+          "description": "NEVER POPULATED (see the message comment). The override's OAuthApp ID\n is available from the getOrgOAuthApp RPC (GetOrgOAuthAppOutput.oauth_app_id).",
           "required": false
         }
       ]


### PR DESCRIPTION
## Summary

Fixes the never-firing BYOA org-override signal ([stigmer-cloud#401](https://github.com/stigmer/stigmer-cloud/issues/401)): `OAuthStatus.effective_oauth_source`/`effective_oauth_app_id` were promised by the proto but populated by no edition, so `useMcpServerCredentials.isOrgOAuthApp` could never be `true` — an org that configured BYOA saw no "Using your OAuth app" state anywhere, and on vendor-blocked servers the sign-in button stayed **disabled** even though the org's own app would work.

**Why not enrich server-side (the issue's first suggestion):** the resolution is per (server, **caller's active org**), and that org is client-side context the read RPCs never carry — `get` has no org, and `getByReference`'s org is the server's *owning* org (the lookup key), which differs from the caller's org in the console's cross-org "all" scope: exactly the marketplace flow BYOA exists for. Resource-org enrichment would have kept the bug alive there and misreported the owning org's override to foreign viewers. Full ruling in the triage project's DD-020 (renumbered; the parallel oss#558 session's DD-019 published first).

## What changed

- **`useMcpServerCredentials`** composes `useOrgOAuthApp` (`getOrgOAuthApp`, keyed on the same `activeOrg ?? org` every operational lane uses) and derives `effectiveOAuthSource` / `isOrgOAuthApp` / `canBringOwnApp` client-side. Public hook API unchanged — the fields just become true for the first time. Unknown states (lookup in flight/failed/org null) report `UNSPECIFIED`, never a guessed `PLATFORM`. Skipped entirely for manual/DCR servers (no extra RPC).
- **`useOrgOAuthApp`** read side degrades UNIMPLEMENTED to "no override" (the `useSkillVersions` precedent; helper hoisted to `internal/isUnimplemented.ts`). This is deliberately the SDK-degrade half of #558 — that issue keeps its own ruling on implementing the surface OSS-side. Mutations still fail loudly.
- **`McpServerConnectDialog`** gains the caller-side org-override gate the detail view and config panel already had (`blocked && !isOrgOAuthApp` disable, blocked-notice suppression, "Sign in with your app" label) — without it the now-firing signal would have made the dialog a new dead end.
- **Proto truthing**: `OAuthStatus` fields 3-4 + message/enum comments record the structural finding and point to `getOrgOAuthApp`; fields kept for wire compatibility. Stubs (Go/TS/Java/Python hashes), codegen schema, and generated docs regenerated.
- **Demo fixtures** (`byoa-setup`, `oauth-connect-flow`) stop seeding the inert fields; both tours already mock `getOrgOAuthApp`, so they now render from the real source.

## Verification

- Red-first: the new derivation table (8 cases) + blocked-with-override surface pins fail 8/18 against the pre-change code; 18/18 green after.
- Full `sdk/react` suite: **388 files / 4284 tests green**, typecheck clean.
- `make protos` + `gen-proto-sdk-docs` + `gen-react-sdk-docs` regenerated; site typecheck failures are byte-identical to clean main (pre-existing `~source` generation, unrelated).
- NOT verified: live cloud round-trip (needs the paired cloud deploy for `getOrgOAuthApp` responses — behavior pinned via router-transport mocks).

## Notes for reviewers

- `make protos` also surfaced pre-existing gazelle drift on main (`tools/codegen/generator` BUILD still lists the renamed `integration_test.go` from #568; environment controller deps stale from #557). Deliberately **excluded** from this PR — separate repair PR per the #575 precedent.
- Paired cloud PR truths the `McpServerVendorApprovalEnricher` javadoc and carries `Closes stigmer-cloud#401`.

Made with [Cursor](https://cursor.com)
