### PR TITLE
fix(sdk/react): sentinels carry the __start__/__end__ pseudo-kind and omit data-task-kind

### DIFF
--- a/sdk/react/src/workflow/WorkflowNode.tsx
+++ b/sdk/react/src/workflow/WorkflowNode.tsx
@@ -28,7 +28,7 @@ export const WorkflowNode = memo(function WorkflowNode({
   selected,
 }: NodeProps & { data: CanvasTaskNodeData }) {
   const mode = useWorkflowGraphMode();
-  const visualSpec = getVisualSpec(data.isSentinel ? id : data.kindString);
+  const visualSpec = getVisualSpec(data.kindString);
   const categoryColor = CATEGORY_COLORS[data.category];
   const errorCount = data.errorCount ?? 0;
   const isNested = NESTED_TASK_KINDS.has(data.kindString);
@@ -38,7 +38,10 @@ export const WorkflowNode = memo(function WorkflowNode({
   return (
     <div
       data-visual-class={data.visualClass}
-      data-task-kind={data.kindString}
+      // data-task-kind is a sanctioned e2e/embedding hook meaning "real
+      // workflow task kind" — sentinels omit it and are targeted via
+      // data-id + data-visual-class instead (oss#581).
+      data-task-kind={data.isSentinel ? undefined : data.kindString}
       data-execution-status={executionState?.status}
       data-diff-status={diffState?.status}
       aria-label={buildAriaLabel(data, errorCount, executionState?.status)}

--- a/sdk/react/src/workflow/__tests__/WorkflowNode.test.tsx
+++ b/sdk/react/src/workflow/__tests__/WorkflowNode.test.tsx
@@ -1,0 +1,93 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import type { NodeProps } from "@xyflow/react";
+import { WorkflowTaskKind } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb";
+import { WorkflowNode } from "../WorkflowNode";
+import { START_NODE_ID, END_NODE_ID } from "../workflow-graph-model";
+import type { CanvasTaskNodeData } from "../workflow-graph-conversions";
+
+// NodeHandles and NodeActions render @xyflow/react primitives (Handle,
+// NodeToolbar) that throw outside a live React Flow canvas. Stub them so
+// WorkflowNode's own DOM contract can be asserted in isolation — the
+// established pattern for React Flow-adjacent component tests in this suite.
+vi.mock("../node-shell/NodeHandles.js", () => ({
+  NodeHandles: () => null,
+}));
+vi.mock("../node-shell/NodeActions.js", () => ({
+  NodeActions: () => null,
+}));
+
+function makeData(overrides: Partial<CanvasTaskNodeData>): CanvasTaskNodeData {
+  return {
+    taskName: "analyze",
+    kind: WorkflowTaskKind.agent_call,
+    kindString: "agent_call",
+    category: "ai",
+    visualClass: "task-card",
+    displayName: "Agent Call",
+    ariaShapeLabel: "card",
+    config: {},
+    isSentinel: false,
+    ...overrides,
+  };
+}
+
+function renderNode(id: string, data: CanvasTaskNodeData) {
+  const props = { id, data, selected: false } as unknown as NodeProps & {
+    data: CanvasTaskNodeData;
+  };
+  return render(<WorkflowNode {...props} />);
+}
+
+afterEach(cleanup);
+
+describe("WorkflowNode data-task-kind contract (oss#581)", () => {
+  test("task nodes expose their kind string as data-task-kind", () => {
+    const { container } = renderNode("analyze", makeData({}));
+    const node = container.querySelector('[role="button"]');
+    expect(node).not.toBeNull();
+    expect(node!.getAttribute("data-task-kind")).toBe("agent_call");
+  });
+
+  test("sentinel nodes carry no data-task-kind attribute", () => {
+    for (const [id, taskName] of [
+      [START_NODE_ID, "Start"],
+      [END_NODE_ID, "End"],
+    ] as const) {
+      const { container, unmount } = renderNode(
+        id,
+        makeData({
+          taskName,
+          kind: WorkflowTaskKind.workflow_task_kind_unspecified,
+          kindString: id,
+          category: id === START_NODE_ID ? "start" : "end",
+          visualClass: "terminal-pill",
+          displayName: taskName,
+          ariaShapeLabel: "pill",
+          isSentinel: true,
+        }),
+      );
+      const node = container.querySelector('[role="button"]');
+      expect(node).not.toBeNull();
+      expect(node!.hasAttribute("data-task-kind")).toBe(false);
+      unmount();
+    }
+  });
+
+  test("the internal unknown_* enum fallback never reaches the DOM", () => {
+    const { container } = renderNode(
+      START_NODE_ID,
+      makeData({
+        taskName: "Start",
+        kind: WorkflowTaskKind.workflow_task_kind_unspecified,
+        kindString: START_NODE_ID,
+        category: "start",
+        visualClass: "terminal-pill",
+        displayName: "Start",
+        ariaShapeLabel: "pill",
+        isSentinel: true,
+      }),
+    );
+    expect(container.querySelector('[data-task-kind^="unknown_"]')).toBeNull();
+  });
+});

--- a/sdk/react/src/workflow/__tests__/overview-graph.test.ts
+++ b/sdk/react/src/workflow/__tests__/overview-graph.test.ts
@@ -51,6 +51,23 @@ describe("Overview graph pipeline", () => {
     expect((taskNode!.data as CanvasTaskNodeData).isSentinel).toBeFalsy();
   });
 
+  test("sentinel nodes carry the pseudo-kind as kindString, never the enum fallback (oss#581)", () => {
+    const laid = applyDagreLayout(threeNodeGraph);
+    const { nodes } = toReactFlowElements(laid);
+    const startData = nodes.find((n) => n.id === START_NODE_ID)!.data as CanvasTaskNodeData;
+    const endData = nodes.find((n) => n.id === END_NODE_ID)!.data as CanvasTaskNodeData;
+    expect(startData.kindString).toBe(START_NODE_ID);
+    expect(endData.kindString).toBe(END_NODE_ID);
+  });
+
+  test("no node's kindString is ever the internal unknown_* fallback", () => {
+    const laid = applyDagreLayout(threeNodeGraph);
+    const { nodes } = toReactFlowElements(laid);
+    for (const node of nodes) {
+      expect((node.data as CanvasTaskNodeData).kindString).not.toMatch(/^unknown_/);
+    }
+  });
+
   test("task nodes carry correct kindString and category", () => {
     const laid = applyDagreLayout(threeNodeGraph);
     const { nodes } = toReactFlowElements(laid);

--- a/sdk/react/src/workflow/layout/registry-dimensions.ts
+++ b/sdk/react/src/workflow/layout/registry-dimensions.ts
@@ -1,6 +1,5 @@
 import { getVisualSpec } from "../task-type-visual-registry.js";
-import { taskKindToString } from "../workflow-graph-conversions.js";
-import { START_NODE_ID, END_NODE_ID } from "../workflow-graph-model.js";
+import { graphNodeKindString } from "../workflow-graph-conversions.js";
 import type { WorkflowGraphNode } from "../workflow-graph-model.js";
 import type { NodeDimensions } from "./types.js";
 
@@ -23,8 +22,6 @@ import type { NodeDimensions } from "./types.js";
  * wrapping in `useCallback` (DD-010).
  */
 export function registryNodeDimensions(node: WorkflowGraphNode): NodeDimensions {
-  const isSentinel = node.id === START_NODE_ID || node.id === END_NODE_ID;
-  const kindKey = isSentinel ? node.id : taskKindToString(node.kind);
-  const spec = getVisualSpec(kindKey);
+  const spec = getVisualSpec(graphNodeKindString(node));
   return { width: spec.defaultWidth, height: spec.defaultHeight + spec.captionHeight };
 }

--- a/sdk/react/src/workflow/task-type-visual-registry.ts
+++ b/sdk/react/src/workflow/task-type-visual-registry.ts
@@ -4,6 +4,7 @@ import {
   SENTINEL_NODE_WIDTH,
   SENTINEL_NODE_HEIGHT,
 } from "./canvas-constants.js";
+import { START_NODE_ID, END_NODE_ID } from "./workflow-graph-model.js";
 
 /**
  * Semantic shape identifier for workflow nodes.
@@ -203,9 +204,10 @@ export const VISUAL_REGISTRY: ReadonlyMap<string, TaskTypeVisualSpec> = Object.f
     ["notification", EVENT_CIRCLE],
     ["raise_error", EVENT_CIRCLE],
 
-    // sentinels
-    ["__start__", TERMINAL_PILL],
-    ["__end__", TERMINAL_PILL_END],
+    // Sentinel pseudo-kinds: keyed by the sentinel node ids, which double
+    // as the sentinels' kindString (see graphNodeKindString).
+    [START_NODE_ID, TERMINAL_PILL],
+    [END_NODE_ID, TERMINAL_PILL_END],
   ]),
 );
 

--- a/sdk/react/src/workflow/workflow-graph-conversions.ts
+++ b/sdk/react/src/workflow/workflow-graph-conversions.ts
@@ -58,6 +58,22 @@ export function taskKindToString(kind: WorkflowTaskKind): string {
   return TASK_KIND_STRINGS.get(kind) ?? `unknown_${kind}`;
 }
 
+/**
+ * Canonical kind key for a graph node.
+ *
+ * Task nodes resolve to their `WorkflowTaskKind` enum name; the start/end
+ * sentinels resolve to their pseudo-kind (`__start__` / `__end__`), which
+ * doubles as their node id and their key in the visual registry. Sentinels
+ * carry enum value 0, which `taskKindToString` would render as its internal
+ * `unknown_*` fallback — routing them through here keeps that fallback out
+ * of every user-visible surface (oss#581).
+ */
+export function graphNodeKindString(node: WorkflowGraphNode): string {
+  return node.id === START_NODE_ID || node.id === END_NODE_ID
+    ? node.id
+    : taskKindToString(node.kind);
+}
+
 export function stringToTaskKind(str: string): WorkflowTaskKind {
   return STRING_TO_TASK_KIND.get(str) ?? WorkflowTaskKind.workflow_task_kind_unspecified;
 }
@@ -148,7 +164,6 @@ export function yamlToGraph(yaml: string): WorkflowGraphModel {
   for (const task of tasks) {
     const config = (task.task_config ?? task.taskConfig ?? {}) as JsonObject;
     const kindEnum = stringToTaskKind(task.kind);
-    const kindStr = kindEnum !== WorkflowTaskKind.workflow_task_kind_unspecified ? task.kind : task.kind;
 
     nodes.push({
       id: task.name,
@@ -469,6 +484,13 @@ export interface NodeExecutionState {
 export interface CanvasTaskNodeData extends Record<string, unknown> {
   taskName: string;
   kind: WorkflowTaskKind;
+  /**
+   * Canonical kind key (see {@link graphNodeKindString}): the
+   * `WorkflowTaskKind` enum name for task nodes, or the `__start__` /
+   * `__end__` pseudo-kind for sentinels — never `taskKindToString`'s
+   * internal `unknown_*` fallback. Rendered as the `data-task-kind` DOM
+   * attribute on task nodes only; sentinels omit that attribute.
+   */
   kindString: string;
   category: TopologyNodeCategory;
   visualClass: VisualClass;
@@ -511,8 +533,8 @@ export function toReactFlowElements(graph: WorkflowGraphModel): {
 } {
   const nodes: Node[] = graph.nodes.map((node) => {
     const isSentinel = node.id === START_NODE_ID || node.id === END_NODE_ID;
-    const kindString = taskKindToString(node.kind);
-    const visualSpec = getVisualSpec(isSentinel ? node.id : kindString);
+    const kindString = graphNodeKindString(node);
+    const visualSpec = getVisualSpec(kindString);
     return {
       id: node.id,
       type: CANVAS_TASK_NODE_TYPE,

--- a/test/e2e/tests/functional/workflow-overview.spec.ts
+++ b/test/e2e/tests/functional/workflow-overview.spec.ts
@@ -106,8 +106,9 @@ test.describe("Workflow overview page", () => {
     const nodeVisible = await reactFlowNode.isVisible().catch(() => false);
     test.skip(!nodeVisible, "No graph nodes rendered");
 
-    // Find a non-sentinel node (sentinel nodes like Start/End are filtered)
-    const taskNode = page.locator('[data-task-kind]:not([data-task-kind="start"]):not([data-task-kind="end"])').first();
+    // Find a non-sentinel node — sentinels carry no data-task-kind (oss#581),
+    // so the bare attribute selector matches real task nodes only.
+    const taskNode = page.locator("[data-task-kind]").first();
     const taskVisible = await taskNode.isVisible().catch(() => false);
     test.skip(!taskVisible, "No task nodes rendered");
 

--- a/test/e2e/tests/interactive/workflow-node-shapes.spec.ts
+++ b/test/e2e/tests/interactive/workflow-node-shapes.spec.ts
@@ -110,9 +110,13 @@ test.describe("Workflow node visual classes (T01)", () => {
     );
 
     const startNode = getEditorCanvas(page).locator(
-      '[data-task-kind="workflow_task_kind_unspecified"][data-visual-class="terminal-pill"]',
+      '[data-id="__start__"][data-visual-class="terminal-pill"]',
     );
     await expect(startNode.first()).toBeVisible({ timeout: 10_000 });
+
+    // data-task-kind means "real workflow task kind" — sentinels must not
+    // carry it (oss#581).
+    await expect(startNode.first()).not.toHaveAttribute("data-task-kind");
   });
 
   test("node ARIA labels include display name and task name", async ({


### PR DESCRIPTION
## Summary
The workflow canvas's start/end sentinel nodes rendered `data-task-kind="unknown_0"` — `taskKindToString`'s internal enum fallback leaking into a sanctioned e2e/embedding DOM hook. Sentinels now carry the intentional `__start__`/`__end__` pseudo-kind internally and omit the `data-task-kind` attribute entirely, so the attribute means "real workflow task kind" on every canvas surface.

## Context
Sentinels use `WorkflowTaskKind` value 0, which `TASK_KIND_STRINGS` deliberately excludes, so every canvas exposed the `unknown_0` fallback artifact on two first-class nodes. The old e2e suite had already calcified around the previous accidental value (`workflow_task_kind_unspecified`), proving accidental contracts get anchored on. Found by the oss#571 session while re-anchoring the interactive suite.

## Changes
- `workflow-graph-conversions.ts`: new `graphNodeKindString(node)` — the single source of the "sentinels resolve to their pseudo-kind, tasks to their enum name" invariant; `toReactFlowElements` uses it for both `kindString` and the visual-registry lookup. Documented the `CanvasTaskNodeData.kindString` contract. Removed a dead `kindStr` assignment in `yamlToGraph` (both ternary branches were identical, variable unused).
- `WorkflowNode.tsx`: `data-task-kind` is omitted for sentinels; the visual-spec lookup no longer needs the `isSentinel ? id : kindString` substitution.
- `registry-dimensions.ts`: replaced its private copy of the substitution ternary with the shared helper.
- `task-type-visual-registry.ts`: sentinel keys now reference `START_NODE_ID`/`END_NODE_ID` instead of duplicate string literals, making "registry key == node id == sentinel kindString" compiler-visible.
- New `WorkflowNode.test.tsx` (React Flow-dependent children stubbed per suite precedent) pinning the DOM contract; conversion-level pins in `overview-graph.test.ts`.
- E2e: `interactive/workflow-node-shapes.spec.ts` sentinel test re-anchored to `data-id` + `data-visual-class` (was anchored on the pre-regression accidental value, failing today) and now asserts sentinels carry no `data-task-kind`; `functional/workflow-overview.spec.ts` dropped `:not()` filters on `"start"`/`"end"` kind values that never existed — with omission the bare `[data-task-kind]` selector is correct by construction.

## Implementation notes
- Omission (rather than rendering `data-task-kind="__start__"`) was the owner-ruled shape: it makes every bare `[data-task-kind]` selector mean "real task nodes" and converges with how the oss#571 re-anchored specs already target sentinels.
- `taskKindToString`'s `unknown_*` fallback stays — legitimate forward-compat for future enum values — but can no longer reach the DOM.
- The unit-level DOM pin matters because the interactive e2e project currently runs in no CI lane (oss#572).

## Breaking changes
- None for real task nodes. Anyone selecting sentinels via `data-task-kind="unknown_0"` was anchored on an acknowledged bug artifact; `data-id="__start__"`/`"__end__"` is the supported hook.

## Test plan
- Red-first: 3 new assertions fail on the old code (`unknown_0` observed), pass after.
- Full `sdk/react` suite: 4279 tests / 388 files green; `tsc --noEmit` clean on `sdk/react` and `test/e2e`.
- Touched e2e specs not executed (interactive/functional lanes require the full-stack harness; no CI lane runs them today — oss#572).

## Risks
- Low: cosmetic DOM attribute change scoped to sentinels. Rollback is a clean revert.

Closes #581

Coordination: the in-progress oss#571 session re-anchors `workflow-node-shapes.spec.ts`; whichever PR merges second resolves a trivial one-line overlap in the sentinel test.

Made with [Cursor](https://cursor.com)