### PR TITLE
chore(codegen): catch up regen debt — sdk/go metadata mirror, commons schema, pkg/server gazelle

### DIFF
--- a/backend/services/stigmer-server/pkg/server/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/server/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "server",
     srcs = [
+        "registry_cors.go",
         "server.go",
         "temporal_manager.go",
     ],
@@ -100,4 +101,10 @@ go_library(
         "@io_temporal_go_sdk//log",
         "@io_temporal_go_sdk//worker",
     ],
+)
+
+go_test(
+    name = "server_test",
+    srcs = ["registry_cors_test.go"],
+    embed = [":server"],
 )

--- a/sdk/go/proto/ai/stigmer/commons/apiresource/metadata.pb.go
+++ b/sdk/go/proto/ai/stigmer/commons/apiresource/metadata.pb.go
@@ -52,6 +52,14 @@ type ApiResourceMetadata struct {
 	// - PUBLIC: Anyone can access (read). Write access still requires org membership.
 	// Default: config-driven per kind — blueprint kinds (marked
 	// defaults_to_org_visibility) default to ORG; all other kinds default to PRIVATE.
+	//
+	// Mutation contract: visibility is set at create and changed ONLY through
+	// the kind's UpdateVisibility RPC, where the visibility guards live
+	// (per-kind level support, default-instance rejection). A plain Update
+	// preserves the stored value — a request-carried level is ignored, never
+	// applied. Declarative clients that want a manifest's visibility to land
+	// on update must follow up with UpdateVisibility (the CLI and MCP apply
+	// surfaces do this automatically).
 	Visibility ApiResourceVisibility `protobuf:"varint,5,opt,name=visibility,proto3,enum=ai.stigmer.commons.apiresource.ApiResourceVisibility" json:"visibility,omitempty"`
 	// Key-value labels for organization and filtering.
 	Labels map[string]string `protobuf:"bytes,6,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`

--- a/tools/codegen/schemas/services/commons.json
+++ b/tools/codegen/schemas/services/commons.json
@@ -64,7 +64,7 @@
               "visibility_platform"
             ]
           },
-          "description": "Visibility controls who can access this resource.\n - PRIVATE: Only members of the owning organization can access.\n - PUBLIC: Anyone can access (read). Write access still requires org membership.\n Default: config-driven per kind — blueprint kinds (marked\n defaults_to_org_visibility) default to ORG; all other kinds default to PRIVATE.",
+          "description": "Visibility controls who can access this resource.\n - PRIVATE: Only members of the owning organization can access.\n - PUBLIC: Anyone can access (read). Write access still requires org membership.\n Default: config-driven per kind — blueprint kinds (marked\n defaults_to_org_visibility) default to ORG; all other kinds default to PRIVATE.\n\n Mutation contract: visibility is set at create and changed ONLY through\n the kind's UpdateVisibility RPC, where the visibility guards live\n (per-kind level support, default-instance rejection). A plain Update\n preserves the stored value — a request-carried level is ignored, never\n applied. Declarative clients that want a manifest's visibility to land\n on update must follow up with UpdateVisibility (the CLI and MCP apply\n surfaces do this automatically).",
           "required": false
         },
         {


### PR DESCRIPTION
## Summary
Repurposed after #583 merged carrying the original two gazelle fixes. This now catches up the REMAINING regen debt `make protos` reveals on clean main:
- `sdk/go/proto/.../apiresource/metadata.pb.go` + `tools/codegen/schemas/services/commons.json`: the visibility mutation-contract proto comment merged without its sdk/go mirror + docs-schema regen.
- `backend/services/stigmer-server/pkg/server/BUILD.bazel`: `registry_cors.go` (+ its go_test) added without a gazelle rerun.

All three diffs are verbatim `make protos` output on clean main (nothing hand-edited). Found while rebasing #583 for the stigmer-cloud#401 session.

## Test plan
- [x] Diffs reproduced identically by `make protos` on a clean tree