### PR TITLE
fix(console): wire workflow instance row actions (Run, Delete) in both client apps

### DIFF
--- a/client-apps/desktop/src/pages/workflow/WorkflowDetailPage.tsx
+++ b/client-apps/desktop/src/pages/workflow/WorkflowDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   useCopyResource,
   useConfirmAction,
   useDeleteResource,
+  useDeleteWorkflowInstance,
   useElkLayoutEngine,
   ConfirmDialog,
   useBreadcrumbOverride,
@@ -19,6 +20,7 @@ import {
   type DetailAction,
   type AdditionalTab,
 } from "@stigmer/react";
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 
 const elkWorkerFactory = () =>
   new Worker(new URL("elkjs/lib/elk-worker.min.js", import.meta.url));
@@ -44,11 +46,21 @@ export default function WorkflowDetailPage() {
   const viewerOrg = useActiveOrgSlug();
   // Scoped to the active org so the run dialog's instance picker offers
   // the same rows as the Instances tab (falls back to the workflow's org
-  // when no org context is active).
-  const { instances } = useWorkflowInstances(workflow?.metadata?.id, viewerOrg || org);
+  // when no org context is active). This is a separate fetch from the
+  // Instances tab's own list, so instance create/delete must refetch it
+  // explicitly (alongside the instancesRefreshKey bump) or the picker
+  // drifts stale.
+  const { instances, refetch: refetchInstances } = useWorkflowInstances(
+    workflow?.metadata?.id,
+    viewerOrg || org,
+  );
+  const { deleteInstance } = useDeleteWorkflowInstance();
   const [showRunDialog, setShowRunDialog] = useState(false);
   const [showCreateInstanceDialog, setShowCreateInstanceDialog] = useState(false);
   const [instancesRefreshKey, setInstancesRefreshKey] = useState(0);
+  // Instance targeted by a row-level "Run" — preselects the run dialog's
+  // picker. null means the header Run button (server-resolved default).
+  const [runInstanceId, setRunInstanceId] = useState<string | null>(null);
 
   useEffect(() => () => setLabel(null), [setLabel]);
 
@@ -79,10 +91,49 @@ export default function WorkflowDetailPage() {
         ? {
             id: "run",
             label: "Run",
-            onAction: () => setShowRunDialog(true),
+            onAction: () => {
+              setRunInstanceId(null);
+              setShowRunDialog(true);
+            },
           }
         : undefined,
     [workflow],
+  );
+
+  const handleInstanceRun = useCallback((instance: WorkflowInstance) => {
+    setRunInstanceId(instance.metadata?.id ?? null);
+    setShowRunDialog(true);
+  }, []);
+
+  const handleInstanceDelete = useCallback(
+    async (instance: WorkflowInstance) => {
+      const name =
+        instance.metadata?.name || instance.metadata?.slug || "this instance";
+      // Honest copy: instance deletion does NOT cascade to executions on
+      // either edition — they stay visible on the workflow's Executions tab
+      // (spec.workflow_id is denormalized onto every execution at create).
+      const confirmed = await confirm({
+        title: `Delete ${name}?`,
+        description:
+          "This permanently removes the instance and its environment bindings. " +
+          "Executions already run against it are preserved in the workflow's execution history. " +
+          "This action cannot be undone.",
+        confirmLabel: "Delete",
+        variant: "destructive",
+      });
+      if (!confirmed) return;
+      const id = instance.metadata?.id;
+      if (!id) return;
+      try {
+        await deleteInstance(id);
+        toast.success("Instance deleted");
+        setInstancesRefreshKey((k) => k + 1);
+        refetchInstances();
+      } catch {
+        toast.error("Failed to delete instance");
+      }
+    },
+    [confirm, deleteInstance, refetchInstances],
   );
 
   const handleSaveSuccess = useCallback(() => {
@@ -203,6 +254,8 @@ export default function WorkflowDetailPage() {
           onTabChange={setActiveTab}
           onExecutionClick={(id) => navigate(`/executions/${id}`)}
           onCreateInstanceClick={() => setShowCreateInstanceDialog(true)}
+          onInstanceRunClick={handleInstanceRun}
+          onInstanceDeleteClick={handleInstanceDelete}
           onOpenInEditor={handleOpenInEditor}
           onViewLatestRun={handleViewLatestRun}
           instancesRefreshKey={instancesRefreshKey}
@@ -221,6 +274,7 @@ export default function WorkflowDetailPage() {
           workflow={workflow}
           instances={instances}
           defaultInstanceId={workflow.status?.defaultInstanceId}
+          initialInstanceId={runInstanceId}
           onSuccess={handleRunSuccess}
           onError={handleRunError}
         />
@@ -234,6 +288,7 @@ export default function WorkflowDetailPage() {
           onCreated={() => {
             toast.success("Instance created");
             setInstancesRefreshKey((k) => k + 1);
+            refetchInstances();
           }}
         />
       )}

--- a/client-apps/web/src/domain/workflow/WorkflowDetailPage.tsx
+++ b/client-apps/web/src/domain/workflow/WorkflowDetailPage.tsx
@@ -14,6 +14,7 @@ import {
   useCopyResource,
   useConfirmAction,
   useDeleteResource,
+  useDeleteWorkflowInstance,
   useExportResource,
   useElkLayoutEngine,
   ConfirmDialog,
@@ -22,6 +23,7 @@ import {
   type DetailAction,
   type AdditionalTab,
 } from "@stigmer/react";
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import { useStaticRouteParam } from "@/domain/_shared/hooks/useStaticRouteParam";
 import { useExecutionNavigation } from "@/domain/workflow/execution-navigation";
 
@@ -57,11 +59,21 @@ export function WorkflowDetailPageInner({
   const viewerOrg = useActiveOrgSlug();
   // Scoped to the active org so the run dialog's instance picker offers
   // the same rows as the Instances tab (falls back to the workflow's org
-  // when no org context is active).
-  const { instances } = useWorkflowInstances(workflow?.metadata?.id, viewerOrg || org);
+  // when no org context is active). This is a separate fetch from the
+  // Instances tab's own list, so instance create/delete must refetch it
+  // explicitly (alongside the instancesRefreshKey bump) or the picker
+  // drifts stale.
+  const { instances, refetch: refetchInstances } = useWorkflowInstances(
+    workflow?.metadata?.id,
+    viewerOrg || org,
+  );
+  const { deleteInstance } = useDeleteWorkflowInstance();
   const [showRunDialog, setShowRunDialog] = useState(false);
   const [showCreateInstanceDialog, setShowCreateInstanceDialog] = useState(false);
   const [instancesRefreshKey, setInstancesRefreshKey] = useState(0);
+  // Instance targeted by a row-level "Run" — preselects the run dialog's
+  // picker. null means the header Run button (server-resolved default).
+  const [runInstanceId, setRunInstanceId] = useState<string | null>(null);
   const { copyYaml, copyJson, downloadYaml } = useExportResource({
     kind: "Workflow",
     resource: workflow,
@@ -96,10 +108,49 @@ export function WorkflowDetailPageInner({
         ? {
             id: "run",
             label: "Run",
-            onAction: () => setShowRunDialog(true),
+            onAction: () => {
+              setRunInstanceId(null);
+              setShowRunDialog(true);
+            },
           }
         : undefined,
     [workflow],
+  );
+
+  const handleInstanceRun = useCallback((instance: WorkflowInstance) => {
+    setRunInstanceId(instance.metadata?.id ?? null);
+    setShowRunDialog(true);
+  }, []);
+
+  const handleInstanceDelete = useCallback(
+    async (instance: WorkflowInstance) => {
+      const name =
+        instance.metadata?.name || instance.metadata?.slug || "this instance";
+      // Honest copy: instance deletion does NOT cascade to executions on
+      // either edition — they stay visible on the workflow's Executions tab
+      // (spec.workflow_id is denormalized onto every execution at create).
+      const confirmed = await confirm({
+        title: `Delete ${name}?`,
+        description:
+          "This permanently removes the instance and its environment bindings. " +
+          "Executions already run against it are preserved in the workflow's execution history. " +
+          "This action cannot be undone.",
+        confirmLabel: "Delete",
+        variant: "destructive",
+      });
+      if (!confirmed) return;
+      const id = instance.metadata?.id;
+      if (!id) return;
+      try {
+        await deleteInstance(id);
+        toast.success("Instance deleted");
+        setInstancesRefreshKey((k) => k + 1);
+        refetchInstances();
+      } catch {
+        toast.error("Failed to delete instance");
+      }
+    },
+    [confirm, deleteInstance, refetchInstances],
   );
 
   const handleSaveSuccess = useCallback(() => {
@@ -239,6 +290,8 @@ export function WorkflowDetailPageInner({
           onTabChange={setActiveTab}
           onExecutionClick={(id) => navigateToExecution(id)}
           onCreateInstanceClick={() => setShowCreateInstanceDialog(true)}
+          onInstanceRunClick={handleInstanceRun}
+          onInstanceDeleteClick={handleInstanceDelete}
           onOpenInEditor={handleOpenInEditor}
           onViewLatestRun={handleViewLatestRun}
           instancesRefreshKey={instancesRefreshKey}
@@ -257,6 +310,7 @@ export function WorkflowDetailPageInner({
           workflow={workflow}
           instances={instances}
           defaultInstanceId={workflow.status?.defaultInstanceId}
+          initialInstanceId={runInstanceId}
           onSuccess={handleRunSuccess}
           onError={handleRunError}
         />
@@ -270,6 +324,7 @@ export function WorkflowDetailPageInner({
           onCreated={() => {
             toast.success("Instance created");
             setInstancesRefreshKey((k) => k + 1);
+            refetchInstances();
           }}
         />
       )}

--- a/sdk/react/src/workflow/WorkflowRunDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowRunDialog.tsx
@@ -25,6 +25,16 @@ export interface WorkflowRunDialogProps {
    */
   readonly defaultInstanceId?: string;
   /**
+   * Instance to preselect when the dialog opens — wire this from a
+   * row-level "Run" action so the form reflects the instance the user
+   * clicked. Applied on each open transition (after the form resets);
+   * ignored when the id is not in `instances`, so a stale id degrades
+   * to the default option. Omit (or pass `null`) for the
+   * server-resolved default. Same convention as
+   * {@link SessionComposer}'s `initialInstanceId`.
+   */
+  readonly initialInstanceId?: string | null;
+  /**
    * Called after the execution is created successfully.
    * Receives the execution ID — use for navigation.
    */
@@ -67,6 +77,7 @@ export function WorkflowRunDialog({
   workflow,
   instances,
   defaultInstanceId,
+  initialInstanceId,
   onSuccess,
   onError,
 }: WorkflowRunDialogProps) {
@@ -94,11 +105,27 @@ export function WorkflowRunDialog({
     if (!dialog) return;
     if (open && !dialog.open) {
       flow.reset();
+      // Preselection must follow reset (reset clears the selection back to
+      // the server-resolved default). Guarded against stale ids: an instance
+      // deleted between the caller capturing the id and this open falls back
+      // to the default option instead of a <select> value with no option.
+      if (
+        initialInstanceId &&
+        instances.some((i) => i.metadata?.id === initialInstanceId)
+      ) {
+        flow.setSelectedInstanceId(initialInstanceId);
+      }
       dialog.showModal();
     } else if (!open && dialog.open) {
       dialog.close();
     }
-  }, [open, flow.reset]);
+  }, [
+    open,
+    flow.reset,
+    flow.setSelectedInstanceId,
+    initialInstanceId,
+    instances,
+  ]);
 
   const handleDialogCancel = useCallback(
     (e: React.SyntheticEvent) => {

--- a/sdk/react/src/workflow/__tests__/WorkflowRunDialog.test.tsx
+++ b/sdk/react/src/workflow/__tests__/WorkflowRunDialog.test.tsx
@@ -1,0 +1,127 @@
+// Tests for WorkflowRunDialog's `initialInstanceId` preselection (issue
+// #582): a row-level "Run" must open the dialog with that instance already
+// selected, while reopening without one resets to the server-resolved
+// default. Selection is asserted through the rendered instance <select> —
+// the observable surface — with the real useRunWorkflowFlow underneath.
+
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Stigmer } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { WorkflowRunDialog } from "../WorkflowRunDialog";
+
+beforeAll(() => {
+  // happy-dom does not implement the native <dialog> modal API.
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeWorkflow() {
+  return {
+    metadata: { id: "wf_1", name: "my-workflow", slug: "my-workflow" },
+    spec: { env: {} },
+  } as never;
+}
+
+function makeInstance(id: string, name: string) {
+  return {
+    metadata: { id, name, slug: name },
+    spec: { environmentRefs: [] },
+  } as never;
+}
+
+// Two user instances so the picker always renders (it needs >= 1 user
+// instance when defaultInstanceId is provided).
+const DEFAULT_INSTANCE_ID = "wfi_default";
+const INSTANCES = [
+  makeInstance("wfi_a", "instance-a"),
+  makeInstance("wfi_b", "instance-b"),
+];
+
+const mockClient = {
+  workflowExecution: { create: vi.fn() },
+  environment: { getByReference: vi.fn() },
+} as unknown as Stigmer;
+
+function renderDialog(props?: {
+  open?: boolean;
+  initialInstanceId?: string | null;
+}) {
+  const ui = (dialogProps?: {
+    open?: boolean;
+    initialInstanceId?: string | null;
+  }) => (
+    <StigmerContext.Provider value={mockClient}>
+      <WorkflowRunDialog
+        open={dialogProps?.open ?? true}
+        onOpenChange={vi.fn()}
+        org="acme"
+        workflow={makeWorkflow()}
+        instances={INSTANCES}
+        defaultInstanceId={DEFAULT_INSTANCE_ID}
+        initialInstanceId={dialogProps?.initialInstanceId}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />
+    </StigmerContext.Provider>
+  );
+  const result = render(ui(props));
+  return {
+    ...result,
+    rerenderDialog: (nextProps?: {
+      open?: boolean;
+      initialInstanceId?: string | null;
+    }) => result.rerender(ui(nextProps)),
+  };
+}
+
+function instanceSelect(): HTMLSelectElement {
+  return screen.getByLabelText("Instance") as HTMLSelectElement;
+}
+
+describe("WorkflowRunDialog initialInstanceId", () => {
+  it("preselects the requested instance when the dialog opens", () => {
+    renderDialog({ initialInstanceId: "wfi_b" });
+
+    expect(instanceSelect().value).toBe("wfi_b");
+  });
+
+  it("defaults to the server-resolved option when omitted", () => {
+    renderDialog();
+
+    // "" is the "Default (no specific configuration)" option.
+    expect(instanceSelect().value).toBe("");
+  });
+
+  it("falls back to the default option when the id is stale", () => {
+    renderDialog({ initialInstanceId: "wfi_deleted" });
+
+    expect(instanceSelect().value).toBe("");
+  });
+
+  it("applies the fresh preselection on each open transition", () => {
+    const { rerenderDialog } = renderDialog({ initialInstanceId: "wfi_a" });
+    expect(instanceSelect().value).toBe("wfi_a");
+
+    // Close, then reopen targeting a different instance (a second row's
+    // Run click) — the reset-then-preselect path must apply the new id.
+    rerenderDialog({ open: false, initialInstanceId: "wfi_a" });
+    rerenderDialog({ open: true, initialInstanceId: "wfi_b" });
+    expect(instanceSelect().value).toBe("wfi_b");
+
+    // Reopen with none (the header Run button) — back to the default.
+    rerenderDialog({ open: false, initialInstanceId: "wfi_b" });
+    rerenderDialog({ open: true, initialInstanceId: null });
+    expect(instanceSelect().value).toBe("");
+  });
+});

--- a/sdk/react/src/workflow/instance/useDeleteWorkflowInstance.ts
+++ b/sdk/react/src/workflow/instance/useDeleteWorkflowInstance.ts
@@ -10,8 +10,11 @@ export interface UseDeleteWorkflowInstanceReturn {
   /**
    * Delete a workflow instance by ID. Returns the deleted resource.
    *
-   * WARNING: Deleting an instance cascades — all executions belonging
-   * to this instance are permanently removed.
+   * Deletion does NOT cascade to executions: runs already created
+   * against the instance are preserved and stay visible in the parent
+   * workflow's execution history (every execution carries a
+   * denormalized workflow reference). Only the instance itself — its
+   * environment bindings and configuration — is removed.
    */
   readonly deleteInstance: (id: string) => Promise<WorkflowInstance>;
   /** `true` while the delete request is in flight. */
@@ -29,8 +32,10 @@ export interface UseDeleteWorkflowInstanceReturn {
  * The caller is responsible for handling post-delete UI updates
  * (e.g., refreshing the instance list, closing a detail panel).
  *
- * Deletion cascades to all WorkflowExecution resources that belong
- * to the instance. The confirmation UI should warn the user about this.
+ * Deletion is instance-only on both editions — executions are NOT
+ * cascaded (deliberate platform posture: they keep a denormalized
+ * workflow reference and remain in the workflow's execution history).
+ * Confirmation UI must not claim execution history is deleted.
  *
  * @example
  * ```tsx

--- a/test/e2e/tests/interactive/workflow-instance-management.spec.ts
+++ b/test/e2e/tests/interactive/workflow-instance-management.spec.ts
@@ -106,7 +106,7 @@ test.describe("Workflow Instance Management", () => {
     }
   });
 
-  test("Delete instance shows cascade warning", async ({
+  test("Delete instance shows confirmation with honest copy", async ({
     page,
     testWorkflow,
   }) => {
@@ -117,15 +117,19 @@ test.describe("Workflow Instance Management", () => {
     await instancesTab.click();
 
     // Row actions live in a per-row overflow (kebab) menu. If a row exists,
-    // open its menu and choose Delete to surface the cascade warning.
+    // open its menu and choose Delete to surface the confirmation dialog.
     const rowMenu = page.getByRole("button", { name: /^Actions for/ }).first();
     if (await rowMenu.isVisible()) {
       await rowMenu.click();
       await page.getByRole("menuitem", { name: "Delete" }).click();
 
-      // Should show cascade warning
+      // Instance deletion does NOT cascade to executions (issue #582 owner
+      // ruling): the confirmation says so instead of claiming history is
+      // destroyed.
       await expect(
-        page.getByText("permanently delete this instance and all its execution history"),
+        page.getByText(
+          "permanently removes the instance and its environment bindings",
+        ),
       ).toBeVisible();
     }
   });


### PR DESCRIPTION
## Summary

`WorkflowInstanceList` (SDK) renders a per-row kebab with **Run** and **Delete** behind `onRunClick`/`onDeleteClick` props, but neither client app wired them — the Instances tab showed an Actions column with permanently empty cells, so a user could create instances but never delete (or row-run) one from either console.

- **Both client apps** (`client-apps/web` + `client-apps/desktop`, DD-016 parity) now pass `onInstanceRunClick`/`onInstanceDeleteClick` to `WorkflowDetailView`, following the `AgentDetailPage` instance-delete precedent (host-side confirm → SDK delete hook → toast + refresh).
- **Row-level Run preselects the clicked instance** via a new opt-in `WorkflowRunDialog.initialInstanceId` prop — the same name/semantics `SessionComposer` and `NewSessionViewer` already use (DD-011: backward compatible; a stale id degrades to the default option). Applied after the dialog's reset-on-open, covered by a new unit test suite.
- **Honest delete confirmation (owner ruling on #582)**: instance deletion does NOT cascade to executions on either edition — the OSS pipeline deletes only the instance row + search index, cloud runs the canonical default delete pipeline, and `normalizeWorkflowRefStep` denormalizes `spec.workflow_id` onto every execution precisely so runs stay visible in the workflow's Executions tab afterwards. The confirm dialog now says executions are preserved; the `useDeleteWorkflowInstance` JSDoc and the e2e assertion carried the same false cascade claim and are corrected in the same pass.
- **Latent staleness fix**: each page holds a separate `useWorkflowInstances` list feeding the run dialog's picker, which never observed `instancesRefreshKey` — created (and now deleted) instances drifted stale until remount. Create/delete success now also calls that hook's `refetch`.

## Coordination

The in-progress oss#571 session's re-anchored `workflow-instance-management.spec.ts` (un-merged) carries a `test.fixme` for this issue with the old cascade copy — flagged on #582 so the un-fixme lands with the honest assertion text (one-string rebase).

## Test plan

- [x] New `WorkflowRunDialog.test.tsx`: preselection on open, stale-id fallback, reset-to-default, fresh preselection per open transition (4 tests)
- [x] Full `sdk/react` suite: 389 files / 4283 tests green
- [x] Typecheck + lint clean on sdk/react, web, desktop (0 errors; warnings pre-existing in unrelated files)
- [x] `verify-esm-node`: 9 packages Node-ESM clean (DD-018)
- [x] Live end-to-end against a hermetic stack (Temporal + stigmer-server + web dev): create instance → kebab renders → row Run opens dialog preselected to that instance → row Delete shows honest confirmation → row removed

Closes #582

Made with [Cursor](https://cursor.com)