### PR TITLE
fix(ci): rebuild the seedpack canary lane so it actually runs its tests

### DIFF
--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -139,13 +139,20 @@ jobs:
           echo "$install_dir" >> "$GITHUB_PATH"
           "$install_dir/planton" version
 
+      # The CLI's documented non-interactive (CI/CD) auth path. It registers
+      # the hosted planton.ai instance — `secret get` refuses to run with no
+      # backend configured — and validates the key, so a dead PLANTON_API_KEY
+      # fails here with a clear error, not mid-fetch.
+      - name: Authenticate Planton CLI
+        env:
+          PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
+        run: planton login --api-key "$PLANTON_API_KEY"
+
       # Empty-value guard matters here: the canary tests t.Skip on missing
       # env vars, so a silently-empty export would turn the lane green with
       # every vendor skipped. GITHUB_ENV values are not auto-masked, hence
       # the explicit add-mask before each write.
       - name: Fetch canary credentials
-        env:
-          PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
         run: |
           fetch() {
             local env_name="$1" slug="$2"

--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -139,22 +139,23 @@ jobs:
           echo "$install_dir" >> "$GITHUB_PATH"
           "$install_dir/planton" version
 
-      # The CLI's documented non-interactive (CI/CD) auth path: registers the
-      # hosted planton.ai instance — `secret get` refuses to run with no
-      # backend configured. --skip-validation because the CLI's whoAmI
-      # validation RPC is Unimplemented on the prod backend (CLI/backend
-      # skew, observed 2026-08-13); the fetch step's per-secret empty-value
-      # guards live-validate the key immediately afterwards anyway.
-      - name: Authenticate Planton CLI
-        env:
-          PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
-        run: planton login --api-key "$PLANTON_API_KEY" --skip-validation
-
+      # Stateless env-driven CLI configuration — the overrides the CLI
+      # provides for exactly this: PLANTON_API_ENDPOINT satisfies the
+      # backend guard and wins endpoint resolution outright, PLANTON_API_KEY
+      # is first in the credential chain. No `planton login` state: the
+      # login command's --api-key path is broken both ways right now
+      # (validation calls a whoAmI RPC that is Unimplemented on prod;
+      # --skip-validation stores the key under an empty account the store
+      # cannot find again — observed 2026-08-13).
+      #
       # Empty-value guard matters here: the canary tests t.Skip on missing
       # env vars, so a silently-empty export would turn the lane green with
       # every vendor skipped. GITHUB_ENV values are not auto-masked, hence
       # the explicit add-mask before each write.
       - name: Fetch canary credentials
+        env:
+          PLANTON_API_ENDPOINT: api.live.planton.ai:443
+          PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
         run: |
           fetch() {
             local env_name="$1" slug="$2"

--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -139,14 +139,16 @@ jobs:
           echo "$install_dir" >> "$GITHUB_PATH"
           "$install_dir/planton" version
 
-      # The CLI's documented non-interactive (CI/CD) auth path. It registers
-      # the hosted planton.ai instance — `secret get` refuses to run with no
-      # backend configured — and validates the key, so a dead PLANTON_API_KEY
-      # fails here with a clear error, not mid-fetch.
+      # The CLI's documented non-interactive (CI/CD) auth path: registers the
+      # hosted planton.ai instance — `secret get` refuses to run with no
+      # backend configured. --skip-validation because the CLI's whoAmI
+      # validation RPC is Unimplemented on the prod backend (CLI/backend
+      # skew, observed 2026-08-13); the fetch step's per-secret empty-value
+      # guards live-validate the key immediately afterwards anyway.
       - name: Authenticate Planton CLI
         env:
           PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
-        run: planton login --api-key "$PLANTON_API_KEY"
+        run: planton login --api-key "$PLANTON_API_KEY" --skip-validation
 
       # Empty-value guard matters here: the canary tests t.Skip on missing
       # env vars, so a silently-empty export would turn the lane green with

--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -31,7 +31,10 @@ env:
   # Pinned deliberately: this lane's whole history is silent drift, so CLI
   # bumps are a reviewed one-line change, not an auto-latest surprise. The
   # binary is the same asset the plantonhq/tap Homebrew formula wraps.
-  PLANTON_CLI_VERSION: v0.0.34-cli.20260812.1
+  # 20260805.0 is the newest build proven against prod: 20260812.1 calls
+  # v1alpha1 RPCs (whoAmI, organization getBySlug) that api.live.planton.ai
+  # does not implement yet (observed 2026-08-13).
+  PLANTON_CLI_VERSION: v0.0.34-cli.20260805.0
 
 jobs:
   build-service-jar:

--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -103,7 +103,7 @@ jobs:
       # TestCanary_NoAuth_Fetch_Connects spawns `uvx mcp-server-fetch`;
       # ubuntu-24.04 runners do not ship uv (actions/runner-images#10533).
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v10.0.0
 
       - name: Install npm workspace dependencies
         run: npm ci

--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -1,5 +1,10 @@
 # Live-tests marketplace MCP servers: transport reachability plus canary calls
 # with real vendor credentials fetched from Planton at run time.
+#
+# The suites are full-harness integration tests (test/integration TestMain
+# boots the stigmer-service JAR, Temporal, and the unified runner), so this
+# lane builds the JAR from stigmer-cloud first — the ci.integration-canary
+# two-job shape. Without a JAR the suite exits 0 having run nothing (oss#565).
 
 name: ci.seedpack-canary
 
@@ -7,47 +12,196 @@ on:
   schedule:
     - cron: '0 2 * * 1-5'  # Weekdays at 2am UTC
   workflow_dispatch:
+    inputs:
+      cloud_ref:
+        description: "stigmer-cloud git ref to build the service JAR from"
+        required: false
+        type: string
+        default: "main"
+
+concurrency:
+  group: seedpack-canary-${{ github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
+  checks: write
+
+env:
+  # Pinned deliberately: this lane's whole history is silent drift, so CLI
+  # bumps are a reviewed one-line change, not an auto-latest surprise. The
+  # binary is the same asset the plantonhq/tap Homebrew formula wraps.
+  PLANTON_CLI_VERSION: v0.0.34-cli.20260812.1
 
 jobs:
-  seedpack-canary:
+  build-service-jar:
+    name: Build Service JAR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Checkout stigmer-cloud
+        uses: actions/checkout@v4
         with:
-          go-version-file: test/integration/go.mod
-          cache-dependency-path: test/integration/go.sum
-      - uses: actions/setup-node@v4
+          repository: stigmer/stigmer-cloud
+          ref: ${{ inputs.cloud_ref || 'main' }}
+          path: stigmer-cloud
+          token: ${{ secrets.STIGMER_CLOUD_TOKEN }}
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          node-version: '20'
+          bazelisk-cache: true
+          disk-cache: integration-jar
+          repository-cache: true
+
+      - name: Build fat JAR
+        working-directory: stigmer-cloud
+        run: ./bazelw build //backend/services/stigmer-service:stigmer_service_fatjar
+
+      - name: Upload JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: stigmer-service-jar
+          path: stigmer-cloud/bazel-bin/backend/services/stigmer-service/stigmer_service_fatjar.jar
+          retention-days: 1
+          if-no-files-found: error
+
+  seedpack-canary:
+    name: Seedpack Canary
+    runs-on: ubuntu-latest
+    needs: build-service-jar
+    timeout-minutes: 45
+    # Harness images come from the GHCR mirror, not Docker Hub (issue #334);
+    # see test/integration/harness/images.go.
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download service JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: stigmer-service-jar
+          path: .artifacts
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      # TestCanary_NoAuth_Fetch_Connects spawns `uvx mcp-server-fetch`;
+      # ubuntu-24.04 runners do not ship uv (actions/runner-images#10533).
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v9
+
+      - name: Install npm workspace dependencies
+        run: npm ci
+
+      - name: Build proto stubs
+        run: npm run build -w @stigmer/protos
+
+      - name: Install and build unified runner
+        working-directory: backend/services/runner
+        run: npm ci && npm run build
+
+      - name: Install Temporal CLI
+        uses: temporalio/setup-temporal@v0
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
+      - name: Install OpenFGA CLI
+        run: |
+          go install github.com/openfga/cli/cmd/fga@latest
+          fga version
+
+      # Direct pinned download: cli.planton.cloud (the old install host) is
+      # dead, and a `curl | bash` pipe hid that failure until the next step.
+      # A dead CDN now fails HERE, loudly.
       - name: Install Planton CLI
         run: |
-          curl -fsSL https://cli.planton.cloud/install.sh | bash
+          install_dir="${RUNNER_TEMP}/planton-cli"
+          mkdir -p "$install_dir"
+          curl -fsSL -o "$install_dir/planton" \
+            "https://downloads.planton.app/cli/${PLANTON_CLI_VERSION}/planton-${PLANTON_CLI_VERSION}-linux-amd64"
+          chmod +x "$install_dir/planton"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/planton" version
+
+      # Empty-value guard matters here: the canary tests t.Skip on missing
+      # env vars, so a silently-empty export would turn the lane green with
+      # every vendor skipped. GITHUB_ENV values are not auto-masked, hence
+      # the explicit add-mask before each write.
       - name: Fetch canary credentials
-        run: |
-          planton secret get mcp-canary-tavily-api-key --org stigmer --plain > /dev/null
-          echo "TAVILY_API_KEY=$(planton secret get mcp-canary-tavily-api-key --org stigmer --plain)" >> $GITHUB_ENV
-          echo "GITHUB_MCP_TOKEN=$(planton secret get mcp-canary-github-token --org stigmer --plain)" >> $GITHUB_ENV
-          echo "STRIPE_ACCESS_TOKEN=$(planton secret get mcp-canary-stripe-token --org stigmer --plain)" >> $GITHUB_ENV
-          echo "LINEAR_ACCESS_TOKEN=$(planton secret get mcp-canary-linear-api-key --org stigmer --plain)" >> $GITHUB_ENV
-          echo "GOOGLE_MAPS_API_KEY=$(planton secret get mcp-canary-google-maps-api-key --org stigmer --plain)" >> $GITHUB_ENV
         env:
           PLANTON_API_KEY: ${{ secrets.PLANTON_API_KEY }}
+        run: |
+          fetch() {
+            local env_name="$1" slug="$2"
+            local value
+            value="$(planton secret get "$slug" --org stigmer --key value -o plain)"
+            if [ -z "$value" ]; then
+              echo "::error::Planton secret '$slug' returned an empty value"
+              exit 1
+            fi
+            echo "::add-mask::$value"
+            echo "${env_name}=${value}" >> "$GITHUB_ENV"
+          }
+          fetch TAVILY_API_KEY      mcp-canary-tavily-api-key
+          fetch GITHUB_MCP_TOKEN    mcp-canary-github-token
+          fetch STRIPE_ACCESS_TOKEN mcp-canary-stripe-token
+          fetch LINEAR_ACCESS_TOKEN mcp-canary-linear-api-key
+          fetch GOOGLE_MAPS_API_KEY mcp-canary-google-maps-api-key
+
       - name: Run transport reachability tests
-        run: make test-seedpack-transport
-      - name: Run canary tests
-        run: make test-seedpack-canary
         env:
-          STIGMER_MCP_CANARY: "true"
+          STIGMER_SERVICE_JAR: ${{ github.workspace }}/.artifacts/stigmer_service_fatjar.jar
+        run: make test-seedpack-transport
+
+      - name: Run canary tests
+        env:
+          STIGMER_SERVICE_JAR: ${{ github.workspace }}/.artifacts/stigmer_service_fatjar.jar
+        run: make test-seedpack-canary
+
+      - name: Upload seedpack test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seedpack-test-results
+          path: |
+            test/integration/.test-output-seedpack-transport/
+            test/integration/.test-output-seedpack-canary/
+          retention-days: 30
+          if-no-files-found: ignore
+          # The output dirs are dot-prefixed and upload-artifact@v4 excludes
+          # hidden paths by default — without this the artifact is silently
+          # empty (found on the integration-canary lane's first real run, #323).
+          include-hidden-files: true
+
+      - name: Publish seedpack test report
+        if: always() && hashFiles('test/integration/.test-output-seedpack-*/junit.xml') != ''
+        uses: dorny/test-reporter@v3
+        with:
+          name: Seedpack Test Report
+          path: test/integration/.test-output-seedpack-*/junit.xml
+          reporter: java-junit
 
   # Scheduled runs are unattended; manual dispatches are watched (#477).
   # Shared file-or-comment mechanics live in notify-failure.yaml.
   notify-failure:
     name: File Seedpack Canary Failure Issue
-    needs: seedpack-canary
+    needs: [build-service-jar, seedpack-canary]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/Makefile
+++ b/Makefile
@@ -494,10 +494,10 @@ test-seedpack-static: ## Run seedpack static validation tests (fast, no network)
 	cd seedpack && go test -v -count=1 ./...
 
 test-seedpack-transport: ## Run seedpack transport reachability tests (network required, nightly)
-	cd test/integration && go test -v -tags integration -run TestSeedpack -timeout 300s -count=1 ./...
+	$(MAKE) -C test/integration test-seedpack-transport
 
 test-seedpack-canary: ## Run seedpack canary tests with real credentials (nightly)
-	cd test/integration && STIGMER_MCP_CANARY=true go test -v -tags integration -run TestCanary -timeout 600s -count=1 ./...
+	$(MAKE) -C test/integration test-seedpack-canary
 
 # ─── Tidy ────────────────────────────────────
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -237,6 +237,53 @@ test-canary: check-runner-node ensure-service-jar ## Run canary tests (live prov
 		--packages ./... \
 		-- -tags integration -timeout 600s -count=1 -run 'TestCanary_'
 
+# ─── Seedpack lanes ──────────────────────────
+# Both run inside this package's full harness (TestMain boots the service JAR,
+# Temporal, and the unified runner), so the go-test timeout must absorb the
+# boot — the suite's standard 900s, not a probe-sized budget. The prerequisites
+# close the vacuous-green mode: without ensure-service-jar a missing JAR makes
+# TestMain exit 0 having run nothing (oss#565).
+#
+# No LLM keys here by design: the TestSeedpackWorkflow_* tests the transport
+# regex also matches skip themselves without ANTHROPIC/OPENAI keys, and the
+# provider canaries the canary regex also matches skip without them too —
+# lane disjointness is enforced by the tests' own env guards.
+
+.PHONY: test-seedpack-transport
+test-seedpack-transport: check-runner-node ensure-service-jar ## Run seedpack transport reachability tests (network required, nightly)
+	@command -v gotestsum >/dev/null 2>&1 || { \
+		echo "error: gotestsum not found"; \
+		echo "  install: go install gotest.tools/gotestsum@latest"; \
+		exit 1; \
+	}
+	@mkdir -p .test-output-seedpack-transport
+	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
+	INTEGRATION_TEST_OUTPUT_DIR=$(abspath .test-output-seedpack-transport) gotestsum \
+		--junitfile .test-output-seedpack-transport/junit.xml \
+		--junitfile-testsuite-name short \
+		--jsonfile .test-output-seedpack-transport/test-output.json \
+		--format testname \
+		--packages ./... \
+		-- -tags integration -timeout 900s -count=1 -run 'TestSeedpack'
+
+.PHONY: test-seedpack-canary
+test-seedpack-canary: check-runner-node ensure-service-jar ## Run seedpack canary tests with real credentials (nightly)
+	@command -v gotestsum >/dev/null 2>&1 || { \
+		echo "error: gotestsum not found"; \
+		echo "  install: go install gotest.tools/gotestsum@latest"; \
+		exit 1; \
+	}
+	@mkdir -p .test-output-seedpack-canary
+	STIGMER_MCP_CANARY=true \
+	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
+	INTEGRATION_TEST_OUTPUT_DIR=$(abspath .test-output-seedpack-canary) gotestsum \
+		--junitfile .test-output-seedpack-canary/junit.xml \
+		--junitfile-testsuite-name short \
+		--jsonfile .test-output-seedpack-canary/test-output.json \
+		--format testname \
+		--packages ./... \
+		-- -tags integration -timeout 900s -count=1 -run 'TestCanary_'
+
 .PHONY: test-workflow-architect
 test-workflow-architect: check-runner-node ensure-service-jar ## Run Workflow Architect agent E2E tests (auto-fetches API keys)
 	@command -v gotestsum >/dev/null 2>&1 || { \

--- a/test/integration/seedpack_mcp_canary_test.go
+++ b/test/integration/seedpack_mcp_canary_test.go
@@ -16,9 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Deliberately NOT marked is_secret (owner ruling, oss#565): these canaries
+// measure vendor reachability and auth, not the platform's secret lane.
+// is_secret triggers encrypt-at-write (oss#405), and the read-back handler
+// decrypts only for scope-bound runner tokens (minted by the OSS server
+// only) or cloud sandbox ambient credentials — the harness's user-
+// authenticated runner is neither, so secret values arrive redacted and
+// every connect fails before reaching the vendor. The missing end-to-end
+// coverage of the secret discovery path is tracked in oss#579.
 func runtimeEnvFromString(key, value string) map[string]*executionctxv1.ExecutionValue {
 	return map[string]*executionctxv1.ExecutionValue{
-		key: {Value: value, IsSecret: true},
+		key: {Value: value},
 	}
 }
 
@@ -87,7 +95,12 @@ func TestCanary_NoAuth_Fetch_Connects(t *testing.T) {
 			ServerType: &mcpserverv1.McpServerSpec_Stdio{
 				Stdio: &mcpserverv1.StdioServerConfig{
 					Command: "uvx",
-					Args:    []string{"mcp-server-fetch"},
+					// mcp<2: the MCP Python SDK 2.0 renamed McpError to
+					// MCPError and mcp-server-fetch declares mcp>=1.1.3 with
+					// no ceiling, so an unpinned resolve dies at import
+					// (caught by this canary's first real run, oss#565).
+					// Drop the pin once upstream migrates or adds a ceiling.
+					Args: []string{"--with", "mcp<2", "mcp-server-fetch"},
 				},
 			},
 		},

--- a/test/integration/seedpack_mcp_canary_test.go
+++ b/test/integration/seedpack_mcp_canary_test.go
@@ -295,12 +295,17 @@ func TestCanary_ApiKey_GoogleMaps(t *testing.T) {
 			Org:  "test-org",
 		},
 		Spec: &mcpserverv1.McpServerSpec{
-			Description: "Canary test: Google Maps (custom header API key)",
+			Description: "Canary test: Google Maps (API key)",
+			// Mirrors seedpack/mcp-servers/google-maps.yaml — the canary's
+			// value is proving the shipped seedpack shape still connects.
+			// This test had drifted behind the seedpack onto Google's
+			// retired v1alpha endpoint (caught by the lane's first real
+			// run, oss#565); keep the two in lockstep.
 			ServerType: &mcpserverv1.McpServerSpec_Http{
 				Http: &mcpserverv1.HttpServerConfig{
-					Url: "https://mcp.googleapis.com/v1alpha/maps:streamGenerateContent",
+					Url: "https://mapstools.googleapis.com/mcp",
 					Headers: map[string]string{
-						"X-Goog-Api-Key": "${GOOGLE_MAPS_API_KEY}",
+						"Authorization": "Bearer ${GOOGLE_MAPS_API_KEY}",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

`ci.seedpack-canary` had failed all 60 of its recorded scheduled runs — and was born unable to be green honestly. Three nested failures, only the shallowest visible:

1. **Visible red**: the Planton CLI install curled dead host `cli.planton.cloud` through a failure-masking `curl | bash` pipe, so the step passed and the next step died with `planton: command not found`.
2. **Latent, one step later**: the secret fetch used `--plain`, a flag the current CLI dropped (today: `--key value -o plain`).
3. **Load-bearing**: both make targets ran bare `go test` in `test/integration`, whose TestMain **exits 0 with a warning when the stigmer-service JAR is absent** — and this workflow never built one. Absent breaks 1–2, the lane would have been vacuously green since birth, running zero tests. Fixing only the visible breakage would have shipped that green lie.

## Changes

- **Workflow rebuilt on the `ci.integration-canary` two-job pattern** (no new architecture): `build-service-jar` (stigmer-cloud checkout + Bazel fat JAR + artifact with `if-no-files-found: error`) → `seedpack-canary` (full harness deps, GHCR testcontainers mirror, `setup-uv` for the stdio canary, result artifacts + report).
- **Seedpack make targets move into `test/integration/Makefile`** behind `check-runner-node` + `ensure-service-jar` (the exit-0 mode is retired for local runs too), with gotestsum junit output and the suite's boot-inclusive 900s timeout — the old 300s/600s budgets predate the harness boot and would kill the binary mid-boot. Root target names unchanged (they delegate).
- **Planton CLI**: pinned fail-loud download from `downloads.planton.app` (`20260805.0` — the newest build proven against prod; `20260812.1` calls `v1alpha1` RPCs prod doesn't implement). Fully env-driven auth (`PLANTON_API_ENDPOINT` + `PLANTON_API_KEY`), per-secret empty-value guards (tests `t.Skip` on missing env vars — an empty export would green-with-all-skips), `::add-mask::` before `GITHUB_ENV`.
- **Canary test fixes from the first-ever real execution**:
  - Credentials no longer marked `is_secret` (owner ruling: the canaries measure vendor reachability/auth, not the secret lane, which by design redacts for the harness's user-authenticated runner — the missing end-to-end secret-path coverage is #579).
  - The stdio fetch canary pins `--with "mcp<2"`: MCP Python SDK 2.0 renamed `McpError`→`MCPError` and `mcp-server-fetch` declares no ceiling — real ecosystem drift, caught by this lane's first run.
  - The Google Maps canary repointed to the seedpack's current endpoint (`mapstools.googleapis.com/mcp`) — the test had drifted onto Google's retired `v1alpha` URL.

## Verification

- actionlint zero findings; `go vet` clean.
- Live `workflow_dispatch` iterations from this branch (notify-failure is schedule-only — no scratch issues): transport suite **green, 88 tests / 4 honest skips** — the first real test execution in the lane's life; canary suite down to **one failure: the GitHub canary's dead PAT** (`api.github.com/user` 401s the May-provisioned token — owner rotation of Planton secret `mcp-canary-github-token` in flight; a full-green dispatch run will be linked here once rotated).

## Spawned

- #569 — transport probes pay a full-stack harness boot they never use (package placement follow-up).
- #579 — `is_secret` connect credentials undeliverable to the discovery runner outside cloud sandboxes; no e2e secret discovery coverage (needs design ruling, #405/#535 lineage).

Closes #565

Made with [Cursor](https://cursor.com)