### PR TITLE
docs(ci): correct stale BuildBuddy comment — cache is opt-in since stigmer-cloud#405

### DIFF
--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -81,9 +81,10 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 1: Build the Stigmer Cloud Java service fat JAR from source.
   #
-  # Uses Bazel with the repo's own .bazelrc (which configures BuildBuddy
-  # remote cache for read-only access). The setup-bazel action adds local
-  # disk and repository caching for faster subsequent runs.
+  # Uses Bazel with the repo's own .bazelrc. BuildBuddy is opt-in there
+  # (stigmer-cloud#405 / DD-020: no committed key, --config=bb), and this job
+  # deliberately does not opt in, so the build is fully offline. The
+  # setup-bazel action's disk and repository caches keep subsequent runs warm.
   # ---------------------------------------------------------------------------
   build-service-jar:
     name: Build Service JAR


### PR DESCRIPTION
## Summary

Comment-only fix in `ci.integration-offline.yaml`: the job's comment described the stigmer-cloud checkout's `.bazelrc` as configuring "BuildBuddy remote cache for read-only access" — stale on both counts since [stigmer-cloud PR #409](https://github.com/stigmer/stigmer-cloud/pull/409) (the committed key was removed after an audit proved it write-capable; BuildBuddy is now opt-in via `--config=bb`, so this job's builds are fully offline).

## Context

Follow-up recorded in [stigmer-cloud#405](https://github.com/stigmer/stigmer-cloud/issues/405) and triage DD-020. No behavior change — the job never opted into anything; only the comment lied.

Made with [Cursor](https://cursor.com)