### PR TITLE
fix(sdk/react): sync canvas on undo/redo; make keyboard undo reachable

### DIFF
--- a/sdk/react/src/workflow/WorkflowCanvasEditor.tsx
+++ b/sdk/react/src/workflow/WorkflowCanvasEditor.tsx
@@ -87,7 +87,7 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
   layoutEngine,
 }: WorkflowCanvasEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const canvas = useWorkflowCanvas(yaml, containerRef, { layoutEngine: layoutEngine ?? undefined });
+  const canvas = useWorkflowCanvas(yaml, { layoutEngine: layoutEngine ?? undefined });
   const [paletteCollapsed, setPaletteCollapsed] = useState(false);
   const togglePalette = useCallback(() => setPaletteCollapsed((p) => !p), []);
 
@@ -161,7 +161,34 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
     copySelection: canvas.copySelection,
     pasteAtCenter: canvas.pasteAtCenter,
     cutSelection: canvas.cutSelection,
+    undo: canvas.undo,
+    redo: canvas.redo,
   });
+
+  // All canvas shortcuts are gated on focus being inside the container,
+  // but React Flow's pane prevents default on mousedown, so pane clicks
+  // never move focus into it on their own — without this, Cmd+Z (etc.)
+  // after a pane interaction silently does nothing (oss#588). Focusing
+  // unconditionally also commits-and-blurs an inspector field when the
+  // user clicks back into the canvas. Scoped to the canvas column so
+  // palette and inspector clicks keep their native focus flow; when the
+  // press lands on a real focusable (node, toolbar button, picker
+  // input), the default mousedown focus takes over right after.
+  const handleCanvasPointerDownCapture = useCallback(() => {
+    containerRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  // Deleting the focused node drops DOM focus to <body> when React Flow
+  // unmounts the element, disarming every canvas shortcut at exactly the
+  // moment the user reaches for Cmd+Z (oss#588). Return focus to the
+  // container after any node deletion so undo stays reachable.
+  const handleNodesDelete = useCallback(
+    (deleted: Parameters<typeof canvas.onNodesDelete>[0]) => {
+      canvas.onNodesDelete(deleted);
+      containerRef.current?.focus({ preventScroll: true });
+    },
+    [canvas.onNodesDelete],
+  );
 
   useEffect(() => {
     onDirtyChange?.(canvas.isDirty);
@@ -239,10 +266,10 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
 
   const handleContextMenuDeleteNode = useCallback(
     (nodeId: string) => {
-      canvas.onNodesDelete([{ id: nodeId } as import("@xyflow/react").Node]);
+      handleNodesDelete([{ id: nodeId } as import("@xyflow/react").Node]);
       setContextMenu(null);
     },
-    [canvas.onNodesDelete],
+    [handleNodesDelete],
   );
 
   const handleContextMenuDuplicateNode = useCallback(
@@ -371,6 +398,9 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
   const handleContextMenuDeleteSelection = useCallback(() => {
     canvas.deleteSelection();
     setContextMenu(null);
+    // Same focus restoration as handleNodesDelete — the selection may
+    // include the focused node element.
+    containerRef.current?.focus({ preventScroll: true });
   }, [canvas.deleteSelection]);
 
   const handleSelectionContextMenu = useCallback(
@@ -475,9 +505,9 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
 
   const handleDeleteNode = useCallback(
     (nodeId: string) => {
-      canvas.onNodesDelete([{ id: nodeId } as import("@xyflow/react").Node]);
+      handleNodesDelete([{ id: nodeId } as import("@xyflow/react").Node]);
     },
-    [canvas.onNodesDelete],
+    [handleNodesDelete],
   );
 
   const handleDuplicateNode = useCallback(
@@ -580,7 +610,7 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
 
       {showPalette && !paletteCollapsed && <WorkflowTaskPalette />}
 
-      <div className="stg:relative stg:flex-1">
+      <div className="stg:relative stg:flex-1" onPointerDownCapture={handleCanvasPointerDownCapture}>
         {showPalette && (
           <PaletteToggle
             collapsed={paletteCollapsed}
@@ -613,7 +643,7 @@ const WorkflowCanvasEditorInner = memo(function WorkflowCanvasEditorInner({
               isValidConnection={canvas.isValidConnection}
               onDrop={canvas.onDrop}
               onDragOver={canvas.onDragOver}
-              onNodesDelete={canvas.onNodesDelete}
+              onNodesDelete={handleNodesDelete}
               onEdgesDelete={canvas.onEdgesDelete}
               onNodeContextMenu={handleNodeContextMenu}
               onEdgeContextMenu={handleEdgeContextMenu}

--- a/sdk/react/src/workflow/__tests__/graph-history.test.ts
+++ b/sdk/react/src/workflow/__tests__/graph-history.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { GraphHistory, DeleteNodeCommand } from "../graph-commands";
+import { yamlToGraph } from "../workflow-graph-conversions";
+import { START_NODE_ID, END_NODE_ID } from "../workflow-graph-model";
+
+// Direct coverage for the GraphHistory command stack and the
+// DeleteNodeCommand round-trip. Before oss#588 nothing exercised
+// GraphHistory itself — the canvas-sync bug lived one layer up
+// (useGraphHistory/useWorkflowCanvas), but the stack's synchronous
+// return-the-model contract is what that fix builds on, so it is
+// pinned here.
+
+const FIXTURE_YAML = `apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: undo-fixture
+spec:
+  document:
+    dsl: "1.0.0"
+    namespace: test
+    name: undo-fixture
+    version: "0.0.1"
+  tasks:
+    - name: step_1
+      kind: agent_call
+      task_config:
+        agent: "org/agent-slug"
+        message: "first"
+      flow:
+        then: step_2
+    - name: step_2
+      kind: agent_call
+      task_config:
+        agent: "org/agent-slug"
+        message: "second"
+      flow:
+        then: end
+`;
+
+function nodeIds(model: { nodes: readonly { id: string }[] }): string[] {
+  return model.nodes.map((n) => n.id);
+}
+
+describe("GraphHistory — delete/undo/redo round-trip", () => {
+  it("dispatch(DeleteNodeCommand) removes the node and its edges", () => {
+    const initial = yamlToGraph(FIXTURE_YAML);
+    const history = new GraphHistory(initial);
+
+    const next = history.dispatch(new DeleteNodeCommand("step_2", "step_2"));
+
+    expect(nodeIds(next)).not.toContain("step_2");
+    expect(next.edges.some((e) => e.source === "step_2" || e.target === "step_2")).toBe(false);
+    expect(history.canUndo).toBe(true);
+    expect(history.canRedo).toBe(false);
+  });
+
+  it("undo() synchronously returns the model with the node and edges restored", () => {
+    const initial = yamlToGraph(FIXTURE_YAML);
+    const history = new GraphHistory(initial);
+    const deleted = history.dispatch(new DeleteNodeCommand("step_2", "step_2"));
+    const removedEdgeCount = initial.edges.length - deleted.edges.length;
+    expect(removedEdgeCount).toBeGreaterThan(0);
+
+    const restored = history.undo();
+
+    expect(nodeIds(restored)).toContain("step_2");
+    expect(restored.edges).toHaveLength(initial.edges.length);
+    expect(history.current).toBe(restored);
+    expect(history.canUndo).toBe(false);
+    expect(history.canRedo).toBe(true);
+  });
+
+  it("redo() synchronously returns the model with the node removed again", () => {
+    const initial = yamlToGraph(FIXTURE_YAML);
+    const history = new GraphHistory(initial);
+    history.dispatch(new DeleteNodeCommand("step_2", "step_2"));
+    history.undo();
+
+    const redone = history.redo();
+
+    expect(nodeIds(redone)).not.toContain("step_2");
+    expect(history.canUndo).toBe(true);
+    expect(history.canRedo).toBe(false);
+  });
+
+  it("undo()/redo() on an empty stack return the current model unchanged", () => {
+    const initial = yamlToGraph(FIXTURE_YAML);
+    const history = new GraphHistory(initial);
+
+    expect(history.undo()).toBe(initial);
+    expect(history.redo()).toBe(initial);
+  });
+
+  it("sentinels survive the round-trip", () => {
+    const initial = yamlToGraph(FIXTURE_YAML);
+    const history = new GraphHistory(initial);
+    history.dispatch(new DeleteNodeCommand("step_1", "step_1"));
+    const restored = history.undo();
+
+    expect(nodeIds(restored)).toContain(START_NODE_ID);
+    expect(nodeIds(restored)).toContain(END_NODE_ID);
+  });
+});

--- a/sdk/react/src/workflow/__tests__/useCanvasKeyboardShortcuts.undo.test.ts
+++ b/sdk/react/src/workflow/__tests__/useCanvasKeyboardShortcuts.undo.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCanvasKeyboardShortcuts } from "../useCanvasKeyboardShortcuts";
+import type { UseCanvasKeyboardShortcutsOptions } from "../useCanvasKeyboardShortcuts";
+
+// Keyboard undo/redo binding (moved here from useGraphHistory with the
+// oss#588 fix so the shortcut routes through the orchestrator's
+// canvas-syncing undo/redo instead of a raw model mutation).
+
+let container: HTMLDivElement;
+
+function makeOptions(
+  overrides: Partial<UseCanvasKeyboardShortcutsOptions> = {},
+): UseCanvasKeyboardShortcutsOptions {
+  return {
+    containerRef: { current: container },
+    selection: null,
+    duplicateNode: vi.fn(),
+    selectAll: vi.fn(),
+    clearSelection: vi.fn(),
+    onRequestTaskPicker: vi.fn(),
+    onDismiss: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    ...overrides,
+  };
+}
+
+function pressModZ(target: EventTarget, shiftKey = false) {
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "z",
+      metaKey: true,
+      shiftKey,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  container.tabIndex = -1;
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+describe("useCanvasKeyboardShortcuts — undo/redo", () => {
+  it("Mod+Z triggers undo when focus is inside the container", () => {
+    const options = makeOptions();
+    renderHook(() => useCanvasKeyboardShortcuts(options));
+
+    container.focus();
+    pressModZ(container);
+
+    expect(options.undo).toHaveBeenCalledTimes(1);
+    expect(options.redo).not.toHaveBeenCalled();
+  });
+
+  it("Mod+Shift+Z triggers redo when focus is inside the container", () => {
+    const options = makeOptions();
+    renderHook(() => useCanvasKeyboardShortcuts(options));
+
+    container.focus();
+    pressModZ(container, true);
+
+    expect(options.redo).toHaveBeenCalledTimes(1);
+    expect(options.undo).not.toHaveBeenCalled();
+  });
+
+  it("Mod+Z does nothing when focus is outside the container", () => {
+    const options = makeOptions();
+    renderHook(() => useCanvasKeyboardShortcuts(options));
+
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+    pressModZ(outside);
+
+    expect(options.undo).not.toHaveBeenCalled();
+    outside.remove();
+  });
+
+  it("Mod+Z in a text input inside the container keeps native text undo", () => {
+    const options = makeOptions();
+    renderHook(() => useCanvasKeyboardShortcuts(options));
+
+    const input = document.createElement("input");
+    container.appendChild(input);
+    input.focus();
+    pressModZ(input);
+
+    expect(options.undo).not.toHaveBeenCalled();
+  });
+
+  it("Ctrl+Z (non-Mac modifier) also triggers undo", () => {
+    const options = makeOptions();
+    renderHook(() => useCanvasKeyboardShortcuts(options));
+
+    container.focus();
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "z",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(options.undo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/react/src/workflow/__tests__/useWorkflowCanvas.undo.test.tsx
+++ b/sdk/react/src/workflow/__tests__/useWorkflowCanvas.undo.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { useWorkflowCanvas } from "../useWorkflowCanvas";
+
+// Regression tests for oss#588: undoing a node deletion restored the graph
+// MODEL (inspector rebinds, history entry consumed) but the React Flow
+// nodes array was synced from a stale pre-undo snapshot, so the canvas
+// node never reappeared. These tests exercise the hook composition — the
+// exact layer the bug lived in; the pure command stack is covered in
+// graph-history.test.ts.
+
+const FIXTURE_YAML = `apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: undo-fixture
+spec:
+  document:
+    dsl: "1.0.0"
+    namespace: test
+    name: undo-fixture
+    version: "0.0.1"
+  tasks:
+    - name: step_1
+      kind: agent_call
+      task_config:
+        agent: "org/agent-slug"
+        message: "first"
+      flow:
+        then: step_2
+    - name: step_2
+      kind: agent_call
+      task_config:
+        agent: "org/agent-slug"
+        message: "second"
+      flow:
+        then: end
+`;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ReactFlowProvider>{children}</ReactFlowProvider>;
+}
+
+function renderCanvas() {
+  return renderHook(() => useWorkflowCanvas(FIXTURE_YAML), { wrapper });
+}
+
+function canvasNodeIds(result: { current: { nodes: readonly { id: string }[] } }): string[] {
+  return result.current.nodes.map((n) => n.id);
+}
+
+describe("useWorkflowCanvas — undo/redo canvas sync (oss#588)", () => {
+  it("parses the fixture into canvas nodes", () => {
+    const { result } = renderCanvas();
+    expect(canvasNodeIds(result)).toEqual(
+      expect.arrayContaining(["step_1", "step_2"]),
+    );
+  });
+
+  it("undo after a node delete restores the node on the CANVAS, not just the model", () => {
+    const { result } = renderCanvas();
+
+    const target = result.current.nodes.find((n) => n.id === "step_2");
+    expect(target).toBeDefined();
+
+    act(() => {
+      result.current.onNodesDelete([target!]);
+    });
+    expect(canvasNodeIds(result)).not.toContain("step_2");
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    // The model restores (this always worked — the inspector saw it) …
+    expect(result.current.graph?.nodes.map((n) => n.id)).toContain("step_2");
+    // … and the canvas must restore with it (the oss#588 gap).
+    expect(canvasNodeIds(result)).toContain("step_2");
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+  });
+
+  it("undo restores the deleted node's edges on the canvas", () => {
+    const { result } = renderCanvas();
+    const edgeCountBefore = result.current.edges.length;
+
+    const target = result.current.nodes.find((n) => n.id === "step_2");
+    act(() => {
+      result.current.onNodesDelete([target!]);
+    });
+    expect(result.current.edges.length).toBeLessThan(edgeCountBefore);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.edges.length).toBe(edgeCountBefore);
+  });
+
+  it("redo after an undo removes the node from the canvas again", () => {
+    const { result } = renderCanvas();
+
+    const target = result.current.nodes.find((n) => n.id === "step_2");
+    act(() => {
+      result.current.onNodesDelete([target!]);
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(canvasNodeIds(result)).toContain("step_2");
+
+    act(() => {
+      result.current.redo();
+    });
+
+    expect(result.current.graph?.nodes.map((n) => n.id)).not.toContain("step_2");
+    expect(canvasNodeIds(result)).not.toContain("step_2");
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("undo with an empty history leaves the canvas untouched", () => {
+    const { result } = renderCanvas();
+    const before = canvasNodeIds(result);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(canvasNodeIds(result)).toEqual(before);
+  });
+});

--- a/sdk/react/src/workflow/useCanvasKeyboardShortcuts.ts
+++ b/sdk/react/src/workflow/useCanvasKeyboardShortcuts.ts
@@ -19,6 +19,14 @@ export interface UseCanvasKeyboardShortcutsOptions {
   readonly copySelection?: () => void;
   readonly pasteAtCenter?: () => void;
   readonly cutSelection?: () => void;
+  /**
+   * Undo/redo MUST be the orchestrator's canvas-syncing wrappers
+   * (`useWorkflowCanvas.undo`/`redo`), never `useGraphHistory`'s raw
+   * mutations — a model mutation that skips the React Flow sync leaves
+   * the inspector editing a node the canvas doesn't show (oss#588).
+   */
+  readonly undo?: () => void;
+  readonly redo?: () => void;
 }
 
 function isTextInput(target: EventTarget | null): boolean {
@@ -39,12 +47,15 @@ function isFocusInsideContainer(container: HTMLElement): boolean {
  * Canvas-scoped keyboard shortcuts for the workflow editor.
  *
  * Binds shortcuts that are only active when focus is inside the canvas
- * container, using the same capture-phase listener pattern as
- * {@link useGraphHistory} (undo/redo). Bare-key shortcuts (N, Escape)
- * are suppressed when a text input has focus.
+ * container, using a capture-phase document listener. Shortcuts that
+ * collide with native text-editing (undo/redo, copy/paste/cut, bare
+ * keys) are suppressed when a text input has focus, so inspector
+ * fields keep their native behavior.
  *
  * | Shortcut          | Action                                |
  * |-------------------|---------------------------------------|
+ * | `Ctrl/Cmd+Z`      | Undo (canvas-synced, see oss#588)     |
+ * | `Ctrl/Cmd+Shift+Z`| Redo                                  |
  * | `Ctrl/Cmd+D`      | Duplicate selected node               |
  * | `Ctrl/Cmd+A`      | Select all non-sentinel nodes         |
  * | `Ctrl/Cmd+C`      | Copy selected node(s) to clipboard    |
@@ -66,6 +77,8 @@ export function useCanvasKeyboardShortcuts({
   copySelection,
   pasteAtCenter,
   cutSelection,
+  undo,
+  redo,
 }: UseCanvasKeyboardShortcutsOptions): void {
   useEffect(() => {
     const container = containerRef.current;
@@ -75,6 +88,21 @@ export function useCanvasKeyboardShortcuts({
       if (!container || !isFocusInsideContainer(container)) return;
 
       const isMod = e.metaKey || e.ctrlKey;
+
+      // Ctrl/Cmd+Z / Ctrl/Cmd+Shift+Z — undo/redo. Text inputs keep
+      // their native text undo (deliberate change with oss#588: the old
+      // binding hijacked Cmd+Z while typing in inspector fields).
+      if (isMod && !e.altKey && e.key.toLowerCase() === "z") {
+        if (isTextInput(e.target)) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.shiftKey) {
+          redo?.();
+        } else {
+          undo?.();
+        }
+        return;
+      }
 
       // Ctrl/Cmd+D — duplicate selected node
       if (isMod && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "d") {
@@ -169,5 +197,7 @@ export function useCanvasKeyboardShortcuts({
     copySelection,
     pasteAtCenter,
     cutSelection,
+    undo,
+    redo,
   ]);
 }

--- a/sdk/react/src/workflow/useGraphHistory.ts
+++ b/sdk/react/src/workflow/useGraphHistory.ts
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
-import type { RefObject } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { WorkflowGraphModel } from "./workflow-graph-model.js";
 import type { GraphCommand } from "./graph-commands.js";
 import { GraphHistory } from "./graph-commands.js";
@@ -12,27 +11,34 @@ export interface UseGraphHistoryReturn {
   readonly canUndo: boolean;
   readonly canRedo: boolean;
   readonly dispatch: (command: GraphCommand) => WorkflowGraphModel;
-  readonly undo: () => void;
-  readonly redo: () => void;
+  readonly undo: () => WorkflowGraphModel | null;
+  readonly redo: () => WorkflowGraphModel | null;
   readonly reset: (model: WorkflowGraphModel) => void;
 }
 
 /**
  * React wrapper around {@link GraphHistory} providing undo/redo state
- * management and keyboard shortcut binding.
+ * management.
  *
- * Keyboard shortcuts (Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z) are only active
- * when the referenced container element contains the active focus target,
- * preventing conflicts with other editors on the page.
+ * Every mutation (`dispatch`, `undo`, `redo`) returns the resulting model
+ * SYNCHRONOUSLY so callers can derive dependent state (React Flow
+ * elements) in the same event handler. `currentModel` is a render-time
+ * snapshot — inside a callback it may be stale, so consumers reacting to
+ * a mutation must use the returned model, never `currentModel`
+ * (oss#588 was exactly that stale read).
+ *
+ * This hook deliberately owns NO DOM listeners: it cannot sync the canvas,
+ * so letting it mutate the model from a keyboard shortcut would desync
+ * model and canvas. Keyboard undo/redo binding lives with the other
+ * canvas shortcuts in `useCanvasKeyboardShortcuts`, wired to the
+ * orchestrator's syncing wrappers (`useWorkflowCanvas.undo`/`redo`).
  *
  * @param initialModel - The starting graph model (from YAML parse).
- * @param containerRef - Ref to the DOM element that scopes keyboard shortcuts.
  *
  * @since T15 Batch 2 (Node Authoring)
  */
 export function useGraphHistory(
   initialModel: WorkflowGraphModel | null,
-  containerRef: RefObject<HTMLDivElement | null>,
 ): UseGraphHistoryReturn {
   const historyRef = useRef<GraphHistory | null>(null);
   const [model, setModel] = useState<WorkflowGraphModel | null>(null);
@@ -61,20 +67,22 @@ export function useGraphHistory(
     [forceUpdate],
   );
 
-  const undo = useCallback(() => {
+  const undo = useCallback((): WorkflowGraphModel | null => {
     const history = historyRef.current;
-    if (!history?.canUndo) return;
+    if (!history?.canUndo) return null;
     const next = history.undo();
     setModel(next);
     forceUpdate();
+    return next;
   }, [forceUpdate]);
 
-  const redo = useCallback(() => {
+  const redo = useCallback((): WorkflowGraphModel | null => {
     const history = historyRef.current;
-    if (!history?.canRedo) return;
+    if (!history?.canRedo) return null;
     const next = history.redo();
     setModel(next);
     forceUpdate();
+    return next;
   }, [forceUpdate]);
 
   const reset = useCallback(
@@ -89,33 +97,6 @@ export function useGraphHistory(
     },
     [forceUpdate],
   );
-
-  // Keyboard shortcuts: Ctrl/Cmd+Z (undo), Ctrl/Cmd+Shift+Z (redo)
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    function handleKeyDown(e: KeyboardEvent) {
-      if (!container?.contains(document.activeElement) && document.activeElement !== container) {
-        return;
-      }
-
-      const isMod = e.metaKey || e.ctrlKey;
-      if (!isMod || e.key.toLowerCase() !== "z") return;
-
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (e.shiftKey) {
-        redo();
-      } else {
-        undo();
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown, true);
-    return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [containerRef, undo, redo]);
 
   const canUndo = historyRef.current?.canUndo ?? false;
   const canRedo = historyRef.current?.canRedo ?? false;

--- a/sdk/react/src/workflow/useWorkflowCanvas.ts
+++ b/sdk/react/src/workflow/useWorkflowCanvas.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
-import type { RefObject } from "react";
 import { useNodesState, useEdgesState, useReactFlow } from "@xyflow/react";
 import type {
   Node,
@@ -165,14 +164,12 @@ export interface UseWorkflowCanvasReturn {
  * is derived from the model after each mutation.
  *
  * @param yaml - The workflow YAML to initialize from. Changes trigger re-parse.
- * @param containerRef - Ref to the canvas container for keyboard shortcut scoping.
  * @param options - Optional configuration including a custom layout engine.
  *
  * @since T15 (Visual Canvas Editor)
  */
 export function useWorkflowCanvas(
   yaml: string | null,
-  containerRef: RefObject<HTMLDivElement | null>,
   options?: UseWorkflowCanvasOptions,
 ): UseWorkflowCanvasReturn {
   const [error, setError] = useState<string | null>(null);
@@ -195,7 +192,7 @@ export function useWorkflowCanvas(
   }, [yaml]);
 
   // Set up graph history with the parsed model
-  const history = useGraphHistory(parsedModel, containerRef);
+  const history = useGraphHistory(parsedModel);
 
   // Sync: when YAML changes, reset the history and RF elements
   useEffect(() => {
@@ -1083,15 +1080,20 @@ export function useWorkflowCanvas(
   // Undo / Redo (delegates to history, then syncs RF)
   // ---------------------------------------------------------------------------
 
+  // Sync from the model RETURNED by the mutation, mirroring dispatch().
+  // `history.currentModel` is a render-time snapshot — reading it here
+  // after undo()/redo() yields the PRE-mutation model (oss#588: the
+  // canvas re-rendered the still-deleted graph while the inspector,
+  // reading state on the next render, showed the restored node).
   const undo = useCallback(() => {
-    history.undo();
-    syncFromModel(history.currentModel);
-  }, [history, syncFromModel]);
+    const next = history.undo();
+    if (next) syncFromModel(next);
+  }, [history.undo, syncFromModel]);
 
   const redo = useCallback(() => {
-    history.redo();
-    syncFromModel(history.currentModel);
-  }, [history, syncFromModel]);
+    const next = history.redo();
+    if (next) syncFromModel(next);
+  }, [history.redo, syncFromModel]);
 
   // ---------------------------------------------------------------------------
   // Dirty tracking: model reference comparison

--- a/test/e2e/tests/functional/workflow-context-menu.spec.ts
+++ b/test/e2e/tests/functional/workflow-context-menu.spec.ts
@@ -217,12 +217,6 @@ test.describe("Workflow context menus and keyboard shortcuts (T11)", () => {
     page,
     testMultiKindWorkflow,
   }) => {
-    // Live-confirmed product bug: undo restores the MODEL (the inspector
-    // rebinds to the deleted node, the history entry is consumed) but the
-    // canvas node never re-renders — the assertion below is correct and
-    // ready; un-fixme when the canvas derivation picks up restored nodes.
-    test.fixme(true, "undo restores model but not the canvas node — stigmer/stigmer#588");
-
     await navigateToVisualEditor(
       page,
       testMultiKindWorkflow.org,
@@ -238,16 +232,39 @@ test.describe("Workflow context menus and keyboard shortcuts (T11)", () => {
       timeout: 5_000,
     });
 
-    // Undo via the toolbar button — the Cmd+Z shortcut is gated on focus
-    // being INSIDE the canvas container (useGraphHistory), and React
-    // Flow's drag handler prevents default on node mousedown, so pointer
-    // interactions never move focus there. Keyboard undo after a
-    // pointer-driven delete is therefore unreachable without tabbing —
-    // a keyboard-a11y gap noted in the oss#571 wrap-up; the button is
-    // the discoverable affordance either way.
     const undoButton = page.getByRole("button", { name: "Undo" });
     await expect(undoButton).toBeEnabled();
     await undoButton.click();
+
+    await expect(getCanvasNode(page, "init_vars")).toBeAttached({
+      timeout: 5_000,
+    });
+  });
+
+  test("Cmd/Ctrl+Z restores a deleted node after pointer interactions", async ({
+    page,
+    testMultiKindWorkflow,
+  }) => {
+    // Pins the oss#588 focus fix: canvas pointerdown now moves focus
+    // into the container, so the keyboard shortcut is reachable after a
+    // pointer-driven delete (previously it required tabbing into the
+    // canvas — the shortcut the Undo tooltip advertises did nothing).
+    await navigateToVisualEditor(
+      page,
+      testMultiKindWorkflow.org,
+      testMultiKindWorkflow.slug,
+    );
+    await assertNoErrorBoundary(page);
+
+    const node = await getCanvasNode(page, "init_vars");
+    await node.click();
+    await page.keyboard.press("Delete");
+
+    await expect(getCanvasNode(page, "init_vars")).not.toBeAttached({
+      timeout: 5_000,
+    });
+
+    await page.keyboard.press("ControlOrMeta+z");
 
     await expect(getCanvasNode(page, "init_vars")).toBeAttached({
       timeout: 5_000,


### PR DESCRIPTION
## Summary

Fixes #588 — undoing a node deletion in the visual workflow editor restored the graph MODEL (the inspector rebound to the node, the history entry was consumed) but the canvas node never reappeared, leaving an inspector editing a node the canvas doesn't show.

### Root cause: an ownership violation, not just a stale closure

React Flow state is deliberately a separate copy of the graph model, re-derived at every structural mutation (`AD-T15-B2-001`). Every forward mutation gets the fresh model as `dispatch()`'s synchronous return value and syncs from it. Undo/redo were the only two paths that couldn't — both through `useGraphHistory`:

1. **Toolbar undo synced from a stale snapshot**: `useGraphHistory.undo()` returned `void`, so `useWorkflowCanvas.undo()` synced from `history.currentModel` — a plain property on the render-time object literal, i.e. the **pre-undo** (still-deleted) model. The canvas was actively re-set to the deleted graph.
2. **Keyboard undo never synced at all**: `useGraphHistory` owned its own document-level Cmd+Z listener that mutated the model with structurally no way to inform the canvas.

### Fix: restore single ownership of "mutate then sync"

- `useGraphHistory` is now a **pure state wrapper**: `undo()`/`redo()` return the resulting model synchronously (mirroring `dispatch`), the keyboard listener and `containerRef` param are removed, and the doc comment records the ownership rule. (`GraphHistory`, the pure command stack, was always correct.)
- `useWorkflowCanvas.undo`/`redo` sync from the returned model — the exact idiom every other mutation already uses.
- **Cmd+Z / Cmd+Shift+Z move into `useCanvasKeyboardShortcuts`** (the canvas-scoped keyboard home), wired to the orchestrator's syncing wrappers. A model mutation that skips the canvas sync is now unrepresentable.
- Deliberate behavior change: the relocated binding gains the `isTextInput` guard the other mod-shortcuts already had — **Cmd+Z while typing in an inspector field now does native text undo** instead of silently undoing graph structure.

### Focus reachability (the issue's second finding)

All canvas shortcuts are gated on focus being inside the container, but pointer interactions never armed it: React Flow's pane prevents default on mousedown, and deleting the focused node element drops DOM focus to `<body>` at exactly the moment the user reaches for Cmd+Z. Now:

- pointer-down on the canvas column focuses the container (`preventScroll`), also committing-and-blurring inspector fields when the user clicks back into the canvas;
- node deletion (Delete key, context menu, inspector action) returns focus to the container.

The toolbar's Undo/Redo tooltips advertise these shortcuts — they now work after mouse interactions.

All hooks touched are internal (not exported from any SDK barrel); no public API change. Both client apps (web, desktop) get the fix through the shared SDK.

## Test plan

- [x] Red-first: 3 new hook-level tests failed on main with the exact symptom split (model restored, canvas not), pass with the fix — `useWorkflowCanvas.undo.test.tsx`
- [x] New direct coverage for the `GraphHistory` command stack (previously untested) — `graph-history.test.ts`
- [x] New binding tests: Mod+Z/Mod+Shift+Z routing, focus gate, text-input guard — `useCanvasKeyboardShortcuts.undo.test.ts`
- [x] E2E: un-fixme'd the ready `"undo restores a deleted node"` assertion and added the keyboard-path variant — **12/12 green on a live stack** (fresh boot, Temporal + stigmer-server + runner)
- [x] Full sdk/react suite: 4319 tests / 394 files green; lint + typecheck + prefix-classnames clean; test/e2e typecheck clean
- [x] Canvas-surface functional specs (context-menu, layout, inspector, overview, editor) all green under parallel run; remaining functional-project failures reproduced identically on clean main (30s `networkidle` timeouts under full-parallel dev-server load — pre-existing, CI pins workers=1)

Made with [Cursor](https://cursor.com)