### PR TITLE
fix(codegen): make generator_test pass in the Bazel sandbox

### DIFF
--- a/tools/codegen/generator/BUILD.bazel
+++ b/tools/codegen/generator/BUILD.bazel
@@ -72,7 +72,6 @@ go_test(
     srcs = [
         "conversion_test.go",
         "docs_yaml_gate_test.go",
-        "internal_leak_gate_test.go",
         "main_test.go",
         "mdx_fence_scanner_test.go",
         "schema_loading_test.go",
@@ -85,4 +84,18 @@ go_test(
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/descriptorpb",
     ],
+)
+
+# The @internal leak gate scans four committed workspace trees (see the test
+# for the list) that the Bazel sandbox does not stage. Run via `go test`
+# (`make check-go` covers the tools module), not Bazel. Tagged "manual" so
+# wildcard `bazel test //...` skips it, matching the go-test-only convention
+# used by seedpack and test/integration. The gazelle:exclude keeps gazelle
+# from folding the file back into generator_test; this rule is hand-owned.
+# gazelle:exclude internal_leak_gate_test.go
+go_test(
+    name = "internal_leak_gate_test",
+    srcs = ["internal_leak_gate_test.go"],
+    embed = [":generator_lib"],
+    tags = ["manual"],
 )

--- a/tools/codegen/generator/main_test.go
+++ b/tools/codegen/generator/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -466,9 +468,27 @@ func TestTsProtoFileToSuffix(t *testing.T) {
 	}
 }
 
+// TestTsResolveEnumImport pins the resolver's one branching decision: an enum
+// imports from enum_pb when its package ships a dedicated enum.proto, and
+// falls back to spec_pb otherwise. The resolver's check is a pure existence
+// probe against the apis tree, so the fixture fakes exactly that — a package
+// directory with an enum.proto and packages without one — instead of reading
+// the live repo tree (which the Bazel sandbox does not stage). That the REAL
+// workflow package keeps WorkflowTaskKind in enum.proto is guarded end to end
+// by the committed sdk/typescript/src/gen output, which imports enum_pb and
+// typechecks in check-node.
 func TestTsResolveEnumImport(t *testing.T) {
+	apisRoot := t.TempDir()
+	enumProto := filepath.Join(apisRoot, "ai", "stigmer", "agentic", "workflow", "v1", "enum.proto")
+	if err := os.MkdirAll(filepath.Dir(enumProto), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(enumProto, []byte("// existence is all the resolver probes\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	saved := tsApisDir
-	tsApisDir = "../../../apis"
+	tsApisDir = apisRoot
 	defer func() { tsApisDir = saved }()
 
 	tests := []struct {
@@ -477,16 +497,19 @@ func TestTsResolveEnumImport(t *testing.T) {
 		wantName string
 	}{
 		{
+			// The package with a dedicated enum.proto → enum_pb.
 			"ai.stigmer.agentic.workflow.v1.WorkflowTaskKind",
 			"@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb",
 			"WorkflowTaskKind",
 		},
 		{
+			// No enum.proto → the spec_pb fallback (non-versioned package shape).
 			"ai.stigmer.commons.apiresource.apiresourcekind.ApiResourceKind",
 			"@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/spec_pb",
 			"ApiResourceKind",
 		},
 		{
+			// No enum.proto → the spec_pb fallback (versioned package shape).
 			"ai.stigmer.iam.oauthapp.v1.VendorApprovalStatus",
 			"@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb",
 			"VendorApprovalStatus",


### PR DESCRIPTION
## Summary

Closes #596.

`//tools/codegen/generator:generator_test` carried two failures visible only under Bazel — both with one root cause: **the sandbox does not stage the repo tree**. (The go-test lane runs the same tests green from the repo tree on every PR; nothing in CI runs `bazel test`, so the failures sat invisible until a verification pass hit them.)

Two corrections to the issue's framing, established during this session's design pass:

1. **The "cannot build" half was already fixed.** PR #583's gazelle run repaired the `generator_test` srcs (~40 min after #596 was filed). On clean main the target builds and fails exactly the two tests.
2. **There is no resolver/pin drift.** `WorkflowTaskKind` really lives in `apis/.../workflow/v1/enum.proto` and the committed TS gen output correctly imports `enum_pb`. The sandbox failure was the resolver's `os.Stat` probe silently falling back to `spec_pb` when the `apis/` tree is absent — an environment problem, not a behavior drift. Neither "fix" nor "re-pin" of the resolver was warranted.

## Changes

- **`TestTsResolveEnumImport` is now hermetic**: a `t.TempDir()` fixture fakes the one thing the resolver probes (`enum.proto` existence), pinning both branches deliberately — `enum_pb` when the package ships a dedicated `enum.proto`, the `spec_pb` fallback when it doesn't. Previously two of the three cases passed vacuously in the sandbox (they expected the fallback value). The end-to-end "WorkflowTaskKind imports enum_pb" property stays guarded by the committed `sdk/typescript/src/gen` output, which typechecks in `check-node`.
- **`TestNoInternalSectionsLeak` moves to its own hand-owned, `manual`-tagged `go_test` target**: it is a genuine repo gate scanning four committed workspace trees the sandbox does not stage. This follows the repo's documented go-test-only convention (seedpack's `manual` tag, `test/integration`'s empty BUILD) rather than inventing runfiles wiring. A `# gazelle:exclude` directive keeps gazelle idempotent. `make check-go` (the `tools` module) remains the gate's executor on every PR — no coverage loss.

## Verification

- Red-first baseline on clean main: target builds, exactly the two known tests fail with the sandbox-path signatures.
- `bazel test //tools/codegen/generator:generator_test`: **PASSED**, every test executing (verbose run inspected — no skips).
- `bazel test //tools/...`: the manual gate target is correctly excluded from wildcards.
- `go test -race -timeout 30s ./codegen/generator/...` (the `check-go` shape): green, including the leak gate (explicitly re-run verbose).
- `bazel run //:gazelle`: fully idempotent — zero BUILD churn.
- `go vet` + `gofmt`: clean.

## Discovered, out of scope

`bazel test //tools/...` surfaced that `//tools/codegen/proto2schema:proto2schema_test` fails to **link** on clean main (`google.golang.org/protobuf/types/pluginpb` package conflict: protocompile `wellknownimports` vs `org_golang_google_protobuf`) — the same invisible-under-bazel class as this issue, pre-existing and untouched by this PR. Filed separately.

Made with [Cursor](https://cursor.com)