### PR TITLE
test(seedpack): move transport reachability probes out of the full-stack harness

### DIFF
--- a/.github/workflows/ci.seedpack-canary.yaml
+++ b/.github/workflows/ci.seedpack-canary.yaml
@@ -1,10 +1,17 @@
 # Live-tests marketplace MCP servers: transport reachability plus canary calls
 # with real vendor credentials fetched from Planton at run time.
 #
-# The suites are full-harness integration tests (test/integration TestMain
-# boots the stigmer-service JAR, Temporal, and the unified runner), so this
-# lane builds the JAR from stigmer-cloud first — the ci.integration-canary
-# two-job shape. Without a JAR the suite exits 0 having run nothing (oss#565).
+# Two independent test jobs, deliberately decoupled (oss#569):
+#   - seedpack-transport: credential-free HTTP probes from the seedpack
+#     module — no harness, no JAR, runs in parallel with the JAR build.
+#   - seedpack-canary: full-harness integration tests (test/integration
+#     TestMain boots the stigmer-service JAR, Temporal, and the unified
+#     runner), so it builds the JAR from stigmer-cloud first — the
+#     ci.integration-canary two-job shape. Without a JAR the suite exits 0
+#     having run nothing (oss#565).
+# Decoupled so a vendor outage (transport red) still yields canary signal
+# and vice versa — as sequential steps, the first failure hid the second
+# suite entirely.
 
 name: ci.seedpack-canary
 
@@ -37,6 +44,46 @@ env:
   PLANTON_CLI_VERSION: v0.0.34-cli.20260805.0
 
 jobs:
+  seedpack-transport:
+    name: Seedpack Transport Reachability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
+      - name: Run transport reachability tests
+        run: make test-seedpack-transport
+
+      - name: Upload transport test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seedpack-transport-test-results
+          path: seedpack/.test-output-transport/
+          retention-days: 30
+          if-no-files-found: ignore
+          # The output dir is dot-prefixed and upload-artifact@v4 excludes
+          # hidden paths by default — without this the artifact is silently
+          # empty (found on the integration-canary lane's first real run, #323).
+          include-hidden-files: true
+
+      - name: Publish transport test report
+        if: always() && hashFiles('seedpack/.test-output-transport/junit.xml') != ''
+        uses: dorny/test-reporter@v3
+        with:
+          name: Seedpack Transport Test Report
+          path: seedpack/.test-output-transport/junit.xml
+          reporter: java-junit
+
   build-service-jar:
     name: Build Service JAR
     runs-on: ubuntu-latest
@@ -177,44 +224,37 @@ jobs:
           fetch LINEAR_ACCESS_TOKEN mcp-canary-linear-api-key
           fetch GOOGLE_MAPS_API_KEY mcp-canary-google-maps-api-key
 
-      - name: Run transport reachability tests
-        env:
-          STIGMER_SERVICE_JAR: ${{ github.workspace }}/.artifacts/stigmer_service_fatjar.jar
-        run: make test-seedpack-transport
-
       - name: Run canary tests
         env:
           STIGMER_SERVICE_JAR: ${{ github.workspace }}/.artifacts/stigmer_service_fatjar.jar
         run: make test-seedpack-canary
 
-      - name: Upload seedpack test results
+      - name: Upload seedpack canary test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: seedpack-test-results
-          path: |
-            test/integration/.test-output-seedpack-transport/
-            test/integration/.test-output-seedpack-canary/
+          name: seedpack-canary-test-results
+          path: test/integration/.test-output-seedpack-canary/
           retention-days: 30
           if-no-files-found: ignore
-          # The output dirs are dot-prefixed and upload-artifact@v4 excludes
+          # The output dir is dot-prefixed and upload-artifact@v4 excludes
           # hidden paths by default — without this the artifact is silently
           # empty (found on the integration-canary lane's first real run, #323).
           include-hidden-files: true
 
-      - name: Publish seedpack test report
-        if: always() && hashFiles('test/integration/.test-output-seedpack-*/junit.xml') != ''
+      - name: Publish seedpack canary test report
+        if: always() && hashFiles('test/integration/.test-output-seedpack-canary/junit.xml') != ''
         uses: dorny/test-reporter@v3
         with:
-          name: Seedpack Test Report
-          path: test/integration/.test-output-seedpack-*/junit.xml
+          name: Seedpack Canary Test Report
+          path: test/integration/.test-output-seedpack-canary/junit.xml
           reporter: java-junit
 
   # Scheduled runs are unattended; manual dispatches are watched (#477).
   # Shared file-or-comment mechanics live in notify-failure.yaml.
   notify-failure:
     name: File Seedpack Canary Failure Issue
-    needs: [build-service-jar, seedpack-canary]
+    needs: [seedpack-transport, build-service-jar, seedpack-canary]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/Makefile
+++ b/Makefile
@@ -493,8 +493,27 @@ benchmark-cursor-modes: ## Compare Cursor local vs cloud runtime latency and tok
 test-seedpack-static: ## Run seedpack static validation tests (fast, no network)
 	cd seedpack && go test -v -count=1 ./...
 
+# Runs the seedpack module with the `transport` build tag, which compiles in
+# the live HTTP probes (seedpack/transport_test.go) alongside the static
+# validation tests — no harness, no service JAR (the probes moved out of
+# test/integration's full-stack TestMain, oss#569). The static tests riding
+# along cost sub-second and fail with a clearer message than a probe would
+# when a YAML itself is broken. gotestsum for the junit.xml the nightly
+# ci.seedpack-canary lane's test report consumes.
 test-seedpack-transport: ## Run seedpack transport reachability tests (network required, nightly)
-	$(MAKE) -C test/integration test-seedpack-transport
+	@command -v gotestsum >/dev/null 2>&1 || { \
+		echo "error: gotestsum not found"; \
+		echo "  install: go install gotest.tools/gotestsum@latest"; \
+		exit 1; \
+	}
+	@mkdir -p seedpack/.test-output-transport
+	cd seedpack && gotestsum \
+		--junitfile .test-output-transport/junit.xml \
+		--junitfile-testsuite-name short \
+		--jsonfile .test-output-transport/test-output.json \
+		--format testname \
+		--packages ./... \
+		-- -tags transport -timeout 120s -count=1
 
 test-seedpack-canary: ## Run seedpack canary tests with real credentials (nightly)
 	$(MAKE) -C test/integration test-seedpack-canary

--- a/seedpack/transport_test.go
+++ b/seedpack/transport_test.go
@@ -1,6 +1,19 @@
-//go:build integration
+//go:build transport
 
-package integration
+package seedpack
+
+// Transport reachability probes for the marketplace MCP catalog: live HTTP
+// against every vendor endpoint declared in mcp-servers/*.yaml. This is the
+// tier between static validation and the credentialed canaries — it answers
+// "is the endpoint still there and speaking MCP?" without any credentials.
+//
+// The `transport` build tag keeps the probes out of the static tier by
+// construction: `go test ./...` (make test-seedpack-static) must stay
+// deterministic and network-free, and a tag enforces that at compile time
+// rather than by convention. Run via `make test-seedpack-transport` (root),
+// which is also what the nightly ci.seedpack-canary lane invokes. The probes
+// need no harness — they moved here from test/integration, where they paid a
+// full service-JAR + testcontainers boot they never used (oss#569).
 
 import (
 	"bytes"
@@ -13,70 +26,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
-
-// The seedpack catalog is HTTP-only (stdio MCP servers are local-runner-only
-// and are not shipped in the marketplace), so the schema models the http
-// transport exclusively.
-type mcpServerYAML struct {
-	Spec struct {
-		HTTP *struct {
-			URL string `yaml:"url"`
-		} `yaml:"http"`
-		Auth *struct {
-			OAuthAppRef  *struct{} `yaml:"oauth_app_ref"`
-			TargetEnvVar string    `yaml:"target_env_var"`
-		} `yaml:"auth"`
-	} `yaml:"spec"`
-}
-
-func loadSeedpackMcpServers(t *testing.T) map[string]mcpServerYAML {
-	t.Helper()
-
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("unable to determine test file path via runtime.Caller")
-	}
-	seedpackDir := filepath.Join(filepath.Dir(thisFile), "..", "..", "seedpack", "mcp-servers")
-
-	entries, err := os.ReadDir(seedpackDir)
-	if err != nil {
-		t.Fatalf("failed to read seedpack directory %s: %v", seedpackDir, err)
-	}
-
-	servers := make(map[string]mcpServerYAML)
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
-			continue
-		}
-		name := strings.TrimSuffix(entry.Name(), ".yaml")
-
-		data, err := os.ReadFile(filepath.Join(seedpackDir, entry.Name()))
-		if err != nil {
-			t.Fatalf("failed to read %s: %v", entry.Name(), err)
-		}
-
-		var srv mcpServerYAML
-		if err := yaml.Unmarshal(data, &srv); err != nil {
-			t.Fatalf("failed to parse %s: %v", entry.Name(), err)
-		}
-		servers[name] = srv
-	}
-
-	if len(servers) == 0 {
-		t.Fatal("no MCP server YAML files found in seedpack directory")
-	}
-	t.Logf("loaded %d MCP server definitions from %s", len(servers), seedpackDir)
-	return servers
-}
 
 func isDNSError(err error) bool {
 	if err == nil {
@@ -93,11 +46,9 @@ func isDNSError(err error) bool {
 
 // isTransientNetworkError reports whether err is an environmental network
 // condition outside the test's control (DNS failure, request timeout, or a
-// transient connection-level error). These tests are live canaries against
-// third-party MCP endpoints and run in parallel inside the full offline suite,
-// where contention can push a healthy endpoint past the client deadline. Such
-// conditions say nothing about the seedpack definition under test, so callers
-// skip rather than fail when they occur.
+// transient connection-level error). These probes are live canaries against
+// third-party endpoints; such conditions say nothing about the seedpack
+// definition under test, so callers skip rather than fail when they occur.
 func isTransientNetworkError(err error) bool {
 	if err == nil {
 		return false
@@ -124,7 +75,7 @@ func isTransientNetworkError(err error) bool {
 }
 
 func TestSeedpackHttp_EndpointReachable(t *testing.T) {
-	servers := loadSeedpackMcpServers(t)
+	servers := loadAllMcpServers(t)
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -155,14 +106,15 @@ func TestSeedpackHttp_EndpointReachable(t *testing.T) {
 			defer resp.Body.Close()
 
 			t.Logf("HEAD %s -> %d %s", srv.Spec.HTTP.URL, resp.StatusCode, resp.Status)
-			assert.Less(t, resp.StatusCode, 500,
-				"expected non-5xx status code; server may be down")
+			if resp.StatusCode >= 500 {
+				t.Errorf("expected non-5xx status code, got %d; server may be down", resp.StatusCode)
+			}
 		})
 	}
 }
 
 func TestSeedpackHttp_OAuthDiscoveryAvailable(t *testing.T) {
-	servers := loadSeedpackMcpServers(t)
+	servers := loadAllMcpServers(t)
 
 	client := &http.Client{Timeout: 10 * time.Second}
 
@@ -200,27 +152,28 @@ func TestSeedpackHttp_OAuthDiscoveryAvailable(t *testing.T) {
 				t.Skipf("skipping %s: OAuth discovery endpoint returned 404 (RFC 8414 not implemented by vendor)", name)
 			}
 
-			if !assert.Equal(t, http.StatusOK, resp.StatusCode,
-				"OAuth discovery endpoint should return 200") {
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("OAuth discovery endpoint should return 200, got %d", resp.StatusCode)
 				t.Logf("response body (truncated): %.500s", string(body))
 				return
 			}
 
 			var doc map[string]interface{}
-			if !assert.NoError(t, json.Unmarshal(body, &doc),
-				"OAuth discovery response should be valid JSON") {
+			if err := json.Unmarshal(body, &doc); err != nil {
+				t.Errorf("OAuth discovery response should be valid JSON: %v", err)
 				t.Logf("response body (truncated): %.500s", string(body))
 				return
 			}
 
-			assert.Contains(t, doc, "authorization_endpoint",
-				"OAuth discovery document must contain authorization_endpoint")
+			if _, ok := doc["authorization_endpoint"]; !ok {
+				t.Error("OAuth discovery document must contain authorization_endpoint")
+			}
 		})
 	}
 }
 
 func TestSeedpackHttp_McpProtocolResponse(t *testing.T) {
-	servers := loadSeedpackMcpServers(t)
+	servers := loadAllMcpServers(t)
 
 	initPayload := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stigmer-canary-test","version":"1.0.0"}}}`)
 
@@ -270,8 +223,10 @@ func TestSeedpackHttp_McpProtocolResponse(t *testing.T) {
 				return
 			}
 
-			assert.True(t, json.Valid(body),
-				"response should be valid JSON (not HTML error page); got: %.300s", string(body))
+			if !json.Valid(body) {
+				t.Errorf("response should be valid JSON (not HTML error page); got: %.300s", string(body))
+				return
+			}
 
 			var rpcResp map[string]interface{}
 			if json.Unmarshal(body, &rpcResp) == nil {

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -237,34 +237,18 @@ test-canary: check-runner-node ensure-service-jar ## Run canary tests (live prov
 		--packages ./... \
 		-- -tags integration -timeout 600s -count=1 -run 'TestCanary_'
 
-# ─── Seedpack lanes ──────────────────────────
-# Both run inside this package's full harness (TestMain boots the service JAR,
+# ─── Seedpack canary lane ────────────────────
+# Runs inside this package's full harness (TestMain boots the service JAR,
 # Temporal, and the unified runner), so the go-test timeout must absorb the
 # boot — the suite's standard 900s, not a probe-sized budget. The prerequisites
 # close the vacuous-green mode: without ensure-service-jar a missing JAR makes
-# TestMain exit 0 having run nothing (oss#565).
+# TestMain exit 0 having run nothing (oss#565). The harness-free transport
+# reachability probes used to live here too; they moved to the seedpack
+# module (root `make test-seedpack-transport`, oss#569).
 #
-# No LLM keys here by design: the TestSeedpackWorkflow_* tests the transport
-# regex also matches skip themselves without ANTHROPIC/OPENAI keys, and the
-# provider canaries the canary regex also matches skip without them too —
-# lane disjointness is enforced by the tests' own env guards.
-
-.PHONY: test-seedpack-transport
-test-seedpack-transport: check-runner-node ensure-service-jar ## Run seedpack transport reachability tests (network required, nightly)
-	@command -v gotestsum >/dev/null 2>&1 || { \
-		echo "error: gotestsum not found"; \
-		echo "  install: go install gotest.tools/gotestsum@latest"; \
-		exit 1; \
-	}
-	@mkdir -p .test-output-seedpack-transport
-	STIGMER_SERVICE_JAR=$(STIGMER_SERVICE_JAR) \
-	INTEGRATION_TEST_OUTPUT_DIR=$(abspath .test-output-seedpack-transport) gotestsum \
-		--junitfile .test-output-seedpack-transport/junit.xml \
-		--junitfile-testsuite-name short \
-		--jsonfile .test-output-seedpack-transport/test-output.json \
-		--format testname \
-		--packages ./... \
-		-- -tags integration -timeout 900s -count=1 -run 'TestSeedpack'
+# No LLM keys here by design: the provider canaries the TestCanary_ regex
+# also matches skip themselves without ANTHROPIC/OPENAI keys — lane
+# disjointness is enforced by the tests' own env guards.
 
 .PHONY: test-seedpack-canary
 test-seedpack-canary: check-runner-node ensure-service-jar ## Run seedpack canary tests with real credentials (nightly)


### PR DESCRIPTION
## Summary

Fixes [#569](https://github.com/stigmer/stigmer/issues/569): the `TestSeedpackHttp_*` transport probes are pure HTTP (read `mcp-servers/*.yaml`, probe vendor endpoints) but lived in `test/integration`, whose `TestMain` unconditionally boots the service JAR, five testcontainers, and the unified runner — a multi-minute boot for seconds of probing, paid **twice** per nightly `ci.seedpack-canary` run.

- **Probes move to `seedpack/transport_test.go` behind a `transport` build tag.** The static tier (`go test ./...`, `make test-seedpack-static`) stays deterministic and network-free by compile-time construction rather than convention. The probes reuse the static tier's `loadAllMcpServers` (embedded FS — no more `runtime.Caller` path-walking) and its YAML schema struct, killing the duplicate loader and duplicate struct. `testify` usage rewritten to the standard library so the seedpack module stays dependency-light.
- **Root `make test-seedpack-transport` runs the seedpack module directly** (gotestsum + junit for the CI report, probe-sized 120s timeout) with no JAR / harness / runner prerequisites. The `test/integration` target is deleted along with the `-run 'TestSeedpack'` regex family, shrinking the guard-disciplined regex overlap the issue called out.
- **`ci.seedpack-canary` splits transport into its own credential-free job** running in parallel with the JAR build. Previously transport and canary were sequential steps, so a vendor outage (transport red) hid the canary signal entirely, and vice versa. Both jobs now always report, with per-job artifacts and junit reports; `notify-failure` covers both.

### Found during review, beyond the issue

The PR-blocking Core integration lane (`ci.integration-offline.yaml`, `make test-integration`) runs the package **unfiltered**, so every backend PR was probing ~34 live vendor endpoints inside a lane meant to be deterministic — a vendor 5xx could red an unrelated PR (the probes assert non-5xx). This move removes that vendor-network dependence from the blocking gate; vendor health signal now lives exclusively in the nightly transport lane. Deliberate behavior change: the Core lane loses these three tests.

### Deliberately not done (scope discipline)

- No `discovery_url` handling in the OAuth probe (schema field exists, no shipped YAML sets it) and no probe-coverage expansion to DCR-OAuth servers — this is a behavior-preserving move; coverage expansion is a separate conversation.
- Bazel: gazelle run produced zero BUILD churn — files behind custom build tags are invisible to gazelle, and the seedpack `go_test` is `manual` regardless, so the probes have zero bazel coupling (`test/integration`'s BUILD is deliberately empty).

## Measured

| | Before | After |
|---|---|---|
| Local `make test-seedpack-transport` | multi-minute (JAR build + testcontainers boot) | **5.1s** (263 tests: static + all probes live, 2 honest skips) |
| CI transport suite | 74s harness-bound step, serialized behind JAR build + ~4 min toolchain setup | independent job: checkout + Go + gotestsum only, parallel with the JAR build |
| Nightly stack boots | 2 | 1 |

## Verification

- `make test-seedpack-static`: green, 1.8s, `TestSeedpackHttp` compiled out (0 matches in output)
- `make test-seedpack-transport`: live run green (all probes pass against real vendor endpoints)
- `go vet -tags transport ./...` (seedpack) and `go vet -tags integration .` (test/integration): clean
- `make tidy`: no module drift; Go lint (`go vet` all modules + `gofmt -s`): clean
- Stale-reference sweep: `TestSeedpackHttp` / old output dir / old filename appear nowhere outside the new file

Closes #569

Made with [Cursor](https://cursor.com)