### PR TITLE
feat(sdk/java): add handwritten BillingClient for the billing service

### DIFF
--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -77,6 +77,7 @@ Every resource type has a typed client accessible as a method on `StigmerClient`
 | `workflowExecutions()`   | WorkflowExecution  |
 | `workflowInstances()`    | WorkflowInstance   |
 | `search()`               | Cross-resource search |
+| `billing()`              | Credit balance, ledger, and Stripe billing |
 
 ## Common Operations
 
@@ -137,6 +138,29 @@ try (StigmerClient client = StigmerClient.builder("sk_live_abc123").build()) {
 }
 ```
 
+## Billing
+
+Credit balance queries, ledger history, and manual credit adjustments for an
+organization. Commands require the `can_manage_billing` permission on the org:
+
+```java
+import ai.stigmer.sdk.BillingClient;
+import ai.stigmer.billing.v1.CreditBalance;
+import ai.stigmer.billing.v1.CreditLedgerEntry;
+
+try (StigmerClient client = StigmerClient.builder("sk_live_abc123").build()) {
+    CreditBalance balance = client.billing().getCreditBalance(orgId);
+
+    CreditLedgerEntry entry = client.billing().adjustCredits(
+        BillingClient.AdjustCreditsParams.builder()
+            .orgId(orgId)
+            .amountMicros(25_000_000L) // +$25.00
+            .reason("initial tenant funding")
+            .idempotencyKey("fund-" + orgId)
+            .build());
+}
+```
+
 ## Error Handling
 
 All SDK operations throw `StigmerException` (unchecked) with structured error codes:
@@ -188,4 +212,4 @@ cd sdk/java
 make codegen
 ```
 
-Handwritten code lives outside `gen/`: `StigmerClient.java`, `SearchClient.java`, and `internal/transport/`.
+Handwritten code lives outside `gen/`: `StigmerClient.java`, `BillingClient.java`, `SearchClient.java`, `GitHubClient.java`, and `internal/transport/`.

--- a/sdk/java/src/main/java/ai/stigmer/sdk/BillingClient.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/BillingClient.java
@@ -1,0 +1,923 @@
+package ai.stigmer.sdk;
+
+import ai.stigmer.billing.v1.AdjustCreditsInput;
+import ai.stigmer.billing.v1.BillingAccount;
+import ai.stigmer.billing.v1.BillingCommandControllerGrpc;
+import ai.stigmer.billing.v1.BillingQueryControllerGrpc;
+import ai.stigmer.billing.v1.BillingUsageReportResponse;
+import ai.stigmer.billing.v1.CreateBillingPortalSessionInput;
+import ai.stigmer.billing.v1.CreateBillingPortalSessionResponse;
+import ai.stigmer.billing.v1.CreateCreditCheckoutSessionInput;
+import ai.stigmer.billing.v1.CreateCreditCheckoutSessionResponse;
+import ai.stigmer.billing.v1.CreditBalance;
+import ai.stigmer.billing.v1.CreditLedgerEntry;
+import ai.stigmer.billing.v1.CreditLedgerResponse;
+import ai.stigmer.billing.v1.CustomerModelPricingResponse;
+import ai.stigmer.billing.v1.DecideModelPricingOverrideInput;
+import ai.stigmer.billing.v1.GetBillingAccountInput;
+import ai.stigmer.billing.v1.GetBillingUsageReportInput;
+import ai.stigmer.billing.v1.GetCreditBalanceInput;
+import ai.stigmer.billing.v1.GetCreditLedgerInput;
+import ai.stigmer.billing.v1.GetCustomerModelPricingInput;
+import ai.stigmer.billing.v1.GetModelPricingGovernanceInput;
+import ai.stigmer.billing.v1.GetOrCreateBillingAccountInput;
+import ai.stigmer.billing.v1.LedgerEntryType;
+import ai.stigmer.billing.v1.LedgerView;
+import ai.stigmer.billing.v1.ListModelPricingBaselinesInput;
+import ai.stigmer.billing.v1.ModelPricingBaseline;
+import ai.stigmer.billing.v1.ModelPricingBaselinesResponse;
+import ai.stigmer.billing.v1.ModelPricingGovernanceResponse;
+import ai.stigmer.billing.v1.ModelPricingOverride;
+import ai.stigmer.billing.v1.RetireModelPricingBaselineInput;
+import ai.stigmer.billing.v1.SetAutoRechargeConfigInput;
+import ai.stigmer.billing.v1.UpsertModelPricingBaselineInput;
+import ai.stigmer.commons.rpc.PageInfo;
+import ai.stigmer.sdk.gen.Page;
+import ai.stigmer.sdk.gen.StigmerException;
+import com.google.protobuf.Timestamp;
+import io.grpc.Channel;
+import io.grpc.StatusRuntimeException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Client for the billing bounded context.
+ *
+ * <p>Wraps the user-facing billing RPCs: account provisioning, balance
+ * queries, ledger history, manual credit adjustments, credit purchases via
+ * Stripe Checkout, and the platform-operator pricing surfaces. Internal
+ * execution-billing RPCs (authorize, report, finalize) are not exposed —
+ * they are called only by the Temporal workflow and agent runner.
+ *
+ * <p>Billing is not an API Resource: RPCs authorize against the owning
+ * organization ({@code can_view_billing} for queries,
+ * {@code can_manage_billing} for commands), and the pricing-governance
+ * methods require platform-operator privileges.
+ *
+ * <pre>{@code
+ * CreditBalance balance = client.billing().getCreditBalance(orgId);
+ *
+ * CreditLedgerEntry entry = client.billing().adjustCredits(
+ *     BillingClient.AdjustCreditsParams.builder()
+ *         .orgId(orgId)
+ *         .amountMicros(25_000_000L) // +$25.00
+ *         .reason("initial tenant funding")
+ *         .idempotencyKey("fund-" + orgId)
+ *         .build());
+ * }</pre>
+ */
+public final class BillingClient {
+
+    private final BillingCommandControllerGrpc.BillingCommandControllerBlockingStub command;
+    private final BillingQueryControllerGrpc.BillingQueryControllerBlockingStub query;
+
+    BillingClient(Channel channel) {
+        this.command = BillingCommandControllerGrpc.newBlockingStub(channel);
+        this.query = BillingQueryControllerGrpc.newBlockingStub(channel);
+    }
+
+    // -- Account & balance ------------------------------------------------------
+
+    /**
+     * Provisions or retrieves the billing account for an organization.
+     *
+     * <p>Idempotent: creates the account on first call, returns the existing
+     * account on subsequent calls.
+     */
+    public BillingAccount getOrCreateBillingAccount(String orgId) {
+        Objects.requireNonNull(orgId, "orgId is required");
+        try {
+            return command.getOrCreateBillingAccount(GetOrCreateBillingAccountInput.newBuilder()
+                    .setOrgId(orgId)
+                    .build());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /** Retrieves the billing account for an organization. */
+    public BillingAccount getBillingAccount(String orgId) {
+        Objects.requireNonNull(orgId, "orgId is required");
+        try {
+            return query.getBillingAccount(GetBillingAccountInput.newBuilder()
+                    .setOrgId(orgId)
+                    .build());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /** Retrieves the credit balance breakdown for an organization. */
+    public CreditBalance getCreditBalance(String orgId) {
+        Objects.requireNonNull(orgId, "orgId is required");
+        try {
+            return query.getCreditBalance(GetCreditBalanceInput.newBuilder()
+                    .setOrgId(orgId)
+                    .build());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Manually adjusts an organization's credit balance.
+     *
+     * <p>Produces an immutable ledger entry for audit. Requires the
+     * {@code can_manage_billing} permission on the organization.
+     */
+    public CreditLedgerEntry adjustCredits(AdjustCreditsParams params) {
+        try {
+            return command.adjustCredits(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /** Retrieves paginated credit ledger entries with optional filters. */
+    public CreditLedgerResponse getCreditLedger(GetCreditLedgerParams params) {
+        try {
+            return query.getCreditLedger(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Retrieves an aggregated billing usage report for a date range.
+     *
+     * <p>Returns total provider cost, total billable amount, execution and
+     * LLM call counts, and a per-model breakdown with cost tier attribution.
+     */
+    public BillingUsageReportResponse getBillingUsageReport(GetBillingUsageReportParams params) {
+        try {
+            return query.getBillingUsageReport(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    // -- Stripe integration -------------------------------------------------------
+
+    /**
+     * Creates a Stripe Checkout Session to purchase a credit pack.
+     *
+     * <p>Returns the Stripe-hosted checkout URL; redirect the user there to
+     * complete payment. Credits are provisioned asynchronously via webhook
+     * after payment succeeds.
+     */
+    public CreateCreditCheckoutSessionResponse createCreditCheckoutSession(
+            CreateCreditCheckoutSessionParams params) {
+        try {
+            return command.createCreditCheckoutSession(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Creates a Stripe Customer Portal session for payment method management.
+     *
+     * <p>Returns the Stripe-hosted portal URL; redirect the user there to
+     * add, update, or remove saved payment methods. Requires an existing
+     * Stripe Customer (created during the first credit purchase).
+     */
+    public CreateBillingPortalSessionResponse createBillingPortalSession(
+            CreateBillingPortalSessionParams params) {
+        try {
+            return command.createBillingPortalSession(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Configures automatic credit recharge for an organization.
+     *
+     * <p>When enabled, the billing system charges the account's saved payment
+     * method whenever the available balance drops below the configured
+     * threshold. Returns the updated {@link BillingAccount}.
+     */
+    public BillingAccount setAutoRechargeConfig(SetAutoRechargeConfigParams params) {
+        try {
+            return command.setAutoRechargeConfig(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    // -- Model pricing ------------------------------------------------------------
+
+    /** Retrieves the customer-facing model price list with default pricing. */
+    public CustomerModelPricingResponse getCustomerModelPricing() {
+        return getCustomerModelPricing("");
+    }
+
+    /**
+     * Retrieves the customer-facing model price list with markup applied.
+     *
+     * <p>Returns per-million-token prices for all billable models, organized
+     * by harness and cost tier. Pass an org ID to resolve org-specific policy
+     * overrides; pass an empty string for default pricing.
+     */
+    public CustomerModelPricingResponse getCustomerModelPricing(String orgId) {
+        Objects.requireNonNull(orgId, "orgId must not be null (use \"\" for default pricing)");
+        try {
+            return query.getCustomerModelPricing(GetCustomerModelPricingInput.newBuilder()
+                    .setOrgId(orgId)
+                    .build());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Retrieves the platform pricing governance view: baseline vs effective
+     * rates per model, active override provenance, and pending sign-off
+     * proposals from the pricing feedback loop.
+     *
+     * <p>Platform-operator surface: rates are raw provider prices, pre-markup.
+     */
+    public ModelPricingGovernanceResponse getModelPricingGovernance() {
+        try {
+            return query.getModelPricingGovernance(
+                    GetModelPricingGovernanceInput.getDefaultInstance());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /** Retrieves the model registry baseline catalog (ACTIVE entries only). */
+    public ModelPricingBaselinesResponse listModelPricingBaselines() {
+        return listModelPricingBaselines(false);
+    }
+
+    /**
+     * Retrieves the model registry baseline catalog.
+     *
+     * <p>Platform-operator surface. When {@code includeHistory} is true,
+     * includes SUPERSEDED and RETIRED revisions (the full append-only audit
+     * history) in addition to ACTIVE entries.
+     */
+    public ModelPricingBaselinesResponse listModelPricingBaselines(boolean includeHistory) {
+        try {
+            return query.listModelPricingBaselines(ListModelPricingBaselinesInput.newBuilder()
+                    .setIncludeHistory(includeHistory)
+                    .build());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Records a human decision on a PENDING_SIGNOFF pricing override.
+     *
+     * <p>Approving makes the override ACTIVE (superseding any current ACTIVE
+     * override on the same pricing key) and recomposes the effective
+     * registry; rejecting archives it for audit.
+     */
+    public ModelPricingOverride decideModelPricingOverride(DecideModelPricingOverrideParams params) {
+        try {
+            return command.decideModelPricingOverride(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Creates or revises one model registry baseline entry (catalog + list
+     * prices).
+     *
+     * <p>Append-only: an existing ACTIVE entry for the same
+     * (modelId, provider, harness) key is superseded, never mutated, and the
+     * effective registry recomposes immediately.
+     */
+    public ModelPricingBaseline upsertModelPricingBaseline(UpsertModelPricingBaselineParams params) {
+        try {
+            return command.upsertModelPricingBaseline(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    /**
+     * Retires one model from the registry catalog.
+     *
+     * <p>The model disappears from every price surface on the next
+     * composition pass; the document is kept for audit and the key can be
+     * revived by a subsequent upsert.
+     */
+    public ModelPricingBaseline retireModelPricingBaseline(RetireModelPricingBaselineParams params) {
+        try {
+            return command.retireModelPricingBaseline(params.toProto());
+        } catch (StatusRuntimeException e) {
+            throw StigmerException.wrap(e);
+        }
+    }
+
+    private static Timestamp protoTimestamp(Instant instant) {
+        return Timestamp.newBuilder()
+                .setSeconds(instant.getEpochSecond())
+                .setNanos(instant.getNano())
+                .build();
+    }
+
+    // -- AdjustCreditsParams ------------------------------------------------------
+
+    /** Parameters for manually adjusting an organization's credit balance. */
+    public static final class AdjustCreditsParams {
+        final String orgId;
+        final long amountMicros;
+        final String reason;
+        final String idempotencyKey;
+
+        private AdjustCreditsParams(Builder builder) {
+            this.orgId = builder.orgId;
+            this.amountMicros = builder.amountMicros;
+            this.reason = builder.reason;
+            this.idempotencyKey = builder.idempotencyKey;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        AdjustCreditsInput toProto() {
+            return AdjustCreditsInput.newBuilder()
+                    .setOrgId(orgId)
+                    .setAmountMicros(amountMicros)
+                    .setReason(reason)
+                    .setIdempotencyKey(idempotencyKey)
+                    .build();
+        }
+
+        public static final class Builder {
+            private String orgId;
+            private long amountMicros;
+            private String reason;
+            private String idempotencyKey;
+
+            private Builder() {}
+
+            /** Organization ID whose balance to adjust (required). */
+            public Builder orgId(String orgId) {
+                this.orgId = Objects.requireNonNull(orgId);
+                return this;
+            }
+
+            /** Micro-USD to adjust by: positive adds credits, negative removes. */
+            public Builder amountMicros(long amountMicros) {
+                this.amountMicros = amountMicros;
+                return this;
+            }
+
+            /** Human-readable reason for the adjustment, recorded in the audit trail (required). */
+            public Builder reason(String reason) {
+                this.reason = Objects.requireNonNull(reason);
+                return this;
+            }
+
+            /** Client-supplied deduplication key to prevent double-processing (required). */
+            public Builder idempotencyKey(String idempotencyKey) {
+                this.idempotencyKey = Objects.requireNonNull(idempotencyKey);
+                return this;
+            }
+
+            public AdjustCreditsParams build() {
+                Objects.requireNonNull(orgId, "orgId is required");
+                Objects.requireNonNull(reason, "reason is required");
+                Objects.requireNonNull(idempotencyKey, "idempotencyKey is required");
+                return new AdjustCreditsParams(this);
+            }
+        }
+    }
+
+    // -- GetCreditLedgerParams ----------------------------------------------------
+
+    /** Parameters for querying the credit ledger. */
+    public static final class GetCreditLedgerParams {
+        final String orgId;
+        final Page page;
+        final List<LedgerEntryType> typeFilter;
+        final LedgerView view;
+        final Instant startTime;
+        final Instant endTime;
+
+        private GetCreditLedgerParams(Builder builder) {
+            this.orgId = builder.orgId;
+            this.page = builder.page;
+            this.typeFilter = builder.typeFilter;
+            this.view = builder.view;
+            this.startTime = builder.startTime;
+            this.endTime = builder.endTime;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        GetCreditLedgerInput toProto() {
+            GetCreditLedgerInput.Builder req = GetCreditLedgerInput.newBuilder()
+                    .setOrgId(orgId)
+                    .addAllTypeFilter(typeFilter);
+            if (page != null) {
+                req.setPage(PageInfo.newBuilder()
+                        .setNum(page.getNum())
+                        .setSize(page.getSize())
+                        .build());
+            }
+            if (view != null) {
+                req.setView(view);
+            }
+            if (startTime != null) {
+                req.setStartTime(protoTimestamp(startTime));
+            }
+            if (endTime != null) {
+                req.setEndTime(protoTimestamp(endTime));
+            }
+            return req.build();
+        }
+
+        public static final class Builder {
+            private String orgId;
+            private Page page;
+            private List<LedgerEntryType> typeFilter = List.of();
+            private LedgerView view;
+            private Instant startTime;
+            private Instant endTime;
+
+            private Builder() {}
+
+            /** Organization ID whose ledger to query (required). */
+            public Builder orgId(String orgId) {
+                this.orgId = Objects.requireNonNull(orgId);
+                return this;
+            }
+
+            /** Pagination parameters. */
+            public Builder page(Page page) {
+                this.page = page;
+                return this;
+            }
+
+            /** Filter to specific entry types. Empty means all types. */
+            public Builder typeFilter(List<LedgerEntryType> typeFilter) {
+                this.typeFilter = Objects.requireNonNull(typeFilter);
+                return this;
+            }
+
+            /**
+             * Server-resolved ledger slice. {@link LedgerView#ledger_view_statement}
+             * returns only customer-facing money-movement entries and excludes
+             * internal mechanics (per-call usage debits, reservation
+             * holds/releases). Defaults to the full ledger.
+             */
+            public Builder view(LedgerView view) {
+                this.view = view;
+                return this;
+            }
+
+            /** Filter to entries on or after this instant. */
+            public Builder startTime(Instant startTime) {
+                this.startTime = startTime;
+                return this;
+            }
+
+            /** Filter to entries on or before this instant. */
+            public Builder endTime(Instant endTime) {
+                this.endTime = endTime;
+                return this;
+            }
+
+            public GetCreditLedgerParams build() {
+                Objects.requireNonNull(orgId, "orgId is required");
+                return new GetCreditLedgerParams(this);
+            }
+        }
+    }
+
+    // -- GetBillingUsageReportParams ------------------------------------------------
+
+    /** Parameters for querying the aggregated billing usage report. */
+    public static final class GetBillingUsageReportParams {
+        final String orgId;
+        final Instant startTime;
+        final Instant endTime;
+
+        private GetBillingUsageReportParams(Builder builder) {
+            this.orgId = builder.orgId;
+            this.startTime = builder.startTime;
+            this.endTime = builder.endTime;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        GetBillingUsageReportInput toProto() {
+            return GetBillingUsageReportInput.newBuilder()
+                    .setOrgId(orgId)
+                    .setStartTime(protoTimestamp(startTime))
+                    .setEndTime(protoTimestamp(endTime))
+                    .build();
+        }
+
+        public static final class Builder {
+            private String orgId;
+            private Instant startTime;
+            private Instant endTime;
+
+            private Builder() {}
+
+            /** Organization ID to report on (required). */
+            public Builder orgId(String orgId) {
+                this.orgId = Objects.requireNonNull(orgId);
+                return this;
+            }
+
+            /** Start of the reporting period (required). */
+            public Builder startTime(Instant startTime) {
+                this.startTime = Objects.requireNonNull(startTime);
+                return this;
+            }
+
+            /** End of the reporting period (required). */
+            public Builder endTime(Instant endTime) {
+                this.endTime = Objects.requireNonNull(endTime);
+                return this;
+            }
+
+            public GetBillingUsageReportParams build() {
+                Objects.requireNonNull(orgId, "orgId is required");
+                Objects.requireNonNull(startTime, "startTime is required");
+                Objects.requireNonNull(endTime, "endTime is required");
+                return new GetBillingUsageReportParams(this);
+            }
+        }
+    }
+
+    // -- CreateCreditCheckoutSessionParams --------------------------------------------
+
+    /** Parameters for creating a Stripe Checkout Session. */
+    public static final class CreateCreditCheckoutSessionParams {
+        final String orgId;
+        final String packId;
+        final String successUrl;
+        final String cancelUrl;
+
+        private CreateCreditCheckoutSessionParams(Builder builder) {
+            this.orgId = builder.orgId;
+            this.packId = builder.packId;
+            this.successUrl = builder.successUrl;
+            this.cancelUrl = builder.cancelUrl;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        CreateCreditCheckoutSessionInput toProto() {
+            return CreateCreditCheckoutSessionInput.newBuilder()
+                    .setOrgId(orgId)
+                    .setPackId(packId)
+                    .setSuccessUrl(successUrl)
+                    .setCancelUrl(cancelUrl)
+                    .build();
+        }
+
+        public static final class Builder {
+            private String orgId;
+            private String packId;
+            private String successUrl;
+            private String cancelUrl;
+
+            private Builder() {}
+
+            /** Organization purchasing the credits (required). */
+            public Builder orgId(String orgId) {
+                this.orgId = Objects.requireNonNull(orgId);
+                return this;
+            }
+
+            /** Credit pack to purchase, e.g. "starter", "growth", "team" (required). */
+            public Builder packId(String packId) {
+                this.packId = Objects.requireNonNull(packId);
+                return this;
+            }
+
+            /** URL to redirect to after successful payment (required). */
+            public Builder successUrl(String successUrl) {
+                this.successUrl = Objects.requireNonNull(successUrl);
+                return this;
+            }
+
+            /** URL to redirect to if the user cancels checkout (required). */
+            public Builder cancelUrl(String cancelUrl) {
+                this.cancelUrl = Objects.requireNonNull(cancelUrl);
+                return this;
+            }
+
+            public CreateCreditCheckoutSessionParams build() {
+                Objects.requireNonNull(orgId, "orgId is required");
+                Objects.requireNonNull(packId, "packId is required");
+                Objects.requireNonNull(successUrl, "successUrl is required");
+                Objects.requireNonNull(cancelUrl, "cancelUrl is required");
+                return new CreateCreditCheckoutSessionParams(this);
+            }
+        }
+    }
+
+    // -- CreateBillingPortalSessionParams ---------------------------------------------
+
+    /** Parameters for creating a Stripe Billing Portal session. */
+    public static final class CreateBillingPortalSessionParams {
+        final String orgId;
+        final String returnUrl;
+
+        private CreateBillingPortalSessionParams(Builder builder) {
+            this.orgId = builder.orgId;
+            this.returnUrl = builder.returnUrl;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        CreateBillingPortalSessionInput toProto() {
+            return CreateBillingPortalSessionInput.newBuilder()
+                    .setOrgId(orgId)
+                    .setReturnUrl(returnUrl)
+                    .build();
+        }
+
+        public static final class Builder {
+            private String orgId;
+            private String returnUrl;
+
+            private Builder() {}
+
+            /** Organization whose billing to manage (required). */
+            public Builder orgId(String orgId) {
+                this.orgId = Objects.requireNonNull(orgId);
+                return this;
+            }
+
+            /** URL to redirect to after the user exits the Stripe portal (required). */
+            public Builder returnUrl(String returnUrl) {
+                this.returnUrl = Objects.requireNonNull(returnUrl);
+                return this;
+            }
+
+            public CreateBillingPortalSessionParams build() {
+                Objects.requireNonNull(orgId, "orgId is required");
+                Objects.requireNonNull(returnUrl, "returnUrl is required");
+                return new CreateBillingPortalSessionParams(this);
+            }
+        }
+    }
+
+    // -- SetAutoRechargeConfigParams --------------------------------------------------
+
+    /** Parameters for configuring automatic credit recharge. */
+    public static final class SetAutoRechargeConfigParams {
+        final String orgId;
+        final boolean enabled;
+        final long thresholdMicros;
+        final long rechargeAmountMicros;
+        final long monthlyCapMicros;
+
+        private SetAutoRechargeConfigParams(Builder builder) {
+            this.orgId = builder.orgId;
+            this.enabled = builder.enabled;
+            this.thresholdMicros = builder.thresholdMicros;
+            this.rechargeAmountMicros = builder.rechargeAmountMicros;
+            this.monthlyCapMicros = builder.monthlyCapMicros;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        SetAutoRechargeConfigInput toProto() {
+            return SetAutoRechargeConfigInput.newBuilder()
+                    .setOrgId(orgId)
+                    .setEnabled(enabled)
+                    .setThresholdMicros(thresholdMicros)
+                    .setRechargeAmountMicros(rechargeAmountMicros)
+                    .setMonthlyCapMicros(monthlyCapMicros)
+                    .build();
+        }
+
+        public static final class Builder {
+            private String orgId;
+            private boolean enabled;
+            private long thresholdMicros;
+            private long rechargeAmountMicros;
+            private long monthlyCapMicros;
+
+            private Builder() {}
+
+            /** Organization to configure (required). */
+            public Builder orgId(String orgId) {
+                this.orgId = Objects.requireNonNull(orgId);
+                return this;
+            }
+
+            /** Whether to enable auto-recharge. Disabling preserves the other settings. */
+            public Builder enabled(boolean enabled) {
+                this.enabled = enabled;
+                return this;
+            }
+
+            /** Trigger recharge when available balance drops below this micro-USD amount. */
+            public Builder thresholdMicros(long thresholdMicros) {
+                this.thresholdMicros = thresholdMicros;
+                return this;
+            }
+
+            /** Fixed micro-USD amount to charge per recharge event. */
+            public Builder rechargeAmountMicros(long rechargeAmountMicros) {
+                this.rechargeAmountMicros = rechargeAmountMicros;
+                return this;
+            }
+
+            /** Maximum total auto-recharge spend per calendar month, in micro-USD. */
+            public Builder monthlyCapMicros(long monthlyCapMicros) {
+                this.monthlyCapMicros = monthlyCapMicros;
+                return this;
+            }
+
+            public SetAutoRechargeConfigParams build() {
+                Objects.requireNonNull(orgId, "orgId is required");
+                return new SetAutoRechargeConfigParams(this);
+            }
+        }
+    }
+
+    // -- DecideModelPricingOverrideParams ---------------------------------------------
+
+    /** Parameters for deciding a pending pricing override. */
+    public static final class DecideModelPricingOverrideParams {
+        final String overrideId;
+        final boolean approve;
+        final String decisionNote;
+
+        private DecideModelPricingOverrideParams(Builder builder) {
+            this.overrideId = builder.overrideId;
+            this.approve = builder.approve;
+            this.decisionNote = builder.decisionNote;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        DecideModelPricingOverrideInput toProto() {
+            return DecideModelPricingOverrideInput.newBuilder()
+                    .setOverrideId(overrideId)
+                    .setApprove(approve)
+                    .setDecisionNote(decisionNote)
+                    .build();
+        }
+
+        public static final class Builder {
+            private String overrideId;
+            private boolean approve;
+            private String decisionNote = "";
+
+            private Builder() {}
+
+            /** The PENDING_SIGNOFF override to decide (required). */
+            public Builder overrideId(String overrideId) {
+                this.overrideId = Objects.requireNonNull(overrideId);
+                return this;
+            }
+
+            /**
+             * {@code true} approves (the override becomes ACTIVE and supersedes
+             * any current ACTIVE override on the same key); {@code false} rejects.
+             */
+            public Builder approve(boolean approve) {
+                this.approve = approve;
+                return this;
+            }
+
+            /** Optional note recorded on the decision for the audit trail. */
+            public Builder decisionNote(String decisionNote) {
+                this.decisionNote = Objects.requireNonNull(decisionNote);
+                return this;
+            }
+
+            public DecideModelPricingOverrideParams build() {
+                Objects.requireNonNull(overrideId, "overrideId is required");
+                return new DecideModelPricingOverrideParams(this);
+            }
+        }
+    }
+
+    // -- UpsertModelPricingBaselineParams ---------------------------------------------
+
+    /** Parameters for creating or revising a model registry baseline entry. */
+    public static final class UpsertModelPricingBaselineParams {
+        final ModelPricingBaseline baseline;
+        final String revisionNote;
+
+        private UpsertModelPricingBaselineParams(Builder builder) {
+            this.baseline = builder.baseline;
+            this.revisionNote = builder.revisionNote;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        UpsertModelPricingBaselineInput toProto() {
+            return UpsertModelPricingBaselineInput.newBuilder()
+                    .setBaseline(baseline)
+                    .setRevisionNote(revisionNote)
+                    .build();
+        }
+
+        public static final class Builder {
+            private ModelPricingBaseline baseline;
+            private String revisionNote = "";
+
+            private Builder() {}
+
+            /**
+             * The baseline entry to create or revise, keyed by
+             * (modelId, provider, harness). Lifecycle fields (baselineId,
+             * status, decision stamps, pricing effectiveAt) are server-owned
+             * and ignored (required).
+             */
+            public Builder baseline(ModelPricingBaseline baseline) {
+                this.baseline = Objects.requireNonNull(baseline);
+                return this;
+            }
+
+            /** Optional operator note recorded on the revision for the audit trail. */
+            public Builder revisionNote(String revisionNote) {
+                this.revisionNote = Objects.requireNonNull(revisionNote);
+                return this;
+            }
+
+            public UpsertModelPricingBaselineParams build() {
+                Objects.requireNonNull(baseline, "baseline is required");
+                return new UpsertModelPricingBaselineParams(this);
+            }
+        }
+    }
+
+    // -- RetireModelPricingBaselineParams ---------------------------------------------
+
+    /** Parameters for retiring a model from the registry catalog. */
+    public static final class RetireModelPricingBaselineParams {
+        final String modelId;
+        final String provider;
+        final String harness;
+        final String revisionNote;
+
+        private RetireModelPricingBaselineParams(Builder builder) {
+            this.modelId = builder.modelId;
+            this.provider = builder.provider;
+            this.harness = builder.harness;
+            this.revisionNote = builder.revisionNote;
+        }
+
+        public static Builder builder() { return new Builder(); }
+
+        RetireModelPricingBaselineInput toProto() {
+            return RetireModelPricingBaselineInput.newBuilder()
+                    .setModelId(modelId)
+                    .setProvider(provider)
+                    .setHarness(harness)
+                    .setRevisionNote(revisionNote)
+                    .build();
+        }
+
+        public static final class Builder {
+            private String modelId;
+            private String provider;
+            private String harness;
+            private String revisionNote = "";
+
+            private Builder() {}
+
+            /** Model identifier to retire (required). */
+            public Builder modelId(String modelId) {
+                this.modelId = Objects.requireNonNull(modelId);
+                return this;
+            }
+
+            /** LLM provider of the entry, e.g. "anthropic" (required). */
+            public Builder provider(String provider) {
+                this.provider = Objects.requireNonNull(provider);
+                return this;
+            }
+
+            /** Execution harness of the entry, "native" or "cursor" (required). */
+            public Builder harness(String harness) {
+                this.harness = Objects.requireNonNull(harness);
+                return this;
+            }
+
+            /** Optional operator note recorded on the retirement. */
+            public Builder revisionNote(String revisionNote) {
+                this.revisionNote = Objects.requireNonNull(revisionNote);
+                return this;
+            }
+
+            public RetireModelPricingBaselineParams build() {
+                Objects.requireNonNull(modelId, "modelId is required");
+                Objects.requireNonNull(provider, "provider is required");
+                Objects.requireNonNull(harness, "harness is required");
+                return new RetireModelPricingBaselineParams(this);
+            }
+        }
+    }
+}

--- a/sdk/java/src/main/java/ai/stigmer/sdk/StigmerClient.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/StigmerClient.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
  * <p>On top of the generated resource clients, {@code StigmerClient} adds:
  * <ul>
  *   <li>Configuration and gRPC channel setup</li>
+ *   <li>{@link #billing()} credit management and Stripe integration client</li>
  *   <li>Cross-resource {@link #search()} client</li>
  *   <li>{@link #github()} OAuth integration client</li>
  * </ul>
@@ -38,6 +39,7 @@ public final class StigmerClient extends GeneratedClient implements AutoCloseabl
     private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
 
     private final ManagedChannel channel;
+    private final BillingClient billing;
     private final SearchClient search;
     private final GitHubClient github;
     private final RunnerAdapter runnerAdapter;
@@ -45,6 +47,7 @@ public final class StigmerClient extends GeneratedClient implements AutoCloseabl
     private StigmerClient(ManagedChannel channel, RunnerAdapter runnerAdapter) {
         super(channel);
         this.channel = channel;
+        this.billing = new BillingClient(channel);
         this.search = new SearchClient(channel);
         this.github = new GitHubClient(channel);
         this.runnerAdapter = runnerAdapter;
@@ -56,6 +59,9 @@ public final class StigmerClient extends GeneratedClient implements AutoCloseabl
     }
 
     // -- Extra clients (not code-generated) ------------------------------------
+
+    /** Returns the billing client for credit management and Stripe integration. */
+    public BillingClient billing() { return billing; }
 
     /** Returns the cross-resource search client. */
     public SearchClient search() { return search; }

--- a/sdk/java/src/test/java/ai/stigmer/sdk/BillingClientTest.java
+++ b/sdk/java/src/test/java/ai/stigmer/sdk/BillingClientTest.java
@@ -1,0 +1,263 @@
+package ai.stigmer.sdk;
+
+import ai.stigmer.billing.v1.AdjustCreditsInput;
+import ai.stigmer.billing.v1.CreateBillingPortalSessionInput;
+import ai.stigmer.billing.v1.CreateCreditCheckoutSessionInput;
+import ai.stigmer.billing.v1.DecideModelPricingOverrideInput;
+import ai.stigmer.billing.v1.GetBillingUsageReportInput;
+import ai.stigmer.billing.v1.GetCreditLedgerInput;
+import ai.stigmer.billing.v1.LedgerEntryType;
+import ai.stigmer.billing.v1.LedgerView;
+import ai.stigmer.billing.v1.ModelPricingBaseline;
+import ai.stigmer.billing.v1.RetireModelPricingBaselineInput;
+import ai.stigmer.billing.v1.SetAutoRechargeConfigInput;
+import ai.stigmer.billing.v1.UpsertModelPricingBaselineInput;
+import ai.stigmer.sdk.gen.Page;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Wire-shape pins for {@link BillingClient} param-to-proto conversion.
+ *
+ * <p>Each params class owns its proto request construction via a
+ * package-private {@code toProto()}; these tests pin that mapping (field
+ * routing, optional-field presence, timestamp conversion) and the builders'
+ * required-field enforcement, without needing a gRPC server.
+ */
+class BillingClientTest {
+
+    // -- AdjustCreditsParams ----------------------------------------------------
+
+    @Test
+    void adjustCredits_toProto_mapsAllFields() {
+        AdjustCreditsInput proto = BillingClient.AdjustCreditsParams.builder()
+                .orgId("org_123")
+                .amountMicros(-5_000_000L)
+                .reason("correct double grant")
+                .idempotencyKey("adj-2026-08-13-01")
+                .build()
+                .toProto();
+
+        assertEquals("org_123", proto.getOrgId());
+        assertEquals(-5_000_000L, proto.getAmountMicros());
+        assertEquals("correct double grant", proto.getReason());
+        assertEquals("adj-2026-08-13-01", proto.getIdempotencyKey());
+    }
+
+    @Test
+    void adjustCredits_missingRequiredFields_throw() {
+        assertThrows(NullPointerException.class, () -> BillingClient.AdjustCreditsParams.builder()
+                .amountMicros(1L).reason("r").idempotencyKey("k").build());
+        assertThrows(NullPointerException.class, () -> BillingClient.AdjustCreditsParams.builder()
+                .orgId("org_123").amountMicros(1L).idempotencyKey("k").build());
+        assertThrows(NullPointerException.class, () -> BillingClient.AdjustCreditsParams.builder()
+                .orgId("org_123").amountMicros(1L).reason("r").build());
+    }
+
+    // -- GetCreditLedgerParams --------------------------------------------------
+
+    @Test
+    void getCreditLedger_toProto_mapsAllFilters() {
+        Instant start = Instant.parse("2026-08-01T00:00:00Z");
+        Instant end = Instant.parse("2026-08-13T00:00:00.000000500Z");
+
+        GetCreditLedgerInput proto = BillingClient.GetCreditLedgerParams.builder()
+                .orgId("org_123")
+                .page(new Page(2, 50))
+                .typeFilter(List.of(LedgerEntryType.purchase_credit, LedgerEntryType.usage_debit))
+                .view(LedgerView.ledger_view_statement)
+                .startTime(start)
+                .endTime(end)
+                .build()
+                .toProto();
+
+        assertEquals("org_123", proto.getOrgId());
+        assertEquals(2, proto.getPage().getNum());
+        assertEquals(50, proto.getPage().getSize());
+        assertEquals(
+                List.of(LedgerEntryType.purchase_credit, LedgerEntryType.usage_debit),
+                proto.getTypeFilterList());
+        assertEquals(LedgerView.ledger_view_statement, proto.getView());
+        assertEquals(start.getEpochSecond(), proto.getStartTime().getSeconds());
+        assertEquals(end.getEpochSecond(), proto.getEndTime().getSeconds());
+        assertEquals(500, proto.getEndTime().getNanos());
+    }
+
+    @Test
+    void getCreditLedger_toProto_omitsUnsetOptionals() {
+        GetCreditLedgerInput proto = BillingClient.GetCreditLedgerParams.builder()
+                .orgId("org_123")
+                .build()
+                .toProto();
+
+        assertFalse(proto.hasPage());
+        assertTrue(proto.getTypeFilterList().isEmpty());
+        assertEquals(LedgerView.ledger_view_unspecified, proto.getView());
+        assertFalse(proto.hasStartTime());
+        assertFalse(proto.hasEndTime());
+    }
+
+    @Test
+    void getCreditLedger_missingOrgId_throws() {
+        assertThrows(NullPointerException.class,
+                () -> BillingClient.GetCreditLedgerParams.builder().build());
+    }
+
+    // -- GetBillingUsageReportParams ----------------------------------------------
+
+    @Test
+    void getBillingUsageReport_toProto_convertsInstants() {
+        Instant start = Instant.parse("2026-07-01T00:00:00Z");
+        Instant end = Instant.parse("2026-08-01T00:00:00Z");
+
+        GetBillingUsageReportInput proto = BillingClient.GetBillingUsageReportParams.builder()
+                .orgId("org_123")
+                .startTime(start)
+                .endTime(end)
+                .build()
+                .toProto();
+
+        assertEquals("org_123", proto.getOrgId());
+        assertEquals(start.getEpochSecond(), proto.getStartTime().getSeconds());
+        assertEquals(end.getEpochSecond(), proto.getEndTime().getSeconds());
+    }
+
+    @Test
+    void getBillingUsageReport_missingTimeRange_throws() {
+        assertThrows(NullPointerException.class,
+                () -> BillingClient.GetBillingUsageReportParams.builder()
+                        .orgId("org_123").endTime(Instant.now()).build());
+        assertThrows(NullPointerException.class,
+                () -> BillingClient.GetBillingUsageReportParams.builder()
+                        .orgId("org_123").startTime(Instant.now()).build());
+    }
+
+    // -- Stripe params ------------------------------------------------------------
+
+    @Test
+    void createCreditCheckoutSession_toProto_mapsAllFields() {
+        CreateCreditCheckoutSessionInput proto =
+                BillingClient.CreateCreditCheckoutSessionParams.builder()
+                        .orgId("org_123")
+                        .packId("starter")
+                        .successUrl("https://app.example.com/billing/success")
+                        .cancelUrl("https://app.example.com/billing/cancel")
+                        .build()
+                        .toProto();
+
+        assertEquals("org_123", proto.getOrgId());
+        assertEquals("starter", proto.getPackId());
+        assertEquals("https://app.example.com/billing/success", proto.getSuccessUrl());
+        assertEquals("https://app.example.com/billing/cancel", proto.getCancelUrl());
+    }
+
+    @Test
+    void createCreditCheckoutSession_missingRequiredFields_throw() {
+        assertThrows(NullPointerException.class,
+                () -> BillingClient.CreateCreditCheckoutSessionParams.builder()
+                        .orgId("org_123").packId("starter")
+                        .successUrl("https://a").build());
+    }
+
+    @Test
+    void createBillingPortalSession_toProto_mapsAllFields() {
+        CreateBillingPortalSessionInput proto =
+                BillingClient.CreateBillingPortalSessionParams.builder()
+                        .orgId("org_123")
+                        .returnUrl("https://app.example.com/billing")
+                        .build()
+                        .toProto();
+
+        assertEquals("org_123", proto.getOrgId());
+        assertEquals("https://app.example.com/billing", proto.getReturnUrl());
+    }
+
+    @Test
+    void setAutoRechargeConfig_toProto_mapsAllFields() {
+        SetAutoRechargeConfigInput proto = BillingClient.SetAutoRechargeConfigParams.builder()
+                .orgId("org_123")
+                .enabled(true)
+                .thresholdMicros(5_000_000L)
+                .rechargeAmountMicros(25_000_000L)
+                .monthlyCapMicros(100_000_000L)
+                .build()
+                .toProto();
+
+        assertEquals("org_123", proto.getOrgId());
+        assertTrue(proto.getEnabled());
+        assertEquals(5_000_000L, proto.getThresholdMicros());
+        assertEquals(25_000_000L, proto.getRechargeAmountMicros());
+        assertEquals(100_000_000L, proto.getMonthlyCapMicros());
+    }
+
+    // -- Pricing governance params --------------------------------------------------
+
+    @Test
+    void decideModelPricingOverride_toProto_defaultsNoteToEmpty() {
+        DecideModelPricingOverrideInput proto =
+                BillingClient.DecideModelPricingOverrideParams.builder()
+                        .overrideId("ovr_123")
+                        .approve(true)
+                        .build()
+                        .toProto();
+
+        assertEquals("ovr_123", proto.getOverrideId());
+        assertTrue(proto.getApprove());
+        assertEquals("", proto.getDecisionNote());
+    }
+
+    @Test
+    void upsertModelPricingBaseline_toProto_mapsBaselineAndNote() {
+        ModelPricingBaseline baseline = ModelPricingBaseline.newBuilder()
+                .setModelId("claude-fable-5")
+                .setProvider("anthropic")
+                .setHarness("native")
+                .build();
+
+        UpsertModelPricingBaselineInput proto =
+                BillingClient.UpsertModelPricingBaselineParams.builder()
+                        .baseline(baseline)
+                        .revisionNote("provider price change 2026-08")
+                        .build()
+                        .toProto();
+
+        assertEquals(baseline, proto.getBaseline());
+        assertEquals("provider price change 2026-08", proto.getRevisionNote());
+    }
+
+    @Test
+    void upsertModelPricingBaseline_missingBaseline_throws() {
+        assertThrows(NullPointerException.class,
+                () -> BillingClient.UpsertModelPricingBaselineParams.builder().build());
+    }
+
+    @Test
+    void retireModelPricingBaseline_toProto_mapsKey() {
+        RetireModelPricingBaselineInput proto =
+                BillingClient.RetireModelPricingBaselineParams.builder()
+                        .modelId("legacy-model")
+                        .provider("openai")
+                        .harness("native")
+                        .build()
+                        .toProto();
+
+        assertEquals("legacy-model", proto.getModelId());
+        assertEquals("openai", proto.getProvider());
+        assertEquals("native", proto.getHarness());
+        assertEquals("", proto.getRevisionNote());
+    }
+
+    @Test
+    void retireModelPricingBaseline_missingKeyFields_throw() {
+        assertThrows(NullPointerException.class,
+                () -> BillingClient.RetireModelPricingBaselineParams.builder()
+                        .modelId("m").provider("p").build());
+    }
+}

--- a/sdk/java/src/test/java/ai/stigmer/sdk/StigmerClientTest.java
+++ b/sdk/java/src/test/java/ai/stigmer/sdk/StigmerClientTest.java
@@ -78,6 +78,7 @@ class StigmerClientTest {
             assertNotNull(client.workflow);
             assertNotNull(client.workflowExecution);
             assertNotNull(client.workflowInstance);
+            assertNotNull(client.billing());
             assertNotNull(client.search());
             assertNotNull(client.github());
         }


### PR DESCRIPTION
## Summary

Adds a handwritten `BillingClient` to the Java SDK, accessible as `client.billing()` on `StigmerClient`, covering the org-facing billing surface — including `adjustCredits`, `getCreditBalance`, and `getCreditLedger` — plus the platform-operator pricing methods.

## Context

The Java SDK had no client for `ai.stigmer.billing.v1` (#390): the protos, generated stubs in `stigmer-java-protos`, and live server RPCs all exist, but SDK consumers had to hand-roll raw gRPC stubs. Platform integrators operating `platform_managed` orgs need `getCreditBalance` + `adjustCredits` to provision usable tenant orgs.

## Changes

- `sdk/java/src/main/java/ai/stigmer/sdk/BillingClient.java`: new handwritten client wrapping `BillingCommandControllerGrpc` / `BillingQueryControllerGrpc` with 15 methods: account provisioning, balance, ledger (with pagination, type/view filters, and time-range filters), manual credit adjustments, usage report, Stripe checkout/portal, auto-recharge config, and the four pricing-governance operator methods. Builder-based param objects own their proto conversion via package-private `toProto()`.
- `StigmerClient`: new `billing()` accessor wired alongside `search()` and `github()`.
- `BillingClientTest`: 16 wire-shape and required-field pins for the param→proto mapping (no gRPC server needed); `StigmerClientTest` asserts the new sub-client is accessible.
- `sdk/java/README.md`: billing row in the client table, a usage example (`getCreditBalance` + `adjustCredits`), and corrected handwritten-files list.

## Implementation notes

- The issue proposed generating the client from a `billing.json` codegen schema. This PR deliberately goes handwritten instead, matching the established architecture: the codegen pipeline serves API-Resource-shaped packages, and non-resource bounded contexts (search, github, platform — and billing, which the TypeScript SDK already implements by hand in `sdk/typescript/src/billing.ts`) get handwritten clients per SDK. A generated client would have been misnamed (`BillingAccountClient`), taken raw proto inputs, produced a docs page with fabricated resource fields, and collided with the existing handwritten TS billing client.
- Surface mirrors the TS `BillingClient` (which excludes the three engine-internal RPCs called only by the Temporal workflow and LLM proxy), and adds `adjustCredits` — the issue's core ask — plus ledger `startTime`/`endTime` filters the proto supports.
- No generated code is touched; the codegen freshness gate passes as a no-op.

## Breaking changes

- None (additive only).

## Test plan

- Mirrored `ci.java-sdk.yaml` locally: installed `stigmer-java-protos` from `apis/stubs/java`, ran `make -C sdk/java codegen` + `git diff --exit-code` on `gen/` (no drift), then `make -C sdk/java verify` — all suites green (`BillingClientTest` 16/16, `StigmerClientTest` 7/7, plus existing suites).
- Not verified: live RPC round-trips against a running server (no integration-test harness exists in this SDK).

## Risks

- Low: additive handwritten code with no changes to generated or shared files. Rollback is deleting the new files and the three-line `StigmerClient` wiring.

## Checklist

- [x] Docs updated (if needed)
- [x] Tests added/updated (if needed)
- [x] Backward compatible

Closes #390

Made with [Cursor](https://cursor.com)