### PR TITLE
fix(docs): classify guides/runners/payload-encryption; make the docs gate binding

### DIFF
--- a/.github/workflows/ci.docs-noop.yaml
+++ b/.github/workflows/ci.docs-noop.yaml
@@ -1,0 +1,49 @@
+# =============================================================================
+# Documentation CI — no-op twin
+# =============================================================================
+# `Lint & Build` (ci.docs) is a REQUIRED status check on main, but ci.docs
+# only runs on PRs that touch docs-adjacent paths. A required check that never
+# reports blocks the PR forever, so this twin reports a passing `Lint & Build`
+# on exactly the PRs ci.docs skips.
+#
+# The two workflows must stay complements: `paths-ignore` here mirrors the
+# `paths` list in ci.docs.yaml entry for entry. When you change one list,
+# change the other in the same commit — a gap strands PRs on a check that
+# never arrives; an overlap runs both (harmless, the twin is free).
+#
+# Why this exists (the class behind stigmer/stigmer#610): the docs inventory
+# gate flagged an unclassified page on PR #518 and the PR merged over the red
+# check anyway. Making the check required is what gives the gate teeth.
+# =============================================================================
+
+name: ci.docs-noop
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "site/**"
+      - "apis/**"
+      - "tools/codegen/**"
+      - "client-apps/cli/**"
+      - "sdk/ink/**"
+      - "sdk/react/**"
+      - "sdk/embed/**"
+      - ".vale.ini"
+      - ".prettierrc"
+      - ".lychee.toml"
+      - "vale/**"
+
+concurrency:
+  group: docs-noop-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-build:
+    # Must match ci.docs.yaml's job name exactly — the required status check
+    # matches on this name, and each PR must get it from exactly one workflow.
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: No docs-adjacent changes
+        run: echo "No docs-adjacent paths changed — docs gate not applicable."

--- a/.github/workflows/ci.docs.yaml
+++ b/.github/workflows/ci.docs.yaml
@@ -8,6 +8,9 @@
 
 name: ci.docs
 
+# `Lint & Build` is a required status check on main. ci.docs-noop.yaml reports
+# a passing twin on the PRs these path filters skip — its `paths-ignore` list
+# must mirror this `paths` list entry for entry; change both in one commit.
 on:
   pull_request:
     paths:

--- a/docs/_inventory/classification.yaml
+++ b/docs/_inventory/classification.yaml
@@ -484,6 +484,15 @@ pages:
       Claude) by setting backend env vars on a direct-mode runner.
     medium: none
 
+  guides/runners/payload-encryption:
+    fate: keep
+    diataxis: how-to
+    teaches:
+      Encrypt every Temporal payload the runner produces (AES-256-GCM) so
+      decrypted workflow secrets never rest in Temporal history — two env vars
+      set on both the runner and the server.
+    medium: none
+
   guides/runners/ipc-protocol:
     fate: keep
     diataxis: reference


### PR DESCRIPTION
## Summary

- Adds the missing `docs/_inventory/classification.yaml` entry for `guides/runners/payload-encryption` (`keep` / `how-to` / `medium: none`), un-reddening ci.docs on every main push and restoring the docs deploy lane. Verified locally: `make check-docs-inventory` → `196 pages OK`.
- Closes the class, not just the instance: the inventory gate **did** flag this exact page on [PR #518](https://github.com/stigmer/stigmer/pull/518) — the PR merged over the red check ([failing job](https://github.com/stigmer/stigmer/actions/runs/31586321282/job/94080881154)). Adds `ci.docs-noop.yaml`, a no-op twin that reports a passing `Lint & Build` on PRs touching no docs-adjacent paths, so the check can be made **required** on `main` without stranding non-docs PRs on a check that never reports. The twin's `paths-ignore` mirrors ci.docs's `paths` entry for entry, with reciprocal comments in both files.
- Branch-protection follow-through (after this merges): add `Lint & Build` to `main`'s required status checks — owner-ruled in the session that produced this PR.

## Test plan

- [x] `make check-docs-inventory` green locally (196 pages OK)
- [ ] ci.docs `Lint & Build` green on this PR (this PR touches `docs/**`, so the real workflow runs)
- [ ] After merge: first main push runs ci.docs green; docs deploy lane resumes

Closes #610

Made with [Cursor](https://cursor.com)