### PR TITLE
fix(repo): disable gazelle proto generation for protocompile — pluginpb link conflict

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,24 @@ go_sdk.download(
 # Read Go deps from go.work (includes root + CLI + SDK modules)
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//:go.work")
+
+# protocompile vendors google/protobuf/compiler/plugin.proto (as embedded
+# data for its std-import feature). Without this override, gazelle sees that
+# .proto and synthesizes a go_proto_library whose importpath —
+# google.golang.org/protobuf/types/pluginpb, from the proto's go_package —
+# duplicates the real protobuf-go package, and any binary linking both (e.g.
+# via jhump/protoreflect) fails with a "multiple copies of package" link
+# error (oss#604). "gazelle:proto disable" stops gazelle generating
+# proto-derived Go rules inside that module; nothing consumes them.
+# This mirrors gazelle's own default override (bazel-gazelle PR #2278,
+# shipped in v0.48.0) — delete it once gazelle here is bumped past 0.47.0.
+go_deps.gazelle_override(
+    directives = [
+        "gazelle:proto disable",
+    ],
+    path = "github.com/bufbuild/protocompile",
+)
+
 use_repo(
     go_deps,
     "build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go",  # keep: Required for protovalidate protobuf types


### PR DESCRIPTION
## Summary

`//tools/codegen/proto2schema:proto2schema_test` fails to **link** on clean main:

```
package conflict error: google.golang.org/protobuf/types/pluginpb: multiple copies of package passed to linker:
    @@gazelle++go_deps+com_github_bufbuild_protocompile//wellknownimports/google/protobuf/compiler
    @@gazelle++go_deps+org_golang_google_protobuf//types/pluginpb
```

**Root cause** (verified in the generated external repo): protocompile vendors `google/protobuf/compiler/plugin.proto` as embedded data for its std-import feature. Gazelle sees that `.proto` and synthesizes a `go_proto_library` whose `importpath` — `google.golang.org/protobuf/types/pluginpb`, taken from the proto's `go_package` option — duplicates the real protobuf-go package. Any binary linking both (proto2schema does, via `jhump/protoreflect`) fails at link.

**Fix**: a `gazelle_override` on `github.com/bufbuild/protocompile` with `gazelle:proto disable`, so gazelle stops generating proto-derived Go rules inside that module (nothing consumes them — the vendored protos are `embedsrcs` data). This mirrors gazelle's own **default** override, merged upstream in [bazel-gazelle PR #2278](https://github.com/bazel-contrib/bazel-gazelle/pull/2278) and shipped in gazelle v0.48.0; this repo pins 0.47.0, one release too old to get it for free. The override comment marks it deletable once gazelle is bumped past 0.47.0 (follow-up tracked separately).

This is the repo's first `gazelle_override` — the inline comment explains the phantom-package mechanism and the exit condition so it doesn't calcify.

## Verification

- `bazel test //tools/codegen/proto2schema:proto2schema_test` — was FAILED TO BUILD, now **PASSED**
- `bazel cquery 'deps(...)' | rg pluginpb` — exactly one provider (`@org_golang_google_protobuf//types/pluginpb`); the phantom is gone from the graph
- `bazel test //tools/...` — both test targets green
- `cd tools && go test ./codegen/proto2schema/...` — go-test lane unaffected, green
- `tools/codegen/proto2schema` is the repo's only protoreflect/protocompile consumer (import grep), so no other target could regress

Closes #604

Made with [Cursor](https://cursor.com)