### PR TITLE
feat(sdk/react): per-message copy affordance with quiet-affordance contrast

### DIFF
--- a/sdk/react/src/execution/MessageEntry.tsx
+++ b/sdk/react/src/execution/MessageEntry.tsx
@@ -20,6 +20,7 @@ import {
 import { PlanDocumentMessage } from "./PlanDocumentMessage.js";
 import { useRenderTracer } from "../internal/dev/index.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link MessageEntry}. */
 export interface MessageEntryProps {
@@ -192,29 +193,29 @@ function HumanMessage({
         />
       )}
       <p className="stg:text-sm stg:text-foreground stg:whitespace-pre-wrap">{content}</p>
-      {onEdit && (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                onClick={onEdit}
-                aria-label="Edit message"
-                className={cn(
-                  "stg:absolute stg:-top-2.5 stg:-right-2.5 stg:inline-flex stg:h-7 stg:w-7 stg:items-center stg:justify-center stg:rounded-full",
-                  "stg:border stg:border-border stg:bg-card stg:text-muted-foreground stg:shadow-sm stg:transition",
-                  "stg:hover:text-foreground stg:hover:bg-accent-hover",
-                  "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
-                  "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
-                )}
-              />
-            }
-          >
-            <EditIcon />
-          </TooltipTrigger>
-          <TooltipContent side="top">Edit</TooltipContent>
-        </Tooltip>
-      )}
+      {/* The hover-revealed action cluster on the bubble's shoulder: copy is
+          always offered (the message text is the content), edit only when the
+          host wired the callback. */}
+      <div className="stg:absolute stg:-top-2.5 stg:-right-2.5 stg:flex stg:gap-1">
+        <CopyMessageButton text={content} variant="bubble" />
+        {onEdit && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={onEdit}
+                  aria-label="Edit message"
+                  className={BUBBLE_ACTION_CLASSES}
+                />
+              }
+            >
+              <EditIcon />
+            </TooltipTrigger>
+            <TooltipContent side="top">Edit</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
     </div>
   );
 }
@@ -269,7 +270,7 @@ function AiMessage({
       role="article"
       aria-label="AI response"
       aria-busy={isStreaming}
-      className={cn("stg:px-4 stg:py-3", className)}
+      className={cn("stg:group stg:px-4 stg:py-3", className)}
     >
       <div className="stgm-prose">
         <Streamdown
@@ -280,7 +281,115 @@ function AiMessage({
           {markdown}
         </Streamdown>
       </div>
+      {/* The quiet per-message actions row (issue #278). Height is reserved
+          whenever it renders, so the hover reveal never shifts the prose; it
+          appears only once the message settles — a streaming message's text
+          is still changing, so a copy would race the content. Copies the
+          display markdown (fence-unwrapped), i.e. what the reader sees. */}
+      {!isStreaming && markdown.trim().length > 0 && (
+        <div className="stg:mt-1 stg:flex stg:h-6 stg:items-center">
+          <CopyMessageButton text={markdown} variant="quiet" />
+        </div>
+      )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-message copy affordance (issue #278)
+// ---------------------------------------------------------------------------
+
+// The floating circular action on a human bubble's shoulder — shared by the
+// copy and edit buttons so the cluster reads as one control family.
+const BUBBLE_ACTION_CLASSES = cn(
+  "stg:inline-flex stg:h-7 stg:w-7 stg:items-center stg:justify-center stg:rounded-full",
+  "stg:border stg:border-border stg:bg-card stg:text-muted-foreground stg:shadow-sm stg:transition",
+  "stg:hover:text-foreground stg:hover:bg-accent-hover",
+  "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
+  "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+);
+
+// The quiet in-flow variant for AI prose: no border or fill, one contrast
+// step below the reading text (`muted-foreground-subtle`, rising to
+// `muted-foreground` on hover) — findable when wanted, invisible while
+// reading. The same hover/focus reveal keeps both variants keyboard-reachable.
+const QUIET_ACTION_CLASSES = cn(
+  "stg:inline-flex stg:h-6 stg:w-6 stg:items-center stg:justify-center stg:rounded-md",
+  "stg:text-muted-foreground-subtle stg:transition",
+  "stg:hover:text-muted-foreground stg:hover:bg-accent-hover",
+  "stg:opacity-0 stg:group-hover:opacity-100 stg:focus-visible:opacity-100",
+  "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
+);
+
+/**
+ * The per-message copy control: writes the message's text to the clipboard
+ * and flips to a check for the feedback window. `variant` selects the visual
+ * home — `"bubble"` joins the human bubble's floating action cluster,
+ * `"quiet"` sits in the AI message's reserved actions row.
+ */
+function CopyMessageButton({
+  text,
+  variant,
+}: {
+  text: string;
+  variant: "bubble" | "quiet";
+}) {
+  const { copy, copied } = useCopyFeedback();
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={() => void copy(text)}
+            aria-label={copied ? "Copied" : "Copy message"}
+            className={
+              variant === "bubble" ? BUBBLE_ACTION_CLASSES : QUIET_ACTION_CLASSES
+            }
+          />
+        }
+      >
+        {copied ? <CheckIcon /> : <CopyMessageIcon />}
+      </TooltipTrigger>
+      <TooltipContent side="top">{copied ? "Copied" : "Copy"}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CopyMessageIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
   );
 }
 

--- a/sdk/react/src/execution/__tests__/MessageEntry-copy.test.tsx
+++ b/sdk/react/src/execution/__tests__/MessageEntry-copy.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { MessageType } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import { MessageEntry } from "../MessageEntry";
+
+// ---------------------------------------------------------------------------
+// Per-message copy affordance (stigmer/stigmer#278): every settled human and
+// AI message carries a quiet copy control that writes the message's text to
+// the clipboard, with transient "Copied" feedback. The affordance is
+// hover-revealed but always in the DOM (keyboard/screen-reader reachable).
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function message(type: MessageType, content: string, isStreaming = false) {
+  return create(AgentMessageSchema, { type, content, isStreaming });
+}
+
+function stubClipboard() {
+  const writeText = vi.fn(() => Promise.resolve());
+  vi.stubGlobal("navigator", { clipboard: { writeText } });
+  return writeText;
+}
+
+describe("MessageEntry copy affordance", () => {
+  it("copies a human message's text on click and flips to Copied feedback", async () => {
+    const writeText = stubClipboard();
+    render(
+      <MessageEntry
+        message={message(MessageType.MESSAGE_HUMAN, "run the deploy again")}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Copy message"));
+    expect(writeText).toHaveBeenCalledExactlyOnceWith("run the deploy again");
+
+    // The affordance answers with its transient feedback state.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Copied")).toBeTruthy();
+    });
+  });
+
+  it("copies an AI message's markdown — formatting characters included", () => {
+    const writeText = stubClipboard();
+    const md = "## Plan\n\n- step **one**\n- step `two`";
+    render(<MessageEntry message={message(MessageType.MESSAGE_AI, md)} />);
+
+    fireEvent.click(screen.getByLabelText("Copy message"));
+    expect(writeText).toHaveBeenCalledExactlyOnceWith(md);
+  });
+
+  it("copies the fence-unwrapped markdown the reader actually sees", () => {
+    // A model that wraps its whole reply in a ```markdown fence renders
+    // unwrapped (MessageEntry's render seam); the copy must match the render,
+    // not re-wrap what the user is looking at.
+    const writeText = stubClipboard();
+    render(
+      <MessageEntry
+        message={message(MessageType.MESSAGE_AI, "```markdown\n# Title\nbody\n```")}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Copy message"));
+    expect(writeText).toHaveBeenCalledExactlyOnceWith("# Title\nbody");
+  });
+
+  it("offers no copy while an AI message is still streaming", () => {
+    stubClipboard();
+    render(
+      <MessageEntry
+        message={message(MessageType.MESSAGE_AI, "partial answer…", true)}
+      />,
+    );
+    expect(screen.queryByLabelText("Copy message")).toBeNull();
+  });
+
+  it("offers no copy on system messages", () => {
+    stubClipboard();
+    render(
+      <MessageEntry
+        message={message(MessageType.MESSAGE_SYSTEM, "execution resumed")}
+      />,
+    );
+    expect(screen.queryByLabelText("Copy message")).toBeNull();
+  });
+
+  it("keeps copy and edit as siblings on a human bubble when editing is wired", () => {
+    stubClipboard();
+    const onEdit = vi.fn();
+    render(
+      <MessageEntry
+        message={message(MessageType.MESSAGE_HUMAN, "tweak this")}
+        onEdit={onEdit}
+      />,
+    );
+
+    // Both affordances present and independently operable.
+    expect(screen.getByLabelText("Copy message")).toBeTruthy();
+    fireEvent.click(screen.getByLabelText("Edit message"));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("claims no copy when the clipboard write is rejected", async () => {
+    // Insecure context / denied permission: the button must not flash
+    // "Copied" for a copy that never happened.
+    const writeText = vi.fn(() => Promise.reject(new Error("denied")));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    render(
+      <MessageEntry message={message(MessageType.MESSAGE_HUMAN, "hello")} />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Copy message"));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByLabelText("Copied")).toBeNull();
+    expect(screen.getByLabelText("Copy message")).toBeTruthy();
+  });
+});

--- a/sdk/react/src/internal/useCopyFeedback.ts
+++ b/sdk/react/src/internal/useCopyFeedback.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** How long the transient `copied` flag stays true after a successful copy. */
+const COPIED_FEEDBACK_MS = 2000;
+
+/** Return value of {@link useCopyFeedback}. */
+export interface UseCopyFeedbackReturn {
+  /**
+   * Write `text` to the clipboard. Resolves once the copy has been attempted;
+   * a rejected clipboard write (insecure context, denied permission) leaves
+   * `copied` false so the affordance never claims a copy that didn't happen.
+   */
+  readonly copy: (text: string) => Promise<void>;
+
+  /**
+   * `true` for a brief window after a successful copy (drives "Copied"
+   * affordance feedback), then resets automatically.
+   */
+  readonly copied: boolean;
+}
+
+/**
+ * Behavior hook for the copy-with-feedback shape: write locally-held text to
+ * the clipboard and flash a transient `copied` flag for the affordance swap.
+ *
+ * This is the fetch-free sibling of `useArtifactCopy` (which resolves remote
+ * artifact bytes at click time); use it wherever the text to copy is already
+ * in hand — message content, identifiers, code blocks. One implementation
+ * keeps the feedback window and the unmount-safety identical across surfaces.
+ */
+export function useCopyFeedback(): UseCopyFeedbackReturn {
+  const [copied, setCopied] = useState(false);
+
+  // Clear the pending "copied" timer on unmount so a resolved copy never sets
+  // state on an unmounted component.
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (copiedTimer.current !== null) clearTimeout(copiedTimer.current);
+    };
+  }, []);
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (copiedTimer.current !== null) clearTimeout(copiedTimer.current);
+    copiedTimer.current = setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+  }, []);
+
+  return useMemo(() => ({ copy, copied }), [copy, copied]);
+}


### PR DESCRIPTION
## Summary

- Every settled chat message now carries a copy control (issue's ask: message-level copy "out of the box", with Cursor's clipboard-icon-per-message as prior art):
  - **Human bubbles**: the copy button joins the existing hover-revealed Edit cluster on the bubble's shoulder — same circular control family, same `group-hover` + `focus-visible` reveal, so the affordance discipline stays uniform.
  - **AI messages**: a quiet reserved-height actions row after the prose (no layout shift on reveal; a natural home for future affordances). The icon sits one contrast step below reading text — `muted-foreground-subtle` rising to `muted-foreground` on hover — the issue's "findable when wanted, invisible while reading" discipline, using token variants only (no opacity modifiers, per house rule).
- Copies what the reader sees: the fence-unwrapped markdown for AI messages (a reply wrapped whole in a ```` ```markdown ```` fence copies unwrapped, matching the render), raw text for human messages. Hidden while a message streams — a copy would race the content.
- Extracts the clipboard-with-feedback shape into a shared internal `useCopyFeedback` hook (the fetch-free sibling of `useArtifactCopy`): 2s `copied` window, unmount-safe timer, and a rejected clipboard write (insecure context, denied permission) never flashes "Copied".
- Hosts that don't want the affordance use the existing `MessageThreadSlots.MessageEntry` override; no new props added until a host asks.

Follow-up filed separately: ~18 SDK files hand-roll `navigator.clipboard.writeText` + local feedback state — a consolidation sweep onto `useCopyFeedback` is its own chore issue.

## Test plan

- [x] 7 new `MessageEntry` copy tests: human copy + feedback flip, AI markdown fidelity (formatting chars), fence-unwrap copy parity, hidden-while-streaming, no copy on system messages, copy+edit coexistence, rejected-write honesty
- [x] Full sdk/react suite: 4333/4333 green; `tsc` build + `lint:prefix` clean

Closes #278

Made with [Cursor](https://cursor.com)