### PR TITLE
fix(server): cascade workflow delete to all instances

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "apply.go",
         "create.go",
         "delete.go",
+        "delete_cascade.go",
         "get_version.go",
         "list_versions.go",
         "populate_serverless_validation_step.go",
@@ -23,6 +24,7 @@ go_library(
     deps = [
         "//apis/stubs/go/ai/stigmer/agentic/workflow/v1:workflow",
         "//apis/stubs/go/ai/stigmer/agentic/workflow/v1/serverless",
+        "//apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1:workflowinstance",
         "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
         "//backend/libs/go/grpc",
@@ -44,6 +46,7 @@ go_library(
 go_test(
     name = "controller_test",
     srcs = [
+        "delete_cascade_test.go",
         "tag_version_test.go",
         "validate_spec_step_test.go",
         "validate_spec_test.go",
@@ -54,6 +57,7 @@ go_test(
     deps = [
         "//apis/stubs/go/ai/stigmer/agentic/workflow/v1:workflow",
         "//apis/stubs/go/ai/stigmer/agentic/workflow/v1/serverless",
+        "//apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1:workflowexecution",
         "//apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1:workflowinstance",
         "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
@@ -71,6 +75,7 @@ go_test(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_grpc//test/bufconn",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/delete.go
@@ -15,7 +15,8 @@ import (
 // 1. ValidateProto - Validate proto field constraints (workflow ID wrapper)
 // 2. ExtractResourceId - Extract ID from WorkflowId.Value wrapper
 // 3. LoadExistingForDelete - Load workflow from database (stores in context)
-// 4. DeleteResource - Delete workflow from database
+// 4. CascadeDeleteInstances - Delete ALL the workflow's instances (see delete_cascade.go)
+// 5. DeleteResource - Delete workflow from database
 func (c *WorkflowController) Delete(ctx context.Context, workflowId *workflowv1.WorkflowId) (*workflowv1.Workflow, error) {
 	// Create request context with the ID wrapper
 	reqCtx := pipeline.NewRequestContext(ctx, workflowId)
@@ -41,7 +42,8 @@ func (c *WorkflowController) buildDeletePipeline() *pipeline.Pipeline[*workflowv
 		AddStep(steps.NewValidateProtoStep[*workflowv1.WorkflowId]()).                                      // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*workflowv1.WorkflowId]()).                                  // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*workflowv1.WorkflowId, *workflowv1.Workflow](c.store)). // 3. Load workflow
-		AddStep(steps.NewDeleteResourceStep[*workflowv1.WorkflowId](c.store)).                              // 4. Delete from database
-		AddStep(steps.NewDeleteSearchIndexStep[*workflowv1.WorkflowId](c.store)).                           // 5. Remove from search index
+		AddStep(newCascadeDeleteInstancesStep(c.store)).                                                    // 4. Cascade: instances before parent
+		AddStep(steps.NewDeleteResourceStep[*workflowv1.WorkflowId](c.store)).                              // 5. Delete from database
+		AddStep(steps.NewDeleteSearchIndexStep[*workflowv1.WorkflowId](c.store)).                           // 6. Remove from search index
 		Build()
 }

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/delete_cascade.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/delete_cascade.go
@@ -1,0 +1,110 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
+	workflowinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"google.golang.org/protobuf/proto"
+)
+
+// Workflow deletion cascades to ALL of the workflow's instances — the
+// system-managed default AND user-created ones — before the workflow row
+// itself is removed (children before parent, so a mid-failure retry
+// converges: the agent/session cascade ordering).
+//
+// This deliberately goes FURTHER than the agent cascade
+// (agent/controller/delete_cascade.go), which spares personal instances as
+// "inert dangling references". That rationale holds for the dangling
+// REFERENCE (spec.workflow_id is an immutable ID, never reused) but not for
+// the dangling SLUG: WorkflowInstance slugs are org-scoped, and the parent
+// workflow's detail page is the only instance-management surface — so an
+// orphan occupies its slug org-wide forever with no UI left to delete it
+// (stigmer/stigmer#592, repro'd live). Instances are configuration OF the
+// workflow, meaningless without it; owner ruling: they go with it.
+//
+// What deliberately SURVIVES a workflow delete, and must never be swept
+// into this cascade:
+//
+//   - WorkflowExecutions — historical record, same posture as sessions
+//     (owner ruling on #582). They carry a denormalized spec.workflow_id
+//     and remain viewable after the workflow (and now its instances) are
+//     gone.
+//   - Version/audit rows (resource_audit) — surviving executions render
+//     their historical graphs via getWorkflowVersion(workflow_id,
+//     version_hash), so deleting version rows would break the execution
+//     viewer for exactly the executions the ruling preserves.
+//
+// Both editions implement this contract; the cloud edition additionally
+// cleans up each instance's FGA tuples (no IAM system in OSS).
+
+// cascadeDeleteInstancesStep deletes every instance of the workflow
+// (row + search-index entry) before the workflow is deleted.
+//
+// Instances are matched by spec.workflow_id — a required, validated field
+// on every instance — so a single ID sweep covers the default instance
+// too; no pointer-or-slug resolution is needed (unlike the agent cascade,
+// whose default instance may predate the status pointer).
+type cascadeDeleteInstancesStep struct {
+	store store.Store
+}
+
+func newCascadeDeleteInstancesStep(s store.Store) *cascadeDeleteInstancesStep {
+	return &cascadeDeleteInstancesStep{store: s}
+}
+
+func (s *cascadeDeleteInstancesStep) Name() string {
+	return "CascadeDeleteInstances"
+}
+
+func (s *cascadeDeleteInstancesStep) Execute(ctx *pipeline.RequestContext[*workflowv1.WorkflowId]) error {
+	workflow, ok := ctx.Get(steps.ExistingResourceKey).(*workflowv1.Workflow)
+	if !ok {
+		return grpclib.InternalError(nil, "workflow not found in context (LoadExistingForDelete must run first)")
+	}
+	workflowID := workflow.GetMetadata().GetId()
+
+	resources, err := s.store.ListResources(ctx.Context(), apiresourcekind.ApiResourceKind_workflow_instance)
+	if err != nil {
+		return grpclib.InternalError(err, "failed to list workflow instances for cascade delete")
+	}
+
+	deleted := 0
+	for _, data := range resources {
+		instance := &workflowinstancev1.WorkflowInstance{}
+		if err := proto.Unmarshal(data, instance); err != nil {
+			continue
+		}
+		if instance.GetSpec().GetWorkflowId() != workflowID {
+			continue
+		}
+		instanceID := instance.GetMetadata().GetId()
+		if err := s.store.DeleteResource(ctx.Context(), apiresourcekind.ApiResourceKind_workflow_instance, instanceID); err != nil {
+			return grpclib.InternalError(err, fmt.Sprintf(
+				"failed to cascade-delete instance %s of workflow %s", instanceID, workflowID))
+		}
+
+		// Best-effort, matching DeleteSearchIndexStep: a stale index entry is
+		// a cosmetic search artifact, not a correctness problem.
+		if err := s.store.DeleteSearchIndex(ctx.Context(), apiresourcekind.ApiResourceKind_workflow_instance, instanceID); err != nil {
+			log.Warn().Err(err).
+				Str("instance_id", instanceID).
+				Msg("CascadeDeleteInstances: failed to remove search index entry (best-effort)")
+		}
+		deleted++
+	}
+
+	if deleted > 0 {
+		log.Info().
+			Int("count", deleted).
+			Str("workflow_id", workflowID).
+			Msg("Cascade-deleted instances of workflow")
+	}
+	return nil
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/delete_cascade_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/delete_cascade_test.go
@@ -1,0 +1,181 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
+	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
+	workflowinstancev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/libs/go/store/sqlite"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/downstream/workflowinstance"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestWorkflowController_Delete_Cascade pins the stigmer/stigmer#592
+// contract: deleting a workflow removes ALL of its instances — the
+// system-managed default AND user-created ones — while other workflows'
+// instances and the workflow's executions survive. Unlike the agent
+// cascade tests (which hand-save instances against a nil instance
+// client), these drive the REAL workflow + workflow-instance controllers
+// over in-process gRPC, so default-instance provisioning and the
+// org-scoped duplicate check behave exactly as in production.
+func TestWorkflowController_Delete_Cascade(t *testing.T) {
+	// newCascadeHarness wires a fresh store with both controllers connected;
+	// the returned stub creates USER instances through the full create
+	// pipeline (slug resolution, parent load, duplicate check).
+	newCascadeHarness := func(t *testing.T) (*WorkflowController, workflowinstancev1.WorkflowInstanceCommandControllerClient, store.Store) {
+		t.Helper()
+		s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+		if err != nil {
+			t.Fatalf("failed to create store: %v", err)
+		}
+		t.Cleanup(func() { s.Close() })
+
+		_, instanceConn, cleanup := setupInProcessServers(t, s)
+		t.Cleanup(cleanup)
+
+		controller := NewWorkflowController(s, workflowinstance.NewClient(instanceConn), nil)
+		return controller, workflowinstancev1.NewWorkflowInstanceCommandControllerClient(instanceConn), s
+	}
+
+	createWorkflow := func(t *testing.T, c *WorkflowController, name string) *workflowv1.Workflow {
+		t.Helper()
+		created, err := c.Create(contextWithWorkflowKind(), createValidWorkflow(name, "cascade test workflow"))
+		if err != nil {
+			t.Fatalf("Create workflow %q failed: %v", name, err)
+		}
+		if created.GetStatus().GetDefaultInstanceId() == "" {
+			t.Fatalf("precondition: workflow %q should have a provisioned default instance", name)
+		}
+		return created
+	}
+
+	createUserInstance := func(t *testing.T, stub workflowinstancev1.WorkflowInstanceCommandControllerClient, name, workflowID string) *workflowinstancev1.WorkflowInstance {
+		t.Helper()
+		created, err := stub.Create(context.Background(), &workflowinstancev1.WorkflowInstance{
+			ApiVersion: "agentic.stigmer.ai/v1",
+			Kind:       "WorkflowInstance",
+			Metadata: &apiresource.ApiResourceMetadata{
+				Name: name,
+				Org:  "test-org",
+			},
+			Spec: &workflowinstancev1.WorkflowInstanceSpec{WorkflowId: workflowID},
+		})
+		if err != nil {
+			t.Fatalf("Create user instance %q failed: %v", name, err)
+		}
+		return created
+	}
+
+	assertGone := func(t *testing.T, s store.Store, kind apiresourcekind.ApiResourceKind, id string, msg proto.Message) {
+		t.Helper()
+		if err := s.GetResource(context.Background(), kind, id, msg); err == nil {
+			t.Errorf("expected %s %s to be cascade-deleted, but it still exists", kind, id)
+		}
+	}
+
+	assertSurvives := func(t *testing.T, s store.Store, kind apiresourcekind.ApiResourceKind, id string, msg proto.Message) {
+		t.Helper()
+		if err := s.GetResource(context.Background(), kind, id, msg); err != nil {
+			t.Errorf("expected %s %s to survive the cascade, but it is gone: %v", kind, id, err)
+		}
+	}
+
+	t.Run("deletes the default and every user instance; bystanders survive", func(t *testing.T) {
+		controller, instanceStub, s := newCascadeHarness(t)
+
+		target := createWorkflow(t, controller, "Cascade Target")
+		targetUser := createUserInstance(t, instanceStub, "team-setup", target.Metadata.Id)
+
+		bystander := createWorkflow(t, controller, "Cascade Bystander")
+		bystanderUser := createUserInstance(t, instanceStub, "bystander-setup", bystander.Metadata.Id)
+
+		if _, err := controller.Delete(contextWithWorkflowKind(), &workflowv1.WorkflowId{Value: target.Metadata.Id}); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+
+		assertGone(t, s, apiresourcekind.ApiResourceKind_workflow_instance, target.Status.DefaultInstanceId, &workflowinstancev1.WorkflowInstance{})
+		assertGone(t, s, apiresourcekind.ApiResourceKind_workflow_instance, targetUser.Metadata.Id, &workflowinstancev1.WorkflowInstance{})
+
+		assertSurvives(t, s, apiresourcekind.ApiResourceKind_workflow, bystander.Metadata.Id, &workflowv1.Workflow{})
+		assertSurvives(t, s, apiresourcekind.ApiResourceKind_workflow_instance, bystander.Status.DefaultInstanceId, &workflowinstancev1.WorkflowInstance{})
+		assertSurvives(t, s, apiresourcekind.ApiResourceKind_workflow_instance, bystanderUser.Metadata.Id, &workflowinstancev1.WorkflowInstance{})
+	})
+
+	t.Run("recreate at the same slug converges after delete", func(t *testing.T) {
+		controller, _, _ := newCascadeHarness(t)
+
+		created := createWorkflow(t, controller, "Recreate Workflow")
+
+		if _, err := controller.Delete(contextWithWorkflowKind(), &workflowv1.WorkflowId{Value: created.Metadata.Id}); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+
+		// The DD-010 poison shape this cascade kills: without it, the orphaned
+		// "<slug>-default" instance makes the recreate's default provisioning
+		// collide (or silently adopt the orphan).
+		recreated := createWorkflow(t, controller, "Recreate Workflow")
+		if recreated.Metadata.Slug != created.Metadata.Slug {
+			t.Errorf("expected recreated slug %q, got %q", created.Metadata.Slug, recreated.Metadata.Slug)
+		}
+		if recreated.Metadata.Id == created.Metadata.Id {
+			t.Error("expected a fresh workflow ID on recreate")
+		}
+	})
+
+	t.Run("freed user-instance slug is reusable org-wide", func(t *testing.T) {
+		controller, instanceStub, _ := newCascadeHarness(t)
+
+		// The #582 session's live repro: instance slugs are org-scoped, so an
+		// orphan blocked the slug for every LATER workflow's instances.
+		first := createWorkflow(t, controller, "First Owner")
+		createUserInstance(t, instanceStub, "verify-592", first.Metadata.Id)
+
+		if _, err := controller.Delete(contextWithWorkflowKind(), &workflowv1.WorkflowId{Value: first.Metadata.Id}); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+
+		second := createWorkflow(t, controller, "Second Owner")
+		reused := createUserInstance(t, instanceStub, "verify-592", second.Metadata.Id)
+		if reused.Metadata.Slug != "verify-592" {
+			t.Errorf("expected reused slug %q, got %q", "verify-592", reused.Metadata.Slug)
+		}
+	})
+
+	t.Run("executions survive the cascade", func(t *testing.T) {
+		controller, instanceStub, s := newCascadeHarness(t)
+
+		created := createWorkflow(t, controller, "Executed Workflow")
+		instance := createUserInstance(t, instanceStub, "executed-setup", created.Metadata.Id)
+
+		// Executions are historical record (the #582 ruling) — they reference
+		// the workflow and instance by immutable IDs and must outlive both.
+		execution := &workflowexecutionv1.WorkflowExecution{
+			ApiVersion: "agentic.stigmer.ai/v1",
+			Kind:       "WorkflowExecution",
+			Metadata: &apiresource.ApiResourceMetadata{
+				Id:   "wfe_cascade_survivor",
+				Name: "cascade survivor run",
+				Org:  "test-org",
+			},
+			Spec: &workflowexecutionv1.WorkflowExecutionSpec{
+				WorkflowId:         created.Metadata.Id,
+				WorkflowInstanceId: instance.Metadata.Id,
+			},
+		}
+		if err := s.SaveResource(context.Background(), apiresourcekind.ApiResourceKind_workflow_execution, execution.Metadata.Id, execution); err != nil {
+			t.Fatalf("failed to save execution: %v", err)
+		}
+
+		if _, err := controller.Delete(contextWithWorkflowKind(), &workflowv1.WorkflowId{Value: created.Metadata.Id}); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+
+		assertGone(t, s, apiresourcekind.ApiResourceKind_workflow_instance, instance.Metadata.Id, &workflowinstancev1.WorkflowInstance{})
+		assertSurvives(t, s, apiresourcekind.ApiResourceKind_workflow_execution, "wfe_cascade_survivor", &workflowexecutionv1.WorkflowExecution{})
+	})
+}

--- a/client-apps/desktop/src/pages/workflow/WorkflowDetailPage.tsx
+++ b/client-apps/desktop/src/pages/workflow/WorkflowDetailPage.tsx
@@ -159,7 +159,9 @@ export default function WorkflowDetailPage() {
     const confirmed = await confirm({
       title: `Delete ${resourceName}?`,
       description:
-        "This action cannot be undone. The workflow and its configuration will be permanently removed.",
+        "This permanently removes the workflow and all of its instances. " +
+        "Past executions are preserved in the execution history. " +
+        "This action cannot be undone.",
       confirmLabel: "Delete",
       variant: "destructive",
     });

--- a/client-apps/desktop/src/pages/workflow/WorkflowListPage.tsx
+++ b/client-apps/desktop/src/pages/workflow/WorkflowListPage.tsx
@@ -71,7 +71,9 @@ export default function WorkflowListPage() {
       const confirmed = await confirm({
         title: `Delete ${item.name || item.slug}?`,
         description:
-          "This action cannot be undone. The workflow and its configuration will be permanently removed.",
+          "This permanently removes the workflow and all of its instances. " +
+          "Past executions are preserved in the execution history. " +
+          "This action cannot be undone.",
         confirmLabel: "Delete",
         variant: "destructive",
       });

--- a/client-apps/web/src/domain/workflow/WorkflowDetailPage.tsx
+++ b/client-apps/web/src/domain/workflow/WorkflowDetailPage.tsx
@@ -176,7 +176,9 @@ export function WorkflowDetailPageInner({
     const confirmed = await confirm({
       title: `Delete ${resourceName}?`,
       description:
-        "This action cannot be undone. The workflow and its configuration will be permanently removed.",
+        "This permanently removes the workflow and all of its instances. " +
+        "Past executions are preserved in the execution history. " +
+        "This action cannot be undone.",
       confirmLabel: "Delete",
       variant: "destructive",
     });

--- a/client-apps/web/src/domain/workflow/WorkflowListPage.tsx
+++ b/client-apps/web/src/domain/workflow/WorkflowListPage.tsx
@@ -77,7 +77,9 @@ export function WorkflowListPage() {
       const confirmed = await confirm({
         title: `Delete ${item.name || item.slug}?`,
         description:
-          "This action cannot be undone. The workflow and its configuration will be permanently removed.",
+          "This permanently removes the workflow and all of its instances. " +
+          "Past executions are preserved in the execution history. " +
+          "This action cannot be undone.",
         confirmLabel: "Delete",
         variant: "destructive",
       });

--- a/sdk/react/src/workflow/instance/WorkflowInstanceDetailPanel.tsx
+++ b/sdk/react/src/workflow/instance/WorkflowInstanceDetailPanel.tsx
@@ -296,7 +296,8 @@ export function WorkflowInstanceDetailPanel({
             ) : (
               <div className="stg:space-y-2 stg:rounded-md stg:border stg:border-destructive/30 stg:p-3 stg:bg-destructive/5">
                 <p className="stg:text-xs stg:text-destructive stg:font-medium">
-                  This will permanently delete this instance and all its execution history.
+                  This permanently removes the instance and its environment bindings. Executions
+                  already run against it are preserved in the workflow&apos;s execution history.
                   This action cannot be undone.
                 </p>
                 {deleteError && (

--- a/test/conformance/src/suites/workflow.conformance.test.ts
+++ b/test/conformance/src/suites/workflow.conformance.test.ts
@@ -25,6 +25,7 @@ import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
 import { uniqueName } from "../support/naming";
+import { makeWorkflowInstance } from "../support/workflowinstances";
 import { WORKFLOW_API_VERSION, WORKFLOW_KIND, makeWorkflow, makeWorkflowSpec } from "../support/workflows";
 import { createTarget, type TargetProfile } from "../targets";
 
@@ -229,6 +230,55 @@ describe("Workflow instance conformance — default-instance visibility guard", 
       "Default instances do not have their own visibility - access always follows " +
         "the parent blueprint. Change the blueprint's visibility instead.",
     );
+  });
+});
+
+describe("Workflow conformance — delete cascades instances (stigmer#592)", () => {
+  it("delete removes the default and user instances, freeing the workflow slug and the org-wide instance slug", async () => {
+    // The cascade ruling: instances are configuration OF the workflow and go
+    // with it (default AND user-created), unlike executions which survive as
+    // historical record (the #582 ruling). Without the cascade, the orphaned
+    // "<slug>-default" poisons a same-slug recreate, and a user instance's
+    // org-scoped slug stays occupied forever with no UI left to delete it.
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("cascade");
+
+    const created = await clients.workflowCommand.create(makeWorkflow({ org, name }));
+    const workflowId = created.metadata!.id;
+    const defaultInstanceId = created.status?.defaultInstanceId;
+    expect(defaultInstanceId, "create provisions a default instance").toMatch(/^win_[0-9a-z]+$/);
+
+    const instanceName = uniqueName("cfg");
+    const userInstance = await clients.workflowInstanceCommand.create(
+      makeWorkflowInstance({ org, name: instanceName, workflowId }),
+    );
+
+    await clients.workflowCommand.delete({ value: workflowId });
+
+    await expectGrpcCode(
+      () => clients.workflowInstanceQuery.get({ value: defaultInstanceId! }),
+      Code.NotFound,
+      "default instance after cascade",
+    );
+    await expectGrpcCode(
+      () => clients.workflowInstanceQuery.get({ value: userInstance.metadata!.id }),
+      Code.NotFound,
+      "user instance after cascade",
+    );
+
+    // The workflow slug is free again: recreate converges instead of
+    // colliding with the orphaned default instance (the DD-010 poison).
+    const recreated = await createWorkflow(org, name);
+    expect(recreated.metadata?.slug).toBe(created.metadata?.slug);
+    expect(recreated.metadata?.id).not.toBe(workflowId);
+
+    // The user instance's org-scoped slug is free again (the #582 live
+    // repro: a fresh workflow's instance was rejected as a duplicate).
+    const reused = await clients.workflowInstanceCommand.create(
+      makeWorkflowInstance({ org, name: instanceName, workflowId: recreated.metadata!.id }),
+    );
+    fixtures.defer(() => clients.workflowInstanceCommand.delete({ value: reused.metadata!.id }));
+    expect(reused.metadata?.slug).toBe(userInstance.metadata?.slug);
   });
 });
 


### PR DESCRIPTION
## Summary

Workflow delete cascaded nothing: the orphaned `<slug>-default` instance poisoned a same-slug recreate (the DD-010 class the agent cascade already solves), and user-instance orphans occupied the org-wide instance-slug namespace forever with no UI left to delete them (repro'd live by the #582 session — see #592).

**Owner ruling**: workflow delete cascades ALL instances — default and user-created. Instances are configuration OF the workflow. Two classes deliberately SURVIVE, documented in the cascade's package comment so they are never "cleaned up": executions (historical record, the #582 ruling) and version/audit rows (surviving executions render their historical graphs from them — found on this session's completeness sweep; the issue's inventory missed it).

## Changes

- **`cascadeDeleteInstancesStep`** (`workflow/controller/delete_cascade.go`): matches `spec.workflow_id` (required + validated, so one ID sweep covers the default instance — no pointer-or-slug fallback needed, unlike the agent cascade), deletes row + search index per instance, children before parent so a mid-failure retry converges.
- **Unit tests** drive the REAL workflow + workflow-instance controllers over in-process gRPC (production default-instance provisioning and duplicate checks). Red-first proven: all four subtests fail without the cascade, reproducing both bugs verbatim.
- **Conformance pin** (workflow suite): delete → both instances NotFound → same-slug workflow recreate converges → org-wide instance slug reusable. Red-first proven against BOTH unpatched editions (local-go and the unpatched cloud fat JAR).
- **Honest delete-confirmation copy** (the #582/#590 discipline) in all four client-app pages: instances are deleted, executions are kept. Also fixes the pre-#590 leftover in `WorkflowInstanceDetailPanel` that falsely claimed execution history is deleted.

Cloud twin: stigmer-cloud PR (CascadeDeleteInstancesStep in `WorkflowDeleteHandler`, + FGA tuple cleanup). **Merge the cloud PR first** — this PR's conformance pin is red against an undeployed cloud edition.

Records: DD-022 (workflow-delete cascade + survivor set); agent asymmetry follow-up: #611.

## Verification

- `workflow/controller` unit tests: red-first, then green; bazel target green (gazelle run)
- Conformance vs local-go: 246/246; vs patched cloud fat JAR: 246 passed / 1 skipped; pin red vs both unpatched editions
- `go build` + `go vet` green; sdk/react + web + desktop typechecks green

Closes #592

Made with [Cursor](https://cursor.com)