### PR TITLE
fix(server): name default instances from the parent's slug, not its display name

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/agent/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/create.go
@@ -107,16 +107,14 @@ func (s *createDefaultInstanceStep) Execute(ctx *pipeline.RequestContext[*agentv
 
 	agent := ctx.NewState()
 	agentID := agent.GetMetadata().GetId()
-	agentSlug := agent.GetMetadata().GetName()
-	agentOrg := agent.GetMetadata().GetOrg()
 
 	log.Info().
 		Str("agent_id", agentID).
-		Str("name", agentSlug).
-		Str("org", agentOrg).
+		Str("slug", agent.GetMetadata().GetSlug()).
+		Str("org", agent.GetMetadata().GetOrg()).
 		Msg("Creating default instance for agent")
 
-	instanceRequest := defaultinstance.BuildRequest(agentID, agentSlug, agentOrg)
+	instanceRequest := defaultinstance.BuildRequest(agent.GetMetadata())
 
 	// Use Apply (not Create) for idempotency. Agent delete now cascades the
 	// default instance, so this normally routes to CREATE; the UPDATE route

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/controller/create.go
@@ -344,8 +344,7 @@ func (s *createDefaultInstanceIfNeededStep) Execute(ctx *pipeline.RequestContext
 		Str("agent_id", agentID).
 		Msg("Agent missing default instance, creating one")
 
-	instanceRequest := defaultinstance.BuildRequest(
-		agentID, agent.GetMetadata().GetName(), agent.GetMetadata().GetOrg())
+	instanceRequest := defaultinstance.BuildRequest(agent.GetMetadata())
 
 	// 4. Create instance via downstream client (in-process, system credentials)
 	createdInstance, err := s.agentInstanceClient.CreateAsSystem(ctx.Context(), instanceRequest)

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/controller/update_visibility_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/controller/update_visibility_test.go
@@ -174,7 +174,12 @@ func TestAgentInstanceController_UpdateVisibility_DefaultRejectionPrecedesLevelC
 }
 
 func TestDefaultInstanceBuildRequest_StampsSystemManagedLabels(t *testing.T) {
-	request := defaultinstance.BuildRequest("agt_x", "my-agent", "org-1")
+	request := defaultinstance.BuildRequest(&apiresource.ApiResourceMetadata{
+		Id:   "agt_x",
+		Name: "My Agent",
+		Slug: "my-agent",
+		Org:  "org-1",
+	})
 
 	assert.Equal(t, "my-agent-default", request.GetMetadata().GetName())
 	assert.Equal(t, "my-agent-default", defaultinstance.Slug("my-agent"))

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "defaultinstance",
@@ -7,6 +7,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//apis/stubs/go/ai/stigmer/agentic/agentinstance/v1:agentinstance",
+        "//apis/stubs/go/ai/stigmer/commons/apiresource",
+        "//backend/libs/go/apiresource",
+    ],
+)
+
+go_test(
+    name = "defaultinstance_test",
+    srcs = ["defaultinstance_test.go"],
+    embed = [":defaultinstance"],
+    deps = [
         "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//backend/libs/go/apiresource",
     ],

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance/defaultinstance.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance/defaultinstance.go
@@ -53,22 +53,34 @@ func Slug(agentSlug string) string {
 }
 
 // BuildRequest builds the AgentInstance proto for a default-instance
-// creation request. Callers hand it to the agentinstance downstream client
-// (Create/Apply AsSystem), which owns persistence and validation.
-func BuildRequest(agentID, agentSlug, orgID string) *agentinstancev1.AgentInstance {
+// creation request from the parent agent's metadata. Callers hand it to the
+// agentinstance downstream client (Create/Apply AsSystem), which owns
+// persistence and validation.
+//
+// Taking the metadata rather than loose strings is deliberate: the instance
+// is named from the agent's SLUG — the kebab-case identity whose
+// "<slug>-default" shape the delete cascade's fallback lookup reconstructs
+// via Slug() — never from the free-form display name. Every historical call
+// site passed metadata.name for the slug parameter, which held together only
+// while GenerateSlug(name + "-default") happened to re-derive
+// slug + "-default" (stigmer/stigmer#355); reading the slug at this single
+// source makes the wrong-field mistake unwritable. All callers see a
+// populated slug: create pipelines run after ResolveSlugStep, and the
+// self-heal paths load an already-persisted parent.
+func BuildRequest(agent *apiresourcepb.ApiResourceMetadata) *agentinstancev1.AgentInstance {
 	return &agentinstancev1.AgentInstance{
 		ApiVersion: apiVersion,
 		Kind:       kind,
 		Metadata: &apiresourcepb.ApiResourceMetadata{
-			Name: Slug(agentSlug),
-			Org:  orgID,
+			Name: Slug(agent.GetSlug()),
+			Org:  agent.GetOrg(),
 			Labels: map[string]string{
 				apiresource.DefaultInstanceLabel: apiresource.ReservedLabelTrue,
 				apiresource.SystemManagedLabel:   apiresource.ReservedLabelTrue,
 			},
 		},
 		Spec: &agentinstancev1.AgentInstanceSpec{
-			AgentId:     agentID,
+			AgentId:     agent.GetId(),
 			Description: description,
 		},
 	}

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance/defaultinstance_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance/defaultinstance_test.go
@@ -1,0 +1,53 @@
+package defaultinstance
+
+// Pins the naming contract the delete cascade depends on
+// (stigmer/stigmer#355): the default instance is named from the agent's
+// SLUG, never its display name. The fixture's name deliberately slugifies
+// to something other than the explicit slug — the exact case where the old
+// name-fed call sites produced an instance the cascade's
+// Slug(agent.GetSlug()) fallback could no longer find.
+
+import (
+	"testing"
+
+	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/backend/libs/go/apiresource"
+)
+
+func TestBuildRequestNamesInstanceFromSlugNotName(t *testing.T) {
+	agent := &apiresourcepb.ApiResourceMetadata{
+		Id:   "agt_123",
+		Name: "Support Assistant (EU)", // slugifies to support-assistant-eu, not the explicit slug
+		Slug: "support-bot",
+		Org:  "acme",
+	}
+
+	request := BuildRequest(agent)
+
+	if got, want := request.GetMetadata().GetName(), "support-bot-default"; got != want {
+		t.Errorf("instance name derived from the wrong field: got %q, want %q", got, want)
+	}
+	if got, want := request.GetMetadata().GetName(), Slug(agent.GetSlug()); got != want {
+		t.Errorf("instance name %q must equal the cascade's fallback lookup %q", got, want)
+	}
+	if got, want := request.GetSpec().GetAgentId(), "agt_123"; got != want {
+		t.Errorf("agent_id: got %q, want %q", got, want)
+	}
+	if got, want := request.GetMetadata().GetOrg(), "acme"; got != want {
+		t.Errorf("org: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildRequestStampsReservedLabels(t *testing.T) {
+	request := BuildRequest(&apiresourcepb.ApiResourceMetadata{
+		Id: "agt_x", Name: "X", Slug: "x", Org: "org-1",
+	})
+
+	labels := request.GetMetadata().GetLabels()
+	if labels[apiresource.DefaultInstanceLabel] != apiresource.ReservedLabelTrue {
+		t.Errorf("missing %s label", apiresource.DefaultInstanceLabel)
+	}
+	if labels[apiresource.SystemManagedLabel] != apiresource.ReservedLabelTrue {
+		t.Errorf("missing %s label", apiresource.SystemManagedLabel)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/session/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/create.go
@@ -139,8 +139,7 @@ func (s *resolveDefaultAgentInstanceStep) Execute(ctx *pipeline.RequestContext[*
 	if defaultInstanceID == "" {
 		log.Info().Str("agent_id", agentID).Msg("Default instance missing, creating one")
 
-		instanceRequest := defaultinstance.BuildRequest(
-			agentID, defaultAgent.GetMetadata().GetName(), defaultAgent.GetMetadata().GetOrg())
+		instanceRequest := defaultinstance.BuildRequest(defaultAgent.GetMetadata())
 
 		createdInstance, createErr := s.agentInstanceClient.CreateAsSystem(ctx.Context(), instanceRequest)
 		if createErr != nil {

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/create.go
@@ -102,17 +102,15 @@ func (s *createDefaultInstanceStep) Name() string {
 func (s *createDefaultInstanceStep) Execute(ctx *pipeline.RequestContext[*workflowv1.Workflow]) error {
 	workflow := ctx.NewState()
 	workflowID := workflow.GetMetadata().GetId()
-	workflowSlug := workflow.GetMetadata().GetName()
-	workflowOrg := workflow.GetMetadata().GetOrg()
 
 	log.Info().
 		Str("workflow_id", workflowID).
-		Str("slug", workflowSlug).
-		Str("org", workflowOrg).
+		Str("slug", workflow.GetMetadata().GetSlug()).
+		Str("org", workflow.GetMetadata().GetOrg()).
 		Msg("Creating default instance for workflow")
 
 	// 1. Build default instance request
-	instanceRequest := defaultinstance.BuildRequest(workflowID, workflowSlug, workflowOrg)
+	instanceRequest := defaultinstance.BuildRequest(workflow.GetMetadata())
 
 	// 2. Create instance via downstream client (in-process, system credentials)
 	// This calls WorkflowInstanceCommandController.Create() in-process

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/controller/create.go
@@ -216,8 +216,7 @@ func (s *createDefaultInstanceIfNeededStep) Execute(ctx *pipeline.RequestContext
 
 	// 3. Default instance ID not set - check if instance exists by slug
 	// This handles the case where instance was created but workflow status update failed
-	workflowSlug := workflow.GetMetadata().GetName()
-	defaultInstanceSlug := defaultinstance.Slug(workflowSlug)
+	defaultInstanceSlug := defaultinstance.Slug(workflow.GetMetadata().GetSlug())
 
 	log.Debug().
 		Str("workflow_id", workflowID).
@@ -279,8 +278,7 @@ func (s *createDefaultInstanceIfNeededStep) Execute(ctx *pipeline.RequestContext
 		Str("workflow_id", workflowID).
 		Msg("Default instance not found, creating new one")
 
-	instanceRequest := defaultinstance.BuildRequest(
-		workflowID, workflowSlug, workflow.GetMetadata().GetOrg())
+	instanceRequest := defaultinstance.BuildRequest(workflow.GetMetadata())
 
 	// 6. Create instance via downstream gRPC (system context)
 	createdInstance, err := s.workflowInstanceClient.CreateAsSystem(ctx.Context(), instanceRequest)

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/defaultinstance/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/defaultinstance/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "defaultinstance",
@@ -7,6 +7,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//apis/stubs/go/ai/stigmer/agentic/workflowinstance/v1:workflowinstance",
+        "//apis/stubs/go/ai/stigmer/commons/apiresource",
+        "//backend/libs/go/apiresource",
+    ],
+)
+
+go_test(
+    name = "defaultinstance_test",
+    srcs = ["defaultinstance_test.go"],
+    embed = [":defaultinstance"],
+    deps = [
         "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//backend/libs/go/apiresource",
     ],

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/defaultinstance/defaultinstance.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/defaultinstance/defaultinstance.go
@@ -30,22 +30,29 @@ func Slug(workflowSlug string) string {
 }
 
 // BuildRequest builds the WorkflowInstance proto for a default-instance
-// creation request. Callers hand it to the workflowinstance downstream
-// client (Create/Apply AsSystem), which owns persistence and validation.
-func BuildRequest(workflowID, workflowSlug, orgID string) *workflowinstancev1.WorkflowInstance {
+// creation request from the parent workflow's metadata. Callers hand it to
+// the workflowinstance downstream client (Create/Apply AsSystem), which owns
+// persistence and validation.
+//
+// Takes the metadata rather than loose strings for the same reason as the
+// agentinstance twin: the instance is named from the workflow's SLUG (the
+// identity Slug() reconstructs for fallback lookups), never the free-form
+// display name — reading it at this single source makes the wrong-field
+// mistake unwritable (stigmer/stigmer#355).
+func BuildRequest(workflow *apiresourcepb.ApiResourceMetadata) *workflowinstancev1.WorkflowInstance {
 	return &workflowinstancev1.WorkflowInstance{
 		ApiVersion: apiVersion,
 		Kind:       kind,
 		Metadata: &apiresourcepb.ApiResourceMetadata{
-			Name: Slug(workflowSlug),
-			Org:  orgID,
+			Name: Slug(workflow.GetSlug()),
+			Org:  workflow.GetOrg(),
 			Labels: map[string]string{
 				apiresource.DefaultInstanceLabel: apiresource.ReservedLabelTrue,
 				apiresource.SystemManagedLabel:   apiresource.ReservedLabelTrue,
 			},
 		},
 		Spec: &workflowinstancev1.WorkflowInstanceSpec{
-			WorkflowId:  workflowID,
+			WorkflowId:  workflow.GetId(),
 			Description: description,
 		},
 	}

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/defaultinstance/defaultinstance_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/defaultinstance/defaultinstance_test.go
@@ -1,0 +1,52 @@
+package defaultinstance
+
+// The workflow twin of the agentinstance defaultinstance test: pins that the
+// default instance is named from the workflow's SLUG, never its display name
+// (stigmer/stigmer#355), so slug-based fallback lookups
+// (workflow-execution self-heal, future delete cascade) can always
+// reconstruct it via Slug().
+
+import (
+	"testing"
+
+	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/backend/libs/go/apiresource"
+)
+
+func TestBuildRequestNamesInstanceFromSlugNotName(t *testing.T) {
+	workflow := &apiresourcepb.ApiResourceMetadata{
+		Id:   "wf_123",
+		Name: "Nightly Sync (US)", // slugifies to nightly-sync-us, not the explicit slug
+		Slug: "nightly-sync",
+		Org:  "acme",
+	}
+
+	request := BuildRequest(workflow)
+
+	if got, want := request.GetMetadata().GetName(), "nightly-sync-default"; got != want {
+		t.Errorf("instance name derived from the wrong field: got %q, want %q", got, want)
+	}
+	if got, want := request.GetMetadata().GetName(), Slug(workflow.GetSlug()); got != want {
+		t.Errorf("instance name %q must equal the slug-fallback lookup %q", got, want)
+	}
+	if got, want := request.GetSpec().GetWorkflowId(), "wf_123"; got != want {
+		t.Errorf("workflow_id: got %q, want %q", got, want)
+	}
+	if got, want := request.GetMetadata().GetOrg(), "acme"; got != want {
+		t.Errorf("org: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildRequestStampsReservedLabels(t *testing.T) {
+	request := BuildRequest(&apiresourcepb.ApiResourceMetadata{
+		Id: "wf_x", Name: "X", Slug: "x", Org: "org-1",
+	})
+
+	labels := request.GetMetadata().GetLabels()
+	if labels[apiresource.DefaultInstanceLabel] != apiresource.ReservedLabelTrue {
+		t.Errorf("missing %s label", apiresource.DefaultInstanceLabel)
+	}
+	if labels[apiresource.SystemManagedLabel] != apiresource.ReservedLabelTrue {
+		t.Errorf("missing %s label", apiresource.SystemManagedLabel)
+	}
+}


### PR DESCRIPTION
## Summary
Default agent/workflow instances are now named from the parent's resolved `metadata.slug` instead of its free-form `metadata.name`, and both `defaultinstance.BuildRequest` helpers take the parent's metadata so the wrong-field mistake can no longer be written at any call site.

## Context
The issue cites one line (`agent/controller/create.go`: `agentSlug := agent.GetMetadata().GetName()`), but the census found the identical mistake at **all five** call sites of the two `defaultinstance` helpers — agent create, session self-heal, agent-execution self-heal, workflow create, workflow-execution self-heal — plus a sixth occurrence where workflow-execution's self-heal **slug lookup** was built from the display name (a lookup by `"My Flow-default"` against stored kebab-case instance slugs).

Everything worked only while `GenerateSlug(name + "-default") == slug + "-default"` held by accident. An agent or workflow whose explicit slug differs from its name-derived slug silently breaks the delete cascade's fallback lookup and the self-heal path.

## Changes
- `agentinstance/defaultinstance.BuildRequest` and `workflowinstance/defaultinstance.BuildRequest` now take the parent's `*ApiResourceMetadata` and read ID, slug, and org internally. The package docs already promise "single source of the naming convention"; this makes the promise structural.
- All five call sites updated mechanically; the workflow-execution self-heal lookup now reconstructs the instance slug from `GetSlug()`.
- New regression tests in both packages pin the contract with a fixture whose display name slugifies differently from its explicit slug — the exact case the old code broke on.

## Implementation notes
- `Slug()` keeps its signature: the delete cascade's fallback already feeds it the correct field.
- Coordination: the in-flight workflow-delete-cascade session (#592) will consume `defaultinstance.Slug()` for its fallback; this fix makes that fallback trustworthy for newly created instances. No shared files with that session's delete-path work.
- The cloud edition's Java `DefaultAgentInstanceFactory` has the same class at four call sites (`getMetadata().getName()` fed as the slug) — filed separately as a stigmer-cloud issue rather than fixed cross-repo here.

## Breaking changes
- None. Legacy instances created from a divergent display name keep their stored slug; the authoritative `status.default_instance_id` pointer path is unaffected.

## Test plan
- New `defaultinstance_test.go` in both packages (name-from-slug pin + reserved-labels pin).
- Existing `TestDefaultInstanceBuildRequest_StampsSystemManagedLabels` updated to the metadata signature with a name/slug-divergent fixture.
- Full `stigmer-server` Go test suite green; `gofmt` clean.

## Risks
- Low: creation-time behavior changes only for parents whose name and slug diverge, where the old behavior was the bug. Rollback: revert the commit.

Closes #355

Made with [Cursor](https://cursor.com)