### PR TITLE
fix(sdk/react): make canvas dirty tracking serialization-aware — position-only edits no longer arm Save (#609)

### DIFF
--- a/sdk/react/src/workflow/__tests__/useWorkflowCanvas.dirty.test.tsx
+++ b/sdk/react/src/workflow/__tests__/useWorkflowCanvas.dirty.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+import type { Node } from "@xyflow/react";
+import { useWorkflowCanvas } from "../useWorkflowCanvas";
+
+// Regression tests for oss#609: isDirty was a model-reference comparison
+// while graphToYaml serializes no positions. A position-only edit session
+// (drag, auto-layout) armed Save and showed "Modified", but saving
+// round-tripped byte-identical YAML — and because hosts reset the baseline
+// by feeding saved YAML back through the `yaml` prop (string-change gated),
+// the flag could never clear. Dirty now means "saving would change the
+// document": position-only sessions never arm, content saves still clear
+// through the yaml-prop feedback loop.
+
+const FIXTURE_YAML = `apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: dirty-fixture
+spec:
+  document:
+    dsl: "1.0.0"
+    namespace: test
+    name: dirty-fixture
+    version: "0.0.1"
+  tasks:
+    - name: step_1
+      kind: agent_call
+      task_config:
+        agent: "org/agent-slug"
+        message: "first"
+      flow:
+        then: step_2
+    - name: step_2
+      kind: agent_call
+      task_config:
+        agent: "org/agent-slug"
+        message: "second"
+      flow:
+        then: end
+`;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ReactFlowProvider>{children}</ReactFlowProvider>;
+}
+
+function renderCanvas() {
+  return renderHook(({ yaml }: { yaml: string }) => useWorkflowCanvas(yaml), {
+    initialProps: { yaml: FIXTURE_YAML },
+    wrapper,
+  });
+}
+
+type CanvasResult = ReturnType<typeof renderCanvas>["result"];
+
+const DRAG_EVENT = {} as React.MouseEvent;
+
+/** Drives one full drag gesture the way React Flow produces it. */
+function drag(result: CanvasResult, id: string, to: { x: number; y: number }) {
+  const startNode = result.current.nodes.find((n) => n.id === id);
+  expect(startNode).toBeDefined();
+
+  act(() => {
+    result.current.onNodeDragStart(DRAG_EVENT, startNode!, [startNode!]);
+  });
+  act(() => {
+    result.current.onNodesChange([{ id, type: "position", position: to, dragging: true }]);
+    result.current.onNodesChange([{ id, type: "position", position: to, dragging: false }]);
+  });
+  const stopped: Node = { ...startNode!, position: to };
+  act(() => {
+    result.current.onNodeDragStop(DRAG_EVENT, stopped, [stopped]);
+  });
+}
+
+describe("useWorkflowCanvas — dirty semantics (oss#609)", () => {
+  it("a drag-only session is NOT dirty — saving it would change nothing", () => {
+    const { result } = renderCanvas();
+    expect(result.current.isDirty).toBe(false);
+
+    drag(result, "step_2", { x: 640, y: 480 });
+
+    // The drag IS in the model and undoable (oss#602)…
+    expect(result.current.canUndo).toBe(true);
+    // …but positions don't serialize, so the document is unchanged.
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("an auto-layout-only session is NOT dirty", async () => {
+    const { result } = renderCanvas();
+
+    // Nudge a node off its dagre position first so auto-layout has real
+    // work to do (a no-op layout wouldn't even dispatch).
+    drag(result, "step_2", { x: 640, y: 480 });
+    await act(async () => {
+      await result.current.autoLayout();
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("a content edit IS dirty", () => {
+    const { result } = renderCanvas();
+
+    act(() => {
+      result.current.renameNode("step_1", "step_1_renamed");
+    });
+
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("a content edit that is undone is NOT dirty again", () => {
+    const { result } = renderCanvas();
+
+    act(() => {
+      result.current.renameNode("step_1", "step_1_renamed");
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("the save feedback loop clears dirty: edit → serialize → feed back through the yaml prop", () => {
+    const { result, rerender } = renderCanvas();
+
+    act(() => {
+      result.current.renameNode("step_1", "step_1_renamed");
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    // WorkflowEditorView's handleCanvasSave: serializeToYaml() → setYaml()
+    // → the string re-enters through the `yaml` prop and resets the baseline.
+    const saved = result.current.serializeToYaml();
+    expect(saved).not.toBeNull();
+    rerender({ yaml: saved! });
+
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("drag + content edit is dirty; the save loop clears it even though positions never persist", () => {
+    const { result, rerender } = renderCanvas();
+
+    drag(result, "step_2", { x: 640, y: 480 });
+    act(() => {
+      result.current.renameNode("step_1", "step_1_renamed");
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    const saved = result.current.serializeToYaml();
+    expect(saved).not.toBeNull();
+    rerender({ yaml: saved! });
+
+    // Pre-#609 this was the trap: the position delta kept the model
+    // reference unequal forever, so dirty survived its own save.
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("cosmetic YAML formatting differences do not read as dirty", () => {
+    // Host YAML with extra blank lines / comments parses to the same model;
+    // the baseline is the canonical re-serialization, so the comparison is
+    // canonical-vs-canonical from the first render.
+    const cosmetic = `${FIXTURE_YAML}\n# trailing comment\n`;
+    const { result } = renderHook(({ yaml }: { yaml: string }) => useWorkflowCanvas(yaml), {
+      initialProps: { yaml: cosmetic },
+      wrapper,
+    });
+
+    expect(result.current.isDirty).toBe(false);
+
+    drag(result, "step_2", { x: 640, y: 480 });
+    expect(result.current.isDirty).toBe(false);
+  });
+});

--- a/sdk/react/src/workflow/useWorkflowCanvas.ts
+++ b/sdk/react/src/workflow/useWorkflowCanvas.ts
@@ -68,6 +68,20 @@ import type { LayoutEngine } from "./layout/index.js";
 import { serializeSelection, pasteClipboard } from "./clipboard.js";
 import type { ClipboardEntry } from "./clipboard.js";
 
+/**
+ * Serializes a graph model to canonical YAML, or `null` if serialization
+ * fails. graphToYaml is total on models produced by yamlToGraph (its sort is
+ * cycle-protected and unknown kinds fall back to `unknown_N`), so `null` is
+ * a defensive outcome, not an expected one.
+ */
+function serializeGraphOrNull(model: WorkflowGraphModel): string | null {
+  try {
+    return graphToYaml(model);
+  } catch {
+    return null;
+  }
+}
+
 /** Selection state for the canvas inspector. */
 export interface CanvasSelection {
   readonly type: "node" | "edge";
@@ -180,6 +194,10 @@ export function useWorkflowCanvas(
   const [error, setError] = useState<string | null>(null);
   const [selection, setSelection] = useState<CanvasSelection | null>(null);
   const initialModelRef = useRef<WorkflowGraphModel | null>(null);
+  // Serialized form of the baseline model, kept in lockstep with
+  // initialModelRef. Dirty tracking compares serializations, not references —
+  // see the "Dirty tracking" section below for why.
+  const initialYamlRef = useRef<string | null>(null);
 
   const [nodes, setNodes, onNodesChangeRaw] = useNodesState([] as Node[]);
   const [edges, setEdges, onEdgesChangeRaw] = useEdgesState([] as Edge[]);
@@ -206,6 +224,7 @@ export function useWorkflowCanvas(
       setNodes([]);
       setEdges([]);
       initialModelRef.current = null;
+      initialYamlRef.current = null;
       return;
     }
 
@@ -214,6 +233,10 @@ export function useWorkflowCanvas(
       const laidOut = applyDagreLayout(parsed);
       history.reset(laidOut);
       initialModelRef.current = laidOut;
+      // Baseline is the canonical re-serialization, not the incoming string:
+      // dirty comparisons must be canonical-vs-canonical, immune to cosmetic
+      // formatting differences in host-provided YAML.
+      initialYamlRef.current = serializeGraphOrNull(laidOut);
       setError(null);
 
       const elements = toReactFlowElements(laidOut);
@@ -224,6 +247,7 @@ export function useWorkflowCanvas(
       setNodes([]);
       setEdges([]);
       initialModelRef.current = null;
+      initialYamlRef.current = null;
     }
   }, [yaml]);
 
@@ -449,6 +473,7 @@ export function useWorkflowCanvas(
         };
         history.reset(bootstrapModel);
         initialModelRef.current = bootstrapModel;
+        initialYamlRef.current = serializeGraphOrNull(bootstrapModel);
 
         const autoEdge = {
           id: generateEdgeId(),
@@ -1158,20 +1183,33 @@ export function useWorkflowCanvas(
   }, [history.redo, syncFromModel]);
 
   // ---------------------------------------------------------------------------
-  // Dirty tracking: model reference comparison
+  // Dirty tracking: serialization comparison (oss#609)
+  //
+  // Dirty means "saving would change the document". Node positions are not
+  // part of the serialized YAML (dagre recomputes them on every load), so a
+  // position-only edit session (drags, auto-layout) must NOT read as dirty:
+  // its save would round-trip byte-identical YAML, and because hosts reset
+  // the baseline by feeding saved YAML back through the `yaml` prop (whose
+  // re-parse effect is string-change gated), a reference-based flag could
+  // never clear afterwards — an armed Save button that saving cannot disarm.
+  // graphToYaml is total on parsed models (cycle-protected sort, unknown-kind
+  // fallback) and O(nodes+edges), cheap enough to compare per model change.
   // ---------------------------------------------------------------------------
 
   const graph = history.currentModel.nodes.length > 0 ? history.currentModel : null;
-  const isDirty = initialModelRef.current !== null && graph !== initialModelRef.current;
+  const currentYaml = useMemo(
+    () => (graph ? serializeGraphOrNull(graph) : null),
+    [graph],
+  );
+  // Reference comparison remains as the fallback for the defensive case where
+  // serialization failed (null); failing dirty-side keeps Save reachable.
+  const isDirty =
+    initialModelRef.current !== null &&
+    (currentYaml !== null && initialYamlRef.current !== null
+      ? currentYaml !== initialYamlRef.current
+      : graph !== initialModelRef.current);
 
-  const serializeToYaml = useCallback((): string | null => {
-    if (!graph) return null;
-    try {
-      return graphToYaml(graph);
-    } catch {
-      return null;
-    }
-  }, [graph]);
+  const serializeToYaml = useCallback((): string | null => currentYaml, [currentYaml]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## Summary

Closes #609.

`useWorkflowCanvas.isDirty` was a model-**reference** comparison while `graphToYaml` serializes no positions. A position-only edit session (node drags — every drag since #608 — or auto-layout) armed Save and showed "Modified", but saving round-tripped byte-identical YAML; and because hosts reset the baseline by feeding saved YAML back through the `yaml` prop (whose re-parse effect is string-change gated), the flag could never clear. Hosts wiring `onDirtyChange` to navigation guards got an undismissable "unsaved changes" prompt (the Visual→Code switch in `WorkflowEditorView` is one today).

**Dirty now means "saving would change the document"**: `isDirty` compares the memoized canonical serialization of the current model against a serialized baseline (`initialYamlRef`, kept in lockstep with `initialModelRef` at all three assignment sites, including the empty-canvas bootstrap).

- Position-only sessions never arm Save or the "Modified" pill; the drag stays in the model and remains undoable (#602 behavior untouched).
- Content saves clear exactly as before, through the yaml-prop feedback loop — including after mixed drag+edit sessions, which previously wedged the flag forever.
- Cosmetic host-YAML formatting differences can't read as dirty: the baseline is the canonical re-serialization, so comparisons are canonical-vs-canonical.
- `graphToYaml` is total on parsed models (cycle-protected sort, `unknown_N` kind fallback) and O(nodes+edges); a defensive treat-as-dirty fallback covers the never-observed serialization-failure case. `serializeToYaml` now returns the same memoized string, removing a duplicate serialization on save.

Layout persistence (giving hand-arranged positions a home in the document) is deliberately out of scope, per the issue.

## Test plan

- [x] New `useWorkflowCanvas.dirty.test.tsx` (7 cases) — **red-first: 4/7 fail on main** (drag-only, auto-layout-only, drag+edit save loop, cosmetic formatting), all 7 green with the fix
- [x] Existing drag (#602) and undo (#588) canvas suites green
- [x] Full `@stigmer/react` suite: 4333 tests / 396 files green; lint green; typecheck green
- [x] e2e dirty-signal spec (`workflow-context-menu.spec.ts`) asserts on a content change (toggle-disabled) — unaffected by design

Made with [Cursor](https://cursor.com)