### PR TITLE
fix(repo): force a single workspace @bufbuild/protobuf via root resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "tsx": "^4.21.0"
   },
   "resolutions": {
+    "@bufbuild/protobuf": "2.12.0",
     "@stigmer/protos": "workspace:*",
     "@stigmer/sdk": "workspace:*",
     "@stigmer/theme": "workspace:*",


### PR DESCRIPTION
## Summary

- Every **fresh clone/worktree of main currently gets ~477 TypeScript errors** in `sdk/typescript` and an OOM-crashing `mcp-server` typecheck. Root cause: the root `yarn.lock` is untracked (97c6e8e28), so caret ranges re-resolve on install — when `@bufbuild/protobuf` 2.13.0 published upstream, the six caret-range consumers (sdk/typescript, sdk/react, sdk/ink, mcp-server, cli, demos) split from the exact-pinned 2.12.0 packages (apis/stubs/ts, runner, web, site), putting **two copies** of protobuf-es in the tree. Branded message types don't unify across copies, so `create(XSchema, …)` degrades to `Message<string>` everywhere.
- One root `resolutions` entry restores the single-copy invariant workspace-wide. Published packages are untouched — `@bufbuild/protobuf` remains a caret peer dependency of `@stigmer/sdk` for external consumers.
- Established checkouts kept working off pre-split `node_modules`, which is why nobody saw this; no CI lane runs the TS SDK `tsc` build (adjacent to the #264 CI-gap class).

## Verification

- With this pin applied in a fresh worktree: nested `apis/stubs/ts/node_modules/@bufbuild/protobuf` copy disappears, `tsc -p tsconfig.build.json --noEmit` in `sdk/typescript` goes from 477 errors to 0, and the full vitest suite passes (26 files, 395 tests).

Discovered while working stigmer/stigmer#607 (billing SDK parity).

Made with [Cursor](https://cursor.com)