### PR TITLE
fix(sdk): mint DOM ids and radio names with useId — kill duplicate-id collisions on double-mounted library pages

### DIFF
--- a/sdk/react/src/access/ManageAccessDialog.tsx
+++ b/sdk/react/src/access/ManageAccessDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, type ReactNode } from "react";
+import { useCallback, useId, useRef, type ReactNode } from "react";
 import { cn } from "@stigmer/theme";
 import { hasGrantableRoles } from "@stigmer/sdk";
 import { PeopleWithAccess } from "../iam-policy/PeopleWithAccess.js";
@@ -78,6 +78,12 @@ export function ManageAccessDialog({
 }: ManageAccessDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
+  // Instance-scoped title id (oss#593): a reusable component must not
+  // hardcode DOM ids — hosts legitimately mount this dialog more than once
+  // per page (e.g. zone-cached detail pages), and duplicate ids break the
+  // aria-labelledby association for every copy after the first.
+  const titleId = useId();
+
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
     onOpenChange(false);
@@ -108,7 +114,7 @@ export function ManageAccessDialog({
         "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         "stg:backdrop:bg-black/50",
       )}
-      aria-labelledby="manage-access-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so the access-list fetch is lazy. */}
       {open && (
@@ -117,7 +123,7 @@ export function ManageAccessDialog({
           <div className="stg:flex stg:items-start stg:justify-between stg:border-b stg:border-border stg:px-6 stg:py-4">
             <div className="stg:min-w-0">
               <h2
-                id="manage-access-title"
+                id={titleId}
                 className="stg:text-base stg:font-semibold stg:text-foreground"
               >
                 Manage access

--- a/sdk/react/src/agent-instance/CreateAgentInstanceDialog.tsx
+++ b/sdk/react/src/agent-instance/CreateAgentInstanceDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
@@ -41,6 +41,15 @@ export function CreateAgentInstanceDialog({
 }: CreateAgentInstanceDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const { create, isCreating, error, clearError } = useCreateAgentInstance();
+
+  // Instance-scoped element ids (oss#593): a reusable component must not
+  // hardcode DOM ids — hosts legitimately mount this dialog more than once
+  // per page (e.g. zone-cached detail pages), and duplicate ids silently
+  // break the label→input association for every copy after the first.
+  const baseId = useId();
+  const titleId = `${baseId}-title`;
+  const nameId = `${baseId}-name`;
+  const descriptionId = `${baseId}-description`;
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -108,12 +117,12 @@ export function CreateAgentInstanceDialog({
         "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         "stg:backdrop:bg-black/50",
       )}
-      aria-labelledby="create-agent-instance-title"
+      aria-labelledby={titleId}
     >
       <form onSubmit={handleSubmit} className="stg:flex stg:flex-col">
         {/* Header */}
         <div className="stg:flex stg:items-center stg:justify-between stg:border-b stg:border-border stg:px-6 stg:py-4">
-          <h2 id="create-agent-instance-title" className="stg:text-base stg:font-semibold stg:text-foreground">
+          <h2 id={titleId} className="stg:text-base stg:font-semibold stg:text-foreground">
             Create Agent Instance
           </h2>
           <button
@@ -134,11 +143,11 @@ export function CreateAgentInstanceDialog({
         <div className="stg:space-y-5 stg:px-6 stg:py-5">
           {/* Name */}
           <div>
-            <label htmlFor="agent-instance-name" className="stg:block stg:text-sm stg:font-medium stg:text-foreground stg:mb-1.5">
+            <label htmlFor={nameId} className="stg:block stg:text-sm stg:font-medium stg:text-foreground stg:mb-1.5">
               Name <span className="stg:text-destructive">*</span>
             </label>
             <input
-              id="agent-instance-name"
+              id={nameId}
               type="text"
               required
               value={name}
@@ -160,11 +169,11 @@ export function CreateAgentInstanceDialog({
 
           {/* Description */}
           <div>
-            <label htmlFor="agent-instance-description" className="stg:block stg:text-sm stg:font-medium stg:text-foreground stg:mb-1.5">
+            <label htmlFor={descriptionId} className="stg:block stg:text-sm stg:font-medium stg:text-foreground stg:mb-1.5">
               Description
             </label>
             <textarea
-              id="agent-instance-description"
+              id={descriptionId}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What is this instance used for?"

--- a/sdk/react/src/channel/ChannelCredentialsDialog.tsx
+++ b/sdk/react/src/channel/ChannelCredentialsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
@@ -53,6 +53,12 @@ export function ChannelCredentialsDialog({
 }: ChannelCredentialsDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
+  // Instance-scoped title id (oss#593): a reusable component must not
+  // hardcode DOM ids — hosts legitimately mount this dialog more than once
+  // per page (e.g. zone-cached detail pages), and duplicate ids break the
+  // aria-labelledby association for every copy after the first.
+  const titleId = useId();
+
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
     onOpenChange(false);
@@ -82,7 +88,7 @@ export function ChannelCredentialsDialog({
         "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
       )}
-      aria-labelledby="channel-credentials-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its draft resets per session —
           reopening never resumes stale, unsaved edits. */}
@@ -92,6 +98,7 @@ export function ChannelCredentialsDialog({
           channel={channel}
           onSaved={onSaved}
           onClose={handleClose}
+          titleId={titleId}
         />
       )}
     </dialog>
@@ -103,11 +110,14 @@ function ChannelCredentialsDialogBody({
   channel,
   onSaved,
   onClose,
+  titleId,
 }: {
   readonly agent: Agent;
   readonly channel: AgentChannel;
   readonly onSaved?: () => void;
   readonly onClose: () => void;
+  /** Heading id minted by the outer dialog for its aria-labelledby. */
+  readonly titleId: string;
 }) {
   const channelName =
     channel.metadata?.name || channel.metadata?.slug || "this channel";
@@ -142,7 +152,7 @@ function ChannelCredentialsDialogBody({
       <div className="stg:flex stg:items-start stg:justify-between stg:gap-3 stg:border-b stg:border-border stg:px-5 stg:py-4">
         <div className="stg:min-w-0">
           <h2
-            id="channel-credentials-title"
+            id={titleId}
             className="stg:text-sm stg:font-semibold stg:text-foreground"
           >
             Tool credentials

--- a/sdk/react/src/channel/ConnectSlackDialog.tsx
+++ b/sdk/react/src/channel/ConnectSlackDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getErrorReason, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
@@ -91,6 +91,12 @@ export function ConnectSlackDialog({
 }: ConnectSlackDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
+  // Instance-scoped title id (oss#593): a reusable component must not
+  // hardcode DOM ids — hosts legitimately mount this dialog more than once
+  // per page (e.g. zone-cached detail pages), and duplicate ids break the
+  // aria-labelledby association for every copy after the first.
+  const titleId = useId();
+
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
     onOpenChange(false);
@@ -122,7 +128,7 @@ export function ConnectSlackDialog({
         "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
       )}
-      aria-labelledby="connect-slack-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its flow state resets per
           session — reopening the dialog never resumes a stale flow. */}
@@ -132,6 +138,7 @@ export function ConnectSlackDialog({
           channel={channel ?? null}
           onChannelsChanged={onChannelsChanged}
           onClose={handleClose}
+          titleId={titleId}
           channelAppsHref={channelAppsHref}
         />
       )}
@@ -149,6 +156,8 @@ interface ConnectSlackDialogBodyProps {
   readonly onChannelsChanged?: () => void;
   readonly onClose: () => void;
   readonly channelAppsHref?: string;
+  /** Heading id minted by the outer dialog for its aria-labelledby. */
+  readonly titleId: string;
 }
 
 function ConnectSlackDialogBody({
@@ -157,6 +166,7 @@ function ConnectSlackDialogBody({
   onChannelsChanged,
   onClose,
   channelAppsHref,
+  titleId,
 }: ConnectSlackDialogBodyProps) {
   const deploymentMode = useDeploymentMode();
   const agentName = agent.metadata?.name || agent.metadata?.slug || "this agent";
@@ -276,7 +286,7 @@ function ConnectSlackDialogBody({
       <div className="stg:flex stg:items-start stg:justify-between stg:gap-3 stg:border-b stg:border-border stg:px-5 stg:py-4">
         <div className="stg:flex stg:items-center stg:gap-2.5">
           <SlackMarkIcon className="stg:size-5 stg:text-foreground" />
-          <h2 id="connect-slack-title" className="stg:text-sm stg:font-semibold stg:text-foreground">
+          <h2 id={titleId} className="stg:text-sm stg:font-semibold stg:text-foreground">
             {channel ? "Reconnect to Slack" : "Connect to Slack"}
           </h2>
         </div>

--- a/sdk/react/src/channel/ConnectWhatsAppDialog.tsx
+++ b/sdk/react/src/channel/ConnectWhatsAppDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getErrorReason, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
@@ -102,6 +102,12 @@ export function ConnectWhatsAppDialog({
 }: ConnectWhatsAppDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
+  // Instance-scoped title id (oss#593): a reusable component must not
+  // hardcode DOM ids — hosts legitimately mount this dialog more than once
+  // per page (e.g. zone-cached detail pages), and duplicate ids break the
+  // aria-labelledby association for every copy after the first.
+  const titleId = useId();
+
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
     onOpenChange(false);
@@ -133,7 +139,7 @@ export function ConnectWhatsAppDialog({
         "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
       )}
-      aria-labelledby="connect-whatsapp-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its flow state resets per
           session — reopening the dialog never resumes a stale flow. */}
@@ -144,6 +150,7 @@ export function ConnectWhatsAppDialog({
           onChannelsChanged={onChannelsChanged}
           onClose={handleClose}
           channelAppsHref={channelAppsHref}
+          titleId={titleId}
         />
       )}
     </dialog>
@@ -160,6 +167,8 @@ interface ConnectWhatsAppDialogBodyProps {
   readonly onChannelsChanged?: () => void;
   readonly onClose: () => void;
   readonly channelAppsHref?: string;
+  /** Heading id minted by the outer dialog for its aria-labelledby. */
+  readonly titleId: string;
 }
 
 function ConnectWhatsAppDialogBody({
@@ -168,6 +177,7 @@ function ConnectWhatsAppDialogBody({
   onChannelsChanged,
   onClose,
   channelAppsHref,
+  titleId,
 }: ConnectWhatsAppDialogBodyProps) {
   const stigmer = useStigmer();
   const deploymentMode = useDeploymentMode();
@@ -314,7 +324,7 @@ function ConnectWhatsAppDialogBody({
       <div className="stg:flex stg:items-start stg:justify-between stg:gap-3 stg:border-b stg:border-border stg:px-5 stg:py-4">
         <div className="stg:flex stg:items-center stg:gap-2.5">
           <WhatsAppMarkIcon className="stg:size-5 stg:text-foreground" />
-          <h2 id="connect-whatsapp-title" className="stg:text-sm stg:font-semibold stg:text-foreground">
+          <h2 id={titleId} className="stg:text-sm stg:font-semibold stg:text-foreground">
             {channel ? "Reconnect to WhatsApp" : "Connect to WhatsApp"}
           </h2>
         </div>

--- a/sdk/react/src/iam-policy/RoleSelector.tsx
+++ b/sdk/react/src/iam-policy/RoleSelector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import { cn } from "@stigmer/theme";
@@ -47,6 +48,12 @@ export function RoleSelector({
   disabled = false,
   className,
 }: RoleSelectorProps) {
+  // Instance-scoped radio-group name (oss#593): a hardcoded name would make
+  // every mounted RoleSelector share ONE radio group — with two copies on a
+  // page (e.g. zone-cached detail pages), keyboard selection escapes into
+  // the other, possibly aria-hidden, copy.
+  const groupName = useId();
+
   const { options, selected: internalSelected, select } = useRoleSelector(
     kind,
     defaultRole,
@@ -84,7 +91,7 @@ export function RoleSelector({
             >
               <input
                 type="radio"
-                name="stgm-role-selector"
+                name={groupName}
                 value={opt.value}
                 checked={isChecked}
                 disabled={disabled}

--- a/sdk/react/src/sharing/ShareAgentDialog.tsx
+++ b/sdk/react/src/sharing/ShareAgentDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState, type FormEvent } from "react";
+import { useCallback, useId, useMemo, useRef, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
 import {
   MAX_ALLOWED_ORIGINS,
@@ -139,6 +139,12 @@ export function ShareAgentDialog({
 }: ShareAgentDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
+  // Instance-scoped title id (oss#593): a reusable component must not
+  // hardcode DOM ids — hosts legitimately mount this dialog more than once
+  // per page (e.g. zone-cached detail pages), and duplicate ids break the
+  // aria-labelledby association for every copy after the first.
+  const titleId = useId();
+
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
     onOpenChange(false);
@@ -170,7 +176,7 @@ export function ShareAgentDialog({
         "stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
       )}
-      aria-labelledby="share-agent-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its draft state resets per
           session — reopening the dialog never shows a stale draft. */}
@@ -182,6 +188,7 @@ export function ShareAgentDialog({
           buildShareUrl={buildShareUrl}
           onSharingChanged={onSharingChanged}
           onClose={handleClose}
+          titleId={titleId}
         />
       )}
     </dialog>
@@ -207,6 +214,7 @@ function ShareAgentDialogBody({
   buildShareUrl,
   onSharingChanged,
   onClose,
+  titleId,
 }: {
   readonly agent: Agent;
   readonly share: AgentShare | null;
@@ -214,6 +222,8 @@ function ShareAgentDialogBody({
   readonly buildShareUrl?: (org: string, slug: string) => string;
   readonly onSharingChanged?: () => void;
   readonly onClose: () => void;
+  /** Heading id minted by the outer dialog for its aria-labelledby. */
+  readonly titleId: string;
 }) {
   const [created, setCreated] = useState<AgentShare | null>(null);
   const activeShare = share ?? created;
@@ -229,7 +239,7 @@ function ShareAgentDialogBody({
       <div className="stg:flex stg:items-start stg:justify-between stg:border-b stg:border-border stg:px-6 stg:py-4">
         <div className="stg:min-w-0">
           <h2
-            id="share-agent-title"
+            id={titleId}
             className="stg:text-base stg:font-semibold stg:text-foreground"
           >
             {isCreating ? "Create share" : "Share"}
@@ -321,6 +331,11 @@ function CreateShareForm({
 }) {
   const agentName = agent.metadata?.name || (agent.metadata?.slug ?? "");
   const isCrossOrg = shareOrg !== (agent.metadata?.org ?? "");
+
+  // Instance-scoped field ids (oss#593) — see the outer dialog's titleId.
+  const baseId = useId();
+  const nameId = `${baseId}-name`;
+  const slugId = `${baseId}-slug`;
 
   const [name, setName] = useState(agentName);
   const [slug, setSlug] = useState(agent.metadata?.slug ?? "");
@@ -421,13 +436,13 @@ function CreateShareForm({
       {/* ---- Name ---- */}
       <div className="stg:space-y-1">
         <label
-          htmlFor="stgm-new-share-name"
+          htmlFor={nameId}
           className="stg:text-xs stg:font-medium stg:text-foreground"
         >
           Name
         </label>
         <input
-          id="stgm-new-share-name"
+          id={nameId}
           type="text"
           value={name}
           onChange={(e) => handleNameChange(e.target.value)}
@@ -457,13 +472,13 @@ function CreateShareForm({
       {/* ---- Slug ---- */}
       <div className="stg:space-y-1">
         <label
-          htmlFor="stgm-new-share-slug"
+          htmlFor={slugId}
           className="stg:text-xs stg:font-medium stg:text-foreground"
         >
           Slug
         </label>
         <input
-          id="stgm-new-share-slug"
+          id={slugId}
           type="text"
           value={slug}
           onChange={(e) => handleSlugChange(e.target.value)}
@@ -532,6 +547,9 @@ function ShareAgentForm({
   readonly onSharingChanged?: () => void;
 }) {
   const agentName = agent.metadata?.name || (agent.metadata?.slug ?? "");
+
+  // Instance-scoped label id (oss#593) — see the outer dialog's titleId.
+  const enabledLabelId = useId();
 
   // The latest server share is the single baseline: the draft, the link
   // token, and the share id for rotation all derive from it.
@@ -644,7 +662,7 @@ function ShareAgentForm({
         <div className="stg:flex stg:items-start stg:justify-between stg:gap-4">
           <div className="stg:min-w-0">
             <span
-              id="share-enabled-label"
+              id={enabledLabelId}
               className="stg:text-sm stg:font-medium stg:text-foreground"
             >
               {isOrgAudience
@@ -657,7 +675,7 @@ function ShareAgentForm({
             checked={draft.enabled}
             onCheckedChange={handleToggle}
             disabled={isPending}
-            aria-labelledby="share-enabled-label"
+            aria-labelledby={enabledLabelId}
           />
         </div>
         {!isCrossOrg && (

--- a/sdk/react/src/workflow/WorkflowCanvasInner.tsx
+++ b/sdk/react/src/workflow/WorkflowCanvasInner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import {
   ReactFlow,
   Controls,
@@ -92,6 +92,11 @@ export function WorkflowCanvasInner({
   onSelectionContextMenu,
   nodeErrors,
 }: WorkflowCanvasInnerProps) {
+  // Instance-scoped React Flow id (oss#593): React Flow derives its internal
+  // DOM ids (aria descriptions, SVG marker/pattern defs) from this id, so two
+  // mounted graphs without explicit ids collide.
+  const flowId = useId();
+
   const enrichedNodes = useMemo(() => {
     if (!nodeErrors || nodeErrors.size === 0) return nodes;
     return nodes.map((node) => {
@@ -114,6 +119,7 @@ export function WorkflowCanvasInner({
 
   return (
     <ReactFlow
+      id={flowId}
       nodes={enrichedNodes}
       edges={edges}
       onNodesChange={onNodesChange}

--- a/sdk/react/src/workflow/WorkflowDiffGraph.tsx
+++ b/sdk/react/src/workflow/WorkflowDiffGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, useCallback, useEffect, useId, useMemo, useRef } from "react";
 import {
   ReactFlow,
   Controls,
@@ -73,6 +73,11 @@ function WorkflowDiffGraphInner({
   onTaskClick,
   className,
 }: WorkflowDiffGraphProps) {
+  // Instance-scoped React Flow id (oss#593): React Flow derives its internal
+  // DOM ids (aria descriptions, SVG marker/pattern defs) from this id, so two
+  // mounted graphs without explicit ids collide.
+  const flowId = useId();
+
   const {
     nodes,
     edges,
@@ -146,6 +151,7 @@ function WorkflowDiffGraphInner({
           </div>
         )}
         <ReactFlow
+          id={flowId}
           nodes={nodesWithSelection}
           edges={edges}
           nodeTypes={nodeTypes}

--- a/sdk/react/src/workflow/WorkflowOverviewGraph.tsx
+++ b/sdk/react/src/workflow/WorkflowOverviewGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   Controls,
@@ -96,6 +96,13 @@ function WorkflowOverviewGraphInner({
   nodesDraggable: draggable = false,
   className,
 }: WorkflowOverviewGraphProps) {
+  // Instance-scoped React Flow id (oss#593): React Flow derives its internal
+  // DOM ids (aria descriptions, SVG marker/pattern defs) from this id, so two
+  // mounted graphs without explicit ids collide — e.g. the zone-cached detail
+  // page renders a hidden copy whose defs hijack the visible copy's url(#…)
+  // and aria-describedby references.
+  const flowId = useId();
+
   const {
     nodes: baseNodes,
     nodesWithSelection,
@@ -216,6 +223,7 @@ function WorkflowOverviewGraphInner({
     <WorkflowGraphModeProvider mode="overview">
       <div ref={containerRef} className={cn("stg:relative stg:h-full stg:w-full", className)}>
         <ReactFlow
+          id={flowId}
           nodes={displayNodes}
           edges={edges}
           onNodesChange={draggable ? handleNodesChange : undefined}

--- a/test/e2e/tests/interactive/duplicate-dom-ids.spec.ts
+++ b/test/e2e/tests/interactive/duplicate-dom-ids.spec.ts
@@ -1,0 +1,130 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../../fixtures";
+
+/**
+ * Duplicate DOM id / radio-name audit on library detail pages
+ * (stigmer/stigmer#593).
+ *
+ * The library zone bypasses Next.js routing for detail navigation
+ * (static-export constraint): `LibraryNavigationProvider` initializes
+ * `activeDetail` from `window.location.pathname`, and `LibraryLayout`
+ * renders that overlay copy while ALSO keeping the route-rendered copy
+ * mounted (hidden + aria-hidden). On a DIRECT load of a detail URL both
+ * copies are the same detail page — so any SDK component that hardcodes a
+ * DOM id and renders it unconditionally duplicates that id, and
+ * document-order id lookup resolves label/aria-labelledby associations
+ * into the HIDDEN copy: screen readers land on aria-hidden nodes and
+ * getByLabel locators match nothing. A hardcoded radio-group `name` is the
+ * same defect with sharper teeth: radios in both copies join ONE keyboard
+ * group. (Click-through navigation arms only the overlay over the hidden
+ * LIST page, so the deep-link/reload path is the one that must be audited.)
+ *
+ * The fix (oss#593, following the oss#571 precedent) is instance-scoped
+ * ids/names minted with useId(). These specs pin that invariant on the two
+ * double-mounted surfaces that carry always-rendered dialog forms; the
+ * page-wide audit also catches any future component that regresses into
+ * hardcoded ids on these pages.
+ */
+
+/** Ids page-wide that appear more than once (always invalid HTML). */
+async function findDuplicateIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const counts = new Map<string, number>();
+    for (const el of Array.from(document.querySelectorAll("[id]"))) {
+      counts.set(el.id, (counts.get(el.id) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .filter(([, n]) => n > 1)
+      .map(([id, n]) => `${id} x${n}`);
+  });
+}
+
+/**
+ * Radio-group names whose inputs span BOTH the aria-hidden route copy and
+ * the visible overlay copy — i.e. two component instances merged into one
+ * keyboard group. (A name shared within one copy is a legitimate group.)
+ */
+async function findLeakedRadioGroups(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const groups = new Map<string, { hidden: number; visible: number }>();
+    for (const el of Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="radio"][name]'),
+    )) {
+      const g = groups.get(el.name) ?? { hidden: 0, visible: 0 };
+      if (el.closest('[aria-hidden="true"]')) g.hidden += 1;
+      else g.visible += 1;
+      groups.set(el.name, g);
+    }
+    return [...groups.entries()]
+      .filter(([, g]) => g.hidden > 0 && g.visible > 0)
+      .map(([name]) => name);
+  });
+}
+
+/**
+ * Asserts the double-mount is actually armed before auditing — a passing
+ * audit on a single-mounted page would prove nothing. Armed means the
+ * page heading exists TWICE: once in the hidden route copy, once in the
+ * visible overlay (CSS locators, unlike role locators, see through
+ * aria-hidden).
+ */
+async function auditDoubleMountedPage(page: Page, headingText: string) {
+  const diagnostics = await page.evaluate((text) => {
+    const headings = Array.from(document.querySelectorAll("h1, h2")).filter(
+      (h) => (h.textContent ?? "").includes(text),
+    );
+    const hiddenWrapper = document.querySelector('div.hidden[aria-hidden="true"]');
+    return {
+      headingCopies: headings.length,
+      hiddenWrapperPresent: hiddenWrapper !== null,
+      hiddenWrapperChildCount: hiddenWrapper?.childElementCount ?? 0,
+    };
+  }, headingText);
+  expect(
+    diagnostics.headingCopies,
+    `double-mount not armed: expected the detail heading in both the hidden route copy and the visible overlay (diagnostics: ${JSON.stringify(diagnostics)})`,
+  ).toBeGreaterThanOrEqual(2);
+
+  const duplicateIds = await findDuplicateIds(page);
+  expect(duplicateIds, `duplicate DOM ids: ${duplicateIds.join(", ")}`).toEqual([]);
+
+  const leakedGroups = await findLeakedRadioGroups(page);
+  expect(
+    leakedGroups,
+    `radio groups spanning hidden+visible copies: ${leakedGroups.join(", ")}`,
+  ).toEqual([]);
+}
+
+test.describe("Library detail pages carry no duplicate DOM ids", () => {
+  test("agent detail page (direct load arms overlay + hidden route copy)", async ({
+    page,
+    testAgent,
+  }) => {
+    await page.goto(`/library/agents/${testAgent.org}/${testAgent.slug}`);
+
+    await expect(
+      page.getByRole("heading", { name: testAgent.slug }).first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // CreateAgentInstanceDialog renders its form unconditionally (closed
+    // <dialog> still in the DOM), so before the useId fix this audit fails
+    // with the agent-instance name/description ids duplicated across the
+    // hidden and visible copies.
+    await auditDoubleMountedPage(page, testAgent.slug);
+  });
+
+  test("workflow detail page (direct load arms overlay + hidden route copy)", async ({
+    page,
+    testWorkflow,
+  }) => {
+    await page.goto(`/library/workflows/${testWorkflow.org}/${testWorkflow.slug}`);
+
+    await expect(
+      page.getByRole("heading", { name: testWorkflow.slug }).first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Guards the CreateWorkflowInstanceDialog useId fix (oss#571) and any
+    // future hardcoded-id regression on this surface.
+    await auditDoubleMountedPage(page, testWorkflow.slug);
+  });
+});


### PR DESCRIPTION
## Summary

The web console's library zone bypasses Next.js routing for detail navigation (static-export constraint), and `LibraryLayout` keeps the route-rendered copy mounted (hidden + `aria-hidden`) beneath the visible overlay copy. On a **direct load of a detail URL** (deep link / reload) both copies render the same detail page — so every hardcoded DOM id that renders unconditionally duplicates, and document-order id lookup resolves label/`aria-labelledby` associations into the **hidden** copy: screen readers land on aria-hidden nodes and `getByLabel` locators match nothing (part of the interactive-spec rot #571 re-anchored around). A hardcoded radio-group `name` is the same defect with sharper teeth: radios in both copies join one keyboard group, so arrow-key selection escapes into invisible elements.

#593's headline casualty (`CreateWorkflowInstanceDialog`) was already fixed by the #571 session; this PR kills the rest of the class on the double-mounted surfaces, mirroring that `useId()` convention:

- **`CreateAgentInstanceDialog`** — the identical live twin (`agent-instance-name` / `-description` / title), form rendered even while closed, so its ids duplicated on every agent detail deep-load
- **`ConnectSlackDialog`, `ConnectWhatsAppDialog`, `ChannelCredentialsDialog`** — title id minted in the outer dialog, threaded to the body as a prop
- **`ManageAccessDialog`** (title) and **`RoleSelector`** (radio group `name` — the keyboard-group collision)
- **`ShareAgentDialog`** — title, share name/slug field ids, enabled-switch label id
- **React Flow graphs** (`WorkflowOverviewGraph`, `WorkflowDiffGraph`, `WorkflowCanvasInner`) — found by this PR's new audit spec: React Flow derives its internal DOM ids (aria descriptions, SVG marker/pattern defs) from its instance id, so the two mounted canvases collided (`react-flow__node-desc-1 x2`, `pattern-1 x2`, …). Each mount now passes a `useId()`-minted `id` — React Flow's documented mechanism for multiple flows per page.

## Regression fence

New interactive e2e spec `test/e2e/tests/interactive/duplicate-dom-ids.spec.ts` pins the invariant where it lives: deep-loads agent and workflow detail pages, **asserts the double-mount is actually armed** (detail heading present in both copies — a vacuous pass is impossible), then audits the page for duplicate ids and radio groups leaking across the hidden/visible boundary. Red-verified: with the pre-fix dialog restored, it fails with exactly the issue's signature (`create-agent-instance-title x2, agent-instance-name x2, agent-instance-description x2`).

## Verification

- e2e audit spec: red on pre-fix code, green on this branch (both pages, armed double-mount)
- `@stigmer/react` vitest: 4326 tests / 395 files pass
- `@stigmer/react` eslint + prefix check: clean; full lib chain (`protos → sdk → theme → react`) builds
- Repo-wide grep: nothing outside these components references any renamed id (tests locate via `getByLabel`/roles — which this fix *repairs*)

## Follow-ups filed

- #619 — sweep the remaining ~50 hardcoded ids / ~10 radio names across the SDK, then fence the class with an ESLint restriction
- #621 — the `LibraryLayout` double-mount itself (render cost + design decision; desktop's layout doesn't double-mount, so the reference apps currently diverge)

Closes #593

Made with [Cursor](https://cursor.com)