### PR TITLE
feat(sdk): billing client parity for Go and Python; TS adjustCredits + ledger time filters

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -65,6 +65,23 @@ The client provides sub-clients for each resource type:
 | `client.Session`        | Session         | Get, Create, Update, Apply, Delete, List, ListByAgentInstance |
 | `client.AgentExecution` | AgentExecution  | Get, Create, Subscribe, List, ListBySession, Cancel, Pause, Resume, Terminate, Recover, SubmitApproval, UploadAttachment, GetArtifactDownloadUrl |
 | `client.Search`         | Cross-resource  | Query |
+| `client.Billing`        | Billing         | GetOrCreateBillingAccount, GetBillingAccount, GetCreditBalance, AdjustCredits, GetCreditLedger, GetBillingUsageReport, CreateCreditCheckoutSession, CreateBillingPortalSession, SetAutoRechargeConfig, GetCustomerModelPricing + operator pricing methods |
+
+## Billing
+
+Credit balance queries, ledger history, and manual credit adjustments for an
+organization. Commands require the `can_manage_billing` permission on the org:
+
+```go
+balance, err := client.Billing.GetCreditBalance(ctx, orgID)
+
+entry, err := client.Billing.AdjustCredits(ctx, &stigmer.AdjustCreditsParams{
+    OrgID:          orgID,
+    AmountMicros:   25_000_000, // +$25.00
+    Reason:         "initial tenant funding",
+    IdempotencyKey: "fund-" + orgID,
+})
+```
 
 ## Configuration
 

--- a/sdk/go/billing.go
+++ b/sdk/go/billing.go
@@ -1,0 +1,399 @@
+package stigmer
+
+import (
+	"context"
+	"time"
+
+	"github.com/stigmer/stigmer/sdk/go/v3/internal/gen"
+	billingv1 "github.com/stigmer/stigmer/sdk/go/v3/proto/ai/stigmer/billing/v1"
+	rpc "github.com/stigmer/stigmer/sdk/go/v3/proto/ai/stigmer/commons/rpc"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Proto payload re-exports for the billing bounded context. Response
+// messages are returned as-is (the search.go convention): the proto types
+// are the contract, and hand-mapped mirrors would only drift from it.
+type (
+	// BillingAccount is an organization's billing account with balance and auto-recharge config.
+	BillingAccount = billingv1.BillingAccount
+	// CreditBalance is the credit balance breakdown (available, reserved, total).
+	CreditBalance = billingv1.CreditBalance
+	// CreditLedgerEntry is one immutable credit ledger entry.
+	CreditLedgerEntry = billingv1.CreditLedgerEntry
+	// CreditLedgerResponse is a paginated page of ledger entries.
+	CreditLedgerResponse = billingv1.CreditLedgerResponse
+	// BillingUsageReportResponse is an aggregated usage report for a date range.
+	BillingUsageReportResponse = billingv1.BillingUsageReportResponse
+	// CreateCreditCheckoutSessionResponse holds the Stripe-hosted checkout URL.
+	CreateCreditCheckoutSessionResponse = billingv1.CreateCreditCheckoutSessionResponse
+	// CreateBillingPortalSessionResponse holds the Stripe-hosted portal URL.
+	CreateBillingPortalSessionResponse = billingv1.CreateBillingPortalSessionResponse
+	// CustomerModelPricingResponse is the customer-facing model price list.
+	CustomerModelPricingResponse = billingv1.CustomerModelPricingResponse
+	// ModelPricingGovernanceResponse is the operator pricing governance view.
+	ModelPricingGovernanceResponse = billingv1.ModelPricingGovernanceResponse
+	// ModelPricingBaselinesResponse is the model registry baseline catalog.
+	ModelPricingBaselinesResponse = billingv1.ModelPricingBaselinesResponse
+	// ModelPricingBaseline is one model registry baseline entry (catalog + list prices).
+	ModelPricingBaseline = billingv1.ModelPricingBaseline
+	// ModelPricingOverride is one pricing override from the feedback loop.
+	ModelPricingOverride = billingv1.ModelPricingOverride
+	// LedgerEntryType filters ledger queries to specific entry types.
+	LedgerEntryType = billingv1.LedgerEntryType
+	// LedgerView selects a server-resolved slice of the ledger.
+	LedgerView = billingv1.LedgerView
+)
+
+// AdjustCreditsParams configures a manual credit adjustment.
+type AdjustCreditsParams struct {
+	OrgID string
+	// AmountMicros is positive to add credits, negative to remove.
+	AmountMicros int64
+	// Reason is recorded on the ledger entry (audit trail).
+	Reason string
+	// IdempotencyKey deduplicates retries of the same adjustment.
+	IdempotencyKey string
+}
+
+// GetCreditLedgerParams configures a credit ledger query.
+type GetCreditLedgerParams struct {
+	OrgID string
+	// Page selects a result page; nil returns the server default page.
+	Page *Page
+	// TypeFilter narrows to specific entry types. Empty means all types.
+	TypeFilter []LedgerEntryType
+	// StartTime filters to entries on or after this timestamp. Zero means unbounded.
+	StartTime time.Time
+	// EndTime filters to entries on or before this timestamp. Zero means unbounded.
+	EndTime time.Time
+	// View selects a server-resolved ledger slice. LedgerView_ledger_view_statement
+	// returns only customer-facing money-movement entries and excludes internal
+	// mechanics (per-call usage debits, reservation holds/releases). When both
+	// View and TypeFilter are set, the effective filter is their intersection.
+	View LedgerView
+}
+
+// GetBillingUsageReportParams configures a billing usage report query.
+type GetBillingUsageReportParams struct {
+	OrgID     string
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+// CreateCheckoutSessionParams configures a Stripe Checkout Session.
+type CreateCheckoutSessionParams struct {
+	OrgID      string
+	PackID     string
+	SuccessURL string
+	CancelURL  string
+}
+
+// CreateBillingPortalSessionParams configures a Stripe Billing Portal session.
+type CreateBillingPortalSessionParams struct {
+	OrgID     string
+	ReturnURL string
+}
+
+// SetAutoRechargeConfigParams configures automatic credit recharge.
+type SetAutoRechargeConfigParams struct {
+	OrgID                string
+	Enabled              bool
+	ThresholdMicros      int64
+	RechargeAmountMicros int64
+	MonthlyCapMicros     int64
+}
+
+// GetCustomerModelPricingParams configures a customer model pricing query.
+type GetCustomerModelPricingParams struct {
+	// OrgID resolves org-specific policy overrides. Empty for default pricing.
+	OrgID string
+}
+
+// DecideModelPricingOverrideParams records a decision on a pending pricing override.
+type DecideModelPricingOverrideParams struct {
+	// OverrideID identifies the PENDING_SIGNOFF override to decide.
+	OverrideID string
+	// Approve true makes the override ACTIVE (superseding any current ACTIVE
+	// override on the same pricing key); false rejects it.
+	Approve bool
+	// DecisionNote is an optional note recorded on the decision (audit trail).
+	DecisionNote string
+}
+
+// ListModelPricingBaselinesParams configures a baseline catalog query.
+type ListModelPricingBaselinesParams struct {
+	// IncludeHistory true includes SUPERSEDED and RETIRED revisions (the full
+	// audit history). Default: ACTIVE documents only.
+	IncludeHistory bool
+}
+
+// UpsertModelPricingBaselineParams creates or revises a baseline entry.
+type UpsertModelPricingBaselineParams struct {
+	// Baseline is the entry to create or revise, keyed by
+	// (modelId, provider, harness). Lifecycle fields (baselineId, status,
+	// decision stamps, pricing effectiveAt) are server-owned and ignored.
+	Baseline *ModelPricingBaseline
+	// RevisionNote is an optional operator note recorded on the revision.
+	RevisionNote string
+}
+
+// RetireModelPricingBaselineParams retires a model from the registry catalog.
+type RetireModelPricingBaselineParams struct {
+	ModelID  string
+	Provider string
+	Harness  string
+	// RevisionNote is an optional operator note recorded on the retirement.
+	RevisionNote string
+}
+
+// BillingClient provides the billing bounded context: account provisioning,
+// balance queries, ledger history, credit purchases via Stripe Checkout, and
+// the operator model-pricing surfaces.
+//
+// Internal execution-billing RPCs (authorizeExecution, recordLlmCallUsage,
+// finalizeExecution) are not exposed — they are called only by the Temporal
+// workflow and the LLM proxy.
+type BillingClient struct {
+	command billingv1.BillingCommandControllerClient
+	query   billingv1.BillingQueryControllerClient
+}
+
+func newBillingClient(conn grpc.ClientConnInterface) *BillingClient {
+	return &BillingClient{
+		command: billingv1.NewBillingCommandControllerClient(conn),
+		query:   billingv1.NewBillingQueryControllerClient(conn),
+	}
+}
+
+// GetOrCreateBillingAccount provisions or retrieves the billing account for
+// an organization. Idempotent: creates the account on first call, returns the
+// existing account on subsequent calls.
+func (b *BillingClient) GetOrCreateBillingAccount(ctx context.Context, orgID string) (*BillingAccount, error) {
+	resp, err := b.command.GetOrCreateBillingAccount(ctx, &billingv1.GetOrCreateBillingAccountInput{OrgId: orgID})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// GetBillingAccount retrieves the billing account for an organization.
+func (b *BillingClient) GetBillingAccount(ctx context.Context, orgID string) (*BillingAccount, error) {
+	resp, err := b.query.GetBillingAccount(ctx, &billingv1.GetBillingAccountInput{OrgId: orgID})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// GetCreditBalance retrieves the credit balance breakdown for an organization.
+func (b *BillingClient) GetCreditBalance(ctx context.Context, orgID string) (*CreditBalance, error) {
+	resp, err := b.query.GetCreditBalance(ctx, &billingv1.GetCreditBalanceInput{OrgId: orgID})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// AdjustCredits manually adjusts an organization's credit balance.
+//
+// Positive AmountMicros adds credits (e.g. funding a tenant org), negative
+// removes them. The adjustment is recorded as a ledger entry with the
+// supplied reason; the idempotency key deduplicates retries. Requires
+// can_manage_billing on the org.
+func (b *BillingClient) AdjustCredits(ctx context.Context, params *AdjustCreditsParams) (*CreditLedgerEntry, error) {
+	resp, err := b.command.AdjustCredits(ctx, &billingv1.AdjustCreditsInput{
+		OrgId:          params.OrgID,
+		AmountMicros:   params.AmountMicros,
+		Reason:         params.Reason,
+		IdempotencyKey: params.IdempotencyKey,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// GetCreditLedger retrieves paginated credit ledger entries with optional filters.
+func (b *BillingClient) GetCreditLedger(ctx context.Context, params *GetCreditLedgerParams) (*CreditLedgerResponse, error) {
+	req := &billingv1.GetCreditLedgerInput{
+		OrgId:      params.OrgID,
+		TypeFilter: params.TypeFilter,
+		View:       params.View,
+	}
+	if params.Page != nil {
+		req.Page = &rpc.PageInfo{Num: params.Page.Num, Size: params.Page.Size}
+	}
+	if !params.StartTime.IsZero() {
+		req.StartTime = timestamppb.New(params.StartTime)
+	}
+	if !params.EndTime.IsZero() {
+		req.EndTime = timestamppb.New(params.EndTime)
+	}
+	resp, err := b.query.GetCreditLedger(ctx, req)
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// GetBillingUsageReport retrieves an aggregated billing usage report for a
+// date range: total provider cost, total billable amount, execution and LLM
+// call counts, and a per-model breakdown with cost tier attribution.
+func (b *BillingClient) GetBillingUsageReport(ctx context.Context, params *GetBillingUsageReportParams) (*BillingUsageReportResponse, error) {
+	resp, err := b.query.GetBillingUsageReport(ctx, &billingv1.GetBillingUsageReportInput{
+		OrgId:     params.OrgID,
+		StartTime: timestamppb.New(params.StartTime),
+		EndTime:   timestamppb.New(params.EndTime),
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// CreateCreditCheckoutSession creates a Stripe Checkout Session to purchase a
+// credit pack. The caller should redirect the user to the returned checkout
+// URL; credits are provisioned asynchronously via webhook after payment.
+func (b *BillingClient) CreateCreditCheckoutSession(ctx context.Context, params *CreateCheckoutSessionParams) (*CreateCreditCheckoutSessionResponse, error) {
+	resp, err := b.command.CreateCreditCheckoutSession(ctx, &billingv1.CreateCreditCheckoutSessionInput{
+		OrgId:      params.OrgID,
+		PackId:     params.PackID,
+		SuccessUrl: params.SuccessURL,
+		CancelUrl:  params.CancelURL,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// CreateBillingPortalSession creates a Stripe Billing Portal session for
+// payment method management. The caller should redirect the user to the
+// returned portal URL; changes are synced back via webhooks.
+func (b *BillingClient) CreateBillingPortalSession(ctx context.Context, params *CreateBillingPortalSessionParams) (*CreateBillingPortalSessionResponse, error) {
+	resp, err := b.command.CreateBillingPortalSession(ctx, &billingv1.CreateBillingPortalSessionInput{
+		OrgId:     params.OrgID,
+		ReturnUrl: params.ReturnURL,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// SetAutoRechargeConfig configures automatic credit recharge for an
+// organization. When enabled, the billing system charges the account's saved
+// payment method whenever the available balance drops below the configured
+// threshold. Returns the updated BillingAccount.
+func (b *BillingClient) SetAutoRechargeConfig(ctx context.Context, params *SetAutoRechargeConfigParams) (*BillingAccount, error) {
+	resp, err := b.command.SetAutoRechargeConfig(ctx, &billingv1.SetAutoRechargeConfigInput{
+		OrgId:                params.OrgID,
+		Enabled:              params.Enabled,
+		ThresholdMicros:      params.ThresholdMicros,
+		RechargeAmountMicros: params.RechargeAmountMicros,
+		MonthlyCapMicros:     params.MonthlyCapMicros,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// GetCustomerModelPricing retrieves the customer-facing model price list with
+// markup applied — the prices the customer pays, organized by harness and
+// cost tier. Pass params to resolve org-specific policy overrides; nil params
+// returns default pricing.
+func (b *BillingClient) GetCustomerModelPricing(ctx context.Context, params *GetCustomerModelPricingParams) (*CustomerModelPricingResponse, error) {
+	req := &billingv1.GetCustomerModelPricingInput{}
+	if params != nil {
+		req.OrgId = params.OrgID
+	}
+	resp, err := b.query.GetCustomerModelPricing(ctx, req)
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// GetModelPricingGovernance retrieves the platform pricing governance view:
+// baseline vs effective rates per model, ACTIVE override provenance, and
+// pending sign-off proposals from the pricing feedback loop.
+//
+// Platform-operator surface (can_manage_model_pricing on platform:stigmer):
+// rates are raw provider prices, pre-markup.
+func (b *BillingClient) GetModelPricingGovernance(ctx context.Context) (*ModelPricingGovernanceResponse, error) {
+	resp, err := b.query.GetModelPricingGovernance(ctx, &billingv1.GetModelPricingGovernanceInput{})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// ListModelPricingBaselines retrieves the model registry baseline catalog:
+// ACTIVE entries by default, or the full append-only revision history with
+// IncludeHistory. Nil params lists ACTIVE entries.
+//
+// Platform-operator surface (can_manage_model_pricing on platform:stigmer):
+// rates are raw provider prices, pre-markup.
+func (b *BillingClient) ListModelPricingBaselines(ctx context.Context, params *ListModelPricingBaselinesParams) (*ModelPricingBaselinesResponse, error) {
+	req := &billingv1.ListModelPricingBaselinesInput{}
+	if params != nil {
+		req.IncludeHistory = params.IncludeHistory
+	}
+	resp, err := b.query.ListModelPricingBaselines(ctx, req)
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// DecideModelPricingOverride records a human decision on a PENDING_SIGNOFF
+// pricing override. Approving makes the override ACTIVE (superseding any
+// current ACTIVE override on the same pricing key) and recomposes the
+// effective registry; rejecting archives it for audit. Returns the decided
+// override with the decision stamped.
+func (b *BillingClient) DecideModelPricingOverride(ctx context.Context, params *DecideModelPricingOverrideParams) (*ModelPricingOverride, error) {
+	resp, err := b.command.DecideModelPricingOverride(ctx, &billingv1.DecideModelPricingOverrideInput{
+		OverrideId:   params.OverrideID,
+		Approve:      params.Approve,
+		DecisionNote: params.DecisionNote,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// UpsertModelPricingBaseline creates or revises one model registry baseline
+// entry (catalog + list prices). Append-only: an existing ACTIVE entry for
+// the same (modelId, provider, harness) key is superseded, never mutated, and
+// the effective registry recomposes immediately. Returns the new revision
+// with server-stamped lifecycle fields.
+func (b *BillingClient) UpsertModelPricingBaseline(ctx context.Context, params *UpsertModelPricingBaselineParams) (*ModelPricingBaseline, error) {
+	resp, err := b.command.UpsertModelPricingBaseline(ctx, &billingv1.UpsertModelPricingBaselineInput{
+		Baseline:     params.Baseline,
+		RevisionNote: params.RevisionNote,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}
+
+// RetireModelPricingBaseline retires one model from the registry catalog.
+// The model disappears from every price surface on the next composition pass;
+// the document is kept for audit and the key can be revived by a subsequent
+// upsert.
+func (b *BillingClient) RetireModelPricingBaseline(ctx context.Context, params *RetireModelPricingBaselineParams) (*ModelPricingBaseline, error) {
+	resp, err := b.command.RetireModelPricingBaseline(ctx, &billingv1.RetireModelPricingBaselineInput{
+		ModelId:      params.ModelID,
+		Provider:     params.Provider,
+		Harness:      params.Harness,
+		RevisionNote: params.RevisionNote,
+	})
+	if err != nil {
+		return nil, gen.WrapErr(err)
+	}
+	return resp, nil
+}

--- a/sdk/go/billing_test.go
+++ b/sdk/go/billing_test.go
@@ -1,0 +1,330 @@
+package stigmer
+
+// Wire-shape tests for BillingClient: each test injects a fake generated stub
+// that captures the outgoing request proto and returns a canned response, then
+// asserts the SDK params mapped onto the right proto fields. This mirrors
+// sdk/java's BillingClientTest and is the reference pattern for testing the
+// handwritten (non-resource) clients.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	billingv1 "github.com/stigmer/stigmer/sdk/go/v3/proto/ai/stigmer/billing/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeBillingCommand captures requests to the command controller. Only the
+// RPCs exercised by tests are implemented with capture-and-respond bodies;
+// the engine-internal RPCs return nil because the SDK never calls them.
+type fakeBillingCommand struct {
+	billingv1.BillingCommandControllerClient
+
+	adjustCreditsIn  *billingv1.AdjustCreditsInput
+	adjustCreditsOut *billingv1.CreditLedgerEntry
+	adjustCreditsErr error
+
+	autoRechargeIn *billingv1.SetAutoRechargeConfigInput
+	checkoutIn     *billingv1.CreateCreditCheckoutSessionInput
+	retireIn       *billingv1.RetireModelPricingBaselineInput
+}
+
+func (f *fakeBillingCommand) AdjustCredits(_ context.Context, in *billingv1.AdjustCreditsInput, _ ...grpc.CallOption) (*billingv1.CreditLedgerEntry, error) {
+	f.adjustCreditsIn = in
+	if f.adjustCreditsErr != nil {
+		return nil, f.adjustCreditsErr
+	}
+	return f.adjustCreditsOut, nil
+}
+
+func (f *fakeBillingCommand) SetAutoRechargeConfig(_ context.Context, in *billingv1.SetAutoRechargeConfigInput, _ ...grpc.CallOption) (*billingv1.BillingAccount, error) {
+	f.autoRechargeIn = in
+	return &billingv1.BillingAccount{}, nil
+}
+
+func (f *fakeBillingCommand) CreateCreditCheckoutSession(_ context.Context, in *billingv1.CreateCreditCheckoutSessionInput, _ ...grpc.CallOption) (*billingv1.CreateCreditCheckoutSessionResponse, error) {
+	f.checkoutIn = in
+	return &billingv1.CreateCreditCheckoutSessionResponse{}, nil
+}
+
+func (f *fakeBillingCommand) RetireModelPricingBaseline(_ context.Context, in *billingv1.RetireModelPricingBaselineInput, _ ...grpc.CallOption) (*billingv1.ModelPricingBaseline, error) {
+	f.retireIn = in
+	return &billingv1.ModelPricingBaseline{}, nil
+}
+
+// fakeBillingQuery captures requests to the query controller.
+type fakeBillingQuery struct {
+	billingv1.BillingQueryControllerClient
+
+	ledgerIn  *billingv1.GetCreditLedgerInput
+	usageIn   *billingv1.GetBillingUsageReportInput
+	pricingIn *billingv1.GetCustomerModelPricingInput
+	listIn    *billingv1.ListModelPricingBaselinesInput
+}
+
+func (f *fakeBillingQuery) GetCreditLedger(_ context.Context, in *billingv1.GetCreditLedgerInput, _ ...grpc.CallOption) (*billingv1.CreditLedgerResponse, error) {
+	f.ledgerIn = in
+	return &billingv1.CreditLedgerResponse{}, nil
+}
+
+func (f *fakeBillingQuery) GetBillingUsageReport(_ context.Context, in *billingv1.GetBillingUsageReportInput, _ ...grpc.CallOption) (*billingv1.BillingUsageReportResponse, error) {
+	f.usageIn = in
+	return &billingv1.BillingUsageReportResponse{}, nil
+}
+
+func (f *fakeBillingQuery) GetCustomerModelPricing(_ context.Context, in *billingv1.GetCustomerModelPricingInput, _ ...grpc.CallOption) (*billingv1.CustomerModelPricingResponse, error) {
+	f.pricingIn = in
+	return &billingv1.CustomerModelPricingResponse{}, nil
+}
+
+func (f *fakeBillingQuery) ListModelPricingBaselines(_ context.Context, in *billingv1.ListModelPricingBaselinesInput, _ ...grpc.CallOption) (*billingv1.ModelPricingBaselinesResponse, error) {
+	f.listIn = in
+	return &billingv1.ModelPricingBaselinesResponse{}, nil
+}
+
+func TestBillingAdjustCredits_MapsParams(t *testing.T) {
+	fake := &fakeBillingCommand{
+		adjustCreditsOut: &billingv1.CreditLedgerEntry{AmountMicros: 25_000_000},
+	}
+	client := &BillingClient{command: fake}
+
+	entry, err := client.AdjustCredits(context.Background(), &AdjustCreditsParams{
+		OrgID:          "acme",
+		AmountMicros:   25_000_000,
+		Reason:         "initial tenant funding",
+		IdempotencyKey: "fund-acme-001",
+	})
+	if err != nil {
+		t.Fatalf("AdjustCredits: %v", err)
+	}
+	if entry.GetAmountMicros() != 25_000_000 {
+		t.Errorf("entry.AmountMicros = %d, want 25000000", entry.GetAmountMicros())
+	}
+
+	in := fake.adjustCreditsIn
+	if in.GetOrgId() != "acme" {
+		t.Errorf("OrgId = %q, want acme", in.GetOrgId())
+	}
+	if in.GetAmountMicros() != 25_000_000 {
+		t.Errorf("AmountMicros = %d, want 25000000", in.GetAmountMicros())
+	}
+	if in.GetReason() != "initial tenant funding" {
+		t.Errorf("Reason = %q", in.GetReason())
+	}
+	if in.GetIdempotencyKey() != "fund-acme-001" {
+		t.Errorf("IdempotencyKey = %q", in.GetIdempotencyKey())
+	}
+}
+
+func TestBillingAdjustCredits_WrapsGRPCError(t *testing.T) {
+	fake := &fakeBillingCommand{
+		adjustCreditsErr: status.Error(codes.PermissionDenied, "can_manage_billing required"),
+	}
+	client := &BillingClient{command: fake}
+
+	_, err := client.AdjustCredits(context.Background(), &AdjustCreditsParams{OrgID: "acme"})
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) {
+		t.Fatalf("error = %v (%T), want *stigmer.Error", err, err)
+	}
+	if sdkErr.GRPCCode != codes.PermissionDenied {
+		t.Errorf("GRPCCode = %v, want PermissionDenied", sdkErr.GRPCCode)
+	}
+}
+
+func TestBillingGetCreditLedger_MapsAllFilters(t *testing.T) {
+	fake := &fakeBillingQuery{}
+	client := &BillingClient{query: fake}
+
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	_, err := client.GetCreditLedger(context.Background(), &GetCreditLedgerParams{
+		OrgID:      "acme",
+		Page:       &Page{Num: 2, Size: 50},
+		TypeFilter: []LedgerEntryType{billingv1.LedgerEntryType_adjustment_credit},
+		StartTime:  start,
+		EndTime:    end,
+		View:       billingv1.LedgerView_ledger_view_statement,
+	})
+	if err != nil {
+		t.Fatalf("GetCreditLedger: %v", err)
+	}
+
+	in := fake.ledgerIn
+	if in.GetOrgId() != "acme" {
+		t.Errorf("OrgId = %q, want acme", in.GetOrgId())
+	}
+	if in.GetPage().GetNum() != 2 || in.GetPage().GetSize() != 50 {
+		t.Errorf("Page = %v, want num=2 size=50", in.GetPage())
+	}
+	if len(in.GetTypeFilter()) != 1 || in.GetTypeFilter()[0] != billingv1.LedgerEntryType_adjustment_credit {
+		t.Errorf("TypeFilter = %v", in.GetTypeFilter())
+	}
+	if got := in.GetStartTime().AsTime(); !got.Equal(start) {
+		t.Errorf("StartTime = %v, want %v", got, start)
+	}
+	if got := in.GetEndTime().AsTime(); !got.Equal(end) {
+		t.Errorf("EndTime = %v, want %v", got, end)
+	}
+	if in.GetView() != billingv1.LedgerView_ledger_view_statement {
+		t.Errorf("View = %v, want statement", in.GetView())
+	}
+}
+
+func TestBillingGetCreditLedger_OmitsUnsetOptionals(t *testing.T) {
+	fake := &fakeBillingQuery{}
+	client := &BillingClient{query: fake}
+
+	if _, err := client.GetCreditLedger(context.Background(), &GetCreditLedgerParams{OrgID: "acme"}); err != nil {
+		t.Fatalf("GetCreditLedger: %v", err)
+	}
+
+	in := fake.ledgerIn
+	if in.GetPage() != nil {
+		t.Errorf("Page = %v, want nil", in.GetPage())
+	}
+	if in.GetStartTime() != nil || in.GetEndTime() != nil {
+		t.Errorf("time range = [%v, %v], want unset", in.GetStartTime(), in.GetEndTime())
+	}
+	if in.GetView() != billingv1.LedgerView_ledger_view_unspecified {
+		t.Errorf("View = %v, want unspecified", in.GetView())
+	}
+}
+
+func TestBillingGetBillingUsageReport_MapsTimestamps(t *testing.T) {
+	fake := &fakeBillingQuery{}
+	client := &BillingClient{query: fake}
+
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC)
+	if _, err := client.GetBillingUsageReport(context.Background(), &GetBillingUsageReportParams{
+		OrgID:     "acme",
+		StartTime: start,
+		EndTime:   end,
+	}); err != nil {
+		t.Fatalf("GetBillingUsageReport: %v", err)
+	}
+
+	in := fake.usageIn
+	if in.GetOrgId() != "acme" {
+		t.Errorf("OrgId = %q, want acme", in.GetOrgId())
+	}
+	if got := in.GetStartTime().AsTime(); !got.Equal(start) {
+		t.Errorf("StartTime = %v, want %v", got, start)
+	}
+	if got := in.GetEndTime().AsTime(); !got.Equal(end) {
+		t.Errorf("EndTime = %v, want %v", got, end)
+	}
+}
+
+func TestBillingSetAutoRechargeConfig_MapsParams(t *testing.T) {
+	fake := &fakeBillingCommand{}
+	client := &BillingClient{command: fake}
+
+	if _, err := client.SetAutoRechargeConfig(context.Background(), &SetAutoRechargeConfigParams{
+		OrgID:                "acme",
+		Enabled:              true,
+		ThresholdMicros:      5_000_000,
+		RechargeAmountMicros: 20_000_000,
+		MonthlyCapMicros:     100_000_000,
+	}); err != nil {
+		t.Fatalf("SetAutoRechargeConfig: %v", err)
+	}
+
+	in := fake.autoRechargeIn
+	if !in.GetEnabled() {
+		t.Error("Enabled = false, want true")
+	}
+	if in.GetThresholdMicros() != 5_000_000 ||
+		in.GetRechargeAmountMicros() != 20_000_000 ||
+		in.GetMonthlyCapMicros() != 100_000_000 {
+		t.Errorf("micros = (%d, %d, %d), want (5000000, 20000000, 100000000)",
+			in.GetThresholdMicros(), in.GetRechargeAmountMicros(), in.GetMonthlyCapMicros())
+	}
+}
+
+func TestBillingCreateCreditCheckoutSession_MapsParams(t *testing.T) {
+	fake := &fakeBillingCommand{}
+	client := &BillingClient{command: fake}
+
+	if _, err := client.CreateCreditCheckoutSession(context.Background(), &CreateCheckoutSessionParams{
+		OrgID:      "acme",
+		PackID:     "pack-25",
+		SuccessURL: "https://app.example.com/billing?ok=1",
+		CancelURL:  "https://app.example.com/billing",
+	}); err != nil {
+		t.Fatalf("CreateCreditCheckoutSession: %v", err)
+	}
+
+	in := fake.checkoutIn
+	if in.GetPackId() != "pack-25" {
+		t.Errorf("PackId = %q, want pack-25", in.GetPackId())
+	}
+	if in.GetSuccessUrl() != "https://app.example.com/billing?ok=1" || in.GetCancelUrl() != "https://app.example.com/billing" {
+		t.Errorf("urls = (%q, %q)", in.GetSuccessUrl(), in.GetCancelUrl())
+	}
+}
+
+func TestBillingGetCustomerModelPricing_NilParamsMeansDefaultPricing(t *testing.T) {
+	fake := &fakeBillingQuery{}
+	client := &BillingClient{query: fake}
+
+	if _, err := client.GetCustomerModelPricing(context.Background(), nil); err != nil {
+		t.Fatalf("GetCustomerModelPricing: %v", err)
+	}
+	if fake.pricingIn.GetOrgId() != "" {
+		t.Errorf("OrgId = %q, want empty for default pricing", fake.pricingIn.GetOrgId())
+	}
+
+	if _, err := client.GetCustomerModelPricing(context.Background(), &GetCustomerModelPricingParams{OrgID: "acme"}); err != nil {
+		t.Fatalf("GetCustomerModelPricing: %v", err)
+	}
+	if fake.pricingIn.GetOrgId() != "acme" {
+		t.Errorf("OrgId = %q, want acme", fake.pricingIn.GetOrgId())
+	}
+}
+
+func TestBillingListModelPricingBaselines_NilParamsMeansActiveOnly(t *testing.T) {
+	fake := &fakeBillingQuery{}
+	client := &BillingClient{query: fake}
+
+	if _, err := client.ListModelPricingBaselines(context.Background(), nil); err != nil {
+		t.Fatalf("ListModelPricingBaselines: %v", err)
+	}
+	if fake.listIn.GetIncludeHistory() {
+		t.Error("IncludeHistory = true, want false for nil params")
+	}
+
+	if _, err := client.ListModelPricingBaselines(context.Background(), &ListModelPricingBaselinesParams{IncludeHistory: true}); err != nil {
+		t.Fatalf("ListModelPricingBaselines: %v", err)
+	}
+	if !fake.listIn.GetIncludeHistory() {
+		t.Error("IncludeHistory = false, want true")
+	}
+}
+
+func TestBillingRetireModelPricingBaseline_MapsKey(t *testing.T) {
+	fake := &fakeBillingCommand{}
+	client := &BillingClient{command: fake}
+
+	if _, err := client.RetireModelPricingBaseline(context.Background(), &RetireModelPricingBaselineParams{
+		ModelID:      "claude-sonnet-4.5",
+		Provider:     "anthropic",
+		Harness:      "native",
+		RevisionNote: "deprecated upstream",
+	}); err != nil {
+		t.Fatalf("RetireModelPricingBaseline: %v", err)
+	}
+
+	in := fake.retireIn
+	if in.GetModelId() != "claude-sonnet-4.5" || in.GetProvider() != "anthropic" || in.GetHarness() != "native" {
+		t.Errorf("key = (%q, %q, %q)", in.GetModelId(), in.GetProvider(), in.GetHarness())
+	}
+	if in.GetRevisionNote() != "deprecated upstream" {
+		t.Errorf("RevisionNote = %q", in.GetRevisionNote())
+	}
+}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -16,11 +16,13 @@ import (
 // to interact with the Stigmer platform.
 //
 // All resource clients (Agent, Skill, Organization, etc.) are available
-// via the embedded gen.Client. The Search and GitHub clients are added separately.
+// via the embedded gen.Client. The Search, GitHub and Billing clients are
+// added separately (non-resource bounded contexts get handwritten clients).
 type Client struct {
 	*gen.Client
-	Search *SearchClient
-	GitHub *GitHubClient
+	Search  *SearchClient
+	GitHub  *GitHubClient
+	Billing *BillingClient
 
 	// DefaultExecutionTarget is applied as the default for session and
 	// workflow execution creation when the per-call input does not
@@ -85,6 +87,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 		Client:                 gen.NewClient(conn),
 		Search:                 newSearchClient(conn),
 		GitHub:                 newGitHubClient(conn),
+		Billing:                newBillingClient(conn),
 		DefaultExecutionTarget: cfg.executionTarget,
 		RunnerAdapter:          cfg.runnerAdapter,
 		conn:                   conn,

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -104,6 +104,25 @@ with StigmerClient("sk_live_abc123") as client:
     ))
 ```
 
+## Billing
+
+Credit balance queries, ledger history, and manual credit adjustments for an
+organization. Commands require the `can_manage_billing` permission on the org:
+
+```python
+from stigmer import StigmerClient, AdjustCreditsParams
+
+with StigmerClient("sk_live_abc123") as client:
+    balance = client.billing.get_credit_balance(org_id)
+
+    entry = client.billing.adjust_credits(AdjustCreditsParams(
+        org_id=org_id,
+        amount_micros=25_000_000,  # +$25.00
+        reason="initial tenant funding",
+        idempotency_key=f"fund-{org_id}",
+    ))
+```
+
 ## Error Handling
 
 All SDK operations raise `StigmerError` with structured error codes:

--- a/sdk/python/src/stigmer/__init__.py
+++ b/sdk/python/src/stigmer/__init__.py
@@ -9,6 +9,18 @@ Usage::
         print(agent.metadata.name)
 """
 
+from ._billing import (
+    AdjustCreditsParams,
+    BillingClient,
+    CreateBillingPortalSessionParams,
+    CreateCheckoutSessionParams,
+    DecideModelPricingOverrideParams,
+    GetBillingUsageReportParams,
+    GetCreditLedgerParams,
+    RetireModelPricingBaselineParams,
+    SetAutoRechargeConfigParams,
+    UpsertModelPricingBaselineParams,
+)
 from ._client import StigmerClient
 from ._runner_adapter import RunnerAdapter
 from ._github import (
@@ -111,6 +123,17 @@ __all__ = [
     "StigmerClient",
     # Runner adapter
     "RunnerAdapter",
+    # Billing
+    "AdjustCreditsParams",
+    "BillingClient",
+    "CreateBillingPortalSessionParams",
+    "CreateCheckoutSessionParams",
+    "DecideModelPricingOverrideParams",
+    "GetBillingUsageReportParams",
+    "GetCreditLedgerParams",
+    "RetireModelPricingBaselineParams",
+    "SetAutoRechargeConfigParams",
+    "UpsertModelPricingBaselineParams",
     # GitHub
     "ExchangeOAuthCodeParams",
     "GetOAuthAuthorizeUrlParams",

--- a/sdk/python/src/stigmer/_billing.py
+++ b/sdk/python/src/stigmer/_billing.py
@@ -1,0 +1,408 @@
+"""Billing client for the Stigmer SDK."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import grpc
+
+from ai.stigmer.billing.v1 import billing_account_pb2
+from ai.stigmer.billing.v1 import command_pb2_grpc
+from ai.stigmer.billing.v1 import credit_pb2
+from ai.stigmer.billing.v1 import io_pb2 as billing_io_pb2
+from ai.stigmer.billing.v1 import model_pricing_baseline_pb2
+from ai.stigmer.billing.v1 import pricing_override_pb2
+from ai.stigmer.billing.v1 import query_pb2_grpc
+from ai.stigmer.commons.rpc import pagination_pb2
+
+from ._gen._errors import wrap_error
+from ._gen._types import Page
+
+
+@dataclass
+class AdjustCreditsParams:
+    """Parameters for a manual credit adjustment."""
+
+    org_id: str
+    amount_micros: int
+    """Positive to add credits, negative to remove."""
+    reason: str
+    """Human-readable reason recorded on the ledger entry (audit trail)."""
+    idempotency_key: str
+    """Client-supplied deduplication key to prevent double-processing."""
+
+
+@dataclass
+class GetCreditLedgerParams:
+    """Parameters for querying the credit ledger."""
+
+    org_id: str
+    page: Page | None = None
+    type_filter: list[int] = field(default_factory=list)
+    """Filter to specific ``LedgerEntryType`` values. Empty means all types."""
+    start_time: datetime | None = None
+    """Filter to entries on or after this timestamp."""
+    end_time: datetime | None = None
+    """Filter to entries on or before this timestamp."""
+    view: int = 0
+    """Server-resolved ledger slice (``LedgerView``). ``ledger_view_statement``
+    returns only customer-facing money-movement entries and excludes internal
+    mechanics (per-call usage debits, reservation holds/releases). When both
+    ``view`` and ``type_filter`` are set, the effective filter is their
+    intersection."""
+
+
+@dataclass
+class GetBillingUsageReportParams:
+    """Parameters for querying the billing usage report."""
+
+    org_id: str
+    start_time: datetime
+    end_time: datetime
+
+
+@dataclass
+class CreateCheckoutSessionParams:
+    """Parameters for creating a Stripe Checkout Session."""
+
+    org_id: str
+    pack_id: str
+    success_url: str
+    cancel_url: str
+
+
+@dataclass
+class CreateBillingPortalSessionParams:
+    """Parameters for creating a Stripe Billing Portal session."""
+
+    org_id: str
+    return_url: str
+
+
+@dataclass
+class SetAutoRechargeConfigParams:
+    """Parameters for configuring auto-recharge."""
+
+    org_id: str
+    enabled: bool
+    threshold_micros: int
+    recharge_amount_micros: int
+    monthly_cap_micros: int
+
+
+@dataclass
+class DecideModelPricingOverrideParams:
+    """Parameters for deciding a pending pricing override."""
+
+    override_id: str
+    """The PENDING_SIGNOFF override to decide."""
+    approve: bool
+    """``True`` approves (the override becomes ACTIVE and supersedes any
+    current ACTIVE override on the same pricing key); ``False`` rejects."""
+    decision_note: str = ""
+    """Optional note recorded on the decision for the audit trail."""
+
+
+@dataclass
+class UpsertModelPricingBaselineParams:
+    """Parameters for creating or revising a model registry baseline entry."""
+
+    baseline: model_pricing_baseline_pb2.ModelPricingBaseline
+    """The baseline entry to create or revise, keyed by
+    (model_id, provider, harness). Lifecycle fields (baseline_id, status,
+    decision stamps, pricing effective_at) are server-owned and ignored."""
+    revision_note: str = ""
+    """Optional operator note recorded on the revision for the audit trail."""
+
+
+@dataclass
+class RetireModelPricingBaselineParams:
+    """Parameters for retiring a model from the registry catalog."""
+
+    model_id: str
+    provider: str
+    harness: str
+    revision_note: str = ""
+    """Optional operator note recorded on the retirement."""
+
+
+class BillingClient:
+    """Billing bounded-context client.
+
+    Wraps the user-facing billing RPCs: account provisioning, balance
+    queries, ledger history, credit purchases via Stripe Checkout, and the
+    operator model-pricing surfaces.  Responses are returned as proto
+    messages — the proto types are the contract.
+
+    Internal execution-billing RPCs (``authorizeExecution``,
+    ``recordLlmCallUsage``, ``finalizeExecution``) are not exposed — they
+    are called only by the Temporal workflow and the LLM proxy.
+    """
+
+    def __init__(self, channel: grpc.Channel) -> None:
+        self._command = command_pb2_grpc.BillingCommandControllerStub(channel)
+        self._query = query_pb2_grpc.BillingQueryControllerStub(channel)
+
+    # ── Account & balance ────────────────────────────────────────────────
+
+    def get_or_create_billing_account(
+        self, org_id: str
+    ) -> billing_account_pb2.BillingAccount:
+        """Provision or retrieve the billing account for an organization.
+
+        Idempotent: creates the account on first call, returns the existing
+        account on subsequent calls.
+        """
+        req = billing_io_pb2.GetOrCreateBillingAccountInput(org_id=org_id)
+        try:
+            return self._command.getOrCreateBillingAccount(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def get_billing_account(self, org_id: str) -> billing_account_pb2.BillingAccount:
+        """Retrieve the billing account for an organization."""
+        req = billing_io_pb2.GetBillingAccountInput(org_id=org_id)
+        try:
+            return self._query.getBillingAccount(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def get_credit_balance(self, org_id: str) -> billing_account_pb2.CreditBalance:
+        """Retrieve the credit balance breakdown for an organization."""
+        req = billing_io_pb2.GetCreditBalanceInput(org_id=org_id)
+        try:
+            return self._query.getCreditBalance(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def adjust_credits(
+        self, params: AdjustCreditsParams
+    ) -> credit_pb2.CreditLedgerEntry:
+        """Manually adjust an organization's credit balance.
+
+        Positive ``amount_micros`` adds credits (e.g. funding a tenant org),
+        negative removes them.  The adjustment is recorded as a ledger entry
+        with the supplied reason; the idempotency key deduplicates retries.
+        Requires ``can_manage_billing`` on the org.
+        """
+        req = billing_io_pb2.AdjustCreditsInput(
+            org_id=params.org_id,
+            amount_micros=params.amount_micros,
+            reason=params.reason,
+            idempotency_key=params.idempotency_key,
+        )
+        try:
+            return self._command.adjustCredits(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def get_credit_ledger(
+        self, params: GetCreditLedgerParams
+    ) -> billing_io_pb2.CreditLedgerResponse:
+        """Retrieve paginated credit ledger entries with optional filters."""
+        req = billing_io_pb2.GetCreditLedgerInput(
+            org_id=params.org_id,
+            type_filter=params.type_filter,
+            view=params.view,
+        )
+        if params.page is not None:
+            req.page.CopyFrom(
+                pagination_pb2.PageInfo(num=params.page.num, size=params.page.size)
+            )
+        if params.start_time is not None:
+            req.start_time.FromDatetime(params.start_time)
+        if params.end_time is not None:
+            req.end_time.FromDatetime(params.end_time)
+        try:
+            return self._query.getCreditLedger(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def get_billing_usage_report(
+        self, params: GetBillingUsageReportParams
+    ) -> billing_io_pb2.BillingUsageReportResponse:
+        """Retrieve an aggregated billing usage report for a date range.
+
+        Returns total provider cost, total billable amount, execution and
+        LLM call counts, and a per-model breakdown with cost tier attribution.
+        """
+        req = billing_io_pb2.GetBillingUsageReportInput(org_id=params.org_id)
+        req.start_time.FromDatetime(params.start_time)
+        req.end_time.FromDatetime(params.end_time)
+        try:
+            return self._query.getBillingUsageReport(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    # ── Stripe ───────────────────────────────────────────────────────────
+
+    def create_credit_checkout_session(
+        self, params: CreateCheckoutSessionParams
+    ) -> billing_io_pb2.CreateCreditCheckoutSessionResponse:
+        """Create a Stripe Checkout Session to purchase a credit pack.
+
+        Returns the Stripe-hosted checkout URL.  The caller should redirect
+        the user to ``checkout_url`` to complete payment; credits are
+        provisioned asynchronously via webhook after payment succeeds.
+        """
+        req = billing_io_pb2.CreateCreditCheckoutSessionInput(
+            org_id=params.org_id,
+            pack_id=params.pack_id,
+            success_url=params.success_url,
+            cancel_url=params.cancel_url,
+        )
+        try:
+            return self._command.createCreditCheckoutSession(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def create_billing_portal_session(
+        self, params: CreateBillingPortalSessionParams
+    ) -> billing_io_pb2.CreateBillingPortalSessionResponse:
+        """Create a Stripe Billing Portal session for payment method management.
+
+        Returns the Stripe-hosted portal URL.  The caller should redirect the
+        user to ``portal_url``; changes are synced back via webhooks.
+        """
+        req = billing_io_pb2.CreateBillingPortalSessionInput(
+            org_id=params.org_id,
+            return_url=params.return_url,
+        )
+        try:
+            return self._command.createBillingPortalSession(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def set_auto_recharge_config(
+        self, params: SetAutoRechargeConfigParams
+    ) -> billing_account_pb2.BillingAccount:
+        """Configure automatic credit recharge for an organization.
+
+        When enabled, the billing system charges the account's saved payment
+        method whenever the available balance drops below the configured
+        threshold.  Returns the updated ``BillingAccount``.
+        """
+        req = billing_io_pb2.SetAutoRechargeConfigInput(
+            org_id=params.org_id,
+            enabled=params.enabled,
+            threshold_micros=params.threshold_micros,
+            recharge_amount_micros=params.recharge_amount_micros,
+            monthly_cap_micros=params.monthly_cap_micros,
+        )
+        try:
+            return self._command.setAutoRechargeConfig(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    # ── Pricing ──────────────────────────────────────────────────────────
+
+    def get_customer_model_pricing(
+        self, org_id: str = ""
+    ) -> billing_io_pb2.CustomerModelPricingResponse:
+        """Retrieve the customer-facing model price list with markup applied.
+
+        These are the prices the customer pays, organized by harness and
+        cost tier.  Pass ``org_id`` to resolve org-specific policy overrides;
+        omit for default pricing.
+        """
+        req = billing_io_pb2.GetCustomerModelPricingInput(org_id=org_id)
+        try:
+            return self._query.getCustomerModelPricing(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def get_model_pricing_governance(
+        self,
+    ) -> billing_io_pb2.ModelPricingGovernanceResponse:
+        """Retrieve the platform pricing governance view.
+
+        Baseline vs effective rates per model, ACTIVE override provenance,
+        and pending sign-off proposals from the pricing feedback loop.
+
+        Platform-operator surface (``can_manage_model_pricing`` on
+        ``platform:stigmer``): rates are raw provider prices, pre-markup.
+        """
+        req = billing_io_pb2.GetModelPricingGovernanceInput()
+        try:
+            return self._query.getModelPricingGovernance(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def list_model_pricing_baselines(
+        self, include_history: bool = False
+    ) -> billing_io_pb2.ModelPricingBaselinesResponse:
+        """Retrieve the model registry baseline catalog.
+
+        ACTIVE entries by default, or the full append-only revision history
+        with ``include_history=True``.
+
+        Platform-operator surface (``can_manage_model_pricing`` on
+        ``platform:stigmer``): rates are raw provider prices, pre-markup.
+        """
+        req = billing_io_pb2.ListModelPricingBaselinesInput(
+            include_history=include_history
+        )
+        try:
+            return self._query.listModelPricingBaselines(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def decide_model_pricing_override(
+        self, params: DecideModelPricingOverrideParams
+    ) -> pricing_override_pb2.ModelPricingOverride:
+        """Record a human decision on a PENDING_SIGNOFF pricing override.
+
+        Approving makes the override ACTIVE (superseding any current ACTIVE
+        override on the same pricing key) and recomposes the effective
+        registry; rejecting archives it for audit.  Returns the decided
+        override with the decision stamped.
+        """
+        req = billing_io_pb2.DecideModelPricingOverrideInput(
+            override_id=params.override_id,
+            approve=params.approve,
+            decision_note=params.decision_note,
+        )
+        try:
+            return self._command.decideModelPricingOverride(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def upsert_model_pricing_baseline(
+        self, params: UpsertModelPricingBaselineParams
+    ) -> model_pricing_baseline_pb2.ModelPricingBaseline:
+        """Create or revise one model registry baseline entry.
+
+        Append-only: an existing ACTIVE entry for the same
+        (model_id, provider, harness) key is superseded, never mutated, and
+        the effective registry recomposes immediately.  Returns the new
+        revision with server-stamped lifecycle fields.
+        """
+        req = billing_io_pb2.UpsertModelPricingBaselineInput(
+            baseline=params.baseline,
+            revision_note=params.revision_note,
+        )
+        try:
+            return self._command.upsertModelPricingBaseline(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e
+
+    def retire_model_pricing_baseline(
+        self, params: RetireModelPricingBaselineParams
+    ) -> model_pricing_baseline_pb2.ModelPricingBaseline:
+        """Retire one model from the registry catalog.
+
+        The model disappears from every price surface on the next composition
+        pass; the document is kept for audit and the key can be revived by a
+        subsequent upsert.
+        """
+        req = billing_io_pb2.RetireModelPricingBaselineInput(
+            model_id=params.model_id,
+            provider=params.provider,
+            harness=params.harness,
+            revision_note=params.revision_note,
+        )
+        try:
+            return self._command.retireModelPricingBaseline(req)
+        except grpc.RpcError as e:
+            raise wrap_error(e) from e

--- a/sdk/python/src/stigmer/_client.py
+++ b/sdk/python/src/stigmer/_client.py
@@ -7,6 +7,7 @@ from types import TracebackType
 
 import grpc
 
+from ._billing import BillingClient
 from ._gen._client import GeneratedClient
 from ._github import GitHubClient
 from ._runner_adapter import RunnerAdapter
@@ -34,6 +35,7 @@ class StigmerClient(GeneratedClient):
     - Configuration and gRPC channel setup
     - Cross-resource :attr:`search` client
     - :attr:`github` OAuth integration client
+    - :attr:`billing` bounded-context client
 
     Usage::
 
@@ -53,6 +55,7 @@ class StigmerClient(GeneratedClient):
 
     search: SearchClient
     github: GitHubClient
+    billing: BillingClient
     default_execution_target: int
     runner_adapter: RunnerAdapter | None
 
@@ -93,6 +96,7 @@ class StigmerClient(GeneratedClient):
         self.runner_adapter = runner_adapter
         self.search = SearchClient(self._channel)
         self.github = GitHubClient(self._channel)
+        self.billing = BillingClient(self._channel)
 
     def close(self) -> None:
         """Release the underlying gRPC channel."""

--- a/sdk/python/tests/test_billing.py
+++ b/sdk/python/tests/test_billing.py
@@ -1,0 +1,212 @@
+"""Wire-shape tests for BillingClient.
+
+Each test injects a fake stub that captures the outgoing request proto and
+returns a canned response, then asserts the SDK params mapped onto the right
+proto fields.  This mirrors sdk/java's BillingClientTest and sdk/go's
+billing_test.go — the reference pattern for testing the handwritten
+(non-resource) clients.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import grpc
+import pytest
+
+from ai.stigmer.billing.v1 import billing_account_pb2
+from ai.stigmer.billing.v1 import credit_pb2
+from ai.stigmer.billing.v1 import enum_pb2
+from ai.stigmer.billing.v1 import io_pb2 as billing_io_pb2
+
+from stigmer import StigmerClient
+from stigmer._billing import (
+    AdjustCreditsParams,
+    GetBillingUsageReportParams,
+    GetCreditLedgerParams,
+    SetAutoRechargeConfigParams,
+)
+from stigmer._gen._errors import StigmerError
+from stigmer._gen._types import Page
+
+
+class _FakeRpcError(grpc.RpcError):
+    """Minimal grpc.RpcError double carrying a status code and details."""
+
+    def __init__(self, code: grpc.StatusCode, details: str) -> None:
+        self._code = code
+        self._details = details
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str:
+        return self._details
+
+
+class _CapturingCommandStub:
+    def __init__(self) -> None:
+        self.adjust_credits_in = None
+        self.adjust_credits_error: grpc.RpcError | None = None
+        self.auto_recharge_in = None
+
+    def adjustCredits(self, req):  # noqa: N802 — proto RPC name
+        self.adjust_credits_in = req
+        if self.adjust_credits_error is not None:
+            raise self.adjust_credits_error
+        return credit_pb2.CreditLedgerEntry(amount_micros=req.amount_micros)
+
+    def setAutoRechargeConfig(self, req):  # noqa: N802 — proto RPC name
+        self.auto_recharge_in = req
+        return billing_account_pb2.BillingAccount()
+
+
+class _CapturingQueryStub:
+    def __init__(self) -> None:
+        self.ledger_in = None
+        self.usage_in = None
+        self.pricing_in = None
+
+    def getCreditLedger(self, req):  # noqa: N802 — proto RPC name
+        self.ledger_in = req
+        return billing_io_pb2.CreditLedgerResponse()
+
+    def getBillingUsageReport(self, req):  # noqa: N802 — proto RPC name
+        self.usage_in = req
+        return billing_io_pb2.BillingUsageReportResponse()
+
+    def getCustomerModelPricing(self, req):  # noqa: N802 — proto RPC name
+        self.pricing_in = req
+        return billing_io_pb2.CustomerModelPricingResponse()
+
+
+@pytest.fixture()
+def client():
+    with StigmerClient("test-key", base_url="localhost:7234", insecure=True) as c:
+        yield c
+
+
+class TestBillingClientWiring:
+    def test_client_exposes_billing(self, client: StigmerClient) -> None:
+        assert client.billing is not None
+
+    def test_adjust_credits_maps_params(self, client: StigmerClient) -> None:
+        fake = _CapturingCommandStub()
+        client.billing._command = fake
+
+        entry = client.billing.adjust_credits(
+            AdjustCreditsParams(
+                org_id="acme",
+                amount_micros=25_000_000,
+                reason="initial tenant funding",
+                idempotency_key="fund-acme-001",
+            )
+        )
+        assert entry.amount_micros == 25_000_000
+
+        req = fake.adjust_credits_in
+        assert req.org_id == "acme"
+        assert req.amount_micros == 25_000_000
+        assert req.reason == "initial tenant funding"
+        assert req.idempotency_key == "fund-acme-001"
+
+    def test_adjust_credits_wraps_grpc_error(self, client: StigmerClient) -> None:
+        fake = _CapturingCommandStub()
+        fake.adjust_credits_error = _FakeRpcError(
+            grpc.StatusCode.PERMISSION_DENIED, "can_manage_billing required"
+        )
+        client.billing._command = fake
+
+        with pytest.raises(StigmerError):
+            client.billing.adjust_credits(
+                AdjustCreditsParams(
+                    org_id="acme",
+                    amount_micros=1,
+                    reason="r",
+                    idempotency_key="k",
+                )
+            )
+
+    def test_get_credit_ledger_maps_all_filters(self, client: StigmerClient) -> None:
+        fake = _CapturingQueryStub()
+        client.billing._query = fake
+
+        start = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 8, 13, tzinfo=timezone.utc)
+        client.billing.get_credit_ledger(
+            GetCreditLedgerParams(
+                org_id="acme",
+                page=Page(num=2, size=50),
+                type_filter=[enum_pb2.adjustment_credit],
+                start_time=start,
+                end_time=end,
+                view=enum_pb2.ledger_view_statement,
+            )
+        )
+
+        req = fake.ledger_in
+        assert req.org_id == "acme"
+        assert (req.page.num, req.page.size) == (2, 50)
+        assert list(req.type_filter) == [enum_pb2.adjustment_credit]
+        assert req.start_time.ToDatetime(tzinfo=timezone.utc) == start
+        assert req.end_time.ToDatetime(tzinfo=timezone.utc) == end
+        assert req.view == enum_pb2.ledger_view_statement
+
+    def test_get_credit_ledger_omits_unset_optionals(self, client: StigmerClient) -> None:
+        fake = _CapturingQueryStub()
+        client.billing._query = fake
+
+        client.billing.get_credit_ledger(GetCreditLedgerParams(org_id="acme"))
+
+        req = fake.ledger_in
+        assert not req.HasField("page")
+        assert not req.HasField("start_time")
+        assert not req.HasField("end_time")
+        assert req.view == enum_pb2.ledger_view_unspecified
+
+    def test_get_billing_usage_report_maps_timestamps(self, client: StigmerClient) -> None:
+        fake = _CapturingQueryStub()
+        client.billing._query = fake
+
+        start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 7, 31, 23, 59, 59, tzinfo=timezone.utc)
+        client.billing.get_billing_usage_report(
+            GetBillingUsageReportParams(org_id="acme", start_time=start, end_time=end)
+        )
+
+        req = fake.usage_in
+        assert req.org_id == "acme"
+        assert req.start_time.ToDatetime(tzinfo=timezone.utc) == start
+        assert req.end_time.ToDatetime(tzinfo=timezone.utc) == end
+
+    def test_set_auto_recharge_config_maps_params(self, client: StigmerClient) -> None:
+        fake = _CapturingCommandStub()
+        client.billing._command = fake
+
+        client.billing.set_auto_recharge_config(
+            SetAutoRechargeConfigParams(
+                org_id="acme",
+                enabled=True,
+                threshold_micros=5_000_000,
+                recharge_amount_micros=20_000_000,
+                monthly_cap_micros=100_000_000,
+            )
+        )
+
+        req = fake.auto_recharge_in
+        assert req.enabled is True
+        assert req.threshold_micros == 5_000_000
+        assert req.recharge_amount_micros == 20_000_000
+        assert req.monthly_cap_micros == 100_000_000
+
+    def test_get_customer_model_pricing_defaults_to_empty_org(
+        self, client: StigmerClient
+    ) -> None:
+        fake = _CapturingQueryStub()
+        client.billing._query = fake
+
+        client.billing.get_customer_model_pricing()
+        assert fake.pricing_in.org_id == ""
+
+        client.billing.get_customer_model_pricing(org_id="acme")
+        assert fake.pricing_in.org_id == "acme"

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -63,6 +63,23 @@ Every resource type has a typed client accessible as a property on the `Stigmer`
 | `workflowExecution`  | WorkflowExecution  |
 | `workflowInstance`   | WorkflowInstance   |
 | `search`             | Cross-resource search |
+| `billing`            | Billing (credits, ledger, Stripe) |
+
+### Billing
+
+Credit balance queries, ledger history, and manual credit adjustments for an
+organization. Commands require the `can_manage_billing` permission on the org:
+
+```typescript
+const balance = await stigmer.billing.getCreditBalance(orgId);
+
+const entry = await stigmer.billing.adjustCredits({
+  orgId,
+  amountMicros: 25_000_000n, // +$25.00
+  reason: "initial tenant funding",
+  idempotencyKey: `fund-${orgId}`,
+});
+```
 
 ### Common operations
 

--- a/sdk/typescript/src/__tests__/billing.test.ts
+++ b/sdk/typescript/src/__tests__/billing.test.ts
@@ -1,0 +1,102 @@
+// Wire-shape tests for BillingClient: a router transport fakes the billing
+// services in-process, captures the outgoing request messages, and the tests
+// assert the SDK params mapped onto the right proto fields. This mirrors
+// sdk/java's BillingClientTest and sdk/go's billing_test.go — the reference
+// pattern for testing the handwritten (non-resource) clients.
+import { describe, expect, it } from "vitest";
+import { createRouterTransport, type Transport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { timestampDate } from "@bufbuild/protobuf/wkt";
+import { BillingCommandController } from "@stigmer/protos/ai/stigmer/billing/v1/command_pb";
+import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
+import {
+  CreditLedgerResponseSchema,
+  type AdjustCreditsInput,
+  type GetCreditLedgerInput,
+} from "@stigmer/protos/ai/stigmer/billing/v1/io_pb";
+import { CreditLedgerEntrySchema } from "@stigmer/protos/ai/stigmer/billing/v1/credit_pb";
+import { LedgerEntryType, LedgerView } from "@stigmer/protos/ai/stigmer/billing/v1/enum_pb";
+import { BillingClient } from "../billing.js";
+
+interface Captured {
+  adjustCredits?: AdjustCreditsInput;
+  getCreditLedger?: GetCreditLedgerInput;
+}
+
+function fakeTransport(captured: Captured): Transport {
+  return createRouterTransport(({ service }) => {
+    service(BillingCommandController, {
+      adjustCredits: (req) => {
+        captured.adjustCredits = req;
+        return create(CreditLedgerEntrySchema, { amountMicros: req.amountMicros });
+      },
+    });
+    service(BillingQueryController, {
+      getCreditLedger: (req) => {
+        captured.getCreditLedger = req;
+        return create(CreditLedgerResponseSchema, {});
+      },
+    });
+  });
+}
+
+describe("BillingClient.adjustCredits", () => {
+  it("maps params onto AdjustCreditsInput and returns the ledger entry", async () => {
+    const captured: Captured = {};
+    const client = new BillingClient(fakeTransport(captured));
+
+    const entry = await client.adjustCredits({
+      orgId: "acme",
+      amountMicros: 25_000_000n,
+      reason: "initial tenant funding",
+      idempotencyKey: "fund-acme-001",
+    });
+
+    expect(entry.amountMicros).toBe(25_000_000n);
+    expect(captured.adjustCredits?.orgId).toBe("acme");
+    expect(captured.adjustCredits?.amountMicros).toBe(25_000_000n);
+    expect(captured.adjustCredits?.reason).toBe("initial tenant funding");
+    expect(captured.adjustCredits?.idempotencyKey).toBe("fund-acme-001");
+  });
+});
+
+describe("BillingClient.getCreditLedger", () => {
+  it("maps all filters including the time range", async () => {
+    const captured: Captured = {};
+    const client = new BillingClient(fakeTransport(captured));
+
+    const startTime = new Date("2026-08-01T00:00:00Z");
+    const endTime = new Date("2026-08-13T00:00:00Z");
+    await client.getCreditLedger({
+      orgId: "acme",
+      page: { num: 2, size: 50 },
+      typeFilter: [LedgerEntryType.adjustment_credit],
+      startTime,
+      endTime,
+      view: LedgerView.statement,
+    });
+
+    const req = captured.getCreditLedger;
+    expect(req?.orgId).toBe("acme");
+    expect(req?.page?.num).toBe(2);
+    expect(req?.page?.size).toBe(50);
+    expect(req?.typeFilter).toEqual([LedgerEntryType.adjustment_credit]);
+    expect(req?.startTime && timestampDate(req.startTime)).toEqual(startTime);
+    expect(req?.endTime && timestampDate(req.endTime)).toEqual(endTime);
+    expect(req?.view).toBe(LedgerView.statement);
+  });
+
+  it("omits unset optional filters", async () => {
+    const captured: Captured = {};
+    const client = new BillingClient(fakeTransport(captured));
+
+    await client.getCreditLedger({ orgId: "acme" });
+
+    const req = captured.getCreditLedger;
+    expect(req?.page).toBeUndefined();
+    expect(req?.startTime).toBeUndefined();
+    expect(req?.endTime).toBeUndefined();
+    expect(req?.typeFilter).toEqual([]);
+    expect(req?.view).toBe(LedgerView.unspecified);
+  });
+});

--- a/sdk/typescript/src/billing.ts
+++ b/sdk/typescript/src/billing.ts
@@ -6,6 +6,7 @@ import {
   GetOrCreateBillingAccountInputSchema,
   GetBillingAccountInputSchema,
   GetCreditBalanceInputSchema,
+  AdjustCreditsInputSchema,
   GetCreditLedgerInputSchema,
   CreateCreditCheckoutSessionInputSchema,
   CreateBillingPortalSessionInputSchema,
@@ -25,6 +26,7 @@ import {
   type ModelPricingGovernanceResponse,
   type ModelPricingBaselinesResponse,
 } from "@stigmer/protos/ai/stigmer/billing/v1/io_pb";
+import type { CreditLedgerEntry } from "@stigmer/protos/ai/stigmer/billing/v1/credit_pb";
 import type { ModelPricingOverride } from "@stigmer/protos/ai/stigmer/billing/v1/pricing_override_pb";
 import type { ModelPricingBaseline } from "@stigmer/protos/ai/stigmer/billing/v1/model_pricing_baseline_pb";
 import type { BillingAccount, CreditBalance } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
@@ -56,12 +58,27 @@ export interface SetAutoRechargeConfigParams {
   readonly monthlyCapMicros: bigint;
 }
 
+/** Parameters for a manual credit adjustment. */
+export interface AdjustCreditsParams {
+  readonly orgId: string;
+  /** Positive to add credits, negative to remove. */
+  readonly amountMicros: bigint;
+  /** Human-readable reason recorded on the ledger entry (audit trail). */
+  readonly reason: string;
+  /** Client-supplied deduplication key to prevent double-processing. */
+  readonly idempotencyKey: string;
+}
+
 /** Parameters for querying the credit ledger. */
 export interface GetCreditLedgerParams {
   readonly orgId: string;
   /** Pagination: `{ num, size }` where `num` is the 0-based page number. */
   readonly page?: { readonly num: number; readonly size: number };
   readonly typeFilter?: LedgerEntryType[];
+  /** Filter to entries on or after this timestamp. */
+  readonly startTime?: Date;
+  /** Filter to entries on or before this timestamp. */
+  readonly endTime?: Date;
   /**
    * Server-resolved ledger slice. When set to `LedgerView.statement`, the
    * server returns only customer-facing money-movement entry types and
@@ -182,6 +199,29 @@ export class BillingClient {
     }
   }
 
+  /**
+   * Manually adjust an organization's credit balance.
+   *
+   * Positive `amountMicros` adds credits (e.g. funding a tenant org),
+   * negative removes them. The adjustment is recorded as a ledger entry
+   * with the supplied reason; the idempotency key deduplicates retries.
+   * Requires `can_manage_billing` on the org.
+   */
+  async adjustCredits(params: AdjustCreditsParams): Promise<CreditLedgerEntry> {
+    try {
+      return await this.command.adjustCredits(
+        create(AdjustCreditsInputSchema, {
+          orgId: params.orgId,
+          amountMicros: params.amountMicros,
+          reason: params.reason,
+          idempotencyKey: params.idempotencyKey,
+        }),
+      );
+    } catch (e) {
+      throw wrapError(e);
+    }
+  }
+
   /** Retrieve paginated credit ledger entries with optional filters. */
   async getCreditLedger(params: GetCreditLedgerParams): Promise<CreditLedgerResponse> {
     try {
@@ -195,6 +235,8 @@ export class BillingClient {
             }),
           }),
           ...(params.typeFilter?.length && { typeFilter: params.typeFilter }),
+          ...(params.startTime && { startTime: timestampFromDate(params.startTime) }),
+          ...(params.endTime && { endTime: timestampFromDate(params.endTime) }),
           ...(params.view !== undefined && { view: params.view }),
         }),
       );

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -85,6 +85,7 @@ export type { RecentActivityEntry as RecentActivityEntryProto } from "./activity
 // Billing client
 export {
   BillingClient,
+  type AdjustCreditsParams,
   type CreateCheckoutSessionParams,
   type CreateBillingPortalSessionParams,
   type SetAutoRechargeConfigParams,


### PR DESCRIPTION
Closes #607.

## Summary

- Mirrors the Java `BillingClient` reference surface (15 methods, [#606](https://github.com/stigmer/stigmer/pull/606)) into the Go and Python SDKs via the established handwritten non-resource client pattern (`search`/`github`/`platform`), and closes the two TypeScript gaps: `adjustCredits` (the org-admin RPC platform integrators need to fund `platform_managed` tenant orgs) and `getCreditLedger` `startTime`/`endTime` range filters. Engine-internal RPCs (`authorizeExecution`, `recordLlmCallUsage`, `finalizeExecution`) stay excluded by design.
- **Go** (`sdk/go/billing.go`): `Client.Billing` beside `Search`/`GitHub`; native params structs in, proto messages out (the `search.go` type-alias convention — no hand-mapped response mirrors to drift out of sync); `gen.WrapErr` error mapping.
- **Python** (`sdk/python/src/stigmer/_billing.py`): the `_github.py` dataclass shape, exposed as `client.billing`, params + client exported from the package root.
- **READMEs** for all three languages mirroring the #606 Java template.

## Tests — establishes the wire-shape pattern in Go and Python

Go and Python previously had **no tests at all** for their handwritten clients; `BillingClientTest.java` was the only precedent. This PR lands the pattern in all three languages: fake stubs capture the outgoing request proto, assertions pin the params→proto field mapping, optional-field omission, and error wrapping (Go 10 tests, Python 8, TS 3 via `createRouterTransport`).

## Verification

- Go: `gofmt` clean, `go vet`, full `sdk/go` suite under `-race` (green against the new #613 CI gates; branch rebased on current main)
- Python: 25/25 via pytest — also proves the published `stigmer-protos` wheel ships the billing stubs
- TypeScript: `tsc -p tsconfig.build.json` clean and 395/395 vitest. Note: clean-clone typechecking currently requires [#628](https://github.com/stigmer/stigmer/pull/628) (single workspace `@bufbuild/protobuf`), discovered while verifying this PR — recommend merging #628 first.

Made with [Cursor](https://cursor.com)