### PR TITLE
chore(cli): remove the dead llm.model concept — the registry owns the model, per-run overrides ride stigmer run --model

### DIFF
--- a/client-apps/cli/docs/commands/setup.mdx
+++ b/client-apps/cli/docs/commands/setup.mdx
@@ -10,8 +10,9 @@ configuration, preserving every other setting.
 Supported providers: `anthropic`, and `skip` to clear the configuration.
 
 You don't pick a model during setup: the platform model registry selects the
-default automatically, so it stays current without CLI updates. To pin a
-specific model, pass `--model` explicitly.
+default automatically, so it stays current without CLI updates. To run a
+specific model, pass `--model` to [`stigmer run`](./run) — model choice is a
+per-run decision, not a setup-time setting.
 
 {/* AUTO_USAGE */}
 

--- a/client-apps/cli/src/commands/setup.ts
+++ b/client-apps/cli/src/commands/setup.ts
@@ -1,11 +1,17 @@
 // `stigmer setup` — configure the LLM provider used for agent execution.
 //
 // Two paths share one decision core (local/setup/wizard.ts): a non-interactive
-// flag path (`--provider`, `--api-key`, `--model`) for scripts and CI, and an
+// flag path (`--provider`, `--api-key`) for scripts and CI, and an
 // interactive API-key prompt when no provider flag is given. Both write to
 // backend.local.llm, preserving every other config field. The valid provider
 // set is owned by wizard.ts's PROVIDER_CHOICES (Anthropic-only + skip — the
 // only story the native runner serves).
+//
+// Setup deliberately has NO model concept: the platform model registry owns
+// the execution default, and per-run overrides belong to `stigmer run
+// --model`. A setup-level pin used to exist but never reached execution
+// (oss#314) — config that looks authoritative but is dead invites exactly the
+// bug class Session 29 fixed, so it is structurally gone rather than wired up.
 
 import type { Command } from "commander";
 import { homedir } from "node:os";
@@ -14,7 +20,6 @@ import { addResultFlags, resultFormat } from "./shared.js";
 
 interface SetupFlags extends OutputFlags {
   provider?: string;
-  model?: string;
   apiKey?: string;
 }
 
@@ -23,7 +28,6 @@ export function registerSetup(program: Command): void {
     .command("setup")
     .description("configure the LLM provider for agent execution")
     .option("--provider <name>", "provider: anthropic, or skip to clear (non-interactive)")
-    .option("--model <name>", "pin a specific model (defaults to the platform-selected model)")
     .option("--api-key <key>", "Anthropic API key")
     .action((options: SetupFlags) => runSetup(options));
   addResultFlags(setup);
@@ -47,7 +51,6 @@ async function runSetup(options: SetupFlags): Promise<void> {
       ]);
     }
     updated = applyChoice(config, provider as (typeof PROVIDER_CHOICES)[number], {
-      model: options.model,
       apiKey: options.apiKey,
     });
   } else {

--- a/client-apps/cli/src/local/daemon/launch.ts
+++ b/client-apps/cli/src/local/daemon/launch.ts
@@ -95,7 +95,7 @@ export async function up(options: UpOptions = {}, home: string = homedir()): Pro
 
   await applySeedpackBestEffort(home);
 
-  saveStartupConfig(data, buildStartupConfig(data, logs, temporal.address, config, daemonPid, options));
+  saveStartupConfig(data, buildStartupConfig(data, logs, temporal.address, daemonPid, options));
 }
 
 /**
@@ -246,18 +246,13 @@ function buildStartupConfig(
   data: string,
   logs: string,
   temporalAddr: string,
-  config: Config,
   daemonPid: number,
   options: UpOptions,
 ): StartupConfig {
-  const local = config.backend.local as { llm?: { provider?: string; model?: string; base_url?: string } } | undefined;
   return {
     data_dir: data,
     log_dir: logs,
     temporal_addr: temporalAddr,
-    llm_provider: local?.llm?.provider ?? "",
-    llm_model: local?.llm?.model ?? "",
-    llm_base_url: local?.llm?.base_url ?? "",
     execution_mode: "local",
     sandbox_image: "",
     sandbox_auto_pull: false,

--- a/client-apps/cli/src/local/llm-config.test.ts
+++ b/client-apps/cli/src/local/llm-config.test.ts
@@ -4,7 +4,6 @@ import {
   detectProviderFromEnv,
   readLlm,
   resolveApiKey,
-  resolveModel,
   resolveProvider,
   setLlm,
 } from "./llm-config.js";
@@ -32,17 +31,6 @@ describe("resolveProvider", () => {
   });
 });
 
-describe("resolveModel", () => {
-  it("returns the explicit override, else empty — the registry owns the default", () => {
-    // No hardcoded model version anywhere in the CLI: unset means "platform
-    // default", resolved by the runner from the model registry.
-    expect(resolveModel(config({ llm: { provider: "anthropic" } }), {})).toBe("");
-    expect(resolveModel(config(), {})).toBe("");
-    expect(resolveModel(config({ llm: { provider: "anthropic", model: "claude-x" } }), {})).toBe("claude-x");
-    expect(resolveModel(config({ llm: { provider: "anthropic" } }), { STIGMER_LLM_MODEL: "envm" })).toBe("envm");
-  });
-});
-
 describe("resolveApiKey", () => {
   it("uses ANTHROPIC_API_KEY, then config", () => {
     const cfg = config({ llm: { provider: "anthropic", api_key: "cfgkey" } });
@@ -58,12 +46,21 @@ describe("resolveApiKey", () => {
 describe("setLlm", () => {
   it("preserves sibling local keys and can clear the section", () => {
     const cfg = config({ temporal: { managed: true }, llm: { provider: "anthropic" } });
-    const updated = setLlm(cfg, { provider: "anthropic", model: "m" });
-    expect(readLlm(updated)).toEqual({ provider: "anthropic", model: "m" });
+    const updated = setLlm(cfg, { provider: "anthropic", api_key: "k" });
+    expect(readLlm(updated)).toEqual({ provider: "anthropic", api_key: "k" });
     expect((updated.backend.local as { temporal: unknown }).temporal).toEqual({ managed: true });
 
     const cleared = setLlm(cfg, undefined);
     expect(readLlm(cleared)).toBeUndefined();
     expect((cleared.backend.local as { temporal: unknown }).temporal).toEqual({ managed: true });
+  });
+
+  it("replaces the section wholesale — a stale model key from a pre-oss#314 config does not survive a rewrite", () => {
+    // The graceful-migration contract: old configs may carry llm.model (the
+    // removed dead pin). Reads ignore it (LlmSettings no longer models it);
+    // the next setup write clears it because setLlm never merges.
+    const cfg = config({ llm: { provider: "anthropic", model: "stale-pin", api_key: "k" } });
+    const rewritten = setLlm(cfg, { provider: "anthropic", api_key: "k" });
+    expect(readLlm(rewritten)).toEqual({ provider: "anthropic", api_key: "k" });
   });
 });

--- a/client-apps/cli/src/local/llm-config.ts
+++ b/client-apps/cli/src/local/llm-config.ts
@@ -4,7 +4,7 @@
 // The config module (config/config.ts) carries `backend.local` through verbatim
 // so the CLI never drops fields it does not model. This module adds a *typed
 // lens* for the one sub-tree setup owns — `local.llm` — and resolves the
-// effective provider/model with env-override precedence (env > config file >
+// effective provider/key with env-override precedence (env > config file >
 // API-key autodetect). Writes merge into a shallow copy of `local`, preserving
 // every sibling key (temporal, execution, …).
 //
@@ -12,10 +12,13 @@
 // Anthropic clients, and the platform model registry's native-harness entries
 // are all Anthropic models. Two invariants follow:
 //
-//   1. The model registry — not this config — owns the default execution model.
-//      The runner resolves it from the registry at execution time, so this
-//      module never hardcodes a model version (hardcoded versions here drifted
-//      from the registry repeatedly). An unset model means "platform default".
+//   1. The model registry — not this config — owns the execution model, so
+//      there is deliberately NO model field here. A config-level model pin
+//      existed once but never reached execution (oss#314): the launcher
+//      forwards only the API key, making such a pin config-that-lies. Per-run
+//      overrides belong to `stigmer run --model`. Stale `model` keys in
+//      existing config files are silently ignored (verbatim carry-through)
+//      and cleared by the next `setup` write.
 //   2. `provider` exists to route the right API key to the runner, not to
 //      select an execution backend; "anthropic" is the only provider the local
 //      stack can serve.
@@ -25,7 +28,6 @@ import type { Config } from "../config/config.js";
 /** LLM settings as persisted under `backend.local.llm` (snake_case = YAML keys). */
 export interface LlmSettings {
   provider?: string;
-  model?: string;
   api_key?: string;
 }
 
@@ -59,15 +61,6 @@ export function resolveProvider(config: Config, env: NodeJS.ProcessEnv = process
   const llm = readLlm(config);
   if (llm?.provider) return llm.provider;
   return detectProviderFromEnv(env);
-}
-
-/**
- * Effective model override: env override > config. Empty string means "no
- * override" — the runner picks the default from the platform model registry.
- */
-export function resolveModel(config: Config, env: NodeJS.ProcessEnv = process.env): string {
-  if (env.STIGMER_LLM_MODEL) return env.STIGMER_LLM_MODEL;
-  return readLlm(config)?.model ?? "";
 }
 
 /** Effective API key: ANTHROPIC_API_KEY env var > config. */

--- a/client-apps/cli/src/local/setup/wizard.test.ts
+++ b/client-apps/cli/src/local/setup/wizard.test.ts
@@ -21,11 +21,10 @@ describe("PROVIDER_CHOICES", () => {
 });
 
 describe("buildLlmForChoice", () => {
-  it("persists no model unless explicitly overridden — the registry owns the default", () => {
+  it("persists provider and key only — there is no model concept, the registry owns it (oss#314)", () => {
     expect(buildLlmForChoice("anthropic")).toEqual({ provider: "anthropic" });
-    expect(buildLlmForChoice("anthropic", { apiKey: "k", model: "m" })).toEqual({
+    expect(buildLlmForChoice("anthropic", { apiKey: "k" })).toEqual({
       provider: "anthropic",
-      model: "m",
       api_key: "k",
     });
   });

--- a/client-apps/cli/src/local/setup/wizard.ts
+++ b/client-apps/cli/src/local/setup/wizard.ts
@@ -7,9 +7,9 @@
 // Local agent execution is Anthropic-only (the native runner only constructs
 // Anthropic clients and the registry's native entries are Anthropic models),
 // so the interactive flow is a single API-key prompt rather than a provider
-// menu. The model is deliberately NOT asked for: the platform model registry
-// owns the execution default, and an explicit override is a power-user flag
-// (`stigmer setup --model …`), not a setup question.
+// menu. There is no model concept here at all: the platform model registry
+// owns the execution default, and per-run overrides belong to `stigmer run
+// --model` (oss#314 removed the dead setup-level pin).
 
 import type { Config } from "../../config/config.js";
 import { type LlmSettings, setLlm } from "../llm-config.js";
@@ -27,19 +27,17 @@ export type ProviderChoice = (typeof PROVIDER_CHOICES)[number];
 
 export interface SelectionInputs {
   apiKey?: string;
-  model?: string;
 }
 
 /**
- * Resolve a provider choice (plus optional overrides) to the LLM settings to
- * persist. "skip" yields `undefined`, which clears the section. An omitted
- * model is stored as absent — meaning "platform default", resolved from the
- * model registry at execution time.
+ * Resolve a provider choice (plus an optional API key) to the LLM settings to
+ * persist. "skip" yields `undefined`, which clears the section — including any
+ * stale `model` key from a pre-oss#314 config, since setLlm replaces the
+ * section wholesale.
  */
 export function buildLlmForChoice(choice: ProviderChoice, inputs: SelectionInputs = {}): LlmSettings | undefined {
   if (choice === "skip") return undefined;
   const settings: LlmSettings = { provider: choice };
-  if (inputs.model) settings.model = inputs.model;
   if (inputs.apiKey) settings.api_key = inputs.apiKey;
   return settings;
 }

--- a/client-apps/cli/src/local/state/startup-config.ts
+++ b/client-apps/cli/src/local/state/startup-config.ts
@@ -1,19 +1,23 @@
-// Configuration captured at `up` time so the daemon can restart components with
-// the same settings the user launched with. Persisted as `startup-config.json`
-// in the data dir; JSON keys are snake_case to match the Go CLI's file.
+// A diagnostic snapshot of the settings `up` launched with, persisted as
+// `startup-config.json` in the data dir and removed by `down`. Nothing in the
+// CLI or daemon reads it back — it exists for humans and support tooling
+// inspecting a running stack, so keep it truthful: a field that no component
+// consumes does not belong here (oss#314 removed the write-only llm_* trio).
+// JSON keys stay snake_case for continuity with previously-written files.
 
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { STARTUP_CONFIG_FILE } from "../constants.js";
 
-/** The persisted launch configuration. Mirrors the Go `StartupConfig` struct. */
+/**
+ * The persisted launch snapshot. `loadStartupConfig` parses leniently (a cast,
+ * not a validator), so files written by older CLIs with extra fields — e.g.
+ * the removed llm_* trio — load without migration.
+ */
 export interface StartupConfig {
   data_dir: string;
   log_dir: string;
   temporal_addr: string;
-  llm_provider: string;
-  llm_model: string;
-  llm_base_url: string;
   execution_mode: string;
   sandbox_image: string;
   sandbox_auto_pull: boolean;

--- a/client-apps/cli/src/local/state/state.test.ts
+++ b/client-apps/cli/src/local/state/state.test.ts
@@ -82,9 +82,6 @@ describe("startup-config", () => {
       data_dir: dir,
       log_dir: join(dir, "logs"),
       temporal_addr: "127.0.0.1:7233",
-      llm_provider: "anthropic",
-      llm_model: "claude",
-      llm_base_url: "",
       execution_mode: "local",
       sandbox_image: "",
       sandbox_auto_pull: false,
@@ -97,6 +94,29 @@ describe("startup-config", () => {
     expect(loadStartupConfig(dir)).toEqual(config);
     removeStartupConfig(dir);
     expect(loadStartupConfig(dir)).toBeNull();
+  });
+
+  it("loads files written by older CLIs carrying since-removed fields (e.g. the llm_* trio)", () => {
+    // The lenient-load contract oss#314 leans on: no migration for on-disk
+    // files — extra keys simply come along and nothing consumes them.
+    const dir = tempDir("stigmer-startup-");
+    const legacy = {
+      data_dir: dir,
+      log_dir: join(dir, "logs"),
+      temporal_addr: "127.0.0.1:7233",
+      llm_provider: "anthropic",
+      llm_model: "claude",
+      llm_base_url: "",
+      execution_mode: "local",
+      sandbox_image: "",
+      sandbox_auto_pull: false,
+      sandbox_cleanup: true,
+      sandbox_ttl: 0,
+      stigmer_server_pid: 999,
+      server_only: false,
+    };
+    writeFileSync(join(dir, "startup-config.json"), JSON.stringify(legacy));
+    expect(loadStartupConfig(dir)).toMatchObject({ temporal_addr: "127.0.0.1:7233", stigmer_server_pid: 999 });
   });
 });
 

--- a/client-apps/cli/src/local/status.test.ts
+++ b/client-apps/cli/src/local/status.test.ts
@@ -62,12 +62,12 @@ describe("buildStatusResult", () => {
     expect(field(result, "Web UI", "Temporal")).toBe("http://localhost:8233");
   });
 
-  it("shows an explicit model override verbatim", async () => {
+  it("ignores a stale model key from a pre-oss#314 config — the pin never reached execution, so status must not display it", async () => {
     writeHealth({ daemon_pid: process.pid, started_at: new Date().toISOString(), components: {} });
     writeFileSync(configPath(home), "backend:\n  type: local\n  local:\n    llm:\n      provider: anthropic\n      model: claude-x\n      api_key: sk-x\n");
 
     const result = await buildStatusResult(home, open);
-    expect(field(result, "LLM Configuration", "Model")).toBe("claude-x");
+    expect(field(result, "LLM Configuration", "Model")).toBe("Auto (platform default)");
   });
 
   it("reports a non-anthropic provider as unknown — local execution is Anthropic-only", async () => {

--- a/client-apps/cli/src/local/status.ts
+++ b/client-apps/cli/src/local/status.ts
@@ -13,7 +13,7 @@ import { load as loadConfig } from "../config/config.js";
 import { configPath } from "../config/paths.js";
 import { CommandResult } from "../output/command-result.js";
 import { SERVER_PORT, TEMPORAL_UI_PORT, WEB_CONSOLE_PORT } from "./constants.js";
-import { resolveApiKey, resolveModel, resolveProvider } from "./llm-config.js";
+import { resolveApiKey, resolveProvider } from "./llm-config.js";
 import { tcpConnects } from "./net/tcp.js";
 import { dataDir } from "./paths.js";
 import { type ComponentState, type HealthState, loadHealthState } from "./state/health-state.js";
@@ -130,12 +130,11 @@ function addLlmSection(result: CommandResult, home: string): void {
     return;
   }
 
-  // An unset model is not a gap: the platform model registry picks the
-  // execution default, so the CLI reports that truthfully instead of asserting
-  // a version it does not control.
-  const model = resolveModel(config);
+  // The model line is a constant: the platform model registry picks the
+  // execution default and the CLI has no model concept to report (oss#314
+  // removed the dead config pin). Per-run overrides ride `stigmer run --model`.
   section.field("Provider", "Anthropic (Cloud)");
-  section.field("Model", model !== "" ? model : "Auto (platform default)");
+  section.field("Model", "Auto (platform default)");
   section.field("API Key", resolveApiKey(config) !== "" ? "Configured ✓" : "Not configured ✗");
 }
 

--- a/docs/cli/commands/setup.mdx
+++ b/docs/cli/commands/setup.mdx
@@ -18,8 +18,9 @@ configuration, preserving every other setting.
 Supported providers: `anthropic`, and `skip` to clear the configuration.
 
 You don't pick a model during setup: the platform model registry selects the
-default automatically, so it stays current without CLI updates. To pin a
-specific model, pass `--model` explicitly.
+default automatically, so it stays current without CLI updates. To run a
+specific model, pass `--model` to [`stigmer run`](./run) — model choice is a
+per-run decision, not a setup-time setting.
 
 ## Usage
 
@@ -42,13 +43,12 @@ stigmer setup --provider skip
 
 ## Options
 
-| Flag         | Type     | Default | Description                                                    |
-| ------------ | -------- | ------- | -------------------------------------------------------------- |
-| `--api-key`  | `string` |         | Anthropic API key                                              |
-| `--json`     | `bool`   |         | emit the result as JSON                                        |
-| `--model`    | `string` |         | pin a specific model (defaults to the platform-selected model) |
-| `--provider` | `string` |         | provider: anthropic, or skip to clear (non-interactive)        |
-| `--quiet`    | `bool`   |         | print only the status line                                     |
+| Flag         | Type     | Default | Description                                             |
+| ------------ | -------- | ------- | ------------------------------------------------------- |
+| `--api-key`  | `string` |         | Anthropic API key                                       |
+| `--json`     | `bool`   |         | emit the result as JSON                                 |
+| `--provider` | `string` |         | provider: anthropic, or skip to clear (non-interactive) |
+| `--quiet`    | `bool`   |         | print only the status line                              |
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Closes #314 — the Session-29 follow-up, executed as the "A-honest" option the issue named (owner-ruled at plan approval).

Session 29 established that the CLI's configured model **never reaches execution**: the launcher forwards only the API key, and the runner resolves the model from the platform model registry. This PR makes that contract structural instead of accidental — the CLI no longer has a config-level model concept at all.

## What was dead (all verified by census)

- `startup-config.json`'s `llm_provider` / `llm_model` / `llm_base_url`: written at `up`, **read by nothing anywhere** (`loadStartupConfig` had zero callers; the file is a diagnostic snapshot). `llm_base_url` even read a config key no writer ever produced.
- `LlmSettings.model` + `resolveModel` + the `STIGMER_LLM_MODEL` env override: exactly one consumer — the `status` display, which showed a "pinned" model that did not run.
- `stigmer setup --model`: a documented flag promising to "pin a specific model" that pinned nothing. **Worse than dead — it lied**: setup accepted the pin, `status` displayed it, and execution ignored it.

## What changed

- `startup-config.ts` / `launch.ts`: the `llm_*` trio removed from the snapshot; header comment truthed (the "mirrors the Go CLI's file" claim was stale fiction — no Go reader exists).
- `llm-config.ts`: `model` removed from the lens; `provider` + `api_key` stay (they route the API key — load-bearing).
- `setup.ts` / `wizard.ts`: the `--model` flag and its plumbing removed. Scripts passing `--model` now fail loudly with commander's unknown-option error — they were already broken silently.
- `status.ts`: the Model line is now the constant truth, `Auto (platform default)`.
- Docs: `setup.mdx` regenerated — the flags table (generated from the live commander tree) drops `--model`, and the prose points users at `stigmer run --model`, where model choice actually works and belongs. **`stigmer run --model` / `draft --model` are untouched** — that is a real execution-time override, a different flag.

## Graceful on-disk handling (no migration)

- Old `startup-config.json` files with the extra keys load fine (lenient parse) — pinned by a new test.
- Old config files with `llm.model` are silently ignored on read and cleared by the next `setup` write (`setLlm` replaces the section wholesale) — pinned by new tests in `llm-config.test.ts` and `status.test.ts` (the stale-pin-must-not-display case).

## Verification

- `tsc --noEmit` clean; CLI suite 876/876 green (90 files).
- `make gen-cli-docs` regenerated; repo-wide census confirms nothing outside `client-apps/cli` imports the touched modules.

Made with [Cursor](https://cursor.com)