### PR TITLE
chore(sdk/react): converge 38 SpinnerIcon copies and 8 relative-time formatters onto shared homes

### DIFF
--- a/sdk/react/src/activity/format-relative-time.ts
+++ b/sdk/react/src/activity/format-relative-time.ts
@@ -1,16 +1,18 @@
 /**
- * Compact relative-time formatter for recent-activity rows.
+ * The SDK's compact relative-time vocabulary: one deterministic "how long
+ * ago" formatter so timestamps read identically everywhere (consolidated
+ * from eight per-component drifting copies — stigmer-cloud#269). Pass
+ * `now` to freeze the clock in tests.
  *
- * The recents list sorts by LAST ACTIVITY (`statusAudit.updatedAt`), while
- * execution names embed their CREATION time — so an old run legitimately
- * re-bumped by a status change (a cancel, a late failure) sorts above
- * newer-named items and reads as "wrong order" unless the row says why it
- * is there. This stamp is that explanation: it renders the sort key the
- * user cannot otherwise see.
- *
- * Compact single-unit output — a sidebar row suffix, not prose:
+ * Compact single-unit output — a row suffix, not prose:
  * `now`, `5m`, `3h`, `6d`, then a short date (`Jul 12`, `Jul 12, 2025`)
  * once "days ago" stops being how people think about it.
+ *
+ * Born on the recents list, where it renders the otherwise-invisible sort
+ * key: the list sorts by LAST ACTIVITY (`statusAudit.updatedAt`) while
+ * execution names embed their CREATION time, so an old run re-bumped by a
+ * late status change sorts above newer-named items and reads as "wrong
+ * order" unless the row says why it is there.
  */
 export function formatRelativeTime(date: Date, now?: Date): string {
   const ref = now ?? new Date();

--- a/sdk/react/src/api-key/ApiKeyListPanel.tsx
+++ b/sdk/react/src/api-key/ApiKeyListPanel.tsx
@@ -9,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js"
 import { useApiKeyList } from "./useApiKeyList.js";
 import { useDeleteApiKey } from "./useDeleteApiKey.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -296,27 +297,6 @@ function formatShortDate(date: Date): string {
     day: "numeric",
     year: "numeric",
   });
-}
-
-function formatRelativeTime(date: Date, now?: Date): string {
-  const ref = now?.getTime() ?? Date.now();
-  const diffMs = ref - date.getTime();
-
-  if (diffMs < 0) return "Just now";
-
-  const seconds = Math.floor(diffMs / 1000);
-  if (seconds < 60) return "Just now";
-
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-
-  return formatShortDate(date);
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/react/src/api-key/ApiKeyListPanel.tsx
+++ b/sdk/react/src/api-key/ApiKeyListPanel.tsx
@@ -8,6 +8,7 @@ import type { ApiKey } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/api_pb";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useApiKeyList } from "./useApiKeyList.js";
 import { useDeleteApiKey } from "./useDeleteApiKey.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -200,7 +201,7 @@ function ApiKeyRow({
               "stg:disabled:pointer-events-none stg:disabled:opacity-50",
             )}
           >
-            {isDeleting && <SpinnerIcon />}
+            {isDeleting && <SpinnerIcon size={12} />}
             Delete
           </button>
           <button
@@ -363,20 +364,3 @@ function TrashIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/api-key/CreateApiKeyForm.tsx
+++ b/sdk/react/src/api-key/CreateApiKeyForm.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ApiKey } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/api_pb";
 import { useCreateApiKey } from "./useCreateApiKey.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -155,7 +156,7 @@ export function CreateApiKeyForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create API key
         </button>
 
@@ -236,24 +237,3 @@ function ExpiryRadio({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/channel-app/ChannelAppDetailPanel.tsx
+++ b/sdk/react/src/channel-app/ChannelAppDetailPanel.tsx
@@ -17,7 +17,8 @@ import {
   WHATSAPP_CHANNEL_APP_WEBHOOK_FIELDS,
   whatsappChannelAppWebhookUrl,
 } from "./whatsappAppSetup.js";
-import { CopyBlock, CopyRow, FormField, SpinnerIcon } from "./internal.js";
+import { CopyBlock, CopyRow, FormField } from "./internal.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -148,7 +149,7 @@ export function ChannelAppDetailPanel({
                 "stg:disabled:pointer-events-none stg:disabled:opacity-40",
               )}
             >
-              {isDeleting && <SpinnerIcon />}
+              {isDeleting && <SpinnerIcon size={12} />}
               Delete
             </button>
             <button
@@ -321,7 +322,7 @@ function SlackAppDetail({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isUpdating && <SpinnerIcon />}
+          {isUpdating && <SpinnerIcon size={12} />}
           Save credentials
         </button>
       </form>
@@ -501,7 +502,7 @@ function WhatsAppAppDetail({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isUpdating && <SpinnerIcon />}
+          {isUpdating && <SpinnerIcon size={12} />}
           Save credentials
         </button>
       </form>

--- a/sdk/react/src/channel-app/CreateChannelAppForm.tsx
+++ b/sdk/react/src/channel-app/CreateChannelAppForm.tsx
@@ -14,7 +14,8 @@ import {
   slackChannelAppRedirectUrl,
 } from "./slackAppSetup.js";
 import { generateWhatsAppVerifyToken } from "./whatsappAppSetup.js";
-import { CopyBlock, FormField, SpinnerIcon } from "./internal.js";
+import { CopyBlock, FormField } from "./internal.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -241,7 +242,7 @@ export function CreateChannelAppForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Register channel app
         </button>
 

--- a/sdk/react/src/channel-app/internal.tsx
+++ b/sdk/react/src/channel-app/internal.tsx
@@ -159,21 +159,3 @@ function useCopy(value: string) {
 
   return { copied, copy };
 }
-
-export function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/composer/ComposerToolbar.tsx
+++ b/sdk/react/src/composer/ComposerToolbar.tsx
@@ -18,9 +18,9 @@ import {
   PaperclipIcon,
   WorkspaceIcon,
   ArrowUpIcon,
-  SpinnerIcon,
   StopIcon,
 } from "./icons.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 export interface ComposerToolbarProps {
   readonly disabled: boolean;

--- a/sdk/react/src/composer/icons.tsx
+++ b/sdk/react/src/composer/icons.tsx
@@ -54,24 +54,6 @@ export function ArrowUpIcon() {
   );
 }
 
-export function SpinnerIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}
-
 /**
  * Filled rounded square — the universal "stop" glyph. Sized to ~62% of the
  * viewBox so it reads as a confident, deliberate mark (not a stray dot) when

--- a/sdk/react/src/conversation/ConversationComposer.tsx
+++ b/sdk/react/src/conversation/ConversationComposer.tsx
@@ -7,7 +7,7 @@ import { getUserMessage } from "@stigmer/sdk";
 import { ChannelSendOutcome } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
 import type { SendChannelMessageOutput } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
 import { Button } from "../button/Button.js";
-import { SpinnerIcon } from "../composer/icons.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 import { useComposer } from "../composer/useComposer.js";
 
 /** Props for {@link ConversationComposer}. */

--- a/sdk/react/src/dashboard/DashboardFailedRuns.tsx
+++ b/sdk/react/src/dashboard/DashboardFailedRuns.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import { cn } from "@stigmer/theme";
 import type { DashboardFailedRun } from "./types.js";
+import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 export interface DashboardFailedRunsProps {
   readonly failedRuns: readonly DashboardFailedRun[];
@@ -10,17 +11,6 @@ export interface DashboardFailedRunsProps {
   /** Called when the user clicks "View" on a failed run. */
   readonly onViewClick?: (id: string, type: DashboardFailedRun["type"]) => void;
   readonly className?: string;
-}
-
-function timeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 /**
@@ -89,7 +79,7 @@ export const DashboardFailedRuns = memo(function DashboardFailedRuns({
                 )}
               </div>
               <span className="stg:shrink-0 stg:text-muted-foreground">
-                {timeAgo(run.failedAt)}
+                {formatRelativeTime(run.failedAt)}
               </span>
               {onViewClick && (
                 <button

--- a/sdk/react/src/environment/CreateEnvironmentForm.tsx
+++ b/sdk/react/src/environment/CreateEnvironmentForm.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
 import { useCreateEnvironment } from "./useCreateEnvironment.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -144,7 +145,7 @@ export function CreateEnvironmentForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create environment
         </button>
 
@@ -167,24 +168,3 @@ export function CreateEnvironmentForm({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/environment/EnvVarForm.tsx
+++ b/sdk/react/src/environment/EnvVarForm.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import type { EnvVarInput } from "@stigmer/sdk";
 import { useScrollShadows } from "../internal/useScrollShadows.js";
 import { ScrollFade } from "../internal/ScrollFade.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /**
  * Describes a single environment variable the form should collect.
@@ -414,7 +415,7 @@ export function EnvVarForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isSubmitting && <SpinnerIcon />}
+          {isSubmitting && <SpinnerIcon size={12} />}
           {resolvedSubmitLabel}
         </button>
       </div>
@@ -466,20 +467,3 @@ function EyeOffIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/environment/EnvironmentVariableEditor.tsx
+++ b/sdk/react/src/environment/EnvironmentVariableEditor.tsx
@@ -17,6 +17,7 @@ import { PermissionGate } from "../iam-policy/PermissionGate.js";
 import { useUpdateEnvironmentVariables } from "./useUpdateEnvironmentVariables.js";
 import { useRemoveEnvironmentVariables } from "./useRemoveEnvironmentVariables.js";
 import { useRevealSecretValue } from "./useRevealSecretValue.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -367,7 +368,7 @@ function VariableRow({
             label="Save"
             variant="primary"
           >
-            {isSaving ? <SpinnerIcon /> : <CheckIcon />}
+            {isSaving ? <SpinnerIcon size={12} /> : <CheckIcon />}
           </ActionButton>
 
           <ActionButton
@@ -436,7 +437,7 @@ function VariableRow({
               label="Confirm delete"
               variant="danger"
             >
-              {isDeleting ? <SpinnerIcon /> : <CheckIcon />}
+              {isDeleting ? <SpinnerIcon size={12} /> : <CheckIcon />}
             </ActionButton>
             <ActionButton
               onClick={() => setMode("idle")}
@@ -469,7 +470,7 @@ function VariableRow({
                     variant="muted"
                   >
                     {isRevealing ? (
-                      <SpinnerIcon />
+                      <SpinnerIcon size={12} />
                     ) : revealedValue !== null ? (
                       <EyeOffIcon />
                     ) : (
@@ -609,7 +610,7 @@ function AddVariableForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isAdding && <SpinnerIcon />}
+          {isAdding && <SpinnerIcon size={12} />}
           Add
         </button>
         <button
@@ -815,20 +816,3 @@ function PlusIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/execution/ArtifactApplyButton.tsx
+++ b/sdk/react/src/execution/ArtifactApplyButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { SpinnerIcon } from "../internal/thread-card/glyphs.js";
 
 /** Props for {@link ArtifactApplyButton}. */
 export interface ArtifactApplyButtonProps {
@@ -51,7 +52,7 @@ export function ArtifactApplyButton({
     >
       {isApplying ? (
         <span className="stg:inline-flex stg:items-center stg:gap-1.5">
-          <SpinnerIcon />
+          <SpinnerIcon size={12} className="stg:shrink-0" />
           Applying{"\u2026"}
         </span>
       ) : (
@@ -61,19 +62,3 @@ export function ArtifactApplyButton({
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      className="stg:shrink-0 stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
-    </svg>
-  );
-}

--- a/sdk/react/src/execution/FileReviewCard.tsx
+++ b/sdk/react/src/execution/FileReviewCard.tsx
@@ -28,6 +28,7 @@ import {
   fileReviewability,
   type FileReviewability,
 } from "./file-review-status.js";
+import { SpinnerIcon } from "../internal/thread-card/glyphs.js";
 
 /** A stable empty set so the default `submittingDecisionKeys` keeps a constant ref. */
 const NO_KEYS: ReadonlySet<string> = new Set();
@@ -1063,23 +1064,3 @@ function bulkLabels(
   return { approve: `${approveVerb} all`, reject: "Reject all" };
 }
 
-// ---------------------------------------------------------------------------
-// Inline SVG icon
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="10"
-      height="10"
-      viewBox="0 0 12 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
-    </svg>
-  );
-}

--- a/sdk/react/src/execution/FollowUpInput.tsx
+++ b/sdk/react/src/execution/FollowUpInput.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { cn } from "@stigmer/theme";
 import { ModelSelector } from "../models/ModelSelector.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link FollowUpInput}. */
 export interface FollowUpInputProps {
@@ -204,19 +205,3 @@ function ArrowUpIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/execution/SubAgentSection.tsx
+++ b/sdk/react/src/execution/SubAgentSection.tsx
@@ -23,6 +23,7 @@ import {
   findActiveTodo,
   todoCompletionSummary,
 } from "./TodoList.js";
+import { SpinnerIcon } from "../internal/thread-card/glyphs.js";
 
 /** Props for {@link SubAgentSection}. */
 export interface SubAgentSectionProps {
@@ -206,7 +207,7 @@ function CollapsibleCard({
         <span className="stg:min-w-0 stg:flex-1 stg:truncate">{displayLabel}</span>
         {isRunning && (
           <span className="stg:shrink-0 stg:text-muted-foreground" aria-hidden="true">
-            <SpinnerIcon />
+            <SpinnerIcon size={12} />
           </span>
         )}
         <span
@@ -482,7 +483,8 @@ const SUB_AGENT_STATUS_MAP: Record<SubAgentStatus, SubAgentStatusInfo> = {
     label: "Running",
     colorClass: "stg:text-foreground",
     badgeClass: "stg:bg-muted stg:text-foreground",
-    icon: SpinnerIcon,
+    // Sized up to match this map's 12px siblings (the glyph defaults to 10).
+    icon: () => <SpinnerIcon size={12} />,
   },
   [SubAgentStatus.SUB_AGENT_COMPLETED]: {
     label: "Completed",
@@ -507,22 +509,6 @@ const SUB_AGENT_STATUS_MAP: Record<SubAgentStatus, SubAgentStatusInfo> = {
 // ---------------------------------------------------------------------------
 // Inline SVG icons
 // ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      className="stg:animate-spin"
-    >
-      <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
-    </svg>
-  );
-}
 
 function CheckCircleIcon() {
   return (

--- a/sdk/react/src/execution/ToolRunGroup.tsx
+++ b/sdk/react/src/execution/ToolRunGroup.tsx
@@ -12,6 +12,7 @@ import { useAutoDisclosure } from "../internal/useAutoDisclosure.js";
 import { ApprovalContext } from "./ApprovalContext.js";
 import { ToolCallItem, CATEGORY_ICON } from "./ToolCallItem.js";
 import type { ToolCategory } from "./tool-categories.js";
+import { SpinnerIcon } from "../internal/thread-card/glyphs.js";
 
 /** Props for {@link ToolRunGroup}. */
 export interface ToolRunGroupProps {
@@ -239,14 +240,6 @@ const STATUS_ICON: Record<AggregateStatus, () => React.JSX.Element> = {
 // ---------------------------------------------------------------------------
 // Inline SVG icons — kept inline for SDK independence (codebase pattern)
 // ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" className="stg:animate-spin">
-      <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
-    </svg>
-  );
-}
 
 function ClockIcon() {
   return (

--- a/sdk/react/src/iam-policy/GrantAccessForm.tsx
+++ b/sdk/react/src/iam-policy/GrantAccessForm.tsx
@@ -12,6 +12,7 @@ import { getUserMessage, iamRoleToString } from "@stigmer/sdk";
 import { useCreateIamPolicy } from "./useCreateIamPolicy.js";
 import { RoleSelector } from "./RoleSelector.js";
 import { PrincipalPicker, type SelectedPrincipal } from "./PrincipalPicker.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link GrantAccessForm}. */
 export interface GrantAccessFormProps {
@@ -151,7 +152,7 @@ export function GrantAccessForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Grant access
         </button>
 
@@ -174,20 +175,3 @@ export function GrantAccessForm({
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/iam-policy/OrgMembersPanel.tsx
+++ b/sdk/react/src/iam-policy/OrgMembersPanel.tsx
@@ -24,6 +24,7 @@ import { useCreateIamPolicy } from "./useCreateIamPolicy.js";
 import { useDeleteIamPolicy } from "./useDeleteIamPolicy.js";
 import { RoleSelector } from "./RoleSelector.js";
 import { ProviderBadge } from "./ProviderBadge.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -368,7 +369,7 @@ function RemoveConfirmation({
             "stg:disabled:pointer-events-none stg:disabled:opacity-50",
           )}
         >
-          {isRevoking && <SpinnerIcon />}
+          {isRevoking && <SpinnerIcon size={12} />}
           Remove
         </button>
         <button
@@ -499,7 +500,7 @@ function ChangeRoleRow({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isWorking && <SpinnerIcon />}
+          {isWorking && <SpinnerIcon size={12} />}
           {isWorking ? "Changing role…" : "Confirm"}
         </button>
         <button
@@ -562,20 +563,3 @@ function TrashIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/identity-provider/CreateIdentityProviderForm.tsx
+++ b/sdk/react/src/identity-provider/CreateIdentityProviderForm.tsx
@@ -6,6 +6,7 @@ import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import { useCreateIdentityProvider } from "./useCreateIdentityProvider.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link CreateIdentityProviderForm}. */
 export interface CreateIdentityProviderFormProps {
@@ -265,7 +266,7 @@ export function CreateIdentityProviderForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create identity provider
         </button>
 
@@ -505,24 +506,3 @@ function ToggleSwitch({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
@@ -7,6 +7,7 @@ import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identitypr
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt";
 import { useUpdateIdentityProvider } from "./useUpdateIdentityProvider.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link IdentityProviderDetailPanel}. */
 export interface IdentityProviderDetailPanelProps {
@@ -345,7 +346,7 @@ export function IdentityProviderDetailPanel({
                 "stg:disabled:pointer-events-none stg:disabled:opacity-40",
               )}
             >
-              {isUpdating && <SpinnerIcon />}
+              {isUpdating && <SpinnerIcon size={12} />}
               Save changes
             </button>
             <button
@@ -846,20 +847,3 @@ function ArrowLeftIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/identity-provider/IdentityProviderListPanel.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderListPanel.tsx
@@ -8,6 +8,7 @@ import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identitypr
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { useIdentityProviderList } from "./useIdentityProviderList.js";
 import { useDeleteIdentityProvider } from "./useDeleteIdentityProvider.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link IdentityProviderListPanel}. */
 export interface IdentityProviderListPanelProps {
@@ -197,7 +198,7 @@ function IdpRow({
               "stg:disabled:pointer-events-none stg:disabled:opacity-50",
             )}
           >
-            {isDeleting && <SpinnerIcon />}
+            {isDeleting && <SpinnerIcon size={12} />}
             Delete
           </button>
           <button
@@ -366,20 +367,3 @@ function TrashIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/identity-provider/IdentityProviderWizard.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderWizard.tsx
@@ -13,6 +13,7 @@ import { ProviderPicker } from "./ProviderPicker.js";
 import { useCreateIdentityProvider } from "./useCreateIdentityProvider.js";
 import { useOidcDiscovery } from "./useOidcDiscovery.js";
 import type { ProviderPreset, ProviderConfig } from "./presets.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link IdentityProviderWizard}. */
 export interface IdentityProviderWizardProps {
@@ -438,7 +439,7 @@ function ConfigureStep({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isLoading && <SpinnerIcon />}
+          {isLoading && <SpinnerIcon size={12} />}
           Continue
         </button>
         <TextButton onClick={onBack} disabled={isLoading}>
@@ -611,7 +612,7 @@ function ReviewStep({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create identity provider
         </button>
         <TextButton onClick={onBack} disabled={isCreating}>
@@ -980,20 +981,3 @@ function CancelButton({
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/identity-provider/SsoLoginPrompt.tsx
+++ b/sdk/react/src/identity-provider/SsoLoginPrompt.tsx
@@ -185,6 +185,7 @@ function resolvePhase(
 // ---------------------------------------------------------------------------
 
 import { forwardRef } from "react";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 interface OrgInputFormProps {
   readonly value: string;
@@ -244,7 +245,7 @@ function LoadingState({ org }: { org: string }) {
       aria-busy="true"
       aria-label={`Looking up SSO provider for ${org}`}
     >
-      <SpinnerIcon />
+      <SpinnerIcon size={20} className="stg:text-muted-foreground" />
       <p className="stg:text-sm stg:text-muted-foreground">
         Looking up <span className="stg:font-medium stg:text-foreground">{org}</span>&hellip;
       </p>
@@ -366,23 +367,6 @@ function ErrorState({
 // Icons
 // ---------------------------------------------------------------------------
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin stg:text-muted-foreground"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}
 
 function SsoShieldIcon() {
   return (

--- a/sdk/react/src/internal/DecisionButton.tsx
+++ b/sdk/react/src/internal/DecisionButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { SpinnerIcon } from "../internal/thread-card/glyphs.js";
 
 /** The visual weight of a {@link DecisionButton}. */
 export type DecisionVariant = "primary" | "ghost" | "danger";
@@ -106,23 +107,3 @@ export function DecisionButton({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Inline SVG icon
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="10"
-      height="10"
-      viewBox="0 0 12 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
-    </svg>
-  );
-}

--- a/sdk/react/src/internal/SpinnerIcon.tsx
+++ b/sdk/react/src/internal/SpinnerIcon.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@stigmer/theme";
+
+/**
+ * The SDK's canonical in-flight spinner: a three-quarter arc on a 16×16
+ * grid, colored by `currentColor` so the consumer's text token drives it
+ * (never hardcoded values — Dont-Do #3). Extracted from ~33 identical
+ * per-component copies (stigmer-cloud#270); new busy states import this
+ * instead of pasting another one.
+ *
+ * `size` is the rendered box; the glyph scales from the same viewBox, so
+ * every size renders the identical shape. Decorative by contract
+ * (`aria-hidden`) — pair it with visible or `sr-only` text when the busy
+ * state itself must be announced.
+ *
+ * The thread-card rows deliberately use a finer quarter-arc micro-glyph
+ * instead — see `internal/thread-card/glyphs.tsx`.
+ *
+ * @internal Not part of the public API.
+ */
+export function SpinnerIcon({
+  size = 16,
+  className,
+}: {
+  readonly size?: number;
+  readonly className?: string;
+} = {}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className={cn("stg:animate-spin", className)}
+      aria-hidden="true"
+    >
+      <path d="M8 2a6 6 0 1 0 6 6" />
+    </svg>
+  );
+}

--- a/sdk/react/src/internal/thread-card/glyphs.tsx
+++ b/sdk/react/src/internal/thread-card/glyphs.tsx
@@ -13,10 +13,31 @@ import { cn } from "@stigmer/theme";
  * @internal Not part of the public API.
  */
 
-/** Quarter-arc spinner for an in-flight item. */
-export function SpinnerIcon() {
+/**
+ * Quarter-arc spinner for an in-flight item. Deliberately finer than the
+ * SDK-wide `internal/SpinnerIcon` (1.5 stroke on a 12 grid vs 2 on 16) —
+ * the micro-row weight this vocabulary is built around. Card-adjacent
+ * surfaces that used to carry their own copies (tool-run groups, file
+ * review, decision buttons) size it up via `size` instead.
+ */
+export function SpinnerIcon({
+  size = 10,
+  className,
+}: {
+  readonly size?: number;
+  readonly className?: string;
+} = {}) {
   return (
-    <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" className="stg:animate-spin">
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      className={cn("stg:animate-spin", className)}
+      aria-hidden="true"
+    >
       <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
     </svg>
   );

--- a/sdk/react/src/invitation/InvitationManager.tsx
+++ b/sdk/react/src/invitation/InvitationManager.tsx
@@ -17,6 +17,7 @@ import { useRevokeInvitation } from "./useRevokeInvitation.js";
 import { InvitationCreatedAlert } from "./InvitationCreatedAlert.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { RoleSelector } from "../iam-policy/RoleSelector.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -358,7 +359,7 @@ function CreateInvitationForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create invite link
         </button>
 
@@ -572,7 +573,7 @@ function RevokeConfirmation({
             "stg:disabled:pointer-events-none stg:disabled:opacity-50",
           )}
         >
-          {isRevoking && <SpinnerIcon />}
+          {isRevoking && <SpinnerIcon size={12} />}
           Revoke
         </button>
         <button
@@ -836,20 +837,3 @@ function RevokeIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/invitation/InvitationRedemption.tsx
+++ b/sdk/react/src/invitation/InvitationRedemption.tsx
@@ -7,6 +7,7 @@ import type { Invitation } from "@stigmer/protos/ai/stigmer/iam/invitation/v1/ap
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { useInvitationPreview } from "./useInvitationPreview.js";
 import { useRedeemInvitation } from "./useRedeemInvitation.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -261,7 +262,7 @@ export function InvitationRedemption({
                     "stg:transition-colors",
                   )}
                 >
-                  {isRedeeming && <SpinnerIcon />}
+                  {isRedeeming && <SpinnerIcon size={14} />}
                   {isRedeeming ? "Accepting\u2026" : "Accept Invitation"}
                 </button>
                 {redeemError && (
@@ -442,20 +443,3 @@ function SuccessIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/mcp-server/OAuthAppForm.tsx
+++ b/sdk/react/src/mcp-server/OAuthAppForm.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link OAuthAppForm}. */
 export interface OAuthAppFormProps {
@@ -214,7 +215,7 @@ export function OAuthAppForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isSubmitting && <SpinnerIcon />}
+          {isSubmitting && <SpinnerIcon size={12} />}
           Save
         </button>
       </div>
@@ -285,20 +286,3 @@ function EyeOffIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/oauth-app/CreateOAuthAppForm.tsx
+++ b/sdk/react/src/oauth-app/CreateOAuthAppForm.tsx
@@ -6,6 +6,7 @@ import { getUserMessage } from "@stigmer/sdk";
 import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
 import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
 import { useCreateOAuthApp } from "./useCreateOAuthApp.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -319,7 +320,7 @@ export function CreateOAuthAppForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create OAuth app
         </button>
 
@@ -430,20 +431,3 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/oauth-app/OAuthAppDetailPanel.tsx
+++ b/sdk/react/src/oauth-app/OAuthAppDetailPanel.tsx
@@ -8,6 +8,7 @@ import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1
 import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt";
 import { useUpdateOAuthApp } from "./useUpdateOAuthApp.js";
 import { useDeleteOAuthApp } from "./useDeleteOAuthApp.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -265,7 +266,7 @@ export function OAuthAppDetailPanel({
                 "stg:disabled:pointer-events-none stg:disabled:opacity-40",
               )}
             >
-              {isDeleting && <SpinnerIcon />}
+              {isDeleting && <SpinnerIcon size={12} />}
               Delete permanently
             </button>
             <button
@@ -425,7 +426,7 @@ export function OAuthAppDetailPanel({
                 "stg:disabled:pointer-events-none stg:disabled:opacity-40",
               )}
             >
-              {isUpdating && <SpinnerIcon />}
+              {isUpdating && <SpinnerIcon size={12} />}
               Save changes
             </button>
             <button
@@ -652,20 +653,3 @@ function ArrowLeftIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/organization/CreateOrganizationForm.tsx
+++ b/sdk/react/src/organization/CreateOrganizationForm.tsx
@@ -9,6 +9,7 @@ import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/ap
 import { useCreateOrganization } from "./useCreateOrganization.js";
 import { generateSlug } from "../internal/slug.js";
 import { validateMessage, getFieldError } from "../internal/validate.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -234,7 +235,7 @@ export function CreateOrganizationForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create organization
         </button>
 
@@ -257,24 +258,3 @@ export function CreateOrganizationForm({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/organization/OrgProfilePanel.tsx
+++ b/sdk/react/src/organization/OrgProfilePanel.tsx
@@ -14,6 +14,7 @@ import { useOrganization } from "./useOrganization.js";
 import { useUpdateOrganization } from "./useUpdateOrganization.js";
 import { useIdentityProviderList } from "../identity-provider/useIdentityProviderList.js";
 import { useResourceAvailable, ApiResourceKind } from "../deployment-mode.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -323,7 +324,7 @@ export function OrgProfilePanel({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isUpdating && <SpinnerIcon />}
+          {isUpdating && <SpinnerIcon size={12} />}
           Save changes
         </button>
 
@@ -525,24 +526,3 @@ function LogoPreview({ url }: { url: string }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// SpinnerIcon
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/platform-client/CreatePlatformClientForm.tsx
+++ b/sdk/react/src/platform-client/CreatePlatformClientForm.tsx
@@ -11,6 +11,7 @@ import { getUserMessage } from "@stigmer/sdk";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import type { PlatformClientCreateResponse } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/io_pb";
 import { useCreatePlatformClient } from "./useCreatePlatformClient.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link CreatePlatformClientForm}. */
 export interface CreatePlatformClientFormProps {
@@ -348,7 +349,7 @@ export function CreatePlatformClientForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={12} />}
           Create platform client
         </button>
 
@@ -500,20 +501,3 @@ function XIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/platform-client/PlatformClientDetailPanel.tsx
+++ b/sdk/react/src/platform-client/PlatformClientDetailPanel.tsx
@@ -15,6 +15,7 @@ import type { PlatformClientCreateResponse } from "@stigmer/protos/ai/stigmer/ia
 import { useUpdatePlatformClient } from "./useUpdatePlatformClient.js";
 import { useRotatePlatformClientSecret } from "./useRotatePlatformClientSecret.js";
 import { useDeletePlatformClient } from "./useDeletePlatformClient.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link PlatformClientDetailPanel}. */
 export interface PlatformClientDetailPanelProps {
@@ -478,7 +479,7 @@ export function PlatformClientDetailPanel({
                 "stg:disabled:pointer-events-none stg:disabled:opacity-40",
               )}
             >
-              {isUpdating && <SpinnerIcon />}
+              {isUpdating && <SpinnerIcon size={12} />}
               Save changes
             </button>
             <button
@@ -520,7 +521,7 @@ export function PlatformClientDetailPanel({
                     "stg:disabled:pointer-events-none stg:disabled:opacity-50",
                   )}
                 >
-                  {isRotating && <SpinnerIcon />}
+                  {isRotating && <SpinnerIcon size={12} />}
                   Rotate
                 </button>
                 <button
@@ -587,7 +588,7 @@ export function PlatformClientDetailPanel({
                     "stg:disabled:pointer-events-none stg:disabled:opacity-50",
                   )}
                 >
-                  {isDeleting && <SpinnerIcon />}
+                  {isDeleting && <SpinnerIcon size={12} />}
                   Delete
                 </button>
                 <button
@@ -879,20 +880,3 @@ function ArrowLeftIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/platform-client/PlatformClientListPanel.tsx
+++ b/sdk/react/src/platform-client/PlatformClientListPanel.tsx
@@ -8,6 +8,7 @@ import type { PlatformClient } from "@stigmer/protos/ai/stigmer/iam/platformclie
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { usePlatformClientList } from "./usePlatformClientList.js";
 import { useDeletePlatformClient } from "./useDeletePlatformClient.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link PlatformClientListPanel}. */
 export interface PlatformClientListPanelProps {
@@ -200,7 +201,7 @@ function PlatformClientRow({
               "stg:disabled:pointer-events-none stg:disabled:opacity-50",
             )}
           >
-            {isDeleting && <SpinnerIcon />}
+            {isDeleting && <SpinnerIcon size={12} />}
             Delete
           </button>
           <button
@@ -411,20 +412,3 @@ function TrashIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/resource-creation/WizardNav.tsx
+++ b/sdk/react/src/resource-creation/WizardNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link WizardNav}. */
 export interface WizardNavProps {
@@ -98,7 +99,7 @@ export function WizardNav({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isSubmitting && <SpinnerIcon />}
+          {isSubmitting && <SpinnerIcon size={14} />}
           {nextLabel}
           {!isSubmitting && <ArrowRightIcon className="stg:size-3.5" />}
         </button>
@@ -145,20 +146,3 @@ function ArrowRightIcon({ className }: { readonly className?: string }) {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/schedule/ScheduleDetailView.tsx
+++ b/sdk/react/src/schedule/ScheduleDetailView.tsx
@@ -71,6 +71,7 @@ import { useResumeSchedule } from "./useResumeSchedule.js";
 import { useSetScheduleEnabled } from "./useSetScheduleEnabled.js";
 import { useTriggerSchedule } from "./useTriggerSchedule.js";
 import { useUpdateScheduleSpec } from "./useUpdateScheduleSpec.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link ScheduleDetailView}. */
 export interface ScheduleDetailViewProps {
@@ -1311,7 +1312,7 @@ function InlineEditActions({
             "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
           )}
         >
-          {isSaving && <SpinnerIcon />}
+          {isSaving && <SpinnerIcon size={14} />}
           Save
         </button>
       </div>
@@ -1632,20 +1633,3 @@ function PencilIcon({ className }: { readonly className?: string }) {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/schedule/ScheduleForm.tsx
+++ b/sdk/react/src/schedule/ScheduleForm.tsx
@@ -24,6 +24,7 @@ import { CadenceField } from "./CadenceField.js";
 import { TimeZoneField, browserTimeZone } from "./TimeZoneField.js";
 import { useCreateSchedule } from "./useCreateSchedule.js";
 import { cadenceToCron, validateCron, type CadencePreset } from "./cadence.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -467,7 +468,7 @@ export function ScheduleForm({
             "stg:disabled:pointer-events-none stg:disabled:opacity-40",
           )}
         >
-          {isCreating && <SpinnerIcon />}
+          {isCreating && <SpinnerIcon size={14} />}
           Create schedule
         </button>
 
@@ -597,20 +598,3 @@ function ChevronIcon() {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/version-history/VersionTimelineEntry.tsx
+++ b/sdk/react/src/version-history/VersionTimelineEntry.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@stigmer/theme";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import type { VersionTimelineEntryProps } from "./types.js";
+import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 /**
  * A single row in a version timeline.
@@ -204,27 +205,6 @@ function GitProvenanceRow({
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
-
-function formatRelativeTime(date: Date): string {
-  const now = Date.now();
-  const diffMs = now - date.getTime();
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
-  const diffHr = Math.floor(diffMin / 60);
-  const diffDays = Math.floor(diffHr / 24);
-
-  if (diffSec < 60) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24) return `${diffHr}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
-
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: date.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
-  });
-}
 
 function normalizeGitUrl(url: string): string | null {
   if (!url) return null;

--- a/sdk/react/src/workflow/FailedRunsWidget.tsx
+++ b/sdk/react/src/workflow/FailedRunsWidget.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { cn } from "@stigmer/theme";
+import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 export interface FailedRunsWidgetProps {
   /** Recent failed executions to display. */
@@ -12,14 +13,6 @@ export interface FailedRunsWidgetProps {
   /** Called when the user clicks "View" on a failed execution. */
   readonly onViewClick?: (executionId: string) => void;
   readonly className?: string;
-}
-
-function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
-  return `${Math.floor(seconds / 86400)}d ago`;
 }
 
 /**
@@ -85,7 +78,7 @@ export const FailedRunsWidget = memo(function FailedRunsWidget({
                     </p>
                     {failedDate && (
                       <p className="stg:mt-0.5 stg:text-xs stg:text-muted-foreground">
-                        {formatTimeAgo(failedDate)}
+                        {formatRelativeTime(failedDate)}
                       </p>
                     )}
                   </div>

--- a/sdk/react/src/workflow/PendingApprovalsWidget.tsx
+++ b/sdk/react/src/workflow/PendingApprovalsWidget.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { PendingApproval } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { cn } from "@stigmer/theme";
+import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 export interface PendingApprovalsWidgetProps {
   readonly approvals: readonly PendingApproval[];
@@ -12,14 +13,6 @@ export interface PendingApprovalsWidgetProps {
   /** Called when the user clicks "Review" on an approval. */
   readonly onReviewClick?: (executionId: string) => void;
   readonly className?: string;
-}
-
-function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
-  return `${Math.floor(seconds / 86400)}d ago`;
 }
 
 /**
@@ -98,7 +91,7 @@ export const PendingApprovalsWidget = memo(function PendingApprovalsWidget({
                     <p className="stg:mt-0.5 stg:truncate stg:text-xs stg:text-muted-foreground">
                       Task: {approval.taskName}
                       {requestedAt && (
-                        <> &middot; {formatTimeAgo(requestedAt)}</>
+                        <> &middot; {formatRelativeTime(requestedAt)}</>
                       )}
                     </p>
                   </div>

--- a/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from "./useWorkflowArchitectFlow.js";
 import { MessageThread } from "../execution/MessageThread.js";
 import { WorkflowDiffGraph } from "./WorkflowDiffGraph.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link WorkflowArchitectDialog}. */
 export interface WorkflowArchitectDialogProps {
@@ -279,7 +280,7 @@ function StreamingPhase({
             Workflow Architect
           </h3>
           <span className="stg:inline-flex stg:items-center stg:gap-1.5 stg:text-xs stg:text-muted-foreground">
-            <SpinnerIcon />
+            <SpinnerIcon size={14} />
             {flow.phase === "starting" ? "Starting…" : "Working…"}
           </span>
         </div>
@@ -436,7 +437,7 @@ function ResultPhase({
               "stg:disabled:pointer-events-none stg:disabled:opacity-40",
             )}
           >
-            {isApplying && <SpinnerIcon />}
+            {isApplying && <SpinnerIcon size={14} />}
             {isApplying ? "Creating…" : "Create Workflow"}
           </button>
         </div>
@@ -502,24 +503,3 @@ function ErrorPhase({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Shared components
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon({ size = 14 }: { readonly size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/workflow/WorkflowExplainDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowExplainDialog.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@stigmer/theme";
 import { useExplainWorkflowFlow, type ExplainPhase } from "./useExplainWorkflowFlow.js";
 import { MessageThread } from "../execution/MessageThread.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link WorkflowExplainDialog}. */
 export interface WorkflowExplainDialogProps {
@@ -102,7 +103,7 @@ export function WorkflowExplainDialog({
             </h3>
             {flow.isStreaming && (
               <span className="stg:inline-flex stg:items-center stg:gap-1.5 stg:text-xs stg:text-muted-foreground">
-                <SpinnerIcon />
+                <SpinnerIcon size={14} />
                 Analyzing…
               </span>
             )}
@@ -209,20 +210,3 @@ export function WorkflowExplainDialog({
   );
 }
 
-function SpinnerIcon({ size = 14 }: { readonly size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/workflow/WorkflowRefinePanel.tsx
+++ b/sdk/react/src/workflow/WorkflowRefinePanel.tsx
@@ -6,6 +6,7 @@ import { useRefineWorkflowFlow, type RefinePhase } from "./useRefineWorkflowFlow
 import { MessageThread } from "../execution/MessageThread.js";
 import { computeUnifiedDiff, type DiffLine } from "./workflow-yaml-diff.js";
 import { WorkflowDiffGraph } from "./WorkflowDiffGraph.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link WorkflowRefinePanel}. */
 export interface WorkflowRefinePanelProps {
@@ -173,7 +174,7 @@ export function WorkflowRefinePanel({
         {/* Starting indicator (before stream connects) */}
         {flow.phase === "starting" && (
           <div className="stg:flex stg:flex-col stg:items-center stg:justify-center stg:gap-2 stg:py-8">
-            <SpinnerIcon />
+            <SpinnerIcon size={14} />
             <p className="stg:text-xs stg:text-muted-foreground">
               Starting Workflow Architect…
             </p>
@@ -429,20 +430,3 @@ function CloseIcon() {
   );
 }
 
-function SpinnerIcon({ size = 14 }: { readonly size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/workflow/WorkflowRepairCard.tsx
+++ b/sdk/react/src/workflow/WorkflowRepairCard.tsx
@@ -6,6 +6,7 @@ import { useDiagnoseExecutionFlow, type DiagnosePhase } from "./useDiagnoseExecu
 import { MessageThread } from "../execution/MessageThread.js";
 import { computeUnifiedDiff, type DiffLine } from "./workflow-yaml-diff.js";
 import { WorkflowDiffGraph } from "./WorkflowDiffGraph.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link WorkflowRepairCard}. */
 export interface WorkflowRepairCardProps {
@@ -160,7 +161,7 @@ export function WorkflowRepairCard({
         {/* Starting indicator */}
         {flow.phase === "starting" && !hasConversation && (
           <div className="stg:flex stg:flex-col stg:items-center stg:justify-center stg:gap-2 stg:py-8">
-            <SpinnerIcon />
+            <SpinnerIcon size={14} />
             <p className="stg:text-xs stg:text-muted-foreground">
               Starting Workflow Architect…
             </p>
@@ -436,20 +437,3 @@ function CloseIcon() {
   );
 }
 
-function SpinnerIcon({ size = 14 }: { readonly size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/workflow/WorkflowRunDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowRunDialog.tsx
@@ -6,6 +6,7 @@ import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/ap
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import { useRunWorkflowFlow } from "./useRunWorkflowFlow.js";
 import { WorkflowRunForm } from "./WorkflowRunForm.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 /** Props for {@link WorkflowRunDialog}. */
 export interface WorkflowRunDialogProps {
@@ -225,7 +226,7 @@ export function WorkflowRunDialog({
               "stg:disabled:pointer-events-none stg:disabled:opacity-40",
             )}
           >
-            {flow.isSubmitting && <SpinnerIcon />}
+            {flow.isSubmitting && <SpinnerIcon size={14} />}
             {flow.isSubmitting ? "Starting…" : "Run Workflow"}
           </button>
         </div>
@@ -234,24 +235,3 @@ export function WorkflowRunDialog({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-function SpinnerIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M8 2a6 6 0 1 0 6 6" />
-    </svg>
-  );
-}

--- a/sdk/react/src/workflow/WorkflowTaskApprovalSummary.tsx
+++ b/sdk/react/src/workflow/WorkflowTaskApprovalSummary.tsx
@@ -13,6 +13,7 @@ import {
   type TaskDetailApprovalDecision,
   type TaskReviewerView,
 } from "./task-detail/task-approval.js";
+import { SpinnerIcon } from "../internal/thread-card/glyphs.js";
 
 /** Props for {@link WorkflowTaskApprovalSummary}. */
 export interface WorkflowTaskApprovalSummaryProps {
@@ -101,7 +102,7 @@ export const WorkflowTaskApprovalSummary = memo(function WorkflowTaskApprovalSum
       {/* Decision header */}
       {isFinalizing ? (
         <div className="stg:flex stg:items-center stg:gap-2 stg:text-xs stg:text-muted-foreground">
-          <SpinnerIcon />
+          <SpinnerIcon size={12} />
           <span>Decision recorded — finalizing…</span>
         </div>
       ) : (
@@ -315,19 +316,3 @@ function ToneIcon({ tone }: { readonly tone: DecisionTone }) {
   );
 }
 
-function SpinnerIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      className="stg:animate-spin"
-      aria-hidden="true"
-    >
-      <path d="M6 1.5A4.5 4.5 0 1 1 1.5 6" strokeLinecap="round" />
-    </svg>
-  );
-}

--- a/sdk/react/src/workflow/WorkflowVersionTimeline.tsx
+++ b/sdk/react/src/workflow/WorkflowVersionTimeline.tsx
@@ -6,6 +6,7 @@ import { useWorkflowVersions } from "./useWorkflowVersions.js";
 import { WorkflowVersionBadge } from "./WorkflowVersionBadge.js";
 import type { VersionEntry } from "../version-history/types.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 /** Props for {@link WorkflowVersionTimeline}. */
 export interface WorkflowVersionTimelineProps {
@@ -248,31 +249,6 @@ function EmptyState({ className }: { readonly className?: string }) {
       </p>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Utilities
-// ---------------------------------------------------------------------------
-
-function formatRelativeTime(date: Date): string {
-  const now = Date.now();
-  const diffMs = now - date.getTime();
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
-  const diffHr = Math.floor(diffMin / 60);
-  const diffDays = Math.floor(diffHr / 24);
-
-  if (diffSec < 60) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24) return `${diffHr}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
-
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: date.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/react/src/workflow/execution-comparison/ExecutionComparisonPicker.tsx
+++ b/sdk/react/src/workflow/execution-comparison/ExecutionComparisonPicker.tsx
@@ -6,6 +6,7 @@ import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecu
 import { useWorkflowExecutionList } from "../useWorkflowExecutionList.js";
 import { WorkflowExecutionPhaseBadge } from "../WorkflowExecutionPhaseBadge.js";
 import { formatDuration } from "../format-utils.js";
+import { formatRelativeTime } from "../../activity/format-relative-time.js";
 
 /** Props for {@link ExecutionComparisonPicker}. */
 export interface ExecutionComparisonPickerProps {
@@ -183,7 +184,7 @@ export const ExecutionComparisonPicker = memo(function ExecutionComparisonPicker
                     {name}
                   </span>
                   <span className="stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]">
-                    {startedAt ? formatRelative(startedAt) : "—"}
+                    {startedAt ? formatStartedAt(startedAt) : "—"}
                     {durationMs != null && ` · ${formatDuration(durationMs)}`}
                   </span>
                 </div>
@@ -228,13 +229,8 @@ function getDurationMs(startedAt: string | undefined, completedAt: string | unde
   return e - s;
 }
 
-function formatRelative(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  const now = Date.now();
-  const diff = now - d.getTime();
-  if (diff < 60_000) return "just now";
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+/** ISO wire value → the shared compact stamp; unparseable renders as absent. */
+function formatStartedAt(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "—" : formatRelativeTime(date);
 }

--- a/sdk/react/src/workflow/execution-history/ExecutionHistoryTable.tsx
+++ b/sdk/react/src/workflow/execution-history/ExecutionHistoryTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "./derive-execution-row.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../internal/tooltip.js";
 import { TruncatedText } from "../../internal/truncated-text.js";
+import { formatRelativeTime } from "../../activity/format-relative-time.js";
 
 // ---------------------------------------------------------------------------
 // Column definitions
@@ -435,29 +436,4 @@ function LoadingSkeleton({
       </table>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Relative time formatter
-// ---------------------------------------------------------------------------
-
-function formatRelativeTime(date: Date): string {
-  const now = Date.now();
-  const diff = now - date.getTime();
-
-  if (diff < 0) return date.toLocaleString();
-  if (diff < 60_000) return "just now";
-  if (diff < 3_600_000) {
-    const mins = Math.floor(diff / 60_000);
-    return `${mins}m ago`;
-  }
-  if (diff < 86_400_000) {
-    const hours = Math.floor(diff / 3_600_000);
-    return `${hours}h ago`;
-  }
-  if (diff < 604_800_000) {
-    const days = Math.floor(diff / 86_400_000);
-    return `${days}d ago`;
-  }
-  return date.toLocaleDateString();
 }


### PR DESCRIPTION
## Summary
Two deliberate duplication sweeps over the sdk/react component surface, one commit each: every local `SpinnerIcon` copy converges on a shared glyph (38 definitions deleted), and every private "time ago" formatter converges on the shared `formatRelativeTime` helper (8 deleted). Net −882/+185 lines.

## Context
stigmer-cloud#270 counted eight spinner copies at filing (2026-08-08); the class had grown to 38 by this sweep — the strongest argument for killing it now. stigmer-cloud#269's eight formatters had drifted into four different output shapes. The two sweeps overlap files, so one PR owns both. Owner ruling at plan approval: full sweep, not just the originally-named eight.

## Changes
**Spinners (commit 1)** — the census found two glyph families, each converging on its own home:
- 33 copies of the 16-grid three-quarter arc → new `internal/SpinnerIcon.tsx` (`size` + `className`; default is the viewBox-natural 16; every converted call site passes its measured original size — rendered pixels unchanged everywhere)
- 6 copies of the 12-grid quarter-arc micro-glyph → its existing home `internal/thread-card/glyphs.tsx`, which grows the same optional `size` (default 10 keeps current consumers identical)
- The two exported copies (`composer/icons.tsx`, `channel-app/internal.tsx`) deleted, their three importers repointed (neither reached the public API)
- Definition-baked extras moved to call sites (`SsoLoginPrompt`'s text token, `ArtifactApplyButton`'s `stg:shrink-0`); both shared glyphs are zero-arg callable so `STATUS_ICON`-style component references keep working; 3 copies gain the `aria-hidden` they were missing

**Formatters (commit 2)** — all eight sites now delegate to `activity/format-relative-time` (deterministic under an injected clock, future-skew-safe); its doc comment now names it the SDK-wide vocabulary. Before/after per site:

| Component | Before | After |
|---|---|---|
| DashboardFailedRuns | `just now` / `5m ago` / `3h ago` / `45d ago` | `now` / `5m` / `3h` / `Jul 12` |
| PendingApprovalsWidget | `just now` / `5m ago` / `3h ago` / `45d ago` | same as above |
| FailedRunsWidget | `just now` / `5m ago` / `3h ago` / `45d ago` | same as above |
| ExecutionHistoryTable | `just now` / `5m ago` / locale date >7d | `now` / `5m` / `Jul 12` >7d |
| ExecutionComparisonPicker | `just now` / `5m ago` / `Jul 12` >24h; unparseable ISO echoed raw | `now` / `5m` / `Jul 12` >7d; unparseable renders `—` |
| ApiKeyListPanel | `Just now` / `5m ago` / long date >30d | `now` / `5m` / `Jul 12` >7d |
| VersionTimelineEntry | `just now` / `5m ago` / `3w ago` / date >30d | `now` / `5m` / `Jul 12` >7d |
| WorkflowVersionTimeline | identical to VersionTimelineEntry | same |

## Implementation notes
- The thread-card micro-glyph is NOT merged into the arc glyph — different visual weight (1.5 stroke on 12 vs 2 on 16) inside a documented vocabulary; each family got its own canonical home
- `formatRelativeTime` stays in `activity/` — it is public API (exported through the package index), so relocating to `internal/` would contradict that directory's contract
- Excluded on semantic grounds: `InvitationManager.formatRelativeExpiry` is future-directed ("expires in…"), not an instance of this class
- Recorded, not swept: `ToolRunGroup` + `SubAgentSection` also carry local copies of the OTHER thread-card glyphs (Clock/Check/X/Dot) — converging them means size-parameterizing the whole vocabulary, its own decision (noted on the issue)

## Breaking changes
- None to the public API. Visible timestamp text changes as tabled above — deliberate per stigmer-cloud#269

## Test plan
- Full sdk/react gate green: tsc, 397 files / 4360 vitest tests, eslint + prefix check
- Codemod was fail-loud (exactly one definition match per file, measured original size per site); leftover-definition and orphaned-banner scans clean

Closes stigmer/stigmer-cloud#269
Closes stigmer/stigmer-cloud#270

Made with [Cursor](https://cursor.com)