### PR TITLE
feat(sdk/react): vision preflight — warn before upload when images exceed the budget or the model is blind

### DIFF
--- a/backend/services/runner/src/shared/__tests__/attachment-vision.test.ts
+++ b/backend/services/runner/src/shared/__tests__/attachment-vision.test.ts
@@ -291,6 +291,10 @@ describe("VisionBudget — size and count budgets", () => {
   });
 
   it("ships the production constants agreed in T04 (raw bytes)", () => {
+    // Also the ADVERTISED == ENFORCED drift alarm (stigmer/stigmer#365):
+    // the registry document advertises these exact values in its
+    // `limits.vision` block, pinned by the cloud codec's own test. If this
+    // fails, the budget changed on one side only — update both together.
     expect(MAX_VISION_IMAGE_BYTES).toBe(3 * 1024 * 1024);
     expect(MAX_VISION_TOTAL_BYTES).toBe(4 * 1024 * 1024);
     expect(MAX_VISION_IMAGES).toBe(10);

--- a/backend/services/runner/src/shared/attachment-vision.ts
+++ b/backend/services/runner/src/shared/attachment-vision.ts
@@ -32,6 +32,15 @@
 
 // ---------------------------------------------------------------------------
 // Budget constants (owner decision, 2026-08-09; project T04)
+//
+// ADVERTISED == ENFORCED (stigmer/stigmer#365): the model registry document
+// advertises these values in its `limits.vision` block (rendered by the
+// cloud's ModelRegistryDocumentCodec, mirrored verbatim by the OSS server)
+// so clients can warn BEFORE an upload this budget would degrade. Both sides
+// pin the literal values in tests — attachment-vision.test.ts here, the
+// codec test there — so changing either side alone fails its own suite.
+// Update both together; deploy the runner first if the budget ever shrinks
+// (never advertise more than the runner accepts).
 // ---------------------------------------------------------------------------
 
 /**

--- a/sdk/react/src/attachment/__tests__/vision-preflight.test.ts
+++ b/sdk/react/src/attachment/__tests__/vision-preflight.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "vitest";
+import {
+  assessVisionPreflight,
+  visionPreflightMessage,
+  type VisionPreflightAttachment,
+} from "../vision-preflight";
+import type { ModelInfo, VisionLimits } from "../../models/registry";
+
+/** The production budget the registry advertises (3 MiB / 4 MiB / 10). */
+const LIMITS: VisionLimits = {
+  maxImageBytes: 3 * 1024 * 1024,
+  maxTotalBytes: 4 * 1024 * 1024,
+  maxImages: 10,
+};
+
+function image(name: string, sizeBytes: number, contentType = "image/png"): VisionPreflightAttachment {
+  return { name, sizeBytes, contentType };
+}
+
+function model(overrides?: Partial<ModelInfo>): ModelInfo {
+  return {
+    modelId: "test-model",
+    provider: "anthropic",
+    displayName: "Test Model",
+    shortDescription: "",
+    speedTier: "fast",
+    costTier: "standard",
+    harness: "native",
+    featured: false,
+    serviceTiers: [],
+    ...overrides,
+  };
+}
+
+describe("assessVisionPreflight — tri-state silence", () => {
+  it("warns about nothing when limits are absent (older server)", () => {
+    const result = assessVisionPreflight([image("huge.png", 50 * 1024 * 1024)], {
+      model: model(),
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.modelCannotSeeImages).toBe(false);
+  });
+
+  it("stays silent on an unassessed model (visionCapability undefined)", () => {
+    const result = assessVisionPreflight([image("a.png", 100)], {
+      model: model(),
+      limits: LIMITS,
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("never treats an unknown model as blind", () => {
+    const result = assessVisionPreflight([image("a.png", 100)], { limits: LIMITS });
+    expect(result.modelCannotSeeImages).toBe(false);
+  });
+
+  it("returns no warnings for zero attachments", () => {
+    expect(assessVisionPreflight([], { model: model(), limits: LIMITS }).warnings).toEqual([]);
+  });
+});
+
+describe("assessVisionPreflight — vision candidates", () => {
+  it("ignores non-image attachments entirely, even huge ones", () => {
+    const result = assessVisionPreflight(
+      [
+        { name: "big.pdf", sizeBytes: 50 * 1024 * 1024, contentType: "application/pdf" },
+        { name: "big.zip", sizeBytes: 50 * 1024 * 1024, contentType: "application/zip" },
+      ],
+      { model: model({ visionCapability: false }), limits: LIMITS },
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.modelCannotSeeImages).toBe(false);
+  });
+
+  it("ignores SVG — image/* but not a runner vision type", () => {
+    const result = assessVisionPreflight(
+      [image("diagram.svg", 50 * 1024 * 1024, "image/svg+xml")],
+      { model: model(), limits: LIMITS },
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("assesses all four runner vision types, case-insensitively", () => {
+    const oversized = LIMITS.maxImageBytes + 1;
+    const result = assessVisionPreflight(
+      [
+        image("a.png", oversized, "image/png"),
+        image("b.jpg", oversized, "image/JPEG"),
+        image("c.webp", oversized, "image/webp"),
+        image("d.gif", oversized, "image/gif"),
+      ],
+      { limits: LIMITS },
+    );
+    expect(result.warnings.map((w) => w.reason)).toEqual([
+      "too_large", "too_large", "too_large", "too_large",
+    ]);
+  });
+});
+
+describe("assessVisionPreflight — per-image cap (too_large)", () => {
+  it("accepts an image exactly at the cap", () => {
+    const result = assessVisionPreflight([image("edge.png", LIMITS.maxImageBytes)], {
+      limits: LIMITS,
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("degrades an image one byte over the cap", () => {
+    const result = assessVisionPreflight([image("over.png", LIMITS.maxImageBytes + 1)], {
+      limits: LIMITS,
+    });
+    expect(result.warnings).toEqual([
+      { name: "over.png", sizeBytes: LIMITS.maxImageBytes + 1, reason: "too_large" },
+    ]);
+  });
+
+  it("mirrors the production regression: a 3.59 MiB PNG warns", () => {
+    // The prod-verified case from stigmer/stigmer#365 — this image uploaded
+    // fine and then surprised the user with a disclosure after the turn.
+    const bytes = Math.round(3.59 * 1024 * 1024);
+    const result = assessVisionPreflight([image("photo.png", bytes)], { limits: LIMITS });
+    expect(result.warnings[0]?.reason).toBe("too_large");
+  });
+});
+
+describe("assessVisionPreflight — per-turn budget (budget_exhausted)", () => {
+  it("replicates the runner's admission: an oversized image does NOT consume budget", () => {
+    // 3.5 MiB is over the per-image cap (degraded, not counted); the two
+    // 1.9 MiB images then fit the 4 MiB total exactly like the runner
+    // would admit them. A naive sum (7.3 MiB) would wrongly warn on all.
+    const result = assessVisionPreflight(
+      [
+        image("oversized.png", 3.5 * 1024 * 1024),
+        image("ok-1.png", 1.9 * 1024 * 1024),
+        image("ok-2.png", 1.9 * 1024 * 1024),
+      ],
+      { limits: LIMITS },
+    );
+    expect(result.warnings).toEqual([
+      { name: "oversized.png", sizeBytes: 3.5 * 1024 * 1024, reason: "too_large" },
+    ]);
+  });
+
+  it("degrades the image that would cross the total-byte budget, in attachment order", () => {
+    const twoMib = 2 * 1024 * 1024;
+    const result = assessVisionPreflight(
+      [image("a.png", twoMib), image("b.png", twoMib), image("c.png", twoMib)],
+      { limits: LIMITS },
+    );
+    // a (2 MiB) + b (2 MiB) = 4 MiB exactly; c would cross.
+    expect(result.warnings).toEqual([
+      { name: "c.png", sizeBytes: twoMib, reason: "budget_exhausted" },
+    ]);
+  });
+
+  it("degrades images past the count cap", () => {
+    const tiny = 1024;
+    const images = Array.from({ length: 12 }, (_, i) => image(`img-${i}.png`, tiny));
+    const result = assessVisionPreflight(images, { limits: LIMITS });
+    expect(result.warnings.map((w) => w.name)).toEqual(["img-10.png", "img-11.png"]);
+    expect(result.warnings.every((w) => w.reason === "budget_exhausted")).toBe(true);
+  });
+
+  it("admits a smaller later image after an earlier refusal (runner semantics: sequential offers, no reservation)", () => {
+    // The runner offers every image in order and never reserves budget for
+    // a refused one; the preflight must not be cleverer or dumber than the
+    // enforcement it predicts.
+    const result = assessVisionPreflight(
+      [
+        image("big.png", 3 * 1024 * 1024),
+        image("medium.png", 2 * 1024 * 1024), // 3+2 > 4 → refused
+        image("small.png", 512 * 1024),       // 3+0.5 ≤ 4 → admitted
+      ],
+      { limits: LIMITS },
+    );
+    expect(result.warnings).toEqual([
+      { name: "medium.png", sizeBytes: 2 * 1024 * 1024, reason: "budget_exhausted" },
+    ]);
+  });
+});
+
+describe("assessVisionPreflight — blind model (model_no_vision)", () => {
+  it("short-circuits the byte math: every image warns model_no_vision, sizes irrelevant", () => {
+    const result = assessVisionPreflight(
+      [image("tiny.png", 10), image("huge.png", 50 * 1024 * 1024)],
+      { model: model({ visionCapability: false }), limits: LIMITS },
+    );
+    expect(result.modelCannotSeeImages).toBe(true);
+    expect(result.warnings).toEqual([
+      { name: "tiny.png", sizeBytes: 10, reason: "model_no_vision" },
+      { name: "huge.png", sizeBytes: 50 * 1024 * 1024, reason: "model_no_vision" },
+    ]);
+  });
+
+  it("applies the capability verdict even without limits (older server)", () => {
+    const result = assessVisionPreflight([image("a.png", 10)], {
+      model: model({ visionCapability: false }),
+    });
+    expect(result.modelCannotSeeImages).toBe(true);
+  });
+
+  it("an explicitly sighted model gets the normal byte assessment", () => {
+    const result = assessVisionPreflight([image("a.png", LIMITS.maxImageBytes + 1)], {
+      model: model({ visionCapability: true }),
+      limits: LIMITS,
+    });
+    expect(result.modelCannotSeeImages).toBe(false);
+    expect(result.warnings[0]?.reason).toBe("too_large");
+  });
+});
+
+describe("visionPreflightMessage", () => {
+  it("returns null for a clean preflight", () => {
+    expect(
+      visionPreflightMessage({ warnings: [], modelCannotSeeImages: false }),
+    ).toBeNull();
+  });
+
+  it("leads with the model for a blind-model preflight, never file advice", () => {
+    const preflight = assessVisionPreflight([image("a.png", 10)], {
+      model: model({ visionCapability: false, displayName: "Kimi K3" }),
+      limits: LIMITS,
+    });
+    const message = visionPreflightMessage(preflight, {
+      limits: LIMITS,
+      modelDisplayName: "Kimi K3",
+    });
+    expect(message).toBe(
+      "Kimi K3 can't view images — attached images will reach the agent as files only.",
+    );
+  });
+
+  it("names a single oversized file with its size and the actual cap", () => {
+    const preflight = assessVisionPreflight(
+      [image("screenshot.png", Math.round(3.6 * 1024 * 1024))],
+      { limits: LIMITS },
+    );
+    const message = visionPreflightMessage(preflight, { limits: LIMITS });
+    expect(message).toBe(
+      "screenshot.png (3.6 MB) exceeds the 3.0 MB inline-image limit and will reach the agent as a file, not an image.",
+    );
+  });
+
+  it("names two oversized files, then switches to a count for more", () => {
+    const over = LIMITS.maxImageBytes + 1;
+    const two = assessVisionPreflight(
+      [image("a.png", over), image("b.png", over)],
+      { limits: LIMITS },
+    );
+    expect(visionPreflightMessage(two, { limits: LIMITS })).toContain(
+      "a.png and b.png exceed",
+    );
+
+    const three = assessVisionPreflight(
+      [image("a.png", over), image("b.png", over), image("c.png", over)],
+      { limits: LIMITS },
+    );
+    expect(visionPreflightMessage(three, { limits: LIMITS })).toContain(
+      "3 images exceed",
+    );
+  });
+
+  it("explains the per-turn budget for budget_exhausted", () => {
+    const twoMib = 2 * 1024 * 1024;
+    const preflight = assessVisionPreflight(
+      [image("a.png", twoMib), image("b.png", twoMib), image("c.png", twoMib)],
+      { limits: LIMITS },
+    );
+    const message = visionPreflightMessage(preflight, { limits: LIMITS });
+    expect(message).toBe(
+      "c.png is over this turn's inline-image budget (10 images, 4.0 MB total) and will reach the agent as a file.",
+    );
+  });
+
+  it("joins mixed too_large and budget_exhausted reasons into one line", () => {
+    const preflight = {
+      warnings: [
+        { name: "big.png", sizeBytes: 4 * 1024 * 1024, reason: "too_large" as const },
+        { name: "late.png", sizeBytes: 1024, reason: "budget_exhausted" as const },
+      ],
+      modelCannotSeeImages: false,
+    };
+    const message = visionPreflightMessage(preflight, { limits: LIMITS });
+    expect(message).toContain("big.png");
+    expect(message).toContain("late.png");
+    expect(message).toContain("; ");
+  });
+
+  it("degrades copy gracefully when limits are unknown", () => {
+    const preflight = {
+      warnings: [
+        { name: "big.png", sizeBytes: 4 * 1024 * 1024, reason: "too_large" as const },
+      ],
+      modelCannotSeeImages: false,
+    };
+    const message = visionPreflightMessage(preflight);
+    expect(message).toBe(
+      "big.png (4.0 MB) exceeds the inline-image size limit and will reach the agent as a file, not an image.",
+    );
+  });
+
+  it("falls back to generic wording when the blind model has no display name", () => {
+    const preflight = {
+      warnings: [{ name: "a.png", sizeBytes: 10, reason: "model_no_vision" as const }],
+      modelCannotSeeImages: true,
+    };
+    expect(visionPreflightMessage(preflight)).toBe(
+      "The selected model can't view images — attached images will reach the agent as files only.",
+    );
+  });
+});

--- a/sdk/react/src/attachment/index.ts
+++ b/sdk/react/src/attachment/index.ts
@@ -22,6 +22,18 @@ export type { ClipboardFilesSource } from "./clipboard.js";
 
 export { prepareImageForVision } from "./prepare-image.js";
 export {
+  assessVisionPreflight,
+  visionPreflightMessage,
+} from "./vision-preflight.js";
+export type {
+  AssessVisionPreflightOptions,
+  VisionPreflight,
+  VisionPreflightAttachment,
+  VisionPreflightMessageOptions,
+  VisionPreflightReason,
+  VisionPreflightWarning,
+} from "./vision-preflight.js";
+export {
   MAX_VISION_LONG_EDGE_PX,
   MAX_VISION_PIXELS,
   exceedsVisionResolution,

--- a/sdk/react/src/attachment/vision-preflight.ts
+++ b/sdk/react/src/attachment/vision-preflight.ts
@@ -1,0 +1,236 @@
+/**
+ * Client-side vision preflight — predicts, before a turn is spent, which
+ * attached images the runner will refuse to deliver inline and why
+ * (stigmer/stigmer#365, stigmer/stigmer#386).
+ *
+ * The runner is the enforcement authority (`VisionBudget` in its
+ * `shared/attachment-vision.ts`); this module is the warning authority.
+ * To never warn differently than the runner behaves, it replicates the
+ * runner's admission semantics against the SAME data the runner uses:
+ *
+ * - the byte budget arrives via the registry document's `limits.vision`
+ *   block ({@link VisionLimits}) — advertised == enforced;
+ * - the model's vision capability arrives via the per-model
+ *   `capabilities` block ({@link ModelInfo.visionCapability});
+ * - reasons reuse the runner's disclosure vocabulary
+ *   (`VisionDegradedReason`), so a warning here and a disclosure in the
+ *   agent's reply always tell one story.
+ *
+ * Tri-state discipline: absent limits or an unassessed model produce NO
+ * warnings. A client that cannot know the budget must stay silent, not
+ * guess — the runner's own disclosure remains the backstop.
+ *
+ * Deliberately assessed client-side reasons are a SUBSET of the runner's:
+ * `unsupported_format` and `type_mismatch` need magic-byte sniffing that a
+ * declared content type cannot honestly stand in for (and pasted images are
+ * already normalized by `prepareImageForVision`), so those two remain
+ * runner-disclosed only.
+ */
+
+import type { ModelInfo, VisionLimits } from "../models/registry.js";
+import { formatFileSize } from "./attachment-utils.js";
+
+/**
+ * Content types the runner recognizes as vision candidates (its
+ * `VisionMimeType` set). Anything else — PDFs, SVGs, archives — rides the
+ * normal file story with no inline-vision expectation and no warning.
+ */
+const VISION_CANDIDATE_TYPES: ReadonlySet<string> = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+/** Minimal attachment shape the preflight needs — pure data, no `File`. */
+export interface VisionPreflightAttachment {
+  /** Display name used in warning copy (the chip's filename). */
+  readonly name: string;
+  /** Raw byte size — what the runner's budget counts. */
+  readonly sizeBytes: number;
+  /** Declared/detected MIME type (`AttachmentEntry.contentType`). */
+  readonly contentType: string;
+}
+
+/**
+ * Why an image will not be viewable inline — the client-assessable subset
+ * of the runner's `VisionDegradedReason` vocabulary, same spellings.
+ */
+export type VisionPreflightReason =
+  /** Raw bytes exceed the per-image cap; a smaller re-export would fix it. */
+  | "too_large"
+  /** Image is fine but the turn's total/count budget is already spent. */
+  | "budget_exhausted"
+  /** The selected model is explicitly assessed as unable to see images. */
+  | "model_no_vision";
+
+/** One image the runner is predicted to degrade, and why. */
+export interface VisionPreflightWarning {
+  readonly name: string;
+  readonly sizeBytes: number;
+  readonly reason: VisionPreflightReason;
+}
+
+/** Result of {@link assessVisionPreflight}. */
+export interface VisionPreflight {
+  /** Predicted-degraded images in attachment order. Empty = all clear. */
+  readonly warnings: readonly VisionPreflightWarning[];
+  /**
+   * True when the selected model is explicitly blind (`vision: false`)
+   * and at least one image is attached. When set, every image warning
+   * carries `model_no_vision` — resending smaller images cannot help, so
+   * warning UI should lead with the model, not the files.
+   */
+  readonly modelCannotSeeImages: boolean;
+}
+
+const NO_WARNINGS: VisionPreflight = { warnings: [], modelCannotSeeImages: false };
+
+/** Options for {@link assessVisionPreflight}. */
+export interface AssessVisionPreflightOptions {
+  /**
+   * The model the turn will run on. `undefined` (unknown/still loading)
+   * disables the capability verdict, never the byte assessment.
+   */
+  readonly model?: ModelInfo | undefined;
+  /**
+   * The advertised byte budget from `useModelRegistry().visionLimits`.
+   * `undefined` (older server, still loading) disables the byte
+   * assessment, never the capability verdict.
+   */
+  readonly limits?: VisionLimits | undefined;
+}
+
+/**
+ * Predict which attached images the runner will degrade this turn.
+ *
+ * Pure and deterministic — safe to call in render (memoized by callers).
+ * Non-image attachments never warn. The byte assessment replicates the
+ * runner's sequential admission: an image over the per-image cap is
+ * degraded WITHOUT consuming budget; remaining images are admitted in
+ * order until the count or total-byte budget is exhausted.
+ */
+export function assessVisionPreflight(
+  attachments: readonly VisionPreflightAttachment[],
+  options?: AssessVisionPreflightOptions,
+): VisionPreflight {
+  const candidates = attachments.filter((a) =>
+    VISION_CANDIDATE_TYPES.has(a.contentType.toLowerCase()),
+  );
+  if (candidates.length === 0) return NO_WARNINGS;
+
+  // The capability gate short-circuits the byte math: on an explicitly
+  // blind model no image is deliverable at any size, and mixing byte
+  // warnings in would wrongly suggest a smaller resend could help.
+  if (options?.model?.visionCapability === false) {
+    return {
+      warnings: candidates.map((a) => ({
+        name: a.name,
+        sizeBytes: a.sizeBytes,
+        reason: "model_no_vision",
+      })),
+      modelCannotSeeImages: true,
+    };
+  }
+
+  const limits = options?.limits;
+  if (!limits) return NO_WARNINGS;
+
+  const warnings: VisionPreflightWarning[] = [];
+  let acceptedCount = 0;
+  let acceptedBytes = 0;
+
+  for (const image of candidates) {
+    if (image.sizeBytes > limits.maxImageBytes) {
+      warnings.push({ name: image.name, sizeBytes: image.sizeBytes, reason: "too_large" });
+      continue;
+    }
+    if (
+      acceptedCount >= limits.maxImages ||
+      acceptedBytes + image.sizeBytes > limits.maxTotalBytes
+    ) {
+      warnings.push({
+        name: image.name,
+        sizeBytes: image.sizeBytes,
+        reason: "budget_exhausted",
+      });
+      continue;
+    }
+    acceptedCount += 1;
+    acceptedBytes += image.sizeBytes;
+  }
+
+  return warnings.length === 0
+    ? NO_WARNINGS
+    : { warnings, modelCannotSeeImages: false };
+}
+
+/** Options for {@link visionPreflightMessage}. */
+export interface VisionPreflightMessageOptions {
+  /** The advertised budget — names the caps in the copy when present. */
+  readonly limits?: VisionLimits | undefined;
+  /** Display name of the selected model, for the capability wording. */
+  readonly modelDisplayName?: string | undefined;
+}
+
+/**
+ * One-line human copy for a {@link VisionPreflight} — the client-side twin
+ * of the runner's `visionDisclosureLines`, worded for BEFORE the turn
+ * ("will arrive as a file") instead of after ("was not viewable").
+ *
+ * Returns `null` when there is nothing to warn about. Copy rules:
+ * - a blind model leads with the model, never the files — no smaller
+ *   resend can help, so file-size advice would be dishonest;
+ * - `too_large` names the files (up to two, then a count) and the actual
+ *   cap, so the fix — export smaller — is self-evident;
+ * - `budget_exhausted` explains the per-turn budget, the only fix being
+ *   fewer images this turn.
+ */
+export function visionPreflightMessage(
+  preflight: VisionPreflight,
+  options?: VisionPreflightMessageOptions,
+): string | null {
+  if (preflight.warnings.length === 0) return null;
+
+  if (preflight.modelCannotSeeImages) {
+    const model = options?.modelDisplayName ?? "The selected model";
+    return `${model} can't view images — attached images will reach the agent as files only.`;
+  }
+
+  const tooLarge = preflight.warnings.filter((w) => w.reason === "too_large");
+  const exhausted = preflight.warnings.filter((w) => w.reason === "budget_exhausted");
+  const parts: string[] = [];
+
+  if (tooLarge.length > 0) {
+    const capPhrase = options?.limits
+      ? `the ${formatFileSize(options.limits.maxImageBytes)} inline-image limit`
+      : "the inline-image size limit";
+    if (tooLarge.length === 1) {
+      const w = tooLarge[0];
+      parts.push(
+        `${w.name} (${formatFileSize(w.sizeBytes)}) exceeds ${capPhrase} and will reach the agent as a file, not an image`,
+      );
+    } else if (tooLarge.length === 2) {
+      parts.push(
+        `${tooLarge[0].name} and ${tooLarge[1].name} exceed ${capPhrase} and will reach the agent as files, not images`,
+      );
+    } else {
+      parts.push(
+        `${tooLarge.length} images exceed ${capPhrase} and will reach the agent as files, not images`,
+      );
+    }
+  }
+
+  if (exhausted.length > 0) {
+    const budget = options?.limits
+      ? `this turn's inline-image budget (${options.limits.maxImages} images, ${formatFileSize(options.limits.maxTotalBytes)} total)`
+      : "this turn's inline-image budget";
+    parts.push(
+      exhausted.length === 1
+        ? `${exhausted[0].name} is over ${budget} and will reach the agent as a file`
+        : `${exhausted.length} images are over ${budget} and will reach the agent as files`,
+    );
+  }
+
+  return parts.length === 0 ? null : `${parts.join("; ")}.`;
+}

--- a/sdk/react/src/composer/SessionComposer.tsx
+++ b/sdk/react/src/composer/SessionComposer.tsx
@@ -10,6 +10,11 @@ import type { HarnessOption } from "../models/harness.js";
 import type { ServiceTierOption } from "../models/service-tier.js";
 import type { InteractionModeOption } from "./InteractionModePicker.js";
 import { parseModelKey } from "../models/registry.js";
+import { useModelRegistry } from "../models/useModelRegistry.js";
+import {
+  assessVisionPreflight,
+  visionPreflightMessage,
+} from "../attachment/vision-preflight.js";
 import { WorkspaceEditor } from "../workspace/WorkspaceEditor.js";
 import { AgentPicker } from "../agent/AgentPicker.js";
 import { AgentEnvForm, type AgentEnvFormSubmitOptions } from "../agent/AgentEnvForm.js";
@@ -753,6 +758,52 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
       ? { onValidationError: onAttachmentValidationError }
       : undefined,
   );
+
+  // -------------------------------------------------------------------------
+  // Vision preflight (stigmer/stigmer#365, #386) — predicts which attached
+  // images the runner will degrade to "not viewable inline" (per-image /
+  // per-turn byte budget from the registry document) or that the selected
+  // model is explicitly blind. Non-blocking by design: the files still
+  // upload and mount fine, they just won't reach the model as pixels — so
+  // this warns, it never gates the send.
+  // -------------------------------------------------------------------------
+
+  const {
+    getByKey: registryGetByKey,
+    getModel: registryGetModel,
+    defaultModel: registryDefaultModel,
+    visionLimits,
+  } = useModelRegistry();
+  const visionNotice = useMemo(() => {
+    if (!enableAttachments || attachments.entries.length === 0) return null;
+    // modelId may be a compound "harness/id" key (unified picker) or a
+    // plain id — resolve through the unambiguous compound lookup first,
+    // mirroring the submit path's parseModelKey handling.
+    const selectedModel = modelId
+      ? (registryGetByKey(modelId) ?? registryGetModel(modelId))
+      : registryDefaultModel;
+    const preflight = assessVisionPreflight(
+      attachments.entries.map((e) => ({
+        name: e.file.name,
+        sizeBytes: e.file.size,
+        contentType: e.contentType,
+      })),
+      { model: selectedModel, limits: visionLimits },
+    );
+    return visionPreflightMessage(preflight, {
+      limits: visionLimits,
+      modelDisplayName: selectedModel?.displayName,
+    });
+  }, [
+    enableAttachments,
+    attachments.entries,
+    modelId,
+    registryGetByKey,
+    registryGetModel,
+    registryDefaultModel,
+    visionLimits,
+  ]);
+
   const fileRefs = useFileReferences();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -1633,6 +1684,25 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
           >
             <ChipSpinner />
             <span>Waiting for attachments to finish uploading…</span>
+          </div>
+        )}
+
+        {/* Zone 2.65: Vision preflight warning (stigmer/stigmer#365, #386) —
+            derives from the attached entries, so it appears the moment an
+            image over the advertised budget lands (paste/drop/pick) or the
+            selected model is explicitly blind, and disappears when the
+            offending attachment is removed or the model changes. Warning
+            styling (not muted): unlike the upload wait, this is a problem
+            the user can fix BEFORE spending the turn. Non-blocking — the
+            files still upload and mount; they just won't reach the model
+            as pixels. */}
+        {visionNotice && (
+          <div
+            role="status"
+            className="stg:mx-3 stg:mb-2 stg:flex stg:items-center stg:gap-2 stg:rounded-md stg:bg-warning/10 stg:px-2.5 stg:py-1.5 stg:text-xs stg:text-warning"
+          >
+            <AlertTriangleIcon />
+            <span>{visionNotice}</span>
           </div>
         )}
 

--- a/sdk/react/src/composer/__tests__/SessionComposer-visionPreflight.test.tsx
+++ b/sdk/react/src/composer/__tests__/SessionComposer-visionPreflight.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Stigmer } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { ModelRegistryContext } from "../../models/ModelRegistryContext";
+import type { ModelRegistryState } from "../../models/ModelRegistryContext";
+import { parseRegistryDocument } from "../../models/registry";
+import type { VisionLimits } from "../../models/registry";
+import { SessionComposer } from "../SessionComposer";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** The production budget the registry advertises (3 MiB / 4 MiB / 10). */
+const LIMITS: VisionLimits = {
+  maxImageBytes: 3 * 1024 * 1024,
+  maxTotalBytes: 4 * 1024 * 1024,
+  maxImages: 10,
+};
+
+/**
+ * Registry fixture routed through the REAL document parser so this test
+ * also breaks if the parse contract drifts. kimi-k3 mirrors the live
+ * registry's explicitly-blind cursor model.
+ */
+const REGISTRY_DOCUMENT = parseRegistryDocument({
+  limits: { vision: { ...LIMITS } },
+  models: [
+    {
+      id: "claude-sonnet-4.6",
+      displayName: "Claude Sonnet 4.6",
+      provider: "anthropic",
+      harness: "native",
+      costTier: "standard",
+      featured: true,
+      capabilities: { toolUse: true, vision: true, streaming: true, thinking: true, adaptiveThinking: false },
+      pricing: { inputPricePerMillion: 3, outputPricePerMillion: 15, cacheWritePricePerMillion: 3.75, cacheReadPricePerMillion: 0.3 },
+    },
+    {
+      id: "kimi-k3",
+      displayName: "Kimi K3",
+      provider: "moonshot",
+      harness: "cursor",
+      costTier: "economy",
+      featured: false,
+      capabilities: { toolUse: true, vision: false, streaming: true, thinking: false, adaptiveThinking: false },
+      pricing: { inputPricePerMillion: 1, outputPricePerMillion: 3, cacheWritePricePerMillion: 1, cacheReadPricePerMillion: 0.1 },
+    },
+  ],
+});
+
+function createUploadMockClient(): Stigmer {
+  return {
+    agentExecution: {
+      uploadAttachment: vi.fn().mockResolvedValue({ storageKey: "attachments/test/file" }),
+    },
+    environment: { getPersonal: vi.fn().mockResolvedValue(null) },
+    baseUrl: "http://localhost:8080",
+    getAuthCredential: vi.fn().mockResolvedValue("test-token"),
+    config: {
+      baseUrl: "http://localhost:8080",
+      getAccessToken: vi.fn().mockResolvedValue(""),
+    },
+  } as unknown as Stigmer;
+}
+
+function createWrapper(registry?: Partial<ModelRegistryState>) {
+  const client = createUploadMockClient();
+  const state: ModelRegistryState = {
+    models: REGISTRY_DOCUMENT.models,
+    visionLimits: REGISTRY_DOCUMENT.visionLimits,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    ...registry,
+  };
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <StigmerContext.Provider value={client}>
+        <ModelRegistryContext.Provider value={state}>
+          {children}
+        </ModelRegistryContext.Provider>
+      </StigmerContext.Provider>
+    );
+  };
+}
+
+function pngFile(name: string, sizeBytes: number): File {
+  return new File([new Uint8Array(sizeBytes)], name, { type: "image/png" });
+}
+
+function pasteFiles(textarea: Element, files: File[]) {
+  fireEvent.paste(textarea, {
+    clipboardData: {
+      files: files as unknown as FileList,
+      getData: () => "",
+      types: ["Files"],
+    },
+  });
+}
+
+const OVERSIZED = Math.round(3.6 * 1024 * 1024);
+const SMALL = 64 * 1024;
+
+afterEach(cleanup);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SessionComposer — vision preflight notice (#365, #386)", () => {
+  it("warns at paste time when an image exceeds the advertised per-image cap", async () => {
+    render(<SessionComposer onSubmit={vi.fn()} />, { wrapper: createWrapper() });
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [pngFile("screenshot.png", OVERSIZED)]);
+    });
+
+    const notice = screen.getByText(
+      /screenshot\.png \(3\.6 MB\) exceeds the 3\.0 MB inline-image limit/,
+    );
+    expect(notice).toBeTruthy();
+    expect(notice.closest('[role="status"]')).toBeTruthy();
+  });
+
+  it("stays silent for images within the budget", async () => {
+    render(<SessionComposer onSubmit={vi.fn()} />, { wrapper: createWrapper() });
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [pngFile("small.png", SMALL)]);
+    });
+
+    expect(screen.queryByText(/inline-image/)).toBeNull();
+  });
+
+  it("stays silent when the server advertises no limits (older server, tri-state)", async () => {
+    render(<SessionComposer onSubmit={vi.fn()} />, {
+      wrapper: createWrapper({ visionLimits: undefined }),
+    });
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [pngFile("huge.png", OVERSIZED)]);
+    });
+
+    expect(screen.queryByText(/inline-image/)).toBeNull();
+  });
+
+  it("clears the warning when the offending attachment is removed", async () => {
+    render(<SessionComposer onSubmit={vi.fn()} />, { wrapper: createWrapper() });
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [pngFile("screenshot.png", OVERSIZED)]);
+    });
+    expect(screen.getByText(/exceeds the 3\.0 MB inline-image limit/)).toBeTruthy();
+
+    const removeButton = screen.getByRole("button", { name: /remove screenshot\.png/i });
+    await act(async () => {
+      fireEvent.click(removeButton);
+    });
+
+    expect(screen.queryByText(/inline-image/)).toBeNull();
+  });
+
+  it("leads with the model when the selected model is explicitly blind", async () => {
+    render(
+      <SessionComposer onSubmit={vi.fn()} defaultModelId="cursor/kimi-k3" />,
+      { wrapper: createWrapper() },
+    );
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [pngFile("tiny.png", SMALL)]);
+    });
+
+    expect(
+      screen.getByText(
+        "Kimi K3 can't view images — attached images will reach the agent as files only.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("never warns about non-image attachments on a blind model", async () => {
+    render(
+      <SessionComposer onSubmit={vi.fn()} defaultModelId="cursor/kimi-k3" />,
+      { wrapper: createWrapper() },
+    );
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [
+        new File([new Uint8Array(SMALL)], "notes.pdf", { type: "application/pdf" }),
+      ]);
+    });
+
+    expect(screen.queryByText(/can't view images/)).toBeNull();
+  });
+
+  it("does not gate the send — the warned message still submits with the attachment", async () => {
+    const onSubmit = vi.fn();
+    render(<SessionComposer onSubmit={onSubmit} />, { wrapper: createWrapper() });
+    const textarea = screen.getByRole("textbox");
+
+    await act(async () => {
+      pasteFiles(textarea, [pngFile("screenshot.png", OVERSIZED)]);
+    });
+    expect(screen.getByText(/exceeds the 3\.0 MB inline-image limit/)).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "look at this anyway" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][2]?.attachments).toHaveLength(1);
+  });
+});

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -40,7 +40,9 @@ export {
   modelKey,
   parseModelKey,
   fetchModelRegistry,
+  fetchModelRegistryDocument,
   parseRegistryJson,
+  parseRegistryDocument,
   useModelRegistry,
   ModelRegistryContext,
   ModelSelector,
@@ -52,6 +54,7 @@ export {
 } from "./models/index.js";
 export type {
   ModelInfo,
+  ModelRegistryDocument,
   ModelRegistryState,
   ParsedModelKey,
   Provider,
@@ -61,6 +64,7 @@ export type {
   ModelSelectorProps,
   HarnessSelectorProps,
   HarnessOption,
+  VisionLimits,
 } from "./models/index.js";
 
 // Workspace — behavior hooks and styled components
@@ -469,13 +473,14 @@ export type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agent
 export { ExecutionArtifactKind } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 
 // Attachment — file upload behavior hook, styled chip list, clipboard paste,
-// and vision-resolution image preparation
+// vision-resolution image preparation, and vision preflight warnings
 export {
   useAttachments,
   AttachmentChipList,
   MAX_ATTACHMENT_BYTES,
   MAX_VISION_LONG_EDGE_PX,
   MAX_VISION_PIXELS,
+  assessVisionPreflight,
   detectContentType,
   exceedsVisionResolution,
   extractClipboardFiles,
@@ -484,15 +489,22 @@ export {
   prepareImageForVision,
   uniquifyFilename,
   validateAttachmentSize,
+  visionPreflightMessage,
 } from "./attachment/index.js";
 export type {
   AttachmentPhase,
   AttachmentEntry,
+  AssessVisionPreflightOptions,
   ClipboardFilesSource,
   UseAttachmentsOptions,
   UseAttachmentsReturn,
   AttachmentChipListProps,
   VisionFitSize,
+  VisionPreflight,
+  VisionPreflightAttachment,
+  VisionPreflightMessageOptions,
+  VisionPreflightReason,
+  VisionPreflightWarning,
 } from "./attachment/index.js";
 
 // File Reference — workspace file-reference behavior hook and styled chip list

--- a/sdk/react/src/models/ModelRegistryContext.ts
+++ b/sdk/react/src/models/ModelRegistryContext.ts
@@ -1,11 +1,17 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import type { ModelInfo } from "./registry.js";
+import type { ModelInfo, VisionLimits } from "./registry.js";
 
 /** Internal state held by the model registry context provider. */
 export interface ModelRegistryState {
   readonly models: readonly ModelInfo[];
+  /**
+   * Document-level vision byte budget (stigmer/stigmer#365).
+   * `undefined` while loading or when the served document predates the
+   * `limits` block — consumers stay silent rather than assume a budget.
+   */
+  readonly visionLimits?: VisionLimits;
   readonly isLoading: boolean;
   readonly error: Error | null;
   /** Retry fetching the model registry. No-op while a fetch is in flight. */

--- a/sdk/react/src/models/ModelSelector.tsx
+++ b/sdk/react/src/models/ModelSelector.tsx
@@ -629,6 +629,17 @@ function ModelRow({
       <div className="stg:flex stg:w-full stg:items-center stg:gap-2">
         <span className="stg:flex-1 stg:truncate stg:text-left stg:font-medium">{model.displayName}</span>
 
+        {/* Explicit vision:false only (stigmer/stigmer#386) — an unassessed
+            model (absent capabilities block) shows nothing, per the
+            registry's tri-state convention. Visible text, not a tooltip:
+            keyboard and touch users must see it before picking the model. */}
+        {model.visionCapability === false && (
+          <span className="stg:flex stg:shrink-0 stg:items-center stg:gap-0.5 stg:text-[0.6rem] stg:text-muted-foreground">
+            <NoImageInputIcon />
+            No image input
+          </span>
+        )}
+
         <span className="stg:shrink-0 stg:text-[0.6rem] stg:text-muted-foreground">
           {showSpeedBadge
             ? `${SPEED_TIER_LABEL[model.speedTier]} ${COST_TIER_LABEL[model.costTier]}`
@@ -679,6 +690,32 @@ function CheckIcon({ className }: { className?: string }) {
       strokeLinejoin="round"
     >
       <path d="M2 6L5 9L10 3" />
+    </svg>
+  );
+}
+
+/**
+ * "Image with a slash" glyph for models explicitly assessed as unable to
+ * see images. Decorative (`aria-hidden`) — the wrapping span carries the
+ * accessible text.
+ */
+function NoImageInputIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="1.5" y="2" width="9" height="8" rx="1.2" />
+      <path d="M1.5 8L4.2 5.6L6.4 7.6" />
+      <circle cx="7.6" cy="4.6" r="0.8" fill="currentColor" stroke="none" />
+      <path d="M1 1L11 11" />
     </svg>
   );
 }

--- a/sdk/react/src/models/__tests__/ModelSelector-visionIndicator.test.tsx
+++ b/sdk/react/src/models/__tests__/ModelSelector-visionIndicator.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ModelSelector } from "../ModelSelector";
+import { ModelRegistryContext } from "../ModelRegistryContext";
+import type { ModelInfo } from "../registry";
+
+// Shim ResizeObserver for Base UI's positioner (the
+// scheduleCreation.test.tsx pattern).
+beforeAll(() => {
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+  }
+});
+
+/**
+ * "No image input" indicator on model rows (stigmer/stigmer#386).
+ *
+ * Tri-state contract: the indicator renders ONLY for models the registry
+ * explicitly assessed as blind (`visionCapability === false`). A sighted
+ * model shows nothing, and — the load-bearing case — an UNASSESSED model
+ * (absent capabilities block) also shows nothing: most registry entries
+ * were never capability-assessed, and flagging them all as blind would
+ * be wrong for nearly every one.
+ */
+
+const BLIND: ModelInfo = {
+  modelId: "kimi-k3",
+  provider: "moonshot",
+  displayName: "Kimi K3",
+  shortDescription: "Text-only economy model",
+  speedTier: "fast",
+  costTier: "economy",
+  harness: "cursor",
+  featured: true,
+  serviceTiers: [],
+  visionCapability: false,
+};
+
+const SIGHTED: ModelInfo = {
+  modelId: "composer-2.5",
+  provider: "cursor",
+  displayName: "Composer 2.5",
+  shortDescription: "Fast agentic model",
+  speedTier: "fastest",
+  costTier: "economy",
+  harness: "cursor",
+  featured: true,
+  serviceTiers: [],
+  visionCapability: true,
+};
+
+const UNASSESSED: ModelInfo = {
+  modelId: "mystery-model",
+  provider: "cursor",
+  displayName: "Mystery Model",
+  shortDescription: "Never capability-assessed",
+  speedTier: "fast",
+  costTier: "standard",
+  harness: "cursor",
+  featured: true,
+  serviceTiers: [],
+};
+
+function renderSelector() {
+  return render(
+    <ModelRegistryContext.Provider
+      value={{
+        models: [BLIND, SIGHTED, UNASSESSED],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      }}
+    >
+      <ModelSelector
+        value="composer-2.5"
+        onValueChange={vi.fn()}
+        harness="cursor"
+      />
+    </ModelRegistryContext.Provider>,
+  );
+}
+
+async function openPopover(triggerLabel: string) {
+  fireEvent.click(screen.getByRole("button", { name: new RegExp(triggerLabel) }));
+  await screen.findByPlaceholderText("Search models…");
+}
+
+/** A model row inside the popup list (never matches the trigger). */
+function modelOption(displayName: string): HTMLElement {
+  const option = screen
+    .getAllByText(displayName)
+    .map((el) => el.closest<HTMLElement>("[data-model-option]"))
+    .find((el) => el != null);
+  if (!option) throw new Error(`No popup option for "${displayName}"`);
+  return option;
+}
+
+afterEach(cleanup);
+
+describe("ModelSelector — no-image-input indicator", () => {
+  it("marks an explicitly blind model with visible badge text", async () => {
+    renderSelector();
+    await openPopover("Composer 2.5");
+
+    // Visible text, not a tooltip — keyboard and touch users must see it
+    // before picking the model (stigmer/no-native-title).
+    const row = modelOption("Kimi K3");
+    expect(row.textContent).toContain("No image input");
+  });
+
+  it("shows nothing on an explicitly sighted model", async () => {
+    renderSelector();
+    await openPopover("Composer 2.5");
+
+    expect(modelOption("Composer 2.5").textContent).not.toContain("No image input");
+  });
+
+  it("shows nothing on an unassessed model (tri-state: absent is not false)", async () => {
+    renderSelector();
+    await openPopover("Composer 2.5");
+
+    expect(modelOption("Mystery Model").textContent).not.toContain("No image input");
+  });
+});

--- a/sdk/react/src/models/__tests__/useModelRegistry.test.tsx
+++ b/sdk/react/src/models/__tests__/useModelRegistry.test.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_CURSOR_MODEL_ID,
   DISABLED_PROVIDERS,
   modelKey,
+  parseRegistryDocument,
   parseRegistryJson,
 } from "../registry";
 import { ModelRegistryContext } from "../ModelRegistryContext";
@@ -105,6 +106,101 @@ function createWrapper(models: readonly ModelInfo[] = TEST_MODELS) {
     );
   };
 }
+
+describe("parseRegistryDocument vision data (#365, #386)", () => {
+  const entry = (overrides: Record<string, unknown>) => ({
+    id: "m",
+    displayName: "M",
+    provider: "anthropic",
+    harness: "native",
+    costTier: "standard",
+    pricing: { inputPricePerMillion: 1, outputPricePerMillion: 2, cacheWritePricePerMillion: 0, cacheReadPricePerMillion: 0 },
+    ...overrides,
+  });
+
+  it("parses explicit vision:false into visionCapability", () => {
+    const doc = parseRegistryDocument({
+      models: [entry({ capabilities: { toolUse: true, vision: false, streaming: true, thinking: false, adaptiveThinking: false } })],
+    });
+    expect(doc.models[0].visionCapability).toBe(false);
+  });
+
+  it("parses explicit vision:true into visionCapability", () => {
+    const doc = parseRegistryDocument({
+      models: [entry({ capabilities: { toolUse: true, vision: true, streaming: true, thinking: true, adaptiveThinking: false } })],
+    });
+    expect(doc.models[0].visionCapability).toBe(true);
+  });
+
+  it("keeps an unassessed model free of the visionCapability key (tri-state, never coerced to false)", () => {
+    const doc = parseRegistryDocument({ models: [entry({})] });
+    expect(doc.models[0].visionCapability).toBeUndefined();
+    expect("visionCapability" in doc.models[0]).toBe(false);
+  });
+
+  it("treats a malformed capabilities block as unassessed", () => {
+    const doc = parseRegistryDocument({
+      models: [entry({ capabilities: "broken" }), entry({ id: "m2", capabilities: { vision: "yes" } })],
+    });
+    expect(doc.models[0].visionCapability).toBeUndefined();
+    expect(doc.models[1].visionCapability).toBeUndefined();
+  });
+
+  it("parses the document-level limits.vision block", () => {
+    const doc = parseRegistryDocument({
+      limits: { vision: { maxImageBytes: 3145728, maxTotalBytes: 4194304, maxImages: 10 } },
+      models: [entry({})],
+    });
+    expect(doc.visionLimits).toEqual({
+      maxImageBytes: 3145728,
+      maxTotalBytes: 4194304,
+      maxImages: 10,
+    });
+  });
+
+  it("leaves visionLimits undefined for documents predating the limits block", () => {
+    const doc = parseRegistryDocument({ models: [entry({})] });
+    expect(doc.visionLimits).toBeUndefined();
+  });
+
+  it.each([
+    ["missing field", { vision: { maxImageBytes: 1, maxTotalBytes: 2 } }],
+    ["non-numeric field", { vision: { maxImageBytes: "3MB", maxTotalBytes: 2, maxImages: 1 } }],
+    ["zero cap", { vision: { maxImageBytes: 0, maxTotalBytes: 2, maxImages: 1 } }],
+    ["negative cap", { vision: { maxImageBytes: 1, maxTotalBytes: -2, maxImages: 1 } }],
+    ["vision not an object", { vision: 42 }],
+  ])("rejects a garbled limits block (%s) rather than half-parsing it", (_name, limits) => {
+    const doc = parseRegistryDocument({ limits, models: [entry({})] });
+    expect(doc.visionLimits).toBeUndefined();
+  });
+
+  it("keeps parseRegistryJson byte-compatible (models only, same rows)", () => {
+    const raw = {
+      limits: { vision: { maxImageBytes: 1, maxTotalBytes: 2, maxImages: 3 } },
+      models: [entry({})],
+    };
+    expect(parseRegistryJson(raw)).toEqual([...parseRegistryDocument(raw).models]);
+  });
+});
+
+describe("useModelRegistry visionLimits pass-through (#365)", () => {
+  it("exposes visionLimits from context", () => {
+    const limits = { maxImageBytes: 3145728, maxTotalBytes: 4194304, maxImages: 10 };
+    const state: ModelRegistryState = {
+      models: TEST_MODELS, visionLimits: limits, isLoading: false, error: null, refetch: noopRefetch,
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ModelRegistryContext.Provider value={state}>{children}</ModelRegistryContext.Provider>
+    );
+    const { result } = renderHook(() => useModelRegistry(), { wrapper });
+    expect(result.current.visionLimits).toEqual(limits);
+  });
+
+  it("stays undefined when the context has no limits (older server)", () => {
+    const { result } = renderHook(() => useModelRegistry(), { wrapper: createWrapper() });
+    expect(result.current.visionLimits).toBeUndefined();
+  });
+});
 
 describe("parseRegistryJson service tiers (#357)", () => {
   it("surfaces pricingVariants keys as serviceTiers", () => {

--- a/sdk/react/src/models/index.ts
+++ b/sdk/react/src/models/index.ts
@@ -1,6 +1,6 @@
-export { DEFAULT_MODEL_ID, DEFAULT_CURSOR_MODEL_ID, DISABLED_PROVIDERS, modelKey, parseModelKey, resolveDefaultModelId, fetchModelRegistry, parseRegistryJson } from "./registry.js";
+export { DEFAULT_MODEL_ID, DEFAULT_CURSOR_MODEL_ID, DISABLED_PROVIDERS, modelKey, parseModelKey, resolveDefaultModelId, fetchModelRegistry, fetchModelRegistryDocument, parseRegistryJson, parseRegistryDocument } from "./registry.js";
 export type { ParsedModelKey, DefaultModelResolution, DefaultModelSource } from "./registry.js";
-export type { ModelInfo, Provider, CostTier, SpeedTier } from "./registry.js";
+export type { ModelInfo, ModelRegistryDocument, Provider, CostTier, SpeedTier, VisionLimits } from "./registry.js";
 export { useModelRegistry } from "./useModelRegistry.js";
 export type { UseModelRegistryReturn, UseModelRegistryOptions } from "./useModelRegistry.js";
 export { ModelRegistryContext, useModelRegistryContext } from "./ModelRegistryContext.js";

--- a/sdk/react/src/models/registry.ts
+++ b/sdk/react/src/models/registry.ts
@@ -100,6 +100,52 @@ export interface ModelInfo {
    * not a selectable option.
    */
   readonly serviceTiers: readonly string[];
+  /**
+   * Tri-state vision capability from the registry's `capabilities` block
+   * (stigmer/stigmer#386). The registry serializes `capabilities` only for
+   * models whose capabilities were actually assessed, so:
+   *
+   * - `true` — images sent with a turn reach the model
+   * - `false` — explicitly assessed as blind; warn at selection/send time
+   * - `undefined` — never assessed; **stay silent, never treat as false**
+   *
+   * Mirrors the runner's `parseVisionCapability` convention
+   * (backend/services/runner/src/shared/model-registry.ts) — both sides
+   * parse the same document and must agree on what absence means.
+   */
+  readonly visionCapability?: boolean;
+}
+
+/**
+ * Document-level vision byte budget advertised by the registry
+ * (stigmer/stigmer#365) — the runner's inline-image delivery caps, exposed
+ * so clients can warn *before* an upload the runner would degrade to
+ * "not viewable inline". Field names match the runner's `VisionBudget`
+ * options verbatim (backend/services/runner/src/shared/attachment-vision.ts).
+ *
+ * ADVERTISED == ENFORCED: the serving side (cloud
+ * `ModelRegistryDocumentCodec`) and the runner pin the same literal values
+ * in their test suites. Treat an absent block as unassessed — no warnings —
+ * exactly like the per-model `capabilities` tri-state.
+ */
+export interface VisionLimits {
+  /** Per-image raw byte cap for inline vision delivery. */
+  readonly maxImageBytes: number;
+  /** Per-turn total byte cap across all inline images. */
+  readonly maxTotalBytes: number;
+  /** Per-turn inline image count cap. */
+  readonly maxImages: number;
+}
+
+/**
+ * Parsed model-registry document: the per-model list plus document-level
+ * platform metadata. `visionLimits` is `undefined` when the served document
+ * predates the `limits` block (older servers) — consumers must stay silent
+ * rather than assume a budget.
+ */
+export interface ModelRegistryDocument {
+  readonly models: readonly ModelInfo[];
+  readonly visionLimits?: VisionLimits;
 }
 
 /**
@@ -166,7 +212,44 @@ interface RegistryJsonEntry {
   };
   /** Variant-key → variant pricing block; only the key set matters here. */
   pricingVariants?: Record<string, unknown>;
+  /** Capability flags; present only for capability-assessed models. */
+  capabilities?: unknown;
   $comment?: string;
+}
+
+/**
+ * Extract `capabilities.vision` preserving the tri-state: a missing or
+ * malformed `capabilities` block stays `undefined` (never coerced to
+ * false). Byte-for-byte the runner's convention — see
+ * `parseVisionCapability` in the runner's `shared/model-registry.ts`.
+ */
+function parseVisionCapability(capabilities: unknown): boolean | undefined {
+  if (!capabilities || typeof capabilities !== "object") return undefined;
+  const vision = (capabilities as Record<string, unknown>).vision;
+  return typeof vision === "boolean" ? vision : undefined;
+}
+
+/**
+ * Parse the document-level `limits.vision` block. Returns `undefined` for
+ * documents that predate the block or carry a malformed one — absence
+ * means "unassessed", and a partial block must not masquerade as a budget
+ * (warning against a garbled cap is worse than staying silent).
+ */
+function parseVisionLimits(data: Record<string, unknown>): VisionLimits | undefined {
+  const limits = data.limits;
+  if (!limits || typeof limits !== "object") return undefined;
+  const vision = (limits as Record<string, unknown>).vision;
+  if (!vision || typeof vision !== "object") return undefined;
+
+  const { maxImageBytes, maxTotalBytes, maxImages } = vision as Record<string, unknown>;
+  if (
+    typeof maxImageBytes !== "number" || maxImageBytes <= 0 ||
+    typeof maxTotalBytes !== "number" || maxTotalBytes <= 0 ||
+    typeof maxImages !== "number" || maxImages <= 0
+  ) {
+    return undefined;
+  }
+  return { maxImageBytes, maxTotalBytes, maxImages };
 }
 
 const VALID_COST_TIERS = new Set(["economy", "standard", "premium"]);
@@ -184,49 +267,76 @@ function isModelEntry(entry: RegistryJsonEntry): entry is Required<Pick<Registry
 }
 
 /**
- * Parse raw registry JSON (from the API or a static file) into `ModelInfo[]`.
+ * Parse a raw registry document (from the API or a static file) into the
+ * per-model list plus document-level metadata.
  *
- * Expects the shape `{ models: RegistryJsonEntry[] }`. Filters out comment
- * entries and invalid rows, then maps to the `ModelInfo` interface.
+ * Expects the shape `{ models: RegistryJsonEntry[], limits?: {...} }`.
+ * Filters out comment entries and invalid rows. Unknown top-level fields
+ * are ignored (the document contract is additive).
  */
-export function parseRegistryJson(data: unknown): ModelInfo[] {
-  if (!data || typeof data !== "object") return [];
-  const models = (data as Record<string, unknown>).models;
-  if (!Array.isArray(models)) return [];
+export function parseRegistryDocument(data: unknown): ModelRegistryDocument {
+  if (!data || typeof data !== "object") return { models: [] };
+  const root = data as Record<string, unknown>;
+  const models = root.models;
+  if (!Array.isArray(models)) return { models: [] };
 
-  return (models as RegistryJsonEntry[])
+  const parsed = (models as RegistryJsonEntry[])
     .filter(isModelEntry)
-    .map((m) => ({
-      modelId: m.id,
-      provider: m.provider as Provider,
-      displayName: m.displayName,
-      shortDescription: m.shortDescription ?? "",
-      speedTier: (VALID_SPEED_TIERS.has(m.speedTier ?? "") ? m.speedTier : "fast") as SpeedTier,
-      costTier: m.costTier as CostTier,
-      harness: m.harness as HarnessOption,
-      featured: m.featured ?? false,
-      serviceTiers:
-        m.pricingVariants && typeof m.pricingVariants === "object"
-          ? Object.keys(m.pricingVariants).sort()
-          : [],
-    }));
+    .map((m) => {
+      const visionCapability = parseVisionCapability(m.capabilities);
+      return {
+        modelId: m.id,
+        provider: m.provider as Provider,
+        displayName: m.displayName,
+        shortDescription: m.shortDescription ?? "",
+        speedTier: (VALID_SPEED_TIERS.has(m.speedTier ?? "") ? m.speedTier : "fast") as SpeedTier,
+        costTier: m.costTier as CostTier,
+        harness: m.harness as HarnessOption,
+        featured: m.featured ?? false,
+        serviceTiers:
+          m.pricingVariants && typeof m.pricingVariants === "object"
+            ? Object.keys(m.pricingVariants).sort()
+            : [],
+        // Conditional spread keeps unassessed models free of the key
+        // (tri-state absence, not an explicit undefined).
+        ...(visionCapability !== undefined ? { visionCapability } : {}),
+      };
+    });
+
+  const visionLimits = parseVisionLimits(root);
+  return {
+    models: parsed,
+    ...(visionLimits !== undefined ? { visionLimits } : {}),
+  };
 }
 
 /**
- * Fetch the model registry from the authenticated API endpoint.
+ * Parse raw registry JSON into `ModelInfo[]`.
+ *
+ * Thin compatibility wrapper over {@link parseRegistryDocument} — prefer
+ * the document parser when the caller also needs document-level metadata
+ * such as {@link VisionLimits}.
+ */
+export function parseRegistryJson(data: unknown): ModelInfo[] {
+  return [...parseRegistryDocument(data).models];
+}
+
+/**
+ * Fetch the model-registry document from the authenticated API endpoint.
  *
  * @param apiUrl - Base URL of the Stigmer Cloud API (e.g. `https://api.stigmer.ai`)
  * @param token - Bearer token for authentication (from `client.getAuthCredential()`)
  * @param customFetch - Optional custom `fetch` implementation. Required in
  *   Tauri where the global `fetch` is restricted by webview CSP/CORS policies.
  *   When omitted, the global `fetch` is used.
- * @returns Parsed `ModelInfo[]`.
+ * @returns Parsed {@link ModelRegistryDocument} — models plus document-level
+ *   metadata like {@link VisionLimits}.
  */
-export async function fetchModelRegistry(
+export async function fetchModelRegistryDocument(
   apiUrl: string,
   token: string | null,
   customFetch?: typeof globalThis.fetch,
-): Promise<ModelInfo[]> {
+): Promise<ModelRegistryDocument> {
   const doFetch = customFetch ?? globalThis.fetch;
   const headers: Record<string, string> = {};
   if (token) {
@@ -235,7 +345,25 @@ export async function fetchModelRegistry(
   const res = await doFetch(`${apiUrl}/v1/proxy/model-registry`, { headers });
   if (!res.ok) throw new Error(`Model registry fetch failed: ${res.status}`);
   const data: unknown = await res.json();
-  return parseRegistryJson(data);
+  return parseRegistryDocument(data);
+}
+
+/**
+ * Fetch the model registry from the authenticated API endpoint.
+ *
+ * Thin compatibility wrapper over {@link fetchModelRegistryDocument} —
+ * prefer the document fetch when the caller also needs document-level
+ * metadata such as {@link VisionLimits}.
+ *
+ * @returns Parsed `ModelInfo[]`.
+ */
+export async function fetchModelRegistry(
+  apiUrl: string,
+  token: string | null,
+  customFetch?: typeof globalThis.fetch,
+): Promise<ModelInfo[]> {
+  const document = await fetchModelRegistryDocument(apiUrl, token, customFetch);
+  return [...document.models];
 }
 
 /**

--- a/sdk/react/src/models/useModelRegistry.ts
+++ b/sdk/react/src/models/useModelRegistry.ts
@@ -9,6 +9,7 @@ import {
   modelKey,
   type ModelInfo,
   type Provider,
+  type VisionLimits,
 } from "./registry.js";
 import type { HarnessOption } from "./harness.js";
 import { useModelRegistryContext } from "./ModelRegistryContext.js";
@@ -51,6 +52,12 @@ export interface UseModelRegistryReturn {
    * Always unambiguous, even in unified mode.
    */
   readonly getByKey: (key: string) => ModelInfo | undefined;
+  /**
+   * Document-level vision byte budget advertised by the registry
+   * (stigmer/stigmer#365). `undefined` while loading or when the server
+   * predates the `limits` block — treat as unassessed and stay silent.
+   */
+  readonly visionLimits: VisionLimits | undefined;
   /** `true` while the model registry is being fetched from the API. */
   readonly isLoading: boolean;
   /** Non-null if the API fetch failed. Models will be empty in this case. */
@@ -87,7 +94,7 @@ export interface UseModelRegistryReturn {
  */
 export function useModelRegistry(options?: UseModelRegistryOptions): UseModelRegistryReturn {
   const harness = options?.harness;
-  const { models: allModels, isLoading, error, refetch } = useModelRegistryContext();
+  const { models: allModels, visionLimits, isLoading, error, refetch } = useModelRegistryContext();
 
   return useMemo(() => {
     const isUnified = harness === undefined;
@@ -143,9 +150,10 @@ export function useModelRegistry(options?: UseModelRegistryOptions): UseModelReg
       providers,
       featured: featuredModels,
       getByKey: (key: string) => byCompoundKey.get(key),
+      visionLimits,
       isLoading,
       error,
       refetch,
     };
-  }, [harness, allModels, isLoading, error, refetch]);
+  }, [harness, allModels, visionLimits, isLoading, error, refetch]);
 }

--- a/sdk/react/src/provider.tsx
+++ b/sdk/react/src/provider.tsx
@@ -24,7 +24,7 @@ import { ColorModeContext, useSystemColorMode } from "./color-mode.js";
 import { PortalContainerContext } from "./portal-container.js";
 import { ModelRegistryContext } from "./models/ModelRegistryContext.js";
 import type { ModelRegistryState } from "./models/ModelRegistryContext.js";
-import { fetchModelRegistry } from "./models/registry.js";
+import { fetchModelRegistryDocument } from "./models/registry.js";
 import { TaskKindRegistryContext } from "./workflow/TaskKindRegistryContext.js";
 import type { TaskKindRegistryState } from "./workflow/TaskKindRegistryContext.js";
 import type { TaskKindDescriptor } from "./workflow/types.js";
@@ -347,6 +347,7 @@ function useModelRegistryFetch(client: Stigmer): ModelRegistryState {
   const [version, setVersion] = useState(0);
   const [state, setState] = useState<Omit<ModelRegistryState, "refetch">>({
     models: [],
+    visionLimits: undefined,
     isLoading: true,
     error: null,
   });
@@ -370,7 +371,7 @@ function useModelRegistryFetch(client: Stigmer): ModelRegistryState {
       }
     }
 
-    return fetchModelRegistry(c.baseUrl, token, c.fetch);
+    return fetchModelRegistryDocument(c.baseUrl, token, c.fetch);
   }, []);
 
   useEffect(() => {
@@ -385,9 +386,14 @@ function useModelRegistryFetch(client: Stigmer): ModelRegistryState {
       setState((prev) => (prev.isLoading ? prev : { ...prev, isLoading: true }));
 
       try {
-        const models = await doFetch(signal);
-        if (!signal.aborted && models) {
-          setState({ models, isLoading: false, error: null });
+        const document = await doFetch(signal);
+        if (!signal.aborted && document) {
+          setState({
+            models: document.models,
+            visionLimits: document.visionLimits,
+            isLoading: false,
+            error: null,
+          });
           fetchAttemptRef.current = 0;
         }
       } catch (err: unknown) {


### PR DESCRIPTION
## Summary

Closes #365. Closes #386.

Today a user attaches a 3.6 MiB screenshot, spends a full agent turn, and only then learns from a disclosure line that the image was "not viewable inline" (verified live in prod on 2026-08-10). This PR moves the warning to **before** the turn, at both seams:

- **Registry data layer**: new `parseRegistryDocument` / `fetchModelRegistryDocument` parse the document-level `limits.vision` block (`VisionLimits` — the runner's byte budget, advertised by the serving side per #365; cloud twin: stigmer/stigmer-cloud#428) and the per-model `capabilities.vision` flag into `ModelInfo.visionCapability`, mirroring the runner's tri-state convention byte-for-byte (absent = unassessed, never coerced to `false`). Existing public exports (`fetchModelRegistry`, `parseRegistryJson`) are unchanged thin wrappers. `useModelRegistry` exposes `visionLimits`.
- **`assessVisionPreflight`** (new, `attachment/vision-preflight.ts`): pure helper that replicates the runner's admission semantics — per-image cap degrades without consuming budget, sequential count/total admission — and reuses the runner's disclosure vocabulary (`too_large` / `budget_exhausted` / `model_no_vision`), so a warning here and a disclosure in the agent's reply always tell one story. `visionPreflightMessage` is its copy twin (the client-side `visionDisclosureLines`). Both exported headless-first.
- **`SessionComposer` Zone 2.65**: non-blocking warning row (house zone pattern, warning treatment) derived from attached entries — appears at paste/drop/pick time, clears on removal or model change, never gates the send (the file still uploads and mounts; it just won't reach the model as pixels). Propagates to every composer surface (session view, follow-up, new-session) from one implementation point — no client app renders `SessionComposer` directly, so DD-016 parity holds by construction.
- **`ModelSelector`**: visible "No image input" micro-badge on explicitly blind models (`kimi-k3` is live in the registry today) — visible text rather than a tooltip so keyboard/touch users see it before picking (`stigmer/no-native-title`).
- **Runner**: cross-reference comment on the budget constants; the existing pinned-literal test is the OSS half of the ADVERTISED == ENFORCED drift alarm (the cloud codec test pins the other half).

Tri-state discipline throughout: an older server without the `limits` block, or an unassessed model, produces zero warnings — silence, never guesses.

Scoped out deliberately: per-chip warning badges on `AttachmentChipList` (the notice row names the offending files; the thumbnail tiles were just reworked in #371/#372 and an overlay there is polish with visual-regression risk).

## Test plan

- [x] `vision-preflight.test.ts` — 25 cases: boundary values (at-cap / one-over), runner-faithful admission order (oversized doesn't consume budget; sequential offers, no reservation), count/total exhaustion, tri-state silence (no limits / unassessed model / unknown model), candidate typing (SVG and non-images never warn), message copy branches
- [x] `useModelRegistry.test.tsx` — document parsing: capability tri-state, garbled-limits rejection, `parseRegistryJson` byte-compat, `visionLimits` pass-through
- [x] `ModelSelector-visionIndicator.test.tsx` — blind / sighted / unassessed rows
- [x] `SessionComposer-visionPreflight.test.tsx` — paste-time warning with real parser fixtures, removal clears, blind-model wording, older-server silence, non-gating send
- [x] Full `@stigmer/react` suite: 400 files / 4409 tests green; `tsc --noEmit` clean; eslint clean; runner `attachment-vision.test.ts` 34/34

Made with [Cursor](https://cursor.com)