### PR TITLE
feat(sdk/react): marketplace definition-drift notice with one-click refresh for MCP servers

### DIFF
--- a/docs/sdk/react/attachment.mdx
+++ b/docs/sdk/react/attachment.mdx
@@ -134,6 +134,33 @@ function CustomComposer() {
 
 ## Types
 
+### assessVisionPreflight
+
+Predict which attached images the runner will degrade this turn.
+
+Pure and deterministic — safe to call in render (memoized by callers).
+Non-image attachments never warn. The byte assessment replicates the
+runner's sequential admission: an image over the per-image cap is
+degraded WITHOUT consuming budget; remaining images are admitted in
+order until the count or total-byte budget is exhausted.
+
+```tsx
+function assessVisionPreflight(attachments: readonly VisionPreflightAttachment[], options?: AssessVisionPreflightOptions): VisionPreflight
+```
+
+
+### AssessVisionPreflightOptions
+
+Options for [`assessVisionPreflight`](#assessvisionpreflight).
+
+<TypeTable
+  type={{
+    limits: { type: "VisionLimits", description: "The advertised byte budget from `useModelRegistry().visionLimits`. `undefined` (older server, still loading) disables the byte assessment, never the capability verdict.", typeDescriptionLink: "/docs/sdk/react/models#visionlimits" },
+    model: { type: "ModelInfo", description: "The model the turn will run on. `undefined` (unknown/still loading) disables the capability verdict, never the byte assessment.", typeDescriptionLink: "/docs/sdk/react/models#modelinfo" },
+  }}
+/>
+
+
 ### AttachmentEntry
 
 State for a single file being managed by the hook.
@@ -367,6 +394,81 @@ Integer pixel dimensions produced by [`fitToVisionResolution`](#fittovisionresol
   type={{
     height: { type: "number", description: "", required: true },
     width: { type: "number", description: "", required: true },
+  }}
+/>
+
+
+### VisionPreflight
+
+Result of [`assessVisionPreflight`](#assessvisionpreflight).
+
+<TypeTable
+  type={{
+    modelCannotSeeImages: { type: "boolean", description: "True when the selected model is explicitly blind (`vision: false`) and at least one image is attached. When set, every image warning carries `model_no_vision` — resending smaller images cannot help, so warning UI should lead with the model, not the files.", required: true },
+    warnings: { type: "readonly VisionPreflightWarning[]", description: "Predicted-degraded images in attachment order. Empty = all clear.", required: true },
+  }}
+/>
+
+
+### VisionPreflightAttachment
+
+Minimal attachment shape the preflight needs — pure data, no `File`.
+
+<TypeTable
+  type={{
+    contentType: { type: "string", description: "Declared/detected MIME type (`AttachmentEntry.contentType`).", required: true },
+    name: { type: "string", description: "Display name used in warning copy (the chip's filename).", required: true },
+    sizeBytes: { type: "number", description: "Raw byte size — what the runner's budget counts.", required: true },
+  }}
+/>
+
+
+### visionPreflightMessage
+
+One-line human copy for a [`VisionPreflight`](#visionpreflight) — the client-side twin
+of the runner's `visionDisclosureLines`, worded for BEFORE the turn
+("will arrive as a file") instead of after ("was not viewable").
+
+Returns `null` when there is nothing to warn about. Copy rules:
+- a blind model leads with the model, never the files — no smaller
+  resend can help, so file-size advice would be dishonest;
+- `too_large` names the files (up to two, then a count) and the actual
+  cap, so the fix — export smaller — is self-evident;
+- `budget_exhausted` explains the per-turn budget, the only fix being
+  fewer images this turn.
+
+```tsx
+function visionPreflightMessage(preflight: VisionPreflight, options?: VisionPreflightMessageOptions): string | null
+```
+
+
+### VisionPreflightMessageOptions
+
+Options for [`visionPreflightMessage`](#visionpreflightmessage).
+
+<TypeTable
+  type={{
+    limits: { type: "VisionLimits", description: "The advertised budget — names the caps in the copy when present.", typeDescriptionLink: "/docs/sdk/react/models#visionlimits" },
+    modelDisplayName: { type: "string", description: "Display name of the selected model, for the capability wording." },
+  }}
+/>
+
+
+### VisionPreflightReason
+
+Why an image will not be viewable inline — the client-assessable subset
+of the runner's `VisionDegradedReason` vocabulary, same spellings.
+
+
+### VisionPreflightWarning
+
+One image the runner is predicted to degrade, and why.
+
+<TypeTable
+  type={{
+    name: { type: "string", description: "", required: true },
+    reason: { type: "VisionPreflightReason", description: "", required: true, typeDescriptionLink: "#visionpreflightreason" },
+    sizeBytes: { type: "number", description: "", required: true },
   }}
 />
 

--- a/docs/sdk/react/models.mdx
+++ b/docs/sdk/react/models.mdx
@@ -51,6 +51,7 @@ function useModelRegistry(options?: UseModelRegistryOptions): UseModelRegistryRe
     models: { type: "readonly ModelInfo[]", description: "All enabled models for the selected mode." },
     providers: { type: "readonly Provider[]", description: "Ordered list of enabled provider identifiers." },
     refetch: { type: "() => void", description: "Retry fetching the model registry. No-op while a fetch is in flight." },
+    visionLimits: { type: "VisionLimits | undefined", description: "Document-level vision byte budget advertised by the registry (stigmer/stigmer#365). `undefined` while loading or when the server predates the `limits` block — treat as unassessed and stay silent." },
   }}
 />
 
@@ -199,8 +200,21 @@ To re-enable a provider, simply remove it from this set.
 
 Fetch the model registry from the authenticated API endpoint.
 
+Thin compatibility wrapper over [`fetchModelRegistryDocument`](#fetchmodelregistrydocument) —
+prefer the document fetch when the caller also needs document-level
+metadata such as [`VisionLimits`](#visionlimits).
+
 ```tsx
 function fetchModelRegistry(apiUrl: string, token: string | null, customFetch?: (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>): Promise<ModelInfo[]>
+```
+
+
+### fetchModelRegistryDocument
+
+Fetch the model-registry document from the authenticated API endpoint.
+
+```tsx
+function fetchModelRegistryDocument(apiUrl: string, token: string | null, customFetch?: (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>): Promise<ModelRegistryDocument>
 ```
 
 
@@ -246,6 +260,7 @@ UI-relevant metadata for a single platform-supported LLM model.
     serviceTiers: { type: "readonly string[]", description: "Pricing-variant keys the registry prices for this model (e.g. `[\"fast\"]`). A priced variant is a *selectable* service tier (stigmer/stigmer#357): the fast-tier switch in the model popover's options area renders only while the selected model's `serviceTiers` includes it. Empty for models with no variants.  Distinct from speedTier, which is a static latency badge, not a selectable option.", required: true },
     shortDescription: { type: "string", description: "3-6 word pitch explaining why to pick this model. Shown in the curated view.", required: true },
     speedTier: { type: "SpeedTier", description: "Latency characteristic shown as a badge (Fastest / Fast / Balanced / Slow).", required: true },
+    visionCapability: { type: "boolean", description: "Tri-state vision capability from the registry's `capabilities` block (stigmer/stigmer#386). The registry serializes `capabilities` only for models whose capabilities were actually assessed, so:  - `true` — images sent with a turn reach the model - `false` — explicitly assessed as blind; warn at selection/send time - `undefined` — never assessed; **stay silent, never treat as false**  Mirrors the runner's `parseVisionCapability` convention (backend/services/runner/src/shared/model-registry.ts) — both sides parse the same document and must agree on what absence means." },
   }}
 />
 
@@ -278,6 +293,21 @@ this context instead of a static JSON import, enabling always-fresh
 model data without npm package updates.
 
 
+### ModelRegistryDocument
+
+Parsed model-registry document: the per-model list plus document-level
+platform metadata. `visionLimits` is `undefined` when the served document
+predates the `limits` block (older servers) — consumers must stay silent
+rather than assume a budget.
+
+<TypeTable
+  type={{
+    models: { type: "readonly ModelInfo[]", description: "", required: true },
+    visionLimits: { type: "VisionLimits", description: "", typeDescriptionLink: "#visionlimits" },
+  }}
+/>
+
+
 ### ModelRegistryState
 
 Internal state held by the model registry context provider.
@@ -288,6 +318,7 @@ Internal state held by the model registry context provider.
     isLoading: { type: "boolean", description: "", required: true },
     models: { type: "readonly ModelInfo[]", description: "", required: true },
     refetch: { type: "() => void", description: "Retry fetching the model registry. No-op while a fetch is in flight.", required: true },
+    visionLimits: { type: "VisionLimits", description: "Document-level vision byte budget (stigmer/stigmer#365). `undefined` while loading or when the served document predates the `limits` block — consumers stay silent rather than assume a budget.", typeDescriptionLink: "#visionlimits" },
   }}
 />
 
@@ -314,12 +345,27 @@ function parseModelKey(key: string): ParsedModelKey | undefined
 ```
 
 
+### parseRegistryDocument
+
+Parse a raw registry document (from the API or a static file) into the
+per-model list plus document-level metadata.
+
+Expects the shape `{ models: RegistryJsonEntry[], limits?: {...} }`.
+Filters out comment entries and invalid rows. Unknown top-level fields
+are ignored (the document contract is additive).
+
+```tsx
+function parseRegistryDocument(data: unknown): ModelRegistryDocument
+```
+
+
 ### parseRegistryJson
 
-Parse raw registry JSON (from the API or a static file) into `ModelInfo[]`.
+Parse raw registry JSON into `ModelInfo[]`.
 
-Expects the shape `{ models: RegistryJsonEntry[] }`. Filters out comment
-entries and invalid rows, then maps to the `ModelInfo` interface.
+Thin compatibility wrapper over [`parseRegistryDocument`](#parseregistrydocument) — prefer
+the document parser when the caller also needs document-level metadata
+such as [`VisionLimits`](#visionlimits).
 
 ```tsx
 function parseRegistryJson(data: unknown): ModelInfo[]
@@ -350,6 +396,28 @@ Options for [`useModelRegistry`](#usemodelregistry).
 <TypeTable
   type={{
     harness: { type: "HarnessOption", description: "Restrict to a single harness.  - `\"cursor\"` — only Cursor-harness models, default → DEFAULT_CURSOR_MODEL_ID - `\"native\"` — only native-harness models, filtered by DISABLED_PROVIDERS - omitted — **unified mode**: all enabled models from both harnesses", typeDescriptionLink: "#harnessoption" },
+  }}
+/>
+
+
+### VisionLimits
+
+Document-level vision byte budget advertised by the registry
+(stigmer/stigmer#365) — the runner's inline-image delivery caps, exposed
+so clients can warn *before* an upload the runner would degrade to
+"not viewable inline". Field names match the runner's `VisionBudget`
+options verbatim (backend/services/runner/src/shared/attachment-vision.ts).
+
+ADVERTISED == ENFORCED: the serving side (cloud
+`ModelRegistryDocumentCodec`) and the runner pin the same literal values
+in their test suites. Treat an absent block as unassessed — no warnings —
+exactly like the per-model `capabilities` tri-state.
+
+<TypeTable
+  type={{
+    maxImageBytes: { type: "number", description: "Per-image raw byte cap for inline vision delivery.", required: true },
+    maxImages: { type: "number", description: "Per-turn inline image count cap.", required: true },
+    maxTotalBytes: { type: "number", description: "Per-turn total byte cap across all inline images.", required: true },
   }}
 />
 

--- a/docs/sdk/resources/mcp-server.mdx
+++ b/docs/sdk/resources/mcp-server.mdx
@@ -272,6 +272,7 @@ const mcpServer = await stigmer.mcpServer.apply({
   labels: {},
   description: "...",
   iconUrl: "...",
+  tags: [],
   stdio: {},
   http: {},
   defaultEnabledTools: [],
@@ -292,6 +293,7 @@ mcpServer, err := client.McpServer.Apply(ctx, &stigmer.McpServerInput{
   Labels:              map[string]string{},
   Description:         "...",
   IconUrl:             "...",
+  Tags:                []string{},
   Stdio:               &stigmer.StdioServerConfigInput{},
   Http:                &stigmer.HttpServerConfigInput{},
   DefaultEnabledTools: []string{},
@@ -312,6 +314,7 @@ mcp_server = client.mcp_servers.apply(McpServerInput(
     labels={},
     description="...",
     icon_url="...",
+    tags=[],
     stdio=None,
     http=None,
     default_enabled_tools=[],
@@ -332,6 +335,7 @@ McpServer mcpServer = client.mcpServers().apply(McpServerInput.builder()
     .labels(Map.of())
     .description("...")
     .iconUrl("...")
+    .tags(List.of())
     .stdio(null)
     .http(null)
     .defaultEnabledTools(List.of())
@@ -365,6 +369,7 @@ const mcpServer = await stigmer.mcpServer.create({
   labels: {},
   description: "...",
   iconUrl: "...",
+  tags: [],
   stdio: {},
   http: {},
   defaultEnabledTools: [],
@@ -385,6 +390,7 @@ mcpServer, err := client.McpServer.Create(ctx, &stigmer.McpServerInput{
   Labels:              map[string]string{},
   Description:         "...",
   IconUrl:             "...",
+  Tags:                []string{},
   Stdio:               &stigmer.StdioServerConfigInput{},
   Http:                &stigmer.HttpServerConfigInput{},
   DefaultEnabledTools: []string{},
@@ -405,6 +411,7 @@ mcp_server = client.mcp_servers.create(McpServerInput(
     labels={},
     description="...",
     icon_url="...",
+    tags=[],
     stdio=None,
     http=None,
     default_enabled_tools=[],
@@ -425,6 +432,7 @@ McpServer mcpServer = client.mcpServers().create(McpServerInput.builder()
     .labels(Map.of())
     .description("...")
     .iconUrl("...")
+    .tags(List.of())
     .stdio(null)
     .http(null)
     .defaultEnabledTools(List.of())
@@ -456,6 +464,7 @@ const mcpServer = await stigmer.mcpServer.update({
   labels: {},
   description: "...",
   iconUrl: "...",
+  tags: [],
   stdio: {},
   http: {},
   defaultEnabledTools: [],
@@ -476,6 +485,7 @@ mcpServer, err := client.McpServer.Update(ctx, &stigmer.McpServerInput{
   Labels:              map[string]string{},
   Description:         "...",
   IconUrl:             "...",
+  Tags:                []string{},
   Stdio:               &stigmer.StdioServerConfigInput{},
   Http:                &stigmer.HttpServerConfigInput{},
   DefaultEnabledTools: []string{},
@@ -496,6 +506,7 @@ mcp_server = client.mcp_servers.update(McpServerInput(
     labels={},
     description="...",
     icon_url="...",
+    tags=[],
     stdio=None,
     http=None,
     default_enabled_tools=[],
@@ -516,6 +527,7 @@ McpServer mcpServer = client.mcpServers().update(McpServerInput.builder()
     .labels(Map.of())
     .description("...")
     .iconUrl("...")
+    .tags(List.of())
     .stdio(null)
     .http(null)
     .defaultEnabledTools(List.of())
@@ -935,6 +947,7 @@ Input for creating or updating a MCP Server.
     labels: { type: "Record<string, string>", description: "Key-value labels." },
     description: { type: "string", description: "Human-readable description for marketplace display and documentation." },
     iconUrl: { type: "string", description: "Icon URL for UI display in marketplace and agent configuration screens." },
+    tags: { type: "string[]", description: "Categorization tags for discoverability in the marketplace." },
     stdio: { type: "StdioServerConfigInput", description: "stdio-based server (subprocess with stdin/stdout communication).", typeDescriptionLink: "#stdioserverconfiginput" },
     http: { type: "HttpServerConfigInput", description: "HTTP-based server (HTTP + Server-Sent Events communication).", typeDescriptionLink: "#httpserverconfiginput" },
     defaultEnabledTools: { type: "string[]", description: "Default tools to enable from this MCP server." },

--- a/sdk/go/internal/gen/mcpserver.go
+++ b/sdk/go/internal/gen/mcpserver.go
@@ -152,6 +152,7 @@ type McpServerInput struct {
 	Visibility          apiresource.ApiResourceVisibility
 	Description         string
 	IconUrl             string
+	Tags                []string
 	Stdio               *StdioServerConfigInput
 	Http                *HttpServerConfigInput
 	DefaultEnabledTools []string
@@ -209,6 +210,7 @@ func (i *McpServerInput) toProto() (*mcpserverv1.McpServer, error) {
 	}
 	resource.Spec.Description = i.Description
 	resource.Spec.IconUrl = i.IconUrl
+	resource.Spec.Tags = i.Tags
 	if i.Stdio != nil {
 		m := &mcpserverv1.StdioServerConfig{}
 		m.Command = i.Stdio.Command
@@ -293,6 +295,7 @@ func McpServerInputFromProto(p *mcpserverv1.McpServer) *McpServerInput {
 	if s := p.GetSpec(); s != nil {
 		input.Description = s.GetDescription()
 		input.IconUrl = s.GetIconUrl()
+		input.Tags = s.GetTags()
 		input.DefaultEnabledTools = s.GetDefaultEnabledTools()
 		if len(s.GetEnv()) > 0 {
 			input.Env = make(map[string]*EnvVarDeclarationInput, len(s.GetEnv()))

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/McpServerInput.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/McpServerInput.java
@@ -22,6 +22,7 @@ public final class McpServerInput {
     private final ApiResourceVisibility visibility;
     private final String description;
     private final String iconUrl;
+    private final java.util.List<String> tags;
     private final StdioServerConfigInput stdio;
     private final HttpServerConfigInput http;
     private final java.util.List<String> defaultEnabledTools;
@@ -39,6 +40,7 @@ public final class McpServerInput {
         this.visibility = builder.visibility;
         this.description = builder.description;
         this.iconUrl = builder.iconUrl;
+        this.tags = builder.tags;
         this.stdio = builder.stdio;
         this.http = builder.http;
         this.defaultEnabledTools = builder.defaultEnabledTools;
@@ -56,6 +58,9 @@ public final class McpServerInput {
         }
         if (this.iconUrl != null) {
             spec.setIconUrl(this.iconUrl);
+        }
+        if (this.tags != null && !this.tags.isEmpty()) {
+            spec.addAllTags(this.tags);
         }
         if (this.stdio != null) {
             spec.setStdio(this.stdio.toProto());
@@ -113,6 +118,7 @@ public final class McpServerInput {
         private ApiResourceVisibility visibility;
         private String description;
         private String iconUrl;
+        private java.util.List<String> tags;
         private StdioServerConfigInput stdio;
         private HttpServerConfigInput http;
         private java.util.List<String> defaultEnabledTools;
@@ -131,6 +137,7 @@ public final class McpServerInput {
         public Builder visibility(ApiResourceVisibility visibility) { this.visibility = visibility; return this; }
         public Builder description(String description) { this.description = description; return this; }
         public Builder iconUrl(String iconUrl) { this.iconUrl = iconUrl; return this; }
+        public Builder tags(java.util.List<String> tags) { this.tags = tags; return this; }
         public Builder stdio(StdioServerConfigInput stdio) { this.stdio = stdio; return this; }
         public Builder http(HttpServerConfigInput http) { this.http = http; return this; }
         public Builder defaultEnabledTools(java.util.List<String> defaultEnabledTools) { this.defaultEnabledTools = defaultEnabledTools; return this; }

--- a/sdk/python/src/stigmer/_gen/_mcpserver.py
+++ b/sdk/python/src/stigmer/_gen/_mcpserver.py
@@ -158,6 +158,7 @@ class McpServerInput:
     visibility: int = 0
     description: str = ""
     icon_url: str = ""
+    tags: list[str] = field(default_factory=list)
     stdio: StdioServerConfigInput | None = None
     http: HttpServerConfigInput | None = None
     default_enabled_tools: list[str] = field(default_factory=list)
@@ -174,6 +175,8 @@ class McpServerInput:
             repository_url=self.repository_url,
             github_stars=self.github_stars,
         )
+        if self.tags:
+            spec.tags.extend(self.tags)
         if self.stdio is not None:
             spec.stdio.CopyFrom(self.stdio._to_proto())
         if self.http is not None:

--- a/sdk/react/src/mcp-server/DefinitionDriftNotice.tsx
+++ b/sdk/react/src/mcp-server/DefinitionDriftNotice.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { cn } from "@stigmer/theme";
+import type { McpServerDefinitionDrift } from "./useMcpServerDefinitionDrift.js";
+import type { DriftFieldId } from "./internal/definitionDrift.js";
+
+/** Props for {@link DefinitionDriftNotice}. */
+export interface DefinitionDriftNoticeProps {
+  /**
+   * The detected drift from {@link useMcpServerDefinitionDrift}, or
+   * `null`. The notice renders `null` when there is no drift.
+   */
+  readonly drift: McpServerDefinitionDrift | null;
+  /** Applies the marketplace configuration and re-runs discovery. */
+  readonly onRefresh: () => void;
+  /** `true` while the refresh (update + re-discovery) is in flight. */
+  readonly isRefreshing: boolean;
+  /** Additional CSS class names for the root container. */
+  readonly className?: string;
+}
+
+/** Human-readable labels for the drifted field groups. */
+const DRIFT_FIELD_LABELS: Record<DriftFieldId, string> = {
+  transport: "connection type",
+  endpoint: "endpoint URL",
+  headers: "request headers",
+  queryParams: "query parameters",
+  timeout: "request timeout",
+  command: "launch command",
+  workingDirectory: "working directory",
+  environmentVariables: "environment variables",
+  authentication: "authentication",
+};
+
+/**
+ * Tells the owner of an org-owned MCP server that its connection-defining
+ * configuration differs from the current marketplace definition, and
+ * offers a one-click refresh (stigmer/stigmer#228).
+ *
+ * Without this notice, a server copied before a template fix is stranded
+ * forever: the user sees only downstream symptoms ("Token expired", 401s)
+ * with no indication that the root cause is a stale definition and no
+ * recovery path short of hand-editing YAML. This surfaces the actual
+ * state and pairs it with the action that fixes it (Nielsen: visibility
+ * of system status; error recovery).
+ *
+ * The copy says the configuration **differs** — never "was updated" —
+ * because the marketplace counterpart is matched by slug, and a
+ * hand-made server that happens to share a marketplace name must not be
+ * told a false history. Naming the differing fields keeps the claim
+ * verifiable, and the refresh explicitly promises what it preserves.
+ *
+ * Self-gating: renders `null` unless drift was detected. Callers render
+ * it unconditionally next to the other connection notices, mirroring
+ * {@link OAuthRequiredNotice}.
+ *
+ * All visual properties flow through `--stgm-*` design tokens. No
+ * Console-specific dependencies — safe for platform-builder embedding.
+ */
+export function DefinitionDriftNotice({
+  drift,
+  onRefresh,
+  isRefreshing,
+  className,
+}: DefinitionDriftNoticeProps) {
+  if (!drift) return null;
+
+  const fieldList = drift.changedFields
+    .map((id) => DRIFT_FIELD_LABELS[id])
+    .join(", ");
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "stg:bg-muted-subtle stg:text-muted-foreground stg:flex stg:items-start stg:gap-2.5 stg:rounded-lg stg:border stg:border-transparent stg:px-4 stg:py-3",
+        className,
+      )}
+    >
+      <RefreshIcon className="stg:mt-0.5 stg:size-4 stg:shrink-0" />
+      <div className="stg:flex-1">
+        <p className="stg:text-xs stg:leading-relaxed">
+          This server&apos;s configuration differs from the current
+          marketplace definition ({fieldList}). Refreshing applies the
+          marketplace configuration and re-runs discovery — your enabled
+          tools and approval pins are kept.
+        </p>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          data-cursor-target="definition-drift-refresh"
+          className="stg:bg-primary stg:text-primary-foreground stg:hover:bg-primary-hover stg:mt-2 stg:inline-flex stg:items-center stg:gap-1 stg:rounded-md stg:px-2.5 stg:py-1 stg:text-[11px] stg:font-medium stg:disabled:opacity-60"
+        >
+          {isRefreshing ? "Refreshing…" : "Refresh configuration"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RefreshIcon({ className }: { readonly className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M13.5 8a5.5 5.5 0 1 1-1.61-3.89" />
+      <path d="M13.5 2v3h-3" />
+    </svg>
+  );
+}

--- a/sdk/react/src/mcp-server/McpServerDetailView.tsx
+++ b/sdk/react/src/mcp-server/McpServerDetailView.tsx
@@ -710,7 +710,7 @@ export function McpServerDetailView({
       </Section>
 
       {(editable || (spec && spec.tags.length > 0)) && (
-        <TagsSection tags={spec?.tags ?? []} editable={editable} isSaving={isUpdating} saveMcpField={saveMcpField} />
+        <TagsSection tags={spec?.tags ?? []} editable={editable} />
       )}
     </ResourceDetailShell>
     {access.dialog}
@@ -1836,34 +1836,13 @@ function EnvSection({
 function TagsSection({
   tags,
   editable,
-  isSaving,
-  saveMcpField,
 }: {
   readonly tags: readonly string[];
   readonly editable?: boolean;
-  readonly isSaving?: boolean;
-  readonly saveMcpField?: <K extends keyof import("@stigmer/sdk").McpServerInput>(
-    field: K,
-    value: import("@stigmer/sdk").McpServerInput[K],
-  ) => Promise<boolean>;
 }) {
-  const tagRows: KeyValueRow[] = useMemo(
-    () => tags.map((t) => ({ key: t, value: "" })),
-    [tags],
-  );
-
-  const handleTagsSave = useCallback(
-    async (rows: KeyValueRow[]) => {
-      if (!saveMcpField) return false;
-      // Tags are stored as string[] on the spec but not directly on McpServerInput.
-      // For now, save them through the full input by modifying the spec.
-      // Tags don't have a direct field on McpServerInput, so we handle this at
-      // a higher level if needed. For now, show read-only in edit mode.
-      return false;
-    },
-    [saveMcpField],
-  );
-
+  // Display-only by design: tags are curated marketplace categorization,
+  // not per-connection state. (McpServerInput does carry `tags`, so an
+  // editing affordance is unblocked if the product ever wants one.)
   return (
     <Section title="Tags" count={tags.length}>
       <div className="stg:flex stg:flex-wrap stg:gap-1.5 stg:p-3">

--- a/sdk/react/src/mcp-server/McpServerDetailView.tsx
+++ b/sdk/react/src/mcp-server/McpServerDetailView.tsx
@@ -27,6 +27,9 @@ import type { OAuthConnectPhase } from "./useMcpServerOAuthConnect.js";
 import { StdioSandboxNotice } from "./StdioSandboxNotice.js";
 import { OAuthRequiredNotice } from "./OAuthRequiredNotice.js";
 import { VendorApprovalBlockedNotice } from "./VendorApprovalBlockedNotice.js";
+import { DefinitionDriftNotice } from "./DefinitionDriftNotice.js";
+import { useMcpServerDefinitionDrift } from "./useMcpServerDefinitionDrift.js";
+import { buildRefreshInput } from "./internal/definitionDrift.js";
 import { useDisconnectOAuth } from "./useDisconnectOAuth.js";
 import { useOrgOAuthApp } from "./useOrgOAuthApp.js";
 import { OAuthAppForm } from "./OAuthAppForm.js";
@@ -226,6 +229,50 @@ export function McpServerDetailView({
   const credentials = useMcpServerCredentials(activeOrg ?? org, mcpServer ?? null);
   const connection = useMcpServerConnect();
   const oauth = useMcpServerOAuthConnect();
+
+  // Definition drift is only checked for editable servers: the paired
+  // refresh writes to the resource, so read-only viewers (e.g. anyone
+  // browsing another org's marketplace row) have nothing to act on.
+  const { drift: definitionDrift } = useMcpServerDefinitionDrift(
+    editable ? (mcpServer ?? null) : null,
+  );
+  const [isRefreshingDefinition, setIsRefreshingDefinition] = useState(false);
+  const handleDefinitionRefresh = useCallback(async () => {
+    if (!mcpServer?.metadata?.id || !definitionDrift) return;
+    setIsRefreshingDefinition(true);
+    try {
+      const updated = await updateMcpServer(
+        buildRefreshInput(mcpServer, definitionDrift.template),
+      );
+      onResourceUpdated?.(updated);
+      // The update RPC does not re-run discovery (only apply does), so
+      // reconnect explicitly — the refreshed transport/auth configuration
+      // is exactly what discovery needs to be retried against.
+      const envKeys = Object.keys(updated.spec?.env ?? {});
+      await connection.connect(
+        updated.metadata!.id,
+        activeOrg ?? org,
+        undefined,
+        envKeys,
+      );
+    } catch {
+      // Update errors surface through useUpdateMcpServer's error state;
+      // a failed re-discovery lands in connection.error next to the
+      // Connect button. Either way the page stays usable.
+    } finally {
+      setIsRefreshingDefinition(false);
+      refetch();
+    }
+  }, [
+    mcpServer,
+    definitionDrift,
+    updateMcpServer,
+    onResourceUpdated,
+    connection,
+    activeOrg,
+    org,
+    refetch,
+  ]);
   const disconnectOAuth = useDisconnectOAuth();
   const orgOAuthApp = useOrgOAuthApp(
     mcpServer?.metadata?.id ?? null,
@@ -588,6 +635,12 @@ export function McpServerDetailView({
       {/* scrollTarget: guided tours/demos bring the connect flow into view
           (see IdentityTransportStep's "mcp-transport" for the convention). */}
       <Section title="Connection" scrollTarget="mcp-connection">
+        <DefinitionDriftNotice
+          drift={definitionDrift}
+          onRefresh={handleDefinitionRefresh}
+          isRefreshing={isRefreshingDefinition}
+          className="stg:mb-3"
+        />
         <StdioSandboxNotice serverType={spec?.serverType} className="stg:mb-3" />
         <OAuthRequiredNotice oauthOnly={spec?.auth?.oauthOnly} className="stg:mb-3" />
         <ConnectBar

--- a/sdk/react/src/mcp-server/__tests__/DefinitionDriftNotice.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/DefinitionDriftNotice.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { samples } from "../../test/samples";
+import { DefinitionDriftNotice } from "../DefinitionDriftNotice";
+import type { McpServerDefinitionDrift } from "../useMcpServerDefinitionDrift";
+
+afterEach(cleanup);
+
+function drift(): McpServerDefinitionDrift {
+  return {
+    template: samples.mcpServer({ name: "Monday", org: "stigmer", slug: "monday" }),
+    changedFields: ["headers", "authentication"],
+  };
+}
+
+describe("DefinitionDriftNotice", () => {
+  it("renders null when there is no drift", () => {
+    const { container } = render(
+      <DefinitionDriftNotice drift={null} onRefresh={() => {}} isRefreshing={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("says the configuration DIFFERS (never 'was updated') and names the fields", () => {
+    render(
+      <DefinitionDriftNotice drift={drift()} onRefresh={() => {}} isRefreshing={false} />,
+    );
+    const notice = screen.getByRole("status");
+    // Honest copy: slug-matching is a heuristic, so the notice must state
+    // a verifiable present-tense fact, not invent an update history.
+    expect(notice.textContent).toContain("differs from the current marketplace definition");
+    expect(notice.textContent).not.toContain("was updated");
+    expect(notice.textContent).toContain("request headers, authentication");
+    // The refresh promise: what survives.
+    expect(notice.textContent).toContain("enabled tools and approval pins are kept");
+  });
+
+  it("fires onRefresh from the action button", async () => {
+    const onRefresh = vi.fn();
+    render(
+      <DefinitionDriftNotice drift={drift()} onRefresh={onRefresh} isRefreshing={false} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Refresh configuration" }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button and shows progress while refreshing", () => {
+    render(
+      <DefinitionDriftNotice drift={drift()} onRefresh={() => {}} isRefreshing />,
+    );
+    const button = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Refreshing…",
+    });
+    expect(button.disabled).toBe(true);
+  });
+});

--- a/sdk/react/src/mcp-server/__tests__/definitionDrift.test.ts
+++ b/sdk/react/src/mcp-server/__tests__/definitionDrift.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import {
+  HttpServerConfigSchema,
+  McpServerAuthSchema,
+  McpServerSpecSchema,
+  StdioServerConfigSchema,
+  ToolApprovalPolicySchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import { EnvVarDeclarationSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { samples } from "../../test/samples";
+import {
+  buildRefreshInput,
+  computeDefinitionDrift,
+} from "../internal/definitionDrift";
+
+/**
+ * Pins the drift comparison and refresh-payload semantics of
+ * stigmer/stigmer#228. The scenarios mirror the reporting incident: the
+ * monday.com seedpack template was fixed (custom token header ->
+ * `Authorization: Bearer`, plus `oauth_only`), and pre-fix copies had to
+ * detect exactly that class of change — while cosmetic template edits
+ * (descriptions, icons, tags) must never nag.
+ */
+
+/** The org copy: pre-fix monday.com configuration. */
+function preFixCopy(): McpServer {
+  const server = samples.mcpServer({ name: "Monday", org: "acme", slug: "monday" });
+  server.spec = create(McpServerSpecSchema, {
+    description: "monday.com MCP server",
+    iconUrl: "https://example.com/monday.svg",
+    tags: ["monday", "project-management"],
+    serverType: {
+      case: "http",
+      value: create(HttpServerConfigSchema, {
+        url: "https://mcp.monday.com/mcp",
+        headers: { MONDAY_TOKEN: "${MONDAY_ACCESS_TOKEN}" },
+      }),
+    },
+    env: {
+      MONDAY_ACCESS_TOKEN: create(EnvVarDeclarationSchema, {
+        isSecret: true,
+        description: "monday.com personal API token",
+      }),
+    },
+    defaultEnabledTools: ["boards_list"],
+    pinnedToolApprovals: [
+      create(ToolApprovalPolicySchema, {
+        toolName: "items_delete",
+        message: "Deletes board items",
+        fromDestructiveHint: true,
+      }),
+    ],
+    auth: create(McpServerAuthSchema, {
+      targetEnvVar: "MONDAY_ACCESS_TOKEN",
+      tokenLifetimeHint: "1h",
+    }),
+  });
+  return server;
+}
+
+/** The marketplace template after the fix. */
+function fixedTemplate(): McpServer {
+  const server = preFixCopy();
+  server.metadata!.org = "stigmer";
+  server.spec!.serverType = {
+    case: "http",
+    value: create(HttpServerConfigSchema, {
+      url: "https://mcp.monday.com/mcp",
+      headers: { Authorization: "Bearer ${MONDAY_ACCESS_TOKEN}" },
+    }),
+  };
+  server.spec!.env = {
+    MONDAY_ACCESS_TOKEN: create(EnvVarDeclarationSchema, {
+      isSecret: true,
+      // Rewritten by the fix — descriptions are cosmetic and must not
+      // register as environment-variable drift on their own.
+      description: "OAuth access token, obtained automatically via Connect.",
+    }),
+  };
+  server.spec!.auth = create(McpServerAuthSchema, {
+    targetEnvVar: "MONDAY_ACCESS_TOKEN",
+    tokenLifetimeHint: "1h",
+    oauthOnly: true,
+  });
+  // Policy fields differ on the template: a refresh must NOT import them.
+  server.spec!.defaultEnabledTools = [];
+  server.spec!.pinnedToolApprovals = [];
+  return server;
+}
+
+describe("computeDefinitionDrift", () => {
+  it("returns null when connection-defining configuration matches", () => {
+    expect(computeDefinitionDrift(preFixCopy(), preFixCopy())).toBeNull();
+  });
+
+  it("detects the monday.com incident: header fix + oauth_only", () => {
+    expect(computeDefinitionDrift(preFixCopy(), fixedTemplate())).toEqual([
+      "headers",
+      "authentication",
+    ]);
+  });
+
+  it("ignores cosmetic-only template changes", () => {
+    const template = preFixCopy();
+    template.spec!.description = "A much better description";
+    template.spec!.iconUrl = "https://example.com/new-icon.svg";
+    template.spec!.tags = ["monday", "pm", "extra"];
+    template.spec!.repositoryUrl = "https://github.com/mondaycom/mcp-v2";
+    template.spec!.githubStars = 999;
+    expect(computeDefinitionDrift(preFixCopy(), template)).toBeNull();
+  });
+
+  it("ignores user policy differences (enabled tools, approval pins)", () => {
+    const template = preFixCopy();
+    template.spec!.defaultEnabledTools = ["boards_list", "items_create"];
+    template.spec!.pinnedToolApprovals = [];
+    expect(computeDefinitionDrift(preFixCopy(), template)).toBeNull();
+  });
+
+  it("detects endpoint URL changes", () => {
+    const template = preFixCopy();
+    (template.spec!.serverType.value as { url: string }).url =
+      "https://mcp2.monday.com/mcp";
+    expect(computeDefinitionDrift(preFixCopy(), template)).toEqual(["endpoint"]);
+  });
+
+  it("detects a transport switch as a single coarse change", () => {
+    const template = preFixCopy();
+    template.spec!.serverType = {
+      case: "stdio",
+      value: create(StdioServerConfigSchema, { command: "npx" }),
+    };
+    expect(computeDefinitionDrift(preFixCopy(), template)).toEqual(["transport"]);
+  });
+
+  it("detects functional env changes (new required var)", () => {
+    const template = preFixCopy();
+    template.spec!.env = {
+      ...template.spec!.env,
+      MONDAY_WORKSPACE_ID: create(EnvVarDeclarationSchema, { isSecret: false }),
+    };
+    expect(computeDefinitionDrift(preFixCopy(), template)).toEqual([
+      "environmentVariables",
+    ]);
+  });
+
+  it("detects an is_secret flip as functional env drift", () => {
+    const template = preFixCopy();
+    template.spec!.env = {
+      MONDAY_ACCESS_TOKEN: create(EnvVarDeclarationSchema, {
+        isSecret: false,
+        description: "monday.com personal API token",
+      }),
+    };
+    expect(computeDefinitionDrift(preFixCopy(), template)).toEqual([
+      "environmentVariables",
+    ]);
+  });
+
+  it("compares stdio command and args", () => {
+    const current = preFixCopy();
+    current.spec!.serverType = {
+      case: "stdio",
+      value: create(StdioServerConfigSchema, {
+        command: "npx",
+        args: ["-y", "@mondaycom/mcp@1"],
+      }),
+    };
+    const template = preFixCopy();
+    template.spec!.serverType = {
+      case: "stdio",
+      value: create(StdioServerConfigSchema, {
+        command: "npx",
+        args: ["-y", "@mondaycom/mcp@2"],
+      }),
+    };
+    expect(computeDefinitionDrift(current, template)).toEqual(["command"]);
+  });
+
+  it("treats header map key order as irrelevant", () => {
+    const current = preFixCopy();
+    current.spec!.serverType = {
+      case: "http",
+      value: create(HttpServerConfigSchema, {
+        url: "https://mcp.monday.com/mcp",
+        headers: { "X-One": "1", "X-Two": "2" },
+      }),
+    };
+    const template = preFixCopy();
+    template.spec!.serverType = {
+      case: "http",
+      value: create(HttpServerConfigSchema, {
+        url: "https://mcp.monday.com/mcp",
+        headers: { "X-Two": "2", "X-One": "1" },
+      }),
+    };
+    expect(computeDefinitionDrift(current, template)).toBeNull();
+  });
+});
+
+describe("buildRefreshInput", () => {
+  it("takes the definition from the template and keeps the user's identity and policy", () => {
+    const current = preFixCopy();
+    const template = fixedTemplate();
+    const input = buildRefreshInput(current, template);
+
+    // Identity: the update lands on the user's own resource.
+    expect(input.name).toBe("Monday");
+    expect(input.org).toBe("acme");
+    expect(input.slug).toBe("monday");
+
+    // Definition: the fixed template configuration wins.
+    expect(input.http?.headers).toEqual({
+      Authorization: "Bearer ${MONDAY_ACCESS_TOKEN}",
+    });
+    expect(input.auth?.oauthOnly).toBe(true);
+    expect(input.env?.MONDAY_ACCESS_TOKEN?.description).toBe(
+      "OAuth access token, obtained automatically via Connect.",
+    );
+
+    // User policy: never reset by a refresh (the template has neither).
+    expect(input.defaultEnabledTools).toEqual(["boards_list"]);
+    expect(input.pinnedToolApprovals).toEqual([
+      {
+        toolName: "items_delete",
+        message: "Deletes board items",
+        fromDestructiveHint: true,
+      },
+    ]);
+  });
+
+  it("carries a template transport switch cleanly", () => {
+    const current = preFixCopy();
+    const template = preFixCopy();
+    template.spec!.serverType = {
+      case: "stdio",
+      value: create(StdioServerConfigSchema, { command: "npx", args: ["-y", "mcp"] }),
+    };
+    const input = buildRefreshInput(current, template);
+    expect(input.stdio).toEqual({ command: "npx", args: ["-y", "mcp"] });
+    expect(input.http).toBeUndefined();
+  });
+});

--- a/sdk/react/src/mcp-server/__tests__/mcpServerToInput.test.ts
+++ b/sdk/react/src/mcp-server/__tests__/mcpServerToInput.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { create, toJson } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import {
+  HttpServerConfigSchema,
+  McpServerAuthSchema,
+  McpServerSpecSchema,
+  StdioServerConfigSchema,
+  ToolApprovalPolicySchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import { EnvVarDeclarationSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { buildMcpServerProto } from "@stigmer/sdk";
+import { mcpServerToInput } from "../internal/mcpServerToInput.js";
+
+/**
+ * `mcpServerToInput` powers every read-modify-write update in the SDK: the
+ * backend does FULL spec replacement, so any spec field the conversion
+ * fails to carry is silently ERASED by the very next inline edit. That is
+ * not hypothetical — `spec.tags` and `auth.oauth_only` were lost this way
+ * until the conversion (and the SDK input type) learned them.
+ *
+ * Two layers of protection:
+ *
+ * 1. A field-inventory fence: pins the exact field set of every proto
+ *    message the conversion traverses. Adding a field to the proto makes
+ *    this test fail with instructions, instead of shipping a new
+ *    silent-data-loss bug.
+ * 2. A round-trip proof: a fully-populated server survives
+ *    `mcpServerToInput` -> `buildMcpServerProto` with its spec intact.
+ */
+
+// ---------------------------------------------------------------------------
+// Layer 1 — field-inventory fence
+// ---------------------------------------------------------------------------
+
+/**
+ * Every message the conversion walks, with its complete expected field set
+ * (proto `localName`s; oneof members appear as individual fields).
+ *
+ * If this fails because a field was ADDED: map the new field in
+ * `mcpServerToInput`, populate it in `fullyPopulatedServer` below, and only
+ * then extend the expected list here.
+ */
+const EXPECTED_FIELD_INVENTORY: ReadonlyArray<
+  readonly [DescMessage, readonly string[]]
+> = [
+  [
+    McpServerSpecSchema,
+    [
+      "auth",
+      "defaultEnabledTools",
+      "description",
+      "env",
+      "githubStars",
+      "http",
+      "iconUrl",
+      "pinnedToolApprovals",
+      "repositoryUrl",
+      "stdio",
+      "tags",
+    ],
+  ],
+  [StdioServerConfigSchema, ["args", "command", "workingDir"]],
+  [HttpServerConfigSchema, ["headers", "queryParams", "timeoutSeconds", "url"]],
+  [EnvVarDeclarationSchema, ["description", "isSecret", "optional"]],
+  [ToolApprovalPolicySchema, ["fromDestructiveHint", "message", "toolName"]],
+  [
+    McpServerAuthSchema,
+    [
+      "discoveryUrl",
+      "oauthAppRef",
+      "oauthOnly",
+      "scopeHints",
+      "targetEnvVar",
+      "tokenLifetimeHint",
+    ],
+  ],
+];
+
+describe("mcpServerToInput field-inventory fence", () => {
+  it.each(
+    EXPECTED_FIELD_INVENTORY.map(
+      ([schema, fields]) => [schema.typeName, schema, fields] as const,
+    ),
+  )("%s has exactly the fields the conversion maps", (_name, schema, fields) => {
+    const actual = schema.fields.map((f) => f.localName).sort();
+    expect(
+      actual,
+      `${schema.typeName} changed shape. Map any new field in ` +
+        "mcpServerToInput (unmapped spec fields are ERASED on the next " +
+        "update), populate it in this file's fullyPopulatedServer fixture, " +
+        "then update EXPECTED_FIELD_INVENTORY.",
+    ).toEqual([...fields].sort());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2 — round-trip proof
+// ---------------------------------------------------------------------------
+
+/**
+ * A server with EVERY spec field set to a non-default value, so any field
+ * the conversion drops shows up as a round-trip diff.
+ */
+function fullyPopulatedServer(transport: "stdio" | "http") {
+  const server = create(McpServerSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "McpServer",
+    metadata: create(ApiResourceMetadataSchema, {
+      name: "Monday",
+      org: "acme",
+      slug: "monday",
+      labels: { "stigmer.ai/category": "productivity" },
+    }),
+    spec: create(McpServerSpecSchema, {
+      description: "monday.com MCP server",
+      iconUrl: "https://example.com/monday.svg",
+      tags: ["monday", "project-management"],
+      defaultEnabledTools: ["boards_list", "items_create"],
+      env: {
+        MONDAY_ACCESS_TOKEN: create(EnvVarDeclarationSchema, {
+          isSecret: true,
+          description: "OAuth access token",
+          optional: true,
+        }),
+      },
+      pinnedToolApprovals: [
+        create(ToolApprovalPolicySchema, {
+          toolName: "items_delete",
+          message: "Deletes board items",
+          fromDestructiveHint: true,
+        }),
+      ],
+      repositoryUrl: "https://github.com/mondaycom/mcp",
+      githubStars: 387,
+      auth: create(McpServerAuthSchema, {
+        oauthAppRef: create(ApiResourceReferenceSchema, {
+          org: "stigmer",
+          slug: "monday-oauth",
+          kind: ApiResourceKind.oauth_app,
+        }),
+        targetEnvVar: "MONDAY_ACCESS_TOKEN",
+        tokenLifetimeHint: "1h",
+        scopeHints: ["boards:read", "boards:write"],
+        discoveryUrl: "https://auth.monday.com/.well-known/oauth",
+        oauthOnly: true,
+      }),
+    }),
+  });
+
+  if (transport === "stdio") {
+    server.spec!.serverType = {
+      case: "stdio",
+      value: create(StdioServerConfigSchema, {
+        command: "npx",
+        args: ["-y", "@mondaycom/mcp"],
+        workingDir: "/workspace",
+      }),
+    };
+  } else {
+    server.spec!.serverType = {
+      case: "http",
+      value: create(HttpServerConfigSchema, {
+        url: "https://mcp.monday.com/mcp",
+        headers: { Authorization: "Bearer ${MONDAY_ACCESS_TOKEN}" },
+        queryParams: { version: "2" },
+        timeoutSeconds: 45,
+      }),
+    };
+  }
+
+  return server;
+}
+
+describe("mcpServerToInput round-trip", () => {
+  it.each(["stdio", "http"] as const)(
+    "a fully-populated %s server survives toInput -> buildProto with spec intact",
+    (transport) => {
+      const original = fullyPopulatedServer(transport);
+      const rebuilt = buildMcpServerProto(mcpServerToInput(original));
+
+      expect(toJson(McpServerSpecSchema, rebuilt.spec!)).toEqual(
+        toJson(McpServerSpecSchema, original.spec!),
+      );
+
+      // Metadata identity fields the conversion is responsible for.
+      // (visibility is intentionally absent: the backend preserves it on
+      // update, and updateVisibility is its dedicated write path.)
+      expect(rebuilt.metadata?.name).toBe("Monday");
+      expect(rebuilt.metadata?.org).toBe("acme");
+      expect(rebuilt.metadata?.slug).toBe("monday");
+      expect(rebuilt.metadata?.labels).toEqual({
+        "stigmer.ai/category": "productivity",
+      });
+    },
+  );
+});

--- a/sdk/react/src/mcp-server/__tests__/useMcpServerDefinitionDrift.test.tsx
+++ b/sdk/react/src/mcp-server/__tests__/useMcpServerDefinitionDrift.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { create } from "@bufbuild/protobuf";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { Stigmer } from "@stigmer/sdk";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import { SearchService } from "@stigmer/protos/ai/stigmer/search/v1/query_pb";
+import {
+  SearchResponseSchema,
+  SearchResultSchema,
+} from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+import {
+  HttpServerConfigSchema,
+  McpServerSpecSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { samples } from "../../test/samples";
+import { StigmerContext } from "../../context";
+import { useMcpServerDefinitionDrift } from "../useMcpServerDefinitionDrift";
+
+/**
+ * Pins the template-resolution rules of the drift check
+ * (stigmer/stigmer#228): the marketplace counterpart is a cross-org
+ * PUBLIC row with the exact same slug — found through the search RPC's
+ * `crossOrgPublic` scope, the SDK's only client-side definition of
+ * "marketplace". Zero candidates, ambiguity, and transport failures all
+ * resolve to `null` (advisory affordance, never an error state).
+ */
+
+afterEach(cleanup);
+
+function serverWithHeaders(
+  org: string,
+  headers: Record<string, string>,
+): McpServer {
+  const server = samples.mcpServer({ name: "Monday", org, slug: "monday" });
+  server.spec = create(McpServerSpecSchema, {
+    serverType: {
+      case: "http",
+      value: create(HttpServerConfigSchema, {
+        url: "https://mcp.monday.com/mcp",
+        headers,
+      }),
+    },
+  });
+  return server;
+}
+
+function searchEntry(org: string) {
+  return create(SearchResultSchema, {
+    kind: ApiResourceKind.mcp_server,
+    id: `mcp-${org}`,
+    name: "Monday",
+    slug: "monday",
+    org,
+  });
+}
+
+function renderDrift(
+  server: McpServer | null,
+  register: Parameters<typeof createRouterTransport>[0],
+) {
+  const client = new Stigmer({
+    baseUrl: "/",
+    getAccessToken: () => "test-token",
+    customTransport: createRouterTransport(register),
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <StigmerContext.Provider value={client}>{children}</StigmerContext.Provider>
+  );
+  return renderHook(() => useMcpServerDefinitionDrift(server), { wrapper });
+}
+
+const STALE_HEADERS = { MONDAY_TOKEN: "${MONDAY_ACCESS_TOKEN}" };
+const FIXED_HEADERS = { Authorization: "Bearer ${MONDAY_ACCESS_TOKEN}" };
+
+describe("useMcpServerDefinitionDrift", () => {
+  it("reports drift against a single cross-org public row with the same slug", async () => {
+    const { result } = renderDrift(
+      serverWithHeaders("acme", STALE_HEADERS),
+      (router) => {
+        router.service(SearchService, {
+          search: () =>
+            create(SearchResponseSchema, {
+              entries: [searchEntry("acme"), searchEntry("stigmer")],
+            }),
+        });
+        router.service(McpServerQueryController, {
+          getByReference: () => serverWithHeaders("stigmer", FIXED_HEADERS),
+        });
+      },
+    );
+
+    await waitFor(() => expect(result.current.drift).not.toBeNull());
+    expect(result.current.drift?.changedFields).toEqual(["headers"]);
+    expect(result.current.drift?.template.metadata?.org).toBe("stigmer");
+  });
+
+  it("stays quiet when the configurations match", async () => {
+    const { result } = renderDrift(
+      serverWithHeaders("acme", FIXED_HEADERS),
+      (router) => {
+        router.service(SearchService, {
+          search: () =>
+            create(SearchResponseSchema, { entries: [searchEntry("stigmer")] }),
+        });
+        router.service(McpServerQueryController, {
+          getByReference: () => serverWithHeaders("stigmer", FIXED_HEADERS),
+        });
+      },
+    );
+
+    // Settle the async check, then confirm no drift was reported.
+    await new Promise((r) => setTimeout(r, 20));
+    await waitFor(() => expect(result.current.drift).toBeNull());
+  });
+
+  it("stays quiet when no foreign-org row shares the slug", async () => {
+    const { result } = renderDrift(
+      serverWithHeaders("acme", STALE_HEADERS),
+      (router) => {
+        router.service(SearchService, {
+          search: () =>
+            create(SearchResponseSchema, { entries: [searchEntry("acme")] }),
+        });
+      },
+    );
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.drift).toBeNull();
+  });
+
+  it("stays quiet when multiple foreign orgs share the slug (ambiguous template)", async () => {
+    const { result } = renderDrift(
+      serverWithHeaders("acme", STALE_HEADERS),
+      (router) => {
+        router.service(SearchService, {
+          search: () =>
+            create(SearchResponseSchema, {
+              entries: [searchEntry("stigmer"), searchEntry("other-org")],
+            }),
+        });
+      },
+    );
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.drift).toBeNull();
+  });
+
+  it("fails quiet when the search RPC errors", async () => {
+    const { result } = renderDrift(
+      serverWithHeaders("acme", STALE_HEADERS),
+      (router) => {
+        router.service(SearchService, {
+          search: () => {
+            throw new ConnectError("boom", Code.Unavailable);
+          },
+        });
+      },
+    );
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.drift).toBeNull();
+  });
+
+  it("skips entirely when passed null", async () => {
+    const { result } = renderDrift(null, () => {});
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.drift).toBeNull();
+  });
+});

--- a/sdk/react/src/mcp-server/internal/definitionDrift.ts
+++ b/sdk/react/src/mcp-server/internal/definitionDrift.ts
@@ -1,0 +1,158 @@
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServerInput } from "@stigmer/sdk";
+import { mcpServerToInput } from "./mcpServerToInput.js";
+
+/**
+ * Connection-defining field groups a marketplace definition can drift on.
+ *
+ * Stable identifiers, not display copy — {@link DefinitionDriftNotice}
+ * owns the human-readable labels. Cosmetic fields (description, icon,
+ * tags, repository metadata, env var descriptions) are deliberately NOT
+ * drift: they cannot break a connection, so they never nag — they simply
+ * ride along when the user refreshes.
+ */
+export type DriftFieldId =
+  | "transport"
+  | "endpoint"
+  | "headers"
+  | "queryParams"
+  | "timeout"
+  | "command"
+  | "workingDirectory"
+  | "environmentVariables"
+  | "authentication";
+
+/**
+ * Deep equality over the plain-object projections produced by
+ * `mcpServerToInput`. Key order is irrelevant (proto map iteration order
+ * is not canonical); `undefined` values and absent keys are equivalent
+ * (the conversion uses `undefined` for proto defaults).
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((v, i) => deepEqual(v, b[i]))
+    );
+  }
+  if (isRecord(a) && isRecord(b)) {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const key of keys) {
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/**
+ * The functional shape of an env declaration map: which vars exist,
+ * whether they are secret, whether they are optional. Descriptions are
+ * guidance for humans — a description-only template edit must not raise
+ * a drift notice.
+ */
+function functionalEnvShape(env: McpServerInput["env"]) {
+  if (!env) return undefined;
+  const shape: Record<string, { isSecret?: boolean; optional?: boolean }> = {};
+  for (const [key, decl] of Object.entries(env)) {
+    shape[key] = { isSecret: decl.isSecret, optional: decl.optional };
+  }
+  return shape;
+}
+
+/**
+ * Compares an org-owned MCP server against the marketplace definition it
+ * mirrors and reports which connection-defining field groups differ, or
+ * `null` when the connection-defining configuration matches.
+ *
+ * The comparison runs on `mcpServerToInput` projections rather than raw
+ * protos: that conversion is the SDK's canonical read-modify-write lens,
+ * and its exhaustiveness is fence-tested — so a new spec field cannot
+ * silently bypass this comparison either.
+ */
+export function computeDefinitionDrift(
+  current: McpServer,
+  template: McpServer,
+): readonly DriftFieldId[] | null {
+  const cur = mcpServerToInput(current);
+  const tpl = mcpServerToInput(template);
+
+  const changed: DriftFieldId[] = [];
+
+  const curTransport = cur.stdio ? "stdio" : cur.http ? "http" : "none";
+  const tplTransport = tpl.stdio ? "stdio" : tpl.http ? "http" : "none";
+
+  if (curTransport !== tplTransport) {
+    changed.push("transport");
+  } else if (curTransport === "http") {
+    if (cur.http!.url !== tpl.http!.url) changed.push("endpoint");
+    if (!deepEqual(cur.http!.headers, tpl.http!.headers)) changed.push("headers");
+    if (!deepEqual(cur.http!.queryParams, tpl.http!.queryParams)) {
+      changed.push("queryParams");
+    }
+    if (cur.http!.timeoutSeconds !== tpl.http!.timeoutSeconds) {
+      changed.push("timeout");
+    }
+  } else if (curTransport === "stdio") {
+    if (
+      cur.stdio!.command !== tpl.stdio!.command ||
+      !deepEqual(cur.stdio!.args, tpl.stdio!.args)
+    ) {
+      changed.push("command");
+    }
+    if (cur.stdio!.workingDir !== tpl.stdio!.workingDir) {
+      changed.push("workingDirectory");
+    }
+  }
+
+  if (!deepEqual(functionalEnvShape(cur.env), functionalEnvShape(tpl.env))) {
+    changed.push("environmentVariables");
+  }
+
+  if (!deepEqual(cur.auth, tpl.auth)) {
+    changed.push("authentication");
+  }
+
+  return changed.length > 0 ? changed : null;
+}
+
+/**
+ * Builds the update payload for a one-click "refresh from marketplace".
+ *
+ * Definition fields — transport, env declarations, auth, and the cosmetic
+ * description/icon/tags/repository metadata — come from the template.
+ * The user's own choices survive: identity (name/org/slug/labels), tool
+ * enablement, and pinned approval policies. Visibility is not part of the
+ * input contract at all (the backend preserves it on update;
+ * `updateVisibility` is its dedicated write path).
+ *
+ * Built by merging two `mcpServerToInput` projections, so the preserved
+ * set is the explicit override list below and nothing can be lost in
+ * translation (the conversion is fence-tested exhaustive).
+ */
+export function buildRefreshInput(
+  current: McpServer,
+  template: McpServer,
+): McpServerInput {
+  const cur = mcpServerToInput(current);
+  const tpl = mcpServerToInput(template);
+
+  return {
+    ...tpl,
+    // Identity: the update must land on the user's own resource.
+    name: cur.name,
+    org: cur.org,
+    slug: cur.slug,
+    labels: cur.labels,
+    // User policy: never reset by a definition refresh.
+    defaultEnabledTools: cur.defaultEnabledTools,
+    pinnedToolApprovals: cur.pinnedToolApprovals,
+  };
+}

--- a/sdk/react/src/mcp-server/internal/mcpServerToInput.ts
+++ b/sdk/react/src/mcp-server/internal/mcpServerToInput.ts
@@ -36,6 +36,7 @@ export function mcpServerToInput(server: McpServer): McpServerInput {
       ? spec.pinnedToolApprovals.map((p) => ({
           toolName: p.toolName || undefined,
           message: p.message || undefined,
+          fromDestructiveHint: p.fromDestructiveHint || undefined,
         }))
       : undefined;
 
@@ -48,6 +49,7 @@ export function mcpServerToInput(server: McpServer): McpServerInput {
         tokenLifetimeHint: spec.auth.tokenLifetimeHint || undefined,
         scopeHints: spec.auth.scopeHints.length > 0 ? [...spec.auth.scopeHints] : undefined,
         discoveryUrl: spec.auth.discoveryUrl || undefined,
+        oauthOnly: spec.auth.oauthOnly || undefined,
       }
     : undefined;
 
@@ -60,6 +62,7 @@ export function mcpServerToInput(server: McpServer): McpServerInput {
       : undefined,
     description: spec?.description || undefined,
     iconUrl: spec?.iconUrl || undefined,
+    tags: spec?.tags?.length ? [...spec.tags] : undefined,
     defaultEnabledTools: spec?.defaultEnabledTools?.length
       ? [...spec.defaultEnabledTools]
       : undefined,

--- a/sdk/react/src/mcp-server/useMcpServerDefinitionDrift.ts
+++ b/sdk/react/src/mcp-server/useMcpServerDefinitionDrift.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { useStigmer } from "../hooks.js";
+import { useFetch } from "../internal/useFetch.js";
+import {
+  computeDefinitionDrift,
+  type DriftFieldId,
+} from "./internal/definitionDrift.js";
+
+/** A detected divergence from the marketplace definition. */
+export interface McpServerDefinitionDrift {
+  /** The marketplace definition the comparison ran against. */
+  readonly template: McpServer;
+  /** Connection-defining field groups that differ. Never empty. */
+  readonly changedFields: readonly DriftFieldId[];
+}
+
+/** Return value of {@link useMcpServerDefinitionDrift}. */
+export interface UseMcpServerDefinitionDriftReturn {
+  /**
+   * The detected drift, or `null` — which covers all of: still checking,
+   * no marketplace counterpart, ambiguous counterpart, configurations
+   * match, or the check failed. Consumers need no other state: this is an
+   * advisory affordance, not page data.
+   */
+  readonly drift: McpServerDefinitionDrift | null;
+}
+
+/**
+ * Detects when an org-owned MCP server's connection-defining
+ * configuration has drifted from the marketplace definition it mirrors
+ * (stigmer/stigmer#228: a template fix — e.g. monday.com's OAuth header —
+ * never reached servers copied before the fix, stranding them on a
+ * configuration that can never connect).
+ *
+ * **How the marketplace counterpart is found.** Connected copies carry no
+ * reference back to their template, so the hook uses the platform's own
+ * client-side definition of "marketplace": the search RPC's
+ * `crossOrgPublic` scope (what the library's "All" tab shows). A public
+ * row with the exact same slug from a different org is treated as the
+ * template. Zero or multiple candidates means there is nothing
+ * trustworthy to compare against — the hook stays quiet.
+ *
+ * **Fail-quiet by design.** Drift detection is advisory. No network
+ * error, missing template, or ambiguity may ever degrade the detail page,
+ * so every failure path resolves to `null` rather than an error state.
+ *
+ * Pass `null` to skip (stable no-op) — callers gate on editability, since
+ * the paired refresh action writes to the resource and the notice is
+ * meaningless to viewers who cannot act on it.
+ */
+export function useMcpServerDefinitionDrift(
+  mcpServer: McpServer | null,
+): UseMcpServerDefinitionDriftReturn {
+  const stigmer = useStigmer();
+
+  const org = mcpServer?.metadata?.org ?? null;
+  const slug = mcpServer?.metadata?.slug ?? null;
+
+  const { data: drift } = useFetch<McpServerDefinitionDrift | null>(
+    mcpServer && org && slug
+      ? async () => {
+          try {
+            const result = await stigmer.mcpServer.list({
+              org,
+              query: slug,
+              crossOrgPublic: true,
+            });
+            const candidateOrgs = [
+              ...new Set(
+                result.entries
+                  .filter((e) => e.slug === slug && e.org && e.org !== org)
+                  .map((e) => e.org),
+              ),
+            ];
+            if (candidateOrgs.length !== 1) return null;
+
+            const template = await stigmer.mcpServer.getByReference({
+              org: candidateOrgs[0],
+              slug,
+            });
+            const changedFields = computeDefinitionDrift(mcpServer, template);
+            return changedFields ? { template, changedFields } : null;
+          } catch {
+            return null;
+          }
+        }
+      : null,
+    [mcpServer, org, slug, stigmer],
+    null,
+  );
+
+  return { drift };
+}

--- a/sdk/typescript/src/gen/mcpserver.ts
+++ b/sdk/typescript/src/gen/mcpserver.ts
@@ -153,6 +153,7 @@ export interface McpServerInput {
   visibility?: ApiResourceVisibility;
   description?: string;
   iconUrl?: string;
+  tags?: string[];
   stdio?: StdioServerConfigInput;
   http?: HttpServerConfigInput;
   defaultEnabledTools?: string[];
@@ -256,6 +257,7 @@ export function buildMcpServerProto(input: McpServerInput): McpServer {
   const spec = Object.assign(create(McpServerSpecSchema), stripUndefined({
     description: input.description,
     iconUrl: input.iconUrl,
+    tags: input.tags,
     defaultEnabledTools: input.defaultEnabledTools,
     env,
     pinnedToolApprovals,

--- a/tools/codegen/generator/sdk_client.go
+++ b/tools/codegen/generator/sdk_client.go
@@ -90,9 +90,16 @@ type sdkResourceConfig struct {
 }
 
 // metaFieldNames are fields that always come from ApiResourceMetadata.
-// Spec fields with these names are skipped to avoid struct field conflicts.
+// Spec fields with these names are skipped to avoid struct field conflicts
+// with the metadata-derived input header (Name/Slug/Org/Labels/Visibility).
+//
+// "Tags" is deliberately NOT in this list: no generator emits a
+// metadata-level tags input field, so there is nothing to conflict with —
+// and McpServer has a real spec-level `tags` field (marketplace
+// categorization, set by the seedpack) that the exclusion used to swallow,
+// making it impossible to carry through SDK read-modify-write updates.
 var metaFieldNames = map[string]bool{
-	"Name": true, "Org": true, "Tags": true, "Visibility": true, "Labels": true,
+	"Name": true, "Org": true, "Visibility": true, "Labels": true,
 }
 
 // resourceGenInfo tracks generated type names per resource for client.go/types.go generation.


### PR DESCRIPTION
## Summary

Fixes the class of incident behind #228: an org-owned copy of a marketplace MCP server never learns its template was fixed. The reporter's pre-fix monday.com copy kept the retired `MONDAY_TOKEN` header forever, showing only "Token expired" with no user-facing recovery path.

### Step 0 — fix the lossy read-modify-write seam (commit 1)

The refresh writes through `mcpServerToInput` → update, and that seam silently erased three spec fields on **every** inline edit today (the backend does full spec replacement):

- The codegen generator's `metaFieldNames` exclusion swallowed spec-level `Tags` for all SDK inputs. The entry protected nothing (no generator emits a metadata-level tags input field) while blocking McpServer's real `spec.tags` — set by nearly every seedpack YAML. Removed; TS/Go/Python/Java clients regenerated (verified: mcpserver is the only resource with a spec-level `Tags`, so the regen diff is mcpserver-scoped).
- `mcpServerToInput` missed `auth.oauthOnly` (the exact field the monday fix #217 added) and `pinnedToolApprovals[].fromDestructiveHint`.

A new test locks the seam two ways: a **field-inventory fence** over every proto message the conversion walks (a new spec field fails with mapping instructions instead of shipping a new silent-data-loss bug), and a fully-populated **round-trip proof**.

### The feature (commit 2)

- **Detection is client-side in the shared SDK** — one implementation for both editions; the server rows are the runtime source of truth and are publicly readable. The template is located through the SDK's only client-side definition of "marketplace": the search RPC's `crossOrgPublic` scope. A single public foreign-org row with the exact same slug is the template; zero/ambiguous candidates and all failures stay quiet (advisory affordance, never an error state).
- **`computeDefinitionDrift`** compares only connection-defining fields (transport, env declaration *shape*, auth). Cosmetic fields — descriptions, icon, tags, repository metadata, env var descriptions — never nag but ride along on refresh.
- **`buildRefreshInput`** takes the definition from the template and preserves the user's identity and policy (enabled tools, approval pins). BYOA-safe: an org's own OAuth app lives in a separate `OAuthAppOverride` binding, never on the spec.
- **`DefinitionDriftNotice`** joins the self-gating notice family (`OAuthRequiredNotice` idiom) in the detail view's Connection section, gated on `editable`. The copy says the configuration **differs** — never "was updated" — because slug-matching is a heuristic and a hand-made namesake server must not be told a false history.
- **Refresh reconnects explicitly**: the update RPC does not re-run discovery (only apply does).

The remaining hop — cloud's platform rows lagging the git seedpack because re-seeding is a manual ops step (the reporter's actual first cause) — is filed separately as a cloud follow-up.

## Test plan

- [x] New: seam field-inventory fence + round-trip proof (8), drift compare + refresh payload semantics (12), template-resolution + fail-quiet hook tests (6), notice gating/copy/action tests (4)
- [x] Full `@stigmer/react` suite: 401 files / 4392 tests green
- [x] `@stigmer/sdk` + `@stigmer/react` typecheck, react lint, gofmt/vet, generator Go tests, Java SDK build, Python gen compiles
- [x] `make gen-proto-sdk-docs-check`, `make format-docs-check`, `make check-docs-yaml` green
- [x] Rebased on main after #638/#641/#642 merged; `make protos` re-run on the merged tree — zero diff (regen idempotent)

Closes #228

Made with [Cursor](https://cursor.com)