### PR TITLE
refactor(sdk/react): consolidate 17 hand-rolled clipboard-feedback call sites onto useCopyFeedback

### DIFF
--- a/sdk/react/src/api-key/ApiKeyCreatedAlert.tsx
+++ b/sdk/react/src/api-key/ApiKeyCreatedAlert.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef } from "react";
 import { cn } from "@stigmer/theme";
+import { selectElementText } from "../internal/select-element-text.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -47,25 +49,14 @@ export function ApiKeyCreatedAlert({
   onDismiss,
   className,
 }: ApiKeyCreatedAlertProps) {
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
+  const revealRef = useRef<HTMLElement>(null);
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(rawKey);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback: select the text so the user can manually copy
-      const el = document.getElementById("stgm-api-key-reveal");
-      if (el) {
-        const selection = window.getSelection();
-        const range = document.createRange();
-        range.selectNodeContents(el);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      }
-    }
-  }, [rawKey]);
+    if (await copy(rawKey)) return;
+    // Rejected write: select the revealed key so the user can copy manually.
+    if (revealRef.current) selectElementText(revealRef.current);
+  }, [copy, rawKey]);
 
   return (
     <div
@@ -100,6 +91,7 @@ export function ApiKeyCreatedAlert({
 
       <div className="stg:flex stg:items-center stg:gap-2">
         <code
+          ref={revealRef}
           id="stgm-api-key-reveal"
           className={cn(
             "stg:min-w-0 stg:flex-1 stg:select-all stg:truncate stg:rounded-md",

--- a/sdk/react/src/channel-app/internal.tsx
+++ b/sdk/react/src/channel-app/internal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { cn } from "@stigmer/theme";
 import { TruncatedText } from "../internal/truncated-text.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /**
  * Internal building blocks shared by the channel-app forms and panels.
@@ -148,14 +149,11 @@ function CopyButton({
 }
 
 function useCopy(value: string) {
-  const [copied, setCopied] = useState(false);
+  const { copy: copyText, copied } = useCopyFeedback();
 
   const copy = useCallback(() => {
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    });
-  }, [value]);
+    void copyText(value);
+  }, [copyText, value]);
 
   return { copied, copy };
 }

--- a/sdk/react/src/cursor-accounts/MemberCoverageTable.tsx
+++ b/sdk/react/src/cursor-accounts/MemberCoverageTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 import { cn } from "@stigmer/theme";
 import {
   CursorMemberKeyState,
@@ -420,21 +420,10 @@ function KeyStatusBadge({
  * would join the operator's own Cursor account to the team.
  */
 function CopyInviteButton({ inviteLink }: { readonly inviteLink: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(inviteLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard unavailable (permissions, non-secure context) — the
-      // section description still points at the Cursor dashboard.
-    }
-  }, [inviteLink]);
+  const { copy, copied } = useCopyFeedback();
 
   return (
-    <Button size="sm" variant="outline" onClick={() => void handleCopy()}>
+    <Button size="sm" variant="outline" onClick={() => void copy(inviteLink)}>
       {copied ? "Copied" : "Copy invite"}
     </Button>
   );

--- a/sdk/react/src/execution/FilePathLink.tsx
+++ b/sdk/react/src/execution/FilePathLink.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { cn } from "@stigmer/theme";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 import { FilePathContext } from "./FilePathContext.js";
 import { resolvePathAction, splitDisplayPath } from "./file-path-resolver.js";
 
@@ -27,8 +28,6 @@ export interface FilePathLinkProps {
   /** Additional CSS class names for the root element. */
   readonly className?: string;
 }
-
-const COPIED_FEEDBACK_MS = 2000;
 
 /**
  * Interactive file path display that replaces inert `<span>` path
@@ -62,7 +61,7 @@ export function FilePathLink({
   className,
 }: FilePathLinkProps) {
   const { workspaceEntries, onFilePathClick } = useContext(FilePathContext);
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
 
   const resolved = useMemo(
     () => resolvePathAction(path, workspaceEntries),
@@ -80,11 +79,8 @@ export function FilePathLink({
 
   const handleCopy = useCallback(() => {
     const value = resolved.action === "copy" ? resolved.value : path;
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
-    });
-  }, [resolved, path]);
+    void copy(value);
+  }, [resolved, path, copy]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {

--- a/sdk/react/src/execution/WriteBackCard.tsx
+++ b/sdk/react/src/execution/WriteBackCard.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 import type { WorkspaceWriteBack } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/writeback_pb";
 import { WorkspaceWriteBackPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/writeback_pb";
 import { cn } from "@stigmer/theme";
 import { DiffSummary } from "../version-history/DiffSummary.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { TruncatedText } from "../internal/truncated-text.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 import {
   parseDiffStatSummary,
   trailingDiffStatLine,
@@ -202,9 +203,6 @@ function PullRequestRow({ url, number }: { url: string; number: number }) {
 // Branch row — info + sibling hover-revealed copy control
 // ---------------------------------------------------------------------------
 
-/** How long the copy control shows its "copied" confirmation. */
-const COPIED_FEEDBACK_MS = 2000;
-
 function BranchRow({
   branchName,
   baseBranch,
@@ -212,27 +210,10 @@ function BranchRow({
   branchName: string;
   baseBranch: string;
 }) {
-  const [copied, setCopied] = useState(false);
-
-  // Clear the pending feedback timer on unmount so a resolved copy never
-  // sets state on an unmounted component (same guard as useArtifactCopy).
-  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    return () => {
-      if (copiedTimer.current !== null) clearTimeout(copiedTimer.current);
-    };
-  }, []);
-
+  const { copy, copied } = useCopyFeedback();
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(branchName).then(() => {
-      setCopied(true);
-      if (copiedTimer.current !== null) clearTimeout(copiedTimer.current);
-      copiedTimer.current = setTimeout(
-        () => setCopied(false),
-        COPIED_FEEDBACK_MS,
-      );
-    });
-  }, [branchName]);
+    void copy(branchName);
+  }, [copy, branchName]);
 
   return (
     <div className="stg:group stg:flex stg:items-stretch">

--- a/sdk/react/src/execution/useArtifactInspection.ts
+++ b/sdk/react/src/execution/useArtifactInspection.ts
@@ -12,8 +12,7 @@ import {
   useApplyResource,
   type ApplyResourceResult,
 } from "../library/useApplyResource.js";
-
-const COPIED_FEEDBACK_MS = 2000;
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Options for {@link useArtifactInspection}. */
 export interface UseArtifactInspectionOptions {
@@ -198,14 +197,11 @@ export function useArtifactInspection(
 
   // --- Copy -----------------------------------------------------------------
 
-  const [copied, setCopied] = useState(false);
+  const { copy: copyToClipboard, copied } = useCopyFeedback();
   const copy = useCallback(() => {
     if (!content) return;
-    void navigator.clipboard.writeText(content).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
-    });
-  }, [content]);
+    void copyToClipboard(content);
+  }, [content, copyToClipboard]);
 
   return useMemo(
     () => ({

--- a/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { useCallback, useRef, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
@@ -8,6 +8,8 @@ import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt";
 import { useUpdateIdentityProvider } from "./useUpdateIdentityProvider.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+import { selectElementText } from "../internal/select-element-text.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link IdentityProviderDetailPanel}. */
 export interface IdentityProviderDetailPanelProps {
@@ -489,8 +491,6 @@ function Field({
 // View mode — copyable field
 // ---------------------------------------------------------------------------
 
-const COPIED_FEEDBACK_MS = 2000;
-
 function CopyableField({
   label,
   value,
@@ -500,25 +500,15 @@ function CopyableField({
   value: string;
   hint?: string;
 }) {
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
+  const revealRef = useRef<HTMLElement>(null);
   const valueId = "stgm-idp-sso-login-url";
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
-    } catch {
-      const el = document.getElementById(valueId);
-      if (el) {
-        const selection = window.getSelection();
-        const range = document.createRange();
-        range.selectNodeContents(el);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      }
-    }
-  }, [value]);
+    if (await copy(value)) return;
+    // Rejected write: select the revealed value so the user can copy manually.
+    if (revealRef.current) selectElementText(revealRef.current);
+  }, [copy, value]);
 
   return (
     <div>
@@ -528,6 +518,7 @@ function CopyableField({
       <dd className="stg:mt-0.5">
         <div className="stg:flex stg:items-center stg:gap-2">
           <span
+            ref={revealRef}
             id={valueId}
             className="stg:text-foreground stg:break-all stg:font-mono stg:text-xs stg:select-all"
           >
@@ -535,7 +526,7 @@ function CopyableField({
           </span>
           <button
             type="button"
-            onClick={handleCopy}
+            onClick={() => void handleCopy()}
             className={cn(
               "stg:shrink-0 stg:rounded stg:px-1.5 stg:py-0.5 stg:text-[0.6rem]",
               "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",

--- a/sdk/react/src/internal/__tests__/useCopyFeedback.test.ts
+++ b/sdk/react/src/internal/__tests__/useCopyFeedback.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useCopyFeedback } from "../useCopyFeedback";
+
+describe("useCopyFeedback", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("resolves true and flashes `copied` for a successful write", async () => {
+    const { result } = renderHook(() => useCopyFeedback());
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.copy("hello");
+    });
+
+    expect(outcome).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("resolves false and never claims `copied` for a rejected write", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    const { result } = renderHook(() => useCopyFeedback());
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.copy("secret");
+    });
+
+    expect(outcome).toBe(false);
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("restarts the feedback window on a rapid second copy", async () => {
+    const { result } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copy("one");
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await result.current.copy("two");
+    });
+
+    // 1.5s into the second window: still showing feedback.
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("does not set state after unmount when the timer would fire", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result, unmount } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copy("bye");
+    });
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // React warns on setState-after-unmount via console.error; silence means
+    // the unmount cleanup cleared the pending timer.
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/sdk/react/src/internal/select-element-text.ts
+++ b/sdk/react/src/internal/select-element-text.ts
@@ -1,0 +1,17 @@
+/**
+ * Select an element's text content, replacing any existing selection.
+ *
+ * The honest fallback for one-time secret reveals (API keys, invite URLs,
+ * client secrets) when the clipboard write is rejected (insecure context,
+ * denied permission): instead of claiming "Copied" for a copy that didn't
+ * happen, the revealed value is selected so the user can copy it manually.
+ * Pair with `useCopyFeedback` — branch on its `copy()` result.
+ */
+export function selectElementText(el: HTMLElement): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/sdk/react/src/internal/useCopyFeedback.ts
+++ b/sdk/react/src/internal/useCopyFeedback.ts
@@ -8,11 +8,14 @@ const COPIED_FEEDBACK_MS = 2000;
 /** Return value of {@link useCopyFeedback}. */
 export interface UseCopyFeedbackReturn {
   /**
-   * Write `text` to the clipboard. Resolves once the copy has been attempted;
-   * a rejected clipboard write (insecure context, denied permission) leaves
-   * `copied` false so the affordance never claims a copy that didn't happen.
+   * Write `text` to the clipboard. Resolves `true` when the write landed and
+   * `false` when it was rejected (insecure context, denied permission); a
+   * rejected write leaves `copied` false so the affordance never claims a
+   * copy that didn't happen. Callers with a manual fallback (e.g. selecting
+   * the on-screen text for a hand copy) branch on the result; plain
+   * affordances can ignore it.
    */
-  readonly copy: (text: string) => Promise<void>;
+  readonly copy: (text: string) => Promise<boolean>;
 
   /**
    * `true` for a brief window after a successful copy (drives "Copied"
@@ -46,11 +49,12 @@ export function useCopyFeedback(): UseCopyFeedbackReturn {
     try {
       await navigator.clipboard.writeText(text);
     } catch {
-      return;
+      return false;
     }
     setCopied(true);
     if (copiedTimer.current !== null) clearTimeout(copiedTimer.current);
     copiedTimer.current = setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+    return true;
   }, []);
 
   return useMemo(() => ({ copy, copied }), [copy, copied]);

--- a/sdk/react/src/invitation/InvitationCreatedAlert.tsx
+++ b/sdk/react/src/invitation/InvitationCreatedAlert.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef } from "react";
 import { cn } from "@stigmer/theme";
+import { selectElementText } from "../internal/select-element-text.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -47,24 +49,14 @@ export function InvitationCreatedAlert({
   onDismiss,
   className,
 }: InvitationCreatedAlertProps) {
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
+  const revealRef = useRef<HTMLElement>(null);
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(inviteUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      const el = document.getElementById("stgm-invite-url-reveal");
-      if (el) {
-        const selection = window.getSelection();
-        const range = document.createRange();
-        range.selectNodeContents(el);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      }
-    }
-  }, [inviteUrl]);
+    if (await copy(inviteUrl)) return;
+    // Rejected write: select the revealed URL so the user can copy manually.
+    if (revealRef.current) selectElementText(revealRef.current);
+  }, [copy, inviteUrl]);
 
   return (
     <div
@@ -99,6 +91,7 @@ export function InvitationCreatedAlert({
 
       <div className="stg:flex stg:items-center stg:gap-2">
         <code
+          ref={revealRef}
           id="stgm-invite-url-reveal"
           className={cn(
             "stg:min-w-0 stg:flex-1 stg:select-all stg:truncate stg:rounded-md",

--- a/sdk/react/src/invitation/InvitationManager.tsx
+++ b/sdk/react/src/invitation/InvitationManager.tsx
@@ -18,6 +18,7 @@ import { InvitationCreatedAlert } from "./InvitationCreatedAlert.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { RoleSelector } from "../iam-policy/RoleSelector.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -399,7 +400,7 @@ function InvitationRow({
   onCancelRevoke: () => void;
   onRevoked: () => void;
 }) {
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
 
   const id = invitation.metadata?.id ?? "";
   const label = invitation.spec?.label || invitation.metadata?.name || "Unnamed invite";
@@ -411,15 +412,9 @@ function InvitationRow({
   const expiresAt = invitation.spec?.expiresAt;
   const isActive = state === InvitationState.active;
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(buildInviteUrl(token));
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // silently fail — copy is a convenience, not critical
-    }
-  }, [token, buildInviteUrl]);
+  const handleCopy = useCallback(() => {
+    void copy(buildInviteUrl(token));
+  }, [copy, token, buildInviteUrl]);
 
   if (isRevoking) {
     return (

--- a/sdk/react/src/library/useExportResource.ts
+++ b/sdk/react/src/library/useExportResource.ts
@@ -8,6 +8,7 @@ import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/ap
 import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import { serializeManifest } from "@stigmer/sdk";
 import { toast } from "../feedback/toast.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 import { serializeWorkflowYaml } from "../workflow/serialize-workflow-yaml.js";
 
 // ---------------------------------------------------------------------------
@@ -98,17 +99,25 @@ export function useExportResource({
     return resource.metadata?.slug || resource.metadata?.name || "resource";
   }, [resource]);
 
+  const { copy: copyText } = useCopyFeedback();
+
   const copyYaml = useCallback(async () => {
     if (!yaml) return;
-    await copyToClipboard(yaml);
-    toast.success("YAML copied to clipboard");
-  }, [yaml]);
+    if (await copyText(yaml)) {
+      toast.success("YAML copied to clipboard");
+    } else {
+      toast.error("Couldn't copy YAML");
+    }
+  }, [copyText, yaml]);
 
   const copyJson = useCallback(async () => {
     if (!json) return;
-    await copyToClipboard(json);
-    toast.success("JSON copied to clipboard");
-  }, [json]);
+    if (await copyText(json)) {
+      toast.success("JSON copied to clipboard");
+    } else {
+      toast.error("Couldn't copy JSON");
+    }
+  }, [copyText, json]);
 
   const downloadYaml = useCallback(() => {
     if (!yaml) return;
@@ -124,29 +133,6 @@ export function useExportResource({
     () => ({ copyYaml, copyJson, downloadYaml, downloadJson, yaml, json }),
     [copyYaml, copyJson, downloadYaml, downloadJson, yaml, json],
   );
-}
-
-// ---------------------------------------------------------------------------
-// Clipboard
-// ---------------------------------------------------------------------------
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    fallbackCopy(text);
-  }
-}
-
-function fallbackCopy(text: string): void {
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.position = "fixed";
-  textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand("copy");
-  document.body.removeChild(textarea);
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/react/src/organization/OrgProfilePanel.tsx
+++ b/sdk/react/src/organization/OrgProfilePanel.tsx
@@ -15,6 +15,7 @@ import { useUpdateOrganization } from "./useUpdateOrganization.js";
 import { useIdentityProviderList } from "../identity-provider/useIdentityProviderList.js";
 import { useResourceAvailable, ApiResourceKind } from "../deployment-mode.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -454,14 +455,7 @@ function ReadOnlyField({
   value: string;
   mono?: boolean;
 }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  }, [value]);
+  const { copy, copied } = useCopyFeedback();
 
   if (!value) return null;
 
@@ -481,7 +475,7 @@ function ReadOnlyField({
         </span>
         <button
           type="button"
-          onClick={handleCopy}
+          onClick={() => void copy(value)}
           className={cn(
             "stg:rounded stg:px-1.5 stg:py-0.5 stg:text-[0.6rem]",
             "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",

--- a/sdk/react/src/platform-client/PlatformClientSecretAlert.tsx
+++ b/sdk/react/src/platform-client/PlatformClientSecretAlert.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef } from "react";
 import { cn } from "@stigmer/theme";
+import { selectElementText } from "../internal/select-element-text.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link PlatformClientSecretAlert}. */
 export interface PlatformClientSecretAlertProps {
@@ -16,8 +18,6 @@ export interface PlatformClientSecretAlertProps {
   /** Additional CSS class names for the root container. */
   readonly className?: string;
 }
-
-const COPIED_FEEDBACK_MS = 2000;
 
 /**
  * One-time reveal component displayed after a platform client is
@@ -50,34 +50,6 @@ export function PlatformClientSecretAlert({
   onDismiss,
   className,
 }: PlatformClientSecretAlertProps) {
-  const [copiedField, setCopiedField] = useState<
-    "id" | "secret" | null
-  >(null);
-
-  const handleCopy = useCallback(
-    async (value: string, field: "id" | "secret") => {
-      try {
-        await navigator.clipboard.writeText(value);
-        setCopiedField(field);
-        setTimeout(() => setCopiedField(null), COPIED_FEEDBACK_MS);
-      } catch {
-        const el = document.getElementById(
-          field === "secret"
-            ? "stgm-pc-secret-reveal"
-            : "stgm-pc-client-id-reveal",
-        );
-        if (el) {
-          const selection = window.getSelection();
-          const range = document.createRange();
-          range.selectNodeContents(el);
-          selection?.removeAllRanges();
-          selection?.addRange(range);
-        }
-      }
-    },
-    [],
-  );
-
   const title =
     context === "created"
       ? "Platform client created"
@@ -117,26 +89,12 @@ export function PlatformClientSecretAlert({
           id="stgm-pc-client-id-reveal"
           label="Client ID"
           value={clientId}
-          copied={copiedField === "id"}
-          onCopy={() => handleCopy(clientId, "id")}
         />
         <CopyableField
           id="stgm-pc-secret-reveal"
           label="Client secret"
           value={clientSecret}
-          copied={copiedField === "secret"}
-          onCopy={() => handleCopy(clientSecret, "secret")}
         />
-      </div>
-
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        className="stg:sr-only"
-      >
-        {copiedField === "id" && "Client ID copied to clipboard"}
-        {copiedField === "secret" && "Client secret copied to clipboard"}
       </div>
     </div>
   );
@@ -150,15 +108,23 @@ function CopyableField({
   id,
   label,
   value,
-  copied,
-  onCopy,
 }: {
   id: string;
   label: string;
   value: string;
-  copied: boolean;
-  onCopy: () => void;
 }) {
+  // Each field owns its feedback: the copied flag and the select-text
+  // fallback belong to the markup they describe, so two fields never
+  // share (and race on) one parent-level "which field copied" state.
+  const { copy, copied } = useCopyFeedback();
+  const revealRef = useRef<HTMLElement>(null);
+
+  const handleCopy = useCallback(async () => {
+    if (await copy(value)) return;
+    // Rejected write: select the revealed value so the user can copy manually.
+    if (revealRef.current) selectElementText(revealRef.current);
+  }, [copy, value]);
+
   return (
     <div>
       <span className="stg:text-[0.65rem] stg:font-medium stg:text-muted-foreground">
@@ -166,6 +132,7 @@ function CopyableField({
       </span>
       <div className="stg:mt-0.5 stg:flex stg:items-center stg:gap-2">
         <code
+          ref={revealRef}
           id={id}
           className={cn(
             "stg:min-w-0 stg:flex-1 stg:select-all stg:truncate stg:rounded-md",
@@ -177,7 +144,7 @@ function CopyableField({
         </code>
         <button
           type="button"
-          onClick={onCopy}
+          onClick={() => void handleCopy()}
           aria-label={`Copy ${label}`}
           className={cn(
             "stg:inline-flex stg:shrink-0 stg:items-center stg:gap-1.5 stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs stg:font-medium",
@@ -188,6 +155,15 @@ function CopyableField({
           {copied ? <CheckIcon /> : <CopyIcon />}
           {copied ? "Copied" : "Copy"}
         </button>
+      </div>
+
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="stg:sr-only"
+      >
+        {copied && `${label} copied to clipboard`}
       </div>
     </div>
   );

--- a/sdk/react/src/resource-detail/useCopyResource.ts
+++ b/sdk/react/src/resource-detail/useCopyResource.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo } from "react";
 import { toast } from "../feedback/toast.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 export interface UseCopyResourceReturn {
   /** Copy arbitrary text to the clipboard with toast feedback. */
@@ -17,9 +18,10 @@ export interface UseCopyResourceReturn {
 /**
  * Clipboard helper for resource detail pages.
  *
- * Wraps `navigator.clipboard.writeText` with toast feedback so every
- * copy action is confirmed visually (Nielsen heuristic #1 — visibility
- * of system status). Falls back to a hidden textarea for older browsers.
+ * Wraps the shared copy behavior (`useCopyFeedback`) with toast feedback so
+ * every copy action is confirmed visually (Nielsen heuristic #1 — visibility
+ * of system status). A rejected write (insecure context, denied permission)
+ * toasts an error instead of claiming a copy that didn't happen.
  *
  * @example
  * ```tsx
@@ -31,15 +33,18 @@ export interface UseCopyResourceReturn {
  * ```
  */
 export function useCopyResource(): UseCopyResourceReturn {
-  const copy = useCallback(async (text: string, label: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      toast.success(`${label} copied`);
-    } catch {
-      fallbackCopy(text);
-      toast.success(`${label} copied`);
-    }
-  }, []);
+  const { copy: copyText } = useCopyFeedback();
+
+  const copy = useCallback(
+    async (text: string, label: string) => {
+      if (await copyText(text)) {
+        toast.success(`${label} copied`);
+      } else {
+        toast.error(`Couldn't copy ${label}`);
+      }
+    },
+    [copyText],
+  );
 
   const copyId = useCallback(
     (id: string) => copy(id, "ID"),
@@ -60,15 +65,4 @@ export function useCopyResource(): UseCopyResourceReturn {
     () => ({ copy, copyId, copySlug, copyQualifiedSlug }),
     [copy, copyId, copySlug, copyQualifiedSlug],
   );
-}
-
-function fallbackCopy(text: string): void {
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.position = "fixed";
-  textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand("copy");
-  document.body.removeChild(textarea);
 }

--- a/sdk/react/src/workflow/ViewYamlDialog.tsx
+++ b/sdk/react/src/workflow/ViewYamlDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { cn } from "@stigmer/theme";
 import type { WorkflowGraphModel } from "./workflow-graph-model.js";
 import { taskToYaml } from "./inspector/task-to-yaml.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link ViewYamlDialog}. */
 export interface ViewYamlDialogProps {
@@ -32,7 +33,7 @@ export const ViewYamlDialog = memo(function ViewYamlDialog({
   onClose,
 }: ViewYamlDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
 
   const node = nodeId && graph
     ? graph.nodes.find((n) => n.id === nodeId) ?? null
@@ -58,25 +59,9 @@ export const ViewYamlDialog = memo(function ViewYamlDialog({
     return () => dialog.removeEventListener("close", handleClose);
   }, [onClose]);
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(yaml);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback for environments without clipboard API
-      const textarea = document.createElement("textarea");
-      textarea.value = yaml;
-      textarea.style.position = "fixed";
-      textarea.style.opacity = "0";
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textarea);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  }, [yaml]);
+  const handleCopy = useCallback(() => {
+    void copy(yaml);
+  }, [copy, yaml]);
 
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDialogElement>) => {

--- a/sdk/react/src/workflow/WorkflowArtifactDocument.tsx
+++ b/sdk/react/src/workflow/WorkflowArtifactDocument.tsx
@@ -3,15 +3,14 @@
 // Editor-area document rendering one workflow Artifact resource's content.
 // Domain: workflow (the Artifact-resource counterpart of execution/ArtifactDocument).
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import type { Artifact } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
 import { cn } from "@stigmer/theme";
 import { ArtifactFileContent } from "../execution/ArtifactFileContent.js";
 import { formatArtifactSize } from "../execution/artifact-utils.js";
 import { useArtifactContentById } from "../execution/useArtifactContentById.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 import { useWorkflowArtifactDownload } from "./useWorkflowArtifactDownload.js";
-
-const COPIED_FEEDBACK_MS = 2000;
 
 /** Props for {@link WorkflowArtifactDocument}. */
 export interface WorkflowArtifactDocumentProps {
@@ -78,14 +77,11 @@ export function WorkflowArtifactDocument({
 
   const { download, isDownloading } = useWorkflowArtifactDownload();
 
-  const [copied, setCopied] = useState(false);
+  const { copy: copyToClipboard, copied } = useCopyFeedback();
   const copy = useCallback(() => {
     if (!content) return;
-    void navigator.clipboard.writeText(content).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
-    });
-  }, [content]);
+    void copyToClipboard(content);
+  }, [content, copyToClipboard]);
 
   const showCopy = content !== null;
 

--- a/sdk/react/src/workflow/WorkflowExplainDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowExplainDialog.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { useExplainWorkflowFlow, type ExplainPhase } from "./useExplainWorkflowFlow.js";
 import { MessageThread } from "../execution/MessageThread.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link WorkflowExplainDialog}. */
 export interface WorkflowExplainDialogProps {
@@ -75,13 +76,12 @@ export function WorkflowExplainDialog({
     [onOpenChange],
   );
 
+  const { copy, copied } = useCopyFeedback();
   const handleCopy = useCallback(() => {
     if (flow.explanation) {
-      navigator.clipboard.writeText(flow.explanation).catch(() => {
-        /* Clipboard unavailable in some contexts */
-      });
+      void copy(flow.explanation);
     }
-  }, [flow.explanation]);
+  }, [copy, flow.explanation]);
 
   return (
     <dialog
@@ -200,7 +200,7 @@ export function WorkflowExplainDialog({
                   "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring",
                 )}
               >
-                Copy to clipboard
+                {copied ? "Copied" : "Copy to clipboard"}
               </button>
             )}
           </div>

--- a/sdk/react/src/workflow/WorkflowVersionBadge.tsx
+++ b/sdk/react/src/workflow/WorkflowVersionBadge.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { memo, useCallback, useState } from "react";
+import { memo } from "react";
 import { cn } from "@stigmer/theme";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link WorkflowVersionBadge}. */
 export interface WorkflowVersionBadgeProps {
@@ -41,18 +42,8 @@ export const WorkflowVersionBadge = memo(function WorkflowVersionBadge({
   isCurrent,
   className,
 }: WorkflowVersionBadgeProps) {
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyFeedback();
   const truncated = versionHash.slice(0, 8);
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(versionHash);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard API may be unavailable in some contexts
-    }
-  }, [versionHash]);
 
   return (
     <span className={cn("stg:inline-flex stg:items-center stg:gap-1.5", className)}>
@@ -75,7 +66,7 @@ export const WorkflowVersionBadge = memo(function WorkflowVersionBadge({
           render={
             <button
               type="button"
-              onClick={handleCopy}
+              onClick={() => void copy(versionHash)}
               className={cn(
                 "stg:shrink-0 stg:rounded stg:bg-muted stg:px-1.5 stg:py-0.5 stg:font-mono stg:text-[11px] stg:font-medium stg:text-foreground stg:transition-colors",
                 "stg:hover:bg-accent-hover",


### PR DESCRIPTION
## Summary

Closes #623.

PR #622 extracted the canonical copy-with-feedback shape into `internal/useCopyFeedback` (2s feedback window, unmount-safe timer, rejected-write honesty) and deliberately left the ~17 existing hand-rolled call sites for their own reviewable sweep. This is that sweep: after it, `rg navigator.clipboard.writeText sdk/react/src` returns exactly the two canonical hooks (`useCopyFeedback` + its fetch-at-click sibling `useArtifactCopy`).

Two small shared-surface changes carry the sweep:

- **`useCopyFeedback.copy()` now resolves `Promise<boolean>`** (did the write land). No call site rendered an error object, so the issue's suggested `error` field would have been dead weight — the boolean is the minimal honest contract for callers with a real fallback. Non-breaking for existing consumers.
- **New `internal/selectElementText` helper** for the secrets-reveal fallback (select the revealed value so the user can copy manually). Four alerts each hand-rolled this around `document.getElementById` on hardcoded DOM ids; they now use refs — which also decouples them from #619's upcoming id sweep.

## Before / after, per site

| Site | Before | After |
|---|---|---|
| `WorkflowVersionBadge` | 1.5s window, no cleanup | hook (2s, unmount-safe) |
| `WriteBackCard` (BranchRow) | own unmount-safe timer (correct, duplicated) | hook |
| `useArtifactInspection` | 2s, no cleanup, bare `.then()` | hook |
| `WorkflowArtifactDocument` | 2s, no cleanup, bare `.then()` | hook |
| `ViewYamlDialog` | 2s + hidden-textarea `execCommand` fallback | hook; legacy fallback deleted |
| `channel-app/internal` (`useCopy`) | mini-hook, 1.5s, no cleanup | delegates to hook |
| `OrgProfilePanel` (ReadOnlyField) | 1.5s, bare `.then()` — **unhandled rejection** | hook |
| `FilePathLink` | bare `.then()` — **unhandled rejection** | hook; link/handler resolution untouched |
| `MemberCoverageTable` (CopyInviteButton) | 2s, silent catch | hook |
| `InvitationManager` (invite row) | 2s, silent catch | hook |
| `WorkflowExplainDialog` | fire-and-forget, **no feedback at all** | hook + "Copied" swap (small UX gain) |
| `ApiKeyCreatedAlert` | select-text fallback via `getElementById` | hook result + ref + `selectElementText` |
| `InvitationCreatedAlert` | same | same |
| `PlatformClientSecretAlert` | parent-level "which field copied" state for 2 fields | each `CopyableField` owns feedback + its own sr-only announcement |
| `IdentityProviderDetailPanel` (CopyableField) | select-text fallback via `getElementById` | hook result + ref + `selectElementText` |
| `useCopyResource` | **toasted success even when the write failed** and the unverified `execCommand` fallback ran | honest: `toast.success` on landed write, `toast.error` otherwise; fallback deleted |
| `useExportResource` | silent `execCommand` fallback | honest toasts; fallback deleted |

Deliberate visible changes (all tiny): three sites' feedback window unifies 1.5s → 2s; `WorkflowExplainDialog` gains a "Copied" confirmation; a rejected write in the toast surfaces now shows an error toast instead of a false success.

## Test plan

- [x] New dedicated `useCopyFeedback` test fences the contract: boolean result, rejected writes never claim `copied`, feedback-window restart, unmount safety (4 tests)
- [x] Full sdk/react suite: 4415 tests green
- [x] `npm run typecheck` green
- [x] `npm run lint` green (0 errors; pre-existing warnings untouched)

Made with [Cursor](https://cursor.com)