### PR TITLE
chore(sdk/react): converge 21 dialog backdrops onto the --stgm-backdrop token, then fence the class

### DIFF
--- a/sdk/react/eslint.config.mjs
+++ b/sdk/react/eslint.config.mjs
@@ -14,6 +14,9 @@ export default defineConfig([
     rules: {
       "stigmer/sdk-import-boundaries": "error",
       "stigmer/no-native-title": "error",
+      // Error (not warn): the oss#373 sweep left zero violations, so the
+      // fence can hold the line from day one.
+      "stigmer/no-hardcoded-backdrop": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/no-main-tokens-in-sidebar": "warn",
     },

--- a/sdk/react/src/access/ManageAccessDialog.tsx
+++ b/sdk/react/src/access/ManageAccessDialog.tsx
@@ -112,7 +112,7 @@ export function ManageAccessDialog({
       onClose={handleClose}
       className={cn(
         "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/agent-instance/CreateAgentInstanceDialog.tsx
+++ b/sdk/react/src/agent-instance/CreateAgentInstanceDialog.tsx
@@ -115,7 +115,7 @@ export function CreateAgentInstanceDialog({
       onClose={handleClose}
       className={cn(
         "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/channel/ChannelConversationsDialog.tsx
+++ b/sdk/react/src/channel/ChannelConversationsDialog.tsx
@@ -97,7 +97,7 @@ export function ChannelConversationsDialog({
       onClose={handleClose}
       className={cn(
         "stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
+        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
       aria-labelledby="channel-conversations-title"
     >

--- a/sdk/react/src/channel/ChannelCredentialsDialog.tsx
+++ b/sdk/react/src/channel/ChannelCredentialsDialog.tsx
@@ -86,7 +86,7 @@ export function ChannelCredentialsDialog({
       onClose={handleClose}
       className={cn(
         "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
+        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/channel/ChannelTemplatesDialog.tsx
+++ b/sdk/react/src/channel/ChannelTemplatesDialog.tsx
@@ -120,7 +120,7 @@ export function ChannelTemplatesDialog({
         // Wider than the conversations dialog on purpose: template
         // bodies are the content, and a narrow column shreds them.
         "stg:w-full stg:max-w-2xl stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
+        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
       aria-labelledby="channel-templates-title"
     >

--- a/sdk/react/src/channel/ConnectSlackDialog.tsx
+++ b/sdk/react/src/channel/ConnectSlackDialog.tsx
@@ -126,7 +126,7 @@ export function ConnectSlackDialog({
       onClose={handleClose}
       className={cn(
         "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
+        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/channel/ConnectWhatsAppDialog.tsx
+++ b/sdk/react/src/channel/ConnectWhatsAppDialog.tsx
@@ -137,7 +137,7 @@ export function ConnectWhatsAppDialog({
       onClose={handleClose}
       className={cn(
         "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
+        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/manifest/ApplyManifestDialog.tsx
+++ b/sdk/react/src/manifest/ApplyManifestDialog.tsx
@@ -156,7 +156,7 @@ export function ApplyManifestDialog({
       onCancel={handleCancel}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/manifest/EditResourceYamlDialog.tsx
+++ b/sdk/react/src/manifest/EditResourceYamlDialog.tsx
@@ -116,7 +116,7 @@ export function EditResourceYamlDialog({
       onCancel={handleCancel}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
+++ b/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
@@ -124,7 +124,7 @@ export function McpServerConnectDialog({
       onClick={handleBackdropClick}
       className={cn(
         "stg:m-auto stg:max-h-[85vh] stg:w-full stg:max-w-md stg:overflow-visible stg:rounded-lg stg:border stg:border-border stg:bg-card stg:p-0 stg:text-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         className,
       )}
     >

--- a/sdk/react/src/mcp-server/McpServerDetailView.tsx
+++ b/sdk/react/src/mcp-server/McpServerDetailView.tsx
@@ -712,7 +712,7 @@ export function McpServerDetailView({
         onCancel={handleByoaDialogCancel}
         className={cn(
           "stg:m-auto stg:w-full stg:max-w-md stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-6 stg:shadow-lg",
-          "stg:backdrop:bg-black/50",
+          "stg:backdrop:bg-backdrop",
         )}
       >
         <h3 className="stg:mb-4 stg:text-base stg:font-semibold stg:text-foreground">

--- a/sdk/react/src/resource-detail/ConfirmDialog.tsx
+++ b/sdk/react/src/resource-detail/ConfirmDialog.tsx
@@ -81,7 +81,7 @@ export function ConfirmDialog({
       onCancel={handleDialogCancel}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-sm stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/sharing/ShareAgentDialog.tsx
+++ b/sdk/react/src/sharing/ShareAgentDialog.tsx
@@ -174,7 +174,7 @@ export function ShareAgentDialog({
       onClose={handleClose}
       className={cn(
         "stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-black/50" : "stg:relative",
+        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/skill/SkillDiffDialog.tsx
+++ b/sdk/react/src/skill/SkillDiffDialog.tsx
@@ -100,7 +100,7 @@ export function SkillDiffDialog({ state, onClose }: SkillDiffDialogProps) {
       onClick={handleBackdropClick}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:h-[85vh] stg:w-full stg:max-w-4xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/workflow/ViewYamlDialog.tsx
+++ b/sdk/react/src/workflow/ViewYamlDialog.tsx
@@ -92,7 +92,7 @@ export const ViewYamlDialog = memo(function ViewYamlDialog({
       ref={dialogRef}
       className={cn(
         "stgm stg:m-auto stg:max-h-[80vh] stg:w-full stg:max-w-lg stg:rounded-lg stg:border stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-background,#fff)] stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-black/40",
+        "stg:backdrop:bg-backdrop",
       )}
       onClick={handleBackdropClick}
       aria-label={node ? `YAML for ${node.taskName}` : "View YAML"}

--- a/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
@@ -120,7 +120,7 @@ export function WorkflowArchitectDialog({
       onClick={handleBackdropClick}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/workflow/WorkflowExplainDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowExplainDialog.tsx
@@ -90,7 +90,7 @@ export function WorkflowExplainDialog({
       onClick={handleBackdropClick}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-2xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/workflow/WorkflowRunDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowRunDialog.tsx
@@ -155,7 +155,7 @@ export function WorkflowRunDialog({
       onClick={handleBackdropClick}
       className={cn(
         "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
         "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
       )}
     >

--- a/sdk/react/src/workflow/execution-comparison/ExecutionComparisonPicker.tsx
+++ b/sdk/react/src/workflow/execution-comparison/ExecutionComparisonPicker.tsx
@@ -120,7 +120,7 @@ export const ExecutionComparisonPicker = memo(function ExecutionComparisonPicker
       ref={dialogRef}
       className={cn(
         "stgm stg:m-auto stg:max-h-[70vh] stg:w-full stg:max-w-md stg:rounded-lg stg:border stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-background,#fff)] stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-black/40",
+        "stg:backdrop:bg-backdrop",
       )}
       onClick={handleBackdropClick}
       aria-label="Select execution to compare"

--- a/sdk/react/src/workflow/instance/CreateWorkflowInstanceDialog.tsx
+++ b/sdk/react/src/workflow/instance/CreateWorkflowInstanceDialog.tsx
@@ -115,7 +115,7 @@ export function CreateWorkflowInstanceDialog({
       onClose={handleClose}
       className={cn(
         "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
       )}
       aria-labelledby={titleId}
     >

--- a/sdk/react/src/workflow/templates/WorkflowTemplatePreview.tsx
+++ b/sdk/react/src/workflow/templates/WorkflowTemplatePreview.tsx
@@ -83,7 +83,7 @@ export function WorkflowTemplatePreview({
       ref={dialogRef}
       className={cn(
         "stgm stg:m-auto stg:max-h-[85vh] stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-0 stg:shadow-lg",
-        "stg:backdrop:bg-black/50",
+        "stg:backdrop:bg-backdrop",
       )}
     >
       <div className="stg:flex stg:flex-col">

--- a/tools/eslint-plugin-stigmer/index.js
+++ b/tools/eslint-plugin-stigmer/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const noHardcodedBackdrop = require("./rules/no-hardcoded-backdrop");
 const noMainTokensInSidebar = require("./rules/no-main-tokens-in-sidebar");
 const noNativeTitle = require("./rules/no-native-title");
 const noTokenOpacityModifiers = require("./rules/no-token-opacity-modifiers");
@@ -11,6 +12,7 @@ const plugin = {
     version: "0.0.0",
   },
   rules: {
+    "no-hardcoded-backdrop": noHardcodedBackdrop,
     "no-main-tokens-in-sidebar": noMainTokensInSidebar,
     "no-native-title": noNativeTitle,
     "no-token-opacity-modifiers": noTokenOpacityModifiers,

--- a/tools/eslint-plugin-stigmer/rules/no-hardcoded-backdrop.js
+++ b/tools/eslint-plugin-stigmer/rules/no-hardcoded-backdrop.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const { extractClassNames } = require("../src/class-extractor");
+
+// The theme ships a designed backdrop token (--stgm-backdrop, mapped to
+// bg-backdrop) with distinct light/dark values in every preset. Before the
+// oss#373 sweep, dialogs hardcoded `backdrop:bg-black/50` instead — and the
+// class GREW from ~12 to 21 files between the issue's filing and the sweep,
+// which is why this fence exists: a hardcoded scrim silently exempts itself
+// from preset theming (a light-mode host gets a black scrim where the theme
+// specifies a translucent near-white one).
+
+const BACKDROP_VARIANT = "backdrop";
+const ALLOWED_UTILITY = "bg-backdrop";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require the --stgm-backdrop token (backdrop:bg-backdrop) for dialog ::backdrop colors",
+    },
+    messages: {
+      hardcodedBackdrop:
+        '"{{ cls }}" hardcodes the dialog backdrop color. ' +
+        "The theme ships a designed backdrop token with per-preset light/dark values — " +
+        'use "backdrop:bg-backdrop" (--stgm-backdrop) so presets keep control of the scrim.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (
+          node.name.type !== "JSXIdentifier" ||
+          node.name.name !== "className"
+        ) {
+          return;
+        }
+
+        const entries = extractClassNames(node);
+
+        for (const { className: cls, node: reportNode } of entries) {
+          const parts = cls.split(":");
+          if (parts.length < 2) continue;
+
+          const utility = parts[parts.length - 1];
+          const variants = parts.slice(0, -1);
+
+          if (!variants.includes(BACKDROP_VARIANT)) continue;
+          if (!utility.startsWith("bg-")) continue;
+          // Opacity modifiers on the token itself (bg-backdrop/50) are the
+          // no-token-opacity-modifiers rule's report, not a hardcoded color.
+          if (utility === ALLOWED_UTILITY || utility.startsWith(`${ALLOWED_UTILITY}/`)) {
+            continue;
+          }
+
+          context.report({
+            node: reportNode,
+            messageId: "hardcodedBackdrop",
+            data: { cls },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
Migrates every dialog off hardcoded `backdrop:bg-black/50` (two files at `/40`) onto the designed `--stgm-backdrop` theme token, and adds a lint fence so the class cannot regrow.

Closes #373

## Context
The theme ships a designed backdrop token with distinct light/dark values in every preset, but nothing used it until `AttachmentImageLightbox` (#371) — every other dialog hardcoded the color, violating Dont-Do #3 (`sdk-console-architecture.mdc`). A preset cannot restyle the scrim, and a light-mode host gets a black scrim where the theme specifies a translucent near-white. The class also grew from ~12 files at filing to 21 at this sweep — the regrowth is why the fence ships in the same PR.

## Changes
- 21 files: `stg:backdrop:bg-black/50|40` → `stg:backdrop:bg-backdrop` (census verified 0 remaining, 22 total consumers including the lightbox).
- New `stigmer/no-hardcoded-backdrop` eslint rule in `tools/eslint-plugin-stigmer` (fifth rule, same `class-extractor` machinery): bans backdrop-variant `bg-*` utilities other than `bg-backdrop`. Enabled at **error** in `sdk/react/eslint.config.mjs` — the sweep leaves zero violations, so the fence holds the line from day one. Opacity modifiers on the token itself remain `no-token-opacity-modifiers`' report.
- The two `/40` outliers (`ViewYamlDialog`, `ExecutionComparisonPicker`) converge with the rest — per-dialog scrim opacity is exactly the inconsistency the token ends; neither file records a reason for the lighter scrim.

## Implementation notes
- **Deliberate appearance change** in light mode: black scrim → the theme's translucent near-white (per-preset tinted, e.g. corporate's blue-cast). Owner-reviewed via before/after screenshots across monochrome + corporate in both modes (session record).
- The issue floats a shared dialog shell (21 hand-rolled `<dialog>`s); deliberately deferred — it would collide with the in-flight #619 useId sweep, and the fence makes deferral safe. Follow-up issue to be filed.

## Breaking changes
- None for behavior. Hosts overriding `--stgm-backdrop` now (correctly) affect all dialogs.

## Test plan
- Full sdk/react suite on this base: 404 files / 4441 tests green.
- `npm run lint` clean (fence active at error); negative test confirmed the rule rejects a reintroduced `backdrop:bg-black/50`.
- Visual review: light+dark × monochrome+corporate screenshots, before/after.

## Risks
- Purely visual; rollback is a revert. Rebase note: 3 swept files (`ChannelConversationsDialog`, `ChannelTemplatesDialog`, `WorkflowArchitectDialog`) are also in the in-flight #619 useId sweep census — whichever merges second rebase-checks; `tools/eslint-plugin-stigmer/index.js` likewise gains a rule in both.

## Checklist
- [x] Tests: covered by existing dialog suites (classes only) + lint fence negative test
- [x] Backward compatible

Made with [Cursor](https://cursor.com)