### PR TITLE
refactor(sdk/react): mint all DOM ids and radio-group names with useId(), fence the class with a lint rule

### DIFF
--- a/sdk/react/eslint.config.mjs
+++ b/sdk/react/eslint.config.mjs
@@ -17,8 +17,18 @@ export default defineConfig([
       // Error (not warn): the oss#373 sweep left zero violations, so the
       // fence can hold the line from day one.
       "stigmer/no-hardcoded-backdrop": "error",
+      "stigmer/no-literal-dom-ids": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/no-main-tokens-in-sidebar": "warn",
+    },
+  },
+  {
+    // Tests mount components once and control their own DOM — literal ids
+    // there are not a collision class, so the fence stays out of them.
+    files: ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
+    plugins: { stigmer: stigmerPlugin },
+    rules: {
+      "stigmer/no-literal-dom-ids": "off",
     },
   },
 ]);

--- a/sdk/react/src/agent/steps/CapabilitiesStep.tsx
+++ b/sdk/react/src/agent/steps/CapabilitiesStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import type { McpServerUsageInput, ResourceRef } from "@stigmer/sdk";
 import { McpServerPicker } from "../../mcp-server/McpServerPicker.js";
@@ -142,13 +142,16 @@ function CollapsibleSection({
   readonly onToggle: (id: string) => void;
   readonly children: React.ReactNode;
 }) {
+  // The disclosure-panel DOM id is minted per mount — deriving it from the
+  // semantic section key would collide when two wizards mount on one page.
+  const panelId = useId();
   return (
     <div className="stg:overflow-hidden stg:rounded-lg stg:border stg:border-border">
       <button
         type="button"
         onClick={() => onToggle(id)}
         aria-expanded={expanded}
-        aria-controls={`stgm-wizard-section-${id}`}
+        aria-controls={panelId}
         className={cn(
           "stg:flex stg:w-full stg:items-center stg:justify-between stg:px-4 stg:py-3 stg:text-left stg:transition-colors",
           "stg:hover:bg-accent-hover",
@@ -174,7 +177,7 @@ function CollapsibleSection({
 
       {expanded && (
         <div
-          id={`stgm-wizard-section-${id}`}
+          id={panelId}
           className="stg:border-t stg:border-border stg:px-4 stg:py-4"
         >
           {children}

--- a/sdk/react/src/agent/steps/IdentityStep.tsx
+++ b/sdk/react/src/agent/steps/IdentityStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useId } from "react";
 import { cn } from "@stigmer/theme";
 import { generateSlug } from "../../internal/slug.js";
 import type { AgentWizardData } from "./types.js";
@@ -28,6 +28,7 @@ export function IdentityStep({
   updateData,
   validationError,
 }: IdentityStepProps) {
+  const baseId = useId();
   const handleNameChange = useCallback(
     (value: string) => {
       if (!data.slugTouched) {
@@ -72,13 +73,13 @@ export function IdentityStep({
         {/* Name */}
         <div className="stg:space-y-1.5">
           <label
-            htmlFor="stgm-wizard-agent-name"
+            htmlFor={`${baseId}-name`}
             className="stg:text-sm stg:font-medium stg:text-foreground"
           >
             Name <span className="stg:text-destructive">*</span>
           </label>
           <input
-            id="stgm-wizard-agent-name"
+            id={`${baseId}-name`}
             type="text"
             value={data.name}
             onChange={(e) => handleNameChange(e.target.value)}
@@ -95,13 +96,13 @@ export function IdentityStep({
         {/* Slug */}
         <div className="stg:space-y-1.5">
           <label
-            htmlFor="stgm-wizard-agent-slug"
+            htmlFor={`${baseId}-slug`}
             className="stg:text-sm stg:font-medium stg:text-foreground"
           >
             Slug
           </label>
           <input
-            id="stgm-wizard-agent-slug"
+            id={`${baseId}-slug`}
             type="text"
             value={data.slug}
             onChange={(e) => handleSlugChange(e.target.value)}
@@ -129,13 +130,13 @@ export function IdentityStep({
       {/* Description */}
       <div className="stg:space-y-1.5">
         <label
-          htmlFor="stgm-wizard-agent-description"
+          htmlFor={`${baseId}-description`}
           className="stg:text-sm stg:font-medium stg:text-foreground"
         >
           Description
         </label>
         <input
-          id="stgm-wizard-agent-description"
+          id={`${baseId}-description`}
           type="text"
           value={data.description}
           onChange={(e) => updateData({ description: e.target.value })}
@@ -153,13 +154,13 @@ export function IdentityStep({
       <div className="stg:grid stg:gap-4 stg:sm:grid-cols-2">
         <div className="stg:space-y-1.5">
           <label
-            htmlFor="stgm-wizard-agent-icon"
+            htmlFor={`${baseId}-icon`}
             className="stg:text-sm stg:font-medium stg:text-foreground"
           >
             Icon URL
           </label>
           <input
-            id="stgm-wizard-agent-icon"
+            id={`${baseId}-icon`}
             type="url"
             value={data.iconUrl}
             onChange={(e) => updateData({ iconUrl: e.target.value })}
@@ -177,13 +178,17 @@ export function IdentityStep({
             Visibility
           </legend>
           <div className="stg:flex stg:gap-2">
+            {/* The radio-group name is minted per mount: a hardcoded name
+                would merge two mounted wizards into one keyboard group. */}
             <VisibilityOption
+              name={`${baseId}-visibility`}
               value="private"
               label="Private"
               checked={data.visibility === "private"}
               onChange={() => updateData({ visibility: "private" })}
             />
             <VisibilityOption
+              name={`${baseId}-visibility`}
               value="public"
               label="Public"
               checked={data.visibility === "public"}
@@ -196,7 +201,7 @@ export function IdentityStep({
       {/* Instructions */}
       <div className="stg:space-y-1.5">
         <label
-          htmlFor="stgm-wizard-agent-instructions"
+          htmlFor={`${baseId}-instructions`}
           className="stg:text-sm stg:font-medium stg:text-foreground"
         >
           Instructions
@@ -205,7 +210,7 @@ export function IdentityStep({
           The system prompt that defines this agent&apos;s behavior.
         </p>
         <textarea
-          id="stgm-wizard-agent-instructions"
+          id={`${baseId}-instructions`}
           value={data.instructions}
           onChange={(e) => updateData({ instructions: e.target.value })}
           placeholder="You are a helpful assistant that..."
@@ -226,11 +231,13 @@ export function IdentityStep({
 // ---------------------------------------------------------------------------
 
 function VisibilityOption({
+  name,
   value,
   label,
   checked,
   onChange,
 }: {
+  readonly name: string;
   readonly value: string;
   readonly label: string;
   readonly checked: boolean;
@@ -247,7 +254,7 @@ function VisibilityOption({
     >
       <input
         type="radio"
-        name="stgm-wizard-agent-visibility"
+        name={name}
         value={value}
         checked={checked}
         onChange={onChange}

--- a/sdk/react/src/api-key/ApiKeyCreatedAlert.tsx
+++ b/sdk/react/src/api-key/ApiKeyCreatedAlert.tsx
@@ -92,7 +92,6 @@ export function ApiKeyCreatedAlert({
       <div className="stg:flex stg:items-center stg:gap-2">
         <code
           ref={revealRef}
-          id="stgm-api-key-reveal"
           className={cn(
             "stg:min-w-0 stg:flex-1 stg:select-all stg:truncate stg:rounded-md",
             "stg:border stg:border-input stg:bg-background stg:px-2.5 stg:py-1.5",

--- a/sdk/react/src/api-key/CreateApiKeyForm.tsx
+++ b/sdk/react/src/api-key/CreateApiKeyForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { useCallback, useId, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ApiKey } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/api_pb";
@@ -62,6 +62,7 @@ export function CreateApiKeyForm({
   className,
 }: CreateApiKeyFormProps) {
   const { create, isCreating, error, clearError } = useCreateApiKey();
+  const baseId = useId();
 
   const [name, setName] = useState(initialName);
   const [expiry, setExpiry] = useState<ExpiryOption>("never");
@@ -97,13 +98,13 @@ export function CreateApiKeyForm({
         {/* Name */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-new-apikey-name"
+            htmlFor={`${baseId}-name`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Name
           </label>
           <input
-            id="stgm-new-apikey-name"
+            id={`${baseId}-name`}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -126,9 +127,12 @@ export function CreateApiKeyForm({
             Expiration
           </legend>
           <div className="stg:flex stg:flex-wrap stg:gap-2">
+            {/* The radio-group name is minted per mount: a hardcoded name
+                would merge two mounted forms into one keyboard group. */}
             {EXPIRY_OPTIONS.map(({ value, label }) => (
               <ExpiryRadio
                 key={value}
+                name={`${baseId}-expiry`}
                 value={value}
                 label={label}
                 checked={expiry === value}
@@ -201,12 +205,14 @@ function daysFromNow(days: number): Date {
 // ---------------------------------------------------------------------------
 
 function ExpiryRadio({
+  name,
   value,
   label,
   checked,
   disabled,
   onChange,
 }: {
+  name: string;
   value: ExpiryOption;
   label: string;
   checked: boolean;
@@ -225,7 +231,7 @@ function ExpiryRadio({
     >
       <input
         type="radio"
-        name="stgm-apikey-expiry"
+        name={name}
         value={value}
         checked={checked}
         disabled={disabled}

--- a/sdk/react/src/billing/AutoRechargeCard.tsx
+++ b/sdk/react/src/billing/AutoRechargeCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useId } from "react";
 import { cn } from "@stigmer/theme";
 import type { AutoRechargeConfig } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
 import { BillingAccountStatus } from "@stigmer/protos/ai/stigmer/billing/v1/enum_pb";
@@ -64,6 +64,7 @@ export function AutoRechargeCard({
   onSaved,
   className,
 }: AutoRechargeCardProps) {
+  const baseId = useId();
   const { setConfig, isSubmitting, error, clearError } =
     useSetAutoRechargeConfig();
 
@@ -168,7 +169,7 @@ export function AutoRechargeCard({
       {canConfigure && (
         <div className="stg:mt-4 stg:space-y-3">
           <DollarInput
-            id="ar-threshold"
+            id={`${baseId}-threshold`}
             label="When balance drops below"
             value={threshold}
             onChange={setThreshold}
@@ -176,7 +177,7 @@ export function AutoRechargeCard({
             placeholder="e.g. 5"
           />
           <DollarInput
-            id="ar-amount"
+            id={`${baseId}-amount`}
             label="Recharge amount"
             value={amount}
             onChange={setAmount}
@@ -184,7 +185,7 @@ export function AutoRechargeCard({
             placeholder="e.g. 50"
           />
           <DollarInput
-            id="ar-cap"
+            id={`${baseId}-cap`}
             label="Monthly cap"
             value={cap}
             onChange={setCap}

--- a/sdk/react/src/billing/BillingSection.tsx
+++ b/sdk/react/src/billing/BillingSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { BillingAccountStatus } from "@stigmer/protos/ai/stigmer/billing/v1/enum_pb";
@@ -53,14 +53,15 @@ export function BillingSection({
   onDismissCheckoutSuccess,
   className,
 }: BillingSectionProps) {
+  const headingId = useId();
   const { activeOrg } = useOrg();
   const mode = useDeploymentMode();
   const orgId = activeOrg?.metadata?.id ?? "";
 
   return (
-    <section aria-labelledby="billing-heading" className={className}>
+    <section aria-labelledby={headingId} className={className}>
       <h2
-        id="billing-heading"
+        id={headingId}
         className="stg:text-foreground stg:mb-1 stg:text-sm stg:font-semibold"
       >
         Billing

--- a/sdk/react/src/channel-app/ChannelAppDetailPanel.tsx
+++ b/sdk/react/src/channel-app/ChannelAppDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
@@ -188,6 +188,7 @@ function SlackAppDetail({
   readonly consoleOrigin?: string;
   readonly onUpdated?: (app: ChannelApp) => void;
 }) {
+  const baseId = useId();
   const stigmer = useStigmer();
   const { update, isUpdating, error: updateError, clearError } = useUpdateChannelApp();
 
@@ -278,7 +279,7 @@ function SlackAppDetail({
         </p>
 
         <FormField
-          id="stgm-chapp-edit-client-id"
+          id={`${baseId}-client-id`}
           label="Client ID"
           value={clientId}
           onChange={setClientId}
@@ -287,7 +288,7 @@ function SlackAppDetail({
           required
         />
         <FormField
-          id="stgm-chapp-edit-client-secret"
+          id={`${baseId}-client-secret`}
           label="Client secret"
           value={clientSecret}
           onChange={setClientSecret}
@@ -297,7 +298,7 @@ function SlackAppDetail({
           required
         />
         <FormField
-          id="stgm-chapp-edit-signing-secret"
+          id={`${baseId}-signing-secret`}
           label="Signing secret"
           value={signingSecret}
           onChange={setSigningSecret}
@@ -343,6 +344,7 @@ function WhatsAppAppDetail({
   readonly createHandoff?: ChannelAppCreateHandoff;
   readonly onUpdated?: (app: ChannelApp) => void;
 }) {
+  const baseId = useId();
   const stigmer = useStigmer();
   const { update, isUpdating, error: updateError, clearError } = useUpdateChannelApp();
 
@@ -447,7 +449,7 @@ function WhatsAppAppDetail({
         </p>
 
         <FormField
-          id="stgm-chapp-edit-app-id"
+          id={`${baseId}-app-id`}
           label="App ID"
           value={metaAppId}
           onChange={setMetaAppId}
@@ -456,7 +458,7 @@ function WhatsAppAppDetail({
           required
         />
         <FormField
-          id="stgm-chapp-edit-app-secret"
+          id={`${baseId}-app-secret`}
           label="App secret"
           value={appSecret}
           onChange={setAppSecret}
@@ -466,7 +468,7 @@ function WhatsAppAppDetail({
           required
         />
         <FormField
-          id="stgm-chapp-edit-access-token"
+          id={`${baseId}-access-token`}
           label="Access token"
           value={accessToken}
           onChange={setAccessToken}
@@ -476,7 +478,7 @@ function WhatsAppAppDetail({
           required
         />
         <FormField
-          id="stgm-chapp-edit-verify-token"
+          id={`${baseId}-verify-token`}
           label="Verify token"
           value={verifyToken}
           onChange={setVerifyToken}

--- a/sdk/react/src/channel-app/CreateChannelAppForm.tsx
+++ b/sdk/react/src/channel-app/CreateChannelAppForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
@@ -81,6 +81,7 @@ export function CreateChannelAppForm({
   onCancel,
   className,
 }: CreateChannelAppFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } = useCreateChannelApp();
 
   const [provider, setProvider] = useState<ChannelProviderId>("slack");
@@ -186,7 +187,7 @@ export function CreateChannelAppForm({
         />
 
         <FormField
-          id="stgm-chapp-name"
+          id={`${baseId}-name`}
           label="Name"
           value={name}
           onChange={setName}
@@ -283,6 +284,7 @@ function ProviderPicker({
   readonly onChange: (id: ChannelProviderId) => void;
   readonly disabled: boolean;
 }) {
+  const groupName = useId();
   return (
     <fieldset>
       <legend className="stg:mb-1.5 stg:block stg:text-xs stg:font-medium stg:text-foreground">
@@ -304,7 +306,7 @@ function ProviderPicker({
               <input
                 id={`stgm-chapp-provider-${p.id}`}
                 type="radio"
-                name="stgm-chapp-provider"
+                name={`${groupName}-provider`}
                 checked={checked}
                 onChange={() => onChange(p.id)}
                 disabled={disabled}
@@ -343,6 +345,7 @@ function SlackCreateSection({
   readonly onSigningSecretChange: (v: string) => void;
   readonly disabled: boolean;
 }) {
+  const baseId = useId();
   return (
     <>
       <div className="stg:space-y-1.5">
@@ -381,7 +384,7 @@ function SlackCreateSection({
         </p>
 
         <FormField
-          id="stgm-chapp-client-id"
+          id={`${baseId}-client-id`}
           label="Client ID"
           value={clientId}
           onChange={onClientIdChange}
@@ -391,7 +394,7 @@ function SlackCreateSection({
         />
 
         <FormField
-          id="stgm-chapp-client-secret"
+          id={`${baseId}-client-secret`}
           label="Client secret"
           value={clientSecret}
           onChange={onClientSecretChange}
@@ -402,7 +405,7 @@ function SlackCreateSection({
         />
 
         <FormField
-          id="stgm-chapp-signing-secret"
+          id={`${baseId}-signing-secret`}
           label="Signing secret"
           value={signingSecret}
           onChange={onSigningSecretChange}
@@ -442,6 +445,7 @@ function WhatsAppCreateSection({
   readonly onVerifyTokenChange: (v: string) => void;
   readonly disabled: boolean;
 }) {
+  const baseId = useId();
   return (
     <>
       <div className="stg:space-y-1.5">
@@ -477,7 +481,7 @@ function WhatsAppCreateSection({
         </p>
 
         <FormField
-          id="stgm-chapp-app-id"
+          id={`${baseId}-app-id`}
           label="App ID"
           value={appId}
           onChange={onAppIdChange}
@@ -487,7 +491,7 @@ function WhatsAppCreateSection({
         />
 
         <FormField
-          id="stgm-chapp-app-secret"
+          id={`${baseId}-app-secret`}
           label="App secret"
           value={appSecret}
           onChange={onAppSecretChange}
@@ -499,7 +503,7 @@ function WhatsAppCreateSection({
         />
 
         <FormField
-          id="stgm-chapp-access-token"
+          id={`${baseId}-access-token`}
           label="Access token"
           value={accessToken}
           onChange={onAccessTokenChange}
@@ -511,7 +515,7 @@ function WhatsAppCreateSection({
         />
 
         <FormField
-          id="stgm-chapp-verify-token"
+          id={`${baseId}-verify-token`}
           label="Verify token"
           value={verifyToken}
           onChange={onVerifyTokenChange}

--- a/sdk/react/src/channel/ChannelConversationsDialog.tsx
+++ b/sdk/react/src/channel/ChannelConversationsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useId, useRef } from "react";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { MessageSquare, User, X } from "lucide-react";
 import { cn } from "@stigmer/theme";
@@ -69,6 +69,7 @@ export function ChannelConversationsDialog({
   modal = true,
 }: ChannelConversationsDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
@@ -99,11 +100,12 @@ export function ChannelConversationsDialog({
         "stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
-      aria-labelledby="channel-conversations-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so each opening fetches fresh. */}
       {open && (
         <ChannelConversationsDialogBody
+          titleId={titleId}
           channel={channel}
           sessionHref={sessionHref}
           onClose={handleClose}
@@ -114,10 +116,12 @@ export function ChannelConversationsDialog({
 }
 
 function ChannelConversationsDialogBody({
+  titleId,
   channel,
   sessionHref,
   onClose,
 }: {
+  readonly titleId: string;
   readonly channel: AgentChannel;
   readonly sessionHref?: (sessionId: string) => string;
   readonly onClose: () => void;
@@ -133,7 +137,7 @@ function ChannelConversationsDialogBody({
       <div className="stg:flex stg:items-start stg:justify-between stg:gap-3 stg:border-b stg:border-border stg:px-5 stg:py-4">
         <div className="stg:min-w-0">
           <h2
-            id="channel-conversations-title"
+            id={titleId}
             className="stg:text-sm stg:font-semibold stg:text-popover-foreground"
           >
             Sessions

--- a/sdk/react/src/channel/ChannelTemplatesDialog.tsx
+++ b/sdk/react/src/channel/ChannelTemplatesDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, type ReactNode } from "react";
+import { useCallback, useId, useRef, type ReactNode } from "react";
 import { ExternalLink, LayoutTemplate, X } from "lucide-react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
@@ -90,6 +90,7 @@ export function ChannelTemplatesDialog({
   modal = true,
 }: ChannelTemplatesDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
@@ -122,12 +123,13 @@ export function ChannelTemplatesDialog({
         "stg:w-full stg:max-w-2xl stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
         modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
       )}
-      aria-labelledby="channel-templates-title"
+      aria-labelledby={titleId}
     >
       {/* Body mounts only while open so each opening fetches fresh —
           approval statuses change on the provider's side at any time. */}
       {open && (
         <ChannelTemplatesDialogBody
+          titleId={titleId}
           channel={channel}
           onEditYaml={onEditYaml}
           onClose={handleClose}
@@ -138,10 +140,12 @@ export function ChannelTemplatesDialog({
 }
 
 function ChannelTemplatesDialogBody({
+  titleId,
   channel,
   onEditYaml,
   onClose,
 }: {
+  readonly titleId: string;
   readonly channel: AgentChannel;
   readonly onEditYaml?: () => void;
   readonly onClose: () => void;
@@ -154,7 +158,7 @@ function ChannelTemplatesDialogBody({
       <div className="stg:flex stg:items-start stg:justify-between stg:gap-3 stg:border-b stg:border-border stg:px-5 stg:py-4">
         <div className="stg:min-w-0">
           <h2
-            id="channel-templates-title"
+            id={titleId}
             className="stg:text-sm stg:font-semibold stg:text-popover-foreground"
           >
             Templates

--- a/sdk/react/src/conversation/ConversationListPane.tsx
+++ b/sdk/react/src/conversation/ConversationListPane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useRef } from "react";
+import { memo, useCallback, useId, useRef } from "react";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { MessageSquare, TriangleAlert, User } from "lucide-react";
 import { cn } from "@stigmer/theme";
@@ -110,6 +110,7 @@ export function ConversationListPane({
   now,
   className,
 }: ConversationListPaneProps) {
+  const channelFilterId = useId();
   const providerById = new Map(
     channels.map((channel) => [
       channel.metadata?.id ?? "",
@@ -129,11 +130,11 @@ export function ConversationListPane({
           )}
           {channels.length > 1 && (
             <>
-              <label className="stg:sr-only" htmlFor="stgm-conversation-channel-filter">
+              <label className="stg:sr-only" htmlFor={channelFilterId}>
                 Filter by channel
               </label>
               <select
-                id="stgm-conversation-channel-filter"
+                id={channelFilterId}
                 value={channelFilter}
                 onChange={(e) => onChannelFilterChange(e.target.value)}
                 className={cn(

--- a/sdk/react/src/environment/CreateEnvironmentForm.tsx
+++ b/sdk/react/src/environment/CreateEnvironmentForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
@@ -48,6 +48,7 @@ export function CreateEnvironmentForm({
   onCancel,
   className,
 }: CreateEnvironmentFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } = useCreateEnvironment();
 
   const [name, setName] = useState("");
@@ -81,13 +82,13 @@ export function CreateEnvironmentForm({
       <div className="stg:space-y-2">
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-new-env-name"
+            htmlFor={`${baseId}-name`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Name
           </label>
           <input
-            id="stgm-new-env-name"
+            id={`${baseId}-name`}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -106,14 +107,14 @@ export function CreateEnvironmentForm({
 
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-new-env-desc"
+            htmlFor={`${baseId}-desc`}
             className="stg:text-xs stg:font-medium stg:text-muted-foreground"
           >
             Description{" "}
             <span className="stg:text-muted-foreground-subtle">(optional)</span>
           </label>
           <input
-            id="stgm-new-env-desc"
+            id={`${baseId}-desc`}
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}

--- a/sdk/react/src/identity-provider/CreateIdentityProviderForm.tsx
+++ b/sdk/react/src/identity-provider/CreateIdentityProviderForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
@@ -51,6 +51,7 @@ export function CreateIdentityProviderForm({
   onCancel,
   className,
 }: CreateIdentityProviderFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } =
     useCreateIdentityProvider();
 
@@ -156,7 +157,7 @@ export function CreateIdentityProviderForm({
     <form onSubmit={handleSubmit} className={cn("stg:space-y-3", className)}>
       <div className="stg:space-y-3">
         <FormField
-          id="stgm-idp-name"
+          id={`${baseId}-name`}
           label="Name"
           value={name}
           onChange={setName}
@@ -166,7 +167,7 @@ export function CreateIdentityProviderForm({
         />
 
         <FormField
-          id="stgm-idp-jwks"
+          id={`${baseId}-jwks`}
           label="JWKS URI"
           value={jwksUri}
           onChange={setJwksUri}
@@ -176,7 +177,7 @@ export function CreateIdentityProviderForm({
         />
 
         <FormField
-          id="stgm-idp-issuers"
+          id={`${baseId}-issuers`}
           label="Allowed issuers"
           value={issuers}
           onChange={setIssuers}
@@ -187,7 +188,7 @@ export function CreateIdentityProviderForm({
         />
 
         <FormField
-          id="stgm-idp-audience"
+          id={`${baseId}-audience`}
           label="Expected audience"
           value={audience}
           onChange={setAudience}
@@ -224,7 +225,7 @@ export function CreateIdentityProviderForm({
 
         {isSso && (
           <FormField
-            id="stgm-idp-client-id"
+            id={`${baseId}-client-id`}
             label="OIDC client ID"
             value={oidcClientId}
             onChange={setOidcClientId}
@@ -373,6 +374,7 @@ function JitSection({
   onTenantOrgClaimChange: (v: string) => void;
   disabled: boolean;
 }) {
+  const baseId = useId();
   if (isSso) {
     return (
       <div className="stg:rounded-md stg:border stg:border-border-muted stg:bg-muted-faint stg:px-3 stg:py-2">
@@ -416,13 +418,13 @@ function JitSection({
         <>
           <div className="stg:space-y-1">
             <label
-              htmlFor="stgm-idp-grant-role"
+              htmlFor={`${baseId}-grant-role`}
               className="stg:text-xs stg:font-medium stg:text-foreground"
             >
               Auto-grant role
             </label>
             <select
-              id="stgm-idp-grant-role"
+              id={`${baseId}-grant-role`}
               value={String(autoGrantRole)}
               onChange={(e) => onAutoGrantRoleChange(Number(e.target.value) as IamRole)}
               disabled={disabled}
@@ -444,7 +446,7 @@ function JitSection({
           </div>
 
           <FormField
-            id="stgm-idp-tenant-claim"
+            id={`${baseId}-tenant-claim`}
             label="Tenant org claim"
             value={tenantOrgClaim}
             onChange={onTenantOrgClaimChange}

--- a/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
@@ -58,6 +58,7 @@ export function IdentityProviderDetailPanel({
   ssoLoginUrl,
   className,
 }: IdentityProviderDetailPanelProps) {
+  const baseId = useId();
   const spec = identityProvider.spec;
   const meta = identityProvider.metadata;
 
@@ -233,7 +234,7 @@ export function IdentityProviderDetailPanel({
       ) : (
         <form onSubmit={handleSave} className="stg:space-y-3">
           <FieldInput
-            id="stgm-idp-edit-name"
+            id={`${baseId}-name`}
             label="Display name"
             value={displayName}
             onChange={setDisplayName}
@@ -242,7 +243,7 @@ export function IdentityProviderDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-idp-edit-jwks"
+            id={`${baseId}-jwks`}
             label="JWKS URI"
             value={jwksUri}
             onChange={setJwksUri}
@@ -251,7 +252,7 @@ export function IdentityProviderDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-idp-edit-issuers"
+            id={`${baseId}-issuers`}
             label="Allowed issuers"
             value={issuers}
             onChange={setIssuers}
@@ -261,7 +262,7 @@ export function IdentityProviderDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-idp-edit-audience"
+            id={`${baseId}-audience`}
             label="Expected audience"
             value={audience}
             onChange={setAudience}
@@ -270,7 +271,7 @@ export function IdentityProviderDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-idp-edit-userinfo"
+            id={`${baseId}-userinfo`}
             label="Userinfo endpoint"
             value={userinfoEndpoint}
             onChange={setUserinfoEndpoint}
@@ -307,7 +308,7 @@ export function IdentityProviderDetailPanel({
 
           {isSso && (
             <FieldInput
-              id="stgm-idp-edit-client-id"
+              id={`${baseId}-client-id`}
               label="OIDC client ID"
               value={oidcClientId}
               onChange={setOidcClientId}
@@ -502,7 +503,6 @@ function CopyableField({
 }) {
   const { copy, copied } = useCopyFeedback();
   const revealRef = useRef<HTMLElement>(null);
-  const valueId = "stgm-idp-sso-login-url";
 
   const handleCopy = useCallback(async () => {
     if (await copy(value)) return;
@@ -519,7 +519,6 @@ function CopyableField({
         <div className="stg:flex stg:items-center stg:gap-2">
           <span
             ref={revealRef}
-            id={valueId}
             className="stg:text-foreground stg:break-all stg:font-mono stg:text-xs stg:select-all"
           >
             {value}
@@ -661,6 +660,7 @@ function JitEditSection({
   onTenantOrgClaimChange: (v: string) => void;
   disabled?: boolean;
 }) {
+  const baseId = useId();
   if (isSso) {
     return (
       <div className="stg:rounded-md stg:border stg:border-border-muted stg:bg-muted-faint stg:px-3 stg:py-2">
@@ -704,13 +704,13 @@ function JitEditSection({
         <>
           <div className="stg:space-y-1">
             <label
-              htmlFor="stgm-idp-edit-grant-role"
+              htmlFor={`${baseId}-grant-role`}
               className="stg:text-xs stg:font-medium stg:text-foreground"
             >
               Auto-grant role
             </label>
             <select
-              id="stgm-idp-edit-grant-role"
+              id={`${baseId}-grant-role`}
               value={String(autoGrantRole)}
               onChange={(e) => onAutoGrantRoleChange(Number(e.target.value) as IamRole)}
               disabled={disabled}
@@ -732,7 +732,7 @@ function JitEditSection({
           </div>
 
           <FieldInput
-            id="stgm-idp-edit-tenant-claim"
+            id={`${baseId}-tenant-claim`}
             label="Tenant org claim"
             value={tenantOrgClaim}
             onChange={onTenantOrgClaimChange}

--- a/sdk/react/src/identity-provider/IdentityProviderWizard.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderWizard.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useState,
-  type FormEvent,
-} from "react";
+import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
@@ -366,6 +362,7 @@ function ConfigureStep({
   onContinue: () => void;
   onCancel?: () => void;
 }) {
+  const baseId = useId();
   const allVarsFilled = preset.variables.every(
     (v) => (vars[v.key] ?? "").trim() !== "",
   );
@@ -403,7 +400,7 @@ function ConfigureStep({
 
       {/* Common fields */}
       <FieldInput
-        id="stgm-idp-wiz-name"
+        id={`${baseId}-name`}
         label="Display name"
         value={name}
         onChange={onNameChange}
@@ -413,7 +410,7 @@ function ConfigureStep({
       />
 
       <FieldInput
-        id="stgm-idp-wiz-audience"
+        id={`${baseId}-audience`}
         label="Expected audience"
         value={audience}
         onChange={onAudienceChange}
@@ -508,6 +505,7 @@ function ReviewStep({
   onSubmit: (e: FormEvent) => void;
   onCancel?: () => void;
 }) {
+  const baseId = useId();
   const canSubmit =
     jwksUri.trim() !== "" &&
     issuers.trim() !== "" &&
@@ -531,7 +529,7 @@ function ReviewStep({
       </p>
 
       <FieldInput
-        id="stgm-idp-wiz-jwks"
+        id={`${baseId}-jwks`}
         label="JWKS URI"
         value={jwksUri}
         onChange={onJwksUriChange}
@@ -541,7 +539,7 @@ function ReviewStep({
       />
 
       <FieldInput
-        id="stgm-idp-wiz-issuers"
+        id={`${baseId}-issuers`}
         label="Allowed issuers"
         value={issuers}
         onChange={onIssuersChange}
@@ -552,7 +550,7 @@ function ReviewStep({
       />
 
       <FieldInput
-        id="stgm-idp-wiz-userinfo"
+        id={`${baseId}-userinfo`}
         label="Userinfo endpoint"
         value={userinfoEndpoint}
         onChange={onUserinfoEndpointChange}
@@ -571,7 +569,7 @@ function ReviewStep({
 
       {isSso && (
         <FieldInput
-          id="stgm-idp-wiz-client-id"
+          id={`${baseId}-client-id`}
           label="OIDC client ID"
           value={oidcClientId}
           onChange={onOidcClientIdChange}
@@ -826,6 +824,7 @@ function JitProvisioningSection({
   onTenantOrgClaimChange: (v: string) => void;
   disabled?: boolean;
 }) {
+  const baseId = useId();
   if (isSso) {
     return (
       <div className="stg:rounded-md stg:border stg:border-border-muted stg:bg-muted-faint stg:px-3 stg:py-2">
@@ -868,7 +867,7 @@ function JitProvisioningSection({
       {autoGrant && (
         <>
           <FieldInput
-            id="stgm-idp-wiz-grant-role"
+            id={`${baseId}-grant-role`}
             label="Auto-grant role"
             value={String(autoGrantRole)}
             onChange={(v) => onAutoGrantRoleChange(Number(v) as IamRole)}
@@ -880,7 +879,7 @@ function JitProvisioningSection({
           />
 
           <FieldInput
-            id="stgm-idp-wiz-tenant-claim"
+            id={`${baseId}-tenant-claim`}
             label="Tenant org claim"
             value={tenantOrgClaim}
             onChange={onTenantOrgClaimChange}

--- a/sdk/react/src/identity-provider/SsoLoginPrompt.tsx
+++ b/sdk/react/src/identity-provider/SsoLoginPrompt.tsx
@@ -184,7 +184,7 @@ function resolvePhase(
 // Sub-components
 // ---------------------------------------------------------------------------
 
-import { forwardRef } from "react";
+import { forwardRef, useId } from "react";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
 
 interface OrgInputFormProps {
@@ -195,17 +195,18 @@ interface OrgInputFormProps {
 
 const OrgInputForm = forwardRef<HTMLInputElement, OrgInputFormProps>(
   function OrgInputForm({ value, onChange, onSubmit }, ref) {
+    const inputId = useId();
     return (
       <form onSubmit={onSubmit} className="stg:space-y-3">
         <label
-          htmlFor="sso-org-input"
+          htmlFor={inputId}
           className="stg:block stg:text-sm stg:font-medium stg:text-foreground"
         >
           Organization
         </label>
         <input
           ref={ref}
-          id="sso-org-input"
+          id={inputId}
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}

--- a/sdk/react/src/invitation/InvitationCreatedAlert.tsx
+++ b/sdk/react/src/invitation/InvitationCreatedAlert.tsx
@@ -92,7 +92,6 @@ export function InvitationCreatedAlert({
       <div className="stg:flex stg:items-center stg:gap-2">
         <code
           ref={revealRef}
-          id="stgm-invite-url-reveal"
           className={cn(
             "stg:min-w-0 stg:flex-1 stg:select-all stg:truncate stg:rounded-md",
             "stg:border stg:border-input stg:bg-background stg:px-2.5 stg:py-1.5",

--- a/sdk/react/src/invitation/InvitationManager.tsx
+++ b/sdk/react/src/invitation/InvitationManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { useCallback, useId, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
 import {
   getUserMessage,
@@ -232,6 +232,7 @@ function CreateInvitationForm({
   onCancel: () => void;
 }) {
   const { create, isCreating, error, clearError } = useCreateInvitation();
+  const baseId = useId();
 
   const [label, setLabel] = useState("");
   const [role, setRole] = useState<IamRole>(IamRole.viewer);
@@ -268,14 +269,14 @@ function CreateInvitationForm({
       {/* Label */}
       <div className="stg:space-y-1">
         <label
-          htmlFor="stgm-new-invite-label"
+          htmlFor={`${baseId}-label`}
           className="stg:text-xs stg:font-medium stg:text-foreground"
         >
           Label{" "}
           <span className="stg:font-normal stg:text-muted-foreground">(optional)</span>
         </label>
         <input
-          id="stgm-new-invite-label"
+          id={`${baseId}-label`}
           type="text"
           value={label}
           onChange={(e) => setLabel(e.target.value)}
@@ -306,9 +307,12 @@ function CreateInvitationForm({
           Expires in
         </legend>
         <div className="stg:flex stg:flex-wrap stg:gap-2">
+          {/* Radio-group names are minted per mount: a hardcoded name would
+              merge two mounted forms into one keyboard group. */}
           {EXPIRY_OPTIONS.map(({ value, label: optLabel }) => (
             <ExpiryRadio
               key={value}
+              name={`${baseId}-expiry`}
               value={value}
               label={optLabel}
               checked={expiry === value}
@@ -326,6 +330,7 @@ function CreateInvitationForm({
         </legend>
         <div className="stg:flex stg:flex-wrap stg:gap-2">
           <RedemptionRadio
+            name={`${baseId}-redemption`}
             value="unlimited"
             label="Unlimited"
             description="Anyone with the link can join"
@@ -334,6 +339,7 @@ function CreateInvitationForm({
             onChange={setRedemptionMode}
           />
           <RedemptionRadio
+            name={`${baseId}-redemption`}
             value="single"
             label="Single use"
             description="One person only"
@@ -634,12 +640,14 @@ const STATE_BADGE_CONFIG: Record<InvitationState, { label: string; className: st
 // ---------------------------------------------------------------------------
 
 function ExpiryRadio({
+  name,
   value,
   label,
   checked,
   disabled,
   onChange,
 }: {
+  name: string;
   value: ExpiryOption;
   label: string;
   checked: boolean;
@@ -658,7 +666,7 @@ function ExpiryRadio({
     >
       <input
         type="radio"
-        name="stgm-invite-expiry"
+        name={name}
         value={value}
         checked={checked}
         disabled={disabled}
@@ -671,6 +679,7 @@ function ExpiryRadio({
 }
 
 function RedemptionRadio({
+  name,
   value,
   label,
   description,
@@ -678,6 +687,7 @@ function RedemptionRadio({
   disabled,
   onChange,
 }: {
+  name: string;
   value: RedemptionMode;
   label: string;
   description: string;
@@ -697,7 +707,7 @@ function RedemptionRadio({
     >
       <input
         type="radio"
-        name="stgm-invite-redemption"
+        name={name}
         value={value}
         checked={checked}
         disabled={disabled}

--- a/sdk/react/src/mcp-server/steps/EnvironmentAuthStep.tsx
+++ b/sdk/react/src/mcp-server/steps/EnvironmentAuthStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import type { McpServerWizardData, EnvVarEntry } from "./types.js";
 
@@ -25,6 +25,7 @@ export function EnvironmentAuthStep({
   data,
   updateData,
 }: EnvironmentAuthStepProps) {
+  const baseId = useId();
   const [envExpanded, setEnvExpanded] = useState(data.env.length > 0);
 
   return (
@@ -41,7 +42,6 @@ export function EnvironmentAuthStep({
 
       {/* Environment Variables */}
       <CollapsibleSection
-        id="env"
         title="Environment Variables"
         subtitle="Secrets and configuration the server requires at runtime"
         count={data.env.length}
@@ -56,7 +56,6 @@ export function EnvironmentAuthStep({
 
       {/* Auth Configuration */}
       <CollapsibleSection
-        id="auth"
         title="OAuth Authentication"
         subtitle="Configure OAuth for servers that require user authorization"
         expanded={data.authEnabled}
@@ -66,13 +65,13 @@ export function EnvironmentAuthStep({
           <div className="stg:grid stg:gap-4 stg:sm:grid-cols-2">
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-auth-app-org"
+                htmlFor={`${baseId}-app-org`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 OAuth App Organization
               </label>
               <input
-                id="stgm-wizard-mcp-auth-app-org"
+                id={`${baseId}-app-org`}
                 type="text"
                 value={data.authOAuthAppOrg}
                 onChange={(e) =>
@@ -89,13 +88,13 @@ export function EnvironmentAuthStep({
 
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-auth-app-slug"
+                htmlFor={`${baseId}-app-slug`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 OAuth App Slug
               </label>
               <input
-                id="stgm-wizard-mcp-auth-app-slug"
+                id={`${baseId}-app-slug`}
                 type="text"
                 value={data.authOAuthAppSlug}
                 onChange={(e) =>
@@ -113,13 +112,13 @@ export function EnvironmentAuthStep({
 
           <div className="stg:space-y-1.5">
             <label
-              htmlFor="stgm-wizard-mcp-auth-target-var"
+              htmlFor={`${baseId}-target-var`}
               className="stg:text-sm stg:font-medium stg:text-foreground"
             >
               Target Environment Variable
             </label>
             <input
-              id="stgm-wizard-mcp-auth-target-var"
+              id={`${baseId}-target-var`}
               type="text"
               value={data.authTargetEnvVar}
               onChange={(e) =>
@@ -140,13 +139,13 @@ export function EnvironmentAuthStep({
           <div className="stg:grid stg:gap-4 stg:sm:grid-cols-2">
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-auth-lifetime"
+                htmlFor={`${baseId}-lifetime`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 Token Lifetime Hint
               </label>
               <input
-                id="stgm-wizard-mcp-auth-lifetime"
+                id={`${baseId}-lifetime`}
                 type="text"
                 value={data.authTokenLifetimeHint}
                 onChange={(e) =>
@@ -163,13 +162,13 @@ export function EnvironmentAuthStep({
 
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-auth-scopes"
+                htmlFor={`${baseId}-scopes`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 Scope Hints
               </label>
               <input
-                id="stgm-wizard-mcp-auth-scopes"
+                id={`${baseId}-scopes`}
                 type="text"
                 value={data.authScopeHints}
                 onChange={(e) =>
@@ -190,13 +189,13 @@ export function EnvironmentAuthStep({
 
           <div className="stg:space-y-1.5">
             <label
-              htmlFor="stgm-wizard-mcp-auth-discovery"
+              htmlFor={`${baseId}-discovery`}
               className="stg:text-sm stg:font-medium stg:text-foreground"
             >
               Discovery URL
             </label>
             <input
-              id="stgm-wizard-mcp-auth-discovery"
+              id={`${baseId}-discovery`}
               type="url"
               value={data.authDiscoveryUrl}
               onChange={(e) =>
@@ -221,7 +220,6 @@ export function EnvironmentAuthStep({
 // ---------------------------------------------------------------------------
 
 function CollapsibleSection({
-  id,
   title,
   subtitle,
   count,
@@ -229,7 +227,6 @@ function CollapsibleSection({
   onToggle,
   children,
 }: {
-  readonly id: string;
   readonly title: string;
   readonly subtitle: string;
   readonly count?: number;
@@ -237,13 +234,16 @@ function CollapsibleSection({
   readonly onToggle: () => void;
   readonly children: React.ReactNode;
 }) {
+  // The disclosure-panel DOM id is minted per mount — deriving it from a
+  // static section key would collide when two wizards mount on one page.
+  const panelId = useId();
   return (
     <div className="stg:overflow-hidden stg:rounded-lg stg:border stg:border-border">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={expanded}
-        aria-controls={`stgm-wizard-section-${id}`}
+        aria-controls={panelId}
         className={cn(
           "stg:flex stg:w-full stg:items-center stg:justify-between stg:px-4 stg:py-3 stg:text-left stg:transition-colors",
           "stg:hover:bg-accent-hover",
@@ -269,7 +269,7 @@ function CollapsibleSection({
 
       {expanded && (
         <div
-          id={`stgm-wizard-section-${id}`}
+          id={panelId}
           className="stg:border-t stg:border-border stg:px-4 stg:py-4"
         >
           {children}

--- a/sdk/react/src/mcp-server/steps/IdentityTransportStep.tsx
+++ b/sdk/react/src/mcp-server/steps/IdentityTransportStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useId } from "react";
 import { cn } from "@stigmer/theme";
 import { generateSlug } from "../../internal/slug.js";
 import type { McpServerWizardData, KeyValueEntry } from "./types.js";
@@ -35,6 +35,7 @@ export function IdentityTransportStep({
   updateData,
   validationError,
 }: IdentityTransportStepProps) {
+  const baseId = useId();
   const handleNameChange = useCallback(
     (value: string) => {
       if (!data.slugTouched) {
@@ -79,13 +80,13 @@ export function IdentityTransportStep({
       <div className="stg:grid stg:gap-4 stg:sm:grid-cols-2">
         <div className="stg:space-y-1.5">
           <label
-            htmlFor="stgm-wizard-mcp-name"
+            htmlFor={`${baseId}-name`}
             className="stg:text-sm stg:font-medium stg:text-foreground"
           >
             Name <span className="stg:text-destructive">*</span>
           </label>
           <input
-            id="stgm-wizard-mcp-name"
+            id={`${baseId}-name`}
             type="text"
             value={data.name}
             onChange={(e) => handleNameChange(e.target.value)}
@@ -101,13 +102,13 @@ export function IdentityTransportStep({
 
         <div className="stg:space-y-1.5">
           <label
-            htmlFor="stgm-wizard-mcp-slug"
+            htmlFor={`${baseId}-slug`}
             className="stg:text-sm stg:font-medium stg:text-foreground"
           >
             Slug
           </label>
           <input
-            id="stgm-wizard-mcp-slug"
+            id={`${baseId}-slug`}
             type="text"
             value={data.slug}
             onChange={(e) => handleSlugChange(e.target.value)}
@@ -135,13 +136,13 @@ export function IdentityTransportStep({
       {/* Description */}
       <div className="stg:space-y-1.5">
         <label
-          htmlFor="stgm-wizard-mcp-description"
+          htmlFor={`${baseId}-description`}
           className="stg:text-sm stg:font-medium stg:text-foreground"
         >
           Description
         </label>
         <input
-          id="stgm-wizard-mcp-description"
+          id={`${baseId}-description`}
           type="text"
           value={data.description}
           onChange={(e) => updateData({ description: e.target.value })}
@@ -159,13 +160,13 @@ export function IdentityTransportStep({
       <div className="stg:grid stg:gap-4 stg:sm:grid-cols-2">
         <div className="stg:space-y-1.5">
           <label
-            htmlFor="stgm-wizard-mcp-icon"
+            htmlFor={`${baseId}-icon`}
             className="stg:text-sm stg:font-medium stg:text-foreground"
           >
             Icon URL
           </label>
           <input
-            id="stgm-wizard-mcp-icon"
+            id={`${baseId}-icon`}
             type="url"
             value={data.iconUrl}
             onChange={(e) => updateData({ iconUrl: e.target.value })}
@@ -184,14 +185,14 @@ export function IdentityTransportStep({
           </legend>
           <div className="stg:flex stg:gap-2">
             <RadioOption
-              name="stgm-wizard-mcp-visibility"
+              name={`${baseId}-visibility`}
               value="private"
               label="Private"
               checked={data.visibility === "private"}
               onChange={() => updateData({ visibility: "private" })}
             />
             <RadioOption
-              name="stgm-wizard-mcp-visibility"
+              name={`${baseId}-visibility`}
               value="public"
               label="Public"
               checked={data.visibility === "public"}
@@ -209,14 +210,14 @@ export function IdentityTransportStep({
         </legend>
         <div className="stg:flex stg:gap-2">
           <RadioOption
-            name="stgm-wizard-mcp-transport"
+            name={`${baseId}-transport`}
             value="http"
             label="HTTP (Streamable HTTP / SSE)"
             checked={data.transportType === "http"}
             onChange={() => updateData({ transportType: "http" })}
           />
           <RadioOption
-            name="stgm-wizard-mcp-transport"
+            name={`${baseId}-transport`}
             value="stdio"
             label="Stdio (local process)"
             checked={data.transportType === "stdio"}
@@ -236,13 +237,13 @@ export function IdentityTransportStep({
           <div className="stg:flex stg:flex-col stg:gap-4 stg:rounded-lg stg:border stg:border-border stg:p-4">
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-http-url"
+                htmlFor={`${baseId}-http-url`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 URL <span className="stg:text-destructive">*</span>
               </label>
               <input
-                id="stgm-wizard-mcp-http-url"
+                id={`${baseId}-http-url`}
                 type="url"
                 value={data.httpUrl}
                 onChange={(e) => updateData({ httpUrl: e.target.value })}
@@ -274,13 +275,13 @@ export function IdentityTransportStep({
 
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-http-timeout"
+                htmlFor={`${baseId}-http-timeout`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 Timeout (seconds)
               </label>
               <input
-                id="stgm-wizard-mcp-http-timeout"
+                id={`${baseId}-http-timeout`}
                 type="number"
                 min={0}
                 step={1}
@@ -308,13 +309,13 @@ export function IdentityTransportStep({
           <div className="stg:flex stg:flex-col stg:gap-4 stg:rounded-lg stg:border stg:border-border stg:p-4">
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-stdio-command"
+                htmlFor={`${baseId}-stdio-command`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 Command <span className="stg:text-destructive">*</span>
               </label>
               <input
-                id="stgm-wizard-mcp-stdio-command"
+                id={`${baseId}-stdio-command`}
                 type="text"
                 value={data.stdioCommand}
                 onChange={(e) => updateData({ stdioCommand: e.target.value })}
@@ -329,13 +330,13 @@ export function IdentityTransportStep({
 
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-stdio-args"
+                htmlFor={`${baseId}-stdio-args`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 Arguments
               </label>
               <input
-                id="stgm-wizard-mcp-stdio-args"
+                id={`${baseId}-stdio-args`}
                 type="text"
                 value={data.stdioArgs}
                 onChange={(e) => updateData({ stdioArgs: e.target.value })}
@@ -353,13 +354,13 @@ export function IdentityTransportStep({
 
             <div className="stg:space-y-1.5">
               <label
-                htmlFor="stgm-wizard-mcp-stdio-workdir"
+                htmlFor={`${baseId}-stdio-workdir`}
                 className="stg:text-sm stg:font-medium stg:text-foreground"
               >
                 Working Directory
               </label>
               <input
-                id="stgm-wizard-mcp-stdio-workdir"
+                id={`${baseId}-stdio-workdir`}
                 type="text"
                 value={data.stdioWorkingDir}
                 onChange={(e) =>

--- a/sdk/react/src/oauth-app/CreateOAuthAppForm.tsx
+++ b/sdk/react/src/oauth-app/CreateOAuthAppForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
@@ -57,6 +57,7 @@ export function CreateOAuthAppForm({
   onCancel,
   className,
 }: CreateOAuthAppFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } = useCreateOAuthApp();
 
   const [name, setName] = useState("");
@@ -152,7 +153,7 @@ export function CreateOAuthAppForm({
     <form onSubmit={handleSubmit} className={cn("stg:space-y-3", className)}>
       <div className="stg:space-y-3">
         <FormField
-          id="stgm-oauth-name"
+          id={`${baseId}-name`}
           label="Name"
           value={name}
           onChange={setName}
@@ -162,7 +163,7 @@ export function CreateOAuthAppForm({
         />
 
         <FormField
-          id="stgm-oauth-provider"
+          id={`${baseId}-provider`}
           label="Provider"
           value={provider}
           onChange={setProvider}
@@ -173,7 +174,7 @@ export function CreateOAuthAppForm({
         />
 
         <FormField
-          id="stgm-oauth-client-id"
+          id={`${baseId}-client-id`}
           label="Client ID"
           value={clientId}
           onChange={setClientId}
@@ -183,7 +184,7 @@ export function CreateOAuthAppForm({
         />
 
         <FormField
-          id="stgm-oauth-client-secret"
+          id={`${baseId}-client-secret`}
           label="Client secret"
           value={clientSecret}
           onChange={setClientSecret}
@@ -194,7 +195,7 @@ export function CreateOAuthAppForm({
         />
 
         <FormField
-          id="stgm-oauth-auth-url"
+          id={`${baseId}-auth-url`}
           label="Authorization URL"
           value={authorizationUrl}
           onChange={setAuthorizationUrl}
@@ -205,7 +206,7 @@ export function CreateOAuthAppForm({
         />
 
         <FormField
-          id="stgm-oauth-token-url"
+          id={`${baseId}-token-url`}
           label="Token URL"
           value={tokenUrl}
           onChange={setTokenUrl}
@@ -229,7 +230,7 @@ export function CreateOAuthAppForm({
           {showAdvanced && (
             <div className="stg:mt-2 stg:space-y-3 stg:border-l-2 stg:border-border-muted stg:pl-3">
               <FormField
-                id="stgm-oauth-scopes"
+                id={`${baseId}-scopes`}
                 label="Scopes"
                 value={scopes}
                 onChange={setScopes}
@@ -239,7 +240,7 @@ export function CreateOAuthAppForm({
               />
 
               <FormField
-                id="stgm-oauth-userinfo-url"
+                id={`${baseId}-userinfo-url`}
                 label="Userinfo URL"
                 value={userinfoUrl}
                 onChange={setUserinfoUrl}
@@ -249,7 +250,7 @@ export function CreateOAuthAppForm({
               />
 
               <FormField
-                id="stgm-oauth-scope-param"
+                id={`${baseId}-scope-param`}
                 label="Scope parameter name"
                 value={scopeParameterName}
                 onChange={setScopeParameterName}
@@ -260,13 +261,13 @@ export function CreateOAuthAppForm({
 
               <div className="stg:space-y-1">
                 <label
-                  htmlFor="stgm-oauth-approval-status"
+                  htmlFor={`${baseId}-approval-status`}
                   className="stg:text-xs stg:font-medium stg:text-foreground"
                 >
                   Vendor approval status
                 </label>
                 <select
-                  id="stgm-oauth-approval-status"
+                  id={`${baseId}-approval-status`}
                   value={vendorApprovalStatus}
                   onChange={(e) =>
                     setVendorApprovalStatus(
@@ -291,7 +292,7 @@ export function CreateOAuthAppForm({
               </div>
 
               <FormField
-                id="stgm-oauth-approval-docs"
+                id={`${baseId}-approval-docs`}
                 label="Vendor approval docs URL"
                 value={vendorApprovalDocsUrl}
                 onChange={setVendorApprovalDocsUrl}

--- a/sdk/react/src/oauth-app/OAuthAppDetailPanel.tsx
+++ b/sdk/react/src/oauth-app/OAuthAppDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
@@ -62,6 +62,7 @@ export function OAuthAppDetailPanel({
   onBack,
   className,
 }: OAuthAppDetailPanelProps) {
+  const baseId = useId();
   const spec = oauthApp.spec;
   const meta = oauthApp.metadata;
 
@@ -298,7 +299,7 @@ export function OAuthAppDetailPanel({
       ) : (
         <form onSubmit={handleSave} className="stg:space-y-3">
           <FieldInput
-            id="stgm-oauth-edit-provider"
+            id={`${baseId}-provider`}
             label="Provider"
             value={provider}
             onChange={setProvider}
@@ -307,7 +308,7 @@ export function OAuthAppDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-oauth-edit-client-id"
+            id={`${baseId}-client-id`}
             label="Client ID"
             value={clientId}
             onChange={setClientId}
@@ -316,7 +317,7 @@ export function OAuthAppDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-oauth-edit-client-secret"
+            id={`${baseId}-client-secret`}
             label="Client secret"
             value={clientSecret}
             onChange={setClientSecret}
@@ -326,7 +327,7 @@ export function OAuthAppDetailPanel({
             disabled={isUpdating}
           />
           <FieldInput
-            id="stgm-oauth-edit-auth-url"
+            id={`${baseId}-auth-url`}
             label="Authorization URL"
             value={authorizationUrl}
             onChange={setAuthorizationUrl}
@@ -335,7 +336,7 @@ export function OAuthAppDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-oauth-edit-token-url"
+            id={`${baseId}-token-url`}
             label="Token URL"
             value={tokenUrl}
             onChange={setTokenUrl}
@@ -344,7 +345,7 @@ export function OAuthAppDetailPanel({
             required
           />
           <FieldInput
-            id="stgm-oauth-edit-scopes"
+            id={`${baseId}-scopes`}
             label="Scopes"
             value={scopes}
             onChange={setScopes}
@@ -353,7 +354,7 @@ export function OAuthAppDetailPanel({
             disabled={isUpdating}
           />
           <FieldInput
-            id="stgm-oauth-edit-userinfo-url"
+            id={`${baseId}-userinfo-url`}
             label="Userinfo URL"
             value={userinfoUrl}
             onChange={setUserinfoUrl}
@@ -362,7 +363,7 @@ export function OAuthAppDetailPanel({
             disabled={isUpdating}
           />
           <FieldInput
-            id="stgm-oauth-edit-scope-param"
+            id={`${baseId}-scope-param`}
             label="Scope parameter name"
             value={scopeParameterName}
             onChange={setScopeParameterName}
@@ -373,13 +374,13 @@ export function OAuthAppDetailPanel({
 
           <div className="stg:space-y-1">
             <label
-              htmlFor="stgm-oauth-edit-approval-status"
+              htmlFor={`${baseId}-approval-status`}
               className="stg:text-xs stg:font-medium stg:text-foreground"
             >
               Vendor approval status
             </label>
             <select
-              id="stgm-oauth-edit-approval-status"
+              id={`${baseId}-approval-status`}
               value={vendorApprovalStatus}
               onChange={(e) =>
                 setVendorApprovalStatus(
@@ -401,7 +402,7 @@ export function OAuthAppDetailPanel({
           </div>
 
           <FieldInput
-            id="stgm-oauth-edit-approval-docs"
+            id={`${baseId}-approval-docs`}
             label="Vendor approval docs URL"
             value={vendorApprovalDocsUrl}
             onChange={setVendorApprovalDocsUrl}

--- a/sdk/react/src/organization/CreateOrganizationForm.tsx
+++ b/sdk/react/src/organization/CreateOrganizationForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useRef, useState } from "react";
 import { create as createMessage } from "@bufbuild/protobuf";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
@@ -48,6 +48,7 @@ export function CreateOrganizationForm({
   onCancel,
   className,
 }: CreateOrganizationFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } = useCreateOrganization();
 
   const [name, setName] = useState("");
@@ -121,13 +122,13 @@ export function CreateOrganizationForm({
         {/* ---- Name ---- */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-new-org-name"
+            htmlFor={`${baseId}-name`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Name
           </label>
           <input
-            id="stgm-new-org-name"
+            id={`${baseId}-name`}
             type="text"
             value={name}
             onChange={(e) => handleNameChange(e.target.value)}
@@ -158,13 +159,13 @@ export function CreateOrganizationForm({
         {/* ---- Slug ---- */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-new-org-slug"
+            htmlFor={`${baseId}-slug`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Slug
           </label>
           <input
-            id="stgm-new-org-slug"
+            id={`${baseId}-slug`}
             type="text"
             value={slug}
             onChange={(e) => handleSlugChange(e.target.value)}
@@ -196,14 +197,14 @@ export function CreateOrganizationForm({
         {/* ---- Description ---- */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-new-org-desc"
+            htmlFor={`${baseId}-desc`}
             className="stg:text-xs stg:font-medium stg:text-muted-foreground"
           >
             Description{" "}
             <span className="stg:text-muted-foreground-subtle">(optional)</span>
           </label>
           <input
-            id="stgm-new-org-desc"
+            id={`${baseId}-desc`}
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}

--- a/sdk/react/src/organization/OrgProfilePanel.tsx
+++ b/sdk/react/src/organization/OrgProfilePanel.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type FormEvent,
-} from "react";
+import { type FormEvent, useCallback, useEffect, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
@@ -62,6 +56,7 @@ export function OrgProfilePanel({
   onUpdated,
   className,
 }: OrgProfilePanelProps) {
+  const baseId = useId();
   const {
     organization,
     isLoading: isFetching,
@@ -225,13 +220,13 @@ export function OrgProfilePanel({
         {/* Name */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-org-profile-name"
+            htmlFor={`${baseId}-name`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Name
           </label>
           <input
-            id="stgm-org-profile-name"
+            id={`${baseId}-name`}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -252,13 +247,13 @@ export function OrgProfilePanel({
         {/* Description */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-org-profile-desc"
+            htmlFor={`${baseId}-desc`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Description
           </label>
           <textarea
-            id="stgm-org-profile-desc"
+            id={`${baseId}-desc`}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             maxLength={DESCRIPTION_MAX_LEN}
@@ -280,13 +275,13 @@ export function OrgProfilePanel({
         {/* Logo URL */}
         <div className="stg:space-y-1">
           <label
-            htmlFor="stgm-org-profile-logo"
+            htmlFor={`${baseId}-logo`}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Logo URL
           </label>
           <input
-            id="stgm-org-profile-logo"
+            id={`${baseId}-logo`}
             type="url"
             value={logoUrl}
             onChange={(e) => setLogoUrl(e.target.value)}

--- a/sdk/react/src/platform-client/CreatePlatformClientForm.tsx
+++ b/sdk/react/src/platform-client/CreatePlatformClientForm.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useState,
-  type FormEvent,
-  type KeyboardEvent,
-} from "react";
+import { type FormEvent, type KeyboardEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
@@ -59,6 +54,7 @@ export function CreatePlatformClientForm({
   onCancel,
   className,
 }: CreatePlatformClientFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } =
     useCreatePlatformClient();
 
@@ -161,7 +157,7 @@ export function CreatePlatformClientForm({
   return (
     <form onSubmit={handleSubmit} className={cn("stg:space-y-3", className)}>
       <FormField
-        id="stgm-pc-name"
+        id={`${baseId}-name`}
         label="Name"
         value={name}
         onChange={setName}
@@ -184,13 +180,13 @@ export function CreatePlatformClientForm({
         {!neverExpires && (
           <div className="stg:space-y-1">
             <label
-              htmlFor="stgm-pc-expires-at"
+              htmlFor={`${baseId}-expires-at`}
               className="stg:text-xs stg:font-medium stg:text-foreground"
             >
               Expires at
             </label>
             <input
-              id="stgm-pc-expires-at"
+              id={`${baseId}-expires-at`}
               type="datetime-local"
               value={expiresAt}
               onChange={(e) => setExpiresAt(e.target.value)}
@@ -235,13 +231,13 @@ export function CreatePlatformClientForm({
         {autoGrant && (
           <div className="stg:space-y-1">
             <label
-              htmlFor="stgm-pc-grant-role"
+              htmlFor={`${baseId}-grant-role`}
               className="stg:text-xs stg:font-medium stg:text-foreground"
             >
               Auto-grant role
             </label>
             <select
-              id="stgm-pc-grant-role"
+              id={`${baseId}-grant-role`}
               value={String(autoGrantRole)}
               onChange={(e) =>
                 setAutoGrantRole(Number(e.target.value) as IamRole)

--- a/sdk/react/src/platform-client/PlatformClientDetailPanel.tsx
+++ b/sdk/react/src/platform-client/PlatformClientDetailPanel.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useState,
-  type FormEvent,
-  type KeyboardEvent,
-} from "react";
+import { type FormEvent, type KeyboardEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
@@ -75,6 +70,7 @@ export function PlatformClientDetailPanel({
   onBack,
   className,
 }: PlatformClientDetailPanelProps) {
+  const baseId = useId();
   const spec = platformClient.spec;
   const meta = platformClient.metadata;
 
@@ -319,13 +315,13 @@ export function PlatformClientDetailPanel({
             {!neverExpires && (
               <div className="stg:space-y-1">
                 <label
-                  htmlFor="stgm-pc-edit-expires-at"
+                  htmlFor={`${baseId}-expires-at`}
                   className="stg:text-xs stg:font-medium stg:text-foreground"
                 >
                   Expires at
                 </label>
                 <input
-                  id="stgm-pc-edit-expires-at"
+                  id={`${baseId}-expires-at`}
                   type="datetime-local"
                   value={expiresAt}
                   onChange={(e) => setExpiresAt(e.target.value)}
@@ -366,13 +362,13 @@ export function PlatformClientDetailPanel({
             {autoGrant && (
               <div className="stg:space-y-1">
                 <label
-                  htmlFor="stgm-pc-edit-grant-role"
+                  htmlFor={`${baseId}-grant-role`}
                   className="stg:text-xs stg:font-medium stg:text-foreground"
                 >
                   Auto-grant role
                 </label>
                 <select
-                  id="stgm-pc-edit-grant-role"
+                  id={`${baseId}-grant-role`}
                   value={String(autoGrantRole)}
                   onChange={(e) =>
                     setAutoGrantRole(

--- a/sdk/react/src/platform-client/PlatformClientSecretAlert.tsx
+++ b/sdk/react/src/platform-client/PlatformClientSecretAlert.tsx
@@ -86,12 +86,10 @@ export function PlatformClientSecretAlert({
 
       <div className="stg:space-y-2">
         <CopyableField
-          id="stgm-pc-client-id-reveal"
           label="Client ID"
           value={clientId}
         />
         <CopyableField
-          id="stgm-pc-secret-reveal"
           label="Client secret"
           value={clientSecret}
         />
@@ -105,11 +103,9 @@ export function PlatformClientSecretAlert({
 // ---------------------------------------------------------------------------
 
 function CopyableField({
-  id,
   label,
   value,
 }: {
-  id: string;
   label: string;
   value: string;
 }) {
@@ -133,7 +129,6 @@ function CopyableField({
       <div className="stg:mt-0.5 stg:flex stg:items-center stg:gap-2">
         <code
           ref={revealRef}
-          id={id}
           className={cn(
             "stg:min-w-0 stg:flex-1 stg:select-all stg:truncate stg:rounded-md",
             "stg:border stg:border-input stg:bg-background stg:px-2.5 stg:py-1.5",

--- a/sdk/react/src/schedule/ScheduleForm.tsx
+++ b/sdk/react/src/schedule/ScheduleForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
 import {
   getUserMessage,
@@ -85,6 +85,7 @@ export function ScheduleForm({
   onCancel,
   className,
 }: ScheduleFormProps) {
+  const baseId = useId();
   const { create, isCreating, error, clearError } = useCreateSchedule();
 
   const [name, setName] = useState("");
@@ -210,11 +211,11 @@ export function ScheduleForm({
     >
       {/* Name */}
       <div className="stg:space-y-1">
-        <label htmlFor="stgm-new-schedule-name" className={labelClasses}>
+        <label htmlFor={`${baseId}-name`} className={labelClasses}>
           Name
         </label>
         <input
-          id="stgm-new-schedule-name"
+          id={`${baseId}-name`}
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -228,13 +229,13 @@ export function ScheduleForm({
 
       {/* Target agent */}
       <div className="stg:space-y-1">
-        <span id="stgm-new-schedule-agent-label" className={labelClasses}>
+        <span id={`${baseId}-agent-label`} className={labelClasses}>
           Agent to run
         </span>
         <Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
           <Popover.Trigger
             disabled={isCreating}
-            aria-labelledby="stgm-new-schedule-agent-label"
+            aria-labelledby={`${baseId}-agent-label`}
             className={cn(
               "stg:flex stg:w-full stg:items-center stg:justify-between stg:rounded-md stg:border stg:border-input stg:bg-background stg:px-2.5 stg:py-1.5 stg:text-left stg:text-xs",
               "stg:focus-visible:outline-none stg:focus-visible:ring-1 stg:focus-visible:ring-ring",
@@ -268,11 +269,11 @@ export function ScheduleForm({
 
       {/* Message */}
       <div className="stg:space-y-1">
-        <label htmlFor="stgm-new-schedule-message" className={labelClasses}>
+        <label htmlFor={`${baseId}-message`} className={labelClasses}>
           Message
         </label>
         <textarea
-          id="stgm-new-schedule-message"
+          id={`${baseId}-message`}
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           placeholder="The instruction the agent receives on every fire — write it for a run with no human present."
@@ -315,7 +316,7 @@ export function ScheduleForm({
           schedule fire, so the picker is filtered to visibility_org —
           the same credential surface a channel binding uses. */}
       <div className="stg:space-y-1">
-        <span id="stgm-new-schedule-env-label" className={labelClasses}>
+        <span id={`${baseId}-env-label`} className={labelClasses}>
           Environments <span className="stg:font-normal stg:text-muted-foreground">(optional)</span>
         </span>
         <EnvironmentPicker
@@ -392,12 +393,12 @@ export function ScheduleForm({
           surface: nobody is watching a 3 AM fire (DD-018 D-5). Clamped
           by the platform profile; tool-round bounds stay API-only. */}
       <div className="stg:space-y-1">
-        <label htmlFor="stgm-new-schedule-budget" className={labelClasses}>
+        <label htmlFor={`${baseId}-budget`} className={labelClasses}>
           Budget per run (USD){" "}
           <span className="stg:font-normal stg:text-muted-foreground">(optional)</span>
         </label>
         <input
-          id="stgm-new-schedule-budget"
+          id={`${baseId}-budget`}
           type="number"
           min="0"
           step="any"
@@ -416,11 +417,11 @@ export function ScheduleForm({
 
       {/* Time zone */}
       <div className="stg:space-y-1">
-        <label htmlFor="stgm-new-schedule-tz" className={labelClasses}>
+        <label htmlFor={`${baseId}-tz`} className={labelClasses}>
           Time zone
         </label>
         <TimeZoneField
-          id="stgm-new-schedule-tz"
+          id={`${baseId}-tz`}
           value={timeZone}
           onChange={setTimeZone}
           disabled={isCreating}
@@ -430,16 +431,16 @@ export function ScheduleForm({
       {/* Enabled */}
       <div className="stg:flex stg:items-start stg:gap-3">
         <Switch
-          id="stgm-new-schedule-enabled"
+          id={`${baseId}-enabled`}
           checked={enabled}
           onCheckedChange={setEnabled}
           disabled={isCreating}
-          aria-labelledby="stgm-new-schedule-enabled-label"
+          aria-labelledby={`${baseId}-enabled-label`}
         />
         <div className="stg:space-y-0.5">
           <label
-            id="stgm-new-schedule-enabled-label"
-            htmlFor="stgm-new-schedule-enabled"
+            id={`${baseId}-enabled-label`}
+            htmlFor={`${baseId}-enabled`}
             className={labelClasses}
           >
             Enabled

--- a/sdk/react/src/settings/ApiKeysSection.tsx
+++ b/sdk/react/src/settings/ApiKeysSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import type { ApiKey } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/api_pb";
 import { ApiKeyListPanel } from "../api-key/ApiKeyListPanel.js";
 import { CreateApiKeyForm } from "../api-key/CreateApiKeyForm.js";
@@ -16,6 +16,7 @@ type FlowState =
 
 /** Settings section for listing and creating organization API keys. */
 export function ApiKeysSection() {
+  const headingId = useId();
   const org = useActiveOrgSlug();
   const apiKeysAvailable = useResourceAvailable(ApiResourceKind.api_key);
   const [flow, setFlow] = useState<FlowState>({ phase: "idle" });
@@ -37,10 +38,10 @@ export function ApiKeysSection() {
   }, []);
 
   return (
-    <section aria-labelledby="api-keys-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-center stg:justify-between">
         <h2
-          id="api-keys-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           API Keys

--- a/sdk/react/src/settings/ChannelAppsSection.tsx
+++ b/sdk/react/src/settings/ChannelAppsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
 import { ChannelAppListPanel } from "../channel-app/ChannelAppListPanel.js";
 import {
@@ -38,6 +38,7 @@ type FlowState =
  * Channels tab offers it as the serving app.
  */
 export function ChannelAppsSection() {
+  const headingId = useId();
   const org = useActiveOrgSlug();
   // Channel installs (the consumer of these credentials) are cloud-only;
   // gate the whole section the way the Channels tab gates connects.
@@ -72,10 +73,10 @@ export function ChannelAppsSection() {
   }, []);
 
   return (
-    <section aria-labelledby="channel-apps-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-center stg:justify-between">
         <h2
-          id="channel-apps-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           Channel Apps

--- a/sdk/react/src/settings/EnvironmentsSection.tsx
+++ b/sdk/react/src/settings/EnvironmentsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { getUserMessage } from "@stigmer/sdk";
 import { usePersonalEnvironment } from "../environment/usePersonalEnvironment.js";
 import { EnvironmentVariableEditor } from "../environment/EnvironmentVariableEditor.js";
@@ -47,12 +47,13 @@ function PersonalEnvironmentCard({ org }: { org: string }) {
   }, [org, isLoading, environment, getOrCreate]);
 
   const environmentId = environment?.metadata?.id;
+  const headingId = useId();
 
   return (
-    <section aria-labelledby="personal-env-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-baseline stg:gap-2">
         <h2
-          id="personal-env-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           Personal Environment
@@ -97,11 +98,13 @@ function EnvironmentsCard({ org }: { org: string }) {
     listRefetchRef.current?.();
   }, []);
 
+  const headingId = useId();
+
   return (
-    <section aria-labelledby="org-env-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-center stg:justify-between">
         <h2
-          id="org-env-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           Environments

--- a/sdk/react/src/settings/IdentityProvidersSection.tsx
+++ b/sdk/react/src/settings/IdentityProvidersSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
 import { IdentityProviderListPanel } from "../identity-provider/IdentityProviderListPanel.js";
 import { IdentityProviderWizard } from "../identity-provider/IdentityProviderWizard.js";
@@ -28,6 +28,7 @@ type FlowState =
 export function IdentityProvidersSection({
   ssoLoginBaseUrl,
 }: IdentityProvidersSectionProps = {}) {
+  const headingId = useId();
   const { activeOrg } = useOrg();
   const idpAvailable = useResourceAvailable(ApiResourceKind.identity_provider);
   const orgSlug = activeOrg?.metadata?.slug ?? "";
@@ -54,10 +55,10 @@ export function IdentityProvidersSection({
     (typeof window !== "undefined" ? window.location.origin : "");
 
   return (
-    <section aria-labelledby="identity-providers-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-center stg:justify-between">
         <h2
-          id="identity-providers-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           Identity Providers

--- a/sdk/react/src/settings/InvitationsSection.tsx
+++ b/sdk/react/src/settings/InvitationsSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { InvitationManager } from "../invitation/InvitationManager.js";
 import { useResourceAvailable, ApiResourceKind } from "../deployment-mode.js";
 import { CloudFeatureNotice } from "../internal/CloudFeatureNotice.js";
@@ -7,14 +8,15 @@ import { useActiveOrgSlug } from "../organization/OrgProvider.js";
 
 /** Settings section for creating and managing organization invitations. */
 export function InvitationsSection() {
+  const headingId = useId();
   const org = useActiveOrgSlug();
   const invitationsAvailable = useResourceAvailable(ApiResourceKind.invitation);
 
   return (
-    <section aria-labelledby="invitations-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3">
         <h2
-          id="invitations-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           Invitations

--- a/sdk/react/src/settings/MembersSection.tsx
+++ b/sdk/react/src/settings/MembersSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { OrgMembersPanel } from "../iam-policy/OrgMembersPanel.js";
 import { useResourceAvailable, ApiResourceKind } from "../deployment-mode.js";
 import { CloudFeatureNotice } from "../internal/CloudFeatureNotice.js";
@@ -8,6 +9,7 @@ import { useIdentityProviderList } from "../identity-provider/useIdentityProvide
 
 /** Settings section for organization membership and role management. */
 export function MembersSection() {
+  const headingId = useId();
   const { activeOrg } = useOrg();
   const membersAvailable = useResourceAvailable(ApiResourceKind.iam_policy);
   const idpAvailable = useResourceAvailable(ApiResourceKind.identity_provider);
@@ -23,9 +25,9 @@ export function MembersSection() {
   );
 
   return (
-    <section aria-labelledby="members-heading">
+    <section aria-labelledby={headingId}>
       <h2
-        id="members-heading"
+        id={headingId}
         className="stg:text-foreground stg:mb-1 stg:text-sm stg:font-semibold"
       >
         Members

--- a/sdk/react/src/settings/OAuthAppsSection.tsx
+++ b/sdk/react/src/settings/OAuthAppsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
 import { OAuthAppListPanel } from "../oauth-app/OAuthAppListPanel.js";
 import { CreateOAuthAppForm } from "../oauth-app/CreateOAuthAppForm.js";
@@ -16,6 +16,7 @@ type FlowState =
 
 /** Settings section for organization OAuth app credentials. */
 export function OAuthAppsSection() {
+  const headingId = useId();
   const org = useActiveOrgSlug();
   const oauthAppsAvailable = useResourceAvailable(ApiResourceKind.oauth_app);
 
@@ -42,10 +43,10 @@ export function OAuthAppsSection() {
   }, []);
 
   return (
-    <section aria-labelledby="oauth-apps-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-center stg:justify-between">
         <h2
-          id="oauth-apps-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           OAuth Apps

--- a/sdk/react/src/settings/OrgProfileSection.tsx
+++ b/sdk/react/src/settings/OrgProfileSection.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useId } from "react";
 import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
 import { OrgProfilePanel } from "../organization/OrgProfilePanel.js";
 import { useOrg } from "../organization/OrgProvider.js";
 
 /** Settings section for editing the active organization profile. */
 export function OrgProfileSection() {
+  const headingId = useId();
   const { activeOrg, refresh } = useOrg();
   const orgId = activeOrg?.metadata?.id ?? "";
 
@@ -18,9 +19,9 @@ export function OrgProfileSection() {
   );
 
   return (
-    <section aria-labelledby="org-profile-heading">
+    <section aria-labelledby={headingId}>
       <h2
-        id="org-profile-heading"
+        id={headingId}
         className="stg:text-foreground stg:mb-1 stg:text-sm stg:font-semibold"
       >
         Organization Profile

--- a/sdk/react/src/settings/PlatformClientsSection.tsx
+++ b/sdk/react/src/settings/PlatformClientsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import type { PlatformClient } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/api_pb";
 import type { PlatformClientCreateResponse } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/io_pb";
 import { PlatformClientListPanel } from "../platform-client/PlatformClientListPanel.js";
@@ -24,6 +24,7 @@ type FlowState =
 
 /** Settings section for creating and maintaining platform clients. */
 export function PlatformClientsSection() {
+  const headingId = useId();
   const org = useActiveOrgSlug();
   const pcAvailable = useResourceAvailable(ApiResourceKind.platform_client);
 
@@ -71,10 +72,10 @@ export function PlatformClientsSection() {
   }, []);
 
   return (
-    <section aria-labelledby="platform-clients-heading">
+    <section aria-labelledby={headingId}>
       <div className="stg:mb-3 stg:flex stg:items-center stg:justify-between">
         <h2
-          id="platform-clients-heading"
+          id={headingId}
           className="stg:text-foreground stg:text-sm stg:font-semibold"
         >
           Platform Clients

--- a/sdk/react/src/settings/UsageSection.tsx
+++ b/sdk/react/src/settings/UsageSection.tsx
@@ -1,17 +1,19 @@
 "use client";
 
+import { useId } from "react";
 import { OrgUsagePanel } from "../usage/OrgUsagePanel.js";
 import { useOrg } from "../organization/OrgProvider.js";
 
 /** Settings section for organization usage and cost reporting. */
 export function UsageSection() {
+  const headingId = useId();
   const { activeOrg } = useOrg();
   const orgId = activeOrg?.metadata?.id ?? "";
 
   return (
-    <section aria-labelledby="usage-heading">
+    <section aria-labelledby={headingId}>
       <h2
-        id="usage-heading"
+        id={headingId}
         className="stg:text-foreground stg:mb-1 stg:text-sm stg:font-semibold"
       >
         Usage

--- a/sdk/react/src/sidebar/__tests__/WorkspaceSidebar.test.tsx
+++ b/sdk/react/src/sidebar/__tests__/WorkspaceSidebar.test.tsx
@@ -274,7 +274,10 @@ describe("WorkspaceSidebar — chrome", () => {
     expect(screen.getByTestId("footer-slot")).toBeTruthy();
     const toggle = screen.getByLabelText("Collapse sidebar");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(toggle.getAttribute("aria-controls")).toBe("sidebar");
+    // The nav id is minted per mount; assert the association, not the value.
+    const controlsId = toggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId!)?.tagName).toBe("NAV");
   });
 
   it("resolves the org switcher from the mocked transport", async () => {

--- a/sdk/react/src/sidebar/chrome.tsx
+++ b/sdk/react/src/sidebar/chrome.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import { PanelLeft } from "lucide-react";
 import { cn } from "@stigmer/theme";
 import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
@@ -46,9 +46,8 @@ export interface SidebarChromeProps {
 /**
  * Outer sidebar frame: `<nav>` container, top row, content, footer band.
  *
- * The `id="sidebar"` / `aria-controls` pairing matches the console's DOM
- * contract (the app shell's floating "Open sidebar" button targets it);
- * only one sidebar renders at a time, so the id cannot collide.
+ * The nav id exists solely for the collapse toggle's `aria-controls`
+ * association; it is minted per mount like every SDK DOM id.
  */
 export function SidebarChrome({
   ariaLabel,
@@ -58,9 +57,10 @@ export function SidebarChrome({
   footer,
   children,
 }: SidebarChromeProps) {
+  const navId = useId();
   return (
     <nav
-      id="sidebar"
+      id={navId}
       aria-label={ariaLabel}
       className="stg:bg-sidebar stg:text-sidebar-foreground stg:flex stg:h-full stg:flex-col"
     >
@@ -70,7 +70,7 @@ export function SidebarChrome({
           type="button"
           onClick={onCollapse}
           aria-expanded={isOpen}
-          aria-controls="sidebar"
+          aria-controls={navId}
           aria-label="Collapse sidebar"
           className={cn(
             "stg:inline-flex stg:size-7 stg:shrink-0 stg:items-center stg:justify-center stg:rounded-md",

--- a/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
 import {
   useWorkflowArchitectFlow,
@@ -177,6 +177,7 @@ function InputPhase({
   readonly flow: ReturnType<typeof useWorkflowArchitectFlow>;
   readonly onClose: () => void;
 }) {
+  const promptId = useId();
   return (
     <>
       <div className="stg:border-b stg:border-border stg:px-6 stg:py-4">
@@ -201,7 +202,7 @@ function InputPhase({
 
         <div className="stg:flex stg:flex-col stg:gap-1">
           <label
-            htmlFor="architect-prompt"
+            htmlFor={promptId}
             className="stg:text-xs stg:font-medium stg:text-foreground"
           >
             Description
@@ -210,7 +211,7 @@ function InputPhase({
             </span>
           </label>
           <textarea
-            id="architect-prompt"
+            id={promptId}
             value={flow.prompt}
             onChange={(e) => flow.setPrompt(e.target.value)}
             placeholder="e.g., A workflow that enriches customer data using my data-agent, validates the output, and sends a Slack notification on failure"

--- a/sdk/react/src/workflow/picker/BranchAddPopover.tsx
+++ b/sdk/react/src/workflow/picker/BranchAddPopover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, useCallback, useRef, useEffect } from "react";
+import { memo, useState, useCallback, useId, useRef, useEffect } from "react";
 import { Popover } from "@base-ui/react/popover";
 import { cn } from "@stigmer/theme";
 import { useStigmerPortalContainer } from "../../portal-container.js";
@@ -76,6 +76,7 @@ export const BranchAddPopover = memo(function BranchAddPopover({
   side = "bottom",
   align = "start",
 }: BranchAddPopoverProps) {
+  const errorId = useId();
   const portalContainer = useStigmerPortalContainer();
   const config = MODE_CONFIG[mode];
   const nameRef = useRef<HTMLInputElement>(null);
@@ -175,11 +176,11 @@ export const BranchAddPopover = memo(function BranchAddPopover({
                       nameError ? "stg:border-[var(--stgm-destructive,#ef4444)]" : "stg:border-border",
                     )}
                     aria-invalid={!!nameError}
-                    aria-describedby={nameError ? "branch-name-error" : undefined}
+                    aria-describedby={nameError ? errorId : undefined}
                   />
                   {nameError && (
                     <p
-                      id="branch-name-error"
+                      id={errorId}
                       className="stg:mt-0.5 stg:text-[10px] stg:text-[var(--stgm-destructive,#ef4444)]"
                     >
                       {nameError}

--- a/test/e2e/tests/functional/settings.spec.ts
+++ b/test/e2e/tests/functional/settings.spec.ts
@@ -13,64 +13,59 @@ import { test, expect } from "@playwright/test";
  *   show CloudFeatureNotice in OSS mode)
  */
 
+// Sections are located through the accessibility tree: each settings
+// section is a <section aria-labelledby={headingId}> whose heading gives it
+// an accessible name, i.e. role=region. The heading ids themselves are
+// minted per mount with useId() (oss#619) and carry no stable value to
+// anchor on — the accessible name is the contract.
 const SETTINGS_SECTIONS = [
   {
     path: "/settings/api-keys",
-    headingId: "api-keys-heading",
     headingText: "API Keys",
     cloudGated: true,
   },
   {
     path: "/settings/environments",
-    headingId: "personal-env-heading",
     headingText: "Personal Environment",
     cloudGated: false,
   },
   {
     path: "/settings/members",
-    headingId: "members-heading",
     headingText: "Members",
     cloudGated: true,
   },
   {
     path: "/settings/invitations",
-    headingId: "invitations-heading",
     headingText: "Invitations",
     cloudGated: true,
   },
   {
     path: "/settings/identity-providers",
-    headingId: "identity-providers-heading",
     headingText: "Identity Providers",
     cloudGated: true,
   },
   {
     path: "/settings/platform-clients",
-    headingId: "platform-clients-heading",
     headingText: "Platform Clients",
     cloudGated: true,
   },
   {
     path: "/settings/oauth-apps",
-    headingId: "oauth-apps-heading",
     headingText: "OAuth Apps",
     cloudGated: true,
   },
   {
     path: "/settings/org-profile",
-    headingId: "org-profile-heading",
     headingText: "Organization Profile",
     cloudGated: false,
   },
   {
     path: "/settings/billing",
-    headingId: "billing-heading",
     headingText: "Billing",
     cloudGated: true,
   },
   {
     path: "/settings/usage",
-    headingId: "usage-heading",
     headingText: "Usage",
     cloudGated: false,
   },
@@ -130,9 +125,14 @@ test.describe("Settings sections", () => {
     }) => {
       await page.goto(section.path);
 
-      const sectionHeading = page.locator(`#${section.headingId}`);
-      await expect(sectionHeading).toBeVisible({ timeout: 15_000 });
-      await expect(sectionHeading).toHaveText(section.headingText);
+      // The region only has this accessible name if the heading↔section
+      // aria-labelledby association is intact — the same wiring the old
+      // literal-id selectors asserted, now checked through semantics.
+      const region = page.getByRole("region", { name: section.headingText });
+      await expect(region).toBeVisible({ timeout: 15_000 });
+      await expect(
+        region.getByRole("heading", { name: section.headingText }),
+      ).toBeVisible();
 
       await expect(page.getByText("Something went wrong")).toHaveCount(0);
     });
@@ -144,21 +144,17 @@ test.describe("Settings sections", () => {
     }) => {
       await page.goto(section.path);
 
-      const sectionHeading = page.locator(`#${section.headingId}`);
-      await expect(sectionHeading).toBeVisible({ timeout: 15_000 });
+      const region = page.getByRole("region", { name: section.headingText });
+      await expect(region).toBeVisible({ timeout: 15_000 });
 
-      const cloudNotice = page
-        .locator(`section[aria-labelledby="${section.headingId}"]`)
-        .locator('[role="status"]');
-      const sectionContent = page.locator(
-        `section[aria-labelledby="${section.headingId}"]`,
-      );
-
-      await expect(sectionContent).toBeVisible();
+      const cloudNotice = region.locator('[role="status"]');
       const hasCloudNotice = await cloudNotice.isVisible();
 
       if (hasCloudNotice) {
-        await expect(cloudNotice).toContainText(/not available in local mode/);
+        // The notices' wording varies per section ("not available in local
+        // mode", "available on Stigmer Cloud", …) — the durable invariant is
+        // that every gating notice points at Stigmer Cloud.
+        await expect(cloudNotice).toContainText(/Stigmer Cloud|local mode/);
       }
     });
   }

--- a/tools/eslint-plugin-stigmer/index.js
+++ b/tools/eslint-plugin-stigmer/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const noHardcodedBackdrop = require("./rules/no-hardcoded-backdrop");
+const noLiteralDomIds = require("./rules/no-literal-dom-ids");
 const noMainTokensInSidebar = require("./rules/no-main-tokens-in-sidebar");
 const noNativeTitle = require("./rules/no-native-title");
 const noTokenOpacityModifiers = require("./rules/no-token-opacity-modifiers");
@@ -13,6 +14,7 @@ const plugin = {
   },
   rules: {
     "no-hardcoded-backdrop": noHardcodedBackdrop,
+    "no-literal-dom-ids": noLiteralDomIds,
     "no-main-tokens-in-sidebar": noMainTokensInSidebar,
     "no-native-title": noNativeTitle,
     "no-token-opacity-modifiers": noTokenOpacityModifiers,

--- a/tools/eslint-plugin-stigmer/rules/no-literal-dom-ids.js
+++ b/tools/eslint-plugin-stigmer/rules/no-literal-dom-ids.js
@@ -1,0 +1,133 @@
+"use strict";
+
+// Hardcoded DOM ids are systematically wrong in an embeddable component
+// library: a host may legitimately mount ANY SDK component more than once
+// per page (the console's zone-cached detail pages already do), and every
+// literal `id=` is a latent collision — duplicate ids silently break
+// label→input and ARIA associations for every copy after the first
+// (stigmer/stigmer#619, #593, #571). Literal radio `name=` is the worse
+// class: two mounts merge into ONE keyboard group, so arrow keys and
+// checked-state bleed across unrelated forms.
+//
+// The house pattern: mint ids per mount with React's useId() — one
+// `const baseId = useId()` per component, derived per-field ids
+// (`` `${baseId}-name` ``), threaded to body components as props when the
+// id-bearing markup lives elsewhere. IDREF reference attributes (htmlFor,
+// aria-labelledby, …) must use the same minted value, so their literal
+// forms are banned alongside `id` — a literal IDREF can only dangle or
+// point at another component's DOM.
+//
+// Detection mirrors no-native-title's discipline: only host (lowercase)
+// JSX elements and known prop-forwarders are flagged, so component props
+// that happen to be called `id` (React's <Profiler id=…>, semantic keys
+// like <CollapsibleSection id=…>) never false-positive.
+//
+// Honest limitation: expression-derived ids (`id={`${prefix}-${i}`}`) are
+// not traceable by lint. The audited call sites all derive from useId();
+// the literal class fenced here is the only regrowth pattern observed.
+
+const ID_ATTRIBUTES = new Set([
+  "id",
+  "htmlFor",
+  "aria-labelledby",
+  "aria-describedby",
+  "aria-controls",
+  "aria-owns",
+  "aria-activedescendant",
+]);
+
+const FORWARDING_COMPONENT_NAMES = new Set(["Button"]);
+const FORWARDING_NAME_SUFFIX = /Trigger$/;
+
+/**
+ * Resolves whether the JSX element owning this attribute renders the
+ * attribute into the DOM (host element or a known prop-forwarding
+ * component). Returns the printable element name when it does.
+ */
+function domRenderingElementName(openingElement) {
+  const nameNode = openingElement.name;
+
+  if (nameNode.type === "JSXIdentifier") {
+    const name = nameNode.name;
+    if (/^[a-z]/.test(name)) return name;
+    if (FORWARDING_COMPONENT_NAMES.has(name)) return name;
+    if (FORWARDING_NAME_SUFFIX.test(name)) return name;
+    return null;
+  }
+
+  if (
+    nameNode.type === "JSXMemberExpression" &&
+    nameNode.property.type === "JSXIdentifier" &&
+    FORWARDING_NAME_SUFFIX.test(nameNode.property.name)
+  ) {
+    return `${nameNode.object.name ?? ""}.${nameNode.property.name}`;
+  }
+
+  return null;
+}
+
+/** True when the owning element is `<input type="radio">` with a literal type. */
+function isRadioInput(openingElement) {
+  const nameNode = openingElement.name;
+  if (nameNode.type !== "JSXIdentifier" || nameNode.name !== "input") {
+    return false;
+  }
+  return openingElement.attributes.some(
+    (attr) =>
+      attr.type === "JSXAttribute" &&
+      attr.name.type === "JSXIdentifier" &&
+      attr.name.name === "type" &&
+      attr.value &&
+      attr.value.type === "Literal" &&
+      attr.value.value === "radio",
+  );
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow literal DOM ids, IDREF references, and radio-group names — the SDK is an embeddable library, so every hardcoded id is a latent duplicate-id collision; mint them per mount with useId()",
+    },
+    messages: {
+      literalId:
+        "Literal `{{ attribute }}` on <{{ element }}> is a latent duplicate-id collision — a host may mount this" +
+        " component more than once per page. Mint the id per mount: `const baseId = useId()` plus derived" +
+        " per-field ids (see CreateWorkflowInstanceDialog), threading it to body components as a prop if needed.",
+      literalRadioName:
+        "Literal radio `name` on <input type=\"radio\"> merges every mounted copy of this component into ONE" +
+        " keyboard group (arrow keys and checked state bleed across forms). Mint the group name per mount from" +
+        " `useId()` and thread it to each option in the group.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.type !== "JSXIdentifier") return;
+        if (!node.value || node.value.type !== "Literal") return;
+        if (typeof node.value.value !== "string") return;
+
+        const attrName = node.name.name;
+
+        if (attrName === "name" && isRadioInput(node.parent)) {
+          context.report({ node, messageId: "literalRadioName" });
+          return;
+        }
+
+        if (!ID_ATTRIBUTES.has(attrName)) return;
+
+        const element = domRenderingElementName(node.parent);
+        if (element === null) return;
+
+        context.report({
+          node,
+          messageId: "literalId",
+          data: { attribute: attrName, element },
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Closes #619. Stacked on #650 (the clipboard sweep) — its ref conversion decoupled the secrets-reveal alerts from their hardcoded ids, which this PR then deletes.

The systematic remainder of #593: hardcoded DOM ids are latent collisions in an embeddable library — a host may mount any SDK component more than once per page (the console's zone-cached detail pages already do), and duplicate ids silently break label→input and ARIA associations for every copy after the first. Literal radio `name=` is the worse class: two mounts merge into one keyboard group.

### The sweep

On the established #571/#593 pattern (one `useId()` `baseId` per component, derived per-field ids, threaded to body components as props):

- **143 literal `id=`**, **46 `htmlFor=`**, **~19 literal ARIA IDREF references** (`aria-labelledby` etc.), and **5 files' literal radio `name=`** across ~40 files — wizard steps, create forms, detail panels, settings sections, dialogs, sidebar chrome.
- **The derived cousin the literal census couldn't see**: both wizard `CollapsibleSection`s built their disclosure-panel ids from static section keys (`stgm-wizard-section-env`) — still colliding across mounts. The panel id is now minted inside the component.
- The four secrets-reveal ids left unreferenced by #650's ref conversion are **deleted**, not minted — they served nothing.
- Deliberately untouched: component props named `id` that never reach the DOM (React `<Profiler id=…>`, `PrimaryNavRow`/`CollapsibleSection` semantic keys), and expression-derived ids already minted from `useId()` (workspace search `optionId`, the Mermaid render counter).

### The fence

New `stigmer/no-literal-dom-ids` rule in `tools/eslint-plugin-stigmer`, enabled `"error"` for `sdk/react/src`. Detection mirrors `no-native-title`'s host-element discipline, so component props never false-positive; flags literal `id`/`htmlFor`/ARIA-IDREF on host elements and literal `name` on `input[type="radio"]`. Tests are exempt (mount once, own their DOM). Red-green verified — all three violation classes flag, component props pass. Honest limitation documented in the rule: expression-derived ids are not lint-traceable; the literal class is the only regrowth pattern observed.

### Test re-anchoring (owner-ruled)

- `settings.spec.ts` located sections by literal heading ids; it now uses `getByRole("region", { name })` — a `<section aria-labelledby=…>` with an accessible name IS role=region, so the spec still proves the heading↔section association, through semantics that survive minting.
- Found in passing: its Billing assertion had been **broken on main** since `ca5b397ff` reworded the notice (the #572 assertion-rot class, invisible with no e2e lane) — fixed to the durable invariant (gating notices name Stigmer Cloud).
- `WorkspaceSidebar.test.tsx` now asserts the `aria-controls` association, not the literal `"sidebar"` value; `chrome.tsx`'s stale "console DOM contract" comment corrected (no app shell references `#sidebar` — verified).

### Safety

Every renamed id was grepped repo-wide before renaming: zero external references beyond the settings spec (no `#stgm-` selectors anywhere in client apps, demos, site, docs, or CSS; e2e clean).

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green **with the fence enabled** (doubles as proof of sweep completeness); rule red-green verified
- [x] 4415 sdk/react unit tests green
- [x] `settings.spec.ts` functional e2e: 20/20 against a locally booted full stack (Temporal + stigmer-server + runner)
- [x] `duplicate-dom-ids.spec.ts` interactive audit: 2/2 against the swept build

Made with [Cursor](https://cursor.com)