### PR TITLE
feat(sdk/react): tool-call density hierarchy — quiet rows for metadata-only tools, silent success, >= 1s duration chips

### DIFF
--- a/sdk/react/src/execution/SubAgentSection.tsx
+++ b/sdk/react/src/execution/SubAgentSection.tsx
@@ -12,7 +12,7 @@ import { useRenderTracer } from "../internal/dev/index.js";
 import { useAutoDisclosure } from "../internal/useAutoDisclosure.js";
 import { useElapsedSince, formatElapsed } from "../internal/useElapsedSince.js";
 import { cn } from "@stigmer/theme";
-import { formatDuration } from "./ToolCallDetail.js";
+import { formatHeaderDuration } from "./ToolCallDetail.js";
 import { MessageEntry } from "./MessageEntry.js";
 import { ToolCallGroup } from "./ToolCallGroup.js";
 import { ApprovalContext } from "./ApprovalContext.js";
@@ -81,7 +81,10 @@ export const SubAgentSection = memo(function SubAgentSection({
 }: SubAgentSectionProps) {
   useRenderTracer("SubAgentSection", { status: sub.status, name: sub.name });
 
-  const duration = formatDuration(sub.startedAt, sub.completedAt);
+  // Header chip threshold (>= 1s) shared with ToolCallItem — a sub-second
+  // sub-agent is noise by the same rule, and the two row kinds must speak
+  // one duration vocabulary.
+  const duration = formatHeaderDuration(sub.startedAt, sub.completedAt);
   const statusInfo = SUB_AGENT_STATUS_MAP[sub.status];
   const StatusIcon = statusInfo.icon;
   const isFailed = sub.status === SubAgentStatus.SUB_AGENT_FAILED;

--- a/sdk/react/src/execution/ToolCallDetail.tsx
+++ b/sdk/react/src/execution/ToolCallDetail.tsx
@@ -347,3 +347,22 @@ export function formatDuration(
   const seconds = Math.round((ms % 60_000) / 1000);
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
+
+/**
+ * {@link formatDuration} for header duration chips: returns `null` below one
+ * second. A duration chip earns its place only when it carries information —
+ * a `4ms` chip on a directory listing draws the eye to the least interesting
+ * row in the thread (stigmer#274), so sub-second work renders no chip at all.
+ * `formatDuration` itself stays exact — it is public API with consumers that
+ * want the precise value.
+ */
+export function formatHeaderDuration(
+  startedAt: string,
+  completedAt: string,
+): string | null {
+  const formatted = formatDuration(startedAt, completedAt);
+  // Exactly the sub-second arm of formatDuration ("123ms"); every other arm
+  // is >= 1s by construction.
+  if (formatted === null || formatted.endsWith("ms")) return null;
+  return formatted;
+}

--- a/sdk/react/src/execution/ToolCallItem.tsx
+++ b/sdk/react/src/execution/ToolCallItem.tsx
@@ -15,15 +15,15 @@ import {
   ThreadCardShell,
   ThreadCardHeader,
   ThreadCardBody,
+  type ThreadCardVariant,
   SpinnerIcon,
   ClockIcon,
-  CheckCircleIcon,
   XCircleIcon,
   DotIcon,
   SlashCircleIcon,
 } from "../internal/thread-card/index.js";
 import { TerminalTail } from "./TerminalSession.js";
-import { ToolCallDetail, formatDuration } from "./ToolCallDetail.js";
+import { ToolCallDetail, formatHeaderDuration } from "./ToolCallDetail.js";
 import { SubAgentSection } from "./SubAgentSection.js";
 import { ApprovalCardBody } from "./ApprovalCard.js";
 import { useApproval } from "./ApprovalContext.js";
@@ -94,6 +94,13 @@ export interface ToolCallItemProps {
  * content-overflow reveal — never govern the same body, which is what removes
  * the old "expand, then Show more" double control.
  *
+ * Orthogonal to the layout modes is the **chrome tier** (the density axis,
+ * stigmer#274): metadata-only categories (read / list / search / think)
+ * render as quiet unboxed lines — no card frame — while content-bearing
+ * categories keep their cards. A quiet row escalates to a card while gated
+ * or failed; its disclosed body renders under a light left rail instead of a
+ * border. See {@link ToolChrome}.
+ *
  * Shows category-aware labels (e.g., "Shell", "Read", "Edit") with
  * the primary argument as a subtitle, a category-specific icon, and
  * an inline approval decision badge when applicable.
@@ -118,11 +125,17 @@ export const ToolCallItem = memo(function ToolCallItem({
   useRenderTracer("ToolCallItem", { status: toolCall.status, id: toolCall.id });
 
   const status = mapToolCallStatus(toolCall);
+  // Success is the silent default: a completed row renders NO status icon —
+  // a green check on every settled row teaches the eye to ignore status
+  // entirely, so state is shown only when it says something (running, gated,
+  // failed, interrupted). Failure shouts; success is quiet (stigmer#274).
   const StatusIcon = STATUS_ICON[status];
-  const duration = formatDuration(toolCall.startedAt, toolCall.completedAt);
+  // Header chips only when the duration carries information (>= 1s); the
+  // sub-second chips were noise pinned to the least interesting rows.
+  const duration = formatHeaderDuration(toolCall.startedAt, toolCall.completedAt);
   const isSubAgent = subAgentExecution != null;
 
-  const { category, label, primaryArg, result, resultSummary, disclosure } =
+  const { category, label, primaryArg, result, resultSummary, disclosure, chrome } =
     useToolPresentation(toolCall);
   const CategoryIcon = CATEGORY_ICON[category];
 
@@ -189,6 +202,24 @@ export const ToolCallItem = memo(function ToolCallItem({
   const gateAccent =
     approval != null ? (category === "delete" ? "destructive" : "warning") : null;
 
+  // The chrome tier (the density axis, stigmer#274): metadata-only rows
+  // (read / list / search / think) render as quiet unboxed lines — no card
+  // frame — so the conversation reads as prose with quiet evidence attached.
+  // A row escalates to a card while it carries something a bare line cannot:
+  // a pending gate (the decision surface, including its accent) or a failure
+  // (error output is content). Running deliberately does NOT escalate — a
+  // quiet row's in-flight state rides its label and status glyph, not a
+  // frame. Nested rows (inside an expanded fold chip) stay divider rows:
+  // their container owns the frame.
+  const rowFailed =
+    toolCall.status === ToolCallStatus.TOOL_CALL_FAILED ||
+    result.type === "error";
+  const variant: ThreadCardVariant = !bordered
+    ? "row"
+    : chrome === "quiet" && !isSubAgent && approval == null && !rowFailed
+      ? "quiet"
+      : "card";
+
   // Completed/skipped Read items are non-expandable — the clickable
   // path in the row is the complete information. Failed reads remain
   // expandable to show the error.
@@ -229,12 +260,14 @@ export const ToolCallItem = memo(function ToolCallItem({
         </span>
       )}
 
-      <span
-        className={cn("stg:shrink-0", STATUS_COLOR[status])}
-        aria-hidden="true"
-      >
-        <StatusIcon />
-      </span>
+      {StatusIcon && (
+        <span
+          className={cn("stg:shrink-0", STATUS_COLOR[status])}
+          aria-hidden="true"
+        >
+          <StatusIcon />
+        </span>
+      )}
 
       {duration && (
         <span className="stg:shrink-0 stg:tabular-nums stg:text-muted-foreground">
@@ -247,7 +280,7 @@ export const ToolCallItem = memo(function ToolCallItem({
   if (isNonExpandableRead) {
     return (
       <ThreadCardShell
-        bordered={bordered}
+        variant={variant}
         accent={gateAccent}
         cursorTarget="tool-call-row"
         className={className}
@@ -381,14 +414,16 @@ export const ToolCallItem = memo(function ToolCallItem({
     const showBody = approval != null || result.type !== "empty";
     return (
       <ThreadCardShell
-        bordered={bordered}
+        variant={variant}
         accent={gateAccent}
         cursorTarget="tool-call-row"
         className={className}
       >
         <ThreadCardHeader>{headerInner}</ThreadCardHeader>
         {showBody && (
-          <ThreadCardBody cursorTarget="tool-preview">{body}</ThreadCardBody>
+          <ThreadCardBody cursorTarget="tool-preview" rail={variant === "quiet"}>
+            {body}
+          </ThreadCardBody>
         )}
       </ThreadCardShell>
     );
@@ -402,7 +437,7 @@ export const ToolCallItem = memo(function ToolCallItem({
   if (tailSession) {
     return (
       <ThreadCardShell
-        bordered={bordered}
+        variant={variant}
         accent={gateAccent}
         cursorTarget="tool-call-row"
         className={className}
@@ -433,7 +468,7 @@ export const ToolCallItem = memo(function ToolCallItem({
   // header with Enter/Space keyboard parity and the chevron.
   return (
     <ThreadCardShell
-      bordered={bordered}
+      variant={variant}
       accent={gateAccent}
       cursorTarget="tool-call-row"
       className={className}
@@ -442,7 +477,9 @@ export const ToolCallItem = memo(function ToolCallItem({
         {headerInner}
       </ThreadCardHeader>
 
-      {expanded && <ThreadCardBody>{body}</ThreadCardBody>}
+      {expanded && (
+        <ThreadCardBody rail={variant === "quiet"}>{body}</ThreadCardBody>
+      )}
     </ThreadCardShell>
   );
 });
@@ -664,11 +701,14 @@ function McpPlugIcon() {
 // Status icons — the shared thread-card glyph set (T05)
 // ---------------------------------------------------------------------------
 
-const STATUS_ICON: Record<ItemStatus, () => React.JSX.Element> = {
+// `completed` is deliberately iconless — success is the silent default, so
+// the states that remain visible (spinner, clock, cross, slash) all carry
+// real signal (stigmer#274).
+const STATUS_ICON: Record<ItemStatus, (() => React.JSX.Element) | null> = {
   running: SpinnerIcon,
   waiting: ClockIcon,
   failed: XCircleIcon,
-  completed: CheckCircleIcon,
+  completed: null,
   pending: DotIcon,
   interrupted: SlashCircleIcon,
 };

--- a/sdk/react/src/execution/ToolRunGroup.tsx
+++ b/sdk/react/src/execution/ToolRunGroup.tsx
@@ -88,11 +88,12 @@ export const ToolRunGroup = memo(function ToolRunGroup({
       role="group"
       aria-label={label}
       data-cursor-target="tool-run-group"
-      className={cn(
-        "stg:rounded-lg stg:border stg:border-border-prominent stg:overflow-hidden",
-        className,
-      )}
+      className={className}
     >
+      {/* Quiet chrome (stigmer#274): the folded run is metadata-only by
+          construction (its categories are the quiet set), so the chip renders
+          as an unboxed line — same tier as the lone read/list/search rows it
+          folds — never a bordered card shouting over the conversation. */}
       <button
         type="button"
         aria-expanded={expanded}
@@ -100,7 +101,6 @@ export const ToolRunGroup = memo(function ToolRunGroup({
         className={cn(
           "stg:flex stg:w-full stg:cursor-pointer stg:items-center stg:gap-2 stg:px-2.5 stg:py-1.5 stg:text-left stg:text-xs stg:text-muted-foreground stg:transition-colors",
           "stg:hover:bg-muted-subtle",
-          // ring-inset so the card's overflow-hidden does not clip the focus ring.
           "stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-inset stg:focus-visible:ring-ring",
         )}
       >
@@ -110,16 +110,19 @@ export const ToolRunGroup = memo(function ToolRunGroup({
         <span className="stg:min-w-0 stg:flex-1 stg:truncate stg:font-medium stg:text-foreground">
           {label}
         </span>
-        <span className={cn("stg:shrink-0", STATUS_COLOR[status])} aria-hidden="true">
-          <StatusIcon />
-        </span>
+        {StatusIcon && (
+          <span className={cn("stg:shrink-0", STATUS_COLOR[status])} aria-hidden="true">
+            <StatusIcon />
+          </span>
+        )}
         <ChevronIcon expanded={expanded} />
       </button>
 
       {expanded && (
-        <div className="stg:border-t stg:border-border-muted">
-          {/* The chip is already the card; its children render as
-              divider-separated rows (bordered={false}) to avoid a card-in-a-card. */}
+        // With no card frame, the disclosed rows sit under a light left rail
+        // (the quiet-tier body containment, mirroring ThreadCardBody's rail)
+        // as divider-separated rows — their container owns the frame.
+        <div className="stg:ml-1.5 stg:border-l-2 stg:border-border-muted stg:pl-2">
           {toolCalls.map((tc) => (
             <ToolCallItem key={tc.id || tc.name} toolCall={tc} bordered={false} />
           ))}
@@ -229,11 +232,13 @@ const STATUS_COLOR: Record<AggregateStatus, string> = {
   pending: "stg:text-muted-foreground",
 };
 
-const STATUS_ICON: Record<AggregateStatus, () => React.JSX.Element> = {
+// `completed` is deliberately iconless — success is the silent default,
+// matching the tool rows' own status vocabulary (stigmer#274).
+const STATUS_ICON: Record<AggregateStatus, (() => React.JSX.Element) | null> = {
   running: SpinnerIcon,
   waiting: ClockIcon,
   failed: XCircleIcon,
-  completed: CheckCircleIcon,
+  completed: null,
   pending: DotIcon,
 };
 
@@ -246,15 +251,6 @@ function ClockIcon() {
     <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="6" cy="6" r="4.5" />
       <path d="M6 3.5V6L7.5 7.5" />
-    </svg>
-  );
-}
-
-function CheckCircleIcon() {
-  return (
-    <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="6" cy="6" r="4.5" />
-      <path d="M4 6L5.5 7.5L8 4.5" />
     </svg>
   );
 }

--- a/sdk/react/src/execution/__tests__/ToolCallDetail.test.tsx
+++ b/sdk/react/src/execution/__tests__/ToolCallDetail.test.tsx
@@ -28,7 +28,9 @@ vi.mock("../useFileChangeContent", () => ({
   useFileChangeContent: () => mockContent,
 }));
 
-const { ToolCallDetail } = await import("../ToolCallDetail");
+const { ToolCallDetail, formatDuration, formatHeaderDuration } = await import(
+  "../ToolCallDetail"
+);
 const { FileReviewContext } = await import("../FileReviewContext");
 
 beforeEach(() => {
@@ -377,5 +379,35 @@ describe("ToolCallDetail — write body", () => {
     expect(container.textContent).not.toContain("captured-after");
     // ...still inside the shared pixel clamp (unchanged behavior).
     expect(container.querySelector(CLAMP)).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Duration formatting — the exact helper vs the >= 1s header-chip variant
+// ---------------------------------------------------------------------------
+
+describe("formatHeaderDuration", () => {
+  const T0 = "2026-08-13T10:00:00.000Z";
+  const at = (ms: number) => new Date(Date.parse(T0) + ms).toISOString();
+
+  it("suppresses sub-second durations that formatDuration would render", () => {
+    // The exact helper keeps its public contract...
+    expect(formatDuration(T0, at(400))).toBe("400ms");
+    // ...while the header-chip variant treats the same span as noise.
+    expect(formatHeaderDuration(T0, at(400))).toBeNull();
+  });
+
+  it("passes through everything from one second up, exactly as formatDuration renders it", () => {
+    const cases = [1000, 2500, 61_000, 180_000];
+    for (const ms of cases) {
+      expect(formatHeaderDuration(T0, at(ms))).toBe(formatDuration(T0, at(ms)));
+      expect(formatHeaderDuration(T0, at(ms))).not.toBeNull();
+    }
+  });
+
+  it("stays null for missing or invalid timestamps, like the exact helper", () => {
+    expect(formatHeaderDuration("", at(400))).toBeNull();
+    expect(formatHeaderDuration(T0, "")).toBeNull();
+    expect(formatHeaderDuration("not-a-date", at(2000))).toBeNull();
   });
 });

--- a/sdk/react/src/execution/__tests__/ToolCallItem.test.tsx
+++ b/sdk/react/src/execution/__tests__/ToolCallItem.test.tsx
@@ -37,6 +37,8 @@ function makeToolCall(opts: {
   mcpServerSlug?: string;
   status?: ToolCallStatus;
   fileChangeSetId?: string;
+  startedAt?: string;
+  completedAt?: string;
 }): ToolCall {
   return create(ToolCallSchema, {
     id: opts.id ?? opts.name,
@@ -46,6 +48,8 @@ function makeToolCall(opts: {
     mcpServerSlug: opts.mcpServerSlug ?? "",
     status: opts.status ?? ToolCallStatus.TOOL_CALL_COMPLETED,
     fileChangeSetId: opts.fileChangeSetId ?? "",
+    startedAt: opts.startedAt ?? "",
+    completedAt: opts.completedAt ?? "",
   });
 }
 
@@ -570,6 +574,172 @@ describe("ToolCallItem disclosure", () => {
     row = container.querySelector('[data-cursor-target="tool-call-row"]')!;
     expect(row.className).not.toContain("stg:rounded-lg");
     expect(row.className).toContain("stg:border-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Density tier — quiet unboxed lines for metadata-only rows (stigmer#274)
+// ---------------------------------------------------------------------------
+
+function rowRoot(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-cursor-target="tool-call-row"]')!;
+}
+function isQuietLine(container: HTMLElement): boolean {
+  const cls = rowRoot(container).className;
+  return !cls.includes("stg:rounded-lg") && !cls.includes("stg:border-b");
+}
+
+describe("ToolCallItem density tier", () => {
+  it("renders metadata-only rows as quiet unboxed lines (read / list / search / think)", () => {
+    const cases: ToolCall[] = [
+      makeToolCall({ name: "Read", args: { path: "/a.ts" } }),
+      makeToolCall({ name: "ls", args: { path: "/src" } }),
+      makeToolCall({ name: "Grep", args: { pattern: "foo" }, result: "2 matches" }),
+      makeToolCall({ name: "think", args: { thought: "considering options" } }),
+    ];
+    for (const tc of cases) {
+      const { container, unmount } = render(<ToolCallItem toolCall={tc} />);
+      expect(isQuietLine(container), `${tc.name} should be a quiet line`).toBe(true);
+      unmount();
+    }
+  });
+
+  it("keeps content-bearing rows as cards (shell / edit)", () => {
+    const cases: ToolCall[] = [
+      makeToolCall({ name: "Shell", args: { command: "echo hi" }, result: "hi" }),
+      makeToolCall({
+        name: "StrReplace",
+        args: { path: "/a.ts", old_string: "a", new_string: "b" },
+      }),
+    ];
+    for (const tc of cases) {
+      const { container, unmount } = render(<ToolCallItem toolCall={tc} />);
+      expect(rowRoot(container).className, `${tc.name} should stay a card`).toContain(
+        "stg:border-border-prominent",
+      );
+      unmount();
+    }
+  });
+
+  it("escalates a quiet row to a card when it fails — error output is content", () => {
+    const failed = makeToolCall({
+      name: "Read",
+      args: { path: "/a.ts" },
+      status: ToolCallStatus.TOOL_CALL_FAILED,
+      result: '{"status":"error","message":"permission denied"}',
+    });
+    const { container } = render(<ToolCallItem toolCall={failed} />);
+    expect(rowRoot(container).className).toContain("stg:border-border-prominent");
+  });
+
+  it("escalates a quiet row to a card while gated — a decision surface is never frameless", () => {
+    const gated = makeToolCall({
+      id: "tc-read-gated",
+      name: "Read",
+      args: { path: "/secret" },
+      status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+    });
+    const approval: PendingApproval = create(PendingApprovalSchema, {
+      toolCallId: "tc-read-gated",
+      toolName: "Read",
+      argsPreview: '{"path":"/secret"}',
+    });
+    const ctx: ApprovalContextValue = {
+      approvalsByToolCallId: new Map([["tc-read-gated", approval]]),
+      onSubmit: () => {},
+      submittingIds: new Set(),
+      errorsByToolCallId: new Map(),
+    };
+    const { container } = render(
+      <ApprovalContext.Provider value={ctx}>
+        <ToolCallItem toolCall={gated} />
+      </ApprovalContext.Provider>,
+    );
+    const cls = rowRoot(container).className;
+    expect(cls).toContain("stg:border-border-prominent");
+    expect(cls).toContain("stg:border-l-warning");
+  });
+
+  it("stays a quiet line while running — the in-flight state rides the label, not a frame", () => {
+    const running = makeToolCall({
+      name: "Read",
+      args: { path: "/a.ts" },
+      status: ToolCallStatus.TOOL_CALL_RUNNING,
+    });
+    const { container } = render(<ToolCallItem toolCall={running} />);
+    expect(isQuietLine(container)).toBe(true);
+    expect(container.querySelector(".stg\\:animate-spin")).not.toBeNull();
+  });
+
+  it("contains a quiet row's disclosed body under a left rail instead of a border", () => {
+    // Grep is a summary category with a real result body: expanding the quiet
+    // line must bound the body with the rail (the ThinkingMessage precedent),
+    // never leave it bleeding into the thread.
+    const tc = makeToolCall({
+      name: "Grep",
+      args: { pattern: "foo" },
+      result: "src/a.ts:1: foo",
+    });
+    const { container } = render(<ToolCallItem toolCall={tc} />);
+    fireEvent.click(rowHeaderToggle(container)!);
+    expect(container.querySelector(".stg\\:border-l-2")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status vocabulary — success is silent, everything visible carries signal
+// ---------------------------------------------------------------------------
+
+describe("ToolCallItem status vocabulary", () => {
+  it("renders no status icon on a completed row — success is the silent default", () => {
+    const { container } = render(
+      <ToolCallItem
+        toolCall={makeToolCall({ name: "Shell", args: { command: "echo hi" }, result: "hi" })}
+      />,
+    );
+    expect(container.querySelector(".stg\\:text-success")).toBeNull();
+  });
+
+  it("keeps the failed icon — failure shouts", () => {
+    const { container } = render(
+      <ToolCallItem
+        toolCall={makeToolCall({
+          name: "Shell",
+          args: { command: "false" },
+          status: ToolCallStatus.TOOL_CALL_FAILED,
+        })}
+      />,
+    );
+    expect(container.querySelector(".stg\\:text-destructive")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Duration chips — shown only when they carry information (>= 1s)
+// ---------------------------------------------------------------------------
+
+describe("ToolCallItem duration chip", () => {
+  it("suppresses a sub-second duration — the chip would be noise", () => {
+    const tc = makeToolCall({
+      name: "Read",
+      args: { path: "/a.ts" },
+      startedAt: "2026-08-13T10:00:00.000Z",
+      completedAt: "2026-08-13T10:00:00.400Z",
+    });
+    render(<ToolCallItem toolCall={tc} />);
+    expect(screen.queryByText("400ms")).toBeNull();
+  });
+
+  it("shows a duration of a second or more — it carries information", () => {
+    const tc = makeToolCall({
+      name: "Shell",
+      args: { command: "sleep 2" },
+      result: "",
+      startedAt: "2026-08-13T10:00:00.000Z",
+      completedAt: "2026-08-13T10:00:02.500Z",
+    });
+    render(<ToolCallItem toolCall={tc} />);
+    expect(screen.getByText("2.5s")).toBeTruthy();
   });
 });
 

--- a/sdk/react/src/execution/__tests__/ToolRunGroup.test.tsx
+++ b/sdk/react/src/execution/__tests__/ToolRunGroup.test.tsx
@@ -90,9 +90,12 @@ describe("ToolRunGroup", () => {
     );
     expect(container.querySelector(".stg\\:animate-spin")).toBeNull();
     expect(chipExpanded(container)).toBe(false);
-    // The aggregate resolves to the terminal branch (completed chip in
-    // text-success), not the non-terminal pending fallback (muted dot).
-    expect(container.querySelector(".stg\\:text-success")).not.toBeNull();
+    // The aggregate resolves to the terminal branch — which is silent
+    // (completed renders NO status icon, stigmer#274) — not the non-terminal
+    // pending fallback, which renders its muted dot as a third header svg
+    // beside the category icon and chevron.
+    const headerSvgs = container.querySelectorAll("button svg");
+    expect(headerSvgs.length).toBe(2);
     expect(screen.getByText("Read 2 files")).toBeTruthy();
   });
 
@@ -121,7 +124,7 @@ describe("ToolRunGroup", () => {
     expect(screen.getByLabelText("Approve")).toBeTruthy();
   });
 
-  it("is a bordered card whose expanded children are borderless divider rows", () => {
+  it("is a quiet unboxed line whose expanded children sit under a left rail as divider rows", () => {
     const { container } = render(
       <ToolRunGroup
         category="read"
@@ -129,21 +132,50 @@ describe("ToolRunGroup", () => {
       />,
     );
 
+    // Quiet chrome (stigmer#274): the fold is metadata-only by construction,
+    // so the chip must never render as a bordered card shouting over the
+    // conversation. Class presence only — actual rendering is guarded by the
+    // layer-invariant + e2e computed-style tests (happy-dom does not resolve
+    // `@layer`).
     const chip = container.querySelector('[data-cursor-target="tool-run-group"]')!;
-    expect(chip.className).toContain("stg:rounded-lg");
-    // Class presence only — actual rendering is guarded by the layer-invariant +
-    // e2e computed-style tests (happy-dom does not resolve `@layer`).
-    expect(chip.className).toContain("stg:border-border-prominent");
+    expect(chip.className).not.toContain("stg:rounded-lg");
+    expect(chip.className).not.toContain("stg:border-border-prominent");
 
     fireEvent.click(screen.getByText("Read 2 files"));
 
-    // The chip is the card; its child rows are dividers, never nested cards.
+    // With no card frame, the rail container owns the boundary; child rows
+    // are dividers, never nested cards.
+    expect(container.querySelector(".stg\\:border-l-2")).not.toBeNull();
     const rows = container.querySelectorAll('[data-cursor-target="tool-call-row"]');
     expect(rows.length).toBe(2);
     for (const row of rows) {
       expect(row.className).not.toContain("stg:rounded-lg");
       expect(row.className).toContain("stg:border-b");
     }
+  });
+
+  it("renders no status icon once the run settles successfully — success is silent", () => {
+    const { container } = render(
+      <ToolRunGroup
+        category="read"
+        toolCalls={[makeRead("r1", "/a.ts"), makeRead("r2", "/b.ts")]}
+      />,
+    );
+    // Header svgs: the category icon and the chevron — no green check.
+    expect(container.querySelectorAll("button svg").length).toBe(2);
+  });
+
+  it("keeps the failed icon when a folded call failed — failure shouts", () => {
+    const { container } = render(
+      <ToolRunGroup
+        category="read"
+        toolCalls={[
+          makeRead("r1", "/a.ts"),
+          makeRead("r2", "/b.ts", ToolCallStatus.TOOL_CALL_FAILED),
+        ]}
+      />,
+    );
+    expect(container.querySelector(".stg\\:text-destructive")).not.toBeNull();
   });
 
   it("honours a custom label formatter", () => {

--- a/sdk/react/src/execution/__tests__/tool-presenter.test.tsx
+++ b/sdk/react/src/execution/__tests__/tool-presenter.test.tsx
@@ -155,6 +155,28 @@ describe("useToolPresentation", () => {
     });
   });
 
+  describe("chrome", () => {
+    it("quiets metadata-only categories and keeps content-bearing ones as cards", () => {
+      const quiet = makeToolCall({ name: "Read", args: { path: "/x" } });
+      const card = makeToolCall({ name: "Shell", args: { command: "ls" }, result: "files" });
+      expect(renderHook(() => useToolPresentation(quiet)).result.current.chrome).toBe("quiet");
+      expect(renderHook(() => useToolPresentation(card)).result.current.chrome).toBe("card");
+    });
+
+    it("lets a registered presenter restore the boxed look for a kind", () => {
+      const dispose = registerToolPresenter(ToolKind.FILE_READ, {
+        chrome: () => "card",
+      });
+      try {
+        const tc = makeToolCall({ name: "Read", args: { path: "/x" } });
+        const { result } = renderHook(() => useToolPresentation(tc));
+        expect(result.current.chrome).toBe("card");
+      } finally {
+        dispose();
+      }
+    });
+  });
+
   describe("runGroupable", () => {
     it("folds read-only repetitive categories", () => {
       for (const name of ["Read", "Grep", "Glob"]) {

--- a/sdk/react/src/execution/tool-categories.ts
+++ b/sdk/react/src/execution/tool-categories.ts
@@ -56,6 +56,49 @@ export type ToolCategory =
 export type ToolDisclosure = "summary" | "preview" | "tail";
 
 /**
+ * How much *chrome* a tool row carries in the thread — the density axis,
+ * orthogonal to {@link ToolDisclosure} (how much of the result to show).
+ *
+ * - `"card"` — a self-contained bordered card. For content-bearing rows
+ *   (shell, edit, fetch, MCP), where the body is real evidence worth a frame.
+ * - `"quiet"` — an unboxed single text line, no border, no card. For
+ *   metadata-only rows (read / list / search / think) whose label + argument
+ *   already tell the whole story: a 4 ms directory listing must not shout as
+ *   loudly as a 3-minute shell run (Cursor's chat is the reference UX — prose
+ *   with quiet evidence attached, not a stack of equally-loud widgets).
+ *
+ * This is the *settled default*. A row escalates to `"card"` regardless of
+ * category while it carries something the quiet line cannot: a pending
+ * approval gate (a decision surface) or a failure (error output is content).
+ * That escalation is owned by the component layer and is deliberately not
+ * override-able — a gate must never render without its frame.
+ */
+export type ToolChrome = "card" | "quiet";
+
+/**
+ * Categories whose settled summary row IS the complete information, rendered
+ * as quiet unboxed lines by default. Mirrors {@link RUN_GROUPABLE_CATEGORIES}
+ * plus `think` (a thought's row reads like narration, not evidence) — the
+ * same low-signal set, on the chrome axis instead of the folding axis.
+ */
+const QUIET_CATEGORIES: ReadonlySet<ToolCategory> = new Set<ToolCategory>([
+  "read",
+  "list",
+  "search",
+  "think",
+]);
+
+/**
+ * Returns the default {@link ToolChrome} for a presentation category.
+ * Consumers can override per {@link ToolKind} via {@link registerToolPresenter}
+ * (`chrome: () => "card"` to restore the boxed look for a kind), exactly like
+ * the disclosure axis.
+ */
+export function defaultChromeForCategory(category: ToolCategory): ToolChrome {
+  return QUIET_CATEGORIES.has(category) ? "quiet" : "card";
+}
+
+/**
  * Categories whose result is foregrounded as a persistent bounded preview by
  * default — those for which the compact one-liner cannot convey what happened,
  * so the output itself carries the meaning. All other categories default to

--- a/sdk/react/src/execution/tool-presenter.ts
+++ b/sdk/react/src/execution/tool-presenter.ts
@@ -19,10 +19,11 @@ import type { ToolResultView } from "@stigmer/sdk";
 import {
   resolveToolCategoryFromCall,
   extractPrimaryArg,
+  defaultChromeForCategory,
   defaultDisclosureForCategory,
   isRunGroupableCategory,
 } from "./tool-categories.js";
-import type { ToolCategory, ToolDisclosure } from "./tool-categories.js";
+import type { ToolCategory, ToolChrome, ToolDisclosure } from "./tool-categories.js";
 import { summarizeResultView } from "./ResultView.js";
 
 /** Optional per-kind overrides for label, summary, disclosure, and run-grouping. */
@@ -37,6 +38,15 @@ export interface ToolPresenter {
    * (`() => "preview"`) without forking the components.
    */
   readonly disclosure?: (toolCall: ToolCall, result: ToolResultView) => ToolDisclosure;
+  /**
+   * Overrides the default chrome tier — quiet unboxed line vs bordered card
+   * (see {@link ToolChrome}). Use to restore the boxed look for a kind
+   * (`() => "card"`) or to quiet a chatty custom tool (`() => "quiet"`).
+   * A pending approval gate or a failure always escalates the row to a card
+   * regardless of this override — a decision surface and error output must
+   * never render frameless.
+   */
+  readonly chrome?: (toolCall: ToolCall, result: ToolResultView) => ToolChrome;
   /**
    * Overrides whether consecutive same-kind calls fold into one collapsible
    * "Read 5 files" chip. Use to fold a chatty custom tool (`() => true`) or to
@@ -128,6 +138,13 @@ export interface ToolPresentation {
    */
   readonly disclosure: ToolDisclosure;
   /**
+   * Default chrome tier for this tool — `"quiet"` renders an unboxed line,
+   * `"card"` a bordered card (see {@link ToolChrome}). A pending gate or a
+   * failure escalates to `"card"` in the component layer; this is the
+   * *settled* default.
+   */
+  readonly chrome: ToolChrome;
+  /**
    * Whether consecutive same-kind calls fold into one collapsible chip — the
    * run-grouping axis, orthogonal to {@link disclosure}. See
    * {@link isRunGroupableCategory}.
@@ -155,6 +172,9 @@ export function useToolPresentation(toolCall: ToolCall): ToolPresentation {
     const disclosure =
       override?.disclosure?.(toolCall, result) ??
       defaultDisclosureForCategory(categoryInfo.category);
+    const chrome =
+      override?.chrome?.(toolCall, result) ??
+      defaultChromeForCategory(categoryInfo.category);
     const runGroupable =
       override?.runGroupable?.(toolCall) ??
       isRunGroupableCategory(categoryInfo.category);
@@ -167,6 +187,7 @@ export function useToolPresentation(toolCall: ToolCall): ToolPresentation {
       result,
       resultSummary,
       disclosure,
+      chrome,
       runGroupable,
     };
   }, [toolCall]);

--- a/sdk/react/src/internal/__tests__/ThreadCardShell.test.tsx
+++ b/sdk/react/src/internal/__tests__/ThreadCardShell.test.tsx
@@ -1,9 +1,9 @@
 // Contract tests for the shared thread-card shell (T05/T06): the chrome
-// axes (bordered vs divider row, gate accent), the header gestures
-// (`expand` / `none` — `select` died with the Inspect drill-down, T06)
-// with their ARIA semantics, and the nested-button keydown guard. The two
-// consuming threads pin their own compositions; this file pins what they
-// share.
+// tiers (card / nested divider row / quiet unboxed line, gate accent), the
+// header gestures (`expand` / `none` — `select` died with the Inspect
+// drill-down, T06) with their ARIA semantics, and the nested-button keydown
+// guard. The two consuming threads pin their own compositions; this file
+// pins what they share.
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
@@ -16,7 +16,7 @@ import {
 afterEach(cleanup);
 
 describe("ThreadCardShell chrome", () => {
-  it("renders a bordered card by default and a divider row when nested", () => {
+  it("renders a bordered card by default, a divider row when nested, and no chrome when quiet", () => {
     const { rerender, container } = render(
       <ThreadCardShell cursorTarget="row">
         <ThreadCardHeader>content</ThreadCardHeader>
@@ -27,12 +27,22 @@ describe("ThreadCardShell chrome", () => {
     expect(root().className).toContain("stg:border-border-prominent");
 
     rerender(
-      <ThreadCardShell cursorTarget="row" bordered={false}>
+      <ThreadCardShell cursorTarget="row" variant="row">
         <ThreadCardHeader>content</ThreadCardHeader>
       </ThreadCardShell>,
     );
     expect(root().className).toContain("stg:border-b");
     expect(root().className).not.toContain("stg:border-border-prominent");
+
+    rerender(
+      <ThreadCardShell cursorTarget="row" variant="quiet">
+        <ThreadCardHeader>content</ThreadCardHeader>
+      </ThreadCardShell>,
+    );
+    // The quiet tier is an unboxed line: no card border, no divider.
+    expect(root().className).not.toContain("stg:border-border-prominent");
+    expect(root().className).not.toContain("stg:border-b");
+    expect(root().className).not.toContain("stg:rounded-lg");
   });
 
   it("carries the gate accent", () => {
@@ -43,6 +53,19 @@ describe("ThreadCardShell chrome", () => {
     );
     const root = container.querySelector('[data-cursor-target="row"]') as HTMLElement;
     expect(root.className).toContain("stg:border-l-warning");
+  });
+
+  it("never draws the gate accent on a quiet shell — escalation is the caller's job", () => {
+    // The quiet tier deliberately ignores `accent`: a gated row must be
+    // escalated to variant="card" by its component, never rendered as an
+    // accented bare line (see ThreadCardVariant).
+    const { container } = render(
+      <ThreadCardShell cursorTarget="row" variant="quiet" accent="warning">
+        <ThreadCardHeader>content</ThreadCardHeader>
+      </ThreadCardShell>,
+    );
+    const root = container.querySelector('[data-cursor-target="row"]') as HTMLElement;
+    expect(root.className).not.toContain("stg:border-l-warning");
   });
 });
 
@@ -101,5 +124,18 @@ describe("ThreadCardBody", () => {
   it("carries the id for aria-controls wiring", () => {
     render(<ThreadCardBody id="detail-1">body</ThreadCardBody>);
     expect(document.getElementById("detail-1")?.textContent).toBe("body");
+  });
+
+  it("swaps the card padding for a left rail when the body is quiet-contained", () => {
+    const { rerender } = render(<ThreadCardBody id="detail-1">body</ThreadCardBody>);
+    const el = () => document.getElementById("detail-1")!;
+    expect(el().className).not.toContain("stg:border-l-2");
+
+    rerender(
+      <ThreadCardBody id="detail-1" rail>
+        body
+      </ThreadCardBody>,
+    );
+    expect(el().className).toContain("stg:border-l-2");
   });
 });

--- a/sdk/react/src/internal/thread-card/ThreadCardShell.tsx
+++ b/sdk/react/src/internal/thread-card/ThreadCardShell.tsx
@@ -14,7 +14,8 @@ import { ChevronIcon } from "./glyphs.js";
  * Three pieces, composed via children (slots-as-children, never a
  * mega-prop card — each thread's composition stays explicit):
  *
- * - {@link ThreadCardShell} — the chrome: bordered card vs divider row,
+ * - {@link ThreadCardShell} — the chrome tier: bordered card, nested divider
+ *   row, or quiet unboxed line ({@link ThreadCardVariant}), plus the
  *   pending-gate accent.
  * - {@link ThreadCardHeader} — the one-line header region with a
  *   primary gesture: `expand` (summary rows, `aria-expanded`, appends
@@ -41,15 +42,25 @@ import { ChevronIcon } from "./glyphs.js";
 // Shell — the card chrome
 // ---------------------------------------------------------------------------
 
+/**
+ * The chrome tier of a thread row (the density axis at the shell level):
+ *
+ * - `"card"` — a self-contained bordered card (the default).
+ * - `"row"` — a divider-separated row for rows nested inside a container
+ *   that already provides the frame (e.g. an expanded `ToolRunGroup` fold),
+ *   avoiding a card-in-a-card.
+ * - `"quiet"` — no chrome at all: an unboxed line for metadata-only rows
+ *   whose header IS the complete information (reads, listings, thoughts).
+ *   The gate accent is deliberately not drawn in this tier — a row carrying
+ *   an accent must be escalated to `"card"` by the caller, never rendered
+ *   as an accented bare line.
+ */
+export type ThreadCardVariant = "card" | "row" | "quiet";
+
 /** Props for {@link ThreadCardShell}. */
 export interface ThreadCardShellProps {
-  /**
-   * Whether the row renders as its own self-contained card (a thin rounded
-   * border). Set to `false` when nested inside a container that already
-   * provides the border — e.g. the folded `ToolRunGroup` chip — where the
-   * row degrades to a divider-separated row to avoid a card-in-a-card.
-   */
-  readonly bordered?: boolean;
+  /** The chrome tier — see {@link ThreadCardVariant}. Defaults to `"card"`. */
+  readonly variant?: ThreadCardVariant;
   /**
    * A restrained left accent for a row awaiting a human decision —
    * `"warning"` for ordinary gates, `"destructive"` for delete gates.
@@ -64,25 +75,31 @@ export interface ThreadCardShellProps {
   readonly children: ReactNode;
 }
 
+const VARIANT_CHROME: Record<Exclude<ThreadCardVariant, "card">, string> = {
+  row: "stg:border-b stg:border-border-muted stg:last:border-b-0",
+  quiet: "",
+};
+
 /** The thread card's outer chrome. See the module doc for the full contract. */
 export function ThreadCardShell({
-  bordered = true,
+  variant = "card",
   accent = null,
   cursorTarget,
   className,
   ref,
   children,
 }: ThreadCardShellProps) {
-  const chrome = bordered
-    ? cn(
-        // border-prominent (not border): a transparent card needs a line the
-        // eye actually catches — the default border token is white at 14%
-        // opacity, which vanishes on the dark thread surface.
-        "stg:rounded-lg stg:border stg:border-border-prominent stg:overflow-hidden",
-        accent === "warning" && "stg:border-l-2 stg:border-l-warning",
-        accent === "destructive" && "stg:border-l-2 stg:border-l-destructive",
-      )
-    : "stg:border-b stg:border-border-muted stg:last:border-b-0";
+  const chrome =
+    variant === "card"
+      ? cn(
+          // border-prominent (not border): a transparent card needs a line the
+          // eye actually catches — the default border token is white at 14%
+          // opacity, which vanishes on the dark thread surface.
+          "stg:rounded-lg stg:border stg:border-border-prominent stg:overflow-hidden",
+          accent === "warning" && "stg:border-l-2 stg:border-l-warning",
+          accent === "destructive" && "stg:border-l-2 stg:border-l-destructive",
+        )
+      : VARIANT_CHROME[variant];
 
   return (
     <div ref={ref} data-cursor-target={cursorTarget} className={cn(chrome, className)}>
@@ -176,13 +193,28 @@ export interface ThreadCardBodyProps {
   readonly id?: string;
   /** Rendered as `data-cursor-target` for e2e targeting. */
   readonly cursorTarget?: string;
+  /**
+   * Body containment for a `"quiet"` shell: with no card border around it, a
+   * disclosed body needs its own boundary — a light left rail (the
+   * `ThinkingMessage` expanded-state precedent) instead of the card's padding
+   * box. Ignored for card/row shells, whose frame already bounds the body.
+   */
+  readonly rail?: boolean;
   readonly children: ReactNode;
 }
 
 /** The thread card's body padding contract. */
-export function ThreadCardBody({ id, cursorTarget, children }: ThreadCardBodyProps) {
+export function ThreadCardBody({ id, cursorTarget, rail = false, children }: ThreadCardBodyProps) {
   return (
-    <div id={id} data-cursor-target={cursorTarget} className="stg:px-2.5 stg:pb-2.5 stg:pt-1">
+    <div
+      id={id}
+      data-cursor-target={cursorTarget}
+      className={
+        rail
+          ? "stg:ml-1.5 stg:border-l-2 stg:border-border-muted stg:py-1 stg:pl-3 stg:pr-2.5"
+          : "stg:px-2.5 stg:pb-2.5 stg:pt-1"
+      }
+    >
       {children}
     </div>
   );

--- a/sdk/react/src/internal/thread-card/index.ts
+++ b/sdk/react/src/internal/thread-card/index.ts
@@ -2,6 +2,7 @@ export {
   ThreadCardShell,
   ThreadCardHeader,
   ThreadCardBody,
+  type ThreadCardVariant,
   type ThreadCardShellProps,
   type ThreadCardHeaderProps,
   type ThreadCardHeaderGesture,


### PR DESCRIPTION
## Summary

Closes #274.

The message thread now follows the density convention users know from mainstream agent chats — the conversation reads as *prose with quiet evidence attached*, not a stack of equally-loud widgets:

- **Quiet tier**: metadata-only tool calls (read / list / search / think) and the folded "Read N files" chip render as unboxed single lines — no card chrome. Content-bearing tools (shell, edit, fetch, MCP) keep their cards. A quiet row **escalates to a card** while gated (the decision surface, with its accent) or failed (error output is content); its disclosed body sits under a light left rail (the `ThinkingMessage` precedent).
- **Silent success**: completed rows render no status icon, in both status vocabularies (`ToolCallItem` and `ToolRunGroup`'s aggregate). Running / waiting / failed / interrupted keep theirs — every visible state carries signal.
- **Duration chips only when meaningful**: header chips render at >= 1s via a new `formatHeaderDuration`; `formatDuration` (public API) keeps its exact contract. `SubAgentSection` headers share the threshold.

## Design notes

- The chrome tier is a **policy axis in `tool-categories.ts`** beside the existing disclosure axis, with a `chrome` override on `registerToolPresenter` — one line restores the boxed look per kind (`chrome: () => "card"`). Gate/failure escalation is deliberately not overridable.
- `ThreadCardShell` grows a third variant (`"quiet"`), replacing the boolean `bordered` on the internal shell (the component-level `ToolCallItem.bordered` public prop is unchanged). The run chip converges onto the same tier vocabulary instead of its hand-rolled chrome.
- **Ships as the new default** (the #620 shell-tail precedent): the issue's ask is the default presentation, and the presenter registry is the escape hatch. DOM anchors (`data-cursor-target`) are unchanged — restyle, not restructure.
- The **workflow task thread deliberately keeps** its completed check: few, high-stakes DAG nodes where per-task completion is information, unlike dozens of small tool calls where it is noise.

## Verification

- `@stigmer/react`: 405 files / 4487 tests green (13 new: quiet tier per category, escalation on gate/failure/running, silent success in both vocabularies, duration threshold incl. `formatHeaderDuration` table, shell variant contract incl. quiet-ignores-accent).
- `npm run build -w @stigmer/react` (tsc + styles) green; eslint 0 errors on changed files; `prefix-classnames --check` OK.
- Visual pass in Chromium (light + dark) on a representative conversation: quiet reads/list/search/think + fold chip, edit/shell cards, escalated failed read.
- Rebased on main past #644/#651/#652; no conflicts.

## Risk

Embedders that styled *against* the card chrome of read/list/search rows will see the new quiet default; `registerToolPresenter(kind, { chrome: () => "card" })` restores the old look per kind. No exports removed or renamed.

Made with [Cursor](https://cursor.com)