### PR TITLE
ci: fix integration-providers lane — retired Python agent-runner step made it unrunnable

### DIFF
--- a/.github/workflows/ci.integration-providers.yaml
+++ b/.github/workflows/ci.integration-providers.yaml
@@ -5,8 +5,8 @@
 # Cursor. These are MANUAL-ONLY (workflow_dispatch).
 #
 # Tests exercise:
-#   - llm_call: direct LLM API calls via workflow-runner (cheap, ~$0.001/test)
-#   - agent_call: full pipeline through Java + Python agent-runner (~$0.01/test)
+#   - llm_call: direct LLM API calls through the unified Node runner (cheap, ~$0.001/test)
+#   - agent_call: full pipeline through the Java service + unified Node runner (~$0.01/test)
 #   - session-routing Tier 3: full E2E via Cursor SDK
 #
 # Cost: under $0.10 per full run with claude-sonnet-4-6.
@@ -96,27 +96,30 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      # The runner setup mirrors ci.integration-offline.yaml: the harness
+      # prefers the pre-built dist/main.js (raw .ts proto stubs break the
+      # Temporal webpack bundler) and every test in the provider set
+      # (TestWorkflow*/TestAgentExecution) runs through the unified runner.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          python-version: "3.12"
+          node-version-file: ".nvmrc"
+
+      - name: Install npm workspace dependencies
+        run: npm ci
+
+      - name: Build proto stubs
+        run: npm run build -w @stigmer/protos
+
+      - name: Install and build unified runner
+        working-directory: backend/services/runner
+        run: npm ci && npm run build
 
       - name: Install Temporal CLI
         uses: temporalio/setup-temporal@v0
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.12.1
-
-      - name: Install agent-runner dependencies
-        working-directory: backend/services/agent-runner
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install -e ".[dev]"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
 
       - name: Run provider integration tests
         env:

--- a/.github/workflows/docs/release-workflow.md
+++ b/.github/workflows/docs/release-workflow.md
@@ -60,7 +60,6 @@ git push origin main
 
 **Use this to:**
 - Test if your code compiles on all platforms
-- Verify agent-runner source embeds correctly
 - Check binary sizes
 - Download and manually test binaries before releasing
 
@@ -140,13 +139,15 @@ Git tag:
 
 GitHub Release assets:
 - `stigmer-v1.0.0-darwin-arm64.tar.gz`
-- `stigmer-v1.0.0-darwin-amd64.tar.gz`
-- `stigmer-v1.0.0-linux-amd64.tar.gz`
+- `stigmer-server-v1.0.0-darwin-amd64.tar.gz`
+- `stigmer-server-v1.0.0-linux-amd64.tar.gz`
 - Checksums (`.sha256` files)
 
-Homebrew formula:
-- Updated `Formula/stigmer.rb` with new version and checksums
-- Installs all three binaries (`stigmer`, `stigmer-server`, `stigmer-workflow-runner`)
+Distribution:
+- The `stigmer` CLI ships as the `@stigmer/cli` npm package; it downloads the
+  matching standalone `stigmer-server` asset on demand
+- The Homebrew tap (`stigmer/tap/stigmer`) is deliberately NOT bumped by this
+  workflow (see the note in `release.cli.yaml`)
 
 ## Version Numbering Strategy
 
@@ -178,8 +179,8 @@ Mark as pre-release in GitHub Actions or manually edit the release.
 1. **Test locally first**
    ```bash
    make build
-   ./bin/stigmer --version
-   ls -lh bin/stigmer bin/stigmer-server bin/stigmer-workflow-runner
+   ls -lh bin/stigmer-server
+   # The CLI ships as the @stigmer/cli npm package — no local bin/stigmer
    ```
 
 2. **Push to main and verify test build**
@@ -196,10 +197,10 @@ Mark as pre-release in GitHub Actions or manually edit the release.
 
 ### Release Checklist
 
-- [ ] All three binaries compile locally (`make build`)
+- [ ] The server binary compiles locally (`make build`)
 - [ ] Tests pass
 - [ ] Test build succeeded on all platforms
-- [ ] Downloaded and verified test binaries work (CLI, server, workflow-runner)
+- [ ] Downloaded and verified test binaries work (CLI via npm, server)
 - [ ] Decided on version number (e.g., `1.0.1`)
 - [ ] Ready to create git tag and release
 
@@ -321,11 +322,11 @@ git push origin main
 
 The workflow follows a **build → verify → tag → release** pattern:
 
-1. ✅ **Build first** - Compile three binaries (`stigmer`, `stigmer-server`,
-   `stigmer-workflow-runner`) on all platforms
+1. ✅ **Build first** - Compile the `stigmer-server` binary on all platforms
+   (the CLI ships separately as the `@stigmer/cli` npm package)
 2. ✅ **Verify** - All builds must succeed  
 3. ✅ **Tag** - Create git tag only after success
-4. ✅ **Release** - Publish tarballs (containing all three binaries) to GitHub
+4. ✅ **Release** - Publish the `stigmer-server` tarballs to GitHub
 
 This ensures:
 - Clean git history (no failed release tags)


### PR DESCRIPTION
## Summary

- `ci.integration-providers.yaml` still installed dependencies for `backend/services/agent-runner`, a directory that no longer exists — every run died at that step before reaching the provider tests the lane exists to run (#647).
- Deletes the dead install step AND the `Setup Python` step (its only consumer; the provider test set — `TestWorkflow*`/`TestAgentExecution` — never shells out to Python; the Python SDK acceptance test is offline-lane-only and builds its own venv).
- Adds the unified-runner setup block from `ci.integration-offline.yaml` (`npm ci`, `@stigmer/protos` build, runner `npm ci && npm run build`): the whole provider set executes through the unified Node runner, `make test-providers` gates on `check-runner-node`, and the harness prefers the pre-built `dist/main.js`.
- Truths the lane header ("via workflow-runner" / "Java + Python agent-runner" → the unified runner) and rides the `release-workflow.md` fix per the issue: no more `stigmer-workflow-runner` binary or three-binary release fiction — releases ship `stigmer-server` tarballs and the CLI ships as `@stigmer/cli` on npm (verified against `release.cli.yaml` and the root Makefile).

## Test plan

- [x] YAML lints clean
- [x] Setup block byte-mirrors the offline lane's proven steps
- [ ] Post-merge: a manual `workflow_dispatch` run (~$0.10) is the real verification — happy to trigger it on request

Closes #647

Made with [Cursor](https://cursor.com)