### PR TITLE
docs: retire remaining agent-runner/workflow-runner references outside backend/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 **Prerequisites**:
 - Go 1.25 or later
-- Python 3.11 or later
-- Node.js 22 or later (for web console)
+- Node.js 22 or later (web console + unified runner)
 - `buf` CLI tool
 
 **Clone and build**:
@@ -21,7 +20,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 ```bash
 git clone https://github.com/stigmer/stigmer.git
 cd stigmer
-make setup     # Install Go/Python dependencies
+make setup     # Install Go dependencies and git hooks
 npm install    # Install Node.js dependencies (web console + proto stubs)
 make local     # Build the local stigmer-server (the CLI runs from @stigmer/cli)
 make test      # Run tests
@@ -43,11 +42,10 @@ npm start -w @stigmer/cli -- up
 stigmer/
 ├── apis/                          # Protobuf definitions and generated stubs
 ├── backend/
-│   ├── libs/                      # Shared libraries (Go, Python)
+│   ├── libs/                      # Shared libraries (Go)
 │   └── services/
 │       ├── stigmer-server/        # Main gRPC server
-│       ├── workflow-runner/       # Temporal workflow runner
-│       └── agent-runner/          # Python agent execution engine
+│       └── runner/                # Unified TypeScript runner (agent sessions + workflow tasks)
 ├── client-apps/
 │   ├── cli/                       # Go CLI (stigmer command)
 │   └── web/                       # Next.js web console
@@ -77,7 +75,7 @@ Protocol Buffer definitions are in `apis/`. After modifying protos:
 make protos
 ```
 
-This generates Go and Python code from `.proto` files.
+This generates Go, Java, Python, and TypeScript stubs from `.proto` files.
 
 ## How to Contribute
 
@@ -180,12 +178,11 @@ func (b *Backend) CreateExecution(ctx context.Context, req *pb.CreateExecutionRe
 }
 ```
 
-### Python
+### Python (applies to `sdk/python`)
 
 **Follow PEP 8**:
 - Type hints for function signatures
 - Docstrings for classes and functions
-- `black` for formatting (enforced by CI)
 
 **Example**:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Resource definitions are portable across both modes. The CLI talks to the same g
 ### Prerequisites
 
 - Go 1.25+
-- Python 3.11+ with [Poetry](https://python-poetry.org/)
 - Node.js 22+
 - Git, Make
 

--- a/apis/ai/stigmer/agentic/agentexecution/docs/async-workflow-integration.md
+++ b/apis/ai/stigmer/agentic/agentexecution/docs/async-workflow-integration.md
@@ -131,12 +131,12 @@ Both success and failure paths must call completion. If the agent fails, call th
 
 ## `callback_token` in Status
 
-The token is also stored in `AgentExecutionStatus.callback_token` for reference by the agent-runner:
+The token is also stored in `AgentExecutionStatus.callback_token` for reference by the runner:
 
 | Location | Purpose |
 |---|---|
 | `spec.callback_token` | Set by the caller when creating the execution |
-| `status.callback_token` | Copied by the system into status for the agent-runner to read during completion |
+| `status.callback_token` | Copied by the system into status for the runner to read during completion |
 
 The status field is system-managed. Never set it directly.
 

--- a/apis/ai/stigmer/agentic/agentexecution/docs/attachments-and-artifacts.md
+++ b/apis/ai/stigmer/agentic/agentexecution/docs/attachments-and-artifacts.md
@@ -105,7 +105,7 @@ When you attach a directory, the CLI zips it and sets `extract: true`:
 stigmer run my-agent "Analyze this project" --attach ./my-project/
 ```
 
-The agent-runner extracts the ZIP at the mount path, making all files accessible under their original relative paths.
+The runner extracts the ZIP at the mount path, making all files accessible under their original relative paths.
 
 ---
 

--- a/apis/ai/stigmer/agentic/agentexecution/docs/context-management.md
+++ b/apis/ai/stigmer/agentic/agentexecution/docs/context-management.md
@@ -24,7 +24,7 @@ Stigmer monitors token usage during every AgentExecution and automatically summa
 
 **How it works:**
 
-1. After each LLM call, the agent-runner checks the current token count
+1. After each LLM call, the runner checks the current token count
 2. When the token count exceeds the **trigger threshold** (default: ~90% of the model's context window), summarization is triggered
 3. A lightweight economy model (e.g., `claude-haiku-4` for Anthropic, `gpt-4o-mini` for OpenAI) generates a summary of the older conversation history
 4. The older messages are replaced by the summary, reducing context to approximately the **target token count** (default: ~80% of the context window)

--- a/apis/ai/stigmer/agentic/skill/docs/skill-md-format.md
+++ b/apis/ai/stigmer/agentic/skill/docs/skill-md-format.md
@@ -219,7 +219,7 @@ Good candidates for `references/`:
 
 ### The `scripts/` Directory
 
-Use `scripts/` for executable files that the agent runs as tools. The agent-runner extracts skill artifacts into `/bin/skills/<version_hash>/` in the execution sandbox. Scripts in this directory become available at that path.
+Use `scripts/` for executable files that the agent runs as tools. The runner extracts skill artifacts into `/bin/skills/<version_hash>/` in the execution sandbox. Scripts in this directory become available at that path.
 
 Reference scripts in your `SKILL.md` body with their execution path:
 

--- a/apis/ai/stigmer/agentic/skill/docs/versioning.md
+++ b/apis/ai/stigmer/agentic/skill/docs/versioning.md
@@ -139,7 +139,7 @@ When a push updates a skill, the previous version is **archived**, not deleted. 
 - Not visible in `stigmer list skills` output
 - Not returned by `getByReference` when resolving `latest` or a tag name
 - Still accessible via their hash (e.g., `version: a1b2c3d4...`)
-- Still available for artifact download by the agent-runner
+- Still available for artifact download by the runner
 
 The archive is permanent — there is no way to delete archived versions via the CLI. This ensures agents that were configured with a specific hash always have access to their artifact.
 

--- a/backend/services/stigmer-server/README.md
+++ b/backend/services/stigmer-server/README.md
@@ -267,8 +267,8 @@ Not applicable for open-source local deployment. Stigmer Server runs as a local 
 
 ## Related Services
 
-- **agent-runner** - Python Temporal worker for agent execution
-- **workflow-runner** - Go Temporal worker for workflow execution
+- **runner** (`backend/services/runner`) - Unified TypeScript Temporal worker
+  that executes agent sessions and workflow tasks
 
 ## Related Documentation
 
@@ -279,5 +279,5 @@ Not applicable for open-source local deployment. Stigmer Server runs as a local 
 
 ---
 
-**Last Updated**: January 19, 2026  
+**Last Updated**: August 13, 2026  
 **Maintained By**: Stigmer Engineering Team

--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -72,7 +72,7 @@ stigmer server
 
 On first run, an interactive prompt asks for your Anthropic API key — local
 agent execution runs on Anthropic Claude models. The server starts Temporal for
-durable execution and the agent-runner for AI agent processing.
+durable execution and the runner process that executes your agents.
 
 ## Quick start
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -842,11 +842,13 @@ harness via the `@cursor/sdk`.
 
 #### Workflow Runner
 
-The Go Temporal worker that executes Workflow tasks.
+Retired term. Workflow tasks are executed by the unified TypeScript runner
+(see Agent Runner) — there is no separate workflow worker.
 
-- **Capitalize**: Yes.
-- **Context rule**: Architecture docs only. Same as Agent Runner---embedded in
-  `stigmer server`.
+- **Capitalize**: Yes (when quoting historical docs).
+- **Context rule**: Do not use in new writing. Any doc describing a "Go
+  Temporal worker that executes Workflow tasks" is describing the retired
+  service — point it at the Agent Runner entry instead.
 
 ---
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -428,8 +428,12 @@ test-sdk: check-runner-node ensure-service-jar ## Run SDK acceptance smoke tests
 		--packages ./... \
 		-- -tags integration -timeout 300s -count=1 $(call quarantine_skip_args) -run 'TestSDKAcceptance' -v
 
-REPLAY_HISTORY_OUTPUT_DIR ?= ../../backend/services/workflow-runner/test/replay/testdata/replay-histories
+# Captured histories land locally by default. The old default pointed at
+# backend/services/workflow-runner/test/replay/testdata/ — a directory that
+# left with the retired Go workflow-runner; no committed gold-master location
+# exists today. Override REPLAY_HISTORY_OUTPUT_DIR to export elsewhere.
 REPLAY_CAPTURE_OUTPUT_DIR ?= .test-output-replay-capture
+REPLAY_HISTORY_OUTPUT_DIR ?= $(REPLAY_CAPTURE_OUTPUT_DIR)/replay-histories
 
 .PHONY: capture-replay-histories
 capture-replay-histories: check-runner-node ensure-service-jar ## Capture Temporal event histories for replay determinism tests

--- a/test/integration/replay_capture_test.go
+++ b/test/integration/replay_capture_test.go
@@ -26,9 +26,10 @@ import (
 //
 //	make capture-replay-histories
 //
-// The exported histories are gold masters: they are committed to the repo at
-// backend/services/workflow-runner/test/replay/testdata/replay-histories/
-// and replayed on every PR that touches the workflow-runner code.
+// The exported histories are candidate gold masters for replay determinism
+// tests. Since the Go workflow-runner retired there is no committed home for
+// them — they land in REPLAY_HISTORY_OUTPUT_DIR (default: the capture output
+// dir) until a replay suite for the unified runner adopts them.
 func TestCaptureReplayHistories(t *testing.T) {
 	if os.Getenv("CAPTURE_REPLAY_HISTORIES") == "" {
 		t.Skip("set CAPTURE_REPLAY_HISTORIES=1 to run (or use: make capture-replay-histories)")


### PR DESCRIPTION
## Summary

- Works the verified straggler list from the cloud#277 post-merge census (#648): PR #642 fixed the backend front door; these are the onboarding-visible leftovers.
- `CONTRIBUTING.md` (repo tree, Python-3.11 prereq, setup claim, protos languages, Python section rescoped to `sdk/python`), root `README.md` (no Python/Poetry needed to build), `docs/vocabulary.md` (Workflow Runner entry marked retired, pointing at the unified runner — the entry the 2026-08-08 pass missed), `stigmer-server` README (Related Services bottom section + stale footer), `docs/cli/index.mdx`, and the five `apis/**/docs` prose spots.
- `test/integration/Makefile`: `REPLAY_HISTORY_OUTPUT_DIR` defaulted into the nonexistent workflow-runner testdata tree; captured histories now land in the capture output dir, and the capture test's gold-master comment (the source of that fiction) is truthed.
- Deliberately untouched, per the census caution: the literal `"/runtimes/agent-runner/"` sandbox-path constants in `prompt-builder.ts`/`blueprint-resolver.ts` (functional, not prose) and the harness's "ported from Python" provenance notes.

## Test plan

- [x] `vale docs/vocabulary.md docs/cli/index.mdx` — 0 errors (24 pre-existing warnings unchanged)
- [x] `go vet -tags integration ./test/integration/...` (comment-only Go change compiles)
- [x] Census grep across all touched files: only deliberate historical references remain

Closes #648

Made with [Cursor](https://cursor.com)