### PR TITLE
feat(runner): file deletions join apply-then-review on CAS-captured workspaces

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hook-script.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hook-script.test.ts
@@ -753,11 +753,47 @@ d("generated approval hook (preToolUse + beforeMCPExecution)", () => {
       expect(obs.secretPaths).toEqual([]);
     });
 
-    it("still gates a gitignored DELETE (no CAS capture path, parity with deep-agent)", async () => {
+    it("stages a non-secret gitignored DELETE and allows it (issue #303)", async () => {
       const h = setup({ captureMode: true, captureIgnored: true, gitignored: ["*.log"] });
-      expect(h.decide(hookDelete("app.log")).permission).toBe("deny");
+      writeFileSync(join(h.root, "app.log"), "DOOMED", "utf-8");
+      expect(h.decide(hookDelete("app.log")).permission).toBe("allow");
+      // Flowed, not denied — reviewed post-hoc as a DELETE entry, not a pause.
+      expect(h.ledger()).toEqual([]);
+      const obs = await h.observations();
+      expect(obs.secretPaths).toEqual([]);
+      expect(obs.captured).toHaveLength(1);
+      expect(obs.captured[0].path).toBe("app.log");
+      // The pre-delete bytes are staged — the restorable "before" side.
+      expect(Buffer.from(obs.captured[0].before!).toString("utf8")).toBe("DOOMED");
+    });
+
+    it("first-touch-wins across write-then-delete: the true pre-turn before survives", async () => {
+      const h = setup({ captureMode: true, captureIgnored: true, gitignored: ["*.log"] });
+      writeFileSync(join(h.root, "app.log"), "ORIGINAL", "utf-8");
+      expect(h.decide(hookWrite("app.log", "REWRITTEN")).permission).toBe("allow");
+      // Simulate the write having applied, then a delete later this turn.
+      writeFileSync(join(h.root, "app.log"), "REWRITTEN", "utf-8");
+      expect(h.decide(hookDelete("app.log")).permission).toBe("allow");
+      const obs = await h.observations();
+      expect(obs.captured).toHaveLength(1);
+      expect(Buffer.from(obs.captured[0].before!).toString("utf8")).toBe("ORIGINAL");
+    });
+
+    it("keeps a SECRET-LIKE gitignored delete on the deny-gate: approvable, never staged (issue #303)", async () => {
+      // Unlike a secret write (hard-blocked — its content must never surface), a
+      // delete's args expose no secret content, so a human may approve it. Its
+      // before-bytes must never enter the sidecar though: staging would both
+      // persist the secret bytes and mark the path "secret", making the boundary
+      // author a blocking DIFF_UNREVIEWABLE for a merely-gated delete.
+      const h = setup({ captureMode: true, captureIgnored: true, gitignored: [".env"] });
+      writeFileSync(join(h.root, ".env"), "API_KEY=abc", "utf-8");
+      const d = h.decide(hookDelete(".env"));
+      expect(d.permission).toBe("deny");
+      expect(d.raw).toContain("submitted to the user for approval"); // gated, not blocked
+      expect(h.ledger().map((e) => e.kind)).toEqual(["approval"]);
       const obs = await h.observations();
       expect(obs.captured).toEqual([]);
+      expect(obs.secretPaths).toEqual([]); // no secret marker for a gated delete
     });
 
     it("with captureIgnored OFF, a gitignored write stays denied and stages nothing", async () => {
@@ -768,10 +804,10 @@ d("generated approval hook (preToolUse + beforeMCPExecution)", () => {
     });
   });
 
-  // Slice 2c: a NON-git workspace has no git snapshot, so EVERY file write is
-  // CAS-staged and flowed for review (not only gitignored ones), a delete stays
-  // gated (no CAS delete-capture path, parity with the deep-agent), and shell/MCP
-  // gate as always. The workspace is deliberately NOT git-initialized.
+  // Slice 2c: a NON-git workspace has no git snapshot, so EVERY file write and
+  // (issue #303) every non-secret delete is CAS-staged and flowed for review —
+  // not only gitignored ones — while shell/MCP gate as always. The workspace is
+  // deliberately NOT git-initialized.
   describe("non-git workspace CAS capture (Slice 2c)", () => {
     it("stages EVERY write (not just gitignored) and allows it, no denial", async () => {
       const h = setup({ captureMode: true, captureIgnored: true, gitWorkspace: false });
@@ -806,12 +842,27 @@ d("generated approval hook (preToolUse + beforeMCPExecution)", () => {
       expect(obs.secretPaths).toEqual([".env"]);
     });
 
-    it("still gates a DELETE (deny-gate, parity with deep-agent) and stages nothing", async () => {
+    it("stages a DELETE with its pre-delete bytes and allows it (issue #303)", async () => {
       const h = setup({ captureMode: true, captureIgnored: true, gitWorkspace: false });
-      expect(h.decide(hookDelete("notes.md")).permission).toBe("deny");
-      expect(h.ledger()).toHaveLength(1);
+      writeFileSync(join(h.root, "notes.md"), "KEEP ME", "utf-8");
+      expect(h.decide(hookDelete("notes.md")).permission).toBe("allow");
+      expect(h.ledger()).toEqual([]);
+      const obs = await h.observations();
+      expect(obs.captured).toHaveLength(1);
+      expect(obs.captured[0].path).toBe("notes.md");
+      expect(Buffer.from(obs.captured[0].before!).toString("utf8")).toBe("KEEP ME");
+    });
+
+    it("keeps a secret-like DELETE gated (approvable) and stages nothing", async () => {
+      const h = setup({ captureMode: true, captureIgnored: true, gitWorkspace: false });
+      writeFileSync(join(h.root, ".env"), "API_KEY=abc", "utf-8");
+      const d = h.decide(hookDelete(".env"));
+      expect(d.permission).toBe("deny");
+      expect(d.raw).toContain("submitted to the user for approval");
+      expect(h.ledger().map((e) => e.kind)).toEqual(["approval"]);
       const obs = await h.observations();
       expect(obs.captured).toEqual([]);
+      expect(obs.secretPaths).toEqual([]);
     });
 
     it("still gates shell (never git-reversible, never CAS-captured)", async () => {

--- a/backend/services/runner/src/activities/execute-cursor/capture-flow.ts
+++ b/backend/services/runner/src/activities/execute-cursor/capture-flow.ts
@@ -112,10 +112,11 @@ export function captureBaselineToLedger(opts: {
  * bytes withheld from durable storage.
  *
  * `deniedTokens` are the identities the hook gated this turn (shell/MCP, or a
- * gitignored delete). A streamed file-edit row whose identity is in that set is
- * left for the deny-gate reconcile path — it did NOT flow. A flowed gitignored
- * write is NOT in that set (the hook allowed it), so it is stamped like any
- * other flowed edit and its captured delta surfaces as a CAS entry in the set.
+ * secret-like delete — non-secret CAS deletes flow since issue #303). A streamed
+ * file-edit row whose identity is in that set is left for the deny-gate
+ * reconcile path — it did NOT flow. A flowed gitignored write or delete is NOT
+ * in that set (the hook allowed it), so it is stamped like any other flowed
+ * edit and its captured delta surfaces as a CAS entry in the set.
  *
  * `hitlDir`/`storage` are omitted only by callers with no artifact storage
  * (captureIgnored off); the CAS half is then skipped and this is a git-only

--- a/backend/services/runner/src/activities/execute-cursor/cas-observations.ts
+++ b/backend/services/runner/src/activities/execute-cursor/cas-observations.ts
@@ -1,5 +1,6 @@
 /**
- * The Cursor harness's disk-backed observer for gitignored file writes — the
+ * The Cursor harness's disk-backed observer for CAS-owned file mutations —
+ * gitignored / non-git writes, and (issue #303) pre-delete byte capture — the
  * out-of-process analog of the deep-agent `CasCaptureFilesystemBackend`
  * ({@link ../execute-deep-agent/cas-capture-backend.js}).
  *
@@ -185,14 +186,19 @@ export function buildSecretClassifyScript(): string {
 
 /**
  * Build the standalone Node.js script the hook runs to observe a single
- * gitignored write — the disk-backed mirror of `CasCaptureFilesystemBackend`'s
- * `recordBefore` plus the DD-E secret gate.
+ * CAS-owned mutation — the disk-backed mirror of `CasCaptureFilesystemBackend`'s
+ * `recordBefore` plus the DD-E secret gate. Staging is mutation-agnostic: it
+ * records the PRE-mutation bytes, so the hook runs it for a write/edit and —
+ * issue #303 — for a delete (whose before-bytes exist only until the tool runs;
+ * the boundary later reads after=null and authors the DELETE). The hook's
+ * delete arm pre-classifies secrets and never invokes this for a secret-like
+ * delete (a gated delete must not leave a "secret" marker in the sidecar).
  *
  * Invoked as `printf %s "$SALIENT" | node -e '<this>' <workspaceRoot> <obsDir>`
  * — the (arbitrary) salient path arrives on stdin so no argv escaping is needed;
  * the two absolute paths ride argv. Prints one token on stdout for the hook:
  *  - `captured` — non-secret: staged the pre-turn bytes (first-touch-wins), the
- *    hook then ALLOWS the write to flow;
+ *    hook then ALLOWS the mutation to flow;
  *  - `secret`   — secret-like: recorded a content-less marker, the hook then
  *    DENIES with the security message (nothing is written);
  *  - `error`    — the path escaped the workspace or a filesystem error occurred,

--- a/backend/services/runner/src/activities/execute-cursor/hook-script.ts
+++ b/backend/services/runner/src/activities/execute-cursor/hook-script.ts
@@ -574,9 +574,8 @@ if echo "$STATE" | grep -q '"captureIgnored":true'; then
 fi
 # gitWorkspace selects the capture substrate (Slice 2c). Default true when the
 # key is absent (older state files). When false the workspace is NOT a git tree:
-# there is no git snapshot, so EVERY file write is CAS-staged below (not only
-# gitignored ones), the git-tracked flow arm is skipped, and a delete stays gated
-# (no CAS delete-capture path, parity with the deep-agent).
+# there is no git snapshot, so EVERY file write/delete is CAS-staged below (not
+# only gitignored ones) and the git-tracked flow arm is skipped.
 GIT_WORKSPACE=true
 if echo "$STATE" | grep -q '"gitWorkspace":false'; then
   GIT_WORKSPACE=false
@@ -597,9 +596,10 @@ fi
 # secret-like one must be hard-blocked in every mode. WHICH writes are CAS-owned
 # depends on the substrate: in a git tree it is only the GITIGNORED writes (git
 # captures the tracked ones); in a NON-GIT workspace it is EVERY write (there is
-# no git snapshot). Only a built-in write/edit (category "write") takes this arm;
-# deletes and shell/MCP stay on the deny-gate below (parity with the deep-agent
-# approval gate). The staging runs on the runner's own Node binary (the
+# no git snapshot). Only a built-in write/edit (category "write") takes THIS arm;
+# deletes take their own staging arm just below (issue #303), shell/MCP stay on
+# the deny-gate (parity with the deep-agent approval gate). The staging runs on
+# the runner's own Node binary (the
 # disk-backed mirror of CasCaptureFilesystemBackend.recordBefore): the salient
 # path rides stdin (no argv escaping), the workspace root and the per-turn
 # cas-observations dir ride argv. "captured" -> allow (apply-then-review);
@@ -626,6 +626,32 @@ if [ "$CAPTURE_IGNORED" = "true" ] && [ "$CATEGORY" = "write" ] && [ -n "$SALIEN
     record_denial "$PRIMARY_TOKEN" "capture-error"
     echo '{"permission":"deny","agent_message":"${APPROVAL_REQUIRED_AGENT_MESSAGE}","user_message":"Tool requires approval: '"$TOOL_NAME"'"}'
     exit 0
+  fi
+fi
+
+# --- Capture mode: observe CAS-owned deletes for review (issue #303) --------
+# The delete twin of the write arm above — a non-secret CAS-owned delete stages
+# its before-bytes (the one moment they still exist on disk) and flows; the
+# turn boundary then reads after=null and authors a reviewable, restorable
+# DELETE entry. One deliberate difference from the write arm: the path is
+# classified for secret-likeness BEFORE any staging touches the sidecar. A
+# secret-like delete must stay on the deny-gate below where a human may still
+# approve it (its args expose no secret content, unlike a write) — staging it
+# would both persist the secret before-bytes and mark the sidecar "secret",
+# making the boundary author a blocking DIFF_UNREVIEWABLE for a merely-gated
+# delete. Every failure mode (secret, classify error, staging error) falls
+# through to the deny-gate rather than denying here, so grants and leases keep
+# applying to a gated delete exactly as before this arm existed; the eventual
+# resolution records its own ledger kind.
+if [ "$CAPTURE_IGNORED" = "true" ] && [ "$CATEGORY" = "delete" ] && [ -n "$SALIENT" ] && { [ "$GIT_WORKSPACE" = "false" ] || __stigmer_is_gitignored "$SALIENT"; }; then
+  DELETE_SECRET_RESULT=$(printf '%s' "$SALIENT" | ELECTRON_RUN_AS_NODE=1 "$NODE_BIN" -e '${secretClassifyScript}' 2>/dev/null || echo error)
+  if [ "$DELETE_SECRET_RESULT" = "ok" ]; then
+    OBS_DIR="$(dirname "$STATE_FILE")/${CAS_OBSERVATIONS_DIRNAME}"
+    OBS_RESULT=$(printf '%s' "$SALIENT" | ELECTRON_RUN_AS_NODE=1 "$NODE_BIN" -e '${observationStagingScript}' "$GIT_ROOT" "$OBS_DIR" 2>/dev/null || echo error)
+    if [ "$OBS_RESULT" = "captured" ]; then
+      echo '{"permission":"allow"}'
+      exit 0
+    fi
   fi
 fi
 
@@ -700,13 +726,13 @@ if [ -n "$CATEGORY" ]; then
   # Capture mode (GIT tree only): a git-tracked file mutation (write/edit/delete)
   # flows freely — the runner captures the whole change set with git at the turn
   # boundary and gates it per-file for review. A gitignored path is invisible to
-  # that git snapshot: a non-secret gitignored WRITE was already handled above
-  # (staged + allowed, or hard-blocked) when captureIgnored is on; here it only
-  # reaches the deny-gate when captureIgnored is off (no artifact storage) or it is
-  # a gitignored DELETE (no CAS capture path, parity with deep-agent). shell
-  # (category "shell") never takes this branch and stays gated as always. In a
-  # NON-GIT workspace this arm is skipped entirely (there is no git diff): writes
-  # were CAS-staged above and a delete falls through to the deny-gate.
+  # that git snapshot: a non-secret gitignored WRITE or DELETE was already
+  # handled above (staged + allowed, hard-blocked, or left to fall through) when
+  # captureIgnored is on; here it only reaches the deny-gate when captureIgnored
+  # is off (no artifact storage), or it is a secret-like DELETE (approvable, but
+  # never staged — issue #303). shell (category "shell") never takes this branch
+  # and stays gated as always. In a NON-GIT workspace this arm is skipped
+  # entirely (there is no git diff): writes and deletes were CAS-staged above.
   if [ "$CAPTURE_MODE" = "true" ] && [ "$GIT_WORKSPACE" = "true" ] && { [ "$CATEGORY" = "write" ] || [ "$CATEGORY" = "delete" ]; }; then
     if ! __stigmer_is_gitignored "$SALIENT"; then
       echo '{"permission":"allow"}'

--- a/backend/services/runner/src/activities/execute-deep-agent/cas-capture-backend.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/cas-capture-backend.ts
@@ -21,7 +21,9 @@
  *
  * deepagents mutates only via `write` (create/overwrite) and `edit` (modify);
  * there is no backend delete/rename, so this observes CREATE and MODIFY. A
- * gitignored delete can only arrive via shell, which stays on the approval gate.
+ * delete-category tool consequently cannot be observed here — the approval gate
+ * records its before-bytes at authorization time instead (`captureDeleteBefore`,
+ * issue #303). A delete via shell (`rm`) stays on the approval gate as always.
  *
  * @since File-Change HITL Redesign (Phase 3 — CAS deep-agent wiring); sub-agent
  * gitignored capture parity (Session 26, DD-19); shell restore (issue #248)

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -676,6 +676,14 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
           isCapturablePath,
           captureIgnored: captureMode && !!artifactStorage,
           recordBlockedSecret: (rawPath: string) => casObserver.recordBlockedSecret(rawPath),
+          // Pre-delete byte capture (issue #303): deepagents has no backend
+          // delete method for the CAS backend to observe, so a flowing delete's
+          // before-bytes are recorded by the gate at authorization time, through
+          // the SAME shared observer — the turn boundary then reads after=null
+          // and authors a reviewable, restorable DELETE. recordBefore's own
+          // ownership predicate (gitignored-only in a git tree, everything in
+          // non-git) agrees with the gate's not-capturable condition.
+          captureDeleteBefore: (rawPath: string) => casObserver.recordBefore(rawPath),
           unattended,
           unattendedSkips,
         }

--- a/backend/services/runner/src/activities/execute-deep-agent/subagent-wiring.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/subagent-wiring.ts
@@ -110,19 +110,26 @@ export function buildSubAgentMiddleware(
   stack.push(createToolTruncationMiddleware(options.toolTruncation));
 
   if (options.approvalGate) {
-    // captureIgnored (DD-19): a sub-agent flows gitignored writes into CAS iff a
-    // CAS observer backs its filesystem backend (compileSubagents passes this as
+    // captureIgnored (DD-19): a sub-agent flows gitignored writes — and, since
+    // issue #303, non-secret CAS-owned deletes — into CAS iff a CAS observer
+    // backs its filesystem backend (compileSubagents passes this as
     // `!!casObserver`). When true, inherit the parent gate verbatim so its
-    // captureIgnored + recordBlockedSecret feed the SAME shared observer that
-    // backs the sub-agent's writes. When false (default; non-capture mode, or no
-    // observer), force CAS routing off and drop the blocked-secret sink so
-    // gitignored paths stay on the interrupt gate — a flowed gitignored edit on an
-    // unobserved backend would apply unobserved, unreviewable bytes. Sub-agent
-    // git-tracked edits are always captured by the backend-agnostic boundary diff.
+    // captureIgnored + recordBlockedSecret + captureDeleteBefore feed the SAME
+    // shared observer that backs the sub-agent's writes. When false (default;
+    // non-capture mode, or no observer), force CAS routing off and drop both
+    // observer sinks so gitignored paths stay on the interrupt gate — a flowed
+    // gitignored edit on an unobserved backend would apply unobserved,
+    // unreviewable bytes. Sub-agent git-tracked edits are always captured by
+    // the backend-agnostic boundary diff.
     stack.push(createApprovalGateMiddleware(
       options.captureIgnored
         ? options.approvalGate
-        : { ...options.approvalGate, captureIgnored: false, recordBlockedSecret: undefined },
+        : {
+            ...options.approvalGate,
+            captureIgnored: false,
+            recordBlockedSecret: undefined,
+            captureDeleteBefore: undefined,
+          },
     ));
   }
 

--- a/backend/services/runner/src/middleware/__tests__/approval-gate.test.ts
+++ b/backend/services/runner/src/middleware/__tests__/approval-gate.test.ts
@@ -423,7 +423,10 @@ describe("ApprovalGateMiddleware", () => {
       expect(mockedInterrupt).toHaveBeenCalledTimes(1);
     });
 
-    it("KEEPS GATING a gitignored delete", async () => {
+    it("KEEPS GATING a gitignored delete when no CAS routing is configured", async () => {
+      // captureIgnored unset: there is no substrate to capture the before-bytes
+      // into, so the delete stays on the interrupt gate (fail-closed). The CAS
+      // delete-flow cases live in the captureIgnored suite below (issue #303).
       const mw = createApprovalGateMiddleware(makeConfig({
         fileCaptureMode: true,
         isCapturablePath: async () => false,
@@ -621,6 +624,132 @@ describe("ApprovalGateMiddleware", () => {
       expect(handler).toHaveBeenCalledTimes(1);
       expect(recordBlockedSecret).not.toHaveBeenCalled();
       expect(mockedInterrupt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("capture mode — CAS delete capture (captureDeleteBefore, issue #303)", () => {
+    it("flows a non-secret CAS-owned delete: captures before-bytes, runs, never interrupts", async () => {
+      const handler = vi.fn(passthrough);
+      const captureDeleteBefore = vi.fn(async () => {});
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      try {
+        const mw = createApprovalGateMiddleware(makeConfig({
+          fileCaptureMode: true,
+          isCapturablePath: async () => false, // gitignored / non-git
+          captureIgnored: true,
+          captureDeleteBefore,
+          fingerprintKey: "test-key",
+          executionId: "exec-del",
+        }));
+
+        const result = await mw.wrapToolCall!(
+          makeRequest({ name: "delete", args: { path: "scratch/tmp.txt" } }),
+          handler,
+        );
+
+        expect((result as ToolMessage).content).toBe("tool result");
+        expect(captureDeleteBefore).toHaveBeenCalledWith("scratch/tmp.txt");
+        expect(handler).toHaveBeenCalledTimes(1); // the delete flowed (apply-then-review)
+        expect(mockedInterrupt).not.toHaveBeenCalled();
+
+        // The gateway records the flow with file_capture provenance, like writes.
+        const receipt = logSpy.mock.calls
+          .map((c) => String(c[0] ?? ""))
+          .filter((line) => line.startsWith("[hitl-gateway] receipt "))
+          .map((line) => JSON.parse(line.slice("[hitl-gateway] receipt ".length)) as Record<string, unknown>)[0];
+        expect(receipt.policySource).toBe("file_capture");
+        expect(receipt.category).toBe("delete");
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
+
+    it("captures before-bytes BEFORE the tool runs (the bytes exist only until then)", async () => {
+      const order: string[] = [];
+      const captureDeleteBefore = vi.fn(async () => { order.push("capture"); });
+      const handler = vi.fn((req: ToolCallRequest) => {
+        order.push("delete");
+        return passthrough(req);
+      });
+      const mw = createApprovalGateMiddleware(makeConfig({
+        fileCaptureMode: true,
+        isCapturablePath: async () => false,
+        captureIgnored: true,
+        captureDeleteBefore,
+      }));
+
+      await mw.wrapToolCall!(
+        makeRequest({ name: "delete", args: { path: "scratch/tmp.txt" } }),
+        handler,
+      );
+
+      expect(order).toEqual(["capture", "delete"]);
+    });
+
+    it("keeps a SECRET-LIKE delete on the interrupt gate: approvable, never captured, never hard-blocked", async () => {
+      // A delete's args expose no secret content (unlike a write), so a human
+      // may safely approve it — but its before-bytes must never enter CAS.
+      const handler = vi.fn(passthrough);
+      const captureDeleteBefore = vi.fn(async () => {});
+      const recordBlockedSecret = vi.fn();
+      const mw = createApprovalGateMiddleware(makeConfig({
+        fileCaptureMode: true,
+        isCapturablePath: async () => false,
+        captureIgnored: true,
+        captureDeleteBefore,
+        recordBlockedSecret,
+      }));
+      mockedInterrupt.mockReturnValue({ action: "approve" });
+
+      const result = await mw.wrapToolCall!(
+        makeRequest({ name: "delete", args: { path: ".env" } }),
+        handler,
+      );
+
+      expect(mockedInterrupt).toHaveBeenCalledTimes(1); // gated, not blocked
+      expect(captureDeleteBefore).not.toHaveBeenCalled(); // bytes never staged
+      expect(recordBlockedSecret).not.toHaveBeenCalled(); // not a blocked write
+      expect(handler).toHaveBeenCalledTimes(1); // the human approved it
+      expect((result as ToolMessage).content).toBe("tool result");
+    });
+
+    it("keeps gating a CAS-owned delete when no captureDeleteBefore is configured", async () => {
+      // Fail-closed: a delete whose before-bytes cannot be captured cannot be
+      // reviewed post-hoc, so it must be approved up front.
+      const mw = createApprovalGateMiddleware(makeConfig({
+        fileCaptureMode: true,
+        isCapturablePath: async () => false,
+        captureIgnored: true,
+      }));
+      mockedInterrupt.mockReturnValue({ action: "approve" });
+
+      await mw.wrapToolCall!(
+        makeRequest({ name: "delete", args: { path: "scratch/tmp.txt" } }),
+        passthrough,
+      );
+
+      expect(mockedInterrupt).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps gating a delete with captureIgnored OFF even when captureDeleteBefore is present", async () => {
+      // An unobserved-backend gate (captureIgnored false) must not flow deletes:
+      // the callback alone is not a substrate.
+      const captureDeleteBefore = vi.fn(async () => {});
+      const mw = createApprovalGateMiddleware(makeConfig({
+        fileCaptureMode: true,
+        isCapturablePath: async () => false,
+        captureIgnored: false,
+        captureDeleteBefore,
+      }));
+      mockedInterrupt.mockReturnValue({ action: "approve" });
+
+      await mw.wrapToolCall!(
+        makeRequest({ name: "delete", args: { path: "scratch/tmp.txt" } }),
+        passthrough,
+      );
+
+      expect(mockedInterrupt).toHaveBeenCalledTimes(1);
+      expect(captureDeleteBefore).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/services/runner/src/middleware/approval-gate.ts
+++ b/backend/services/runner/src/middleware/approval-gate.ts
@@ -88,10 +88,11 @@ export interface ApprovalGateConfig {
    * `write`/`delete` whose target path is capturable (git-tracked — see
    * {@link isCapturablePath}) FLOWS instead of interrupting: the edit is reviewed
    * post-hoc as a captured `FileChangeSet`, not gated before it runs. A gitignored
-   * path is NOT capturable, so it stays gated (the git substrate cannot capture or
-   * revert it) — the exact twin of the Cursor hook's `__stigmer_is_gitignored`
-   * allow-branch. `shell` and MCP tools are never bypassed by this flag. Off (the
-   * default) keeps the classic true-pause gate for every mutation.
+   * path is NOT capturable by the git substrate, so it stays gated unless
+   * {@link captureIgnored} routes it into CAS capture — the exact twin of the
+   * Cursor hook's `__stigmer_is_gitignored` allow-branch. `shell` and MCP tools
+   * are never bypassed by this flag. Off (the default) keeps the classic
+   * true-pause gate for every mutation.
    */
   readonly fileCaptureMode?: boolean;
   /**
@@ -107,12 +108,12 @@ export interface ApprovalGateConfig {
    * instead of the interrupt gate, applying the DD-E secret gate. When off, a
    * gitignored path stays on the interrupt gate exactly as before.
    *
-   * TRUE ONLY FOR THE PARENT GATE. Sub-agents build their own plain filesystem
-   * backends, which the CAS observer does not wrap, so flowing their gitignored
-   * edits would apply unobserved, unreviewable bytes. `buildSubAgentMiddleware`
-   * therefore forces this to false for sub-agent gates — it must NOT be inherited
-   * as true. (Sub-agent git-tracked edits are still captured by the turn-boundary
-   * git diff, which is backend-agnostic.)
+   * True only for gates whose backend a CAS observer wraps: the parent gate
+   * always (setup.ts), and — since DD-19 — sub-agent gates too, because
+   * `compileSubagents` gives every sub-agent a CAS-observing backend wired to
+   * the SAME shared observer and `buildSubAgentMiddleware` then inherits this
+   * config verbatim. A gate over an UNOBSERVED backend must keep this false:
+   * flowing its gitignored edits would apply unobserved, unreviewable bytes.
    */
   readonly captureIgnored?: boolean;
   /**
@@ -122,6 +123,20 @@ export interface ApprovalGateConfig {
    * secret; the CONTENT never leaves the workspace). Absent ⇒ nothing recorded.
    */
   readonly recordBlockedSecret?: (rawPath: string) => void;
+  /**
+   * Capture a file's pre-delete bytes into the CAS observer so a CAS-owned
+   * (gitignored / non-git) DELETE can flow under {@link captureIgnored} and be
+   * reviewed post-hoc exactly like a write (issue #303) — the delete twin of the
+   * backend's `recordBefore` write observation. A delete is the one mutation the
+   * backend cannot observe (deepagents has no backend delete method to wrap), so
+   * the gate captures at authorization time instead: the file's bytes are still
+   * on disk here, and the turn boundary then reads after=null and authors a
+   * `FILE_CHANGE_KIND_DELETE` with the same discard-restores contract.
+   *
+   * Absent ⇒ deletes keep today's interrupt-gate behavior (fail-closed: a delete
+   * we cannot capture cannot be reviewed, so it must be approved up front).
+   */
+  readonly captureDeleteBefore?: (rawPath: string) => Promise<void>;
   /**
    * Unattended approval mode (ExecutionConfig.approval_mode = UNATTENDED):
    * the creating surface — a messaging channel, a guest share — has no
@@ -213,22 +228,39 @@ export function createApprovalGateMiddleware(
             emitExecutionReceipt(config, toolCall, serverSlug, category, "auto_approve", "file_capture");
             return await handler(request);
           }
-          // Gitignored path. Only the PARENT gate (captureIgnored) routes it into
-          // CAS capture; sub-agent gates fall through to the interrupt gate below,
-          // exactly as before (their backends are not CAS-observed).
+          // Gitignored / non-git path: a gate whose backend the shared CAS
+          // observer wraps (captureIgnored — the parent gate, and sub-agent
+          // gates since DD-19) routes it into CAS capture; any other gate falls
+          // through to the interrupt gate below.
           if (config.captureIgnored) {
-            if (isSecretLikePath(path)) {
-              // DD-E fail-closed: a secret-like gitignored edit is NEVER applied
-              // and NEVER captured. Record it so the turn boundary authors a
-              // DIFF_UNREVIEWABLE entry (blocking approval); nothing is written.
-              config.recordBlockedSecret?.(path);
-              return secretBlockToolMessage(toolName, path, toolCall.id);
-            }
             if (category === "write") {
+              if (isSecretLikePath(path)) {
+                // DD-E fail-closed: a secret-like gitignored WRITE is NEVER
+                // applied and NEVER captured — its content must not surface
+                // anywhere, approval prompt included. Record it so the turn
+                // boundary authors a DIFF_UNREVIEWABLE entry (blocking
+                // approval); nothing is written.
+                config.recordBlockedSecret?.(path);
+                return secretBlockToolMessage(toolName, path, toolCall.id);
+              }
               // Non-secret gitignored write/edit: flows (apply-then-review). The
               // CAS observer already holds its before-bytes and the turn boundary
-              // captures it into CAS. (A gitignored delete has no backend capture
-              // path, so it falls through to the interrupt gate.)
+              // captures it into CAS.
+              emitExecutionReceipt(config, toolCall, serverSlug, category, "auto_approve", "file_capture");
+              return await handler(request);
+            }
+            if (category === "delete" && config.captureDeleteBefore && !isSecretLikePath(path)) {
+              // Non-secret CAS-owned delete: capture the before-bytes NOW (the
+              // one moment they still exist on disk — no backend delete method
+              // to observe them), then flow. The turn boundary reads after=null
+              // and authors a reviewable, restorable DELETE entry (issue #303).
+              //
+              // A SECRET-LIKE delete deliberately falls through to the interrupt
+              // gate instead: unlike a write, its args expose no secret content,
+              // so a human may safely approve it — but its before-bytes must
+              // never enter CAS, so it cannot flow. (This also aligns the twins:
+              // the Cursor hook routes secret deletes to its deny-gate.)
+              await config.captureDeleteBefore(path);
               emitExecutionReceipt(config, toolCall, serverSlug, category, "auto_approve", "file_capture");
               return await handler(request);
             }
@@ -244,8 +276,10 @@ export function createApprovalGateMiddleware(
       // continues) exactly like the capture-mode secret block — a secret write is
       // never applied or persisted in ANY mode. Placed AFTER the capture block so
       // capture-mode paths stay byte-identical (a capturable write already flowed;
-      // a captureIgnored gitignored secret is already blocked). Deletes carry no
-      // content and stay on the deny-gate. recordBlockedSecret is a no-op unless a
+      // a captureIgnored gitignored secret write is already blocked). A delete
+      // carries no content, so a secret-like delete needs no hard-block: it stays
+      // on the interrupt gate below, where a human may still approve it (its
+      // bytes are simply never captured). recordBlockedSecret is a no-op unless a
       // turn boundary reads it (the git-no-storage case, where it authors a
       // content-less DIFF_UNREVIEWABLE).
       if (!serverSlug && category === "write") {

--- a/backend/services/runner/src/shared/filereview/__tests__/capture.test.ts
+++ b/backend/services/runner/src/shared/filereview/__tests__/capture.test.ts
@@ -946,6 +946,54 @@ describe("capture orchestration — CAS-only non-git workspace (Slice 2a)", () =
     await expect(readFile(join(ws, "drop.txt"), "utf-8")).rejects.toThrow();
   });
 
+  it("authors a DELETE from {before, after:null} and reconciles it both ways (issue #303)", async () => {
+    // The delete flow end-to-end at this seam: the harness captured the
+    // pre-delete bytes and the file is gone from disk (the tool ran). The
+    // candidate must carry a DELETE with the before blob; an approved DELETE
+    // stays deleted, a rejected DELETE is restored byte-exact from the blob.
+    const status = newStatus();
+    const storage = makeStorage();
+    const readBlob = reconcilerReadBlob(storage);
+    const enc = (s: string) => new TextEncoder().encode(s);
+
+    const baseline = await captureBaselineToLedger({
+      status, gitRoot: ws, executionId: EXEC_ID, changeSetId: CHANGE_SET_ID,
+      harnessId: HARNESS, gitWorkspace: false,
+    });
+    await captureCandidateToLedger({
+      status, gitRoot: ws, executionId: EXEC_ID, changeSetId: CHANGE_SET_ID,
+      baselineTree: baseline, harnessId: HARNESS, gitWorkspace: false, storage,
+      casCaptures: [
+        { path: "gone-approved.txt", before: enc("A"), after: null, captureClass: FileCaptureClass.NON_GIT_CAS },
+        { path: "gone-rejected.txt", before: enc("B"), after: null, captureClass: FileCaptureClass.NON_GIT_CAS },
+      ],
+    });
+
+    const cand = candidateChanges(status);
+    expect(cand.map((c) => c.kind)).toEqual([FileChangeKind.DELETE, FileChangeKind.DELETE]);
+    // A DELETE names its path on the BEFORE side only, with the restorable blob.
+    expect(cand.map((c) => c.pathBefore)).toEqual(["gone-approved.txt", "gone-rejected.txt"]);
+    expect(cand.map((c) => c.pathAfter)).toEqual(["", ""]);
+    expect(cand[0].before?.body.case).toBe("ref");
+    expect(cand[0].after).toBeUndefined();
+
+    const changeSet = decidedChangeSet(status, {
+      "gone-approved.txt": FileDecisionAction.APPROVE,
+      "gone-rejected.txt": FileDecisionAction.REJECT,
+    });
+    const result = await applyCaptureDecisions({
+      status, gitRoot: ws, executionId: EXEC_ID, changeSet, harnessId: HARNESS,
+      gitWorkspace: false, storage, readBlob,
+    });
+
+    expect(result.failed).toBe(false);
+    expect(result.approvedPaths).toEqual(["gone-approved.txt"]);
+    expect(result.rejectedPaths).toEqual(["gone-rejected.txt"]);
+    // Approved DELETE: the file stays gone. Rejected DELETE: restored byte-exact.
+    await expect(readFile(join(ws, "gone-approved.txt"), "utf-8")).rejects.toThrow();
+    expect(await readFile(join(ws, "gone-rejected.txt"), "utf-8")).toBe("B");
+  });
+
   it("is not a capture turn when neither a git ref nor a CAS manifest exists", async () => {
     const status = newStatus();
     const storage = makeStorage();


### PR DESCRIPTION
## Summary

Closes #303.

On a non-git workspace (the CAS substrate — the common shape for embedded desktop products attaching a plain project folder) and for gitignored paths in a git tree, a **write** flowed through apply-then-review while a **delete** always parked the run in `EXECUTION_WAITING_FOR_APPROVAL`. This PR makes deletions flow exactly like writes where a capture substrate exists, reviewed post-hoc in the Changes ledger with the same discard-restores contract.

**The substrate was already delete-complete** — `classifyCasChange` maps `after=null` to `FILE_CHANGE_KIND_DELETE`, `applyCasApproved` removes an approved delete, `restoreCasToBaseline` restores a rejected one byte-exact from the before-blob, and the React/CLI review UIs render DELETE entries substrate-agnostically. Only the two harness gates blocked the flow; this PR is confined to them.

### Cursor harness (the live surface — `Delete` is a real CLI built-in)

- New delete staging arm in the generated hook, beside the write arm: classifies the path for secret-likeness **before** any staging, then stages the pre-delete bytes into the cas-observations sidecar and allows. The turn boundary already reads `after=null` and authors the DELETE; flowed delete rows were already stamped by `stampFlowedFileEditRows`.
- A gated (secret-like) delete never touches the sidecar — staging would persist the secret bytes AND mark the path `secret`, wrongly authoring a blocking `DIFF_UNREVIEWABLE` for a merely-gated delete.

### Deep-agent harness (parity twin)

- New `ApprovalGateConfig.captureDeleteBefore` seam: deepagents has no backend delete method for the CAS backend to observe, so the gate records the before-bytes at authorization time through the SAME shared observer, then flows with a `file_capture` receipt. Wired in `setup.ts` to `casObserver.recordBefore`.
- Sub-agent gates inherit verbatim per DD-19 (they share the observer); the unobserved-backend branch strips the new seam alongside `recordBlockedSecret`.
- Note: deepagents ships no delete tool today — this arm is exercised by tests and keeps the deliberately-mirrored twins true.

### Secret-delete semantics aligned across the twins

The harnesses previously **diverged**: the deep-agent gate hard-blocked a secret-like gitignored delete while the Cursor hook routed it to the approvable interrupt gate. Both now converge on: **secret-like delete → interrupt gate (approvable, never staged/captured)**. A delete's args expose no secret content — a human may safely approve deleting `.env` — but its bytes must never enter CAS, so it cannot flow. Writes keep their hard-block (content must never surface).

Stale pre-DD-19 comments ("sub-agent backends are not CAS-observed") truthed along the way.

## Test plan

- [x] New gate cases: non-secret CAS delete flows (callback + receipt + capture-before-run ordering); secret-like delete interrupts (not hard-blocked, not flowed); no-callback and captureIgnored-off postures keep gating
- [x] New hook cases (real script execution): gitignored + non-git delete staged & allowed with pre-delete bytes; write-then-delete first-touch-wins; secret-like delete deny-gated as kind `approval` with an empty sidecar
- [x] New capture orchestration case: `{before, after:null}` authors a DELETE (path on the before side, blob ref) and reconciles both ways (approved stays deleted, rejected restored byte-exact)
- [x] Full runner suite: 269 files / 4560 tests green; `tsc -p tsconfig.build.json --noEmit` clean

Made with [Cursor](https://cursor.com)