### PR TITLE
feat(sdk/react): WorkflowExecutionViewer panel — controlled/observable open state + omit mode

### DIFF
--- a/docs/sdk/react/execution.mdx
+++ b/docs/sdk/react/execution.mdx
@@ -3269,6 +3269,45 @@ const shouldFetch = isTextArtifact(artifact) && Number(artifact.sizeBytes) < MAX
 ```
 
 
+### LivenessStatusLine
+
+The thread's ambient-liveness anchor (stigmer#277): a quiet one-line status
+at the bottom of the thread while an execution is live but nothing else on
+screen is visibly moving — the exact stretches (model generation between
+tool calls) where users conclude the agent died and reach for a restart.
+
+The label carries the shared `stgm-shimmer-label` sweep, the same treatment
+as a running tool row's title and the thinking indicator, so "alive" reads
+identically everywhere. [`MessageThread`](#messagethread) emits it only while the
+active execution is `IN_PROGRESS` with no running tool call, no live
+sub-agent, and no pending approval — when a gate is waiting on the *user*,
+shimmering "Working…" would be a lie, and when a tool is running, its own
+row carries the sweep. It disappears the moment the execution settles
+(phase-driven, DD-009 — never inferred from the stream going quiet).
+
+Replaceable via [`MessageThreadSlots.LivenessStatusLine`](#livenessstatusline) (the
+SetupProgress precedent) for hosts that want their own liveness voice.
+
+All visual properties flow through `--stgm-*` tokens.
+
+```tsx
+<LivenessStatusLine />
+<LivenessStatusLine label="Reviewing your data…" />
+```
+
+
+### LivenessStatusLineProps
+
+Props for [`LivenessStatusLine`](#livenessstatusline).
+
+<TypeTable
+  type={{
+    className: { type: "string", description: "Additional CSS class names for the root container." },
+    label: { type: "string", description: "The status copy. Defaults to `\"Working…\"` — deliberately generic: the thread has no model-authored account of what the agent is doing between visible events (that seam is stigmer#276), so the line claims only what is provably true." },
+  }}
+/>
+
+
 ### MessageEntry
 
 Renders a single message in the conversation thread.
@@ -3332,6 +3371,7 @@ render defeats that for its rows.
   type={{
     ApprovalCard: { type: "ComponentType<ApprovalCardProps>", description: "The HITL tool-approval gate card." },
     ExecutionErrorNotice: { type: "ComponentType<ExecutionErrorNoticeProps>", description: "The terminal execution-failure notice. Receives the raw server-reported reason and the retry wiring, so a host can turn the failure into its own recovery moment (classify the reason, offer an alternate engine, link support) instead of the built-in Show more / Retry treatment." },
+    LivenessStatusLine: { type: "ComponentType<LivenessStatusLineProps>", description: "The ambient-liveness status line at the thread's tail while the active execution is live between visible events (stigmer#277). Override to supply a host-voiced label or richer treatment; the emission policy (when the line appears at all) stays with the thread." },
     MessageEntry: { type: "ComponentType<MessageEntryProps>", description: "All message bubbles — human, assistant, thinking, and system entries. Also wraps the failed-send bubble (the inline Retry chrome around it stays built-in)." },
     PlanArtifactCard: { type: "ComponentType<PlanArtifactCardProps>", description: "Completed Plan turn that published a plan artifact." },
     PlanCompletionCard: { type: "ComponentType<PlanCompletionCardProps>", description: "Completed Plan turn without an artifact — the bare Implement CTA." },
@@ -4038,6 +4078,13 @@ The two disclosure axes — the card-level chevron and a block's
 content-overflow reveal — never govern the same body, which is what removes
 the old "expand, then Show more" double control.
 
+Orthogonal to the layout modes is the **chrome tier** (the density axis,
+stigmer#274): metadata-only categories (read / list / search / think)
+render as quiet unboxed lines — no card frame — while content-bearing
+categories keep their cards. A quiet row escalates to a card while gated
+or failed; its disclosed body renders under a light left rail instead of a
+border. See `ToolChrome`.
+
 Shows category-aware labels (e.g., "Shell", "Read", "Edit") with
 the primary argument as a subtitle, a category-specific icon, and
 an inline approval decision badge when applicable.
@@ -4116,6 +4163,7 @@ The fully-resolved presentation for a tool call, returned by [`useToolPresentati
 <TypeTable
   type={{
     category: { type: "ToolCategory", description: "Presentation category (1:1 with kind).", required: true },
+    chrome: { type: "ToolChrome", description: "Default chrome tier for this tool — `\"quiet\"` renders an unboxed line, `\"card\"` a bordered card (see ToolChrome). A pending gate or a failure escalates to `\"card\"` in the component layer; this is the *settled* default.", required: true },
     disclosure: { type: "ToolDisclosure", description: "Default inline disclosure for this tool — `\"preview\"` keeps a bounded, persistent preview of the result, `\"summary\"` keeps a compact row. The active/awaiting state can still force a row open; this is the *settled* default.", required: true, typeDescriptionLink: "#tooldisclosure" },
     kind: { type: "ToolKind", description: "Harness-agnostic kind (wire field, with name fallback).", required: true },
     label: { type: "string", description: "Display label, e.g. \"Edit\", \"Shell\".", required: true },
@@ -4133,6 +4181,7 @@ Optional per-kind overrides for label, summary, disclosure, and run-grouping.
 
 <TypeTable
   type={{
+    chrome: { type: "(toolCall: ToolCall, result: ToolResultView) => ToolChrome", description: "Overrides the default chrome tier — quiet unboxed line vs bordered card (see ToolChrome). Use to restore the boxed look for a kind (`() => \"card\"`) or to quiet a chatty custom tool (`() => \"quiet\"`). A pending approval gate or a failure always escalates the row to a card regardless of this override — a decision surface and error output must never render frameless." },
     disclosure: { type: "(toolCall: ToolCall, result: ToolResultView) => ToolDisclosure", description: "Overrides the default inline disclosure. Use to keep a noisy MCP tool compact (`() => \"summary\"`) or to foreground a custom tool's output (`() => \"preview\"`) without forking the components." },
     label: { type: "(toolCall: ToolCall) => string", description: "Overrides the display label (e.g. \"Shell\" -> \"Run command\")." },
     runGroupable: { type: "(toolCall: ToolCall) => boolean", description: "Overrides whether consecutive same-kind calls fold into one collapsible \"Read 5 files\" chip. Use to fold a chatty custom tool (`() => true`) or to keep a normally-folded category as standalone rows (`() => false`) without forking the thread layout. Defaults to isRunGroupableCategory." },

--- a/docs/sdk/react/resource-detail.mdx
+++ b/docs/sdk/react/resource-detail.mdx
@@ -40,9 +40,10 @@ function useConfirmAction(): UseConfirmActionReturn
 
 Clipboard helper for resource detail pages.
 
-Wraps `navigator.clipboard.writeText` with toast feedback so every
-copy action is confirmed visually (Nielsen heuristic #1 — visibility
-of system status). Falls back to a hidden textarea for older browsers.
+Wraps the shared copy behavior (`useCopyFeedback`) with toast feedback so
+every copy action is confirmed visually (Nielsen heuristic #1 — visibility
+of system status). A rejected write (insecure context, denied permission)
+toasts an error instead of claiming a copy that didn't happen.
 
 **Signature**
 

--- a/docs/sdk/react/workflow.mdx
+++ b/docs/sdk/react/workflow.mdx
@@ -3661,7 +3661,10 @@ Options for [`useWorkflowExecutionPanel`](#useworkflowexecutionpanel).
 
 <TypeTable
   type={{
+    defaultOpen: { type: "boolean", description: "Initial open state in uncontrolled mode. Ignored when UseWorkflowExecutionPanelOptions.open is provided." },
     defaultView: { type: "string", description: "The panel's home view. Defaults to `\"artifacts\"` — the one facet this panel carries today (there is no workspace file source yet, so no built-in Explorer to land on)." },
+    onOpenChange: { type: "(open: boolean) => void", description: "Called on every effective open/close transition — in BOTH modes, matching `useSessionPanel`'s convention (and departing from `useDetailTabs`'s DD-T05A-001 for the same principled reason): this panel opens ITSELF (`openDiagnosis`, `openArtifact`, `openFileChange`, `openFile` all expand a collapsed panel), and an embedding host that must react to those moments — widen a dock, make room for a diagnosis conversation — has no other seam. Passing only this callback observes the panel without controlling it.  In controlled mode this fires once per open/close REQUEST (the host may decline by not updating `open` — a later identical request re-fires); in uncontrolled mode it fires once per actual transition." },
+    open: { type: "boolean", description: "Controlled open state. When provided, the host owns whether the panel is expanded: internal open intents (the chip toggle, Diagnose, an artifact/file-change/file open) no longer flip state themselves — they surface through UseWorkflowExecutionPanelOptions.onOpenChange and the panel follows this value. Leave `undefined` for the self-managing default. The same seam `useSessionPanel` carries (#651); kept domain-local, like the controllers themselves." },
   }}
 />
 
@@ -4029,7 +4032,7 @@ families and view semantics are domain-specific.
     closeEditor: { type: "(entryId: string, path: string) => void", description: "Close an editor tab. The panel stays open when the group empties.", required: true },
     closePanel: { type: "() => void", description: "Collapse the panel to the chip, preserving editors and view.", required: true },
     editorsStore: { type: "WorkspaceEditorsStore", description: "The open-editor group store; subscribe with `useWorkspaceEditors`.", required: true },
-    isOpen: { type: "boolean", description: "Whether the panel is expanded or collapsed to the chip.", required: true },
+    isOpen: { type: "boolean", description: "Whether the panel is expanded or collapsed to the chip. In controlled mode (UseWorkflowExecutionPanelOptions.open) this mirrors the host's value.", required: true },
     openArtifact: { type: "(artifact: Artifact) => void", description: "Open (or focus) an artifact as an editor-pane document tab and expand the panel. Uses the PREVIEW slot — casual artifact browsing reuses one tab (single-click) and double-clicking pins it, matching the session panel's artifact-tab semantics.", required: true },
     openDiagnosis: { type: "() => void", description: "Open (or focus) the AI-diagnosis conversation as a pinned editor-pane document tab and expand the panel — the singleton analog of the session's `openPlanDocument`. Idempotent: the tab (not an owner-level boolean) is the single source of truth for \"diagnosis is active\", so re-invoking Diagnose focuses the existing conversation.", required: true },
     openFile: { type: "(entryId: string, path: string, options?: OpenFileOptions) => void", description: "Open a file as a preview tab and expand the panel. Unused until a workspace-source slice wires a lister, but part of the controller's stable surface so the viewer's editor wiring never changes shape.", required: true },
@@ -4042,6 +4045,23 @@ families and view semantics are domain-specific.
     view: { type: "string", description: "The active rail view id (an injected facet — `\"artifacts\"` today).", required: true },
   }}
 />
+
+
+### WorkflowExecutionPanelMode
+
+Whether [`WorkflowExecutionViewer`](#workflowexecutionviewer) offers the execution panel surface.
+
+- `"auto"` (default) — the panel and its toggle chip are available.
+- `"none"` — the panel and chip are absent entirely, and Diagnose is
+  withheld with them (the diagnosis conversation renders inside the
+  panel, so without one the affordance would be a dead end). For hosts
+  whose surrounding surface already renders artifacts/changes/usage.
+
+The workflow twin of the session organisms' `SessionPanelMode` — a
+deliberately separate union, like the panel controllers themselves, so
+each organism's vocabulary can grow domain-specific modes. A union (not
+a boolean) so a future mode — e.g. a host-rendered panel fed by the
+SDK's controller — extends the vocabulary instead of breaking it.
 
 
 ### WorkflowExecutionPhaseBadge
@@ -4102,12 +4122,16 @@ Props for [`WorkflowExecutionViewer`](#workflowexecutionviewer).
 <TypeTable
   type={{
     className: { type: "string", description: "Additional CSS class names for the root container." },
+    defaultPanelOpen: { type: "boolean", description: "Initial open state of the execution panel in uncontrolled mode — a docking host that wants the artifacts rail visible from the first paint passes `true`. Ignored when WorkflowExecutionViewerProps.panelOpen is provided." },
     executionId: { type: "string", description: "ID of the workflow execution to display.", required: true },
     headerActions: { type: "ReactNode", description: "Host-supplied action elements rendered in the header action group (e.g. a Share control). Routing/auth-agnostic per DD-004." },
     nodesDraggable: { type: "boolean", description: "Whether task nodes in the execution graph can be dragged to rearrange the layout for presentations. Drag positions are ephemeral and not persisted." },
     onNavigateToAgentExecution: { type: "(agentExecutionId: string) => void", description: "Callback when the user clicks a link to a child agent execution. Receives the AgentExecution ID. The host application is responsible for navigation — this keeps the component routing-agnostic (DD-004)." },
     onNavigateToWorkflowEditor: { type: "(yaml: string, workflowSlug: string) => void", description: "Callback when the user clicks \"Apply Fix\" in the repair card. Receives the suggested YAML and the workflow slug. The host application handles navigation to the workflow editor (DD-004)." },
+    onPanelOpenChange: { type: "(open: boolean) => void", description: "Called on every panel open/close transition, in BOTH modes — pass it alone (uncontrolled) to simply observe the panel, e.g. widening a docked pane when Diagnose expands it and reclaiming the room on close. See UseWorkflowExecutionPanelOptions.onOpenChange for the exact request-vs-transition semantics in each mode." },
     org: { type: "string", description: "Organization slug — needed for AI diagnosis authorization." },
+    panel: { type: "WorkflowExecutionPanelMode", description: "Whether the viewer offers the execution panel at all. `\"none\"` removes the panel AND its toggle chip and withholds the Diagnose action (its conversation renders inside the panel) — for hosts whose surrounding surface already presents the execution's artifacts and usage.", typeDescriptionLink: "#workflowexecutionpanelmode" },
+    panelOpen: { type: "boolean", description: "Controlled open state of the execution panel. When provided, the host owns the panel: the chip toggle, Diagnose, and artifact/file-change opens surface through WorkflowExecutionViewerProps.onPanelOpenChange instead of flipping state, and the panel follows this value. Leave `undefined` for the self-managing default." },
   }}
 />
 

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -1889,6 +1889,7 @@ export type {
   WorkflowTaskListProps,
   WorkflowDetailViewProps,
   WorkflowExecutionViewerProps,
+  WorkflowExecutionPanelMode,
   WorkflowExecutionHeaderProps,
   WorkflowExecutionPanelController,
   UseWorkflowExecutionPanelOptions,

--- a/sdk/react/src/workflow/WorkflowExecutionViewer.tsx
+++ b/sdk/react/src/workflow/WorkflowExecutionViewer.tsx
@@ -85,12 +85,64 @@ function readStoredCenterView(): CenterView {
   return "thread";
 }
 
+/**
+ * Whether {@link WorkflowExecutionViewer} offers the execution panel surface.
+ *
+ * - `"auto"` (default) — the panel and its toggle chip are available.
+ * - `"none"` — the panel and chip are absent entirely, and Diagnose is
+ *   withheld with them (the diagnosis conversation renders inside the
+ *   panel, so without one the affordance would be a dead end). For hosts
+ *   whose surrounding surface already renders artifacts/changes/usage.
+ *
+ * The workflow twin of the session organisms' `SessionPanelMode` — a
+ * deliberately separate union, like the panel controllers themselves, so
+ * each organism's vocabulary can grow domain-specific modes. A union (not
+ * a boolean) so a future mode — e.g. a host-rendered panel fed by the
+ * SDK's controller — extends the vocabulary instead of breaking it.
+ */
+export type WorkflowExecutionPanelMode = "auto" | "none";
+
 /** Props for {@link WorkflowExecutionViewer}. */
 export interface WorkflowExecutionViewerProps {
   /** ID of the workflow execution to display. */
   readonly executionId: string;
   /** Organization slug — needed for AI diagnosis authorization. */
   readonly org?: string;
+  /**
+   * Whether the viewer offers the execution panel at all. `"none"` removes
+   * the panel AND its toggle chip and withholds the Diagnose action (its
+   * conversation renders inside the panel) — for hosts whose surrounding
+   * surface already presents the execution's artifacts and usage.
+   *
+   * @default "auto"
+   */
+  readonly panel?: WorkflowExecutionPanelMode;
+  /**
+   * Initial open state of the execution panel in uncontrolled mode — a
+   * docking host that wants the artifacts rail visible from the first paint
+   * passes `true`. Ignored when
+   * {@link WorkflowExecutionViewerProps.panelOpen} is provided.
+   *
+   * @default false
+   */
+  readonly defaultPanelOpen?: boolean;
+  /**
+   * Controlled open state of the execution panel. When provided, the host
+   * owns the panel: the chip toggle, Diagnose, and artifact/file-change
+   * opens surface through
+   * {@link WorkflowExecutionViewerProps.onPanelOpenChange} instead of
+   * flipping state, and the panel follows this value. Leave `undefined`
+   * for the self-managing default.
+   */
+  readonly panelOpen?: boolean;
+  /**
+   * Called on every panel open/close transition, in BOTH modes — pass it
+   * alone (uncontrolled) to simply observe the panel, e.g. widening a
+   * docked pane when Diagnose expands it and reclaiming the room on close.
+   * See {@link UseWorkflowExecutionPanelOptions.onOpenChange} for the exact
+   * request-vs-transition semantics in each mode.
+   */
+  readonly onPanelOpenChange?: (open: boolean) => void;
   /**
    * Callback when the user clicks a link to a child agent execution.
    * Receives the AgentExecution ID. The host application is responsible
@@ -150,6 +202,10 @@ export const WorkflowExecutionViewer = memo(function WorkflowExecutionViewer({
   onNavigateToWorkflowEditor,
   headerActions,
   nodesDraggable,
+  panel: panelMode = "auto",
+  defaultPanelOpen,
+  panelOpen,
+  onPanelOpenChange,
   className,
 }: WorkflowExecutionViewerProps) {
   const {
@@ -306,11 +362,24 @@ export const WorkflowExecutionViewer = memo(function WorkflowExecutionViewer({
     ],
   );
 
+  // The one flag every panel affordance keys on: the host opted out
+  // (`panel="none"`). Everything the panel touches — the chip, the split's
+  // secondary pane, and Diagnose (whose conversation renders inside the
+  // panel) — gates on this, so the affordances can never drift apart.
+  const panelEnabled = panelMode !== "none";
+
   // The execution-level workspace panel (facets + virtual document
   // tabs). The controller lives at the owner level — the editors-store
   // SUBSCRIPTION stays inside ExecutionWorkspacePanel so tab churn re-renders
   // only the panel subtree, never the streaming graph (DD-009/DD-010).
-  const panel = useWorkflowExecutionPanel();
+  const panel = useWorkflowExecutionPanel({
+    // With the panel disabled the controller is pinned controlled-closed
+    // and unobserved — airtight inertness, not just hidden UI: no intent
+    // can flip state or reach the host's callback.
+    open: panelEnabled ? panelOpen : false,
+    defaultOpen: defaultPanelOpen,
+    onOpenChange: panelEnabled ? onPanelOpenChange : undefined,
+  });
 
   const [showComparePicker, setShowComparePicker] = useState(false);
   const [compareTargetId, setCompareTargetId] = useState<string | null>(null);
@@ -467,8 +536,11 @@ export const WorkflowExecutionViewer = memo(function WorkflowExecutionViewer({
         actions={actions}
         // Diagnose opens (or focuses) the singleton diagnosis document tab —
         // the tab itself is the "diagnosis is active" state, so there is no
-        // owner-level isDiagnosing boolean to keep in sync (SSOT).
-        onDiagnose={org ? panel.openDiagnosis : undefined}
+        // owner-level isDiagnosing boolean to keep in sync (SSOT). A viewer
+        // without a panel (panel="none") withholds the action: the
+        // conversation renders inside the panel, so offering it would be a
+        // dead end.
+        onDiagnose={org && panelEnabled ? panel.openDiagnosis : undefined}
         onCompare={handleOpenComparePicker}
         headerActions={
           <>
@@ -477,12 +549,15 @@ export const WorkflowExecutionViewer = memo(function WorkflowExecutionViewer({
                 Usage facet gives the panel data-independent content (its
                 empty state is honest even before any usage accrues). The
                 badge stays the artifact count: artifacts are countable
-                collateral, usage is a continuous quantity. */}
-            <PanelChip
-              isOpen={panel.isOpen}
-              onToggle={panel.isOpen ? panel.closePanel : panel.openPanel}
-              badgeCount={artifacts.length}
-            />
+                collateral, usage is a continuous quantity. A viewer without
+                a panel (panel="none") has no toggle: it is simply absent. */}
+            {panelEnabled && (
+              <PanelChip
+                isOpen={panel.isOpen}
+                onToggle={panel.isOpen ? panel.closePanel : panel.openPanel}
+                badgeCount={artifacts.length}
+              />
+            )}
           </>
         }
       />
@@ -613,8 +688,10 @@ export const WorkflowExecutionViewer = memo(function WorkflowExecutionViewer({
         secondary={
           // Content unmounts while collapsed (matching the session panel
           // region); the editors store lives on the controller, so open tabs
-          // survive a collapse/expand cycle.
-          panel.isOpen ? (
+          // survive a collapse/expand cycle. The panelEnabled guard is
+          // belt-and-braces beside the pinned-closed controller: with
+          // panel="none", isOpen can never be true.
+          panel.isOpen && panelEnabled ? (
             <ExecutionWorkspacePanel
               panel={panel}
               executionId={executionId}

--- a/sdk/react/src/workflow/__tests__/panelNegotiation.test.tsx
+++ b/sdk/react/src/workflow/__tests__/panelNegotiation.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import type { DerivedCostSummary } from "../../internal/store/workflow-execution-event-store";
+import { useWorkflowExecution } from "../useWorkflowExecution";
+import { useWorkflowExecutionEventStream } from "../useWorkflowExecutionEventStream";
+import { useWorkflowExecutionArtifacts } from "../useWorkflowExecutionArtifacts";
+import { useWorkflowExecutionFileChanges } from "../useWorkflowExecutionFileChanges";
+import { useWorkflowExecutionActions } from "../useWorkflowExecutionActions";
+import { WorkflowExecutionViewer } from "../WorkflowExecutionViewer";
+
+// ---------------------------------------------------------------------------
+// Wiring-contract tests for the execution panel's host-negotiation surface
+// (issue #654): `panel="none"` omission, `defaultPanelOpen`, and the
+// controlled/observed `panelOpen` + `onPanelOpenChange` pair — the workflow
+// mirror of the session organisms' #651 contract (see the session
+// panelNegotiation suite). Workflow-specific beat: Diagnose gates on the
+// panel too, because its conversation renders inside the panel.
+//
+// Same probe/stub setup as the approvals suite: data hooks are stubbed to a
+// loaded, task-less execution; the graph and comparison picker are inert.
+// ---------------------------------------------------------------------------
+
+vi.mock("../useWorkflowExecution", () => ({
+  useWorkflowExecution: vi.fn(),
+}));
+vi.mock("../useWorkflowExecutionEventStream", () => ({
+  useWorkflowExecutionEventStream: vi.fn(),
+}));
+vi.mock("../useWorkflowExecutionArtifacts", () => ({
+  useWorkflowExecutionArtifacts: vi.fn(),
+}));
+vi.mock("../useWorkflowExecutionFileChanges", () => ({
+  useWorkflowExecutionFileChanges: vi.fn(),
+}));
+vi.mock("../useWorkflowExecutionActions", () => ({
+  useWorkflowExecutionActions: vi.fn(),
+}));
+vi.mock("../WorkflowExecutionGraph", () => ({
+  WorkflowExecutionGraph: () => <div data-testid="graph-stub" />,
+}));
+vi.mock("../execution-comparison/ExecutionComparisonPicker", () => ({
+  ExecutionComparisonPicker: () => null,
+}));
+
+const mockedUseWorkflowExecution = vi.mocked(useWorkflowExecution);
+const mockedUseEventStream = vi.mocked(useWorkflowExecutionEventStream);
+const mockedUseArtifacts = vi.mocked(useWorkflowExecutionArtifacts);
+const mockedUseFileChanges = vi.mocked(useWorkflowExecutionFileChanges);
+const mockedUseActions = vi.mocked(useWorkflowExecutionActions);
+
+const COST_SUMMARY: DerivedCostSummary = {
+  costConsumedMicros: 0n,
+  costRemainingMicros: -1n,
+  tokensConsumed: 0n,
+  tokensRemaining: -1n,
+  thresholdBreached: false,
+};
+
+function arrange(phase: ExecutionPhase = ExecutionPhase.EXECUTION_IN_PROGRESS) {
+  mockedUseWorkflowExecution.mockReturnValue({
+    execution: create(WorkflowExecutionSchema, {
+      metadata: { id: "wex_1", name: "nightly-report" },
+      spec: { workflowId: "wf_1" },
+      status: { phase, startedAt: "2026-07-15T00:00:00Z", tasks: [] },
+    }),
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useWorkflowExecution>);
+  mockedUseEventStream.mockReturnValue({
+    events: [],
+    taskStates: new Map(),
+    costSummary: COST_SUMMARY,
+    streamState: { stage: "streaming" },
+    totalTasks: 0,
+    error: null,
+    reconnect: vi.fn(),
+  } as unknown as ReturnType<typeof useWorkflowExecutionEventStream>);
+  mockedUseArtifacts.mockReturnValue({
+    artifacts: [],
+  } as unknown as ReturnType<typeof useWorkflowExecutionArtifacts>);
+  mockedUseFileChanges.mockReturnValue({
+    fileChanges: [],
+    fileChangeCount: 0,
+    isLoading: false,
+    isRefetching: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useWorkflowExecutionFileChanges>);
+  mockedUseActions.mockReturnValue({
+    cancel: vi.fn(),
+    terminate: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    recover: vi.fn(),
+    submitApproval: vi.fn(),
+    submitTaskApproval: vi.fn(),
+    submitFileDecision: vi.fn(),
+    isSubmitting: false,
+    error: null,
+    clearError: vi.fn(),
+    approvalSubmittingToolCallIds: new Set<string>(),
+    approvalErrorsByToolCallId: new Map<string, Error>(),
+    taskApprovalSubmittingTaskNames: new Set<string>(),
+    taskApprovalErrorsByTaskName: new Map<string, Error>(),
+    fileDecisionSubmittingKeys: new Set<string>(),
+    fileDecisionErrorsByKey: new Map<string, Error>(),
+  } as unknown as ReturnType<typeof useWorkflowExecutionActions>);
+}
+
+function chipButton(): HTMLElement | null {
+  return (
+    screen.queryByRole("button", { name: "Show panel" }) ??
+    screen.queryByRole("button", { name: "Hide panel" })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe('WorkflowExecutionViewer — panel="none"', () => {
+  it("removes the chip and never renders the panel", () => {
+    arrange();
+    render(<WorkflowExecutionViewer executionId="wex_1" panel="none" />);
+    expect(chipButton()).toBeNull();
+  });
+
+  it("withholds Diagnose — its conversation renders inside the panel", () => {
+    arrange(ExecutionPhase.EXECUTION_FAILED);
+    render(
+      <WorkflowExecutionViewer executionId="wex_1" org="acme" panel="none" />,
+    );
+    expect(screen.queryByRole("button", { name: "Diagnose" })).toBeNull();
+    // The failed-state actions that live OUTSIDE the panel are untouched.
+    expect(screen.getByRole("button", { name: "Recover" })).toBeDefined();
+  });
+
+  it("keeps controlled props inert — panelOpen cannot force a surface that does not exist", () => {
+    arrange();
+    const onPanelOpenChange = vi.fn();
+    render(
+      <WorkflowExecutionViewer
+        executionId="wex_1"
+        panel="none"
+        panelOpen={true}
+        onPanelOpenChange={onPanelOpenChange}
+      />,
+    );
+    expect(chipButton()).toBeNull();
+    expect(onPanelOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkflowExecutionViewer — Diagnose in the default panel mode", () => {
+  it("offers Diagnose on a failed execution (the contrast for the none-mode withholding)", () => {
+    arrange(ExecutionPhase.EXECUTION_FAILED);
+    render(<WorkflowExecutionViewer executionId="wex_1" org="acme" />);
+    expect(screen.getByRole("button", { name: "Diagnose" })).toBeDefined();
+  });
+});
+
+describe("WorkflowExecutionViewer — observed panel state (uncontrolled + onPanelOpenChange)", () => {
+  it("reports chip toggles without taking control", () => {
+    arrange();
+    const seen: boolean[] = [];
+    render(
+      <WorkflowExecutionViewer
+        executionId="wex_1"
+        onPanelOpenChange={(open) => seen.push(open)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show panel" }));
+    expect(seen).toEqual([true]);
+    fireEvent.click(screen.getByRole("button", { name: "Hide panel" }));
+    expect(seen).toEqual([true, false]);
+  });
+
+  it("starts open with defaultPanelOpen, without a spurious notification", () => {
+    arrange();
+    const onPanelOpenChange = vi.fn();
+    render(
+      <WorkflowExecutionViewer
+        executionId="wex_1"
+        defaultPanelOpen
+        onPanelOpenChange={onPanelOpenChange}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Hide panel" })).toBeDefined();
+    expect(onPanelOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkflowExecutionViewer — controlled panel state", () => {
+  it("follows panelOpen and surfaces the chip's request without applying it", () => {
+    arrange();
+    const seen: boolean[] = [];
+    const onPanelOpenChange = (open: boolean) => seen.push(open);
+    const { rerender } = render(
+      <WorkflowExecutionViewer
+        executionId="wex_1"
+        panelOpen={false}
+        onPanelOpenChange={onPanelOpenChange}
+      />,
+    );
+
+    // The chip requests; the host owns the state — nothing moves yet.
+    fireEvent.click(screen.getByRole("button", { name: "Show panel" }));
+    expect(seen).toEqual([true]);
+    expect(screen.getByRole("button", { name: "Show panel" })).toBeDefined();
+
+    // The host grants the request: the panel opens and the chip flips.
+    rerender(
+      <WorkflowExecutionViewer
+        executionId="wex_1"
+        panelOpen={true}
+        onPanelOpenChange={onPanelOpenChange}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Hide panel" })).toBeDefined();
+  });
+});

--- a/sdk/react/src/workflow/__tests__/useWorkflowExecutionPanel.test.ts
+++ b/sdk/react/src/workflow/__tests__/useWorkflowExecutionPanel.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   useWorkflowExecutionPanel,
   workflowArtifactTabPath,
+  type UseWorkflowExecutionPanelOptions,
 } from "../useWorkflowExecutionPanel";
 
 function artifact(id: string, displayName: string) {
@@ -236,5 +237,104 @@ describe("useWorkflowExecutionPanel openDiagnosis", () => {
     expect(editors.map((e) => e.entryId)).toContain(
       DIAGNOSIS_DOCUMENT_ENTRY_ID,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The controlled/observable open-state seam — the #651 contract mirrored from
+// useSessionPanel (#654). The panel opens ITSELF (Diagnose, artifact/change
+// opens), so onOpenChange fires in BOTH modes; controlled mode surfaces
+// requests without applying them, and a declined request stays re-fireable.
+// ---------------------------------------------------------------------------
+
+function renderSeamPanel(initial?: UseWorkflowExecutionPanelOptions) {
+  return renderHook(
+    (opts: UseWorkflowExecutionPanelOptions) => useWorkflowExecutionPanel(opts),
+    { initialProps: { ...initial } as UseWorkflowExecutionPanelOptions },
+  );
+}
+
+describe("useWorkflowExecutionPanel — observed open state (uncontrolled + onOpenChange)", () => {
+  it("reports the chip toggle without taking control", () => {
+    const seen: boolean[] = [];
+    const { result } = renderSeamPanel({ onOpenChange: (o) => seen.push(o) });
+    act(() => result.current.openPanel());
+    expect(result.current.isOpen).toBe(true);
+    act(() => result.current.closePanel());
+    expect(result.current.isOpen).toBe(false);
+    expect(seen).toEqual([true, false]);
+  });
+
+  it("reports internal open intents (openDiagnosis, openArtifact), once per actual transition", () => {
+    const seen: boolean[] = [];
+    const { result } = renderSeamPanel({ onOpenChange: (o) => seen.push(o) });
+    act(() => result.current.openDiagnosis());
+    // Already open — further open intents are not transitions.
+    act(() => result.current.openArtifact(artifact("art_1", "report.json")));
+    act(() => result.current.openPanel());
+    expect(seen).toEqual([true]);
+  });
+
+  it("starts open when defaultOpen is set, without a spurious notification", () => {
+    const seen: boolean[] = [];
+    const { result } = renderSeamPanel({
+      defaultOpen: true,
+      onOpenChange: (o) => seen.push(o),
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(seen).toEqual([]);
+  });
+});
+
+describe("useWorkflowExecutionPanel — controlled open state", () => {
+  it("follows the host's open value and ignores defaultOpen", () => {
+    const { result, rerender } = renderSeamPanel({ open: false, defaultOpen: true });
+    expect(result.current.isOpen).toBe(false);
+    rerender({ open: true, defaultOpen: true });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("surfaces intents through onOpenChange without flipping state itself", () => {
+    const seen: boolean[] = [];
+    const onOpenChange = (o: boolean) => seen.push(o);
+    const { result, rerender } = renderSeamPanel({ open: false, onOpenChange });
+    act(() => result.current.openPanel());
+    expect(seen).toEqual([true]);
+    expect(result.current.isOpen).toBe(false);
+    // The host grants the request.
+    rerender({ open: true, onOpenChange });
+    expect(result.current.isOpen).toBe(true);
+    act(() => result.current.closePanel());
+    expect(seen).toEqual([true, false]);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("re-fires a declined request (once per request, not per transition)", () => {
+    const seen: boolean[] = [];
+    const onOpenChange = (o: boolean) => seen.push(o);
+    const { result } = renderSeamPanel({ open: false, onOpenChange });
+    act(() => result.current.openArtifact(artifact("art_1", "a.json")));
+    // The host declined (open stayed false) — a later intent must re-fire,
+    // not be swallowed by a stale "already requested" memory.
+    act(() => result.current.openFileChange(fileChange("src/a.ts")));
+    expect(seen).toEqual([true, true]);
+  });
+
+  it("Diagnose is reported, not applied — but the tab is pinned and ready", () => {
+    const seen: boolean[] = [];
+    const onOpenChange = (o: boolean) => seen.push(o);
+    const { result } = renderSeamPanel({ open: false, onOpenChange });
+    act(() => result.current.openDiagnosis());
+    expect(seen).toEqual([true]);
+    expect(result.current.isOpen).toBe(false);
+    // Tab state stays SDK-owned: the diagnosis tab is pinned regardless, so
+    // the moment the host opens the panel the conversation greets the user.
+    expect(result.current.editorsStore.getSnapshot().editors).toEqual([
+      {
+        entryId: DIAGNOSIS_DOCUMENT_ENTRY_ID,
+        path: DIAGNOSIS_DOCUMENT_PATH,
+        preview: false,
+      },
+    ]);
   });
 });

--- a/sdk/react/src/workflow/index.ts
+++ b/sdk/react/src/workflow/index.ts
@@ -177,6 +177,7 @@ export {
 export {
   WorkflowExecutionViewer,
   type WorkflowExecutionViewerProps,
+  type WorkflowExecutionPanelMode,
 } from "./WorkflowExecutionViewer.js";
 
 export {

--- a/sdk/react/src/workflow/useWorkflowExecutionPanel.ts
+++ b/sdk/react/src/workflow/useWorkflowExecutionPanel.ts
@@ -3,7 +3,7 @@
 // State + actions for the workflow execution viewer's WorkspaceSurface panel.
 // Domain: workflow (the lean analog of session/useSessionPanel).
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { Artifact } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
 import type { FileChange } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 import {
@@ -50,7 +50,11 @@ export function workflowArtifactTabPath(artifact: Artifact): string {
 export interface WorkflowExecutionPanelController {
   /** The open-editor group store; subscribe with `useWorkspaceEditors`. */
   readonly editorsStore: WorkspaceEditorsStore;
-  /** Whether the panel is expanded or collapsed to the chip. */
+  /**
+   * Whether the panel is expanded or collapsed to the chip. In controlled
+   * mode ({@link UseWorkflowExecutionPanelOptions.open}) this mirrors the
+   * host's value.
+   */
   readonly isOpen: boolean;
   /** The active rail view id (an injected facet — `"artifacts"` today). */
   readonly view: string;
@@ -119,6 +123,38 @@ export interface UseWorkflowExecutionPanelOptions {
    * @default "artifacts"
    */
   readonly defaultView?: string;
+  /**
+   * Controlled open state. When provided, the host owns whether the panel is
+   * expanded: internal open intents (the chip toggle, Diagnose, an
+   * artifact/file-change/file open) no longer flip state themselves — they
+   * surface through {@link UseWorkflowExecutionPanelOptions.onOpenChange}
+   * and the panel follows this value. Leave `undefined` for the
+   * self-managing default. The same seam `useSessionPanel` carries (#651);
+   * kept domain-local, like the controllers themselves.
+   */
+  readonly open?: boolean;
+  /**
+   * Initial open state in uncontrolled mode. Ignored when
+   * {@link UseWorkflowExecutionPanelOptions.open} is provided.
+   *
+   * @default false
+   */
+  readonly defaultOpen?: boolean;
+  /**
+   * Called on every effective open/close transition — in BOTH modes,
+   * matching `useSessionPanel`'s convention (and departing from
+   * `useDetailTabs`'s DD-T05A-001 for the same principled reason): this
+   * panel opens ITSELF (`openDiagnosis`, `openArtifact`, `openFileChange`,
+   * `openFile` all expand a collapsed panel), and an embedding host that
+   * must react to those moments — widen a dock, make room for a diagnosis
+   * conversation — has no other seam. Passing only this callback observes
+   * the panel without controlling it.
+   *
+   * In controlled mode this fires once per open/close REQUEST (the host may
+   * decline by not updating `open` — a later identical request re-fires); in
+   * uncontrolled mode it fires once per actual transition.
+   */
+  readonly onOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -126,13 +162,59 @@ export interface UseWorkflowExecutionPanelOptions {
  */
 export function useWorkflowExecutionPanel({
   defaultView = "artifacts",
+  open,
+  defaultOpen = false,
+  onOpenChange,
 }: UseWorkflowExecutionPanelOptions = {}): WorkflowExecutionPanelController {
   const editorsStore = useWorkspaceEditorsStoreRef();
-  const [isOpen, setIsOpen] = useState(false);
+
+  // Uncontrolled-by-default / controlled-when-`open`-is-provided (React's own
+  // value/defaultValue convention — presence of the value prop decides, so an
+  // observe-only host can pass just `onOpenChange`). Same shape as
+  // `useSessionPanel`; re-transcribed rather than extracted because the
+  // controllers are deliberately not shared (see the interface doc above).
+  const isControlled = open !== undefined;
+  const [internalIsOpen, setInternalIsOpen] = useState(defaultOpen);
+  const isOpen = isControlled ? open : internalIsOpen;
+
+  // Latest-ref idiom: the host's callback and the mode/value mirrors live in
+  // refs so `requestOpenChange` — and every action callback built on it —
+  // stays referentially stable regardless of how the host authored
+  // `onOpenChange` (DD-010: an inline lambda must not churn the memoized
+  // controller and re-render the panel subtree).
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+  const isControlledRef = useRef(isControlled);
+  isControlledRef.current = isControlled;
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
+
+  // The single seam every open/close intent routes through — the chip
+  // toggle, Diagnose, artifact/file-change/file opens, and the surface's
+  // collapse affordance. Uncontrolled: apply + notify (the ref is updated
+  // eagerly so two same-tick intents produce one notification). Controlled:
+  // notify only — the host owns the state, and the panel follows the `open`
+  // prop; the ref is NOT updated, so a declined request stays re-fireable.
+  const requestOpenChange = useCallback((next: boolean) => {
+    if (isOpenRef.current === next) return;
+    if (!isControlledRef.current) {
+      isOpenRef.current = next;
+      setInternalIsOpen(next);
+    }
+    onOpenChangeRef.current?.(next);
+  }, []);
+
   const [view, setViewState] = useState(defaultView);
 
-  const openPanel = useCallback(() => setIsOpen(true), []);
-  const closePanel = useCallback(() => setIsOpen(false), []);
+  const openPanel = useCallback(
+    () => requestOpenChange(true),
+    [requestOpenChange],
+  );
+
+  const closePanel = useCallback(
+    () => requestOpenChange(false),
+    [requestOpenChange],
+  );
 
   const setView = useCallback((viewId: string) => setViewState(viewId), []);
 
@@ -141,15 +223,15 @@ export function useWorkflowExecutionPanel({
       DIAGNOSIS_DOCUMENT_ENTRY_ID,
       DIAGNOSIS_DOCUMENT_PATH,
     );
-    setIsOpen(true);
-  }, [editorsStore]);
+    requestOpenChange(true);
+  }, [editorsStore, requestOpenChange]);
 
   const openFile = useCallback(
     (entryId: string, path: string, options?: OpenFileOptions) => {
       editorsStore.openPreview(entryId, path, options);
-      setIsOpen(true);
+      requestOpenChange(true);
     },
-    [editorsStore],
+    [editorsStore, requestOpenChange],
   );
 
   const openArtifact = useCallback(
@@ -158,9 +240,9 @@ export function useWorkflowExecutionPanel({
         ARTIFACT_DOCUMENT_ENTRY_ID,
         workflowArtifactTabPath(artifact),
       );
-      setIsOpen(true);
+      requestOpenChange(true);
     },
-    [editorsStore],
+    [editorsStore, requestOpenChange],
   );
 
   const pinArtifact = useCallback(
@@ -179,9 +261,9 @@ export function useWorkflowExecutionPanel({
         FILE_CHANGE_DOCUMENT_ENTRY_ID,
         fileChangeTabPath(change),
       );
-      setIsOpen(true);
+      requestOpenChange(true);
     },
-    [editorsStore],
+    [editorsStore, requestOpenChange],
   );
 
   const pinFileChange = useCallback(


### PR DESCRIPTION
## Summary

Closes #654 — the workflow mirror of #651's SessionViewer panel contract, now that the pattern, tests, and TSDoc conventions are on main.

- **Hook seam**: `useWorkflowExecutionPanel` gains `open` / `defaultOpen` / `onOpenChange`. Every open intent — `openPanel`, `closePanel`, `openDiagnosis`, `openFile`, `openArtifact`, `openFileChange` — routes through one `requestOpenChange` seam (latest-ref idiom, DD-010: the memoized controller never churns on an inline host callback). Uncontrolled: apply + notify. Controlled: notify only — a declined request stays re-fireable.
- **Viewer quartet** on `WorkflowExecutionViewerProps`: `panel` (new `WorkflowExecutionPanelMode = "auto" | "none"` union — deliberately domain-local, like the panel controllers themselves), `defaultPanelOpen`, `panelOpen`, `onPanelOpenChange`.
- **One `panelEnabled` flag** gates the chip, the split's secondary pane, **and Diagnose** — the workflow-specific trigger beyond the issue text: the diagnosis conversation renders inside the panel, so a panel-less viewer withholds the affordance instead of offering a dead end. Disabled ⇒ the controller is pinned controlled-closed and unobserved (the #651 "airtight inertness" contract).
- **No layout surgery**: the existing `collapsedPane` wiring already renders a clean full-width graph when the controller is pinned closed.

## Tests

- Mirrored the `useSessionPanel` controlled/observed describe blocks onto `useWorkflowExecutionPanel` (8 cases, incl. the declined-request re-fire and no-spurious-notification-on-`defaultOpen`), adapted to the workflow intents (Diagnose in place of the plan auto-open).
- New `workflow/__tests__/panelNegotiation.test.tsx` (7 cases): none-mode inertness incl. the withheld Diagnose (with the Recover-button contrast), observed chip toggles, `defaultPanelOpen`, controlled follow-without-apply.
- Full sdk/react suite: **4505 tests / 407 files green**; `tsc --noEmit` clean.

## Notes

- **DD-016 parity**: both `WorkflowExecutionDetailPage` consumers (web + desktop) reviewed — the quartet is opt-in with unchanged defaults (DD-011), so neither needs changes.
- Regenerated SDK docs: `workflow.mdx` (this change); `execution.mdx` / `resource-detail.mdx` were stale from #658/#650 and ride along (the #651 precedent).
- `npm run tsdoc:check` fails on **pristine origin/main** with 11 warnings (unresolved `{@link}`s in session/composer/execution surfaces — none from this branch, verified by stash-baseline). Filing separately.

Made with [Cursor](https://cursor.com)