### PR TITLE
fix(sdk-react): repoint the 11 dead tsdoc links so the strict tsdoc:check gate is green on main

### DIFF
--- a/sdk/react/src/channel/useChannelSessions.ts
+++ b/sdk/react/src/channel/useChannelSessions.ts
@@ -1,6 +1,9 @@
 "use client";
 
 import { create } from "@bufbuild/protobuf";
+// AgentChannel is type-only here so the doc link below resolves (the sibling
+// channel hooks import it for real use); the strict tsdoc gate guards it.
+import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import { ListSessionsByChannelRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/io_pb";
 import { useStigmer } from "../hooks.js";

--- a/sdk/react/src/execution/ToolCallItem.tsx
+++ b/sdk/react/src/execution/ToolCallItem.tsx
@@ -30,7 +30,9 @@ import { useApproval } from "./ApprovalContext.js";
 import { useFileReviewRowState } from "./FileReviewContext.js";
 import type { FileReviewRowState } from "./file-review-status.js";
 import { FilePathLink } from "./FilePathLink.js";
-import { isFileCategory, type ToolCategory } from "./tool-categories.js";
+// ToolChrome is type-only here so the doc link below resolves; the strict
+// tsdoc gate (tsdoc:check) guards it against removal.
+import { isFileCategory, type ToolCategory, type ToolChrome } from "./tool-categories.js";
 import { useToolPresentation } from "./tool-presenter.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 

--- a/sdk/react/src/session/useSessionConversation.ts
+++ b/sdk/react/src/session/useSessionConversation.ts
@@ -21,7 +21,9 @@ import type { ServiceTierOption } from "../models/service-tier.js";
 import { useStigmer } from "../hooks.js";
 import { toError } from "../internal/toError.js";
 import { useConversationStoreRef } from "../internal/store/index.js";
-import { useCreateAgentExecution } from "../execution/useCreateAgentExecution.js";
+// Type-only import so the SharedAgentExecutionFields doc links below resolve;
+// the strict tsdoc gate (tsdoc:check) guards it against removal.
+import { useCreateAgentExecution, type SharedAgentExecutionFields } from "../execution/useCreateAgentExecution.js";
 import { useExecutionStream } from "../execution/useExecutionStream.js";
 import { useAgentExecutionActions } from "../execution/useAgentExecutionActions.js";
 import { useSubmitApproval } from "../execution/useSubmitApproval.js";
@@ -79,7 +81,7 @@ export interface SendFollowUpOptions {
    * instance. Keys must be declared in the agent's env declarations
    * (a whitelist, not a value source) or they are dropped.
    *
-   * @see {@link CreateAgentExecutionInput.runtimeEnv}
+   * @see {@link SharedAgentExecutionFields.runtimeEnv}
    */
   readonly runtimeEnv?: Record<string, EnvVarInput>;
   /**
@@ -89,7 +91,7 @@ export interface SendFollowUpOptions {
    * `agentExecution.uploadAttachment()`. Forwarded directly to
    * execution creation.
    *
-   * @see {@link CreateAgentExecutionInput.attachments}
+   * @see {@link SharedAgentExecutionFields.attachments}
    */
   readonly attachments?: AttachmentInput[];
   /**
@@ -106,19 +108,19 @@ export interface SendFollowUpOptions {
    * the unspecified-vs-explicit distinction (unset resolves to standard on
    * the platform side — never the provider account default).
    *
-   * @see {@link CreateAgentExecutionInput.serviceTier}
+   * @see {@link SharedAgentExecutionFields.serviceTier}
    */
   readonly serviceTier?: ServiceTierOption;
   /**
    * Marks this execution as a Build-from-plan turn.
    *
-   * @see {@link CreateAgentExecutionInput.buildFromPlan}
+   * @see {@link SharedAgentExecutionFields.buildFromPlan}
    */
   readonly buildFromPlan?: boolean;
   /**
    * Auto-approve every tool call for this execution (bypass the HITL gate).
    *
-   * @see {@link CreateAgentExecutionInput.autoApproveAll}
+   * @see {@link SharedAgentExecutionFields.autoApproveAll}
    */
   readonly autoApproveAll?: boolean;
   /**
@@ -127,7 +129,7 @@ export interface SendFollowUpOptions {
    * Lightweight "attention" signals — no upload, no injection. The agent
    * reads these files directly from the workspace filesystem.
    *
-   * @see {@link CreateAgentExecutionInput.workspaceFileRefs}
+   * @see {@link SharedAgentExecutionFields.workspaceFileRefs}
    */
   readonly workspaceFileRefs?: string[];
   /**
@@ -136,7 +138,7 @@ export interface SendFollowUpOptions {
    * The conversation read model hides the superseded execution so the
    * edited message replaces the original in place.
    *
-   * @see {@link CreateAgentExecutionInput.supersedesExecutionId}
+   * @see {@link SharedAgentExecutionFields.supersedesExecutionId}
    */
   readonly supersedesExecutionId?: string;
 }

--- a/sdk/react/src/workflow/useApprovalBoundary.ts
+++ b/sdk/react/src/workflow/useApprovalBoundary.ts
@@ -29,7 +29,7 @@ export interface ApprovalBoundaryCrossing {
  * the decision surface (the panel's Inspect Approval tab) is never hidden
  * while the run is blocked.
  *
- * Same diffing shape as {@link useExecutionAnnouncements} (prev-map ref,
+ * Same diffing shape as `useExecutionAnnouncements` (prev-map ref,
  * diff on each map commit). A task first observed already in
  * `waiting_approval` counts as entered — with rAF-coalesced commits the
  * running→waiting transition can collapse into the task's first appearance.

--- a/sdk/react/typedoc.json
+++ b/sdk/react/typedoc.json
@@ -3,6 +3,9 @@
   "entryPoints": ["./src/index.ts"],
   "json": "typedoc-output.json",
   "externalSymbolLinkMappings": {
+    "typescript": {
+      "Error": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
+    },
     "@stigmer/protos": {
       "*": "https://stigmer.ai/docs/api-reference"
     },


### PR DESCRIPTION
## Summary

`npm run tsdoc:check` (typedoc `--treatValidationWarningsAsErrors`, in the `make check` chain) fails on pristine main with 11 unresolved `{@link}` warnings, so every sdk/react branch inherits a red gate it didn't cause. One pass over the 11 sites, each with a "what did the author mean to link" judgment:

- **7x `CreateAgentExecutionInput.<field>` in `SendFollowUpOptions`** (`useSessionConversation.ts`): repointed to `SharedAgentExecutionFields.<field>` — the exported interface where those fields (and their canonical docs) actually live; member links on the intersection type can never resolve. A type-only import brings the symbol into scope.
- **`ToolChrome` in `ToolCallItem`**: type-only import from `tool-categories.js` (the sibling files that link it already import it).
- **`AgentChannel` in `useChannelSessions`**: type-only import matching the sibling channel hooks' import.
- **`Error` in `SessionComposerProps.onAgentSetupErrorChange`**: `externalSymbolLinkMappings` entry pointing the global at MDN (the escape the config already uses for cross-package links).
- **`useExecutionAnnouncements` in `useApprovalBoundary`**: de-linked to a code reference — the hook is deliberately not part of the documented entry surface, so no link target exists.

The doc-only type imports are self-fencing: if a future cleanup removes one, the strict gate goes red again and points at the exact site.

Closes #669

## Test plan

- [x] Red-first: `npm run tsdoc:check` reproduced all 11 warnings on pristine main before the fix
- [x] `npm run tsdoc:check` — zero warnings after
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (0 errors)
- [x] `npm test` — 4505/4505 across 407 files
- [x] `make gen-react-sdk-docs` — regenerated docs byte-identical (no staleness introduced)

Made with [Cursor](https://cursor.com)