### PR TITLE
fix(cli): deterministic skill packaging + pre-packaged archive push (--archive)

### DIFF
--- a/client-apps/cli/docs/commands/push.mdx
+++ b/client-apps/cli/docs/commands/push.mdx
@@ -49,6 +49,29 @@ stigmer push skill --git-url https://github.com/acme/skills --subdir api-validat
 stigmer push skill --git-url https://github.com/acme/skills --git-ref v2.0.0
 ```
 
+**Archive push**: Push a ZIP you already built, byte-for-byte. The registered
+version hash is the SHA-256 of the file itself, so it matches any checksum
+your release pipeline published for the artifact. The archive must contain
+`SKILL.md` at its root; packaging flags (`--ignore`, `--include`,
+`--no-gitignore`) don't apply since packaging already happened.
+
+```bash
+# Push a pre-packaged skill archive as-is
+stigmer push skill --archive dist/my-skill.zip --tag v1.2.3 -m "release v1.2.3"
+
+# Validate the archive without pushing
+stigmer push skill --archive dist/my-skill.zip --dry-run
+```
+
+### Version identity
+
+A skill version is identified by the SHA-256 of its uploaded ZIP, and the CLI
+packages directories deterministically (sorted entries, fixed timestamps):
+pushing unchanged content produces the same bytes — and therefore the same
+version — no matter when or where the push runs. A CI job that pushes on
+every merge only registers a new version when the skill's content actually
+changed; unchanged pushes report `Status: unchanged`.
+
 ### File filtering
 
 By default, the CLI respects `.gitignore` patterns. Use `--ignore` and

--- a/client-apps/cli/src/commands/push.ts
+++ b/client-apps/cli/src/commands/push.ts
@@ -19,6 +19,7 @@ interface PushFlags {
   gitUrl?: string;
   gitRef?: string;
   subdir?: string;
+  archive?: string;
   ignore?: string[];
   include?: string[];
   gitignore?: boolean; // false when --no-gitignore is passed (commander negation)
@@ -37,6 +38,7 @@ export function registerPush(program: Command): void {
     .option("--git-url <url>", "push from a remote git repository URL")
     .option("--git-ref <ref>", "git reference (tag, branch, or commit SHA) for remote push")
     .option("--subdir <dir>", "subdirectory within the git repository containing the artifact")
+    .option("--archive <file>", "push a pre-packaged ZIP archive as-is (version hash = the file's SHA-256)")
     .option("--ignore <pattern>", "additional pattern to ignore (repeatable)", collect, [])
     .option("--include <pattern>", "pattern to force-include (repeatable)", collect, [])
     .option("--no-gitignore", "don't respect .gitignore patterns")
@@ -72,6 +74,11 @@ async function runPush(type: string, path: string | undefined, options: PushFlag
   const tag = options.tag ?? "latest";
   const message = options.message ?? "";
 
+  if (options.archive !== undefined && options.archive !== "") {
+    await pushArchive(client.stigmer, skill, { org, tag, message, path, options });
+    return;
+  }
+
   if (options.gitUrl !== undefined && options.gitUrl !== "") {
     await pushRemote(client.stigmer, skill, { org, tag, message, ignoreOptions, decisionSink, options });
     return;
@@ -93,6 +100,73 @@ async function runPush(type: string, path: string | undefined, options: PushFlag
 
   const result = await skill.pushSkill(client.stigmer, directory, org, tag, message, ignoreOptions, decisionSink);
   process.stdout.write(renderResult(result, skill));
+}
+
+interface ArchiveContext {
+  org: string;
+  tag: string;
+  message: string;
+  path: string | undefined;
+  options: PushFlags;
+}
+
+/**
+ * Push a pre-packaged skill archive (`--archive`). The bytes are uploaded
+ * as-is, so source-mode and filtering flags have nothing to act on — passing
+ * one alongside --archive is a contradiction we fail loudly rather than
+ * silently ignore.
+ */
+async function pushArchive(
+  client: import("@stigmer/sdk").Stigmer,
+  skill: typeof import("../resources/skill.js"),
+  ctx: ArchiveContext,
+): Promise<void> {
+  const conflicts: string[] = [];
+  if (ctx.path !== undefined && ctx.path !== "") conflicts.push("[path]");
+  if (ctx.options.gitUrl !== undefined && ctx.options.gitUrl !== "") conflicts.push("--git-url");
+  if (ctx.options.gitRef !== undefined && ctx.options.gitRef !== "") conflicts.push("--git-ref");
+  if (ctx.options.subdir !== undefined && ctx.options.subdir !== "") conflicts.push("--subdir");
+  if ((ctx.options.ignore ?? []).length > 0) conflicts.push("--ignore");
+  if ((ctx.options.include ?? []).length > 0) conflicts.push("--include");
+  if (ctx.options.gitignore === false) conflicts.push("--no-gitignore");
+  if (conflicts.length > 0) {
+    throw new UsageError(
+      `--archive pushes a pre-packaged ZIP as-is and cannot be combined with: ${conflicts.join(", ")}\n\n` +
+        "Packaging already happened when the archive was built.",
+    );
+  }
+
+  const archivePath = ctx.options.archive ?? "";
+  if (ctx.options.dryRun === true) {
+    process.stdout.write(renderArchiveDryRun(archivePath, skill.readSkillArchive(archivePath), skill));
+    return;
+  }
+
+  const result = await skill.pushSkillFromArchive(client, archivePath, ctx.org, ctx.tag, ctx.message);
+  process.stdout.write(renderResult(result, skill));
+}
+
+function renderArchiveDryRun(
+  archivePath: string,
+  archive: import("../resources/skill.js").SkillArchive,
+  skill: typeof import("../resources/skill.js"),
+): string {
+  const lines = [
+    "",
+    `Dry run - validating skill archive: ${archivePath}`,
+    "",
+    `Skill name:   ${archive.meta.name}`,
+    `Files:        ${archive.fileCount}`,
+    `Content size: ${skill.formatBytes(archive.totalSize)}`,
+    `Upload size:  ${skill.formatBytes(archive.bytes.length)}`,
+    "",
+    "The archive bytes are uploaded as-is: the registered version hash is the",
+    "SHA-256 of this file, so it matches any checksum you published for it.",
+    "",
+    "Run without --dry-run to push the skill artifact.",
+    "",
+  ];
+  return `${lines.join("\n")}\n`;
 }
 
 interface RemoteContext {

--- a/client-apps/cli/src/resources/skill.test.ts
+++ b/client-apps/cli/src/resources/skill.test.ts
@@ -1,13 +1,13 @@
 // Unit tests for the skill packaging layer: SKILL.md frontmatter parsing, the
 // ignore-filtered zip walk, dry-run analysis, and byte/hash formatting.
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import type { Stigmer } from "@stigmer/sdk";
-import { unzipSync } from "fflate";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { unzipSync, zipSync } from "fflate";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { classify, ExitCode } from "../errors/index.js";
 import {
   analyzeDryRun,
@@ -17,6 +17,8 @@ import {
   parseSkillMetadata,
   parseVisibility,
   pushSkill,
+  pushSkillFromArchive,
+  readSkillArchive,
   shortHash,
 } from "./skill.js";
 
@@ -113,12 +115,17 @@ describe("parseVisibility", () => {
 
 // A minimal fake of the SDK surface pushSkill touches: skill.push + skill.updateVisibility.
 function fakeClient(pushMeta: { id?: string; visibility?: ApiResourceVisibility }) {
-  const calls = { push: 0, updateVisibility: [] as Array<{ resourceId: string; visibility: ApiResourceVisibility }> };
+  const calls = {
+    push: 0,
+    pushedArtifacts: [] as Uint8Array[],
+    updateVisibility: [] as Array<{ resourceId: string; visibility: ApiResourceVisibility }>,
+  };
   const skillMessage = { metadata: { ...pushMeta } };
   const client = {
     skill: {
-      async push() {
+      async push(request?: { artifact?: Uint8Array }) {
         calls.push++;
+        if (request?.artifact !== undefined) calls.pushedArtifacts.push(request.artifact);
         return skillMessage;
       },
       async updateVisibility(input: { resourceId: string; visibility: ApiResourceVisibility }) {
@@ -196,6 +203,113 @@ describe("createSkillZip", () => {
     writeFileSync(join(dir, ".env"), "SECRET=1\n");
     const { bytes } = createSkillZip(dir, { respectGitignore: true, extraIgnore: [], extraInclude: [".env"] });
     expect(Object.keys(unzipSync(bytes))).toContain(".env");
+  });
+});
+
+describe("createSkillZip determinism", () => {
+  // Version identity is the server-side SHA-256 of the zip bytes, so identical
+  // content must produce identical bytes no matter when or where it was
+  // checked out (stigmer/stigmer#671). Distinct source mtimes model the fresh
+  // CI checkout; distinct wall-clock runs are inherent to running twice.
+  it("produces byte-identical zips for identical content across mtimes and wall-clock time", () => {
+    const otherDir = mkdtempSync(join(tmpdir(), "skill-test-b-"));
+    vi.useFakeTimers();
+    try {
+      for (const d of [dir, otherDir]) {
+        writeFileSync(join(d, "SKILL.md"), SKILL_MD);
+        mkdirSync(join(d, "references"));
+        writeFileSync(join(d, "references", "guide.md"), "# Guide\n");
+      }
+      // Backdate one copy: same content, different filesystem timestamps
+      // (models a fresh CI checkout).
+      const past = new Date("2020-06-15T12:00:00Z");
+      utimesSync(join(otherDir, "SKILL.md"), past, past);
+      utimesSync(join(otherDir, "references", "guide.md"), past, past);
+
+      // Advance the clock between runs: without a pinned mtime, fflate stamps
+      // zip-creation time into every entry (DOS 2-second granularity), so two
+      // pushes minutes apart would differ even from the same directory.
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const a = createSkillZip(dir, NO_IGNORE).bytes;
+      vi.setSystemTime(new Date("2026-01-01T00:05:00Z"));
+      const b = createSkillZip(otherDir, NO_IGNORE).bytes;
+      expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it("changes bytes when content changes", () => {
+    writeFileSync(join(dir, "SKILL.md"), SKILL_MD);
+    const before = createSkillZip(dir, NO_IGNORE).bytes;
+    writeFileSync(join(dir, "extra.md"), "new content\n");
+    const after = createSkillZip(dir, NO_IGNORE).bytes;
+    expect(Buffer.from(before).equals(Buffer.from(after))).toBe(false);
+  });
+});
+
+describe("readSkillArchive", () => {
+  function writeArchive(files: Record<string, string>): string {
+    const zipped = zipSync(
+      Object.fromEntries(Object.entries(files).map(([p, c]) => [p, new TextEncoder().encode(c)])),
+    );
+    const archivePath = join(dir, "skill.zip");
+    writeFileSync(archivePath, zipped);
+    return archivePath;
+  }
+
+  it("accepts an archive with a root SKILL.md and reports entry stats", () => {
+    const archivePath = writeArchive({
+      "SKILL.md": SKILL_MD,
+      "references/guide.md": "# Guide\n",
+    });
+    const archive = readSkillArchive(archivePath);
+    expect(archive.meta.name).toBe("my-skill");
+    expect(archive.fileCount).toBe(2);
+    expect(archive.totalSize).toBeGreaterThan(0);
+  });
+
+  it("rejects an archive whose SKILL.md is only nested (root-only contract, DD-018)", () => {
+    const archivePath = writeArchive({ "my-skill/SKILL.md": SKILL_MD });
+    expect(() => readSkillArchive(archivePath)).toThrow(/root of/);
+  });
+
+  it("rejects a file that is not a ZIP archive", () => {
+    const archivePath = join(dir, "not-a-zip.zip");
+    writeFileSync(archivePath, "plain text");
+    expect(() => readSkillArchive(archivePath)).toThrow(/not a valid ZIP/);
+  });
+
+  it("rejects a missing file with a usage error", () => {
+    const err = (() => {
+      try {
+        readSkillArchive(join(dir, "absent.zip"));
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(classify(err)?.exitCode).toBe(ExitCode.Usage);
+  });
+});
+
+describe("pushSkillFromArchive", () => {
+  it("uploads the archive bytes untouched (checksum parity) and applies declared visibility", async () => {
+    const zipped = zipSync({
+      "SKILL.md": new TextEncoder().encode("---\nname: my-skill\nvisibility: public\n---\n# S\n"),
+    });
+    const archivePath = join(dir, "skill.zip");
+    writeFileSync(archivePath, zipped);
+    const { client, calls } = fakeClient({ id: "skill-123", visibility: ApiResourceVisibility.visibility_private });
+
+    const result = await pushSkillFromArchive(client, archivePath, "stigmer", "", "release v1.2.3");
+
+    expect(calls.push).toBe(1);
+    expect(Buffer.from(calls.pushedArtifacts[0]).equals(Buffer.from(zipped))).toBe(true);
+    expect(calls.updateVisibility).toEqual([
+      { resourceId: "skill-123", visibility: ApiResourceVisibility.visibility_public },
+    ]);
+    expect(result.skillName).toBe("my-skill");
   });
 });
 

--- a/client-apps/cli/src/resources/skill.ts
+++ b/client-apps/cli/src/resources/skill.ts
@@ -14,13 +14,24 @@ import { GitProvenanceSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { UpdateVisibilityInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 import type { Stigmer } from "@stigmer/sdk";
-import { zipSync } from "fflate";
+import { strFromU8, unzipSync, zipSync } from "fflate";
 import { parse as parseYaml } from "yaml";
 import { UsageError } from "../errors/index.js";
 import { getGitBranchName, getGitCommit, getGitRemoteUrl, getGitRepoRoot } from "./git.js";
 import { createMatcher, REASON_TEXT, type Reason } from "./ignore/index.js";
 
 export const SKILL_FILE = "SKILL.md";
+
+// A skill version's identity is the server-side SHA-256 of the uploaded zip
+// bytes, so packaging must be a pure function of content — otherwise
+// re-pushing unchanged content registers a new version and the server's
+// unchanged-content no-op never fires (stigmer/stigmer#671). fflate stamps
+// zip-creation time into every entry when no mtime is given; pinning the DOS
+// epoch (the earliest representable zip timestamp) removes the only
+// byte-level variance. Local-field Date construction is deliberate: DOS
+// timestamps store wall-clock fields, so this encodes identically in every
+// timezone.
+const DETERMINISTIC_ZIP_MTIME = new Date(1980, 0, 1);
 // Kebab-case, optionally scoped with dot-separated namespaces (e.g.
 // "platform.planton-architecture"). Every segment must be alphanumeric, so no
 // leading/trailing/consecutive separators. The derived slug renders dots as hyphens.
@@ -102,7 +113,16 @@ export function parseSkillMetadata(dir: string): SkillMetadata {
   } catch (err) {
     throw new Error(`failed to read ${SKILL_FILE}: ${(err as Error).message}`);
   }
+  return parseSkillMetadataContent(content);
+}
 
+/**
+ * Parse SKILL.md content directly — the shared core behind the directory
+ * path (`parseSkillMetadata`) and the pre-packaged archive path
+ * (`pushSkillFromArchive`), where the content comes out of a zip entry
+ * rather than the filesystem.
+ */
+export function parseSkillMetadataContent(content: string): SkillMetadata {
   const frontmatter = extractFrontmatter(content);
   const parsed = (parseYaml(frontmatter) ?? {}) as Record<string, unknown>;
   const name = typeof parsed.name === "string" ? parsed.name : "";
@@ -233,7 +253,7 @@ export function createSkillZip(
   };
   walk(dir, "");
 
-  const bytes = zipSync(files, { level: 6 });
+  const bytes = zipSync(files, { level: 6, mtime: DETERMINISTIC_ZIP_MTIME });
   return { bytes, stats };
 }
 
@@ -371,6 +391,92 @@ export async function pushSkillFromClone(
   const response = await client.skill.push(request);
   const applied = await applyDeclaredVisibility(client, response, visibility);
   return toResult(applied, name, params.message, stats.totalSize, visibility);
+}
+
+/** A validated pre-packaged skill archive (`--archive`), ready to upload. */
+export interface SkillArchive {
+  /** The archive file's exact bytes — uploaded untouched. */
+  readonly bytes: Uint8Array;
+  /** Metadata parsed from the archive's root SKILL.md. */
+  readonly meta: SkillMetadata;
+  /** Number of file entries (directory markers excluded). */
+  readonly fileCount: number;
+  /** Total uncompressed size of all file entries, in bytes. */
+  readonly totalSize: number;
+}
+
+/**
+ * Read and validate a pre-packaged skill archive.
+ *
+ * Client-side validation is deliberately minimal — root SKILL.md present and
+ * frontmatter parses (the same contract the console's upload preview checks);
+ * the server remains the authoritative validator. The unzip filter inflates
+ * ONLY SKILL.md: entry metadata is enough for the count/size summary, and
+ * validation must not pay for decompressing a large artifact.
+ */
+export function readSkillArchive(archivePath: string): SkillArchive {
+  let raw: Buffer;
+  try {
+    raw = readFileSync(archivePath);
+  } catch (err) {
+    throw new UsageError(`failed to read archive ${archivePath}: ${(err as Error).message}`);
+  }
+  const bytes = new Uint8Array(raw);
+
+  let fileCount = 0;
+  let totalSize = 0;
+  let unzipped: Record<string, Uint8Array>;
+  try {
+    unzipped = unzipSync(bytes, {
+      filter: (info) => {
+        if (!info.name.endsWith("/")) {
+          fileCount++;
+          totalSize += info.originalSize;
+        }
+        return info.name === SKILL_FILE;
+      },
+    });
+  } catch (err) {
+    throw new UsageError(`${archivePath} is not a valid ZIP archive: ${(err as Error).message}`);
+  }
+
+  const skillMd = unzipped[SKILL_FILE];
+  if (skillMd === undefined) {
+    throw new UsageError(
+      `${SKILL_FILE} not found at the root of ${archivePath}\n\n` +
+        `A skill archive must contain ${SKILL_FILE} at its root (not inside a directory) defining the skill interface`,
+    );
+  }
+
+  return { bytes, meta: parseSkillMetadataContent(strFromU8(skillMd)), fileCount, totalSize };
+}
+
+/**
+ * Push a pre-packaged skill archive as-is (`--archive`).
+ *
+ * The bytes are uploaded untouched, so the engine's version hash is the
+ * SHA-256 of the file on disk — release pipelines that publish checksums get
+ * engine version identities that match them (stigmer/stigmer#671). Git
+ * provenance is deliberately omitted: the archive was built elsewhere, so the
+ * local checkout says nothing about the artifact's origin.
+ */
+export async function pushSkillFromArchive(
+  client: Stigmer,
+  archivePath: string,
+  org: string,
+  tag: string,
+  message: string,
+): Promise<PushResult> {
+  const archive = readSkillArchive(archivePath);
+  const request = create(PushSkillRequestSchema, {
+    org,
+    artifact: archive.bytes,
+    tag: tag === "" ? "latest" : tag,
+    message,
+  });
+  const response = await client.skill.push(request);
+  const applied = await applyDeclaredVisibility(client, response, archive.meta.visibility);
+  return toResult(applied, archive.meta.name, message, archive.totalSize, archive.meta.visibility);
 }
 
 /**

--- a/docs/cli/commands/push.mdx
+++ b/docs/cli/commands/push.mdx
@@ -36,18 +36,19 @@ stigmer push skill --dry-run
 
 ## Options
 
-| Flag              | Type     | Default  | Description                                                    |
-| ----------------- | -------- | -------- | -------------------------------------------------------------- |
-| `--dry-run`       | `bool`   |          | validate without pushing                                       |
-| `--git-ref`       | `string` |          | git reference (tag, branch, or commit SHA) for remote push     |
-| `--git-url`       | `string` |          | push from a remote git repository URL                          |
-| `--ignore`        | `string` |          | additional pattern to ignore (repeatable)                      |
-| `--include`       | `string` |          | pattern to force-include (repeatable)                          |
-| `--message`, `-m` | `string` |          | version message describing what changed                        |
-| `--no-gitignore`  | `bool`   |          | don't respect .gitignore patterns                              |
-| `--subdir`        | `string` |          | subdirectory within the git repository containing the artifact |
-| `--tag`           | `string` | `latest` | version tag for the artifact                                   |
-| `--verbose`       | `bool`   |          | show detailed output including ignore decisions                |
+| Flag              | Type     | Default  | Description                                                               |
+| ----------------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `--archive`       | `string` |          | push a pre-packaged ZIP archive as-is (version hash = the file's SHA-256) |
+| `--dry-run`       | `bool`   |          | validate without pushing                                                  |
+| `--git-ref`       | `string` |          | git reference (tag, branch, or commit SHA) for remote push                |
+| `--git-url`       | `string` |          | push from a remote git repository URL                                     |
+| `--ignore`        | `string` |          | additional pattern to ignore (repeatable)                                 |
+| `--include`       | `string` |          | pattern to force-include (repeatable)                                     |
+| `--message`, `-m` | `string` |          | version message describing what changed                                   |
+| `--no-gitignore`  | `bool`   |          | don't respect .gitignore patterns                                         |
+| `--subdir`        | `string` |          | subdirectory within the git repository containing the artifact            |
+| `--tag`           | `string` | `latest` | version tag for the artifact                                              |
+| `--verbose`       | `bool`   |          | show detailed output including ignore decisions                           |
 
 ### Source modes
 
@@ -73,6 +74,29 @@ stigmer push skill --git-url https://github.com/acme/skills --subdir api-validat
 # Push a specific version
 stigmer push skill --git-url https://github.com/acme/skills --git-ref v2.0.0
 ```
+
+**Archive push**: Push a ZIP you already built, byte-for-byte. The registered
+version hash is the SHA-256 of the file itself, so it matches any checksum your
+release pipeline published for the artifact. The archive must contain `SKILL.md`
+at its root; packaging flags (`--ignore`, `--include`, `--no-gitignore`) don't
+apply since packaging already happened.
+
+```bash
+# Push a pre-packaged skill archive as-is
+stigmer push skill --archive dist/my-skill.zip --tag v1.2.3 -m "release v1.2.3"
+
+# Validate the archive without pushing
+stigmer push skill --archive dist/my-skill.zip --dry-run
+```
+
+### Version identity
+
+A skill version is identified by the SHA-256 of its uploaded ZIP, and the CLI
+packages directories deterministically (sorted entries, fixed timestamps):
+pushing unchanged content produces the same bytes — and therefore the same
+version — no matter when or where the push runs. A CI job that pushes on every
+merge only registers a new version when the skill's content actually changed;
+unchanged pushes report `Status: unchanged`.
 
 ### File filtering
 


### PR DESCRIPTION
## Summary

A skill version's identity is the server-side SHA-256 of the uploaded zip bytes, and the server already no-ops unchanged content (`ArchiveCurrentSkillStep`'s change gate) — but the CLI defeated it on **every** push: fflate stamps zip-creation time into each entry when no `mtime` is given, so identical content produced different bytes run to run. This is worse than the issue reports — not just fresh CI checkouts; even a local same-directory re-push registered a new version once the clock passed the 2-second DOS granularity. The fix is entirely client-side; hash semantics and the server are untouched.

- **Deterministic packaging, always on**: the walk already sorted entries; `createSkillZip` now pins the DOS-epoch `mtime` (local-field construction — DOS timestamps store wall-clock fields, so bytes are identical in every timezone). Packaging is now a pure function of content, which is what activates the server's existing unchanged-content no-op from anywhere.
- **`--archive <file>`**: push a ZIP you already built, byte-for-byte, so the registered version hash equals the checksum your release pipeline published. Client validation mirrors the console upload's contract (root `SKILL.md`, frontmatter parses — via a small `parseSkillMetadataContent` refactor shared by both paths); only `SKILL.md` is inflated during validation. Mutually exclusive with `[path]`, `--git-url`/`--git-ref`/`--subdir`, and the filtering flags — a contradiction fails loudly. Git provenance is deliberately omitted (the archive was built elsewhere). `--dry-run` validates and summarizes without pushing.
- Docs: `push.mdx` gains the archive mode and a "Version identity" section; regenerated via `make gen-cli-docs` (freshness check green).

**One-time consequence, by design**: the first post-upgrade push of unchanged content registers ONE final new version (old timestamped hash → deterministic hash), then no-ops forever.

Closes #671

## Test plan

- [x] Red-first: the determinism test (fake timers advance the clock between two zips of identical content with different file mtimes) fails against the old packaging, passes with the fix
- [x] Byte-parity test: `pushSkillFromArchive` uploads the archive bytes untouched
- [x] Archive validation: nested-only SKILL.md rejected (DD-018 root-only), non-ZIP rejected, missing file is a usage error
- [x] Full CLI suite 883/883; typecheck + lint clean
- [x] `make gen-cli-docs-check` — CLI docs up to date

Made with [Cursor](https://cursor.com)