### PR TITLE
fix(sdk): composer submits exactly what the model pill displays

### DIFF
--- a/docs/sdk/react/execution.mdx
+++ b/docs/sdk/react/execution.mdx
@@ -3269,6 +3269,45 @@ const shouldFetch = isTextArtifact(artifact) && Number(artifact.sizeBytes) < MAX
 ```
 
 
+### LivenessStatusLine
+
+The thread's ambient-liveness anchor (stigmer#277): a quiet one-line status
+at the bottom of the thread while an execution is live but nothing else on
+screen is visibly moving — the exact stretches (model generation between
+tool calls) where users conclude the agent died and reach for a restart.
+
+The label carries the shared `stgm-shimmer-label` sweep, the same treatment
+as a running tool row's title and the thinking indicator, so "alive" reads
+identically everywhere. [`MessageThread`](#messagethread) emits it only while the
+active execution is `IN_PROGRESS` with no running tool call, no live
+sub-agent, and no pending approval — when a gate is waiting on the *user*,
+shimmering "Working…" would be a lie, and when a tool is running, its own
+row carries the sweep. It disappears the moment the execution settles
+(phase-driven, DD-009 — never inferred from the stream going quiet).
+
+Replaceable via [`MessageThreadSlots.LivenessStatusLine`](#livenessstatusline) (the
+SetupProgress precedent) for hosts that want their own liveness voice.
+
+All visual properties flow through `--stgm-*` tokens.
+
+```tsx
+<LivenessStatusLine />
+<LivenessStatusLine label="Reviewing your data…" />
+```
+
+
+### LivenessStatusLineProps
+
+Props for [`LivenessStatusLine`](#livenessstatusline).
+
+<TypeTable
+  type={{
+    className: { type: "string", description: "Additional CSS class names for the root container." },
+    label: { type: "string", description: "The status copy. Defaults to `\"Working…\"` — deliberately generic: the thread has no model-authored account of what the agent is doing between visible events (that seam is stigmer#276), so the line claims only what is provably true." },
+  }}
+/>
+
+
 ### MessageEntry
 
 Renders a single message in the conversation thread.
@@ -3332,6 +3371,7 @@ render defeats that for its rows.
   type={{
     ApprovalCard: { type: "ComponentType<ApprovalCardProps>", description: "The HITL tool-approval gate card." },
     ExecutionErrorNotice: { type: "ComponentType<ExecutionErrorNoticeProps>", description: "The terminal execution-failure notice. Receives the raw server-reported reason and the retry wiring, so a host can turn the failure into its own recovery moment (classify the reason, offer an alternate engine, link support) instead of the built-in Show more / Retry treatment." },
+    LivenessStatusLine: { type: "ComponentType<LivenessStatusLineProps>", description: "The ambient-liveness status line at the thread's tail while the active execution is live between visible events (stigmer#277). Override to supply a host-voiced label or richer treatment; the emission policy (when the line appears at all) stays with the thread." },
     MessageEntry: { type: "ComponentType<MessageEntryProps>", description: "All message bubbles — human, assistant, thinking, and system entries. Also wraps the failed-send bubble (the inline Retry chrome around it stays built-in)." },
     PlanArtifactCard: { type: "ComponentType<PlanArtifactCardProps>", description: "Completed Plan turn that published a plan artifact." },
     PlanCompletionCard: { type: "ComponentType<PlanCompletionCardProps>", description: "Completed Plan turn without an artifact — the bare Implement CTA." },
@@ -4038,6 +4078,13 @@ The two disclosure axes — the card-level chevron and a block's
 content-overflow reveal — never govern the same body, which is what removes
 the old "expand, then Show more" double control.
 
+Orthogonal to the layout modes is the **chrome tier** (the density axis,
+stigmer#274): metadata-only categories (read / list / search / think)
+render as quiet unboxed lines — no card frame — while content-bearing
+categories keep their cards. A quiet row escalates to a card while gated
+or failed; its disclosed body renders under a light left rail instead of a
+border. See `ToolChrome`.
+
 Shows category-aware labels (e.g., "Shell", "Read", "Edit") with
 the primary argument as a subtitle, a category-specific icon, and
 an inline approval decision badge when applicable.
@@ -4116,6 +4163,7 @@ The fully-resolved presentation for a tool call, returned by [`useToolPresentati
 <TypeTable
   type={{
     category: { type: "ToolCategory", description: "Presentation category (1:1 with kind).", required: true },
+    chrome: { type: "ToolChrome", description: "Default chrome tier for this tool — `\"quiet\"` renders an unboxed line, `\"card\"` a bordered card (see ToolChrome). A pending gate or a failure escalates to `\"card\"` in the component layer; this is the *settled* default.", required: true },
     disclosure: { type: "ToolDisclosure", description: "Default inline disclosure for this tool — `\"preview\"` keeps a bounded, persistent preview of the result, `\"summary\"` keeps a compact row. The active/awaiting state can still force a row open; this is the *settled* default.", required: true, typeDescriptionLink: "#tooldisclosure" },
     kind: { type: "ToolKind", description: "Harness-agnostic kind (wire field, with name fallback).", required: true },
     label: { type: "string", description: "Display label, e.g. \"Edit\", \"Shell\".", required: true },
@@ -4133,6 +4181,7 @@ Optional per-kind overrides for label, summary, disclosure, and run-grouping.
 
 <TypeTable
   type={{
+    chrome: { type: "(toolCall: ToolCall, result: ToolResultView) => ToolChrome", description: "Overrides the default chrome tier — quiet unboxed line vs bordered card (see ToolChrome). Use to restore the boxed look for a kind (`() => \"card\"`) or to quiet a chatty custom tool (`() => \"quiet\"`). A pending approval gate or a failure always escalates the row to a card regardless of this override — a decision surface and error output must never render frameless." },
     disclosure: { type: "(toolCall: ToolCall, result: ToolResultView) => ToolDisclosure", description: "Overrides the default inline disclosure. Use to keep a noisy MCP tool compact (`() => \"summary\"`) or to foreground a custom tool's output (`() => \"preview\"`) without forking the components." },
     label: { type: "(toolCall: ToolCall) => string", description: "Overrides the display label (e.g. \"Shell\" -> \"Run command\")." },
     runGroupable: { type: "(toolCall: ToolCall) => boolean", description: "Overrides whether consecutive same-kind calls fold into one collapsible \"Read 5 files\" chip. Use to fold a chatty custom tool (`() => true`) or to keep a normally-folded category as standalone rows (`() => false`) without forking the thread layout. Defaults to isRunGroupableCategory." },

--- a/docs/sdk/react/resource-detail.mdx
+++ b/docs/sdk/react/resource-detail.mdx
@@ -40,9 +40,10 @@ function useConfirmAction(): UseConfirmActionReturn
 
 Clipboard helper for resource detail pages.
 
-Wraps `navigator.clipboard.writeText` with toast feedback so every
-copy action is confirmed visually (Nielsen heuristic #1 — visibility
-of system status). Falls back to a hidden textarea for older browsers.
+Wraps the shared copy behavior (`useCopyFeedback`) with toast feedback so
+every copy action is confirmed visually (Nielsen heuristic #1 — visibility
+of system status). A rejected write (insecure context, denied permission)
+toasts an error instead of claiming a copy that didn't happen.
 
 **Signature**
 

--- a/sdk/react/src/composer/SessionComposer.tsx
+++ b/sdk/react/src/composer/SessionComposer.tsx
@@ -7,7 +7,7 @@ import { useComposer } from "./useComposer.js";
 import { ComposerToolbar } from "./ComposerToolbar.js";
 import { type ConfigureMenuItem } from "./ConfigureMenu.js";
 import type { HarnessOption } from "../models/harness.js";
-import type { ServiceTierOption } from "../models/service-tier.js";
+import { FAST_SERVICE_TIER, type ServiceTierOption } from "../models/service-tier.js";
 import type { InteractionModeOption } from "./InteractionModePicker.js";
 import { parseModelKey } from "../models/registry.js";
 import { useModelRegistry } from "../models/useModelRegistry.js";
@@ -659,8 +659,22 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
 
   // Service tier (#357): composer-local state like modelId. "standard" is
   // the resting default; the ModelSelector's fail-safe resets it when the
-  // user switches to a model without a fast tier.
+  // user switches to a model without a fast tier. Whether an armed "fast"
+  // actually rides the submit is decided by the derived effective run
+  // selection below (#663) — state here records the user's intent only.
   const [serviceTier, setServiceTier] = useState<ServiceTierOption>("standard");
+
+  // Active harness mirror: controlled hosts (both viewers) keep the
+  // `harness` prop current, but with `showHarnessSelector` the dropdown
+  // lives inside ModelSelector and an uncontrolled host would leave the
+  // prop stale — the mirror keeps the effective-model resolution scoped
+  // to the harness the picker is actually showing.
+  const [activeHarness, setActiveHarness] = useState<HarnessOption>(
+    harness ?? "native",
+  );
+  useEffect(() => {
+    if (harness !== undefined) setActiveHarness(harness);
+  }, [harness]);
 
   const [displayNames, setDisplayNames] = useState<Map<string, string>>(
     () => new Map(),
@@ -771,36 +785,91 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
   const {
     getByKey: registryGetByKey,
     getModel: registryGetModel,
-    defaultModel: registryDefaultModel,
     visionLimits,
+    isLoading: isRegistryLoading,
   } = useModelRegistry();
-  const visionNotice = useMemo(() => {
-    if (!enableAttachments || attachments.entries.length === 0) return null;
+  const { defaultModel: harnessDefaultModel } = useModelRegistry({
+    harness: activeHarness,
+  });
+
+  // -------------------------------------------------------------------------
+  // Effective run selection (stigmer/stigmer#663) — the ONE resolution of
+  // "which model and tier will this send actually run". The model pill,
+  // the fast-tier gate, the vision preflight, and the submit payload all
+  // read it, so the pill can never promise a selection the wire doesn't
+  // carry (the #663 failure: a fallback pill with an armed fast tier over
+  // an empty model — refused fail-closed at create).
+  //
+  // Adoption of the harness default is gated on `showModelSelector`: with
+  // no pill there is no displayed promise, and whoever hid the picker owns
+  // the model (the guest share profile server-side, a host pin) — the
+  // guest no-modelName invariant depends on this gate staying put.
+  // -------------------------------------------------------------------------
+
+  const effective = useMemo(() => {
     // modelId may be a compound "harness/id" key (unified picker) or a
     // plain id — resolve through the unambiguous compound lookup first,
     // mirroring the submit path's parseModelKey handling.
-    const selectedModel = modelId
+    const stateModel = modelId
       ? (registryGetByKey(modelId) ?? registryGetModel(modelId))
-      : registryDefaultModel;
+      : undefined;
+
+    let effectiveModelId = modelId;
+    let effectiveModel = stateModel;
+    if (showModelSelector && !isRegistryLoading && stateModel === undefined) {
+      // Empty state, or an id the registry no longer lists (e.g. a retired
+      // model carried over from the last execution): the pill falls back to
+      // the harness default, so the submission adopts it too. While the
+      // registry is still loading nothing can be classified — pass the raw
+      // id through unmodified rather than misadopting the default.
+      effectiveModelId = harnessDefaultModel?.modelId ?? modelId;
+      effectiveModel = harnessDefaultModel;
+    }
+
+    // "fast" rides the submit only while the effective model prices the
+    // variant — the same rule the trigger badge renders and the server
+    // enforces fail-closed (#357). An armed tier surviving onto a model
+    // with no fast variant (e.g. a prop-driven `defaultModelId` re-sync,
+    // which bypasses ModelSelector's user-pick reset) is thereby
+    // unsendable, not just unstyled.
+    const effectiveServiceTier: ServiceTierOption =
+      serviceTier === "fast"
+        && (effectiveModel?.serviceTiers.includes(FAST_SERVICE_TIER) ?? false)
+        ? "fast"
+        : "standard";
+
+    return { modelId: effectiveModelId, model: effectiveModel, serviceTier: effectiveServiceTier };
+  }, [
+    modelId,
+    serviceTier,
+    showModelSelector,
+    isRegistryLoading,
+    registryGetByKey,
+    registryGetModel,
+    harnessDefaultModel,
+  ]);
+
+  // Vision preflight consumes the effective model — previously it kept a
+  // third private resolution (unified-registry default) that could name a
+  // different model than both the pill and the payload.
+  const visionNotice = useMemo(() => {
+    if (!enableAttachments || attachments.entries.length === 0) return null;
     const preflight = assessVisionPreflight(
       attachments.entries.map((e) => ({
         name: e.file.name,
         sizeBytes: e.file.size,
         contentType: e.contentType,
       })),
-      { model: selectedModel, limits: visionLimits },
+      { model: effective.model, limits: visionLimits },
     );
     return visionPreflightMessage(preflight, {
       limits: visionLimits,
-      modelDisplayName: selectedModel?.displayName,
+      modelDisplayName: effective.model?.displayName,
     });
   }, [
     enableAttachments,
     attachments.entries,
-    modelId,
-    registryGetByKey,
-    registryGetModel,
-    registryDefaultModel,
+    effective.model,
     visionLimits,
   ]);
 
@@ -974,27 +1043,32 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
           : undefined);
       const hasFileRefs = enableFileReferences && fileRefs.hasRefs;
       const buildFromPlan = overrides?.buildFromPlan;
-      // Carried only when the user actively chose fast: an untouched
-      // tier means "platform default" (which resolves to standard in
-      // the runner), and the UNSPECIFIED-vs-explicit distinction is
-      // load-bearing telemetry (#357).
-      const effectiveServiceTier = serviceTier === "fast" ? serviceTier : undefined;
+      // Carried only when fast is actually in effect (armed by the user
+      // AND priced by the effective model — see the effective run
+      // selection): an untouched tier means "platform default" (which
+      // resolves to standard in the runner), and the UNSPECIFIED-vs-
+      // explicit distinction is load-bearing telemetry (#357).
+      const submitServiceTier =
+        effective.serviceTier === "fast" ? effective.serviceTier : undefined;
 
       const context: SessionComposerSubmitContext | undefined =
         hasEnv || hasAttachments || effectiveMode || hasFileRefs || buildFromPlan
-        || effectiveServiceTier
+        || submitServiceTier
           ? {
               runtimeEnv: hasEnv ? env : undefined,
               attachments: hasAttachments ? attachmentInputs : undefined,
               interactionMode: effectiveMode,
-              serviceTier: effectiveServiceTier,
+              serviceTier: submitServiceTier,
               workspaceFileRefs: hasFileRefs ? [...fileRefs.refs] : undefined,
               buildFromPlan,
             }
           : undefined;
 
-      const resolvedModelId = modelId
-        ? (parseModelKey(modelId)?.modelId ?? modelId)
+      // The payload carries the effective model — exactly what the pill
+      // displays (#663), stripped to a plain id when the state holds a
+      // compound "harness/id" key.
+      const resolvedModelId = effective.modelId
+        ? (parseModelKey(effective.modelId)?.modelId ?? effective.modelId)
         : undefined;
       onSubmit(message, resolvedModelId, context);
 
@@ -1005,7 +1079,7 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
         fileRefs.clear();
       }
     },
-    [onSubmit, modelId, serviceTier, stigmer, agentSetup.state, mcpSetup.pendingRuntimeEnv, sessionVariables, enableAttachments, attachments, personalEnv, showInteractionModePicker, interactionMode],
+    [onSubmit, effective, stigmer, agentSetup.state, mcpSetup.pendingRuntimeEnv, sessionVariables, enableAttachments, attachments, personalEnv, showInteractionModePicker, interactionMode],
   );
 
   const composer = useComposer({
@@ -1033,6 +1107,7 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
 
   const handleHarnessChange = useCallback(
     (h: HarnessOption) => {
+      setActiveHarness(h);
       onHarnessChange?.(h);
     },
     [onHarnessChange],
@@ -1804,7 +1879,9 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
           interactionMode={interactionMode}
           onInteractionModeChange={handleInteractionModeChange}
           showModelSelector={showModelSelector}
-          modelId={modelId}
+          // The pill renders the effective selection — the same value the
+          // submit payload carries (#663), never a fallback of its own.
+          modelId={effective.modelId}
           onModelChange={handleModelChange}
           serviceTier={serviceTier}
           onServiceTierChange={setServiceTier}

--- a/sdk/react/src/composer/__tests__/SessionComposer-modelCoherence.test.tsx
+++ b/sdk/react/src/composer/__tests__/SessionComposer-modelCoherence.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { type ReactNode } from "react";
+import type { Stigmer } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { ModelRegistryContext } from "../../models/ModelRegistryContext";
+import type { ModelInfo } from "../../models/registry";
+import { SessionComposer } from "../SessionComposer";
+
+// Shim ResizeObserver for Base UI's positioner (the
+// scheduleCreation.test.tsx pattern).
+beforeAll(() => {
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+  }
+});
+
+/**
+ * Effective run selection coherence (stigmer/stigmer#663): the submission
+ * must carry exactly the model the pill displays, and "fast" must only
+ * ride the wire while the effective model prices it. The original defect:
+ * an empty composer displayed the registry fallback with a toggleable
+ * FAST badge, then sent `service_tier: fast` with NO model — refused
+ * fail-closed by the server ("Couldn't send." + a Retry that can never
+ * succeed).
+ */
+
+const AUTO: ModelInfo = {
+  modelId: "default",
+  provider: "cursor",
+  displayName: "Auto",
+  shortDescription: "Automatic model selection",
+  speedTier: "fast",
+  costTier: "standard",
+  harness: "cursor",
+  featured: true,
+  serviceTiers: [],
+};
+
+const FAST_CAPABLE: ModelInfo = {
+  modelId: "composer-2.5",
+  provider: "cursor",
+  displayName: "Composer 2.5",
+  shortDescription: "Fast agentic model",
+  speedTier: "fastest",
+  costTier: "economy",
+  harness: "cursor",
+  featured: true,
+  serviceTiers: ["fast"],
+};
+
+const NO_FAST: ModelInfo = {
+  modelId: "gpt-5.3-codex",
+  provider: "openai",
+  displayName: "GPT-5.3 Codex",
+  shortDescription: "No fast variant",
+  speedTier: "fast",
+  costTier: "standard",
+  harness: "cursor",
+  featured: true,
+  serviceTiers: [],
+};
+
+function createMinimalStigmerMock(): Stigmer {
+  return {
+    agentExecution: { uploadAttachment: vi.fn() },
+    environment: { getPersonal: vi.fn().mockResolvedValue(null) },
+    baseUrl: "http://localhost:8080",
+    getAuthCredential: vi.fn().mockResolvedValue("test-token"),
+    config: {
+      baseUrl: "http://localhost:8080",
+      getAccessToken: vi.fn().mockResolvedValue(""),
+    },
+  } as unknown as Stigmer;
+}
+
+function createWrapper(
+  client: Stigmer,
+  registry: { models: readonly ModelInfo[]; isLoading?: boolean },
+) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <StigmerContext.Provider value={client}>
+        <ModelRegistryContext.Provider
+          value={{
+            models: [...registry.models],
+            isLoading: registry.isLoading ?? false,
+            error: null,
+            refetch: vi.fn(),
+          }}
+        >
+          {children}
+        </ModelRegistryContext.Provider>
+      </StigmerContext.Provider>
+    );
+  };
+}
+
+function submitMessage(message: string) {
+  const textarea = screen.getByRole("textbox");
+  fireEvent.change(textarea, { target: { value: message } });
+  fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+}
+
+/** Open the picker and flip the fast-tier switch (Base UI portals mount
+ * asynchronously in jsdom — the switch is awaited). */
+async function toggleFastTier(triggerName: RegExp) {
+  fireEvent.click(screen.getByRole("button", { name: triggerName }));
+  const toggle = await screen.findByRole("switch", { name: "Fast tier" });
+  fireEvent.click(toggle);
+  fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+}
+
+afterEach(cleanup);
+
+describe("SessionComposer — effective run selection (#663)", () => {
+  it("adopts the displayed harness default when no model is selected", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <SessionComposer onSubmit={onSubmit} harness="cursor" />,
+      { wrapper: createWrapper(createMinimalStigmerMock(), { models: [FAST_CAPABLE, AUTO, NO_FAST] }) },
+    );
+
+    // The pill displays the harness default (Auto for cursor)…
+    expect(screen.getByRole("button", { name: /Auto/ })).toBeTruthy();
+
+    submitMessage("hello");
+
+    // …and the submission carries exactly that model, never undefined.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0][1]).toBe("default");
+  });
+
+  it("renders no fast-tier switch for a fresh cursor composer (Auto has no tier dimension)", async () => {
+    render(
+      <SessionComposer onSubmit={vi.fn()} harness="cursor" />,
+      { wrapper: createWrapper(createMinimalStigmerMock(), { models: [FAST_CAPABLE, AUTO, NO_FAST] }) },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Auto/ }));
+    // Popover content mounts async; settle on the options area appearing.
+    await screen.findByRole("dialog");
+    expect(screen.queryByRole("switch", { name: "Fast tier" })).toBeNull();
+  });
+
+  it("drops an armed fast tier when a prop-driven model change lands on a model without a fast variant", async () => {
+    const onSubmit = vi.fn();
+    const wrapper = createWrapper(createMinimalStigmerMock(), {
+      models: [FAST_CAPABLE, AUTO, NO_FAST],
+    });
+    const { rerender } = render(
+      <SessionComposer onSubmit={onSubmit} harness="cursor" defaultModelId="composer-2.5" />,
+      { wrapper },
+    );
+
+    // Arm fast on the fast-capable model (user-driven), then let the host
+    // re-sync `defaultModelId` onto a model with no fast variant — the
+    // path that bypasses ModelSelector's user-pick reset.
+    await toggleFastTier(/Composer 2\.5/);
+    rerender(
+      <SessionComposer onSubmit={onSubmit} harness="cursor" defaultModelId="gpt-5.3-codex" />,
+    );
+
+    submitMessage("resynced");
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0][1]).toBe("gpt-5.3-codex");
+    // The armed tier is unsendable, not just unstyled (#357 fail-closed rule).
+    expect(onSubmit.mock.calls[0][2]?.serviceTier).toBeUndefined();
+  });
+
+  it("never adopts a default while the model selector is hidden (the hider owns the model)", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <SessionComposer onSubmit={onSubmit} harness="cursor" showModelSelector={false} />,
+      { wrapper: createWrapper(createMinimalStigmerMock(), { models: [FAST_CAPABLE, AUTO, NO_FAST] }) },
+    );
+
+    submitMessage("guest-shaped send");
+
+    // No pill, no promise: guests' server-side profile (and #664 pins)
+    // own the model — the composer must not invent one.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("adopts the displayed default over a model id the registry no longer lists", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <SessionComposer onSubmit={onSubmit} harness="cursor" defaultModelId="retired-model" />,
+      { wrapper: createWrapper(createMinimalStigmerMock(), { models: [FAST_CAPABLE, AUTO, NO_FAST] }) },
+    );
+
+    submitMessage("stale id");
+
+    // The pill cannot display "retired-model" (unknown → falls back to the
+    // harness default), so the payload must not carry it either.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0][1]).toBe("default");
+  });
+
+  it("passes the raw model id through while the registry is still loading", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <SessionComposer onSubmit={onSubmit} harness="cursor" defaultModelId="composer-2.5" />,
+      { wrapper: createWrapper(createMinimalStigmerMock(), { models: [], isLoading: true }) },
+    );
+
+    submitMessage("early send");
+
+    // Nothing can be classified mid-load: adopt nothing, rewrite nothing.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0][1]).toBe("composer-2.5");
+  });
+});

--- a/sdk/react/src/models/__tests__/resolveDefaultModel.test.ts
+++ b/sdk/react/src/models/__tests__/resolveDefaultModel.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_CURSOR_MODEL_ID,
+  DEFAULT_MODEL_ID,
+  resolveDefaultModelId,
+  type ModelInfo,
+} from "../registry";
+
+/**
+ * The harness-default arm is a contract, not a suggestion
+ * (stigmer/stigmer#663): this resolution feeds the composer's pill, and
+ * the submission adopts what the pill displays — so the default must be
+ * what the platform actually runs for an unpinned execution:
+ *
+ * - cursor → the registry's Auto entry (the runner coerces an empty
+ *   model_name to "default")
+ * - native → the runner's getDefaultModel() rule (featured + standard
+ *   cost, then any standard cost)
+ */
+
+function model(overrides: Partial<ModelInfo> & { modelId: string }): ModelInfo {
+  return {
+    provider: "anthropic",
+    displayName: overrides.modelId,
+    shortDescription: "",
+    speedTier: "fast",
+    costTier: "standard",
+    harness: "native",
+    featured: false,
+    serviceTiers: [],
+    ...overrides,
+  };
+}
+
+describe("resolveDefaultModelId — cursor harness", () => {
+  it("prefers the Auto entry over featured models listed before it (the production order that caused #663)", () => {
+    // Mirrors the live registry: featured premium models precede Auto.
+    const models = [
+      model({ modelId: "claude-opus-4-8", harness: "cursor", featured: true, costTier: "premium" }),
+      model({ modelId: DEFAULT_CURSOR_MODEL_ID, harness: "cursor", featured: true }),
+    ];
+    expect(resolveDefaultModelId("cursor", models)).toEqual({
+      modelId: DEFAULT_CURSOR_MODEL_ID,
+      source: "harness_default",
+    });
+  });
+
+  it("falls back to the first featured cursor model when the registry has no Auto entry", () => {
+    const models = [
+      model({ modelId: "composer-2.5", harness: "cursor", featured: true }),
+    ];
+    expect(resolveDefaultModelId("cursor", models).modelId).toBe("composer-2.5");
+  });
+
+  it("falls back to the hardcoded cursor id on an empty registry", () => {
+    expect(resolveDefaultModelId("cursor", [])).toEqual({
+      modelId: DEFAULT_CURSOR_MODEL_ID,
+      source: "platform_fallback",
+    });
+  });
+
+  it("lets an explicit user preference win over Auto", () => {
+    const models = [
+      model({ modelId: DEFAULT_CURSOR_MODEL_ID, harness: "cursor", featured: true }),
+      model({ modelId: "composer-2.5", harness: "cursor", featured: true }),
+    ];
+    expect(
+      resolveDefaultModelId("cursor", models, { userPreference: "composer-2.5" }),
+    ).toEqual({ modelId: "composer-2.5", source: "user_preference" });
+  });
+});
+
+describe("resolveDefaultModelId — native harness", () => {
+  it("skips a featured premium model for the featured standard-cost one (the runner's own rule)", () => {
+    const models = [
+      model({ modelId: "claude-opus-4.6", featured: true, costTier: "premium" }),
+      model({ modelId: "claude-sonnet-4.6", featured: true, costTier: "standard" }),
+    ];
+    expect(resolveDefaultModelId("native", models)).toEqual({
+      modelId: "claude-sonnet-4.6",
+      source: "harness_default",
+    });
+  });
+
+  it("falls back to any standard-cost model when no featured one is standard", () => {
+    const models = [
+      model({ modelId: "claude-opus-4.6", featured: true, costTier: "premium" }),
+      model({ modelId: "gpt-4o", featured: false, costTier: "standard" }),
+    ];
+    expect(resolveDefaultModelId("native", models).modelId).toBe("gpt-4o");
+  });
+
+  it("falls back to the first featured model when the registry lists no standard-cost model at all", () => {
+    const models = [
+      model({ modelId: "claude-opus-4.6", featured: true, costTier: "premium" }),
+      model({ modelId: "ollama-local", featured: false, costTier: "economy" }),
+    ];
+    expect(resolveDefaultModelId("native", models).modelId).toBe("claude-opus-4.6");
+  });
+
+  it("falls back to the hardcoded native id on an empty registry", () => {
+    expect(resolveDefaultModelId("native", [])).toEqual({
+      modelId: DEFAULT_MODEL_ID,
+      source: "platform_fallback",
+    });
+  });
+
+  it("never resolves across harnesses (a cursor Auto entry is invisible to native)", () => {
+    const models = [
+      model({ modelId: DEFAULT_CURSOR_MODEL_ID, harness: "cursor", featured: true }),
+      model({ modelId: "claude-sonnet-4.6", featured: true, costTier: "standard" }),
+    ];
+    expect(resolveDefaultModelId("native", models).modelId).toBe("claude-sonnet-4.6");
+  });
+});

--- a/sdk/react/src/models/__tests__/useModelRegistry.test.tsx
+++ b/sdk/react/src/models/__tests__/useModelRegistry.test.tsx
@@ -342,13 +342,12 @@ describe("useModelRegistry", () => {
       expect(cursorModels).toHaveLength(0);
     });
 
-    it("resolves defaultModel to the first featured native model", () => {
+    it("resolves defaultModel to the featured standard-cost native model (what an unpinned execution runs, #663)", () => {
       const { result } = renderHook(() =>
         useModelRegistry({ harness: "native" }),
       { wrapper: createWrapper() });
-      const featured = result.current.featured;
-      expect(featured.length).toBeGreaterThan(0);
-      expect(result.current.defaultModel!.modelId).toBe(featured[0].modelId);
+      expect(result.current.defaultModel!.modelId).toBe("claude-sonnet-4.6");
+      expect(result.current.defaultModel!.costTier).toBe("standard");
     });
   });
 

--- a/sdk/react/src/models/registry.ts
+++ b/sdk/react/src/models/registry.ts
@@ -402,11 +402,28 @@ export interface DefaultModelResolution {
  *
  * Priority (Phase 1 — no backend):
  * 1. localStorage user preference (passed in as `userPreference`)
- * 2. First featured model for the harness from the registry
+ * 2. What the platform actually runs when nothing is pinned (see below)
  * 3. Hardcoded platform fallback
  *
  * Future phases will add org-level and agent-level defaults between
  * user preference and harness default.
+ *
+ * **The harness-default arm is a contract, not a suggestion**
+ * (stigmer/stigmer#663): this resolution feeds the composer's model pill,
+ * and the submission adopts what the pill displays — so the default MUST
+ * be the model the platform would run for an unpinned execution, or the
+ * pill promises one model while a different one serves the request.
+ * Concretely:
+ *
+ * - `cursor` — the registry's Auto entry ({@link DEFAULT_CURSOR_MODEL_ID}):
+ *   the runner coerces an empty `model_name` to `"default"` (Auto), so
+ *   suggesting Auto and sending it explicitly are byte-identical to the
+ *   pre-#663 empty send. Auto prices no fast variant, so the fast-tier
+ *   switch correctly never renders for a fresh composer.
+ * - `native` — the runner's own `getDefaultModel()` rule: featured AND
+ *   standard cost, then any standard-cost model. A first-featured pick
+ *   with no cost filter (the pre-#663 behavior) could suggest — and now
+ *   would run — a premium model for users who never opened the picker.
  */
 export function resolveDefaultModelId(
   harness: HarnessOption,
@@ -438,6 +455,28 @@ export function resolveDefaultModelId(
     if (model) return { modelId: model.modelId, source: "agent_default" };
   }
 
+  if (harness === "cursor") {
+    const auto = models.find(
+      (m) => m.harness === harness && m.modelId === DEFAULT_CURSOR_MODEL_ID,
+    );
+    if (auto) return { modelId: auto.modelId, source: "harness_default" };
+  } else {
+    // Mirrors the runner's unpinned resolution (featured+standard, then
+    // any standard). Deliberately NOT extracted to share with the runner:
+    // the runner reads its own registry snapshot on another process.
+    const standardDefault =
+      models.find(
+        (m) => m.harness === harness && m.featured && m.costTier === "standard",
+      )
+      ?? models.find((m) => m.harness === harness && m.costTier === "standard");
+    if (standardDefault) {
+      return { modelId: standardDefault.modelId, source: "harness_default" };
+    }
+  }
+
+  // Degenerate registries only (no Auto entry / no standard-cost model):
+  // fall back to the old first-featured pick before the hardcoded id, so
+  // the suggestion at least names a model that exists.
   const featured = models.find(
     (m) => m.harness === harness && m.featured,
   );


### PR DESCRIPTION
## Summary

Fixes the community-reported fail-closed send (#663): the composer's model pill and its submit payload resolved the model **independently**, so an empty/unvalidated model state displayed the registry fallback with a toggleable FAST badge while the wire carried `service_tier: fast` and **no** `model_name` — refused by the server ("Couldn't send." with a Retry that can never succeed). A second defect in the same report: the fast-tier fail-safe lived only in the user-driven `selectModel` path, so a prop-driven `defaultModelId` re-sync could carry an armed fast onto a model with no priced fast variant.

## What changed

**One effective run selection.** `SessionComposer` now derives a single `(model, tier)` resolution that the pill, the FAST badge, the vision preflight (previously a *third* private resolution), and the submit payload all read — coherence by construction, not by resets:

- Empty or registry-unknown model state adopts the displayed harness default. Adoption is **gated on `showModelSelector`**: with the picker hidden there is no displayed promise, and whoever hid it owns the model (preserves the test-pinned guest no-modelName invariant).
- `"fast"` rides the wire only while the effective model prices the variant — the same rule the trigger badge renders (`fastActive`) and the server enforces fail-closed (#357). An armed tier surviving a prop-driven model change is now unsendable, not just unstyled. The armed state still persists across fast-capable switches (ModelSelector's documented behavior).

**Truthful default suggestion.** `resolveDefaultModelId`'s harness-default arm now names what the platform actually runs unpinned, so adoption changes **zero execution behavior** (owner-ruled):

- cursor → the registry's **Auto** entry: the runner coerces an empty `model_name` to `"default"`, so sending it explicitly is byte-identical to the old empty send. Auto prices no fast variant, so the fast toggle correctly never renders for a fresh composer — the reported scenario becomes structurally impossible.
- native → the runner's own `getDefaultModel()` rule (featured + standard cost, then any standard). The old first-featured-regardless-of-cost pick could promise a premium model while Auto/standard served the request.

**Deliberate non-changes** (recorded so nobody "fixes" them): the flow hooks stay pass-through — a host calling them directly with an incoherent pair gets the server's loud fail-closed message, the right teacher for host-code errors. The `serviceTier`-only-when-fast telemetry contract (#357) is preserved.

Docs note: the `execution.mdx`/`resource-detail.mdx` deltas are pre-existing staleness (the #658 `LivenessStatusLine` docs were never regenerated) riding along to keep the CI staleness gate green.

## Test plan

- [x] New `resolveDefaultModel.test.ts` (9 cases) — includes the exact production-order regression (featured premium listed before Auto)
- [x] New `SessionComposer-modelCoherence.test.tsx` (6 cases) — the reporter's repro, the prop-driven re-sync bypass, the hidden-picker adoption gate, retired-id fallback, registry-loading pass-through
- [x] Full `@stigmer/react` suite: 408 files / 4506 tests green; lint 0 errors; typecheck clean; ESM specifier gate ok for `sdk/react`
- [x] Docs regenerated (`make gen-react-sdk-docs`)

Closes #663

Made with [Cursor](https://cursor.com)