### PR TITLE
perf(runner): cache the skill mount by version hash — skip artifact re-transfer when content is unchanged

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveSkills } from "../skill-resolver.js";
@@ -17,6 +17,7 @@ function makeSkillProto(overrides: {
   description?: string;
   skillMd?: string;
   artifactStorageKey?: string;
+  versionHash?: string;
 } = {}) {
   return {
     metadata: {
@@ -31,7 +32,7 @@ function makeSkillProto(overrides: {
     },
     status: {
       artifactStorageKey: overrides.artifactStorageKey ?? "",
-      versionHash: "abc",
+      versionHash: overrides.versionHash ?? "abc",
     },
   } as any;
 }
@@ -75,12 +76,14 @@ describe("resolveSkills — artifact extraction", () => {
       ...clientOverrides,
     } as any;
 
+    // Re-run resolution for the same session — the mount-cache tests model
+    // one session's successive executions, which share the platform dir.
+    const resolveAgain = () =>
+      resolveSkills(client, refs, { sessionId, primaryWorkspaceDir: workspaceDir });
+
     try {
-      const result = await resolveSkills(client, refs, {
-        sessionId,
-        primaryWorkspaceDir: workspaceDir,
-      });
-      return { result, platformDir, client };
+      const result = await resolveAgain();
+      return { result, platformDir, client, resolveAgain };
     } catch (err) {
       // Clean up on failure
       rmSync(platformDir, { recursive: true, force: true });
@@ -184,6 +187,159 @@ describe("resolveSkills — artifact extraction", () => {
 
       const skillDir = join(platformDir, "skills", "flaky-skill");
       expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toBe("# Flaky");
+    } finally {
+      cleanupPlatformDir(platformDir);
+    }
+  });
+
+  it("re-resolving an unchanged version skips the artifact download (mount cache hit)", async () => {
+    const artifact = buildZip([
+      { name: "SKILL.md", content: "# Cached" },
+      { name: "references/guide.md", content: "guide" },
+    ]);
+    const getSkillByReference = vi.fn().mockResolvedValue(
+      makeSkillProto({
+        name: "cached-skill",
+        slug: "cached-skill",
+        skillMd: "# Cached",
+        artifactStorageKey: "artifacts/cached.zip",
+        versionHash: "hash-v1",
+      }),
+    );
+    const getSkillArtifact = vi.fn().mockResolvedValue({ artifact });
+
+    const { result, platformDir, client, resolveAgain } = await resolveWithMockClient(
+      [makeRef("cached-skill")],
+      { getSkillByReference, getSkillArtifact },
+    );
+
+    try {
+      expect(result).toHaveLength(1);
+      expect(client.getSkillArtifact).toHaveBeenCalledTimes(1);
+
+      const second = await resolveAgain();
+      expect(second).toHaveLength(1);
+      expect(second[0].name).toBe("cached-skill");
+      // Metadata was re-fetched (latest-version freshness)...
+      expect(client.getSkillByReference).toHaveBeenCalledTimes(2);
+      // ...but the artifact transfer and rewrite were skipped.
+      expect(client.getSkillArtifact).toHaveBeenCalledTimes(1);
+
+      const skillDir = join(platformDir, "skills", "cached-skill");
+      expect(readFileSync(join(skillDir, "references", "guide.md"), "utf-8")).toBe("guide");
+    } finally {
+      cleanupPlatformDir(platformDir);
+    }
+  });
+
+  it("re-downloads on version change and clears stale files from the old mount", async () => {
+    const v1 = makeSkillProto({
+      name: "evolving-skill",
+      slug: "evolving-skill",
+      skillMd: "# V1",
+      artifactStorageKey: "artifacts/v1.zip",
+      versionHash: "hash-v1",
+    });
+    const v2 = makeSkillProto({
+      name: "evolving-skill",
+      slug: "evolving-skill",
+      skillMd: "# V2",
+      artifactStorageKey: "artifacts/v2.zip",
+      versionHash: "hash-v2",
+    });
+    const artifactV1 = buildZip([{ name: "references/removed-in-v2.md", content: "old" }]);
+    const artifactV2 = buildZip([{ name: "references/new-in-v2.md", content: "new" }]);
+
+    const getSkillByReference = vi.fn().mockResolvedValueOnce(v1).mockResolvedValueOnce(v2);
+    const getSkillArtifact = vi
+      .fn()
+      .mockResolvedValueOnce({ artifact: artifactV1 })
+      .mockResolvedValueOnce({ artifact: artifactV2 });
+
+    const { platformDir, client, resolveAgain } = await resolveWithMockClient(
+      [makeRef("evolving-skill")],
+      { getSkillByReference, getSkillArtifact },
+    );
+
+    try {
+      const skillDir = join(platformDir, "skills", "evolving-skill");
+      expect(readFileSync(join(skillDir, "references", "removed-in-v2.md"), "utf-8")).toBe("old");
+
+      await resolveAgain();
+      expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+      expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toBe("# V2");
+      expect(readFileSync(join(skillDir, "references", "new-in-v2.md"), "utf-8")).toBe("new");
+      // The v1-only file must not linger in the v2 mount (the stale-file leak).
+      expect(existsSync(join(skillDir, "references", "removed-in-v2.md"))).toBe(false);
+    } finally {
+      cleanupPlatformDir(platformDir);
+    }
+  });
+
+  it("does not cache a SKILL.md-only fallback — the next execution retries the download", async () => {
+    const proto = makeSkillProto({
+      name: "retry-skill",
+      slug: "retry-skill",
+      skillMd: "# Retry",
+      artifactStorageKey: "artifacts/retry.zip",
+      versionHash: "hash-v1",
+    });
+    const artifact = buildZip([{ name: "references/late.md", content: "finally" }]);
+    const getSkillByReference = vi.fn().mockResolvedValue(proto);
+    const getSkillArtifact = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network timeout"))
+      .mockResolvedValueOnce({ artifact });
+
+    const { result, platformDir, client, resolveAgain } = await resolveWithMockClient(
+      [makeRef("retry-skill")],
+      { getSkillByReference, getSkillArtifact },
+    );
+
+    try {
+      // First pass degraded to SKILL.md only.
+      expect(result).toHaveLength(1);
+      const skillDir = join(platformDir, "skills", "retry-skill");
+      expect(existsSync(join(skillDir, "references"))).toBe(false);
+
+      // Second pass retries and completes the mount.
+      await resolveAgain();
+      expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+      expect(readFileSync(join(skillDir, "references", "late.md"), "utf-8")).toBe("finally");
+
+      // Third pass is a cache hit.
+      await resolveAgain();
+      expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+    } finally {
+      cleanupPlatformDir(platformDir);
+    }
+  });
+
+  it("treats a corrupted mount marker as stale and remounts", async () => {
+    const artifact = buildZip([{ name: "references/guide.md", content: "guide" }]);
+    const getSkillByReference = vi.fn().mockResolvedValue(
+      makeSkillProto({
+        name: "tampered-skill",
+        slug: "tampered-skill",
+        skillMd: "# Tampered",
+        artifactStorageKey: "artifacts/tampered.zip",
+        versionHash: "hash-v1",
+      }),
+    );
+    const getSkillArtifact = vi.fn().mockResolvedValue({ artifact });
+
+    const { platformDir, client, resolveAgain } = await resolveWithMockClient(
+      [makeRef("tampered-skill")],
+      { getSkillByReference, getSkillArtifact },
+    );
+
+    try {
+      const skillDir = join(platformDir, "skills", "tampered-skill");
+      writeFileSync(join(skillDir, ".stigmer-mount.json"), "not json {");
+
+      await resolveAgain();
+      expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+      expect(readFileSync(join(skillDir, "references", "guide.md"), "utf-8")).toBe("guide");
     } finally {
       cleanupPlatformDir(platformDir);
     }

--- a/backend/services/runner/src/activities/execute-cursor/skill-resolver.ts
+++ b/backend/services/runner/src/activities/execute-cursor/skill-resolver.ts
@@ -7,9 +7,17 @@
  * - Uses a platform-managed directory outside the workspace
  * - Ensures the workspace `.stigmer` symlink (see stigmer-link.ts)
  * - Returns metadata for prompt injection
+ *
+ * The mount is cached by the skill's content-addressed version hash
+ * (stigmer/stigmer#672): metadata is fetched on every execution (that keeps
+ * latest-version freshness), but the artifact download and file rewrite are
+ * skipped when the mounted content's hash already matches. The session's
+ * platform dir survives across executions, so on an active session every
+ * message after the first pays a metadata read instead of a full artifact
+ * transfer.
  */
 
-import { mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import type { StigmerClient } from "../../client/stigmer-client.js";
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
@@ -20,6 +28,25 @@ import { extractZipFileEntries } from "../../shared/zip-extract.js";
 import { ensureStigmerSymlink, STIGMER_LOCAL_STATE_DIR } from "../../shared/workspace/stigmer-link.js";
 
 const SKILLS_SUBDIR = "skills";
+
+/**
+ * Marker recording what a skill's mount directory currently holds. Written
+ * LAST, after every file of the mount landed — a crash mid-write leaves no
+ * marker, so the next execution remounts instead of trusting a partial tree.
+ */
+const MOUNT_MARKER_FILE = ".stigmer-mount.json";
+
+interface MountMarker {
+  /** Content-addressed version hash (`Skill.status.version_hash`) of the mounted content. */
+  versionHash: string;
+  /**
+   * Whether the artifact's files are part of the mount. `false` when the
+   * skill has no artifact OR when the download failed and the mount fell
+   * back to SKILL.md only — the latter makes the next execution retry the
+   * download rather than cache the degraded mount.
+   */
+  artifactMounted: boolean;
+}
 
 export interface SkillResolverOptions {
   sessionId: string;
@@ -61,11 +88,34 @@ export async function resolveSkills(
   for (const ref of skillRefs) {
     try {
       const skill = await client.getSkillByReference(ref);
+      const spec = skill.spec;
+      if (!spec?.skillMd) {
+        console.warn(`[resolveSkills] skill ${ref.org}/${ref.slug} fetched but had no skillMd content`);
+        continue;
+      }
+
+      const name = spec.name || skill.metadata?.slug || "unknown";
+      const skillDir = join(skillsDir, name);
+      const versionHash = skill.status?.versionHash ?? "";
+      const wantsArtifact = Boolean(skill.status?.artifactStorageKey);
+      const meta: SkillMetadata = {
+        name,
+        description: spec.description || `Skill: ${name}`,
+        path: join(STIGMER_LOCAL_STATE_DIR, SKILLS_SUBDIR, name, "SKILL.md"),
+      };
+
+      if (versionHash !== "" && (await mountIsFresh(skillDir, versionHash, wantsArtifact))) {
+        results.push(meta);
+        console.log(
+          `[resolveSkills] mount cache hit: ${name} (version ${versionHash.slice(0, 12)}) — skipping artifact transfer`,
+        );
+        continue;
+      }
 
       let artifactBytes: Uint8Array | undefined;
-      if (skill.status?.artifactStorageKey) {
+      if (wantsArtifact) {
         try {
-          const resp = await client.getSkillArtifact(skill.status.artifactStorageKey);
+          const resp = await client.getSkillArtifact(skill.status!.artifactStorageKey);
           if (resp.artifact && resp.artifact.length > 0) {
             artifactBytes = resp.artifact;
           }
@@ -77,13 +127,9 @@ export async function resolveSkills(
         }
       }
 
-      const meta = await writeSkill(skill, skillsDir, options.primaryWorkspaceDir, artifactBytes);
-      if (meta) {
-        results.push(meta);
-        console.log(`[resolveSkills] wrote skill: ${meta.name} -> ${meta.path}`);
-      } else {
-        console.warn(`[resolveSkills] skill ${ref.org}/${ref.slug} fetched but had no skillMd content`);
-      }
+      await writeSkillMount(skill, skillDir, artifactBytes);
+      results.push(meta);
+      console.log(`[resolveSkills] wrote skill: ${name} -> ${meta.path}`);
     } catch (err) {
       console.warn(
         `[resolveSkills] failed to resolve skill ${ref.org}/${ref.slug}: ${err instanceof Error ? err.message : err}`,
@@ -98,24 +144,47 @@ export async function resolveSkills(
   return results;
 }
 
-async function writeSkill(
-  skill: Skill,
-  skillsDir: string,
-  workspaceDir: string,
-  artifactBytes?: Uint8Array,
-): Promise<SkillMetadata | null> {
-  const spec = skill.spec;
-  if (!spec?.skillMd) return null;
+/**
+ * Whether the mount at `skillDir` already holds this version's content.
+ *
+ * Fresh means: the marker's hash matches AND the mount isn't a degraded
+ * SKILL.md-only fallback when the skill does carry an artifact. Any read or
+ * parse failure counts as stale — the remount is the safe default.
+ */
+async function mountIsFresh(skillDir: string, versionHash: string, wantsArtifact: boolean): Promise<boolean> {
+  try {
+    const raw = await readFile(join(skillDir, MOUNT_MARKER_FILE), "utf-8");
+    const marker = JSON.parse(raw) as Partial<MountMarker>;
+    return marker.versionHash === versionHash && (marker.artifactMounted === true || !wantsArtifact);
+  } catch {
+    return false;
+  }
+}
 
-  const name = spec.name || skill.metadata?.slug || "unknown";
-  const skillDir = join(skillsDir, name);
+/**
+ * (Re)write a skill's mount directory from scratch.
+ *
+ * The directory is removed first so files deleted between versions don't
+ * linger in the mount, then SKILL.md and the artifact files are written, and
+ * the marker is stamped LAST (see MOUNT_MARKER_FILE for the crash-safety
+ * contract). SKILL.md always comes from `spec.skillMd` — the server's
+ * authoritative copy — never from the zip; both the zip's SKILL.md and any
+ * stray marker-named entry are excluded from extraction so the mount's
+ * ownership of those two files is unconditional.
+ */
+async function writeSkillMount(
+  skill: Skill,
+  skillDir: string,
+  artifactBytes: Uint8Array | undefined,
+): Promise<void> {
+  await rm(skillDir, { recursive: true, force: true });
   await mkdir(skillDir, { recursive: true });
 
-  const skillMdPath = join(skillDir, "SKILL.md");
-  await writeFile(skillMdPath, spec.skillMd, "utf-8");
+  await writeFile(join(skillDir, "SKILL.md"), skill.spec!.skillMd, "utf-8");
 
-  if (artifactBytes && artifactBytes.length > 0) {
-    const entries = await extractZipFileEntries(artifactBytes, { exclude: ["SKILL.md"] });
+  const artifactMounted = artifactBytes !== undefined && artifactBytes.length > 0;
+  if (artifactMounted) {
+    const entries = await extractZipFileEntries(artifactBytes, { exclude: ["SKILL.md", MOUNT_MARKER_FILE] });
     for (const entry of entries) {
       const filePath = join(skillDir, entry.path);
       await mkdir(dirname(filePath), { recursive: true });
@@ -123,13 +192,11 @@ async function writeSkill(
     }
   }
 
-  const relativePath = join(STIGMER_LOCAL_STATE_DIR, SKILLS_SUBDIR, name, "SKILL.md");
-
-  return {
-    name,
-    description: spec.description || `Skill: ${name}`,
-    path: relativePath,
-  };
+  const versionHash = skill.status?.versionHash ?? "";
+  if (versionHash !== "") {
+    const marker: MountMarker = { versionHash, artifactMounted };
+    await writeFile(join(skillDir, MOUNT_MARKER_FILE), JSON.stringify(marker), "utf-8");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`resolveSkills` fetched the skill's content-addressed `versionHash` on every execution and then unconditionally re-downloaded and re-wrote every attached skill artifact anyway — at tens of MB per skill that's real per-message latency and write churn on an active session (reported with a 17MB/~900-file reference pack). The session's platform mount survives across executions and skill resolution runs under the workspace lock, so the mount is now cached by that hash:

- **Metadata is still fetched every execution** (latest-version freshness is untouched); the artifact download and file rewrite are skipped when the mounted content's hash already matches — a cache hit costs a metadata read.
- **Crash-safe by ordering, not locking**: a `.stigmer-mount.json` marker is stamped LAST, after every file of the mount landed. A crash mid-write leaves no marker, so the next execution remounts instead of trusting a partial tree. A corrupted marker reads as stale.
- **A degraded mount is never cached**: when the artifact download fails, the SKILL.md-only fallback writes a marker that records the missing artifact, so the next execution retries the download instead of serving the degraded mount for the rest of the session.
- **Fixes a stale-file leak in passing**: the old code rewrote over the previous version's mount without clearing it, so files deleted between versions lingered forever. Remounts now rebuild the directory from scratch.
- Cache hits/misses are logged (this issue was diagnosed from execution logs; that observability stays).

The zip's `SKILL.md` and any stray marker-named entry are excluded from extraction, so the mount's ownership of those two files is unconditional.

Closes #672

## Test plan

- [x] Red-first: 3 of 4 new tests fail against the old resolver (unchanged-version skip, stale-file clearing on version change, fallback retry); the 4th pins the corrupted-marker safety property of the new mechanism
- [x] Cache hit: second resolve never calls `getSkillArtifact`, mount intact
- [x] Version change: re-downloads, SKILL.md updated, v1-only file gone
- [x] Failed download → retried next execution → then cached
- [x] Full runner suite 4564 passed / 6 skipped; typecheck clean

Made with [Cursor](https://cursor.com)