### PR TITLE
chore(runner): drop dangling cache-bake comment from Dockerfile.sandbox

### DIFF
--- a/backend/services/runner/Dockerfile.sandbox
+++ b/backend/services/runner/Dockerfile.sandbox
@@ -92,7 +92,6 @@ RUN curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux
         -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
-# --- Pre-warm seedpack MCP server caches (warm-agent-surfaces Phase 1) ---
 # --- Unified runner ---
 COPY --from=builder /build/backend/services/runner/dist/ /runner/dist/
 COPY --from=builder /build/backend/services/runner/node_modules/ /runner/node_modules/


### PR DESCRIPTION
## Summary

- Removes the "Pre-warm seedpack MCP server caches (warm-agent-surfaces Phase 1)" section header that `e729406d6` left dangling in `Dockerfile.sandbox` — the bake step under it was deleted when stdio MCP servers became local-runner-only, and the Dockerfile's own header already documents that no MCP caches are pre-warmed.
- This is the record-keeping tail of #322: the issue's gate ("prune the marketplace catalog first") dissolved rather than being satisfied — the bake was removed for an orthogonal reason that holds regardless of catalog pruning. Registry measurement across the removal (adjacent same-day releases): `main-7c9f45f` **1294.5 MiB** → `main-401855f` **321.9 MiB** compressed (−75%), the 972.5 MiB bake layer gone; `latest` today is 336.3 MiB.

Closes #322

## Test plan

- [x] Comment-only change; image content is untouched by definition (no RUN/COPY/ENV edits)

Made with [Cursor](https://cursor.com)