### PR TITLE
feat(sdk/react): attention banner offers Take over; awaiting dot becomes legible

### DIFF
--- a/docs/sdk/react/conversation.mdx
+++ b/docs/sdk/react/conversation.mdx
@@ -313,12 +313,17 @@ function useConversationTimeline(agentChannelId: string, conversationKey: string
 ### ConversationAttentionBanner
 
 The needs-attention banner (channel-conversations DD-008): the
-escalating agent's reason, verbatim, with the false-alarm dismissal.
+escalating agent's reason, verbatim, with the escalation's ANSWER
+beside its false-alarm dismissal.
+
+Take over is the primary action because the human arriving IS the
+answer to an escalation — taking over clears attention structurally.
+It renders only while the agent holds the conversation on a channel
+with a staff lane; a human already holding it IS the attention
+answered, so only Dismiss remains.
 
 Dismiss is `clearAttention` — attention clears in place and control
-never moves (taking over also clears it, structurally, because the
-human arriving IS the answer to an escalation). Renders nothing while
-the conversation is unflagged.
+never moves. Renders nothing while the conversation is unflagged.
 
 **Props** — `ConversationAttentionBannerProps`
 
@@ -327,6 +332,7 @@ the conversation is unflagged.
     className: { type: "string", description: "Additional classes for the banner container." },
     conversation: { type: "ChannelConversation", description: "The conversation's fresh participation state.", required: true },
     participation: { type: "UseConversationParticipationReturn", description: "The participation commands (from `useConversationParticipation`).", required: true, typeDescriptionLink: "#useconversationparticipationreturn" },
+    supportsStaffReplies: { type: "boolean", description: "Whether the channel's provider has a staff send lane — the same fact ConversationControlBanner takes. When `false` the banner offers only Dismiss: a takeover would silence the agent with no way to reply, and the control banner beside this one already explains the missing lane. Defaults to `true`." },
   }}
 />
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -842,13 +842,13 @@ harness via the `@cursor/sdk`.
 
 #### Workflow Runner
 
-Retired term. Workflow tasks are executed by the unified TypeScript runner
-(see Agent Runner) — there is no separate workflow worker.
+Retired term. Workflow tasks are executed by the unified TypeScript runner (see
+Agent Runner) — there is no separate workflow worker.
 
 - **Capitalize**: Yes (when quoting historical docs).
-- **Context rule**: Do not use in new writing. Any doc describing a "Go
-  Temporal worker that executes Workflow tasks" is describing the retired
-  service — point it at the Agent Runner entry instead.
+- **Context rule**: Do not use in new writing. Any doc describing a "Go Temporal
+  worker that executes Workflow tasks" is describing the retired service — point
+  it at the Agent Runner entry instead.
 
 ---
 

--- a/sdk/react/src/conversation/ConversationAttentionBanner.tsx
+++ b/sdk/react/src/conversation/ConversationAttentionBanner.tsx
@@ -3,7 +3,10 @@
 import { TriangleAlert } from "lucide-react";
 import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
-import type { ChannelConversation } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+import {
+  ConversationControl,
+  type ChannelConversation,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
 import { Button } from "../button/Button.js";
 import type { UseConversationParticipationReturn } from "./useConversationParticipation.js";
 
@@ -13,28 +16,51 @@ export interface ConversationAttentionBannerProps {
   readonly conversation: ChannelConversation;
   /** The participation commands (from `useConversationParticipation`). */
   readonly participation: UseConversationParticipationReturn;
+  /**
+   * Whether the channel's provider has a staff send lane — the same
+   * fact `ConversationControlBanner` takes. When `false` the banner
+   * offers only Dismiss: a takeover would silence the agent with no way
+   * to reply, and the control banner beside this one already explains
+   * the missing lane, so a disabled Take over here would duplicate it.
+   * Defaults to `true` for hosts that only wire providers with staff
+   * lanes.
+   */
+  readonly supportsStaffReplies?: boolean;
   /** Additional classes for the banner container. */
   readonly className?: string;
 }
 
 /**
  * The needs-attention banner (channel-conversations DD-008): the
- * escalating agent's reason, verbatim, with the false-alarm dismissal.
+ * escalating agent's reason, verbatim, with the escalation's ANSWER
+ * beside its false-alarm dismissal.
+ *
+ * Take over is the primary action because the human arriving IS the
+ * answer to an escalation — taking over clears attention structurally
+ * (cloud#266 / F-20: the answer used to live one banner away in
+ * equal-weight chrome, so staff read the plea and missed the response).
+ * It renders only while the agent holds the conversation on a channel
+ * with a staff lane; a human already holding it IS the attention
+ * answered, so only Dismiss remains.
  *
  * Dismiss is `clearAttention` — attention clears in place and control
- * never moves (taking over also clears it, structurally, because the
- * human arriving IS the answer to an escalation). Renders nothing while
- * the conversation is unflagged.
+ * never moves. Renders nothing while the conversation is unflagged.
  */
 export function ConversationAttentionBanner({
   conversation,
   participation,
+  supportsStaffReplies = true,
   className,
 }: ConversationAttentionBannerProps) {
   if (!conversation.needsAttention) return null;
 
-  const { clearAttention, pendingCommands, commandErrors } = participation;
-  const error = commandErrors.get("clearAttention");
+  const { takeOver, clearAttention, pendingCommands, commandErrors } = participation;
+  // Take over's failure renders on the control banner too — same
+  // command, same truth; a rare failure showing twice on the stacked
+  // banners beats it hiding beside the button the staffer pressed.
+  const error = commandErrors.get("clearAttention") ?? commandErrors.get("takeOver");
+  const humanHeld = conversation.control === ConversationControl.control_human;
+  const offersTakeOver = !humanHeld && supportsStaffReplies;
 
   return (
     <div
@@ -56,18 +82,37 @@ export function ConversationAttentionBanner({
             )}
           </span>
         </p>
-        <Button
-          variant="outline"
-          size="xs"
-          onClick={() =>
-            void clearAttention().catch(() => {
-              // Recorded in commandErrors and rendered below.
-            })
-          }
-          disabled={pendingCommands.has("clearAttention")}
-        >
-          {pendingCommands.has("clearAttention") ? "Dismissing…" : "Dismiss"}
-        </Button>
+        {/* One shrink-proof group, right-aligned even after a wrap
+            (ml-auto): under a long reason the actions used to wrap to
+            the bottom-LEFT and read as part of the message (F-20). */}
+        <div className="stg:ml-auto stg:flex stg:shrink-0 stg:items-center stg:gap-2">
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() =>
+              void clearAttention().catch(() => {
+                // Recorded in commandErrors and rendered below.
+              })
+            }
+            disabled={pendingCommands.has("clearAttention")}
+          >
+            {pendingCommands.has("clearAttention") ? "Dismissing…" : "Dismiss"}
+          </Button>
+          {offersTakeOver && (
+            <Button
+              variant="primary"
+              size="xs"
+              onClick={() =>
+                void takeOver().catch(() => {
+                  // Recorded in commandErrors and rendered below.
+                })
+              }
+              disabled={pendingCommands.has("takeOver")}
+            >
+              {pendingCommands.has("takeOver") ? "Taking over…" : "Take over"}
+            </Button>
+          )}
+        </div>
       </div>
       {error && (
         <p className="stg:mt-1 stg:text-xs stg:text-destructive">{getUserMessage(error)}</p>

--- a/sdk/react/src/conversation/ConversationListPane.tsx
+++ b/sdk/react/src/conversation/ConversationListPane.tsx
@@ -193,7 +193,11 @@ export function ConversationListPane({
             {/* One context-only provider arms every row's attention
                 tooltip (the WorkspaceSidebar recents-list precedent). */}
             <TooltipProvider>
-              <ul className="stg:space-y-0.5">
+              {/* The SDK's own list reset (the MemberKeysPanel
+                  convention): hosts without a global preflight would
+                  otherwise render inbox rows with UA bullets and
+                  indent. */}
+              <ul className="stg:m-0 stg:list-none stg:space-y-0.5 stg:p-0">
                 {conversations.map((conversation) => (
                   <ConversationRow
                     key={`${conversation.agentChannelId}:${conversation.conversationKey}`}
@@ -333,6 +337,20 @@ function ConversationFilterToggle({
   );
 }
 
+/**
+ * The awaiting dot's meaning, shared verbatim by its tooltip and its
+ * sr-only text — one string per strength so sighted-hover and
+ * screen-reader users hear the identical fact. The copy carries the
+ * DISTINCTION, not just the fact (cloud#266): who holds the
+ * conversation is exactly what the two strengths encode, and it names
+ * the stake without promising an outcome — a muted dot survives a dead
+ * agent turn on purpose (DD-011 D-b's recovery path).
+ */
+const AWAITING_COPY: Record<"strong" | "muted", string> = {
+  strong: "Customer awaiting reply — a human has this conversation; the agent will not answer",
+  muted: "Customer awaiting reply — the agent has this conversation",
+};
+
 const ConversationRow = memo(function ConversationRow({
   conversation,
   label,
@@ -425,22 +443,29 @@ const ConversationRow = memo(function ConversationRow({
               // carries a dot under its timestamp. Strength maps the
               // holder (DD-011 D-a): strong when a human holds it — the
               // agent will not answer, a person must — muted when the
-              // agent does. No tooltip and no tab stop (the F-18
-              // discipline); the sr-only text is the accessible meaning.
-              <span className="stg:flex">
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    "stg:size-2 stg:rounded-full",
-                    awaiting === "strong" ? "stg:bg-primary" : "stg:bg-muted-foreground",
-                  )}
-                />
-                <span className="stg:sr-only">
-                  {awaiting === "strong"
-                    ? "Customer awaiting reply — the conversation is human-held"
-                    : "Customer awaiting reply"}
-                </span>
-              </span>
+              // agent does. Strong is FILLED and muted is a hollow RING
+              // (cloud#266): fill-vs-outline reads as "act vs watching"
+              // without decoding color, and color alone inverted in dark
+              // mode, where the muted gray outshone the strong primary.
+              // The meaning rides the house tooltip (the attention
+              // icon's exact pattern above — span trigger inside the row
+              // button, out of the tab order, sr-only as the accessible
+              // name); a bare dot told a first-time viewer nothing.
+              <Tooltip>
+                <TooltipTrigger render={<span className="stg:flex" />}>
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "stg:size-2 stg:rounded-full",
+                      awaiting === "strong"
+                        ? "stg:bg-primary"
+                        : "stg:border-2 stg:border-muted-foreground",
+                    )}
+                  />
+                  <span className="stg:sr-only">{AWAITING_COPY[awaiting]}</span>
+                </TooltipTrigger>
+                <TooltipContent side="top">{AWAITING_COPY[awaiting]}</TooltipContent>
+              </Tooltip>
             )}
           </span>
         )}

--- a/sdk/react/src/conversation/ConversationsWorkbench.tsx
+++ b/sdk/react/src/conversation/ConversationsWorkbench.tsx
@@ -340,6 +340,7 @@ export function ConversationsWorkbench({
             <ConversationAttentionBanner
               conversation={detail.conversation}
               participation={participation}
+              supportsStaffReplies={descriptor?.supportsStaffReplies ?? true}
             />
           )}
           {detail.conversation && (

--- a/sdk/react/src/conversation/__tests__/ConversationAttentionBanner.test.tsx
+++ b/sdk/react/src/conversation/__tests__/ConversationAttentionBanner.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { create } from "@bufbuild/protobuf";
-import { ChannelConversationSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+import {
+  ChannelConversationSchema,
+  ConversationControl,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
 import { ConversationAttentionBanner } from "../ConversationAttentionBanner";
 import type {
   ConversationCommand,
@@ -23,7 +26,7 @@ function participation(
 ): UseConversationParticipationReturn {
   return {
     reply: vi.fn(),
-    takeOver: vi.fn(),
+    takeOver: vi.fn().mockResolvedValue(conversation()),
     handBack: vi.fn(),
     clearAttention: vi.fn().mockResolvedValue(conversation()),
     pendingCommands: new Set<ConversationCommand>(),
@@ -78,5 +81,76 @@ describe("ConversationAttentionBanner", () => {
       />,
     );
     expect(screen.getByText("agent channel ach_1 not found")).toBeDefined();
+  });
+
+  it("offers Take over beside Dismiss while the agent holds it — the escalation's answer lives where the escalation speaks (cloud#266, F-20)", async () => {
+    const user = userEvent.setup();
+    const p = participation();
+    render(
+      <ConversationAttentionBanner
+        conversation={conversation({ needsAttention: true })}
+        participation={p}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Take over" }));
+    expect(p.takeOver).toHaveBeenCalled();
+    // Dismiss stays — the false-alarm path never disappears.
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeDefined();
+  });
+
+  it("offers only Dismiss when a human already holds it — the human arriving IS the attention answered", () => {
+    render(
+      <ConversationAttentionBanner
+        conversation={conversation({
+          needsAttention: true,
+          control: ConversationControl.control_human,
+          controlledBy: "idt_staff",
+        })}
+        participation={participation()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Take over" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeDefined();
+  });
+
+  it("offers only Dismiss on senderless providers — the control banner already explains the missing lane", () => {
+    render(
+      <ConversationAttentionBanner
+        conversation={conversation({ needsAttention: true })}
+        participation={participation()}
+        supportsStaffReplies={false}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Take over" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeDefined();
+  });
+
+  it("shows the takeover in flight and renders its failure verbatim", () => {
+    const { rerender } = render(
+      <ConversationAttentionBanner
+        conversation={conversation({ needsAttention: true })}
+        participation={participation({
+          pendingCommands: new Set<ConversationCommand>(["takeOver"]),
+        })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Taking over…" })).toBeDefined();
+
+    rerender(
+      <ConversationAttentionBanner
+        conversation={conversation({ needsAttention: true })}
+        participation={participation({
+          commandErrors: new Map([
+            ["takeOver", new Error("this channel is disabled: set spec.enabled to resume messaging on it")],
+          ]),
+        })}
+      />,
+    );
+    expect(
+      screen.getByText("this channel is disabled: set spec.enabled to resume messaging on it"),
+    ).toBeDefined();
   });
 });

--- a/sdk/react/src/conversation/__tests__/ConversationListPane.test.tsx
+++ b/sdk/react/src/conversation/__tests__/ConversationListPane.test.tsx
@@ -145,7 +145,7 @@ describe("ConversationListPane", () => {
     ).toBeDefined();
   });
 
-  it("uses the house tooltip for the attention badge and no native titles anywhere (F-18)", () => {
+  it("uses the house tooltip for the attention badge and awaiting dot, no native titles anywhere (F-18)", () => {
     const { container } = render(
       <ConversationListPane
         {...baseProps()}
@@ -154,6 +154,9 @@ describe("ConversationListPane", () => {
             displayName: "Pat with a very long name that will truncate",
             needsAttention: true,
             attentionReason: "refund I cannot process",
+            // The awaiting dot renders too, so its tooltip trigger is
+            // under the same no-title / no-tab-stop assertions below.
+            awaitingReply: true,
           }),
         ]}
       />,
@@ -204,8 +207,12 @@ describe("ConversationListPane", () => {
       />,
     );
 
+    // The copy names the stake, not just the fact (cloud#266): a
+    // human-held wait is one only a person can end.
     expect(
-      screen.getByText("Customer awaiting reply — the conversation is human-held"),
+      screen.getByText(
+        "Customer awaiting reply — a human has this conversation; the agent will not answer",
+      ),
     ).toBeDefined();
   });
 
@@ -217,9 +224,13 @@ describe("ConversationListPane", () => {
       />,
     );
 
-    expect(screen.getByText("Customer awaiting reply")).toBeDefined();
     expect(
-      screen.queryByText("Customer awaiting reply — the conversation is human-held"),
+      screen.getByText("Customer awaiting reply — the agent has this conversation"),
+    ).toBeDefined();
+    expect(
+      screen.queryByText(
+        "Customer awaiting reply — a human has this conversation; the agent will not answer",
+      ),
     ).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Fixes the two conversation attention affordance gaps in [stigmer-cloud#266](https://github.com/stigmer/stigmer-cloud/issues/266) (F-20 + the session-25 muted-dot watch item), pinned with fresh renders and ruled with the owner before implementation.

**1. The escalation's answer now lives where the escalation speaks (F-20).** `ConversationAttentionBanner` offered only "Dismiss" — the false-alarm path — while the escalation's real answer, "Take over", sat on the control banner below in identical small outline chrome. Taking over clears attention structurally ("the human arriving IS the answer"), so the attention banner now offers **Take over as its primary action** beside a secondary Dismiss:

- Renders only while the agent holds the conversation on a channel with a staff lane (new optional `supportsStaffReplies` prop, default `true`, wired from `ConversationsWorkbench`; senderless providers keep Dismiss-only — the control banner already explains the missing lane).
- A human already holding it IS the attention answered → Dismiss only.
- The action group is shrink-proof (`ml-auto`/`shrink-0`) so a long escalation reason no longer wraps Dismiss to the bottom-left where it read as part of the message.
- Take over's pending state and verbatim failure render on the banner (shared `commandErrors` truth with the control banner).

**2. The awaiting-reply dot carries its meaning.** Muted (agent-held) becomes a **hollow ring**; strong (human-held) stays **filled primary** — fill-vs-outline reads without decoding color, and fixes the dark-mode inversion where the muted gray literally outshone the strong primary. Both strengths gain the house tooltip (the attention badge's exact span-trigger pattern — no tab stop, no native title) sharing one copy string with the sr-only text: the copy now names the distinction ("a human has this conversation; the agent will not answer" vs "the agent has this conversation").

**3. Drive-bys, deliberately small:** the pane's `<ul>` gets the SDK's own list reset (`m-0/list-none/p-0`, the MemberKeysPanel convention) so hosts without a global preflight stop rendering inbox rows with UA bullets; `docs/vocabulary.md` re-formatted in its own commit because `make format-docs-check` was red on pristine main.

## Verification

- `@stigmer/react`: full vitest suite (168 tests, 14 files) green, including 4 new attention-banner tests and the extended F-18 structural test; a11y suite (77 tests) green; `lint` + `lint:prefix` + `typecheck` clean.
- Docs gates: `lint-docs` 0 errors, `check-docs-yaml` green, `format-docs-check` green after the vocabulary.md heal.
- Visually verified in both themes by rendering the real components with fixture data.

Closes stigmer/stigmer-cloud#266

Made with [Cursor](https://cursor.com)
