### PR TITLE
refactor(sdk/react): one DialogShell primitive for all 24 hand-rolled dialogs, fenced by lint

### DIFF
--- a/sdk/react/eslint.config.mjs
+++ b/sdk/react/eslint.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig([
       // Error (not warn): the oss#373 sweep left zero violations, so the
       // fence can hold the line from day one.
       "stigmer/no-hardcoded-backdrop": "error",
+      // Same posture: the oss#653 sweep converged every <dialog> onto the
+      // DialogShell primitive, so this fence starts at zero violations.
+      "stigmer/no-handrolled-dialog": "error",
       "stigmer/no-literal-dom-ids": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/no-main-tokens-in-sidebar": "warn",

--- a/sdk/react/src/access/ManageAccessDialog.tsx
+++ b/sdk/react/src/access/ManageAccessDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useId, useRef, type ReactNode } from "react";
+import { useCallback, useId, type ReactNode } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { hasGrantableRoles } from "@stigmer/sdk";
 import { PeopleWithAccess } from "../iam-policy/PeopleWithAccess.js";
 import { ResourceVisibilityControl } from "../library/ResourceVisibilityControl.js";
@@ -76,8 +77,6 @@ export function ManageAccessDialog({
   visibility,
   extraSection,
 }: ManageAccessDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   // Instance-scoped title id (oss#593): a reusable component must not
   // hardcode DOM ids — hosts legitimately mount this dialog more than once
   // per page (e.g. zone-cached detail pages), and duplicate ids break the
@@ -85,35 +84,16 @@ export function ManageAccessDialog({
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
-
-  // Sync native dialog open state (matches the SDK dialog convention).
-  const prevOpenRef = useRef(false);
-  if (open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
 
   const showPeople = hasGrantableRoles(resource.kind);
 
   return (
-    <dialog
-      ref={dialogRef}
-      onClose={handleClose}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-backdrop",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      width="md"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so the access-list fetch is lazy. */}
@@ -206,7 +186,7 @@ export function ManageAccessDialog({
           </div>
         </div>
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/agent-instance/CreateAgentInstanceDialog.tsx
+++ b/sdk/react/src/agent-instance/CreateAgentInstanceDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
 import type { ResourceRef } from "@stigmer/sdk";
@@ -39,7 +40,6 @@ export function CreateAgentInstanceDialog({
   agentId,
   onCreated,
 }: CreateAgentInstanceDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const { create, isCreating, error, clearError } = useCreateAgentInstance();
 
   // Instance-scoped element ids (oss#593): a reusable component must not
@@ -65,10 +65,16 @@ export function CreateAgentInstanceDialog({
   }, [clearError]);
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
     resetForm();
   }, [onOpenChange, resetForm]);
+
+  const handleShellOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) handleClose();
+    },
+    [handleClose],
+  );
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -93,30 +99,11 @@ export function CreateAgentInstanceDialog({
     [name, org, agentId, description, environmentRefs, visibility, create, onCreated, handleClose],
   );
 
-  // Sync native dialog open state
-  const prevOpenRef = useRef(false);
-  if (open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      // Must defer showModal to after render
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      onClose={handleClose}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-backdrop",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={handleShellOpenChange}
+      width="lg"
       aria-labelledby={titleId}
     >
       <form onSubmit={handleSubmit} className="stg:flex stg:flex-col">
@@ -255,7 +242,7 @@ export function CreateAgentInstanceDialog({
           </button>
         </div>
       </form>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/attachment/AttachmentImageLightbox.tsx
+++ b/sdk/react/src/attachment/AttachmentImageLightbox.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 
 /** Props for {@link AttachmentImageLightbox}. */
 export interface AttachmentImageLightboxProps {
@@ -48,47 +49,23 @@ export function AttachmentImageLightbox({
   onClose,
   className,
 }: AttachmentImageLightboxProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
-
-  // Escape arrives as the native `cancel` event; intercept it so the
-  // caller's `open` prop stays the single source of truth for visibility.
-  const handleCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onClose();
-    },
-    [onClose],
-  );
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onClose();
-      }
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) onClose();
     },
     [onClose],
   );
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleCancel}
-      onClick={handleBackdropClick}
+    <DialogShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      dismissOnBackdrop
       aria-label={`Preview ${filename}`}
+      // Lightbox outlier: viewport-relative sizing (not a width preset) and
+      // the background surface for image content.
       className={cn(
-        "stg:fixed stg:inset-0 stg:m-auto stg:max-h-[85vh] stg:max-w-[85vw] stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-0 stg:text-foreground stg:shadow-lg stg:outline-none",
-        "stg:backdrop:bg-backdrop",
+        "stg:w-auto stg:max-h-[85vh] stg:max-w-[85vw] stg:bg-background stg:text-foreground stg:outline-none",
         className,
       )}
     >
@@ -127,7 +104,7 @@ export function AttachmentImageLightbox({
           </div>
         </div>
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/channel/ChannelConversationsDialog.tsx
+++ b/sdk/react/src/channel/ChannelConversationsDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useId, useRef } from "react";
+import { useCallback, useId } from "react";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { MessageSquare, User, X } from "lucide-react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
@@ -68,38 +69,18 @@ export function ChannelConversationsDialog({
   sessionHref,
   modal = true,
 }: ChannelConversationsDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Sync native dialog open state (matches the SDK dialog convention).
-  const prevOpenRef = useRef(false);
-  if (modal && open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      open={modal ? undefined : open}
-      onClose={handleClose}
-      className={cn(
-        "stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={modal}
+      width="lg"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so each opening fetches fresh. */}
@@ -111,7 +92,7 @@ export function ChannelConversationsDialog({
           onClose={handleClose}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/channel/ChannelCredentialsDialog.tsx
+++ b/sdk/react/src/channel/ChannelCredentialsDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { getUserMessage, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
@@ -51,8 +52,6 @@ export function ChannelCredentialsDialog({
   onSaved,
   modal = true,
 }: ChannelCredentialsDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   // Instance-scoped title id (oss#593): a reusable component must not
   // hardcode DOM ids — hosts legitimately mount this dialog more than once
   // per page (e.g. zone-cached detail pages), and duplicate ids break the
@@ -60,34 +59,15 @@ export function ChannelCredentialsDialog({
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Sync native dialog open state (matches the SDK dialog convention).
-  const prevOpenRef = useRef(false);
-  if (modal && open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      open={modal ? undefined : open}
-      onClose={handleClose}
-      className={cn(
-        "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={modal}
+      width="md"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its draft resets per session —
@@ -101,7 +81,7 @@ export function ChannelCredentialsDialog({
           titleId={titleId}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/channel/ChannelTemplatesDialog.tsx
+++ b/sdk/react/src/channel/ChannelTemplatesDialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useId, useRef, type ReactNode } from "react";
+import { useCallback, useId, type ReactNode } from "react";
 import { ExternalLink, LayoutTemplate, X } from "lucide-react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import type { ChannelTemplate } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
@@ -89,40 +90,20 @@ export function ChannelTemplatesDialog({
   onEditYaml,
   modal = true,
 }: ChannelTemplatesDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Sync native dialog open state (matches the SDK dialog convention).
-  const prevOpenRef = useRef(false);
-  if (modal && open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      open={modal ? undefined : open}
-      onClose={handleClose}
-      className={cn(
-        // Wider than the conversations dialog on purpose: template
-        // bodies are the content, and a narrow column shreds them.
-        "stg:w-full stg:max-w-2xl stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={modal}
+      // Wider than the conversations dialog on purpose: template
+      // bodies are the content, and a narrow column shreds them.
+      width="2xl"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so each opening fetches fresh —
@@ -135,7 +116,7 @@ export function ChannelTemplatesDialog({
           onClose={handleClose}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/channel/ConnectSlackDialog.tsx
+++ b/sdk/react/src/channel/ConnectSlackDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { getErrorReason, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
@@ -89,8 +90,6 @@ export function ConnectSlackDialog({
   modal = true,
   channelAppsHref,
 }: ConnectSlackDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   // Instance-scoped title id (oss#593): a reusable component must not
   // hardcode DOM ids — hosts legitimately mount this dialog more than once
   // per page (e.g. zone-cached detail pages), and duplicate ids break the
@@ -98,36 +97,15 @@ export function ConnectSlackDialog({
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Sync native dialog open state (matches the SDK dialog convention).
-  // Non-modal hosts pass `open` as a plain attribute instead — the dialog
-  // renders in-flow with no top layer to manage.
-  const prevOpenRef = useRef(false);
-  if (modal && open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      open={modal ? undefined : open}
-      onClose={handleClose}
-      className={cn(
-        "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={modal}
+      width="md"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its flow state resets per
@@ -142,7 +120,7 @@ export function ConnectSlackDialog({
           channelAppsHref={channelAppsHref}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/channel/ConnectWhatsAppDialog.tsx
+++ b/sdk/react/src/channel/ConnectWhatsAppDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { getErrorReason, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
@@ -100,8 +101,6 @@ export function ConnectWhatsAppDialog({
   modal = true,
   channelAppsHref,
 }: ConnectWhatsAppDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   // Instance-scoped title id (oss#593): a reusable component must not
   // hardcode DOM ids — hosts legitimately mount this dialog more than once
   // per page (e.g. zone-cached detail pages), and duplicate ids break the
@@ -109,36 +108,15 @@ export function ConnectWhatsAppDialog({
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Sync native dialog open state (matches the SDK dialog convention).
-  // Non-modal hosts pass `open` as a plain attribute instead — the dialog
-  // renders in-flow with no top layer to manage.
-  const prevOpenRef = useRef(false);
-  if (modal && open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      open={modal ? undefined : open}
-      onClose={handleClose}
-      className={cn(
-        "stg:w-full stg:max-w-md stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={modal}
+      width="md"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its flow state resets per
@@ -153,7 +131,7 @@ export function ConnectWhatsAppDialog({
           titleId={titleId}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/execution/ArtifactPreviewModal.tsx
+++ b/sdk/react/src/execution/ArtifactPreviewModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { useArtifactDownload } from "./useArtifactDownload.js";
 import { formatArtifactSize } from "./artifact-utils.js";
 import { ArtifactContentBody } from "./ArtifactContentBody.js";
@@ -253,37 +254,24 @@ export function ArtifactPreviewModal({
   onImplement,
   className,
 }: ArtifactPreviewModalProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
-
-  const handleCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onClose();
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) onClose();
     },
     [onClose],
   );
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleCancel}
+    <DialogShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      width="3xl"
       aria-label={`Preview ${artifact.name}`}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-0 stg:text-foreground stg:shadow-lg stg:outline-none",
-        "stg:[&::backdrop]:bg-black/50",
-        className,
-      )}
+      // Background surface is deliberate for content previews. The
+      // previously hardcoded ::backdrop color (bg-black/50 — it escaped the
+      // #652 fence via the arbitrary-variant spelling) now rides the
+      // shell's token backdrop.
+      className={cn("stg:bg-background stg:text-foreground stg:outline-none", className)}
     >
       {open && (
         <ArtifactPreviewContent
@@ -296,7 +284,7 @@ export function ArtifactPreviewModal({
           onImplement={onImplement}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/internal/DialogShell.tsx
+++ b/sdk/react/src/internal/DialogShell.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import type { ReactNode, SyntheticEvent } from "react";
+import { cn } from "@stigmer/theme";
+
+/**
+ * Width presets for {@link DialogShell}, mapping to Tailwind `max-w-*`
+ * utilities. Free-form sizes (e.g. a lightbox's `85vw`) ride `className`,
+ * which wins over the preset via `cn()`'s tailwind-merge.
+ */
+export type DialogShellWidth = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
+
+const WIDTH_CLASS: Record<DialogShellWidth, string> = {
+  sm: "stg:max-w-sm",
+  md: "stg:max-w-md",
+  lg: "stg:max-w-lg",
+  xl: "stg:max-w-xl",
+  "2xl": "stg:max-w-2xl",
+  "3xl": "stg:max-w-3xl",
+  "4xl": "stg:max-w-4xl",
+};
+
+/** Props for {@link DialogShell}. */
+export interface DialogShellProps {
+  /** Whether the dialog is open (controlled — the SDK dialog convention). */
+  readonly open: boolean;
+  /**
+   * Called with `false` when the dialog should close: Escape / the platform
+   * cancel gesture, or a native close the host did not drive (e.g. a
+   * `method="dialog"` form submit). The shell never closes itself — state
+   * stays authoritative, so a host that ignores the callback keeps the
+   * dialog open (matching the pre-extraction per-dialog behavior).
+   */
+  readonly onOpenChange: (open: boolean) => void;
+  /** Max-width preset (default `"md"`). See {@link DialogShellWidth}. */
+  readonly width?: DialogShellWidth;
+  /**
+   * Modal (default) renders in the top layer via `showModal()` — focus trap,
+   * Escape, and the token backdrop. `modal={false}` renders the dialog
+   * in-flow (`open` attribute, relative positioning, no backdrop, no focus
+   * trap) — the channel-dialog embedding mode.
+   */
+  readonly modal?: boolean;
+  /**
+   * Merged after the shell's own chrome, so deliberate outliers (a
+   * lightbox's viewport sizing, a fullscreen graph's `h-[90vh]`, a
+   * `bg-background` surface) override the defaults per class.
+   */
+  readonly className?: string;
+  /** Dialog content. Lazy-mounting bodies (`{open && …}`) stay caller-owned. */
+  readonly children: ReactNode;
+  /** Accessible name, when no visible heading labels the dialog. */
+  readonly "aria-label"?: string;
+  /** Id of the visible heading that labels the dialog. */
+  readonly "aria-labelledby"?: string;
+}
+
+/**
+ * The one dialog shell (stigmer#653). Owns everything every modal dialog in
+ * the SDK used to re-transcribe by hand: the `<dialog>` element and its
+ * `showModal()`/`close()` lifecycle, cancel/Escape wiring, the token
+ * backdrop (`--stgm-backdrop`), the open animation, and the base
+ * positioning/chrome — parameterized by {@link DialogShellWidth}.
+ *
+ * Converged chrome: `rounded-xl` + `shadow-xl` on the `popover` token
+ * surface (the token family for top-layer content). Before the extraction
+ * the 24 hand-rolled shells had drifted across `rounded-lg/xl`,
+ * `shadow-lg/xl/2xl`, three background tokens, two hardcoded backdrops that
+ * escaped the #652 fence, and animation classes present on some dialogs and
+ * missing from others.
+ *
+ * Internal on purpose — not exported from the package until a host needs it.
+ * The `stigmer/no-handrolled-dialog` lint rule fences new `<dialog>`
+ * elements onto this shell.
+ *
+ * @example
+ * ```tsx
+ * <DialogShell open={open} onOpenChange={setOpen} width="lg" aria-labelledby={titleId}>
+ *   {open && <MyDialogBody titleId={titleId} onClose={() => setOpen(false)} />}
+ * </DialogShell>
+ * ```
+ */
+export function DialogShell({
+  open,
+  onOpenChange,
+  width = "md",
+  modal = true,
+  className,
+  children,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
+}: DialogShellProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // Sync the native top-layer state to the controlled prop. Runs on mount
+  // too, so a shell mounted with `open` already true shows immediately.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || !modal) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open, modal]);
+
+  // Escape / platform cancel: keep the native dialog open (preventDefault)
+  // and report the intent — the controlled `open` prop then drives the
+  // actual close through the effect above.
+  const handleCancel = useCallback(
+    (e: SyntheticEvent<HTMLDialogElement>) => {
+      e.preventDefault();
+      onOpenChange(false);
+    },
+    [onOpenChange],
+  );
+
+  // A native close the effect did not perform (e.g. a `method="dialog"`
+  // form submit) must not leave the controlled state stranded open.
+  const handleClose = useCallback(() => {
+    if (open) onOpenChange(false);
+  }, [open, onOpenChange]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      open={modal ? undefined : open || undefined}
+      onCancel={modal ? handleCancel : undefined}
+      onClose={modal ? handleClose : undefined}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      className={cn(
+        "stg:w-full stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-xl",
+        modal
+          ? cn(
+              "stg:fixed stg:inset-0 stg:z-50 stg:m-auto",
+              "stg:backdrop:bg-backdrop",
+              "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
+            )
+          : "stg:relative",
+        WIDTH_CLASS[width],
+        className,
+      )}
+    >
+      {children}
+    </dialog>
+  );
+}

--- a/sdk/react/src/internal/DialogShell.tsx
+++ b/sdk/react/src/internal/DialogShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import type { ReactNode, SyntheticEvent } from "react";
+import type { MouseEvent, ReactNode, SyntheticEvent } from "react";
 import { cn } from "@stigmer/theme";
 
 /**
@@ -42,6 +42,15 @@ export interface DialogShellProps {
    * trap) — the channel-dialog embedding mode.
    */
   readonly modal?: boolean;
+  /**
+   * Light dismiss: a click on the backdrop (the dialog element itself —
+   * clicks inside the content land on descendants) reports close intent.
+   * The house rule from the pre-extraction census: read-only viewers
+   * (diff/YAML/explain/lightbox/pickers) dismiss on backdrop, form dialogs
+   * do NOT — a stray click must never discard a half-filled form. Default
+   * `false`.
+   */
+  readonly dismissOnBackdrop?: boolean;
   /**
    * Merged after the shell's own chrome, so deliberate outliers (a
    * lightbox's viewport sizing, a fullscreen graph's `h-[90vh]`, a
@@ -86,6 +95,7 @@ export function DialogShell({
   onOpenChange,
   width = "md",
   modal = true,
+  dismissOnBackdrop = false,
   className,
   children,
   "aria-label": ariaLabel,
@@ -122,12 +132,22 @@ export function DialogShell({
     if (open) onOpenChange(false);
   }, [open, onOpenChange]);
 
+  // Backdrop clicks hit the <dialog> element itself; clicks anywhere in the
+  // content land on a descendant, so the target check is exact.
+  const handleClick = useCallback(
+    (e: MouseEvent<HTMLDialogElement>) => {
+      if (e.target === e.currentTarget) onOpenChange(false);
+    },
+    [onOpenChange],
+  );
+
   return (
     <dialog
       ref={dialogRef}
       open={modal ? undefined : open || undefined}
       onCancel={modal ? handleCancel : undefined}
       onClose={modal ? handleClose : undefined}
+      onClick={modal && dismissOnBackdrop ? handleClick : undefined}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       className={cn(

--- a/sdk/react/src/internal/__tests__/DialogShell.test.tsx
+++ b/sdk/react/src/internal/__tests__/DialogShell.test.tsx
@@ -160,6 +160,45 @@ describe("DialogShell chrome", () => {
   });
 });
 
+describe("DialogShell backdrop dismiss", () => {
+  it("dismissOnBackdrop: a click on the dialog element itself reports close intent", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <DialogShell open onOpenChange={onOpenChange} dismissOnBackdrop>
+        <p>body</p>
+      </DialogShell>,
+    );
+
+    fireEvent.click(dialogOf(container));
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("dismissOnBackdrop: clicks on content descendants never dismiss", () => {
+    const onOpenChange = vi.fn();
+    const { container, getByText } = render(
+      <DialogShell open onOpenChange={onOpenChange} dismissOnBackdrop>
+        <p>body</p>
+      </DialogShell>,
+    );
+
+    fireEvent.click(getByText("body"));
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(dialogOf(container).open).toBe(true);
+  });
+
+  it("default: backdrop clicks are inert (form dialogs)", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <DialogShell open onOpenChange={onOpenChange}>
+        <p>body</p>
+      </DialogShell>,
+    );
+
+    fireEvent.click(dialogOf(container));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
 describe("DialogShell non-modal mode", () => {
   it("renders in-flow: open attribute, no backdrop, no fixed positioning", () => {
     const { container, rerender } = render(

--- a/sdk/react/src/internal/__tests__/DialogShell.test.tsx
+++ b/sdk/react/src/internal/__tests__/DialogShell.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * DialogShell (stigmer#653): the one modal shell — showModal lifecycle,
+ * cancel/Escape wiring with state authority, native-close sync, the token
+ * backdrop + converged chrome, and the non-modal in-flow mode.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { DialogShell } from "../DialogShell";
+
+// happy-dom does not implement the native dialog show/close methods.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(cleanup);
+
+function dialogOf(container: HTMLElement): HTMLDialogElement {
+  return container.querySelector("dialog")!;
+}
+
+describe("DialogShell lifecycle", () => {
+  it("opens via showModal when the controlled prop flips true", () => {
+    const { container, rerender } = render(
+      <DialogShell open={false} onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    expect(dialogOf(container).open).toBe(false);
+
+    rerender(
+      <DialogShell open onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    expect(dialogOf(container).open).toBe(true);
+  });
+
+  it("shows immediately when mounted already open", () => {
+    const { container } = render(
+      <DialogShell open onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    expect(dialogOf(container).open).toBe(true);
+  });
+
+  it("closes the native dialog when the controlled prop flips false", () => {
+    const { container, rerender } = render(
+      <DialogShell open onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    rerender(
+      <DialogShell open={false} onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    expect(dialogOf(container).open).toBe(false);
+  });
+
+  it("Escape/cancel reports intent but never closes on its own — state stays authoritative", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <DialogShell open onOpenChange={onOpenChange}>
+        <p>body</p>
+      </DialogShell>,
+    );
+
+    fireEvent(dialogOf(container), new Event("cancel", { cancelable: true }));
+
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    // The shell prevented the native close; the dialog stays open until the
+    // host flips the prop.
+    expect(dialogOf(container).open).toBe(true);
+  });
+
+  it("syncs the controlled state when something else closes the dialog natively", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <DialogShell open onOpenChange={onOpenChange}>
+        <p>body</p>
+      </DialogShell>,
+    );
+
+    // e.g. a method="dialog" form submit closes without going through props.
+    const dialog = dialogOf(container);
+    dialog.close();
+    fireEvent(dialog, new Event("close"));
+
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("does not re-report a close the host itself drove", () => {
+    const onOpenChange = vi.fn();
+    const { container, rerender } = render(
+      <DialogShell open onOpenChange={onOpenChange}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    rerender(
+      <DialogShell open={false} onOpenChange={onOpenChange}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    // The effect's own dialog.close() fires a native close event in real
+    // browsers — replay it against the now-false prop.
+    fireEvent(dialogOf(container), new Event("close"));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("DialogShell chrome", () => {
+  it("carries the token backdrop, animation, positioning, and width preset", () => {
+    const { container } = render(
+      <DialogShell open onOpenChange={() => {}} width="3xl">
+        <p>body</p>
+      </DialogShell>,
+    );
+    const cls = dialogOf(container).className;
+
+    expect(cls).toContain("stg:backdrop:bg-backdrop");
+    expect(cls).toContain("stg:open:animate-in");
+    expect(cls).toContain("stg:fixed");
+    expect(cls).toContain("stg:m-auto");
+    expect(cls).toContain("stg:max-w-3xl");
+    expect(cls).toContain("stg:bg-popover");
+  });
+
+  it("className overrides the shell's own chrome per class (tailwind-merge)", () => {
+    const { container } = render(
+      <DialogShell
+        open
+        onOpenChange={() => {}}
+        className="stg:bg-background stg:max-w-[85vw]"
+      >
+        <p>body</p>
+      </DialogShell>,
+    );
+    const cls = dialogOf(container).className;
+
+    expect(cls).toContain("stg:bg-background");
+    expect(cls).not.toContain("stg:bg-popover");
+    expect(cls).toContain("stg:max-w-[85vw]");
+    expect(cls).not.toContain("stg:max-w-md");
+  });
+
+  it("labels the dialog for assistive tech", () => {
+    const { container } = render(
+      <DialogShell open onOpenChange={() => {}} aria-label="Confirm delete">
+        <p>body</p>
+      </DialogShell>,
+    );
+    expect(dialogOf(container).getAttribute("aria-label")).toBe("Confirm delete");
+  });
+});
+
+describe("DialogShell non-modal mode", () => {
+  it("renders in-flow: open attribute, no backdrop, no fixed positioning", () => {
+    const { container, rerender } = render(
+      <DialogShell open modal={false} onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    const dialog = dialogOf(container);
+
+    expect(dialog.open).toBe(true);
+    expect(dialog.className).toContain("stg:relative");
+    expect(dialog.className).not.toContain("stg:backdrop:bg-backdrop");
+    expect(dialog.className).not.toContain("stg:fixed");
+
+    rerender(
+      <DialogShell open={false} modal={false} onOpenChange={() => {}}>
+        <p>body</p>
+      </DialogShell>,
+    );
+    expect(dialogOf(container).open).toBe(false);
+  });
+});

--- a/sdk/react/src/manifest/ApplyManifestDialog.tsx
+++ b/sdk/react/src/manifest/ApplyManifestDialog.tsx
@@ -2,6 +2,7 @@
 
 import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { toast } from "../feedback/toast.js";
 import { RedactedSecretsNotice } from "./RedactedSecretsNotice.js";
 import {
@@ -71,21 +72,9 @@ export function ApplyManifestDialog({
   org,
   onApplied,
 }: ApplyManifestDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const manifest = useApplyManifest(org);
   const { reset } = manifest;
-
-  // Sync dialog open state with the native <dialog> element.
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
 
   // Start each session clean.
   useEffect(() => {
@@ -109,10 +98,11 @@ export function ApplyManifestDialog({
     if (applied.length > 0) onApplied?.(applied);
   }, [onOpenChange, manifest.entries, onApplied]);
 
-  const handleCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      closeAndMaybeRefresh();
+  // Escape/cancel routes through the same dismiss-after-partial path as the
+  // Close button, via the shell's single close-intent callback.
+  const handleShellOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) closeAndMaybeRefresh();
     },
     [closeAndMaybeRefresh],
   );
@@ -151,15 +141,7 @@ export function ApplyManifestDialog({
     !manifest.isApplying;
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleCancel}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
-    >
+    <DialogShell open={open} onOpenChange={handleShellOpenChange} width="3xl" aria-label="Apply YAML">
       <div className="stg:flex stg:flex-col stg:gap-4 stg:p-6">
         {/* Header */}
         <div className="stg:flex stg:flex-col stg:gap-1">
@@ -252,7 +234,7 @@ export function ApplyManifestDialog({
           </div>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/manifest/EditResourceYamlDialog.tsx
+++ b/sdk/react/src/manifest/EditResourceYamlDialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
+import { lazy, Suspense, useCallback, useEffect } from "react";
 import type { Message } from "@bufbuild/protobuf";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { getUserMessage, type AppliedManifest } from "@stigmer/sdk";
 import { toast } from "../feedback/toast.js";
 import { RedactedSecretsNotice } from "./RedactedSecretsNotice.js";
@@ -67,33 +68,13 @@ export function EditResourceYamlDialog({
   resource,
   onApplied,
 }: EditResourceYamlDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const edit = useEditResourceYaml({ resource });
   const { reset } = edit;
-
-  // Sync dialog open state with the native <dialog> element.
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
 
   // Discard stale edits from a previous session when the dialog opens.
   useEffect(() => {
     if (open) reset();
   }, [open, reset]);
-
-  const handleCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
 
   const handleApply = useCallback(async () => {
     try {
@@ -111,15 +92,7 @@ export function EditResourceYamlDialog({
     edit.validation.status === "valid" && edit.isDirty && !edit.isApplying;
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleCancel}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
-    >
+    <DialogShell open={open} onOpenChange={onOpenChange} width="3xl" aria-label="Edit YAML">
       <div className="stg:flex stg:flex-col stg:gap-4 stg:p-6">
         {/* Header */}
         <div className="stg:flex stg:flex-col stg:gap-1">
@@ -233,7 +206,7 @@ export function EditResourceYamlDialog({
           </div>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
+++ b/sdk/react/src/mcp-server/McpServerConnectDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import type { EnvVarInput } from "@stigmer/sdk";
 import { useMcpServer } from "./useMcpServer.js";
 import { useMcpServerCredentials } from "./useMcpServerCredentials.js";
@@ -88,29 +89,11 @@ export function McpServerConnectDialog({
   onOpenDetails,
   className,
 }: McpServerConnectDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const resolvedOrg = activeOrg || org;
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
-
-  const handleDialogClose = useCallback(() => {
-    onClose();
-  }, [onClose]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onClose();
-      }
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) onClose();
     },
     [onClose],
   );
@@ -118,15 +101,18 @@ export function McpServerConnectDialog({
   if (!open) return null;
 
   return (
-    <dialog
-      ref={dialogRef}
-      onClose={handleDialogClose}
-      onClick={handleBackdropClick}
+    <DialogShell
+      open
+      onOpenChange={handleOpenChange}
+      width="md"
+      dismissOnBackdrop
+      // Card surface + visible overflow are deliberate: the connect form
+      // hosts popovers that extend past the dialog bounds.
       className={cn(
-        "stg:m-auto stg:max-h-[85vh] stg:w-full stg:max-w-md stg:overflow-visible stg:rounded-lg stg:border stg:border-border stg:bg-card stg:p-0 stg:text-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
+        "stg:max-h-[85vh] stg:overflow-visible stg:bg-card stg:text-foreground",
         className,
       )}
+      aria-label={`Connect ${slug}`}
     >
       <div
         className="stg:flex stg:max-h-[85vh] stg:flex-col stg:overflow-y-auto stg:p-6"
@@ -141,7 +127,7 @@ export function McpServerConnectDialog({
           onOpenDetails={onOpenDetails}
         />
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/mcp-server/McpServerDetailView.tsx
+++ b/sdk/react/src/mcp-server/McpServerDetailView.tsx
@@ -36,6 +36,7 @@ import { OAuthAppForm } from "./OAuthAppForm.js";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ErrorMessage } from "../error/ErrorMessage.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
+import { DialogShell } from "../internal/DialogShell.js";
 import { EnvVarForm } from "../environment/EnvVarForm.js";
 import type { EnvVarFormVariable } from "../environment/EnvVarForm.js";
 import { VisibilityBadge } from "../library/VisibilitySelector.js";
@@ -282,7 +283,6 @@ export function McpServerDetailView({
   const [showCredentialForm, setShowCredentialForm] = useState(defaultShowCredentialForm);
   const [showByoaForm, setShowByoaForm] = useState(false);
   const [capabilityTab, setCapabilityTab] = useState<CapabilityTab>(defaultCapabilityTab);
-  const byoaDialogRef = useRef<HTMLDialogElement>(null);
 
   const onResourceLoadRef = useRef(onResourceLoad);
   onResourceLoadRef.current = onResourceLoad;
@@ -388,20 +388,9 @@ export function McpServerDetailView({
     }
   }, [mcpServer, disconnectOAuth, credentials, refetch, activeOrg, org]);
 
-  // BYOA dialog lifecycle — native <dialog> toggle
-  useEffect(() => {
-    const dialog = byoaDialogRef.current;
-    if (!dialog) return;
-    if (showByoaForm && !dialog.open) {
-      dialog.showModal();
-    } else if (!showByoaForm && dialog.open) {
-      dialog.close();
-    }
-  }, [showByoaForm]);
-
-  const handleByoaDialogCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
+  const handleByoaOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) return;
       setShowByoaForm(false);
       orgOAuthApp.clearErrors();
     },
@@ -706,14 +695,13 @@ export function McpServerDetailView({
         )}
       </Section>
 
-      {/* BYOA dialog — native <dialog> for zero-dependency modal behavior */}
-      <dialog
-        ref={byoaDialogRef}
-        onCancel={handleByoaDialogCancel}
-        className={cn(
-          "stg:m-auto stg:w-full stg:max-w-md stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-6 stg:shadow-lg",
-          "stg:backdrop:bg-backdrop",
-        )}
+      {/* BYOA dialog */}
+      <DialogShell
+        open={showByoaForm}
+        onOpenChange={handleByoaOpenChange}
+        width="md"
+        className="stg:p-6"
+        aria-label="Use your own OAuth app"
       >
         <h3 className="stg:mb-4 stg:text-base stg:font-semibold stg:text-foreground">
           Use your own OAuth app
@@ -729,7 +717,7 @@ export function McpServerDetailView({
           isSubmitting={orgOAuthApp.isSetting}
           error={orgOAuthApp.setError}
         />
-      </dialog>
+      </DialogShell>
 
       <Section title="Capabilities" scrollTarget="mcp-capabilities">
         <Tabs

--- a/sdk/react/src/resource-detail/ConfirmDialog.tsx
+++ b/sdk/react/src/resource-detail/ConfirmDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import type { ConfirmState } from "./types.js";
 
 export interface ConfirmDialogProps {
@@ -16,9 +17,8 @@ export interface ConfirmDialogProps {
 /**
  * Accessible confirmation dialog for destructive actions.
  *
- * Uses the native `<dialog>` element with `showModal()` for built-in
- * focus trapping, Escape key handling, and backdrop. Styled via
- * `--stgm-*` design tokens.
+ * Renders on {@link DialogShell} (native `<dialog>` + `showModal()` — focus
+ * trapping, Escape, token backdrop). Styled via `--stgm-*` design tokens.
  *
  * Pairs with {@link useConfirmAction} which manages the imperative
  * `confirm()` → Promise pattern.
@@ -51,22 +51,9 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (state && !dialog.open) {
-      dialog.showModal();
-    } else if (!state && dialog.open) {
-      dialog.close();
-    }
-  }, [state]);
-
-  const handleDialogCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onCancel();
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onCancel();
     },
     [onCancel],
   );
@@ -76,15 +63,7 @@ export function ConfirmDialog({
   const isDestructive = state.variant === "destructive";
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleDialogCancel}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-sm stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
-    >
+    <DialogShell open onOpenChange={handleOpenChange} width="sm" aria-label={state.title}>
       <div className="stg:flex stg:flex-col stg:gap-4 stg:p-6">
         <div className="stg:flex stg:flex-col stg:gap-1.5">
           <h3 className="stg:text-base stg:font-semibold stg:text-foreground">
@@ -122,6 +101,6 @@ export function ConfirmDialog({
           </button>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }

--- a/sdk/react/src/sharing/ShareAgentDialog.tsx
+++ b/sdk/react/src/sharing/ShareAgentDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId, useMemo, useRef, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import {
   MAX_ALLOWED_ORIGINS,
   StigmerError,
@@ -137,8 +138,6 @@ export function ShareAgentDialog({
   onSharingChanged,
   modal = true,
 }: ShareAgentDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   // Instance-scoped title id (oss#593): a reusable component must not
   // hardcode DOM ids — hosts legitimately mount this dialog more than once
   // per page (e.g. zone-cached detail pages), and duplicate ids break the
@@ -146,36 +145,15 @@ export function ShareAgentDialog({
   const titleId = useId();
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Sync native dialog open state (matches the SDK dialog convention).
-  // Non-modal hosts pass `open` as a plain attribute instead — the dialog
-  // renders in-flow with no top layer to manage.
-  const prevOpenRef = useRef(false);
-  if (modal && open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      open={modal ? undefined : open}
-      onClose={handleClose}
-      className={cn(
-        "stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        modal ? "stg:fixed stg:inset-0 stg:m-auto stg:backdrop:bg-backdrop" : "stg:relative",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      modal={modal}
+      width="lg"
       aria-labelledby={titleId}
     >
       {/* Body mounts only while open so its draft state resets per
@@ -191,7 +169,7 @@ export function ShareAgentDialog({
           titleId={titleId}
         />
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/skill/SkillDiffDialog.tsx
+++ b/sdk/react/src/skill/SkillDiffDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { useSkillDiff } from "./useSkillDiff.js";
 import { MultiFileDiffView } from "../version-history/MultiFileDiffView.js";
 import { ErrorMessage } from "../error/ErrorMessage.js";
@@ -57,31 +58,9 @@ export interface SkillDiffDialogProps {
  * ```
  */
 export function SkillDiffDialog({ state, onClose }: SkillDiffDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (state && !dialog.open) {
-      dialog.showModal();
-    } else if (!state && dialog.open) {
-      dialog.close();
-    }
-  }, [state]);
-
-  const handleDialogCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onClose();
-    },
-    [onClose],
-  );
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
     },
     [onClose],
   );
@@ -94,15 +73,13 @@ export function SkillDiffDialog({ state, onClose }: SkillDiffDialogProps) {
   if (!state) return null;
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleDialogCancel}
-      onClick={handleBackdropClick}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:h-[85vh] stg:w-full stg:max-w-4xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
+    <DialogShell
+      open
+      onOpenChange={handleOpenChange}
+      width="4xl"
+      dismissOnBackdrop
+      className="stg:h-[85vh]"
+      aria-label="Skill version diff"
     >
       <div className="stg:flex stg:h-full stg:flex-col">
         {/* Header */}
@@ -142,7 +119,7 @@ export function SkillDiffDialog({ state, onClose }: SkillDiffDialogProps) {
           ) : null}
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/workflow/ViewYamlDialog.tsx
+++ b/sdk/react/src/workflow/ViewYamlDialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { memo, useCallback, useEffect, useRef } from "react";
-import { cn } from "@stigmer/theme";
+import { memo, useCallback } from "react";
 import type { WorkflowGraphModel } from "./workflow-graph-model.js";
 import { taskToYaml } from "./inspector/task-to-yaml.js";
+import { DialogShell } from "../internal/DialogShell.js";
 import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 
 /** Props for {@link ViewYamlDialog}. */
@@ -32,7 +32,6 @@ export const ViewYamlDialog = memo(function ViewYamlDialog({
   graph,
   onClose,
 }: ViewYamlDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const { copy, copied } = useCopyFeedback();
 
   const node = nodeId && graph
@@ -41,45 +40,27 @@ export const ViewYamlDialog = memo(function ViewYamlDialog({
 
   const yaml = node ? taskToYaml(node) : "";
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (nodeId && node) {
-      if (!dialog.open) dialog.showModal();
-    } else {
-      if (dialog.open) dialog.close();
-    }
-  }, [nodeId, node]);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    const handleClose = () => onClose();
-    dialog.addEventListener("close", handleClose);
-    return () => dialog.removeEventListener("close", handleClose);
-  }, [onClose]);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
 
   const handleCopy = useCallback(() => {
     void copy(yaml);
   }, [copy, yaml]);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
   return (
-    <dialog
-      ref={dialogRef}
-      className={cn(
-        "stgm stg:m-auto stg:max-h-[80vh] stg:w-full stg:max-w-lg stg:rounded-lg stg:border stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-background,#fff)] stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-backdrop",
-      )}
-      onClick={handleBackdropClick}
+    <DialogShell
+      open={Boolean(nodeId && node)}
+      onOpenChange={handleOpenChange}
+      width="lg"
+      dismissOnBackdrop
+      // `stgm` re-establishes the theme scope (this dialog renders from the
+      // workflow canvas); the var-fallback styling of the body predates the
+      // token utilities and stays untouched here.
+      className="stgm stg:max-h-[80vh] stg:bg-[var(--stgm-background,#fff)] stg:border-[var(--stgm-border,#e5e5e5)]"
       aria-label={node ? `YAML for ${node.taskName}` : "View YAML"}
     >
       {node && (
@@ -121,7 +102,7 @@ export const ViewYamlDialog = memo(function ViewYamlDialog({
           </div>
         </div>
       )}
-    </dialog>
+    </DialogShell>
   );
 });
 

--- a/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowArchitectDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import {
   useWorkflowArchitectFlow,
   type ArchitectPhase,
@@ -64,8 +65,6 @@ export function WorkflowArchitectDialog({
   onSuccess,
   onError,
 }: WorkflowArchitectDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   const handleSuccess = useCallback(
     (successOrg: string, slug: string) => {
       onOpenChange(false);
@@ -80,54 +79,23 @@ export function WorkflowArchitectDialog({
     onError,
   });
 
+  // Each opening starts from a clean prompt.
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
-      flow.reset();
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
+    if (open) flow.reset();
   }, [open, flow.reset]);
 
-  const handleDialogCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onOpenChange(false);
-      }
-    },
-    [onOpenChange],
-  );
-
-  const isWorking =
-    flow.phase === "starting" ||
-    flow.phase === "streaming" ||
-    flow.phase === "applying";
-
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleDialogCancel}
-      onClick={handleBackdropClick}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      width="3xl"
+      dismissOnBackdrop
+      aria-label="Workflow Architect"
     >
       <div className="stg:flex stg:flex-col">
         <DialogPhase flow={flow} onClose={() => onOpenChange(false)} />
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/workflow/WorkflowExplainDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowExplainDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import { useExplainWorkflowFlow, type ExplainPhase } from "./useExplainWorkflowFlow.js";
 import { MessageThread } from "../execution/MessageThread.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
@@ -36,8 +37,6 @@ export function WorkflowExplainDialog({
   org,
   currentYaml,
 }: WorkflowExplainDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   const flow = useExplainWorkflowFlow({
     org,
     currentYaml,
@@ -46,35 +45,13 @@ export function WorkflowExplainDialog({
     },
   });
 
-  // Show/hide dialog
+  // Each opening starts a fresh explanation.
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
+    if (open) {
       flow.reset();
-      dialog.showModal();
       flow.explain();
-    } else if (!open && dialog.open) {
-      dialog.close();
     }
   }, [open, flow.reset, flow.explain]);
-
-  const handleDialogCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onOpenChange(false);
-      }
-    },
-    [onOpenChange],
-  );
 
   const { copy, copied } = useCopyFeedback();
   const handleCopy = useCallback(() => {
@@ -84,15 +61,12 @@ export function WorkflowExplainDialog({
   }, [copy, flow.explanation]);
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleDialogCancel}
-      onClick={handleBackdropClick}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-2xl stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      width="2xl"
+      dismissOnBackdrop
+      aria-label="Workflow Explanation"
     >
       <div className="stg:flex stg:flex-col">
         {/* Header */}
@@ -206,7 +180,7 @@ export function WorkflowExplainDialog({
           </div>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/workflow/WorkflowGraphFullscreenDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowGraphFullscreenDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import { WorkflowOverviewGraph } from "./WorkflowOverviewGraph.js";
 
@@ -38,23 +39,9 @@ export function WorkflowGraphFullscreenDialog({
   onClose,
   onOpenInEditor,
 }: WorkflowGraphFullscreenDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
-
-  const handleCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onClose();
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) onClose();
     },
     [onClose],
   );
@@ -62,14 +49,15 @@ export function WorkflowGraphFullscreenDialog({
   const workflowName = workflow?.metadata?.name || "Task Flow";
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleCancel}
+    <DialogShell
+      open={open}
+      onOpenChange={handleOpenChange}
       aria-label={`${workflowName} — full view`}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:h-[90vh] stg:w-[95vw] stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-0 stg:text-foreground stg:shadow-2xl stg:outline-none",
-        "stg:[&::backdrop]:bg-black/60",
-      )}
+      // Near-full-viewport outlier: free-form sizing and the background
+      // surface for the graph canvas. The previously hardcoded ::backdrop
+      // color (bg-black/60 — it predated and escaped the #652 fence via the
+      // arbitrary-variant spelling) now rides the shell's token backdrop.
+      className="stg:h-[90vh] stg:w-[95vw] stg:max-w-none stg:bg-background stg:text-foreground stg:outline-none"
     >
       {open && (
         <div className="stg:flex stg:h-full stg:flex-col">
@@ -101,7 +89,7 @@ export function WorkflowGraphFullscreenDialog({
           </div>
         </div>
       )}
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/workflow/WorkflowRunDialog.tsx
+++ b/sdk/react/src/workflow/WorkflowRunDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../internal/DialogShell.js";
 import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import { useRunWorkflowFlow } from "./useRunWorkflowFlow.js";
@@ -82,8 +83,6 @@ export function WorkflowRunDialog({
   onSuccess,
   onError,
 }: WorkflowRunDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   const handleSuccess = useCallback(
     (executionId: string) => {
       onOpenChange(false);
@@ -100,25 +99,19 @@ export function WorkflowRunDialog({
     onError,
   });
 
-  // Sync open state with the native dialog
+  // Each opening starts from a clean form.
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
-      flow.reset();
-      // Preselection must follow reset (reset clears the selection back to
-      // the server-resolved default). Guarded against stale ids: an instance
-      // deleted between the caller capturing the id and this open falls back
-      // to the default option instead of a <select> value with no option.
-      if (
-        initialInstanceId &&
-        instances.some((i) => i.metadata?.id === initialInstanceId)
-      ) {
-        flow.setSelectedInstanceId(initialInstanceId);
-      }
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
+    if (!open) return;
+    flow.reset();
+    // Preselection must follow reset (reset clears the selection back to
+    // the server-resolved default). Guarded against stale ids: an instance
+    // deleted between the caller capturing the id and this open falls back
+    // to the default option instead of a <select> value with no option.
+    if (
+      initialInstanceId &&
+      instances.some((i) => i.metadata?.id === initialInstanceId)
+    ) {
+      flow.setSelectedInstanceId(initialInstanceId);
     }
   }, [
     open,
@@ -128,36 +121,16 @@ export function WorkflowRunDialog({
     instances,
   ]);
 
-  const handleDialogCancel = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onOpenChange(false);
-      }
-    },
-    [onOpenChange],
-  );
-
   const workflowName =
     workflow.metadata?.name || workflow.metadata?.slug || "Workflow";
 
   return (
-    <dialog
-      ref={dialogRef}
-      onCancel={handleDialogCancel}
-      onClick={handleBackdropClick}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:z-50 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-lg stg:border stg:border-border stg:bg-popover stg:p-0 stg:text-popover-foreground stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-        "stg:open:animate-in stg:open:fade-in-0 stg:open:zoom-in-95",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      width="lg"
+      dismissOnBackdrop
+      aria-label={`Run ${workflowName}`}
     >
       <div className="stg:flex stg:flex-col">
         {/* Header */}
@@ -231,7 +204,7 @@ export function WorkflowRunDialog({
           </button>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/workflow/execution-comparison/ExecutionComparisonPicker.tsx
+++ b/sdk/react/src/workflow/execution-comparison/ExecutionComparisonPicker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../../internal/DialogShell.js";
 import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
 import { useWorkflowExecutionList } from "../useWorkflowExecutionList.js";
 import { WorkflowExecutionPhaseBadge } from "../WorkflowExecutionPhaseBadge.js";
@@ -48,7 +49,6 @@ export const ExecutionComparisonPicker = memo(function ExecutionComparisonPicker
   onConfirm,
   onClose,
 }: ExecutionComparisonPickerProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const { executions, isLoading } = useWorkflowExecutionList({
@@ -83,24 +83,6 @@ export const ExecutionComparisonPicker = memo(function ExecutionComparisonPicker
   }, [open, candidates, selectedId, basePhase]);
 
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open) {
-      if (!dialog.open) dialog.showModal();
-    } else {
-      if (dialog.open) dialog.close();
-    }
-  }, [open]);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    const handleClose = () => onClose();
-    dialog.addEventListener("close", handleClose);
-    return () => dialog.removeEventListener("close", handleClose);
-  }, [onClose]);
-
-  useEffect(() => {
     if (!open) setSelectedId(null);
   }, [open]);
 
@@ -108,21 +90,22 @@ export const ExecutionComparisonPicker = memo(function ExecutionComparisonPicker
     if (selectedId) onConfirm(selectedId);
   }, [selectedId, onConfirm]);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) onClose();
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) onClose();
     },
     [onClose],
   );
 
   return (
-    <dialog
-      ref={dialogRef}
-      className={cn(
-        "stgm stg:m-auto stg:max-h-[70vh] stg:w-full stg:max-w-md stg:rounded-lg stg:border stg:border-[var(--stgm-border,#e5e5e5)] stg:bg-[var(--stgm-background,#fff)] stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-backdrop",
-      )}
-      onClick={handleBackdropClick}
+    <DialogShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      width="md"
+      dismissOnBackdrop
+      // `stgm` re-establishes the theme scope (rendered from the workflow
+      // canvas); the var-fallback styling predates the token utilities.
+      className="stgm stg:max-h-[70vh] stg:bg-[var(--stgm-background,#fff)] stg:border-[var(--stgm-border,#e5e5e5)]"
       aria-label="Select execution to compare"
     >
       <div className="stg:flex stg:flex-col">
@@ -217,7 +200,7 @@ export const ExecutionComparisonPicker = memo(function ExecutionComparisonPicker
           </button>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 });
 

--- a/sdk/react/src/workflow/instance/CreateWorkflowInstanceDialog.tsx
+++ b/sdk/react/src/workflow/instance/CreateWorkflowInstanceDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../../internal/DialogShell.js";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import type { ResourceRef } from "@stigmer/sdk";
@@ -39,7 +40,6 @@ export function CreateWorkflowInstanceDialog({
   workflowId,
   onCreated,
 }: CreateWorkflowInstanceDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const { create, isCreating, error, clearError } = useCreateWorkflowInstance();
 
   // Instance-scoped element ids (oss#571): a reusable component must not
@@ -65,10 +65,16 @@ export function CreateWorkflowInstanceDialog({
   }, [clearError]);
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onOpenChange(false);
     resetForm();
   }, [onOpenChange, resetForm]);
+
+  const handleShellOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) handleClose();
+    },
+    [handleClose],
+  );
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -93,30 +99,11 @@ export function CreateWorkflowInstanceDialog({
     [name, org, workflowId, description, environmentRefs, visibility, create, onCreated, handleClose],
   );
 
-  // Sync native dialog open state
-  const prevOpenRef = useRef(false);
-  if (open !== prevOpenRef.current) {
-    prevOpenRef.current = open;
-    if (open) {
-      // Must defer showModal to after render
-      requestAnimationFrame(() => {
-        if (dialogRef.current && !dialogRef.current.open) {
-          dialogRef.current.showModal();
-        }
-      });
-    } else if (dialogRef.current?.open) {
-      dialogRef.current.close();
-    }
-  }
-
   return (
-    <dialog
-      ref={dialogRef}
-      onClose={handleClose}
-      className={cn(
-        "stg:fixed stg:inset-0 stg:m-auto stg:w-full stg:max-w-lg stg:rounded-xl stg:border stg:border-border stg:bg-popover stg:p-0 stg:shadow-xl",
-        "stg:backdrop:bg-backdrop",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={handleShellOpenChange}
+      width="lg"
       aria-labelledby={titleId}
     >
       <form onSubmit={handleSubmit} className="stg:flex stg:flex-col">
@@ -255,7 +242,7 @@ export function CreateWorkflowInstanceDialog({
           </button>
         </div>
       </form>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/sdk/react/src/workflow/templates/WorkflowTemplatePreview.tsx
+++ b/sdk/react/src/workflow/templates/WorkflowTemplatePreview.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { DialogShell } from "../../internal/DialogShell.js";
 import { parse as parseYaml } from "yaml";
 import {
   ReactFlowProvider,
@@ -42,25 +43,12 @@ export function WorkflowTemplatePreview({
   onClose,
   onSelect,
 }: WorkflowTemplatePreviewProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    const handleClose = () => onClose();
-    dialog.addEventListener("close", handleClose);
-    return () => dialog.removeEventListener("close", handleClose);
-  }, [onClose]);
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) onClose();
+    },
+    [onClose],
+  );
 
   const handleSelect = useCallback(() => {
     if (template) onSelect(template);
@@ -72,19 +60,21 @@ export function WorkflowTemplatePreview({
   );
 
   if (!template || !meta) {
-    return <dialog ref={dialogRef} className="stg:hidden" />;
+    return null;
   }
 
   const categoryLabel =
     TEMPLATE_CATEGORY_LABELS[template.category] ?? template.category;
 
   return (
-    <dialog
-      ref={dialogRef}
-      className={cn(
-        "stgm stg:m-auto stg:max-h-[85vh] stg:w-full stg:max-w-3xl stg:rounded-lg stg:border stg:border-border stg:bg-background stg:p-0 stg:shadow-lg",
-        "stg:backdrop:bg-backdrop",
-      )}
+    <DialogShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      width="3xl"
+      // `stgm` re-establishes the theme scope (rendered from the template
+      // browser canvas); background surface is deliberate for the graph.
+      className="stgm stg:max-h-[85vh] stg:bg-background"
+      aria-label={`Preview ${template.name}`}
     >
       <div className="stg:flex stg:flex-col">
         {/* Header */}
@@ -193,7 +183,7 @@ export function WorkflowTemplatePreview({
           </button>
         </div>
       </div>
-    </dialog>
+    </DialogShell>
   );
 }
 

--- a/tools/eslint-plugin-stigmer/index.js
+++ b/tools/eslint-plugin-stigmer/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const noHandrolledDialog = require("./rules/no-handrolled-dialog");
 const noHardcodedBackdrop = require("./rules/no-hardcoded-backdrop");
 const noLiteralDomIds = require("./rules/no-literal-dom-ids");
 const noMainTokensInSidebar = require("./rules/no-main-tokens-in-sidebar");
@@ -13,6 +14,7 @@ const plugin = {
     version: "0.0.0",
   },
   rules: {
+    "no-handrolled-dialog": noHandrolledDialog,
     "no-hardcoded-backdrop": noHardcodedBackdrop,
     "no-literal-dom-ids": noLiteralDomIds,
     "no-main-tokens-in-sidebar": noMainTokensInSidebar,

--- a/tools/eslint-plugin-stigmer/rules/no-handrolled-dialog.js
+++ b/tools/eslint-plugin-stigmer/rules/no-handrolled-dialog.js
@@ -1,0 +1,46 @@
+"use strict";
+
+// The SDK has one dialog shell: internal/DialogShell.tsx owns the <dialog>
+// element, its showModal()/close() lifecycle, cancel/Escape wiring, the
+// --stgm-backdrop token, the open animation, and the base chrome. Before the
+// stigmer#653 sweep those were re-transcribed across 24 hand-rolled shells
+// and had drifted (two hardcoded backdrops, three background tokens, split
+// radius/shadow, animation present-or-absent). This fence keeps the class
+// dead: a new <dialog> element belongs inside DialogShell, everywhere else
+// renders <DialogShell>.
+
+const SHELL_FILE_SUFFIX = "internal/DialogShell.tsx";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require the shared DialogShell primitive instead of hand-rolled <dialog> elements",
+    },
+    messages: {
+      handrolledDialog:
+        "Hand-rolled <dialog> element. Render the internal DialogShell " +
+        "primitive instead (sdk/react/src/internal/DialogShell.tsx) — it owns " +
+        "the showModal lifecycle, cancel/Escape wiring, the --stgm-backdrop " +
+        "token, the open animation, and the base chrome, so dialogs cannot " +
+        "drift apart again (stigmer#653).",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    if (filename.replaceAll("\\", "/").endsWith(SHELL_FILE_SUFFIX)) {
+      return {};
+    }
+
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.type === "JSXIdentifier" && node.name.name === "dialog") {
+          context.report({ node, messageId: "handrolledDialog" });
+        }
+      },
+    };
+  },
+};

--- a/tools/eslint-plugin-stigmer/rules/no-hardcoded-backdrop.js
+++ b/tools/eslint-plugin-stigmer/rules/no-hardcoded-backdrop.js
@@ -10,8 +10,36 @@ const { extractClassNames } = require("../src/class-extractor");
 // from preset theming (a light-mode host gets a black scrim where the theme
 // specifies a translucent near-white one).
 
-const BACKDROP_VARIANT = "backdrop";
+// Both spellings of the ::backdrop variant: the named Tailwind variant and
+// the arbitrary-selector form. The #652 sweep fenced only the named variant,
+// and two hardcoded scrims survived unseen as `[&::backdrop]:bg-black/50`
+// and `/60` until the #653 dialog-shell sweep found them.
+const BACKDROP_VARIANTS = new Set(["backdrop", "[&::backdrop]"]);
 const ALLOWED_UTILITY = "bg-backdrop";
+
+/**
+ * Split a class into its variant segments + utility, treating `:` inside
+ * square brackets as content, not a separator — `stg:[&::backdrop]:bg-x`
+ * yields ["stg", "[&::backdrop]", "bg-x"], where a naive split would shred
+ * the arbitrary selector on its own `::`.
+ */
+function splitSegments(cls) {
+  const segments = [];
+  let current = "";
+  let depth = 0;
+  for (const ch of cls) {
+    if (ch === "[") depth += 1;
+    else if (ch === "]") depth = Math.max(0, depth - 1);
+    if (ch === ":" && depth === 0) {
+      segments.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  segments.push(current);
+  return segments;
+}
 
 module.exports = {
   meta: {
@@ -42,13 +70,13 @@ module.exports = {
         const entries = extractClassNames(node);
 
         for (const { className: cls, node: reportNode } of entries) {
-          const parts = cls.split(":");
+          const parts = splitSegments(cls);
           if (parts.length < 2) continue;
 
           const utility = parts[parts.length - 1];
           const variants = parts.slice(0, -1);
 
-          if (!variants.includes(BACKDROP_VARIANT)) continue;
+          if (!variants.some((v) => BACKDROP_VARIANTS.has(v))) continue;
           if (!utility.startsWith("bg-")) continue;
           // Opacity modifiers on the token itself (bg-backdrop/50) are the
           // no-token-opacity-modifiers rule's report, not a hardcoded color.


### PR DESCRIPTION
## Summary

Closes #653.

Every modal dialog in `@stigmer/react` re-transcribed the same shell by hand: the `<dialog>` element, its `showModal()`/`close()` lifecycle, cancel/Escape wiring, the backdrop, the open animation, and the base positioning/chrome. The census at sweep time was **24 sites** (the issue estimated 21 — it grew), and they had genuinely drifted: split `rounded-lg/xl` and `shadow-lg/xl/2xl`, three background tokens, animation classes present on some dialogs and missing from others, three different open-state syncing idioms, and **two hardcoded backdrops (`bg-black/50`, `/60`) that escaped the #652 fence** via the `[&::backdrop]:` arbitrary-variant spelling.

All 24 now render one internal primitive, `internal/DialogShell.tsx`, which owns the element, the lifecycle, cancel/Escape (state stays authoritative — the shell never closes itself), native-close sync (a `method="dialog"` submit can't strand the controlled state), the `--stgm-backdrop` token, the open animation, and the converged chrome — parameterized by a width preset. Nothing visibly changes for users beyond deliberate convergence (below); this deletes the drift class.

## Design notes

- **API is the codebase's own convention**: controlled `open`/`onOpenChange` (the comment in `ManageAccessDialog` already called this "the SDK dialog convention"), matching the #651/#654 panel seam vocabulary. Lazy-mounted bodies (`{open && …}`) stay caller-owned.
- **Two principled axes discovered in the census, now explicit props**: `modal` (the channel family's in-flow embedding mode — no top layer, no backdrop) and `dismissOnBackdrop` (the house rule as found: read-only viewers light-dismiss, form dialogs never do — a stray click must not discard a half-filled form).
- **Deliberate convergences, flagged for review**: chrome unifies on `rounded-xl` + `shadow-xl` + `popover` tokens (the token family for top-layer content; roughly half the dialogs used each spelling before); every modal gains the open animation (previously present on ~a third); true outliers (image lightbox, near-fullscreen graph, `bg-card`/`bg-background` surfaces) keep their look via `className` overrides, which win per-class through `cn()`.
- **Fence**: new `stigmer/no-handrolled-dialog` rule (seventh in the plugin, error severity, zero violations at land) — a new `<dialog>` element outside the shell file fails lint. The #652 backdrop rule also gains **bracket-aware variant splitting**, closing the `[&::backdrop]:` gap that let the two hardcoded scrims through (red-green verified on both spellings, token forms stay allowed).
- Not exported from the package (per the issue): promoted only if a host needs it.

## Verification

- `@stigmer/react`: 4553 tests green (13 new: lifecycle incl. mount-open, cancel-intent-without-self-close, native-close sync + no-double-report, backdrop-dismiss on/off/content-click, non-modal mode, chrome + width + className-override + aria contracts); all existing dialog suites pass against the shell unchanged.
- **Browser a11y suite (axe + real layout): 77/77 green** — including the dialog-heavy suites.
- `tsc --noEmit` clean; eslint **0 errors** (69 pre-existing warnings, unchanged count); `prefix-classnames --check` OK.
- Fence red-green: probe file with a raw `<dialog>` + both hardcoded-backdrop spellings produced all three errors; swept tree produces zero.
- Rebased past #668/#674/#694 (the other in-flight sdk/react merges); full suite re-verified on the combined tree, and #694's new code carries no raw dialog.

## Risk

No public API changes (the primitive is internal). Visible deltas are the deliberate convergences above — radius/shadow unification on ~half the dialogs and uniform open animation. `registerToolPresenter`-style per-dialog escape hatches are unnecessary: outlier styling rides `className`.

Made with [Cursor](https://cursor.com)