### PR TITLE
fix(docs): format vocabulary.md so the required Lint & Build check passes on main

### DIFF
--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -842,13 +842,13 @@ harness via the `@cursor/sdk`.
 
 #### Workflow Runner
 
-Retired term. Workflow tasks are executed by the unified TypeScript runner
-(see Agent Runner) — there is no separate workflow worker.
+Retired term. Workflow tasks are executed by the unified TypeScript runner (see
+Agent Runner) — there is no separate workflow worker.
 
 - **Capitalize**: Yes (when quoting historical docs).
-- **Context rule**: Do not use in new writing. Any doc describing a "Go
-  Temporal worker that executes Workflow tasks" is describing the retired
-  service — point it at the Agent Runner entry instead.
+- **Context rule**: Do not use in new writing. Any doc describing a "Go Temporal
+  worker that executes Workflow tasks" is describing the retired service — point
+  it at the Agent Runner entry instead.
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/vocabulary.md` landed unformatted via #662, so `make format-docs-check` — the first step of the required **Lint & Build** check — fails on every push to main and on every docs-adjacent PR. This is the one-file instance fix: `npx prettier --write docs/vocabulary.md` (5 lines reflowed, no content change).

Closes #688

## How #662 merged over the red check (the #610-class question, investigated)

PR #662's own check rollup shows **both** `Lint & Build: FAILURE (ci.docs)` **and** `Lint & Build: SUCCESS (ci.docs-noop)`. The noop twin's `paths-ignore` fires whenever *any* changed file falls outside the docs paths, while the real lane's `paths` fires whenever *any* changed file falls inside them — so a **mixed PR** (docs + non-docs files, exactly what #662 was) runs both workflows, and the twin's unconditionally-green check satisfied branch protection despite the real failure. The twin's header contract ("each PR must get it from exactly one workflow") only holds for PRs entirely on one side of the partition. The class-level fix (e.g. collapsing the twin into ci.docs behind an in-workflow change-detection gate) is deliberately **not** in this PR — it changes required-check topology and needs an owner ruling; findings reported on the issue.

## Verification

Every step of the Lint & Build job run locally on this branch (node 22.22.1 per `.nvmrc`): `make format-docs-check` ✓, `make -C site test-unit` (138 passed) ✓, `node scripts/verify-scenar-tours.mjs` (20 tours clean) ✓, `make check-docs-inventory` (196 pages OK) ✓, `make build-site` ✓ — so this PR turns the whole job green, not just the prettier step.

Made with [Cursor](https://cursor.com)