### PR TITLE
fix(ci): let the clean-room typecheck job install without a lockfile — override Yarn's CI-default immutable installs

### DIFF
--- a/.github/workflows/ci.ts-sdk.yaml
+++ b/.github/workflows/ci.ts-sdk.yaml
@@ -160,8 +160,15 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      # Yarn Berry defaults enableImmutableInstalls to true when CI=true,
+      # which aborts any install that would write a lockfile (YN0028). This
+      # job's entire design is a lockfile-free fresh resolve, so the CI
+      # default must be overridden here — without it the lane can never pass
+      # (issue #687: red on every run since it shipped).
       - name: Install dependencies (yarn, fresh resolution)
         run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
 
       - name: Build @stigmer/protos dist
         run: yarn workspace @stigmer/protos run build


### PR DESCRIPTION
## Summary

The `typecheck (clean-room resolution)` job in `ci.ts-sdk.yaml` has never passed: Yarn Berry flips `enableImmutableInstalls` to `true` when `CI=true`, aborting with YN0028 any install that would write a lockfile — and this job's entire design is a lockfile-free fresh resolve (the root `yarn.lock` is deliberately gitignored so every caret range re-resolves like an integrator's fresh clone). The fix sets `YARN_ENABLE_IMMUTABLE_INSTALLS: "false"` on exactly that install step, with a comment explaining why the CI default is fatal here. The env-var form names the precise config knob whose CI-conditional default is the bug.

Closes #687

## Verification

This workflow lists itself in its own `paths` filters, so this PR triggers the lane — the clean-room job going green on this PR's checks is the issue's own closing condition (its first-ever pass). The locked-resolution job is untouched.

Made with [Cursor](https://cursor.com)