### PR TITLE
fix(runner): preserve bytes through zip-extract — binary skill assets no longer corrupt on mount

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/skill-resolver.ts
+++ b/backend/services/runner/src/activities/execute-cursor/skill-resolver.ts
@@ -188,7 +188,7 @@ async function writeSkillMount(
     for (const entry of entries) {
       const filePath = join(skillDir, entry.path);
       await mkdir(dirname(filePath), { recursive: true });
-      await writeFile(filePath, entry.content, "utf-8");
+      await writeFile(filePath, entry.content);
     }
   }
 

--- a/backend/services/runner/src/shared/__tests__/zip-extract.test.ts
+++ b/backend/services/runner/src/shared/__tests__/zip-extract.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { extractZipFileEntries } from "../zip-extract.js";
+import { extractZipFileEntries, type ZipFileEntry } from "../zip-extract.js";
 import { buildZip } from "../../__test-utils__/zip-fixtures.js";
+
+/**
+ * Decode entries for text-content assertions. The production contract is
+ * bytes (issue #683); decoding belongs to the tests that want to assert on
+ * human-readable fixtures, not to the module under test.
+ */
+function decoded(entries: ZipFileEntry[]): { path: string; content: string }[] {
+  return entries.map((e) => ({ path: e.path, content: new TextDecoder().decode(e.content) }));
+}
 
 // ─── extractZipFileEntries ───────────────────────────────────────────────
 
@@ -12,9 +21,10 @@ describe("extractZipFileEntries", () => {
     ]);
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toHaveLength(2);
-    expect(entries[0]).toEqual({ path: "SKILL.md", content: "# My Skill" });
-    expect(entries[1]).toEqual({ path: "references/schema.md", content: "# Schema\n\nTable definitions." });
+    expect(decoded(entries)).toEqual([
+      { path: "SKILL.md", content: "# My Skill" },
+      { path: "references/schema.md", content: "# Schema\n\nTable definitions." },
+    ]);
   });
 
   it("extracts deflated files", async () => {
@@ -22,8 +32,7 @@ describe("extractZipFileEntries", () => {
     const zip = buildZip([{ name: "notes.txt", content, method: "deflated" }]);
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toHaveLength(1);
-    expect(entries[0]).toEqual({ path: "notes.txt", content });
+    expect(decoded(entries)).toEqual([{ path: "notes.txt", content }]);
   });
 
   it("skips directory entries", async () => {
@@ -123,6 +132,32 @@ describe("extractZipFileEntries", () => {
     expect(entries).toHaveLength(1);
   });
 
+  // ── Binary safety (issue #683) ──────────────────────────────────────────
+
+  it("round-trips a stored binary entry byte-identically", async () => {
+    // PNG magic followed by bytes that are not valid UTF-8 (0x89 alone, a
+    // lone continuation byte, an unpaired lead byte). A decode/encode
+    // round-trip replaces these with U+FFFD — the corruption this pins.
+    const binary = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00, 0x80, 0xc3,
+    ]);
+    const zip = buildZip([{ name: "references/diagram.png", content: binary }]);
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toHaveLength(1);
+    expect(new Uint8Array(entries[0].content)).toEqual(binary);
+  });
+
+  it("round-trips a deflated binary entry byte-identically", async () => {
+    const binary = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) binary[i] = i; // every byte value once
+    const zip = buildZip([{ name: "assets/font.woff2", content: binary, method: "deflated" }]);
+
+    const entries = await extractZipFileEntries(zip);
+    expect(entries).toHaveLength(1);
+    expect(new Uint8Array(entries[0].content)).toEqual(binary);
+  });
+
   // ── Streaming entries (issue #450) ─────────────────────────────────────
 
   it("extracts Go-default streaming archives (deflated, data descriptors)", async () => {
@@ -132,7 +167,7 @@ describe("extractZipFileEntries", () => {
     ]);
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toEqual([
+    expect(decoded(entries)).toEqual([
       { path: "SKILL.md", content: "# Streamed Skill" },
       { path: "references/notes.md", content: "streamed notes" },
     ]);
@@ -151,7 +186,7 @@ describe("extractZipFileEntries", () => {
     ]);
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toEqual([
+    expect(decoded(entries)).toEqual([
       { path: "poison.md", content: poisoned },
       { path: "after.md", content: "the entry after the poisoned one" },
     ]);
@@ -162,7 +197,7 @@ describe("extractZipFileEntries", () => {
     const zip = buildZip([{ name: "cd-sizes.txt", content, streaming: true }]);
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toEqual([{ path: "cd-sizes.txt", content }]);
+    expect(decoded(entries)).toEqual([{ path: "cd-sizes.txt", content }]);
   });
 
   // ── Central directory edge cases ───────────────────────────────────────
@@ -173,7 +208,7 @@ describe("extractZipFileEntries", () => {
     });
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toEqual([{ path: "a.txt", content: "aaa" }]);
+    expect(decoded(entries)).toEqual([{ path: "a.txt", content: "aaa" }]);
   });
 
   it("is not fooled by EOCD signature bytes inside the archive comment", async () => {
@@ -185,7 +220,7 @@ describe("extractZipFileEntries", () => {
     });
 
     const entries = await extractZipFileEntries(zip);
-    expect(entries).toEqual([{ path: "a.txt", content: "aaa" }]);
+    expect(decoded(entries)).toEqual([{ path: "a.txt", content: "aaa" }]);
   });
 
   it("returns empty array when the central directory is missing", async () => {

--- a/backend/services/runner/src/shared/skill-writer.ts
+++ b/backend/services/runner/src/shared/skill-writer.ts
@@ -162,7 +162,7 @@ async function extractZipToWorkspace(
 ): Promise<void> {
   const entries = await extractZipFileEntries(zipBytes);
   for (const entry of entries) {
-    await backend.writeFile(`${targetDir}/${entry.path}`, entry.content);
+    await backend.writeFileBuffer(`${targetDir}/${entry.path}`, Buffer.from(entry.content));
   }
 }
 
@@ -174,7 +174,7 @@ async function extractZipToWorkspaceExcluding(
 ): Promise<void> {
   const entries = await extractZipFileEntries(zipBytes, { exclude: [excludeName] });
   for (const entry of entries) {
-    await backend.writeFile(`${targetDir}/${entry.path}`, entry.content);
+    await backend.writeFileBuffer(`${targetDir}/${entry.path}`, Buffer.from(entry.content));
   }
 }
 

--- a/backend/services/runner/src/shared/zip-extract.ts
+++ b/backend/services/runner/src/shared/zip-extract.ts
@@ -1,6 +1,13 @@
 /**
- * Skill-artifact ZIP extraction: text-decoded entries with non-fatal
+ * Skill-artifact ZIP extraction: byte-preserving entries with non-fatal
  * structural failure.
+ *
+ * Entries are returned as raw bytes, never decoded: skill artifacts carry
+ * binary assets (images, fonts, archives) alongside text, and a UTF-8
+ * decode/encode round-trip silently corrupts anything that isn't valid
+ * UTF-8 (issue #683). No consumer parses entry content as text — SKILL.md
+ * is excluded from extraction on every path and written from the Skill
+ * spec instead — so there is deliberately no text accessor to misuse.
  *
  * Structural parsing lives in zip-structure.ts (central-directory-based —
  * see that module's doc for why local-header walks are never acceptable,
@@ -33,8 +40,8 @@ import { EOCD_MIN_SIZE, parseZipStructure, type ZipStructuralEntry } from "./zip
 export interface ZipFileEntry {
   /** Relative path within the archive (forward-slash separated). */
   readonly path: string;
-  /** Decoded text content of the file. */
-  readonly content: string;
+  /** Raw file bytes, exactly as stored in the archive. */
+  readonly content: Uint8Array;
 }
 
 /**
@@ -91,17 +98,17 @@ function isExcluded(name: string, excludeSet: ReadonlySet<string>): boolean {
 
 // ─── Decompression ───────────────────────────────────────────────────────
 
-async function decompressEntry(entry: ZipStructuralEntry): Promise<string> {
+async function decompressEntry(entry: ZipStructuralEntry): Promise<Uint8Array> {
   if (entry.compressionMethod === 0) {
-    return new TextDecoder().decode(entry.compressedData);
+    return entry.compressedData;
   }
 
   if (entry.compressionMethod === 8) {
-    return new Promise<string>((resolve, reject) => {
+    return new Promise<Uint8Array>((resolve, reject) => {
       const inflate = createInflateRaw();
       const chunks: Buffer[] = [];
       inflate.on("data", (chunk: Buffer) => chunks.push(chunk));
-      inflate.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+      inflate.on("end", () => resolve(Buffer.concat(chunks)));
       inflate.on("error", reject);
       inflate.end(Buffer.from(entry.compressedData));
     });


### PR DESCRIPTION
## Summary

`extractZipFileEntries` returned every entry as a UTF-8-decoded `string`, and both consumers wrote that string back to disk — so any binary file in a skill artifact (images, fonts, compiled assets) went through a decode/encode round-trip and mounted corrupted, with no error anywhere. The entry contract is now bytes end to end: `ZipFileEntry.content: Uint8Array`, the decode deleted from decompression, and both write paths byte-preserving.

Closes #683

## Design

- **Bytes-only, deliberately no text accessor**: a consumer audit showed nothing parses entry content as text — `SKILL.md` (the only text anyone parses) is excluded from extraction on every path and written from the Skill spec instead. The module doc now records this so the contract can't silently regress.
- **Consumers migrate onto existing seams**: `skill-resolver.ts` drops the `"utf-8"` argument (node `writeFile` takes bytes natively); `skill-writer.ts` switches to the `WorkspaceBackend.writeFileBuffer` method that already existed — the same binary-safe path the attachment injector uses. No backend contract change.
- Stored entries are now returned zero-copy (a subarray view of the archive buffer); deflated entries come out of the inflate stream as before, minus the `toString("utf-8")`.

## Verification

Red-first: two new regression tests (stored PNG-magic + invalid-UTF-8 bytes; deflated all-256-byte-values) failed against the old contract, pass now — byte-identical round-trips. Existing text-fixture assertions migrated behind a test-side `decoded()` helper (decoding belongs to tests asserting on readable fixtures, not to the module). Full runner suite: **4606 passed / 6 skipped, 0 failures**; `tsc --noEmit` clean.

Made with [Cursor](https://cursor.com)