### PR TITLE
fix(sdk-react): skill upload preview enforces root-only SKILL.md — nested archives now fail before upload with the zip-the-contents hint

### DIFF
--- a/sdk/react/src/skill/__tests__/useSkillUpload.test.ts
+++ b/sdk/react/src/skill/__tests__/useSkillUpload.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { zipSync, strToU8 } from "fflate";
+import { useSkillUpload } from "../useSkillUpload";
+
+const SKILL_MD = "---\nname: my-skill\ndescription: A test skill\n---\n# My Skill\n";
+
+/** Build a real ZIP (fflate, the same library the hook unpacks with) as a File. */
+function zipFile(files: Record<string, Uint8Array>): File {
+  return new File([zipSync(files)], "skill.zip", { type: "application/zip" });
+}
+
+async function process(files: Record<string, Uint8Array>) {
+  const { result } = renderHook(() => useSkillUpload());
+  await act(() => result.current.processFile(zipFile(files)));
+  return result;
+}
+
+describe("useSkillUpload", () => {
+  it("accepts a root SKILL.md and produces a preview", async () => {
+    const result = await process({
+      "SKILL.md": strToU8(SKILL_MD),
+      "references/schema.md": strToU8("# Schema"),
+    });
+
+    expect(result.current.validationError).toBeNull();
+    expect(result.current.preview?.name).toBe("my-skill");
+    expect(result.current.preview?.description).toBe("A test skill");
+    expect(result.current.artifact).not.toBeNull();
+  });
+
+  // The layout contract is root-only on both editions (DD-018, #452). The
+  // preview exists to catch the "zipped the folder instead of its contents"
+  // mistake BEFORE upload — accepting nested here and failing at push is the
+  // exact confusion issue #684 pins.
+  it("rejects a nested-only SKILL.md with the zip-the-contents hint", async () => {
+    const result = await process({
+      "my-skill/SKILL.md": strToU8(SKILL_MD),
+      "my-skill/references/schema.md": strToU8("# Schema"),
+    });
+
+    expect(result.current.preview).toBeNull();
+    expect(result.current.artifact).toBeNull();
+    expect(result.current.validationError).toBe(
+      "Found my-skill/SKILL.md — SKILL.md must be at the archive root. " +
+        "Zip the skill folder's contents, not the folder itself.",
+    );
+  });
+
+  it("detects a deeply nested SKILL.md for the hint (any depth, server parity)", async () => {
+    const result = await process({
+      "wrapper/my-skill/SKILL.md": strToU8(SKILL_MD),
+    });
+
+    expect(result.current.preview).toBeNull();
+    expect(result.current.validationError).toContain("Found wrapper/my-skill/SKILL.md");
+  });
+
+  it("rejects an archive with no SKILL.md anywhere with the plain root-level message", async () => {
+    const result = await process({
+      "README.md": strToU8("# Not a skill"),
+    });
+
+    expect(result.current.preview).toBeNull();
+    expect(result.current.validationError).toBe(
+      "ZIP must contain a SKILL.md file at the root level",
+    );
+  });
+});

--- a/sdk/react/src/skill/useSkillUpload.ts
+++ b/sdk/react/src/skill/useSkillUpload.ts
@@ -129,10 +129,16 @@ export function useSkillUpload(): UseSkillUploadReturn {
       if (abortRef.current !== callId) return;
 
       const entries = Object.entries(unzipped);
-      const skillMdEntry = findSkillMd(entries);
+      const skillMdEntry = findRootSkillMd(entries);
 
       if (!skillMdEntry) {
-        setValidationError("ZIP must contain a SKILL.md file at the root level");
+        const nestedPath = findNestedSkillMd(entries);
+        setValidationError(
+          nestedPath
+            ? `Found ${nestedPath} — SKILL.md must be at the archive root. ` +
+              "Zip the skill folder's contents, not the folder itself."
+            : "ZIP must contain a SKILL.md file at the root level",
+        );
         return;
       }
 
@@ -207,12 +213,25 @@ function isZip(bytes: Uint8Array): boolean {
   );
 }
 
-function findSkillMd(
+/**
+ * The layout contract is root-only on both editions (DD-018, #452): the
+ * server rejects an archive whose only SKILL.md is nested, so the preview
+ * must too — accepting it here converts a clear pre-upload error into a
+ * confusing post-upload rejection (issue #684).
+ */
+function findRootSkillMd(
   entries: [string, Uint8Array][],
 ): [string, Uint8Array] | undefined {
-  return entries.find(
-    ([path]) => path === "SKILL.md" || path.match(/^[^/]+\/SKILL\.md$/),
-  );
+  return entries.find(([path]) => path === "SKILL.md");
+}
+
+/**
+ * Detect the "zipped the folder instead of its contents" mistake so the
+ * error can say what to do. Any-depth suffix match, mirroring the server's
+ * nested-occurrence detection (skill/storage/zip_extractor.go).
+ */
+function findNestedSkillMd(entries: [string, Uint8Array][]): string | undefined {
+  return entries.find(([path]) => path.endsWith("/SKILL.md"))?.[0];
 }
 
 function parseFrontmatter(content: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

`useSkillUpload`'s `findSkillMd` accepted `SKILL.md` either at the archive root **or** one directory deep — but the layout contract is root-only on both editions (DD-018, #452), so a zip whose only `SKILL.md` is nested got a green client-side preview and then a confusing server rejection at push. The preview exists to catch exactly this "zipped the folder instead of its contents" mistake before upload; validating looser than the server inverted its purpose. The hook's own doc already said "at the root level" — the code now matches it.

Closes #684

## Design

- Root-only acceptance: `path === "SKILL.md"`, exactly the server's contract.
- Nested-only case gets an actionable error naming the found path and mirroring the server's wording (`zip_extractor.go`): "Found my-skill/SKILL.md — SKILL.md must be at the archive root. Zip the skill folder's contents, not the folder itself."
- Nested detection is any-depth (suffix match), matching the server's nested-occurrence detection rather than the old one-level regex.
- With the CLI's `--archive` validation (#679, merged), server, CLI, and console now enforce the same contract with the same hint.

## Verification

These are the hook's first tests (the loose matcher was never pinned): root accepted with preview populated; one-level nested rejected with the exact hint; deep-nested rejected (server-parity depth handling); no-SKILL.md rejected with the plain message. Red-first proven by stash: the two nested cases fail against the old matcher. Full sdk/react suite **4577 passed / 0 failed**; `tsc --noEmit` clean on both configs.

Made with [Cursor](https://cursor.com)