### PR TITLE
fix(client-apps/web): render deep-loaded library detail pages exactly once

### DIFF
--- a/client-apps/web/src/domain/library/LibraryLayout.tsx
+++ b/client-apps/web/src/domain/library/LibraryLayout.tsx
@@ -38,6 +38,22 @@ function LibraryLayoutContent({ children }: { children: React.ReactNode }) {
   const { activeDetail } = useLibraryNavigation();
   const { isFullViewport } = useFullViewportLayout();
 
+  const overlayActive = activeDetail != null;
+
+  // While a detail overlay is active, the route-rendered children stay
+  // mounted but hidden: preserving LIST scroll, filters, and loaded data
+  // under the overlay is the reason this zone bypasses Next routing at
+  // all (see LibraryNavigationProvider). Children that are themselves a
+  // detail page — a cold deep-load of a detail URL — would be the SAME
+  // page the overlay renders, so the route-level detail wrappers yield
+  // to the overlay and render null inside this wrapper
+  // (useRouteDetailYieldsToOverlay, oss#621); only list content is ever
+  // actually kept alive here.
+  //
+  // The desktop app's LibraryLayout renders a plain <Outlet /> with no
+  // overlay: react-router navigates detail routes for real, so neither
+  // case exists there. That divergence is inherent to the static-export
+  // constraint, not drift.
   return (
     <div
       className={cn(
@@ -48,11 +64,12 @@ function LibraryLayoutContent({ children }: { children: React.ReactNode }) {
     >
       {!isFullViewport && <LibraryBreadcrumb />}
       <div
+        data-slot="library-route-children"
         className={cn(
-          activeDetail != null && "hidden",
+          overlayActive && "hidden",
           isFullViewport && "flex min-h-0 flex-1 flex-col",
         )}
-        aria-hidden={activeDetail != null}
+        aria-hidden={overlayActive}
       >
         {children}
       </div>

--- a/client-apps/web/src/domain/library/__tests__/LibraryLayout.test.tsx
+++ b/client-apps/web/src/domain/library/__tests__/LibraryLayout.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+import LibraryLayout from "../LibraryLayout";
+import {
+  useLibraryNavigation,
+  useRouteDetailYieldsToOverlay,
+} from "../library-navigation";
+
+// These tests pin the zone-overlay mount contract (oss#621):
+//
+// - LIST children stay mounted-but-hidden under a detail overlay — the
+//   deliberate list-state preservation the zone's pushState routing exists
+//   to provide.
+// - DETAIL children yield to the overlay via
+//   useRouteDetailYieldsToOverlay, so a cold deep-load of a detail URL
+//   renders the page exactly once: no double data fetching, no second
+//   live instance for document-global behavior. (The five route wrappers'
+//   use of the hook is pinned end-to-end by
+//   test/e2e/tests/interactive/duplicate-dom-ids.spec.ts.)
+
+// The Next pathname is what the router last rendered; the zone's own
+// pushState navigation deliberately does not go through it.
+let mockPathname = "/library/agents";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+// The real detail pages drag the full SDK; markers are enough to count
+// mounted instances. The workflow marker additionally requests
+// full-viewport through the REAL hook to pin the layout's behavior when
+// the overlay drives that shared flag.
+vi.mock("@/domain/library/agents/AgentDetailPage", () => ({
+  AgentDetailPageInner: () => <div data-testid="agent-detail" />,
+}));
+vi.mock("@/domain/library/skills/SkillDetailPage", () => ({
+  SkillDetailPageInner: () => <div data-testid="skill-detail" />,
+}));
+vi.mock("@/domain/library/mcp-servers/McpServerDetailPage", () => ({
+  McpServerDetailPageInner: () => <div data-testid="mcp-server-detail" />,
+}));
+vi.mock("@/domain/workflow/WorkflowDetailPage", async () => {
+  const { useRequestFullViewport } = await import(
+    "@/domain/library/full-viewport-layout"
+  );
+  return {
+    WorkflowDetailPageInner: () => {
+      useRequestFullViewport(true);
+      return <div data-testid="workflow-detail" />;
+    },
+  };
+});
+vi.mock("@/domain/library/schedules/ScheduleDetailPage", () => ({
+  ScheduleDetailPageInner: () => <div data-testid="schedule-detail" />,
+}));
+
+vi.mock("@/domain/library/LibraryBreadcrumb", () => ({
+  LibraryBreadcrumb: () => <nav data-testid="breadcrumb" />,
+}));
+
+/** Point both the Next router mock and the browser URL at `path`. */
+function setRoute(path: string) {
+  mockPathname = path;
+  window.history.replaceState(null, "", path);
+}
+
+/**
+ * Stand-in for a route-level detail wrapper: same yield contract as
+ * AgentDetailPage and its four siblings.
+ */
+function YieldingDetailRouteChild() {
+  const yieldsToOverlay = useRouteDetailYieldsToOverlay();
+  if (yieldsToOverlay) return null;
+  return <div data-testid="route-detail-copy" />;
+}
+
+function NavigateToAgentButton() {
+  const { navigateToDetail } = useLibraryNavigation();
+  return (
+    <button onClick={() => navigateToDetail("agents", "acme", "support-bot")}>
+      open detail
+    </button>
+  );
+}
+
+beforeEach(() => {
+  setRoute("/library/agents");
+});
+
+afterEach(cleanup);
+
+describe("LibraryLayout route-children mounting", () => {
+  it("renders list children normally when no detail is active", () => {
+    render(
+      <LibraryLayout>
+        <div data-testid="route-child" />
+      </LibraryLayout>,
+    );
+
+    const child = screen.getByTestId("route-child");
+    expect(child.parentElement?.classList.contains("hidden")).toBe(false);
+    expect(screen.queryByTestId("agent-detail")).toBeNull();
+  });
+
+  it("keeps list children mounted but hidden under a soft-navigated overlay", () => {
+    render(
+      <LibraryLayout>
+        <div data-testid="route-child" />
+        <NavigateToAgentButton />
+      </LibraryLayout>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "open detail" }));
+
+    // The overlay renders the detail…
+    expect(screen.getByTestId("agent-detail")).not.toBeNull();
+    // …and the list children survive underneath, hidden from view and
+    // from assistive tech — their state is the point of keeping them.
+    const child = screen.getByTestId("route-child");
+    expect(child.parentElement?.classList.contains("hidden")).toBe(true);
+    expect(child.parentElement?.getAttribute("aria-hidden")).toBe("true");
+    expect(window.location.pathname).toBe(
+      "/library/agents/acme/support-bot",
+    );
+  });
+
+  it("renders a deep-loaded detail exactly once: the route copy yields to the overlay", () => {
+    setRoute("/library/agents/acme/support-bot");
+
+    render(
+      <LibraryLayout>
+        <YieldingDetailRouteChild />
+      </LibraryLayout>,
+    );
+
+    // Exactly one copy of the page: the overlay. The route copy — the
+    // same page — must render nothing (oss#621's double-mount).
+    expect(screen.getAllByTestId("agent-detail")).toHaveLength(1);
+    expect(screen.queryByTestId("route-detail-copy")).toBeNull();
+  });
+
+  it("holds a full-viewport request from the overlay while the route copy yields", () => {
+    setRoute("/library/workflows/acme/deploy-flow");
+
+    render(
+      <LibraryLayout>
+        <YieldingDetailRouteChild />
+      </LibraryLayout>,
+    );
+
+    expect(screen.getAllByTestId("workflow-detail")).toHaveLength(1);
+    expect(screen.queryByTestId("route-detail-copy")).toBeNull();
+    // isFullViewport drives the breadcrumb away; the (yielding) route
+    // copy must not disturb the overlay's request on the shared flag.
+    expect(screen.queryByTestId("breadcrumb")).toBeNull();
+  });
+});

--- a/client-apps/web/src/domain/library/agents/AgentDetailPage.tsx
+++ b/client-apps/web/src/domain/library/agents/AgentDetailPage.tsx
@@ -21,7 +21,10 @@ import {
   type DetailAction,
 } from "@stigmer/react";
 import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
-import { useLibraryNavigation } from "@/domain/library/library-navigation";
+import {
+  useLibraryNavigation,
+  useRouteDetailYieldsToOverlay,
+} from "@/domain/library/library-navigation";
 import { useStaticRouteParam } from "@/domain/_shared/hooks/useStaticRouteParam";
 import { getAgentSessionUrl } from "@/domain/session/draft-session";
 import { getAppBaseUrl } from "@/config/env";
@@ -284,10 +287,12 @@ export function AgentDetailPageInner({ org, slug }: AgentDetailPageInnerProps) {
 }
 
 export function AgentDetailPage() {
+  // The zone overlay owns detail rendering while it is active (oss#621).
+  const yieldsToOverlay = useRouteDetailYieldsToOverlay();
   const org = useStaticRouteParam("org", 2);
   const slug = useStaticRouteParam("slug");
 
-  if (!org || !slug) return null;
+  if (yieldsToOverlay || !org || !slug) return null;
 
   return <AgentDetailPageInner org={org} slug={slug} />;
 }

--- a/client-apps/web/src/domain/library/library-navigation.tsx
+++ b/client-apps/web/src/domain/library/library-navigation.tsx
@@ -206,6 +206,31 @@ export function LibraryNavigationProvider({
 // ---------------------------------------------------------------------------
 
 /**
+ * Whether a route-file detail page must yield rendering to the zone
+ * overlay.
+ *
+ * The route-level detail wrappers (`AgentDetailPage` etc.) mount only via
+ * `src/app/library/<type>/[org]/[slug]/page.tsx`. Whenever a detail
+ * overlay is active, the overlay is rendering that same page (or the one
+ * navigated to since), so a route copy under the layout's hidden wrapper
+ * would double-fetch every data hook and give document-global behavior
+ * (portals, focus, keyboard listeners) a second live instance (oss#621).
+ * List pages never yield — preserving their state under the overlay is
+ * the reason this zone keeps children mounted at all.
+ *
+ * Deliberately derived from `activeDetail`, not the URL: after
+ * `navigateToDetail`'s pushState, Next syncs `usePathname()` to the
+ * pushed detail URL without having rendered that route, so the URL cannot
+ * distinguish "Next rendered a detail route" from "a detail URL was
+ * pushed over the list route". The overlay state is the single source of
+ * truth either way.
+ */
+export function useRouteDetailYieldsToOverlay(): boolean {
+  const { activeDetail } = useLibraryNavigation();
+  return activeDetail != null;
+}
+
+/**
  * Access the library navigation context.
  *
  * Throws if called outside `<LibraryNavigationProvider>` — this surfaces

--- a/client-apps/web/src/domain/library/mcp-servers/McpServerDetailPage.tsx
+++ b/client-apps/web/src/domain/library/mcp-servers/McpServerDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   useBreadcrumbOverride,
   type DetailAction,
 } from "@stigmer/react";
+import { useRouteDetailYieldsToOverlay } from "@/domain/library/library-navigation";
 import { useStaticRouteParam } from "@/domain/_shared/hooks/useStaticRouteParam";
 
 interface McpServerDetailPageInnerProps {
@@ -155,10 +156,12 @@ export function McpServerDetailPageInner({
 }
 
 export function McpServerDetailPage() {
+  // The zone overlay owns detail rendering while it is active (oss#621).
+  const yieldsToOverlay = useRouteDetailYieldsToOverlay();
   const org = useStaticRouteParam("org", 2);
   const slug = useStaticRouteParam("slug");
 
-  if (!org || !slug) return null;
+  if (yieldsToOverlay || !org || !slug) return null;
 
   return <McpServerDetailPageInner org={org} slug={slug} />;
 }

--- a/client-apps/web/src/domain/library/schedules/ScheduleDetailPage.tsx
+++ b/client-apps/web/src/domain/library/schedules/ScheduleDetailPage.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
 import { ScheduleDetailView, useBreadcrumbOverride } from "@stigmer/react";
-import { useLibraryNavigation } from "@/domain/library/library-navigation";
+import {
+  useLibraryNavigation,
+  useRouteDetailYieldsToOverlay,
+} from "@/domain/library/library-navigation";
 import { useExecutionNavigation } from "@/domain/workflow/execution-navigation";
 import { useStaticRouteParam } from "@/domain/_shared/hooks/useStaticRouteParam";
 
@@ -75,10 +78,12 @@ export function ScheduleDetailPageInner({
 }
 
 export function ScheduleDetailPage() {
+  // The zone overlay owns detail rendering while it is active (oss#621).
+  const yieldsToOverlay = useRouteDetailYieldsToOverlay();
   const org = useStaticRouteParam("org", 2);
   const slug = useStaticRouteParam("slug");
 
-  if (!org || !slug) return null;
+  if (yieldsToOverlay || !org || !slug) return null;
 
   return <ScheduleDetailPageInner org={org} slug={slug} />;
 }

--- a/client-apps/web/src/domain/library/skills/SkillDetailPage.tsx
+++ b/client-apps/web/src/domain/library/skills/SkillDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   useBreadcrumbOverride,
   type DetailAction,
 } from "@stigmer/react";
+import { useRouteDetailYieldsToOverlay } from "@/domain/library/library-navigation";
 import { useStaticRouteParam } from "@/domain/_shared/hooks/useStaticRouteParam";
 
 interface SkillDetailPageInnerProps {
@@ -101,10 +102,12 @@ export function SkillDetailPageInner({ org, slug }: SkillDetailPageInnerProps) {
 }
 
 export function SkillDetailPage() {
+  // The zone overlay owns detail rendering while it is active (oss#621).
+  const yieldsToOverlay = useRouteDetailYieldsToOverlay();
   const org = useStaticRouteParam("org", 2);
   const slug = useStaticRouteParam("slug");
 
-  if (!org || !slug) return null;
+  if (yieldsToOverlay || !org || !slug) return null;
 
   return <SkillDetailPageInner org={org} slug={slug} />;
 }

--- a/client-apps/web/src/domain/workflow/WorkflowDetailPage.tsx
+++ b/client-apps/web/src/domain/workflow/WorkflowDetailPage.tsx
@@ -24,6 +24,7 @@ import {
   type AdditionalTab,
 } from "@stigmer/react";
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { useRouteDetailYieldsToOverlay } from "@/domain/library/library-navigation";
 import { useStaticRouteParam } from "@/domain/_shared/hooks/useStaticRouteParam";
 import { useExecutionNavigation } from "@/domain/workflow/execution-navigation";
 
@@ -335,10 +336,12 @@ export function WorkflowDetailPageInner({
 }
 
 export function WorkflowDetailPage() {
+  // The zone overlay owns detail rendering while it is active (oss#621).
+  const yieldsToOverlay = useRouteDetailYieldsToOverlay();
   const org = useStaticRouteParam("org", 2);
   const slug = useStaticRouteParam("slug");
 
-  if (!org || !slug) return null;
+  if (yieldsToOverlay || !org || !slug) return null;
 
   return <WorkflowDetailPageInner org={org} slug={slug} />;
 }

--- a/test/e2e/tests/interactive/duplicate-dom-ids.spec.ts
+++ b/test/e2e/tests/interactive/duplicate-dom-ids.spec.ts
@@ -1,29 +1,30 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "../../fixtures";
+import { navigateToAgents, clickResourceCard } from "../../helpers/library";
 
 /**
- * Duplicate DOM id / radio-name audit on library detail pages
- * (stigmer/stigmer#593).
+ * Library zone mount-contract and duplicate DOM id / radio-name audit
+ * (stigmer/stigmer#593, #621).
  *
  * The library zone bypasses Next.js routing for detail navigation
  * (static-export constraint): `LibraryNavigationProvider` initializes
- * `activeDetail` from `window.location.pathname`, and `LibraryLayout`
- * renders that overlay copy while ALSO keeping the route-rendered copy
- * mounted (hidden + aria-hidden). On a DIRECT load of a detail URL both
- * copies are the same detail page — so any SDK component that hardcodes a
- * DOM id and renders it unconditionally duplicates that id, and
- * document-order id lookup resolves label/aria-labelledby associations
- * into the HIDDEN copy: screen readers land on aria-hidden nodes and
- * getByLabel locators match nothing. A hardcoded radio-group `name` is the
- * same defect with sharper teeth: radios in both copies join ONE keyboard
- * group. (Click-through navigation arms only the overlay over the hidden
- * LIST page, so the deep-link/reload path is the one that must be audited.)
+ * `activeDetail` from `window.location.pathname` and `LibraryLayout`
+ * renders the detail as an overlay. The route-rendered children are
+ * handled two ways, and each has its own pin here:
  *
- * The fix (oss#593, following the oss#571 precedent) is instance-scoped
- * ids/names minted with useId(). These specs pin that invariant on the two
- * double-mounted surfaces that carry always-rendered dialog forms; the
- * page-wide audit also catches any future component that regresses into
- * hardcoded ids on these pages.
+ * - DIRECT load of a detail URL: the route children ARE the detail page,
+ *   so LibraryLayout unmounts them entirely (oss#621) — the page renders
+ *   exactly once. Before that fix both copies mounted (one hidden +
+ *   aria-hidden), duplicating every unconditionally-rendered DOM id and
+ *   resolving label/aria-labelledby lookups into the hidden copy (#593's
+ *   symptom).
+ *
+ * - SOFT navigation from a list page: the hidden list copy stays mounted
+ *   BY DESIGN (list scroll/filter state survives under the overlay).
+ *   Hidden list + visible detail is the surviving double-mount shape, so
+ *   the id/radio audits run against it: any SDK component that hardcodes
+ *   a DOM id or radio-group `name` and renders on both surfaces would
+ *   merge the copies (useId() is the fix pattern — oss#571/#593/#619).
  */
 
 /** Ids page-wide that appear more than once (always invalid HTML). */
@@ -40,9 +41,9 @@ async function findDuplicateIds(page: Page): Promise<string[]> {
 }
 
 /**
- * Radio-group names whose inputs span BOTH the aria-hidden route copy and
- * the visible overlay copy — i.e. two component instances merged into one
- * keyboard group. (A name shared within one copy is a legitimate group.)
+ * Radio-group names whose inputs span BOTH an aria-hidden subtree and the
+ * visible page — i.e. two component instances merged into one keyboard
+ * group. (A name shared within one copy is a legitimate group.)
  */
 async function findLeakedRadioGroups(page: Page): Promise<string[]> {
   return page.evaluate(() => {
@@ -61,32 +62,11 @@ async function findLeakedRadioGroups(page: Page): Promise<string[]> {
   });
 }
 
-/**
- * Asserts the double-mount is actually armed before auditing — a passing
- * audit on a single-mounted page would prove nothing. Armed means the
- * page heading exists TWICE: once in the hidden route copy, once in the
- * visible overlay (CSS locators, unlike role locators, see through
- * aria-hidden).
- */
-async function auditDoubleMountedPage(page: Page, headingText: string) {
-  const diagnostics = await page.evaluate((text) => {
-    const headings = Array.from(document.querySelectorAll("h1, h2")).filter(
-      (h) => (h.textContent ?? "").includes(text),
-    );
-    const hiddenWrapper = document.querySelector('div.hidden[aria-hidden="true"]');
-    return {
-      headingCopies: headings.length,
-      hiddenWrapperPresent: hiddenWrapper !== null,
-      hiddenWrapperChildCount: hiddenWrapper?.childElementCount ?? 0,
-    };
-  }, headingText);
-  expect(
-    diagnostics.headingCopies,
-    `double-mount not armed: expected the detail heading in both the hidden route copy and the visible overlay (diagnostics: ${JSON.stringify(diagnostics)})`,
-  ).toBeGreaterThanOrEqual(2);
-
+async function auditIdsAndRadios(page: Page) {
   const duplicateIds = await findDuplicateIds(page);
-  expect(duplicateIds, `duplicate DOM ids: ${duplicateIds.join(", ")}`).toEqual([]);
+  expect(duplicateIds, `duplicate DOM ids: ${duplicateIds.join(", ")}`).toEqual(
+    [],
+  );
 
   const leakedGroups = await findLeakedRadioGroups(page);
   expect(
@@ -95,8 +75,36 @@ async function auditDoubleMountedPage(page: Page, headingText: string) {
   ).toEqual([]);
 }
 
+/**
+ * Pins the oss#621 single-mount contract on a directly-loaded detail URL:
+ * the route copy yields to the overlay (useRouteDetailYieldsToOverlay),
+ * so the route-children slot renders EMPTY and the detail heading exists
+ * exactly ONCE. Counted with CSS selectors — unlike role locators they
+ * see through aria-hidden, so a regression back to a hidden second copy
+ * cannot hide from this count.
+ */
+async function assertSingleMountedDetail(page: Page, headingText: string) {
+  const diagnostics = await page.evaluate((text) => {
+    const slot = document.querySelector('[data-slot="library-route-children"]');
+    return {
+      routeChildrenElementCount: slot?.childElementCount ?? 0,
+      headingCopies: Array.from(document.querySelectorAll("h1, h2")).filter(
+        (h) => (h.textContent ?? "").includes(text),
+      ).length,
+    };
+  }, headingText);
+  expect(
+    diagnostics.routeChildrenElementCount,
+    "route copy rendered content on a direct detail load — the oss#621 yield regressed",
+  ).toBe(0);
+  expect(
+    diagnostics.headingCopies,
+    `expected the detail heading exactly once (route copy yields, oss#621); got ${diagnostics.headingCopies}`,
+  ).toBe(1);
+}
+
 test.describe("Library detail pages carry no duplicate DOM ids", () => {
-  test("agent detail page (direct load arms overlay + hidden route copy)", async ({
+  test("direct load renders the agent detail exactly once — no hidden route copy", async ({
     page,
     testAgent,
   }) => {
@@ -106,14 +114,11 @@ test.describe("Library detail pages carry no duplicate DOM ids", () => {
       page.getByRole("heading", { name: testAgent.slug }).first(),
     ).toBeVisible({ timeout: 15_000 });
 
-    // CreateAgentInstanceDialog renders its form unconditionally (closed
-    // <dialog> still in the DOM), so before the useId fix this audit fails
-    // with the agent-instance name/description ids duplicated across the
-    // hidden and visible copies.
-    await auditDoubleMountedPage(page, testAgent.slug);
+    await assertSingleMountedDetail(page, testAgent.slug);
+    await auditIdsAndRadios(page);
   });
 
-  test("workflow detail page (direct load arms overlay + hidden route copy)", async ({
+  test("direct load renders the workflow detail exactly once — no hidden route copy", async ({
     page,
     testWorkflow,
   }) => {
@@ -123,8 +128,40 @@ test.describe("Library detail pages carry no duplicate DOM ids", () => {
       page.getByRole("heading", { name: testWorkflow.slug }).first(),
     ).toBeVisible({ timeout: 15_000 });
 
-    // Guards the CreateWorkflowInstanceDialog useId fix (oss#571) and any
-    // future hardcoded-id regression on this surface.
-    await auditDoubleMountedPage(page, testWorkflow.slug);
+    await assertSingleMountedDetail(page, testWorkflow.slug);
+    await auditIdsAndRadios(page);
+  });
+
+  test("soft navigation keeps the hidden list copy without id or radio leaks", async ({
+    page,
+    testAgent,
+  }) => {
+    await navigateToAgents(page);
+    await clickResourceCard(page, testAgent.slug);
+
+    await expect(
+      page.getByRole("heading", { name: testAgent.slug }).first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Arming check: the hidden list copy must actually be there — a
+    // passing audit against a single-mounted page proves nothing. The
+    // route-children slot identifies the list copy structurally (its
+    // text content is not reliable evidence: virtualized card grids may
+    // render nothing at display:none).
+    const armed = await page.evaluate(() => {
+      const slot = document.querySelector(
+        '[data-slot="library-route-children"]',
+      );
+      return {
+        slotPresent: slot !== null,
+        slotHidden: slot?.getAttribute("aria-hidden") === "true",
+      };
+    });
+    expect(
+      armed.slotPresent && armed.slotHidden,
+      `hidden list copy not armed under the overlay — the audit has no double-mount to check (${JSON.stringify(armed)})`,
+    ).toBe(true);
+
+    await auditIdsAndRadios(page);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the library-zone double-mount (#621): a cold deep-load of a detail URL rendered the entire detail page twice — once as the visible overlay, once as a hidden route copy whose data hooks all fetched for a tree nobody sees and whose document-global components (portals, focus, keyboard listeners) ran as second live instances.

## Context

The library zone bypasses Next routing for detail navigation (static-export constraint): `LibraryNavigationProvider` overlays detail pages via pushState while keeping the route children mounted-but-hidden. That keep-mounted behavior is deliberate for LIST children (scroll/filter/data state survives under the overlay) — but when the route children are themselves a detail page, they are the SAME page the overlay renders. #593 fixed the user-facing duplicate-DOM-id casualty at the SDK layer; this closes the double-mount itself.

## Changes

- `useRouteDetailYieldsToOverlay` (library-navigation): route-level detail wrappers yield rendering whenever a detail overlay is active; reasoning documented on the hook.
- All five route wrappers (`AgentDetailPage`, `SkillDetailPage`, `McpServerDetailPage`, `WorkflowDetailPage`, `ScheduleDetailPage`) adopt the yield.
- `LibraryLayout`: comment documents the two-case mount contract and the deliberate desktop divergence (plain `<Outlet />`, no overlay — react-router navigates for real); the route-children wrapper gains `data-slot="library-route-children"` as a structural test seam.
- New unit suite pins the mount contract: list children hidden-mounted (designed behavior), deep-loaded detail renders exactly once, and a full-viewport request from the overlay survives the route copy yielding (the shared last-writer-wins flag seam).
- `duplicate-dom-ids.spec.ts` reworked: its old arming assertion REQUIRED the double-mount, which this PR removes. Deep-load tests now pin single-mount (empty route slot + heading exactly once); a new soft-nav test keeps the id/radio audits armed against the surviving by-design hidden-list double-mount.

## Implementation notes

- The decision is deliberately derived from overlay state, NOT the URL. The obvious mechanism — unmount when `usePathname()` parses as a detail path — is live-disproven: Next syncs `usePathname()` to pushState URLs it never rendered, so URL introspection cannot distinguish "Next rendered a detail route" from "a detail URL was pushed over the list route", and would unmount the list copy on every soft navigation (exactly the state loss the zone exists to prevent). The e2e run caught this; the yield-to-overlay mechanism is immune by construction.
- Route wrappers mount only via `src/app/library/<type>/[org]/[slug]/page.tsx`, never the overlay — so yielding there is precise: only the duplicate copy disappears.

## Breaking changes

- None.

## Test plan

- Unit: web 38/38 (4 new in `LibraryLayout.test.tsx`); red-first proven (behavior pins fail on old code, parity pins pass on both).
- E2E against a live full stack (temporal + stigmer-server + runner + web): 3/3 green; red-first proven (all 3 fail on old code). Note: no CI lane runs the interactive project (#572) — runs were local.
- `tsc --noEmit`, `eslint` clean; `make build-web` (production static export) green.

## Risks

- Low: yield is scoped to the five route-level wrappers; list pages are structurally unaffected. Rollback is a straight revert.

Closes #621

Made with [Cursor](https://cursor.com)