### PR TITLE
test(integration): pin the is_secret MCP connect delivery path behind a fail-closed auth gate (#579)

### DIFF
--- a/test/integration/harness/mcp_http_server.go
+++ b/test/integration/harness/mcp_http_server.go
@@ -101,13 +101,10 @@ func imageTool(_ context.Context, _ *mcp.CallToolRequest, _ *imageParams) (*mcp.
 	}, nil, nil
 }
 
-// StartHTTPMcpServer starts an in-process Streamable HTTP MCP test server.
-// The server exposes the same tools as the stdio test server (echo, add, fail,
-// slow) using the official MCP Go SDK transport expected by the native
-// agent-runner (streamable_http).
-func StartHTTPMcpServer(t *testing.T) *httptest.Server {
-	t.Helper()
-
+// newStreamableMcpHandler builds the Streamable HTTP handler exposing the
+// same tools as the stdio test server (echo, add, fail, slow, image).
+// Shared by the open and auth-gated server constructors below.
+func newStreamableMcpHandler() http.Handler {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "mcp-test-server-http",
 		Version: "1.0.0",
@@ -134,10 +131,13 @@ func StartHTTPMcpServer(t *testing.T) *httptest.Server {
 		Description: "Captures the current screen and returns a status line plus a PNG screenshot as MCP image content. For testing inline image rendering of tool results.",
 	}, imageTool)
 
-	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+	return mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return server
 	}, nil)
+}
 
+func startHTTPServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
 	httpServer := httptest.NewServer(handler)
 	t.Cleanup(func() {
 		httpServer.CloseClientConnections()
@@ -145,4 +145,35 @@ func StartHTTPMcpServer(t *testing.T) *httptest.Server {
 	})
 	t.Logf("HTTP MCP test server (streamable) started at %s", httpServer.URL)
 	return httpServer
+}
+
+// StartHTTPMcpServer starts an in-process Streamable HTTP MCP test server.
+// The server exposes the same tools as the stdio test server (echo, add, fail,
+// slow) using the official MCP Go SDK transport expected by the native
+// agent-runner (streamable_http).
+func StartHTTPMcpServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return startHTTPServer(t, newStreamableMcpHandler())
+}
+
+// StartHTTPMcpServerRequiringAuth is StartHTTPMcpServer behind an
+// Authorization gate: every request must carry exactly
+// expectedAuthorization or is refused with 401 before reaching the MCP
+// handler. Fail-closed by construction — discovery against this server can
+// only succeed when the resolved header actually delivered the credential,
+// which is what makes it the pin for the is_secret delivery path
+// (issue #579): a redacted or placeholder-literal value never discovers.
+func StartHTTPMcpServerRequiringAuth(t *testing.T, expectedAuthorization string) *httptest.Server {
+	t.Helper()
+
+	inner := newStreamableMcpHandler()
+	gated := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != expectedAuthorization {
+			t.Logf("HTTP MCP auth gate: refusing request with Authorization=%q", r.Header.Get("Authorization"))
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	})
+	return startHTTPServer(t, gated)
 }

--- a/test/integration/mcp_seedpack_connect_test.go
+++ b/test/integration/mcp_seedpack_connect_test.go
@@ -129,6 +129,62 @@ func TestMcpConnect_PlaceholderResolution_HttpHeaders(t *testing.T) {
 	assert.NotEmpty(t, tools, "tools should be discovered after placeholder resolution")
 }
 
+// TestMcpConnect_SecretDelivery_HttpHeaders pins the is_secret delivery path
+// end to end (issue #579): an IsSecret runtime_env value is encrypted at
+// write into the connect ExecutionContext (#405), the server mints the
+// execution-scoped decrypt token onto the connect work item (#535), and the
+// discovery runner presents it to read the plaintext back. The vendor server
+// refuses anything but the exact secret, so this can only pass when
+// decryption delivered the real value — a redacted or placeholder-literal
+// header 401s and discovery fails. After #565 the canaries deliberately do
+// NOT set is_secret, which made this the only automated coverage of the
+// secret discovery path anywhere.
+func TestMcpConnect_SecretDelivery_HttpHeaders(t *testing.T) {
+	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+	harness.RequireNativePrereqs(t, testHarness)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	clients := harness.NewClients(grpcConn)
+
+	const secret = "test-secret-token-9f8e7d"
+	httpServer := harness.StartHTTPMcpServerRequiringAuth(t, "Bearer "+secret)
+
+	name := "secret-delivery-" + uuid.New().String()[:8]
+	server := applyMcpServer(t, ctx, clients, &mcpserverv1.McpServer{
+		ApiVersion: mcpConnectTestAPIVersion,
+		Kind:       "McpServer",
+		Metadata:   &apiresource.ApiResourceMetadata{Name: name, Org: mcpConnectTestOrg},
+		Spec: &mcpserverv1.McpServerSpec{
+			Description: "Secret credential delivery test (HTTP headers)",
+			ServerType: &mcpserverv1.McpServerSpec_Http{
+				Http: &mcpserverv1.HttpServerConfig{
+					Url: httpServer.URL,
+					Headers: map[string]string{
+						"Authorization": "Bearer ${TOKEN}",
+					},
+				},
+			},
+			Env: map[string]*environmentv1.EnvVarDeclaration{
+				"TOKEN": {Description: "API token for auth (secret)"},
+			},
+		},
+	})
+
+	result, err := clients.McpServerCommand.Connect(ctx, &mcpserverv1.ConnectInput{
+		McpServerId: server.GetMetadata().GetId(),
+		Org:         mcpConnectTestOrg,
+		RuntimeEnv: map[string]*executionctxv1.ExecutionValue{
+			"TOKEN": {Value: secret, IsSecret: true},
+		},
+	})
+
+	require.NoError(t, err, "connect with an is_secret TOKEN must succeed — redacted delivery 401s at the vendor")
+	tools := result.GetStatus().GetDiscoveredCapabilities().GetTools()
+	assert.NotEmpty(t, tools, "tools should be discovered through the auth gate")
+}
+
 // TestMcpConnect_PlaceholderResolution_StdioArgs verifies that ${VAR}
 // placeholders in stdio args are resolved from runtime_env before the
 // subprocess is spawned.


### PR DESCRIPTION
## Summary

After #565 the canaries deliberately do not set `is_secret`, which left the secret MCP discovery path with **zero automated coverage anywhere** — the gap [issue #579](https://github.com/stigmer/stigmer/issues/579) flagged alongside the delivery bug itself. This adds the pin: `TestMcpConnect_SecretDelivery_HttpHeaders`, the `TestMcpConnect_PlaceholderResolution_HttpHeaders` template with `IsSecret: true`, discovering against a new harness server (`StartHTTPMcpServerRequiringAuth`) that 401s anything but the exact secret. Fail-closed by construction: a redacted or placeholder-literal header can never discover, so the test passes only when encrypt-at-write (#405) → scoped-token mint → runner decrypt actually delivered the credential.

Closes #579 (the coverage half; the delivery fix is [stigmer-cloud#439](https://github.com/stigmer/stigmer-cloud/pull/439))

## Deliberately red until stigmer-cloud#439 lands

The suite boots the stigmer-service JAR with the noop sandbox provisioner and a plain runner queue — **exactly the topology #579 reported broken**. Verified locally at the discovery layer, both directions:

- **JAR from current cloud main (red)**: the runner fails with the incident's verbatim error — `CredentialResolutionError: … delivered redacted (TOKEN): the platform refused to decrypt them for this runner` — and the service log shows no decrypt.
- **JAR built from stigmer-cloud#439 (green)**: service logs `Decrypted 1 secret value(s)` for the connect execution; runner logs `Resolved 1 env var(s)` and completes discovery with 5 tools **through the 401 gate**.

## Gating and lanes

Provider-gated identically to its template sibling (`RequireNativePrereqs`: unified runner + `ANTHROPIC_API_KEY`, since the connect workflow's classify phase calls the LLM) — it runs where the sibling runs and skips where it skips. Local full-test verdicts for BOTH tests currently hang in the classify phase against the harness's mock LLM proxy (pre-existing, sibling-equal, unrelated to this change); the discovery-layer log evidence above is the red/green proof.

The harness change extracts the streamable-handler construction so the open and auth-gated servers share one tool surface; `go vet` and `go build` clean.

Made with [Cursor](https://cursor.com)