### PR TITLE
fix(sdk): raise Go/Python/Java client receive caps to the server's 10MB limit

### DIFF
--- a/sdk/go/internal/transport/grpc.go
+++ b/sdk/go/internal/transport/grpc.go
@@ -19,6 +19,14 @@ type Config struct {
 	DialOptions     []grpc.DialOption
 }
 
+// maxRecvMsgSize raises the client's receive cap to the server's own 10MB
+// message limit (stigmer#702). grpc-go's default is 4MB — an invisible
+// library default BELOW the platform's documented behavior, so responses
+// the server would happily serve (e.g. a 4–10MB skill.getArtifact) died
+// client-side with "received message larger than max". The server stays
+// the single limiting authority; callers can still override via DialOptions.
+const maxRecvMsgSize = 10 * 1024 * 1024
+
 // Dial creates a gRPC client connection using the given config.
 // The returned connection is lazily established (non-blocking by default).
 // Use [grpc.ClientConn.Connect] followed by state checks to eagerly verify
@@ -28,7 +36,9 @@ func Dial(cfg Config) (*grpc.ClientConn, error) {
 		return nil, fmt.Errorf("stigmer: target URL is required")
 	}
 
-	opts := make([]grpc.DialOption, 0, len(cfg.DialOptions)+4)
+	opts := make([]grpc.DialOption, 0, len(cfg.DialOptions)+5)
+
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxRecvMsgSize)))
 
 	if cfg.Insecure {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/sdk/go/internal/transport/grpc_test.go
+++ b/sdk/go/internal/transport/grpc_test.go
@@ -1,0 +1,63 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+
+	skillv1 "github.com/stigmer/stigmer/sdk/go/v3/proto/ai/stigmer/agentic/skill/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// oversizedArtifactServer serves a getArtifact response above grpc-go's 4MB
+// default receive cap but below the server's 10MB limit — the exact response
+// class stigmer#702 reported dying client-side.
+type oversizedArtifactServer struct {
+	skillv1.UnimplementedSkillQueryControllerServer
+	artifact []byte
+}
+
+func (s *oversizedArtifactServer) GetArtifact(ctx context.Context, req *skillv1.GetArtifactRequest) (*skillv1.GetArtifactResponse, error) {
+	return &skillv1.GetArtifactResponse{Artifact: s.artifact}, nil
+}
+
+// TestDial_ReceivesResponsesAboveGrpcDefaultCap pins the raised receive cap
+// (stigmer#702): a 5MB response — which the server would always serve, and
+// which grpc-go's invisible 4MB default refused with "received message
+// larger than max" — must arrive intact through Dial's connection.
+func TestDial_ReceivesResponsesAboveGrpcDefaultCap(t *testing.T) {
+	artifact := bytes.Repeat([]byte{0xAB}, 5*1024*1024)
+
+	lis := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	skillv1.RegisterSkillQueryControllerServer(server, &oversizedArtifactServer{artifact: artifact})
+	go func() { _ = server.Serve(lis) }()
+	defer server.Stop()
+
+	conn, err := Dial(Config{
+		Target:   "passthrough:///bufnet",
+		Insecure: true,
+		DialOptions: []grpc.DialOption{
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	resp, err := skillv1.NewSkillQueryControllerClient(conn).GetArtifact(
+		context.Background(),
+		&skillv1.GetArtifactRequest{ArtifactStorageKey: "skills/org/skill/hash.zip"},
+	)
+	if err != nil {
+		t.Fatalf("GetArtifact over 4MB must succeed through the SDK channel (stigmer#702): %v", err)
+	}
+	if !bytes.Equal(resp.GetArtifact(), artifact) {
+		t.Fatalf("artifact bytes corrupted in transit: got %d bytes, want %d", len(resp.GetArtifact()), len(artifact))
+	}
+}

--- a/sdk/java/src/main/java/ai/stigmer/sdk/internal/transport/StigmerChannel.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/internal/transport/StigmerChannel.java
@@ -15,6 +15,16 @@ import java.util.Objects;
  */
 public final class StigmerChannel {
 
+    /**
+     * Client receive cap, raised to the server's own 10MB message limit
+     * (stigmer#702). grpc-java's default is 4MB — an invisible library
+     * default BELOW the platform's documented behavior, so responses the
+     * server would happily serve (e.g. a 4–10MB skill getArtifact) died
+     * client-side with "gRPC message exceeds maximum size". The server
+     * stays the single limiting authority.
+     */
+    static final int MAX_INBOUND_MESSAGE_SIZE = 10 * 1024 * 1024;
+
     private StigmerChannel() {}
 
     /** Creates a {@link ManagedChannel} from the given configuration. */
@@ -29,6 +39,7 @@ public final class StigmerChannel {
             builder = NettyChannelBuilder.forTarget(config.target).useTransportSecurity();
         }
 
+        builder.maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
         builder.intercept(new ApiKeyInterceptor(config.apiKey));
 
         return builder.build();

--- a/sdk/java/src/test/java/ai/stigmer/sdk/internal/transport/StigmerChannelTest.java
+++ b/sdk/java/src/test/java/ai/stigmer/sdk/internal/transport/StigmerChannelTest.java
@@ -1,0 +1,80 @@
+package ai.stigmer.sdk.internal.transport;
+
+import ai.stigmer.agentic.skill.v1.GetArtifactRequest;
+import ai.stigmer.agentic.skill.v1.GetArtifactResponse;
+import ai.stigmer.agentic.skill.v1.SkillQueryControllerGrpc;
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Transport pins: the channel factory must receive responses above
+ * grpc-java's 4MB default (stigmer#702 — the server's limit is 10MB, and an
+ * invisible client-side library default below it refused responses the
+ * server would happily serve with "gRPC message exceeds maximum size").
+ */
+@DisplayName("StigmerChannel")
+class StigmerChannelTest {
+
+    private static final int FIVE_MB = 5 * 1024 * 1024;
+
+    private Server server;
+    private ManagedChannel channel;
+
+    /** Serves a getArtifact response above the 4MB grpc-java default. */
+    private static final class OversizedArtifactService
+            extends SkillQueryControllerGrpc.SkillQueryControllerImplBase {
+        @Override
+        public void getArtifact(GetArtifactRequest request,
+                                StreamObserver<GetArtifactResponse> responseObserver) {
+            byte[] artifact = new byte[FIVE_MB];
+            responseObserver.onNext(GetArtifactResponse.newBuilder()
+                    .setArtifact(ByteString.copyFrom(artifact))
+                    .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = NettyServerBuilder.forPort(0)
+                .addService(new OversizedArtifactService())
+                .build()
+                .start();
+    }
+
+    @AfterEach
+    void stop() throws Exception {
+        if (channel != null) {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        server.shutdownNow();
+        server.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @DisplayName("receives responses above grpc-java's 4MB default cap (stigmer#702)")
+    void receivesResponsesAboveGrpcDefaultCap() {
+        channel = StigmerChannel.create(new StigmerChannel.Config(
+                "localhost:" + server.getPort(), "test-api-key", true));
+
+        GetArtifactResponse response = SkillQueryControllerGrpc.newBlockingStub(channel)
+                .getArtifact(GetArtifactRequest.newBuilder()
+                        .setArtifactStorageKey("skills/org/skill/hash.zip")
+                        .build());
+
+        assertEquals(FIVE_MB, response.getArtifact().size(),
+                "a 5MB artifact must arrive intact through the SDK channel");
+    }
+}

--- a/sdk/python/src/stigmer/_transport.py
+++ b/sdk/python/src/stigmer/_transport.py
@@ -8,6 +8,18 @@ from ._interceptors import AuthInterceptor
 
 DEFAULT_TARGET = "api.stigmer.ai:443"
 
+# Raise the client's receive cap to the server's own 10MB message limit
+# (stigmer#702). grpc's default is 4MB — an invisible library default BELOW
+# the platform's documented behavior, so responses the server would happily
+# serve (e.g. a 4-10MB skill get_artifact) died client-side with
+# "received message larger than max". The server stays the single limiting
+# authority.
+_MAX_RECV_MSG_SIZE = 10 * 1024 * 1024
+
+_CHANNEL_OPTIONS = [
+    ("grpc.max_receive_message_length", _MAX_RECV_MSG_SIZE),
+]
+
 
 def create_channel(
     target: str,
@@ -26,8 +38,10 @@ def create_channel(
         A ``grpc.Channel`` ready for use by resource clients.
     """
     if insecure:
-        channel = grpc.insecure_channel(target)
+        channel = grpc.insecure_channel(target, options=_CHANNEL_OPTIONS)
     else:
-        channel = grpc.secure_channel(target, grpc.ssl_channel_credentials())
+        channel = grpc.secure_channel(
+            target, grpc.ssl_channel_credentials(), options=_CHANNEL_OPTIONS
+        )
 
     return grpc.intercept_channel(channel, AuthInterceptor(api_key))

--- a/sdk/python/tests/test_transport.py
+++ b/sdk/python/tests/test_transport.py
@@ -1,0 +1,60 @@
+"""Transport pins: the channel factory must receive responses above grpc's
+4MB default (stigmer#702 — the server's limit is 10MB, and an invisible
+client-side library default below it refused responses the server would
+happily serve)."""
+
+from __future__ import annotations
+
+from concurrent import futures
+
+import grpc
+import pytest
+
+from ai.stigmer.agentic.skill.v1 import io_pb2, query_pb2_grpc
+
+from stigmer._transport import create_channel
+
+_FIVE_MB = 5 * 1024 * 1024
+
+
+class _OversizedArtifactServicer(query_pb2_grpc.SkillQueryControllerServicer):
+    """Serves a getArtifact response above the 4MB grpc default."""
+
+    def getArtifact(self, request, context):  # noqa: N802 - proto rpc name
+        return io_pb2.GetArtifactResponse(artifact=b"\xab" * _FIVE_MB)
+
+
+@pytest.fixture()
+def oversized_artifact_server():
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=1),
+        # The server must be allowed to SEND the oversized response; the
+        # subject under test is the client's receive cap.
+        options=[("grpc.max_send_message_length", 10 * 1024 * 1024)],
+    )
+    query_pb2_grpc.add_SkillQueryControllerServicer_to_server(
+        _OversizedArtifactServicer(), server
+    )
+    port = server.add_insecure_port("localhost:0")
+    server.start()
+    yield port
+    server.stop(grace=None)
+
+
+def test_receives_responses_above_grpc_default_cap(oversized_artifact_server):
+    """A 5MB artifact response must arrive intact through create_channel
+    (fails with RESOURCE_EXHAUSTED "received message larger than max"
+    without the raised cap)."""
+    channel = create_channel(
+        f"localhost:{oversized_artifact_server}", "test-api-key", insecure=True
+    )
+    try:
+        stub = query_pb2_grpc.SkillQueryControllerStub(channel)
+        response = stub.getArtifact(
+            io_pb2.GetArtifactRequest(
+                artifact_storage_key="skills/org/skill/hash.zip"
+            )
+        )
+        assert len(response.artifact) == _FIVE_MB
+    finally:
+        channel.close()


### PR DESCRIPTION
## Summary

- None of the three gRPC-channel SDKs set a client-side receive limit, so grpc's invisible 4MB default applied to responses — below the server's own 10MB cap. A 4–10MB `skill.getArtifact` died client-side with "received message larger than max" while the server would happily serve it (found by #675's transport audit; Connect-based clients — CLI, TS SDK, runner — were never affected)
- Each transport now pins 10MB, keeping the server the single limiting authority: `MaxCallRecvMsgSize` default call option in `sdk/go/internal/transport/grpc.go` (appended before `cfg.DialOptions`, so the escape hatch still overrides), `grpc.max_receive_message_length` channel option in `sdk/python/src/stigmer/_transport.py`, `maxInboundMessageSize` on both builder paths in `sdk/java/.../StigmerChannel.java`
- Owner ruling (bundle 31 plan review): BOTH arms — this cap raise (defense-in-depth for every unary response) AND the #701 URL-lane adoption; they solve different layers

## Verification — red-first in all three SDKs

Each SDK gets a real wire pin, zero new dependencies: a local gRPC server serves a 5MB `getArtifact` response through the SDK's own channel factory.

- Go (`bufconn` via the `DialOptions` seam): fails without the fix with `received message larger than max (5242885 vs. 4194304)`, green with it; `go test ./internal/transport` green
- Java (netty server on `localhost:0` through `StigmerChannel.create`): fails without the fix with `RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 5242885`; full suite 55/55 green
- Python (grpcio server through `create_channel`): fails without the fix; full suite 26/26 green

Note: `go test ./...` at the sdk/go root is broken on main by the unrelated #717 (fix: #718) — this branch's transport package tests run green independently; will rebase once #718 merges.

Closes #702.

Made with [Cursor](https://cursor.com)