### PR TITLE
fix(sdk/react): components no longer assume a host CSS reset — per-element UA resets + lint fence

### DIFF
--- a/docs/sdk/react/core.mdx
+++ b/docs/sdk/react/core.mdx
@@ -243,6 +243,18 @@ against flexed sizes under flex-item parents (a `flex-1` content
 column makes it balloon even in a content-sized page), so only
 the host — which knows its layout — can apply it safely.
 
+**Hosts without a global CSS reset.** SDK components carry their
+own per-element resets (lists, fieldsets, form controls) and the
+markdown surfaces declare their margins explicitly, so they render
+correctly with no Tailwind-preflight-style reset in the host page
+(#695). Two deliberate boundaries remain the host's: font-family
+inherits from the host (an embedded widget adopting host typography
+is correct — set `--stgm-font-sans` to override), and the host's
+OWN content inside the provider keeps its user-agent styling — the
+SDK never resets elements it did not render. If your reset-less
+page composes its own `<p>`/`<h*>` content between SDK components,
+their user-agent margins are yours to manage.
+
 Two stable selector hooks are part of the public contract:
 `data-stgm-root` marks the in-tree container (and only it);
 `data-stgm-portal` marks the portal container appended to

--- a/sdk/react/eslint.config.mjs
+++ b/sdk/react/eslint.config.mjs
@@ -23,15 +23,22 @@ export default defineConfig([
       "stigmer/no-literal-dom-ids": "error",
       "stigmer/no-token-opacity-modifiers": "warn",
       "stigmer/no-main-tokens-in-sidebar": "warn",
+      // Error (not warn): the #695 sweep left zero violations — every UI
+      // list carries UNSTYLED_LIST and every content list declares its
+      // list-* style, so this fence too starts at zero.
+      "stigmer/require-list-reset": "error",
     },
   },
   {
     // Tests mount components once and control their own DOM — literal ids
     // there are not a collision class, so the fence stays out of them.
+    // Bare lists are likewise legitimate fixtures there (the #695 layout
+    // suite renders unreset elements on purpose to assert UA behavior).
     files: ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
     plugins: { stigmer: stigmerPlugin },
     rules: {
       "stigmer/no-literal-dom-ids": "off",
+      "stigmer/require-list-reset": "off",
     },
   },
 ]);

--- a/sdk/react/src/__tests__/bare-host-resets.layout.test.tsx
+++ b/sdk/react/src/__tests__/bare-host-resets.layout.test.tsx
@@ -1,0 +1,184 @@
+// Bare-host regression suite for the per-element UA resets (#695).
+//
+// Runs in a real Chromium via `vitest.a11y.config.ts` — the defect under
+// guard is the user agent's OWN default list/fieldset/flow-content styling
+// (bullets, 40px indents, stacked margins), which only a real browser
+// applies. happy-dom has no UA stylesheet, so it would pass vacuously.
+//
+// The contract: every SDK component is authored against a zeroed-margin
+// baseline (our consoles ship a global reset). In a host WITHOUT one —
+// third-party embeds, the SDK's stated audience — UI lists and fieldsets
+// carry the `UNSTYLED_LIST`/`UNSTYLED_FIELDSET` per-component resets
+// (`internal/element-resets.ts` records why this class of reset cannot live
+// in styles.css), and the markdown map declares its own top/inline margins.
+// Like the sibling #374 suite (preflight-parity.layout.test.tsx), this
+// renders against the SHIPPED stylesheet (`dist/styles.css`, rebuilt by
+// `npm run build:css`) and nothing else — the page IS the bare host.
+//
+// Three directions, all load-bearing:
+// 1. A control proving the harness is genuinely bare (a raw <ul> DOES show
+//    UA bullets — if this fails, every other assertion here is vacuous).
+// 2. The resets neutralize UA defaults on real, swept components.
+// 3. Utilities and deliberate styling still win (markdown lists keep their
+//    explicit bullets; spacing utilities compose on top of the reset).
+
+import "../../dist/styles.css";
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import Markdown from "react-markdown";
+import type { Stigmer } from "@stigmer/sdk";
+import { TodoItemSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/todo_pb";
+import { TodoStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { StigmerProvider } from "../provider";
+import { TodoList } from "../execution/TodoList.js";
+import { UNSTYLED_FIELDSET, UNSTYLED_LIST } from "../internal/element-resets.js";
+import { MARKDOWN_COMPONENTS } from "../internal/markdown-components.js";
+
+afterEach(cleanup);
+
+// A minimal client (the preflight-parity suite's idiom): a null credential
+// keeps the provider's registry fetches non-blocking so rendering is
+// synchronous and never touches the network.
+function makeClient(): Stigmer {
+  return {
+    baseUrl: "https://example.test",
+    getAuthCredential: async () => null,
+    fetch: (async () => {
+      throw new Error("network disabled in test");
+    }) as unknown as typeof globalThis.fetch,
+  } as unknown as Stigmer;
+}
+
+function renderScoped(ui: React.ReactNode): HTMLElement {
+  render(
+    <StigmerProvider client={makeClient()}>
+      <div data-testid="probe">{ui}</div>
+    </StigmerProvider>,
+  );
+  return document.querySelector('[data-testid="probe"]') as HTMLElement;
+}
+
+function computed(el: Element): CSSStyleDeclaration {
+  return getComputedStyle(el);
+}
+
+const ZERO_MARGINS = ["0px", "0px", "0px", "0px"];
+
+function margins(style: CSSStyleDeclaration): string[] {
+  return [style.marginTop, style.marginRight, style.marginBottom, style.marginLeft];
+}
+
+describe("bare-host per-element resets (#695)", () => {
+  it("CONTROL: the harness is genuinely bare — a raw <ul> wears UA bullets and indent", () => {
+    const probe = renderScoped(
+      <ul>
+        <li>raw</li>
+      </ul>,
+    );
+    const style = computed(probe.querySelector("ul")!);
+
+    expect(style.listStyleType, "no global reset may leak into this page").toBe("disc");
+    expect(style.paddingLeft, "UA padding-inline-start must be present").toBe("40px");
+  });
+
+  describe("UNSTYLED_LIST", () => {
+    it("neutralizes bullets, indent, and margins", () => {
+      const probe = renderScoped(
+        <ul className={UNSTYLED_LIST}>
+          <li>item</li>
+        </ul>,
+      );
+      const style = computed(probe.querySelector("ul")!);
+
+      expect(style.listStyleType).toBe("none");
+      expect(style.paddingLeft).toBe("0px");
+      expect(margins(style)).toEqual(ZERO_MARGINS);
+    });
+
+    it("spacing utilities still win over the reset (tailwind-merge + layer order)", () => {
+      const probe = renderScoped(
+        <ul className={`${UNSTYLED_LIST} stg:p-2`}>
+          <li>item</li>
+        </ul>,
+      );
+
+      expect(computed(probe.querySelector("ul")!).paddingLeft).toBe("8px");
+    });
+
+    it("a real swept organism (TodoList) renders without UA list styling", () => {
+      const probe = renderScoped(
+        <TodoList
+          todos={{
+            t1: create(TodoItemSchema, {
+              id: "t1",
+              content: "Scaffold the component",
+              status: TodoStatus.TODO_IN_PROGRESS,
+            }),
+          }}
+        />,
+      );
+      const style = computed(probe.querySelector('ul[aria-label="Tasks"]')!);
+
+      expect(style.listStyleType).toBe("none");
+      expect(style.paddingLeft).toBe("0px");
+      expect(margins(style)).toEqual(ZERO_MARGINS);
+    });
+  });
+
+  describe("UNSTYLED_FIELDSET", () => {
+    it("neutralizes UA fieldset margins, padding, and min-inline-size", () => {
+      const probe = renderScoped(
+        <>
+          <fieldset data-testid="raw">
+            <legend>raw</legend>
+          </fieldset>
+          <fieldset data-testid="reset" className={UNSTYLED_FIELDSET}>
+            <legend>reset</legend>
+          </fieldset>
+        </>,
+      );
+
+      // Control half: UA fieldset padding really is present in this page.
+      expect(computed(probe.querySelector('[data-testid="raw"]')!).paddingLeft).not.toBe("0px");
+
+      const style = computed(probe.querySelector('[data-testid="reset"]')!);
+      expect(margins(style)).toEqual(ZERO_MARGINS);
+      expect(style.paddingLeft).toBe("0px");
+      expect(style.minWidth, "min-inline-size: min-content breaks flex shrinking").toBe("0px");
+    });
+  });
+
+  describe("markdown map (content elements declare their own margins)", () => {
+    function renderMarkdown(md: string): HTMLElement {
+      return renderScoped(<Markdown components={MARKDOWN_COMPONENTS}>{md}</Markdown>);
+    }
+
+    it("paragraphs carry no UA top margin, so mb-* spacing is the whole rhythm", () => {
+      const probe = renderMarkdown("first\n\nsecond");
+      const [, second] = Array.from(probe.querySelectorAll("p"));
+
+      expect(computed(second).marginTop).toBe("0px");
+    });
+
+    it("blockquotes lose the UA 1em/40px box but keep the authored border+padding treatment", () => {
+      const probe = renderMarkdown("> quoted");
+      const style = computed(probe.querySelector("blockquote")!);
+
+      expect(style.marginTop).toBe("0px");
+      expect(style.marginLeft, "UA margin-inline: 40px must be cleared").toBe("0px");
+      expect(style.marginRight).toBe("0px");
+      expect(style.paddingLeft, "the authored pl-4 treatment stays").toBe("16px");
+    });
+
+    it("content lists KEEP their bullets — the reset is for UI lists only", () => {
+      const probe = renderMarkdown("- one\n- two");
+      const style = computed(probe.querySelector("ul")!);
+
+      expect(style.listStyleType).toBe("disc");
+      expect(style.marginTop, "stacked UA margin-top must be cleared").toBe("0px");
+      expect(style.paddingLeft, "authored pl-5 replaces the UA 40px").toBe("20px");
+    });
+  });
+});

--- a/sdk/react/src/agent-instance/AgentInstanceDetailPanel.tsx
+++ b/sdk/react/src/agent-instance/AgentInstanceDetailPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
@@ -233,7 +234,7 @@ export function AgentInstanceDetailPanel({
               {(spec?.environmentRefs?.length ?? 0) === 0 ? (
                 <p className="stg:text-xs stg:text-muted-foreground">No environments bound.</p>
               ) : (
-                <ol className="stg:space-y-1">
+                <ol className={cn(UNSTYLED_LIST, "stg:space-y-1")}>
                   {spec!.environmentRefs.map((ref, idx) => (
                     <li key={`${ref.slug}-${idx}`} className="stg:flex stg:items-center stg:gap-2 stg:text-sm">
                       <span className="stg:text-xs stg:text-muted-foreground stg:w-4 stg:text-right">{idx + 1}.</span>

--- a/sdk/react/src/agent/steps/IdentityStep.tsx
+++ b/sdk/react/src/agent/steps/IdentityStep.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../../internal/element-resets.js";
 import { generateSlug } from "../../internal/slug.js";
 import type { AgentWizardData } from "./types.js";
 
@@ -173,7 +174,7 @@ export function IdentityStep({
           />
         </div>
 
-        <fieldset className="stg:space-y-1.5">
+        <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-1.5")}>
           <legend className="stg:text-sm stg:font-medium stg:text-foreground">
             Visibility
           </legend>

--- a/sdk/react/src/api-key/CreateApiKeyForm.tsx
+++ b/sdk/react/src/api-key/CreateApiKeyForm.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ApiKey } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/api_pb";
 import { useCreateApiKey } from "./useCreateApiKey.js";
@@ -122,7 +123,7 @@ export function CreateApiKeyForm({
         </div>
 
         {/* Expiry */}
-        <fieldset className="stg:space-y-1.5">
+        <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-1.5")}>
           <legend className="stg:text-xs stg:font-medium stg:text-foreground">
             Expiration
           </legend>

--- a/sdk/react/src/channel-app/CreateChannelAppForm.tsx
+++ b/sdk/react/src/channel-app/CreateChannelAppForm.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, useCallback, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
 import {
@@ -286,7 +287,7 @@ function ProviderPicker({
 }) {
   const groupName = useId();
   return (
-    <fieldset>
+    <fieldset className={UNSTYLED_FIELDSET}>
       <legend className="stg:mb-1.5 stg:block stg:text-xs stg:font-medium stg:text-foreground">
         Provider
       </legend>

--- a/sdk/react/src/channel/ChannelConversationsDialog.tsx
+++ b/sdk/react/src/channel/ChannelConversationsDialog.tsx
@@ -5,6 +5,7 @@ import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { MessageSquare, User, X } from "lucide-react";
 import { cn } from "@stigmer/theme";
 import { DialogShell } from "../internal/DialogShell.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
@@ -153,7 +154,7 @@ function ChannelConversationsDialogBody({
             description="When someone messages this channel, the sessions serving them appear here."
           />
         ) : (
-          <ul className="stg:space-y-1">
+          <ul className={cn(UNSTYLED_LIST, "stg:space-y-1")}>
             {sessions.map((session) => (
               <ConversationRow
                 key={session.metadata?.id}

--- a/sdk/react/src/channel/ChannelTemplatesDialog.tsx
+++ b/sdk/react/src/channel/ChannelTemplatesDialog.tsx
@@ -4,6 +4,7 @@ import { useCallback, useId, type ReactNode } from "react";
 import { ExternalLink, LayoutTemplate, X } from "lucide-react";
 import { cn } from "@stigmer/theme";
 import { DialogShell } from "../internal/DialogShell.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import type { ChannelTemplate } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
@@ -297,7 +298,7 @@ function ChannelTemplatesList({
         </p>
         <WhatsAppManagerLink label="Manage in WhatsApp Manager" />
       </div>
-      <ul className="stg:space-y-2">
+      <ul className={cn(UNSTYLED_LIST, "stg:space-y-2")}>
         {templates.map((template) => (
           <TemplateRow
             key={`${template.name}\u0000${template.language}`}

--- a/sdk/react/src/channel/ConnectSlackDialog.tsx
+++ b/sdk/react/src/channel/ConnectSlackDialog.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
 import { DialogShell } from "../internal/DialogShell.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getErrorReason, type ResourceRef } from "@stigmer/sdk";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
@@ -527,7 +528,7 @@ function FlowProgress({
 
   return (
     <div className="stg:space-y-3" aria-live="polite">
-      <ul className="stg:space-y-2">
+      <ul className={cn(UNSTYLED_LIST, "stg:space-y-2")}>
         {FLOW_STEPS.map((step, i) => {
           const isActive = i === activeIndex;
           const isDone = activeIndex > i;

--- a/sdk/react/src/channel/connect/ServingAppSection.tsx
+++ b/sdk/react/src/channel/connect/ServingAppSection.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../../internal/element-resets.js";
 import type { ResourceRef } from "@stigmer/sdk";
 import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
 
@@ -67,7 +68,7 @@ export function ServingAppSection({
   }
 
   return (
-    <fieldset>
+    <fieldset className={UNSTYLED_FIELDSET}>
       <legend className="stg:mb-1.5 stg:block stg:text-xs stg:font-medium stg:text-foreground">
         Connect as
       </legend>

--- a/sdk/react/src/conversation/ConversationListPane.tsx
+++ b/sdk/react/src/conversation/ConversationListPane.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useId, useRef } from "react";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { MessageSquare, TriangleAlert, User } from "lucide-react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import {
@@ -193,11 +194,7 @@ export function ConversationListPane({
             {/* One context-only provider arms every row's attention
                 tooltip (the WorkspaceSidebar recents-list precedent). */}
             <TooltipProvider>
-              {/* The SDK's own list reset (the MemberKeysPanel
-                  convention): hosts without a global preflight would
-                  otherwise render inbox rows with UA bullets and
-                  indent. */}
-              <ul className="stg:m-0 stg:list-none stg:space-y-0.5 stg:p-0">
+              <ul className={cn(UNSTYLED_LIST, "stg:space-y-0.5")}>
                 {conversations.map((conversation) => (
                   <ConversationRow
                     key={`${conversation.agentChannelId}:${conversation.conversationKey}`}

--- a/sdk/react/src/conversation/ConversationTimelineView.tsx
+++ b/sdk/react/src/conversation/ConversationTimelineView.tsx
@@ -4,6 +4,7 @@ import { memo, useMemo } from "react";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { Ban, Check, CheckCheck, Clock, Info, MessageSquare, TriangleAlert } from "lucide-react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { ConversationTimelineItem } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
 import { channelProviderOf, type ChannelProviderId } from "../channel/providers.js";
@@ -165,7 +166,7 @@ export function ConversationTimelineView({
                   >
                     {day.label}
                   </div>
-                  <ul className="stg:space-y-1.5">
+                  <ul className={cn(UNSTYLED_LIST, "stg:space-y-1.5")}>
                     {day.items.map((item) => (
                       <TimelineItemRow
                         key={item.itemId}

--- a/sdk/react/src/cursor-accounts/CursorAccountsConsole.tsx
+++ b/sdk/react/src/cursor-accounts/CursorAccountsConsole.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage, isPermissionDenied } from "@stigmer/sdk";
 import type { CursorAccount } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/cursor_account_pb";
 import type { CursorAccountSummary } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/io_pb";
@@ -145,7 +146,7 @@ export function CursorAccountsConsole({ className }: CursorAccountsConsoleProps)
             add member execution keys to make it routable.
           </p>
         ) : (
-          <ul role="list" aria-label="Cursor accounts" className="stg:m-0 stg:list-none stg:p-0">
+          <ul role="list" aria-label="Cursor accounts" className={UNSTYLED_LIST}>
             {accounts.map((summary) => (
               <AccountRow
                 key={summary.account?.accountId}

--- a/sdk/react/src/cursor-accounts/MemberKeysPanel.tsx
+++ b/sdk/react/src/cursor-accounts/MemberKeysPanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@stigmer/theme";
 import { getUserMessage } from "@stigmer/sdk";
 import type { CursorAccountView } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/io_pb";
 import { Button } from "../button/index.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { INPUT_CLASSES } from "../internal/form-primitives.js";
 import { toError } from "../internal/toError.js";
 import type { CursorAccountCoverage } from "./cursor-account-coverage.js";
@@ -259,7 +260,7 @@ export function MemberKeysPanel({
             <ul
               role="list"
               aria-label="Import results"
-              className="stg:m-0 stg:list-none stg:space-y-0.5 stg:p-0 stg:text-[11px]"
+              className={cn(UNSTYLED_LIST, "stg:space-y-0.5 stg:text-[11px]")}
             >
               {importResults.map((result) => (
                 <li

--- a/sdk/react/src/dashboard/DashboardFailedRuns.tsx
+++ b/sdk/react/src/dashboard/DashboardFailedRuns.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import type { DashboardFailedRun } from "./types.js";
 import { formatRelativeTime } from "../activity/format-relative-time.js";
 
@@ -54,7 +55,7 @@ export const DashboardFailedRuns = memo(function DashboardFailedRuns({
           No recent failures
         </p>
       ) : (
-        <ul className="stg:space-y-1.5" role="list">
+        <ul className={cn(UNSTYLED_LIST, "stg:space-y-1.5")} role="list">
           {failedRuns.map((run) => (
             <li
               key={run.id}

--- a/sdk/react/src/dependency-graph/DependencyGraph.tsx
+++ b/sdk/react/src/dependency-graph/DependencyGraph.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, type KeyboardEvent } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import type { DependencyGraphProps } from "./types.js";
 import { DependencyTreeNode } from "./DependencyTreeNode.js";
 
@@ -114,7 +115,7 @@ export function DependencyGraph({
         role="tree"
         aria-label={`Dependencies of ${root.label}`}
         onKeyDown={handleKeyDown}
-        className="stg:rounded-lg stg:border stg:border-border stg:p-2"
+        className={cn(UNSTYLED_LIST, "stg:rounded-lg stg:border stg:border-border stg:p-2")}
       >
         <DependencyTreeNode
           node={root}

--- a/sdk/react/src/dependency-graph/DependencyTreeNode.tsx
+++ b/sdk/react/src/dependency-graph/DependencyTreeNode.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, type KeyboardEvent } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import type { DependencyNode, NodeKind } from "./types.js";
 
 interface DependencyTreeNodeProps {
@@ -152,7 +153,7 @@ export function DependencyTreeNode({
       {showChildren && (
         <ul
           role="group"
-          className="stg:relative stg:ml-[11px] stg:border-l stg:border-border stg:pl-3"
+          className={cn(UNSTYLED_LIST, "stg:relative stg:ml-[11px] stg:border-l stg:border-border stg:pl-3")}
         >
           {node.children.map((child) => (
             <DependencyTreeNode

--- a/sdk/react/src/environment/EnvironmentPicker.tsx
+++ b/sdk/react/src/environment/EnvironmentPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId, useMemo } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
 import type { ResourceRef } from "@stigmer/sdk";
 import { useEnvironmentList } from "./useEnvironmentList.js";
@@ -217,7 +218,7 @@ function SelectedList({
   total,
 }: SelectedListProps) {
   return (
-    <ol className="stg:space-y-1.5" aria-label="Selected environments (merge order)">
+    <ol className={cn(UNSTYLED_LIST, "stg:space-y-1.5")} aria-label="Selected environments (merge order)">
       {value.map((ref, index) => (
         <li
           key={`${ref.org}-${ref.slug}-${index}`}

--- a/sdk/react/src/error/SecretFlowErrorGuide.tsx
+++ b/sdk/react/src/error/SecretFlowErrorGuide.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { StigmerError, getUserMessage } from "@stigmer/sdk";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 
 /** Props for {@link SecretFlowErrorGuide}. */
 export interface SecretFlowErrorGuideProps {
@@ -113,7 +114,7 @@ export function SecretFlowErrorGuide({
                 <p className="stg:text-xs stg:text-amber-700 stg:dark:text-amber-300">
                   <span className="stg:font-medium">{server}</span> requires:
                 </p>
-                <ul className="stg:mt-0.5 stg:space-y-0.5">
+                <ul className={cn(UNSTYLED_LIST, "stg:mt-0.5 stg:space-y-0.5")}>
                   {vars.map((v) => (
                     <li
                       key={v}
@@ -131,7 +132,7 @@ export function SecretFlowErrorGuide({
             <p className="stg:text-xs stg:text-amber-700/90 stg:dark:text-amber-300/90">
               You can provide these values in two ways:
             </p>
-            <ul className="stg:mt-1 stg:space-y-0.5 stg:text-xs stg:text-amber-700/80 stg:dark:text-amber-300/80">
+            <ul className={cn(UNSTYLED_LIST, "stg:mt-1 stg:space-y-0.5 stg:text-xs stg:text-amber-700/80 stg:dark:text-amber-300/80")}>
               <li className="stg:flex stg:items-start stg:gap-1.5">
                 <span className="stg:mt-px stg:shrink-0">•</span>
                 <span>

--- a/sdk/react/src/execution/ArtifactContentBody.tsx
+++ b/sdk/react/src/execution/ArtifactContentBody.tsx
@@ -2,6 +2,7 @@
 
 import type { ExecutionArtifact } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/artifact_pb";
 import { ExecutionArtifactKind } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { ArtifactFileContent } from "./ArtifactFileContent.js";
 import type { SkillPackageDetection } from "../library/detect-skill-package.js";
 
@@ -103,7 +104,7 @@ function DirectoryContentView({
           <h3 className="stg:mb-2 stg:text-xs stg:font-medium stg:text-muted-foreground">
             Files ({entries.length})
           </h3>
-          <ul className="stg:space-y-0.5" role="list">
+          <ul className={`${UNSTYLED_LIST} stg:space-y-0.5`} role="list">
             {entries.map((entry) => (
               <li
                 key={entry}

--- a/sdk/react/src/execution/ArtifactsWidget.tsx
+++ b/sdk/react/src/execution/ArtifactsWidget.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from "react";
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import {
   useSessionArtifacts,
   artifactKey,
@@ -116,7 +117,7 @@ export function ArtifactsWidget({
         </span>
       </div>
 
-      <ul role="list" className="stg:flex stg:flex-col">
+      <ul role="list" className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col")}>
         {artifacts.map((entry) => (
           <ArtifactRow
             key={artifactKey(entry.artifact)}

--- a/sdk/react/src/execution/FileChangeProgressBar.tsx
+++ b/sdk/react/src/execution/FileChangeProgressBar.tsx
@@ -3,6 +3,7 @@
 import { memo, useState } from "react";
 import type { FileChangeProgress } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { FileKindBadge, FileLineStats } from "./FileReviewAtoms.js";
 import { FilePathLink } from "./FilePathLink.js";
 
@@ -91,7 +92,7 @@ export const FileChangeProgressBar = memo(function FileChangeProgressBar({
         <FileLineStats linesAdded={linesAdded} linesRemoved={linesRemoved} />
       </div>
       {expanded && (
-        <ul className="stg:mt-2 stg:max-h-[30vh] stg:space-y-1 stg:overflow-y-auto">
+        <ul className={cn(UNSTYLED_LIST, "stg:mt-2 stg:max-h-[30vh] stg:space-y-1 stg:overflow-y-auto")}>
           {entries.map((entry) => {
             const path = entry.pathAfter || entry.pathBefore;
             return (

--- a/sdk/react/src/execution/TodoList.tsx
+++ b/sdk/react/src/execution/TodoList.tsx
@@ -4,6 +4,7 @@ import { useMemo, type ComponentType } from "react";
 import type { TodoItem } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/todo_pb";
 import { TodoStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 
 /** Props for {@link TodoList}. */
 export interface TodoListProps {
@@ -69,7 +70,7 @@ export function TodoList({
   return (
     <ul
       role="list"
-      className={cn("stg:flex stg:flex-col stg:gap-1", className)}
+      className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col stg:gap-1", className)}
       aria-label="Tasks"
     >
       {sortedTodos.map((item) => (

--- a/sdk/react/src/execution/WriteBacksWidget.tsx
+++ b/sdk/react/src/execution/WriteBacksWidget.tsx
@@ -2,6 +2,7 @@
 
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { useSessionWriteBacks } from "../session/useSessionWriteBacks.js";
 import { WriteBackCard } from "./WriteBackCard.js";
 
@@ -71,7 +72,7 @@ export function WriteBacksWidget({
         </span>
       </div>
 
-      <ul role="list" className="stg:flex stg:flex-col stg:gap-3">
+      <ul role="list" className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col stg:gap-3")}>
         {writeBacks.map((entry) => (
           <li key={entry.writeBack.workspaceEntryName}>
             <WriteBackCard writeBack={entry.writeBack} />

--- a/sdk/react/src/iam-policy/PeopleWithAccess.tsx
+++ b/sdk/react/src/iam-policy/PeopleWithAccess.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { PrincipalAccess } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/io_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import { useShareFlow, type ShareFlowResource } from "./useShareFlow.js";
 import { GrantAccessForm } from "./GrantAccessForm.js";
@@ -83,7 +84,7 @@ export function PeopleWithAccess({
         )}
 
         {!isLoading && accessList.length > 0 && (
-          <ul className="stg:space-y-1 stg:mt-2" aria-label="People with access">
+          <ul className={cn(UNSTYLED_LIST, "stg:space-y-1 stg:mt-2")} aria-label="People with access">
             {accessList.map((entry) => (
               <AccessEntry
                 key={entry.principal?.id ?? "unknown"}

--- a/sdk/react/src/iam-policy/PrincipalPicker.tsx
+++ b/sdk/react/src/iam-policy/PrincipalPicker.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useId, useMemo, useRef, useState } from "react";
 import type { ApiResourceRefView } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/io_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import { useResourceAccess } from "./useResourceAccess.js";
 import { ProviderBadge, providerLabel } from "./ProviderBadge.js";
@@ -238,6 +239,7 @@ export function PrincipalPicker({
             role="listbox"
             aria-label="Organization members"
             className={cn(
+              UNSTYLED_LIST,
               "stg:absolute stg:z-10 stg:mt-1 stg:max-h-56 stg:w-full stg:overflow-auto stg:rounded-md stg:border stg:border-border stg:bg-popover stg:py-1 stg:shadow-md",
             )}
           >

--- a/sdk/react/src/iam-policy/RoleSelector.tsx
+++ b/sdk/react/src/iam-policy/RoleSelector.tsx
@@ -4,6 +4,7 @@ import { useId } from "react";
 import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { useRoleSelector } from "./useRoleSelector.js";
 
 /** Props for {@link RoleSelector}. */
@@ -73,7 +74,7 @@ export function RoleSelector({
   }
 
   return (
-    <fieldset className={cn("stg:space-y-1.5", className)}>
+    <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-1.5", className)}>
       <legend className="stg:text-xs stg:font-medium stg:text-foreground">Role</legend>
       <div className="stg:flex stg:flex-wrap stg:gap-2">
         {options.map((opt) => {

--- a/sdk/react/src/identity-provider/CreateIdentityProviderForm.tsx
+++ b/sdk/react/src/identity-provider/CreateIdentityProviderForm.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
@@ -388,7 +389,7 @@ function JitSection({
   }
 
   return (
-    <fieldset className="stg:space-y-2.5" disabled={disabled}>
+    <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2.5")} disabled={disabled}>
       <hr className="stg:border-border-muted" />
       <legend className="stg:text-xs stg:font-medium stg:text-foreground">
         JIT provisioning

--- a/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderDetailPanel.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, useCallback, useId, useRef, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
@@ -674,7 +675,7 @@ function JitEditSection({
   }
 
   return (
-    <fieldset className="stg:space-y-2.5" disabled={disabled}>
+    <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2.5")} disabled={disabled}>
       <hr className="stg:border-border-muted" />
       <legend className="stg:text-xs stg:font-medium stg:text-foreground">
         JIT provisioning

--- a/sdk/react/src/identity-provider/IdentityProviderWizard.tsx
+++ b/sdk/react/src/identity-provider/IdentityProviderWizard.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import type { IdentityProvider } from "@stigmer/protos/ai/stigmer/iam/identityprovider/v1/api_pb";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
@@ -838,7 +839,7 @@ function JitProvisioningSection({
   }
 
   return (
-    <fieldset className="stg:space-y-2.5" disabled={disabled}>
+    <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2.5")} disabled={disabled}>
       <hr className="stg:border-border-muted" />
       <legend className="stg:text-xs stg:font-medium stg:text-foreground">
         JIT provisioning

--- a/sdk/react/src/internal/element-resets.ts
+++ b/sdk/react/src/internal/element-resets.ts
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+// Per-element UA-default resets for preflight-less hosts (#695).
+// Internal — never exported from the package barrel.
+//
+// Why these are per-component classes and NOT stylesheet rules: the #374
+// scoped form-control preflight in `styles.css` could reset every button
+// under `.stgm` because UA control chrome is never wanted. Lists are
+// different — "UI list" vs "content list" is a semantic distinction CSS
+// scoping cannot express. The documented quickstart wraps the host's whole
+// app in `StigmerProvider`, so a `.stgm ul { list-style: none }` rule would
+// strip the bullets off the HOST's own content. Every SDK-rendered UI list
+// therefore declares its own reset (enforced by the `stigmer/require-list-reset`
+// lint rule); markdown-rendered content lists instead declare their bullets
+// explicitly (`stg:list-disc stg:pl-5 ...` in markdown-components.tsx).
+// ---------------------------------------------------------------------------
+
+/**
+ * UA-default reset for a UI `<ul>`/`<ol>` (no bullets, no indent, no
+ * margins). Without it, a host that ships no global CSS reset renders list
+ * markers and ~40px of `padding-inline-start` on every SDK list — invisible
+ * on first-party surfaces (console, desktop, docs tours all ship global
+ * resets), broken in exactly the third-party embeds the SDK exists for.
+ * Spacing utilities (`stg:space-y-*`, `stg:p-*`) compose on top.
+ */
+export const UNSTYLED_LIST = "stg:m-0 stg:list-none stg:p-0";
+
+/**
+ * UA-default reset for `<fieldset>` (margin-inline, padding, and
+ * `min-inline-size: min-content` — the last one silently breaks flex/grid
+ * shrinking). The UA border is already cleared by the `.stgm *` border reset
+ * in `styles.css`, so it is not repeated here.
+ */
+export const UNSTYLED_FIELDSET = "stg:m-0 stg:min-w-0 stg:p-0";

--- a/sdk/react/src/internal/file-tree/FileTreeNode.tsx
+++ b/sdk/react/src/internal/file-tree/FileTreeNode.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, type DragEvent } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../element-resets.js";
 import { FileTypeIcon, FolderTypeIcon } from "../file-icons/index.js";
 import type { TreeNode } from "./tree-node.js";
 
@@ -151,7 +152,7 @@ export function FileTreeNode({
       {isFolder && expanded && node.children && (
         <ul
           role="group"
-          className={cn(indentGuides && "stg:ml-3 stg:border-l stg:border-border")}
+          className={cn(UNSTYLED_LIST, indentGuides && "stg:ml-3 stg:border-l stg:border-border")}
         >
           {node.children.map((child) => (
             <FileTreeNode

--- a/sdk/react/src/internal/markdown-components.tsx
+++ b/sdk/react/src/internal/markdown-components.tsx
@@ -152,12 +152,19 @@ function extractMermaidSource(children: ReactNode): string | null {
  * ensuring correct rendering in both the Stigmer Console and third-party
  * host applications with custom themes.
  *
+ * Margin-bearing elements (`p`, `ul`, `ol`, `pre`, `blockquote`) declare
+ * their top margin (`stg:mt-0`) and blockquote its inline margins
+ * explicitly: the spacing rhythm here is authored via `mb-*` on the
+ * assumption that UA base margins are zero, which is only true when the
+ * host ships a global reset — preflight-less embeds otherwise stack
+ * `margin-top: 1em` (and 40px blockquote indents) on top (#695).
+ *
  * Used by `MessageEntry` (chat messages) and `SkillDetailView` (SKILL.md).
  */
 export const MARKDOWN_COMPONENTS: Components = {
   p({ children, ...props }: MdProps<"p">) {
     return (
-      <p className="stg:text-sm stg:text-foreground stg:mb-3 stg:last:mb-0 stg:leading-relaxed stg:break-words" {...props}>
+      <p className="stg:text-sm stg:text-foreground stg:mt-0 stg:mb-3 stg:last:mb-0 stg:leading-relaxed stg:break-words" {...props}>
         {children}
       </p>
     );
@@ -211,7 +218,7 @@ export const MARKDOWN_COMPONENTS: Components = {
 
   ul({ children, ...props }: MdProps<"ul">) {
     return (
-      <ul className="stg:list-disc stg:pl-5 stg:mb-3 stg:last:mb-0 stg:space-y-1 stg:text-sm stg:text-foreground" {...props}>
+      <ul className="stg:list-disc stg:pl-5 stg:mt-0 stg:mb-3 stg:last:mb-0 stg:space-y-1 stg:text-sm stg:text-foreground" {...props}>
         {children}
       </ul>
     );
@@ -219,7 +226,7 @@ export const MARKDOWN_COMPONENTS: Components = {
 
   ol({ children, ...props }: MdProps<"ol">) {
     return (
-      <ol className="stg:list-decimal stg:pl-5 stg:mb-3 stg:last:mb-0 stg:space-y-1 stg:text-sm stg:text-foreground" {...props}>
+      <ol className="stg:list-decimal stg:pl-5 stg:mt-0 stg:mb-3 stg:last:mb-0 stg:space-y-1 stg:text-sm stg:text-foreground" {...props}>
         {children}
       </ol>
     );
@@ -245,7 +252,7 @@ export const MARKDOWN_COMPONENTS: Components = {
 
     return (
       <pre
-        className="stg:mb-3 stg:last:mb-0 stg:overflow-x-auto stg:rounded-md stg:bg-muted stg:p-3"
+        className="stg:mt-0 stg:mb-3 stg:last:mb-0 stg:overflow-x-auto stg:rounded-md stg:bg-muted stg:p-3"
         {...props}
       >
         {children}
@@ -293,9 +300,12 @@ export const MARKDOWN_COMPONENTS: Components = {
   },
 
   blockquote({ children, ...props }: MdProps<"blockquote">) {
+    // mx-0 matters as much as mt-0 here: UA blockquote margin is `1em 40px`,
+    // so a preflight-less host renders a double indent on BOTH sides on top
+    // of the border-l + pl-4 treatment.
     return (
       <blockquote
-        className="stg:border-l-2 stg:border-border stg:pl-4 stg:mb-3 stg:last:mb-0 stg:text-muted-foreground stg:italic"
+        className="stg:border-l-2 stg:border-border stg:mx-0 stg:mt-0 stg:mb-3 stg:pl-4 stg:last:mb-0 stg:text-muted-foreground stg:italic"
         {...props}
       >
         {children}

--- a/sdk/react/src/invitation/InvitationManager.tsx
+++ b/sdk/react/src/invitation/InvitationManager.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import {
   getUserMessage,
   iamRoleDisplayName,
@@ -302,7 +303,7 @@ function CreateInvitationForm({
       />
 
       {/* Expiry */}
-      <fieldset className="stg:space-y-1.5">
+      <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-1.5")}>
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">
           Expires in
         </legend>
@@ -324,7 +325,7 @@ function CreateInvitationForm({
       </fieldset>
 
       {/* Redemption mode */}
-      <fieldset className="stg:space-y-1.5">
+      <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-1.5")}>
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">
           Usage limit
         </legend>

--- a/sdk/react/src/manifest/ApplyManifestDialog.tsx
+++ b/sdk/react/src/manifest/ApplyManifestDialog.tsx
@@ -3,6 +3,7 @@
 import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
 import { cn } from "@stigmer/theme";
 import { DialogShell } from "../internal/DialogShell.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { toast } from "../feedback/toast.js";
 import { RedactedSecretsNotice } from "./RedactedSecretsNotice.js";
 import {
@@ -189,7 +190,7 @@ export function ApplyManifestDialog({
 
         {/* Per-document preview */}
         {manifest.entries && manifest.entries.length > 0 && (
-          <ul className="stg:flex stg:max-h-48 stg:flex-col stg:gap-2 stg:overflow-y-auto" aria-label="Resources to apply">
+          <ul className={cn(UNSTYLED_LIST, "stg:flex stg:max-h-48 stg:flex-col stg:gap-2 stg:overflow-y-auto")} aria-label="Resources to apply">
             {manifest.entries.map((entry, index) => (
               <PreviewRow key={`${entry.document.handler.yamlKind}/${entry.document.org}/${entry.document.slug}/${index}`} entry={entry} />
             ))}

--- a/sdk/react/src/mcp-server/steps/IdentityTransportStep.tsx
+++ b/sdk/react/src/mcp-server/steps/IdentityTransportStep.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useId } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../../internal/element-resets.js";
 import { generateSlug } from "../../internal/slug.js";
 import type { McpServerWizardData, KeyValueEntry } from "./types.js";
 
@@ -179,7 +180,7 @@ export function IdentityTransportStep({
           />
         </div>
 
-        <fieldset className="stg:space-y-1.5">
+        <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-1.5")}>
           <legend className="stg:text-sm stg:font-medium stg:text-foreground">
             Visibility
           </legend>
@@ -204,7 +205,7 @@ export function IdentityTransportStep({
 
       {/* data-scroll-target: guided tours/demos scroll the transport config
           (the step's decision point) into view within the wizard's scroll area. */}
-      <fieldset className="stg:space-y-3" data-scroll-target="mcp-transport">
+      <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-3")} data-scroll-target="mcp-transport">
         <legend className="stg:text-sm stg:font-medium stg:text-foreground">
           Transport <span className="stg:text-destructive">*</span>
         </legend>

--- a/sdk/react/src/platform-client/CreatePlatformClientForm.tsx
+++ b/sdk/react/src/platform-client/CreatePlatformClientForm.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, type KeyboardEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import type { PlatformClientCreateResponse } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/io_pb";
@@ -167,7 +168,7 @@ export function CreatePlatformClientForm({
       />
 
       {/* Expiry */}
-      <fieldset className="stg:space-y-2" disabled={isCreating}>
+      <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2")} disabled={isCreating}>
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">
           Expiry
         </legend>
@@ -202,7 +203,7 @@ export function CreatePlatformClientForm({
       </fieldset>
 
       {/* JIT provisioning */}
-      <fieldset className="stg:space-y-2.5" disabled={isCreating}>
+      <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2.5")} disabled={isCreating}>
         <hr className="stg:border-border-muted" />
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">
           JIT provisioning
@@ -263,7 +264,7 @@ export function CreatePlatformClientForm({
       </fieldset>
 
       {/* Allowed origins */}
-      <fieldset className="stg:space-y-2" disabled={isCreating}>
+      <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2")} disabled={isCreating}>
         <hr className="stg:border-border-muted" />
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">
           Allowed origins

--- a/sdk/react/src/platform-client/PlatformClientDetailPanel.tsx
+++ b/sdk/react/src/platform-client/PlatformClientDetailPanel.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, type KeyboardEvent, useCallback, useId, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { getUserMessage } from "@stigmer/sdk";
 import { IamRole } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt";
@@ -302,7 +303,7 @@ export function PlatformClientDetailPanel({
           </div>
 
           {/* Expiry */}
-          <fieldset className="stg:space-y-2" disabled={isUpdating}>
+          <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2")} disabled={isUpdating}>
             <legend className="stg:text-xs stg:font-medium stg:text-foreground">
               Expiry
             </legend>
@@ -337,7 +338,7 @@ export function PlatformClientDetailPanel({
           </fieldset>
 
           {/* JIT provisioning */}
-          <fieldset className="stg:space-y-2.5" disabled={isUpdating}>
+          <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2.5")} disabled={isUpdating}>
             <hr className="stg:border-border-muted" />
             <legend className="stg:text-xs stg:font-medium stg:text-foreground">
               JIT provisioning
@@ -393,7 +394,7 @@ export function PlatformClientDetailPanel({
           </fieldset>
 
           {/* Allowed origins */}
-          <fieldset className="stg:space-y-2" disabled={isUpdating}>
+          <fieldset className={cn(UNSTYLED_FIELDSET, "stg:space-y-2")} disabled={isUpdating}>
             <hr className="stg:border-border-muted" />
             <legend className="stg:text-xs stg:font-medium stg:text-foreground">
               Allowed origins

--- a/sdk/react/src/pricing-governance/BaselineEditor.tsx
+++ b/sdk/react/src/pricing-governance/BaselineEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState, type FormEvent } from "react";
+import { UNSTYLED_FIELDSET } from "../internal/element-resets.js";
 import { create } from "@bufbuild/protobuf";
 import { getUserMessage } from "@stigmer/sdk";
 import {
@@ -546,7 +547,7 @@ export function BaselineEditor({
         Featured (appears in the curated default picker list)
       </label>
 
-      <fieldset className="stg:space-y-2">
+      <fieldset className={`${UNSTYLED_FIELDSET} stg:space-y-2`}>
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">
           Rates ($ per million tokens)
         </legend>
@@ -565,7 +566,7 @@ export function BaselineEditor({
         </div>
       </fieldset>
 
-      <fieldset className="stg:space-y-2">
+      <fieldset className={`${UNSTYLED_FIELDSET} stg:space-y-2`}>
         <legend className="stg:text-xs stg:font-medium stg:text-foreground">Pricing variants</legend>
         {form.variants.map((variant, index) => (
           <div key={index} className="stg:space-y-2 stg:rounded-md stg:border stg:border-border-muted stg:px-2.5 stg:py-2">

--- a/sdk/react/src/pricing-governance/PricingGovernanceConsole.tsx
+++ b/sdk/react/src/pricing-governance/PricingGovernanceConsole.tsx
@@ -11,6 +11,7 @@ import { RetireConfirm } from "./RetireConfirm.js";
 import { ModelGovernanceDetail } from "./ModelGovernanceDetail.js";
 import { OperatorAccessNotice } from "./OperatorAccessNotice.js";
 import { GovernanceBadge, PendingOverrideCard, RateCell } from "./governance-primitives.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { INPUT_CLASSES } from "../internal/form-primitives.js";
 import { TruncatedText } from "../internal/truncated-text.js";
 import { ZERO } from "./pricing-format.js";
@@ -328,7 +329,7 @@ function ModelsTab({
               : "The catalog is empty — has the baseline seed migration run?"}
           </p>
         ) : (
-          <ul role="list" aria-label="Models" className="stg:m-0 stg:list-none stg:p-0">
+          <ul role="list" aria-label="Models" className={UNSTYLED_LIST}>
             {view.models.map((row) => (
               <ModelRow key={row.key} row={row} onOpen={() => view.openDetail(row.key)} />
             ))}

--- a/sdk/react/src/provider.tsx
+++ b/sdk/react/src/provider.tsx
@@ -240,6 +240,18 @@ const EMPTY_REVIEW_RENDERERS: ReviewRenderers = {};
  * column makes it balloon even in a content-sized page), so only
  * the host — which knows its layout — can apply it safely.
  *
+ * **Hosts without a global CSS reset.** SDK components carry their
+ * own per-element resets (lists, fieldsets, form controls) and the
+ * markdown surfaces declare their margins explicitly, so they render
+ * correctly with no Tailwind-preflight-style reset in the host page
+ * (#695). Two deliberate boundaries remain the host's: font-family
+ * inherits from the host (an embedded widget adopting host typography
+ * is correct — set `--stgm-font-sans` to override), and the host's
+ * OWN content inside the provider keeps its user-agent styling — the
+ * SDK never resets elements it did not render. If your reset-less
+ * page composes its own `<p>`/`<h*>` content between SDK components,
+ * their user-agent margins are yours to manage.
+ *
  * Two stable selector hooks are part of the public contract:
  * `data-stgm-root` marks the in-tree container (and only it);
  * `data-stgm-portal` marks the portal container appended to

--- a/sdk/react/src/resource-creation/StepIndicator.tsx
+++ b/sdk/react/src/resource-creation/StepIndicator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 
 /** Props for {@link StepIndicator}. */
 export interface StepIndicatorProps {
@@ -37,7 +38,7 @@ export function StepIndicator({
       aria-label="Wizard progress"
       className={cn("stg:flex stg:flex-col stg:gap-1", className)}
     >
-      <ol className="stg:flex stg:flex-col stg:gap-1" role="list">
+      <ol className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col stg:gap-1")} role="list">
         {steps.map((step, index) => {
           const state = getStepState(index, currentStepIndex);
           const isClickable = state === "completed" && onStepClick != null;

--- a/sdk/react/src/schedule/ScheduleDetailView.tsx
+++ b/sdk/react/src/schedule/ScheduleDetailView.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { create } from "@bufbuild/protobuf";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
@@ -1356,7 +1357,7 @@ function EnvironmentRefList({
     return <span className="stg:text-sm stg:text-muted-foreground">—</span>;
   }
   return (
-    <ul className="stg:flex stg:flex-col stg:gap-0.5">
+    <ul className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col stg:gap-0.5")}>
       {refs.map((ref, i) => (
         <li
           key={`${ref.org}/${ref.slug}-${i}`}
@@ -1470,7 +1471,7 @@ function WorkspaceSummary({
     return <span className="stg:text-sm stg:text-muted-foreground">—</span>;
   }
   return (
-    <ul className="stg:flex stg:flex-col stg:gap-0.5">
+    <ul className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col stg:gap-0.5")}>
       {entries.map((entry, i) => {
         const git =
           entry.source?.source?.case === "gitRepo"

--- a/sdk/react/src/schedule/ScheduleRunsTable.tsx
+++ b/sdk/react/src/schedule/ScheduleRunsTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import {
   ScheduleRunOrigin,
@@ -277,7 +278,7 @@ export function ScheduleRunsCompactList({
     return <EmptyRuns />;
   }
   return (
-    <ul className="stg:divide-y stg:divide-border">
+    <ul className={cn(UNSTYLED_LIST, "stg:divide-y stg:divide-border")}>
       {runs.map((run, i) => (
         <CompactRunRow
           key={runKey(run, i)}

--- a/sdk/react/src/session/facets/ArtifactsTab.tsx
+++ b/sdk/react/src/session/facets/ArtifactsTab.tsx
@@ -7,6 +7,7 @@ import {
   artifactKey,
   type SessionArtifactEntry,
 } from "../useSessionArtifacts.js";
+import { UNSTYLED_LIST } from "../../internal/element-resets.js";
 import { ArtifactPreviewModal } from "../../execution/ArtifactPreviewModal.js";
 import { ArtifactRow } from "../../execution/ArtifactRow.js";
 import { isPlanArtifact } from "../../library/detect-plan-artifact.js";
@@ -123,7 +124,7 @@ export function ArtifactsTab({
 
   return (
     <>
-      <ul role="list" className="stg:flex stg:flex-col">
+      <ul role="list" className={`${UNSTYLED_LIST} stg:flex stg:flex-col`}>
         {artifacts.map((entry) => (
           <ArtifactRow
             key={artifactKey(entry.artifact)}

--- a/sdk/react/src/session/facets/ChangesTab.tsx
+++ b/sdk/react/src/session/facets/ChangesTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { UNSTYLED_LIST } from "../../internal/element-resets.js";
 import { useSessionWriteBacks } from "../useSessionWriteBacks.js";
 import { WriteBackCard } from "../../execution/WriteBackCard.js";
 
@@ -48,7 +49,7 @@ export function ChangesTab({
     // Dense row groups matching the Artifacts facet's list — gap separates
     // entries only in multi-repo sessions (single-entry lists stay seamless).
     return (
-      <ul role="list" className="stg:flex stg:flex-col stg:gap-3">
+      <ul role="list" className={`${UNSTYLED_LIST} stg:flex stg:flex-col stg:gap-3`}>
         {writeBacks.map((entry) => (
           <li key={entry.writeBack.workspaceEntryName}>
             <WriteBackCard writeBack={entry.writeBack} />

--- a/sdk/react/src/sharing/ShareAgentDialog.tsx
+++ b/sdk/react/src/sharing/ShareAgentDialog.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useId, useMemo, useRef, useState, type FormEvent } from "react";
 import { cn } from "@stigmer/theme";
 import { DialogShell } from "../internal/DialogShell.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import {
   MAX_ALLOWED_ORIGINS,
   StigmerError,
@@ -1316,7 +1317,7 @@ function OriginsEditor({
       </p>
 
       {draft.allowedOrigins.length > 0 && (
-        <ul className="stg:mt-2 stg:flex stg:flex-col stg:divide-y stg:divide-border stg:rounded-md stg:border stg:border-border">
+        <ul className={cn(UNSTYLED_LIST, "stg:mt-2 stg:flex stg:flex-col stg:divide-y stg:divide-border stg:rounded-md stg:border stg:border-border")}>
           {draft.allowedOrigins.map((origin) => (
             <li
               key={origin}

--- a/sdk/react/src/sidebar/WorkspaceSidebar.tsx
+++ b/sdk/react/src/sidebar/WorkspaceSidebar.tsx
@@ -15,6 +15,7 @@ import type { RecentActivityEntry, RecentActivityGroup } from "../activity/types
 import { groupRecentActivityByTime } from "../activity/group-activity.js";
 import { formatRelativeTime } from "../activity/format-relative-time.js";
 import { recentActivityStatusBadge } from "../activity/entry-status-badge.js";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { ScrollArea } from "../internal/scroll-area.js";
 import {
   Tooltip,
@@ -313,7 +314,7 @@ function ActivityGroupList({
             <p className="stg:text-sidebar-muted-foreground stg:mb-1 stg:px-2 stg:text-[10px] stg:font-medium stg:tracking-wider stg:uppercase">
               {group.label}
             </p>
-            <ul className="stg:space-y-0.5" role="list">
+            <ul className={`${UNSTYLED_LIST} stg:space-y-0.5`} role="list">
               {group.entries.map((entry) => (
                 <ActivityEntry
                   key={entry.id}

--- a/sdk/react/src/skill/SkillFileBrowser.tsx
+++ b/sdk/react/src/skill/SkillFileBrowser.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import Markdown from "react-markdown";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { MARKDOWN_COMPONENTS, REMARK_PLUGINS, stripFrontmatter } from "../internal/markdown-components.js";
 import { buildFileTree, FileTreeNode } from "../internal/file-tree/index.js";
 import { useSkillArtifact } from "./useSkillArtifact.js";
@@ -132,7 +133,7 @@ export function SkillFileBrowser({
           className="stg:border-b stg:border-border stg:md:border-b-0 stg:md:border-r stg:overflow-y-auto"
           aria-label="Skill package file tree"
         >
-          <ul className="stg:py-1" role="tree">
+          <ul className={cn(UNSTYLED_LIST, "stg:py-1")} role="tree">
             {treeNodes.map((node) => (
               <FileTreeNode
                 key={node.path}

--- a/sdk/react/src/workflow/FailedRunsWidget.tsx
+++ b/sdk/react/src/workflow/FailedRunsWidget.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 export interface FailedRunsWidgetProps {
@@ -54,7 +55,7 @@ export const FailedRunsWidget = memo(function FailedRunsWidget({
           No recent failures
         </p>
       ) : (
-        <ul className="stg:space-y-2" role="list">
+        <ul className={cn(UNSTYLED_LIST, "stg:space-y-2")} role="list">
           {executions.map((exec) => {
             const id = exec.metadata?.id;
             const name =

--- a/sdk/react/src/workflow/PendingApprovalsWidget.tsx
+++ b/sdk/react/src/workflow/PendingApprovalsWidget.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { PendingApproval } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { formatRelativeTime } from "../activity/format-relative-time.js";
 
 export interface PendingApprovalsWidgetProps {
@@ -65,7 +66,7 @@ export const PendingApprovalsWidget = memo(function PendingApprovalsWidget({
           No approvals pending
         </p>
       ) : (
-        <ul className="stg:space-y-2" role="list">
+        <ul className={cn(UNSTYLED_LIST, "stg:space-y-2")} role="list">
           {approvals.map((approval) => {
             const requestedAt = approval.requestedAt
               ? timestampDate(approval.requestedAt)

--- a/sdk/react/src/workflow/facets/WorkflowArtifactsTab.tsx
+++ b/sdk/react/src/workflow/facets/WorkflowArtifactsTab.tsx
@@ -5,6 +5,7 @@
 
 import type { Artifact } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
 import { useMemo } from "react";
+import { UNSTYLED_LIST } from "../../internal/element-resets.js";
 import { ArtifactRowView } from "../../execution/ArtifactRowView.js";
 import type { ArtifactRowItem } from "../../execution/artifact-row-item.js";
 import { deriveWorkflowArtifactItems } from "../deriveWorkflowArtifactItems.js";
@@ -55,7 +56,7 @@ export function WorkflowArtifactsTab({
   }
 
   return (
-    <ul role="list" className="stg:flex stg:flex-col">
+    <ul role="list" className={`${UNSTYLED_LIST} stg:flex stg:flex-col`}>
       {entries.map(({ artifact, item }) => (
         <WorkflowArtifactRow
           key={artifact.metadata?.id ?? item.name}

--- a/sdk/react/src/workflow/facets/WorkflowUsageTab.tsx
+++ b/sdk/react/src/workflow/facets/WorkflowUsageTab.tsx
@@ -5,6 +5,7 @@
 
 import { useMemo } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../../internal/element-resets.js";
 import type {
   DerivedCostSummary,
   DerivedTaskState,
@@ -72,7 +73,7 @@ export function WorkflowUsageTab({
           <h3 className="stg:px-2 stg:text-xs stg:font-semibold stg:uppercase stg:tracking-wider stg:text-muted-foreground">
             By task
           </h3>
-          <ul role="list" className="stg:flex stg:flex-col">
+          <ul role="list" className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col")}>
             {items.map((item) => (
               <UsageRow key={item.taskName} item={item} />
             ))}

--- a/sdk/react/src/workflow/inspector/WorkflowSummaryPanel.tsx
+++ b/sdk/react/src/workflow/inspector/WorkflowSummaryPanel.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useMemo, useState, useCallback } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../../internal/element-resets.js";
 import type { WorkflowGraphModel, WorkflowGraphBudget, WorkflowGraphEnvVar } from "../workflow-graph-model.js";
 import { START_NODE_ID, END_NODE_ID } from "../workflow-graph-model.js";
 import { CATEGORY_DISPLAY_NAMES } from "../canvas-constants.js";
@@ -155,7 +156,7 @@ function ValidationSection({
       </button>
 
       {expanded && (
-        <ul className="stg:flex stg:flex-col stg:gap-1" role="list">
+        <ul className={cn(UNSTYLED_LIST, "stg:flex stg:flex-col stg:gap-1")} role="list">
           {Array.from(errors.entries()).map(([nodeId, nodeErrors]) =>
             nodeErrors.map((error, i) => (
               <li

--- a/sdk/react/src/workflow/inspector/tabs/BranchesTab.tsx
+++ b/sdk/react/src/workflow/inspector/tabs/BranchesTab.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useCallback, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_FIELDSET } from "../../../internal/element-resets.js";
 import {
   Tooltip,
   TooltipContent,
@@ -283,7 +284,7 @@ function ForkBranches({
   return (
     <div className="stg:flex stg:flex-col stg:gap-3 stg:px-3 stg:py-3">
       {/* Join policy */}
-      <fieldset>
+      <fieldset className={UNSTYLED_FIELDSET}>
         <legend className="stg:text-xs stg:font-semibold stg:text-[var(--stgm-foreground,#1a1a2e)] stg:mb-1.5">
           Join policy
         </legend>

--- a/sdk/react/src/workflow/inspector/tabs/IterationTab.tsx
+++ b/sdk/react/src/workflow/inspector/tabs/IterationTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useCallback, useState, useMemo } from "react";
+import { UNSTYLED_FIELDSET } from "../../../internal/element-resets.js";
 import type { WorkflowGraphNode } from "../../workflow-graph-model.js";
 import type { InspectorMutations } from "../types.js";
 
@@ -177,7 +178,7 @@ export const IterationTab = memo(function IterationTab({
 
       {/* Error policy */}
       {parallelism > 0 && (
-        <fieldset>
+        <fieldset className={UNSTYLED_FIELDSET}>
           <legend className="stg:text-[10px] stg:font-medium stg:text-[var(--stgm-muted-foreground,#737373)] stg:mb-1.5">
             Error policy
           </legend>

--- a/sdk/react/src/workflow/instance/WorkflowInstanceDetailPanel.tsx
+++ b/sdk/react/src/workflow/instance/WorkflowInstanceDetailPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../../internal/element-resets.js";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
@@ -263,7 +264,7 @@ export function WorkflowInstanceDetailPanel({
               {(spec?.environmentRefs?.length ?? 0) === 0 ? (
                 <p className="stg:text-xs stg:text-muted-foreground">No environments bound.</p>
               ) : (
-                <ol className="stg:space-y-1">
+                <ol className={cn(UNSTYLED_LIST, "stg:space-y-1")}>
                   {spec!.environmentRefs.map((ref, idx) => (
                     <li key={`${ref.slug}-${idx}`} className="stg:flex stg:items-center stg:gap-2 stg:text-sm">
                       <span className="stg:text-xs stg:text-muted-foreground stg:w-4 stg:text-right">{idx + 1}.</span>

--- a/sdk/react/src/workspace/ExplorerTree.tsx
+++ b/sdk/react/src/workspace/ExplorerTree.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { FileTreeNode } from "../internal/file-tree/index.js";
 import type { SelectedWorkspaceFile } from "../internal/store/index.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
@@ -231,7 +232,7 @@ function ExplorerRootBody({
   return (
     <>
       <nav aria-label={`File tree for ${entryName}`}>
-        <ul className="stg:py-0.5 stg:pl-1.5" role="tree">
+        <ul className={cn(UNSTYLED_LIST, "stg:py-0.5 stg:pl-1.5")} role="tree">
           {tree.map((node) => (
             <FileTreeNode
               key={node.path}

--- a/sdk/react/src/workspace/WorkspaceContentSearch.tsx
+++ b/sdk/react/src/workspace/WorkspaceContentSearch.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import type { WorkspaceEntry } from "./useWorkspaceEntries.js";
 import type {
   WorkspaceContentMatch,
@@ -235,7 +236,7 @@ export function WorkspaceContentSearch({
           <MessageState>No files containing &ldquo;{trimmed}&rdquo;.</MessageState>
         ) : (
           <>
-            <ul id={listboxId} role="listbox" aria-label="Search results" className="stg:py-0.5">
+            <ul id={listboxId} role="listbox" aria-label="Search results" className={cn(UNSTYLED_LIST, "stg:py-0.5")}>
               {renderRows({
                 groups,
                 query: trimmed,

--- a/sdk/react/src/workspace/WorkspaceFileSearch.tsx
+++ b/sdk/react/src/workspace/WorkspaceFileSearch.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import type { WorkspaceEntry } from "./useWorkspaceEntries.js";
 import type { WorkspaceFileLister } from "./WorkspaceFileLister.js";
 import type { SelectedWorkspaceFile } from "../internal/store/workspace-file-selection-store.js";
@@ -210,7 +211,7 @@ export function WorkspaceFileSearch({
               id={listboxId}
               role="listbox"
               aria-label="Search results"
-              className="stg:py-0.5"
+              className={cn(UNSTYLED_LIST, "stg:py-0.5")}
             >
               {renderRows({
                 groups,

--- a/sdk/react/src/workspace/WorkspaceSummary.tsx
+++ b/sdk/react/src/workspace/WorkspaceSummary.tsx
@@ -3,6 +3,7 @@
 import type { WorkspaceEntry } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import type { WorkspaceSource } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import { cn } from "@stigmer/theme";
+import { UNSTYLED_LIST } from "../internal/element-resets.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../internal/tooltip.js";
 import { TruncatedText } from "../internal/truncated-text.js";
 
@@ -43,7 +44,7 @@ export function WorkspaceSummary({
   if (entries.length === 0) return null;
 
   return (
-    <ul className={cn("stg:space-y-1.5", className)} aria-label="Workspace entries">
+    <ul className={cn(UNSTYLED_LIST, "stg:space-y-1.5", className)} aria-label="Workspace entries">
       {entries.map((entry) => (
         <li key={entry.name} className="stg:text-xs">
           <div className="stg:flex stg:items-center stg:gap-1.5 stg:font-medium">

--- a/tools/eslint-plugin-stigmer/index.js
+++ b/tools/eslint-plugin-stigmer/index.js
@@ -6,6 +6,7 @@ const noLiteralDomIds = require("./rules/no-literal-dom-ids");
 const noMainTokensInSidebar = require("./rules/no-main-tokens-in-sidebar");
 const noNativeTitle = require("./rules/no-native-title");
 const noTokenOpacityModifiers = require("./rules/no-token-opacity-modifiers");
+const requireListReset = require("./rules/require-list-reset");
 const sdkImportBoundaries = require("./rules/sdk-import-boundaries");
 
 const plugin = {
@@ -20,6 +21,7 @@ const plugin = {
     "no-main-tokens-in-sidebar": noMainTokensInSidebar,
     "no-native-title": noNativeTitle,
     "no-token-opacity-modifiers": noTokenOpacityModifiers,
+    "require-list-reset": requireListReset,
     "sdk-import-boundaries": sdkImportBoundaries,
   },
 };

--- a/tools/eslint-plugin-stigmer/rules/require-list-reset.js
+++ b/tools/eslint-plugin-stigmer/rules/require-list-reset.js
@@ -1,0 +1,91 @@
+"use strict";
+
+const { extractClassNames } = require("../src/class-extractor");
+
+// The named reset for UI lists (sdk/react/src/internal/element-resets.ts).
+const RESET_IDENTIFIER = "UNSTYLED_LIST";
+
+/**
+ * True when any Identifier named UNSTYLED_LIST is reachable from the
+ * className attribute's value (covers `className={UNSTYLED_LIST}` and
+ * `className={cn(UNSTYLED_LIST, ...)}`/template-literal compositions).
+ */
+function referencesResetIdentifier(node) {
+  if (!node || typeof node !== "object") return false;
+
+  if (node.type === "Identifier" && node.name === RESET_IDENTIFIER) {
+    return true;
+  }
+
+  for (const key of Object.keys(node)) {
+    if (key === "parent" || key === "loc" || key === "range") continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      if (value.some((child) => referencesResetIdentifier(child))) return true;
+    } else if (value && typeof value.type === "string") {
+      if (referencesResetIdentifier(value)) return true;
+    }
+  }
+  return false;
+}
+
+/** Strips Tailwind variant prefixes: `stg:last:list-none` -> `list-none`. */
+function stripVariants(cls) {
+  const parts = cls.split(":");
+  return parts[parts.length - 1];
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require every <ul>/<ol> to carry the UNSTYLED_LIST reset or an explicit list-* style (stigmer/stigmer#695)",
+    },
+    messages: {
+      missingListReset:
+        "<{{ element }}> declares no list style, so a host without a global CSS reset renders UA bullets " +
+        "and ~40px of indent (invisible in the console, broken in third-party embeds — stigmer/stigmer#695). " +
+        "UI lists: compose UNSTYLED_LIST from internal/element-resets.js into className. " +
+        "Content lists (markdown): declare the style explicitly (stg:list-disc/stg:list-decimal with stg:pl-* and margins). " +
+        "This cannot live in styles.css: a .stgm-scoped list reset would strip bullets off host content " +
+        "when the host wraps its whole app in StigmerProvider.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (
+          node.name.type !== "JSXIdentifier" ||
+          (node.name.name !== "ul" && node.name.name !== "ol")
+        ) {
+          return;
+        }
+
+        const classNameAttr = node.attributes.find(
+          (attr) =>
+            attr.type === "JSXAttribute" &&
+            attr.name.type === "JSXIdentifier" &&
+            attr.name.name === "className",
+        );
+
+        if (classNameAttr) {
+          if (referencesResetIdentifier(classNameAttr.value)) return;
+
+          const declaresListStyle = extractClassNames(classNameAttr).some(
+            ({ className }) => stripVariants(className).startsWith("list-"),
+          );
+          if (declaresListStyle) return;
+        }
+
+        context.report({
+          node,
+          messageId: "missingListReset",
+          data: { element: node.name.name },
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Closes #695.

In a host **without** a Tailwind-preflight-style global reset — the honest third-party-embedder baseline, the SDK's stated audience — components rendered UA list bullets with ~40px indents, UA fieldset boxes, and stacked markdown margins. Invisible on every first-party surface (console, desktop, docs tours all ship global resets), structurally uncatchable by jsdom.

**Fix shape (owner-ruled):** bounded per-component sweep + lint fence; the p/h* long tail deferred with documented guidance. The issue's alternative (a default-on scoped preflight in `styles.css`) contradicts the recorded #374 rationale in the stylesheet itself: the quickstart wraps the host's whole app in `StigmerProvider`, so a `.stgm`-scoped margin/list reset would strip the **host's own content** styling. "UI list vs content list" is semantic — CSS scoping cannot express it.

### What shipped

- **`internal/element-resets.ts`** — named `UNSTYLED_LIST` / `UNSTYLED_FIELDSET` constants (the `UNSTYLED_BUTTON` precedent), with the button-vs-list asymmetry recorded on the module so the next agent understands why this cannot be a stylesheet rule.
- **Sweep** — every UI `<ul>`/`<ol>` (37 sites) composes `UNSTYLED_LIST`; the four pre-existing hand-rolled resets (`MemberKeysPanel`, `CursorAccountsConsole`, `PricingGovernanceConsole`, `ConversationListPane` from #694) migrate onto the constant; every `<fieldset>` (20 sites) composes `UNSTYLED_FIELDSET` (margins, padding, `min-inline-size: min-content` — the UA border is already cleared by the `.stgm` border reset).
- **Markdown map** — `p`/`ul`/`ol`/`pre` gain `stg:mt-0` (rhythm is authored via `mb-*` against a zeroed baseline) and `blockquote` clears its UA `1em/40px` box (`mx-0 mt-0`) while keeping the authored border+padding treatment. Content lists deliberately KEEP explicit bullets. The plan-document map inherits all of it.
- **Lint fence** — new `stigmer/require-list-reset` (error from day one, zero violations — the #373/#653 sweep-then-fence pattern): every list must reference `UNSTYLED_LIST` or declare an explicit `list-*` style. It immediately earned its keep by catching **three multi-line JSX sites the sweep's regex inventory had missed**.
- **Real-browser regression suite** — `bare-host-resets.layout.test.tsx` (the `preflight-parity.layout.test.tsx` shape, shipped `dist/styles.css`, real Chromium): a control pins that the harness is genuinely bare (a raw `<ul>` DOES wear UA bullets), then asserts the resets on bare elements, a real swept organism (`TodoList`), and the markdown map — plus inverse pins that utilities and content-list bullets still win.
- **Docs** — the `StigmerProvider` TSDoc (and regenerated `docs/sdk/react/core.mdx`) documents the bare-host contract and its two deliberate boundaries: font-family keeps inheriting from the host (`--stgm-font-sans` to override), and host-authored content inside the provider is never reset — deferred p/h* margins there remain the host's to manage.

## Impact

- **Product/UX**: third-party embeds without a CSS reset stop rendering bullets, indents, and double-indented blockquotes on SDK surfaces. First-party surfaces are pixel-identical (their global resets already zeroed everything these classes zero).
- **Maintainability**: the convention is now a named, documented constant enforced by lint — this defect class cannot silently ship again.
- **Risk**: for existing bare-host embedders the swept surfaces *change* (bullets disappear) — that is the fix, aligned with what every first-party surface already showed. No API change; impact-based semver says patch.

## Verification

- eslint + `prefix-classnames --check` green with the new fence at `error`.
- Unit suite: **413 files / 4577 tests** green.
- Real-Chromium suite (`test:a11y` CI gate): **17 files / 85 tests** green, including the new suite.
- `tsc --noEmit` clean; docs regenerated via `make gen-react-sdk-docs` (only the intended `core.mdx` hunk).

Made with [Cursor](https://cursor.com)