### PR TITLE
fix(test/conformance): fence the mock LLM from background/foreign-provider calls — execution lane green again (#715)

### DIFF
--- a/test/conformance/src/harness/mock-llm.ts
+++ b/test/conformance/src/harness/mock-llm.ts
@@ -15,6 +15,26 @@
 // (fileParallelism:false) and tests within a file run serially, so the queue is
 // consumed deterministically.
 //
+// The queue scripts THE AGENT LOOP UNDER TEST — and only it. The runner also
+// makes background LLM calls that are production behavior, not part of any
+// test's script: session-subject titling (#690) fires per execution as a
+// Temporal fire-and-forget racing the agent turn, and letting it claim queued
+// turns broke every agent suite at once (approval gates sailed to COMPLETED on
+// the eaten tool_use turn, forced failures completed, smoke turns starved —
+// stigmer/stigmer#715). Two defenses, in order:
+//   1. Provider fence — this mock speaks ONLY Anthropic; a request on any
+//      other provider's proxy path is answered with a loud 500 instead of a
+//      queued turn (#715's thief was the titling call leaving on the OpenAI
+//      path via the runner's baked gpt-4.1 primaryModel default, eating
+//      Anthropic turns it couldn't even parse; the harness now pins
+//      STIGMER_PRIMARY_MODEL, and this fence makes any regression legible).
+//   2. Signature routing — recognized background calls (the titling system
+//      prompt) are answered out-of-band with a canned body, never from the
+//      queue. A NEW background call class surfaces as a hard 500 ("no queued
+//      response") — extend the signature match here, never the test queues.
+// Out-of-band and fenced requests still appear in requests(): that surface's
+// contract is "everything the model received over the wire".
+//
 // The `delayMs` knob holds a response open, keeping an execution IN_PROGRESS for
 // a controllable window — the AgentExecution analogue of the WorkflowExecution
 // `wait` timer, and the lever for cancel/terminate/pause/resume on a genuinely
@@ -127,6 +147,40 @@ export interface CapturedLlmRequest {
   body: unknown;
 }
 
+// The stable slice of the session-titling system prompt (SYSTEM_PROMPT in
+// backend/services/runner/src/activities/generate-session-subject.ts, kept in
+// lockstep with the cloud activity). Deliberately a short, meaning-bearing
+// substring so prompt wording can evolve around it without breaking the match.
+const TITLE_GENERATION_SIGNATURE = "session title generator";
+
+// The canned title every out-of-band titling call receives. Exported so a
+// suite can pin the full loop: mock answers → activity cleans and caps the
+// text → session subject updates. Must satisfy the activity's post-processing
+// (≤50 chars, no trailing punctuation) to arrive verbatim.
+export const MOCK_SESSION_TITLE = "Conformance Agent Session";
+
+// True when an Anthropic messages payload is the runner's background
+// session-titling call rather than an agent-loop turn. LangChain sends the
+// system prompt as `system`, either a plain string or an array of text blocks
+// depending on client version — both shapes are folded to text before matching.
+function isTitleGenerationRequest(body: unknown): boolean {
+  if (typeof body !== "object" || body === null) {
+    return false;
+  }
+  const system = (body as { system?: unknown }).system;
+  let text: string;
+  if (typeof system === "string") {
+    text = system;
+  } else if (Array.isArray(system)) {
+    text = system
+      .map((block) => (typeof block === "object" && block !== null ? String((block as { text?: unknown }).text ?? "") : ""))
+      .join(" ");
+  } else {
+    return false;
+  }
+  return text.toLowerCase().includes(TITLE_GENERATION_SIGNATURE);
+}
+
 export class MockLlmProxy {
   private server: Server | undefined;
   // FIFO of pending turns; a request claims the head synchronously on arrival.
@@ -135,6 +189,9 @@ export class MockLlmProxy {
   // Every LLM request body this proxy has received, in arrival order. Cleared
   // by reset() at the afterEach boundary like the queue.
   private readonly captured: CapturedLlmRequest[] = [];
+  // Background titling calls answered out-of-band (#690/#715) — an observation
+  // point, deliberately NOT part of consumed()/remaining() queue accounting.
+  private titleRequestCount = 0;
   // In-flight held responses, keyed by an abort callback. releaseHolds() invokes
   // each to unblock a delayed response early (independent of a socket close).
   private readonly activeHolds = new Set<() => void>();
@@ -217,6 +274,7 @@ export class MockLlmProxy {
     this.queue.length = 0;
     this.consumedCount = 0;
     this.captured.length = 0;
+    this.titleRequestCount = 0;
     this.releaseHolds();
     this.draining = false;
   }
@@ -270,6 +328,11 @@ export class MockLlmProxy {
     return this.consumedCount;
   }
 
+  // Background titling calls served out-of-band so far.
+  titleRequests(): number {
+    return this.titleRequestCount;
+  }
+
   async close(): Promise<void> {
     const server = this.server;
     this.server = undefined;
@@ -301,6 +364,38 @@ export class MockLlmProxy {
       typeof parsedBody === "object" &&
       parsedBody !== null &&
       (parsedBody as { stream?: unknown }).stream === true;
+
+    // Provider fence: queued turns are Anthropic-shaped SSE/JSON, so serving
+    // one to another provider's client corrupts BOTH the caller (unparseable
+    // body) and the test (stolen turn). Fail loudly instead — the message
+    // names the fix so a future non-Anthropic caller is a five-minute triage,
+    // not a phase-timeout mystery (#715).
+    const isForeignProvider = path.includes("/v1/proxy/llm/") && !path.includes("/v1/proxy/llm/anthropic");
+    if (isForeignProvider) {
+      writeJson(res, 500, {
+        error:
+          `MockLlmProxy speaks only Anthropic but received ${path}. A runner-side LLM caller ` +
+          `is routing to another provider — pin its model to an Anthropic one in the harness ` +
+          `env (see STIGMER_PRIMARY_MODEL in runner-process.ts) or teach this mock the provider.`,
+      });
+      return;
+    }
+
+    // Background calls are answered out-of-band, NEVER from the queue: the
+    // queue is the agent loop's script, and a background call claiming a turn
+    // starves or derails the loop under test (#715). The canned title is
+    // wired all the way through — the titling activity really parses it and
+    // writes it as the session subject, so suites can pin the feature.
+    if (isTitleGenerationRequest(parsedBody)) {
+      this.titleRequestCount += 1;
+      const body = anthropicText(MOCK_SESSION_TITLE);
+      if (streaming) {
+        writeAnthropicSse(res, body);
+      } else {
+        writeJson(res, 200, body);
+      }
+      return;
+    }
 
     // Claim the head turn synchronously so concurrent or retried calls can't race
     // for the same entry; an empty queue is a test-authoring error, surfaced as 500.

--- a/test/conformance/src/harness/runner-process.ts
+++ b/test/conformance/src/harness/runner-process.ts
@@ -106,6 +106,14 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
         ? {
             STIGMER_PROXY_ENDPOINT: opts.proxy.endpoint,
             STIGMER_TOKEN: opts.proxy.token,
+            // The mock proxy speaks ONLY Anthropic. Background LLM callers
+            // (session titling, #690) route by config.primaryModel, whose
+            // baked default is an OpenAI model — without this pin their
+            // requests leave on the OpenAI proxy path, where the mock cannot
+            // recognize or answer them, and historically they silently ATE
+            // queued agent turns (#715). Keep every LLM caller on the one
+            // provider the mock implements.
+            STIGMER_PRIMARY_MODEL: "claude-sonnet-4-6",
             ARTIFACT_STORAGE_TYPE: "local",
             LOCAL_ARTIFACT_PATH: artifactDir,
             // Point blob downloads at the server's artifact file server when we

--- a/test/conformance/src/suites-execution/agent.harness.smoke.test.ts
+++ b/test/conformance/src/suites-execution/agent.harness.smoke.test.ts
@@ -19,9 +19,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
 import type { MockLlmProxy } from "../harness/mock-llm";
-import { anthropicText } from "../harness/mock-llm";
+import { anthropicText, MOCK_SESSION_TITLE } from "../harness/mock-llm";
 import { makeAgent } from "../support/agents";
 import { awaitTerminal, makeAgentExecution, requireLlmProxy } from "../support/agentexecutions";
+import { pollUntil } from "../support/execution-poll";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
 
@@ -78,8 +79,25 @@ describe("Execution harness smoke — agent text turn", () => {
     expect(final.status?.completedAt, "completed_at is set on completion").toBeTruthy();
 
     // The agent loop consumed exactly its one scripted turn — no extra LLM calls,
-    // none left unserved.
+    // none left unserved. Background titling calls are answered out-of-band by
+    // the mock (#715) and deliberately don't count here.
     expect(mock.remaining(), "the single queued turn was consumed").toBe(0);
     expect(mock.consumed(), "exactly one LLM turn was served").toBe(1);
+
+    // Session titling (#690) rides the same execution: the workflow fires a
+    // background LLM call that the mock answers out-of-band, and the activity
+    // writes the cleaned title over the server's auto-created sentinel. Polled
+    // because the titling branch is fire-and-forget and races the agent turn.
+    const sessionId = final.spec?.sessionId ?? "";
+    expect(sessionId, "a completed run carries its auto-created session id").not.toBe("");
+    await pollUntil(
+      () => clients.sessionQuery.get({ value: sessionId }),
+      (session) => session.spec?.subject === MOCK_SESSION_TITLE,
+      (last, ms) =>
+        `session ${sessionId} subject never became the mock title within ${ms}ms ` +
+        `(last: '${last?.spec?.subject ?? "(unfetched)"}')`,
+      { timeoutMs: 15_000 },
+    );
+    expect(mock.titleRequests(), "the titling call was served out-of-band").toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

`ci.conformance-execution` is red on main (approval fixtures never reach `WAITING_FOR_APPROVAL`, forced failures complete, smoke turns stall). Root cause — with an attribution correction:

- **Not the #703 artifact-transfer merge.** Its run was merely the first to execute after CI concurrency cancelled the runs of six earlier merges; #703's runner diff is confined to the skill artifact download path and the execution fixtures use no skills. (A separate issue on this CI blind spot follows.)
- **The actual regressor is the session-titling fix (#690, `345dfd71c`, inside the cancelled window).** It fires a background LLM call per agent execution (`workflow.Go` fire-and-forget, racing the agent turn). The runner's baked `primaryModel` default (`gpt-4.1`) sends that call out on the **OpenAI** proxy path; the mock's path match still claimed a queued **Anthropic** turn for it. The theft is a race, so failures were intermittent per file: approval tests lost their `tool_use` turn and sailed to `EXECUTION_COMPLETED`, recover tests lost their forced-failure turn, smoke turns starved — the exact CI signature, reproduced locally and confirmed with wire-level capture.

The titling feature itself is correct production behavior; **all fixes are harness-side**:

1. `runner-process.ts` pins `STIGMER_PRIMARY_MODEL` to the Anthropic model the mock speaks — every background LLM caller stays on the one provider the mock implements.
2. `mock-llm.ts` fences foreign-provider proxy paths with a loud 500 naming the fix — a future non-Anthropic caller becomes a five-minute triage instead of a phase-timeout mystery.
3. Recognized background calls (matched on the titling system prompt, a stable substring kept in lockstep with cloud) are answered **out-of-band** with a canned title — never from the test queue, whose contract is now documented: it scripts the agent loop under test, and only it.
4. The smoke test pins the full titling loop (mock answer → activity post-processing → session subject), so #690 keeps end-to-end coverage.

Deliberately untouched: the ungated cloud-target skill-transfer validation pin (`push rejects both artifact sources`) — that red is real missing cloud validation the in-flight cloud#438 session owns.

## Verification

- Before: `agentexecution-approval` + `agent.harness.smoke` — 8 failed / 6 passed in 499s (local repro of the CI signature).
- After: same files — 14/14 passed in 21s, with 10 titling calls observed answered out-of-band.
- Full suite as CI runs it (`CONFORMANCE_TARGET=local-go-execution npm run test:execution`): **121 passed | 2 skipped, 14/15 files, 85s**.

Closes #715

Made with [Cursor](https://cursor.com)