### PR TITLE
chore(repo): bump gazelle 0.47.0 → 0.52.2 — inherit the upstream protocompile override

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_go", version = "0.59.0")
-bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "gazelle", version = "0.52.2")
 bazel_dep(name = "rules_oci", version = "2.2.7")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
@@ -23,24 +23,6 @@ go_sdk.download(
 # Read Go deps from go.work (includes root + CLI + SDK modules)
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//:go.work")
-
-# protocompile vendors google/protobuf/compiler/plugin.proto (as embedded
-# data for its std-import feature). Without this override, gazelle sees that
-# .proto and synthesizes a go_proto_library whose importpath —
-# google.golang.org/protobuf/types/pluginpb, from the proto's go_package —
-# duplicates the real protobuf-go package, and any binary linking both (e.g.
-# via jhump/protoreflect) fails with a "multiple copies of package" link
-# error (oss#604). "gazelle:proto disable" stops gazelle generating
-# proto-derived Go rules inside that module; nothing consumes them.
-# This mirrors gazelle's own default override (bazel-gazelle PR #2278,
-# shipped in v0.48.0) — delete it once gazelle here is bumped past 0.47.0.
-go_deps.gazelle_override(
-    directives = [
-        "gazelle:proto disable",
-    ],
-    path = "github.com/bufbuild/protocompile",
-)
-
 use_repo(
     go_deps,
     "build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go",  # keep: Required for protovalidate protobuf types
@@ -50,7 +32,6 @@ use_repo(
     "com_github_aws_aws_sdk_go_v2_credentials",
     "com_github_aws_aws_sdk_go_v2_service_s3",
     "com_github_golang_jwt_jwt_v5",
-    "com_github_google_cel_go",
     "com_github_google_safearchive",
     "com_github_google_uuid",
     "com_github_improbable_eng_grpc_web",
@@ -60,9 +41,6 @@ use_repo(
     "com_github_oklog_ulid_v2",
     "com_github_pkg_errors",  # keep: Required for CLI error handling
     "com_github_rs_zerolog",
-    "com_github_stigmer_stigmer_apis_stubs_go",
-    "com_github_stigmer_stigmer_backend_libs_go",
-    "com_github_stigmer_stigmer_test_integration",
     "com_github_stretchr_testify",
     "com_github_testcontainers_testcontainers_go",
     "com_github_testcontainers_testcontainers_go_modules_minio",


### PR DESCRIPTION
## Summary

- Bumps `bazel_dep(name = "gazelle")` 0.47.0 → 0.52.2 (current BCR release, tested against Bazel 8) and **deletes the local protocompile `gazelle_override`** — it has been upstream's own default since v0.48.0 ([bazel-gazelle #2278](https://github.com/bazel-contrib/bazel-gazelle/pull/2278)), and the override block's comment named exactly this exit condition (Closes #617).
- `bazel mod tidy` drops four `use_repo` entries the resolver no longer needs (the go.work member modules build from source, not as external repos), retiring the standing "Fix the use_repo calls" warning printed on every build.
- `MODULE.bazel.lock` is untracked in this repo (gitignored), so the whole change is one file.

## Verification (full graph, per the issue's own bar)

- `bazel build //...` green with **1,378/1,378 action cache hits** — the new generator's output is byte-identical on this tree: the feared repo-wide BUILD churn is **zero**
- `bazelw run //:gazelle` regenerates nothing; `-mode=diff` clean
- `bazel test` wildcard (minus the #722 exclusions): 62/62 pass
- The #604 pluginpb protection now flows from the upstream default: `//tools/codegen/proto2schema` links in the wildcard with the local override gone — the override's exit criterion, proven
- rules_go 0.59.0 / Bazel 8.0.0 compatibility: BCR lists gazelle 0.52.2 as tested on Bazel 8.x; the full-graph build+test above is the empirical check

## Stacking

Based on `ci/oss-616-bazel-lane` (PR #723) so the new bazel lane is this bump's verification harness; GitHub retargets to `main` automatically when #723 merges and its branch is deleted.

## Test plan

- [ ] `Bazel Graph` green on this PR (the lane gating its own generator's bump)
- [ ] Retarget-to-main happens cleanly after #723 lands

Made with [Cursor](https://cursor.com)
