### PR TITLE
fix(backend/runner): take custody of runner secrets at boot so agent spawns can never read them

### DIFF
--- a/backend/services/runner/src/activities/call-llm.ts
+++ b/backend/services/runner/src/activities/call-llm.ts
@@ -31,6 +31,7 @@ import {
 import { computeLlmCostMicros, ensureLoaded as ensurePricingLoaded } from "../shared/model-pricing.js";
 import { resolveToApiModelId } from "../shared/model-registry.js";
 import { buildChatModel } from "../shared/model-client.js";
+import { getRunnerSecret } from "../shared/runner-credential-store.js";
 import { checkDirectCredentials } from "../shared/llm-backend.js";
 import { classifyModelCallError } from "../shared/model-error.js";
 
@@ -192,7 +193,10 @@ export async function callLlmAction(
   await ensurePricingLoaded().catch(() => {});
 
   const proxyEndpoint = process.env.STIGMER_PROXY_ENDPOINT;
-  const stigmerToken = process.env.STIGMER_TOKEN;
+  // Per-call store read: rotation (manager updateToken / static renewal)
+  // must be visible to in-flight workers, exactly like the env read it
+  // replaced (#508).
+  const stigmerToken = getRunnerSecret("STIGMER_TOKEN");
   const proxyActive = !!(proxyEndpoint && stigmerToken);
 
   console.log(

--- a/backend/services/runner/src/activities/execute-deep-agent/shell-env.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/shell-env.ts
@@ -1,19 +1,22 @@
 /**
  * Shell environment for the native harness `execute` tool.
  *
- * Per-execution snapshot: runner-manager rotates `STIGMER_TOKEN` in
- * `process.env` at runtime, so this must run inside setup for each execution,
- * never once at process start.
+ * Since #508's boot capture, runner secrets never LIVE in `process.env`, so
+ * the denylist below is defense-in-depth: it keeps this surface safe even if
+ * something re-plants a secret in the environment after boot (a test, an
+ * embedder, a future regression). Still built per execution — the snapshot
+ * must reflect the env as it is now, not at process start.
  */
 
-import { RUNNER_CREDENTIAL_ENV_KEYS } from "../../shared/runner-credential-keys.js";
+import { RUNNER_SECRET_ENV_KEYS } from "../../shared/runner-credential-keys.js";
 
 /**
  * Runner-internal keys that must never reach agent shell commands: every
- * credential the runner holds for its own outbound calls (issue #385). The
- * names — and the rule for adding one — live in runner-credential-keys.ts.
+ * credential the runner holds for its own outbound calls (issue #385) plus
+ * the runner's encryption keys (issue #508). The names — and the rules for
+ * adding one — live in runner-credential-keys.ts.
  */
-export const SHELL_ENV_DENYLIST: readonly string[] = RUNNER_CREDENTIAL_ENV_KEYS;
+export const SHELL_ENV_DENYLIST: readonly string[] = RUNNER_SECRET_ENV_KEYS;
 
 /**
  * Build the environment map passed to deepagents' LocalShellBackend.

--- a/backend/services/runner/src/config.ts
+++ b/backend/services/runner/src/config.ts
@@ -53,6 +53,7 @@ export const DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS = 120_000;
 // three construction sites — mirrors DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS).
 export { DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS } from "./shared/workspace/workspace-lock.js";
 import { DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS } from "./shared/workspace/workspace-lock.js";
+import { getRunnerSecret } from "./shared/runner-credential-store.js";
 
 export interface Config {
   readonly taskQueue: string;
@@ -158,9 +159,13 @@ export function loadConfig(): Config {
       : requireEnv("STIGMER_BACKEND_ENDPOINT"),
   );
 
-  const stigmerToken = (mode === "cloud" || proxyActive)
-    ? requireEnv("STIGMER_TOKEN")
-    : (process.env.STIGMER_TOKEN ?? null);
+  // Secrets resolve through the credential store, not process.env — the
+  // boot capture has already moved them out of the environment (#508).
+  const stigmerTokenValue = getRunnerSecret("STIGMER_TOKEN");
+  if ((mode === "cloud" || proxyActive) && !stigmerTokenValue) {
+    throw new Error("Required environment variable STIGMER_TOKEN is not set");
+  }
+  const stigmerToken = stigmerTokenValue ?? null;
 
   const mcpBridgeEndpoint = process.env.STIGMER_MCP_BRIDGE_ENDPOINT ?? null;
 
@@ -170,8 +175,8 @@ export function loadConfig(): Config {
   // the SDK's authorization header (Cursor access token) passes through to
   // api2.cursor.sh unchanged.
   const cursorApiKey = proxyActive
-    ? (process.env.CURSOR_API_KEY ?? stigmerToken ?? "proxy-managed")
-    : (process.env.CURSOR_API_KEY ?? "");
+    ? (getRunnerSecret("CURSOR_API_KEY") ?? stigmerToken ?? "proxy-managed")
+    : (getRunnerSecret("CURSOR_API_KEY") ?? "");
 
   const workspaceRootDir = resolveWorkspaceRootDir();
 

--- a/backend/services/runner/src/encryption/config.ts
+++ b/backend/services/runner/src/encryption/config.ts
@@ -25,6 +25,8 @@
  * on the next runner boot — there is no live re-key.
  */
 
+import { getRunnerSecret } from "../shared/runner-credential-store.js";
+
 export interface EncryptionKey {
   readonly keyId: string;
   /** 32-byte AES-256 key. */
@@ -75,14 +77,18 @@ const AES_256_KEY_BYTES = 32;
 export function loadPayloadEncryptionConfig(
   bootstrap?: BootstrapKeyMaterial,
 ): PayloadEncryptionConfig | undefined {
-  const rawKey = process.env[KEY_ENV];
+  // Key VALUES resolve through the credential store (the #508 boot capture
+  // moves them out of process.env — agent shells must not read them); the
+  // *_KEY_ID companions are rotation bookkeeping, not secrets, and stay
+  // plain env reads.
+  const rawKey = getRunnerSecret(KEY_ENV);
   if (rawKey) {
     const primary: EncryptionKey = {
       keyId: requireKeyId(KEY_ID_ENV),
       key: parseKey(rawKey, KEY_ENV),
     };
 
-    const rawSecondary = process.env[SECONDARY_KEY_ENV];
+    const rawSecondary = getRunnerSecret(SECONDARY_KEY_ENV);
     const secondary: EncryptionKey | undefined = rawSecondary
       ? {
           keyId: requireKeyId(SECONDARY_KEY_ID_ENV),

--- a/backend/services/runner/src/main.ts
+++ b/backend/services/runner/src/main.ts
@@ -32,6 +32,10 @@ import { createInterface } from "node:readline";
 import { preflightNodeRuntime } from "./preflight.js";
 import { markBoot, emitRunnerBootTiming } from "./shared/cold-start-timing.js";
 import { loadConfig } from "./config.js";
+import {
+  captureRunnerSecrets,
+  getRunnerSecret,
+} from "./shared/runner-credential-store.js";
 import { initTracing, initMetrics } from "./otel.js";
 import { createStigmerRunner } from "./runner.js";
 import { createStigmerRunnerManager } from "./runner-manager.js";
@@ -214,11 +218,12 @@ async function runPoolMode(
   });
 
   // Sandbox credential self-renewal (see sandbox-token-renewal.ts). Watches
-  // the env var because manager.updateToken keeps it in lockstep with the
-  // manager's internal ref: a blank member's pool_sandbox token parks the
-  // loop, the claim's updateToken swaps in a renewable session token, and
-  // from then on renewal applies fresh tokens back through the same
-  // updateToken (which also cascades to the proxy-credential coordinator).
+  // the credential store because manager.updateToken keeps it in lockstep
+  // with the manager's internal ref: a blank member's pool_sandbox token
+  // parks the loop, the claim's updateToken swaps in a renewable session
+  // token, and from then on renewal applies fresh tokens back through the
+  // same updateToken (which also cascades to the proxy-credential
+  // coordinator).
   const { startSandboxTokenRenewal } = await import("./sandbox-token-renewal.js");
   const { StigmerClient } = await import("./client/stigmer-client.js");
   const renewalClient = new StigmerClient({
@@ -226,7 +231,7 @@ async function runPoolMode(
     token: null,
   });
   const tokenRenewal = startSandboxTokenRenewal({
-    getToken: () => process.env.STIGMER_TOKEN ?? null,
+    getToken: () => getRunnerSecret("STIGMER_TOKEN") ?? null,
     renew: (currentToken) =>
       renewalClient.getRunnerScopedToken({ renewal: true }, currentToken),
     applyToken: (token) => manager.updateToken(token),
@@ -448,6 +453,11 @@ async function main(): Promise<void> {
   markBoot("node_start_and_preflight");
 
   checkBuildFreshness();
+
+  // Take custody of runner secrets before the config load reads them (#508).
+  // The factories capture too (they are the library boot doors); doing it
+  // here as well keeps main.ts's own late readers store-only from the start.
+  captureRunnerSecrets();
 
   const config = loadConfig();
   markBoot("config_loaded");

--- a/backend/services/runner/src/payload-codecs.ts
+++ b/backend/services/runner/src/payload-codecs.ts
@@ -15,6 +15,7 @@
 import type { PayloadCodec } from "@temporalio/common";
 import type { Config } from "./config.js";
 import type { BootstrapKeyMaterial } from "./encryption/config.js";
+import { getRunnerSecret } from "./shared/runner-credential-store.js";
 
 export async function createPayloadCodecs(
   config: Config,
@@ -30,7 +31,7 @@ export async function createPayloadCodecs(
   const encryptionConfig = loadPayloadEncryptionConfig(bootstrapKeys);
   if (encryptionConfig) {
     codecs.push(new EncryptionPayloadCodec(encryptionConfig));
-    const source = process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY ? "env" : "bootstrap";
+    const source = getRunnerSecret("STIGMER_PAYLOAD_ENCRYPTION_KEY") ? "env" : "bootstrap";
     console.log(
       `[runner] Payload encryption enabled (source=${source}, ` +
         `key_id=${encryptionConfig.primary.keyId}` +

--- a/backend/services/runner/src/runner-manager.ts
+++ b/backend/services/runner/src/runner-manager.ts
@@ -32,6 +32,11 @@ import type { WorkerActivities } from "./worker.js";
 import { resolveWorkflowSource, OTEL_WORKFLOW_INTERCEPTOR_MODULE } from "./workflow-source.js";
 import { resolveRunnerBootstrap, refreshRunnerAccessToken } from "./bootstrap.js";
 import { assertLlmBackendsPreflight } from "./preflight.js";
+import {
+  captureRunnerSecrets,
+  getRunnerSecret,
+  setRunnerSecret,
+} from "./shared/runner-credential-store.js";
 import { createRunnerTokenCoordinator } from "./runner-token-coordinator.js";
 // Per-task-queue in-flight activity tracking lives in ./in-flight.ts so the
 // activity interceptor (no manager-closure handle) and unit tests can reach it.
@@ -214,6 +219,12 @@ export async function createStigmerRunnerManager(
 ): Promise<StigmerRunnerManager> {
   validateManagerOptions(options);
 
+  // Take custody of runner secrets BEFORE anything else can read them from
+  // env — and before any agent code could spawn with them (#508). Runs here
+  // (not only in main.ts) because this factory is a public library boot door:
+  // in-process embedders like the desktop never execute main.ts.
+  captureRunnerSecrets();
+
   const { registerStigmerDeepagentsProfiles } = await import(
     "./activities/execute-deep-agent/deepagents-profiles.js"
   );
@@ -365,7 +376,7 @@ export async function createStigmerRunnerManager(
   if (
     !bootstrap.payloadEncryption &&
     bootstrap.runnerAccessToken &&
-    !process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY
+    !getRunnerSecret("STIGMER_PAYLOAD_ENCRYPTION_KEY")
   ) {
     console.warn(
       "[runner-manager] Server minted a runner token but returned no payload " +
@@ -592,12 +603,11 @@ export async function createStigmerRunnerManager(
       // proxy credential follows it: only when no token has been minted (so the
       // pre-mint lockstep is preserved), never once the runner owns a minted
       // token. See runner-token-coordinator.ts and the staleness changelogs.
+      // The credential store is the second leg of the pair (it replaced the
+      // process.env.STIGMER_TOKEN write, #508): per-call readers like
+      // call-llm and the registry headers resolve the current token there.
       tokenRef.current = token;
-      if (token) {
-        process.env.STIGMER_TOKEN = token;
-      } else {
-        delete process.env.STIGMER_TOKEN;
-      }
+      setRunnerSecret("STIGMER_TOKEN", token);
       tokenCoordinator.onControlPlaneTokenChanged(token);
       console.log("[runner-manager] Auth token updated");
     },

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -20,6 +20,10 @@ import { DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS, DEFAULT_CURSOR_STREAM_STALL_TI
 import type { WorkerActivities } from "./worker.js";
 import { resolveRunnerBootstrap } from "./bootstrap.js";
 import { assertLlmBackendsPreflight } from "./preflight.js";
+import {
+  captureRunnerSecrets,
+  setRunnerSecret,
+} from "./shared/runner-credential-store.js";
 import { markBoot, emitRunnerBootTiming } from "./shared/cold-start-timing.js";
 
 /**
@@ -118,11 +122,12 @@ export interface StigmerRunner {
  * Wire up self-renewal for a static cloud sandbox's control-plane credential
  * (see sandbox-token-renewal.ts for the model). The applied token reaches
  * every consumer: activity gRPC clients read {@code tokenRef} per request,
- * env-reading call sites (call-llm, registry-endpoint) read
- * {@code process.env.STIGMER_TOKEN} per call, artifact storage resolves the
- * ref per call, and the two Cursor SDK interceptors are updated directly —
- * a static runner has no {@code RunnerTokenCoordinator} minting a separate
- * proxy credential, so its x-stigmer-auth IS this token.
+ * per-call sites (call-llm, registry-endpoint headers) resolve it through
+ * the runner credential store (which replaced the process.env.STIGMER_TOKEN
+ * channel, #508), artifact storage resolves the ref per call, and the two
+ * Cursor SDK interceptors are updated directly — a static runner has no
+ * {@code RunnerTokenCoordinator} minting a separate proxy credential, so its
+ * x-stigmer-auth IS this token.
  */
 async function startStaticSandboxTokenRenewal(
   config: Config,
@@ -157,7 +162,9 @@ async function startStaticSandboxTokenRenewal(
       client.getRunnerScopedToken({ renewal: true }, currentToken),
     applyToken: (token) => {
       tokenRef.current = token;
-      process.env.STIGMER_TOKEN = token;
+      // Store write replaced the process.env.STIGMER_TOKEN write (#508) —
+      // same per-call readers (call-llm, registry headers), no env exposure.
+      setRunnerSecret("STIGMER_TOKEN", token);
       updateInterceptorToken(token);
       updateHttp2InterceptorToken(token);
     },
@@ -189,6 +196,12 @@ export async function createStigmerRunner(
   options: StigmerRunnerOptions,
 ): Promise<StigmerRunner> {
   validateOptions(options);
+
+  // Take custody of runner secrets BEFORE anything else can read them from
+  // env — and before any agent code could spawn with them (#508). Runs here
+  // (not only in main.ts) because this factory is a public library boot door
+  // for in-process embedders.
+  captureRunnerSecrets();
 
   const { registerStigmerDeepagentsProfiles } = await import(
     "./activities/execute-deep-agent/deepagents-profiles.js"

--- a/backend/services/runner/src/shared/__tests__/runner-credential-store.test.ts
+++ b/backend/services/runner/src/shared/__tests__/runner-credential-store.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  captureRunnerSecrets,
+  getRunnerSecret,
+  setRunnerSecret,
+  runnerSecretsEnvView,
+  resetRunnerSecretsForTests,
+} from "../runner-credential-store.js";
+import {
+  RUNNER_CREDENTIAL_ENV_KEYS,
+  RUNNER_ENCRYPTION_ENV_KEYS,
+  RUNNER_SECRET_ENV_KEYS,
+} from "../runner-credential-keys.js";
+
+/** Snapshot/restore of every env slot these tests touch. */
+const savedEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  resetRunnerSecretsForTests();
+  for (const key of RUNNER_SECRET_ENV_KEYS) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  resetRunnerSecretsForTests();
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  savedEnv.clear();
+});
+
+describe("captureRunnerSecrets", () => {
+  it("moves every listed secret out of process.env and into the store", () => {
+    // Plant a value for every name in the source-of-truth list, so a key
+    // added to runner-credential-keys.ts is covered here automatically —
+    // the #385 test idiom, applied to custody.
+    for (const key of RUNNER_SECRET_ENV_KEYS) {
+      process.env[key] = `boot-${key}`;
+    }
+
+    captureRunnerSecrets();
+
+    for (const key of RUNNER_SECRET_ENV_KEYS) {
+      expect(
+        process.env[key],
+        `'${key}' must not remain in process.env after capture — anything ` +
+        `left there is readable by every agent shell command (issue #508)`,
+      ).toBeUndefined();
+      expect(getRunnerSecret(key)).toBe(`boot-${key}`);
+    }
+  });
+
+  it("is idempotent — a second capture cannot re-freeze rotated values", () => {
+    process.env.STIGMER_TOKEN = "boot-token";
+    captureRunnerSecrets();
+    setRunnerSecret("STIGMER_TOKEN", "rotated-token");
+
+    // A late (buggy or racing) boot-door call must be a no-op.
+    process.env.STIGMER_TOKEN = "stale-replant";
+    captureRunnerSecrets();
+
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBe("rotated-token");
+    // The replant stays in env (capture did not consume it) — the live-env
+    // fallback below deliberately does NOT apply when the store holds a
+    // value, so rotation always wins.
+    expect(process.env.STIGMER_TOKEN).toBe("stale-replant");
+    delete process.env.STIGMER_TOKEN;
+  });
+
+  it("scrubs the encryption keys, not only the #385 credentials (issue #508)", () => {
+    // Pins the #508 scope widening by name. The parameterized test above
+    // would pass even if the combined list regressed to the 8 credentials;
+    // this one cannot.
+    for (const key of [
+      "STIGMER_PAYLOAD_ENCRYPTION_KEY",
+      "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY",
+    ]) {
+      expect(RUNNER_ENCRYPTION_ENV_KEYS, `'${key}' must be a captured secret`).toContain(key);
+    }
+    for (const key of [...RUNNER_CREDENTIAL_ENV_KEYS, ...RUNNER_ENCRYPTION_ENV_KEYS]) {
+      expect(RUNNER_SECRET_ENV_KEYS, `'${key}' must be in the scrub list`).toContain(key);
+    }
+  });
+});
+
+describe("getRunnerSecret", () => {
+  it("falls back to a live process.env value the capture never saw", () => {
+    captureRunnerSecrets();
+    // Custody rule 2: a value planted after boot behaves like the env read
+    // the store replaced (test/embedder compatibility) — production only
+    // sets these at process start, so this path is dead there.
+    process.env.STIGMER_TOKEN = "late-planted";
+
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBe("late-planted");
+  });
+
+  it("returns undefined for an absent secret", () => {
+    captureRunnerSecrets();
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBeUndefined();
+  });
+});
+
+describe("setRunnerSecret", () => {
+  it("carries the rotation channel: set updates, null clears", () => {
+    captureRunnerSecrets();
+
+    setRunnerSecret("STIGMER_TOKEN", "minted-1");
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBe("minted-1");
+
+    setRunnerSecret("STIGMER_TOKEN", "minted-2");
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBe("minted-2");
+
+    setRunnerSecret("STIGMER_TOKEN", null);
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBeUndefined();
+  });
+
+  it("never lets a rotated value sit in process.env, even if a writer beats the boot capture", () => {
+    process.env.STIGMER_TOKEN = "boot-token";
+
+    // No captureRunnerSecrets() call yet — the writer forces it.
+    setRunnerSecret("STIGMER_TOKEN", "rotated-early");
+
+    expect(process.env.STIGMER_TOKEN).toBeUndefined();
+    expect(getRunnerSecret("STIGMER_TOKEN")).toBe("rotated-early");
+  });
+});
+
+describe("runnerSecretsEnvView", () => {
+  it("merges captured secrets over process.env without writing them back", () => {
+    process.env.STIGMER_TOKEN = "boot-token";
+    captureRunnerSecrets();
+
+    const view = runnerSecretsEnvView();
+
+    expect(view.STIGMER_TOKEN).toBe("boot-token");
+    expect(view.PATH).toBe(process.env.PATH);
+    expect(
+      process.env.STIGMER_TOKEN,
+      "building the view must not re-plant secrets into process.env",
+    ).toBeUndefined();
+  });
+
+  it("reflects rotation", () => {
+    captureRunnerSecrets();
+    setRunnerSecret("STIGMER_TOKEN", "rotated");
+
+    expect(runnerSecretsEnvView().STIGMER_TOKEN).toBe("rotated");
+  });
+});

--- a/backend/services/runner/src/shared/fingerprint-secret.ts
+++ b/backend/services/runner/src/shared/fingerprint-secret.ts
@@ -20,6 +20,7 @@
  */
 
 import { randomBytes, type BinaryLike } from "node:crypto";
+import { getRunnerSecret } from "./runner-credential-store.js";
 
 const ENV_VAR = "STIGMER_RUNNER_HITL_SECRET";
 
@@ -27,13 +28,14 @@ let cached: Buffer | undefined;
 let warned = false;
 
 /**
- * Return the runner's HITL master secret (env-configured, else a stable
- * per-process random fallback). Memoized.
+ * Return the runner's HITL master secret (operator-configured via the
+ * {@link ENV_VAR} env var, resolved through the credential store since the
+ * #508 boot capture; else a stable per-process random fallback). Memoized.
  */
 export function getRunnerHitlMasterSecret(): BinaryLike {
   if (cached) return cached;
 
-  const fromEnv = process.env[ENV_VAR];
+  const fromEnv = getRunnerSecret(ENV_VAR);
   if (fromEnv && fromEnv.length > 0) {
     cached = Buffer.from(fromEnv, "utf-8");
     return cached;

--- a/backend/services/runner/src/shared/llm-backend.ts
+++ b/backend/services/runner/src/shared/llm-backend.ts
@@ -15,6 +15,7 @@
  */
 
 import type { LlmProvider } from "./llm-proxy.js";
+import { runnerSecretsEnvView } from "./runner-credential-store.js";
 
 // ─── Backend selection ───────────────────────────────────────────────────────
 
@@ -345,7 +346,12 @@ export function checkFoundryPrerequisites(
  */
 export function checkDirectCredentials(
   provider: LlmProvider,
-  env: NodeJS.ProcessEnv = process.env,
+  // Credential keys live in the runner credential store after the boot
+  // capture (#508), so the default is the store view, not bare process.env.
+  // The other checks in this module keep the process.env default: they read
+  // deployment CONFIG (backend selection, regions), which is deliberately
+  // not captured.
+  env: NodeJS.ProcessEnv = runnerSecretsEnvView(),
 ): string | null {
   if (provider === "openai") {
     if (env.OPENAI_API_KEY?.trim()) return null;

--- a/backend/services/runner/src/shared/model-client.ts
+++ b/backend/services/runner/src/shared/model-client.ts
@@ -39,6 +39,7 @@ import {
   toOpenAiServiceTier,
   type EffectiveServiceTier,
 } from "./service-tier.js";
+import { getRunnerSecret } from "./runner-credential-store.js";
 
 export interface BuildChatModelOptions {
   /** Registry id ("claude-haiku-4.5"), "provider:model", or a provider API id. */
@@ -147,11 +148,11 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
   // tests. Prerequisites are re-checked here (not only in
   // the factories' preflight) so paths that construct models without a
   // runner factory still fail at dispatch with the catalog message instead
-  // of mid-request. Credentials are read natively by each SDK from its
-  // standard conventions (GCP: CLOUD_ML_REGION + ADC; AWS: AWS_REGION +
-  // the credential chain / AWS_BEARER_TOKEN_BEDROCK; Foundry:
-  // ANTHROPIC_FOUNDRY_API_KEY, or the Azure credential chain when no key
-  // is set).
+  // of mid-request. Ambient credentials are read natively by each SDK from
+  // its standard conventions (GCP: CLOUD_ML_REGION + ADC; AWS: AWS_REGION +
+  // the credential chain); runner-held keys (AWS_BEARER_TOKEN_BEDROCK,
+  // ANTHROPIC_FOUNDRY_API_KEY) are passed explicitly from the credential
+  // store because the boot capture empties their env slots (#508).
   let backendCreateClient:
     | ((options: { maxRetries?: number; timeout?: number }) => unknown)
     | undefined;
@@ -168,8 +169,17 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     const prereq = checkBedrockPrerequisites();
     if (prereq !== null) throw new Error(prereq);
     const { AnthropicBedrock } = await import("@anthropic-ai/bedrock-sdk");
+    // The SDK's own default for `apiKey` is process.env.AWS_BEARER_TOKEN_BEDROCK,
+    // which the boot capture has emptied (#508) — hand it the stored value
+    // explicitly. `undefined` when absent preserves the SDK's fallthrough to
+    // the ambient AWS credential chain (env keys, IRSA, config files).
+    const bedrockBearerToken = getRunnerSecret("AWS_BEARER_TOKEN_BEDROCK");
     backendCreateClient = (options) =>
-      new AnthropicBedrock({ maxRetries: options.maxRetries, timeout: options.timeout });
+      new AnthropicBedrock({
+        apiKey: bedrockBearerToken,
+        maxRetries: options.maxRetries,
+        timeout: options.timeout,
+      });
     wireModelId = toBedrockModelId(apiModelId);
     if (maxTokens === undefined) {
       // LangChain's per-model maxTokens table prefix-matches the model
@@ -198,8 +208,13 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     // so refreshed tokens flow without reconstruction (pinned by
     // foundry-seam.test.ts). Endpoint (resource or base URL) and the key
     // are read natively by the SDK from its own env vars.
+    // The SDK's own default for `apiKey` is process.env.ANTHROPIC_FOUNDRY_API_KEY,
+    // which the boot capture has emptied (#508) — resolve it from the store
+    // and hand it over explicitly. The either/or stays intact: exactly one of
+    // apiKey / azureADTokenProvider reaches the constructor.
+    const foundryApiKey = getRunnerSecret("ANTHROPIC_FOUNDRY_API_KEY")?.trim() || undefined;
     let azureADTokenProvider: (() => Promise<string>) | undefined;
-    if (!process.env.ANTHROPIC_FOUNDRY_API_KEY?.trim()) {
+    if (!foundryApiKey) {
       const { DefaultAzureCredential, getBearerTokenProvider } = await import("@azure/identity");
       azureADTokenProvider = getBearerTokenProvider(
         new DefaultAzureCredential(),
@@ -210,7 +225,7 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
       new AnthropicFoundry({
         maxRetries: options.maxRetries,
         timeout: options.timeout,
-        ...(azureADTokenProvider ? { azureADTokenProvider } : {}),
+        ...(foundryApiKey ? { apiKey: foundryApiKey } : { azureADTokenProvider }),
       });
     // Unlike the vertex/bedrock ids, the deployment name needs no maxTokens
     // handling: stripping the snapshot date preserves LangChain's per-model
@@ -226,13 +241,14 @@ export async function buildChatModel(opts: BuildChatModelOptions): Promise<Built
     ? buildProxyHeaders(opts.stigmerToken, opts.headerScope ?? {})
     : undefined;
 
-  // Proxy mode authenticates with the Stigmer token; direct mode falls back to
-  // the provider's own env-var key.
+  // Proxy mode authenticates with the Stigmer token; direct mode falls back
+  // to the provider's own key, resolved from the credential store (the boot
+  // capture moved it out of process.env, #508).
   const apiKey = opts.proxyEndpoint
     ? (opts.stigmerToken ?? "proxy-managed")
     : provider === "openai"
-      ? (process.env.OPENAI_API_KEY ?? "")
-      : (process.env.ANTHROPIC_API_KEY ?? "");
+      ? (getRunnerSecret("OPENAI_API_KEY") ?? "")
+      : (getRunnerSecret("ANTHROPIC_API_KEY") ?? "");
 
   // maxRetries applies when a timeout is bound (a retry loop under a bound
   // multiplies the wall-clock budget) or when the caller pinned it

--- a/backend/services/runner/src/shared/registry-endpoint.ts
+++ b/backend/services/runner/src/shared/registry-endpoint.ts
@@ -21,6 +21,7 @@
 
 import { normalizeEndpoint } from "../config.js";
 import type { FetchRetryPolicy } from "./http-retry.js";
+import { runnerSecretsEnvView } from "./runner-credential-store.js";
 
 /** Default local stigmer-server origin — mirrors config.ts's local-mode default. */
 const DEFAULT_LOCAL_BACKEND = "http://localhost:7234";
@@ -68,8 +69,15 @@ export function resolveRegistryBaseUrl(env: NodeJS.ProcessEnv = process.env): st
 /**
  * Build request headers for registry fetches: bearer auth when a token is
  * present (cloud requires it; the local server ignores it).
+ *
+ * The default env is the credential-store view, not bare `process.env`:
+ * both token names are captured out of the environment at boot (#508), and
+ * the store also carries rotated tokens (manager updateToken / static
+ * renewal) that never touch env at all.
  */
-export function buildRegistryHeaders(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export function buildRegistryHeaders(
+  env: NodeJS.ProcessEnv = runnerSecretsEnvView(),
+): Record<string, string> {
   const token = env.STIGMER_TOKEN ?? env.STIGMER_AUTH_TOKEN;
   return token ? { Authorization: `Bearer ${token}` } : {};
 }

--- a/backend/services/runner/src/shared/runner-credential-keys.ts
+++ b/backend/services/runner/src/shared/runner-credential-keys.ts
@@ -10,7 +10,13 @@
  * their sanctioned delivery channel, and denying them here would break it.
  *
  * Consumers:
- * - shell-env.ts: SHELL_ENV_DENYLIST for the native harness `execute` tool.
+ * - runner-credential-store.ts: captures every name listed in this module
+ *   out of `process.env` at boot (issue #508 — the Cursor SDK's local agent
+ *   runtime runs in-process and its shell tool spawns from the runner's own
+ *   env, so credentials must not LIVE there; see that module for custody
+ *   rules).
+ * - shell-env.ts: SHELL_ENV_DENYLIST for the native harness `execute` tool
+ *   (defense-in-depth behind the boot scrub).
  * - mcp-manager.test.ts: leak-tripwire canaries for MCP stdio subprocesses
  *   (that path passes NO runner env by construction; the test plants these
  *   names to prove none leak through).
@@ -43,4 +49,33 @@ export const RUNNER_CREDENTIAL_ENV_KEYS: readonly string[] = [
   // Bedrock backend bearer credential, read by the AWS SDK's chain
   // (llm-backend.ts documents it as a supported auth path).
   "AWS_BEARER_TOKEN_BEDROCK",
+];
+
+/**
+ * Env var names of the runner's non-credential secrets — material that is
+ * not an outbound-call credential (so it does not belong in
+ * {@link RUNNER_CREDENTIAL_ENV_KEYS}, whose inclusion rule is pinned above)
+ * but is every bit as sensitive in an agent-readable environment
+ * (owner ruling on #508: same boot scrub, separate constant so the #385
+ * rule keeps its meaning).
+ *
+ * The `*_KEY_ID` companions are deliberately absent: key identifiers are
+ * rotation bookkeeping, not secrets.
+ */
+export const RUNNER_ENCRYPTION_ENV_KEYS: readonly string[] = [
+  // Temporal payload-encryption keys (encryption/config.ts). An agent that
+  // reads these could decrypt the runner's Temporal history payloads.
+  "STIGMER_PAYLOAD_ENCRYPTION_KEY",
+  "STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY",
+];
+
+/**
+ * Every env name whose VALUE the credential store takes custody of at boot:
+ * the #385 credential set plus the #508 encryption-key set. This is the
+ * scrub list — after `captureRunnerSecrets()`, none of these names remain
+ * in `process.env`.
+ */
+export const RUNNER_SECRET_ENV_KEYS: readonly string[] = [
+  ...RUNNER_CREDENTIAL_ENV_KEYS,
+  ...RUNNER_ENCRYPTION_ENV_KEYS,
 ];

--- a/backend/services/runner/src/shared/runner-credential-store.ts
+++ b/backend/services/runner/src/shared/runner-credential-store.ts
@@ -1,0 +1,115 @@
+/**
+ * Custody point for the runner's own secrets — the VALUES companion to
+ * runner-credential-keys.ts's names (issue #508).
+ *
+ * Why this exists: the Cursor SDK's local agent runtime ships inside
+ * `@cursor/sdk` and runs IN-PROCESS in the runner. Its shell tool spawns
+ * bash with `{...process.env, ...}` and its git layer does the same, so
+ * anything living in the runner's `process.env` is readable by every shell
+ * command the agent runs — and the SDK exposes no env option for local
+ * agents to scrub at the spawn boundary. Denylists on runner-owned spawn
+ * sites (shell-env.ts) cannot reach those vendor spawns. The only fix that
+ * covers every spawn surface, present and future, is for secrets not to
+ * LIVE in `process.env` at all: this module captures them at boot and is
+ * the sole holder afterwards.
+ *
+ * Custody rules:
+ *
+ *  1. `captureRunnerSecrets()` runs at every boot door (both public runner
+ *     factories, plus main() for symmetry) — it MOVES every
+ *     {@link RUNNER_SECRET_ENV_KEYS} value out of `process.env` into a
+ *     module-private map. Idempotent; first call wins.
+ *  2. Reads go through {@link getRunnerSecret}: captured value first, live
+ *     `process.env` as fallback. The fallback keeps the store honest rather
+ *     than frozen — production sets these vars only at process start (the
+ *     capture window), so the fallback is a dead path there, but tests and
+ *     unusual embedders that plant a value later see it behave exactly like
+ *     the env read it replaced.
+ *  3. Rotation writes go through {@link setRunnerSecret} (the
+ *     runner-manager/static-renewal token channel that previously wrote
+ *     `process.env.STIGMER_TOKEN` in lockstep with its tokenRef).
+ *  4. {@link runnerSecretsEnvView} adapts the store to the codebase's
+ *     `env: NodeJS.ProcessEnv` injection seams (llm-backend,
+ *     registry-endpoint). The view re-merges secrets over `process.env` —
+ *     it exists for in-process CONFIG READS ONLY and must never be handed
+ *     to a child process env or any spawn options.
+ *
+ * Embedder note: `@stigmer/runner` is a public library, and capture runs
+ * inside the factories, so embedding the runner scrubs the HOST process's
+ * env of runner secrets at boot. That is the point — agent shells run in
+ * the embedder's process — and host code that still needs a value reads it
+ * through this module.
+ */
+
+import { RUNNER_SECRET_ENV_KEYS } from "./runner-credential-keys.js";
+
+const captured = new Map<string, string>();
+let captureRan = false;
+
+/**
+ * Move every {@link RUNNER_SECRET_ENV_KEYS} value out of `process.env` into
+ * the store. Idempotent — only the first call captures, so a late caller
+ * cannot re-freeze values that rotation has since replaced.
+ */
+export function captureRunnerSecrets(): void {
+  if (captureRan) return;
+  captureRan = true;
+  for (const name of RUNNER_SECRET_ENV_KEYS) {
+    const value = process.env[name];
+    if (value !== undefined) {
+      captured.set(name, value);
+      delete process.env[name];
+    }
+  }
+}
+
+/**
+ * Read a runner secret: captured value first, live `process.env` fallback
+ * (see custody rule 2). Returns `undefined` when the secret is absent —
+ * callers own their missing-secret reaction, exactly as with the env reads
+ * this replaces.
+ */
+export function getRunnerSecret(name: string): string | undefined {
+  return captured.get(name) ?? process.env[name];
+}
+
+/**
+ * Write (or with `null`, clear) a runner secret — the rotation channel.
+ * Ensures capture has run first so a rotated value can never sit in
+ * `process.env` because a writer beat the boot capture.
+ */
+export function setRunnerSecret(name: string, value: string | null): void {
+  captureRunnerSecrets();
+  if (value === null) {
+    captured.delete(name);
+  } else {
+    captured.set(name, value);
+  }
+}
+
+/**
+ * `process.env` with the captured secrets merged back over it — an adapter
+ * for the `env: NodeJS.ProcessEnv` injection seams so their defaults stay
+ * secret-aware after the boot scrub.
+ *
+ * IN-PROCESS CONFIG READS ONLY: never pass this to a spawn/exec env, a
+ * worker thread, or anything else that leaves the process — doing so would
+ * reopen exactly the leak the store closes.
+ */
+export function runnerSecretsEnvView(): NodeJS.ProcessEnv {
+  const view: NodeJS.ProcessEnv = { ...process.env };
+  for (const [name, value] of captured) {
+    view[name] = value;
+  }
+  return view;
+}
+
+/**
+ * Test-only: forget everything captured and re-arm capture. Unit tests that
+ * plant secret env vars and boot pieces of the runner need each test to see
+ * its own values.
+ */
+export function resetRunnerSecretsForTests(): void {
+  captured.clear();
+  captureRan = false;
+}


### PR DESCRIPTION
## Summary

Fixes the #508 credential exposure at its root — with a premise correction found during planning.

**Premise correction** (verified against the installed `@cursor/sdk` v1.0.13 bundle): there is no `cursor-agent` subprocess to scrub. The SDK's entire local agent runtime runs **in-process in the runner** (as `test/integration/agent_execution_cursor_mcp_stdio_env_isolation_test.go` already documents), its shell tool spawns bash with `{...process.env, TERM:"dumb", ...}`, its git layer spreads `process.env` the same way, and `LocalAgentOptions` carries no env parameter — the issue's suggested spawn-boundary scrub has nowhere to attach. The MCP-stdio path is unaffected (declared-env-only, pinned by the existing integration test).

**The fix**: runner secrets no longer *live* in `process.env`, so every spawn surface — the SDK shell today, anything a dependency spawns tomorrow — is safe by construction:

- New `shared/runner-credential-store.ts`: `captureRunnerSecrets()` moves every `RUNNER_SECRET_ENV_KEYS` value out of `process.env` at both public factory boot doors (`createStigmerRunner` / `createStigmerRunnerManager` — embedders like the desktop never execute `main.ts`), and the store is the sole holder afterwards. Reads fall back to live env so injectable-env test patterns keep working; rotation always wins over a late replant.
- The token rotation channel (manager `updateToken`, static sandbox renewal `applyToken`) writes the store instead of `process.env.STIGMER_TOKEN`; per-call readers (`call-llm`, registry headers, config load, HITL fingerprint secret, payload-encryption keys) resolve through it.
- Bedrock and Foundry clients receive their keys explicitly (`apiKey` constructor options) because both SDKs default to the now-empty env slots; absent keys preserve the ambient AWS/Azure chain fallthrough.
- **Scope widening (owner-ruled)**: the Temporal payload-encryption keys join the scrub as `RUNNER_ENCRYPTION_ENV_KEYS` — same leak class, missed by #385's "outbound credentials" inclusion rule, which keeps its documented meaning intact.
- The #385 shell denylist stays as defense-in-depth and now covers the full secret list.

## Test plan

- [x] Process-level mechanism check: with all 10 secrets planted, an inherited-env child (`{...process.env}` — the SDK shell tool's exact spawn pattern) sees **10/10 before capture, 0/10 after**
- [x] New deterministic pins: capture scrubs every listed name (parameterized over the constant so future additions are covered automatically), idempotence vs. rotation, encryption-key scope pin, env-view merge semantics — 9 tests
- [x] `tsc --noEmit` clean
- [x] Full runner suite: 4649 passed / 6 skipped (Node 22.22.1)
- [ ] Live end-to-end agent-shell `env` dump needs an owner-held funded `CURSOR_API_KEY` — the deterministic root pin is stronger (an env that holds no secrets cannot leak them regardless of what the SDK spawns), but the live confirmation is a one-command check once a key is available

Closes #508

Made with [Cursor](https://cursor.com)