### PR TITLE
feat(sdk): adopt the skill artifact transfer lane in the TS, React, Python, and Java SDKs

### DIFF
--- a/client-apps/cli/src/resources/skill.test.ts
+++ b/client-apps/cli/src/resources/skill.test.ts
@@ -4,9 +4,6 @@
 import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { create } from "@bufbuild/protobuf";
-import { Code, ConnectError } from "@connectrpc/connect";
-import { PushSkillRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import type { Stigmer } from "@stigmer/sdk";
 import { unzipSync, zipSync } from "fflate";
@@ -19,7 +16,6 @@ import {
   hasSkillFile,
   parseSkillMetadata,
   parseVisibility,
-  pushRouted,
   pushSkill,
   pushSkillFromArchive,
   readSkillArchive,
@@ -354,76 +350,8 @@ describe("formatBytes / shortHash", () => {
   });
 });
 
-// ─── pushRouted — transfer-lane size routing (#675) ──────────────────────
-
-describe("pushRouted size routing", () => {
-  const INLINE_MAX = 10 * 1024 * 1024 - 64 * 1024;
-
-  function routingFakeClient(overrides: Record<string, any> = {}) {
-    const calls = { push: [] as any[], mint: [] as any[] };
-    const client = {
-      skill: {
-        async push(req: any) {
-          calls.push.push(req);
-          return { metadata: { id: "skill_x" } };
-        },
-        async createArtifactUploadUrl(req: any) {
-          calls.mint.push(req);
-          return { url: "http://localhost:7234/v1/skill-artifacts/uploads/sau_t", artifactUploadRef: "sau_t", ttlSeconds: 900 };
-        },
-        ...overrides,
-      },
-    } as any;
-    return { client, calls };
-  }
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("keeps small artifacts inline (no mint, bytes in the request)", async () => {
-    const { client, calls } = routingFakeClient();
-    const req = create(PushSkillRequestSchema, { org: "acme", artifact: new Uint8Array(1024) });
-
-    await pushRouted(client, req);
-
-    expect(calls.mint).toHaveLength(0);
-    expect(calls.push).toHaveLength(1);
-    expect(calls.push[0].artifact.length).toBe(1024);
-  });
-
-  it("stages large artifacts over HTTP and pushes by reference", async () => {
-    const { client, calls } = routingFakeClient();
-    const artifact = new Uint8Array(INLINE_MAX + 1);
-    const req = create(PushSkillRequestSchema, { org: "acme", artifact, tag: "stable", message: "big" });
-
-    let putBytes = 0;
-    vi.stubGlobal("fetch", vi.fn(async (_url: string, init: any) => {
-      putBytes = init.body.length;
-      return { ok: true } as any;
-    }));
-
-    await pushRouted(client, req);
-
-    expect(calls.mint).toHaveLength(1);
-    expect(calls.mint[0].sizeBytes).toBe(BigInt(artifact.length));
-    expect(putBytes).toBe(artifact.length);
-    expect(calls.push).toHaveLength(1);
-    expect(calls.push[0].artifact.length).toBe(0);
-    expect(calls.push[0].artifactUploadRef).toBe("sau_t");
-    // The rewrite must not lose the rest of the request.
-    expect(calls.push[0].tag).toBe("stable");
-    expect(calls.push[0].message).toBe("big");
-  });
-
-  it("fails loud against servers that predate the transfer lane", async () => {
-    const { client } = routingFakeClient({
-      async createArtifactUploadUrl() {
-        throw new ConnectError("unknown method", Code.Unimplemented);
-      },
-    });
-    const req = create(PushSkillRequestSchema, { org: "acme", artifact: new Uint8Array(INLINE_MAX + 1) });
-
-    await expect(pushRouted(client, req)).rejects.toThrow(/Upgrade stigmer-server/);
-  });
-});
+// The transfer-lane size routing moved down into the SDK (stigmer#701):
+// its pins live in sdk/typescript/src/__tests__/skill.test.ts, exercised
+// through the REAL generated client and error wrapping — the fake client
+// this file previously used threw raw ConnectError, which the SDK's
+// wrapError makes unreachable on the real path.

--- a/client-apps/cli/src/resources/skill.ts
+++ b/client-apps/cli/src/resources/skill.ts
@@ -8,10 +8,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { create } from "@bufbuild/protobuf";
-import { Code, ConnectError } from "@connectrpc/connect";
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
-import type { PushSkillRequest } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
-import { CreateSkillArtifactUploadUrlRequestSchema, PushSkillRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { PushSkillRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
 import { GitProvenanceSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/status_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { UpdateVisibilityInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
@@ -322,67 +320,10 @@ export function analyzeDryRun(dir: string, options: IgnoreOptions): DryRunAnalys
   return { stats, patternSources, sampleIgnored, sampleIncluded };
 }
 
-/**
- * Largest artifact pushed inline in the gRPC request (#675). The server's
- * transport cap is 10MB for the WHOLE message, so the artifact leaves 64KB
- * of headroom for the request envelope (org, tag, provenance, framing).
- * Mirrors the Go SDK's maxInlineArtifactBytes.
- */
-const MAX_INLINE_ARTIFACT_BYTES = 10 * 1024 * 1024 - 64 * 1024;
-
-/**
- * Push, routing the artifact by size (#675): small artifacts travel inline
- * in the request (one round trip, unchanged behavior); larger ones are
- * staged over HTTP via createArtifactUploadUrl — a capability URL, so no
- * auth header — and pushed by reference. The 100MB skill limit therefore
- * no longer collides with the 10MB gRPC message cap.
- */
-export async function pushRouted(client: Stigmer, request: PushSkillRequest): Promise<Skill> {
-  if (request.artifact.length <= MAX_INLINE_ARTIFACT_BYTES) {
-    return client.skill.push(request);
-  }
-
-  let minted;
-  try {
-    minted = await client.skill.createArtifactUploadUrl(
-      create(CreateSkillArtifactUploadUrlRequestSchema, {
-        org: request.org,
-        sizeBytes: BigInt(request.artifact.length),
-      }),
-    );
-  } catch (err) {
-    if (err instanceof ConnectError && err.code === Code.Unimplemented) {
-      // Pre-transfer-lane server: an artifact this size physically cannot
-      // travel inline. Say so instead of surfacing the raw transport error.
-      throw new UsageError(
-        `skill artifact is ${formatBytes(request.artifact.length)}, above the ~10MB gRPC message cap, ` +
-          "and this server does not support the HTTP artifact transfer lane.\n\n" +
-          "Upgrade stigmer-server to push skills of this size.",
-      );
-    }
-    throw err;
-  }
-
-  const resp = await fetch(minted.url, {
-    method: "PUT",
-    // Buffer keeps undici's BodyInit typing happy where a bare Uint8Array
-    // view does not (Node-only code path, so Buffer is always available).
-    body: Buffer.from(request.artifact),
-    headers: { "content-type": "application/zip" },
-  });
-  if (!resp.ok) {
-    const detail = (await resp.text().catch(() => "")).slice(0, 512).trim();
-    throw new Error(`skill artifact upload rejected with HTTP ${resp.status}${detail === "" ? "" : `: ${detail}`}`);
-  }
-
-  // Same request, artifact traveling by reference instead of by value.
-  const byRef = create(PushSkillRequestSchema, {
-    ...request,
-    artifact: new Uint8Array(0),
-    artifactUploadRef: minted.artifactUploadRef,
-  });
-  return client.skill.push(byRef);
-}
+// Size-routed push (#675) moved down into the SDK (stigmer#701): the
+// Stigmer client's `skill.push` routes large artifacts over the HTTP
+// transfer lane itself, so the CLI — like every other SDK consumer — just
+// calls push. See sdk/typescript/src/skill.ts (RoutedSkillClient).
 
 /** Push a skill from a local directory. Git provenance is auto-detected. */
 export async function pushSkill(
@@ -410,7 +351,7 @@ export async function pushSkill(
     message,
     gitProvenance: provenance,
   });
-  const response = await pushRouted(client, request);
+  const response = await client.skill.push(request);
   const applied = await applyDeclaredVisibility(client, response, visibility);
   return toResult(applied, name, message, stats.totalSize, visibility);
 }
@@ -452,7 +393,7 @@ export async function pushSkillFromClone(
     message: params.message,
     gitProvenance: provenance,
   });
-  const response = await pushRouted(client, request);
+  const response = await client.skill.push(request);
   const applied = await applyDeclaredVisibility(client, response, visibility);
   return toResult(applied, name, params.message, stats.totalSize, visibility);
 }
@@ -540,7 +481,7 @@ export async function pushSkillFromArchive(
   });
   // Size-routed like every other push path (#675): pre-packaged archives are
   // the release-pipeline lane, exactly where content-heavy skills come from.
-  const response = await pushRouted(client, request);
+  const response = await client.skill.push(request);
   const applied = await applyDeclaredVisibility(client, response, archive.meta.visibility);
   return toResult(applied, archive.meta.name, message, archive.totalSize, archive.meta.visibility);
 }

--- a/sdk/java/src/main/java/ai/stigmer/sdk/RoutedSkillClient.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/RoutedSkillClient.java
@@ -1,0 +1,145 @@
+package ai.stigmer.sdk;
+
+import ai.stigmer.agentic.skill.v1.CreateSkillArtifactUploadUrlRequest;
+import ai.stigmer.agentic.skill.v1.PushSkillRequest;
+import ai.stigmer.agentic.skill.v1.Skill;
+import ai.stigmer.agentic.skill.v1.SkillArtifactUploadUrl;
+import ai.stigmer.sdk.gen.ErrorCode;
+import ai.stigmer.sdk.gen.SkillClient;
+import ai.stigmer.sdk.gen.StigmerException;
+import com.google.protobuf.ByteString;
+import io.grpc.Channel;
+import io.grpc.Status;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Skill client with transport-aware push routing (stigmer#675 / #701).
+ *
+ * <p>The gRPC transport caps messages at 10MB while skills may be up to
+ * 100MB, so {@link #push} routes by size: small artifacts travel inline in
+ * the request (one round trip, unchanged behavior), larger ones are staged
+ * over HTTP via {@code createArtifactUploadUrl} — a capability URL, so no
+ * auth header — and pushed by reference. Callers never see the mechanics:
+ * {@code push(req)} simply works for any valid skill size.
+ *
+ * <p>Every other method is the generated client's, inherited unchanged.
+ * Wired in via {@code GeneratedClient.newSkillClient}, which
+ * {@link StigmerClient} overrides.
+ */
+public final class RoutedSkillClient extends SkillClient {
+
+    /**
+     * Largest artifact pushed inline in the gRPC request (#675). The
+     * server's transport cap is 10MB for the WHOLE message, so the artifact
+     * leaves 64KB of headroom for the request envelope (org, tag,
+     * provenance, framing). Mirrors the Go SDK's maxInlineArtifactBytes.
+     */
+    public static final int MAX_INLINE_ARTIFACT_BYTES = 10 * 1024 * 1024 - 64 * 1024;
+
+    private final HttpClient httpClient;
+
+    /**
+     * Built from the channel alone — the GeneratedClient factory hook calls
+     * this during its own constructor.
+     */
+    public RoutedSkillClient(Channel channel) {
+        super(channel);
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    /**
+     * Push a skill, routing the artifact by size (see the class comment).
+     *
+     * <p>A request that already carries an {@code artifactUploadRef} is
+     * passed through untouched — the caller has done its own staging.
+     */
+    @Override
+    public Skill push(PushSkillRequest input) {
+        if (!input.getArtifactUploadRef().isEmpty()
+                || input.getArtifact().size() <= MAX_INLINE_ARTIFACT_BYTES) {
+            return super.push(input);
+        }
+        return pushViaUploadUrl(input);
+    }
+
+    /**
+     * Stage the artifact over HTTP and push by reference:
+     * createArtifactUploadUrl → PUT bytes → push(artifactUploadRef).
+     */
+    private Skill pushViaUploadUrl(PushSkillRequest input) {
+        SkillArtifactUploadUrl minted;
+        try {
+            minted = super.createArtifactUploadUrl(CreateSkillArtifactUploadUrlRequest.newBuilder()
+                    .setOrg(input.getOrg())
+                    .setSizeBytes(input.getArtifact().size())
+                    .build());
+        } catch (StigmerException e) {
+            if (e.isUnimplemented()) {
+                // Pre-transfer-lane server: without staging, an artifact
+                // this size physically cannot travel. Say so instead of
+                // surfacing the raw transport error (the #675 failure mode).
+                throw new StigmerException(
+                        ErrorCode.UNKNOWN,
+                        "skill artifact is " + input.getArtifact().size()
+                                + " bytes, above the ~10MB gRPC message cap, and this server does"
+                                + " not support the HTTP artifact transfer lane — upgrade"
+                                + " stigmer-server to push skills of this size",
+                        Status.Code.UNIMPLEMENTED);
+            }
+            throw e;
+        }
+
+        putArtifact(minted.getUrl(), input.getArtifact());
+
+        // Same request, artifact traveling by reference instead of by value.
+        PushSkillRequest byRef = input.toBuilder()
+                .setArtifact(ByteString.EMPTY)
+                .setArtifactUploadRef(minted.getArtifactUploadRef())
+                .build();
+        return super.push(byRef);
+    }
+
+    /**
+     * PUT the artifact ZIP to the staging URL. The URL is the credential
+     * (capability semantics — a pre-signed R2 URL on cloud, the server's own
+     * transfer lane on OSS), so no auth header is attached.
+     */
+    private void putArtifact(String url, ByteString artifact) {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .PUT(HttpRequest.BodyPublishers.ofByteArray(artifact.toByteArray()))
+                .header("Content-Type", "application/zip")
+                .build();
+
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new StigmerException(
+                    ErrorCode.UNKNOWN,
+                    "skill artifact upload failed: " + e.getMessage(),
+                    Status.Code.UNKNOWN);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new StigmerException(
+                    ErrorCode.UNKNOWN,
+                    "skill artifact upload interrupted",
+                    Status.Code.CANCELLED);
+        }
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            String detail = response.body() == null
+                    ? ""
+                    : response.body().substring(0, Math.min(512, response.body().length())).trim();
+            throw new StigmerException(
+                    ErrorCode.UNKNOWN,
+                    "skill artifact upload rejected with HTTP " + response.statusCode()
+                            + (detail.isEmpty() ? "" : ": " + detail),
+                    Status.Code.UNKNOWN);
+        }
+    }
+}

--- a/sdk/java/src/main/java/ai/stigmer/sdk/StigmerClient.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/StigmerClient.java
@@ -58,6 +58,17 @@ public final class StigmerClient extends GeneratedClient implements AutoCloseabl
         return new Builder(apiKey);
     }
 
+    /**
+     * The skill field carries push routing over the artifact transfer lane
+     * (stigmer#675): {@code client.skill.push} simply works for any valid
+     * skill size. Called from GeneratedClient's constructor — builds from
+     * the channel alone, per the hook's contract.
+     */
+    @Override
+    protected ai.stigmer.sdk.gen.SkillClient newSkillClient(io.grpc.Channel channel) {
+        return new RoutedSkillClient(channel);
+    }
+
     // -- Extra clients (not code-generated) ------------------------------------
 
     /** Returns the billing client for credit management and Stripe integration. */

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/GeneratedClient.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/GeneratedClient.java
@@ -54,10 +54,20 @@ public class GeneratedClient {
         this.project = new ProjectClient(channel);
         this.schedule = new ScheduleClient(channel);
         this.session = new SessionClient(channel);
-        this.skill = new SkillClient(channel);
+        this.skill = newSkillClient(channel);
         this.workflow = new WorkflowClient(channel);
         this.workflowExecution = new WorkflowExecutionClient(channel);
         this.workflowInstance = new WorkflowInstanceClient(channel);
+    }
+
+    /**
+     * Factory hook for the skill field (push routing over the artifact transfer lane (stigmer#675/#701)).
+     * Overrides run during this class's constructor, so they must build
+     * the client from the channel argument alone — never from subclass
+     * instance state, which is not initialized yet.
+     */
+    protected SkillClient newSkillClient(Channel channel) {
+        return new SkillClient(channel);
     }
 }
 

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/SkillClient.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/SkillClient.java
@@ -25,12 +25,12 @@ import io.grpc.Channel;
 import io.grpc.StatusRuntimeException;
 
 /** Provides operations on skill resources. */
-public final class SkillClient {
+public class SkillClient {
     private final SkillCommandControllerGrpc.SkillCommandControllerBlockingStub command;
     private final SkillQueryControllerGrpc.SkillQueryControllerBlockingStub query;
     private final SearchServiceGrpc.SearchServiceBlockingStub search;
 
-    SkillClient(Channel channel) {
+    protected SkillClient(Channel channel) {
         this.command = SkillCommandControllerGrpc.newBlockingStub(channel);
         this.query = SkillQueryControllerGrpc.newBlockingStub(channel);
         this.search = SearchServiceGrpc.newBlockingStub(channel);

--- a/sdk/java/src/main/java/ai/stigmer/sdk/gen/StigmerException.java
+++ b/sdk/java/src/main/java/ai/stigmer/sdk/gen/StigmerException.java
@@ -27,6 +27,14 @@ public final class StigmerException extends RuntimeException {
 
     public boolean isRetryable() { return code == ErrorCode.INTERNAL || code == ErrorCode.UNAVAILABLE; }
 
+    /**
+     * The server does not implement the called RPC — the code clients key
+     * capability fallbacks on (e.g. the skill artifact transfer lane's
+     * unary fallback, stigmer#675/#701). Checks the raw grpc code:
+     * UNIMPLEMENTED deliberately has no ErrorCode mapping.
+     */
+    public boolean isUnimplemented() { return grpcCode == Status.Code.UNIMPLEMENTED; }
+
     public static StigmerException wrap(StatusRuntimeException e) {
         ErrorCode code = ErrorCode.fromGrpcCode(e.getStatus().getCode());
         String msg = e.getStatus().getDescription();

--- a/sdk/java/src/test/java/ai/stigmer/sdk/RoutedSkillClientTest.java
+++ b/sdk/java/src/test/java/ai/stigmer/sdk/RoutedSkillClientTest.java
@@ -1,0 +1,202 @@
+package ai.stigmer.sdk;
+
+import ai.stigmer.agentic.skill.v1.CreateSkillArtifactUploadUrlRequest;
+import ai.stigmer.agentic.skill.v1.PushSkillRequest;
+import ai.stigmer.agentic.skill.v1.Skill;
+import ai.stigmer.agentic.skill.v1.SkillArtifactUploadUrl;
+import ai.stigmer.agentic.skill.v1.SkillCommandControllerGrpc;
+import ai.stigmer.sdk.gen.StigmerException;
+import com.google.protobuf.ByteString;
+import com.sun.net.httpserver.HttpServer;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Routing pins for RoutedSkillClient (stigmer#701), mirroring
+ * sdk/go/skill_test.go: a real gRPC server captures pushes/mints and the
+ * JDK's built-in HttpServer plays the staging endpoint — the whole lane
+ * runs at full wire fidelity with zero test-only dependencies.
+ */
+@DisplayName("RoutedSkillClient push routing")
+class RoutedSkillClientTest {
+
+    private static final byte[] SMALL = new byte[1024];
+    private static final byte[] LARGE = new byte[RoutedSkillClient.MAX_INLINE_ARTIFACT_BYTES + 1];
+
+    private final List<PushSkillRequest> pushes = new ArrayList<>();
+    private final AtomicInteger mints = new AtomicInteger();
+    private final AtomicReference<byte[]> stagedBytes = new AtomicReference<>();
+    private final AtomicReference<String> stagedContentType = new AtomicReference<>();
+
+    private Server grpcServer;
+    private HttpServer stagingServer;
+    private ManagedChannel channel;
+    /** Behavior knobs, set per test before the first RPC. */
+    private volatile boolean mintUnimplemented;
+    private volatile int stagingStatus = 200;
+
+    private final class FakeSkillService extends SkillCommandControllerGrpc.SkillCommandControllerImplBase {
+        @Override
+        public void push(PushSkillRequest request, StreamObserver<Skill> responseObserver) {
+            pushes.add(request);
+            responseObserver.onNext(Skill.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void createArtifactUploadUrl(CreateSkillArtifactUploadUrlRequest request,
+                                            StreamObserver<SkillArtifactUploadUrl> responseObserver) {
+            if (mintUnimplemented) {
+                responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+                return;
+            }
+            mints.incrementAndGet();
+            responseObserver.onNext(SkillArtifactUploadUrl.newBuilder()
+                    .setUrl("http://localhost:" + stagingServer.getAddress().getPort() + "/staging/sau_t")
+                    .setArtifactUploadRef("sau_t")
+                    .setTtlSeconds(900)
+                    .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @BeforeEach
+    void start() throws Exception {
+        stagingServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        stagingServer.createContext("/staging", exchange -> {
+            stagedBytes.set(exchange.getRequestBody().readAllBytes());
+            stagedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+            byte[] body = stagingStatus >= 400 ? "staging slot expired".getBytes() : new byte[0];
+            exchange.sendResponseHeaders(stagingStatus, body.length == 0 ? -1 : body.length);
+            if (body.length > 0) {
+                exchange.getResponseBody().write(body);
+            }
+            exchange.close();
+        });
+        stagingServer.start();
+
+        grpcServer = NettyServerBuilder.forPort(0)
+                .maxInboundMessageSize(11 * 1024 * 1024)
+                .addService(new FakeSkillService())
+                .build()
+                .start();
+        channel = ManagedChannelBuilder.forTarget("localhost:" + grpcServer.getPort())
+                .usePlaintext()
+                .maxInboundMessageSize(11 * 1024 * 1024)
+                .build();
+    }
+
+    @AfterEach
+    void stop() throws Exception {
+        channel.shutdownNow();
+        channel.awaitTermination(5, TimeUnit.SECONDS);
+        grpcServer.shutdownNow();
+        grpcServer.awaitTermination(5, TimeUnit.SECONDS);
+        stagingServer.stop(0);
+    }
+
+    private RoutedSkillClient client() {
+        return new RoutedSkillClient(channel);
+    }
+
+    @Test
+    @DisplayName("keeps small artifacts inline — no mint, bytes in the request")
+    void smallArtifactStaysInline() {
+        client().push(PushSkillRequest.newBuilder()
+                .setOrg("acme")
+                .setArtifact(ByteString.copyFrom(SMALL))
+                .build());
+
+        assertEquals(0, mints.get());
+        assertEquals(1, pushes.size());
+        assertEquals(SMALL.length, pushes.get(0).getArtifact().size());
+    }
+
+    @Test
+    @DisplayName("stages large artifacts over HTTP and pushes by reference, preserving the envelope")
+    void largeArtifactRoutesViaUploadUrl() {
+        client().push(PushSkillRequest.newBuilder()
+                .setOrg("acme")
+                .setArtifact(ByteString.copyFrom(LARGE))
+                .setTag("stable")
+                .setMessage("big")
+                .build());
+
+        assertEquals(1, mints.get());
+        assertEquals(LARGE.length, stagedBytes.get().length);
+        assertEquals("application/zip", stagedContentType.get());
+        assertEquals(1, pushes.size());
+        assertEquals(0, pushes.get(0).getArtifact().size());
+        assertEquals("sau_t", pushes.get(0).getArtifactUploadRef());
+        // The by-ref rewrite must not lose the rest of the request.
+        assertEquals("stable", pushes.get(0).getTag());
+        assertEquals("big", pushes.get(0).getMessage());
+    }
+
+    @Test
+    @DisplayName("passes an explicit upload ref through untouched — the caller staged it")
+    void explicitRefPassesThrough() {
+        client().push(PushSkillRequest.newBuilder()
+                .setOrg("acme")
+                .setArtifactUploadRef("sau_mine")
+                .build());
+
+        assertEquals(0, mints.get());
+        assertEquals("sau_mine", pushes.get(0).getArtifactUploadRef());
+    }
+
+    @Test
+    @DisplayName("fails loud against servers that predate the transfer lane")
+    void preLaneServerFailsLoud() {
+        mintUnimplemented = true;
+
+        try {
+            client().push(PushSkillRequest.newBuilder()
+                    .setOrg("acme")
+                    .setArtifact(ByteString.copyFrom(LARGE))
+                    .build());
+            fail("expected StigmerException");
+        } catch (StigmerException e) {
+            assertTrue(e.getMessage().contains("upgrade stigmer-server"),
+                    "the error must carry the recovery guidance: " + e.getMessage());
+        }
+        assertEquals(0, pushes.size());
+    }
+
+    @Test
+    @DisplayName("surfaces the staging rejection body and never proceeds to push")
+    void failedStagingPutSurfacesBodyAndNeverPushes() {
+        stagingStatus = 404;
+
+        try {
+            client().push(PushSkillRequest.newBuilder()
+                    .setOrg("acme")
+                    .setArtifact(ByteString.copyFrom(LARGE))
+                    .build());
+            fail("expected StigmerException");
+        } catch (StigmerException e) {
+            assertTrue(e.getMessage().contains("HTTP 404: staging slot expired"),
+                    "the rejection body must surface: " + e.getMessage());
+        }
+        assertEquals(0, pushes.size());
+    }
+}

--- a/sdk/python/src/stigmer/__init__.py
+++ b/sdk/python/src/stigmer/__init__.py
@@ -75,6 +75,7 @@ from ._gen._session import (
     WorkspaceSourceInput,
 )
 from ._gen._skill import SkillClient, SkillInput
+from ._skill import MAX_INLINE_ARTIFACT_BYTES, RoutedSkillClient
 from ._gen._workflow import (
     ExportInput,
     FlowControlInput,
@@ -161,6 +162,8 @@ __all__ = [
     "ProjectClient",
     "SessionClient",
     "SkillClient",
+    "RoutedSkillClient",
+    "MAX_INLINE_ARTIFACT_BYTES",
     "WorkflowClient",
     "WorkflowExecutionClient",
     "WorkflowInstanceClient",

--- a/sdk/python/src/stigmer/_client.py
+++ b/sdk/python/src/stigmer/_client.py
@@ -12,6 +12,7 @@ from ._gen._client import GeneratedClient
 from ._github import GitHubClient
 from ._runner_adapter import RunnerAdapter
 from ._search import SearchClient
+from ._skill import RoutedSkillClient
 from ._transport import DEFAULT_TARGET, create_channel
 
 ExecutionTargetOption = Literal["local", "cloud"]
@@ -56,6 +57,7 @@ class StigmerClient(GeneratedClient):
     search: SearchClient
     github: GitHubClient
     billing: BillingClient
+    skills: RoutedSkillClient
     default_execution_target: int
     runner_adapter: RunnerAdapter | None
 
@@ -97,6 +99,10 @@ class StigmerClient(GeneratedClient):
         self.search = SearchClient(self._channel)
         self.github = GitHubClient(self._channel)
         self.billing = BillingClient(self._channel)
+        # Shadow the inherited generated client with the size-routing wrapper
+        # (stigmer#675): `client.skills.push` simply works for any valid
+        # skill size — large artifacts ride the HTTP transfer lane.
+        self.skills = RoutedSkillClient(self._channel)
 
     def close(self) -> None:
         """Release the underlying gRPC channel."""

--- a/sdk/python/src/stigmer/_gen/__init__.py
+++ b/sdk/python/src/stigmer/_gen/__init__.py
@@ -43,6 +43,7 @@ from ._errors import (
     is_permission_denied,
     is_retryable,
     is_unauthenticated,
+    is_unimplemented,
     wrap_error,
 )
 
@@ -144,5 +145,6 @@ __all__ = [
     "is_permission_denied",
     "is_retryable",
     "is_unauthenticated",
+    "is_unimplemented",
     "wrap_error",
 ]

--- a/sdk/python/src/stigmer/_gen/_errors.py
+++ b/sdk/python/src/stigmer/_gen/_errors.py
@@ -83,3 +83,14 @@ def is_retryable(err: BaseException) -> bool:
         ErrorCode.INTERNAL,
         ErrorCode.UNAVAILABLE,
     )
+
+
+def is_unimplemented(err: BaseException) -> bool:
+    """The server does not implement the called RPC.
+
+    The code clients key capability fallbacks on (e.g. the skill artifact
+    transfer lane's unary fallback, stigmer#675/#701). Checks the raw gRPC
+    code: UNIMPLEMENTED deliberately has no ErrorCode mapping, so it
+    surfaces as UNKNOWN.
+    """
+    return isinstance(err, StigmerError) and err.grpc_code == grpc.StatusCode.UNIMPLEMENTED

--- a/sdk/python/src/stigmer/_skill.py
+++ b/sdk/python/src/stigmer/_skill.py
@@ -1,0 +1,101 @@
+"""Skill client with transport-aware push routing (stigmer#675 / #701).
+
+The gRPC transport caps messages at 10MB while skills may be up to 100MB,
+so ``push`` routes by size: small artifacts travel inline in the request
+(one round trip, unchanged behavior), larger ones are staged over HTTP via
+``create_artifact_upload_url`` — a capability URL, so no auth header — and
+pushed by reference. Callers never see the mechanics: ``push(req)`` simply
+works for any valid skill size.
+
+Every other method is the generated client's, inherited unchanged.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import grpc
+
+from ai.stigmer.agentic.skill.v1 import api_pb2, io_pb2
+
+from ._gen._errors import ErrorCode, StigmerError, is_unimplemented
+from ._gen._skill import SkillClient
+
+# Largest artifact pushed inline in the gRPC request (#675). The server's
+# transport cap is 10MB for the WHOLE message, so the artifact leaves 64KB
+# of headroom for the request envelope (org, tag, provenance, framing).
+# Mirrors the Go SDK's maxInlineArtifactBytes.
+MAX_INLINE_ARTIFACT_BYTES = 10 * 1024 * 1024 - 64 * 1024
+
+
+class RoutedSkillClient(SkillClient):
+    """Skill operations, with ``push`` routed by artifact size."""
+
+    def push(self, input: io_pb2.PushSkillRequest) -> api_pb2.Skill:
+        """Push a skill, routing the artifact by size (see module docs).
+
+        A request that already carries an ``artifact_upload_ref`` is passed
+        through untouched — the caller has done its own staging.
+        """
+        if input.artifact_upload_ref or len(input.artifact) <= MAX_INLINE_ARTIFACT_BYTES:
+            return super().push(input)
+        return self._push_via_upload_url(input)
+
+    def _push_via_upload_url(self, input: io_pb2.PushSkillRequest) -> api_pb2.Skill:
+        """create_artifact_upload_url -> PUT bytes -> push(artifact_upload_ref)."""
+        try:
+            minted = super().create_artifact_upload_url(
+                io_pb2.CreateSkillArtifactUploadUrlRequest(
+                    org=input.org,
+                    size_bytes=len(input.artifact),
+                )
+            )
+        except StigmerError as err:
+            if is_unimplemented(err):
+                # Pre-transfer-lane server: without staging, an artifact this
+                # size physically cannot travel. Say so instead of surfacing
+                # the raw transport error (the failure mode #675 reported).
+                raise StigmerError(
+                    ErrorCode.UNKNOWN,
+                    f"skill artifact is {len(input.artifact)} bytes, above the ~10MB gRPC "
+                    "message cap, and this server does not support the HTTP artifact "
+                    "transfer lane — upgrade stigmer-server to push skills of this size",
+                    grpc.StatusCode.UNIMPLEMENTED,
+                ) from err
+            raise
+
+        self._put_artifact(minted.url, bytes(input.artifact))
+
+        # Same request, artifact traveling by reference instead of by value.
+        by_ref = io_pb2.PushSkillRequest()
+        by_ref.CopyFrom(input)
+        by_ref.artifact = b""
+        by_ref.artifact_upload_ref = minted.artifact_upload_ref
+        return super().push(by_ref)
+
+    @staticmethod
+    def _put_artifact(url: str, artifact: bytes) -> None:
+        """PUT the artifact ZIP to the staging URL.
+
+        The URL is the credential (capability semantics — a pre-signed R2 URL
+        on cloud, the server's own transfer lane on OSS), so no auth header
+        is attached.
+        """
+        request = urllib.request.Request(
+            url,
+            data=artifact,
+            method="PUT",
+            headers={"Content-Type": "application/zip"},
+        )
+        try:
+            with urllib.request.urlopen(request):
+                pass
+        except urllib.error.HTTPError as err:
+            detail = err.read()[:512].decode("utf-8", errors="replace").strip()
+            raise StigmerError(
+                ErrorCode.UNKNOWN,
+                f"skill artifact upload rejected with HTTP {err.code}"
+                + (f": {detail}" if detail else ""),
+                grpc.StatusCode.UNKNOWN,
+            ) from err

--- a/sdk/python/tests/test_skill_routing.py
+++ b/sdk/python/tests/test_skill_routing.py
@@ -1,0 +1,149 @@
+"""Pins for RoutedSkillClient's size-routed push (stigmer#701) — mirrors
+sdk/go/skill_test.go's routing pins. A fake command stub captures outgoing
+protos; the staging PUT is intercepted at urllib level."""
+
+from __future__ import annotations
+
+import io
+import urllib.error
+import urllib.request
+
+import grpc
+import pytest
+
+from ai.stigmer.agentic.skill.v1 import api_pb2, io_pb2
+
+from stigmer import MAX_INLINE_ARTIFACT_BYTES, RoutedSkillClient, StigmerError
+
+
+class _FakeCommandStub:
+    """Captures push/mint calls; behavior injectable per test."""
+
+    def __init__(self, mint_error: grpc.StatusCode | None = None) -> None:
+        self.pushes: list[io_pb2.PushSkillRequest] = []
+        self.mints: list[io_pb2.CreateSkillArtifactUploadUrlRequest] = []
+        self._mint_error = mint_error
+
+    def push(self, request: io_pb2.PushSkillRequest) -> api_pb2.Skill:
+        self.pushes.append(request)
+        return api_pb2.Skill()
+
+    def createArtifactUploadUrl(  # noqa: N802 - proto rpc name
+        self, request: io_pb2.CreateSkillArtifactUploadUrlRequest
+    ) -> io_pb2.SkillArtifactUploadUrl:
+        if self._mint_error is not None:
+            raise _fake_rpc_error(self._mint_error)
+        self.mints.append(request)
+        return io_pb2.SkillArtifactUploadUrl(
+            url="https://stage.example/put", artifact_upload_ref="sau_t", ttl_seconds=900
+        )
+
+
+def _fake_rpc_error(code: grpc.StatusCode) -> grpc.RpcError:
+    class _Err(grpc.RpcError):
+        def code(self) -> grpc.StatusCode:
+            return code
+
+        def details(self) -> str:
+            return "fake"
+
+    return _Err()
+
+
+def _client(stub: _FakeCommandStub) -> RoutedSkillClient:
+    channel = grpc.insecure_channel("localhost:1")
+    client = RoutedSkillClient(channel)
+    client._command = stub  # the same seam test_billing.py uses
+    return client
+
+
+def test_small_artifact_stays_inline(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _FakeCommandStub()
+    client = _client(stub)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *_a, **_k: pytest.fail("no PUT for inline push")
+    )
+
+    client.push(io_pb2.PushSkillRequest(org="acme", artifact=b"x" * 1024))
+
+    assert len(stub.mints) == 0
+    assert len(stub.pushes) == 1
+    assert len(stub.pushes[0].artifact) == 1024
+
+
+def test_large_artifact_routes_via_upload_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _FakeCommandStub()
+    client = _client(stub)
+    put: dict[str, object] = {}
+
+    def fake_urlopen(request: urllib.request.Request):
+        put["url"] = request.full_url
+        put["bytes"] = len(request.data or b"")
+        put["content_type"] = request.get_header("Content-type")
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+        return _Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    artifact = b"x" * (MAX_INLINE_ARTIFACT_BYTES + 1)
+
+    client.push(io_pb2.PushSkillRequest(org="acme", artifact=artifact, tag="stable", message="big"))
+
+    assert len(stub.mints) == 1
+    assert stub.mints[0].size_bytes == len(artifact)
+    assert put["url"] == "https://stage.example/put"
+    assert put["bytes"] == len(artifact)
+    assert put["content_type"] == "application/zip"
+    assert len(stub.pushes) == 1
+    assert len(stub.pushes[0].artifact) == 0
+    assert stub.pushes[0].artifact_upload_ref == "sau_t"
+    # The by-ref rewrite must not lose the rest of the request.
+    assert stub.pushes[0].tag == "stable"
+    assert stub.pushes[0].message == "big"
+
+
+def test_explicit_ref_passes_through() -> None:
+    stub = _FakeCommandStub()
+    client = _client(stub)
+
+    client.push(io_pb2.PushSkillRequest(org="acme", artifact_upload_ref="sau_mine"))
+
+    assert len(stub.mints) == 0
+    assert stub.pushes[0].artifact_upload_ref == "sau_mine"
+
+
+def test_pre_lane_server_fails_loud() -> None:
+    stub = _FakeCommandStub(mint_error=grpc.StatusCode.UNIMPLEMENTED)
+    client = _client(stub)
+
+    with pytest.raises(StigmerError, match="upgrade stigmer-server"):
+        client.push(
+            io_pb2.PushSkillRequest(org="acme", artifact=b"x" * (MAX_INLINE_ARTIFACT_BYTES + 1))
+        )
+    assert len(stub.pushes) == 0
+
+
+def test_failed_staging_put_surfaces_body_and_never_pushes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _FakeCommandStub()
+    client = _client(stub)
+
+    def rejecting_urlopen(request: urllib.request.Request):
+        raise urllib.error.HTTPError(
+            request.full_url, 404, "Not Found", None, io.BytesIO(b"staging slot expired")
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", rejecting_urlopen)
+
+    with pytest.raises(StigmerError, match="HTTP 404: staging slot expired"):
+        client.push(
+            io_pb2.PushSkillRequest(org="acme", artifact=b"x" * (MAX_INLINE_ARTIFACT_BYTES + 1))
+        )
+    assert len(stub.pushes) == 0

--- a/sdk/react/src/skill/__tests__/SkillFileBrowser.test.tsx
+++ b/sdk/react/src/skill/__tests__/SkillFileBrowser.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { zipSync, strToU8 } from "fflate";
-import type { Stigmer } from "@stigmer/sdk";
+import { StigmerError, type Stigmer } from "@stigmer/sdk";
 import { StigmerContext } from "../../context";
 import { SkillFileBrowser } from "../SkillFileBrowser";
 
@@ -12,14 +12,22 @@ function wrapperFor(stigmer: Stigmer) {
   );
 }
 
+/** Connect's Unimplemented code — what a pre-transfer-lane server answers. */
+const CODE_UNIMPLEMENTED = 12;
+
 /**
  * Builds a real ZIP (via fflate, the same library the unpacker uses) and a
  * Stigmer client whose `skill.getArtifact` serves it — so tests exercise the
  * genuine fetch → unzip → browse path instead of stubbing the unpacker.
+ * The download-URL mint answers Unimplemented (a pre-transfer-lane server),
+ * pinning that the browser degrades to the unary lane it always used.
  */
 function makeStigmerServing(files: Record<string, Uint8Array>) {
   const getArtifact = vi.fn().mockResolvedValue({ artifact: zipSync(files) });
-  return { skill: { getArtifact } } as unknown as Stigmer;
+  const getArtifactDownloadUrl = vi
+    .fn()
+    .mockRejectedValue(new StigmerError("unknown", "unimplemented", CODE_UNIMPLEMENTED));
+  return { skill: { getArtifact, getArtifactDownloadUrl } } as unknown as Stigmer;
 }
 
 function renderBrowser(stigmer: Stigmer) {

--- a/sdk/react/src/skill/__tests__/fetchAndUnpackArtifact.test.ts
+++ b/sdk/react/src/skill/__tests__/fetchAndUnpackArtifact.test.ts
@@ -1,0 +1,90 @@
+// Pins for the artifact fetch lane selection (stigmer#701): URL-first via
+// getArtifactDownloadUrl, with the two deliberate browser degrade arms —
+// Unimplemented mint (pre-lane server) and a failed URL fetch (the shape a
+// missing bucket CORS policy takes in a browser).
+import { describe, expect, it, vi } from "vitest";
+import { strToU8, zipSync } from "fflate";
+import { StigmerError, type Stigmer } from "@stigmer/sdk";
+import { fetchAndUnpackArtifact } from "../internal/fetchAndUnpackArtifact.js";
+
+const CODE_UNIMPLEMENTED = 12;
+const ZIP = zipSync({ "SKILL.md": strToU8("# hi") });
+
+function stigmerWith(overrides: {
+  mint?: ReturnType<typeof vi.fn>;
+  unary?: ReturnType<typeof vi.fn>;
+  fetch?: unknown;
+}): Stigmer {
+  return {
+    skill: {
+      getArtifactDownloadUrl: overrides.mint,
+      getArtifact: overrides.unary,
+    },
+    fetch: overrides.fetch,
+  } as unknown as Stigmer;
+}
+
+describe("fetchAndUnpackArtifact lane selection", () => {
+  it("fetches via the minted download URL, never the unary lane", async () => {
+    const mint = vi.fn().mockResolvedValue({ url: "https://r2.example/skills/get" });
+    const unary = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(new Uint8Array(ZIP).buffer, { status: 200 }));
+
+    const result = await fetchAndUnpackArtifact(
+      stigmerWith({ mint, unary, fetch: fetchImpl }),
+      "skills/org/skill/hash.zip",
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://r2.example/skills/get");
+    expect(unary).not.toHaveBeenCalled();
+    expect(result.contentMap.get("SKILL.md")).toBe("# hi");
+  });
+
+  it("degrades to the unary lane when the mint answers Unimplemented (pre-lane server)", async () => {
+    const mint = vi
+      .fn()
+      .mockRejectedValue(new StigmerError("unknown", "unimplemented", CODE_UNIMPLEMENTED));
+    const unary = vi.fn().mockResolvedValue({ artifact: ZIP });
+
+    const result = await fetchAndUnpackArtifact(
+      stigmerWith({ mint, unary }),
+      "skills/org/skill/hash.zip",
+    );
+
+    expect(unary).toHaveBeenCalledTimes(1);
+    expect(result.contentMap.get("SKILL.md")).toBe("# hi");
+  });
+
+  it("degrades to the unary lane when the URL fetch itself fails (browser CORS shape), warning once", async () => {
+    const mint = vi.fn().mockResolvedValue({ url: "https://r2.example/skills/get" });
+    const unary = vi.fn().mockResolvedValue({ artifact: ZIP });
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const result = await fetchAndUnpackArtifact(
+        stigmerWith({ mint, unary, fetch: fetchImpl }),
+        "skills/org/skill/hash.zip",
+      );
+      expect(unary).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(result.contentMap.get("SKILL.md")).toBe("# hi");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("propagates a non-Unimplemented mint failure — a real error must not be masked", async () => {
+    const mint = vi
+      .fn()
+      .mockRejectedValue(new StigmerError("not-found", "no such artifact", 5));
+    const unary = vi.fn();
+
+    await expect(
+      fetchAndUnpackArtifact(stigmerWith({ mint, unary }), "skills/org/skill/hash.zip"),
+    ).rejects.toThrow(/no such artifact/);
+    expect(unary).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/react/src/skill/internal/fetchAndUnpackArtifact.ts
+++ b/sdk/react/src/skill/internal/fetchAndUnpackArtifact.ts
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { GetArtifactRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
-import type { Stigmer } from "@stigmer/sdk";
+import { isUnimplemented, type Stigmer } from "@stigmer/sdk";
 import type { SkillFileEntry } from "../useSkillUpload.js";
 
 /** Unpacked artifact: file entries for browsing + content map for reading. */
@@ -20,11 +20,10 @@ export async function fetchAndUnpackArtifact(
   stigmer: Stigmer,
   artifactStorageKey: string,
 ): Promise<UnpackedArtifact> {
-  const request = create(GetArtifactRequestSchema, { artifactStorageKey });
-  const response = await stigmer.skill.getArtifact(request);
+  const artifact = await fetchArtifactBytes(stigmer, artifactStorageKey);
 
   const { unzipSync, strFromU8 } = await import("fflate");
-  const unzipped = unzipSync(response.artifact);
+  const unzipped = unzipSync(artifact);
 
   const entries = Object.entries(unzipped);
   const files: SkillFileEntry[] = entries.map(([path, data]) => ({
@@ -48,4 +47,55 @@ export async function fetchAndUnpackArtifact(
   }
 
   return { files, contentMap };
+}
+
+/**
+ * Fetch the artifact ZIP bytes, URL-first (the transfer lane, stigmer#675):
+ * the bytes ride HTTP, so any valid skill (up to the 100MB limit) is
+ * fetchable — the unary `getArtifact` RPC is capped at the server's 10MB
+ * gRPC message limit.
+ *
+ * Fallbacks to the unary lane, deliberately wider than the runner's
+ * mint-Unimplemented-only contract because this code runs in a browser:
+ *
+ * - `Unimplemented` from the mint — a pre-transfer-lane server (the code
+ *   clients key their fallback on, same as every other lane client).
+ * - A failed HTTP fetch of the minted URL — in a browser this is how a
+ *   missing bucket CORS policy surfaces (an opaque `TypeError`,
+ *   indistinguishable from a network failure). The unary lane was the
+ *   status quo and still serves everything under the message cap, so
+ *   degrading beats breaking the console; the warn keeps it observable.
+ */
+async function fetchArtifactBytes(
+  stigmer: Stigmer,
+  artifactStorageKey: string,
+): Promise<Uint8Array> {
+  const request = create(GetArtifactRequestSchema, { artifactStorageKey });
+
+  let minted;
+  try {
+    minted = await stigmer.skill.getArtifactDownloadUrl(request);
+  } catch (err) {
+    if (isUnimplemented(err)) {
+      const response = await stigmer.skill.getArtifact(request);
+      return response.artifact;
+    }
+    throw err;
+  }
+
+  try {
+    const doFetch = stigmer.fetch ?? globalThis.fetch;
+    const resp = await doFetch(minted.url);
+    if (!resp.ok) {
+      throw new Error(`artifact download failed with HTTP ${resp.status}`);
+    }
+    return new Uint8Array(await resp.arrayBuffer());
+  } catch (err) {
+    console.warn(
+      "[stigmer] skill artifact download URL fetch failed (bucket CORS not provisioned for this origin?) — falling back to the unary lane",
+      err,
+    );
+    const response = await stigmer.skill.getArtifact(request);
+    return response.artifact;
+  }
 }

--- a/sdk/react/src/skill/useSkillDiff.ts
+++ b/sdk/react/src/skill/useSkillDiff.ts
@@ -21,7 +21,13 @@ export interface UseSkillDiffReturn {
   readonly error: Error | null;
 }
 
-/** Maximum artifact size (10 MB) to prevent excessive memory usage. */
+/**
+ * Maximum COMBINED unpacked text of both artifacts (10 MB) — a browser
+ * memory guard on holding and diffing two extracted file trees, NOT a
+ * transport limit. The transfer lane (stigmer#675) removed the download
+ * cap, so arbitrarily large valid skills can be *fetched*; what stays
+ * bounded is what this hook is willing to diff in tab memory.
+ */
 const MAX_ARTIFACT_BYTES = 10 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------

--- a/sdk/typescript/src/__tests__/skill.test.ts
+++ b/sdk/typescript/src/__tests__/skill.test.ts
@@ -1,0 +1,150 @@
+// Wire-shape tests for RoutedSkillClient's size-routed push (stigmer#701).
+// A router transport fakes the skill service in-process, so the routing is
+// exercised through the REAL generated client and its error wrapping — the
+// CLI's earlier copy of this logic keyed its fallback on `instanceof
+// ConnectError`, which the SDK's wrapError made unreachable; these pins run
+// the wrapped path. Mirrors sdk/go/skill_test.go's five routing pins.
+import { describe, expect, it, vi } from "vitest";
+import { Code, ConnectError, createRouterTransport, type Transport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { SkillCommandController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/command_pb";
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import {
+  PushSkillRequestSchema,
+  SkillArtifactUploadUrlSchema,
+  type PushSkillRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { StigmerError } from "../gen/errors.js";
+import { MAX_INLINE_ARTIFACT_BYTES, RoutedSkillClient } from "../skill.js";
+
+const STAGING_URL = "http://stage.example/v1/skill-artifacts/uploads/sau_t";
+
+interface Captured {
+  pushes: PushSkillRequest[];
+  mints: number;
+}
+
+/**
+ * In-process skill service. `withMint: false` leaves createArtifactUploadUrl
+ * unregistered, so the router answers Unimplemented — the exact wire shape
+ * of a pre-transfer-lane server.
+ */
+function fakeTransport(captured: Captured, opts: { withMint: boolean } = { withMint: true }): Transport {
+  return createRouterTransport(({ service }) => {
+    service(SkillCommandController, {
+      push: (req) => {
+        captured.pushes.push(req);
+        return create(SkillSchema, {});
+      },
+      ...(opts.withMint
+        ? {
+            createArtifactUploadUrl: (req) => {
+              captured.mints++;
+              expect(req.sizeBytes).toBeGreaterThan(0n);
+              return create(SkillArtifactUploadUrlSchema, {
+                url: STAGING_URL,
+                artifactUploadRef: "sau_t",
+                ttlSeconds: 900,
+              });
+            },
+          }
+        : {}),
+    });
+  });
+}
+
+function okFetch(record: { putUrl?: string; putBytes?: number; contentType?: string }) {
+  return vi.fn(async (url: any, init: any) => {
+    record.putUrl = String(url);
+    record.putBytes = init.body instanceof Uint8Array ? init.body.byteLength : -1;
+    record.contentType = init.headers["content-type"];
+    return new Response(null, { status: 200 });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("RoutedSkillClient.push size routing", () => {
+  it("keeps small artifacts inline — no mint, bytes in the request", async () => {
+    const captured: Captured = { pushes: [], mints: 0 };
+    const client = new RoutedSkillClient(fakeTransport(captured));
+
+    await client.push(create(PushSkillRequestSchema, { org: "acme", artifact: new Uint8Array(1024) }));
+
+    expect(captured.mints).toBe(0);
+    expect(captured.pushes).toHaveLength(1);
+    expect(captured.pushes[0].artifact.length).toBe(1024);
+  });
+
+  it("stages large artifacts over HTTP and pushes by reference, preserving the envelope", async () => {
+    const captured: Captured = { pushes: [], mints: 0 };
+    const record: { putUrl?: string; putBytes?: number; contentType?: string } = {};
+    const client = new RoutedSkillClient(fakeTransport(captured), okFetch(record));
+    const artifact = new Uint8Array(MAX_INLINE_ARTIFACT_BYTES + 1);
+
+    await client.push(create(PushSkillRequestSchema, { org: "acme", artifact, tag: "stable", message: "big" }));
+
+    expect(captured.mints).toBe(1);
+    expect(record.putUrl).toBe(STAGING_URL);
+    expect(record.putBytes).toBe(artifact.length);
+    expect(record.contentType).toBe("application/zip");
+    expect(captured.pushes).toHaveLength(1);
+    expect(captured.pushes[0].artifact.length).toBe(0);
+    expect(captured.pushes[0].artifactUploadRef).toBe("sau_t");
+    // The by-ref rewrite must not lose the rest of the request.
+    expect(captured.pushes[0].tag).toBe("stable");
+    expect(captured.pushes[0].message).toBe("big");
+  });
+
+  it("passes an explicit upload ref through untouched — the caller staged it", async () => {
+    const captured: Captured = { pushes: [], mints: 0 };
+    const client = new RoutedSkillClient(fakeTransport(captured));
+
+    await client.push(create(PushSkillRequestSchema, { org: "acme", artifactUploadRef: "sau_mine" }));
+
+    expect(captured.mints).toBe(0);
+    expect(captured.pushes).toHaveLength(1);
+    expect(captured.pushes[0].artifactUploadRef).toBe("sau_mine");
+  });
+
+  it("fails loud against servers that predate the transfer lane (wrapped Unimplemented)", async () => {
+    const captured: Captured = { pushes: [], mints: 0 };
+    const client = new RoutedSkillClient(fakeTransport(captured, { withMint: false }));
+
+    await expect(
+      client.push(create(PushSkillRequestSchema, { org: "acme", artifact: new Uint8Array(MAX_INLINE_ARTIFACT_BYTES + 1) })),
+    ).rejects.toThrow(/upgrade stigmer-server/);
+    expect(captured.pushes).toHaveLength(0);
+  });
+
+  it("surfaces the staging rejection body and never proceeds to push", async () => {
+    const captured: Captured = { pushes: [], mints: 0 };
+    const rejectingFetch = (async () =>
+      new Response("staging slot expired", { status: 404 })) as unknown as typeof globalThis.fetch;
+    const client = new RoutedSkillClient(fakeTransport(captured), rejectingFetch);
+
+    await expect(
+      client.push(create(PushSkillRequestSchema, { org: "acme", artifact: new Uint8Array(MAX_INLINE_ARTIFACT_BYTES + 1) })),
+    ).rejects.toThrow(/HTTP 404: staging slot expired/);
+    expect(captured.pushes).toHaveLength(0);
+  });
+
+  it("propagates non-Unimplemented mint errors unmasked", async () => {
+    const captured: Captured = { pushes: [], mints: 0 };
+    const transport = createRouterTransport(({ service }) => {
+      service(SkillCommandController, {
+        push: (req) => {
+          captured.pushes.push(req);
+          return create(SkillSchema, {});
+        },
+        createArtifactUploadUrl: () => {
+          throw new ConnectError("artifact too large", Code.InvalidArgument);
+        },
+      });
+    });
+    const client = new RoutedSkillClient(transport);
+
+    await expect(
+      client.push(create(PushSkillRequestSchema, { org: "acme", artifact: new Uint8Array(MAX_INLINE_ARTIFACT_BYTES + 1) })),
+    ).rejects.toSatisfy((err: unknown) => err instanceof StigmerError && err.code === "invalid-argument");
+    expect(captured.pushes).toHaveLength(0);
+  });
+});

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -11,6 +11,7 @@ export {
   isUnauthenticated,
   isPermissionDenied,
   isRetryable,
+  isUnimplemented,
 } from "./gen/errors.js";
 
 /**

--- a/sdk/typescript/src/gen/client.ts
+++ b/sdk/typescript/src/gen/client.ts
@@ -136,4 +136,4 @@ export { type WorkflowExecutionInput } from "./workflowexecution.js";
 export { WorkflowInstanceClient } from "./workflowinstance.js";
 export { type WorkflowInstanceInput } from "./workflowinstance.js";
 export { type ListParams, type ListResult, type DeleteResourceInput, type ResourceRef, type EnvSpecInput, type EnvVarInput, type Page } from "./types.js";
-export { StigmerError, type ErrorCode, isNotFound, isUnauthenticated, isPermissionDenied, isRetryable } from "./errors.js";
+export { StigmerError, type ErrorCode, isNotFound, isUnauthenticated, isPermissionDenied, isRetryable, isUnimplemented } from "./errors.js";

--- a/sdk/typescript/src/gen/errors.ts
+++ b/sdk/typescript/src/gen/errors.ts
@@ -74,3 +74,13 @@ export function isPermissionDenied(err: unknown): boolean {
 export function isRetryable(err: unknown): boolean {
   return err instanceof StigmerError && (err.code === "internal" || err.code === "unavailable");
 }
+
+/**
+ * The server does not implement the called RPC — the code clients key
+ * capability fallbacks on (e.g. the skill artifact transfer lane's unary
+ * fallback, stigmer#675/#701). Checks the raw connect code: Unimplemented
+ * deliberately has no ErrorCode mapping, so it surfaces as "unknown".
+ */
+export function isUnimplemented(err: unknown): boolean {
+  return err instanceof StigmerError && err.connectCode === Code.Unimplemented;
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -41,6 +41,7 @@ export {
   isUnauthenticated,
   isPermissionDenied,
   isRetryable,
+  isUnimplemented,
   type ErrorCategory,
   isConnectError,
   classifyError,
@@ -290,6 +291,7 @@ export {
 } from "./execution/file-review-fold.js";
 export { toDisplayFileChange } from "./execution/to-display-file-change.js";
 export { SkillClient, type SkillInput } from "./gen/skill.js";
+export { RoutedSkillClient, MAX_INLINE_ARTIFACT_BYTES } from "./skill.js";
 export {
   WorkflowClient,
   type WorkflowInput,

--- a/sdk/typescript/src/skill.ts
+++ b/sdk/typescript/src/skill.ts
@@ -1,0 +1,125 @@
+import { create } from "@bufbuild/protobuf";
+import { Code } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
+import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import {
+  CreateSkillArtifactUploadUrlRequestSchema,
+  PushSkillRequestSchema,
+  type PushSkillRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { isUnimplemented, StigmerError } from "./gen/errors.js";
+import { SkillClient } from "./gen/skill.js";
+
+/**
+ * Largest artifact pushed inline in the gRPC request (#675). The server's
+ * transport cap is 10MB for the WHOLE message, so the artifact leaves 64KB
+ * of headroom for the request envelope (org, tag, provenance, framing).
+ * Mirrors the Go SDK's maxInlineArtifactBytes.
+ */
+export const MAX_INLINE_ARTIFACT_BYTES = 10 * 1024 * 1024 - 64 * 1024;
+
+/**
+ * Skill client with transport-aware push routing (stigmer#675 / #701).
+ *
+ * The gRPC transport caps messages at 10MB while skills may be up to 100MB,
+ * so `push` routes by size: small artifacts travel inline in the request
+ * (one round trip, unchanged behavior), larger ones are staged over HTTP
+ * via `createArtifactUploadUrl` — a capability URL, so no auth header —
+ * and pushed by reference. Callers never see the mechanics: `push(req)`
+ * simply works for any valid skill size.
+ *
+ * Every other method is the generated client's, inherited unchanged.
+ */
+export class RoutedSkillClient extends SkillClient {
+  private readonly fetchImpl: typeof globalThis.fetch | undefined;
+
+  /**
+   * @param fetchImpl - Custom `fetch` for the staging PUT. Must be the same
+   *   implementation the transport uses where the global one is restricted
+   *   (the Tauri CSP/CORS case the `Stigmer.fetch` property documents).
+   */
+  constructor(transport: Transport, fetchImpl?: typeof globalThis.fetch) {
+    super(transport);
+    this.fetchImpl = fetchImpl;
+  }
+
+  /**
+   * Push a skill, routing the artifact by size (see the class comment).
+   *
+   * A request that already carries an `artifactUploadRef` is passed through
+   * untouched — the caller has done its own staging.
+   */
+  override async push(input: PushSkillRequest): Promise<Skill> {
+    if (input.artifactUploadRef !== "" || input.artifact.length <= MAX_INLINE_ARTIFACT_BYTES) {
+      return super.push(input);
+    }
+    return this.pushViaUploadUrl(input);
+  }
+
+  /**
+   * Stage the artifact over HTTP and push by reference:
+   * createArtifactUploadUrl → PUT bytes → push(artifactUploadRef).
+   */
+  private async pushViaUploadUrl(input: PushSkillRequest): Promise<Skill> {
+    let minted;
+    try {
+      minted = await super.createArtifactUploadUrl(
+        create(CreateSkillArtifactUploadUrlRequestSchema, {
+          org: input.org,
+          sizeBytes: BigInt(input.artifact.length),
+        }),
+      );
+    } catch (err) {
+      if (isUnimplemented(err)) {
+        // Pre-transfer-lane server: without staging, an artifact this size
+        // physically cannot travel. Say so instead of surfacing the raw
+        // transport error (the failure mode #675 reported).
+        throw new StigmerError(
+          "unknown",
+          `skill artifact is ${input.artifact.length} bytes, above the ~10MB gRPC message cap, ` +
+            "and this server does not support the HTTP artifact transfer lane — " +
+            "upgrade stigmer-server to push skills of this size",
+          Code.Unimplemented,
+          { cause: err },
+        );
+      }
+      throw err;
+    }
+
+    await this.putArtifact(minted.url, input.artifact);
+
+    // Same request, artifact traveling by reference instead of by value.
+    const byRef = create(PushSkillRequestSchema, {
+      ...input,
+      artifact: new Uint8Array(0),
+      artifactUploadRef: minted.artifactUploadRef,
+    });
+    return super.push(byRef);
+  }
+
+  /**
+   * PUT the artifact ZIP to the staging URL. The URL is the credential
+   * (capability semantics — a pre-signed R2 URL on cloud, the server's own
+   * transfer lane on OSS), so no auth header is attached.
+   */
+  private async putArtifact(url: string, artifact: Uint8Array): Promise<void> {
+    const doFetch = this.fetchImpl ?? globalThis.fetch;
+    const resp = await doFetch(url, {
+      method: "PUT",
+      // Both DOM and undici accept an ArrayBufferView body at runtime; the
+      // cast bridges TS 5.7's ArrayBufferLike generic, which BodyInit's
+      // typing predates. A Blob/Buffer wrapper would copy up to 100MB for
+      // nothing, and Buffer is Node-only while this client is isomorphic.
+      body: artifact as unknown as RequestInit["body"],
+      headers: { "content-type": "application/zip" },
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text().catch(() => "")).slice(0, 512).trim();
+      throw new StigmerError(
+        "unknown",
+        `skill artifact upload rejected with HTTP ${resp.status}${detail === "" ? "" : `: ${detail}`}`,
+        Code.Unknown,
+      );
+    }
+  }
+}

--- a/sdk/typescript/src/stigmer.ts
+++ b/sdk/typescript/src/stigmer.ts
@@ -6,6 +6,7 @@ import { GitHubClient } from "./github.js";
 import { ManifestClient } from "./manifest/index.js";
 import { PlatformClient } from "./platform.js";
 import { SearchClient } from "./search.js";
+import { RoutedSkillClient } from "./skill.js";
 import { createStigmerTransport } from "./transport.js";
 import {
   validateConfig,
@@ -82,6 +83,12 @@ export class Stigmer extends GeneratedClient {
   readonly search: SearchClient;
   readonly github: GitHubClient;
   readonly manifest: ManifestClient;
+  /**
+   * Skill operations, with `push` routed by artifact size over the transfer
+   * lane (stigmer#675) — shadows the inherited generated client so
+   * `stigmer.skill.push` simply works for any valid skill size.
+   */
+  override readonly skill: RoutedSkillClient;
 
   private readonly _tokenProvider: TokenProvider;
 
@@ -105,6 +112,7 @@ export class Stigmer extends GeneratedClient {
     this.search = new SearchClient(transport);
     this.github = new GitHubClient(transport);
     this.manifest = new ManifestClient(transport);
+    this.skill = new RoutedSkillClient(transport, config.fetch);
 
     if (this.defaultExecutionTarget != null) {
       this._applyExecutionTargetDefaults();

--- a/test/conformance/src/suites/skill.conformance.test.ts
+++ b/test/conformance/src/suites/skill.conformance.test.ts
@@ -705,7 +705,11 @@ describe("Skill conformance — artifact transfer lane (#675)", () => {
       body: Buffer.from(artifact),
       headers: { "content-type": "application/zip" },
     });
-    expect(put.status, "staging PUT succeeds").toBe(204);
+    // Any 2xx — the contract every lane client enforces (Go's putArtifact,
+    // the SDK routed clients). The OSS lane answers 204; presigned R2/S3/
+    // MinIO PUTs answer 200, so pinning one exact status would make the pin
+    // unsatisfiable by one edition.
+    expect(put.ok, `staging PUT succeeds (HTTP ${put.status})`).toBe(true);
 
     const pushed = await pushSkill(org, new Uint8Array(0), { viaRef: minted.artifactUploadRef });
 

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -39,9 +39,10 @@ export class CloudTarget implements TargetProfile {
     externalOrgLookup: true,
     organizationEnumeration: false,
     versionTagging: true,
-    // Cloud's transfer-lane sibling (R2 pre-signed URLs) has not landed;
-    // clients fall back to the 10MB-capped unary artifact RPCs there.
-    skillArtifactTransferLane: false,
+    // Cloud carries the transfer lane over pre-signed R2 URLs
+    // (stigmer-cloud#438) — the full mint → PUT → push-by-ref →
+    // download-URL pin block runs against this target.
+    skillArtifactTransferLane: true,
     workflowChildApprovalForwarding: true,
     // The hermetic cloud env boots Temporal and the Java service runs the
     // schedule clock (T04 slice 2) — triggers fire for real.

--- a/test/integration/harness/service.go
+++ b/test/integration/harness/service.go
@@ -396,10 +396,12 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_ENDPOINT=%s", r2Endpoint(cfg)),
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_ACCESS_KEY_ID=%s", r2AccessKey(cfg)),
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_SECRET_ACCESS_KEY=%s", r2SecretKey(cfg)),
-		// MinIO can't resolve a bucket subdomain, so the presigner must use
+		// MinIO can't resolve a bucket subdomain, so the presigners must use
 		// path-style addressing or presigned uploads fail with SignatureDoesNotMatch.
-		// Production R2 keeps the virtual-host default (flag is false there).
+		// Production R2 keeps the virtual-host default (flags are false there).
 		"AGENT_EXECUTION_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED=true",
+		// Same for the skill artifact presigner (the transfer lane, stigmer-cloud#438).
+		"SKILL_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED=true",
 
 		// Claim check R2 config
 		"CLAIMCHECK_R2_BUCKET=test-claimcheck-bucket",

--- a/tools/codegen/generator/sdk_client_java.go
+++ b/tools/codegen/generator/sdk_client_java.go
@@ -422,6 +422,14 @@ func generateJavaErrors(outputDir string) error {
 
     public boolean isRetryable() { return code == ErrorCode.INTERNAL || code == ErrorCode.UNAVAILABLE; }
 
+    /**
+     * The server does not implement the called RPC — the code clients key
+     * capability fallbacks on (e.g. the skill artifact transfer lane's
+     * unary fallback, stigmer#675/#701). Checks the raw grpc code:
+     * UNIMPLEMENTED deliberately has no ErrorCode mapping.
+     */
+    public boolean isUnimplemented() { return grpcCode == Status.Code.UNIMPLEMENTED; }
+
     public static StigmerException wrap(StatusRuntimeException e) {
         ErrorCode code = ErrorCode.fromGrpcCode(e.getStatus().getCode());
         String msg = e.getStatus().getDescription();
@@ -1074,7 +1082,14 @@ func generateJavaClientClass(schema *ServiceSchemaFile, cfg sdkResourceConfig, h
 	var body bytes.Buffer
 
 	fmt.Fprintf(&body, "/** Provides operations on %s resources. */\n", schema.Resource)
-	fmt.Fprintf(&body, "public final class %s {\n", cfg.clientName)
+	if _, extensible := javaExtensibleClients[cfg.clientName]; extensible {
+		// Non-final with a protected constructor: the handwritten layer
+		// subclasses this client (see javaExtensibleClients) and the
+		// GeneratedClient factory hook swaps the subclass in.
+		fmt.Fprintf(&body, "public class %s {\n", cfg.clientName)
+	} else {
+		fmt.Fprintf(&body, "public final class %s {\n", cfg.clientName)
+	}
 
 	for _, svc := range schema.Services {
 		stubType := svc.Name + "Grpc." + svc.Name + "BlockingStub"
@@ -1089,7 +1104,11 @@ func generateJavaClientClass(schema *ServiceSchemaFile, cfg sdkResourceConfig, h
 	}
 	body.WriteString("\n")
 
-	fmt.Fprintf(&body, "    %s(Channel channel) {\n", cfg.clientName)
+	ctorVisibility := ""
+	if _, extensible := javaExtensibleClients[cfg.clientName]; extensible {
+		ctorVisibility = "protected "
+	}
+	fmt.Fprintf(&body, "    %s%s(Channel channel) {\n", ctorVisibility, cfg.clientName)
 	for _, svc := range schema.Services {
 		fmt.Fprintf(&body, "        this.%s = %sGrpc.newBlockingStub(channel);\n", svc.Role, svc.Name)
 		if svcNeedsBidi[svc.Role] {
@@ -1870,6 +1889,17 @@ func emitJavaNestedToProtoField(buf *bytes.Buffer, f *FieldSchema, typeMap map[s
 // Aggregate Client (GeneratedClient.java)
 // =========================================================================
 
+// javaExtensibleClients names the resource clients whose exported behavior is
+// customized by a handwritten subclass in the sdk root package. For these the
+// generator emits (a) a non-final class with a protected constructor and
+// (b) a protected factory method on GeneratedClient that the handwritten
+// StigmerClient overrides to return the subclass — Java's equivalent of the
+// Go SDK's handwritten SkillClient shadow and the TS Stigmer field shadow
+// (the handwritten-wraps-generated layering, never the reverse).
+var javaExtensibleClients = map[string]string{
+	"SkillClient": "push routing over the artifact transfer lane (stigmer#675/#701)",
+}
+
 func generateJavaClientFile(outputDir string, resources []resourceGenInfo) error {
 	imports := newJavaImportSet()
 	imports.add("io.grpc.Channel")
@@ -1887,9 +1917,30 @@ func generateJavaClientFile(outputDir string, resources []resourceGenInfo) error
 	body.WriteString("    public GeneratedClient(Channel channel) {\n")
 	for _, r := range resources {
 		fieldName := tsClientFieldName(r.resource)
-		fmt.Fprintf(&body, "        this.%s = new %s(channel);\n", fieldName, r.clientName)
+		if _, extensible := javaExtensibleClients[r.clientName]; extensible {
+			fmt.Fprintf(&body, "        this.%s = new%s(channel);\n", fieldName, r.clientName)
+		} else {
+			fmt.Fprintf(&body, "        this.%s = new %s(channel);\n", fieldName, r.clientName)
+		}
 	}
 	body.WriteString("    }\n")
+
+	for _, r := range resources {
+		reason, extensible := javaExtensibleClients[r.clientName]
+		if !extensible {
+			continue
+		}
+		body.WriteString("\n")
+		fmt.Fprintf(&body, "    /**\n")
+		fmt.Fprintf(&body, "     * Factory hook for the %s field (%s).\n", tsClientFieldName(r.resource), reason)
+		fmt.Fprintf(&body, "     * Overrides run during this class's constructor, so they must build\n")
+		fmt.Fprintf(&body, "     * the client from the channel argument alone — never from subclass\n")
+		fmt.Fprintf(&body, "     * instance state, which is not initialized yet.\n")
+		fmt.Fprintf(&body, "     */\n")
+		fmt.Fprintf(&body, "    protected %s new%s(Channel channel) {\n", r.clientName, r.clientName)
+		fmt.Fprintf(&body, "        return new %s(channel);\n", r.clientName)
+		fmt.Fprintf(&body, "    }\n")
+	}
 	body.WriteString("}\n")
 
 	return writeJavaFile(outputDir, "GeneratedClient.java", javaGenPackage, imports, body.Bytes())

--- a/tools/codegen/generator/sdk_client_python.go
+++ b/tools/codegen/generator/sdk_client_python.go
@@ -1369,6 +1369,17 @@ def is_retryable(err: BaseException) -> bool:
         ErrorCode.INTERNAL,
         ErrorCode.UNAVAILABLE,
     )
+
+
+def is_unimplemented(err: BaseException) -> bool:
+    """The server does not implement the called RPC.
+
+    The code clients key capability fallbacks on (e.g. the skill artifact
+    transfer lane's unary fallback, stigmer#675/#701). Checks the raw gRPC
+    code: UNIMPLEMENTED deliberately has no ErrorCode mapping, so it
+    surfaces as UNKNOWN.
+    """
+    return isinstance(err, StigmerError) and err.grpc_code == grpc.StatusCode.UNIMPLEMENTED
 `)
 	return os.WriteFile(filepath.Join(outputDir, "_errors.py"), buf.Bytes(), 0644)
 }
@@ -1554,6 +1565,7 @@ func generatePythonInit(outputDir string, resources []resourceGenInfo) error {
 	buf.WriteString("    is_permission_denied,\n")
 	buf.WriteString("    is_retryable,\n")
 	buf.WriteString("    is_unauthenticated,\n")
+	buf.WriteString("    is_unimplemented,\n")
 	buf.WriteString("    wrap_error,\n")
 	buf.WriteString(")\n")
 
@@ -1578,6 +1590,7 @@ func generatePythonInit(outputDir string, resources []resourceGenInfo) error {
 	buf.WriteString("    \"is_permission_denied\",\n")
 	buf.WriteString("    \"is_retryable\",\n")
 	buf.WriteString("    \"is_unauthenticated\",\n")
+	buf.WriteString("    \"is_unimplemented\",\n")
 	buf.WriteString("    \"wrap_error\",\n")
 	buf.WriteString("]\n")
 

--- a/tools/codegen/generator/sdk_client_ts.go
+++ b/tools/codegen/generator/sdk_client_ts.go
@@ -1485,7 +1485,7 @@ func generateTSClientFile(outputDir string, resources []resourceGenInfo) error {
 		}
 	}
 	buf.WriteString("export { type ListParams, type ListResult, type DeleteResourceInput, type ResourceRef, type EnvSpecInput, type EnvVarInput, type Page } from \"./types.js\";\n")
-	buf.WriteString("export { StigmerError, type ErrorCode, isNotFound, isUnauthenticated, isPermissionDenied, isRetryable } from \"./errors.js\";\n")
+	buf.WriteString("export { StigmerError, type ErrorCode, isNotFound, isUnauthenticated, isPermissionDenied, isRetryable, isUnimplemented } from \"./errors.js\";\n")
 
 	return os.WriteFile(filepath.Join(outputDir, "client.ts"), buf.Bytes(), 0644)
 }
@@ -1571,6 +1571,16 @@ export function isPermissionDenied(err: unknown): boolean {
 
 export function isRetryable(err: unknown): boolean {
   return err instanceof StigmerError && (err.code === "internal" || err.code === "unavailable");
+}
+
+/**
+ * The server does not implement the called RPC — the code clients key
+ * capability fallbacks on (e.g. the skill artifact transfer lane's unary
+ * fallback, stigmer#675/#701). Checks the raw connect code: Unimplemented
+ * deliberately has no ErrorCode mapping, so it surfaces as "unknown".
+ */
+export function isUnimplemented(err: unknown): boolean {
+  return err instanceof StigmerError && err.connectCode === Code.Unimplemented;
 }
 `)
 	return os.WriteFile(filepath.Join(outputDir, "errors.ts"), buf.Bytes(), 0644)


### PR DESCRIPTION
## Summary

- Completes #703's client story: the Go SDK/CLI/runner adopted the transfer lane there; this adopts it in every remaining first-party client, keeping the four contract points (inline ≤ 10MB−64KB unchanged; `UNIMPLEMENTED` mint → loud upgrade guidance, any other error propagates; failed staging PUT surfaces the server's explanation and never pushes; by-ref rewrite preserves all fields)
- **TS**: the CLI's `pushRouted` moves down into the SDK as `RoutedSkillClient` (extends the generated client; `Stigmer` shadows the inherited `skill` field) — every SDK consumer gets routed push, the CLI copy is deleted. Also fixes a latent bug: the CLI's `instanceof ConnectError` fallback check was dead code on the real path (the SDK's `wrapError` converts first); detection now rides a new `isUnimplemented` predicate, pinned through the real wire shape via `createRouterTransport`
- **React**: `fetchAndUnpackArtifact` goes URL-first with two deliberate browser degrade arms (`Unimplemented` mint; failed URL fetch — the shape missing bucket CORS takes in a browser, warned once). **Premise correction to the issue**: `useSkillDiff`'s 10MB cap is a browser-memory guard on the combined *unpacked* trees, not a transport cap — it stays, re-documented
- **Python**: `RoutedSkillClient` subclass, `client.skills` reassigned by the handwritten `StigmerClient`, stdlib urllib PUT
- **Java**: the generator gains a `javaExtensibleClients` seam (`SkillClient` non-final + protected ctor; `GeneratedClient` constructs through a protected `newSkillClient` factory hook the handwritten `StigmerClient` overrides) — handwritten-wraps-generated, mirroring the Go shadow and the TS field shadow; generated code never depends on handwritten
- **Errors**: `isUnimplemented` added to the TS/Python/Java generated error surfaces (checks the preserved raw code; `Unimplemented` deliberately keeps no `ErrorCode` mapping)
- **Conformance**: cloud target flips `skillArtifactTransferLane: true`; the staging-PUT pin loosens from exactly-204 to 2xx (the contract the clients actually enforce — OSS lane answers 204, presigned R2/S3/MinIO answer 200); the cloud harness wires `SKILL_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED` for the MinIO presigner

## Verification

- TS SDK 411/411 (6 new routing pins through the REAL wrapped-error path); CLI 885/885; React 4581/4581 + eslint + strict tsdoc (4 new lane-selection pins); Python 30/30 (5 new pins); Java 59/59 (5 new full-wire pins: netty gRPC server + JDK `HttpServer` staging endpoint, zero new dependencies); `go test ./tools/codegen/...` green; `make gen-sdk-docs` produced no drift
- **Live cloud acceptance**: full conformance ran against the [stigmer-cloud#453](https://github.com/stigmer/stigmer-cloud/pull/453) build through the hermetic harness — skill suite 50 passed / 1 skipped (the inverse-gated Unimplemented pin, correctly inert now), full run 303 passed / 2 skipped

## Merge order

**After [stigmer-cloud#453](https://github.com/stigmer/stigmer-cloud/pull/453)** — the flipped conformance flag pins the lane the cloud build must serve. (That run also required [stigmer-cloud#452](https://github.com/stigmer/stigmer-cloud/pull/452), the main-boot hotfix this session's acceptance run surfaced.)

Closes #701.

Made with [Cursor](https://cursor.com)