### PR TITLE
feat(schedule,channels,sdk/react): require pinned models on unattended Cursor-harness surfaces

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/schedule_test.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/schedule_test.go
@@ -32,6 +32,11 @@ const (
 	refImmutableMessage   = "spec.agent.agent_ref is immutable (schedule runs %s/%s) — create a new schedule to run a different agent"
 	orgRequiredMessage    = "metadata.org is required for a schedule"
 	localWorkspaceMessage = "must use a git_repo source — a scheduled run has no connected client to serve a local_path"
+	// The core sentence is byte-shared with the cloud policy
+	// (UnattendedModelPinningPolicy); the cloud copy appends its
+	// platform-profile remediation tail, which this edition has no
+	// platform model to honor (stigmer/stigmer#362).
+	modelPinningMessage = "spec.agent.run_config.model_name must name a pinned model when the run would use the Cursor harness — with no pinned model Cursor runs Auto, whose price variant follows the provider account's out-of-band default speed setting (stigmer/stigmer#362)"
 )
 
 // contextWithKind simulates the apiresource interceptor, which injects the
@@ -301,6 +306,43 @@ func TestScheduleCreate(t *testing.T) {
 			t.Fatalf("a git_repo workspace must be accepted: %v", err)
 		}
 	})
+
+	t.Run("rejects an explicit cursor-harness schedule with no pinned model", func(t *testing.T) {
+		// stigmer/stigmer#362: an empty model on the Cursor harness runs
+		// Auto, priced by the provider account's out-of-band default. Only
+		// an EXPLICIT cursor harness trips the rule in this edition — the
+		// OSS default harness is native, where an empty model resolves to
+		// the platform's own registry-priced default.
+		tc := newTestControllers(t)
+		agent := createTestAgent(t, tc, "pinning-guard-agent")
+
+		unpinned := scheduleFor(agent, "unpinned-cursor", true)
+		unpinned.Spec.GetAgent().Harness = sessionv1.Harness_HARNESS_CURSOR
+
+		_, err := tc.schedules.Create(scheduleCtx(), unpinned)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected INVALID_ARGUMENT for an unpinned cursor schedule, got %s (%v)", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), modelPinningMessage) {
+			t.Errorf("expected the model-pinning message, got: %v", err)
+		}
+
+		// A pinned model passes the same gate.
+		pinned := scheduleFor(agent, "pinned-cursor", true)
+		pinned.Spec.GetAgent().Harness = sessionv1.Harness_HARNESS_CURSOR
+		pinned.Spec.GetAgent().RunConfig = &agentexecutionv1.RunConfig{ModelName: "composer-2.5"}
+		if _, err := tc.schedules.Create(scheduleCtx(), pinned); err != nil {
+			t.Fatalf("a pinned cursor schedule must be accepted: %v", err)
+		}
+
+		// The native harness is exempt: an unset harness (the OSS default,
+		// native) with no model stays accepted — the harness-scoped half
+		// of the rule.
+		native := scheduleFor(agent, "native-unpinned", true)
+		if _, err := tc.schedules.Create(scheduleCtx(), native); err != nil {
+			t.Fatalf("an unpinned native-default schedule must be accepted: %v", err)
+		}
+	})
 }
 
 func TestScheduleUpdate(t *testing.T) {
@@ -338,6 +380,26 @@ func TestScheduleUpdate(t *testing.T) {
 		_, err := tc.schedules.Update(scheduleCtx(), updated)
 		if status.Code(err) != codes.InvalidArgument {
 			t.Fatalf("expected INVALID_ARGUMENT for a prefixed cron on update, got %s (%v)", status.Code(err), err)
+		}
+	})
+
+	t.Run("re-validates model pinning on update", func(t *testing.T) {
+		// Update replaces the spec wholesale, so flipping a native
+		// schedule to the cursor harness without pinning a model must
+		// hold the same #362 bar as create.
+		tc := newTestControllers(t)
+		agent := createTestAgent(t, tc, "update-pinning-agent")
+		created := createTestSchedule(t, tc, agent, "update-pinning", true)
+
+		updated := proto.Clone(created).(*schedulev1.Schedule)
+		updated.GetSpec().GetAgent().Harness = sessionv1.Harness_HARNESS_CURSOR
+
+		_, err := tc.schedules.Update(scheduleCtx(), updated)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected INVALID_ARGUMENT for an unpinned cursor flip on update, got %s (%v)", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), modelPinningMessage) {
+			t.Errorf("expected the model-pinning message, got: %v", err)
 		}
 	})
 

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/steps.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/steps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	scheduletemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/schedule/temporal"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -89,6 +90,9 @@ func (s *resolveScheduleDefaultsStep) Execute(ctx *pipeline.RequestContext[*sche
 	if err := validateScheduleWorkspace(spec); err != nil {
 		return err
 	}
+	if err := validateScheduleModelPinning(spec); err != nil {
+		return err
+	}
 
 	// Empty ref org means same-org; make it absolute before the invariant
 	// compares orgs.
@@ -138,6 +142,20 @@ func validateScheduleWorkspace(spec *schedulev1.ScheduleSpec) error {
 				i,
 			)
 		}
+	}
+	return nil
+}
+
+// validateScheduleModelPinning enforces the unattended model-pinning rule
+// (stigmer/stigmer#362) at write time. The rule itself — why the Cursor
+// harness requires a pinned model, why native is exempt, and the
+// edition-honest default-harness divergence — is stated once in
+// scheduletemporal.ScheduleModelPinningRefusal, which the run starter
+// also evaluates as the launch backstop for rows written before the rule
+// existed.
+func validateScheduleModelPinning(spec *schedulev1.ScheduleSpec) error {
+	if reason := scheduletemporal.ScheduleModelPinningRefusal(spec); reason != "" {
+		return grpclib.InvalidArgumentError("%s", reason)
 	}
 	return nil
 }
@@ -222,8 +240,11 @@ func (s *validateScheduleUpdateStep) Execute(ctx *pipeline.RequestContext[*sched
 		return err
 	}
 	// Update replaces the spec wholesale (no defaults resolver), so the
-	// workspace constraint must hold here too.
+	// workspace and model-pinning constraints must hold here too.
 	if err := validateScheduleWorkspace(spec); err != nil {
+		return err
+	}
+	if err := validateScheduleModelPinning(spec); err != nil {
 		return err
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/schedule/temporal/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/schedule/temporal/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "artifact.go",
         "config.go",
+        "modelpinning.go",
         "reconcile.go",
         "runledger.go",
         "runstarter.go",

--- a/backend/services/stigmer-server/pkg/domain/schedule/temporal/modelpinning.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/temporal/modelpinning.go
@@ -1,0 +1,43 @@
+package temporal
+
+import (
+	"strings"
+
+	schedulev1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/schedule/v1"
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
+)
+
+// ScheduleModelPinningRefusal is this edition's one statement of the
+// unattended model-pinning rule (stigmer/stigmer#362): a schedule whose
+// fires would run the CURSOR harness must pin a model. An empty model
+// there selects Auto, whose price variant follows the provider ACCOUNT's
+// out-of-band default speed setting — nobody at a 3 AM fire is watching a
+// rate change. The native harness is exempt on purpose: an empty model
+// resolves to the platform's own registry-priced default at an explicitly
+// requested tier — deterministic, nothing to pin.
+//
+// Only an EXPLICIT cursor harness trips the rule in this edition: an
+// unset harness resolves to the OSS platform default (native), so there
+// is no cursor path to guard. The cloud edition additionally judges its
+// configured default harness (cursor there) through its
+// UnattendedModelPinningPolicy — same contract, each edition's own
+// default-harness truth (the DD-015 divergence posture). The copy
+// mirrors the cloud policy's core sentence minus its cloud-only
+// remediation tail (OSS schedules have no platform execution-profile
+// model to fall back on).
+//
+// Evaluated at write time (the controller's validateScheduleModelPinning
+// delegates here) AND as the run starter's launch backstop, so rows
+// written before the rule existed refuse at fire time instead of running
+// mispriced. Returns the refusal copy, or "" when the fire is allowed.
+func ScheduleModelPinningRefusal(spec *schedulev1.ScheduleSpec) string {
+	if spec.GetAgent().GetHarness() != sessionv1.Harness_HARNESS_CURSOR {
+		return ""
+	}
+	if strings.TrimSpace(spec.GetAgent().GetRunConfig().GetModelName()) != "" {
+		return ""
+	}
+	return "spec.agent.run_config.model_name must name a pinned model when the run would use " +
+		"the Cursor harness — with no pinned model Cursor runs Auto, whose price variant " +
+		"follows the provider account's out-of-band default speed setting (stigmer/stigmer#362)"
+}

--- a/backend/services/stigmer-server/pkg/domain/schedule/temporal/runstarter.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/temporal/runstarter.go
@@ -131,6 +131,20 @@ func (r *RunStarter) StartRun(ctx context.Context, schedule *schedulev1.Schedule
 		return RunTargetMissingOutcome{Reason: missingReason}, nil
 	}
 
+	// Launch backstop of the unattended model-pinning rule
+	// (stigmer/stigmer#362): write-time validation
+	// (validateScheduleModelPinning) holds this bar on every create and
+	// update, but rows written before the rule existed must refuse here
+	// rather than run Auto at the account default's price. A deterministic
+	// refusal feeds the failure streak, so a broken config pauses the
+	// schedule instead of burning silently every fire. Copy matches the
+	// write-time rule — the fix is the same either way.
+	if reason := ScheduleModelPinningRefusal(schedule.GetSpec()); reason != "" {
+		log.Error().Str("schedule_id", scheduleID).Str("reason", reason).
+			Msg("Schedule fire refused by the model-pinning backstop")
+		return RunRefusedOutcome{Reason: reason}, nil
+	}
+
 	executionName := ScheduledExecutionName(scheduleID, nominalFireTime)
 
 	// The clock's own idempotency: a retried activity (or a duplicated

--- a/backend/services/stigmer-server/pkg/domain/schedule/temporal/runstarter_test.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/temporal/runstarter_test.go
@@ -299,3 +299,48 @@ func TestStartRun_DeterministicRefusalsBecomeOutcomes(t *testing.T) {
 	_, err = starter.StartRun(context.Background(), schedule, starterFireTime)
 	require.Error(t, err, "infrastructure failures propagate so the activity retries")
 }
+
+func TestStartRun_ModelPinningBackstop(t *testing.T) {
+	// stigmer/stigmer#362: rows written before the write-time rule (an
+	// explicit-cursor schedule with no pinned model) must refuse at fire
+	// time — a deterministic verdict for the failure streak — instead of
+	// running Auto at the provider account default's price.
+	st, creator, starter := newStarterFixture(t)
+	seedAgent(t, st)
+
+	unpinned := seedSchedule2(t, func(s *schedulev1.Schedule) {
+		s.Spec.GetAgent().Harness = sessionv1.Harness_HARNESS_CURSOR
+	})
+	persistSchedule(t, st, unpinned)
+
+	outcome, err := starter.StartRun(context.Background(), unpinned, starterFireTime)
+	require.NoError(t, err)
+	refused, ok := outcome.(RunRefusedOutcome)
+	require.True(t, ok, "expected RunRefusedOutcome, got %T", outcome)
+	require.Equal(t,
+		"spec.agent.run_config.model_name must name a pinned model when the run would use "+
+			"the Cursor harness — with no pinned model Cursor runs Auto, whose price variant "+
+			"follows the provider account's out-of-band default speed setting (stigmer/stigmer#362)",
+		refused.Reason,
+		"the copy matches the write-time rule — the fix is the same either way")
+	require.Nil(t, creator.created, "no execution may exist for a refused fire")
+
+	// A pinned model fires; the native default (unset harness) is exempt.
+	pinned := seedSchedule2(t, func(s *schedulev1.Schedule) {
+		s.Spec.GetAgent().Harness = sessionv1.Harness_HARNESS_CURSOR
+		s.Spec.GetAgent().RunConfig = &agentexecutionv1.RunConfig{ModelName: "composer-2.5"}
+	})
+	persistSchedule(t, st, pinned)
+	outcome, err = starter.StartRun(context.Background(), pinned, starterFireTime)
+	require.NoError(t, err)
+	require.IsType(t, RunStartedOutcome{}, outcome, "a pinned cursor schedule fires")
+
+	native := seedSchedule2(t, func(s *schedulev1.Schedule) {
+		s.Metadata.Id = "sch_01NATIVE"
+	})
+	persistSchedule(t, st, native)
+	outcome, err = starter.StartRun(context.Background(), native, starterFireTime)
+	require.NoError(t, err)
+	require.IsType(t, RunStartedOutcome{}, outcome,
+		"the native default is exempt — an empty model is deterministic there")
+}

--- a/docs/concepts/harnesses.mdx
+++ b/docs/concepts/harnesses.mdx
@@ -93,6 +93,21 @@ The Harness you choose depends on what your Agent needs to do.
   right Harness when you create the Session — you cannot switch later.
 </Callout>
 
+### Auto and pricing determinism
+
+On the Cursor Harness, leaving the model unset selects **Auto**: Cursor picks
+both the model and its price-bearing variant, governed by the Cursor account's
+own default speed setting. Auto cannot be tier-pinned — its catalog entry has no
+tier dimension — so Auto runs are priced by a setting outside the platform. That
+trade is acceptable when a person is present to watch the cost, so interactive
+sessions may use Auto freely.
+
+Unattended surfaces (schedules and channels) on the Cursor Harness **require a
+pinned model**: configurations without one are refused when written and again
+before each run. The session Usage tab shows the model each run actually
+resolved to, with its billed cost — for Auto runs, that is where the picked
+model becomes visible after the fact.
+
 ## How it works
 
 Both harnesses feed into the same Stigmer pipeline. The difference is which

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -196,6 +196,7 @@ export type {
   UseSessionFileChangesReturn,
   ModelCostEntry,
   UseSessionUsageReturn,
+  ExecutionUsageEntry,
   UseAgentRefFromSessionReturn,
   UseNewSessionFlowOptions,
   UseNewSessionFlowReturn,

--- a/sdk/react/src/session/__tests__/UsageTab.test.tsx
+++ b/sdk/react/src/session/__tests__/UsageTab.test.tsx
@@ -1,0 +1,136 @@
+// The #362 console surface: the Usage tab pairs billing's RESOLVED
+// per-execution model (the after-the-fact truth for Cursor Auto runs)
+// with the tier the runner REQUESTED (the streaming summary's audit
+// record that the account default was never left in control).
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ServiceTier } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { UseSessionUsageReturn } from "../useSessionUsage.js";
+
+// UsageTab's render contract is what this suite pins; the aggregation
+// itself (billing-report-wins, streaming fallback, breakdown mapping) is
+// useSessionUsage's own suite. Mocking the hook also spares the RPC
+// provider plumbing.
+const usageMock = vi.hoisted(() => vi.fn<() => UseSessionUsageReturn>());
+vi.mock("../useSessionUsage.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useSessionUsage: () => usageMock(),
+}));
+
+import { UsageTab } from "../facets/UsageTab.js";
+
+// UsageWidget re-aggregates via the real hook internally — with the module
+// mocked above it sees the same mocked value, which is exactly the intent.
+
+const EMPTY_USAGE: UseSessionUsageReturn = {
+  totalCostUsd: 0,
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  llmCallCount: 0,
+  modelBreakdown: [],
+  executionBreakdown: [],
+  primaryModel: "",
+  primaryProvider: "",
+  hasUsage: false,
+  isEstimated: false,
+};
+
+function usageWith(overrides: Partial<UseSessionUsageReturn>): UseSessionUsageReturn {
+  return {
+    ...EMPTY_USAGE,
+    hasUsage: true,
+    totalCostUsd: 0.0123,
+    totalTokens: 100,
+    llmCallCount: 1,
+    primaryModel: "composer-2.5",
+    primaryProvider: "cursor",
+    ...overrides,
+  };
+}
+
+function executionWithTier(id: string, tier?: ServiceTier) {
+  return create(AgentExecutionSchema, {
+    metadata: { id },
+    spec: { sessionId: "ses_1" },
+    status: {
+      streamingUsage: {
+        totalTokens: 100n,
+        turnCount: 1,
+        estimatedCostUsd: 0.01,
+        model: "default",
+        ...(tier !== undefined ? { requestedServiceTier: tier } : {}),
+      },
+    },
+  });
+}
+
+afterEach(cleanup);
+
+describe("UsageTab (#362 model provenance)", () => {
+  it("shows the empty state when no usage exists", () => {
+    usageMock.mockReturnValue(EMPTY_USAGE);
+    render(<UsageTab executions={[]} />);
+    expect(screen.getByText(/No usage data yet/)).toBeTruthy();
+  });
+
+  it("renders the billing-resolved model per run with its cost — the Auto forensics view", () => {
+    usageMock.mockReturnValue(usageWith({
+      executionBreakdown: [{
+        executionId: "exe_1",
+        resolvedModel: "cursor-grok-4.5-high-fast",
+        billableCostUsd: 0.0123,
+        isEstimated: false,
+      }],
+    }));
+
+    render(<UsageTab executions={[executionWithTier("exe_1", ServiceTier.STANDARD)]} />);
+
+    expect(screen.getByText(/cursor-grok-4\.5-high-fast/)).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Per-execution model and tier" })).toBeTruthy();
+  });
+
+  it("pairs the run with the tier the runner requested", () => {
+    usageMock.mockReturnValue(usageWith({
+      executionBreakdown: [{
+        executionId: "exe_1",
+        resolvedModel: "composer-2.5",
+        billableCostUsd: 0.0123,
+        isEstimated: false,
+      }],
+    }));
+
+    render(<UsageTab executions={[executionWithTier("exe_1", ServiceTier.FAST)]} />);
+
+    expect(screen.getByText("fast requested")).toBeTruthy();
+  });
+
+  it("omits the tier chip for executions that predate the tier attribute", () => {
+    usageMock.mockReturnValue(usageWith({
+      executionBreakdown: [{
+        executionId: "exe_0",
+        resolvedModel: "claude-haiku-4.5",
+        billableCostUsd: 0.0042,
+        isEstimated: false,
+      }],
+    }));
+
+    render(<UsageTab executions={[executionWithTier("exe_0")]} />);
+
+    expect(screen.getByText(/claude-haiku-4\.5/)).toBeTruthy();
+    expect(screen.queryByText(/requested/)).toBeNull();
+  });
+
+  it("renders no provenance list before any billing record lands", () => {
+    usageMock.mockReturnValue(usageWith({ executionBreakdown: [] }));
+
+    render(<UsageTab executions={[executionWithTier("exe_1", ServiceTier.STANDARD)]} />);
+
+    expect(screen.queryByRole("list", { name: "Per-execution model and tier" })).toBeNull();
+  });
+});

--- a/sdk/react/src/session/__tests__/useSessionUsage.test.ts
+++ b/sdk/react/src/session/__tests__/useSessionUsage.test.ts
@@ -53,6 +53,14 @@ function authoritativeReport(billableMicros: bigint): GetSessionUsageReportOutpu
       primaryProvider: "cursor",
     },
     modelBreakdown: [],
+    executions: [
+      {
+        executionId: "exe_1",
+        primaryModel: "claude-sonnet-4-6",
+        billableCostMicros: billableMicros,
+        isEstimated: false,
+      },
+    ],
     isEstimated: false,
   } as unknown as GetSessionUsageReportOutput;
 }
@@ -71,6 +79,7 @@ function emptyReport(): GetSessionUsageReportOutput {
       primaryProvider: "",
     },
     modelBreakdown: [],
+    executions: [],
     isEstimated: true,
   } as unknown as GetSessionUsageReportOutput;
 }
@@ -122,6 +131,16 @@ describe("useSessionUsage", () => {
     // 60_000 micros = $0.06 billable, replacing the $0.05 estimate.
     expect(result.current.totalCostUsd).toBeCloseTo(0.06);
     expect(result.current.llmCallCount).toBe(2);
+    // The #362 provenance rows ride the same report: billing-RESOLVED
+    // model per execution, never the runner's requested echo.
+    expect(result.current.executionBreakdown).toEqual([
+      {
+        executionId: "exe_1",
+        resolvedModel: "claude-sonnet-4-6",
+        billableCostUsd: 0.06,
+        isEstimated: false,
+      },
+    ]);
   });
 
   it("polls the usage report while an execution is in progress", async () => {

--- a/sdk/react/src/session/facets/UsageTab.tsx
+++ b/sdk/react/src/session/facets/UsageTab.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
-import { useSessionUsage } from "../useSessionUsage.js";
-import { UsageWidget } from "../../execution/UsageWidget.js";
+import { ServiceTier } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { useSessionUsage, type ExecutionUsageEntry } from "../useSessionUsage.js";
+import { UsageWidget, formatCost } from "../../execution/UsageWidget.js";
 
 export interface UsageTabProps {
   readonly executions: readonly AgentExecution[];
@@ -11,9 +12,16 @@ export interface UsageTabProps {
 /**
  * Usage facet for the session panel (a `useSessionRailViews` rail view).
  *
- * Uses `useSessionUsage` to determine if data exists, then delegates
- * rendering to the existing `UsageWidget`. Shows an empty state when
- * no usage data is available.
+ * Renders the session totals ({@link UsageWidget}) plus the #362 model
+ * provenance list: per execution, the billing-RESOLVED model with its
+ * cost — for a Cursor Auto run, the only honest answer to "which model
+ * actually ran and what did it cost", since the requested model is empty
+ * by definition there — paired with the tier the runner REQUESTED (the
+ * streaming summary's audit record that the account default was never
+ * left in control). Requested-vs-billed divergence is a platform alarm
+ * (`stigmer.billing.service_tier.mismatch`), not a per-row UI concern.
+ *
+ * Shows an empty state when no usage data is available.
  */
 export function UsageTab({ executions }: UsageTabProps) {
   const usage = useSessionUsage(executions);
@@ -28,5 +36,89 @@ export function UsageTab({ executions }: UsageTabProps) {
     );
   }
 
-  return <UsageWidget executions={executions} />;
+  return (
+    <div className="stg:flex stg:flex-col stg:gap-4">
+      <UsageWidget executions={executions} />
+      {usage.executionBreakdown.length > 0 && (
+        <ExecutionModelList
+          entries={usage.executionBreakdown}
+          executions={executions}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Per-execution model provenance rows, in the report's chronological
+ * order: `#N resolved-model [tier requested] [Estimated]  $cost`.
+ */
+function ExecutionModelList({
+  entries,
+  executions,
+}: {
+  readonly entries: readonly ExecutionUsageEntry[];
+  readonly executions: readonly AgentExecution[];
+}) {
+  return (
+    <div
+      className="stg:flex stg:flex-col stg:gap-1"
+      role="list"
+      aria-label="Per-execution model and tier"
+    >
+      <div className="stg:text-xs stg:font-medium stg:text-foreground">
+        Models per run
+      </div>
+      {entries.map((entry, index) => {
+        const requestedTier = requestedTierLabel(executions, entry.executionId);
+        return (
+          <div
+            key={entry.executionId}
+            className="stg:flex stg:items-baseline stg:justify-between stg:gap-2 stg:text-xs stg:text-muted-foreground"
+            role="listitem"
+          >
+            <span className="stg:truncate">
+              <span className="stg:tabular-nums">#{index + 1}</span>{" "}
+              {entry.resolvedModel || "—"}
+              {requestedTier && (
+                <span className="stg:ml-1 stg:rounded stg:bg-muted stg:px-1 stg:py-0.5 stg:text-[10px] stg:font-medium stg:leading-none">
+                  {requestedTier} requested
+                </span>
+              )}
+              {entry.isEstimated && (
+                <span className="stg:ml-1 stg:rounded stg:bg-muted stg:px-1 stg:py-0.5 stg:text-[10px] stg:font-medium stg:leading-none">
+                  Estimated
+                </span>
+              )}
+            </span>
+            <span className="stg:shrink-0 stg:tabular-nums">
+              {formatCost(entry.billableCostUsd)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The tier the runner requested for one execution, from its streaming
+ * usage summary — present once the runner has translated the execution
+ * config, absent for executions that predate the tier attribute. Never
+ * "unspecified": the runner records the RESOLVED tier (#357's audit
+ * contract).
+ */
+function requestedTierLabel(
+  executions: readonly AgentExecution[],
+  executionId: string,
+): string | null {
+  const match = executions.find((e) => e.metadata?.id === executionId);
+  switch (match?.status?.streamingUsage?.requestedServiceTier) {
+    case ServiceTier.FAST:
+      return "fast";
+    case ServiceTier.STANDARD:
+      return "standard";
+    default:
+      return null;
+  }
 }

--- a/sdk/react/src/session/index.ts
+++ b/sdk/react/src/session/index.ts
@@ -58,6 +58,7 @@ export type { UseSessionFileChangesReturn } from "./useSessionFileChanges.js";
 
 export { useSessionUsage } from "./useSessionUsage.js";
 export type {
+  ExecutionUsageEntry,
   ModelCostEntry,
   UseSessionUsageReturn,
 } from "./useSessionUsage.js";

--- a/sdk/react/src/session/useSessionUsage.ts
+++ b/sdk/react/src/session/useSessionUsage.ts
@@ -41,6 +41,25 @@ export interface ModelCostEntry {
   readonly callCount: number;
 }
 
+/**
+ * Per-execution model provenance from billing records (stigmer/stigmer#362).
+ */
+export interface ExecutionUsageEntry {
+  /** Execution identifier (`metadata.id`). */
+  readonly executionId: string;
+  /**
+   * Billing-resolved primary model — what the provider actually served.
+   * For a Cursor Auto execution this is the after-the-fact answer to
+   * "which model did Auto pick", which the requested model (empty by
+   * definition there) can never give.
+   */
+  readonly resolvedModel: string;
+  /** Billable cost in USD for this execution. */
+  readonly billableCostUsd: number;
+  /** `true` while this execution's records are still provisional. */
+  readonly isEstimated: boolean;
+}
+
 /** Return value of {@link useSessionUsage}. */
 export interface UseSessionUsageReturn {
   /** Aggregate estimated cost in USD across all models. */
@@ -59,6 +78,13 @@ export interface UseSessionUsageReturn {
   readonly llmCallCount: number;
   /** Per-model cost and token breakdown. */
   readonly modelBreakdown: readonly ModelCostEntry[];
+  /**
+   * Per-execution resolved model + cost, chronological, from billing
+   * records (#362). Empty until the first authoritative record lands —
+   * the streaming fallback deliberately contributes none, because the
+   * runner only knows what it REQUESTED, never what the provider served.
+   */
+  readonly executionBreakdown: readonly ExecutionUsageEntry[];
   /** Model with the highest usage in this session. */
   readonly primaryModel: string;
   /** Provider of the primary model. */
@@ -82,6 +108,7 @@ const EMPTY: UseSessionUsageReturn = {
   cacheCreationTokens: 0,
   llmCallCount: 0,
   modelBreakdown: [],
+  executionBreakdown: [],
   primaryModel: "",
   primaryProvider: "",
   hasUsage: false,
@@ -122,6 +149,12 @@ function mapReport(report: GetSessionUsageReportOutput): UseSessionUsageReturn {
     cacheCreationTokens: Number(agg.cacheCreationInputTokens),
     llmCallCount,
     modelBreakdown: report.modelBreakdown.map(mapModelUsage),
+    executionBreakdown: report.executions.map((e) => ({
+      executionId: e.executionId,
+      resolvedModel: e.primaryModel,
+      billableCostUsd: microsToUsd(e.billableCostMicros),
+      isEstimated: e.isEstimated,
+    })),
     primaryModel: agg.primaryModel,
     primaryProvider: agg.primaryProvider,
     hasUsage: llmCallCount > 0 || totalTokens > 0 || billableCost > 0,
@@ -169,6 +202,10 @@ function aggregateStreamingUsage(
     cacheReadTokens,
     cacheCreationTokens,
     llmCallCount: turnCount,
+    // No executionBreakdown here on purpose: the runner only knows the
+    // REQUESTED model; resolved-model rows exist only once billing
+    // records land (#362).
+    executionBreakdown: [],
     modelBreakdown: model
       ? [
           {


### PR DESCRIPTION
## Summary

- **Write-time refusal**: schedule create/update refuse an explicit Cursor-harness spec with no pinned model — an empty model there runs Auto, whose price variant follows the provider account's out-of-band default speed setting (the WhatsApp incident class behind #357/#362). The rule is stated once (`ScheduleModelPinningRefusal`) and consumed by both layers; the cloud edition mirrors the core copy and additionally judges its configured default harness.
- **Launch backstop**: the schedule run starter re-evaluates before every fire, so rows written before the rule refuse deterministically into the failure streak (auto-pause) instead of burning silently every fire.
- **Console visibility**: `useSessionUsage` exposes the billing-resolved per-execution model (`executionBreakdown`), and the session Usage tab renders it with the tier the runner requested — for an Auto run, the after-the-fact answer to "which model actually ran and what did it cost".
- **Docs**: Auto's tier-pinning limitation and the unattended pinned-model rule documented on the harness concepts page.
- The native harness is exempt by owner ruling: an empty model resolves to the platform's registry-priced default at an explicitly requested tier — deterministic, nothing to pin.

Cloud twin: stigmer-cloud PR (channel enforcement lives there — OSS has no channel serving runtime).

## Test plan

- [x] Go: schedule controller create/update refusal matrix + run-starter backstop tests (`go test ./backend/services/stigmer-server/pkg/domain/schedule/...`)
- [x] React SDK: UsageTab provenance rendering + useSessionUsage breakdown mapping (4,578 tests green)
- [x] Cross-edition copy contract pinned in both editions' tests

Closes #362

Made with [Cursor](https://cursor.com)