### PR TITLE
fix(backend/stigmer-server): agent delete cascades ALL instances

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/agent/controller/agent_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/agent_controller_test.go
@@ -242,12 +242,13 @@ func TestAgentController_Delete(t *testing.T) {
 	})
 }
 
-// TestAgentController_Delete_Cascade pins the T08 cascade contract: deleting
-// an agent removes its system-managed default instance and every AgentShare
-// referencing it, while personal instances (and look-alike instances of
-// OTHER agents) survive. The children are org+slug-resolved, so leaving them
-// behind poisons a recreate at the same slug (orphaned default instance) or
-// silently rebinds a stale share to the new agent.
+// TestAgentController_Delete_Cascade pins the cascade contract (#611
+// extended the #592 workflow ruling to agents): deleting an agent removes
+// ALL of its instances — the system-managed default AND members' personal
+// ones — and every AgentShare referencing it, while look-alike children of
+// OTHER agents survive. Instance slugs are org-scoped, so an orphan would
+// occupy its slug org-wide with no UI left to delete it; a stale share
+// would silently rebind to whatever agent is later created at the slug.
 func TestAgentController_Delete_Cascade(t *testing.T) {
 	newAgent := func(name string) *agentv1.Agent {
 		return &agentv1.Agent{
@@ -320,7 +321,7 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 		}
 	}
 
-	t.Run("deletes the default instance via the status pointer", func(t *testing.T) {
+	t.Run("deletes the default instance (status pointer set)", func(t *testing.T) {
 		s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
 		if err != nil {
 			t.Fatalf("failed to create store: %v", err)
@@ -346,7 +347,7 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 		assertGone(t, s, apiresourcekind.ApiResourceKind_agent_instance, "ain_pointer", &agentinstancev1.AgentInstance{})
 	})
 
-	t.Run("deletes a legacy default instance via the slug fallback", func(t *testing.T) {
+	t.Run("deletes a legacy default instance that predates the status pointer", func(t *testing.T) {
 		s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
 		if err != nil {
 			t.Fatalf("failed to create store: %v", err)
@@ -355,7 +356,8 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 		controller := NewAgentController(s, nil)
 
 		// No status.default_instance_id (nil instance client leaves it unset)
-		// — the half-created legacy shape the fallback exists for.
+		// — the half-created legacy shape. The spec.agent_id sweep covers it
+		// without any pointer-or-slug resolution.
 		created, err := controller.Create(contextWithAgentKind(), newAgent("Fallback Agent"))
 		if err != nil {
 			t.Fatalf("Create failed: %v", err)
@@ -369,7 +371,7 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 		assertGone(t, s, apiresourcekind.ApiResourceKind_agent_instance, "ain_fallback", &agentinstancev1.AgentInstance{})
 	})
 
-	t.Run("personal instances and other agents' look-alikes survive", func(t *testing.T) {
+	t.Run("cascades personal instances; other agents' look-alikes survive", func(t *testing.T) {
 		s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
 		if err != nil {
 			t.Fatalf("failed to create store: %v", err)
@@ -382,17 +384,19 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 			t.Fatalf("Create failed: %v", err)
 		}
 
-		// A member's personal instance of THIS agent (different slug).
+		// A member's personal instance of THIS agent (different slug): its
+		// org-scoped slug must be freed with the agent (#611 — the earlier
+		// posture left it as an orphan occupying the slug org-wide).
 		saveInstance(t, s, "ain_personal", "my-personal-setup", created.Metadata.Id)
 		// An instance that merely reuses the "-default" name but belongs to a
-		// DIFFERENT agent — the spec.agent_id guard must protect it.
+		// DIFFERENT agent — the spec.agent_id match must protect it.
 		saveInstance(t, s, "ain_lookalike", created.Metadata.Slug+"-default", "agt_someone_else")
 
 		if _, err := controller.Delete(contextWithAgentKind(), &agentv1.AgentId{Value: created.Metadata.Id}); err != nil {
 			t.Fatalf("Delete failed: %v", err)
 		}
 
-		assertSurvives(t, s, apiresourcekind.ApiResourceKind_agent_instance, "ain_personal", &agentinstancev1.AgentInstance{})
+		assertGone(t, s, apiresourcekind.ApiResourceKind_agent_instance, "ain_personal", &agentinstancev1.AgentInstance{})
 		assertSurvives(t, s, apiresourcekind.ApiResourceKind_agent_instance, "ain_lookalike", &agentinstancev1.AgentInstance{})
 	})
 

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/delete.go
@@ -11,9 +11,9 @@ import (
 
 // Delete deletes an agent by ID using the pipeline pattern.
 //
-// Deletion cascades to the agent's org+slug-resolved children — the
-// system-managed default instance and all AgentShares — before the agent
-// row itself is removed. Personal instances are deliberately not cascaded;
+// Deletion cascades to the agent's children — ALL instances (the
+// system-managed default and members' personal ones, stigmer/stigmer#611)
+// and all same-org AgentShares — before the agent row itself is removed;
 // see delete_cascade.go for the full contract (shared with the cloud
 // edition).
 //
@@ -21,7 +21,7 @@ import (
 // 1. ValidateProto - Validate proto field constraints (agent ID wrapper)
 // 2. ExtractResourceId - Extract ID from AgentId.Value wrapper
 // 3. LoadExistingForDelete - Load agent from database (stores in context)
-// 4. CascadeDeleteDefaultInstance - Delete the default instance (children before parent)
+// 4. CascadeDeleteInstances - Delete ALL instances (children before parent)
 // 5. CascadeDeleteShares - Delete the agent's shares
 // 6. DeleteResource - Delete agent from database
 // 7. DeleteSearchIndex - Remove from search index
@@ -63,7 +63,7 @@ func (c *AgentController) buildDeletePipeline() *pipeline.Pipeline[*agentv1.Agen
 		AddStep(steps.NewValidateProtoStep[*agentv1.AgentId]()).                                // 1. Validate field constraints
 		AddStep(steps.NewExtractResourceIdStep[*agentv1.AgentId]()).                            // 2. Extract ID from wrapper
 		AddStep(steps.NewLoadExistingForDeleteStep[*agentv1.AgentId, *agentv1.Agent](c.store)). // 3. Load agent
-		AddStep(newCascadeDeleteDefaultInstanceStep(c.store)).                                  // 4. Cascade: default instance before parent
+		AddStep(newCascadeDeleteInstancesStep(c.store)).                                        // 4. Cascade: all instances before parent
 		AddStep(newCascadeDeleteSharesStep(c.store)).                                           // 5. Cascade: shares before parent
 		AddStep(steps.NewDeleteResourceStep[*agentv1.AgentId](c.store)).                        // 6. Delete from database
 		AddStep(steps.NewDeleteSearchIndexStep[*agentv1.AgentId](c.store)).                     // 7. Remove from search index

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/delete_cascade.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/delete_cascade.go
@@ -12,22 +12,24 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
-	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentinstance/defaultinstance"
 	"google.golang.org/protobuf/proto"
 )
 
-// Agent deletion cascades to the agent's org+slug-resolved children before
-// the agent row itself is removed (children before parent, so a mid-failure
-// retry converges — the same ordering the cloud edition's
-// SessionDeleteHandler cascade established):
+// Agent deletion cascades to the agent's children before the agent row
+// itself is removed (children before parent, so a mid-failure retry
+// converges — the same ordering the cloud edition's SessionDeleteHandler
+// cascade established):
 //
-//   - The system-managed DEFAULT instance. Its slug is the deterministic
-//     "<agent-slug>-default", so leaving it behind poisons a later recreate
-//     at the same slug (the create pipeline's idempotent apply routes to
-//     UPDATE on the orphan — see cloud design decision 010). Personal
-//     instances are deliberately NOT cascaded: they reference the agent by
-//     immutable ID (never reused), so they become inert dangling
-//     references — the same posture sessions and executions already have.
+//   - ALL of the agent's instances — the system-managed default AND
+//     members' personal ones. An earlier posture spared personal instances
+//     as "inert dangling references"; that holds for the dangling
+//     REFERENCE (spec.agent_id is an immutable ID, never reused) but not
+//     for the dangling SLUG: AgentInstance slugs are org-scoped, and the
+//     parent agent's detail page is the only instance-management surface —
+//     so an orphan occupies its slug org-wide forever with no UI left to
+//     delete it. Instances are configuration OF the agent, meaningless
+//     without it; owner ruling on stigmer/stigmer#611 extends the workflow
+//     ruling (stigmer/stigmer#592): they go with it.
 //
 //   - The agent's SAME-ORG AgentShares. Shares reference the agent by
 //     org+slug (spec.agent_ref), so a stale share would silently rebind —
@@ -39,87 +41,81 @@ import (
 //     fail closed instead — via the dangling-ref check and the
 //     status.agent_id pin every share-resolution gate verifies.
 //
+// What deliberately SURVIVES an agent delete, and must never be swept into
+// this cascade:
+//
+//   - Sessions and AgentExecutions — historical record, the #582 posture.
+//     They reference the agent and instance by immutable IDs and remain
+//     viewable after the agent (and now its instances) are gone.
+//   - Version/audit rows (resource_audit) — surviving sessions and
+//     executions render their historical state from them.
+//
 // Both editions implement this contract; the cloud edition additionally
 // cleans up each child's FGA tuples (no IAM system in OSS).
 
-// cascadeDeleteDefaultInstanceStep deletes the agent's system-managed
-// default instance (row + search-index entry) before the agent is deleted.
+// cascadeDeleteInstancesStep deletes every instance of the agent
+// (row + search-index entry) before the agent is deleted.
 //
-// Resolution is authoritative-first: status.default_instance_id when set,
-// else the "<agent-slug>-default" slug convention for legacy/half-created
-// rows — guarded by spec.agent_id, so a personal instance that merely
-// reuses the name is never touched.
-type cascadeDeleteDefaultInstanceStep struct {
+// Instances are matched by spec.agent_id — a required, validated field on
+// every instance — so a single ID sweep covers the default instance too,
+// including legacy rows that predate the status.default_instance_id
+// pointer; no pointer-or-slug resolution is needed.
+type cascadeDeleteInstancesStep struct {
 	store store.Store
 }
 
-func newCascadeDeleteDefaultInstanceStep(s store.Store) *cascadeDeleteDefaultInstanceStep {
-	return &cascadeDeleteDefaultInstanceStep{store: s}
+func newCascadeDeleteInstancesStep(s store.Store) *cascadeDeleteInstancesStep {
+	return &cascadeDeleteInstancesStep{store: s}
 }
 
-func (s *cascadeDeleteDefaultInstanceStep) Name() string {
-	return "CascadeDeleteDefaultInstance"
+func (s *cascadeDeleteInstancesStep) Name() string {
+	return "CascadeDeleteInstances"
 }
 
-func (s *cascadeDeleteDefaultInstanceStep) Execute(ctx *pipeline.RequestContext[*agentv1.AgentId]) error {
+func (s *cascadeDeleteInstancesStep) Execute(ctx *pipeline.RequestContext[*agentv1.AgentId]) error {
 	agent, ok := ctx.Get(steps.ExistingResourceKey).(*agentv1.Agent)
 	if !ok {
 		return grpclib.InternalError(nil, "agent not found in context (LoadExistingForDelete must run first)")
 	}
+	agentID := agent.GetMetadata().GetId()
 
-	instanceID := s.resolveDefaultInstanceID(ctx, agent)
-	if instanceID == "" {
-		return nil
-	}
-
-	if err := s.store.DeleteResource(ctx.Context(), apiresourcekind.ApiResourceKind_agent_instance, instanceID); err != nil {
-		return grpclib.InternalError(err, fmt.Sprintf(
-			"failed to cascade-delete default instance %s of agent %s",
-			instanceID, agent.GetMetadata().GetId()))
-	}
-
-	// Best-effort, matching DeleteSearchIndexStep: a stale index entry is a
-	// cosmetic search artifact, not a correctness problem.
-	if err := s.store.DeleteSearchIndex(ctx.Context(), apiresourcekind.ApiResourceKind_agent_instance, instanceID); err != nil {
-		log.Warn().Err(err).
-			Str("instance_id", instanceID).
-			Msg("CascadeDeleteDefaultInstance: failed to remove search index entry (best-effort)")
-	}
-
-	log.Info().
-		Str("instance_id", instanceID).
-		Str("agent_id", agent.GetMetadata().GetId()).
-		Msg("Cascade-deleted default instance of agent")
-	return nil
-}
-
-// resolveDefaultInstanceID returns the default instance's ID, or "" when the
-// agent has none (nothing to cascade).
-func (s *cascadeDeleteDefaultInstanceStep) resolveDefaultInstanceID(ctx *pipeline.RequestContext[*agentv1.AgentId], agent *agentv1.Agent) string {
-	if id := agent.GetStatus().GetDefaultInstanceId(); id != "" {
-		return id
-	}
-
-	// Legacy/half-created agents may lack the status pointer; fall back to
-	// the "<agent-slug>-default" naming convention (the shape
-	// defaultinstance.BuildRequest provisions), guarded by spec.agent_id.
-	defaultSlug := defaultinstance.Slug(agent.GetMetadata().GetSlug())
 	resources, err := s.store.ListResources(ctx.Context(), apiresourcekind.ApiResourceKind_agent_instance)
 	if err != nil {
-		log.Warn().Err(err).Msg("CascadeDeleteDefaultInstance: failed to list instances for slug fallback")
-		return ""
+		return grpclib.InternalError(err, "failed to list agent instances for cascade delete")
 	}
+
+	deleted := 0
 	for _, data := range resources {
 		instance := &agentinstancev1.AgentInstance{}
 		if err := proto.Unmarshal(data, instance); err != nil {
 			continue
 		}
-		if instance.GetSpec().GetAgentId() == agent.GetMetadata().GetId() &&
-			instance.GetMetadata().GetSlug() == defaultSlug {
-			return instance.GetMetadata().GetId()
+		if instance.GetSpec().GetAgentId() != agentID {
+			continue
 		}
+		instanceID := instance.GetMetadata().GetId()
+		if err := s.store.DeleteResource(ctx.Context(), apiresourcekind.ApiResourceKind_agent_instance, instanceID); err != nil {
+			return grpclib.InternalError(err, fmt.Sprintf(
+				"failed to cascade-delete instance %s of agent %s", instanceID, agentID))
+		}
+
+		// Best-effort, matching DeleteSearchIndexStep: a stale index entry is
+		// a cosmetic search artifact, not a correctness problem.
+		if err := s.store.DeleteSearchIndex(ctx.Context(), apiresourcekind.ApiResourceKind_agent_instance, instanceID); err != nil {
+			log.Warn().Err(err).
+				Str("instance_id", instanceID).
+				Msg("CascadeDeleteInstances: failed to remove search index entry (best-effort)")
+		}
+		deleted++
 	}
-	return ""
+
+	if deleted > 0 {
+		log.Info().
+			Int("count", deleted).
+			Str("agent_id", agentID).
+			Msg("Cascade-deleted instances of agent")
+	}
+	return nil
 }
 
 // cascadeDeleteSharesStep deletes the agent's same-org AgentShares before

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/controller/agentinstance_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/controller/agentinstance_controller_test.go
@@ -768,3 +768,77 @@ func TestAgentInstanceController_UpdateVisibility(t *testing.T) {
 		}
 	})
 }
+
+// TestAgentInstanceController_SlugReusableAfterAgentDelete pins the
+// stigmer/stigmer#611 contract at the create-pipeline level: agent delete
+// cascades ALL instances, so a personal instance's org-scoped slug must be
+// creatable again afterwards. It lives here rather than beside the agent
+// cascade tests because proving slug REUSE needs the real instance create
+// pipeline (slug resolution + org-scoped duplicate check), which this
+// package's in-process harness already wires — the workflow twin is
+// workflow/controller/delete_cascade_test.go's "freed user-instance slug is
+// reusable org-wide" subtest.
+func TestAgentInstanceController_SlugReusableAfterAgentDelete(t *testing.T) {
+	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer s.Close()
+
+	agentClient, agentInstanceClient, cleanup := setupInProcessServers(t, s)
+	defer cleanup()
+
+	instanceController := NewAgentInstanceController(s, agentClient)
+	agentController := agentcontroller.NewAgentController(s, agentInstanceClient)
+
+	newAgent := func(name string) *agentv1.Agent {
+		return &agentv1.Agent{
+			ApiVersion: "agentic.stigmer.ai/v1",
+			Kind:       "Agent",
+			Metadata: &apiresource.ApiResourceMetadata{
+				Name: name,
+				Org:  "test-org",
+			},
+			Spec: &agentv1.AgentSpec{
+				Instructions: "You are a slug-reuse test agent.",
+			},
+		}
+	}
+	newInstance := func(agentID string) *agentinstancev1.AgentInstance {
+		return &agentinstancev1.AgentInstance{
+			ApiVersion: "agentic.stigmer.ai/v1",
+			Kind:       "AgentInstance",
+			Metadata: &apiresource.ApiResourceMetadata{
+				Name: "verify-611",
+				Org:  "test-org",
+			},
+			Spec: &agentinstancev1.AgentInstanceSpec{AgentId: agentID},
+		}
+	}
+
+	// The #582-class exposure, agent edition: instance slugs are org-scoped,
+	// so an orphan would block the slug for every LATER agent's instances.
+	first, err := agentController.Create(contextWithAgentKind(), newAgent("First Owner"))
+	if err != nil {
+		t.Fatalf("Create first agent failed: %v", err)
+	}
+	if _, err := instanceController.Create(contextWithAgentInstanceKind(), newInstance(first.Metadata.Id)); err != nil {
+		t.Fatalf("Create personal instance failed: %v", err)
+	}
+
+	if _, err := agentController.Delete(contextWithAgentKind(), &agentv1.AgentId{Value: first.Metadata.Id}); err != nil {
+		t.Fatalf("Delete agent failed: %v", err)
+	}
+
+	second, err := agentController.Create(contextWithAgentKind(), newAgent("Second Owner"))
+	if err != nil {
+		t.Fatalf("Create second agent failed: %v", err)
+	}
+	reused, err := instanceController.Create(contextWithAgentInstanceKind(), newInstance(second.Metadata.Id))
+	if err != nil {
+		t.Fatalf("expected the freed instance slug to be reusable, got: %v", err)
+	}
+	if reused.Metadata.Slug != "verify-611" {
+		t.Errorf("expected reused slug %q, got %q", "verify-611", reused.Metadata.Slug)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/delete_cascade.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/delete_cascade.go
@@ -19,15 +19,16 @@ import (
 // itself is removed (children before parent, so a mid-failure retry
 // converges: the agent/session cascade ordering).
 //
-// This deliberately goes FURTHER than the agent cascade
-// (agent/controller/delete_cascade.go), which spares personal instances as
-// "inert dangling references". That rationale holds for the dangling
-// REFERENCE (spec.workflow_id is an immutable ID, never reused) but not for
-// the dangling SLUG: WorkflowInstance slugs are org-scoped, and the parent
+// An earlier agent-side posture spared user instances as "inert dangling
+// references". That rationale holds for the dangling REFERENCE
+// (spec.workflow_id is an immutable ID, never reused) but not for the
+// dangling SLUG: WorkflowInstance slugs are org-scoped, and the parent
 // workflow's detail page is the only instance-management surface — so an
 // orphan occupies its slug org-wide forever with no UI left to delete it
 // (stigmer/stigmer#592, repro'd live). Instances are configuration OF the
-// workflow, meaningless without it; owner ruling: they go with it.
+// workflow, meaningless without it; owner ruling: they go with it. The
+// agent cascade (agent/controller/delete_cascade.go) follows the same
+// contract since stigmer/stigmer#611 extended the ruling.
 //
 // What deliberately SURVIVES a workflow delete, and must never be swept
 // into this cascade:
@@ -49,8 +50,8 @@ import (
 //
 // Instances are matched by spec.workflow_id — a required, validated field
 // on every instance — so a single ID sweep covers the default instance
-// too; no pointer-or-slug resolution is needed (unlike the agent cascade,
-// whose default instance may predate the status pointer).
+// too; no pointer-or-slug resolution is needed (the agent cascade shares
+// this shape).
 type cascadeDeleteInstancesStep struct {
 	store store.Store
 }

--- a/client-apps/desktop/src/pages/library/AgentDetailPage.tsx
+++ b/client-apps/desktop/src/pages/library/AgentDetailPage.tsx
@@ -127,7 +127,9 @@ export default function AgentDetailPage() {
     const confirmed = await confirm({
       title: `Delete ${resourceName}?`,
       description:
-        "This action cannot be undone. The agent and its configuration will be permanently removed.",
+        "This permanently removes the agent and all of its instances. " +
+        "Past sessions and executions are preserved. " +
+        "This action cannot be undone.",
       confirmLabel: "Delete",
       variant: "destructive",
     });

--- a/client-apps/desktop/src/pages/library/AgentListPage.tsx
+++ b/client-apps/desktop/src/pages/library/AgentListPage.tsx
@@ -89,7 +89,9 @@ export default function AgentListPage() {
       const confirmed = await confirm({
         title: `Delete ${item.name || item.slug}?`,
         description:
-          "This action cannot be undone. The agent and its configuration will be permanently removed.",
+          "This permanently removes the agent and all of its instances. " +
+          "Past sessions and executions are preserved. " +
+          "This action cannot be undone.",
         confirmLabel: "Delete",
         variant: "destructive",
       });

--- a/client-apps/web/src/domain/library/agents/AgentDetailPage.tsx
+++ b/client-apps/web/src/domain/library/agents/AgentDetailPage.tsx
@@ -117,7 +117,10 @@ export function AgentDetailPageInner({ org, slug }: AgentDetailPageInnerProps) {
   const handleDelete = useCallback(async () => {
     const confirmed = await confirm({
       title: `Delete ${resourceName}?`,
-      description: "This action cannot be undone. The agent and its configuration will be permanently removed.",
+      description:
+        "This permanently removes the agent and all of its instances. " +
+        "Past sessions and executions are preserved. " +
+        "This action cannot be undone.",
       confirmLabel: "Delete",
       variant: "destructive",
     });

--- a/client-apps/web/src/domain/library/agents/AgentListPage.tsx
+++ b/client-apps/web/src/domain/library/agents/AgentListPage.tsx
@@ -72,7 +72,9 @@ export function AgentListPage() {
       const confirmed = await confirm({
         title: `Delete ${item.name || item.slug}?`,
         description:
-          "This action cannot be undone. The agent and its configuration will be permanently removed.",
+          "This permanently removes the agent and all of its instances. " +
+          "Past sessions and executions are preserved. " +
+          "This action cannot be undone.",
         confirmLabel: "Delete",
         variant: "destructive",
       });

--- a/test/conformance/src/suites/agent.conformance.test.ts
+++ b/test/conformance/src/suites/agent.conformance.test.ts
@@ -16,6 +16,7 @@ import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
 import { AGENT_API_VERSION, AGENT_KIND, makeAgent, makeAgentSpec } from "../support/agents";
+import { makeAgentInstance } from "../support/agentinstances";
 import { makeMcpServer } from "../support/mcpservers";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
@@ -405,6 +406,57 @@ describe("Agent instance conformance — visibility level validation", () => {
       "Default instances do not have their own visibility - access always follows " +
         "the parent blueprint. Change the blueprint's visibility instead.",
     );
+  });
+});
+
+describe("Agent conformance — delete cascades instances (stigmer#611)", () => {
+  it("delete removes the default and personal instances, freeing the agent slug and the org-wide instance slug", async () => {
+    // The agent twin of the workflow cascade pin (stigmer#592): instances
+    // are configuration OF the agent and go with it (default AND personal),
+    // unlike sessions/executions which survive as historical record (the
+    // #582 ruling). Without the cascade, the orphaned "<slug>-default"
+    // poisons a same-slug recreate, and a personal instance's org-scoped
+    // slug stays occupied forever with no UI left to delete it.
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("cascade");
+
+    const created = await clients.agentCommand.create(makeAgent({ org, name }));
+    const agentId = created.metadata!.id;
+    const defaultInstanceId = created.status?.defaultInstanceId;
+    expect(defaultInstanceId, "create provisions a default instance").toMatch(/^ain_[0-9a-z]+$/);
+
+    const instanceName = uniqueName("cfg");
+    const personalInstance = await clients.agentInstanceCommand.create(
+      makeAgentInstance({ org, name: instanceName, agentId }),
+    );
+
+    await clients.agentCommand.delete({ value: agentId });
+
+    await expectGrpcCode(
+      () => clients.agentInstanceQuery.get({ value: defaultInstanceId! }),
+      Code.NotFound,
+      "default instance after cascade",
+    );
+    await expectGrpcCode(
+      () => clients.agentInstanceQuery.get({ value: personalInstance.metadata!.id }),
+      Code.NotFound,
+      "personal instance after cascade",
+    );
+
+    // The agent slug is free again: recreate converges instead of colliding
+    // with the orphaned default instance (the DD-010 poison).
+    const recreated = await createAgent(org, name);
+    expect(recreated.metadata?.slug).toBe(created.metadata?.slug);
+    expect(recreated.metadata?.id).not.toBe(agentId);
+
+    // The personal instance's org-scoped slug is free again (the #611
+    // exposure: with the orphan left behind, this create would be rejected
+    // as a duplicate).
+    const reused = await clients.agentInstanceCommand.create(
+      makeAgentInstance({ org, name: instanceName, agentId: recreated.metadata!.id }),
+    );
+    fixtures.defer(() => clients.agentInstanceCommand.delete({ value: reused.metadata!.id }));
+    expect(reused.metadata?.slug).toBe(personalInstance.metadata?.slug);
   });
 });
 


### PR DESCRIPTION
## Summary

OSS half of #611: agent delete now cascades **all** instances — the system-managed default and members' personal ones — matching the workflow #592 ruling (DD-022). A member's personal `AgentInstance` previously survived as an invisible orphan occupying its org-scoped slug forever.

## Context

The agent cascade's "inert dangling references" rationale holds for the dangling ID (`spec.agent_id` is never reused) but not the dangling slug: instance slugs are org-scoped, and the parent detail page is the only instance-management surface. Owner ruled: extend DD-022 to agents.

## Changes

- Replace `cascadeDeleteDefaultInstanceStep` with a `spec.agent_id` sweep (`cascadeDeleteInstancesStep`) — the workflow cascade's exact shape. Pointer-or-slug fallback is deleted; the required/validated field covers legacy rows without the status pointer
- Flip the unit-test pin: personal instances now cascade; look-alike instances of OTHER agents still survive
- Conformance pin mirroring the workflow one: default + personal instances NotFound after delete, agent slug and org-wide instance slug both freed
- Honest delete-dialog copy in all four client-app pages (web + desktop, list + detail), the #592 copy pattern
- Truth the cross-referencing comments in the workflow cascade

## Implementation notes

- Shares step unchanged
- Sessions, executions, and version/audit rows still survive (immutable-ID references)
- Merge after the paired cloud PR — this conformance pin is red against an unpatched cloud edition (the #592 precedent)

## Breaking changes

- None at the API. Behavior change: deleting an agent now also deletes personal instances.

## Test plan

- [x] `TestAgentController_Delete_Cascade` flipped red-first (personal instances now `assertGone`; look-alikes still survive)
- [x] New conformance pin in `agent.conformance.test.ts`
- [x] Honest copy in web + desktop agent list/detail pages

## Risks

- Low. Same shape as the already-shipped workflow cascade. Rollback: revert this PR.

## Checklist

- [x] Docs updated (cascade comments + four delete dialogs)
- [x] Tests added/updated
- [x] Backward compatible

Closes #611

Made with [Cursor](https://cursor.com)