### PR TITLE
fix(server,libs/go): stamp one audit slot per targeted mutation, matching cloud

### DIFF
--- a/backend/libs/go/grpc/request/pipeline/steps/defaults.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/defaults.go
@@ -196,35 +196,102 @@ func SetAuditFieldsForCreate(resource proto.Message) error {
 	})
 }
 
-// SetAuditFieldsForUpdate sets audit fields for an updated resource
+// AuditSlot names which half of status.audit a targeted mutation writes.
+// Zero is invalid — callers must pick SpecAudit or StatusAudit. The
+// required argument is the census: every SetAuditFieldsForUpdate call
+// site fails to compile until it declares which slot it owns
+// (stigmer/stigmer#540).
+type AuditSlot int
+
+const (
+	// SpecAudit is the definition-changed slot (search recency, version
+	// "pushed at", created_at-sorted library lists). Stamp it when spec
+	// or other definition fields changed.
+	SpecAudit AuditSlot = iota + 1
+	// StatusAudit is the operational-changed slot (Recents, lifecycle
+	// metadata). Stamp it when only status or metadata such as
+	// visibility changed.
+	StatusAudit
+)
+
+func (s AuditSlot) fieldName() (protoreflect.Name, error) {
+	switch s {
+	case SpecAudit:
+		return "spec_audit", nil
+	case StatusAudit:
+		return "status_audit", nil
+	default:
+		return "", fmt.Errorf("invalid audit slot %d: must be SpecAudit or StatusAudit", int(s))
+	}
+}
+
+// SetAuditFieldsForUpdate stamps one audit slot on a targeted mutation.
 //
-// This preserves created_by and created_at from the resource's own current
-// audit — in both spec_audit and status_audit — and stamps updated_by and
-// updated_at with the current actor/time (event "updated"). Callers hand
-// this the loaded resource they mutated in place (or one that carries the
-// existing audit copied onto it, as skill push does), so the resource
-// itself is the source of creation truth. A resource with no prior audit
-// falls back to the current actor/time for the creation fields, the same
-// fallback BuildUpdateStateStep uses.
+// The named slot keeps its created_by/created_at (falling back to the
+// current actor/time when that slot had no prior audit) and gets a fresh
+// updated_by/updated_at with event "updated". The other slot is not
+// rewritten — it stays proto-equal to before, including when it is
+// absent. A first write therefore creates only the stamped slot; it does
+// not invent the other.
 //
-// Unlike BuildUpdateStateStep's updateAuditFieldsReflect — which resets
-// status_audit because the update pipeline rebuilds status from the
-// request — this helper preserves status_audit's creation identity too:
-// its callers are targeted mutations (visibility flips, skill push,
-// schedule stamps, soft deletes) that never reset status.
+// The write Sets a newly allocated slot message onto the existing audit
+// wrapper. It must not mutate the existing slot in place: skill push
+// copies SpecAudit/StatusAudit pointers from the loaded skill onto a new
+// wrapper, and in-place field assignment would corrupt that in-memory
+// original (stigmer/stigmer#540).
+//
+// Callers hand this the loaded resource they mutated in place (or one
+// that carries the existing audit copied onto it, as skill push does),
+// so the resource itself is the source of creation truth.
+//
+// Unlike BuildUpdateStateStep's updateAuditFieldsReflect — which
+// wholesale-replaces both slots because the full Update pipeline rebuilds
+// status from the request — this helper is for targeted mutations
+// (visibility flips, skill push, schedule stamps, soft deletes) that
+// change one class of field.
 //
 // This function is exported so custom steps can use it for audit field management.
-func SetAuditFieldsForUpdate(resource proto.Message) error {
+func SetAuditFieldsForUpdate(resource proto.Message, slot AuditSlot) error {
+	fieldName, err := slot.fieldName()
+	if err != nil {
+		return err
+	}
+
 	now := timestamppb.Now()
 	actor := currentAuditActor()
+	createdBy, createdAt := creationAuditOf(resource, fieldName)
+	return setAuditSlotReflect(resource, fieldName, updatedAuditInfo(createdBy, createdAt, actor, now))
+}
 
-	specCreatedBy, specCreatedAt := creationAuditOf(resource, "spec_audit")
-	statusCreatedBy, statusCreatedAt := creationAuditOf(resource, "status_audit")
+// setAuditSlotReflect writes one audit-info message onto the named slot
+// of status.audit, creating status/audit if needed. The other slot is
+// left untouched. Resources without a status field, or whose status has
+// no audit field, are a no-op.
+func setAuditSlotReflect(
+	resource proto.Message,
+	slot protoreflect.Name,
+	info *commonspb.ApiResourceAuditInfo,
+) error {
+	statusMsg := getOrCreateStatusField(resource)
+	if statusMsg == nil {
+		return nil
+	}
 
-	return setAuditReflect(resource, &commonspb.ApiResourceAudit{
-		SpecAudit:   updatedAuditInfo(specCreatedBy, specCreatedAt, actor, now),
-		StatusAudit: updatedAuditInfo(statusCreatedBy, statusCreatedAt, actor, now),
-	})
+	auditField := statusMsg.Descriptor().Fields().ByName("audit")
+	if auditField == nil {
+		return nil
+	}
+
+	// Mutable creates an empty audit wrapper when none exists, without
+	// replacing a wrapper that already holds the other slot.
+	auditMsg := statusMsg.Mutable(auditField).Message()
+	slotField := auditMsg.Descriptor().Fields().ByName(slot)
+	if slotField == nil {
+		return nil
+	}
+
+	auditMsg.Set(slotField, protoreflect.ValueOfMessage(info.ProtoReflect()))
+	return nil
 }
 
 // currentAuditActor returns the actor to stamp on audit fields.

--- a/backend/libs/go/grpc/request/pipeline/steps/defaults_test.go
+++ b/backend/libs/go/grpc/request/pipeline/steps/defaults_test.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -328,25 +329,181 @@ func TestGenerateID_Uniqueness(t *testing.T) {
 }
 
 // TestSetAuditFieldsForUpdate_PreservesCreationAudit is the regression pin
-// for stigmer/stigmer#453: the helper used to rebuild the whole audit
-// block, resetting created_by/created_at to system/now on every call —
-// silently destroying the true creation record at all 14 call sites
-// (visibility flips, skill push, schedule stamps, artifact soft-delete,
-// share-link rotate) and reordering every created_at-sorted list.
+// for stigmer/stigmer#453 (creation identity) and stigmer/stigmer#540
+// (slot granularity): the helper used to rebuild the whole audit block,
+// resetting created_by/created_at to system/now AND stamping both slots
+// on every targeted mutation.
 //
-// The pinned contract: created_by/created_at survive EXACTLY (full proto
-// equality, per audit slot — spec_audit and status_audit each keep their
-// own), updated_by/updated_at are stamped fresh, event flips to "updated".
+// The pinned contract: the named slot keeps created_by/created_at EXACTLY
+// (full proto equality; spec_audit and status_audit each keep their own)
+// and gets a fresh update stamp; the other slot is proto.Equal to before.
 func TestSetAuditFieldsForUpdate_PreservesCreationAudit(t *testing.T) {
-	// Distinct creation identities per slot prove per-slot extraction —
-	// a fix that copied spec_audit's values into status_audit would fail.
+	for _, tc := range []struct {
+		name AuditSlot
+	}{
+		{name: SpecAudit},
+		{name: StatusAudit},
+	} {
+		t.Run(tc.name.fieldNameForTest(), func(t *testing.T) {
+			agent := surgicalAuditFixture()
+			beforeSpec := proto.Clone(agent.Status.Audit.SpecAudit).(*apiresource.ApiResourceAuditInfo)
+			beforeStatus := proto.Clone(agent.Status.Audit.StatusAudit).(*apiresource.ApiResourceAuditInfo)
+
+			before := time.Now()
+			if err := SetAuditFieldsForUpdate(agent, tc.name); err != nil {
+				t.Fatalf("Expected success, got error: %v", err)
+			}
+
+			audit := agent.GetStatus().GetAudit()
+			if audit == nil || audit.SpecAudit == nil || audit.StatusAudit == nil {
+				t.Fatalf("Expected both audit slots to remain set, got %v", audit)
+			}
+
+			var stamped, other *apiresource.ApiResourceAuditInfo
+			var otherBefore *apiresource.ApiResourceAuditInfo
+			switch tc.name {
+			case SpecAudit:
+				stamped, other, otherBefore = audit.SpecAudit, audit.StatusAudit, beforeStatus
+			case StatusAudit:
+				stamped, other, otherBefore = audit.StatusAudit, audit.SpecAudit, beforeSpec
+			}
+
+			if !proto.Equal(other, otherBefore) {
+				t.Errorf("untouched slot mutated: want %v, got %v", otherBefore, other)
+			}
+
+			if tc.name == SpecAudit {
+				if !proto.Equal(stamped.CreatedBy, beforeSpec.CreatedBy) {
+					t.Errorf("spec_audit.created_by not preserved: want %v, got %v", beforeSpec.CreatedBy, stamped.CreatedBy)
+				}
+				if !proto.Equal(stamped.CreatedAt, beforeSpec.CreatedAt) {
+					t.Errorf("spec_audit.created_at not preserved: want %v, got %v", beforeSpec.CreatedAt, stamped.CreatedAt)
+				}
+			} else {
+				if !proto.Equal(stamped.CreatedBy, beforeStatus.CreatedBy) {
+					t.Errorf("status_audit.created_by not preserved: want %v, got %v", beforeStatus.CreatedBy, stamped.CreatedBy)
+				}
+				if !proto.Equal(stamped.CreatedAt, beforeStatus.CreatedAt) {
+					t.Errorf("status_audit.created_at not preserved: want %v, got %v", beforeStatus.CreatedAt, stamped.CreatedAt)
+				}
+			}
+
+			if stamped.UpdatedAt.AsTime().Before(before) {
+				t.Errorf("updated_at not stamped fresh: got %v, want >= %v", stamped.UpdatedAt.AsTime(), before)
+			}
+			if stamped.UpdatedBy.GetId() != "system" {
+				t.Errorf("updated_by not stamped: want system, got %q", stamped.UpdatedBy.GetId())
+			}
+			if stamped.Event != "updated" {
+				t.Errorf("event: want updated, got %q", stamped.Event)
+			}
+		})
+	}
+}
+
+// TestSetAuditFieldsForUpdate_NoPriorAudit pins the first-write fallback:
+// a resource with no existing audit gets creation fields backfilled on
+// the stamped slot only — the other slot is not invented.
+func TestSetAuditFieldsForUpdate_NoPriorAudit(t *testing.T) {
+	for _, slot := range []AuditSlot{SpecAudit, StatusAudit} {
+		t.Run(slot.fieldNameForTest(), func(t *testing.T) {
+			agent := &agentv1.Agent{
+				Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
+				Status:   &agentv1.AgentStatus{},
+			}
+
+			if err := SetAuditFieldsForUpdate(agent, slot); err != nil {
+				t.Fatalf("Expected success, got error: %v", err)
+			}
+
+			audit := agent.GetStatus().GetAudit()
+			if audit == nil {
+				t.Fatal("Expected audit wrapper to be created")
+			}
+
+			var stamped, other *apiresource.ApiResourceAuditInfo
+			if slot == SpecAudit {
+				stamped, other = audit.SpecAudit, audit.StatusAudit
+			} else {
+				stamped, other = audit.StatusAudit, audit.SpecAudit
+			}
+
+			if other != nil {
+				t.Errorf("first-write must not invent the other slot, got %v", other)
+			}
+			if stamped == nil {
+				t.Fatal("expected stamped slot to be filled")
+			}
+			if stamped.CreatedAt == nil || stamped.CreatedBy == nil {
+				t.Fatalf("expected creation fallback to be filled, got created_by=%v created_at=%v", stamped.CreatedBy, stamped.CreatedAt)
+			}
+			if !proto.Equal(stamped.CreatedAt, stamped.UpdatedAt) {
+				t.Errorf("fallback created_at should equal updated_at, got %v vs %v", stamped.CreatedAt, stamped.UpdatedAt)
+			}
+			if stamped.CreatedBy.GetId() != "system" {
+				t.Errorf("fallback created_by should be system, got %q", stamped.CreatedBy.GetId())
+			}
+			if stamped.Event != "updated" {
+				t.Errorf("event: want updated, got %q", stamped.Event)
+			}
+		})
+	}
+}
+
+// TestSetAuditFieldsForUpdate_InvalidSlot rejects the zero value so a
+// missing argument cannot silently default to a slot.
+func TestSetAuditFieldsForUpdate_InvalidSlot(t *testing.T) {
+	agent := surgicalAuditFixture()
+	if err := SetAuditFieldsForUpdate(agent, 0); err == nil {
+		t.Fatal("expected error for zero AuditSlot")
+	}
+}
+
+// TestSetAuditFieldsForUpdate_DoesNotMutateSharedSlotPointers pins the
+// skill-push pointer-copy hazard: callers copy SpecAudit/StatusAudit
+// pointers from the loaded resource onto a new wrapper. The helper must
+// Set a newly allocated slot message; in-place mutation would corrupt
+// the in-memory original.
+func TestSetAuditFieldsForUpdate_DoesNotMutateSharedSlotPointers(t *testing.T) {
+	existing := surgicalAuditFixture()
+	originalSpec := proto.Clone(existing.Status.Audit.SpecAudit).(*apiresource.ApiResourceAuditInfo)
+	originalStatus := proto.Clone(existing.Status.Audit.StatusAudit).(*apiresource.ApiResourceAuditInfo)
+
+	updated := &agentv1.Agent{
+		Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
+		Status: &agentv1.AgentStatus{
+			Audit: &apiresource.ApiResourceAudit{
+				SpecAudit:   existing.Status.Audit.SpecAudit,
+				StatusAudit: existing.Status.Audit.StatusAudit,
+			},
+		},
+	}
+
+	if err := SetAuditFieldsForUpdate(updated, SpecAudit); err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	if !proto.Equal(existing.Status.Audit.SpecAudit, originalSpec) {
+		t.Errorf("shared spec_audit pointer on the in-memory original was mutated")
+	}
+	if !proto.Equal(existing.Status.Audit.StatusAudit, originalStatus) {
+		t.Errorf("shared status_audit pointer on the in-memory original was mutated")
+	}
+	if proto.Equal(updated.Status.Audit.SpecAudit, existing.Status.Audit.SpecAudit) {
+		t.Errorf("updated spec_audit still sharing the original slot message")
+	}
+	if updated.Status.Audit.StatusAudit != existing.Status.Audit.StatusAudit {
+		t.Errorf("untouched status slot should still be the shared pointer")
+	}
+}
+
+func surgicalAuditFixture() *agentv1.Agent {
 	specCreatedBy := &apiresource.ApiResourceAuditActor{Id: "user-alice"}
 	specCreatedAt := timestamppb.New(time.Date(2024, 3, 15, 10, 30, 0, 123456789, time.UTC))
 	statusCreatedBy := &apiresource.ApiResourceAuditActor{Id: "user-bob"}
 	statusCreatedAt := timestamppb.New(time.Date(2024, 6, 1, 8, 0, 0, 987654321, time.UTC))
 	staleUpdatedAt := timestamppb.New(time.Date(2024, 7, 4, 12, 0, 0, 0, time.UTC))
-
-	agent := &agentv1.Agent{
+	return &agentv1.Agent{
 		Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
 		Status: &agentv1.AgentStatus{
 			Audit: &apiresource.ApiResourceAudit{
@@ -367,85 +524,14 @@ func TestSetAuditFieldsForUpdate_PreservesCreationAudit(t *testing.T) {
 			},
 		},
 	}
-
-	before := time.Now()
-	if err := SetAuditFieldsForUpdate(agent); err != nil {
-		t.Fatalf("Expected success, got error: %v", err)
-	}
-
-	audit := agent.GetStatus().GetAudit()
-	if audit == nil || audit.SpecAudit == nil || audit.StatusAudit == nil {
-		t.Fatalf("Expected both audit slots to be set, got %v", audit)
-	}
-
-	// Creation identity preserved exactly, per slot.
-	if !proto.Equal(audit.SpecAudit.CreatedBy, specCreatedBy) {
-		t.Errorf("spec_audit.created_by not preserved: want %v, got %v", specCreatedBy, audit.SpecAudit.CreatedBy)
-	}
-	if !proto.Equal(audit.SpecAudit.CreatedAt, specCreatedAt) {
-		t.Errorf("spec_audit.created_at not preserved: want %v, got %v", specCreatedAt, audit.SpecAudit.CreatedAt)
-	}
-	if !proto.Equal(audit.StatusAudit.CreatedBy, statusCreatedBy) {
-		t.Errorf("status_audit.created_by not preserved: want %v, got %v", statusCreatedBy, audit.StatusAudit.CreatedBy)
-	}
-	if !proto.Equal(audit.StatusAudit.CreatedAt, statusCreatedAt) {
-		t.Errorf("status_audit.created_at not preserved: want %v, got %v", statusCreatedAt, audit.StatusAudit.CreatedAt)
-	}
-
-	// Update stamp is fresh on both slots.
-	for slot, info := range map[string]*apiresource.ApiResourceAuditInfo{
-		"spec_audit":   audit.SpecAudit,
-		"status_audit": audit.StatusAudit,
-	} {
-		if info.UpdatedAt.AsTime().Before(before) {
-			t.Errorf("%s.updated_at not stamped fresh: got %v, want >= %v", slot, info.UpdatedAt.AsTime(), before)
-		}
-		if info.UpdatedBy.GetId() != "system" {
-			t.Errorf("%s.updated_by not stamped: want system, got %q", slot, info.UpdatedBy.GetId())
-		}
-		if info.Event != "updated" {
-			t.Errorf("%s.event: want updated, got %q", slot, info.Event)
-		}
-	}
 }
 
-// TestSetAuditFieldsForUpdate_NoPriorAudit pins the first-write fallback:
-// a resource with no existing audit gets creation fields backfilled with
-// the current actor/time — the same fallback BuildUpdateStateStep uses —
-// instead of nil creation fields or an error.
-func TestSetAuditFieldsForUpdate_NoPriorAudit(t *testing.T) {
-	agent := &agentv1.Agent{
-		Metadata: &apiresource.ApiResourceMetadata{Name: "Test Agent"},
-		Status:   &agentv1.AgentStatus{},
+func (s AuditSlot) fieldNameForTest() string {
+	name, err := s.fieldName()
+	if err != nil {
+		return fmt.Sprintf("invalid(%d)", int(s))
 	}
-
-	if err := SetAuditFieldsForUpdate(agent); err != nil {
-		t.Fatalf("Expected success, got error: %v", err)
-	}
-
-	audit := agent.GetStatus().GetAudit()
-	if audit == nil || audit.SpecAudit == nil || audit.StatusAudit == nil {
-		t.Fatalf("Expected both audit slots to be set, got %v", audit)
-	}
-
-	for slot, info := range map[string]*apiresource.ApiResourceAuditInfo{
-		"spec_audit":   audit.SpecAudit,
-		"status_audit": audit.StatusAudit,
-	} {
-		if info.CreatedAt == nil || info.CreatedBy == nil {
-			t.Fatalf("%s: expected creation fallback to be filled, got created_by=%v created_at=%v", slot, info.CreatedBy, info.CreatedAt)
-		}
-		// The fallback backfills creation with the same stamp as the update.
-		if !proto.Equal(info.CreatedAt, info.UpdatedAt) {
-			t.Errorf("%s: fallback created_at should equal updated_at, got %v vs %v", slot, info.CreatedAt, info.UpdatedAt)
-		}
-		if info.CreatedBy.GetId() != "system" {
-			t.Errorf("%s: fallback created_by should be system, got %q", slot, info.CreatedBy.GetId())
-		}
-		if info.Event != "updated" {
-			t.Errorf("%s.event: want updated, got %q", slot, info.Event)
-		}
-	}
+	return string(name)
 }
 
 // TestSetAuditFieldsForCreate pins the create stamp: both audit slots set

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/agent_controller_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/agent_controller_test.go
@@ -467,12 +467,12 @@ func TestAgentController_Delete_Cascade(t *testing.T) {
 }
 
 // TestAgentController_UpdateVisibility_PreservesCreationAudit pins the
-// call-site half of the stigmer/stigmer#453 fix: a visibility flip must
-// not rewrite spec_audit.created_by/created_at (before the fix,
-// steps.SetAuditFieldsForUpdate rebuilt the whole audit block, resetting
-// creation to system/now — which also reordered every created_at-sorted
-// list). The steps package pins the helper contract; this test proves the
-// preservation survives the full update-visibility pipeline.
+// call-site half of stigmer/stigmer#453 (creation identity) and
+// stigmer/stigmer#540 (slot granularity): a visibility flip must not
+// rewrite spec_audit at all — not created_*, not updated_*, not event.
+// Before #453 the helper reset creation to system/now; before #540 it
+// still stamped both slots, so spec_audit.event flipped to "updated"
+// and search recency jumped. Status_audit is the slot that moved.
 func TestAgentController_UpdateVisibility_PreservesCreationAudit(t *testing.T) {
 	s, err := sqlite.NewStore(t.TempDir() + "/test.sqlite")
 	if err != nil {
@@ -496,10 +496,11 @@ func TestAgentController_UpdateVisibility_PreservesCreationAudit(t *testing.T) {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	originalSpecAudit := created.GetStatus().GetAudit().GetSpecAudit()
-	if originalSpecAudit.GetCreatedAt() == nil || originalSpecAudit.GetCreatedBy() == nil {
-		t.Fatalf("precondition: create should stamp spec_audit creation, got %v", originalSpecAudit)
+	originalSpecAudit, ok := proto.Clone(created.GetStatus().GetAudit().GetSpecAudit()).(*apiresource.ApiResourceAuditInfo)
+	if !ok || originalSpecAudit.GetCreatedAt() == nil || originalSpecAudit.GetCreatedBy() == nil {
+		t.Fatalf("precondition: create should stamp spec_audit creation, got %v", created.GetStatus().GetAudit().GetSpecAudit())
 	}
+	originalStatusUpdatedAt := created.GetStatus().GetAudit().GetStatusAudit().GetUpdatedAt()
 
 	updated, err := controller.UpdateVisibility(contextWithAgentKind(), &apiresource.UpdateVisibilityInput{
 		ResourceId: created.Metadata.Id,
@@ -514,16 +515,22 @@ func TestAgentController_UpdateVisibility_PreservesCreationAudit(t *testing.T) {
 	}
 
 	specAudit := updated.GetStatus().GetAudit().GetSpecAudit()
-	if !proto.Equal(specAudit.GetCreatedAt(), originalSpecAudit.GetCreatedAt()) {
-		t.Errorf("spec_audit.created_at destroyed by visibility flip: want %v, got %v",
-			originalSpecAudit.GetCreatedAt(), specAudit.GetCreatedAt())
+	if !proto.Equal(specAudit, originalSpecAudit) {
+		t.Errorf("spec_audit mutated by visibility flip: want %v, got %v", originalSpecAudit, specAudit)
 	}
-	if !proto.Equal(specAudit.GetCreatedBy(), originalSpecAudit.GetCreatedBy()) {
-		t.Errorf("spec_audit.created_by destroyed by visibility flip: want %v, got %v",
-			originalSpecAudit.GetCreatedBy(), specAudit.GetCreatedBy())
+
+	statusAudit := updated.GetStatus().GetAudit().GetStatusAudit()
+	if statusAudit.GetEvent() != "updated" {
+		t.Errorf("status_audit.event: want updated, got %q", statusAudit.GetEvent())
 	}
-	if specAudit.GetEvent() != "updated" {
-		t.Errorf("spec_audit.event: want updated, got %q", specAudit.GetEvent())
+	if !statusAudit.GetUpdatedAt().AsTime().After(originalStatusUpdatedAt.AsTime()) &&
+		!statusAudit.GetUpdatedAt().AsTime().Equal(originalStatusUpdatedAt.AsTime()) {
+		// Equal is possible if create+visibility land in the same timestamp
+		// tick; the spec-slot proto.Equal pin is the load-bearing check.
+		t.Errorf("status_audit.updated_at did not move: got %v", statusAudit.GetUpdatedAt())
+	}
+	if proto.Equal(statusAudit.GetUpdatedAt(), originalStatusUpdatedAt) && statusAudit.GetEvent() != "updated" {
+		t.Errorf("status_audit was not stamped")
 	}
 
 	// The persisted row must agree with the response.
@@ -531,9 +538,9 @@ func TestAgentController_UpdateVisibility_PreservesCreationAudit(t *testing.T) {
 	if err := s.GetResource(context.Background(), apiresourcekind.ApiResourceKind_agent, created.Metadata.Id, persisted); err != nil {
 		t.Fatalf("failed to reload agent: %v", err)
 	}
-	if !proto.Equal(persisted.GetStatus().GetAudit().GetSpecAudit().GetCreatedAt(), originalSpecAudit.GetCreatedAt()) {
-		t.Errorf("persisted spec_audit.created_at destroyed: want %v, got %v",
-			originalSpecAudit.GetCreatedAt(), persisted.GetStatus().GetAudit().GetSpecAudit().GetCreatedAt())
+	if !proto.Equal(persisted.GetStatus().GetAudit().GetSpecAudit(), originalSpecAudit) {
+		t.Errorf("persisted spec_audit mutated: want %v, got %v",
+			originalSpecAudit, persisted.GetStatus().GetAudit().GetSpecAudit())
 	}
 }
 

--- a/backend/services/stigmer-server/pkg/domain/agent/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/agent/controller/update_visibility.go
@@ -90,7 +90,7 @@ func (s *setAgentVisibilityStep) Execute(ctx *pipeline.RequestContext[*apiresour
 
 	agent.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(agent); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(agent, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/agentinstance/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/agentinstance/controller/update_visibility.go
@@ -156,7 +156,7 @@ func (s *setInstanceVisibilityStep) Execute(ctx *pipeline.RequestContext[*apires
 
 	instance.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(instance); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(instance, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/agentshare/controller/rotate_share_link.go
+++ b/backend/services/stigmer-server/pkg/domain/agentshare/controller/rotate_share_link.go
@@ -108,7 +108,7 @@ func (s *rotateShareLinkTokenStep) Execute(ctx *pipeline.RequestContext[*agentsh
 	}
 	share.Status.ShareLinkToken = token
 
-	if err := steps.SetAuditFieldsForUpdate(share); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(share, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/artifact/controller/delete.go
+++ b/backend/services/stigmer-server/pkg/domain/artifact/controller/delete.go
@@ -40,7 +40,10 @@ func (c *ArtifactController) Delete(ctx context.Context, id *apiresource.ApiReso
 	}
 	artifact.Status.StorageState = artifactv1.ArtifactStorageState_storage_state_deleted
 
-	if err := steps.SetAuditFieldsForUpdate(artifact); err != nil {
+	// Soft-delete is a status transition (storage_state). Stamp status_audit
+	// only — cloud currently stamps neither slot; OSS stays honest rather
+	// than copying that omission (stigmer/stigmer#540).
+	if err := steps.SetAuditFieldsForUpdate(artifact, steps.StatusAudit); err != nil {
 		log.Error().Err(err).Msg("Failed to set audit fields on artifact delete")
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
-        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/merge_variables_and_persist.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/merge_variables_and_persist.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/rs/zerolog/log"
 	environmentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/environment/v1"
-	commonspb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
 	apiresourceinterceptor "github.com/stigmer/stigmer/backend/libs/go/grpc/interceptors/apiresource"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	pipelinesteps "github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // UpdatedEnvironmentKey is the context key for the modified environment after
@@ -102,7 +100,9 @@ func (s *mergeVariablesAndPersistStep) Execute(ctx *pipeline.RequestContext[*env
 		Str("environment_id", env.GetMetadata().GetId()).
 		Msg("Merged variables into environment")
 
-	updateSpecAudit(env)
+	if err := pipelinesteps.SetAuditFieldsForUpdate(env, pipelinesteps.SpecAudit); err != nil {
+		return grpclib.InternalError(err, "failed to set audit fields")
+	}
 
 	kind := apiresourceinterceptor.GetApiResourceKind(ctx.Context())
 	if err := s.store.SaveResource(ctx.Context(), kind, env.GetMetadata().GetId(), env); err != nil {
@@ -111,28 +111,4 @@ func (s *mergeVariablesAndPersistStep) Execute(ctx *pipeline.RequestContext[*env
 
 	ctx.Set(UpdatedEnvironmentKey, env)
 	return nil
-}
-
-// updateSpecAudit bumps spec_audit.updated_at and updated_by while
-// preserving the original created_at / created_by.
-func updateSpecAudit(env *environmentv1.Environment) {
-	now := timestamppb.Now()
-	actor := &commonspb.ApiResourceAuditActor{Id: "system"}
-
-	if env.Status == nil {
-		env.Status = &commonspb.ApiResourceAuditStatus{}
-	}
-	if env.Status.Audit == nil {
-		env.Status.Audit = &commonspb.ApiResourceAudit{}
-	}
-	if env.Status.Audit.SpecAudit == nil {
-		env.Status.Audit.SpecAudit = &commonspb.ApiResourceAuditInfo{
-			CreatedBy: actor,
-			CreatedAt: now,
-		}
-	}
-
-	env.Status.Audit.SpecAudit.UpdatedBy = actor
-	env.Status.Audit.SpecAudit.UpdatedAt = now
-	env.Status.Audit.SpecAudit.Event = "updated"
 }

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/steps/remove_variable_keys_and_persist.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/steps/remove_variable_keys_and_persist.go
@@ -54,7 +54,9 @@ func (s *removeVariableKeysAndPersistStep) Execute(ctx *pipeline.RequestContext[
 		Str("environment_id", env.GetMetadata().GetId()).
 		Msg("Removed variables from environment")
 
-	updateSpecAudit(env)
+	if err := pipelinesteps.SetAuditFieldsForUpdate(env, pipelinesteps.SpecAudit); err != nil {
+		return grpclib.InternalError(err, "failed to set audit fields")
+	}
 
 	kind := apiresourceinterceptor.GetApiResourceKind(ctx.Context())
 	if err := s.store.SaveResource(ctx.Context(), kind, env.GetMetadata().GetId(), env); err != nil {

--- a/backend/services/stigmer-server/pkg/domain/environment/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/environment/controller/update_visibility.go
@@ -138,7 +138,7 @@ func (s *setEnvironmentVisibilityStep) Execute(ctx *pipeline.RequestContext[*api
 
 	env.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(env); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(env, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/mcpserver/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/mcpserver/controller/update_visibility.go
@@ -90,7 +90,7 @@ func (s *setMcpServerVisibilityStep) Execute(ctx *pipeline.RequestContext[*apire
 
 	mcpServer.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(mcpServer); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(mcpServer, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/resume.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/resume.go
@@ -107,7 +107,7 @@ func (s *clearSchedulePauseStep) Execute(ctx *pipeline.RequestContext[*schedulev
 			live.Status.ConsecutiveFailures = 0
 			// Resuming with strikes left would re-pause on the next
 			// failure — a lie; both clear together, always.
-			if auditErr := steps.SetAuditFieldsForUpdate(live); auditErr != nil {
+			if auditErr := steps.SetAuditFieldsForUpdate(live, steps.StatusAudit); auditErr != nil {
 				return auditErr
 			}
 			return nil

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/trigger.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/trigger.go
@@ -229,7 +229,7 @@ func (s *fireDirectRunStep) stampLastFireAt(ctx context.Context, scheduleID stri
 				live.Status = &schedulev1.ScheduleStatus{}
 			}
 			live.Status.LastFireAt = timestamppb.New(nominal)
-			return steps.SetAuditFieldsForUpdate(live)
+			return steps.SetAuditFieldsForUpdate(live, steps.StatusAudit)
 		})
 	if err != nil && !errors.Is(err, store.ErrNotFound) {
 		log.Warn().Err(err).Str("schedule_id", scheduleID).

--- a/backend/services/stigmer-server/pkg/domain/session/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//apis/stubs/go/ai/stigmer/agentic/agent/v1:agent",
         "//apis/stubs/go/ai/stigmer/agentic/agentexecution/v1:agentexecution",
         "//apis/stubs/go/ai/stigmer/agentic/session/v1:session",
-        "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
         "//backend/libs/go/grpc",
         "//backend/libs/go/grpc/interceptors/apiresource",
@@ -40,7 +39,6 @@ go_library(
         "@com_github_rs_zerolog//log",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_protobuf//proto",
-        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 

--- a/backend/services/stigmer-server/pkg/domain/session/controller/update_subject.go
+++ b/backend/services/stigmer-server/pkg/domain/session/controller/update_subject.go
@@ -5,12 +5,11 @@ import (
 	"errors"
 
 	"github.com/rs/zerolog/log"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
-	commonspb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	grpclib "github.com/stigmer/stigmer/backend/libs/go/grpc"
+	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/query/search/extractor"
 )
@@ -48,7 +47,9 @@ func (c *SessionController) UpdateSubject(
 	}
 	session.Spec.Subject = req.GetSubject()
 
-	updateSpecAuditTimestamp(session)
+	if err := steps.SetAuditFieldsForUpdate(session, steps.SpecAudit); err != nil {
+		return nil, grpclib.InternalError(err, "failed to set audit fields")
+	}
 
 	if err := c.store.SaveResource(ctx, kind, req.GetId(), session); err != nil {
 		return nil, grpclib.InternalError(err, "failed to persist session")
@@ -57,23 +58,6 @@ func (c *SessionController) UpdateSubject(
 	indexSessionSearch(ctx, c, kind, session)
 
 	return session, nil
-}
-
-// updateSpecAuditTimestamp sets updated_at on the session's spec audit.
-func updateSpecAuditTimestamp(session *sessionv1.Session) {
-	now := timestamppb.Now()
-
-	if session.Status == nil {
-		session.Status = &commonspb.ApiResourceAuditStatus{}
-	}
-	if session.Status.Audit == nil {
-		session.Status.Audit = &commonspb.ApiResourceAudit{}
-	}
-	if session.Status.Audit.SpecAudit == nil {
-		session.Status.Audit.SpecAudit = &commonspb.ApiResourceAuditInfo{}
-	}
-	session.Status.Audit.SpecAudit.UpdatedAt = now
-	session.Status.Audit.SpecAudit.Event = "updated"
 }
 
 // indexSessionSearch refreshes the FTS5 search index for a session.

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/push.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/push.go
@@ -493,7 +493,10 @@ func (s *ArchiveCurrentSkillStep) archiveSkill(ctx context.Context, skill *skill
 // 4. Sets status.version_hash and status.artifact_storage_key
 // 5. Sets audit fields using common library helpers:
 //   - For create: SetAuditFieldsForCreate (sets created_at = updated_at = now)
-//   - For update: Preserves existing audit, then updates with SetAuditFieldsForUpdate
+//   - For update: copy existing slot pointers onto a new audit wrapper,
+//     then SetAuditFieldsForUpdate(SpecAudit) — definition changed.
+//     The helper Sets a new spec_audit message so the copied pointers
+//     from the loaded skill are not mutated in place.
 type PopulateSkillFieldsStep struct{}
 
 func (c *SkillController) newPopulateSkillFieldsStep() *PopulateSkillFieldsStep {
@@ -570,13 +573,17 @@ func (s *PopulateSkillFieldsStep) Execute(ctx *pipeline.RequestContext[*skillv1.
 			if skill.Status.Audit == nil {
 				skill.Status.Audit = &apiresourcepb.ApiResourceAudit{}
 			}
-			// Copy spec_audit and status_audit from existing
+			// Copy slot pointers from the loaded skill. The helper below
+			// Sets a newly allocated spec_audit on this wrapper — it must
+			// not mutate SpecAudit in place, or this would also rewrite
+			// existingSkill (stigmer/stigmer#540).
 			skill.Status.Audit.SpecAudit = existingSkill.Status.Audit.SpecAudit
 			skill.Status.Audit.StatusAudit = existingSkill.Status.Audit.StatusAudit
 		}
 
-		// Now update the audit fields (preserves created_at, updates updated_at)
-		if err := steps.SetAuditFieldsForUpdate(skill); err != nil {
+		// Stamp spec_audit only: a push is a definition change. status_audit
+		// stays on the shared pointer, untouched.
+		if err := steps.SetAuditFieldsForUpdate(skill, steps.SpecAudit); err != nil {
 			return fmt.Errorf("failed to set audit fields for update: %w", err)
 		}
 	}

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/push_test.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/push_test.go
@@ -346,6 +346,98 @@ func TestPush_Update_PreservesCreatedAt(t *testing.T) {
 	)
 }
 
+// TestPush_Update_StatusAuditUntouched pins the stigmer/stigmer#540 slot
+// contract at the push call site: a push is a definition change, so it
+// stamps spec_audit only — status_audit stays proto-equal to before.
+// It also proves the in-memory existing skill (whose slot pointers push
+// copies onto the new audit wrapper) is not corrupted by the stamp.
+func TestPush_Update_StatusAuditUntouched(t *testing.T) {
+	controller, store := setupTestController(t)
+	defer store.Close()
+
+	content1 := storage.ValidSkillContent("slot-pin", "# Slot Pin v1")
+	req1 := &skillv1.PushSkillRequest{
+		Artifact: storage.CreateTestZip(content1),
+		Org:      "test-org",
+	}
+	result1, err := controller.Push(contextWithSkillKind(), req1)
+	require.NoError(t, err)
+	require.NotNil(t, result1.Status.Audit.StatusAudit)
+	originalStatusAudit := proto.Clone(result1.Status.Audit.StatusAudit).(*apiresourcepb.ApiResourceAuditInfo)
+
+	time.Sleep(1100 * time.Millisecond)
+
+	content2 := storage.ValidSkillContent("slot-pin", "# Slot Pin v2")
+	req2 := &skillv1.PushSkillRequest{
+		Artifact: storage.CreateTestZip(content2),
+		Org:      "test-org",
+	}
+	result2, err := controller.Push(contextWithSkillKind(), req2)
+	require.NoError(t, err)
+
+	assert.True(t,
+		proto.Equal(result2.Status.Audit.StatusAudit, originalStatusAudit),
+		"push must not stamp status_audit: want %v, got %v",
+		originalStatusAudit, result2.Status.Audit.StatusAudit,
+	)
+	assert.Greater(t,
+		result2.Status.Audit.SpecAudit.UpdatedAt.GetSeconds(),
+		result1.Status.Audit.SpecAudit.UpdatedAt.GetSeconds(),
+		"push must stamp spec_audit.updated_at",
+	)
+
+	// The persisted row agrees.
+	persisted := &skillv1.Skill{}
+	require.NoError(t, store.GetResource(contextWithSkillKind(), apiresourcekind.ApiResourceKind_skill, result2.Metadata.Id, persisted))
+	assert.True(t,
+		proto.Equal(persisted.Status.Audit.StatusAudit, originalStatusAudit),
+		"persisted status_audit mutated by push",
+	)
+}
+
+// TestUpdateVisibility_SpecAuditFrozen pins the stigmer/stigmer#540 slot
+// contract at the skill visibility call site: a visibility flip is a
+// lifecycle change, so it stamps status_audit only. The live skill's
+// spec_audit — the field search extractors read as "definition changed"
+// and version history reads as pushed_at/pushed_by — stays proto-equal
+// to its post-push value.
+func TestUpdateVisibility_SpecAuditFrozen(t *testing.T) {
+	controller, store := setupTestController(t)
+	defer store.Close()
+
+	content := storage.ValidSkillContent("vis-audit-pin", "# Visibility Audit Pin")
+	pushed, err := controller.Push(contextWithSkillKind(), &skillv1.PushSkillRequest{
+		Artifact: storage.CreateTestZip(content),
+		Org:      "test-org",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pushed.Status.Audit.SpecAudit)
+	postPushSpecAudit := proto.Clone(pushed.Status.Audit.SpecAudit).(*apiresourcepb.ApiResourceAuditInfo)
+
+	updated, err := controller.UpdateVisibility(contextWithSkillKind(), &apiresourcepb.UpdateVisibilityInput{
+		ResourceId: pushed.Metadata.Id,
+		Visibility: apiresourcepb.ApiResourceVisibility_visibility_public,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, apiresourcepb.ApiResourceVisibility_visibility_public, updated.Metadata.Visibility)
+
+	assert.True(t,
+		proto.Equal(updated.Status.Audit.SpecAudit, postPushSpecAudit),
+		"visibility flip must not touch spec_audit: want %v, got %v",
+		postPushSpecAudit, updated.Status.Audit.SpecAudit,
+	)
+	assert.Equal(t, "updated", updated.Status.Audit.StatusAudit.GetEvent(),
+		"visibility flip must stamp status_audit")
+
+	// The persisted row agrees.
+	persisted := &skillv1.Skill{}
+	require.NoError(t, store.GetResource(contextWithSkillKind(), apiresourcekind.ApiResourceKind_skill, pushed.Metadata.Id, persisted))
+	assert.True(t,
+		proto.Equal(persisted.Status.Audit.SpecAudit, postPushSpecAudit),
+		"persisted spec_audit mutated by visibility flip",
+	)
+}
+
 // TestPush_Update_UpdatesTimestamp verifies that updating a skill
 // sets a new updated_at timestamp that's later than the initial push.
 func TestPush_Update_UpdatesTimestamp(t *testing.T) {

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/update_visibility.go
@@ -90,7 +90,7 @@ func (s *setVisibilityStep) Execute(ctx *pipeline.RequestContext[*apiresourcepb.
 
 	skill.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(skill); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(skill, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/workflow/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/controller/update_visibility.go
@@ -90,7 +90,7 @@ func (s *setWorkflowVisibilityStep) Execute(ctx *pipeline.RequestContext[*apires
 
 	workflow.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(workflow); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(workflow, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/update_execution_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/update_execution_visibility.go
@@ -96,7 +96,7 @@ func (s *setInstanceExecutionVisibilityStep) Execute(ctx *pipeline.RequestContex
 	}
 	instance.Spec.ExecutionVisibility = input.GetExecutionVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(instance); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(instance, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/update_visibility.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowinstance/controller/update_visibility.go
@@ -136,7 +136,7 @@ func (s *setInstanceVisibilityStep) Execute(ctx *pipeline.RequestContext[*apires
 
 	instance.Metadata.Visibility = input.GetVisibility()
 
-	if err := steps.SetAuditFieldsForUpdate(instance); err != nil {
+	if err := steps.SetAuditFieldsForUpdate(instance, steps.StatusAudit); err != nil {
 		return fmt.Errorf("failed to set audit fields: %w", err)
 	}
 

--- a/test/conformance/src/suites/skill.conformance.test.ts
+++ b/test/conformance/src/suites/skill.conformance.test.ts
@@ -544,6 +544,14 @@ describe("Skill conformance — updateVisibility", () => {
     // The change is durable and observable via a fresh read.
     const fetched = await clients.skillQuery.get({ value: pushed.metadata!.id });
     expect(fetched.metadata?.visibility).toBe(ApiResourceVisibility.visibility_public);
+
+    // Cross-edition audit-slot contract (stigmer#540): a visibility flip is
+    // a lifecycle change, not a definition change, so the live skill's
+    // spec_audit.updated_at — what search recency and version history read
+    // as "definition changed" — must not move from its post-push value.
+    const pushedSpecUpdatedAt = pushed.status?.audit?.specAudit?.updatedAt;
+    expect(pushedSpecUpdatedAt, "push stamps spec_audit.updated_at").toBeDefined();
+    expect(fetched.status?.audit?.specAudit?.updatedAt).toEqual(pushedSpecUpdatedAt);
   });
 
   it("returns NotFound for an unknown skill", async () => {


### PR DESCRIPTION
## Summary

OSS `steps.SetAuditFieldsForUpdate` stamped `updated_*` on **both** `spec_audit` and `status_audit` for every targeted mutation, while cloud stamps only the slot matching the change class. This made OSS search recency lie: a visibility flip bumped `spec_audit.updated_at` — the field search extractors and skill version history read as "definition changed."

This PR aligns OSS to cloud's surgical contract:

- `SetAuditFieldsForUpdate(resource, slot)` now takes a **required** `AuditSlot` (`SpecAudit` / `StatusAudit`; zero is invalid). The compile error at every call site was the census.
- The write primitive changed: the helper **merges one newly allocated slot message** onto the existing audit wrapper (via `Mutable`) instead of wholesale-replacing the whole audit block. The other slot stays proto-equal to before — including staying absent on first write.
- **Status slot** (lifecycle changed): 7 visibility flips (agent, skill, mcpserver, environment, workflow, agentinstance, workflowinstance ×2), agentshare rotate-share-link, schedule trigger/resume stamps, artifact soft-delete.
- **Spec slot** (definition changed): skill push, plus two hand-rolled surgical stamps folded onto the helper — environment `updateSpecAudit` (merge/remove variables) and session `updateSpecAuditTimestamp` (update subject).
- Create (`SetAuditFieldsForCreate`) and the full Update pipeline (`updateAuditFieldsReflect`) keep wholesale replace — they mean both slots.

## Deliberate divergences

- **Artifact soft-delete stamps `status_audit`** — cloud currently stamps *neither* slot there. OSS stays honest (a status field changed) rather than copying the omission; noted as remaining cloud divergence.
- Session update-subject now stamps `updated_by: system` like every other OSS writer (cloud stamps the real caller — that's oss#400, out of scope).

## Tests

- Helper table pins per slot: the untouched slot is `proto.Equal` to before; creation identity survives on the stamped slot (the #453 pin, now per-slot); zero slot errors; first write does not invent the other slot.
- New pointer-sharing pin: skill push copies slot pointers from the loaded skill onto a new wrapper — the helper must `Set` a fresh message, never mutate in place (would corrupt the in-memory original).
- `TestAgentController_UpdateVisibility_PreservesCreationAudit` retargeted: it previously asserted `spec_audit.event == "updated"` after a visibility flip (the both-slots bug frozen as a pin); it now requires the whole spec slot frozen and `status_audit` stamped.
- Skill: push leaves `status_audit` untouched; visibility flip leaves `spec_audit` frozen (live Get + persisted row).
- Conformance: skill `updateVisibility` now pins the live `spec_audit.updated_at` equal to its post-push value on both editions.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `go mod tidy` clean on both modules
- Full `go test ./...` green for `backend/libs/go` and `backend/services/stigmer-server`
- Bazel lane: `steps_test`, agent/skill/session/environment controller tests PASS; gazelle diff clean after refresh
- Conformance TS: changed suite typechecks (4 pre-existing errors in untouched files)

Closes #540


Made with [Cursor](https://cursor.com)