### PR TITLE
ci: exempt main-branch pushes from cancel-in-progress across 15 lanes

### DIFF
--- a/.github/workflows/ci.bazel.yaml
+++ b/.github/workflows/ci.bazel.yaml
@@ -78,7 +78,9 @@ permissions:
 
 concurrency:
   group: bazel-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Decides whether the bazel gates apply, from the PR's actual changed-file

--- a/.github/workflows/ci.codegen.yaml
+++ b/.github/workflows/ci.codegen.yaml
@@ -48,7 +48,9 @@ on:
 
 concurrency:
   group: ci-codegen-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.conformance-cloud.yaml
+++ b/.github/workflows/ci.conformance-cloud.yaml
@@ -47,7 +47,9 @@ on:
 
 concurrency:
   group: conformance-cloud-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.conformance-execution.yaml
+++ b/.github/workflows/ci.conformance-execution.yaml
@@ -35,7 +35,9 @@ on:
 
 concurrency:
   group: conformance-execution-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.conformance.yaml
+++ b/.github/workflows/ci.conformance.yaml
@@ -34,7 +34,9 @@ on:
 
 concurrency:
   group: conformance-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.crate.yaml
+++ b/.github/workflows/ci.crate.yaml
@@ -37,7 +37,9 @@ on:
 
 concurrency:
   group: ci-crate-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.docs.yaml
+++ b/.github/workflows/ci.docs.yaml
@@ -45,7 +45,9 @@ on:
 
 concurrency:
   group: docs-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Make `npm ci` resilient to transient registry drops (ECONNRESET). npm reads
 # these npm_config_* vars, so every install step retries with backoff instead

--- a/.github/workflows/ci.frontend.yaml
+++ b/.github/workflows/ci.frontend.yaml
@@ -65,7 +65,9 @@ on:
 
 concurrency:
   group: frontend-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.go-sdk.yaml
+++ b/.github/workflows/ci.go-sdk.yaml
@@ -51,7 +51,9 @@ on:
 
 concurrency:
   group: ci-go-sdk-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.install-script.yaml
+++ b/.github/workflows/ci.install-script.yaml
@@ -25,7 +25,9 @@ on:
 
 concurrency:
   group: install-script-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Make the installer's `npm install` resilient to transient registry drops
 # (ECONNRESET). npm reads these npm_config_* vars, so the install retries

--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -71,7 +71,9 @@ on:
 
 concurrency:
   group: integration-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.java-sdk.yaml
+++ b/.github/workflows/ci.java-sdk.yaml
@@ -36,7 +36,9 @@ on:
 
 concurrency:
   group: ci-java-sdk-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.replay.yaml
+++ b/.github/workflows/ci.replay.yaml
@@ -48,7 +48,9 @@ on:
 
 concurrency:
   group: replay-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.runner.yaml
+++ b/.github/workflows/ci.runner.yaml
@@ -54,7 +54,9 @@ on:
 
 concurrency:
   group: runner-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.ts-sdk.yaml
+++ b/.github/workflows/ci.ts-sdk.yaml
@@ -76,7 +76,9 @@ on:
 
 concurrency:
   group: ci-ts-sdk-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

~15 workflows shared `group: <lane>-${{ github.head_ref || github.ref }}` + `cancel-in-progress: true`. On PRs, `head_ref` isolates per branch — correct. On main pushes, `head_ref` is empty, so every lane collapsed to one group and **each merge cancelled the previous merge's in-flight runs**. This PR exempts main from cancellation on the 15 affected lanes: `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`.

## Context

During the 2026-08-13 merge window, six consecutive merges went untested on the conformance-execution lane; the first run to survive was blamed for every regression that landed in the cancelled window. #715 was filed against the wrong PR, #716's "last green" narrative was distorted the same way, and while both lanes were red-as-noise a second breakage merged over the first. Owner ruling: exempt main (issue option 1) — PR behavior unchanged, every merge gets a completed run, attribution becomes exact. Cost: merge bursts queue instead of cancel.

## Changes

- The identical three-line change (one-line load-bearing comment + the conditional) on exactly the 15 lanes matching the defect shape: bazel, codegen, conformance, conformance-cloud, conformance-execution, crate, docs, frontend, go-sdk, install-script, integration-offline, java-sdk, replay, runner, ts-sdk.
- Side benefit on the three lanes that also run nightly (bazel, conformance-cloud, integration-offline): a scheduled run can no longer cancel an in-flight merge run (they share the main-ref group today).

## Implementation notes — deliberately untouched lanes

- `ci.e2e`: schedule-only; a new nightly cancelling a stuck previous nightly is desirable.
- `ci.integration-canary`, `ci.integration-providers`, `ci.integration-stress`, `ci.seedpack-canary`: `run_id` groups with `cancel-in-progress: false` — already correct.
- `reconcile-homebrew`: `cancel-in-progress: false` already.
- `release.*`, `ci.seedpack-static`, `mirror-test-images`: no concurrency block (or pages-managed) — nothing to fix.
- The in-flight oss#572 session adds a new interactive-e2e lane: whichever lands second reconciles the new lane with this ruling.

## Breaking changes

- None. PR cancellation behavior is byte-identical; only main-push behavior changes (queue instead of cancel).

## Test plan

- `actionlint` clean on all 15 edited workflows; YAML parses; diff is exactly 3 lines × 15 files; `ci.e2e` and the canary lanes verified untouched.
- The conditional-expression form is GitHub's documented pattern for ref-scoped cancellation.

## Risks

- More Actions minutes during merge bursts (runs queue rather than cancel) — the accepted cost of exact attribution.

Closes #725

Made with [Cursor](https://cursor.com)