### PR TITLE
fix(test/integration): pin a model on every channel fixture — #362 refuses unpinned channel applies

### DIFF
--- a/test/integration/agent_channel_test.go
+++ b/test/integration/agent_channel_test.go
@@ -9,6 +9,7 @@ import (
 
 	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
 	agentchannelv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentchannel/v1"
+	agentexecv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	"github.com/stigmer/stigmer/test/integration/harness"
@@ -30,6 +31,12 @@ import (
 // channelFor builds a Slack channel manifest for an agent, as a YAML apply
 // would send it. Channels have no canonical-slug default (they are
 // N-per-agent), so a name is always provided.
+//
+// The model pin is load-bearing: channels are an unattended surface, so the
+// cloud backend refuses an apply whose run_config names no model when the
+// platform session-default harness is Cursor (stigmer/stigmer#362) — every
+// channel fixture in this package flows through here and inherits the pin
+// (stigmer/stigmer#745).
 func channelFor(agent *agentv1.Agent, name string, enabled bool) *agentchannelv1.AgentChannel {
 	return &agentchannelv1.AgentChannel{
 		ApiVersion: "agentic.stigmer.ai/v1",
@@ -47,6 +54,7 @@ func channelFor(agent *agentv1.Agent, name string, enabled bool) *agentchannelv1
 			ProviderConfig: &agentchannelv1.AgentChannelSpec_Slack{
 				Slack: &agentchannelv1.SlackChannelConfig{},
 			},
+			RunConfig: &agentexecv1.RunConfig{ModelName: "gpt-5-mini"},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
Pins `gpt-5-mini` on the shared channel-fixture builder's `spec.run_config`, turning the `ci.integration-offline` Core lane green on main again.

## Context
Channels are an unattended surface: the cloud backend's `UnattendedModelPinningPolicy` (shipped with stigmer#362) refuses an AgentChannel apply whose `run_config` names no model when the platform session-default harness is Cursor. The integration fixtures predate the rule, so `TestAgentChannel_ApplyToggle` and `TestAgentChannel_EnvironmentRefs` fail at channel apply on main. The blast radius is wider than the issue's two named tests: every channel fixture in the package flows through `channelFor`, and the ghost-agent arm of `TestAgentChannel_InvariantRefusals` had its intended `NOT_FOUND` preempted by the pinning `INVALID_ARGUMENT` (the pinning check runs before the agent load).

## Changes
- `channelFor` (the single choke point every channel fixture in the package flows through, including `applyWhatsAppChannel` and the `channel_app_test.go` builders) now sets `RunConfig{ModelName: "gpt-5-mini"}`, with a comment citing the #362 contract
- `"gpt-5-mini"` matches the sibling unattended surface's existing convention (`agent_share_test.go`)

## Implementation notes
- Rejected alternative: a platform-profile model in the test harness config would fix all fixtures in one line but masks the enforcement suite-wide and hides the unattended-surface contract from future fixtures. The pin on the channel's own spec is the honest shape — the policy never reads the agent's run_config on this surface.

## Test plan
- Full channel-touching suite run locally against a fresh fat JAR built from stigmer-cloud main (which carries the enforcement): all 21 tests across `agent_channel_test.go`, `channel_app_test.go`, `channel_conversation_test.go` PASS — including the ghost-agent NOT_FOUND arm restored to its intended contract

## Risks
- None — test-fixture-only change; no production code touched

Closes #745

Made with [Cursor](https://cursor.com)