### PR TITLE
test(integration): repin agent-delete cascade to the #611 contract — personal instances cascade too

### DIFF
--- a/test/integration/agent_ownership_hygiene_test.go
+++ b/test/integration/agent_ownership_hygiene_test.go
@@ -148,9 +148,11 @@ func TestOrgAdminInheritance_RevokedAdminLosesManagement(t *testing.T) {
 
 // TestAgentDeleteCascade_DefaultInstanceAndShares pins the dual-edition
 // delete contract: deleting an agent removes its system-managed default
-// instance and every AgentShare referencing it (including a renamed share),
-// while a personal instance of the same agent survives as an inert dangling
-// reference. Runs against both editions — no FGA dependency.
+// instance, every AgentShare referencing it (including a renamed share),
+// AND every personal instance — the stigmer#611 DD-022-extension ruling:
+// surviving orphans would squat the org-wide instance-slug namespace
+// (stigmer#751 repinned this from the pre-#611 "personal instances
+// survive" contract). Runs against both editions — no FGA dependency.
 func TestAgentDeleteCascade_DefaultInstanceAndShares(t *testing.T) {
 	require.NotNil(t, grpcConn)
 
@@ -165,7 +167,7 @@ func TestAgentDeleteCascade_DefaultInstanceAndShares(t *testing.T) {
 	defaultInstanceID := agent.GetStatus().GetDefaultInstanceId()
 	require.NotEmpty(t, defaultInstanceID, "agent create must provision the default instance")
 
-	// A personal instance of the SAME agent — must survive the cascade.
+	// A personal instance of the SAME agent — cascades with it (#611).
 	personal, err := clients.AgentInstanceCommand.Apply(ctx, &agentinstancev1.AgentInstance{
 		ApiVersion: "agentic.stigmer.ai/v1",
 		Kind:       "AgentInstance",
@@ -213,11 +215,15 @@ func TestAgentDeleteCascade_DefaultInstanceAndShares(t *testing.T) {
 		assert.Equal(t, codes.NotFound, st.Code())
 	}
 
-	// Personal instance: survives (inert dangling reference by design).
-	survived, err := clients.AgentInstanceQuery.Get(ctx,
+	// Personal instance: gone too — the #611 ruling cascades ALL instances
+	// so no orphan can squat the org-wide instance-slug namespace.
+	_, err = clients.AgentInstanceQuery.Get(ctx,
 		&agentinstancev1.AgentInstanceId{Value: personal.GetMetadata().GetId()})
-	require.NoError(t, err, "a personal instance must survive the agent delete")
-	assert.Equal(t, agentID, survived.GetSpec().GetAgentId())
+	require.Error(t, err, "a personal instance must be cascade-deleted with its agent")
+	st, ok = status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code(),
+		"cascaded personal instance should be NOT_FOUND, got %s", st.Code())
 }
 
 // TestAgentDeleteCascade_CrossPrincipalRecreate reproduces the exact DD-010


### PR DESCRIPTION
## Summary
Repins `TestAgentDeleteCascade_DefaultInstanceAndShares`'s personal-instance arm to the #611 ruling (NOT_FOUND after agent delete), turning the `ci.integration-offline` Core lane green on main again.

## Context
The #611 DD-022-extension ruling made agent delete cascade ALL instances — personal ones included — because surviving orphans squat the org-wide instance-slug namespace ([PR #735](https://github.com/stigmer/stigmer/pull/735) + cloud [PR #457](https://github.com/stigmer/stigmer-cloud/pull/457)). This integration test still asserted the old "personal instance survives" contract against the cloud JAR, so the Core lane has been red on main since that merge (~05:32Z), masking every open PR's Core verdict — including [PR #749](https://github.com/stigmer/stigmer/pull/749)'s.

## Changes
- Personal-instance arm now asserts `NOT_FOUND` after the delete (same shape as the default-instance arm)
- Test doc comment truthed to the ruled contract, citing #611 and this repin

## Test plan
- `TestAgentDeleteCascade_DefaultInstanceAndShares` + `TestAgentDeleteCascade_CrossPrincipalRecreate` run locally against a fresh fat JAR built from stigmer-cloud main (which carries the #457 cascade): both PASS

## Risks
- None — test-only repin to an owner-ruled, conformance-pinned contract

Closes #751

Made with [Cursor](https://cursor.com)