### PR TITLE
test(e2e): re-anchor share-agent-flow to the Shares tab; make the library-flow delete test deterministic

### DIFF
--- a/.github/workflows/ci.e2e-interactive.yaml
+++ b/.github/workflows/ci.e2e-interactive.yaml
@@ -44,7 +44,10 @@ on:
 
 concurrency:
   group: e2e-interactive-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725 — this
+  # lane merged minutes after that sweep and adopts its ruling here).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -165,15 +168,9 @@ jobs:
         working-directory: test/e2e
         run: npx playwright install --with-deps chromium
 
-      # share-agent-flow is excluded pending re-anchoring: it drives the
-      # pre-redesign single-toggle Share dialog, but the agent detail page
-      # moved to a Shares tab with per-share channels — found by this lane's
-      # own bring-up run (deterministic failure, product copy is fine).
-      # Tracked in the follow-up issue linked from #572; drop the filter
-      # when the spec is re-anchored. Local runs still surface it.
       - name: Run interactive E2E suite
         working-directory: test/e2e
-        run: npx playwright test --project=interactive --grep-invert "Share agent flow"
+        run: npx playwright test --project=interactive
 
       - name: Upload test results
         if: always()

--- a/test/e2e/tests/interactive/library-flow.spec.ts
+++ b/test/e2e/tests/interactive/library-flow.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "../../fixtures";
 import {
+  createTestAgent,
+  ensureDefaultOrg,
+} from "../../fixtures/seed-helpers";
+import {
   navigateToAgents,
   verifyResourceInList,
   clickResourceCard,
@@ -33,18 +37,39 @@ test.describe("Library agent flow", () => {
     await assertNoErrorBoundary(page);
   });
 
-  test("resource cards list is empty after agent is deleted", async ({
+  test("deleting an agent removes its card from the library", async ({
     page,
     stigmerClient,
   }) => {
-    await navigateToAgents(page);
-    await assertNoErrorBoundary(page);
+    // Own agent, own lifecycle: the assertion is scoped to THIS card's
+    // disappearance, so parallel workers' fixture agents sharing the list
+    // can never affect the outcome (stigmer#744 — the old shape asserted
+    // global emptiness the fixture model doesn't provide).
+    await ensureDefaultOrg(stigmerClient);
+    const agent = await createTestAgent(stigmerClient);
+    try {
+      await navigateToAgents(page);
+      await assertNoErrorBoundary(page);
+      await verifyResourceInList(page, agent.slug);
 
-    const cardsList = getResourceCardsList(page);
-    const initialVisible = await cardsList.isVisible().catch(() => false);
+      await stigmerClient.agent.delete(agent.id);
 
-    if (!initialVisible) {
-      await expect(page.getByText("No agents yet")).toBeVisible();
+      // Fresh load, then wait for a load-complete signal — either the card
+      // grid (other agents exist) or the empty state — BEFORE asserting
+      // absence, so an in-flight fetch can't produce a vacuous pass.
+      await navigateToAgents(page);
+      await assertNoErrorBoundary(page);
+      await expect(
+        getResourceCardsList(page).or(page.getByText("No agents yet")),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        getResourceCardsList(page)
+          .getByRole("listitem")
+          .filter({ hasText: agent.slug }),
+      ).toHaveCount(0);
+    } finally {
+      // Idempotent if the in-test delete already succeeded.
+      await agent.cleanup();
     }
   });
 });

--- a/test/e2e/tests/interactive/share-agent-flow.spec.ts
+++ b/test/e2e/tests/interactive/share-agent-flow.spec.ts
@@ -4,12 +4,15 @@ import { assertNoErrorBoundary } from "../../helpers/navigation";
 import type { Page } from "@playwright/test";
 
 /**
- * Share flow on the agent detail page: open the Share dialog from the
- * actions menu, toggle sharing on, verify the public chat link renders,
- * copy it, and toggle sharing back off.
+ * Share flow on the agent detail page, anchored to the Shares-tab surface
+ * (stigmer#744): the Share action is pure navigation to the Shares tab,
+ * where each share is its own channel — created through the Create-share
+ * dialog, listed with its chat link, and deleted through the row's
+ * actions menu.
  *
  * Runs against the OSS stack, where permission checks degrade permissive
- * — the Share action is always visible to the single local user.
+ * — the Share action and every share affordance are visible to the
+ * single local user.
  */
 
 async function openAgentDetail(page: Page, org: string, slug: string) {
@@ -20,12 +23,45 @@ async function openAgentDetail(page: Page, org: string, slug: string) {
   await assertNoErrorBoundary(page);
 }
 
-async function openShareDialog(page: Page) {
+// The Share action navigates to the Shares tab; a fresh fixture agent has
+// no shares, so it lands on the first-use empty state.
+async function openSharesTab(page: Page) {
   await page.getByRole("button", { name: "More actions" }).click();
   await page.getByRole("menuitem", { name: "Share" }).click();
-  await expect(
-    page.getByRole("dialog").getByText("Anyone with the link can chat"),
-  ).toBeVisible({ timeout: 10_000 });
+}
+
+// Creates a share through the dialog. The form prefills name and slug from
+// the agent; the slug is overridden because share slugs live in the org's
+// resource namespace, so reusing the agent's own slug would collide.
+async function createShare(page: Page, shareSlug: string) {
+  await page.getByRole("button", { name: "Create share" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Slug").fill(shareSlug);
+  await dialog.getByRole("button", { name: "Create share" }).click();
+
+  // Success flips the dialog from the create form to the share editor.
+  await expect(page.getByText("Share created — the link is live")).toBeVisible(
+    { timeout: 10_000 },
+  );
+  await dialog.getByRole("button", { name: "Done" }).click();
+}
+
+// Deletes the share via the row's actions menu, confirming the destructive
+// dialog, and waits for the list to return to the empty state — leaving
+// the fixture agent unshared for other tests.
+async function deleteShare(page: Page, shareName: string) {
+  await page.getByRole("button", { name: `Actions for ${shareName}` }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+
+  const confirmDialog = page.getByRole("dialog", { name: "Delete share?" });
+  await confirmDialog.getByRole("button", { name: "Delete" }).click();
+
+  await expect(page.getByText("Share deleted")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText("No shares yet")).toBeVisible({
+    timeout: 10_000,
+  });
 }
 
 test.describe("Share agent flow", () => {
@@ -36,71 +72,61 @@ test.describe("Share agent flow", () => {
     await ensureDefaultOrg(stigmerClient);
   });
 
-  test("toggle sharing on, see the link, copy it, toggle off", async ({
+  test("create a share from the Shares tab, see the live link, copy it, delete it", async ({
     page,
     testAgent,
   }) => {
     await openAgentDetail(page, testAgent.org, testAgent.slug);
-    await openShareDialog(page);
+    await openSharesTab(page);
 
-    const dialog = page.getByRole("dialog");
-    const shareSwitch = dialog.getByRole("switch");
-
-    // Fresh agent: sharing starts disabled.
-    await expect(shareSwitch).toHaveAttribute("aria-checked", "false");
-
-    // Enable sharing — persisted by creating the canonical AgentShare
-    // (agentShare.apply) against the real server.
-    await shareSwitch.click();
-    await expect(shareSwitch).toHaveAttribute("aria-checked", "true", {
+    // Fresh agent: the Shares tab opens on the first-use empty state.
+    await expect(page.getByText("No shares yet")).toBeVisible({
       timeout: 10_000,
     });
 
-    // The public chat link renders for this agent.
-    const expectedPath = `/chat/${testAgent.org}/${testAgent.slug}`;
-    await expect(dialog.getByText(expectedPath)).toBeVisible();
+    const shareSlug = `${testAgent.slug}-share`;
+    await createShare(page, shareSlug);
 
-    // Copy the link (clipboard-permission-free assertion: the toast confirms).
-    await dialog.getByRole("button", { name: "Copy" }).first().click();
-    await expect(page.getByText("Link copied")).toBeVisible({ timeout: 5_000 });
-
-    // Toggle sharing back off.
-    await shareSwitch.click();
-    await expect(shareSwitch).toHaveAttribute("aria-checked", "false", {
+    // The list shows the share with its chat link (name stays prefilled
+    // from the agent, so the row is addressed by the agent's name).
+    const expectedPath = `/chat/${testAgent.org}/${shareSlug}`;
+    await expect(page.getByText(expectedPath)).toBeVisible({
       timeout: 10_000,
     });
+
+    // Copy the link (clipboard-permission-free assertion: the toast
+    // confirms; the copied URL additionally carries the link token).
+    await page
+      .getByRole("button", { name: `Copy link for ${testAgent.slug}` })
+      .click();
+    await expect(page.getByText("Link copied")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await deleteShare(page, testAgent.slug);
   });
 
-  test("sharing state persists across a dialog reopen", async ({
+  test("a created share persists across a page reload", async ({
     page,
     testAgent,
   }) => {
     await openAgentDetail(page, testAgent.org, testAgent.slug);
-    await openShareDialog(page);
-
-    const dialog = page.getByRole("dialog");
-    const shareSwitch = dialog.getByRole("switch");
-
-    await shareSwitch.click();
-    await expect(shareSwitch).toHaveAttribute("aria-checked", "true", {
+    await openSharesTab(page);
+    await expect(page.getByText("No shares yet")).toBeVisible({
       timeout: 10_000,
     });
 
-    // Close and reopen — the persisted state must survive the remount.
-    await dialog.getByRole("button", { name: "Done" }).click();
-    await openShareDialog(page);
-    await expect(page.getByRole("dialog").getByRole("switch")).toHaveAttribute(
-      "aria-checked",
-      "true",
-      { timeout: 10_000 },
-    );
+    const shareSlug = `${testAgent.slug}-share`;
+    await createShare(page, shareSlug);
 
-    // Leave the fixture unshared for other tests.
-    await page.getByRole("dialog").getByRole("switch").click();
-    await expect(page.getByRole("dialog").getByRole("switch")).toHaveAttribute(
-      "aria-checked",
-      "false",
-      { timeout: 10_000 },
-    );
+    // Reload and come back through the same entry path — the share is a
+    // server-side resource, so it must survive the full remount.
+    await openAgentDetail(page, testAgent.org, testAgent.slug);
+    await openSharesTab(page);
+    await expect(
+      page.getByText(`/chat/${testAgent.org}/${shareSlug}`),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await deleteShare(page, testAgent.slug);
   });
 });


### PR DESCRIPTION
## Summary
Re-anchors `share-agent-flow.spec.ts` to the Shares-tab surface, makes the library-flow deletion test deterministic and honest, drops the lane's `--grep-invert` exclusion, and adopts the #725 concurrency ruling the lane missed by four minutes.

## Context
Both defects were found by the interactive lane's own bring-up (#572): share-agent-flow drove the pre-redesign single-toggle Share dialog (the agent detail page moved to a Shares tab where each share is its own channel), and the library-flow "deleted" test never deleted anything — it raced an instant `isVisible()` against initial load and asserted a global "No agents yet" that parallel workers' fixture agents make unreachable (when the list WAS visible it asserted nothing at all).

## Changes
- `share-agent-flow.spec.ts`: walks the real surface — Shares tab empty state → Create-share dialog (own slug: share slugs live in the org resource namespace) → live `/chat/{org}/{slug}` link + copy (clipboard permission granted; the toast assertion is now CI-truthful for the first time — the old exclusion meant it never ran in a lane) → delete via the row's actions menu, restoring the empty state; second test pins persistence across a full reload
- `library-flow.spec.ts`: the deletion test now owns its agent's lifecycle and asserts THAT card's disappearance after an explicit load-complete signal (card grid OR empty state visible) — immune to parallel workers
- `ci.e2e-interactive.yaml`: `--grep-invert "Share agent flow"` dropped; `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` adopted (#725 — the lane merged minutes after that sweep and never got the ruling)

## Test plan
- Full interactive project run locally under the lane's exact conditions (mock mode, `--workers=1`): **87 passed, 0 failed** — including both re-anchored share tests and the rewritten library deletion test

## Risks
- None — test + workflow only

Closes #744

Made with [Cursor](https://cursor.com)