### PR TITLE
test(e2e): session specs join the interactive lane via the mock-LLM proxy

### DIFF
--- a/.github/workflows/ci.e2e-interactive.yaml
+++ b/.github/workflows/ci.e2e-interactive.yaml
@@ -168,8 +168,13 @@ jobs:
         working-directory: test/e2e
         run: npx playwright install --with-deps chromium
 
+      # Mock mode gives the session specs zero-secrets agent-turn coverage
+      # (stigmer/stigmer#743): global-setup boots the canned-SSE proxy and the
+      # runner points at it; specs that never invoke the LLM are unaffected.
       - name: Run interactive E2E suite
         working-directory: test/e2e
+        env:
+          STIGMER_E2E_MOCK_LLM: "1"
         run: npx playwright test --project=interactive
 
       - name: Upload test results

--- a/test/e2e/fixtures/mock-llm.ts
+++ b/test/e2e/fixtures/mock-llm.ts
@@ -55,11 +55,15 @@ export type AnthropicContentBlock =
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
 
-// One queued turn: a success body to stream. (The e2e never needs the error /
-// delay levers the conformance proxy carries, so they are intentionally omitted
-// to keep this fixture small.)
+// One queued turn: a success body to stream, optionally after a serve delay.
+// The delay exists for phase-window assertions (sidebar "Running", composer
+// disabled mid-execution): a zero-latency mock completes executions before
+// the page can observe them — the delay restores the latency every real
+// model has (stigmer/stigmer#743). The error levers the conformance proxy
+// carries are still intentionally omitted.
 interface QueuedResponse {
   body: AnthropicMessageBody;
+  delayMs?: number;
 }
 
 // A canned Anthropic text turn that ends the agent loop (stop_reason end_turn).
@@ -134,8 +138,8 @@ export class MockLlmProxy {
   }
 
   // Append a turn to serve. Returns `this` for fluent multi-turn setup.
-  enqueue(body: AnthropicMessageBody): this {
-    this.queue.push({ body });
+  enqueue(body: AnthropicMessageBody, delayMs = 0): this {
+    this.queue.push({ body, delayMs });
     return this;
   }
 
@@ -175,6 +179,29 @@ export class MockLlmProxy {
 
     const streaming = await isStreamingRequest(req);
 
+    // The FIFO scripts CONVERSATION turns. In this stack the model registry
+    // is empty, so every agent turn resolves to the Anthropic-format
+    // fallback model and arrives on an anthropic path (streaming for live
+    // console sessions, non-streaming for API-seeded approval executions).
+    // The ONLY OpenAI-path caller is GenerateSessionSubject's economy-tier
+    // fallback — the session-title call that fires concurrently with a
+    // console session's first agent turn. It gets a fixed completion
+    // instead of a FIFO turn: letting it claim one would make a test's
+    // script race its own session's title call (stigmer/stigmer#743). If a
+    // future runner change moves conversation turns onto an OpenAI path,
+    // the served=aux diag lines below make that visible immediately.
+    if (path.includes("/llm/openai/")) {
+      try {
+        appendMockLog(
+          `${new Date().toISOString()} LLM path=${path} streaming=${streaming} served=aux remaining=${this.queue.length}\n`,
+        );
+      } catch {
+        /* never let diag logging break the proxy */
+      }
+      writeJson(res, 200, auxiliaryCompletion(path));
+      return;
+    }
+
     // Claim the head turn synchronously so concurrent or retried calls can't race
     // for the same entry; an empty queue is a test-authoring error (500).
     const next = this.queue.shift();
@@ -193,6 +220,12 @@ export class MockLlmProxy {
       return;
     }
 
+    // Simulated model latency, applied AFTER the synchronous claim so
+    // concurrent requests still consume distinct turns in enqueue order.
+    if (next.delayMs && next.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, next.delayMs));
+    }
+
     if (streaming) {
       writeAnthropicSse(res, next.body);
     } else {
@@ -207,8 +240,16 @@ export class MockLlmProxy {
   ): Promise<void> {
     if (req.method === "POST" && path === "/__mock/enqueue") {
       const raw = await readBody(req);
-      const body = JSON.parse(raw) as AnthropicMessageBody;
-      this.enqueue(body);
+      // Either a bare AnthropicMessageBody (the original wire shape, still
+      // sent by the approval helpers) or a { body, delayMs } envelope.
+      const parsed = JSON.parse(raw) as
+        | AnthropicMessageBody
+        | { body: AnthropicMessageBody; delayMs?: number };
+      if ("body" in parsed) {
+        this.enqueue(parsed.body, parsed.delayMs ?? 0);
+      } else {
+        this.enqueue(parsed);
+      }
       writeJson(res, 200, { ok: true, remaining: this.remaining() });
       return;
     }
@@ -227,6 +268,33 @@ export class MockLlmProxy {
 
 // Resolves true if the request body opts into streaming (the LangChain SDK
 // default). Non-streaming callers get a plain JSON body instead of SSE.
+/**
+ * Fixed completion for auxiliary (non-streaming) calls, shaped for the
+ * provider the request path names so the caller's response parsing takes its
+ * happy path. Deliberately constant: no spec asserts on auxiliary output
+ * (session titles fall back to a heuristic even on failure), and a constant
+ * keeps the FIFO's meaning exact — one entry per scripted conversation turn.
+ */
+function auxiliaryCompletion(path: string): object {
+  if (path.includes("/llm/openai/")) {
+    return {
+      id: "chatcmpl-mock-aux",
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: "mock-aux",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "Mock session" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+    };
+  }
+  return anthropicText("Mock session");
+}
+
 async function isStreamingRequest(req: IncomingMessage): Promise<boolean> {
   const raw = await readBody(req);
   if (raw.length === 0) return false;

--- a/test/e2e/fixtures/seed-helpers.ts
+++ b/test/e2e/fixtures/seed-helpers.ts
@@ -2,6 +2,8 @@ import { Buffer } from "node:buffer";
 import { crc32 } from "node:zlib";
 import { create } from "@bufbuild/protobuf";
 import type { Stigmer } from "@stigmer/sdk";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { GetDefaultAgentRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
 import { WorkflowTaskKind } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb";
 
 const DEFAULT_ORG = "default";
@@ -37,6 +39,44 @@ export async function ensureDefaultOrg(client: Stigmer): Promise<void> {
     slug: DEFAULT_ORG,
     org: DEFAULT_ORG,
   });
+}
+
+/**
+ * Ensures a platform default agent exists — the agent the session launcher's
+ * send path resolves when the user picked none (`AgentQuery.getDefault`,
+ * keyed on the `stigmer.ai/default-agent=true` label + public visibility).
+ * The e2e stack boots a raw server with no seedpack bootstrap, so without
+ * this seed every launcher send dead-ends on getDefault's NOT_FOUND
+ * (stigmer/stigmer#743). Mirrors the integration harness's boot-time seed;
+ * idempotent — a no-op when a default agent already exists, and tolerant of
+ * a parallel worker winning the create race.
+ */
+export async function ensureDefaultAgent(client: Stigmer): Promise<void> {
+  const getDefaultReq = create(GetDefaultAgentRequestSchema, {
+    org: DEFAULT_ORG,
+  });
+
+  try {
+    await client.agent.getDefault(getDefaultReq);
+    return;
+  } catch {
+    // NOT_FOUND — fall through and seed one.
+  }
+
+  try {
+    await client.agent.create({
+      name: "e2e-default-agent",
+      org: DEFAULT_ORG,
+      instructions:
+        "You are the default test assistant. Keep responses under 20 words.",
+      labels: { "stigmer.ai/default-agent": "true" },
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+  } catch {
+    // A parallel worker may have seeded it between our probe and create;
+    // the fixed name makes the loser's create collide. Verify and settle.
+    await client.agent.getDefault(getDefaultReq);
+  }
 }
 
 /**

--- a/test/e2e/helpers/approval.ts
+++ b/test/e2e/helpers/approval.ts
@@ -1,5 +1,3 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
 import type { Page, Locator } from "@playwright/test";
 import { create } from "@bufbuild/protobuf";
 import type { Stigmer } from "@stigmer/sdk";
@@ -9,73 +7,17 @@ import { TerminateAgentExecutionInputSchema } from "@stigmer/protos/ai/stigmer/a
 import {
   anthropicText,
   anthropicToolUses,
-  type AnthropicMessageBody,
   type ToolUseBlock,
 } from "../fixtures/mock-llm";
+import { getMockControlUrl, MockControl } from "./mock-llm-control";
 
 // Mirrors seed-helpers.ts: the OSS single-tenant org every fixture runs in.
 const DEFAULT_ORG = "default";
 
-// The e2e state file global-setup writes; carries the mock LLM control URL when
-// the stack was booted with STIGMER_E2E_MOCK_LLM.
-const STATE_FILE = path.join(__dirname, "..", ".e2e-server-state.json");
-
-// ---------------------------------------------------------------------------
-// Mock LLM control client (cross-process)
-// ---------------------------------------------------------------------------
-
-/**
- * Reads the deterministic mock LLM proxy's control URL from the e2e state file.
- * Returns `null` when the stack was not booted in mock mode — the approval specs
- * use this to `test.skip` gracefully rather than hang against a real/absent model.
- */
-export function getMockControlUrl(): string | null {
-  if (!fs.existsSync(STATE_FILE)) return null;
-  try {
-    const state = JSON.parse(fs.readFileSync(STATE_FILE, "utf-8")) as {
-      mockLlmControlUrl?: string;
-    };
-    return state.mockLlmControlUrl ?? null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * HTTP client for the mock LLM proxy's control API. A Playwright worker runs in
- * a separate process from the proxy (which lives in globalSetup), so it programs
- * the shared FIFO queue over HTTP rather than by direct method calls.
- */
-export class MockControl {
-  constructor(private readonly baseUrl: string) {}
-
-  /** Append one canned assistant turn to the proxy's queue. */
-  async enqueue(body: AnthropicMessageBody): Promise<void> {
-    const res = await fetch(`${this.baseUrl}/__mock/enqueue`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) {
-      throw new Error(`mock enqueue failed: ${res.status} ${await res.text()}`);
-    }
-  }
-
-  /** Drop any unconsumed turns. Call between tests so leftovers can't leak. */
-  async reset(): Promise<void> {
-    const res = await fetch(`${this.baseUrl}/__mock/reset`, { method: "POST" });
-    if (!res.ok) {
-      throw new Error(`mock reset failed: ${res.status} ${await res.text()}`);
-    }
-  }
-
-  /** Turns still waiting to be served (0 after a run consumed its full script). */
-  async remaining(): Promise<number> {
-    const res = await fetch(`${this.baseUrl}/__mock/remaining`);
-    const body = (await res.json()) as { remaining: number };
-    return body.remaining;
-  }
-}
+// The mock LLM control client moved to its own helper when the session specs
+// became its second consumer (stigmer/stigmer#743); re-exported here so the
+// approval specs' existing imports keep working.
+export { getMockControlUrl, MockControl };
 
 // ---------------------------------------------------------------------------
 // Node-client seeding — gated AgentExecution rendered + resolved in the browser

--- a/test/e2e/helpers/mock-llm-control.ts
+++ b/test/e2e/helpers/mock-llm-control.ts
@@ -1,0 +1,90 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { anthropicText } from "../fixtures/mock-llm";
+import type { AnthropicMessageBody } from "../fixtures/mock-llm";
+
+// The e2e state file global-setup writes; carries the mock LLM control URL when
+// the stack was booted with STIGMER_E2E_MOCK_LLM.
+const STATE_FILE = path.join(__dirname, "..", ".e2e-server-state.json");
+
+/**
+ * Reads the deterministic mock LLM proxy's control URL from the e2e state file.
+ * Returns `null` when the stack was not booted in mock mode — specs use this to
+ * `test.skip` gracefully rather than hang against a real/absent model.
+ */
+export function getMockControlUrl(): string | null {
+  if (!fs.existsSync(STATE_FILE)) return null;
+  try {
+    const state = JSON.parse(fs.readFileSync(STATE_FILE, "utf-8")) as {
+      mockLlmControlUrl?: string;
+    };
+    return state.mockLlmControlUrl ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * HTTP client for the mock LLM proxy's control API. A Playwright worker runs in
+ * a separate process from the proxy (which lives in globalSetup), so it programs
+ * the shared FIFO queue over HTTP rather than by direct method calls.
+ */
+export class MockControl {
+  constructor(private readonly baseUrl: string) {}
+
+  /**
+   * Append one canned assistant turn to the proxy's queue. `delayMs` holds
+   * the turn back before it streams — simulated model latency for tests
+   * that assert mid-execution states (sidebar phase, disabled composer).
+   */
+  async enqueue(body: AnthropicMessageBody, delayMs = 0): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/__mock/enqueue`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(delayMs > 0 ? { body, delayMs } : body),
+    });
+    if (!res.ok) {
+      throw new Error(`mock enqueue failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
+  /** Drop any unconsumed turns. Call between tests so leftovers can't leak. */
+  async reset(): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/__mock/reset`, { method: "POST" });
+    if (!res.ok) {
+      throw new Error(`mock reset failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
+  /** Turns still waiting to be served (0 after a run consumed its full script). */
+  async remaining(): Promise<number> {
+    const res = await fetch(`${this.baseUrl}/__mock/remaining`);
+    const body = (await res.json()) as { remaining: number };
+    return body.remaining;
+  }
+}
+
+/**
+ * Programs the proxy with a fresh script of plain-text assistant turns — one
+ * per LLM call the caller is about to trigger. Resets the FIFO first so a
+ * prior test's unconsumed turns can't leak into this script; the flip side of
+ * that contract is that every test must DRAIN its script (wait for its
+ * executions to complete) before ending, or the next test's reset races the
+ * still-running execution (stigmer/stigmer#743).
+ *
+ * No-op returning false when the stack wasn't booted in mock mode — callers
+ * running against a real provider key just let the live model answer.
+ */
+export async function enqueueCannedTextTurns(
+  texts: readonly string[],
+  opts?: { readonly delayMs?: number },
+): Promise<boolean> {
+  const url = getMockControlUrl();
+  if (!url) return false;
+  const control = new MockControl(url);
+  await control.reset();
+  for (const text of texts) {
+    await control.enqueue(anthropicText(text), opts?.delayMs ?? 0);
+  }
+  return true;
+}

--- a/test/e2e/helpers/session.ts
+++ b/test/e2e/helpers/session.ts
@@ -56,15 +56,6 @@ export async function waitForAIResponse(
 }
 
 /**
- * Sidebar execution status region (visible on lg+ viewports). Holds the
- * always-on phase badge for the active/last execution. The agent's plan/todos
- * now render inline in the thread (see {@link getTodoCard}), not here.
- */
-export function getExecutionProgressRegion(page: Page): Locator {
-  return page.getByRole("region", { name: "Execution progress" });
-}
-
-/**
  * The agent's inline "To-dos" card in the message thread. Present once an
  * execution has written a plan (`status.todos`); collapsed once the plan is
  * fully resolved.
@@ -73,21 +64,10 @@ export function getTodoCard(page: Page): Locator {
   return page.getByRole("region", { name: "Agent to-dos" });
 }
 
-/**
- * Wait for the sidebar execution progress to show a specific phase.
- * Scoped to the "Execution progress" region to avoid matching
- * phase badges that appear inline in the message thread.
- */
-export async function waitForExecutionPhase(
-  page: Page,
-  phase: string,
-  opts?: { timeout?: number },
-): Promise<void> {
-  const region = getExecutionProgressRegion(page);
-  await expect(region.getByRole("status", { name: phase })).toBeVisible({
-    timeout: opts?.timeout ?? 60_000,
-  });
-}
+// The sidebar "Execution progress" phase region helpers were removed with
+// the stigmer#743 re-anchor: no console page renders that region anymore —
+// execution state surfaces as the composer lifecycle plus the settled
+// response in the thread (see waitForAIResponse).
 
 export async function assertComposerDisabled(page: Page): Promise<void> {
   const form = getSessionComposer(page);

--- a/test/e2e/tests/interactive/session-execution-flow.spec.ts
+++ b/test/e2e/tests/interactive/session-execution-flow.spec.ts
@@ -2,53 +2,81 @@ import { test, expect } from "../../fixtures";
 import {
   startNewSession,
   sendFollowUp,
+  waitForAIResponse,
   getAIResponses,
   getUserMessages,
   getMessageThread,
   getSessionComposer,
-  waitForExecutionPhase,
   assertComposerDisabled,
   assertComposerEnabled,
 } from "../../helpers/session";
+import {
+  enqueueCannedTextTurns,
+  getMockControlUrl,
+} from "../../helpers/mock-llm-control";
+import {
+  ensureDefaultAgent,
+  ensureDefaultOrg,
+} from "../../fixtures/seed-helpers";
 import { assertNoErrorBoundary } from "../../helpers/navigation";
 
 const HAS_LLM_KEY = !!(
   process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY
 );
 
+// Simulated model latency for every canned turn in this file: these tests
+// assert MID-execution states (disabled composer), so the execution must stay
+// observable for longer than the page needs to reflect it — a zero-latency
+// turn can complete before the UI ever shows the run (stigmer/stigmer#743).
+const TURN_DELAY_MS = 2_000;
+
+/**
+ * Agent execution through the session surface, anchored to the signals the
+ * CURRENT session viewer exposes (stigmer/stigmer#743 re-anchor): the
+ * composer disables while a run is active and re-enables after, and the
+ * response lands in the thread. The pre-redesign sidebar "Execution
+ * progress" phase region these tests originally pinned is no longer
+ * rendered by any console page — execution phases are deliberately not a
+ * header/sidebar surface anymore.
+ */
 test.describe("Agent execution via session", () => {
-  test.skip(!HAS_LLM_KEY, "Requires ANTHROPIC_API_KEY or OPENAI_API_KEY");
-
-  test("execution progress appears in sidebar during processing", async ({
-    page,
-    testAgent,
-  }) => {
-    await startNewSession(page, "Say exactly: ping");
-    await assertNoErrorBoundary(page);
-
-    // Sidebar execution progress region should appear with a non-terminal phase.
-    // The execution may be Pending or Running depending on timing.
-    await waitForExecutionPhase(page, "Running", { timeout: 30_000 });
+  // The launcher's send path resolves the platform default agent; a raw
+  // e2e stack has neither the org nor that agent seeded. Idempotent.
+  test.beforeAll(async ({ stigmerClient }) => {
+    await ensureDefaultOrg(stigmerClient);
+    await ensureDefaultAgent(stigmerClient);
   });
 
-  test("composer disabled during execution, enabled after completion", async ({
+  // Runnable two ways: against a real provider key, or with zero secrets
+  // against the mock-LLM proxy (STIGMER_E2E_MOCK_LLM=1 — how the CI lane
+  // runs it). Each test programs the proxy with exactly the turns it will
+  // consume and drains them before ending.
+  test.skip(
+    !HAS_LLM_KEY && !getMockControlUrl(),
+    "Requires ANTHROPIC_API_KEY/OPENAI_API_KEY or the mock-LLM stack (STIGMER_E2E_MOCK_LLM=1)",
+  );
+
+  // Folds the old "execution progress appears in sidebar" intent into the
+  // composer lifecycle: the disabled composer IS the user-visible "a run is
+  // in progress" signal on the current surface.
+  test("composer reflects the execution lifecycle: disabled while running, enabled after", async ({
     page,
     testAgent,
   }) => {
+    await enqueueCannedTextTurns(["hello"], { delayMs: TURN_DELAY_MS });
+
     await startNewSession(page, "Say exactly: hello");
     await assertNoErrorBoundary(page);
 
-    // Follow-up composer should exist (session page, not launcher)
+    // Follow-up composer should exist (session page, not launcher).
     const form = getSessionComposer(page);
     await expect(form).toBeVisible({ timeout: 15_000 });
 
-    // Composer should be disabled while execution is active
+    // Disabled while the execution is active — the in-progress signal.
     await assertComposerDisabled(page);
 
-    // Wait for execution to complete
-    await waitForExecutionPhase(page, "Completed", { timeout: 90_000 });
-
-    // Composer should re-enable after terminal phase
+    // The settled response is the completion signal on this surface.
+    await waitForAIResponse(page, { timeout: 90_000 });
     await assertComposerEnabled(page);
   });
 
@@ -56,20 +84,19 @@ test.describe("Agent execution via session", () => {
     page,
     testAgent,
   }) => {
+    await enqueueCannedTextTurns(["world"], { delayMs: TURN_DELAY_MS });
+
     await startNewSession(page, "Say exactly: world");
     await assertNoErrorBoundary(page);
 
-    await waitForExecutionPhase(page, "Completed", { timeout: 90_000 });
+    // Settled response: visible and no longer streaming (not aria-busy).
+    const aiResponse = await waitForAIResponse(page, { timeout: 90_000 });
+    await expect(aiResponse).toBeVisible();
 
     const thread = getMessageThread(page);
     await expect(thread).toBeVisible();
 
-    // At least one AI response should be visible and not still streaming
-    const aiResponse = getAIResponses(page).first();
-    await expect(aiResponse).toBeVisible({ timeout: 10_000 });
-    await expect(aiResponse).not.toHaveAttribute("aria-busy", "true");
-
-    // User message should also be in the thread
+    // User message should also be in the thread.
     const userMsg = getUserMessages(page).first();
     await expect(userMsg).toBeVisible();
     await expect(userMsg).toContainText("Say exactly: world");
@@ -79,9 +106,14 @@ test.describe("Agent execution via session", () => {
     page,
     testAgent,
   }) => {
+    // Two turns: the opening message and the follow-up that carries the image.
+    await enqueueCannedTextTurns(["ready", "got the image"], {
+      delayMs: TURN_DELAY_MS,
+    });
+
     await startNewSession(page, "Say exactly: ready");
     await assertNoErrorBoundary(page);
-    await waitForExecutionPhase(page, "Completed", { timeout: 90_000 });
+    await waitForAIResponse(page, { timeout: 90_000 });
     await assertComposerEnabled(page);
 
     const form = getSessionComposer(page);
@@ -129,37 +161,48 @@ test.describe("Agent execution via session", () => {
       { timeout: 10_000 },
     );
     await expect(chip).toHaveCount(0);
+
+    // Drain the follow-up's turn before ending: the send above started a
+    // second execution; its settled response re-enables the composer.
+    await expect(getAIResponses(page)).toHaveCount(2, { timeout: 90_000 });
+    await assertComposerEnabled(page);
   });
 
   test("follow-up message creates new execution", async ({
     page,
     testAgent,
   }) => {
+    await enqueueCannedTextTurns(["first", "second"], {
+      delayMs: TURN_DELAY_MS,
+    });
+
     await startNewSession(page, "Say exactly: first");
     await assertNoErrorBoundary(page);
 
-    // Wait for first execution to complete
-    await waitForExecutionPhase(page, "Completed", { timeout: 90_000 });
+    // Wait for the first execution to complete.
+    await waitForAIResponse(page, { timeout: 90_000 });
     await assertComposerEnabled(page);
 
-    // Send follow-up
+    // Send follow-up.
     await sendFollowUp(page, "Say exactly: second");
 
-    // User message should appear immediately (optimistic rendering)
+    // User message should appear immediately (optimistic rendering).
     await expect(getUserMessages(page).last()).toContainText(
       "Say exactly: second",
       { timeout: 10_000 },
     );
 
-    // New execution should start — composer disables again
+    // New execution should start — composer disables again.
     await assertComposerDisabled(page);
 
-    // Wait for second execution to complete
-    await waitForExecutionPhase(page, "Completed", { timeout: 90_000 });
+    // Thread ends with two settled AI responses — the second execution's
+    // completion signal — and the composer re-enables.
+    await expect(getAIResponses(page)).toHaveCount(2, { timeout: 90_000 });
+    await expect(getAIResponses(page).last()).not.toHaveAttribute(
+      "aria-busy",
+      "true",
+      { timeout: 90_000 },
+    );
     await assertComposerEnabled(page);
-
-    // Thread should now have multiple AI responses
-    const aiResponses = getAIResponses(page);
-    await expect(aiResponses).toHaveCount(2, { timeout: 10_000 });
   });
 });

--- a/test/e2e/tests/interactive/session-flow.spec.ts
+++ b/test/e2e/tests/interactive/session-flow.spec.ts
@@ -5,6 +5,14 @@ import {
   getMessageThread,
   getUserMessages,
 } from "../../helpers/session";
+import {
+  enqueueCannedTextTurns,
+  getMockControlUrl,
+} from "../../helpers/mock-llm-control";
+import {
+  ensureDefaultAgent,
+  ensureDefaultOrg,
+} from "../../fixtures/seed-helpers";
 import { assertNoErrorBoundary } from "../../helpers/navigation";
 
 const HAS_LLM_KEY = !!(
@@ -12,12 +20,28 @@ const HAS_LLM_KEY = !!(
 );
 
 test.describe("Session chat flow (canary)", () => {
-  test.skip(!HAS_LLM_KEY, "Requires ANTHROPIC_API_KEY or OPENAI_API_KEY");
+  // The launcher's send path resolves the platform default agent; a raw
+  // e2e stack has neither the org nor that agent seeded. Idempotent.
+  test.beforeAll(async ({ stigmerClient }) => {
+    await ensureDefaultOrg(stigmerClient);
+    await ensureDefaultAgent(stigmerClient);
+  });
+
+  // Runnable two ways: against a real provider key, or with zero secrets
+  // against the mock-LLM proxy (STIGMER_E2E_MOCK_LLM=1 — how the CI lane
+  // runs it, stigmer/stigmer#743). Each test programs the proxy with
+  // exactly the turns it will consume and drains them before ending.
+  test.skip(
+    !HAS_LLM_KEY && !getMockControlUrl(),
+    "Requires ANTHROPIC_API_KEY/OPENAI_API_KEY or the mock-LLM stack (STIGMER_E2E_MOCK_LLM=1)",
+  );
 
   test("sending a message produces an AI response in the thread", async ({
     page,
     testAgent,
   }) => {
+    await enqueueCannedTextTurns(["hello world"]);
+
     await startNewSession(page, "Say exactly: hello world");
     await assertNoErrorBoundary(page);
 
@@ -33,11 +57,17 @@ test.describe("Session chat flow (canary)", () => {
     page,
     testAgent,
   }) => {
+    await enqueueCannedTextTurns(["Message received."]);
+
     await startNewSession(page, "Testing message visibility");
     await assertNoErrorBoundary(page);
 
     const userMsg = getUserMessages(page).first();
     await expect(userMsg).toBeVisible({ timeout: 10_000 });
     await expect(userMsg).toContainText("Testing message visibility");
+
+    // Drain the turn before ending: the execution this message started must
+    // consume its scripted response, or the next test's queue reset races it.
+    await waitForAIResponse(page, { timeout: 90_000 });
   });
 });

--- a/test/e2e/tests/interactive/share-agent-flow.spec.ts
+++ b/test/e2e/tests/interactive/share-agent-flow.spec.ts
@@ -65,6 +65,10 @@ async function deleteShare(page: Page, shareName: string) {
 }
 
 test.describe("Share agent flow", () => {
+  // The row's copy affordance writes through navigator.clipboard, which
+  // automated Chromium only allows with an explicit permission grant.
+  test.use({ permissions: ["clipboard-write"] });
+
   // A fresh OSS stack has no organizations, so the OrgGate would block
   // every route on the onboarding screen. Idempotent — a no-op when the
   // stack is reused and the org already exists.


### PR DESCRIPTION
## Summary
Brings `session-flow` + `session-execution-flow` into the zero-secrets `ci.e2e-interactive` lane via the mock-LLM proxy (`STIGMER_E2E_MOCK_LLM=1`), per the owner rulings: same lane job, assertions kept, each test enqueues its own canned turns.

Successor of #756, which GitHub auto-closed when its stacked base branch (#755) was deleted at merge; rebased onto main, content identical.

## Context
The session specs self-skipped without a provider key, so the lane had zero agent-turn coverage (#743). The bring-up surfaced four latent gaps, each fixed at its honest home:

- **No platform default agent in the e2e stack** — every launcher send dead-ended on `getDefault` NOT_FOUND (silent: no RPC ever fired). New idempotent `ensureDefaultAgent` seed, sibling of `ensureDefaultOrg`, mirroring the integration harness's boot seed.
- **The session-title call raced the FIFO** — `GenerateSessionSubject` fires concurrently with the first agent turn and was consuming scripted turns. The mock now serves OpenAI-path calls (the title call's economy-tier fallback is the only OpenAI-path caller in this registry-less stack) a fixed completion; the FIFO's meaning stays exact — one entry per conversation turn. Verified against the approval suite: its failures on my branch are a strict subset of the CLEAN tree's (that pre-existing local flake is now tracked as #754).
- **Zero-latency turns made executions unobservable** — new per-turn `delayMs` (simulated model latency; the fixture's header had explicitly deferred this lever until needed), used by the mid-execution assertions.
- **Five tests pinned a REMOVED surface** — the sidebar "Execution progress" region is rendered by no console page anymore (the session viewer redesign deliberately keeps execution phases off the header/sidebar). Owner-ruled re-anchor: the five tests fold to four on today's signals (composer lifecycle + settled thread response), every user-visible intent kept; the dead helpers are removed.

Also: the mock-control client moved to `helpers/mock-llm-control.ts` (approvals were its first consumer, sessions its second) with re-exports so the approval specs' imports are untouched; each test now drains its script before ending — without that, a test ending mid-execution lets the next test's queue reset race the still-running turn.

## Test plan
- Full interactive project locally under the lane's exact conditions (mock, `--workers=1`): **87 passed, 0 failed**
- Approval suite baseline comparison (fixture safety): failures identical-or-fewer vs pristine main; tracked separately as #754

## Risks
- The OpenAI-path aux discriminator is pinned to the e2e stack's model-resolution reality (empty registry → anthropic-format conversation turns); if that ever changes, the mock's `served=aux` diag lines expose it immediately

Closes #743

Made with [Cursor](https://cursor.com)
