### PR TITLE
feat(cli): seedpack applied-hash truth moves server-side (stigmer.ai/seedpack-hash label)

### DIFF
--- a/client-apps/cli/src/commands/seedpack.ts
+++ b/client-apps/cli/src/commands/seedpack.ts
@@ -3,7 +3,10 @@
 // The seedpack (system agents, skills, MCP servers, workflows under the
 // "stigmer" org) is applied automatically on `stigmer up` in local mode; these
 // commands bootstrap it explicitly against whatever backend is configured
-// (local or cloud). Apply is idempotent via a content-hash marker.
+// (local or cloud). Apply is content-hash idempotent: in cloud mode the truth
+// is the stigmer.ai/seedpack-hash label on the server's seedpack Project (any
+// machine sees the same applied state — cloud#429); in local mode it is a
+// marker file in the data dir, which lives and dies with the local backend.
 //
 // Heavy modules load lazily inside the action so `--help` stays fast (DD-001).
 
@@ -50,7 +53,11 @@ async function runApply(flags: ApplyFlags): Promise<void> {
       info: (line) => process.stderr.write(`${line}\n`),
       warn: (line) => process.stderr.write(`${line}\n`),
     },
-    { markerDir: markerDir(), force: flags.force === true },
+    {
+      markerDir: markerDir(),
+      force: flags.force === true,
+      useServerHash: isCloudMode(load()),
+    },
   );
 
   const label = backendLabel();
@@ -61,11 +68,26 @@ async function runApply(flags: ApplyFlags): Promise<void> {
 }
 
 async function runStatus(flags: OutputFlags): Promise<void> {
-  const { seedpackContentHash } = await import("../local/seedpack/apply.js");
+  const { readServerSeedpackHash, resolveSeedpackOrg, seedpackContentHash } = await import("../local/seedpack/apply.js");
   const { readMarker } = await import("../local/seedpack/content.js");
 
   const hash = seedpackContentHash();
-  const stored = readMarker(markerDir());
+
+  // Cloud mode asks the server (the label on the seedpack Project) so status
+  // is truthful from ANY machine, not just the one that last ran apply.
+  let stored: string | null;
+  let storedLabel: string;
+  if (isCloudMode(load())) {
+    const { connectBackend } = await import("../backend.js");
+    const { ensureAuthenticated } = await import("../config/index.js");
+    const client = connectBackend();
+    ensureAuthenticated(client.config);
+    stored = await readServerSeedpackHash(client.stigmer, resolveSeedpackOrg());
+    storedLabel = "Applied Hash (server)";
+  } else {
+    stored = readMarker(markerDir());
+    storedLabel = "Applied Hash";
+  }
 
   const result = CommandResult.success("Seedpack status");
   const section = result.addSection("");
@@ -74,7 +96,7 @@ async function runStatus(flags: OutputFlags): Promise<void> {
   if (stored === null) {
     section.field("Status", "Not applied (run 'stigmer seedpack apply')");
   } else {
-    section.field("Applied Hash", stored);
+    section.field(storedLabel, stored);
     section.field("Status", stored === hash ? "Up to date" : "Outdated (run 'stigmer seedpack apply' to update)");
   }
   renderResult(result, resultFormat(flags));

--- a/client-apps/cli/src/local/seedpack/apply.test.ts
+++ b/client-apps/cli/src/local/seedpack/apply.test.ts
@@ -1,11 +1,19 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Message } from "@bufbuild/protobuf";
+import type { Stigmer } from "@stigmer/sdk";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildDeclarativeItems, scanResourceFiles } from "../../resources/apply/declarative.js";
 import type { ControllerFn } from "../../resources/apply/handlers.js";
-import { applySeedpack, resolveSeedpackOrg, seedpackContentHash } from "./apply.js";
+import {
+  applySeedpack,
+  readServerSeedpackHash,
+  resolveSeedpackOrg,
+  SEEDPACK_HASH_LABEL,
+  SEEDPACK_PROJECT_SLUG,
+  seedpackContentHash,
+} from "./apply.js";
 import type { SeedpackContent } from "./content.js";
 import { extractSeedpack, readMarker, resolveSeedpackContent } from "./content.js";
 
@@ -43,25 +51,41 @@ function makeContent(): SeedpackContent {
   return { dir, source: "repo" };
 }
 
-// Records each applied message's proto type name; every controller resolves to
-// the same stub apply (the handlers only call `.apply`).
-function recordingDeps() {
+// Records each applied message (and its proto type name); every controller
+// resolves to the same stub apply (the handlers only call `.apply`).
+function recordingDeps(stigmer?: unknown) {
   const applied: string[] = [];
+  const appliedMessages: Message[] = [];
   const controller = (() => ({
     apply: async (m: Message) => {
       applied.push((m as { $typeName: string }).$typeName);
+      appliedMessages.push(m);
       return m;
     },
   })) as unknown as ControllerFn;
   return {
     applied,
+    appliedMessages,
     deps: {
       controller,
-      stigmer: {} as never,
+      stigmer: (stigmer ?? {}) as never,
       info: () => {},
       warn: () => {},
     },
   };
+}
+
+// A Stigmer stub whose project.getByReference reports the given stored hash
+// (null → the label is absent; "absent" → the project itself does not exist).
+function stigmerWithServerHash(stored: string | null | "absent"): Stigmer {
+  return {
+    project: {
+      getByReference: async () => {
+        if (stored === "absent") throw new Error("not found");
+        return { metadata: { labels: stored === null ? {} : { [SEEDPACK_HASH_LABEL]: stored } } };
+      },
+    },
+  } as unknown as Stigmer;
 }
 
 let content: SeedpackContent;
@@ -125,6 +149,91 @@ describe("applySeedpack", () => {
     expect(result.applied).toBe(true);
     expect(forced.applied.length).toBeGreaterThan(0);
   });
+
+  it("stamps the content hash as a reserved label on the applied Project", async () => {
+    const { appliedMessages, deps } = recordingDeps();
+    const result = await applySeedpack(deps, { markerDir, content });
+
+    const project = appliedMessages.find((m) => (m as { $typeName: string }).$typeName.endsWith("Project")) as
+      | { metadata?: { labels: Record<string, string> } }
+      | undefined;
+    expect(project).toBeDefined();
+    expect(project?.metadata?.labels[SEEDPACK_HASH_LABEL]).toBe(result.hash);
+  });
+});
+
+describe("applySeedpack — cloud mode (useServerHash)", () => {
+  it("skips when the server's recorded hash matches, without touching the marker", async () => {
+    const hash = seedpackContentHash({ content });
+    const { applied, deps } = recordingDeps(stigmerWithServerHash(hash));
+
+    const result = await applySeedpack(deps, { markerDir, content, useServerHash: true });
+
+    expect(result.applied).toBe(false);
+    expect(applied).toHaveLength(0);
+    expect(readMarker(markerDir)).toBeNull();
+  });
+
+  it("applies when the server records a different hash — and never writes the marker", async () => {
+    const { applied, deps } = recordingDeps(stigmerWithServerHash("sha256:0000000000000000"));
+
+    const result = await applySeedpack(deps, { markerDir, content, useServerHash: true });
+
+    expect(result.applied).toBe(true);
+    expect(applied.length).toBeGreaterThan(0);
+    // Cloud mode's record is the Project label; a marker here would be a
+    // second record of the same fact, free to drift.
+    expect(readMarker(markerDir)).toBeNull();
+  });
+
+  it("applies when the seedpack Project does not exist yet (first bootstrap)", async () => {
+    const { applied, deps } = recordingDeps(stigmerWithServerHash("absent"));
+
+    const result = await applySeedpack(deps, { markerDir, content, useServerHash: true });
+
+    expect(result.applied).toBe(true);
+    expect(applied.length).toBeGreaterThan(0);
+  });
+
+  it("ignores a stale local marker: the server is the only truth consulted", async () => {
+    const hash = seedpackContentHash({ content });
+    // A leftover marker from the pre-cloud#429 era says "up to date"…
+    const { deps: first } = recordingDeps();
+    await applySeedpack(first, { markerDir, content });
+    // …but the server has never seen this content.
+    const { applied, deps } = recordingDeps(stigmerWithServerHash(null));
+
+    const result = await applySeedpack(deps, { markerDir, content, useServerHash: true });
+
+    expect(result.applied).toBe(true);
+    expect(applied.length).toBeGreaterThan(0);
+    expect(hash).toBe(result.hash);
+  });
+
+  it("re-applies when forced even if the server hash matches", async () => {
+    const hash = seedpackContentHash({ content });
+    const { applied, deps } = recordingDeps(stigmerWithServerHash(hash));
+
+    const result = await applySeedpack(deps, { markerDir, content, useServerHash: true, force: true });
+
+    expect(result.applied).toBe(true);
+    expect(applied.length).toBeGreaterThan(0);
+  });
+});
+
+describe("readServerSeedpackHash", () => {
+  it("returns the recorded label", async () => {
+    const hash = await readServerSeedpackHash(stigmerWithServerHash("sha256:abcdef0123456789"), "stigmer");
+    expect(hash).toBe("sha256:abcdef0123456789");
+  });
+
+  it("returns null when the label is absent", async () => {
+    expect(await readServerSeedpackHash(stigmerWithServerHash(null), "stigmer")).toBeNull();
+  });
+
+  it("returns null when the project cannot be read (never applied / transient failure)", async () => {
+    expect(await readServerSeedpackHash(stigmerWithServerHash("absent"), "stigmer")).toBeNull();
+  });
 });
 
 describe("seedpackContentHash", () => {
@@ -139,6 +248,18 @@ describe("seedpackContentHash", () => {
 // CI canary manifest) must live outside the content set, never beside the
 // McpServer YAMLs where `loadDocuments(strict)` would reject it for missing a
 // `kind`. The synthetic fixtures above can't catch this — only real content can.
+// The cloud-mode hash read addresses the seedpack Project by a pinned slug.
+// The server derives the slug from the manifest's metadata.name, so this pin
+// holds exactly as long as the real seedpack keeps that name — verify against
+// the real content so a rename there fails here, not silently in prod.
+describe("SEEDPACK_PROJECT_SLUG pins the real manifest name", () => {
+  it("matches seedpack/stigmer.yaml metadata.name", () => {
+    const real = resolveSeedpackContent();
+    const manifest = readFileSync(join(real.dir, "stigmer.yaml"), "utf8");
+    expect(manifest).toMatch(new RegExp(`name:\\s*${SEEDPACK_PROJECT_SLUG}\\s*$`, "m"));
+  });
+});
+
 describe("real seedpack content loads through the declarative scanner", () => {
   it("scans + builds apply items without a missing-kind error", () => {
     const real = resolveSeedpackContent();

--- a/client-apps/cli/src/local/seedpack/apply.ts
+++ b/client-apps/cli/src/local/seedpack/apply.ts
@@ -10,11 +10,18 @@
 //   2. the project (stigmer.yaml + agents/skills/mcp-servers/workflows) via the
 //      declarative reconciler, under the target org.
 //
-// Idempotent: a content-hash marker skips the apply when nothing changed.
+// Idempotent, with the applied-hash truth living with the backend it describes
+// (cloud#429): every apply stamps the content hash as a reserved label on the
+// seedpack Project, and cloud-mode runs skip by reading that label back — so
+// any machine (operator laptop, CI) sees the same applied state. Local mode
+// keeps the original marker file (the local data dir lives and dies with the
+// local backend, so a local file IS backend-scoped state there).
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { create } from "@bufbuild/protobuf";
+import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
 import type { Stigmer } from "@stigmer/sdk";
 import { applyItem, resolveApplyItems } from "../../resources/apply/apply.js";
 import { applyDeclarative, detectTrack } from "../../resources/apply/declarative.js";
@@ -31,6 +38,23 @@ import {
 const DEFAULT_ORG = "stigmer";
 const ORG_ENV_VAR = "STIGMER_SEEDPACK_ORG";
 
+/**
+ * Reserved label on the seedpack Project recording the last applied content
+ * hash (cloud#429). Writing a NEW value requires `can_write_reserved_labels`
+ * (the seeding identity's capability); re-sending an unchanged value is an
+ * echo the cloud guard passes for any caller — so re-applies of identical
+ * content are never treated as reserved-label writes.
+ */
+export const SEEDPACK_HASH_LABEL = "stigmer.ai/seedpack-hash";
+
+/**
+ * The seedpack Project's slug. The server derives it from the manifest's
+ * `metadata.name` in `seedpack/stigmer.yaml` — "stigmer-seedpack" is already
+ * slug-shaped, so name and slug coincide. Pinned by a test against the real
+ * content so a rename there fails loudly here.
+ */
+export const SEEDPACK_PROJECT_SLUG = "stigmer-seedpack";
+
 export interface SeedpackApplyDeps {
   /** Raw command-controller accessor (full-proto apply, preserves metadata.id). */
   readonly controller: ControllerFn;
@@ -43,7 +67,7 @@ export interface SeedpackApplyDeps {
 }
 
 export interface SeedpackApplyOptions {
-  /** Directory holding the idempotency marker (data dir for local, config dir for cloud). */
+  /** Directory holding the idempotency marker (local mode only). */
   readonly markerDir: string;
   /** Target org slug. Defaults to STIGMER_SEEDPACK_ORG, then "stigmer". */
   readonly org?: string;
@@ -52,6 +76,13 @@ export interface SeedpackApplyOptions {
   /** Pre-resolved content (injectable for tests); resolved on demand otherwise. */
   readonly content?: SeedpackContent;
   readonly home?: string;
+  /**
+   * Cloud mode: the idempotency truth is the {@link SEEDPACK_HASH_LABEL} on the
+   * server's seedpack Project, read via {@link readServerSeedpackHash} — the
+   * local marker is neither read nor written, so a stateless machine (CI, a
+   * second operator laptop) still skips unchanged content correctly.
+   */
+  readonly useServerHash?: boolean;
 }
 
 export interface SeedpackApplyResult {
@@ -78,16 +109,34 @@ export function seedpackContentHash(opts: Pick<SeedpackApplyOptions, "content" |
 }
 
 /**
+ * Read the applied content hash recorded on the backend's seedpack Project,
+ * or null when it cannot be proven (project absent — never applied — or the
+ * read failed). Null means "apply": the apply itself is idempotent server-side,
+ * so an unprovable state costs one redundant pass, never a skipped update.
+ */
+export async function readServerSeedpackHash(stigmer: Stigmer, org: string): Promise<string | null> {
+  try {
+    const project = await stigmer.project.getByReference({ org, slug: SEEDPACK_PROJECT_SLUG });
+    return project.metadata?.labels?.[SEEDPACK_HASH_LABEL] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Apply the seedpack to the backend the deps connect to. Returns `applied:false`
- * (without touching the backend) when the marker already matches the content
- * hash and `force` is not set.
+ * (without touching the backend beyond the cloud-mode hash read) when the
+ * recorded hash already matches the content hash and `force` is not set.
  */
 export async function applySeedpack(deps: SeedpackApplyDeps, opts: SeedpackApplyOptions): Promise<SeedpackApplyResult> {
   const org = resolveSeedpackOrg(opts.org);
   const content = opts.content ?? resolveSeedpackContent({ home: opts.home });
   const hash = hashSeedpackContent(content.dir);
 
-  if (opts.force !== true && readMarker(opts.markerDir) === hash) {
+  const appliedHash = opts.useServerHash === true
+    ? await readServerSeedpackHash(deps.stigmer, org)
+    : readMarker(opts.markerDir);
+  if (opts.force !== true && appliedHash === hash) {
     return { applied: false, hash, org };
   }
 
@@ -96,8 +145,12 @@ export async function applySeedpack(deps: SeedpackApplyDeps, opts: SeedpackApply
   try {
     extractSeedpack(content.dir, stage);
     await applyOrganizations(deps, stage);
-    await applyProject(deps, stage, org);
-    writeMarker(opts.markerDir, hash);
+    await applyProject(deps, stage, org, hash);
+    // The Project label written above is the cloud-mode record; the marker
+    // stays the local-mode one. Never both — two records of one fact drift.
+    if (opts.useServerHash !== true) {
+      writeMarker(opts.markerDir, hash);
+    }
   } finally {
     rmSync(stage, { recursive: true, force: true });
   }
@@ -124,11 +177,18 @@ async function applyOrganizations(deps: SeedpackApplyDeps, stageDir: string): Pr
 
 // Phase 2: the project (agents, skills, MCP servers, workflows) via the shared
 // declarative reconciler — the same path `stigmer apply` runs for a user project.
-async function applyProject(deps: SeedpackApplyDeps, stageDir: string, org: string): Promise<void> {
+//
+// The content hash is stamped as a reserved label on the Project HERE, in the
+// seedpack path only — general `stigmer apply` never writes reserved labels.
+// The stamp rides the project apply that happens anyway, so recording the hash
+// costs no extra RPC and can never succeed while the apply failed.
+async function applyProject(deps: SeedpackApplyDeps, stageDir: string, org: string, contentHash: string): Promise<void> {
   const detect = detectTrack(stageDir);
-  if (detect.track !== "declarative") {
+  if (detect.track !== "declarative" || detect.project === undefined) {
     throw new Error(`seedpack is not a declarative project (detected '${detect.track}')`);
   }
+  detect.project.metadata ??= create(ApiResourceMetadataSchema, {});
+  detect.project.metadata.labels[SEEDPACK_HASH_LABEL] = contentHash;
   await applyDeclarative(detect, {
     controller: deps.controller,
     stigmer: deps.stigmer,


### PR DESCRIPTION
## Summary

Part of [stigmer/stigmer-cloud#429](https://github.com/stigmer/stigmer-cloud/issues/429) (hop 1 of the oss#228 drift incident): automated re-seeding needs a stateless way to know whether the platform rows already carry the current seedpack — today the only record is a `.seedpack-bootstrapped` marker file on whichever machine last ran apply, so `seedpack status` against prod lies on every other machine and a CI runner would have to `--force` (real writes + MCP discovery sandbox spins on unchanged content).

- **Stamp**: `applySeedpack` (seedpack path ONLY — general `stigmer apply` never writes reserved labels) stamps `stigmer.ai/seedpack-hash: <ContentHash>` as a label on the seedpack Project, riding the project apply that happens anyway. Cloud-side legitimacy is by construction: writing a NEW value requires `can_write_reserved_labels` (the seeding identity's capability, cloud#320); re-sending an unchanged value is an echo `GuardReservedLabelsStep` passes for any caller.
- **Cloud-mode gate**: apply reads the label via `project.getByReference` before doing anything, and skips when it matches the embedded hash (unless `--force`). The local marker is neither read nor written in cloud mode — one fact, one record.
- **Local mode unchanged**: the marker file keeps its role (the local data dir lives and dies with the local backend), so the `stigmer up` bootstrap path is untouched.
- **`seedpack status`**: in cloud mode now reports the server-recorded hash ("Applied Hash (server)") — truthful from any machine.
- `SEEDPACK_PROJECT_SLUG` is pinned by a test against the real `seedpack/stigmer.yaml` name, so a rename there fails the build here.

## Test plan

- [x] 9 new vitest cases: label stamped on apply; cloud skip on matching server hash; apply on differing/absent hash (first bootstrap); stale local marker ignored in cloud mode; `--force` overrides; marker never written in cloud mode; `readServerSeedpackHash` label/absent/error arms; slug pin against real content
- [x] Full seedpack suite 25/25 green; `tsc --noEmit` clean
- [ ] The stigmer-cloud re-seed lane (closes cloud#429) pins the first CLI release containing this change

Made with [Cursor](https://cursor.com)