### PR TITLE
build(runner): collapse the dual @anthropic-ai/sdk copies via the LangChain-stack bump

### DIFF
--- a/backend/services/runner/package-lock.json
+++ b/backend/services/runner/package-lock.json
@@ -17,8 +17,8 @@
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
         "@cursor/sdk": "^1.0.13",
-        "@langchain/anthropic": "^1.4.0",
-        "@langchain/core": "^1.1.47",
+        "@langchain/anthropic": "^1.5.5",
+        "@langchain/core": "^1.2.7",
         "@langchain/langgraph": "^1.3.0",
         "@langchain/mcp-adapters": "^1.1.3",
         "@langchain/openai": "^1.4.0",
@@ -98,27 +98,6 @@
         "@smithy/util-base64": "^2.0.0"
       }
     },
-    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.116.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
-      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@anthropic-ai/foundry-sdk": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/foundry-sdk/-/foundry-sdk-0.4.1.tgz",
@@ -128,31 +107,10 @@
         "@anthropic-ai/sdk": ">=0.115.1 <1"
       }
     },
-    "node_modules/@anthropic-ai/foundry-sdk/node_modules/@anthropic-ai/sdk": {
+    "node_modules/@anthropic-ai/sdk": {
       "version": "0.116.0",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
       "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.95.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.2.tgz",
-      "integrity": "sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -178,27 +136,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.115.1 <1",
         "google-auth-library": "^10.2.0"
-      }
-    },
-    "node_modules/@anthropic-ai/vertex-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.116.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
-      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2224,25 +2161,25 @@
       }
     },
     "node_modules/@langchain/anthropic": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.4.0.tgz",
-      "integrity": "sha512-rs1yVydrHjyiD31uChdCnKZpmDuKa0Bpz8Raiy9GvqnqmfXPMe0oOrap/2paE+NRSinDbtax8mMpP/yv8EbO1A==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.5.5.tgz",
+      "integrity": "sha512-OeWrKNqx4kgJBfpFAbT/wVzeGibAwVdmI9+DifkI/U3ejpVuUpISdSEVvnRIT0aqlk+sf2EI362Rt8FiJwxIDg==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.95.1",
+        "@anthropic-ai/sdk": "^0.115.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.47"
+        "@langchain/core": "^1.2.6"
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.47",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.47.tgz",
-      "integrity": "sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.7.tgz",
+      "integrity": "sha512-NKEjQimC9IR7YKkfirH9Hq1BIFFKd4tjhWvbtjggS+5mE+bM4ZeFwTIUe9BDIz9zi3hzG4DLbRMi5E8k/PwVTA==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",

--- a/backend/services/runner/package.json
+++ b/backend/services/runner/package.json
@@ -68,6 +68,9 @@
     "url": "git+https://github.com/stigmer/stigmer.git",
     "directory": "backend/services/runner"
   },
+  "overrides": {
+    "@anthropic-ai/sdk": "0.116.0"
+  },
   "dependencies": {
     "@anthropic-ai/bedrock-sdk": "^0.32.1",
     "@anthropic-ai/foundry-sdk": "^0.4.1",
@@ -77,8 +80,8 @@
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
     "@cursor/sdk": "^1.0.13",
-    "@langchain/anthropic": "^1.4.0",
-    "@langchain/core": "^1.1.47",
+    "@langchain/anthropic": "^1.5.5",
+    "@langchain/core": "^1.2.7",
     "@langchain/langgraph": "^1.3.0",
     "@langchain/mcp-adapters": "^1.1.3",
     "@langchain/openai": "^1.4.0",

--- a/backend/services/runner/scripts/check-langchain-deps.sh
+++ b/backend/services/runner/scripts/check-langchain-deps.sh
@@ -66,23 +66,26 @@ else
   echo "WARN: Could not determine @langchain/core versions (is npm ci done?)"
 fi
 
-# --- 3. Check @anthropic-ai/sdk copies (known, contained dual) ---
+# --- 3. Check @anthropic-ai/sdk copies (single, override-pinned) ---
 #
-# The tree deliberately carries TWO versions of @anthropic-ai/sdk:
-#   - @langchain/anthropic -> ^0.95.x  (hoisted; serves the public-API path)
-#   - @anthropic-ai/vertex-sdk, @anthropic-ai/bedrock-sdk, AND
-#     @anthropic-ai/foundry-sdk -> >=0.115 (nested, deduped onto one
-#     version; serve only the backend clients constructed via
-#     ChatAnthropic's createClient factory)
-# The versions never exchange class instances (LangChain consumes stream
-# events structurally and classifies errors by HTTP status, not instanceof),
-# and the vertex-seam/bedrock-seam/foundry-seam characterization tests pin
-# the cross-version combinations in CI.
+# The tree carries EXACTLY ONE copy of @anthropic-ai/sdk, held in place by
+# the `overrides` entry in package.json. The override exists because the
+# declared ranges have an empty intersection at their current releases:
+#   - @langchain/anthropic 1.5.x pins ^0.115.0 (0.x caret: excludes 0.116)
+#   - the backend SDKs (@anthropic-ai/vertex-sdk, @anthropic-ai/bedrock-sdk,
+#     @anthropic-ai/foundry-sdk) pin >=0.115.1 <1 (excludes 0.115.0)
+# and npm published only 0.115.0 and 0.116.0 in that window, so natural
+# resolution can never dedupe them. The override resolves everyone to
+# 0.116.0 — one additive minor above LangChain's declared range. Safe
+# because LangChain consumes stream events structurally and classifies
+# errors by HTTP status, not instanceof, and the vertex-seam/bedrock-seam/
+# foundry-seam characterization tests pin the exact combination in CI.
 #
-# Collapse condition: when the LangChain stack bump lands (@langchain/core
-# 1.2.x + @langchain/anthropic 1.5.x, which pins @anthropic-ai/sdk ^0.115),
-# npm dedupes to a single copy — tighten this check to single-copy then.
-# Any dependent other than these four, or a third distinct version, is
+# Override removal condition: drop the package.json override once
+# @langchain/anthropic's @anthropic-ai/sdk range again shares a version
+# with the backend SDKs' range — natural resolution then dedupes on its
+# own and this check keeps guarding the result.
+# Any dependent other than these four, or a SECOND distinct version, is
 # drift and fails the check.
 
 echo ""
@@ -112,8 +115,8 @@ ANTHROPIC_SDK_REPORT=$(npm ls @anthropic-ai/sdk --all --json 2>/dev/null \
       console.log(\`FAIL:unexpected dependents: \${badParents.join(', ')}\`);
       process.exit(0);
     }
-    if (versions.size > 2) {
-      console.log(\`FAIL:more than two distinct versions: \${[...versions].join(', ')}\`);
+    if (versions.size > 1) {
+      console.log(\`FAIL:more than one distinct version: \${[...versions].join(', ')}\`);
       process.exit(0);
     }
     console.log('PASS');
@@ -125,15 +128,16 @@ echo "$ANTHROPIC_SDK_REPORT" | grep -v '^PASS$' | grep -v '^FAIL:' || true
 if echo "$ANTHROPIC_SDK_REPORT" | grep -q '^FAIL:'; then
   echo ""
   echo "FAIL: @anthropic-ai/sdk copy check: $(echo "$ANTHROPIC_SDK_REPORT" | grep '^FAIL:' | sed 's/^FAIL://')"
-  echo "Only @langchain/anthropic (0.95.x) and the backend SDKs (>=0.115):"
-  echo "@anthropic-ai/vertex-sdk, @anthropic-ai/bedrock-sdk, and"
-  echo "@anthropic-ai/foundry-sdk may pull @anthropic-ai/sdk. See the comment"
-  echo "above this check for the rationale and collapse condition."
+  echo "The tree must hold a SINGLE @anthropic-ai/sdk copy (package.json"
+  echo "overrides pins it), and only @langchain/anthropic plus the backend"
+  echo "SDKs (@anthropic-ai/vertex-sdk, @anthropic-ai/bedrock-sdk,"
+  echo "@anthropic-ai/foundry-sdk) may depend on it. See the comment above"
+  echo "this check for the override rationale and its removal condition."
   exit 1
 fi
 
 if echo "$ANTHROPIC_SDK_REPORT" | grep -q '^PASS$'; then
-  echo "OK: @anthropic-ai/sdk copies match the known langchain + backend-sdk set"
+  echo "OK: single @anthropic-ai/sdk copy serving langchain + the backend SDKs"
 else
   echo "WARN: Could not determine @anthropic-ai/sdk copies (is npm ci done?)"
 fi

--- a/backend/services/runner/src/shared/__tests__/bedrock-seam.test.ts
+++ b/backend/services/runner/src/shared/__tests__/bedrock-seam.test.ts
@@ -2,11 +2,11 @@
  * Characterization test for the ChatAnthropic `createClient` ->
  * AnthropicBedrock seam — the integration the T04 bedrock backend adapter
  * is built on. Sibling of vertex-seam.test.ts; same rules: this pins REAL
- * cross-package behavior (`@langchain/anthropic` bundling @anthropic-ai/sdk
- * 0.95.x driving `@anthropic-ai/bedrock-sdk` bundling its own nested
- * >=0.115 copy), so a future bump of either side fails here in CI instead
- * of in production. See scripts/check-langchain-deps.sh for why the two
- * @anthropic-ai/sdk versions coexist and when they collapse to one.
+ * cross-package behavior (`@langchain/anthropic` driving
+ * `@anthropic-ai/bedrock-sdk`, both resolving the single override-pinned
+ * @anthropic-ai/sdk copy), so a future bump of either side fails here in
+ * CI instead of in production. See scripts/check-langchain-deps.sh for
+ * the override rationale and the single-copy invariant it guards.
  *
  * Determinism: zero live credentials, zero network. SigV4 signing runs for
  * real — it is pure HMAC over static test keys passed through the SDK's

--- a/backend/services/runner/src/shared/__tests__/foundry-seam.test.ts
+++ b/backend/services/runner/src/shared/__tests__/foundry-seam.test.ts
@@ -3,11 +3,11 @@
  * AnthropicFoundry seam — the integration the T05 foundry backend adapter
  * is built on. Sibling of vertex-seam.test.ts and bedrock-seam.test.ts;
  * same rules: this pins REAL cross-package behavior (`@langchain/anthropic`
- * bundling @anthropic-ai/sdk 0.95.x driving `@anthropic-ai/foundry-sdk`
- * bundling its own nested >=0.115 copy), so a future bump of either side
- * fails here in CI instead of in production. See
- * scripts/check-langchain-deps.sh for why the two @anthropic-ai/sdk
- * versions coexist and when they collapse to one.
+ * driving `@anthropic-ai/foundry-sdk`, both resolving the single
+ * override-pinned @anthropic-ai/sdk copy), so a future bump of either
+ * side fails here in CI instead of in production. See
+ * scripts/check-langchain-deps.sh for the override rationale and the
+ * single-copy invariant it guards.
  *
  * Determinism: zero live credentials, zero network. API-key auth is a
  * static test key; Entra ID auth is a fake `azureADTokenProvider` (the

--- a/backend/services/runner/src/shared/__tests__/vertex-adapter.test.ts
+++ b/backend/services/runner/src/shared/__tests__/vertex-adapter.test.ts
@@ -123,9 +123,9 @@ describe("buildChatModel vertex adapter", () => {
     // default applies. That default prefix-matches the model string — and the
     // vertex branch hands ChatAnthropic the TRANSLATED string. This pins the
     // equality the zero-behavior-change criterion rests on (verified 16384 ==
-    // 16384 for 4.5-generation ids at @langchain/anthropic 1.4.0); a future
-    // bump that diverges the two forms fails here instead of silently capping
-    // vertex deployments differently from public ones.
+    // 16384 for 4.5-generation ids at @langchain/anthropic 1.4.0, re-verified
+    // at 1.5.5); a future bump that diverges the two forms fails here instead
+    // of silently capping vertex deployments differently from public ones.
     for (const canonical of [
       "claude-sonnet-4-5-20250929",
       "claude-haiku-4-5-20251001",
@@ -135,6 +135,33 @@ describe("buildChatModel vertex adapter", () => {
       const vertexModel = new ChatAnthropic({ model: toVertexModelId(canonical), apiKey: "probe" });
       expect(vertexModel.maxTokens, canonical).toBe(publicModel.maxTokens);
     }
+  });
+
+  it("model.profile goes empty exactly when translation rewrites the id", () => {
+    // ChatAnthropic.profile resolves per model name, and — unlike the
+    // maxTokens default above — its lookup does NOT prefix-match: a dated
+    // id rewritten to Vertex's `@` form resolves {} (verified at
+    // @langchain/anthropic 1.4.0 and again at 1.5.5), while undated ids
+    // pass through toVertexModelId unchanged and keep their full profile.
+    // Nothing in the runner consumes profile directly, but deepagents'
+    // SummarizationMiddleware reads profile.maxInputTokens when present, so
+    // vertex deployments pinned to DATED ids summarize on its fallback
+    // budget rather than the model's real window. This pins both halves of
+    // that contract: if a bump starts resolving `@`-form ids (a welcome
+    // improvement — those deployments' summarization budgets would change),
+    // or stops resolving canonical ids, this fails and the behavior gets
+    // re-decided consciously instead of shifting silently.
+    for (const dated of ["claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001"]) {
+      const publicModel = new ChatAnthropic({ model: dated, apiKey: "probe" });
+      const vertexModel = new ChatAnthropic({ model: toVertexModelId(dated), apiKey: "probe" });
+      expect(publicModel.profile.maxInputTokens, dated).toBeGreaterThan(0);
+      expect(vertexModel.profile, dated).toEqual({});
+    }
+    const undated = "claude-sonnet-4-6";
+    expect(toVertexModelId(undated)).toBe(undated);
+    expect(
+      new ChatAnthropic({ model: undated, apiKey: "probe" }).profile.maxInputTokens,
+    ).toBeGreaterThan(0);
   });
 
   it("forwards the request timeout to the SDK client (STIGMER_LLM_REQUEST_TIMEOUT_MS path)", async () => {

--- a/backend/services/runner/src/shared/__tests__/vertex-seam.test.ts
+++ b/backend/services/runner/src/shared/__tests__/vertex-seam.test.ts
@@ -4,13 +4,13 @@
  *
  * This is NOT a unit test of our code (there is no production vertex code
  * yet). It pins the exact cross-package behavior production will rely on:
- * the REAL `ChatAnthropic` (@langchain/anthropic, bundling @anthropic-ai/sdk
- * 0.95.x) driving the REAL `AnthropicVertex` client (@anthropic-ai/vertex-sdk,
- * bundling its own nested @anthropic-ai/sdk >=0.115). If a future bump of
+ * the REAL `ChatAnthropic` (@langchain/anthropic) driving the REAL
+ * `AnthropicVertex` client (@anthropic-ai/vertex-sdk), both resolving the
+ * single override-pinned @anthropic-ai/sdk copy. If a future bump of
  * either side changes request shaping, streaming event handling, tool-call
  * assembly, or usage accounting across this seam, this suite fails in CI
- * instead of production. See scripts/check-langchain-deps.sh for why two
- * @anthropic-ai/sdk copies coexist and when they collapse to one.
+ * instead of production. See scripts/check-langchain-deps.sh for the
+ * override rationale and the single-copy invariant it guards.
  *
  * Determinism: zero credentials, zero network. Google auth is bypassed by
  * injecting a fake `authClient` (the SDK's supported constructor option —


### PR DESCRIPTION
## Summary

Executes the recorded collapse condition from the provider-backend work: bumps `@langchain/core` to 1.2.7 and `@langchain/anthropic` to 1.5.5 in isolation, and the runner's dependency tree now holds a single `@anthropic-ai/sdk` copy — enforced by the tightened `check-langchain-deps.sh`.

Closes #443

## Context

The tree deliberately carried two `@anthropic-ai/sdk` copies (0.95.2 hoisted for `@langchain/anthropic`, 0.116.0 nested under the vertex/bedrock/foundry SDKs) since T02, with the collapse condition documented in the check script itself.

## Changes

- `@langchain/core` `^1.1.47` → `^1.2.7`, `@langchain/anthropic` `^1.4.0` → `^1.5.5` — nothing else rides; every installed peer range admits core 1.2.x, and `@langchain/core` stays a single copy (1.2.7) across the tree.
- New `overrides: { "@anthropic-ai/sdk": "0.116.0" }` pinning the single copy (owner-approved). The declared ranges have an **empty intersection** at current releases — `@langchain/anthropic` 1.5.x pins `^0.115.0` (excludes 0.116) while all three backend SDKs pin `>=0.115.1 <1` (excludes 0.115.0), and only 0.115.0/0.116.0 exist — so natural resolution can never dedupe them. The override resolves everyone to 0.116.0, one additive minor above LangChain's declared range (the 0.115→0.116 diff is additive: new beta flags, matchable tool-error classes, a User-Agent fix); the seam suites pin the exact combination. Removal condition documented in the check script: drop the override once the ranges regain a common version.
- `check-langchain-deps.sh` tightened from "≤2 versions with a known parent set" to single-copy enforcement, with the header rewritten to record the override rationale and its removal condition.
- Truth-up of the retired "two copies" prose in the `vertex-seam`/`bedrock-seam`/`foundry-seam` test headers.
- New pin in `vertex-adapter.test.ts`: `model.profile` resolves for canonical ids and goes empty exactly when translation rewrites the id to Vertex's `@` form (re-verified at 1.5.5; undated ids pass through translation unchanged and keep their profile) — the acceptance's "re-check profile each bump" is now self-verifying.
- The existing `maxTokens` canonical-vs-translated equality pin passes UNCHANGED at 1.5.5 (comment records the re-verification).

## Implementation notes

- LangChain follows strict semver post-1.0 (breaking changes only in majors). Behaviorally relevant 1.5.x items were reviewed and are covered by existing pins: widened native `streamEvents` coverage (seam suites), the `thinking: disabled` emission fix, and routine model-profile refreshes (the `maxTokens` pin asserts equality, not absolute values).
- Lockfile churn is surgical: the three nested SDK nodes deleted, one hoisted overridden node, plus the two bumped packages.

## Breaking changes

- None.

## Test plan

- `npm run check-deps`: single `@anthropic-ai/sdk` 0.116.0 serving `@langchain/anthropic` + all three backend SDKs; single `@langchain/core` 1.2.7.
- Full runner suite: 4659 passed, 0 failed (6 skipped).
- Offline integration suite (`make test-integration-offline` against the stigmer-cloud fat JAR): 76 tests, 2 skipped, PASS.
- `npm run verify:dist` green; `npm run build:slim` + `verify:slim --no-temporal` green (83.5 MB ≤ 120 MB, authed-guard boot intact).
- `tsc --noEmit` clean.

## Risks

- `@langchain/anthropic` runs one additive minor above its declared SDK range under the override; the vertex/bedrock/foundry seam characterization suites pin the real cross-package behavior in CI, so a genuinely incompatible future combination fails there instead of in production. Rollback is reverting the commit.

## Checklist

- [x] Docs updated (check-script header + seam-test prose truth-up)
- [x] Tests added/updated (model.profile pin; all pins re-verified)
- [x] Backward compatible

Made with [Cursor](https://cursor.com)