### PR TITLE
feat(seedpack): add PayPal Sandbox tile for the sandbox MCP origin

### DIFF
--- a/seedpack/canary/credential-manifest.yaml
+++ b/seedpack/canary/credential-manifest.yaml
@@ -164,6 +164,12 @@ servers:
     env_var: PAYPAL_ACCESS_TOKEN
     notes: "OAuth confirmed by live probe 2026-08-11: /mcp and /sse both answer 401 with an RFC 9728 WWW-Authenticate challenge; anonymous DCR live at /register. Endpoint moved /sse -> /mcp (vendor quickstart is stale: its documented /http returns 404; stigmer/stigmer#231). Authenticated tools/list not yet verified — reporter to confirm post-deploy."
 
+  paypal-sandbox:
+    status: oauth_only
+    auth_type: dcr_oauth
+    env_var: PAYPAL_ACCESS_TOKEN
+    notes: "Sandbox twin of the paypal entry — a distinct origin and therefore a distinct OAuth world (stigmer/stigmer#421). Confirmed by live probe 2026-08-14: /mcp answers 401 with an RFC 9728 WWW-Authenticate challenge (resource_metadata on the sandbox origin); RFC 8414 metadata live with anonymous DCR at /register, PKCE S256. Authenticated tools/list not yet verified — needs a sandbox business account."
+
   slack:
     status: oauth_only
     auth_type: vendor_oauth

--- a/seedpack/mcp-servers/paypal-sandbox.yaml
+++ b/seedpack/mcp-servers/paypal-sandbox.yaml
@@ -1,0 +1,38 @@
+apiVersion: agentic.stigmer.ai/v1
+kind: McpServer
+metadata:
+  name: PayPal Sandbox
+  visibility: visibility_public
+  labels:
+    stigmer.ai/category: "payments"
+spec:
+  description: "PayPal sandbox MCP server for testing payments, invoicing, and e-commerce integrations against developer.paypal.com sandbox accounts. Same tools as the PayPal server; use PayPal for live payments."
+  icon_url: "https://raw.githubusercontent.com/stigmer/stigmer/main/seedpack/icons/mcp-servers/paypal.svg"
+  repository_url: "https://github.com/paypal/paypal-mcp-server"
+  github_stars: 9
+  tags:
+    - paypal
+    - sandbox
+    - payments
+    - e-commerce
+    - invoicing
+  http:
+    # PayPal's sandbox MCP origin — a separate deployment from mcp.paypal.com,
+    # not a path or parameter on it. OAuth grants are origin-scoped (RFC 8414
+    # discovery is scheme+host), so sandbox and production are distinct auth
+    # worlds; this tile exists so a sandbox sign-in and the sandbox endpoint
+    # stay consistent by construction (stigmer/stigmer#421). Verified live
+    # 2026-08-14: /mcp answers 401 with a spec-correct RFC 9728
+    # WWW-Authenticate challenge whose resource_metadata points at the sandbox
+    # origin, and the sandbox publishes its own RFC 8414 metadata with
+    # anonymous DCR at /register (PKCE S256) — the same shape as production.
+    url: "https://mcp.sandbox.paypal.com/mcp"
+    headers:
+      Authorization: "Bearer ${PAYPAL_ACCESS_TOKEN}"
+  env:
+    PAYPAL_ACCESS_TOKEN:
+      is_secret: true
+      description: "PayPal sandbox API key or OAuth access token (generate against a sandbox business account at developer.paypal.com/dashboard)"
+  auth:
+    target_env_var: "PAYPAL_ACCESS_TOKEN"
+    token_lifetime_hint: "1h"

--- a/seedpack/mcp-servers/paypal.yaml
+++ b/seedpack/mcp-servers/paypal.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     stigmer.ai/category: "payments"
 spec:
-  description: "PayPal MCP server for payment processing, invoicing, transaction management, and e-commerce operations."
+  description: "PayPal MCP server for payment processing, invoicing, transaction management, and e-commerce operations. For testing against sandbox credentials, use the PayPal Sandbox server."
   icon_url: "https://raw.githubusercontent.com/stigmer/stigmer/main/seedpack/icons/mcp-servers/paypal.svg"
   repository_url: "https://github.com/paypal/paypal-mcp-server"
   github_stars: 9


### PR DESCRIPTION
## Summary
Adds a `PayPal Sandbox` marketplace tile pointing at `https://mcp.sandbox.paypal.com/mcp`, so developers working against PayPal sandbox credentials can connect to the environment they actually signed into instead of the production origin.

## Context
PayPal runs distinct sandbox and production MCP origins, and the seedpack tile pins production (#421, suggested by the #231 reporter). OAuth grants are origin-scoped — RFC 8414 discovery is scheme+host — so sandbox and production are separate auth worlds. The platform keys OAuth grants, DCR client registrations, managed token environments, and discovered capabilities per McpServer resource, which makes a second resource the design that keeps grant and endpoint consistent by construction; an env-variant selector on the spec would instead re-key the grant model and invent selector UX with no precedent.

## Changes
- `seedpack/mcp-servers/paypal-sandbox.yaml`: new tile (`metadata.name: PayPal Sandbox` → slug `paypal-sandbox`), same `payments` category and icon, sandbox origin URL with the probe evidence inline, sandbox-credential env wording, DCR auth block mirroring the production tile
- `seedpack/mcp-servers/paypal.yaml`: description cross-links the sandbox tile
- `seedpack/canary/credential-manifest.yaml`: `paypal-sandbox` entry (`oauth_only`/`dcr_oauth`) so the nightly canary owns the new endpoint

## Implementation notes
- Verified live 2026-08-14: sandbox `/mcp` answers 401 with a spec-correct RFC 9728 `WWW-Authenticate` challenge (`resource_metadata` on the sandbox origin), and the sandbox publishes its own RFC 8414 metadata with anonymous DCR at `/register` (PKCE S256) — the same shape production had at the #231 fix. The tile works on the existing DCR arm with zero backend code.
- Authenticated `tools/list` not yet verified (needs a sandbox business account) — recorded in the canary manifest note, same caveat the production entry carries.

## Breaking changes
- None

## Test plan
- `go test ./seedpack/...` green (schema guard, category allowlist, auth consistency, manifest completeness, duplicate-name, retired-endpoint denylist, content-hash parity)
- Live endpoint probe evidence recorded inline; the nightly transport canary probes the sandbox URL from now on

## Risks
- Sandbox origin behavior could drift from production; the transport canary and credential manifest catch that. Rollback is deleting the tile + manifest entry.

## Checklist
- [x] Docs updated (if needed) — none required; no guide documents per-vendor endpoints
- [x] Tests added/updated (if needed) — covered by existing guard suite by design
- [x] Backward compatible

Closes #421

Made with [Cursor](https://cursor.com)