### PR TITLE
fix(backend/runner): hash-keyed skill mount cache for the deep-agent path

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync } from "no
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ConnectError, Code } from "@connectrpc/connect";
-import { resolveSkills, downloadArtifact } from "../skill-resolver.js";
+import { resolveSkills } from "../skill-resolver.js";
 import { buildZip } from "../../../__test-utils__/zip-fixtures.js";
 
 /** A server that predates the transfer lane (#675) answers the mint RPC
@@ -390,96 +390,5 @@ describe("resolveSkills — artifact extraction", () => {
   });
 });
 
-// ─── downloadArtifact — transfer lane routing (#675) ─────────────────────
-
-describe("downloadArtifact — transfer lane routing", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  function makeClient(overrides: Record<string, any> = {}) {
-    return {
-      getSkillArtifact: vi.fn().mockResolvedValue({ artifact: new Uint8Array(0) }),
-      getSkillArtifactDownloadUrl: unimplementedMint(),
-      ...overrides,
-    } as any;
-  }
-
-  it("fetches bytes over HTTP when the server mints a download URL", async () => {
-    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
-    const client = makeClient({
-      getSkillArtifactDownloadUrl: vi.fn().mockResolvedValue({
-        url: "http://localhost:7234/v1/skill-artifacts/skills/abc.zip",
-        sizeBytes: 5n,
-        ttlSeconds: 0,
-      }),
-    });
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      arrayBuffer: async () => bytes.buffer,
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const got = await downloadArtifact(client, "skills/abc.zip");
-
-    expect(got).toEqual(bytes);
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:7234/v1/skill-artifacts/skills/abc.zip");
-    // The unary lane (10MB-capped) must not be touched when the URL lane works.
-    expect(client.getSkillArtifact).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the unary RPC when the server predates the lane", async () => {
-    const bytes = new Uint8Array([9, 9]);
-    const client = makeClient({
-      getSkillArtifact: vi.fn().mockResolvedValue({ artifact: bytes }),
-    });
-    vi.stubGlobal("fetch", vi.fn()); // must never be called
-
-    const got = await downloadArtifact(client, "skills/abc.zip");
-
-    expect(got).toEqual(bytes);
-    expect(client.getSkillArtifact).toHaveBeenCalledWith("skills/abc.zip");
-    expect(fetch).not.toHaveBeenCalled();
-  });
-
-  it("does NOT fall back on non-Unimplemented mint failures", async () => {
-    const client = makeClient({
-      getSkillArtifactDownloadUrl: vi.fn().mockRejectedValue(
-        new ConnectError("boom", Code.Internal),
-      ),
-    });
-
-    await expect(downloadArtifact(client, "skills/abc.zip")).rejects.toThrow("boom");
-    // Falling back here would mask real server faults behind the capped lane.
-    expect(client.getSkillArtifact).not.toHaveBeenCalled();
-  });
-
-  it("rejects truncated fetches via the minted size", async () => {
-    const client = makeClient({
-      getSkillArtifactDownloadUrl: vi.fn().mockResolvedValue({
-        url: "http://localhost:7234/v1/skill-artifacts/skills/abc.zip",
-        sizeBytes: 100n,
-        ttlSeconds: 0,
-      }),
-    });
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
-    }));
-
-    await expect(downloadArtifact(client, "skills/abc.zip")).rejects.toThrow(/truncated/);
-  });
-
-  it("surfaces HTTP failures with the status code", async () => {
-    const client = makeClient({
-      getSkillArtifactDownloadUrl: vi.fn().mockResolvedValue({
-        url: "http://localhost:7234/v1/skill-artifacts/skills/gone.zip",
-        sizeBytes: 0n,
-        ttlSeconds: 0,
-      }),
-    });
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
-
-    await expect(downloadArtifact(client, "skills/gone.zip")).rejects.toThrow(/HTTP 404/);
-  });
-});
+// downloadArtifact's transfer-lane routing tests moved with the code to
+// shared/__tests__/skill-mount.test.ts (issue #337 extraction).

--- a/backend/services/runner/src/activities/execute-cursor/skill-resolver.ts
+++ b/backend/services/runner/src/activities/execute-cursor/skill-resolver.ts
@@ -2,8 +2,8 @@
  * Resolves skill resources and writes them to the platform-managed directory.
  *
  * - Fetches skills via gRPC (by reference)
- * - Writes SKILL.md to .stigmer/skills/{name}/SKILL.md
- * - Downloads and extracts ZIP artifacts (references/, scripts/, etc.)
+ * - Mounts each skill via the shared skill-mount mechanics (SKILL.md +
+ *   extracted artifact, hash-keyed cache — see shared/skill-mount.ts)
  * - Uses a platform-managed directory outside the workspace
  * - Ensures the workspace `.stigmer` symlink (see stigmer-link.ts)
  * - Returns metadata for prompt injection
@@ -17,37 +17,19 @@
  * transfer.
  */
 
-import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
-import { join, dirname } from "node:path";
-import { ConnectError, Code } from "@connectrpc/connect";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import type { StigmerClient } from "../../client/stigmer-client.js";
-import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
 import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 import type { SkillMetadata } from "./prompt-builder.js";
 import { getPlatformDir } from "../../shared/workspace/platform-dir.js";
-import { extractZipFileEntries } from "../../shared/zip-extract.js";
+import {
+  SKILLS_SUBDIR,
+  mountIsFresh,
+  downloadArtifact,
+  writeSkillMount,
+} from "../../shared/skill-mount.js";
 import { ensureStigmerSymlink, STIGMER_LOCAL_STATE_DIR } from "../../shared/workspace/stigmer-link.js";
-
-const SKILLS_SUBDIR = "skills";
-
-/**
- * Marker recording what a skill's mount directory currently holds. Written
- * LAST, after every file of the mount landed — a crash mid-write leaves no
- * marker, so the next execution remounts instead of trusting a partial tree.
- */
-const MOUNT_MARKER_FILE = ".stigmer-mount.json";
-
-interface MountMarker {
-  /** Content-addressed version hash (`Skill.status.version_hash`) of the mounted content. */
-  versionHash: string;
-  /**
-   * Whether the artifact's files are part of the mount. `false` when the
-   * skill has no artifact OR when the download failed and the mount fell
-   * back to SKILL.md only — the latter makes the next execution retry the
-   * download rather than cache the degraded mount.
-   */
-  artifactMounted: boolean;
-}
 
 export interface SkillResolverOptions {
   sessionId: string;
@@ -144,113 +126,4 @@ export async function resolveSkills(
   );
 
   return results;
-}
-
-/**
- * Whether the mount at `skillDir` already holds this version's content.
- *
- * Fresh means: the marker's hash matches AND the mount isn't a degraded
- * SKILL.md-only fallback when the skill does carry an artifact. Any read or
- * parse failure counts as stale — the remount is the safe default.
- */
-async function mountIsFresh(skillDir: string, versionHash: string, wantsArtifact: boolean): Promise<boolean> {
-  try {
-    const raw = await readFile(join(skillDir, MOUNT_MARKER_FILE), "utf-8");
-    const marker = JSON.parse(raw) as Partial<MountMarker>;
-    return marker.versionHash === versionHash && (marker.artifactMounted === true || !wantsArtifact);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Download a skill artifact's ZIP bytes, transfer lane first (#675).
- *
- * The URL lane (getArtifactDownloadUrl → HTTP GET) carries any valid skill
- * size; the unary getArtifact response is capped by the server's 10MB gRPC
- * message limit. Servers that predate the lane (and cloud until its sibling
- * lands) answer the mint with UNIMPLEMENTED — those fall back to the unary
- * path, which behaves exactly as before for ≤10MB artifacts.
- *
- * Runs only on a mount-cache miss (#672's hash-keyed marker above) — a hit
- * skips the transfer entirely, whichever lane would have carried it.
- *
- * Exported for tests.
- */
-export async function downloadArtifact(
-  client: StigmerClient,
-  artifactStorageKey: string,
-): Promise<Uint8Array | undefined> {
-  let minted;
-  try {
-    minted = await client.getSkillArtifactDownloadUrl(artifactStorageKey);
-  } catch (err) {
-    if (err instanceof ConnectError && err.code === Code.Unimplemented) {
-      const resp = await client.getSkillArtifact(artifactStorageKey);
-      return resp.artifact && resp.artifact.length > 0 ? resp.artifact : undefined;
-    }
-    throw err;
-  }
-
-  const resp = await fetch(minted.url);
-  if (!resp.ok) {
-    throw new Error(`artifact fetch failed: HTTP ${resp.status} from ${minted.url}`);
-  }
-  const bytes = new Uint8Array(await resp.arrayBuffer());
-  if (minted.sizeBytes > 0n && BigInt(bytes.length) !== minted.sizeBytes) {
-    throw new Error(
-      `artifact fetch truncated: got ${bytes.length} bytes, expected ${minted.sizeBytes}`,
-    );
-  }
-  return bytes.length > 0 ? bytes : undefined;
-}
-
-/**
- * (Re)write a skill's mount directory from scratch.
- *
- * The directory is removed first so files deleted between versions don't
- * linger in the mount, then SKILL.md and the artifact files are written, and
- * the marker is stamped LAST (see MOUNT_MARKER_FILE for the crash-safety
- * contract). SKILL.md always comes from `spec.skillMd` — the server's
- * authoritative copy — never from the zip; both the zip's SKILL.md and any
- * stray marker-named entry are excluded from extraction so the mount's
- * ownership of those two files is unconditional.
- */
-async function writeSkillMount(
-  skill: Skill,
-  skillDir: string,
-  artifactBytes: Uint8Array | undefined,
-): Promise<void> {
-  await rm(skillDir, { recursive: true, force: true });
-  await mkdir(skillDir, { recursive: true });
-
-  await writeFile(join(skillDir, "SKILL.md"), skill.spec!.skillMd, "utf-8");
-
-  const artifactMounted = artifactBytes !== undefined && artifactBytes.length > 0;
-  if (artifactMounted) {
-    const entries = await extractZipFileEntries(artifactBytes, { exclude: ["SKILL.md", MOUNT_MARKER_FILE] });
-    for (const entry of entries) {
-      const filePath = join(skillDir, entry.path);
-      await mkdir(dirname(filePath), { recursive: true });
-      await writeFile(filePath, entry.content);
-    }
-  }
-
-  const versionHash = skill.status?.versionHash ?? "";
-  if (versionHash !== "") {
-    const marker: MountMarker = { versionHash, artifactMounted };
-    await writeFile(join(skillDir, MOUNT_MARKER_FILE), JSON.stringify(marker), "utf-8");
-  }
-}
-
-/**
- * Clean up platform-managed skill directory for a session.
- */
-export async function cleanupSkills(sessionId: string): Promise<void> {
-  const platformDir = getPlatformDir(sessionId);
-  try {
-    await rm(platformDir, { recursive: true, force: true });
-  } catch {
-    // best-effort
-  }
 }

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -88,12 +88,9 @@ import type { ToolApprovalCategory } from "../../shared/tool-kind.js";
 import {
   mergeSkillRefs,
   fetchSkillsByRefs,
-  writeSkills,
-  computeSkillPaths,
-  checkSkillIntegrity,
+  mountSkills,
   generatePromptSection,
   generateAlsoAvailableSection,
-  fetchSkillArtifacts,
 } from "../../shared/skill-writer.js";
 import { filterSkills, SKILL_COUNT_THRESHOLD } from "../../shared/skill-relevance.js";
 import { injectAttachments } from "./attachment-injector.js";
@@ -478,8 +475,11 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       const skills = await fetchSkillsByRefs(client, skillRefs);
 
       if (skills.length > 0) {
-        const artifacts = await fetchSkillArtifacts(client, skills);
-        const { paths: skillPaths } = await writeSkills(skills, workspaceBackend, artifacts);
+        // platformDir is an invariant of this path: provisionWorkspace below
+        // threads ensurePlatformDir into every backend it constructs.
+        const { paths: skillPaths } = await mountSkills(
+          client, skills, workspaceBackend.platformDir!,
+        );
 
         const userMessage = execution.spec!.message || "";
         const skillNames = skills.map(s => s.spec?.name || s.metadata?.slug || "unknown");

--- a/backend/services/runner/src/activities/execute-deep-agent/subagent-transformer.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/subagent-transformer.ts
@@ -42,8 +42,7 @@ import { SubAgentGate } from "../../shared/subagent-gate.js";
 import { isModelRegistered } from "../../shared/model-registry.js";
 import {
   fetchSkillsByRefs,
-  fetchSkillArtifacts,
-  writeSkills,
+  mountSkills,
   generatePromptSection,
 } from "../../shared/skill-writer.js";
 
@@ -681,8 +680,14 @@ export async function transformAndCompileSubagents(
       const skills = await fetchSkillsByRefs(skillClient, refs);
 
       if (skills.length > 0) {
-        const artifacts = await fetchSkillArtifacts(skillClient, skills);
-        const { paths: skillPaths } = await writeSkills(skills, workspaceBackend, artifacts);
+        // Runs after the parent's setup step 7b mounted its skills, so any
+        // skill shared by parent and sub-agent is a cache hit here — the
+        // hash-keyed marker turns the old double download into a no-op.
+        // platformDir is an invariant: provisionWorkspace threads
+        // ensurePlatformDir into every backend it constructs.
+        const { paths: skillPaths } = await mountSkills(
+          skillClient, skills, workspaceBackend.platformDir!,
+        );
 
         for (const skill of skills) {
           const slug = (skill as { metadata?: { slug?: string } }).metadata?.slug;

--- a/backend/services/runner/src/shared/__tests__/skill-mount.test.ts
+++ b/backend/services/runner/src/shared/__tests__/skill-mount.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ConnectError, Code } from "@connectrpc/connect";
+import {
+  MOUNT_MARKER_FILE,
+  mountIsFresh,
+  downloadArtifact,
+  writeSkillMount,
+} from "../skill-mount.js";
+import { buildZip } from "../../__test-utils__/zip-fixtures.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function makeSkillProto(overrides: {
+  name?: string;
+  skillMd?: string;
+  artifactStorageKey?: string;
+  versionHash?: string;
+} = {}) {
+  return {
+    metadata: {
+      id: `skill-${overrides.name ?? "test"}`,
+      slug: overrides.name ?? "test-skill",
+      org: "test-org",
+    },
+    spec: {
+      name: overrides.name ?? "test-skill",
+      description: "A test skill",
+      skillMd: overrides.skillMd ?? "# Test Skill",
+    },
+    status: {
+      artifactStorageKey: overrides.artifactStorageKey ?? "",
+      versionHash: overrides.versionHash ?? "abc",
+    },
+  } as any;
+}
+
+// ─── writeSkillMount + mountIsFresh — marker mechanics ───────────────────
+
+describe("writeSkillMount — marker mechanics", () => {
+  let skillDir: string;
+
+  beforeEach(() => {
+    skillDir = join(mkdtempSync(join(tmpdir(), "skill-mount-")), "test-skill");
+  });
+
+  afterEach(() => {
+    rmSync(join(skillDir, ".."), { recursive: true, force: true });
+  });
+
+  it("stamps a marker recording the hash and a fully mounted artifact", async () => {
+    const artifact = buildZip([{ name: "references/guide.md", content: "guide" }]);
+    await writeSkillMount(makeSkillProto({ versionHash: "hash-v1" }), skillDir, artifact);
+
+    const marker = JSON.parse(readFileSync(join(skillDir, MOUNT_MARKER_FILE), "utf-8"));
+    expect(marker).toEqual({ versionHash: "hash-v1", artifactMounted: true });
+    expect(await mountIsFresh(skillDir, "hash-v1", true)).toBe(true);
+  });
+
+  it("records a degraded SKILL.md-only mount so the next execution retries the artifact", async () => {
+    await writeSkillMount(makeSkillProto({ versionHash: "hash-v1" }), skillDir, undefined);
+
+    const marker = JSON.parse(readFileSync(join(skillDir, MOUNT_MARKER_FILE), "utf-8"));
+    expect(marker).toEqual({ versionHash: "hash-v1", artifactMounted: false });
+    // Stale for a skill that carries an artifact (retry the download)...
+    expect(await mountIsFresh(skillDir, "hash-v1", true)).toBe(false);
+    // ...fresh for a skill that never had one.
+    expect(await mountIsFresh(skillDir, "hash-v1", false)).toBe(true);
+  });
+
+  it("stamps no marker when the skill has no version hash — such mounts never cache", async () => {
+    await writeSkillMount(makeSkillProto({ versionHash: "" }), skillDir, undefined);
+
+    expect(existsSync(join(skillDir, MOUNT_MARKER_FILE))).toBe(false);
+    expect(await mountIsFresh(skillDir, "", false)).toBe(false);
+  });
+
+  it("is stale for a different hash", async () => {
+    await writeSkillMount(makeSkillProto({ versionHash: "hash-v1" }), skillDir, undefined);
+    expect(await mountIsFresh(skillDir, "hash-v2", false)).toBe(false);
+  });
+
+  it("is stale when the marker is missing or unparseable", async () => {
+    expect(await mountIsFresh(skillDir, "hash-v1", false)).toBe(false);
+  });
+
+  it("removes files from a previous mount that the new version no longer carries", async () => {
+    const v1 = buildZip([{ name: "references/removed-in-v2.md", content: "old" }]);
+    const v2 = buildZip([{ name: "references/new-in-v2.md", content: "new" }]);
+
+    await writeSkillMount(makeSkillProto({ versionHash: "hash-v1" }), skillDir, v1);
+    await writeSkillMount(makeSkillProto({ versionHash: "hash-v2" }), skillDir, v2);
+
+    expect(existsSync(join(skillDir, "references", "removed-in-v2.md"))).toBe(false);
+    expect(readFileSync(join(skillDir, "references", "new-in-v2.md"), "utf-8")).toBe("new");
+  });
+
+  it("owns SKILL.md and the marker name unconditionally — zip copies are ignored", async () => {
+    const artifact = buildZip([
+      { name: "SKILL.md", content: "# Stale zip copy" },
+      { name: MOUNT_MARKER_FILE, content: "{\"versionHash\":\"forged\"}" },
+    ]);
+    await writeSkillMount(
+      makeSkillProto({ skillMd: "# Authoritative", versionHash: "hash-v1" }),
+      skillDir,
+      artifact,
+    );
+
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toBe("# Authoritative");
+    const marker = JSON.parse(readFileSync(join(skillDir, MOUNT_MARKER_FILE), "utf-8"));
+    expect(marker.versionHash).toBe("hash-v1");
+  });
+
+  it("rejects zip entries that escape the mount directory", async () => {
+    const artifact = buildZip([{ name: "../escape.txt", content: "evil" }]);
+
+    await expect(
+      writeSkillMount(makeSkillProto({ versionHash: "hash-v1" }), skillDir, artifact),
+    ).rejects.toThrow(/escapes its mount directory/);
+    expect(existsSync(join(skillDir, "..", "escape.txt"))).toBe(false);
+    // The interrupted mount must not have been stamped as complete.
+    expect(existsSync(join(skillDir, MOUNT_MARKER_FILE))).toBe(false);
+  });
+
+  it("writes script entries with the executable bit set", async () => {
+    const artifact = buildZip([
+      { name: "scripts/run.py", content: "print('hi')" },
+      { name: "references/notes.md", content: "notes" },
+    ]);
+    await writeSkillMount(makeSkillProto({ versionHash: "hash-v1" }), skillDir, artifact);
+
+    expect(statSync(join(skillDir, "scripts", "run.py")).mode & 0o111).not.toBe(0);
+    expect(statSync(join(skillDir, "references", "notes.md")).mode & 0o111).toBe(0);
+  });
+});
+
+// ─── downloadArtifact — transfer lane routing (#675) ─────────────────────
+
+/** A server that predates the transfer lane (#675) answers the mint RPC
+ * with UNIMPLEMENTED — the default posture for these tests, which keeps
+ * every pre-existing case pinned to the unary getSkillArtifact fallback. */
+function unimplementedMint() {
+  return vi.fn().mockRejectedValue(new ConnectError("unimplemented", Code.Unimplemented));
+}
+
+describe("downloadArtifact — transfer lane routing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function makeClient(overrides: Record<string, any> = {}) {
+    return {
+      getSkillArtifact: vi.fn().mockResolvedValue({ artifact: new Uint8Array(0) }),
+      getSkillArtifactDownloadUrl: unimplementedMint(),
+      ...overrides,
+    } as any;
+  }
+
+  it("fetches bytes over HTTP when the server mints a download URL", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const client = makeClient({
+      getSkillArtifactDownloadUrl: vi.fn().mockResolvedValue({
+        url: "http://localhost:7234/v1/skill-artifacts/skills/abc.zip",
+        sizeBytes: 5n,
+        ttlSeconds: 0,
+      }),
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => bytes.buffer,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const got = await downloadArtifact(client, "skills/abc.zip");
+
+    expect(got).toEqual(bytes);
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:7234/v1/skill-artifacts/skills/abc.zip");
+    // The unary lane (10MB-capped) must not be touched when the URL lane works.
+    expect(client.getSkillArtifact).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the unary RPC when the server predates the lane", async () => {
+    const bytes = new Uint8Array([9, 9]);
+    const client = makeClient({
+      getSkillArtifact: vi.fn().mockResolvedValue({ artifact: bytes }),
+    });
+    vi.stubGlobal("fetch", vi.fn()); // must never be called
+
+    const got = await downloadArtifact(client, "skills/abc.zip");
+
+    expect(got).toEqual(bytes);
+    expect(client.getSkillArtifact).toHaveBeenCalledWith("skills/abc.zip");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fall back on non-Unimplemented mint failures", async () => {
+    const client = makeClient({
+      getSkillArtifactDownloadUrl: vi.fn().mockRejectedValue(
+        new ConnectError("boom", Code.Internal),
+      ),
+    });
+
+    await expect(downloadArtifact(client, "skills/abc.zip")).rejects.toThrow("boom");
+    // Falling back here would mask real server faults behind the capped lane.
+    expect(client.getSkillArtifact).not.toHaveBeenCalled();
+  });
+
+  it("rejects truncated fetches via the minted size", async () => {
+    const client = makeClient({
+      getSkillArtifactDownloadUrl: vi.fn().mockResolvedValue({
+        url: "http://localhost:7234/v1/skill-artifacts/skills/abc.zip",
+        sizeBytes: 100n,
+        ttlSeconds: 0,
+      }),
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    }));
+
+    await expect(downloadArtifact(client, "skills/abc.zip")).rejects.toThrow(/truncated/);
+  });
+
+  it("surfaces HTTP failures with the status code", async () => {
+    const client = makeClient({
+      getSkillArtifactDownloadUrl: vi.fn().mockResolvedValue({
+        url: "http://localhost:7234/v1/skill-artifacts/skills/gone.zip",
+        sizeBytes: 0n,
+        ttlSeconds: 0,
+      }),
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    await expect(downloadArtifact(client, "skills/gone.zip")).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/backend/services/runner/src/shared/__tests__/skill-writer.test.ts
+++ b/backend/services/runner/src/shared/__tests__/skill-writer.test.ts
@@ -1,17 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ConnectError, Code } from "@connectrpc/connect";
 import {
   mergeSkillRefs,
   fetchSkillsByRefs,
-  writeSkills,
-  computeSkillPaths,
-  checkSkillIntegrity,
+  mountSkills,
   generatePromptSection,
   generateAlsoAvailableSection,
-  fetchSkillArtifacts,
 } from "../skill-writer.js";
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
 import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
-import type { WorkspaceBackend } from "../workspace/types.js";
+import { buildZip } from "../../__test-utils__/zip-fixtures.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -19,16 +20,18 @@ function makeSkill(overrides: {
   id?: string;
   name?: string;
   slug?: string;
+  org?: string;
   description?: string;
   skillMd?: string;
   artifactStorageKey?: string;
+  versionHash?: string;
 } = {}): Skill {
   return {
     metadata: {
       id: overrides.id ?? "skill-id-1",
       name: overrides.name ?? overrides.slug ?? "test-skill",
       slug: overrides.slug ?? "test-skill",
-      org: "test-org",
+      org: overrides.org ?? "test-org",
     },
     spec: {
       name: overrides.name ?? "test-skill",
@@ -38,7 +41,7 @@ function makeSkill(overrides: {
     },
     status: {
       artifactStorageKey: overrides.artifactStorageKey ?? "",
-      versionHash: "abc123",
+      versionHash: overrides.versionHash ?? "abc123",
       state: "active",
     },
   } as any;
@@ -48,46 +51,19 @@ function makeRef(slug: string, org = "test-org"): ApiResourceReference {
   return { slug, org, kind: 43 } as any;
 }
 
+/** A server that predates the transfer lane (#675) answers the mint RPC
+ * with UNIMPLEMENTED, pinning these tests to the unary fallback. */
 function makeMockClient(overrides: Record<string, unknown> = {}) {
   return {
     getSkillByReference: vi.fn().mockImplementation((ref: any) =>
       Promise.resolve(makeSkill({ slug: ref.slug, name: ref.slug })),
     ),
     getSkillArtifact: vi.fn().mockResolvedValue({ artifact: new Uint8Array(0) }),
+    getSkillArtifactDownloadUrl: vi.fn().mockRejectedValue(
+      new ConnectError("unimplemented", Code.Unimplemented),
+    ),
     ...overrides,
   } as any;
-}
-
-function makeMockBackend(): WorkspaceBackend & {
-  writtenFiles: Map<string, string>;
-  executedCommands: string[];
-  existingFiles: Set<string>;
-} {
-  const writtenFiles = new Map<string, string>();
-  const executedCommands: string[] = [];
-  const existingFiles = new Set<string>();
-  return {
-    rootDir: "/workspace",
-    writtenFiles,
-    executedCommands,
-    existingFiles,
-    async writeFile(path: string, content: string) {
-      writtenFiles.set(path, content);
-    },
-    async writeFileBuffer(path: string, content: Buffer) {
-      writtenFiles.set(path, content.toString("utf-8"));
-    },
-    async readFile(path: string) {
-      return writtenFiles.get(path) ?? "";
-    },
-    async exists(path: string) {
-      return writtenFiles.has(path) || existingFiles.has(path);
-    },
-    async execute(command: string) {
-      executedCommands.push(command);
-      return "";
-    },
-  };
 }
 
 // ─── mergeSkillRefs ──────────────────────────────────────────────────────
@@ -151,86 +127,171 @@ describe("fetchSkillsByRefs", () => {
   });
 });
 
-// ─── writeSkills ─────────────────────────────────────────────────────────
+// ─── mountSkills ─────────────────────────────────────────────────────────
 
-describe("writeSkills", () => {
-  it("writes SKILL.md from spec when no artifact", async () => {
-    const backend = makeMockBackend();
+describe("mountSkills", () => {
+  let platformDir: string;
+
+  beforeEach(() => {
+    platformDir = mkdtempSync(join(tmpdir(), "skill-writer-platform-"));
+  });
+
+  afterEach(() => {
+    rmSync(platformDir, { recursive: true, force: true });
+  });
+
+  it("writes SKILL.md and returns agent-visible paths keyed by skill id", async () => {
+    const client = makeMockClient();
     const skills = [makeSkill({ name: "calculator", skillMd: "# Calculator\n\nAdds numbers." })];
-    const result = await writeSkills(skills, backend, new Map());
+    const result = await mountSkills(client, skills, platformDir);
 
     expect(result.paths.get("skill-id-1")).toBe(".stigmer/skills/calculator");
-    expect(backend.writtenFiles.has(".stigmer/skills/calculator/SKILL.md")).toBe(true);
-    expect(backend.writtenFiles.get(".stigmer/skills/calculator/SKILL.md"))
+    expect(readFileSync(join(platformDir, "skills", "calculator", "SKILL.md"), "utf-8"))
       .toBe("# Calculator\n\nAdds numbers.");
   });
 
-  it("runs chmod on script extensions", async () => {
-    const backend = makeMockBackend();
-    const skills = [makeSkill({ name: "runner" })];
-    await writeSkills(skills, backend, new Map());
-    expect(backend.executedCommands.length).toBeGreaterThan(0);
-    expect(backend.executedCommands[0]).toContain("chmod");
+  it("extracts artifact files alongside SKILL.md", async () => {
+    const artifact = buildZip([
+      { name: "SKILL.md", content: "# Stale zip copy" },
+      { name: "references/schema.md", content: "schema" },
+    ]);
+    const client = makeMockClient({
+      getSkillArtifact: vi.fn().mockResolvedValue({ artifact }),
+    });
+    const skills = [makeSkill({
+      name: "db-skill",
+      skillMd: "# Authoritative",
+      artifactStorageKey: "artifacts/db.zip",
+    })];
+    await mountSkills(client, skills, platformDir);
+
+    const skillDir = join(platformDir, "skills", "db-skill");
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toBe("# Authoritative");
+    expect(readFileSync(join(skillDir, "references", "schema.md"), "utf-8")).toBe("schema");
   });
 
   it("handles multiple skills", async () => {
-    const backend = makeMockBackend();
+    const client = makeMockClient();
     const skills = [
       makeSkill({ id: "id-1", name: "skill-a", skillMd: "# A" }),
       makeSkill({ id: "id-2", name: "skill-b", skillMd: "# B" }),
     ];
-    const result = await writeSkills(skills, backend, new Map());
+    const result = await mountSkills(client, skills, platformDir);
     expect(result.paths.size).toBe(2);
     expect(result.paths.get("id-1")).toBe(".stigmer/skills/skill-a");
     expect(result.paths.get("id-2")).toBe(".stigmer/skills/skill-b");
+    expect(existsSync(join(platformDir, "skills", "skill-a", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(platformDir, "skills", "skill-b", "SKILL.md"))).toBe(true);
   });
 
-  it("skips write when skill has no skillMd and no artifact", async () => {
-    const backend = makeMockBackend();
-    const skills = [makeSkill({ skillMd: "" })];
-    (skills[0] as any).spec.skillMd = "";
-    await writeSkills(skills, backend, new Map());
-    expect(backend.writtenFiles.size).toBe(0);
+  it("skips the artifact download when the mounted hash matches (cache hit)", async () => {
+    const artifact = buildZip([{ name: "references/guide.md", content: "guide" }]);
+    const client = makeMockClient({
+      getSkillArtifact: vi.fn().mockResolvedValue({ artifact }),
+    });
+    const skill = makeSkill({
+      name: "cached-skill",
+      artifactStorageKey: "artifacts/cached.zip",
+      versionHash: "hash-v1",
+    });
+
+    await mountSkills(client, [skill], platformDir);
+    expect(client.getSkillArtifact).toHaveBeenCalledTimes(1);
+
+    // Second execution of the same session: same hash, no transfer.
+    const second = await mountSkills(client, [skill], platformDir);
+    expect(client.getSkillArtifact).toHaveBeenCalledTimes(1);
+    expect(second.paths.get("skill-id-1")).toBe(".stigmer/skills/cached-skill");
+    expect(readFileSync(
+      join(platformDir, "skills", "cached-skill", "references", "guide.md"), "utf-8",
+    )).toBe("guide");
   });
-});
 
-// ─── computeSkillPaths ───────────────────────────────────────────────────
+  it("remounts on version change and clears stale files from the old mount", async () => {
+    const artifactV1 = buildZip([{ name: "references/removed-in-v2.md", content: "old" }]);
+    const artifactV2 = buildZip([{ name: "references/new-in-v2.md", content: "new" }]);
+    const client = makeMockClient({
+      getSkillArtifact: vi.fn()
+        .mockResolvedValueOnce({ artifact: artifactV1 })
+        .mockResolvedValueOnce({ artifact: artifactV2 }),
+    });
 
-describe("computeSkillPaths", () => {
-  it("computes paths without side effects", () => {
+    await mountSkills(client, [makeSkill({
+      name: "evolving-skill",
+      skillMd: "# V1",
+      artifactStorageKey: "artifacts/v1.zip",
+      versionHash: "hash-v1",
+    })], platformDir);
+
+    await mountSkills(client, [makeSkill({
+      name: "evolving-skill",
+      skillMd: "# V2",
+      artifactStorageKey: "artifacts/v2.zip",
+      versionHash: "hash-v2",
+    })], platformDir);
+
+    const skillDir = join(platformDir, "skills", "evolving-skill");
+    expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toBe("# V2");
+    expect(readFileSync(join(skillDir, "references", "new-in-v2.md"), "utf-8")).toBe("new");
+    // The v1-only file must not linger in the v2 mount (the stale-file leak).
+    expect(existsSync(join(skillDir, "references", "removed-in-v2.md"))).toBe(false);
+  });
+
+  it("does not cache a degraded SKILL.md-only mount — the next execution retries", async () => {
+    const artifact = buildZip([{ name: "references/late.md", content: "finally" }]);
+    const client = makeMockClient({
+      getSkillArtifact: vi.fn()
+        .mockRejectedValueOnce(new Error("Network timeout"))
+        .mockResolvedValueOnce({ artifact }),
+    });
+    const skill = makeSkill({
+      name: "retry-skill",
+      artifactStorageKey: "artifacts/retry.zip",
+      versionHash: "hash-v1",
+    });
+
+    // First pass degrades to SKILL.md only — never throws.
+    const first = await mountSkills(client, [skill], platformDir);
+    const skillDir = join(platformDir, "skills", "retry-skill");
+    expect(first.paths.get("skill-id-1")).toBe(".stigmer/skills/retry-skill");
+    expect(existsSync(join(skillDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(skillDir, "references"))).toBe(false);
+
+    // Second pass retries and completes the mount.
+    await mountSkills(client, [skill], platformDir);
+    expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(skillDir, "references", "late.md"), "utf-8")).toBe("finally");
+
+    // Third pass is a cache hit.
+    await mountSkills(client, [skill], platformDir);
+    expect(client.getSkillArtifact).toHaveBeenCalledTimes(2);
+  });
+
+  it("mounts only the first claimant when two skills resolve to the same directory", async () => {
+    const client = makeMockClient();
     const skills = [
-      makeSkill({ id: "id-1", name: "calculator" }),
-      makeSkill({ id: "id-2", name: "web-scraper" }),
+      makeSkill({ id: "id-1", org: "org-a", slug: "shared-a", name: "shared-name", skillMd: "# First" }),
+      makeSkill({ id: "id-2", org: "org-b", slug: "shared-b", name: "shared-name", skillMd: "# Second" }),
     ];
-    const paths = computeSkillPaths(skills);
-    expect(paths.get("id-1")).toBe(".stigmer/skills/calculator");
-    expect(paths.get("id-2")).toBe(".stigmer/skills/web-scraper");
+    const result = await mountSkills(client, skills, platformDir);
+
+    // Both ids resolve to the (single) directory; the first claimant's content wins.
+    expect(result.paths.get("id-1")).toBe(".stigmer/skills/shared-name");
+    expect(result.paths.get("id-2")).toBe(".stigmer/skills/shared-name");
+    expect(readFileSync(join(platformDir, "skills", "shared-name", "SKILL.md"), "utf-8"))
+      .toBe("# First");
   });
 
-  it("returns empty map for empty skills", () => {
-    expect(computeSkillPaths([])).toEqual(new Map());
-  });
-});
+  it("skips skills with no skillMd content", async () => {
+    const client = makeMockClient();
+    const skill = makeSkill({ name: "broken", skillMd: "" });
+    (skill as any).spec.skillMd = "";
+    const result = await mountSkills(client, [skill], platformDir);
 
-// ─── checkSkillIntegrity ─────────────────────────────────────────────────
-
-describe("checkSkillIntegrity", () => {
-  it("returns true when sentinel exists", async () => {
-    const backend = makeMockBackend();
-    backend.existingFiles.add(".stigmer/skills/calculator/SKILL.md");
-    const skills = [makeSkill({ id: "id-1", name: "calculator" })];
-    expect(await checkSkillIntegrity(skills, backend)).toBe(true);
-  });
-
-  it("returns false when sentinel is missing", async () => {
-    const backend = makeMockBackend();
-    const skills = [makeSkill({ id: "id-1", name: "calculator" })];
-    expect(await checkSkillIntegrity(skills, backend)).toBe(false);
-  });
-
-  it("returns true for empty skills list", async () => {
-    const backend = makeMockBackend();
-    expect(await checkSkillIntegrity([], backend)).toBe(true);
+    // The path entry exists (naming is total) but nothing was mounted.
+    expect(result.paths.get("skill-id-1")).toBe(".stigmer/skills/broken");
+    expect(existsSync(join(platformDir, "skills", "broken"))).toBe(false);
   });
 });
 
@@ -307,43 +368,5 @@ describe("generateAlsoAvailableSection", () => {
     const section = generateAlsoAvailableSection(["some-skill"]);
     expect(section).toContain(".stigmer/skills/<name>/SKILL.md");
     expect(section).toContain("relevant to your task");
-  });
-});
-
-// ─── fetchSkillArtifacts ─────────────────────────────────────────────────
-
-describe("fetchSkillArtifacts", () => {
-  it("returns empty map when no skills have artifacts", async () => {
-    const client = makeMockClient();
-    const skills = [makeSkill({ artifactStorageKey: "" })];
-    const result = await fetchSkillArtifacts(client, skills);
-    expect(result.size).toBe(0);
-    expect(client.getSkillArtifact).not.toHaveBeenCalled();
-  });
-
-  it("fetches artifacts for skills with storage keys", async () => {
-    const artifactData = new Uint8Array([80, 75, 3, 4]); // ZIP magic bytes
-    const client = makeMockClient({
-      getSkillArtifact: vi.fn().mockResolvedValue({ artifact: artifactData }),
-    });
-    const skills = [makeSkill({ id: "id-1", artifactStorageKey: "artifacts/key.zip" })];
-    const result = await fetchSkillArtifacts(client, skills);
-    expect(result.size).toBe(1);
-    expect(result.get("id-1")).toEqual(artifactData);
-  });
-
-  it("handles partial failures gracefully", async () => {
-    const client = makeMockClient({
-      getSkillArtifact: vi.fn()
-        .mockResolvedValueOnce({ artifact: new Uint8Array([1, 2, 3]) })
-        .mockRejectedValueOnce(new Error("Network error")),
-    });
-    const skills = [
-      makeSkill({ id: "id-1", name: "good", artifactStorageKey: "key1" }),
-      makeSkill({ id: "id-2", name: "bad", artifactStorageKey: "key2" }),
-    ];
-    const result = await fetchSkillArtifacts(client, skills);
-    expect(result.size).toBe(1);
-    expect(result.has("id-1")).toBe(true);
   });
 });

--- a/backend/services/runner/src/shared/skill-mount.ts
+++ b/backend/services/runner/src/shared/skill-mount.ts
@@ -1,0 +1,179 @@
+/**
+ * Skill mount mechanics — the ONE cache shape shared by both harnesses.
+ *
+ * A skill "mount" is the on-disk materialization of a skill inside the
+ * session's platform directory: `{platformDir}/skills/{name}/` holding
+ * SKILL.md plus the artifact's supporting files. Both harnesses write to
+ * that same physical location — the Cursor harness directly, the native
+ * (deep-agent) harness through the `.stigmer/` virtual namespace that
+ * LocalWorkspaceBackend routes there — so they MUST share one cache shape
+ * (issues #337/#672). This module owns that shape:
+ *
+ * - The mount is cached by the skill's content-addressed
+ *   `status.version_hash`: metadata is still fetched every execution
+ *   (that keeps latest-version freshness — push a skill update and the
+ *   very next message picks it up), but the artifact download and file
+ *   rewrite are skipped when the mounted content's hash already matches.
+ * - Remounts rebuild the directory from scratch, so files deleted between
+ *   skill versions never linger in the mount.
+ * - Crash-safe by ordering: the marker is stamped LAST, after every file
+ *   of the mount landed — a crash mid-write leaves no marker, so the next
+ *   execution remounts instead of trusting a partial tree.
+ *
+ * Extracted from execute-cursor/skill-resolver.ts (PR #682) when the
+ * deep-agent path adopted the same cache (issue #337). Orchestration —
+ * which skills to mount, prompt metadata, degradation logging — stays
+ * with each harness; only the per-skill-directory mechanics live here.
+ */
+
+import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { join, dirname, extname, resolve } from "node:path";
+import { ConnectError, Code } from "@connectrpc/connect";
+import type { StigmerClient } from "../client/stigmer-client.js";
+import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { extractZipFileEntries } from "./zip-extract.js";
+
+/** Subdirectory of the platform dir where skill mounts live. */
+export const SKILLS_SUBDIR = "skills";
+
+/**
+ * Marker recording what a skill's mount directory currently holds. Written
+ * LAST, after every file of the mount landed — a crash mid-write leaves no
+ * marker, so the next execution remounts instead of trusting a partial tree.
+ */
+export const MOUNT_MARKER_FILE = ".stigmer-mount.json";
+
+export interface MountMarker {
+  /** Content-addressed version hash (`Skill.status.version_hash`) of the mounted content. */
+  versionHash: string;
+  /**
+   * Whether the artifact's files are part of the mount. `false` when the
+   * skill has no artifact OR when the download failed and the mount fell
+   * back to SKILL.md only — the latter makes the next execution retry the
+   * download rather than cache the degraded mount.
+   */
+  artifactMounted: boolean;
+}
+
+/**
+ * File extensions written with the executable bit set. The ZIP layer is
+ * deliberately mode-blind (path + bytes only, see zip-extract.ts), so
+ * extension is the only signal available for `./script.sh`-style
+ * invocation to work out of the mount.
+ */
+const SCRIPT_EXTENSIONS = new Set([".sh", ".py", ".js", ".ts", ".rb", ".pl"]);
+
+/**
+ * Whether the mount at `skillDir` already holds this version's content.
+ *
+ * Fresh means: the marker's hash matches AND the mount isn't a degraded
+ * SKILL.md-only fallback when the skill does carry an artifact. Any read or
+ * parse failure counts as stale — the remount is the safe default.
+ */
+export async function mountIsFresh(
+  skillDir: string,
+  versionHash: string,
+  wantsArtifact: boolean,
+): Promise<boolean> {
+  try {
+    const raw = await readFile(join(skillDir, MOUNT_MARKER_FILE), "utf-8");
+    const marker = JSON.parse(raw) as Partial<MountMarker>;
+    return marker.versionHash === versionHash && (marker.artifactMounted === true || !wantsArtifact);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Download a skill artifact's ZIP bytes, transfer lane first (#675).
+ *
+ * The URL lane (getArtifactDownloadUrl → HTTP GET) carries any valid skill
+ * size; the unary getArtifact response is capped by the server's 10MB gRPC
+ * message limit. Servers that predate the lane (and cloud until its sibling
+ * lands) answer the mint with UNIMPLEMENTED — those fall back to the unary
+ * path, which behaves exactly as before for ≤10MB artifacts.
+ *
+ * Runs only on a mount-cache miss (the hash-keyed marker above) — a hit
+ * skips the transfer entirely, whichever lane would have carried it.
+ */
+export async function downloadArtifact(
+  client: StigmerClient,
+  artifactStorageKey: string,
+): Promise<Uint8Array | undefined> {
+  let minted;
+  try {
+    minted = await client.getSkillArtifactDownloadUrl(artifactStorageKey);
+  } catch (err) {
+    if (err instanceof ConnectError && err.code === Code.Unimplemented) {
+      const resp = await client.getSkillArtifact(artifactStorageKey);
+      return resp.artifact && resp.artifact.length > 0 ? resp.artifact : undefined;
+    }
+    throw err;
+  }
+
+  const resp = await fetch(minted.url);
+  if (!resp.ok) {
+    throw new Error(`artifact fetch failed: HTTP ${resp.status} from ${minted.url}`);
+  }
+  const bytes = new Uint8Array(await resp.arrayBuffer());
+  if (minted.sizeBytes > 0n && BigInt(bytes.length) !== minted.sizeBytes) {
+    throw new Error(
+      `artifact fetch truncated: got ${bytes.length} bytes, expected ${minted.sizeBytes}`,
+    );
+  }
+  return bytes.length > 0 ? bytes : undefined;
+}
+
+/**
+ * (Re)write a skill's mount directory from scratch.
+ *
+ * The directory is removed first so files deleted between versions don't
+ * linger in the mount, then SKILL.md and the artifact files are written, and
+ * the marker is stamped LAST (see MOUNT_MARKER_FILE for the crash-safety
+ * contract). SKILL.md always comes from `spec.skillMd` — the server's
+ * authoritative copy, which the push pipeline guarantees is non-empty
+ * (push.go hard-fails a ZIP without an extractable SKILL.md) — never from
+ * the zip; both the zip's SKILL.md and any stray marker-named entry are
+ * excluded from extraction so the mount's ownership of those two files is
+ * unconditional.
+ *
+ * Every extracted entry must resolve inside `skillDir`. The server already
+ * rejects traversal at push (google/safearchive), but this runner-side
+ * check is kept as defense-in-depth: it is the guard the deep-agent path
+ * used to get from LocalWorkspaceBackend's platform-path routing, preserved
+ * here when skill writes moved to direct fs.
+ */
+export async function writeSkillMount(
+  skill: Skill,
+  skillDir: string,
+  artifactBytes: Uint8Array | undefined,
+): Promise<void> {
+  await rm(skillDir, { recursive: true, force: true });
+  await mkdir(skillDir, { recursive: true });
+
+  await writeFile(join(skillDir, "SKILL.md"), skill.spec!.skillMd, "utf-8");
+
+  const artifactMounted = artifactBytes !== undefined && artifactBytes.length > 0;
+  if (artifactMounted) {
+    const normalizedSkillDir = resolve(skillDir);
+    const entries = await extractZipFileEntries(artifactBytes, { exclude: ["SKILL.md", MOUNT_MARKER_FILE] });
+    for (const entry of entries) {
+      const filePath = resolve(normalizedSkillDir, entry.path);
+      if (filePath !== normalizedSkillDir && !filePath.startsWith(normalizedSkillDir + "/")) {
+        throw new Error(
+          `skill artifact entry escapes its mount directory: '${entry.path}'`,
+        );
+      }
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, entry.content, {
+        mode: SCRIPT_EXTENSIONS.has(extname(entry.path)) ? 0o755 : 0o644,
+      });
+    }
+  }
+
+  const versionHash = skill.status?.versionHash ?? "";
+  if (versionHash !== "") {
+    const marker: MountMarker = { versionHash, artifactMounted };
+    await writeFile(join(skillDir, MOUNT_MARKER_FILE), JSON.stringify(marker), "utf-8");
+  }
+}

--- a/backend/services/runner/src/shared/skill-writer.ts
+++ b/backend/services/runner/src/shared/skill-writer.ts
@@ -1,5 +1,5 @@
 /**
- * Skill writing and prompt generation for the deep-agent execution path.
+ * Skill mounting and prompt generation for the deep-agent execution path.
  *
  * Follows the Agent Skills specification progressive disclosure model:
  *
@@ -10,19 +10,33 @@
  * 3. Resources (on demand) — scripts, references, and assets are
  *    loaded by the agent only when required.
  *
- * Skills live under `.stigmer/skills/{name}/` relative to the workspace root.
- * Returned paths are workspace-relative so that the agent's sandbox backend
- * resolves them correctly regardless of mount strategy.
+ * Skills physically live in the session's platform directory
+ * (`{platformDir}/skills/{name}/` — the SAME location the Cursor harness
+ * mounts into), and the agent sees them as `.stigmer/skills/{name}/`
+ * through the per-turn workspace symlink (see workspace/stigmer-link.ts).
+ * Returned paths are the agent-visible `.stigmer/…` form.
+ *
+ * Mounts are cached by the skill's content-addressed version hash via the
+ * shared skill-mount mechanics (issue #337, mirroring the Cursor harness's
+ * #672 fix): metadata is fetched every execution — a pushed skill update
+ * still lands on the very next message — but an unchanged skill skips the
+ * artifact download and rewrite entirely.
  */
 
-import type { WorkspaceBackend } from "./workspace/types.js";
+import { join } from "node:path";
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
 import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 import type { StigmerClient } from "../client/stigmer-client.js";
-import { extractZipFileEntries } from "./zip-extract.js";
+import {
+  SKILLS_SUBDIR,
+  mountIsFresh,
+  downloadArtifact,
+  writeSkillMount,
+} from "./skill-mount.js";
+import { STIGMER_LOCAL_STATE_DIR } from "./workspace/stigmer-link.js";
 
-const SKILLS_RELATIVE_BASE = ".stigmer/skills";
-const SCRIPT_EXTENSIONS = new Set([".sh", ".py", ".js", ".ts", ".rb", ".pl"]);
+/** Agent-visible base of the skills tree (via the workspace `.stigmer` symlink). */
+const SKILLS_RELATIVE_BASE = `${STIGMER_LOCAL_STATE_DIR}/${SKILLS_SUBDIR}`;
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
@@ -81,114 +95,100 @@ export async function fetchSkillsByRefs(
   return results;
 }
 
-// ─── Write ───────────────────────────────────────────────────────────────
+// ─── Mount ───────────────────────────────────────────────────────────────
 
 /**
- * Write skill artifacts to the workspace. Returns a map of
- * skill-id -> workspace-relative directory path.
+ * Mount skills into the session's platform directory, downloading each
+ * skill's artifact only on a version-hash cache miss (see skill-mount.ts
+ * for the marker mechanics). Returns a map of skill-id -> agent-visible
+ * directory path.
  *
- * For each skill:
- * - If a ZIP artifact is available, extract it to .stigmer/skills/{name}/
- * - Otherwise, write just the SKILL.md from the spec
- * - Make scripts executable
+ * The returned map is a NAMING function, not a success record: every skill
+ * gets its path entry so prompt generation stays total, while mount
+ * failures degrade that one skill (loud log, no throw) — one broken skill
+ * must never kill the run.
+ *
+ * Skills mount in parallel (each owns an independent directory), EXCEPT
+ * when two skills resolve to the same directory name (same `spec.name`
+ * from different orgs): concurrent remove-and-rewrite passes on one
+ * directory would corrupt the mount, so only the first claimant mounts and
+ * the collision is logged loudly. (The sequential code this replaced
+ * silently let the last writer win — no better, just quieter.)
  */
-export async function writeSkills(
+export async function mountSkills(
+  client: StigmerClient,
   skills: readonly Skill[],
-  workspaceBackend: WorkspaceBackend,
-  artifacts: ReadonlyMap<string, Uint8Array>,
+  platformDir: string,
 ): Promise<SkillPathMap> {
   const paths = new Map<string, string>();
+  const claims = new Map<string, Skill>();
 
-  for (const skill of skills) {
-    const name = skill.spec?.name || skill.metadata?.slug || "unknown";
-    const skillId = skill.metadata?.id ?? name;
-    const relativeDir = `${SKILLS_RELATIVE_BASE}/${name}`;
-    paths.set(skillId, relativeDir);
-
-    const artifactBytes = artifacts.get(skillId);
-    if (skill.spec?.skillMd) {
-      const skillMdPath = `${relativeDir}/SKILL.md`;
-      await workspaceBackend.writeFile(skillMdPath, skill.spec.skillMd);
-      if (artifactBytes && artifactBytes.length > 0) {
-        await extractZipToWorkspaceExcluding(artifactBytes, "SKILL.md", relativeDir, workspaceBackend);
-      }
-    } else if (artifactBytes && artifactBytes.length > 0) {
-      await extractZipToWorkspace(artifactBytes, relativeDir, workspaceBackend);
-    }
-
-    await makeScriptsExecutable(relativeDir, workspaceBackend);
-  }
-
-  return { paths };
-}
-
-/**
- * Compute skill paths without writing anything (for resume integrity checks).
- */
-export function computeSkillPaths(skills: readonly Skill[]): Map<string, string> {
-  const paths = new Map<string, string>();
   for (const skill of skills) {
     const name = skill.spec?.name || skill.metadata?.slug || "unknown";
     const skillId = skill.metadata?.id ?? name;
     paths.set(skillId, `${SKILLS_RELATIVE_BASE}/${name}`);
+
+    // Impossible through the push pipeline (push.go hard-fails a ZIP
+    // without an extractable SKILL.md and always populates spec.skill_md),
+    // so an empty skillMd means a broken resource — skip, same as Cursor.
+    if (!skill.spec?.skillMd) {
+      console.warn(
+        `[skill-writer] skill ${name} (${skillId}) has no skillMd content — skipping mount`,
+      );
+      continue;
+    }
+
+    const prev = claims.get(name);
+    if (prev) {
+      console.warn(
+        `[skill-writer] mount directory collision on '${name}': ` +
+        `${prev.metadata?.org}/${prev.metadata?.slug} already claims it, ` +
+        `skipping ${skill.metadata?.org}/${skill.metadata?.slug}`,
+      );
+      continue;
+    }
+    claims.set(name, skill);
   }
-  return paths;
-}
 
-/**
- * Check workspace integrity for resume fast-path.
- * Returns true if the sentinel SKILL.md file exists for the first skill.
- */
-export async function checkSkillIntegrity(
-  skills: readonly Skill[],
-  workspaceBackend: WorkspaceBackend,
-): Promise<boolean> {
-  if (skills.length === 0) return true;
+  await Promise.all([...claims.entries()].map(async ([name, skill]) => {
+    const skillDir = join(platformDir, SKILLS_SUBDIR, name);
+    try {
+      const versionHash = skill.status?.versionHash ?? "";
+      const wantsArtifact = Boolean(skill.status?.artifactStorageKey);
 
-  const paths = computeSkillPaths(skills);
-  const firstPath = paths.values().next().value;
-  if (!firstPath) return true;
+      if (versionHash !== "" && (await mountIsFresh(skillDir, versionHash, wantsArtifact))) {
+        console.log(
+          `[skill-writer] mount cache hit: ${name} (version ${versionHash.slice(0, 12)}) — skipping artifact transfer`,
+        );
+        return;
+      }
 
-  const sentinel = `${firstPath}/SKILL.md`;
-  return workspaceBackend.exists(sentinel);
-}
+      let artifactBytes: Uint8Array | undefined;
+      if (wantsArtifact) {
+        try {
+          artifactBytes = await downloadArtifact(client, skill.status!.artifactStorageKey);
+        } catch (err) {
+          // Deliberate degradation, but LOUD (#675): the run still gets
+          // SKILL.md, and the marker records artifactMounted=false so the
+          // next execution retries the download.
+          console.error(
+            `[skill-writer] artifact download FAILED for ${name} ` +
+            `(key=${skill.status!.artifactStorageKey}) — mounting SKILL.md WITHOUT the skill's ` +
+            `supporting files (scripts/references will be missing): ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
 
-// ─── ZIP extraction ──────────────────────────────────────────────────────
+      await writeSkillMount(skill, skillDir, artifactBytes);
+      console.log(`[skill-writer] wrote skill mount: ${name}`);
+    } catch (err) {
+      console.warn(
+        `[skill-writer] failed to mount skill ${name}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }));
 
-async function extractZipToWorkspace(
-  zipBytes: Uint8Array,
-  targetDir: string,
-  backend: WorkspaceBackend,
-): Promise<void> {
-  const entries = await extractZipFileEntries(zipBytes);
-  for (const entry of entries) {
-    await backend.writeFileBuffer(`${targetDir}/${entry.path}`, Buffer.from(entry.content));
-  }
-}
-
-async function extractZipToWorkspaceExcluding(
-  zipBytes: Uint8Array,
-  excludeName: string,
-  targetDir: string,
-  backend: WorkspaceBackend,
-): Promise<void> {
-  const entries = await extractZipFileEntries(zipBytes, { exclude: [excludeName] });
-  for (const entry of entries) {
-    await backend.writeFileBuffer(`${targetDir}/${entry.path}`, Buffer.from(entry.content));
-  }
-}
-
-async function makeScriptsExecutable(
-  relativeDir: string,
-  backend: WorkspaceBackend,
-): Promise<void> {
-  const extensions = [...SCRIPT_EXTENSIONS].map(ext => `-name '*${ext}'`).join(" -o ");
-  const cmd = `find ${relativeDir} -type f \\( ${extensions} \\) -exec chmod +x {} \\; 2>/dev/null || true`;
-  try {
-    await backend.execute(cmd);
-  } catch {
-    // Non-fatal: scripts may not be executable in all environments
-  }
+  return { paths };
 }
 
 // ─── Prompt generation ───────────────────────────────────────────────────
@@ -263,38 +263,4 @@ export function generateAlsoAvailableSection(
     "If you determine one of them is relevant to your task, " +
     "read its SKILL.md at `.stigmer/skills/<name>/SKILL.md` to activate it.\n"
   );
-}
-
-// ─── Artifact fetching ───────────────────────────────────────────────────
-
-/**
- * Download skill artifacts for all skills that have a storage key.
- * Returns a map from skill ID to artifact bytes.
- */
-export async function fetchSkillArtifacts(
-  client: StigmerClient,
-  skills: readonly Skill[],
-): Promise<Map<string, Uint8Array>> {
-  const artifacts = new Map<string, Uint8Array>();
-
-  const fetches = skills
-    .filter(s => s.status?.artifactStorageKey)
-    .map(async (skill) => {
-      const key = skill.status!.artifactStorageKey;
-      const skillId = skill.metadata?.id ?? skill.spec?.name ?? "unknown";
-      try {
-        const response = await client.getSkillArtifact(key);
-        if (response.artifact && response.artifact.length > 0) {
-          artifacts.set(skillId, response.artifact);
-        }
-      } catch (err) {
-        console.warn(
-          `[skill-writer] Failed to download artifact for ${skill.spec?.name}: ` +
-          `${err instanceof Error ? err.message : String(err)}. Falling back to SKILL.md only.`,
-        );
-      }
-    });
-
-  await Promise.all(fetches);
-  return artifacts;
 }


### PR DESCRIPTION
## Summary

The deep-agent (native) execution path re-downloaded and re-wrote every skill's artifact on every execution, even when nothing changed. This PR extracts the Cursor harness's proven skill-mount cache (#682) into a shared module and wires the deep-agent path — parent setup and sub-agent transformer — onto the same mechanics, so an unchanged skill costs a metadata read per message instead of a full artifact transfer.

Closes #337

## Context

Both harnesses physically write skills to the same place (`~/.stigmer/sessions/{id}/platform/skills/{name}/`): the Cursor harness directly, the deep-agent path through the workspace backend's `.stigmer/` platform routing. The Cursor side got a hash-keyed mount cache in #682; the deep-agent side (the scope of #337) still downloaded unconditionally over the 10MB-capped unary lane and never swept stale files. Per the issue's sequencing note, this work waited for the #675 transfer-lane restructure (#703) and mirrors #682's marker mechanics rather than inventing a second cache shape — taken one step further by literally sharing the code.

## Changes

- **New `shared/skill-mount.ts`** — mount mechanics extracted from `execute-cursor/skill-resolver.ts`: the `.stigmer-mount.json` marker (version hash + `artifactMounted`, stamped LAST for crash safety), `mountIsFresh`, `writeSkillMount` (remove-then-rewrite so deleted files never linger), and `downloadArtifact` (URL lane with unary fallback).
- **Cursor harness** — `skill-resolver.ts` now imports the shared mechanics; orchestration unchanged.
- **Deep-agent path** — `skill-writer.ts` replaces the two-phase `fetchSkillArtifacts` + `writeSkills` with a single `mountSkills` orchestration (hash match → skip; miss → download → mount), used by both `setup.ts` step 7b and `subagent-transformer.ts`. A skill shared by parent and sub-agent is now downloaded once, not twice.
- **Dead code removed** — `checkSkillIntegrity` (the never-called helper the issue pointed at), `computeSkillPaths`, and the uncalled `cleanupSkills`.

## Implementation notes

- **Traversal guard**: moving deep-agent writes to direct fs would have dropped the backend's platform-path traversal check, so `writeSkillMount` rejects any ZIP entry resolving outside its mount directory — defense-in-depth on top of push-time safearchive validation, and new protection for the Cursor path.
- **Script executability at write time** (mode `0o755` by extension) replaces the deep-agent's shell `find|chmod` sweep; Cursor-mounted skill scripts become executable too (previously they were not).
- **Same-name collision dedupe**: two skills with one `spec.name` resolve to one directory; `mountSkills` mounts the first claimant and warns loudly instead of racing parallel remove-and-rewrite passes (the old sequential code silently let the last writer win).
- **Degraded mounts retry**: a failed artifact download still mounts SKILL.md (loud error), and the marker records `artifactMounted: false` so the next execution retries instead of caching the degraded state.
- **No-SKILL.md skills are skipped** (unified on Cursor semantics): the push pipeline hard-fails a ZIP without an extractable SKILL.md, so the deep-agent's artifact-only branch was dead defensive code.

## Breaking changes

- None. Prompt paths, physical file locations, and the agent-visible view are byte-identical.

## Test plan

- New `shared/__tests__/skill-mount.test.ts`: marker semantics (fresh/stale/degraded/no-hash), stale-file sweep, SKILL.md + marker ownership, traversal rejection, executable bits, and the transfer-lane routing tests (moved with the code).
- Rewritten `shared/__tests__/skill-writer.test.ts`: real-filesystem `mountSkills` cases — cache hit skips the download, version change remounts and sweeps, degraded mount retries then caches, collision dedupe, multi-skill, no-SKILL.md skip.
- Cursor-side `skill-resolver.test.ts` passes unchanged (minus the moved lane tests).
- Full runner suite: 274 files / 4667 tests, all green. `tsc --noEmit` clean.
- Not verified here: a live end-to-end run against a hosted control plane.

## Risks

- Main risk is a Cursor-harness regression; mitigated by extracting the mechanics verbatim and keeping its behavior tests green. Rollback is a single revert — the cache is self-healing (a missing/corrupt marker just remounts).

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [ ] Docs updated (not needed — runner-internal behavior)

Made with [Cursor](https://cursor.com)