### PR TITLE
fix(workflow): honor human_input on_timeout policies — normalize the persisted enum-name vocabulary and fail closed on escalate

### DIFF
--- a/apis/ai/stigmer/agentic/workflow/v1/tasks/human_input.proto
+++ b/apis/ai/stigmer/agentic/workflow/v1/tasks/human_input.proto
@@ -37,6 +37,11 @@ enum HumanInputTimeoutPolicy {
   // Requires a corresponding outcome with then set, or a try_catch handler.
   // Use when timeout should trigger a different workflow path rather than
   // a simple approve/deny decision.
+  //
+  // NOT IMPLEMENTED YET (stigmer/stigmer#781): no runtime exists for this
+  // policy, so validation refuses it at apply and the runner refuses it at
+  // load (stigmer/stigmer#779 fail-closed ruling) — it must never silently
+  // behave as FAIL.
   HUMAN_INPUT_TIMEOUT_ESCALATE = 4;
 }
 
@@ -138,7 +143,7 @@ message HumanInputOutcome {
 //         approvers:
 //           - "team:engineering-leads"
 //         timeout: 86400
-//         on_timeout: HUMAN_INPUT_TIMEOUT_ESCALATE
+//         on_timeout: HUMAN_INPUT_TIMEOUT_DENY
 //         notification_channels:
 //           - "slack:#incident-approvals"
 //       export:

--- a/apis/ai/stigmer/agentic/workflow/v1/tasks/meta/human_input.yaml
+++ b/apis/ai/stigmer/agentic/workflow/v1/tasks/meta/human_input.yaml
@@ -62,7 +62,7 @@ yaml_examples:
         approvers:
           - "team:engineering-leads"
         timeout: 86400
-        on_timeout: HUMAN_INPUT_TIMEOUT_ESCALATE
+        on_timeout: HUMAN_INPUT_TIMEOUT_DENY
         notification_channels:
           - "slack:#incident-approvals"
       export:

--- a/backend/services/runner/src/workflow-engine/__tests__/loader.test.ts
+++ b/backend/services/runner/src/workflow-engine/__tests__/loader.test.ts
@@ -1528,6 +1528,57 @@ do:
       }
     });
 
+    // The server converter persists on_timeout as the proto enum NAME
+    // (HumanInputTimeoutPolicy.String()), so every applied workflow carries
+    // that form in its validated YAML. stigmer/stigmer#779: the loader used
+    // to cast it unvalidated, and the orchestrator's switch silently treated
+    // the unrecognized string as fail.
+    const humanInputYamlWithOnTimeout = (onTimeout: string) => `
+document:
+  dsl: '1.0.0'
+  name: test
+do:
+  - timedApproval:
+      call: human_input
+      with:
+        prompt: "Approve within time limit"
+        timeout: 3600
+        on_timeout: ${onTimeout}
+`;
+
+    it("call: human_input normalizes proto enum-name on_timeout values to the internal policy words", () => {
+      const cases = [
+        ["HUMAN_INPUT_TIMEOUT_FAIL", "fail"],
+        ["HUMAN_INPUT_TIMEOUT_APPROVE", "approve"],
+        ["HUMAN_INPUT_TIMEOUT_DENY", "deny"],
+      ] as const;
+      for (const [wireForm, internalForm] of cases) {
+        const model = loadWorkflowFromYaml(humanInputYamlWithOnTimeout(wireForm));
+        const task = model.do[0].task;
+        expect(task.kind).toBe("human_input");
+        if (task.kind === "human_input") {
+          expect(task.humanInput.onTimeout).toBe(internalForm);
+        }
+      }
+    });
+
+    it("call: human_input rejects the not-implemented escalate policy at load time", () => {
+      for (const form of ["HUMAN_INPUT_TIMEOUT_ESCALATE", "escalate"]) {
+        expect(() => loadWorkflowFromYaml(humanInputYamlWithOnTimeout(form)))
+          .toThrow(/timedApproval.*escalate.*not implemented/);
+      }
+    });
+
+    it("call: human_input rejects unknown on_timeout values instead of silently failing at timeout", () => {
+      expect(() => loadWorkflowFromYaml(humanInputYamlWithOnTimeout("sometimes")))
+        .toThrow(/timedApproval.*unknown on_timeout value 'sometimes'.*fail, approve, deny/);
+    });
+
+    it("call: human_input rejects non-string on_timeout values", () => {
+      expect(() => loadWorkflowFromYaml(humanInputYamlWithOnTimeout("42")))
+        .toThrow(/timedApproval.*on_timeout/);
+    });
+
     it("call: human_input with payload and ui_hint", () => {
       const yaml = `
 document:

--- a/backend/services/runner/src/workflow-engine/__tests__/tasks/human-input.test.ts
+++ b/backend/services/runner/src/workflow-engine/__tests__/tasks/human-input.test.ts
@@ -246,6 +246,123 @@ describe("executeHumanInputTask", () => {
     });
   });
 
+  // HumanInputTaskConfig.outcomes contract (human_input.proto): with custom
+  // outcomes, timeout auto-approve resolves to the FIRST outcome and timeout
+  // auto-deny to the LAST — downstream `then` routing and outcome switches
+  // must see declared outcome names, never the internal approve/deny words a
+  // reviewer was never offered. stigmer/stigmer#779 made this path reachable
+  // for the first time.
+  describe("timeout outcome mapping with custom outcomes", () => {
+    const outcomes = [
+      { name: "proceed", label: "Proceed", then: "deployStep" },
+      { name: "needs_revision", label: "Needs revision", then: "gatherMore" },
+      { name: "reject", label: "Reject" },
+    ];
+
+    it("maps timeout auto-approve to the FIRST outcome and routes its then", async () => {
+      const awaitFn: AwaitHumanInputFn = async () => ({
+        outcome: "approve",
+        auto_resolved: true,
+        reason: "timeout",
+      });
+
+      const taskDef: HumanInputTaskDef = {
+        kind: "human_input",
+        humanInput: { prompt: "Review", timeout: 5, onTimeout: "approve", outcomes },
+      };
+
+      const state = createState();
+      const result = await executeHumanInputTask(taskDef, "gate", state, makeCtx(awaitFn));
+
+      expect(result).toEqual({
+        outcome: "proceed",
+        auto_resolved: true,
+        reason: "timeout",
+        __flow_directive__: "deployStep",
+      });
+      expect(state.data.gate).toEqual({
+        outcome: "proceed",
+        auto_resolved: true,
+        reason: "timeout",
+      });
+    });
+
+    it("maps timeout auto-deny to the LAST outcome", async () => {
+      const awaitFn: AwaitHumanInputFn = async () => ({
+        outcome: "deny",
+        auto_resolved: true,
+        reason: "timeout",
+      });
+
+      const taskDef: HumanInputTaskDef = {
+        kind: "human_input",
+        humanInput: { prompt: "Review", timeout: 5, onTimeout: "deny", outcomes },
+      };
+
+      const result = await executeHumanInputTask(taskDef, "gate", createState(), makeCtx(awaitFn));
+
+      // "reject" is the last outcome and declares no `then` — no directive.
+      expect(result).toEqual({ outcome: "reject", auto_resolved: true, reason: "timeout" });
+    });
+
+    it("reports the mapped outcome on the approval_resolved event", async () => {
+      const emitted: WorkflowEventDescriptor[][] = [];
+      const emitFn: EmitEventsFn = async (events) => { emitted.push(events); };
+      const awaitFn: AwaitHumanInputFn = async () => ({
+        outcome: "approve",
+        auto_resolved: true,
+        reason: "timeout",
+      });
+
+      const taskDef: HumanInputTaskDef = {
+        kind: "human_input",
+        humanInput: { prompt: "Review", timeout: 5, onTimeout: "approve", outcomes },
+      };
+
+      await executeHumanInputTask(taskDef, "gate", createState(), makeCtx(awaitFn, emitFn));
+
+      const resolved = emitted.flat().find((e) => e.type === "approval_resolved");
+      expect(resolved).toMatchObject({ outcome: "proceed", autoResolved: true });
+    });
+
+    it("leaves reviewer-selected outcomes untouched", async () => {
+      const awaitFn: AwaitHumanInputFn = async () => ({
+        outcome: "needs_revision",
+        reviewer: "alice",
+      });
+
+      const taskDef: HumanInputTaskDef = {
+        kind: "human_input",
+        humanInput: { prompt: "Review", timeout: 5, onTimeout: "approve", outcomes },
+      };
+
+      const result = await executeHumanInputTask(taskDef, "gate", createState(), makeCtx(awaitFn));
+
+      expect(result).toEqual({
+        outcome: "needs_revision",
+        reviewer: "alice",
+        __flow_directive__: "gatherMore",
+      });
+    });
+
+    it("keeps plain approve/deny for binary gates without custom outcomes", async () => {
+      const awaitFn: AwaitHumanInputFn = async () => ({
+        outcome: "approve",
+        auto_resolved: true,
+        reason: "timeout",
+      });
+
+      const taskDef: HumanInputTaskDef = {
+        kind: "human_input",
+        humanInput: { prompt: "Review", timeout: 5, onTimeout: "approve" },
+      };
+
+      const result = await executeHumanInputTask(taskDef, "gate", createState(), makeCtx(awaitFn));
+
+      expect(result).toEqual({ outcome: "approve", auto_resolved: true, reason: "timeout" });
+    });
+  });
+
   describe("event emission", () => {
     it("emits approval_requested before blocking with correct fields", async () => {
       const emitted: WorkflowEventDescriptor[][] = [];

--- a/backend/services/runner/src/workflow-engine/loader.ts
+++ b/backend/services/runner/src/workflow-engine/loader.ts
@@ -608,6 +608,51 @@ function parseServiceTier(raw: unknown): string | undefined {
   return canonical;
 }
 
+/**
+ * Maps on_timeout values to the runner's internal policy words, mirroring
+ * SERVICE_TIER_SHORTHANDS. The persisted CNCF YAML carries the proto enum
+ * NAMES (the server converter emits `HumanInputTimeoutPolicy.String()`),
+ * while hand-written fixtures use the lowercase words — both are accepted.
+ * Unknown values are authoring errors: a timeout policy must never silently
+ * fall back to fail (stigmer/stigmer#779 — the unvalidated cast let every
+ * enum-name policy reach the orchestrator unrecognized, so gates configured
+ * to auto-approve/deny failed at their first real timeout instead).
+ */
+const ON_TIMEOUT_VOCABULARY: Record<string, "fail" | "approve" | "deny"> = {
+  fail: "fail",
+  approve: "approve",
+  deny: "deny",
+  HUMAN_INPUT_TIMEOUT_FAIL: "fail",
+  HUMAN_INPUT_TIMEOUT_APPROVE: "approve",
+  HUMAN_INPUT_TIMEOUT_DENY: "deny",
+};
+
+function parseOnTimeout(
+  taskName: string,
+  raw: unknown,
+): "fail" | "approve" | "deny" | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "string") {
+    throw new Error(`human_input task '${taskName}': 'on_timeout' must be a string`);
+  }
+  // The proto declares HUMAN_INPUT_TIMEOUT_ESCALATE but no runtime exists
+  // for it yet; refuse at load rather than misbehave at the gate's timeout.
+  if (raw === "HUMAN_INPUT_TIMEOUT_ESCALATE" || raw === "escalate") {
+    throw new Error(
+      `human_input task '${taskName}': on_timeout policy 'escalate' is not implemented — ` +
+      `use fail, approve, or deny (custom outcomes with 'then' cover reviewer-driven branching)`,
+    );
+  }
+  const policy = ON_TIMEOUT_VOCABULARY[raw];
+  if (!policy) {
+    throw new Error(
+      `human_input task '${taskName}': unknown on_timeout value '${raw}' ` +
+      `(expected: fail, approve, deny, or a HUMAN_INPUT_TIMEOUT_* enum name)`,
+    );
+  }
+  return policy;
+}
+
 function parseHumanInputConfig(taskName: string, raw: unknown): import("./types.js").HumanInputConfig {
   if (!raw || typeof raw !== "object") {
     throw new Error(`human_input task '${taskName}' requires a 'with' configuration block`);
@@ -630,7 +675,7 @@ function parseHumanInputConfig(taskName: string, raw: unknown): import("./types.
       ? obj.approvers.filter((a: unknown) => typeof a === "string") as string[]
       : undefined,
     timeout: typeof obj.timeout === "number" ? obj.timeout : undefined,
-    onTimeout: (obj.on_timeout as "fail" | "approve" | "deny") ?? undefined,
+    onTimeout: parseOnTimeout(taskName, obj.on_timeout),
     // Any JSON shape is a valid payload (expression string, object, array),
     // so only null/undefined mean "no payload" here.
     payload: obj.payload ?? undefined,

--- a/backend/services/runner/src/workflow-engine/tasks/human-input.ts
+++ b/backend/services/runner/src/workflow-engine/tasks/human-input.ts
@@ -96,11 +96,14 @@ export async function executeHumanInputTask(
     ]);
   }
 
-  const result: HumanInputResult = await ctx.awaitHumanInput({
-    signalName,
-    timeoutSeconds,
-    onTimeout,
-  });
+  const result: HumanInputResult = applyTimeoutOutcomeContract(
+    await ctx.awaitHumanInput({
+      signalName,
+      timeoutSeconds,
+      onTimeout,
+    }),
+    config.outcomes,
+  );
 
   if (ctx.emitEvents) {
     await ctx.emitEvents([{
@@ -130,6 +133,31 @@ function validateConfig(config: HumanInputConfig, taskName: string): void {
   if (!config.prompt) {
     throw new Error(`human_input task '${taskName}': 'prompt' is required`);
   }
+}
+
+/**
+ * Applies the proto contract for timeout auto-resolution with custom
+ * outcomes (HumanInputTaskConfig.outcomes doc): auto-approve resolves to
+ * the FIRST declared outcome and auto-deny to the LAST, so `then` routing
+ * and downstream outcome switches see declared outcome names — never the
+ * orchestrator's internal approve/deny words, which a reviewer of a
+ * custom-outcome gate was never offered. Binary gates (no custom outcomes)
+ * keep the plain approve/deny result.
+ */
+function applyTimeoutOutcomeContract(
+  result: HumanInputResult,
+  outcomes: HumanInputConfig["outcomes"],
+): HumanInputResult {
+  if (!result.auto_resolved || result.reason !== "timeout" || !outcomes?.length) {
+    return result;
+  }
+  if (result.outcome === "approve") {
+    return { ...result, outcome: outcomes[0].name };
+  }
+  if (result.outcome === "deny") {
+    return { ...result, outcome: outcomes[outcomes.length - 1].name };
+  }
+  return result;
 }
 
 interface ResolvedReviewPayload {

--- a/backend/services/stigmer-server/pkg/domain/workflow/converter/converter_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/converter/converter_test.go
@@ -350,6 +350,110 @@ func TestProtoToYAML_AgentCallEmissionContract(t *testing.T) {
 	}
 }
 
+// TestProtoToYAML_HumanInputEmissionContract pins the cross-edition emission
+// contract for human_input (issue #779): on_timeout is emitted as the proto
+// enum NAME (HumanInputTimeoutPolicy.String()) — the exact form the runner's
+// loader normalizes to its internal fail/approve/deny words and refuses when
+// unrecognized, so a divergence here strands persisted workflows at load
+// time. The cloud Java InProcessWorkflowValidator must emit the same
+// with-block for this fixture; its twin test rides the Java-parity issue
+// spawned by #779. The contract is parsed structural equality of the
+// with-block, not byte equality of the YAML.
+func TestProtoToYAML_HumanInputEmissionContract(t *testing.T) {
+	config, _ := structpb.NewStruct(map[string]interface{}{
+		"prompt": "Approve escalation for ${ $context.ticket.id }?",
+		"form_schema": map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"notes": map[string]interface{}{"type": "string"},
+			},
+		},
+		"outcomes": []interface{}{
+			map[string]interface{}{"name": "proceed", "label": "Proceed", "then": "deploy"},
+			map[string]interface{}{"name": "reject"},
+		},
+		"approvers":             []interface{}{"team:engineering-leads"},
+		"timeout":               float64(3600),
+		"on_timeout":            "HUMAN_INPUT_TIMEOUT_APPROVE",
+		"notification_channels": []interface{}{"slack:#approvals"},
+		"payload":               "${ $context.draft_revision }",
+		"ui_hint":               "article-diff",
+	})
+
+	spec := &workflowv1.WorkflowSpec{
+		Document: &workflowv1.WorkflowDocument{
+			Dsl:       "1.0.0",
+			Namespace: "test",
+			Name:      "human-input-emission-contract",
+			Version:   "1.0.0",
+		},
+		Tasks: []*workflowv1.WorkflowTask{
+			{
+				Name:       "gate",
+				Kind:       workflowv1.WorkflowTaskKind_human_input,
+				TaskConfig: config,
+			},
+			{
+				Name: "deploy",
+				Kind: workflowv1.WorkflowTaskKind_set_vars,
+				TaskConfig: func() *structpb.Struct {
+					s, _ := structpb.NewStruct(map[string]interface{}{
+						"variables": map[string]interface{}{"deployed": "true"},
+					})
+					return s
+				}(),
+			},
+		},
+	}
+
+	yamlStr, err := NewConverter().ProtoToYAML(spec)
+	if err != nil {
+		t.Fatalf("ProtoToYAML failed: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlStr), &parsed); err != nil {
+		t.Fatalf("emitted YAML does not parse: %v", err)
+	}
+
+	doTasks, ok := parsed["do"].([]interface{})
+	if !ok || len(doTasks) != 2 {
+		t.Fatalf("expected 2 do-tasks, got %v", parsed["do"])
+	}
+	gateTask, ok := doTasks[0].(map[string]interface{})["gate"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing 'gate' task in %v", doTasks[0])
+	}
+	if gateTask["call"] != "human_input" {
+		t.Fatalf("expected call: human_input, got %v", gateTask["call"])
+	}
+
+	expectedWith := map[string]interface{}{
+		"prompt": "Approve escalation for ${ $context.ticket.id }?",
+		"form_schema": map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"notes": map[string]interface{}{"type": "string"},
+			},
+		},
+		"outcomes": []interface{}{
+			map[string]interface{}{"name": "proceed", "label": "Proceed", "then": "deploy"},
+			map[string]interface{}{"name": "reject"},
+		},
+		"approvers":             []interface{}{"team:engineering-leads"},
+		"timeout":               3600,
+		"on_timeout":            "HUMAN_INPUT_TIMEOUT_APPROVE",
+		"notification_channels": []interface{}{"slack:#approvals"},
+		"payload":               "${ $context.draft_revision }",
+		"ui_hint":               "article-diff",
+	}
+
+	if !reflect.DeepEqual(gateTask["with"], expectedWith) {
+		t.Errorf("human_input with-block diverges from the pinned emission contract.\ngot:  %#v\nwant: %#v",
+			gateTask["with"], expectedWith)
+	}
+}
+
 // TestUnmarshalTaskConfig_EnvironmentRefKindDefault verifies the DSL
 // normalizer: an environment_refs item that omits kind unmarshals with
 // kind=environment — the field can reference nothing else, so requiring

--- a/backend/services/stigmer-server/pkg/domain/workflow/registry/data/task-kind-registry.json
+++ b/backend/services/stigmer-server/pkg/domain/workflow/registry/data/task-kind-registry.json
@@ -2331,7 +2331,7 @@
         "type": "object"
       },
       "yamlExamples": [
-        "- name: manager_approval\n  kind: human_input\n  task_config:\n    prompt: \"Approve escalation for ${ $context.triage.severity } incident?\"\n    form_schema:\n      type: object\n      properties:\n        notes:\n          type: string\n          description: \"Optional notes for the engineering team\"\n        priority_override:\n          type: string\n          enum: [P1, P2, P3]\n    outcomes:\n      - name: approve\n        label: \"Approve Escalation\"\n      - name: deny\n        label: \"Reject\"\n        then: re_classify\n    approvers:\n      - \"team:engineering-leads\"\n    timeout: 86400\n    on_timeout: HUMAN_INPUT_TIMEOUT_ESCALATE\n    notification_channels:\n      - \"slack:#incident-approvals\"\n  export:\n    as: \"${ . }\"\n"
+        "- name: manager_approval\n  kind: human_input\n  task_config:\n    prompt: \"Approve escalation for ${ $context.triage.severity } incident?\"\n    form_schema:\n      type: object\n      properties:\n        notes:\n          type: string\n          description: \"Optional notes for the engineering team\"\n        priority_override:\n          type: string\n          enum: [P1, P2, P3]\n    outcomes:\n      - name: approve\n        label: \"Approve Escalation\"\n      - name: deny\n        label: \"Reject\"\n        then: re_classify\n    approvers:\n      - \"team:engineering-leads\"\n    timeout: 86400\n    on_timeout: HUMAN_INPUT_TIMEOUT_DENY\n    notification_channels:\n      - \"slack:#incident-approvals\"\n  export:\n    as: \"${ . }\"\n"
       ],
       "documentationUrl": "/docs/guides/workflows/task-types/human-input",
       "isAiNative": false,

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "budget_warnings.go",
         "crossref.go",
         "expression_warnings.go",
+        "human_input_validation.go",
         "model_validation.go",
         "validator.go",
     ],
@@ -30,6 +31,7 @@ go_test(
     srcs = [
         "budget_warnings_test.go",
         "crossref_test.go",
+        "human_input_validation_test.go",
         "model_validation_test.go",
         "validator_test.go",
     ],

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/human_input_validation.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/human_input_validation.go
@@ -1,0 +1,61 @@
+package validation
+
+import (
+	"fmt"
+
+	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
+	tasksv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1/tasks"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ValidateHumanInputTimeoutPolicies rejects human_input timeout policies the
+// runtime cannot honor. HUMAN_INPUT_TIMEOUT_ESCALATE is declared in the proto
+// but has no runner implementation (stigmer/stigmer#779; implementation
+// tracked in stigmer/stigmer#781): before this rule a
+// workflow carrying it validated, applied, and then silently behaved as FAIL
+// at the gate's first timeout. Fail closed here — a config that cannot run
+// must never persist. The runner's loader carries the same refusal for
+// already-persisted YAML.
+//
+// The rule reads the raw task_config Struct like its siblings
+// (ValidateTaskConfigRequiredFields et al.) so the error speaks the author's
+// own vocabulary. protojson accepts an enum by name or by number, so both
+// spellings are checked.
+func ValidateHumanInputTimeoutPolicies(spec *workflowv1.WorkflowSpec) []string {
+	if spec == nil || len(spec.Tasks) == 0 {
+		return nil
+	}
+
+	escalate := tasksv1.HumanInputTimeoutPolicy_HUMAN_INPUT_TIMEOUT_ESCALATE
+
+	var errors []string
+	for _, task := range spec.Tasks {
+		if task == nil || task.Kind != workflowv1.WorkflowTaskKind_human_input || task.TaskConfig == nil {
+			continue
+		}
+		value, ok := task.TaskConfig.GetFields()["on_timeout"]
+		if !ok {
+			continue
+		}
+
+		isEscalate := false
+		switch v := value.GetKind().(type) {
+		case *structpb.Value_StringValue:
+			isEscalate = v.StringValue == escalate.String()
+		case *structpb.Value_NumberValue:
+			isEscalate = v.NumberValue == float64(escalate.Number())
+		}
+
+		if isEscalate {
+			errors = append(errors, fmt.Sprintf(
+				"task '%s' (human_input): on_timeout policy %s is not implemented yet — use %s, %s, or %s (custom outcomes with 'then' cover reviewer-driven branching)",
+				task.Name,
+				escalate.String(),
+				tasksv1.HumanInputTimeoutPolicy_HUMAN_INPUT_TIMEOUT_FAIL.String(),
+				tasksv1.HumanInputTimeoutPolicy_HUMAN_INPUT_TIMEOUT_APPROVE.String(),
+				tasksv1.HumanInputTimeoutPolicy_HUMAN_INPUT_TIMEOUT_DENY.String(),
+			))
+		}
+	}
+	return errors
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/human_input_validation_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/human_input_validation_test.go
@@ -1,0 +1,133 @@
+package validation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	workflowv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1"
+	serverlessv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflow/v1/serverless"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func makeHumanInputTask(t *testing.T, name string, config map[string]interface{}) *workflowv1.WorkflowTask {
+	t.Helper()
+	cfg, err := structpb.NewStruct(config)
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+	return &workflowv1.WorkflowTask{
+		Name:       name,
+		Kind:       workflowv1.WorkflowTaskKind_human_input,
+		TaskConfig: cfg,
+	}
+}
+
+func makeHumanInputSpec(t *testing.T, tasks ...*workflowv1.WorkflowTask) *workflowv1.WorkflowSpec {
+	t.Helper()
+	return &workflowv1.WorkflowSpec{
+		Document: &workflowv1.WorkflowDocument{
+			Dsl:       "1.0.0",
+			Namespace: "test",
+			Name:      "human-input-policies",
+			Version:   "1.0.0",
+		},
+		Tasks: tasks,
+	}
+}
+
+func TestValidateHumanInputTimeoutPolicies_RejectsEscalate(t *testing.T) {
+	cases := []struct {
+		desc      string
+		onTimeout interface{}
+	}{
+		{"enum name", "HUMAN_INPUT_TIMEOUT_ESCALATE"},
+		{"numeric enum value", float64(4)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			spec := makeHumanInputSpec(t, makeHumanInputTask(t, "gate", map[string]interface{}{
+				"prompt":     "Approve?",
+				"timeout":    float64(60),
+				"on_timeout": c.onTimeout,
+			}))
+
+			errs := ValidateHumanInputTimeoutPolicies(spec)
+			if len(errs) != 1 {
+				t.Fatalf("expected exactly 1 error, got %v", errs)
+			}
+			for _, want := range []string{"gate", "HUMAN_INPUT_TIMEOUT_ESCALATE", "not implemented"} {
+				if !strings.Contains(errs[0], want) {
+					t.Errorf("error should contain %q, got: %s", want, errs[0])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateHumanInputTimeoutPolicies_AcceptsImplementedPolicies(t *testing.T) {
+	for _, policy := range []string{
+		"HUMAN_INPUT_TIMEOUT_FAIL",
+		"HUMAN_INPUT_TIMEOUT_APPROVE",
+		"HUMAN_INPUT_TIMEOUT_DENY",
+	} {
+		spec := makeHumanInputSpec(t, makeHumanInputTask(t, "gate", map[string]interface{}{
+			"prompt":     "Approve?",
+			"timeout":    float64(60),
+			"on_timeout": policy,
+		}))
+
+		if errs := ValidateHumanInputTimeoutPolicies(spec); len(errs) != 0 {
+			t.Errorf("policy %s should validate, got errors: %v", policy, errs)
+		}
+	}
+}
+
+func TestValidateHumanInputTimeoutPolicies_IgnoresAbsentPolicyAndOtherKinds(t *testing.T) {
+	setVarsCfg, _ := structpb.NewStruct(map[string]interface{}{
+		// A set_vars task whose variable VALUE happens to spell the enum name
+		// must not trip a rule scoped to human_input's on_timeout field.
+		"variables": map[string]interface{}{"note": "HUMAN_INPUT_TIMEOUT_ESCALATE"},
+	})
+	spec := makeHumanInputSpec(t,
+		makeHumanInputTask(t, "gate", map[string]interface{}{"prompt": "Approve?"}),
+		&workflowv1.WorkflowTask{
+			Name:       "notes",
+			Kind:       workflowv1.WorkflowTaskKind_set_vars,
+			TaskConfig: setVarsCfg,
+		},
+	)
+
+	if errs := ValidateHumanInputTimeoutPolicies(spec); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+// The validator-level pin: an escalate policy must surface as a user-fixable
+// INVALID result (stigmer/stigmer#779 fail-closed ruling), never persist as
+// VALID the way it did when only the runner's silent default existed.
+func TestInProcessValidator_EscalatePolicyIsInvalid(t *testing.T) {
+	spec := makeHumanInputSpec(t, makeHumanInputTask(t, "gate", map[string]interface{}{
+		"prompt":     "Approve?",
+		"timeout":    float64(60),
+		"on_timeout": "HUMAN_INPUT_TIMEOUT_ESCALATE",
+	}))
+
+	result, err := NewInProcessValidator().Validate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Validate returned transport error: %v", err)
+	}
+	if result.State != serverlessv1.ValidationState_INVALID {
+		t.Fatalf("expected INVALID, got %v (errors: %v)", result.State, result.Errors)
+	}
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "not implemented") && strings.Contains(e, "gate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a not-implemented error naming task 'gate', got: %v", result.Errors)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/validator.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/validator.go
@@ -94,6 +94,12 @@ func (v *InProcessValidator) Validate(ctx context.Context, spec *workflowv1.Work
 		errors = append(errors, modelErrors...)
 	}
 
+	// Step 2d: Human-input timeout policy validation (fail closed on
+	// policies the runtime cannot honor)
+	if policyErrors := ValidateHumanInputTimeoutPolicies(spec); len(policyErrors) > 0 {
+		errors = append(errors, policyErrors...)
+	}
+
 	// Step 3: Budget warnings
 	if budgetWarnings := CheckBudgetWarnings(spec.Budget, spec.Tasks); len(budgetWarnings) > 0 {
 		warnings = append(warnings, budgetWarnings...)

--- a/docs/guides/workflows/authoring.mdx
+++ b/docs/guides/workflows/authoring.mdx
@@ -363,13 +363,13 @@ The `human_input` task pauses execution and waits for a reviewer to respond:
 
 Key fields:
 
-| Field         | Purpose                                                                |
-| ------------- | ---------------------------------------------------------------------- |
-| `prompt`      | What the reviewer sees — supports expressions                          |
-| `form_schema` | Optional JSON Schema for structured input from the reviewer            |
-| `outcomes`    | List of buttons the reviewer can click — each can override `flow.then` |
-| `timeout`     | Seconds to wait before timing out                                      |
-| `on_timeout`  | `HUMAN_INPUT_TIMEOUT_FAIL` or `HUMAN_INPUT_TIMEOUT_SKIP`               |
+| Field         | Purpose                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| `prompt`      | What the reviewer sees — supports expressions                                            |
+| `form_schema` | Optional JSON Schema for structured input from the reviewer                              |
+| `outcomes`    | List of buttons the reviewer can click — each can override `flow.then`                   |
+| `timeout`     | Seconds to wait before timing out                                                        |
+| `on_timeout`  | `HUMAN_INPUT_TIMEOUT_FAIL`, `HUMAN_INPUT_TIMEOUT_APPROVE`, or `HUMAN_INPUT_TIMEOUT_DENY` |
 
 The default `flow.then` applies when the reviewer picks an outcome that does not
 specify its own `then`. In the example above, clicking "Approve" continues to

--- a/docs/guides/workflows/task-types/human-input.mdx
+++ b/docs/guides/workflows/task-types/human-input.mdx
@@ -39,7 +39,7 @@ then resume based on the reviewer's response.
     approvers:
       - "team:engineering-leads"
     timeout: 86400
-    on_timeout: HUMAN_INPUT_TIMEOUT_ESCALATE
+    on_timeout: HUMAN_INPUT_TIMEOUT_DENY
     notification_channels:
       - "slack:#incident-approvals"
   export:

--- a/docs/sdk/resources/mcp-server.mdx
+++ b/docs/sdk/resources/mcp-server.mdx
@@ -1316,7 +1316,7 @@ ConnectStatus records one connect operation — the most recent one.
     workflowId: { type: "string", description: "The Temporal workflow ID of the connect run — the operation handle." },
     startedAt: { type: "string", description: "When the operation was accepted (workflow started)." },
     finishedAt: { type: "string", description: "When the operation settled (success or failure)." },
-    failureCode: { type: "string", description: "gRPC status code name classifying the failure, mirroring what the blocking connect RPC returns for the same outcome: - \"FAILED_PRECONDITION\": the runner refused with a user-facing message (missing credentials, unreachable server) — failure_message renders verbatim." },
+    failureCode: { type: "string", description: "gRPC status code name classifying the failure, mirroring what the blocking connect RPC returns for the same outcome (CamelCase, the Go grpc codes.Code String() form): - \"FailedPrecondition\": the target server (or its credentials/config) refused the connect with a user-facing message — failure_message renders verbatim." },
     failureMessage: { type: "string", description: "Human-readable failure detail." },
     warning: { type: "string", description: "Non-fatal advisory recorded at start time, rendered by clients alongside the CONNECTING state." },
   }}

--- a/sdk/react/src/workflow/ApprovalFormBuilder.tsx
+++ b/sdk/react/src/workflow/ApprovalFormBuilder.tsx
@@ -24,11 +24,15 @@ interface FormFieldEntry {
   enumValues: string;
 }
 
+// HUMAN_INPUT_TIMEOUT_ESCALATE is deliberately absent: the proto declares it
+// but no runtime exists, and the server validator refuses it at apply
+// (stigmer/stigmer#779). The old option also wrote an `escalation_task` field
+// that HumanInputTaskConfig never had, so every config it produced failed
+// the server's strict decode.
 const TIMEOUT_POLICY_OPTIONS = [
   { value: "HUMAN_INPUT_TIMEOUT_FAIL", label: "Fail — task errors on timeout" },
   { value: "HUMAN_INPUT_TIMEOUT_APPROVE", label: "Auto-approve — proceed as approved" },
   { value: "HUMAN_INPUT_TIMEOUT_DENY", label: "Auto-deny — proceed as denied" },
-  { value: "HUMAN_INPUT_TIMEOUT_ESCALATE", label: "Escalate — branch to escalation task" },
 ] as const;
 
 const TIMEOUT_UNITS = [
@@ -107,8 +111,6 @@ export const ApprovalFormBuilder = memo(function ApprovalFormBuilder({
       <TimeoutSection
         timeout={typeof cfg.timeout === "number" ? cfg.timeout : 0}
         onTimeout={typeof cfg.on_timeout === "string" ? cfg.on_timeout : ""}
-        escalationTask={typeof cfg.escalation_task === "string" ? cfg.escalation_task : ""}
-        allTaskNames={allTaskNames}
         onUpdateConfig={onUpdateConfig}
       />
       <StringListSection
@@ -619,14 +621,10 @@ function FormFieldRow({
 function TimeoutSection({
   timeout,
   onTimeout,
-  escalationTask,
-  allTaskNames,
   onUpdateConfig,
 }: {
   timeout: number;
   onTimeout: string;
-  escalationTask: string;
-  allTaskNames: readonly string[];
   onUpdateConfig: (fieldPath: string, value: unknown) => void;
 }) {
   const bestUnit = useMemo(() => {
@@ -664,8 +662,6 @@ function TimeoutSection({
     },
     [timeout, unit, onUpdateConfig],
   );
-
-  const isEscalate = onTimeout === "HUMAN_INPUT_TIMEOUT_ESCALATE";
 
   return (
     <CollapsibleSection title="Timeout">
@@ -710,24 +706,6 @@ function TimeoutSection({
         </div>
       )}
 
-      {isEscalate && (
-        <div className="stg:mt-1.5 stg:flex stg:flex-col stg:gap-1">
-          <label className="stg:text-[10px] stg:text-[var(--stgm-muted-foreground,#737373)]">
-            Escalation task
-          </label>
-          <select
-            value={escalationTask}
-            onChange={(e) => onUpdateConfig("escalation_task", e.target.value || undefined)}
-            className={cn(smallInputClass)}
-            aria-label="Escalation target task"
-          >
-            <option value="">— Select escalation task —</option>
-            {allTaskNames.map((name) => (
-              <option key={name} value={name}>{name}</option>
-            ))}
-          </select>
-        </div>
-      )}
     </CollapsibleSection>
   );
 }

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -324,8 +324,12 @@ completes the run and the downstream task, that a **declared** non-approve outco
 (`deny`) is *data* (resolves and still completes — only the implicit no-outcomes
 binary form fails on deny), that an outcome's `then` **routes** the workflow to
 the named task (proving the submitted outcome value drives behavior through
-observable task statuses), that `on_timeout=HUMAN_INPUT_TIMEOUT_FAIL` fails the
-run on its own, and the negative codes (empty fields / unknown task / non-
+observable task statuses), the full timeout-policy contract — `FAIL` fails the
+run on its own, `APPROVE` completes it and reaches the downstream task, `DENY`
+resolves to the last declared outcome and completes, and a timed-out `APPROVE`
+with custom outcomes maps to the FIRST declared outcome and routes its `then`
+(the stigmer/stigmer#779 pins; before that fix only FAIL passed, by accident) —
+and the negative codes (empty fields / unknown task / non-
 `human_input` task -> `InvalidArgument`; missing execution -> `NotFound`; submit
 on a terminal execution -> `FailedPrecondition`). It deliberately does **not**
 assert idempotency (the signal-based gate is not deduped, unlike the agent DB

--- a/test/conformance/src/suites-execution/workflowexecution-approval.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution-approval.conformance.test.ts
@@ -250,6 +250,88 @@ describe("WorkflowExecution submitWorkflowTaskApproval — timeout policy", () =
       `timed-out gate should FAIL; reached ${ExecutionPhase[final.status?.phase ?? 0]}`,
     ).toBe(ExecutionPhase.EXECUTION_FAILED);
   });
+
+  // The APPROVE/DENY pins below close the stigmer/stigmer#779 gap: the
+  // persisted enum-name policies used to reach the runner unrecognized and
+  // silently behave as FAIL, so only the FAIL pin above ever passed — and it
+  // passed by accident (it would have passed for any garbage policy string).
+
+  it("on_timeout=APPROVE completes the run when no decision arrives", async () => {
+    const { org } = await target.provisionTenancy();
+    const workflowId = await provisionHumanInputWorkflow(org, {
+      timeout: 5,
+      onTimeout: "HUMAN_INPUT_TIMEOUT_APPROVE",
+    });
+
+    const execution = await clients.workflowExecutionCommand.create(
+      makeWorkflowExecution({ org, name: uniqueName("wfx-timeout-approve"), workflowId }),
+    );
+    const executionId = execution.metadata!.id;
+    fixtures.defer(() => clients.workflowExecutionCommand.delete({ value: executionId }));
+
+    // No submit: the timeout auto-approves and the run continues downstream.
+    const final = await awaitTerminal(clients, executionId);
+    expect(
+      final.status?.phase,
+      `auto-approved gate should COMPLETE; reached ${ExecutionPhase[final.status?.phase ?? 0]}`,
+    ).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    expect(
+      taskByName(final, HUMAN_INPUT_AFTER_TASK_NAME)?.status,
+      "the downstream task runs after auto-approval",
+    ).toBe(WorkflowTaskStatus.WORKFLOW_TASK_COMPLETED);
+  });
+
+  it("on_timeout=DENY resolves to the last declared outcome and completes", async () => {
+    const { org } = await target.provisionTenancy();
+    // Default fixture outcomes are declared binary approve/deny — per the
+    // HumanInputTaskConfig.outcomes contract, timeout auto-deny resolves to
+    // the LAST declared outcome ("deny", a data outcome that completes).
+    const workflowId = await provisionHumanInputWorkflow(org, {
+      timeout: 5,
+      onTimeout: "HUMAN_INPUT_TIMEOUT_DENY",
+    });
+
+    const execution = await clients.workflowExecutionCommand.create(
+      makeWorkflowExecution({ org, name: uniqueName("wfx-timeout-deny"), workflowId }),
+    );
+    const executionId = execution.metadata!.id;
+    fixtures.defer(() => clients.workflowExecutionCommand.delete({ value: executionId }));
+
+    const final = await awaitTerminal(clients, executionId);
+    expect(
+      final.status?.phase,
+      `auto-denied gate with a declared deny outcome should COMPLETE; reached ${ExecutionPhase[final.status?.phase ?? 0]}`,
+    ).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+  });
+
+  it("on_timeout=APPROVE maps to the FIRST declared outcome and routes its `then`", async () => {
+    const { org } = await target.provisionTenancy();
+    const workflowId = await provisionHumanInputWorkflow(org, {
+      outcomes: [{ name: "proceed", then: "fastPath" }, { name: "reject" }],
+      routedTasks: ["fastPath"],
+      timeout: 5,
+      onTimeout: "HUMAN_INPUT_TIMEOUT_APPROVE",
+    });
+
+    const execution = await clients.workflowExecutionCommand.create(
+      makeWorkflowExecution({ org, name: uniqueName("wfx-timeout-route"), workflowId }),
+    );
+    const executionId = execution.metadata!.id;
+    fixtures.defer(() => clients.workflowExecutionCommand.delete({ value: executionId }));
+
+    // No submit: auto-approval resolves to "proceed" (first outcome), whose
+    // `then` must route to fastPath — proving downstream sees the declared
+    // outcome name, not the orchestrator's internal "approve".
+    const final = await awaitTerminal(clients, executionId);
+    expect(
+      final.status?.phase,
+      `routed auto-approval should COMPLETE; reached ${ExecutionPhase[final.status?.phase ?? 0]}`,
+    ).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    expect(
+      taskByName(final, "fastPath")?.status,
+      "the first outcome's `then` target runs",
+    ).toBe(WorkflowTaskStatus.WORKFLOW_TASK_COMPLETED);
+  });
 });
 
 describe("WorkflowExecution submitWorkflowTaskApproval — negatives", () => {

--- a/test/conformance/src/support/workflows.ts
+++ b/test/conformance/src/support/workflows.ts
@@ -196,8 +196,9 @@ export interface HumanInputWorkflowOptions {
   // (the test owns the timing). Set with onTimeout to drive the timeout policy.
   timeout?: number;
   // Policy applied when the timeout expires, as the full proto enum string
-  // (e.g. "HUMAN_INPUT_TIMEOUT_FAIL") — this is what the json-schema and the
-  // server converter expect, not the runner's internal short form.
+  // (e.g. "HUMAN_INPUT_TIMEOUT_FAIL") — the form the json-schema and the
+  // server converter expect and persist into validated YAML; the runner
+  // normalizes it to its internal short words at load (stigmer/stigmer#779).
   onTimeout?: string;
   // Trailing set_vars tasks appended after `afterApproval`, used as `then`
   // routing targets so an outcome's jump lands on an observable task.

--- a/test/integration/workflow_hitl_edge_cases_test.go
+++ b/test/integration/workflow_hitl_edge_cases_test.go
@@ -94,6 +94,118 @@ func TestWorkflowHITL_HumanInputTimeout(t *testing.T) {
 	t.Logf("human_input timeout: execution failed after %v (timeout policy: FAIL)", elapsed)
 }
 
+// TestWorkflowHITL_HumanInputTimeoutAutoApprove verifies the #779 fix end to
+// end: on_timeout=HUMAN_INPUT_TIMEOUT_APPROVE (the enum-name form the server
+// converter persists) must auto-approve at timeout instead of failing, and —
+// per the HumanInputTaskConfig.outcomes contract — the auto-approval resolves
+// to the FIRST declared outcome, whose `then` routes the flow. Before #779
+// this execution FAILED: the loader cast the enum name through unvalidated
+// and the orchestrator's switch defaulted it to fail.
+//
+// Workflow: awaitApproval (human_input, timeout=5s, on_timeout=APPROVE,
+// outcomes: proceed → fastPath, reject) → afterApproval (skipped) /
+// fastPath (reached via the mapped first outcome's `then`)
+func TestWorkflowHITL_HumanInputTimeoutAutoApprove(t *testing.T) {
+	require.NotNil(t, grpcConn, "shared gRPC connection must be available")
+	if testHarness.UnifiedRunner == nil {
+		t.Skip("unified runner not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	clients := harness.NewClients(grpcConn)
+	deployer := harness.NewFixtureDeployer(clients, "hitl-auto-approve", suiteLogger)
+	defer deployer.Cleanup(ctx)
+
+	humanInputConfig, err := structpb.NewStruct(map[string]any{
+		"prompt": "This approval auto-approves on timeout",
+		"outcomes": []any{
+			map[string]any{"name": "proceed", "label": "Proceed", "then": "fastPath"},
+			map[string]any{"name": "reject", "label": "Reject"},
+		},
+		"timeout":    float64(5),
+		"on_timeout": "HUMAN_INPUT_TIMEOUT_APPROVE",
+	})
+	require.NoError(t, err)
+
+	afterConfig, err := structpb.NewStruct(map[string]any{
+		"variables": map[string]any{
+			"default_path": "true",
+		},
+	})
+	require.NoError(t, err)
+
+	fastPathConfig, err := structpb.NewStruct(map[string]any{
+		"variables": map[string]any{
+			"routed_to": "fastPath",
+		},
+	})
+	require.NoError(t, err)
+
+	workflow := &workflowv1.Workflow{
+		ApiVersion: "agentic.stigmer.ai/v1",
+		Kind:       "Workflow",
+		Metadata: &apiresource.ApiResourceMetadata{
+			Name: "integration-test-hitl-auto-approve",
+			Org:  "test-org",
+		},
+		Spec: &workflowv1.WorkflowSpec{
+			Description: "Integration test: human_input timeout auto-approve with outcome mapping",
+			Document: &workflowv1.WorkflowDocument{
+				Dsl:       "1.0.0",
+				Namespace: "test-org",
+				Name:      "integration-test-hitl-auto-approve",
+				Version:   "1.0.0",
+			},
+			Tasks: []*workflowv1.WorkflowTask{
+				{
+					Name:       "awaitApproval",
+					Kind:       workflowv1.WorkflowTaskKind_human_input,
+					TaskConfig: humanInputConfig,
+					Export:     &workflowv1.Export{As: "${ . }"},
+				},
+				{
+					Name:       "afterApproval",
+					Kind:       workflowv1.WorkflowTaskKind_set_vars,
+					TaskConfig: afterConfig,
+				},
+				{
+					Name:       "fastPath",
+					Kind:       workflowv1.WorkflowTaskKind_set_vars,
+					TaskConfig: fastPathConfig,
+					Export:     &workflowv1.Export{As: "${ . }"},
+					Flow:       &workflowv1.FlowControl{Then: "end"},
+				},
+			},
+		},
+	}
+
+	start := time.Now()
+	_, execution, err := deployer.DeployAndExecute(ctx, workflow, "hitl timeout auto-approve test")
+	require.NoError(t, err)
+
+	waiter := harness.NewExecutionWaiter(clients.ExecutionQuery, suiteLogger)
+	result, err := waiter.WaitForTerminal(ctx, execution.GetMetadata().GetId(), 90*time.Second)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	harness.AssertPhase(t, result, workflowexecutionv1.ExecutionPhase_EXECUTION_COMPLETED)
+	harness.AssertTaskStatus(t, result, "awaitApproval",
+		workflowexecutionv1.WorkflowTaskStatus_WORKFLOW_TASK_COMPLETED)
+	harness.AssertTaskStatus(t, result, "fastPath",
+		workflowexecutionv1.WorkflowTaskStatus_WORKFLOW_TASK_COMPLETED)
+
+	// afterApproval should have been skipped: the timeout auto-approval maps
+	// to the first outcome ("proceed"), whose `then` routes to fastPath.
+	afterTask := findTaskInExecution(result, "afterApproval")
+	if afterTask != nil {
+		require.NotEqual(t, workflowexecutionv1.WorkflowTaskStatus_WORKFLOW_TASK_COMPLETED,
+			afterTask.GetStatus(), "afterApproval should be skipped — timeout auto-approval routed to fastPath")
+	}
+	t.Logf("human_input timeout auto-approve: completed after %v via first-outcome mapping (proceed → fastPath)", elapsed)
+}
+
 // TestWorkflowHITL_HumanInputOutcomeRouting verifies that selecting a custom
 // outcome with a `then` field routes execution to the named task via the
 // __stigmer_branch_override mechanism.

--- a/tools/codegen/output/task-kind-registry.json
+++ b/tools/codegen/output/task-kind-registry.json
@@ -2331,7 +2331,7 @@
         "type": "object"
       },
       "yamlExamples": [
-        "- name: manager_approval\n  kind: human_input\n  task_config:\n    prompt: \"Approve escalation for ${ $context.triage.severity } incident?\"\n    form_schema:\n      type: object\n      properties:\n        notes:\n          type: string\n          description: \"Optional notes for the engineering team\"\n        priority_override:\n          type: string\n          enum: [P1, P2, P3]\n    outcomes:\n      - name: approve\n        label: \"Approve Escalation\"\n      - name: deny\n        label: \"Reject\"\n        then: re_classify\n    approvers:\n      - \"team:engineering-leads\"\n    timeout: 86400\n    on_timeout: HUMAN_INPUT_TIMEOUT_ESCALATE\n    notification_channels:\n      - \"slack:#incident-approvals\"\n  export:\n    as: \"${ . }\"\n"
+        "- name: manager_approval\n  kind: human_input\n  task_config:\n    prompt: \"Approve escalation for ${ $context.triage.severity } incident?\"\n    form_schema:\n      type: object\n      properties:\n        notes:\n          type: string\n          description: \"Optional notes for the engineering team\"\n        priority_override:\n          type: string\n          enum: [P1, P2, P3]\n    outcomes:\n      - name: approve\n        label: \"Approve Escalation\"\n      - name: deny\n        label: \"Reject\"\n        then: re_classify\n    approvers:\n      - \"team:engineering-leads\"\n    timeout: 86400\n    on_timeout: HUMAN_INPUT_TIMEOUT_DENY\n    notification_channels:\n      - \"slack:#incident-approvals\"\n  export:\n    as: \"${ . }\"\n"
       ],
       "documentationUrl": "/docs/guides/workflows/task-types/human-input",
       "isAiNative": false,


### PR DESCRIPTION
## Summary

Fixes the human_input timeout-policy contract end to end (#779): the server converter persists `on_timeout` as the proto enum NAME (`HUMAN_INPUT_TIMEOUT_APPROVE`), but the runner's loader cast it unvalidated into a lowercase-word vocabulary, so the orchestrator's switch silently treated **every** persisted policy as `fail` — gates configured to auto-approve/deny failed at their first real timeout, with no error naming the mismatch.

### The fix

- **Runner loader** (`workflow-engine/loader.ts`): new `parseOnTimeout` — the symmetric twin of the file's own `parseServiceTier` idiom — normalizes the enum-name forms, keeps the lowercase words (golden fixtures), and refuses unknown values and the unimplemented `escalate` policy loudly at load time. Loader-side normalization was chosen deliberately: converted YAML is persisted in immutable, content-addressed `WorkflowVersionEntry.validated_yaml`, so this heals **every already-applied workflow version** (a converter-side change could not) and fixes both editions at once (cloud runs the same TS runner).
- **Runner executor** (`tasks/human-input.ts`): timeout auto-resolution now honors the proto's documented outcome contract — APPROVE resolves to the FIRST declared outcome, DENY to the LAST, including `then` routing via the existing `__flow_directive__` mechanism. Without this, the newly-live path would ship divergent from its own contract.
- **Server validation**: `ValidateHumanInputTimeoutPolicies` (a new rule in the validator's rule-function family) rejects ESCALATE as a user-fixable INVALID error — no runtime exists for it (implementation tracked in #781; cloud Java-validator parity tracked in stigmer/stigmer-cloud#486).
- **Console** (`sdk/react` ApprovalFormBuilder): the escalate option is removed from the timeout-policy select. It was a triple defect: unimplemented policy, wrote an `escalation_task` field that does not exist in `HumanInputTaskConfig`, and every config it produced failed the server's strict decode.
- **Docs**: sidecar example + regenerated task docs move off ESCALATE; the phantom `HUMAN_INPUT_TIMEOUT_SKIP` is removed from the authoring guide; the ESCALATE enum comment now states the fail-closed posture.

### Pins (red-first)

- Loader tests: enum-name normalization, unknown-value refusal, escalate refusal.
- Executor tests: first/last outcome mapping incl. `then` routing and the approval_resolved event reporting the mapped outcome.
- `TestProtoToYAML_HumanInputEmissionContract`: first human_input emission-contract test (the agent_call pattern) pinning the exact persisted vocabulary.
- Integration: `TestWorkflowHITL_HumanInputTimeoutAutoApprove` (before this fix, that execution FAILED).
- Conformance: APPROVE/DENY timeout pins + first-outcome `then` routing pin — before this fix only the FAIL pin existed, and it passed by accident (any garbage policy string produced the same failure).

## Verification

- Runner: typecheck + full Vitest suite green (117 in the touched files; full suite green).
- Go: validation + converter package tests green, `go vet` across all modules, `make build` green, integration test compile-checked (`go vet -tags integration`).
- Conformance execution suite (`workflowexecution-approval`, local-go + Temporal dev server): **15/15 green including the three new timeout-policy pins**.
- React SDK: lint + typecheck green.
- Docs gates: `check-docs-yaml` (117 blocks), `gen-task-docs-check`, `gen-proto-sdk-docs-check`, `format-docs-check`, `lint-docs`, `buf lint` all green; `gen-task-registry-check` green post-commit (its last arm is a git-cleanliness check).

Closes #779

Made with [Cursor](https://cursor.com)