### PR TITLE
fix(backend/runner): stop classifying SIGTERM worker shutdown as a user pause

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -148,7 +148,7 @@ import type { ClassifiedError } from "./error-classifier.js";
 import { createAgent, createCloudAgent } from "./session-lifecycle.js";
 import { setMaxListeners } from "node:events";
 import { startHeartbeat } from "../../shared/heartbeat.js";
-import { getShutdownSignalForQueue } from "../../runner-manager.js";
+import { classifyTurnInterruption, getShutdownSignalForQueue } from "../../shared/worker-shutdown.js";
 
 /**
  * Creates the activity functions bound to the runner config.
@@ -1398,13 +1398,21 @@ async function executeCursorInner(
     // classifies a shutdown from the shutdown signal directly (in
     // resolvePreBoundaryTerminal). The heartbeat timer may set `cancelled` before
     // the AbortSignal microtask propagates; the direct signal check catches that.
-    const isShutdown = periodicHeartbeat.workerShutdown || (shutdownSignal?.aborted ?? false);
-    if (isShutdown) {
+    // The decision table (including #776's grace-window guard: an aborted
+    // shutdown signal with NO interruption evidence stays "none") lives in
+    // classifyTurnInterruption — shared/worker-shutdown.ts.
+    const interruption = classifyTurnInterruption({
+      heartbeatCancelled: periodicHeartbeat.cancelled,
+      heartbeatWorkerShutdown: periodicHeartbeat.workerShutdown,
+      cancellationSignalAborted: Context.current().cancellationSignal.aborted,
+      shutdownSignalAborted: shutdownSignal?.aborted ?? false,
+    });
+    if (interruption === "worker-shutdown") {
       turnState.pauseDetected = false;
-    } else if (periodicHeartbeat.cancelled) {
+    } else if (interruption === "pause") {
       turnState.pauseDetected = true;
     }
-    workerShutdownDetected = isShutdown;
+    workerShutdownDetected = interruption === "worker-shutdown";
 
     // Post-stream finalize, shared by the primary turn and both recovery retries:
     // finalize the transcript + streaming flags, mark any in-flight sub-agent
@@ -1502,10 +1510,16 @@ async function executeCursorInner(
         return { kind: "return" };
       }
 
-      // Worker shutdown: the runner-manager aborted the shutdown signal. NOT a
+      // Worker shutdown: the runner/manager aborted the shutdown signal. NOT a
       // user pause. Checked via the shutdown signal directly so a retry (whose
-      // periodic heartbeat is already stopped) still classifies it correctly.
-      if (workerShutdownDetected || (shutdownSignal?.aborted ?? false)) {
+      // periodic heartbeat is already stopped) still classifies it correctly —
+      // but only alongside a delivered cancellation: a retry that completed
+      // normally inside the drain grace window must stay a completion (#776's
+      // grace-window guard, mirroring the primary's `interrupted` gate).
+      if (
+        workerShutdownDetected ||
+        ((shutdownSignal?.aborted ?? false) && Context.current().cancellationSignal.aborted)
+      ) {
         status.phase = ExecutionPhase.EXECUTION_FAILED;
         status.error = "Execution interrupted: runner worker was shut down. Retry or resume.";
         status.completedAt = utcTimestamp();
@@ -2147,9 +2161,12 @@ async function executeCursorInner(
     periodicHeartbeat?.stop();
 
     if (err instanceof CancelledFailure) {
-      // workerShutdownDetected means the runner-manager signaled shutdown
-      // before the worker drained. This is infrastructure failure, not pause.
-      if (workerShutdownDetected) {
+      // Worker shutdown is infrastructure failure, not pause. The direct
+      // signal check covers a CancelledFailure thrown BEFORE the post-stream
+      // classification ran (workerShutdownDetected still false); no extra
+      // interruption-evidence gate is needed here — the caught
+      // CancelledFailure IS the evidence (#776).
+      if (workerShutdownDetected || (shutdownSignal?.aborted ?? false)) {
         console.log(`ExecuteCursor cancelled (worker shutdown) for execution ${executionId}`);
         status.phase = ExecutionPhase.EXECUTION_FAILED;
         status.error = "Execution interrupted: runner worker was shut down. Retry or resume.";

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-reject.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-reject.test.ts
@@ -42,6 +42,7 @@ vi.mock("@temporalio/activity", () => ({
     current: () => ({
       cancellationSignal: new AbortController().signal,
       heartbeat: vi.fn(),
+      info: { taskQueue: "test-queue" },
     }),
   },
   CancelledFailure: class CancelledFailure extends Error {},

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-approve-all.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-approve-all.test.ts
@@ -53,6 +53,7 @@ vi.mock("@temporalio/activity", () => ({
       // on it, which a bare `{ aborted: false }` stub cannot satisfy.
       cancellationSignal: new AbortController().signal,
       heartbeat: vi.fn(),
+      info: { taskQueue: "test-queue" },
     }),
   },
   CancelledFailure: class CancelledFailure extends Error {},

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-history.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-history.test.ts
@@ -46,6 +46,7 @@ vi.mock("@temporalio/activity", () => ({
       // on it, which a bare `{ aborted: false }` stub cannot satisfy.
       cancellationSignal: new AbortController().signal,
       heartbeat: vi.fn(),
+      info: { taskQueue: "test-queue" },
     }),
   },
   CancelledFailure: class CancelledFailure extends Error {},

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/index.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/index.test.ts
@@ -12,6 +12,7 @@ vi.mock("@temporalio/activity", () => ({
       // on it, which a bare `{ aborted: false }` stub cannot satisfy.
       cancellationSignal: new AbortController().signal,
       heartbeat: vi.fn(),
+      info: { taskQueue: "test-queue" },
     }),
   },
   CancelledFailure: class CancelledFailure extends Error {},

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/sequential-gate-resume.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/sequential-gate-resume.test.ts
@@ -55,6 +55,7 @@ vi.mock("@temporalio/activity", () => ({
       // on it, which a bare `{ aborted: false }` stub cannot satisfy.
       cancellationSignal: new AbortController().signal,
       heartbeat: vi.fn(),
+      info: { taskQueue: "test-queue" },
     }),
   },
   CancelledFailure: class CancelledFailure extends Error {},

--- a/backend/services/runner/src/activities/execute-deep-agent/index.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/index.ts
@@ -78,9 +78,32 @@ import { stampFlowedFileEditRows, stampFlowedSubAgentFileEditRows } from "./stam
 import { deriveTurnCommandProvenance } from "./command-provenance.js";
 import { describeExecutionError } from "../../shared/model-error.js";
 import { inferProvider, type LlmProvider } from "../../shared/llm-proxy.js";
+import { getShutdownSignalForQueue } from "../../shared/worker-shutdown.js";
 
 /** The harness id stamped on the deep-agent's file-review ledger events. */
 const DEEP_AGENT_HARNESS_ID = "deep-agent";
+
+/**
+ * The worker-shutdown terminal status (#776). A shutdown is not a pause: the
+ * execution will not resume on this worker, so persisting PAUSED would strand
+ * the user with a lie. The copy is byte-identical to the Cursor harness's
+ * worker-shutdown branch so every downstream status.error consumer (the Go and
+ * Java workflow fallbacks, the cloud channel decision table) keys on ONE shape.
+ */
+function buildWorkerShutdownStatus(): AgentExecutionStatus {
+  return create(AgentExecutionStatusSchema, {
+    phase: ExecutionPhase.EXECUTION_FAILED,
+    error: "Execution interrupted: runner worker was shut down. Retry or resume.",
+    completedAt: utcTimestamp(),
+    messages: [
+      create(AgentMessageSchema, {
+        type: MessageType.MESSAGE_SYSTEM,
+        content: "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
+        timestamp: utcTimestamp(),
+      }),
+    ],
+  });
+}
 
 /**
  * Best-effort provider inference for error-message wording. inferProvider
@@ -115,6 +138,11 @@ export function createDeepAgentActivities(config: Config) {
     ): Promise<unknown> => {
       const { executionId, threadId, turnSeq } = normalizeActivityInput(arg0, arg1);
       activityStarted();
+      // Worker-shutdown classification channel (#776): the pause paths below
+      // consult this signal to distinguish "my worker is draining" (SIGTERM,
+      // desktop quit) from "the orchestrator cancelled me" (a real user
+      // pause). See shared/worker-shutdown.ts for the ownership contract.
+      const shutdownSignal = getShutdownSignalForQueue(Context.current().info.taskQueue);
       let setup: SetupResult | null = null;
       // Exclusive turn lock on the workspace working tree — held across the
       // entire tree-mutating window (decision reconcile, agent writes,
@@ -567,6 +595,13 @@ export function createDeepAgentActivities(config: Config) {
 
         if (result.terminalStatus) {
           if (initialStatus.phase === ExecutionPhase.EXECUTION_PAUSED) {
+            // The stream loop marks PAUSED for ANY platform cancellation; a
+            // worker shutdown is not a pause and must not persist as one (#776).
+            if (shutdownSignal?.aborted) {
+              console.log(`[ExecuteDeepAgent] Cancelled (worker shutdown) for execution ${executionId}: events=${result.eventsProcessed}`);
+              await persistStatus(client, executionId, buildWorkerShutdownStatus(), { offload: statusOffload }).catch(() => {});
+              throw new CancelledFailure("Activity cancelled (worker shutdown, not user pause)");
+            }
             await persistStatus(client, executionId, initialStatus, { offload: statusOffload });
             console.log(`[ExecuteDeepAgent] Paused for execution ${executionId}: events=${result.eventsProcessed}`);
             throw new CancelledFailure("Activity paused by orchestrator");
@@ -754,6 +789,13 @@ export function createDeepAgentActivities(config: Config) {
 
       } catch (err: unknown) {
         if (err instanceof CancelledFailure) {
+          // Worker shutdown is infrastructure failure, not pause — the caught
+          // CancelledFailure is itself the interruption evidence (#776).
+          if (shutdownSignal?.aborted) {
+            console.log(`[ExecuteDeepAgent] Cancelled (worker shutdown) for execution ${executionId}`);
+            await persistStatus(client, executionId, buildWorkerShutdownStatus()).catch(() => {});
+            throw err;
+          }
           console.log(`[ExecuteDeepAgent] Cancelled (pause) for execution ${executionId}`);
           const pausedStatus = create(AgentExecutionStatusSchema, {
             phase: ExecutionPhase.EXECUTION_PAUSED,
@@ -763,6 +805,11 @@ export function createDeepAgentActivities(config: Config) {
         }
 
         if (Context.current().cancellationSignal.aborted) {
+          if (shutdownSignal?.aborted) {
+            console.log(`[ExecuteDeepAgent] Error during worker-shutdown cancellation for ${executionId}: ${err}`);
+            await persistStatus(client, executionId, buildWorkerShutdownStatus()).catch(() => {});
+            throw new CancelledFailure("Activity cancelled (worker shutdown, not user pause)");
+          }
           console.log(`[ExecuteDeepAgent] Error during cancellation for ${executionId}, treating as pause: ${err}`);
           const pausedStatus = create(AgentExecutionStatusSchema, {
             phase: ExecutionPhase.EXECUTION_PAUSED,

--- a/backend/services/runner/src/runner-manager.ts
+++ b/backend/services/runner/src/runner-manager.ts
@@ -49,6 +49,10 @@ import {
   setQueueDrainCallback,
   forgetQueue,
 } from "./in-flight.js";
+import {
+  registerWorkerShutdownSignal,
+  unregisterWorkerShutdownSignal,
+} from "./shared/worker-shutdown.js";
 
 const SESSION_QUEUE_PREFIX = "session:";
 const WFEXEC_QUEUE_PREFIX = "wfexec:";
@@ -57,16 +61,10 @@ const WFEXEC_QUEUE_PREFIX = "wfexec:";
 // Mirrors SessionDispatchService's convention: lowercase kind, colon, id.
 const POOL_CONTROL_QUEUE_PREFIX = "sandbox:";
 
-/**
- * Module-level registry of shutdown signals per task queue.
- * Activities running in the same process can read this to determine
- * whether their worker is being shut down (vs orchestrator pause).
- */
-const _shutdownSignalRegistry = new Map<string, AbortSignal>();
-
-export function getShutdownSignalForQueue(taskQueue: string): AbortSignal | undefined {
-  return _shutdownSignalRegistry.get(taskQueue);
-}
+// Re-export for existing importers; the registry itself lives in
+// shared/worker-shutdown.ts so the static runner (runner.ts) and the
+// activities can share it without importing this manager module.
+export { getShutdownSignalForQueue } from "./shared/worker-shutdown.js";
 
 export interface RunnerManagerOptions {
   /**
@@ -411,15 +409,12 @@ export async function createStigmerRunnerManager(
 
   const sessions = new Map<string, ManagedSession>();
   const workflowExecutions = new Map<string, ManagedSession>();
-  const shutdownSignals = new Map<string, AbortController>();
   // At most one per process: a pool member IS its control worker's identity.
   let poolControl: { taskQueue: string; managed: ManagedSession } | null = null;
   let shuttingDown = false;
 
   async function createWorkerOnQueue(taskQueue: string): Promise<ManagedSession> {
-    const shutdownController = new AbortController();
-    shutdownSignals.set(taskQueue, shutdownController);
-    _shutdownSignalRegistry.set(taskQueue, shutdownController.signal);
+    const shutdownController = registerWorkerShutdownSignal(taskQueue);
 
     const worker = await Worker.create({
       connection,
@@ -481,8 +476,7 @@ export async function createStigmerRunnerManager(
     managed.worker.shutdown();
     await managed.runPromise;
     registry.delete(id);
-    shutdownSignals.delete(taskQueue);
-    _shutdownSignalRegistry.delete(taskQueue);
+    unregisterWorkerShutdownSignal(taskQueue);
     forgetQueue(taskQueue);
     console.log(`[runner-manager] Removed ${kind} ${id} (active=${registry.size})`);
   }
@@ -619,6 +613,22 @@ export async function createStigmerRunnerManager(
       console.log(
         `[runner-manager] Shutting down ${totalWorkers} workers (${sessions.size} sessions, ${workflowExecutions.size} workflow executions)...`,
       );
+
+      // Mark every queue's shutdown signal BEFORE draining, so an in-flight
+      // activity cancelled by the drain classifies it as a worker shutdown
+      // rather than a user pause (issue #776 — a SIGTERM'd pool member used
+      // to persist EXECUTION_PAUSED and let raw Temporal drain text reach
+      // status.error). Aborting is classification-only: it stops nothing;
+      // worker.shutdown() below still owns the drain. This is deliberately
+      // NOT done in teardownManaged — single-worker teardowns only run once
+      // the queue is idle, and aborting there is the old view-close bug.
+      for (const session of sessions.values()) {
+        session.shutdownController.abort();
+      }
+      for (const execution of workflowExecutions.values()) {
+        execution.shutdownController.abort();
+      }
+      poolControl?.managed.shutdownController.abort();
 
       const shutdownPromises = [
         ...Array.from(sessions.entries()).map(

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -324,6 +324,16 @@ export async function createStigmerRunner(
   // unaffected — their env-injected platform key wins inside the loader.
   const payloadCodecs = await createPayloadCodecs(config, coordinates.payloadEncryption);
 
+  // Register the queue's shutdown signal BEFORE the worker can poll, so an
+  // activity interrupted by shutdown() below classifies the cancellation as a
+  // worker shutdown, not a user pause (issue #776). Static mode historically
+  // never registered one, leaving CLI daemons with the same misclassification
+  // the desktop manager had.
+  const { registerWorkerShutdownSignal } = await import(
+    "./shared/worker-shutdown.js"
+  );
+  const shutdownController = registerWorkerShutdownSignal(config.taskQueue);
+
   const { startWorker } = await import("./worker.js");
   const worker = await startWorker({ config, activities, payloadCodecs });
   markBoot("worker_created");
@@ -349,6 +359,10 @@ export async function createStigmerRunner(
     },
     shutdown() {
       tokenRenewal?.stop();
+      // Classification first, drain second: an in-flight activity cancelled
+      // by the drain must observe the signal already aborted (see
+      // shared/worker-shutdown.ts for the ownership contract).
+      shutdownController.abort();
       worker.shutdown();
     },
   };

--- a/backend/services/runner/src/shared/__tests__/worker-shutdown.test.ts
+++ b/backend/services/runner/src/shared/__tests__/worker-shutdown.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyTurnInterruption,
+  getShutdownSignalForQueue,
+  registerWorkerShutdownSignal,
+  signalWorkerShutdown,
+  unregisterWorkerShutdownSignal,
+} from "../worker-shutdown.js";
+
+describe("worker-shutdown signal registry", () => {
+  it("registers a live signal an activity can resolve by queue name", () => {
+    const controller = registerWorkerShutdownSignal("session:reg-1");
+    const signal = getShutdownSignalForQueue("session:reg-1");
+    expect(signal).toBe(controller.signal);
+    expect(signal?.aborted).toBe(false);
+    unregisterWorkerShutdownSignal("session:reg-1");
+  });
+
+  it("aborting via signalWorkerShutdown marks the queue's signal (idempotent, unknown queues are no-ops)", () => {
+    registerWorkerShutdownSignal("session:abort-1");
+    signalWorkerShutdown("session:abort-1");
+    signalWorkerShutdown("session:abort-1");
+    expect(getShutdownSignalForQueue("session:abort-1")?.aborted).toBe(true);
+    expect(() => signalWorkerShutdown("session:never-registered")).not.toThrow();
+    unregisterWorkerShutdownSignal("session:abort-1");
+  });
+
+  it("re-registering a reused queue replaces an aborted signal with a fresh one", () => {
+    // A re-created worker on a reused queue (desktop re-opens a session) must
+    // not observe the previous worker's aborted signal as its own shutdown.
+    const first = registerWorkerShutdownSignal("session:reuse-1");
+    first.abort();
+    const second = registerWorkerShutdownSignal("session:reuse-1");
+    expect(getShutdownSignalForQueue("session:reuse-1")).toBe(second.signal);
+    expect(getShutdownSignalForQueue("session:reuse-1")?.aborted).toBe(false);
+    unregisterWorkerShutdownSignal("session:reuse-1");
+  });
+
+  it("unregistering removes the signal", () => {
+    registerWorkerShutdownSignal("session:gone-1");
+    unregisterWorkerShutdownSignal("session:gone-1");
+    expect(getShutdownSignalForQueue("session:gone-1")).toBeUndefined();
+  });
+});
+
+describe("classifyTurnInterruption", () => {
+  const none = {
+    heartbeatCancelled: false,
+    heartbeatWorkerShutdown: false,
+    cancellationSignalAborted: false,
+    shutdownSignalAborted: false,
+  };
+
+  it("an uninterrupted turn is none", () => {
+    expect(classifyTurnInterruption(none)).toBe("none");
+  });
+
+  it("GRACE-WINDOW GUARD (#776): an aborted shutdown signal alone stays none — a run that completed inside the drain grace window must not be failed", () => {
+    expect(
+      classifyTurnInterruption({ ...none, shutdownSignalAborted: true }),
+    ).toBe("none");
+  });
+
+  it("heartbeat cancellation without a shutdown signal is the orchestrator's pause", () => {
+    expect(
+      classifyTurnInterruption({ ...none, heartbeatCancelled: true }),
+    ).toBe("pause");
+  });
+
+  it("heartbeat cancellation WITH the shutdown signal aborted is a worker shutdown, not a pause (the #776 misclassification)", () => {
+    expect(
+      classifyTurnInterruption({
+        ...none,
+        heartbeatCancelled: true,
+        shutdownSignalAborted: true,
+      }),
+    ).toBe("worker-shutdown");
+  });
+
+  it("the heartbeat's own workerShutdown flag classifies directly", () => {
+    expect(
+      classifyTurnInterruption({ ...none, heartbeatWorkerShutdown: true }),
+    ).toBe("worker-shutdown");
+  });
+
+  it("a delivered cancellation with the shutdown signal aborted is a worker shutdown (signal races the heartbeat tick)", () => {
+    expect(
+      classifyTurnInterruption({
+        ...none,
+        cancellationSignalAborted: true,
+        shutdownSignalAborted: true,
+      }),
+    ).toBe("worker-shutdown");
+  });
+
+  it("a delivered cancellation alone (heartbeat timeout / infra cancel) is neither shutdown nor pause", () => {
+    expect(
+      classifyTurnInterruption({ ...none, cancellationSignalAborted: true }),
+    ).toBe("none");
+  });
+});

--- a/backend/services/runner/src/shared/worker-shutdown.ts
+++ b/backend/services/runner/src/shared/worker-shutdown.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-task-queue worker-shutdown signals — the classification channel that
+ * lets an in-flight activity distinguish "my worker is shutting down" from
+ * "the orchestrator cancelled me" (a user pause).
+ *
+ * The signal carries NO lifecycle authority: aborting it never stops a
+ * worker or an activity (Temporal's own drain does that). It exists purely
+ * so the activity's cancellation handling can classify the interruption
+ * honestly — a shutdown is not a pause, and must surface as the
+ * worker-shutdown failure shape the control planes recognize (issue #776).
+ *
+ * Ownership contract:
+ *   - whoever creates a Worker registers a signal for its queue BEFORE the
+ *     worker starts polling;
+ *   - whoever initiates a full shutdown (SIGTERM handler, desktop quit)
+ *     aborts the signal BEFORE calling worker.shutdown(), so activities
+ *     cancelled by the drain observe it already aborted;
+ *   - a graceful single-worker teardown (view close, deferred teardown in
+ *     the runner-manager) must NOT abort — those paths only run once no
+ *     activity is in flight, and aborting earlier is exactly the regression
+ *     that killed running activities on a view close.
+ *
+ * Module-level (not per-manager) because activities resolve their signal by
+ * task-queue name via {@link getShutdownSignalForQueue} without a handle to
+ * the runner/manager instance that created their worker.
+ */
+
+const registry = new Map<string, AbortController>();
+
+/**
+ * Register a fresh shutdown signal for a task queue, replacing any previous
+ * registration (a re-created worker on a reused queue must not observe the
+ * old worker's aborted signal). Returns the controller so the worker's owner
+ * can abort it at shutdown.
+ */
+export function registerWorkerShutdownSignal(taskQueue: string): AbortController {
+  const controller = new AbortController();
+  registry.set(taskQueue, controller);
+  return controller;
+}
+
+/** The signal an activity on `taskQueue` should observe, if one is registered. */
+export function getShutdownSignalForQueue(taskQueue: string): AbortSignal | undefined {
+  return registry.get(taskQueue)?.signal;
+}
+
+/**
+ * Abort the queue's signal, marking any in-flight activity's imminent
+ * cancellation as a worker shutdown. Idempotent; no-op for an unknown queue.
+ */
+export function signalWorkerShutdown(taskQueue: string): void {
+  registry.get(taskQueue)?.abort();
+}
+
+/** Drop the registration once the queue's worker is fully torn down. */
+export function unregisterWorkerShutdownSignal(taskQueue: string): void {
+  registry.delete(taskQueue);
+}
+
+/** The evidence a turn's post-stream classification weighs (see below). */
+export interface TurnInterruptionEvidence {
+  /** The periodic heartbeat threw CancelledFailure with no shutdown signal. */
+  heartbeatCancelled: boolean;
+  /** The periodic heartbeat threw CancelledFailure with the signal aborted. */
+  heartbeatWorkerShutdown: boolean;
+  /** Temporal delivered cancellation to the activity. */
+  cancellationSignalAborted: boolean;
+  /** This queue's worker-shutdown signal is aborted. */
+  shutdownSignalAborted: boolean;
+}
+
+/**
+ * Classify how (whether) a turn's stream was interrupted, from the evidence
+ * available after the stream ends. Pure so the decision table is directly
+ * testable — the activities feed it their heartbeat flags and signals.
+ *
+ * The load-bearing rule is the grace-window guard (#776): an aborted
+ * shutdown signal ALONE is "none", because a run that completes normally
+ * inside the drain grace window reaches the classification with the signal
+ * already aborted and nothing actually interrupted. Shutdown requires
+ * interruption evidence (a heartbeat CancelledFailure or a delivered
+ * cancellation) alongside the signal; a heartbeat cancellation with no
+ * shutdown signal is the orchestrator's pause.
+ */
+export function classifyTurnInterruption(
+  evidence: TurnInterruptionEvidence,
+): "worker-shutdown" | "pause" | "none" {
+  const interrupted =
+    evidence.heartbeatCancelled ||
+    evidence.heartbeatWorkerShutdown ||
+    evidence.cancellationSignalAborted;
+  if (!interrupted) {
+    return "none";
+  }
+  if (evidence.heartbeatWorkerShutdown || evidence.shutdownSignalAborted) {
+    return "worker-shutdown";
+  }
+  return evidence.heartbeatCancelled ? "pause" : "none";
+}

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//backend/services/stigmer-server/pkg/domain/agentexecution/filereview",
         "//backend/services/stigmer-server/pkg/domain/agentexecution/temporal/activities",
         "//backend/services/stigmer-server/pkg/domain/executioncontext/temporal/activities",
+        "//backend/services/stigmer-server/pkg/runnerfailure",
         "@io_temporal_go_api//enums/v1:enums",
         "@io_temporal_go_sdk//converter",
         "@io_temporal_go_sdk//temporal",

--- a/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_impl.go
+++ b/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/workflows/invoke_workflow_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/filereview"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agentexecution/temporal/activities"
 	ecactivities "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/executioncontext/temporal/activities"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/runnerfailure"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
@@ -156,18 +157,23 @@ const MaxRecoveryCycles = 10
 // harness_state_id / LangGraph checkpoint), as opposed to a genuine failure.
 //
 // Recoverable: a HEARTBEAT timeout (the worker stopped heartbeating because it
-// crashed, slept, or was reaped mid-run) and an infrastructure cancellation
+// crashed, slept, or was reaped mid-run), an infrastructure cancellation
 // (CanceledError) that is NOT a user pause (handled by the pause branch) and
-// NOT an external workflow cancellation (the caller guards on ctx.Err()).
+// NOT an external workflow cancellation (the caller guards on ctx.Err()), and
+// a worker-shutdown drain (#776 owner ruling): the Temporal TS worker failing
+// a started activity it could not finish inside the shutdown grace window is
+// the same "worker reaped mid-run" interruption as a heartbeat timeout — a
+// SIGTERM'd pool member's turn resumes on the restarted pod instead of
+// dead-ending with error copy.
 //
-// NOT recoverable here: SCHEDULE_TO_START / START_TO_CLOSE timeouts and
+// NOT recoverable here: SCHEDULE_TO_START / START_TO_CLOSE timeouts and other
 // application errors — re-invoking those would not change the outcome.
 func isRecoverableActivityError(err error) bool {
 	var timeoutErr *temporal.TimeoutError
 	if errors.As(err, &timeoutErr) {
 		return timeoutErr.TimeoutType() == enums.TIMEOUT_TYPE_HEARTBEAT
 	}
-	return temporal.IsCanceledError(err)
+	return temporal.IsCanceledError(err) || runnerfailure.IsWorkerShutdown(err)
 }
 
 // recoveryBackoff returns the delay before re-invoking an interrupted activity.
@@ -963,9 +969,19 @@ func (w *InvokeAgentExecutionWorkflowImpl) updateStatusOnFailure(ctx workflow.Co
 
 	logger.Info("Updating execution status to FAILED", "execution_id", executionID)
 
+	// Recognized worker-shutdown shapes persist the honest platform-failure
+	// copy instead of raw Temporal internals ("Worker is shutting down and
+	// this activity did not complete in time" reached users in the 2026-08-08
+	// incident, #776). The raw text stays in the workflow log (the caller
+	// already logged it) — status.error is a user surface, not a log line.
+	statusError := originalErr.Error()
+	if runnerfailure.IsWorkerShutdown(originalErr) {
+		statusError = runnerfailure.WorkerShutdownStatusError
+	}
+
 	failedStatus := &agentexecutionv1.AgentExecutionStatus{
 		Phase: agentexecutionv1.ExecutionPhase_EXECUTION_FAILED,
-		Error: originalErr.Error(),
+		Error: statusError,
 		Messages: []*agentexecutionv1.AgentMessage{
 			{
 				Type:    agentexecutionv1.MessageType_MESSAGE_SYSTEM,
@@ -973,7 +989,7 @@ func (w *InvokeAgentExecutionWorkflowImpl) updateStatusOnFailure(ctx workflow.Co
 			},
 			{
 				Type:    agentexecutionv1.MessageType_MESSAGE_SYSTEM,
-				Content: fmt.Sprintf("Error details: %s", originalErr.Error()),
+				Content: fmt.Sprintf("Error details: %s", statusError),
 			},
 		},
 	}

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1:workflowexecution",
         "//backend/services/stigmer-server/pkg/domain/executioncontext/temporal/activities",
         "//backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/activities",
+        "//backend/services/stigmer-server/pkg/runnerfailure",
         "@com_github_rs_zerolog//log",
         "@io_temporal_go_api//enums/v1:enums",
         "@io_temporal_go_sdk//client",

--- a/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows/invoke_workflow_impl.go
+++ b/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/workflows/invoke_workflow_impl.go
@@ -7,6 +7,7 @@ import (
 	workflowexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/workflowexecution/v1"
 	ecactivities "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/executioncontext/temporal/activities"
 	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflowexecution/temporal/activities"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/runnerfailure"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
@@ -331,9 +332,18 @@ func (w *InvokeWorkflowExecutionWorkflowImpl) updateStatusOnFailure(ctx workflow
 
 	logger.Info("Updating execution status to FAILED", "execution_id", executionID)
 
+	// Recognized worker-shutdown shapes persist the honest platform-failure
+	// copy instead of raw Temporal drain internals (#776) — same mapping as
+	// the agentexecution twin, shared via pkg/runnerfailure. The raw text
+	// stays in the workflow log (the caller already logged it).
+	statusError := fmt.Sprintf("Workflow execution failed: %s", originalErr.Error())
+	if runnerfailure.IsWorkerShutdown(originalErr) {
+		statusError = runnerfailure.WorkerShutdownStatusError
+	}
+
 	failedStatus := &workflowexecutionv1.WorkflowExecutionStatus{
 		Phase: workflowexecutionv1.ExecutionPhase_EXECUTION_FAILED,
-		Error: fmt.Sprintf("Workflow execution failed: %s", originalErr.Error()),
+		Error: statusError,
 	}
 
 	v := workflow.GetVersion(ctx, "remote-cleanup-stubs", workflow.DefaultVersion, 1)

--- a/backend/services/stigmer-server/pkg/runnerfailure/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/runnerfailure/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "runnerfailure",
+    srcs = ["runnerfailure.go"],
+    importpath = "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/runnerfailure",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_temporal_go_sdk//temporal",
+    ],
+)
+
+go_test(
+    name = "runnerfailure_test",
+    srcs = ["runnerfailure_test.go"],
+    embed = [":runnerfailure"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@io_temporal_go_sdk//temporal",
+    ],
+)

--- a/backend/services/stigmer-server/pkg/runnerfailure/runnerfailure.go
+++ b/backend/services/stigmer-server/pkg/runnerfailure/runnerfailure.go
@@ -1,0 +1,83 @@
+// Package runnerfailure classifies runner activity failures at the polyglot
+// Temporal boundary.
+//
+// The TypeScript runner and this Go control plane meet only through Temporal
+// failure payloads, so "the runner's worker was shut down mid-activity" has no
+// typed representation here — it arrives as one of two message shapes:
+//
+//  1. the activity's own classification, thrown as CancelledFailure
+//     ("Activity cancelled (worker shutdown, not user pause)" — the runner's
+//     execute-cursor/execute-deep-agent shutdown branches), which crosses as
+//     a canceled failure; and
+//  2. the Temporal TS worker's drain failing an activity that could not finish
+//     inside the shutdown grace window ("Worker is shutting down and this
+//     activity did not complete in time"), which crosses as a plain activity
+//     failure — the shape observed live in the 2026-08-08 incident.
+//
+// Both mean the same thing: infrastructure interrupted the turn; the user did
+// nothing. Recognizing them in ONE place keeps two behaviors consistent across
+// the agentexecution and workflowexecution workflows (issue #776):
+//
+//   - status.error carries the honest platform-failure copy instead of raw
+//     Temporal internals (the cloud channel decision table and console users
+//     both read status.error);
+//   - the interruption is treated as recoverable, so the workflow's bounded
+//     recovery loop re-invokes from persisted harness/checkpoint state instead
+//     of dead-ending the turn (owner ruling on #776).
+//
+// The substring matching deliberately mirrors the Java control plane's
+// extractActivityFailureMessage so all editions key on the same shapes.
+package runnerfailure
+
+import (
+	"errors"
+	"strings"
+
+	"go.temporal.io/sdk/temporal"
+)
+
+// WorkerShutdownStatusError is the honest status.error copy for a turn that a
+// worker shutdown interrupted. Byte-identical to the copy the runner persists
+// from its own shutdown branches and to the Java control plane's mapping, so
+// every downstream status.error consumer keys on one string.
+const WorkerShutdownStatusError = "Execution interrupted: runner worker was shut down. Retry or resume."
+
+// canceledMarkers identify a worker shutdown inside a CANCELED failure. A
+// canceled failure's message is authored by the runner's own classification
+// branches (never by agent/tool output), so loose markers are safe here —
+// deliberately the same two the Java control plane matches.
+var canceledMarkers = []string{"worker shutdown", "shutting down"}
+
+// drainMarker identifies the Temporal TS worker's drain text ("Worker is
+// shutting down and this activity did not complete in time") in NON-canceled
+// failure types. Those messages can carry agent/tool output, so the match
+// anchors on the distinctive leading phrase rather than the loose markers.
+const drainMarker = "worker is shutting down"
+
+// IsWorkerShutdown reports whether err (anywhere in its chain) carries a
+// runner worker-shutdown shape. Canceled failures are matched loosely (their
+// messages are runner-authored); everything else must carry the Temporal
+// drain phrase, because the drain shape has crossed the boundary as different
+// failure types across SDK versions.
+func IsWorkerShutdown(err error) bool {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		switch f := e.(type) {
+		case *temporal.CanceledError:
+			lower := strings.ToLower(f.Error())
+			for _, marker := range canceledMarkers {
+				if strings.Contains(lower, marker) {
+					return true
+				}
+			}
+		case *temporal.ApplicationError:
+			if strings.Contains(strings.ToLower(f.Message()), drainMarker) {
+				return true
+			}
+		default:
+			if strings.Contains(strings.ToLower(e.Error()), drainMarker) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/services/stigmer-server/pkg/runnerfailure/runnerfailure_test.go
+++ b/backend/services/stigmer-server/pkg/runnerfailure/runnerfailure_test.go
@@ -1,0 +1,60 @@
+package runnerfailure
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/temporal"
+)
+
+// canceledWithMessage mirrors how the SDK's failure converter materializes a
+// TS CancelledFailure in Go: NewCanceledErrorWithOptions with the failure
+// proto's message (the bare NewCanceledError constructor carries details only).
+func canceledWithMessage(msg string) error {
+	return temporal.NewCanceledErrorWithOptions(temporal.CanceledErrorOptions{Message: msg})
+}
+
+// The runner's own shutdown classification (execute-cursor / execute-deep-agent
+// throw this exact message) must be recognized however it crosses the boundary.
+func TestIsWorkerShutdown_RunnerClassifiedCanceledFailure(t *testing.T) {
+	err := canceledWithMessage("Activity cancelled (worker shutdown, not user pause)")
+	assert.True(t, IsWorkerShutdown(err))
+}
+
+// The Temporal TS worker's drain text — the exact shape captured live in the
+// 2026-08-08 incident — crosses as a non-canceled failure and must map.
+func TestIsWorkerShutdown_DrainText(t *testing.T) {
+	err := temporal.NewApplicationError(
+		"Worker is shutting down and this activity did not complete in time", "")
+	assert.True(t, IsWorkerShutdown(err))
+}
+
+// A wrapped canceled failure (e.g. inside an activity error chain) is still
+// recognized — the recognizer walks the Unwrap chain.
+func TestIsWorkerShutdown_WrappedCanceledFailure(t *testing.T) {
+	err := fmt.Errorf("activity error: %w", canceledWithMessage("worker shutdown"))
+	assert.True(t, IsWorkerShutdown(err))
+}
+
+// A user pause is a canceled failure too — it must NOT classify as shutdown.
+func TestIsWorkerShutdown_PauseIsNotShutdown(t *testing.T) {
+	err := canceledWithMessage("Activity paused by orchestrator")
+	assert.False(t, IsWorkerShutdown(err))
+}
+
+// The loose markers apply ONLY to canceled failures (runner-authored
+// messages). An application error that merely echoes "shutting down" —
+// plausible in agent/tool output — must not be mistaken for a worker drain.
+func TestIsWorkerShutdown_LooseMarkerDoesNotFireOnApplicationErrors(t *testing.T) {
+	err := temporal.NewApplicationError(
+		"tool failed: the database is shutting down for maintenance", "")
+	assert.False(t, IsWorkerShutdown(err))
+}
+
+func TestIsWorkerShutdown_UnrelatedFailures(t *testing.T) {
+	assert.False(t, IsWorkerShutdown(errors.New("connection refused")))
+	assert.False(t, IsWorkerShutdown(temporal.NewApplicationError("model call failed", "")))
+	assert.False(t, IsWorkerShutdown(nil))
+}


### PR DESCRIPTION
## Summary
Fixes the shutdown-vs-pause misclassification from the 2026-08-08 incident: a SIGTERM'd runner's in-flight turn persisted `EXECUTION_PAUSED` ("Execution paused by user") and raw Temporal drain text ("Worker is shutting down and this activity did not complete in time") was persisted verbatim into `status.error`. Shutdown-interrupted turns now persist the honest worker-shutdown failure shape, and the agent workflow auto-resumes them via its existing bounded recovery loop (owner ruling).

## Context
The 2026-05-31 shutdown-vs-pause classifier was a **dead circuit**: the per-queue shutdown `AbortController` (`_shutdownSignalRegistry`) was registered but never aborted anywhere — the deferred-teardown rework deliberately removed the abort from the remove path (it killed running activities on view close) and never re-homed it at process shutdown. Static mode never registered a signal at all. The consuming code's own comment ("the runner-manager aborted the shutdown signal") assumed a wiring that didn't exist.

## Changes
- **`shared/worker-shutdown.ts` (new)**: owns the per-queue signal registry (register/get/abort/unregister with an explicit ownership contract) and the pure `classifyTurnInterruption` decision table.
- **`runner-manager.ts`**: `shutdown()` aborts every managed worker's signal (sessions, workflow executions, pool control) before draining. Single-worker teardowns stay abort-free, preserving the view-close fix. The redundant local `shutdownSignals` map is removed.
- **`runner.ts` (static mode)**: registers a signal for its queue and aborts it in `shutdown()` — CLI daemons had the same misclassification.
- **Grace-window guard**: shutdown classification now requires interruption evidence (heartbeat `CancelledFailure` or delivered cancellation). Without the guard, arming the signal would have wrongly FAILED a run that completed normally inside the drain grace window. Pinned by test.
- **`execute-deep-agent`**: mirrors the classification — it previously treated EVERY `CancelledFailure` as a pause and never read the shutdown signal (same bug, discovered during planning; deliberate scope inclusion). Its worker-shutdown copy is byte-identical to the Cursor harness's so downstream consumers key on one shape.
- **`pkg/runnerfailure` (new, Go)**: recognizes worker-shutdown failure shapes at the polyglot Temporal boundary (runner-authored canceled messages matched loosely; other failure types anchored on the distinctive drain phrase). Mirrors the Java control plane's `extractActivityFailureMessage` markers for cross-edition consistency.
- **Both Go workflows** (`agentexecution` + `workflowexecution`) persist the honest copy instead of raw `err.Error()` for recognized shapes; `isRecoverableActivityError` treats the drain shape as recoverable, so the agent workflow's bounded recovery loop (max 10 cycles) re-invokes from persisted harness state — the incident's turn would auto-resume on the restarted pod instead of erroring.

## Implementation notes
- Aborting the signal is classification-only; the Temporal drain still owns lifecycle.
- Desktop quit mid-turn now resumes when the session reopens instead of showing a fake "paused" state.
- Deep-agent test Context mocks gained `info: { taskQueue }` — the real activity context always carries it.

## Breaking changes
- None. A turn interrupted by shutdown previously showed a dishonest PAUSED or raw drain text; it now shows the honest failure shape or recovers.

## Test plan
- New: `worker-shutdown.test.ts` (registry semantics + full classification decision table incl. the grace-window guard), `runnerfailure_test.go` (all recognized/rejected shapes, constructed the way the SDK failure converter materializes them).
- Full runner suite: 4678 passed. Go: workflows + runnerfailure packages pass; `go vet` + `gofmt` clean; server binary builds.
- Gazelle diff clean for the files in this PR (pre-existing staleness in `seedpack/BUILD.bazel` — missing `paypal-sandbox.yaml` from PR #770 — is untouched and flagged separately).

## Risks
- The recovery-loop engagement changes failure semantics for shutdown-interrupted turns from hard-FAIL to auto-resume (bounded at 10 cycles; ScheduleToStart 5m bounds each wait). Rollback: revert this PR; no data migration involved.

Closes #776

The cloud-side half of the incident surface (mid-turn restart race + the Java mapper's drain-shape gap) ships separately as stigmer/stigmer-cloud#485's PR.

Made with [Cursor](https://cursor.com)