### PR TITLE
fix(workflow): make every authoring validation surface tell the truth — typed offline decode, gated examples/seedpack, live $env namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -864,8 +864,8 @@ format-docs-check: ## Check documentation formatting (CI, no writes)
 	@$(PRETTIER_GUARD)
 	@$(PRETTIER) --check --prose-wrap always $(DOCS_SOURCES)
 
-check-docs-yaml: ## Validate every docs YAML block against the proto contracts, incl. platform-parity protovalidate rules (CI)
-	@go run ./tools/codegen/generator --target=docs-yaml-check --docs-dir docs --rules=enforce
+check-docs-yaml: ## Validate every docs YAML block + raw examples/seedpack manifests against the proto contracts, incl. platform-parity protovalidate rules (CI)
+	@go run ./tools/codegen/generator --target=docs-yaml-check --docs-dir docs --authoring-dirs examples,seedpack --rules=enforce
 
 report-docs-yaml-rules: ## Full-depth protovalidate rule report over docs YAML (incl. latent platform-blind findings; never fails)
 	@go run ./tools/codegen/generator --target=docs-yaml-check --docs-dir docs --rules=report

--- a/client-apps/cli/src/resources/apply/apply.ts
+++ b/client-apps/cli/src/resources/apply/apply.ts
@@ -8,6 +8,7 @@
 
 import { create, fromJson, type JsonValue, type Message } from "@bufbuild/protobuf";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import { UpdateVisibilityInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
@@ -19,6 +20,7 @@ import { UsageError } from "../../errors/index.js";
 import { CommandResult } from "../../output/index.js";
 import { defaultRegistry, Verb } from "../../registry/index.js";
 import { loadDocuments, resolveYamlFiles } from "../documents.js";
+import { decodeWorkflowTaskConfigs } from "../task-configs.js";
 import { type ApplyHandler, APPLY_HANDLERS, type ControllerFn } from "./handlers.js";
 
 export interface ApplyItem {
@@ -112,7 +114,15 @@ export async function applyItem(
  */
 export function marshalItem(item: ApplyItem): Message {
   try {
-    return fromJson(item.handler.schema, item.document, { ignoreUnknownFields: false });
+    const message = fromJson(item.handler.schema, item.document, { ignoreUnknownFields: false });
+    // Workflow task_config blocks live inside an open Struct the top-level
+    // decode cannot see into; decode them per kind so a dry-run (and the
+    // reconciler's marshal) rejects exactly what a real apply rejects
+    // (stigmer/stigmer#778).
+    if (item.handler.kind === ApiResourceKind.workflow) {
+      decodeWorkflowTaskConfigs(message as Workflow);
+    }
+    return message;
   } catch (err) {
     throw new UsageError(`invalid ${item.handler.displayName} in ${item.filePath}: ${(err as Error).message}`);
   }

--- a/client-apps/cli/src/resources/task-configs.test.ts
+++ b/client-apps/cli/src/resources/task-configs.test.ts
@@ -1,0 +1,98 @@
+import { fromJson, type JsonValue } from "@bufbuild/protobuf";
+import { type Workflow, WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import {
+  WorkflowTaskKind,
+  WorkflowTaskKindSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb";
+import { describe, expect, it } from "vitest";
+import { decodeWorkflowTaskConfigs, TASK_CONFIG_SCHEMAS } from "./task-configs.js";
+
+function makeWorkflow(tasks: JsonValue): Workflow {
+  return fromJson(WorkflowSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "Workflow",
+    metadata: { name: "decode-test", org: "acme" },
+    spec: {
+      description: "task-config decode fixture",
+      document: { dsl: "1.0.0", namespace: "acme", name: "decode-test", version: "1.0.0" },
+      tasks,
+    },
+  }) as Workflow;
+}
+
+describe("TASK_CONFIG_SCHEMAS", () => {
+  // The stigmer/stigmer#353 drift class: hold the map and the proto enum to
+  // strict bidirectional equality, so a new task kind cannot ship without a
+  // CLI schema binding and a retired kind cannot linger in the map. The
+  // server-side twin of this promise is unmarshalTaskConfig's kind switch.
+  it("covers every WorkflowTaskKind exactly (bidirectional)", () => {
+    const declaredKinds = WorkflowTaskKindSchema.values
+      .map((v) => v.number as WorkflowTaskKind)
+      .filter((n) => n !== WorkflowTaskKind.workflow_task_kind_unspecified)
+      .sort((a, b) => a - b);
+    const mappedKinds = [...TASK_CONFIG_SCHEMAS.keys()].sort((a, b) => a - b);
+    expect(mappedKinds).toEqual(declaredKinds);
+  });
+});
+
+describe("decodeWorkflowTaskConfigs", () => {
+  it("rejects the string duration form a real apply rejects (the #778 repro)", () => {
+    const workflow = makeWorkflow([
+      { name: "conditional_wait", kind: "wait", task_config: { duration: "5s" } },
+    ]);
+    expect(() => decodeWorkflowTaskConfigs(workflow)).toThrow(
+      /task 'conditional_wait' \(wait\): invalid task_config/,
+    );
+  });
+
+  it("accepts the typed duration object", () => {
+    const workflow = makeWorkflow([
+      { name: "cooldown", kind: "wait", task_config: { duration: { seconds: 5 } } },
+    ]);
+    expect(() => decodeWorkflowTaskConfigs(workflow)).not.toThrow();
+  });
+
+  it("rejects unknown task_config fields, mirroring the server's strict decode", () => {
+    const workflow = makeWorkflow([
+      {
+        name: "gate",
+        kind: "human_input",
+        task_config: { prompt: "Approve?", escalation_task: "somewhere" },
+      },
+    ]);
+    expect(() => decodeWorkflowTaskConfigs(workflow)).toThrow(/gate.*human_input.*task_config/);
+  });
+
+  it("rejects values outside an enum's membership", () => {
+    const workflow = makeWorkflow([
+      {
+        name: "gate",
+        kind: "human_input",
+        task_config: { prompt: "Approve?", timeout: 60, on_timeout: "sometimes" },
+      },
+    ]);
+    expect(() => decodeWorkflowTaskConfigs(workflow)).toThrow(/gate.*invalid task_config/);
+  });
+
+  it("accepts the agent_call DSL shorthands a real apply accepts (never stricter)", () => {
+    const workflow = makeWorkflow([
+      {
+        name: "review",
+        kind: "agent_call",
+        task_config: {
+          agent: "acme/code-reviewer",
+          message: "Review ${ $context.pr.diff }",
+          harness: "cursor",
+          run_config: { model_name: "composer-2.5", service_tier: "fast" },
+          environment_refs: [{ slug: "shared-secrets" }],
+        },
+      },
+    ]);
+    expect(() => decodeWorkflowTaskConfigs(workflow)).not.toThrow();
+  });
+
+  it("skips tasks without a task_config (protovalidate territory, not decode truth)", () => {
+    const workflow = makeWorkflow([{ name: "bare", kind: "set_vars" }]);
+    expect(() => decodeWorkflowTaskConfigs(workflow)).not.toThrow();
+  });
+});

--- a/client-apps/cli/src/resources/task-configs.ts
+++ b/client-apps/cli/src/resources/task-configs.ts
@@ -1,0 +1,150 @@
+// Typed decode of workflow task_config blocks — the offline twin of the
+// server's `unmarshalTaskConfig` (backend/services/stigmer-server/pkg/domain/
+// workflow/converter/unmarshal.go).
+//
+// The Workflow proto models `task_config` as an open google.protobuf.Struct
+// discriminated by `kind`, so the top-level schema decode accepts ANY config
+// payload; a real apply then decodes it into the kind's typed message and
+// rejects what does not fit. Before this module, `stigmer validate` and
+// `apply --dry-run` reported "valid" for configs a real apply refuses
+// (stigmer/stigmer#778).
+//
+// Scope is decode-truth only: field shapes, types, enum membership, unknown
+// fields. Semantic validation (cross-task references, expression namespaces,
+// model registry, protovalidate required-field rules) remains the server's
+// authority via `validateSpec`.
+
+import { type DescMessage, fromJson, type JsonValue } from "@bufbuild/protobuf";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowTaskKind } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb";
+import { AgentCallTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/agent_call_pb";
+import { CallActivityTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/call_activity_pb";
+import { EmitEventTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/emit_event_pb";
+import { EvalTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/eval_pb";
+import { ForTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/for_pb";
+import { ForkTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/fork_pb";
+import { GrpcCallTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/grpc_call_pb";
+import { HttpCallTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/http_call_pb";
+import { HumanInputTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/human_input_pb";
+import { ListenTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/listen_pb";
+import { LlmCallTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/llm_call_pb";
+import { NotificationTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/notification_pb";
+import { RaiseTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/raise_pb";
+import { RunTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/run_pb";
+import { SetTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/set_pb";
+import { SwitchTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/switch_pb";
+import { TransformTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/transform_pb";
+import { TryTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/try_pb";
+import { ValidateTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/validate_pb";
+import { WaitTaskConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/wait_pb";
+
+// Exported for the drift test (task-configs.test.ts), which holds this map and
+// the WorkflowTaskKind enum descriptor to strict bidirectional equality — the
+// stigmer/stigmer#353 drift class: a new task kind cannot ship without a CLI
+// schema binding, and a retired kind cannot linger here. The entries mirror
+// the server's `unmarshalTaskConfig` kind switch one-for-one.
+export const TASK_CONFIG_SCHEMAS: ReadonlyMap<WorkflowTaskKind, DescMessage> = new Map<
+  WorkflowTaskKind,
+  DescMessage
+>([
+  [WorkflowTaskKind.set_vars, SetTaskConfigSchema],
+  [WorkflowTaskKind.http_call, HttpCallTaskConfigSchema],
+  [WorkflowTaskKind.grpc_call, GrpcCallTaskConfigSchema],
+  [WorkflowTaskKind.switch_case, SwitchTaskConfigSchema],
+  [WorkflowTaskKind.for_each, ForTaskConfigSchema],
+  [WorkflowTaskKind.fork, ForkTaskConfigSchema],
+  [WorkflowTaskKind.try_catch, TryTaskConfigSchema],
+  [WorkflowTaskKind.listen, ListenTaskConfigSchema],
+  [WorkflowTaskKind.wait, WaitTaskConfigSchema],
+  [WorkflowTaskKind.activity_call, CallActivityTaskConfigSchema],
+  [WorkflowTaskKind.raise_error, RaiseTaskConfigSchema],
+  [WorkflowTaskKind.run_workflow, RunTaskConfigSchema],
+  [WorkflowTaskKind.agent_call, AgentCallTaskConfigSchema],
+  [WorkflowTaskKind.llm_call, LlmCallTaskConfigSchema],
+  [WorkflowTaskKind.transform, TransformTaskConfigSchema],
+  [WorkflowTaskKind.human_input, HumanInputTaskConfigSchema],
+  [WorkflowTaskKind.validate, ValidateTaskConfigSchema],
+  [WorkflowTaskKind.emit_event, EmitEventTaskConfigSchema],
+  [WorkflowTaskKind.notification, NotificationTaskConfigSchema],
+  [WorkflowTaskKind.eval, EvalTaskConfigSchema],
+]);
+
+/**
+ * Decodes every task's `task_config` into its kind's typed proto message,
+ * throwing on the first config a real apply would reject. Runs on the decoded
+ * Workflow message (after the top-level schema decode), so snake_case and
+ * json-name spellings are already normalized.
+ *
+ * A task with no `task_config` is skipped: its absence is a protovalidate
+ * required-field violation, which is the server's layer, not decode-truth.
+ */
+export function decodeWorkflowTaskConfigs(workflow: Workflow): void {
+  for (const task of workflow.spec?.tasks ?? []) {
+    if (task.taskConfig === undefined) continue;
+    const schema = TASK_CONFIG_SCHEMAS.get(task.kind);
+    if (schema === undefined) continue; // unspecified/unknown kind — the server's layer reports it
+
+    // protobuf-es represents google.protobuf.Struct fields as plain JSON, so
+    // the Struct's content feeds the per-kind decode directly.
+    const config = normalizeTaskConfigShorthands(task.kind, task.taskConfig);
+    try {
+      fromJson(schema, config, { ignoreUnknownFields: false });
+    } catch (err) {
+      throw new Error(
+        `task '${task.name}' (${WorkflowTaskKind[task.kind]}): invalid task_config: ${(err as Error).message}`,
+      );
+    }
+  }
+}
+
+/**
+ * Rewrites user-friendly DSL forms to the shapes the proto decode expects —
+ * the twin of the server's `normalizeEnumShorthands` (unmarshal.go): agent_call
+ * harness shorthands ("cursor" → "HARNESS_CURSOR"), run_config service-tier
+ * shorthands ("fast" → "SERVICE_TIER_FAST"), and the environment_refs kind
+ * default (an omitted kind means environment). Without this twin the offline
+ * decode would be STRICTER than a real apply and fail valid manifests.
+ */
+function normalizeTaskConfigShorthands(kind: WorkflowTaskKind, config: JsonValue): JsonValue {
+  if (kind !== WorkflowTaskKind.agent_call || !isJsonObject(config)) {
+    return config;
+  }
+
+  const normalized: Record<string, JsonValue> = { ...config };
+
+  if (typeof normalized.harness === "string") {
+    const harness = HARNESS_SHORTHANDS[normalized.harness.toLowerCase()];
+    if (harness !== undefined) normalized.harness = harness;
+  }
+
+  if (isJsonObject(normalized.run_config)) {
+    const runConfig: Record<string, JsonValue> = { ...normalized.run_config };
+    if (typeof runConfig.service_tier === "string") {
+      const tier = SERVICE_TIER_SHORTHANDS[runConfig.service_tier.toLowerCase()];
+      if (tier !== undefined) runConfig.service_tier = tier;
+    }
+    normalized.run_config = runConfig;
+  }
+
+  if (Array.isArray(normalized.environment_refs)) {
+    normalized.environment_refs = normalized.environment_refs.map((ref) =>
+      isJsonObject(ref) && ref.kind === undefined ? { ...ref, kind: "environment" } : ref,
+    );
+  }
+
+  return normalized;
+}
+
+const HARNESS_SHORTHANDS: Record<string, string> = {
+  native: "HARNESS_NATIVE",
+  cursor: "HARNESS_CURSOR",
+};
+
+const SERVICE_TIER_SHORTHANDS: Record<string, string> = {
+  standard: "SERVICE_TIER_STANDARD",
+  fast: "SERVICE_TIER_FAST",
+};
+
+function isJsonObject(value: JsonValue | undefined): value is Record<string, JsonValue> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/client-apps/cli/src/resources/validate.test.ts
+++ b/client-apps/cli/src/resources/validate.test.ts
@@ -1,3 +1,4 @@
+import type { JsonValue } from "@bufbuild/protobuf";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { describe, expect, it } from "vitest";
 import { schemaForValidate, validateDocument } from "./validate.js";
@@ -50,5 +51,30 @@ describe("validateDocument", () => {
         metadata: "not-an-object",
       }),
     ).toThrow();
+  });
+
+  // The stigmer/stigmer#778 wiring pin: task_config blocks are typed per kind,
+  // so validate rejects what a real apply rejects instead of waving any Struct
+  // payload through. Decode behavior itself is pinned in task-configs.test.ts.
+  it("decodes workflow task_config blocks per kind", () => {
+    const workflowSchema = schemaForValidate(ApiResourceKind.workflow);
+    if (workflowSchema === undefined) throw new Error("workflow schema unavailable");
+
+    const workflowDoc = (taskConfig: JsonValue): JsonValue => ({
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Workflow",
+      metadata: { name: "wf", org: "acme" },
+      spec: {
+        document: { dsl: "1.0.0", namespace: "acme", name: "wf", version: "1.0.0" },
+        tasks: [{ name: "conditional_wait", kind: "wait", task_config: taskConfig }],
+      },
+    });
+
+    expect(() => validateDocument(workflowSchema, workflowDoc({ duration: "5s" }))).toThrow(
+      /conditional_wait.*invalid task_config/,
+    );
+    expect(() =>
+      validateDocument(workflowSchema, workflowDoc({ duration: { seconds: 5 } })),
+    ).not.toThrow();
   });
 });

--- a/client-apps/cli/src/resources/validate.ts
+++ b/client-apps/cli/src/resources/validate.ts
@@ -8,9 +8,10 @@
 import { type DescMessage, fromJson, type JsonValue } from "@bufbuild/protobuf";
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
-import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { type Workflow, WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+import { decodeWorkflowTaskConfigs } from "./task-configs.js";
 
 // Exported for the verb/dispatch conformance suite (registry/registry.test.ts),
 // which holds this map and the matrix's Verb.Validate promises to strict
@@ -31,5 +32,12 @@ export function schemaForValidate(kind: ApiResourceKind): DescMessage | undefine
 export function validateDocument(schema: DescMessage, document: JsonValue): void {
   // ignoreUnknownFields mirrors the server's lenient unmarshal: forward-compat
   // fields a newer server adds should not fail a slightly older CLI.
-  fromJson(schema, document, { ignoreUnknownFields: true });
+  const message = fromJson(schema, document, { ignoreUnknownFields: true });
+
+  // Workflows carry per-kind typed configs inside an open Struct that the
+  // top-level decode cannot see into — decode them too, so validate stops
+  // passing configs a real apply rejects (stigmer/stigmer#778).
+  if (schema === WorkflowSchema) {
+    decodeWorkflowTaskConfigs(message as Workflow);
+  }
 }

--- a/docs/concepts/workflows.mdx
+++ b/docs/concepts/workflows.mdx
@@ -48,7 +48,7 @@ spec:
       task_config:
         model: "claude-sonnet-4-5"
         system_prompt: "You are a professional content writer."
-        prompt: "Write content about: ${ $context.env.TOPIC }"
+        prompt: "Write content about: ${ $env.TOPIC }"
         temperature: 0.7
         max_tokens: 2000
       export:
@@ -120,7 +120,7 @@ kind-specific configuration).
   kind: llm_call
   task_config:
     model: "gpt-4o-mini"
-    prompt: "Classify this ticket: ${ $context.env.TICKET }"
+    prompt: "Classify this ticket: ${ $env.TICKET }"
     response_schema:
       type: object
       properties:
@@ -173,7 +173,7 @@ graph LR
 
 Data flows between tasks through **expressions**. When a task exports its output
 with `export.as`, later tasks access it via `${ $context.<taskName>.<field> }`.
-Environment variables are available as `${ $context.env.<VAR_NAME> }`.
+Environment variables are available as `${ $env.<VAR_NAME> }`.
 
 Execution is **durable**. Stigmer runs workflows on
 [Temporal](https://temporal.io/), so if the process crashes mid-task, it

--- a/docs/getting-started/first-workflow.mdx
+++ b/docs/getting-started/first-workflow.mdx
@@ -45,7 +45,7 @@ spec:
       task_config:
         model: "claude-sonnet-4-5"
         system_prompt: "You are a concise research assistant."
-        prompt: "Write a 3-paragraph summary about: ${ $context.env.TOPIC }"
+        prompt: "Write a 3-paragraph summary about: ${ $env.TOPIC }"
         temperature: 0.3
         max_tokens: 500
       export:

--- a/docs/guides/workflows/authoring.mdx
+++ b/docs/guides/workflows/authoring.mdx
@@ -63,7 +63,7 @@ tasks:
     kind: llm_call
     task_config:
       model: "gpt-4o-mini"
-      prompt: "Classify this: ${ $context.env.INPUT }"
+      prompt: "Classify this: ${ $env.INPUT }"
       response_schema:
         type: object
         properties:
@@ -108,10 +108,10 @@ Use `${ $context.<taskName>.<field> }` to access earlier task outputs:
 prompt: "Summarize: ${ $context.fetch_data.body }"
 ```
 
-Environment variables are available as `${ $context.env.<VAR_NAME> }`:
+Environment variables are available as `${ $env.<VAR_NAME> }`:
 
 ```yaml validate-as="task-config:llm_call"
-prompt: "Topic: ${ $context.env.TOPIC }"
+prompt: "Topic: ${ $env.TOPIC }"
 ```
 
 ### Setting variables
@@ -123,7 +123,7 @@ The `set_vars` task writes values directly into context:
   kind: set_vars
   task_config:
     variables:
-      started_at: "${ now() }"
+      started_at: "${ now }"
       environment: "production"
   export:
     as: "${ . }"
@@ -484,8 +484,7 @@ spec:
           You are a professional content writer. Write clear, engaging content
           that follows the provided guidelines.
         prompt: >
-          Write content about: ${ $context.env.TOPIC } Guidelines: ${
-          $context.env.GUIDELINES }
+          Write content about: ${ $env.TOPIC } Guidelines: ${ $env.GUIDELINES }
         temperature: 0.7
         max_tokens: 2000
       export:
@@ -529,7 +528,7 @@ spec:
           Revise the draft based on the reviewer's feedback. Preserve what
           works, fix what doesn't.
         prompt: >
-          Original topic: ${ $context.env.TOPIC } Previous draft: ${
+          Original topic: ${ $env.TOPIC } Previous draft: ${
           $context.draft_content.text } Feedback: ${
           $context.review_content.form_data.feedback }
         temperature: 0.5

--- a/docs/guides/workflows/patterns.mdx
+++ b/docs/guides/workflows/patterns.mdx
@@ -60,8 +60,8 @@ spec:
           You are a research analyst. Analyze the provided source material
           thoroughly. Identify key themes, claims, evidence, and gaps.
         prompt: >
-          Analyze the following material on "${ $context.env.TOPIC }": ${
-          $context.env.SOURCE_MATERIAL }
+          Analyze the following material on "${ $env.TOPIC }": ${
+          $env.SOURCE_MATERIAL }
         temperature: 0.3
         max_tokens: 3000
       export:
@@ -234,8 +234,7 @@ spec:
           You are a professional content writer. Write clear, engaging content
           that follows the provided guidelines.
         prompt: >
-          Write content about: ${ $context.env.TOPIC } Guidelines: ${
-          $context.env.GUIDELINES }
+          Write content about: ${ $env.TOPIC } Guidelines: ${ $env.GUIDELINES }
         temperature: 0.7
         max_tokens: 2000
       export:
@@ -279,7 +278,7 @@ spec:
           Revise the draft based on the reviewer's feedback. Preserve what
           works, fix what doesn't.
         prompt: >
-          Original topic: ${ $context.env.TOPIC } Previous draft: ${
+          Original topic: ${ $env.TOPIC } Previous draft: ${
           $context.draft_content.text } Feedback: ${
           $context.review_content.form_data.feedback }
         temperature: 0.5
@@ -345,7 +344,7 @@ tasks:
       system_prompt: >
         You are a support ticket classifier. Analyze the ticket and classify it
         by severity and category.
-      prompt: "Classify this ticket: ${ $context.env.TICKET_DESCRIPTION }"
+      prompt: "Classify this ticket: ${ $env.TICKET_DESCRIPTION }"
       response_schema:
         type: object
         required: [severity, category, summary]
@@ -482,7 +481,7 @@ spec:
       kind: llm_call
       task_config:
         model: "claude-sonnet-4-5"
-        prompt: "Deep analysis of: ${ $context.env.DATA }"
+        prompt: "Deep analysis of: ${ $env.DATA }"
         max_tokens: 4000
       export:
         as: "${ . }"

--- a/examples/agents/support-bot.yaml
+++ b/examples/agents/support-bot.yaml
@@ -6,23 +6,25 @@ metadata:
     team: customer-success
     environment: production
 spec:
+  description: Customer support agent that answers questions and checks GitHub for known problems
   instructions: |
     You are a helpful customer support agent for a SaaS company.
-    
+
     Your responsibilities:
     - Answer customer questions politely and accurately
     - Check GitHub issues for known problems
     - Escalate complex issues to human support
     - Provide links to documentation when relevant
-    
+
     Be concise but friendly. Always verify information before responding.
-  
-  mcpServers:
-    - github      # Access GitHub repositories and issues
-    - filesystem  # Read documentation files
-    - slack       # Post to support channel if needed
-  
-  config:
-    model: claude-3-5-sonnet-20241022
-    temperature: "0.7"
-    max_tokens: "2000"
+
+  mcp_server_usages:
+    # Access GitHub repositories and issues
+    - mcp_server_ref:
+        kind: mcp_server
+        slug: github
+      enabled_tools: [search_issues, get_issue]
+    # Post to the support channel when escalating
+    - mcp_server_ref:
+        kind: mcp_server
+        slug: slack

--- a/examples/workflows/hello-world.yaml
+++ b/examples/workflows/hello-world.yaml
@@ -10,11 +10,11 @@ spec:
     name: hello-world
     version: "1.0.0"
   tasks:
-    - name: set-greeting
+    - name: set_greeting
       kind: set_vars
       task_config:
         variables:
           greeting: "Hello, World!"
-          timestamp: "${now()}"
+          timestamp: "${ now }"
       export:
-        as: "${.}"
+        as: "${ . }"

--- a/examples/workflows/multi-step.yaml
+++ b/examples/workflows/multi-step.yaml
@@ -13,19 +13,19 @@ spec:
     name: multi-step
     version: "1.0.0"
   tasks:
-    - name: initialize-context
+    - name: initialize_context
       kind: set_vars
       task_config:
         variables:
-          workflow_id: "${workflowId}"
-          started_at: "${now()}"
+          workflow_label: "multi-step-example"
+          started_at: "${ now }"
           environment: "production"
       export:
-        as: "${.}"
+        as: "${ . }"
       flow:
-        then: fetch-data
+        then: fetch_data
 
-    - name: fetch-data
+    - name: fetch_data
       kind: http_call
       task_config:
         method: GET
@@ -33,40 +33,41 @@ spec:
           uri: "https://api.example.com/data"
         headers:
           Content-Type: "application/json"
-          X-Workflow-Id: "${context.initialize-context.workflow_id}"
+          X-Workflow-Label: "${ $context.initialize_context.workflow_label }"
       export:
-        as: "${.response}"
+        as: "${ .response }"
       flow:
-        then: process-with-agent
+        then: process_with_agent
 
-    - name: process-with-agent
+    - name: process_with_agent
       kind: agent_call
       task_config:
         agent: data-processor
-        message: "Process this data: ${context.fetch-data.response}"
+        message: "Process this data: ${ $context.fetch_data.response }"
       export:
-        as: "${.processed}"
+        as: "${ .processed }"
       flow:
-        then: conditional-wait
+        then: conditional_wait
 
-    - name: conditional-wait
+    - name: conditional_wait
       kind: wait
       task_config:
-        duration: "5s"
+        duration:
+          seconds: 5
       flow:
-        then: validate-results
+        then: validate_results
 
-    - name: validate-results
+    - name: validate_results
       kind: agent_call
       task_config:
         agent: validator
-        message: "Validate processing results: ${context.process-with-agent.processed}"
+        message: "Validate processing results: ${ $context.process_with_agent.processed }"
       export:
-        as: "${.validation}"
+        as: "${ .validation }"
       flow:
-        then: store-results
+        then: store_results
 
-    - name: store-results
+    - name: store_results
       kind: http_call
       task_config:
         method: POST
@@ -75,11 +76,11 @@ spec:
         headers:
           Content-Type: "application/json"
         body:
-          workflow_id: "${context.initialize-context.workflow_id}"
-          processed_data: "${context.process-with-agent.processed}"
-          validation: "${context.validate-results.validation}"
-          completed_at: "${now()}"
+          workflow_label: "${ $context.initialize_context.workflow_label }"
+          processed_data: "${ $context.process_with_agent.processed }"
+          validation: "${ $context.validate_results.validation }"
+          completed_at: "${ now }"
       export:
-        as: "${.}"
+        as: "${ . }"
       flow:
         then: end

--- a/examples/workflows/pr-review.yaml
+++ b/examples/workflows/pr-review.yaml
@@ -12,61 +12,69 @@ spec:
     namespace: examples
     name: pr-review
     version: "1.0.0"
+  env:
+    REPO:
+      description: "GitHub repository in owner/name form"
+    PR_NUMBER:
+      description: "Pull request number to review"
+    GITHUB_TOKEN:
+      description: "GitHub API token with repo scope"
+      is_secret: true
   tasks:
-    - name: fetch-pr-data
+    - name: fetch_pr_data
       kind: http_call
       task_config:
         method: GET
         endpoint:
-          uri: "https://api.github.com/repos/${repo}/pulls/${pr_number}"
+          uri: "https://api.github.com/repos/${ $env.REPO }/pulls/${ $env.PR_NUMBER }"
         headers:
-          Authorization: "Bearer ${GITHUB_TOKEN}"
+          Authorization: "Bearer ${ $env.GITHUB_TOKEN }"
           Accept: "application/vnd.github.v3+json"
       export:
-        as: "${.}"
+        as: "${ . }"
       flow:
-        then: analyze-code-quality
+        then: analyze_code_quality
 
-    - name: analyze-code-quality
+    - name: analyze_code_quality
       kind: agent_call
       task_config:
         agent: code-reviewer
-        message: "Analyze code quality for PR: ${context.fetch-pr-data.title}\n\nFiles changed: ${context.fetch-pr-data.changed_files}\nDiff: ${context.fetch-pr-data.diff_url}"
+        message: "Analyze code quality for PR: ${ $context.fetch_pr_data.title }\n\nFiles changed: ${ $context.fetch_pr_data.changed_files }\nDiff: ${ $context.fetch_pr_data.diff_url }"
       export:
-        as: "${.analysis}"
+        as: "${ .analysis }"
       flow:
-        then: check-test-coverage
+        then: check_test_coverage
 
-    - name: check-test-coverage
+    - name: check_test_coverage
       kind: agent_call
       task_config:
         agent: test-analyzer
-        message: "Check test coverage for PR diff: ${context.fetch-pr-data.diff_url}"
+        message: "Check test coverage for PR diff: ${ $context.fetch_pr_data.diff_url }"
       export:
-        as: "${.coverage}"
+        as: "${ .coverage }"
       flow:
-        then: generate-review
+        then: generate_review
 
-    - name: generate-review
+    - name: generate_review
       kind: agent_call
       task_config:
         agent: review-synthesizer
-        message: "Generate comprehensive review based on:\nCode Analysis: ${context.analyze-code-quality.analysis}\nTest Coverage: ${context.check-test-coverage.coverage}"
+        message: "Generate comprehensive review based on:\nCode Analysis: ${ $context.analyze_code_quality.analysis }\nTest Coverage: ${ $context.check_test_coverage.coverage }"
       export:
-        as: "${.review}"
+        as: "${ .review }"
       flow:
-        then: post-comment
+        then: post_comment
 
-    - name: post-comment
+    - name: post_comment
       kind: http_call
       task_config:
         method: POST
         endpoint:
-          uri: "https://api.github.com/repos/${repo}/issues/${pr_number}/comments"
+          uri: "https://api.github.com/repos/${ $env.REPO }/issues/${ $env.PR_NUMBER }/comments"
         headers:
-          Authorization: "Bearer ${GITHUB_TOKEN}"
+          Authorization: "Bearer ${ $env.GITHUB_TOKEN }"
           Accept: "application/vnd.github.v3+json"
         body:
-          body: "${context.generate-review.review}"
+          body: "${ $context.generate_review.review }"
       flow:
         then: end

--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,6 +2919,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3758,6 +3759,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3780,6 +3782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3802,6 +3805,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3818,6 +3822,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3834,6 +3839,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3850,6 +3856,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3866,6 +3873,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3882,6 +3890,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3898,6 +3907,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3914,6 +3924,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3930,6 +3941,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3946,6 +3958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3962,6 +3975,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3984,6 +3998,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4006,6 +4021,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4028,6 +4044,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4050,6 +4067,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4072,6 +4090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4094,6 +4113,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4116,6 +4136,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4138,6 +4159,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4157,6 +4179,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4176,6 +4199,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4195,6 +4219,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16907,12 +16932,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/seedpack/skills/workflow-creator/SKILL.md
+++ b/seedpack/skills/workflow-creator/SKILL.md
@@ -124,7 +124,7 @@ Composition rules:
 - `flow.then` must reference a real task name. The last task in a path omits
   `flow.then` (implicit end). Use `then: end` to terminate a branch early.
 - Use `export.as` to publish a task's output; reference it downstream with
-  `${ $context.<task-name>.<field> }`. Run-time inputs are `${ $context.env.NAME }`.
+  `${ $context.<task-name>.<field> }`. Run-time inputs are `${ $env.NAME }`.
 - For `agent_call` and `llm_call` tasks, prefer a `budget` so runaway cost is
   capped. Use `on_invalid` / `max_retries` when you require structured output.
 - Use `switch_case` for branching, `fork` for parallel branches, `human_input`

--- a/seedpack/skills/workflow-creator/references/examples.md
+++ b/seedpack/skills/workflow-creator/references/examples.md
@@ -36,7 +36,7 @@ spec:
         prompt: >
           Analyze the following material:
 
-          ${ $context.env.SOURCE_MATERIAL }
+          ${ $env.SOURCE_MATERIAL }
         temperature: 0.3
         max_tokens: 1500
         timeout: 120
@@ -86,7 +86,7 @@ spec:
       task_config:
         model: "gpt-4o-mini"
         system_prompt: "Classify the ticket by severity. Be conservative with critical."
-        prompt: "Classify this ticket:\n\n${ $context.env.TICKET_DESCRIPTION }"
+        prompt: "Classify this ticket:\n\n${ $env.TICKET_DESCRIPTION }"
         response_schema:
           type: object
           required:
@@ -188,7 +188,7 @@ spec:
                 task_config:
                   model: "claude-sonnet-4.5"
                   system_prompt: "Write a concise executive summary."
-                  prompt: "Summarize:\n\n${ $context.env.SOURCE_MATERIAL }"
+                  prompt: "Summarize:\n\n${ $env.SOURCE_MATERIAL }"
                   max_tokens: 500
                   timeout: 60
                 export:
@@ -200,7 +200,7 @@ spec:
                 task_config:
                   model: "gpt-4o-mini"
                   system_prompt: "Extract key findings."
-                  prompt: "Extract findings:\n\n${ $context.env.SOURCE_MATERIAL }"
+                  prompt: "Extract findings:\n\n${ $env.SOURCE_MATERIAL }"
                   max_tokens: 500
                   timeout: 60
                 export:

--- a/seedpack/skills/workflow-creator/references/schema.md
+++ b/seedpack/skills/workflow-creator/references/schema.md
@@ -54,7 +54,7 @@ document:
 ## spec.env
 
 Declares the inputs a user supplies when starting the workflow. Schema only —
-values are provided at run time. Reference them in tasks via `${ $context.env.NAME }`.
+values are provided at run time. Reference them in tasks via `${ $env.NAME }`.
 
 ```yaml
 env:
@@ -145,7 +145,7 @@ Stigmer uses `${ ... }` expressions to read values across the workflow:
 
 | Reference | Meaning |
 |---|---|
-| `${ $context.env.NAME }` | A run-time input declared in `spec.env` |
+| `${ $env.NAME }` | A run-time input declared in `spec.env` |
 | `${ $context.<task-name> }` | The full exported output of a prior task |
 | `${ $context.<task-name>.<field> }` | A field within a prior task's output |
 | `${ . }` | The current task's input/result (used in `export.as` and `transform.input`) |

--- a/seedpack/skills/workflow-creator/references/validation.md
+++ b/seedpack/skills/workflow-creator/references/validation.md
@@ -51,7 +51,7 @@ the most common issues so the first validation pass is clean.
    them correctly.
 2. **Valid context references** — `${ $context.<task>... }` points at a task that
    runs **before** the referencing task and that uses `export`.
-3. **`env` references declared** — every `${ $context.env.NAME }` has a matching
+3. **`env` references declared** — every `${ $env.NAME }` has a matching
    entry in `spec.env`.
 4. **Structured output exported** — tasks read via `${ $context.<task>.<field> }`
    export their structured result (`export.as: "${ .structured }"` for agent/LLM

--- a/seedpack/workflows/content-review-pipeline.yaml
+++ b/seedpack/workflows/content-review-pipeline.yaml
@@ -37,9 +37,9 @@ spec:
           that follows the provided guidelines. Output well-structured prose
           suitable for publication.
         prompt: >
-          Write content about the following topic: ${ $context.env.TOPIC }
+          Write content about the following topic: ${ $env.TOPIC }
 
-          Guidelines: ${ $context.env.GUIDELINES }
+          Guidelines: ${ $env.GUIDELINES }
         temperature: 0.7
         max_tokens: 2000
         timeout: 120
@@ -88,7 +88,7 @@ spec:
           You are a professional content writer. Revise the draft based on
           the reviewer's feedback. Preserve what works, fix what doesn't.
         prompt: >
-          Original topic: ${ $context.env.TOPIC }
+          Original topic: ${ $env.TOPIC }
 
           Previous draft:
           ${ $context.draft_content.text }
@@ -117,6 +117,6 @@ spec:
             content: .content,
             approved_by: .reviewer
           }
-        input: "${ {topic: $context.env.TOPIC, content: $context.draft_content.text, reviewer: $context.review_content.reviewer} }"
+        input: "${ {topic: $env.TOPIC, content: $context.draft_content.text, reviewer: $context.review_content.reviewer} }"
       export:
         as: "${ . }"

--- a/seedpack/workflows/research-and-summarize.yaml
+++ b/seedpack/workflows/research-and-summarize.yaml
@@ -40,10 +40,10 @@ spec:
           thoroughly. Identify key themes, claims, evidence, and gaps.
           Organize your analysis with clear sections.
         prompt: >
-          Analyze the following material on "${ $context.env.TOPIC }"
-          at ${ $context.env.DEPTH } depth:
+          Analyze the following material on "${ $env.TOPIC }"
+          at ${ $env.DEPTH } depth:
 
-          ${ $context.env.SOURCE_MATERIAL }
+          ${ $env.SOURCE_MATERIAL }
         temperature: 0.3
         max_tokens: 3000
         timeout: 120
@@ -139,7 +139,7 @@ spec:
             key_findings: .findings,
             finding_count: (.findings.findings | length)
           }
-        input: "${ {topic: $context.env.TOPIC, summary: $context.parallel_processing.executive_summary.summarize.text, findings: $context.parallel_processing.key_findings.extract_findings.structured} }"
+        input: "${ {topic: $env.TOPIC, summary: $context.parallel_processing.executive_summary.summarize.text, findings: $context.parallel_processing.key_findings.extract_findings.structured} }"
       export:
         as: "${ . }"
       flow:

--- a/seedpack/workflows/support-ticket-triage.yaml
+++ b/seedpack/workflows/support-ticket-triage.yaml
@@ -39,9 +39,9 @@ spec:
         prompt: >
           Classify this support ticket:
 
-          ${ $context.env.TICKET_DESCRIPTION }
+          ${ $env.TICKET_DESCRIPTION }
 
-          Customer: ${ $context.env.CUSTOMER_EMAIL }
+          Customer: ${ $env.CUSTOMER_EMAIL }
         response_schema:
           type: object
           required:
@@ -100,10 +100,10 @@ spec:
           *Summary*: ${ $context.classify_ticket.summary }
           *Category*: ${ $context.classify_ticket.category }
           *Customer Impact*: ${ $context.classify_ticket.customer_impact }
-          *Customer*: ${ $context.env.CUSTOMER_EMAIL }
+          *Customer*: ${ $env.CUSTOMER_EMAIL }
 
           Original ticket:
-          ${ $context.env.TICKET_DESCRIPTION }
+          ${ $env.TICKET_DESCRIPTION }
 
           Approve escalation to the incident response team?
         outcomes:

--- a/test/conformance/src/suites/mcp.conformance.test.ts
+++ b/test/conformance/src/suites/mcp.conformance.test.ts
@@ -125,4 +125,48 @@ describe("MCP server conformance (live Go server)", () => {
     const getResult = await callTool("get_agent", { org: orgSlug, slug });
     expect(getResult.isError).toBe(true); // NotFound surfaces as a tool error
   });
+
+  // Round-trip pin for validate_workflow_yaml (stigmer/stigmer#778 finding 2):
+  // until 2026-07-28 the MCP client's transport default sent grpc-web to a
+  // server path that rejects it, so the ONLY server-backed validation surface
+  // died with "Content-Type 'application/grpc-web+proto' is not supported".
+  // The roster assertion above never caught that — only a real call does.
+  it("validate_workflow_yaml round-trips the real validation pipeline", async () => {
+    const workflowYaml = (taskConfig: string) => `
+apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: mcp-validate-roundtrip
+  org: ${orgSlug}
+spec:
+  description: conformance validate_workflow_yaml fixture
+  document:
+    dsl: "1.0.0"
+    namespace: ${orgSlug}
+    name: mcp-validate-roundtrip
+    version: "1.0.0"
+  tasks:
+    - name: conditional_wait
+      kind: wait
+      task_config:
+${taskConfig}
+`;
+
+    const valid = await callTool("validate_workflow_yaml", {
+      yaml: workflowYaml("        duration:\n          seconds: 5"),
+    });
+    expect(valid.isError, valid.content[0]?.text).toBeFalsy();
+    const validVerdict = JSON.parse(valid.content[0]?.text ?? "{}");
+    expect(validVerdict.state, JSON.stringify(validVerdict.errors)).toBe("VALID");
+
+    // A config a real apply rejects must come back as a structured INVALID
+    // verdict naming the task — never a transport error.
+    const invalid = await callTool("validate_workflow_yaml", {
+      yaml: workflowYaml('        duration: "5s"'),
+    });
+    expect(invalid.isError, invalid.content[0]?.text).toBeFalsy();
+    const invalidVerdict = JSON.parse(invalid.content[0]?.text ?? "{}");
+    expect(invalidVerdict.state).toBe("INVALID");
+    expect(JSON.stringify(invalidVerdict.errors)).toContain("conditional_wait");
+  });
 });

--- a/tools/codegen/generator/docs_yaml_gate.go
+++ b/tools/codegen/generator/docs_yaml_gate.go
@@ -622,6 +622,101 @@ func decodeYamlDocuments(body string) ([]interface{}, error) {
 // Tree walk and reporting
 // ============================================================================
 
+// deadExpressionNamespacePattern matches the `$context.env` expression
+// namespace, which resolves to null at runtime — environment variables are a
+// top-level `$env` binding, never nested under `$context`. The runner's
+// server-side validator only WARNS about this (expression_warnings.go); here,
+// on authoring surfaces we ship (docs prose and fences, examples, seedpack),
+// it is a hard failure so the dead form can never be taught again
+// (stigmer/stigmer#778 finding 3).
+var deadExpressionNamespacePattern = regexp.MustCompile(`\$context\.env`)
+
+// checkDeadExpressionNamespace scans a file's raw text line by line so every
+// occurrence gets a precise location. Text-level on purpose: the dead form
+// appears in prose, inline code, and YAML strings alike, and all of them
+// teach it.
+func checkDeadExpressionNamespace(path, src string) []docsYamlProblem {
+	var problems []docsYamlProblem
+	for i, line := range strings.Split(src, "\n") {
+		if deadExpressionNamespacePattern.MatchString(line) {
+			problems = append(problems, docsYamlProblem{
+				Path: path,
+				Line: i + 1,
+				Msg: "references the dead '$context.env' expression namespace, which resolves to null at runtime — " +
+					"environment variables are accessed via '$env.<VAR>' ($context holds accumulated task outputs)",
+			})
+		}
+	}
+	return problems
+}
+
+// checkAuthoringDirs walks raw authoring surfaces that ship to users but have
+// no markdown fences — examples/ and seedpack/ — applying the same truth as
+// the docs gate: every YAML document with an apiVersion is validated as a
+// full resource manifest (typed task-config decode and protovalidate rules
+// included), and every file is scanned for the dead expression namespace.
+// YAML files without apiVersion (e.g. seedpack MCP tiles) are namespace-
+// scanned only: they are not resource manifests and have their own suites.
+func checkAuthoringDirs(dirs []string, reg *docsYamlRegistries) (summary authoringDirsSummary, problems []docsYamlProblem, err error) {
+	for _, dir := range dirs {
+		walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			ext := filepath.Ext(path)
+			isYaml := ext == ".yaml" || ext == ".yml"
+			isMarkdown := ext == ".md" || ext == ".mdx"
+			if !isYaml && !isMarkdown {
+				return nil
+			}
+
+			src, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			summary.Files++
+			problems = append(problems, checkDeadExpressionNamespace(path, string(src))...)
+			if !isYaml {
+				return nil
+			}
+
+			docs, decodeErr := decodeYamlDocuments(string(src))
+			if decodeErr != nil {
+				problems = append(problems, docsYamlProblem{Path: path, Msg: fmt.Sprintf("invalid YAML: %v", decodeErr)})
+				return nil
+			}
+			for _, doc := range docs {
+				mapping, isMapping := doc.(map[string]interface{})
+				if !isMapping {
+					continue
+				}
+				if _, hasAPIVersion := mapping["apiVersion"]; !hasAPIVersion {
+					continue
+				}
+				summary.Manifests++
+				reg.rules.beginFence(path, 0)
+				reg.rules.setBlockClass("manifest")
+				for _, msg := range validateManifestDoc(mapping, reg) {
+					problems = append(problems, docsYamlProblem{Path: path, Msg: msg})
+				}
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return summary, problems, walkErr
+		}
+	}
+	return summary, problems, nil
+}
+
+type authoringDirsSummary struct {
+	Files     int
+	Manifests int
+}
+
 type docsYamlSummary struct {
 	Files     int
 	Blocks    int
@@ -675,6 +770,9 @@ func checkDocsYaml(docsDir string, ruleMode docsYamlRuleMode) (docsYamlSummary, 
 		if err != nil {
 			return err
 		}
+		// Whole-file scan (prose, inline code, and fences alike): the dead
+		// namespace teaches wrong wherever it appears.
+		problems = append(problems, checkDeadExpressionNamespace(path, string(src))...)
 		fences, err := scanMarkdownFences(path, string(src))
 		if err != nil {
 			problems = append(problems, docsYamlProblem{Path: path, Msg: err.Error()})
@@ -721,11 +819,28 @@ func checkDocsYaml(docsDir string, ruleMode docsYamlRuleMode) (docsYamlSummary, 
 	return summary, problems, rules, nil
 }
 
-// runDocsYamlCheck is the --target=docs-yaml-check entry point.
-func runDocsYamlCheck(docsDir string, ruleMode docsYamlRuleMode) error {
+// runDocsYamlCheck is the --target=docs-yaml-check entry point. authoringDirs
+// optionally extends the gate beyond docs fences to raw authoring surfaces
+// (examples/, seedpack/) — same registries, same rules, one gate.
+func runDocsYamlCheck(docsDir string, authoringDirs []string, ruleMode docsYamlRuleMode) error {
 	summary, problems, rules, err := checkDocsYaml(docsDir, ruleMode)
 	if err != nil {
 		return err
+	}
+
+	var authoringSummary authoringDirsSummary
+	if len(authoringDirs) > 0 {
+		reg, regErr := buildDocsYamlRegistries()
+		if regErr != nil {
+			return regErr
+		}
+		reg.rules = rules
+		var authoringProblems []docsYamlProblem
+		authoringSummary, authoringProblems, err = checkAuthoringDirs(authoringDirs, reg)
+		if err != nil {
+			return err
+		}
+		problems = append(problems, authoringProblems...)
 	}
 
 	// The report precedes the gate result: in report mode the findings are
@@ -756,6 +871,10 @@ func runDocsYamlCheck(docsDir string, ruleMode docsYamlRuleMode) error {
 
 	fmt.Printf("✓ docs YAML gate: %d blocks across %d files — %d manifests, %d task lists, %d anchored fragments, %d skipped with no-validate, 0 unclassified\n",
 		summary.Blocks, summary.Files, summary.Manifests, summary.TaskLists, summary.Anchored, summary.Skipped)
+	if len(authoringDirs) > 0 {
+		fmt.Printf("✓ authoring surfaces (%s): %d files scanned, %d raw manifests validated, namespace check clean\n",
+			strings.Join(authoringDirs, ", "), authoringSummary.Files, authoringSummary.Manifests)
+	}
 	return nil
 }
 

--- a/tools/codegen/generator/docs_yaml_gate_test.go
+++ b/tools/codegen/generator/docs_yaml_gate_test.go
@@ -450,6 +450,120 @@ func TestCheckDocsYamlOnFixtureTree(t *testing.T) {
 	}
 }
 
+func TestCheckDeadExpressionNamespace(t *testing.T) {
+	problems := checkDeadExpressionNamespace("guide.mdx",
+		"Env vars live at `${ $env.TOPIC }`.\nNever `${ $context.env.TOPIC }`.\nAlso bad: $context.env.OTHER\n")
+	if len(problems) != 2 {
+		t.Fatalf("expected 2 problems, got %v", problems)
+	}
+	if problems[0].Line != 2 || problems[1].Line != 3 {
+		t.Errorf("expected lines 2 and 3, got %d and %d", problems[0].Line, problems[1].Line)
+	}
+	if !strings.Contains(problems[0].Msg, "$env.<VAR>") {
+		t.Errorf("problem should point at the $env namespace, got: %s", problems[0].Msg)
+	}
+}
+
+func TestCheckAuthoringDirsOnFixtureTree(t *testing.T) {
+	dir := t.TempDir()
+
+	// A manifest a real apply rejects (string duration) plus the dead
+	// namespace — both must be flagged (the stigmer/stigmer#778 classes).
+	badManifest := `apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: bad
+spec:
+  description: bad fixture
+  document:
+    dsl: "1.0.0"
+    namespace: examples
+    name: bad
+    version: "1.0.0"
+  tasks:
+    - name: pause
+      kind: wait
+      task_config:
+        duration: "5s"
+`
+	goodManifest := `apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: good
+spec:
+  description: good fixture
+  document:
+    dsl: "1.0.0"
+    namespace: examples
+    name: good
+    version: "1.0.0"
+  tasks:
+    - name: pause
+      kind: wait
+      task_config:
+        duration:
+          seconds: 5
+`
+	// Not a manifest (no apiVersion): namespace-scanned only, never
+	// manifest-validated — the seedpack-tile shape.
+	tileYaml := "name: some-tile\nprompt: \"uses ${ $context.env.TOPIC }\"\n"
+	skillDoc := "# Skill\nUse `${ $env.TOPIC }` — but this file says $context.env.TOPIC once.\n"
+
+	writeFixture := func(rel, content string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFixture("workflows/bad.yaml", badManifest)
+	writeFixture("workflows/good.yaml", goodManifest)
+	writeFixture("tiles/tile.yaml", tileYaml)
+	writeFixture("skills/SKILL.md", skillDoc)
+
+	reg := mustBuildRegistries(t)
+	var err error
+	reg.rules, err = newDocsYamlRuleEval(ruleModeOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	summary, problems, err := checkAuthoringDirs([]string{dir}, reg)
+	if err != nil {
+		t.Fatalf("checkAuthoringDirs: %v", err)
+	}
+	if summary.Files != 4 {
+		t.Errorf("expected 4 files scanned, got %d", summary.Files)
+	}
+	if summary.Manifests != 2 {
+		t.Errorf("expected 2 manifests validated (the tile has no apiVersion), got %d", summary.Manifests)
+	}
+
+	var durationProblem, tileProblem, skillProblem bool
+	for _, p := range problems {
+		if strings.Contains(p.Msg, "WaitTaskConfig") && strings.HasSuffix(p.Path, "bad.yaml") {
+			durationProblem = true
+		}
+		if strings.Contains(p.Msg, "$env.<VAR>") && strings.HasSuffix(p.Path, "tile.yaml") {
+			tileProblem = true
+		}
+		if strings.Contains(p.Msg, "$env.<VAR>") && strings.HasSuffix(p.Path, "SKILL.md") {
+			skillProblem = true
+		}
+		if strings.HasSuffix(p.Path, "good.yaml") {
+			t.Errorf("good manifest should not be flagged: %s", p.Msg)
+		}
+	}
+	if !durationProblem {
+		t.Errorf("string duration in a raw manifest should be flagged, got %v", problems)
+	}
+	if !tileProblem || !skillProblem {
+		t.Errorf("dead namespace should be flagged in both YAML and markdown files, got %v", problems)
+	}
+}
+
 func TestGeneratedDocHint(t *testing.T) {
 	cases := []struct {
 		rel  string

--- a/tools/codegen/generator/main.go
+++ b/tools/codegen/generator/main.go
@@ -540,6 +540,7 @@ func main() {
 	apisDir := flag.String("apis-dir", "", "Root directory of proto API definitions (used by sdk-docs for overview.md loading and by task-docs for the index enrichment template)")
 	docsDir := flag.String("docs-dir", "", "Root directory of the documentation tree (used by the docs-yaml-check target)")
 	rules := flag.String("rules", "off", "Protovalidate rule evaluation for docs-yaml-check: off, report (print findings, never fail), or enforce (findings fail the gate)")
+	authoringDirs := flag.String("authoring-dirs", "", "Comma-separated raw authoring surfaces (e.g. examples,seedpack) the docs-yaml-check target also validates: YAML manifests decode fully, every file is scanned for the dead $context.env namespace")
 	flag.Parse()
 
 	// docs-yaml-check is a pass/fail validator over the docs tree: it reads
@@ -555,7 +556,13 @@ func main() {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
-		if err := runDocsYamlCheck(*docsDir, ruleMode); err != nil {
+		var extraDirs []string
+		for _, dir := range strings.Split(*authoringDirs, ",") {
+			if trimmed := strings.TrimSpace(dir); trimmed != "" {
+				extraDirs = append(extraDirs, trimmed)
+			}
+		}
+		if err := runDocsYamlCheck(*docsDir, extraDirs, ruleMode); err != nil {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary

Fixes all four findings of #778 — one theme: an author following our own guidance wrote a workflow that validated clean and then failed a real apply.

### F1 — offline validate now decodes task configs (CLI)

`stigmer validate` and `apply --dry-run` treated `task_config` as an unchecked Struct, so kind-specific errors sailed through and surfaced only on the real apply. New `client-apps/cli/src/resources/task-configs.ts` decodes every task's config into its kind's typed proto message — the offline twin of the server's `unmarshalTaskConfig`, including the agent_call shorthand shim (harness/service-tier/env-ref) so offline validation is **never stricter than a real apply**. The kind→schema map follows the file's own `VALIDATE_SCHEMAS` handwritten-map-plus-drift-test precedent: a bidirectional pin against the `WorkflowTaskKind` enum means a new task kind cannot ship without a CLI schema binding. Hooked at both seams (`validateDocument` and `marshalItem`, which also covers the declarative reconciler). Scope stays decode-truth; semantic validation remains the server's authority via `validateSpec`.

**Acceptance**: `stigmer validate -f examples/workflows/multi-step.yaml` rejected the shipped example as-was (exit 2, naming the task and value); all rewritten examples now pass.

### F2 — MCP `validate_workflow_yaml`: fixed at source; now pinned

Live repro against a real spawned Go server confirms the grpc-web 415 was fixed by `b7595a4a9` (2026-07-28, shipped in v3.12.4). The conformance suite asserted the tool only in the roster listing — a transport regression was invisible. Added a real round-trip pin: valid YAML → `VALID`; a config a real apply rejects → structured `INVALID` naming the task, never a transport error.

### F3 + F4 — one gate, three surfaces

`make check-docs-yaml` gains `--authoring-dirs examples,seedpack`: raw YAML manifests get the same strict typed decode + protovalidate rules as docs fences, and **every** walked file (docs prose included) is scanned for the dead `$context.env` namespace. First run flagged 51 problems; all fixed:

- **Namespace**: `$context.env.*` → `$env.*` across 4 docs files (17 occurrences) and 7 seedpack files (16 occurrences — 3 live marketplace workflows + the workflow-creator skill refs). The runner only binds `$env`; the old form resolved to null at runtime.
- **Examples rewritten against real contracts** (they sat outside every gate): the string `duration: "5s"`, hyphenated task names (protovalidate's name regex rejects them — all three workflow examples were unappliable), missing-`$` `${context.foo}` references, the invalid `${ now() }` form (jq's builtin is `now`, no parens — verified against the runner's jq engine; the authoring guide taught the broken form too and is fixed), the agent example's nonexistent `config`/`mcpServers` fields, and proper `env:` declarations for pr-review's formerly-unbound variables.

Final gate: `117 docs blocks + 151 authoring files scanned, 57 raw manifests validated, namespace check clean`.

## Verification

- CLI: typecheck + 898/898 tests (incl. the new drift test and decode pins).
- Gate: `tools/codegen/generator` Go tests green (new fixture-tree tests for the authoring walk + namespace scan); extended `check-docs-yaml` green.
- MCP conformance (live Go server): 4/4 incl. the new round-trip.
- `go vet` (tools), `lint-docs`, `format-docs-check`, `gen-cli-docs-check`, `test-seedpack-static`, `@stigmer/mcp-server` tests — all green.

## Deployment note

The three seedpack workflow YAMLs are live marketplace artifacts — the `$env` fix reaches prod via the operator's `stigmer seedpack apply` after the next release (the #238 precedent); recorded on the issue.

Closes #778

Made with [Cursor](https://cursor.com)