### PR TITLE
feat(sdk): console preferences UI — org and account standing context editors

### DIFF
--- a/client-apps/desktop/src/routes.tsx
+++ b/client-apps/desktop/src/routes.tsx
@@ -5,6 +5,7 @@ import {
   type RouteObject,
 } from "react-router-dom";
 import {
+  AccountPreferencesSection,
   ApiKeysSection,
   ChannelAppsSection,
   EnvironmentsSection,
@@ -12,6 +13,7 @@ import {
   InvitationsSection,
   MembersSection,
   OAuthAppsSection,
+  OrgPreferencesSection,
   OrgProfileSection,
   PlatformClientsSection,
   UsageSection,
@@ -281,6 +283,11 @@ const routes: RouteObject[] = [
               { path: "environments", element: <EnvironmentsSection /> },
               { path: "members", element: <MembersSection /> },
               { path: "org-profile", element: <OrgProfileSection /> },
+              { path: "org-preferences", element: <OrgPreferencesSection /> },
+              {
+                path: "account-preferences",
+                element: <AccountPreferencesSection />,
+              },
               { path: "invitations", element: <InvitationsSection /> },
               { path: "identity-providers", element: <IdentityProvidersSection /> },
               { path: "platform-clients", element: <PlatformClientsSection /> },

--- a/client-apps/web/src/app/settings/account-preferences/page.tsx
+++ b/client-apps/web/src/app/settings/account-preferences/page.tsx
@@ -1,0 +1,5 @@
+import { AccountPreferencesSection } from "@stigmer/react";
+
+export default function AccountPreferencesPage() {
+  return <AccountPreferencesSection />;
+}

--- a/client-apps/web/src/app/settings/org-preferences/page.tsx
+++ b/client-apps/web/src/app/settings/org-preferences/page.tsx
@@ -1,0 +1,5 @@
+import { OrgPreferencesSection } from "@stigmer/react";
+
+export default function OrgPreferencesPage() {
+  return <OrgPreferencesSection />;
+}

--- a/sdk/react/src/identity-account/AccountPreferencesPanel.tsx
+++ b/sdk/react/src/identity-account/AccountPreferencesPanel.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { type FormEvent, useCallback, useEffect, useId, useMemo, useState } from "react";
+import { cn } from "@stigmer/theme";
+import { getUserMessage, toIdentityAccountUpdateInput } from "@stigmer/sdk";
+import type { IdentityAccount } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import { useMyIdentityAccount } from "./useMyIdentityAccount.js";
+import { useUpdateIdentityAccount } from "./useUpdateIdentityAccount.js";
+import { useResourceAvailable, ApiResourceKind } from "../deployment-mode.js";
+import { CloudFeatureNotice } from "../internal/CloudFeatureNotice.js";
+import { StandingContextField } from "../internal/StandingContextField.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+
+/** Props for {@link AccountPreferencesPanel}. */
+export interface AccountPreferencesPanelProps {
+  /** Fired with the updated resource after a successful save. */
+  readonly onUpdated?: (account: IdentityAccount) => void;
+  /** Additional CSS class names for the root container. */
+  readonly className?: string;
+}
+
+/**
+ * Self-contained editor for the current user's declared preferences
+ * (`IdentityAccountSpec.preferences.standing_context`).
+ *
+ * The declared text is snapshotted into the user's own eligible agent
+ * executions and delivered to the agent as background context.
+ * Self-service: the account is resolved via `whoAmI()` and updated
+ * through the caller's self-ownership permission — no explicit
+ * permission check is needed. On save, calls `identityAccount.update()`
+ * with the complete mapped input (full-spec-replace safety) and fires
+ * `onUpdated`.
+ *
+ * Cloud-only: the OSS local server has no IdentityAccount (local mode
+ * is single-user, so the organization's preferences cover it). In local
+ * mode the panel renders a {@link CloudFeatureNotice} instead.
+ *
+ * All visual properties flow through `--stgm-*` design tokens. Zero
+ * dependencies on Console routing, auth context, or layout — platform
+ * builders can embed it directly:
+ *
+ * @example
+ * ```tsx
+ * <AccountPreferencesPanel />
+ * ```
+ */
+export function AccountPreferencesPanel({
+  onUpdated,
+  className,
+}: AccountPreferencesPanelProps) {
+  const baseId = useId();
+  const available = useResourceAvailable(ApiResourceKind.identity_account);
+
+  if (!available) {
+    return (
+      <CloudFeatureNotice className={className}>
+        Personal preferences require Stigmer Cloud. Local mode is
+        single-user, so the organization&apos;s preferences apply to every
+        execution — set standing context there instead.
+      </CloudFeatureNotice>
+    );
+  }
+
+  return (
+    <AccountPreferencesForm
+      baseId={baseId}
+      onUpdated={onUpdated}
+      className={className}
+    />
+  );
+}
+
+/**
+ * Inner form, mounted only when IdentityAccount is available — keeps the
+ * data hooks from issuing doomed RPCs against a local server.
+ */
+function AccountPreferencesForm({
+  baseId,
+  onUpdated,
+  className,
+}: {
+  readonly baseId: string;
+  readonly onUpdated?: (account: IdentityAccount) => void;
+  readonly className?: string;
+}) {
+  const {
+    account,
+    isLoading: isFetching,
+    error: fetchError,
+    refetch,
+  } = useMyIdentityAccount();
+
+  const {
+    update,
+    isUpdating,
+    error: updateError,
+    clearError,
+  } = useUpdateIdentityAccount();
+
+  const [standingContext, setStandingContext] = useState("");
+
+  const serverStandingContext =
+    account?.spec?.preferences?.standingContext ?? "";
+
+  // Sync the form field when server data changes.
+  useEffect(() => {
+    if (!account) return;
+    setStandingContext(account.spec?.preferences?.standingContext ?? "");
+  }, [account]);
+
+  const hasChanges = useMemo(
+    () => standingContext.trim() !== serverStandingContext,
+    [standingContext, serverStandingContext],
+  );
+
+  const canSubmit = hasChanges && !isUpdating;
+
+  const handleDiscard = useCallback(() => {
+    setStandingContext(serverStandingContext);
+    clearError();
+  }, [serverStandingContext, clearError]);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      if (!canSubmit || !account) return;
+
+      clearError();
+      try {
+        // update() is a full-spec replace: spread the complete mapped input
+        // so unedited spec fields survive, and override only preferences.
+        const updated = await update({
+          ...toIdentityAccountUpdateInput(account),
+          preferences: { standingContext: standingContext.trim() || undefined },
+        });
+        refetch();
+        onUpdated?.(updated);
+      } catch {
+        // error state is managed by useUpdateIdentityAccount
+      }
+    },
+    [canSubmit, account, standingContext, update, clearError, refetch, onUpdated],
+  );
+
+  // -----------------------------------------------------------------------
+  // Loading state
+  // -----------------------------------------------------------------------
+
+  if (isFetching && !account) {
+    return (
+      <div
+        className={cn("stg:space-y-4", className)}
+        aria-busy="true"
+        aria-label="Loading account preferences"
+      >
+        <div className="stg:bg-muted-subtle stg:h-28 stg:animate-pulse stg:rounded" />
+        <div className="stg:bg-muted-subtle stg:h-8 stg:w-32 stg:animate-pulse stg:rounded" />
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Fetch error
+  // -----------------------------------------------------------------------
+
+  if (fetchError) {
+    return (
+      <div className={cn("stg:space-y-3", className)} role="alert">
+        <p className="stg:text-destructive stg:text-sm">
+          {getUserMessage(fetchError)}
+        </p>
+        <button
+          type="button"
+          onClick={refetch}
+          className={cn(
+            "stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs stg:font-medium",
+            "stg:bg-primary stg:text-primary-foreground stg:hover:bg-primary-hover",
+          )}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!account) return null;
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  return (
+    <form onSubmit={handleSubmit} className={cn("stg:space-y-4", className)}>
+      <StandingContextField
+        id={`${baseId}-standing-context`}
+        value={standingContext}
+        onChange={setStandingContext}
+        disabled={isUpdating}
+        placeholder={
+          "e.g. Keep answers terse. I prefer TypeScript examples. My timezone is IST."
+        }
+        helperText="Shared with agents as background context — not instructions. Applies only to executions you start and is visible on those execution records."
+      />
+
+      {updateError && (
+        <p className="stg:text-destructive stg:text-[0.65rem]" role="alert">
+          {getUserMessage(updateError)}
+        </p>
+      )}
+
+      <div className="stg:flex stg:items-center stg:gap-2">
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className={cn(
+            "stg:inline-flex stg:items-center stg:gap-1.5 stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs stg:font-medium",
+            "stg:bg-primary stg:text-primary-foreground stg:hover:bg-primary-hover",
+            "stg:disabled:pointer-events-none stg:disabled:opacity-40",
+          )}
+        >
+          {isUpdating && <SpinnerIcon size={12} />}
+          Save changes
+        </button>
+
+        {hasChanges && !isUpdating && (
+          <button
+            type="button"
+            onClick={handleDiscard}
+            className={cn(
+              "stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs",
+              "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
+            )}
+          >
+            Discard
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/sdk/react/src/identity-account/__tests__/AccountPreferencesPanel.test.tsx
+++ b/sdk/react/src/identity-account/__tests__/AccountPreferencesPanel.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import {
+  IdentityAccountSchema,
+  type IdentityAccount,
+} from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import type { IdentityAccountInput } from "@stigmer/sdk";
+import type { DeploymentMode } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { DeploymentModeContext } from "../../deployment-mode";
+import { AccountPreferencesPanel } from "../AccountPreferencesPanel";
+
+const ACCOUNT: IdentityAccount = create(IdentityAccountSchema, {
+  metadata: { id: "ia-1", name: "Ada Lovelace", slug: "ada", org: "acme" },
+  spec: {
+    idpId: "auth0|abc",
+    email: "ada@acme.example",
+    preferences: { standingContext: "Keep answers terse." },
+  },
+});
+
+function createMockStigmer(overrides?: {
+  whoAmI?: ReturnType<typeof vi.fn>;
+  update?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    identityAccount: {
+      whoAmI: overrides?.whoAmI ?? vi.fn(async () => ACCOUNT),
+      update: overrides?.update ?? vi.fn(async () => ACCOUNT),
+    },
+  } as never;
+}
+
+function renderPanel(client: unknown, mode: DeploymentMode = "cloud") {
+  return render(
+    <StigmerContext.Provider value={client as never}>
+      <DeploymentModeContext.Provider value={mode}>
+        <AccountPreferencesPanel />
+      </DeploymentModeContext.Provider>
+    </StigmerContext.Provider>,
+  );
+}
+
+afterEach(cleanup);
+
+/**
+ * Waits until the form has synced from server data (the panel copies the
+ * fetched value into local state in a passive effect, one flush after the
+ * field first renders) — interacting earlier races the sync.
+ */
+async function findSyncedField(value: string) {
+  const field = await screen.findByLabelText("Standing context");
+  await waitFor(() => expect(field).toHaveProperty("value", value));
+  return field;
+}
+
+describe("AccountPreferencesPanel", () => {
+  it("renders the cloud notice in local mode without issuing any RPCs", () => {
+    const whoAmI = vi.fn(async () => ACCOUNT);
+    renderPanel(createMockStigmer({ whoAmI }), "local");
+
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByLabelText("Standing context")).toBeNull();
+    // The inner form must not mount — no doomed whoAmI against a local server.
+    expect(whoAmI).not.toHaveBeenCalled();
+  });
+
+  it("loads and displays the caller's declared standing context", async () => {
+    renderPanel(createMockStigmer());
+
+    await findSyncedField("Keep answers terse.");
+  });
+
+  it("saves the full mapped input — identity fields survive (wipe-bug guard)", async () => {
+    const update = vi.fn(async (_input: IdentityAccountInput) => ACCOUNT);
+    renderPanel(createMockStigmer({ update }));
+
+    const field = await findSyncedField("Keep answers terse.");
+    fireEvent.change(field, { target: { value: "Prefer bullet points." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    const input = update.mock.calls[0]![0];
+
+    expect(input.preferences).toEqual({
+      standingContext: "Prefer bullet points.",
+    });
+    // Fields this form never renders must round-trip untouched.
+    expect(input.idpId).toBe("auth0|abc");
+    expect(input.email).toBe("ada@acme.example");
+    // The update pipeline addresses the resource by org + slug.
+    expect(input.org).toBe("acme");
+    expect(input.slug).toBe("ada");
+  });
+
+  it("refetches the account after a successful save", async () => {
+    const whoAmI = vi.fn(async () => ACCOUNT);
+    renderPanel(createMockStigmer({ whoAmI }));
+
+    const field = await findSyncedField("Keep answers terse.");
+    fireEvent.change(field, { target: { value: "New context" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    // Initial load + post-save refetch.
+    await waitFor(() => expect(whoAmI).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows the fetch error with a retry action when whoAmI fails", async () => {
+    const whoAmI = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    renderPanel(createMockStigmer({ whoAmI }));
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+});

--- a/sdk/react/src/identity-account/__tests__/useMyIdentityAccount.test.tsx
+++ b/sdk/react/src/identity-account/__tests__/useMyIdentityAccount.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import {
+  IdentityAccountSchema,
+  type IdentityAccount,
+} from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import type { IdentityAccountInput } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { useMyIdentityAccount } from "../useMyIdentityAccount";
+import { useUpdateIdentityAccount } from "../useUpdateIdentityAccount";
+
+const ACCOUNT: IdentityAccount = create(IdentityAccountSchema, {
+  metadata: { id: "ia-1", name: "Ada", slug: "ada", org: "acme" },
+  spec: { preferences: { standingContext: "Keep answers terse." } },
+});
+
+/** Renders the data hook and exposes its state via data attributes. */
+function FetchProbe() {
+  const { account, isLoading, error, refetch } = useMyIdentityAccount();
+  return (
+    <button
+      type="button"
+      data-testid="probe"
+      data-loading={String(isLoading)}
+      data-error={String(error !== null)}
+      data-context={account?.spec?.preferences?.standingContext ?? ""}
+      onClick={refetch}
+    />
+  );
+}
+
+function UpdateProbe({ input }: { input: IdentityAccountInput }) {
+  const { update, isUpdating, error } = useUpdateIdentityAccount();
+  return (
+    <button
+      type="button"
+      data-testid="probe"
+      data-updating={String(isUpdating)}
+      data-error={String(error !== null)}
+      onClick={() => void update(input).catch(() => undefined)}
+    />
+  );
+}
+
+function withClient(client: unknown, ui: React.ReactNode) {
+  return render(
+    <StigmerContext.Provider value={client as never}>
+      {ui}
+    </StigmerContext.Provider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("useMyIdentityAccount", () => {
+  it("fetches the caller's account via whoAmI and supports refetch", async () => {
+    const whoAmI = vi.fn(async () => ACCOUNT);
+    withClient({ identityAccount: { whoAmI } }, <FetchProbe />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").getAttribute("data-context")).toBe(
+        "Keep answers terse.",
+      ),
+    );
+    expect(whoAmI).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("probe"));
+    await waitFor(() => expect(whoAmI).toHaveBeenCalledTimes(2));
+  });
+
+  it("surfaces errors as state", async () => {
+    const whoAmI = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    withClient({ identityAccount: { whoAmI } }, <FetchProbe />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").getAttribute("data-error")).toBe(
+        "true",
+      ),
+    );
+  });
+});
+
+describe("useUpdateIdentityAccount", () => {
+  it("submits the input through identityAccount.update", async () => {
+    const update = vi.fn(async (_input: IdentityAccountInput) => ACCOUNT);
+    const input: IdentityAccountInput = {
+      name: "Ada",
+      org: "acme",
+      slug: "ada",
+      idpId: "auth0|abc",
+      preferences: { standingContext: "New" },
+    };
+    withClient({ identityAccount: { update } }, <UpdateProbe input={input} />);
+
+    fireEvent.click(screen.getByTestId("probe"));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update.mock.calls[0]![0]).toEqual(input);
+  });
+
+  it("captures update failures in error state", async () => {
+    const update = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    withClient(
+      { identityAccount: { update } },
+      <UpdateProbe input={{ name: "Ada", org: "acme", idpId: "x" }} />,
+    );
+
+    fireEvent.click(screen.getByTestId("probe"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").getAttribute("data-error")).toBe(
+        "true",
+      ),
+    );
+  });
+});

--- a/sdk/react/src/identity-account/index.ts
+++ b/sdk/react/src/identity-account/index.ts
@@ -3,3 +3,9 @@ export {
   type IdentityAccountGateState,
   type UseIdentityAccountGateReturn,
 } from "./useIdentityAccountGate.js";
+export { useMyIdentityAccount } from "./useMyIdentityAccount.js";
+export type { UseMyIdentityAccountReturn } from "./useMyIdentityAccount.js";
+export { useUpdateIdentityAccount } from "./useUpdateIdentityAccount.js";
+export type { UseUpdateIdentityAccountReturn } from "./useUpdateIdentityAccount.js";
+export { AccountPreferencesPanel } from "./AccountPreferencesPanel.js";
+export type { AccountPreferencesPanelProps } from "./AccountPreferencesPanel.js";

--- a/sdk/react/src/identity-account/useMyIdentityAccount.ts
+++ b/sdk/react/src/identity-account/useMyIdentityAccount.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import type { IdentityAccount } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import { useStigmer } from "../hooks.js";
+import { useFetch } from "../internal/useFetch.js";
+
+/** Return value of {@link useMyIdentityAccount}. */
+export interface UseMyIdentityAccountReturn {
+  /** The authenticated user's identity account, or `null` while loading / on error. */
+  readonly account: IdentityAccount | null;
+  /** `true` while the initial fetch is in flight. */
+  readonly isLoading: boolean;
+  /** `true` while a background refetch is in flight and stale data is shown. */
+  readonly isRefetching: boolean;
+  /** Error from the last failed request, or `null` when healthy. */
+  readonly error: Error | null;
+  /** Re-fetch the account from the server (e.g. after an update). */
+  readonly refetch: () => void;
+}
+
+/**
+ * Data hook that fetches the current authenticated user's full
+ * {@link IdentityAccount} via `identityAccount.whoAmI()`.
+ *
+ * Unlike {@link useWhoAmI} (a cached identity lookup for "is this me?"
+ * checks), this hook is a refetchable data source for editors of the
+ * caller's own account — after a mutation, call `refetch()` to re-sync.
+ * `whoAmI()` returns the complete resource, so no follow-up `get()` is
+ * needed.
+ *
+ * Cloud-only by nature: the OSS local server does not implement
+ * IdentityAccount. Gate consumers with
+ * `useResourceAvailable(ApiResourceKind.identity_account)`.
+ *
+ * @example
+ * ```tsx
+ * const { account, refetch } = useMyIdentityAccount();
+ * const standingContext =
+ *   account?.spec?.preferences?.standingContext ?? "";
+ * ```
+ */
+export function useMyIdentityAccount(): UseMyIdentityAccountReturn {
+  const stigmer = useStigmer();
+
+  const { data: account, isLoading, isRefetching, error, refetch } = useFetch(
+    () => stigmer.identityAccount.whoAmI(),
+    [stigmer],
+    null as IdentityAccount | null,
+  );
+
+  return { account, isLoading, isRefetching, error, refetch };
+}

--- a/sdk/react/src/identity-account/useUpdateIdentityAccount.ts
+++ b/sdk/react/src/identity-account/useUpdateIdentityAccount.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { IdentityAccountInput } from "@stigmer/sdk";
+import type { IdentityAccount } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import { useStigmer } from "../hooks.js";
+import { toError } from "../internal/toError.js";
+
+/** Return value of {@link useUpdateIdentityAccount}. */
+export interface UseUpdateIdentityAccountReturn {
+  /** Submit an {@link IdentityAccountInput} to update an identity account. Resolves with the updated resource. */
+  readonly update: (input: IdentityAccountInput) => Promise<IdentityAccount>;
+  /** `true` while the update request is in flight. */
+  readonly isUpdating: boolean;
+  /** Error from the last failed update, or `null` when healthy. */
+  readonly error: Error | null;
+  /** Reset `error` to `null`. */
+  readonly clearError: () => void;
+}
+
+/**
+ * Mutation hook that wraps `identityAccount.update()` with loading and
+ * error state.
+ *
+ * The update RPC is a full-spec replacement addressed by `org` + `slug`
+ * (the generated input carries no id). Build the input from the loaded
+ * resource with `toIdentityAccountUpdateInput` from `@stigmer/sdk` and
+ * override only the fields being edited — sending a partial input wipes
+ * the unsent spec fields.
+ *
+ * Self-service: a user can always update their own account (`can_edit`
+ * via the self-ownership relationship written at account creation).
+ *
+ * @example
+ * ```tsx
+ * const { update, isUpdating, error } = useUpdateIdentityAccount();
+ *
+ * await update({
+ *   ...toIdentityAccountUpdateInput(account),
+ *   preferences: { standingContext: "Keep answers terse." },
+ * });
+ * refetch(); // re-sync the editor
+ * ```
+ */
+export function useUpdateIdentityAccount(): UseUpdateIdentityAccountReturn {
+  const stigmer = useStigmer();
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const update = useCallback(
+    async (input: IdentityAccountInput): Promise<IdentityAccount> => {
+      setIsUpdating(true);
+      setError(null);
+
+      try {
+        return await stigmer.identityAccount.update(input);
+      } catch (err) {
+        setError(toError(err));
+        throw err;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [stigmer],
+  );
+
+  return { update, isUpdating, error, clearError };
+}

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -834,13 +834,20 @@ export type {
   ToolCredentialsReadiness,
 } from "./environment/index.js";
 
-// Identity Account — gate hook for ensuring the caller's identity account exists before app render
+// Identity Account — gate hook, self-account data/mutation hooks, and
+// the account preferences editor
 export {
   useIdentityAccountGate,
+  useMyIdentityAccount,
+  useUpdateIdentityAccount,
+  AccountPreferencesPanel,
 } from "./identity-account/index.js";
 export type {
   IdentityAccountGateState,
   UseIdentityAccountGateReturn,
+  UseMyIdentityAccountReturn,
+  UseUpdateIdentityAccountReturn,
+  AccountPreferencesPanelProps,
 } from "./identity-account/index.js";
 
 // IAM Policy — data hooks, behavior hooks, headless hook, and styled components for access management
@@ -922,6 +929,7 @@ export {
   useUpdateOrganization,
   CreateOrganizationForm,
   OrgProfilePanel,
+  OrgPreferencesPanel,
   OrgSwitcher,
 } from "./organization/index.js";
 export type {
@@ -934,6 +942,7 @@ export type {
   UseUpdateOrganizationReturn,
   CreateOrganizationFormProps,
   OrgProfilePanelProps,
+  OrgPreferencesPanelProps,
   OrgSwitcherProps,
 } from "./organization/index.js";
 
@@ -1066,6 +1075,8 @@ export type { SettingsNavItem, SettingsNavGroup } from "./settings/index.js";
 export { ApiKeysSection } from "./settings/index.js";
 export { MembersSection } from "./settings/index.js";
 export { OrgProfileSection } from "./settings/index.js";
+export { OrgPreferencesSection } from "./settings/index.js";
+export { AccountPreferencesSection } from "./settings/index.js";
 export { EnvironmentsSection } from "./settings/index.js";
 export { InvitationsSection } from "./settings/index.js";
 export { IdentityProvidersSection } from "./settings/index.js";

--- a/sdk/react/src/internal/StandingContextField.tsx
+++ b/sdk/react/src/internal/StandingContextField.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@stigmer/theme";
+
+/**
+ * Both `OrganizationPreferences.standing_context` and
+ * `IdentityAccountPreferences.standing_context` pin `max_len = 2000`
+ * (buf.validate, spec.proto in each package).
+ */
+export const STANDING_CONTEXT_MAX_LEN = 2000;
+/** Show the remaining-characters counter once within this margin. */
+const COUNTER_THRESHOLD = 200;
+
+/** Props for {@link StandingContextField}. */
+export interface StandingContextFieldProps {
+  /** DOM id for the textarea (label association). */
+  readonly id: string;
+  /** Current field value. */
+  readonly value: string;
+  /** Fired with the new value on every edit. */
+  readonly onChange: (value: string) => void;
+  /** Disables editing while a save is in flight. */
+  readonly disabled?: boolean;
+  /**
+   * Renders the field as read-only (still selectable/copyable) for
+   * viewers without edit permission.
+   */
+  readonly readOnly?: boolean;
+  /** Example text shown when the field is empty. */
+  readonly placeholder?: string;
+  /** Helper line rendered under the textarea. */
+  readonly helperText?: ReactNode;
+}
+
+/**
+ * Shared textarea for declared-preference standing context — the one
+ * free-text field both the organization and account preference editors
+ * render. Owns the proto length cap and the remaining-characters
+ * counter; the parent panel owns label, load/save, and dirty state.
+ *
+ * Internal to `@stigmer/react` — the public surface is the panels.
+ */
+export function StandingContextField({
+  id,
+  value,
+  onChange,
+  disabled,
+  readOnly,
+  placeholder,
+  helperText,
+}: StandingContextFieldProps) {
+  const remaining = STANDING_CONTEXT_MAX_LEN - value.length;
+
+  return (
+    <div className="stg:space-y-1">
+      <label
+        htmlFor={id}
+        className="stg:text-xs stg:font-medium stg:text-foreground"
+      >
+        Standing context
+      </label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={STANDING_CONTEXT_MAX_LEN}
+        rows={6}
+        disabled={disabled}
+        readOnly={readOnly}
+        placeholder={readOnly ? undefined : placeholder}
+        className={cn(
+          "stg:w-full stg:resize-y stg:rounded-md stg:border stg:border-input stg:bg-background stg:px-2.5 stg:py-1.5 stg:text-xs stg:text-foreground",
+          "stg:placeholder:text-muted-foreground",
+          "stg:focus-visible:outline-none stg:focus-visible:ring-1 stg:focus-visible:ring-ring",
+          "stg:disabled:pointer-events-none stg:disabled:opacity-50",
+          readOnly && "stg:bg-muted-subtle stg:text-muted-foreground",
+        )}
+      />
+      {helperText && (
+        <p className="stg:text-[0.65rem] stg:text-muted-foreground">
+          {helperText}
+        </p>
+      )}
+      {!readOnly && remaining <= COUNTER_THRESHOLD && (
+        <p className="stg:text-[0.65rem] stg:text-muted-foreground">
+          {remaining} characters left
+        </p>
+      )}
+    </div>
+  );
+}

--- a/sdk/react/src/organization/OrgPreferencesPanel.tsx
+++ b/sdk/react/src/organization/OrgPreferencesPanel.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { type FormEvent, useCallback, useEffect, useId, useMemo, useState } from "react";
+import { cn } from "@stigmer/theme";
+import { getUserMessage, toOrganizationUpdateInput } from "@stigmer/sdk";
+import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { useOrganization } from "./useOrganization.js";
+import { useUpdateOrganization } from "./useUpdateOrganization.js";
+import { useCheckPermission } from "../iam-policy/useCheckPermission.js";
+import { StandingContextField } from "../internal/StandingContextField.js";
+import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+
+/** Props for {@link OrgPreferencesPanel}. */
+export interface OrgPreferencesPanelProps {
+  /** The ID of the organization whose preferences to display and edit. */
+  readonly orgId: string;
+  /** Fired with the updated resource after a successful save. */
+  readonly onUpdated?: (org: Organization) => void;
+  /** Additional CSS class names for the root container. */
+  readonly className?: string;
+}
+
+/**
+ * Self-contained editor for an {@link Organization}'s declared
+ * preferences (`spec.preferences.standing_context`).
+ *
+ * The declared text is snapshotted into every eligible agent execution
+ * run by the organization's members (first-party human operators only)
+ * and delivered to the agent as background context. Editing requires
+ * `can_edit` on the organization; viewers without it get a read-only
+ * rendering. On save, calls `organization.update()` with the complete
+ * mapped input (full-spec-replace safety) and fires `onUpdated`.
+ *
+ * All visual properties flow through `--stgm-*` design tokens. Zero
+ * dependencies on Console routing, auth context, or layout — platform
+ * builders can embed it directly:
+ *
+ * @example
+ * ```tsx
+ * <OrgPreferencesPanel orgId="org-id-123" />
+ * ```
+ */
+export function OrgPreferencesPanel({
+  orgId,
+  onUpdated,
+  className,
+}: OrgPreferencesPanelProps) {
+  const baseId = useId();
+  const {
+    organization,
+    isLoading: isFetching,
+    error: fetchError,
+    refetch,
+  } = useOrganization(orgId || null);
+
+  const {
+    update,
+    isUpdating,
+    error: updateError,
+    clearError,
+  } = useUpdateOrganization();
+
+  // Fail-open: OSS local mode has no IAM service, so editing stays
+  // available there; cloud gets a genuine server verdict.
+  const { allowed: canEdit } = useCheckPermission(
+    orgId ? { kind: "organization", id: orgId } : null,
+    "can_edit",
+  );
+
+  const [standingContext, setStandingContext] = useState("");
+
+  const serverStandingContext =
+    organization?.spec?.preferences?.standingContext ?? "";
+
+  // Sync the form field when server data changes.
+  useEffect(() => {
+    if (!organization) return;
+    setStandingContext(
+      organization.spec?.preferences?.standingContext ?? "",
+    );
+  }, [organization]);
+
+  const hasChanges = useMemo(
+    () => standingContext.trim() !== serverStandingContext,
+    [standingContext, serverStandingContext],
+  );
+
+  const canSubmit = canEdit && hasChanges && !isUpdating;
+
+  const handleDiscard = useCallback(() => {
+    setStandingContext(serverStandingContext);
+    clearError();
+  }, [serverStandingContext, clearError]);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      if (!canSubmit || !organization) return;
+
+      clearError();
+      try {
+        // update() is a full-spec replace: spread the complete mapped input
+        // so unedited spec fields survive, and override only preferences.
+        const updated = await update({
+          ...toOrganizationUpdateInput(organization),
+          preferences: { standingContext: standingContext.trim() || undefined },
+        });
+        refetch();
+        onUpdated?.(updated);
+      } catch {
+        // error state is managed by useUpdateOrganization
+      }
+    },
+    [canSubmit, organization, standingContext, update, clearError, refetch, onUpdated],
+  );
+
+  // -----------------------------------------------------------------------
+  // Loading state
+  // -----------------------------------------------------------------------
+
+  if (isFetching && !organization) {
+    return (
+      <div
+        className={cn("stg:space-y-4", className)}
+        aria-busy="true"
+        aria-label="Loading organization preferences"
+      >
+        <div className="stg:bg-muted-subtle stg:h-28 stg:animate-pulse stg:rounded" />
+        <div className="stg:bg-muted-subtle stg:h-8 stg:w-32 stg:animate-pulse stg:rounded" />
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Fetch error
+  // -----------------------------------------------------------------------
+
+  if (fetchError) {
+    return (
+      <div className={cn("stg:space-y-3", className)} role="alert">
+        <p className="stg:text-destructive stg:text-sm">
+          {getUserMessage(fetchError)}
+        </p>
+        <button
+          type="button"
+          onClick={refetch}
+          className={cn(
+            "stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs stg:font-medium",
+            "stg:bg-primary stg:text-primary-foreground stg:hover:bg-primary-hover",
+          )}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!organization) return null;
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  return (
+    <form onSubmit={handleSubmit} className={cn("stg:space-y-4", className)}>
+      <StandingContextField
+        id={`${baseId}-standing-context`}
+        value={standingContext}
+        onChange={setStandingContext}
+        disabled={isUpdating}
+        readOnly={!canEdit}
+        placeholder={
+          "e.g. We deploy to us-east-1. Our stack is Go and TypeScript. Prefer concise answers."
+        }
+        helperText="Shared with agents as background context — not instructions. Applies to executions started by signed-in members of this organization and is visible on their execution records."
+      />
+
+      {!canEdit && (
+        <p className="stg:text-[0.65rem] stg:text-muted-foreground">
+          Only organization admins can edit these preferences.
+        </p>
+      )}
+
+      {updateError && (
+        <p className="stg:text-destructive stg:text-[0.65rem]" role="alert">
+          {getUserMessage(updateError)}
+        </p>
+      )}
+
+      {canEdit && (
+        <div className="stg:flex stg:items-center stg:gap-2">
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className={cn(
+              "stg:inline-flex stg:items-center stg:gap-1.5 stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs stg:font-medium",
+              "stg:bg-primary stg:text-primary-foreground stg:hover:bg-primary-hover",
+              "stg:disabled:pointer-events-none stg:disabled:opacity-40",
+            )}
+          >
+            {isUpdating && <SpinnerIcon size={12} />}
+            Save changes
+          </button>
+
+          {hasChanges && !isUpdating && (
+            <button
+              type="button"
+              onClick={handleDiscard}
+              className={cn(
+                "stg:rounded-md stg:px-3 stg:py-1.5 stg:text-xs",
+                "stg:text-muted-foreground stg:hover:text-foreground stg:hover:bg-accent-hover",
+              )}
+            >
+              Discard
+            </button>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/sdk/react/src/organization/OrgProfilePanel.tsx
+++ b/sdk/react/src/organization/OrgProfilePanel.tsx
@@ -2,7 +2,7 @@
 
 import { type FormEvent, useCallback, useEffect, useId, useMemo, useState } from "react";
 import { cn } from "@stigmer/theme";
-import { getUserMessage } from "@stigmer/sdk";
+import { getUserMessage, toOrganizationUpdateInput } from "@stigmer/sdk";
 import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
 import { useOrganization } from "./useOrganization.js";
 import { useUpdateOrganization } from "./useUpdateOrganization.js";
@@ -116,10 +116,12 @@ export function OrgProfilePanel({
 
       clearError();
       try {
+        // update() is a full-spec replace: spread the complete mapped input
+        // so unedited spec fields (e.g. preferences) survive the save, and
+        // override only the fields this form edits.
         const updated = await update({
+          ...toOrganizationUpdateInput(organization),
           name: name.trim(),
-          slug: serverSlug,
-          org: serverSlug,
           description: description.trim() || undefined,
           logoUrl: logoUrl.trim() || undefined,
         });
@@ -135,7 +137,6 @@ export function OrgProfilePanel({
       name,
       description,
       logoUrl,
-      serverSlug,
       update,
       clearError,
       refetch,

--- a/sdk/react/src/organization/__tests__/OrgPreferencesPanel.test.tsx
+++ b/sdk/react/src/organization/__tests__/OrgPreferencesPanel.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import {
+  OrganizationSchema,
+  type Organization,
+} from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import type { OrganizationInput } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { DeploymentModeContext } from "../../deployment-mode";
+import { OrgPreferencesPanel } from "../OrgPreferencesPanel";
+
+const ORG: Organization = create(OrganizationSchema, {
+  metadata: { id: "acme", name: "Acme Corp", slug: "acme", org: "acme" },
+  spec: {
+    description: "We make everything.",
+    logoUrl: "https://acme.example/logo.png",
+    preferences: { standingContext: "We deploy to us-east-1." },
+  },
+});
+
+function createMockStigmer(overrides?: {
+  update?: ReturnType<typeof vi.fn>;
+  canEdit?: boolean;
+}) {
+  return {
+    organization: {
+      get: vi.fn(async () => ORG),
+      update: overrides?.update ?? vi.fn(async () => ORG),
+    },
+    iamPolicy: {
+      checkMyPermission: vi.fn(async () => ({
+        isAuthorized: overrides?.canEdit ?? true,
+      })),
+    },
+  } as never;
+}
+
+function renderPanel(client: unknown) {
+  return render(
+    <StigmerContext.Provider value={client as never}>
+      <DeploymentModeContext.Provider value="local">
+        <OrgPreferencesPanel orgId="acme" />
+      </DeploymentModeContext.Provider>
+    </StigmerContext.Provider>,
+  );
+}
+
+afterEach(cleanup);
+
+/**
+ * Waits until the form has synced from server data (the panel copies the
+ * fetched value into local state in a passive effect, one flush after the
+ * field first renders) — interacting earlier races the sync.
+ */
+async function findSyncedField(value: string) {
+  const field = await screen.findByLabelText("Standing context");
+  await waitFor(() => expect(field).toHaveProperty("value", value));
+  return field;
+}
+
+describe("OrgPreferencesPanel", () => {
+  it("loads and displays the declared standing context", async () => {
+    renderPanel(createMockStigmer());
+
+    await findSyncedField("We deploy to us-east-1.");
+  });
+
+  it("saves the full mapped input — unedited profile fields survive (wipe-bug guard)", async () => {
+    const update = vi.fn(async (_input: OrganizationInput) => ORG);
+    renderPanel(createMockStigmer({ update }));
+
+    const field = await findSyncedField("We deploy to us-east-1.");
+    fireEvent.change(field, { target: { value: "Prefer terse answers." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    const input = update.mock.calls[0]![0];
+
+    expect(input.preferences).toEqual({
+      standingContext: "Prefer terse answers.",
+    });
+    // Fields this form never renders must round-trip untouched.
+    expect(input.name).toBe("Acme Corp");
+    expect(input.description).toBe("We make everything.");
+    expect(input.logoUrl).toBe("https://acme.example/logo.png");
+    expect(input.org).toBe("acme");
+    expect(input.slug).toBe("acme");
+  });
+
+  it("clears the standing context when the text is emptied", async () => {
+    const update = vi.fn(async (_input: OrganizationInput) => ORG);
+    renderPanel(createMockStigmer({ update }));
+
+    const field = await findSyncedField("We deploy to us-east-1.");
+    fireEvent.change(field, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update.mock.calls[0]![0].preferences).toEqual({
+      standingContext: undefined,
+    });
+  });
+
+  it("discard resets the field to the server value", async () => {
+    renderPanel(createMockStigmer());
+
+    const field = await findSyncedField("We deploy to us-east-1.");
+    fireEvent.change(field, { target: { value: "Edited but regretted" } });
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+
+    expect(field).toHaveProperty("value", "We deploy to us-east-1.");
+  });
+
+  it("renders read-only with an explanation when the caller lacks can_edit", async () => {
+    renderPanel(createMockStigmer({ canEdit: false }));
+
+    const field = await screen.findByLabelText("Standing context");
+    await waitFor(() =>
+      expect(field).toHaveProperty("readOnly", true),
+    );
+    expect(
+      screen.getByText("Only organization admins can edit these preferences."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+  });
+
+  it("shows the fetch error with a retry action when loading fails", async () => {
+    const client = {
+      organization: {
+        get: vi.fn(async () => {
+          throw new Error("boom");
+        }),
+        update: vi.fn(),
+      },
+      iamPolicy: {
+        checkMyPermission: vi.fn(async () => ({ isAuthorized: true })),
+      },
+    } as never;
+    renderPanel(client);
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+});

--- a/sdk/react/src/organization/__tests__/OrgProfilePanel.test.tsx
+++ b/sdk/react/src/organization/__tests__/OrgProfilePanel.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import {
+  OrganizationSchema,
+  type Organization,
+} from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import type { OrganizationInput } from "@stigmer/sdk";
+import { StigmerContext } from "../../context";
+import { DeploymentModeContext } from "../../deployment-mode";
+import { OrgProfilePanel } from "../OrgProfilePanel";
+
+/**
+ * Regression suite for the full-spec-replace wipe bug (oss#293 Phase 1):
+ * `organization.update()` wholesale replaces the stored spec, so a profile
+ * save that sends only the edited fields silently wipes every other mutable
+ * spec field — most visibly `spec.preferences.standing_context` set via the
+ * CLI or the preferences page. The panel must spread the complete mapped
+ * input and override only what it edits.
+ */
+
+const ORG: Organization = create(OrganizationSchema, {
+  metadata: {
+    id: "acme",
+    name: "Acme Corp",
+    slug: "acme",
+    org: "acme",
+  },
+  spec: {
+    description: "We make everything.",
+    logoUrl: "https://acme.example/logo.png",
+    preferences: { standingContext: "We deploy to us-east-1." },
+  },
+});
+
+function createMockStigmer(overrides?: {
+  update?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    organization: {
+      get: vi.fn(async () => ORG),
+      update: overrides?.update ?? vi.fn(async () => ORG),
+    },
+  } as never;
+}
+
+// Deployment mode "local" keeps the IdentityProvidersSummary sub-panel
+// inert (identity_provider is cloud-only), so no extra client stubs are
+// needed — the suite tests the form, not the summary.
+function renderPanel(client: unknown) {
+  return render(
+    <StigmerContext.Provider value={client as never}>
+      <DeploymentModeContext.Provider value="local">
+        <OrgProfilePanel orgId="acme" />
+      </DeploymentModeContext.Provider>
+    </StigmerContext.Provider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("OrgProfilePanel save payload", () => {
+  it("round-trips unedited spec fields — preferences survive a profile save", async () => {
+    const update = vi.fn(async (_input: OrganizationInput) => ORG);
+    const client = createMockStigmer({ update });
+    renderPanel(client);
+
+    // Wait for the server-sync effect to fill the form before editing —
+    // interacting on first appearance races the sync.
+    const description = await screen.findByLabelText("Description");
+    await waitFor(() =>
+      expect(description).toHaveProperty("value", "We make everything."),
+    );
+    fireEvent.change(description, { target: { value: "New description" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    const input = update.mock.calls[0]![0];
+
+    // The edited field.
+    expect(input.description).toBe("New description");
+    // The unedited fields the form does not render — the wipe-bug guard.
+    expect(input.preferences).toEqual({
+      standingContext: "We deploy to us-east-1.",
+    });
+    expect(input.logoUrl).toBe("https://acme.example/logo.png");
+    // Addressing fields for the update pipeline's org+slug lookup.
+    expect(input.org).toBe("acme");
+    expect(input.slug).toBe("acme");
+    expect(input.name).toBe("Acme Corp");
+  });
+
+  it("sends the edited name and keeps discard/dirty semantics intact", async () => {
+    const update = vi.fn(async (_input: OrganizationInput) => ORG);
+    renderPanel(createMockStigmer({ update }));
+
+    const name = await screen.findByLabelText("Name");
+    await waitFor(() => expect(name).toHaveProperty("value", "Acme Corp"));
+    fireEvent.change(name, { target: { value: "Acme Corporation" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update.mock.calls[0]![0].name).toBe("Acme Corporation");
+    expect(update.mock.calls[0]![0].preferences).toEqual({
+      standingContext: "We deploy to us-east-1.",
+    });
+  });
+});

--- a/sdk/react/src/organization/index.ts
+++ b/sdk/react/src/organization/index.ts
@@ -16,5 +16,7 @@ export { CreateOrganizationForm } from "./CreateOrganizationForm.js";
 export type { CreateOrganizationFormProps } from "./CreateOrganizationForm.js";
 export { OrgProfilePanel } from "./OrgProfilePanel.js";
 export type { OrgProfilePanelProps } from "./OrgProfilePanel.js";
+export { OrgPreferencesPanel } from "./OrgPreferencesPanel.js";
+export type { OrgPreferencesPanelProps } from "./OrgPreferencesPanel.js";
 export { OrgSwitcher } from "./OrgSwitcher.js";
 export type { OrgSwitcherProps } from "./OrgSwitcher.js";

--- a/sdk/react/src/settings/AccountPreferencesSection.tsx
+++ b/sdk/react/src/settings/AccountPreferencesSection.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useId } from "react";
+import { AccountPreferencesPanel } from "../identity-account/AccountPreferencesPanel.js";
+
+/** Settings section for editing the current user's declared preferences. */
+export function AccountPreferencesSection() {
+  const headingId = useId();
+
+  return (
+    <section aria-labelledby={headingId}>
+      <h2
+        id={headingId}
+        className="stg:text-foreground stg:mb-1 stg:text-sm stg:font-semibold"
+      >
+        Account Preferences
+      </h2>
+      <p className="stg:text-muted-foreground stg:mb-6 stg:text-xs">
+        Personal standing context shared with agents on executions you run.
+      </p>
+
+      <AccountPreferencesPanel />
+    </section>
+  );
+}

--- a/sdk/react/src/settings/OrgPreferencesSection.tsx
+++ b/sdk/react/src/settings/OrgPreferencesSection.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useId } from "react";
+import { OrgPreferencesPanel } from "../organization/OrgPreferencesPanel.js";
+import { useOrg } from "../organization/OrgProvider.js";
+
+/** Settings section for editing the active organization's declared preferences. */
+export function OrgPreferencesSection() {
+  const headingId = useId();
+  const { activeOrg } = useOrg();
+  const orgId = activeOrg?.metadata?.id ?? "";
+
+  return (
+    <section aria-labelledby={headingId}>
+      <h2
+        id={headingId}
+        className="stg:text-foreground stg:mb-1 stg:text-sm stg:font-semibold"
+      >
+        Organization Preferences
+      </h2>
+      <p className="stg:text-muted-foreground stg:mb-6 stg:text-xs">
+        Standing context shared with agents on every execution run by this
+        organization&apos;s members.
+      </p>
+
+      {!orgId ? (
+        <p className="stg:text-muted-foreground stg:py-4 stg:text-center stg:text-xs">
+          Select an organization to view its preferences.
+        </p>
+      ) : (
+        <OrgPreferencesPanel orgId={orgId} />
+      )}
+    </section>
+  );
+}

--- a/sdk/react/src/settings/__tests__/settings-nav.test.ts
+++ b/sdk/react/src/settings/__tests__/settings-nav.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { SETTINGS_NAV_GROUPS } from "../settings-nav";
+
+// The nav model is the single source for the sidebar AND both client-app
+// landing grids — these entries disappearing would silently orphan the
+// preference pages everywhere at once.
+describe("SETTINGS_NAV_GROUPS preference entries", () => {
+  it("lists org preferences in the Organization group", () => {
+    const organization = SETTINGS_NAV_GROUPS.find(
+      (g) => g.label === "Organization",
+    );
+    expect(organization).toBeDefined();
+    expect(
+      organization!.items.find((i) => i.href === "/settings/org-preferences")
+        ?.label,
+    ).toBe("Preferences");
+  });
+
+  it("lists account preferences in the Account group", () => {
+    const account = SETTINGS_NAV_GROUPS.find((g) => g.label === "Account");
+    expect(account).toBeDefined();
+    expect(
+      account!.items.find((i) => i.href === "/settings/account-preferences")
+        ?.label,
+    ).toBe("Preferences");
+  });
+});

--- a/sdk/react/src/settings/index.ts
+++ b/sdk/react/src/settings/index.ts
@@ -10,6 +10,8 @@ export { BillingSection } from "./BillingSection.js";
 export type { BillingSectionProps } from "./BillingSection.js";
 export { MembersSection } from "./MembersSection.js";
 export { OrgProfileSection } from "./OrgProfileSection.js";
+export { OrgPreferencesSection } from "./OrgPreferencesSection.js";
+export { AccountPreferencesSection } from "./AccountPreferencesSection.js";
 export { EnvironmentsSection } from "./EnvironmentsSection.js";
 export { InvitationsSection } from "./InvitationsSection.js";
 export { IdentityProvidersSection } from "./IdentityProvidersSection.js";

--- a/sdk/react/src/settings/settings-nav.ts
+++ b/sdk/react/src/settings/settings-nav.ts
@@ -13,6 +13,8 @@ import {
   Plug,
   Scale,
   ShieldCheck,
+  SlidersHorizontal,
+  UserCog,
   Users,
 } from "lucide-react";
 
@@ -55,6 +57,11 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
       "Manage your team, organization identity, and identity providers.",
     items: [
       { href: "/settings/org-profile", label: "Org Profile", icon: Building2 },
+      {
+        href: "/settings/org-preferences",
+        label: "Preferences",
+        icon: SlidersHorizontal,
+      },
       { href: "/settings/members", label: "Members", icon: Users },
       { href: "/settings/invitations", label: "Invitations", icon: Link },
       {
@@ -90,6 +97,17 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
     items: [
       { href: "/settings/billing", label: "Billing", icon: CreditCard },
       { href: "/settings/usage", label: "Usage", icon: BarChart3 },
+    ],
+  },
+  {
+    label: "Account",
+    description: "Personal settings that apply to you across the platform.",
+    items: [
+      {
+        href: "/settings/account-preferences",
+        label: "Preferences",
+        icon: UserCog,
+      },
     ],
   },
 ];

--- a/sdk/typescript/src/__tests__/update-input.test.ts
+++ b/sdk/typescript/src/__tests__/update-input.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import { create, toJson } from "@bufbuild/protobuf";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import {
+  OrganizationSchema,
+  type Organization,
+} from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { OrganizationSpecSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/spec_pb";
+import { ManagementMode } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/enum_pb";
+import {
+  IdentityAccountSchema,
+  type IdentityAccount,
+} from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import { IdentityAccountSpecSchema } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/spec_pb";
+import { IdentityAccountProvisioningMode } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/enum_pb";
+import { buildOrganizationProto } from "../gen/organization";
+import { buildIdentityAccountProto } from "../gen/identityaccount";
+import {
+  toOrganizationUpdateInput,
+  toIdentityAccountUpdateInput,
+} from "../update-input";
+
+/**
+ * Update RPCs are full-spec replacements, so a complete mapper must
+ * round-trip EVERY mutable field of a loaded resource through the generated
+ * builder without loss. These tests pin that contract: fully-populated
+ * resource → mapper → builder → spec (as JSON, defaults omitted) deep-equals
+ * the original. If a mapper drops a field, the wipe-bug class is back.
+ */
+
+function fullOrganization(): Organization {
+  return create(OrganizationSchema, {
+    apiVersion: "tenancy.stigmer.ai/v1",
+    kind: "Organization",
+    metadata: {
+      id: "acme",
+      name: "Acme Corp",
+      slug: "acme",
+      org: "acme",
+      labels: { tier: "gold" },
+      visibility: ApiResourceVisibility.visibility_private,
+    },
+    spec: {
+      description: "We make everything.",
+      logoUrl: "https://acme.example/logo.png",
+      managementMode: ManagementMode.self_managed,
+      identityProviderRef: {
+        org: "acme",
+        slug: "acme-okta",
+        kind: ApiResourceKind.identity_provider,
+      },
+      externalOrgId: "ext-org-1",
+      isPersonal: true,
+      preferences: { standingContext: "We deploy to us-east-1." },
+    },
+  });
+}
+
+function fullIdentityAccount(): IdentityAccount {
+  return create(IdentityAccountSchema, {
+    apiVersion: "iam.stigmer.ai/v1",
+    kind: "IdentityAccount",
+    metadata: {
+      id: "ia-123",
+      name: "Ada Lovelace",
+      slug: "ada-lovelace",
+      org: "acme",
+      labels: { team: "platform" },
+      visibility: ApiResourceVisibility.visibility_private,
+    },
+    spec: {
+      idpId: "auth0|abc123",
+      email: "ada@acme.example",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      pictureUrl: "https://acme.example/ada.png",
+      isMachineAccount: true,
+      provisioningMode: IdentityAccountProvisioningMode.federated,
+      identityProviderRef: { org: "acme", slug: "acme-okta" },
+      preferences: { standingContext: "Keep answers terse." },
+    },
+  });
+}
+
+describe("toOrganizationUpdateInput", () => {
+  it("round-trips a fully-populated organization spec through the builder", () => {
+    const org = fullOrganization();
+
+    const built = buildOrganizationProto(toOrganizationUpdateInput(org));
+
+    expect(toJson(OrganizationSpecSchema, built.spec!)).toEqual(
+      toJson(OrganizationSpecSchema, org.spec!),
+    );
+    expect(built.metadata?.name).toBe("Acme Corp");
+    expect(built.metadata?.slug).toBe("acme");
+    expect(built.metadata?.org).toBe("acme");
+    expect(built.metadata?.labels).toEqual({ tier: "gold" });
+    expect(built.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_private,
+    );
+  });
+
+  it("preserves preferences when a caller overrides only profile fields (the wipe-bug class)", () => {
+    const org = fullOrganization();
+
+    const built = buildOrganizationProto({
+      ...toOrganizationUpdateInput(org),
+      description: "New description",
+    });
+
+    expect(built.spec?.preferences?.standingContext).toBe(
+      "We deploy to us-east-1.",
+    );
+    expect(built.spec?.description).toBe("New description");
+    expect(built.spec?.logoUrl).toBe("https://acme.example/logo.png");
+  });
+
+  it("maps an empty spec without inventing values", () => {
+    const org = create(OrganizationSchema, {
+      metadata: { name: "Bare", slug: "bare", org: "bare" },
+      spec: {},
+    });
+
+    const built = buildOrganizationProto(toOrganizationUpdateInput(org));
+
+    expect(toJson(OrganizationSpecSchema, built.spec!)).toEqual({});
+  });
+
+  it("falls back to the slug when metadata.org is empty", () => {
+    const org = create(OrganizationSchema, {
+      metadata: { name: "Bare", slug: "bare" },
+    });
+
+    expect(toOrganizationUpdateInput(org).org).toBe("bare");
+  });
+});
+
+describe("toIdentityAccountUpdateInput", () => {
+  it("round-trips a fully-populated identity account spec through the builder", () => {
+    const account = fullIdentityAccount();
+
+    const built = buildIdentityAccountProto(
+      toIdentityAccountUpdateInput(account),
+    );
+
+    expect(toJson(IdentityAccountSpecSchema, built.spec!)).toEqual(
+      toJson(IdentityAccountSpecSchema, account.spec!),
+    );
+    expect(built.metadata?.name).toBe("Ada Lovelace");
+    expect(built.metadata?.labels).toEqual({ team: "platform" });
+  });
+
+  it("carries org and slug — the update pipeline's fallback address", () => {
+    const input = toIdentityAccountUpdateInput(fullIdentityAccount());
+
+    expect(input.org).toBe("acme");
+    expect(input.slug).toBe("ada-lovelace");
+  });
+
+  it("preserves the rest of the spec when a caller overrides only preferences", () => {
+    const account = fullIdentityAccount();
+
+    const built = buildIdentityAccountProto({
+      ...toIdentityAccountUpdateInput(account),
+      preferences: { standingContext: "Prefer bullet points." },
+    });
+
+    expect(built.spec?.preferences?.standingContext).toBe(
+      "Prefer bullet points.",
+    );
+    expect(built.spec?.email).toBe("ada@acme.example");
+    expect(built.spec?.idpId).toBe("auth0|abc123");
+    expect(built.spec?.provisioningMode).toBe(
+      IdentityAccountProvisioningMode.federated,
+    );
+  });
+
+  it("clears standing context to wire-absent when the text is emptied", () => {
+    const account = fullIdentityAccount();
+
+    const built = buildIdentityAccountProto({
+      ...toIdentityAccountUpdateInput(account),
+      preferences: { standingContext: "" },
+    });
+
+    // Proto3 empty string is the field default — wire-identical to absent,
+    // which the server compose steps treat as "no preference declared".
+    expect(built.spec?.preferences?.standingContext ?? "").toBe("");
+  });
+});

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -61,6 +61,12 @@ export {
   isResourceAvailable,
 } from "./resource-availability.js";
 
+// Complete update-input mappers (full-spec-replace round-trip safety)
+export {
+  toOrganizationUpdateInput,
+  toIdentityAccountUpdateInput,
+} from "./update-input.js";
+
 // Authorization config and IAM role utilities
 export {
   getGrantableRoles,

--- a/sdk/typescript/src/update-input.ts
+++ b/sdk/typescript/src/update-input.ts
@@ -1,0 +1,124 @@
+// Complete update-input mappers.
+//
+// The platform's update RPCs are FULL-SPEC REPLACEMENTS: the request spec
+// wholesale overwrites the stored spec (both editions; only a small
+// server-side preserve list of immutable identifiers survives). A client
+// that sends only the fields it edits therefore silently WIPES every other
+// mutable spec field — a data-loss bug class, not a single bug
+// (stigmer/stigmer#293 Phase 1 surfaced it when `spec.preferences` set via
+// CLI was dropped by a console profile save).
+//
+// These mappers are the structural fix: they convert a LOADED resource into
+// a complete `*Input` for the generated update builders. Editors spread the
+// mapper output and override only the fields they edit:
+//
+//   await update({ ...toOrganizationUpdateInput(org), description: next });
+//
+// The `CompleteInput` mapped type removes optionality from every Input key,
+// so when codegen adds a new Input field, compilation fails HERE — the one
+// place a human must decide how the new field round-trips — instead of the
+// field silently wiping in every subset-editing form.
+
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import type { IdentityAccount } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/api_pb";
+import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import type { IdentityAccountInput } from "./gen/identityaccount.js";
+import type { OrganizationInput } from "./gen/organization.js";
+import type { ResourceRef } from "./gen/types.js";
+
+/**
+ * Every key of `T`, required to be present. Optional keys keep their
+ * `| undefined` value type (explicit `undefined` is stripped by the proto
+ * builders), so a mapper cannot compile while omitting an Input field.
+ *
+ * Mapping over `keyof Required<T>` (instead of a homomorphic `-?` map)
+ * is deliberate: `-?` would also strip `undefined` from optional value
+ * types, forcing fake values for genuinely absent fields.
+ */
+type CompleteInput<T> = { [K in keyof Required<T>]: T[K] };
+
+/**
+ * Maps a loaded {@link Organization} to a complete {@link OrganizationInput}
+ * for `organization.update()`.
+ *
+ * Proto3 scalar defaults (empty string, `false`, enum `0`) are normalized to
+ * `undefined` — omitting them is wire-identical to sending the default, and
+ * it keeps the built proto in the builders' canonical shape.
+ */
+export function toOrganizationUpdateInput(
+  org: Organization,
+): OrganizationInput {
+  const input: CompleteInput<OrganizationInput> = {
+    name: org.metadata?.name ?? "",
+    slug: org.metadata?.slug || undefined,
+    org: org.metadata?.org || org.metadata?.slug || "",
+    labels: nonEmptyLabels(org.metadata?.labels),
+    visibility: org.metadata?.visibility || undefined,
+    description: org.spec?.description || undefined,
+    logoUrl: org.spec?.logoUrl || undefined,
+    managementMode: org.spec?.managementMode || undefined,
+    identityProviderRef: toResourceRef(org.spec?.identityProviderRef),
+    externalOrgId: org.spec?.externalOrgId || undefined,
+    isPersonal: org.spec?.isPersonal || undefined,
+    preferences: org.spec?.preferences
+      ? { standingContext: org.spec.preferences.standingContext || undefined }
+      : undefined,
+  };
+  return input;
+}
+
+/**
+ * Maps a loaded {@link IdentityAccount} to a complete
+ * {@link IdentityAccountInput} for `identityAccount.update()`.
+ *
+ * The generated builder never sets `metadata.id`; the update pipeline
+ * locates the resource by org + slug instead (and authorizes against the
+ * loaded resource's id), so carrying `org` and `slug` here is what makes
+ * the update addressable.
+ */
+export function toIdentityAccountUpdateInput(
+  account: IdentityAccount,
+): IdentityAccountInput {
+  const input: CompleteInput<IdentityAccountInput> = {
+    name: account.metadata?.name ?? "",
+    slug: account.metadata?.slug || undefined,
+    org: account.metadata?.org ?? "",
+    labels: nonEmptyLabels(account.metadata?.labels),
+    visibility: account.metadata?.visibility || undefined,
+    idpId: account.spec?.idpId ?? "",
+    email: account.spec?.email || undefined,
+    firstName: account.spec?.firstName || undefined,
+    lastName: account.spec?.lastName || undefined,
+    pictureUrl: account.spec?.pictureUrl || undefined,
+    isMachineAccount: account.spec?.isMachineAccount || undefined,
+    provisioningMode: account.spec?.provisioningMode || undefined,
+    identityProviderRef: toResourceRef(account.spec?.identityProviderRef),
+    preferences: account.spec?.preferences
+      ? {
+          standingContext:
+            account.spec.preferences.standingContext || undefined,
+        }
+      : undefined,
+  };
+  return input;
+}
+
+function nonEmptyLabels(
+  labels: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  return labels && Object.keys(labels).length > 0 ? labels : undefined;
+}
+
+function toResourceRef(
+  ref: ApiResourceReference | undefined,
+): ResourceRef | undefined {
+  // The builders treat a ref without org and slug as absent; mirror that so
+  // an empty message round-trips to "no reference".
+  if (!ref || (!ref.org && !ref.slug)) return undefined;
+  return {
+    org: ref.org,
+    slug: ref.slug,
+    ...(ref.version && { version: ref.version }),
+    ...(ref.kind && { kind: ref.kind }),
+  };
+}

--- a/test/e2e/tests/functional/settings.spec.ts
+++ b/test/e2e/tests/functional/settings.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 /**
  * Settings pages structural tests.
  *
- * Verifies that all 12 settings routes render their section heading,
+ * Verifies that the settings routes render their section heading,
  * do not crash with an error boundary, and show either content or
  * a CloudFeatureNotice (role="status") when running against OSS.
  *
@@ -58,6 +58,16 @@ const SETTINGS_SECTIONS = [
     path: "/settings/org-profile",
     headingText: "Organization Profile",
     cloudGated: false,
+  },
+  {
+    path: "/settings/org-preferences",
+    headingText: "Organization Preferences",
+    cloudGated: false,
+  },
+  {
+    path: "/settings/account-preferences",
+    headingText: "Account Preferences",
+    cloudGated: true,
   },
   {
     path: "/settings/billing",


### PR DESCRIPTION
## Summary
Console surfaces for the Phase 1 declared-preferences channel (#293): a **Preferences** page under Organization settings and a new **Account** settings group with a personal Preferences page. Also fixes a latent data-loss bug — the Org Profile save silently wiped `spec.preferences` — and eliminates that bug class with compile-time-complete update-input mappers in `@stigmer/sdk`.

## Context
Phase 1 (#782, cloud#487) shipped the delivery pipeline for `standing_context`, but the only write paths were `stigmer apply` and raw SDK calls. These pages make the feature usable. During planning we found that the update RPCs are full-spec replacements and `OrgProfilePanel` re-sent only the fields it edits — so any profile save destroyed standing context set via CLI.

## Changes
- **`@stigmer/sdk`**: `toOrganizationUpdateInput` / `toIdentityAccountUpdateInput` — map a loaded resource to a complete update input. Their `CompleteInput` mapped type makes compilation fail inside the mapper when codegen adds a new Input field, so future spec fields cannot silently wipe.
- **`@stigmer/react`**:
  - `OrgPreferencesPanel` + `OrgPreferencesSection` — org standing-context editor; read-only (fail-open) for callers without `can_edit`.
  - `AccountPreferencesPanel` + `AccountPreferencesSection` — self-service editor over `whoAmI()`; renders `CloudFeatureNotice` in local mode (OSS has no IdentityAccount; single-user scope collapses into the org per DD-002 D1).
  - New hooks: `useMyIdentityAccount` (refetchable, unlike the cached `useWhoAmI`), `useUpdateIdentityAccount`.
  - Internal `StandingContextField` atom (2000-char proto cap, threshold counter).
  - `settings-nav`: "Preferences" item in Organization group; new "Account" group — sidebar and both landing grids pick it up automatically.
  - **Fix**: `OrgProfilePanel` now spreads the complete mapped input on save.
- **Client apps (DD-016 parity)**: two one-line Next.js pages (web), two router entries (desktop).
- **e2e**: the two new routes added to the table-driven settings spec.

## Implementation notes
- Update RPCs carry no field mask; the pipeline resolves by id or org+slug and authorizes against the loaded resource, so the mappers always carry `org` + `slug` (this is what makes the id-less identity-account self-update addressable).
- Clearing works by construction: empty string → proto3 wire-absent → compose steps treat blank as absent.
- Follow-up candidate (recorded in the project): generate these mappers for all resources in `tools/codegen`.

## Breaking changes
- None. New exports only; `OrgProfilePanel`'s behavior change is the bug fix.

## Test plan
- `@stigmer/sdk`: 429 tests pass (8 new: mapper round-trip/completeness, clear-to-empty).
- `@stigmer/react`: 4642 tests pass (13 new: panels, hooks, nav, and the OrgProfilePanel wipe regression test).
- `make verify-web`, desktop lint+typecheck, `verify-esm-node` (9 packages): clean.
- Playwright settings spec: 23/23 against a live dev server.
- Manual, against a real local server: saved standing context, verified persistence across reload, then saved Org Profile and confirmed the standing context **survives** (the old code wiped it here).

## Risks
- Low. The only touched existing behavior is `OrgProfilePanel`'s save payload, covered by a regression test. Rollback = revert.

Part of #293 (the issue stays open — it spans later phases by design).

Made with [Cursor](https://cursor.com)