### PR TITLE
feat(server/models): validate pinned model names against the registry at write time

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/agentchannel/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/agentchannel/controller/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//backend/libs/go/grpc/request/pipeline",
         "//backend/libs/go/grpc/request/pipeline/steps",
         "//backend/libs/go/store",
+        "//backend/services/stigmer-server/pkg/domain/workflow/registry",
         "@com_github_rs_zerolog//log",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
@@ -42,6 +43,7 @@ go_test(
     deps = [
         "//apis/stubs/go/ai/stigmer/agentic/agent/v1:agent",
         "//apis/stubs/go/ai/stigmer/agentic/agentchannel/v1:agentchannel",
+        "//apis/stubs/go/ai/stigmer/agentic/agentexecution/v1:agentexecution",
         "//apis/stubs/go/ai/stigmer/commons/apiresource",
         "//apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind",
         "//backend/libs/go/grpc/interceptors/apiresource",
@@ -52,5 +54,6 @@ go_test(
         "//backend/services/stigmer-server/pkg/domain/agent/controller",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/backend/services/stigmer-server/pkg/domain/agentchannel/controller/agentchannel_test.go
+++ b/backend/services/stigmer-server/pkg/domain/agentchannel/controller/agentchannel_test.go
@@ -7,6 +7,7 @@ import (
 
 	agentv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agent/v1"
 	agentchannelv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentchannel/v1"
+	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
 	apiresourceinterceptor "github.com/stigmer/stigmer/backend/libs/go/grpc/interceptors/apiresource"
@@ -17,6 +18,7 @@ import (
 	agentcontroller "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/agent/controller"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // The exact error strings shared with the cloud edition (T02 Phase E
@@ -149,6 +151,56 @@ func whatsAppChannelFor(agent *agentv1.Agent, name string) *agentchannelv1.Agent
 			},
 		},
 	}
+}
+
+// The write-time model-pin existence rule (stigmer/stigmer#774): a channel
+// run_config pin the registry knows under NO harness is a typo and refuses
+// at create AND update — before it, the pin rode through opaquely and the
+// serving edition silently ran (and billed) it as Auto. Valid-anywhere
+// pins pass: this edition stores channel specs without a serving runtime,
+// so the harness-scoped judgment belongs to the edition that serves them.
+func TestAgentChannelController_ModelPinExistence(t *testing.T) {
+	tc := newTestControllers(t)
+	agent := createTestAgent(t, tc, "pin-agent")
+
+	withPin := func(name, model string) *agentchannelv1.AgentChannel {
+		ch := channelFor(agent, name, true)
+		ch.Spec.RunConfig = &agentexecutionv1.RunConfig{ModelName: model}
+		return ch
+	}
+
+	t.Run("create refuses a pin unknown to every harness, with a did-you-mean", func(t *testing.T) {
+		_, err := tc.channels.Create(channelCtx(), withPin("typod-pin", "composr-2.5"))
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected INVALID_ARGUMENT for a typo'd pin, got %s (%v)", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), "not in the model registry (any harness)") {
+			t.Errorf("expected the any-harness existence refusal, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "'composer-2.5'") {
+			t.Errorf("expected the did-you-mean suggestion, got: %v", err)
+		}
+	})
+
+	t.Run("create accepts a pin valid under some harness", func(t *testing.T) {
+		if _, err := tc.channels.Create(channelCtx(), withPin("valid-pin", "composer-2.5")); err != nil {
+			t.Fatalf("a registry-known pin must be accepted: %v", err)
+		}
+	})
+
+	t.Run("update refuses the same typo", func(t *testing.T) {
+		created := createTestChannel(t, tc, agent, "update-pin-target", true)
+		updated := proto.Clone(created).(*agentchannelv1.AgentChannel)
+		updated.Spec.RunConfig = &agentexecutionv1.RunConfig{ModelName: "composr-2.5"}
+
+		_, err := tc.channels.Update(channelCtx(), updated)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected INVALID_ARGUMENT for a typo'd pin on update, got %s (%v)", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), "not in the model registry (any harness)") {
+			t.Errorf("expected the any-harness existence refusal, got: %v", err)
+		}
+	})
 }
 
 func TestAgentChannelController_Create(t *testing.T) {

--- a/backend/services/stigmer-server/pkg/domain/agentchannel/controller/steps.go
+++ b/backend/services/stigmer-server/pkg/domain/agentchannel/controller/steps.go
@@ -10,8 +10,27 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline"
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflow/registry"
 	"google.golang.org/protobuf/proto"
 )
+
+// validateChannelModelPin enforces the write-time model-pin EXISTENCE rule
+// (stigmer/stigmer#774) on a channel's run_config: a typo'd pin used to
+// ride through opaquely and silently run (and bill) as Auto wherever the
+// channel serves. Validated against EVERY registry harness section (the
+// "" harness mode) because this edition stores channel specs without a
+// serving runtime — a pin no harness knows is certainly a typo, while the
+// edition that serves the channel judges the pin against its own
+// effective harness (the DD-015 divergence posture). Shared by create
+// (resolveChannelDefaultsStep) and update (validateChannelUpdateStep).
+func validateChannelModelPin(spec *agentchannelv1.AgentChannelSpec) error {
+	if reason := registry.UnknownModelPinRefusal(
+		"spec.run_config.model_name", "", spec.GetRunConfig().GetModelName(),
+	); reason != "" {
+		return grpclib.InvalidArgumentError("%s", reason)
+	}
+	return nil
+}
 
 // findAgentByOrgAndSlug scans agents for an org+slug match. Full-scan
 // lookup matches the store's local/OSS posture (see LoadByReferenceStep);
@@ -104,6 +123,10 @@ func (s *resolveChannelDefaultsStep) Execute(ctx *pipeline.RequestContext[*agent
 	// discover it at install time. Byte-identical with the cloud
 	// edition's AgentChannelDefaultsResolver. Enforced here, not in a
 	// field-level CEL, because the rule conditions on the oneof case.
+	if err := validateChannelModelPin(channel.GetSpec()); err != nil {
+		return err
+	}
+
 	appRef := channel.GetSpec().GetAppRef()
 	if channel.GetSpec().GetWhatsapp() != nil && appRef.GetSlug() == "" {
 		return grpclib.InvalidArgumentError(
@@ -245,6 +268,10 @@ func (s *validateChannelUpdateStep) Execute(ctx *pipeline.RequestContext[*agentc
 			"spec provider is immutable (channel provider is %s) — create a new channel for a different provider",
 			existingProvider,
 		)
+	}
+
+	if err := validateChannelModelPin(ctx.Input().GetSpec()); err != nil {
+		return err
 	}
 
 	return validateAppRefUpdate(ctx, existing)

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//backend/libs/go/grpc/request/pipeline/steps",
         "//backend/libs/go/store",
         "//backend/services/stigmer-server/pkg/domain/schedule/temporal",
+        "//backend/services/stigmer-server/pkg/domain/workflow/registry",
         "@com_github_rs_zerolog//log",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/schedule_test.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/schedule_test.go
@@ -343,6 +343,50 @@ func TestScheduleCreate(t *testing.T) {
 			t.Fatalf("an unpinned native-default schedule must be accepted: %v", err)
 		}
 	})
+
+	t.Run("rejects a pinned model the registry does not know (stigmer/stigmer#774)", func(t *testing.T) {
+		// The EXISTENCE half of the pinning rules: model_name used to be
+		// the one profile knob that failed OPEN — a typo'd pin passed the
+		// write boundary verbatim and every fire silently ran (and billed)
+		// as Auto. Now it refuses at write time with a did-you-mean.
+		tc := newTestControllers(t)
+		agent := createTestAgent(t, tc, "existence-guard-agent")
+
+		typod := scheduleFor(agent, "typod-cursor", true)
+		typod.Spec.GetAgent().Harness = sessionv1.Harness_HARNESS_CURSOR
+		typod.Spec.GetAgent().RunConfig = &agentexecutionv1.RunConfig{ModelName: "composr-2.5"}
+
+		_, err := tc.schedules.Create(scheduleCtx(), typod)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected INVALID_ARGUMENT for a typo'd pin, got %s (%v)", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), "not in the model registry (cursor harness)") {
+			t.Errorf("expected the registry-existence refusal, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "'composer-2.5'") {
+			t.Errorf("expected the did-you-mean suggestion, got: %v", err)
+		}
+
+		// The pin validates against the harness the fires would USE: an
+		// unset harness runs native in this edition (DD-015), so a
+		// native-section model passes there...
+		nativePinned := scheduleFor(agent, "native-pinned", true)
+		nativePinned.Spec.GetAgent().RunConfig = &agentexecutionv1.RunConfig{ModelName: "claude-sonnet-4.6"}
+		if _, err := tc.schedules.Create(scheduleCtx(), nativePinned); err != nil {
+			t.Fatalf("a valid native pin on the default harness must be accepted: %v", err)
+		}
+
+		// ...and a typo'd pin there refuses against the native section.
+		nativeTypo := scheduleFor(agent, "native-typod", true)
+		nativeTypo.Spec.GetAgent().RunConfig = &agentexecutionv1.RunConfig{ModelName: "claude-sonet-4.6"}
+		_, err = tc.schedules.Create(scheduleCtx(), nativeTypo)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected INVALID_ARGUMENT for a typo'd native pin, got %s (%v)", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), "(native harness)") {
+			t.Errorf("expected the native-harness scope in the refusal, got: %v", err)
+		}
+	})
 }
 
 func TestScheduleUpdate(t *testing.T) {

--- a/backend/services/stigmer-server/pkg/domain/schedule/controller/steps.go
+++ b/backend/services/stigmer-server/pkg/domain/schedule/controller/steps.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stigmer/stigmer/backend/libs/go/grpc/request/pipeline/steps"
 	"github.com/stigmer/stigmer/backend/libs/go/store"
 	scheduletemporal "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/schedule/temporal"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflow/registry"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -146,15 +147,28 @@ func validateScheduleWorkspace(spec *schedulev1.ScheduleSpec) error {
 	return nil
 }
 
-// validateScheduleModelPinning enforces the unattended model-pinning rule
-// (stigmer/stigmer#362) at write time. The rule itself — why the Cursor
-// harness requires a pinned model, why native is exempt, and the
-// edition-honest default-harness divergence — is stated once in
-// scheduletemporal.ScheduleModelPinningRefusal, which the run starter
-// also evaluates as the launch backstop for rows written before the rule
-// existed.
+// validateScheduleModelPinning enforces the two unattended model-pinning
+// rules at write time:
+//
+//   - PRESENCE (stigmer/stigmer#362): a Cursor-harness schedule must pin a
+//     model. Stated once in scheduletemporal.ScheduleModelPinningRefusal,
+//     which the run starter also evaluates as the launch backstop for rows
+//     written before the rule existed.
+//   - EXISTENCE (stigmer/stigmer#774): whatever model IS pinned must be in
+//     the registry for the harness the fires would use — a typo'd pin used
+//     to pass through verbatim and silently run (and bill) as Auto. Stated
+//     once in registry.UnknownModelPinRefusal; write-time only BY DESIGN
+//     (no fire-time backstop — see that function's doc for why registry
+//     drift must never break an existing schedule at its 3 AM fire).
 func validateScheduleModelPinning(spec *schedulev1.ScheduleSpec) error {
 	if reason := scheduletemporal.ScheduleModelPinningRefusal(spec); reason != "" {
+		return grpclib.InvalidArgumentError("%s", reason)
+	}
+	if reason := registry.UnknownModelPinRefusal(
+		"spec.agent.run_config.model_name",
+		registry.HarnessName(spec.GetAgent().GetHarness()),
+		spec.GetAgent().GetRunConfig().GetModelName(),
+	); reason != "" {
 		return grpclib.InvalidArgumentError("%s", reason)
 	}
 	return nil

--- a/backend/services/stigmer-server/pkg/domain/workflow/registry/BUILD.bazel
+++ b/backend/services/stigmer-server/pkg/domain/workflow/registry/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "model_registry.go",
         "model_registry_store.go",
+        "pin_validation.go",
         "task_kind_registry.go",
     ],
     embedsrcs = [
@@ -13,7 +14,10 @@ go_library(
     ],
     importpath = "github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/workflow/registry",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_rs_zerolog//log"],
+    deps = [
+        "//apis/stubs/go/ai/stigmer/agentic/session/v1:session",
+        "@com_github_rs_zerolog//log",
+    ],
 )
 
 go_test(
@@ -21,6 +25,8 @@ go_test(
     srcs = [
         "model_registry_store_test.go",
         "model_registry_test.go",
+        "pin_validation_test.go",
     ],
     embed = [":registry"],
+    deps = ["//apis/stubs/go/ai/stigmer/agentic/session/v1:session"],
 )

--- a/backend/services/stigmer-server/pkg/domain/workflow/registry/model_registry_store.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/registry/model_registry_store.go
@@ -160,6 +160,43 @@ func (s *ModelRegistryStore) HasAnyModels() bool {
 	return len(s.modelsByHarness) > 0
 }
 
+// IsValidModelOnAnyHarness reports whether a model reference (canonical id
+// or provider api id) is executable on AT LEAST ONE harness. The
+// existence check for surfaces with no serving harness in this edition
+// (agent channels): a pin no section knows is certainly a typo, while a
+// pin valid anywhere may be right where the spec actually serves.
+func (s *ModelRegistryStore) IsValidModelOnAnyHarness(model string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, models := range s.modelsByHarness {
+		if models[model] {
+			return true
+		}
+	}
+	return false
+}
+
+// CanonicalModelsAcrossHarnesses returns the sorted, deduplicated
+// canonical model ids across every harness section — the did-you-mean
+// candidate pool for the any-harness existence check. Computed per call
+// (refusal-path only); callers may keep the slice.
+func (s *ModelRegistryStore) CanonicalModelsAcrossHarnesses() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := make(map[string]bool)
+	var merged []string
+	for _, models := range s.sortedModelsByHarness {
+		for _, name := range models {
+			if !seen[name] {
+				seen[name] = true
+				merged = append(merged, name)
+			}
+		}
+	}
+	sort.Strings(merged)
+	return merged
+}
+
 // CanonicalModels returns the sorted canonical model ids for a harness
 // (for deterministic did-you-mean suggestions — canonical ids are the
 // documented form, so suggestions never surface provider api ids).

--- a/backend/services/stigmer-server/pkg/domain/workflow/registry/pin_validation.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/registry/pin_validation.go
@@ -1,0 +1,180 @@
+package registry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
+)
+
+// Harness section names as the registry document spells them. Exported so
+// every consumer (workflow validation, schedule/channel pin validation)
+// shares one vocabulary instead of re-declaring string literals.
+const (
+	HarnessNameCursor = "cursor"
+	HarnessNameNative = "native"
+)
+
+const (
+	maxModelSuggestions  = 3
+	maxModelEditDistance = 5
+)
+
+// HarnessName maps the session harness enum to its registry section name.
+// Unset resolves to native — this edition's platform default harness (the
+// DD-015 edition-honest posture: each edition judges pins against the
+// harness ITS runs would actually use; the cloud edition resolves its own
+// configured default).
+func HarnessName(h sessionv1.Harness) string {
+	if h == sessionv1.Harness_HARNESS_CURSOR {
+		return HarnessNameCursor
+	}
+	return HarnessNameNative
+}
+
+// UnknownModelPinRefusal is this edition's one statement of the write-time
+// model-pin EXISTENCE rule (stigmer/stigmer#774, the DD-001 D2/D3
+// remainder): a pinned model_name that is not in the model registry is
+// refused at apply/update, with a did-you-mean. Before this rule,
+// model_name was the one profile knob that failed OPEN — a typo'd pin
+// passed every write boundary and the cursor runner silently fell back to
+// "default" (Auto), billing at Auto rates (the exact class the
+// chat-surface-cost-reduction project existed to close).
+//
+// harness names the registry section the pin's runs would use
+// (HarnessName of the surface's effective harness). Pass "" for surfaces
+// with NO serving harness in this edition (agent channels — this edition
+// stores their spec without a serving runtime): the pin then validates
+// against EVERY harness section and is refused only when no section knows
+// it, which catches the typo class without falsely refusing a model that
+// is valid where the spec will actually serve.
+//
+// Deliberately WRITE-TIME ONLY — unlike the pin-PRESENCE rule
+// (ScheduleModelPinningRefusal), this is NOT evaluated at the run
+// starter's fire-time backstop: upstream registry drift must never break
+// a previously-valid schedule at its 3 AM fire. The runner's divergence
+// detection remains the runtime defense-in-depth, expected to never fire
+// for platform-validated pins.
+//
+// Degrades to a no-op ("") when the registry is empty or lacks the
+// harness section — a build without a usable registry must not refuse
+// every write (the HasAnyModels posture workflow validation established).
+//
+// Returns the refusal copy, or "" when the pin is valid (or unverifiable).
+func UnknownModelPinRefusal(fieldPath, harness, model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ""
+	}
+
+	s := Store()
+	if !s.HasAnyModels() {
+		return ""
+	}
+
+	var candidates []string
+	if harness == "" {
+		if s.IsValidModelOnAnyHarness(model) {
+			return ""
+		}
+		candidates = s.CanonicalModelsAcrossHarnesses()
+	} else {
+		if !s.HasHarness(harness) {
+			return ""
+		}
+		if s.IsValidModel(harness, model) {
+			return ""
+		}
+		candidates = s.CanonicalModels(harness)
+	}
+
+	scope := "any harness"
+	if harness != "" {
+		scope = harness + " harness"
+	}
+	msg := fmt.Sprintf("%s: model '%s' is not in the model registry (%s)",
+		fieldPath, model, scope)
+
+	if suggestions := SuggestSimilarModels(model, candidates); len(suggestions) > 0 {
+		quoted := make([]string, len(suggestions))
+		for i, s := range suggestions {
+			quoted[i] = fmt.Sprintf("'%s'", s)
+		}
+		msg += fmt.Sprintf("; did you mean %s?", strings.Join(quoted, ", "))
+	}
+
+	return msg
+}
+
+// SuggestSimilarModels returns up to three model ids from the candidate
+// list sorted by Levenshtein distance to the target, closest first. Only
+// candidates within the edit-distance cap are included — a far-off typo
+// gets no misleading suggestion. Shared by workflow model validation and
+// the pin-existence rule so every did-you-mean behaves identically.
+func SuggestSimilarModels(target string, candidates []string) []string {
+	type scored struct {
+		name string
+		dist int
+	}
+
+	targetLower := strings.ToLower(target)
+	var matches []scored
+
+	for _, name := range candidates {
+		d := suggestionEditDistance(targetLower, strings.ToLower(name))
+		if d <= maxModelEditDistance {
+			matches = append(matches, scored{name, d})
+		}
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].dist != matches[j].dist {
+			return matches[i].dist < matches[j].dist
+		}
+		return matches[i].name < matches[j].name
+	})
+
+	limit := maxModelSuggestions
+	if len(matches) < limit {
+		limit = len(matches)
+	}
+
+	result := make([]string, limit)
+	for i := 0; i < limit; i++ {
+		result[i] = matches[i].name
+	}
+	return result
+}
+
+// suggestionEditDistance is the standard two-row Levenshtein distance.
+func suggestionEditDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := 0; j <= len(b); j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, min(curr[j-1]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/registry/pin_validation_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/registry/pin_validation_test.go
@@ -1,0 +1,118 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
+)
+
+// These tests run against the bundled registry (the same document the
+// singleton Store() loads), so they pin the rule's behavior on the real
+// model catalog — including the issue's own motivating example: the
+// 'composr-2.5' typo that used to silently bill at Auto rates
+// (stigmer/stigmer#774).
+
+func TestUnknownModelPinRefusal_ValidPinsPass(t *testing.T) {
+	cases := []struct {
+		name    string
+		harness string
+		model   string
+	}{
+		{"valid cursor pin", HarnessNameCursor, "composer-2.5"},
+		{"valid native pin", HarnessNameNative, "claude-sonnet-4.6"},
+		{"provider api id alias", HarnessNameNative, "claude-haiku-4-5-20251001"},
+		{"any-harness mode accepts a model valid anywhere", "", "claude-sonnet-4.6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UnknownModelPinRefusal("spec.run_config.model_name", tc.harness, tc.model); got != "" {
+				t.Errorf("expected no refusal, got: %s", got)
+			}
+		})
+	}
+}
+
+func TestUnknownModelPinRefusal_TypoRefusedWithSuggestion(t *testing.T) {
+	got := UnknownModelPinRefusal(
+		"spec.agent.run_config.model_name", HarnessNameCursor, "composr-2.5")
+	if got == "" {
+		t.Fatal("expected a refusal for the typo'd pin")
+	}
+	if !strings.Contains(got, "spec.agent.run_config.model_name") {
+		t.Errorf("refusal must name the field path, got: %s", got)
+	}
+	if !strings.Contains(got, "not in the model registry (cursor harness)") {
+		t.Errorf("refusal must name the harness scope, got: %s", got)
+	}
+	if !strings.Contains(got, "'composer-2.5'") {
+		t.Errorf("expected the did-you-mean suggestion 'composer-2.5', got: %s", got)
+	}
+}
+
+func TestUnknownModelPinRefusal_AnyHarnessMode(t *testing.T) {
+	// A pin no harness section knows is certainly a typo.
+	got := UnknownModelPinRefusal("spec.run_config.model_name", "", "composr-2.5")
+	if got == "" {
+		t.Fatal("expected a refusal for a pin unknown to every harness")
+	}
+	if !strings.Contains(got, "not in the model registry (any harness)") {
+		t.Errorf("any-harness refusals must say so, got: %s", got)
+	}
+	if !strings.Contains(got, "'composer-2.5'") {
+		t.Errorf("expected a cross-harness suggestion, got: %s", got)
+	}
+}
+
+func TestUnknownModelPinRefusal_DegradesToNoop(t *testing.T) {
+	// An empty pin is not this rule's concern (presence is #362's rule).
+	if got := UnknownModelPinRefusal("f", HarnessNameCursor, ""); got != "" {
+		t.Errorf("an empty pin must pass, got: %s", got)
+	}
+	if got := UnknownModelPinRefusal("f", HarnessNameCursor, "   "); got != "" {
+		t.Errorf("a whitespace pin must pass, got: %s", got)
+	}
+	// A harness section the registry does not know cannot be validated
+	// against — degrade rather than refuse everything (the HasAnyModels
+	// posture; an air-gapped or stale registry must not lock users out).
+	if got := UnknownModelPinRefusal("f", "no-such-harness", "anything"); got != "" {
+		t.Errorf("an unknown harness section must degrade to a no-op, got: %s", got)
+	}
+}
+
+func TestHarnessName_EditionDefaultIsNative(t *testing.T) {
+	if got := HarnessName(sessionv1.Harness_HARNESS_CURSOR); got != HarnessNameCursor {
+		t.Errorf("explicit cursor must map to %q, got %q", HarnessNameCursor, got)
+	}
+	// Unset resolves to native — this edition's platform default (DD-015):
+	// an unset-harness schedule RUNS native here, so its pin must validate
+	// against the native section.
+	if got := HarnessName(sessionv1.Harness_HARNESS_UNSPECIFIED); got != HarnessNameNative {
+		t.Errorf("unset harness must map to %q, got %q", HarnessNameNative, got)
+	}
+}
+
+func TestSuggestSimilarModels_CapsAndOrders(t *testing.T) {
+	candidates := []string{"composer-2.5", "composer-2.0", "gpt-5.3-codex", "zzz-unrelated"}
+	got := SuggestSimilarModels("composr-2.5", candidates)
+	if len(got) == 0 || got[0] != "composer-2.5" {
+		t.Fatalf("closest candidate must come first, got: %v", got)
+	}
+	for _, s := range got {
+		if s == "zzz-unrelated" {
+			t.Errorf("far-off candidates must not be suggested, got: %v", got)
+		}
+	}
+	if far := SuggestSimilarModels("completely-different-name-entirely", candidates); len(far) != 0 {
+		t.Errorf("a far-off typo gets no misleading suggestion, got: %v", far)
+	}
+}
+
+func TestSuggestSimilarModels_MaxThreeAndEmptyCandidates(t *testing.T) {
+	if got := SuggestSimilarModels("a", []string{"a", "aa", "ab", "ac", "ad"}); len(got) > maxModelSuggestions {
+		t.Errorf("expected at most %d suggestions, got %d", maxModelSuggestions, len(got))
+	}
+	if got := SuggestSimilarModels("anything", nil); len(got) != 0 {
+		t.Errorf("expected no suggestions for empty candidates, got: %v", got)
+	}
+}

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/model_validation.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/model_validation.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	agentexecutionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
@@ -21,11 +20,13 @@ import (
 // lockstep: a model that appears in every picker after a refresh must
 // also validate (DD-004).
 
+// Harness names, suggestion machinery, and the write-time pin-existence
+// rule all live in the registry package (the shared validation authority)
+// — this package consumes them so workflow errors and schedule/channel
+// pin errors suggest identically.
 const (
-	maxModelSuggestions  = 3
-	maxModelEditDistance = 5
-	harnessNameNative    = "native"
-	harnessNameCursor    = "cursor"
+	harnessNameNative = registry.HarnessNameNative
+	harnessNameCursor = registry.HarnessNameCursor
 )
 
 // ValidateModelReferences checks that model IDs specified in workflow tasks
@@ -169,17 +170,12 @@ func fastCapableSuffix(models *registry.ModelRegistryStore, harness string) stri
 }
 
 func resolveHarnessName(h sessionv1.Harness) string {
-	switch h {
-	case sessionv1.Harness_HARNESS_CURSOR:
-		return harnessNameCursor
-	default:
-		return harnessNameNative
-	}
+	return registry.HarnessName(h)
 }
 
 func buildModelError(models *registry.ModelRegistryStore,
 	taskName, kindLabel, model, harness string) string {
-	suggestions := suggestSimilarModels(model, models.CanonicalModels(harness))
+	suggestions := registry.SuggestSimilarModels(model, models.CanonicalModels(harness))
 
 	msg := fmt.Sprintf(
 		"task '%s' (%s): model '%s' is not a valid model for harness '%s'",
@@ -195,42 +191,4 @@ func buildModelError(models *registry.ModelRegistryStore,
 	}
 
 	return msg
-}
-
-// suggestSimilarModels returns up to maxModelSuggestions model IDs from the
-// candidate list sorted by Levenshtein distance to the target. Only candidates
-// within maxModelEditDistance are included.
-func suggestSimilarModels(target string, candidates []string) []string {
-	type scored struct {
-		name string
-		dist int
-	}
-
-	targetLower := strings.ToLower(target)
-	var matches []scored
-
-	for _, name := range candidates {
-		d := levenshtein(targetLower, strings.ToLower(name))
-		if d <= maxModelEditDistance {
-			matches = append(matches, scored{name, d})
-		}
-	}
-
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].dist != matches[j].dist {
-			return matches[i].dist < matches[j].dist
-		}
-		return matches[i].name < matches[j].name
-	})
-
-	limit := maxModelSuggestions
-	if len(matches) < limit {
-		limit = len(matches)
-	}
-
-	result := make([]string, limit)
-	for i := 0; i < limit; i++ {
-		result[i] = matches[i].name
-	}
-	return result
 }

--- a/backend/services/stigmer-server/pkg/domain/workflow/validation/model_validation_test.go
+++ b/backend/services/stigmer-server/pkg/domain/workflow/validation/model_validation_test.go
@@ -426,30 +426,7 @@ func TestValidateModelReferences_EmptyTasks(t *testing.T) {
 	}
 }
 
-func TestSuggestSimilarModels_SortedByDistance(t *testing.T) {
-	candidates := []string{"aaa", "aab", "abc", "xyz"}
-	result := suggestSimilarModels("aaa", candidates)
-
-	if len(result) == 0 {
-		t.Fatal("Expected at least one suggestion")
-	}
-	if result[0] != "aaa" {
-		t.Errorf("Expected exact match 'aaa' first, got: %s", result[0])
-	}
-}
-
-func TestSuggestSimilarModels_MaxThree(t *testing.T) {
-	candidates := []string{"a", "aa", "ab", "ac", "ad"}
-	result := suggestSimilarModels("a", candidates)
-
-	if len(result) > maxModelSuggestions {
-		t.Errorf("Expected at most %d suggestions, got %d", maxModelSuggestions, len(result))
-	}
-}
-
-func TestSuggestSimilarModels_EmptyCandidates(t *testing.T) {
-	result := suggestSimilarModels("anything", nil)
-	if len(result) != 0 {
-		t.Errorf("Expected no suggestions for empty candidates, got: %v", result)
-	}
-}
+// The suggestion machinery itself (ordering, the three-suggestion cap,
+// empty candidates) is tested where it now lives: the registry package's
+// pin_validation_test.go (SuggestSimilarModels moved there so workflow and
+// schedule/channel pin errors suggest identically, stigmer/stigmer#774).

--- a/docs/guides/channels/connect-slack.mdx
+++ b/docs/guides/channels/connect-slack.mdx
@@ -199,6 +199,36 @@ channel's status, and applying a manifest never touches them.
 See the [AgentChannel reference](/docs/sdk/resources/agent-channel) for every
 field.
 
+## Pin the model your channel runs
+
+A channel's conversations run unattended — nobody is watching a model picker
+when a workspace member messages your Agent at 3 AM — so the model they use
+is pinned on the channel itself, in `spec.run_config`:
+
+```yaml
+spec:
+  agent_ref:
+    kind: agent
+    org: acme-corp
+    slug: support-agent
+  enabled: true
+  slack: {}
+  run_config:
+    model_name: composer-2.5
+```
+
+The pin overrides the platform's default model for every conversation this
+channel serves, which makes each conversation's price deterministic — an
+unpinned model would follow whatever the serving account's default resolves
+to at that moment.
+
+The pinned name is validated against the platform's model registry when you
+apply the manifest: a name the registry does not know is refused with a
+did-you-mean (`model 'composr-2.5' is not in the model registry … did you
+mean 'composer-2.5'?`) instead of silently falling back to default-model
+pricing at serve time. Any model shown in the console's model picker is
+valid here.
+
 ## Limitations
 
 - A workspace hosts one Agent per Slack app. Register additional


### PR DESCRIPTION
## Summary
Closes the fail-open half of the unattended model-pinning rules (DD-001 D2/D3 remainder): a pinned `model_name` the registry does not know is now refused at schedule and channel apply/update with a did-you-mean, instead of riding through verbatim and silently running — and billing — as Auto.

## Context
`harness` and `approval-mode` both fail closed on a typo, but `model_name` passed every write boundary and the cursor runner's `resolveModelId` silently fell back to `"default"` (Auto) with a `console.warn` nobody watches. After #362 an UNPINNED cursor config is refused loudly — but a TYPO'D pin (`composr-2.5`) still shipped, the exact failure class the chat-surface-cost-reduction project existed to close.

## Changes
- **`registry.UnknownModelPinRefusal`** — this edition's one statement of the write-time pin-existence rule: `HasAnyModels` noop-degrade → `HasHarness` skip → `IsValidModel` → refusal with did-you-mean (`model 'composr-2.5' is not in the model registry (cursor harness); did you mean 'composer-2.5'?`).
- **Schedules**: `validateScheduleModelPinning` (create + update) gains the existence check against the harness the fires would use (unset = native, this edition's default — DD-015).
- **Channels**: create (`resolveChannelDefaultsStep`) + update (`validateChannelUpdateStep`) validate `spec.run_config.model_name` in **any-harness mode** — this edition stores channel specs without a serving runtime, so a pin is refused only when NO harness section knows it (certainly a typo), while the serving edition judges harness-scoped validity.
- **Suggestion machinery promoted** from `workflow/validation` to the `registry` package (`SuggestSimilarModels`, harness-name constants, `HarnessName`) so workflow errors and pin errors suggest identically; workflow validation now delegates.
- **Store** gains `IsValidModelOnAnyHarness` + `CanonicalModelsAcrossHarnesses` for the any-harness mode.
- **Docs**: the Slack channel guide gains "Pin the model your channel runs" with the validation behavior.

## Implementation notes
- **Write-time only, deliberately NO fire-time backstop** — unlike the pin-PRESENCE rule (#362), which fires at launch for pre-rule rows: adding existence at fire time would let upstream registry drift break a previously-valid schedule at its 3 AM fire. The runner's divergence detection stays as runtime defense-in-depth.
- Degrades to a no-op when the registry is empty or lacks the harness section (the established `HasAnyModels` posture) — an air-gapped or stale build never locks users out.
- The console channel-settings model selector is deferred to a follow-up issue per owner ruling: the console does not edit channel `run_config` at all today, so the selector means building the first channel run_config UI — its own UX pass. The Java-edition twin (channel/schedule/share validation + startup env-pin checks + `model_pin_unknown` metric) is tracked as its own stigmer-cloud issue per the oss#779→cloud#486 precedent.

## Breaking changes
- None for valid configs. Manifests carrying a genuinely unknown `model_name` are now refused at write time — which is the fix, not a regression: those pins were already broken (silently running as Auto).

## Test plan
- New `pin_validation_test.go` pins the rule against the real bundled registry, including the issue's own motivating typo. Schedule + channel controller tests cover create/update refusal, did-you-mean copy, harness scoping, and the valid-pin paths.
- `make check-go` fully green (vet, buf lint, all Go module tests, binaries); `./bazelw run //:gazelle` clean.

## Risks
- A stale bundled registry could refuse a brand-new model on an offline install — the same accepted posture as workflow model validation (hourly refresh mitigates; the refusal names the registry as the reason).

Closes #774

Made with [Cursor](https://cursor.com)