### PR TITLE
ci(integration): bump gotestsum pin to v1.13.0 in stress and providers lanes

### DIFF
--- a/.github/workflows/ci.integration-providers.yaml
+++ b/.github/workflows/ci.integration-providers.yaml
@@ -119,7 +119,9 @@ jobs:
         uses: temporalio/setup-temporal@v0
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.1
+        # v1.13.0 matches the offline/canary/seedpack lanes: v1.12.1's pinned
+        # x/tools v0.24.0 no longer compiles under Go 1.25+ (stigmer#799).
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Run provider integration tests
         env:

--- a/.github/workflows/ci.integration-stress.yaml
+++ b/.github/workflows/ci.integration-stress.yaml
@@ -111,8 +111,11 @@ jobs:
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Install OpenFGA CLI
+        # go install matches ci.conformance-cloud: the curl installer
+        # (openfga.dev/api/installcli) started answering 404 — a second latent
+        # break this lane's dead gotestsum pin had been masking (stigmer#799).
         run: |
-          curl -fsSL https://openfga.dev/api/installcli | bash
+          go install github.com/openfga/cli/cmd/fga@latest
           fga version
 
       - name: Download FGA model

--- a/.github/workflows/ci.integration-stress.yaml
+++ b/.github/workflows/ci.integration-stress.yaml
@@ -106,7 +106,9 @@ jobs:
         uses: temporalio/setup-temporal@v0
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.1
+        # v1.13.0 matches the offline/canary/seedpack lanes: v1.12.1's pinned
+        # x/tools v0.24.0 no longer compiles under Go 1.25+ (stigmer#799).
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Install OpenFGA CLI
         run: |


### PR DESCRIPTION
## Summary
Revives the `ci.integration-stress` lane, dead-on-arrival since the runner image moved to Go 1.25: bumps the `gotestsum` pin in the two lanes that were missed when the others moved (stress + providers), and replaces the stress lane's OpenFGA CLI curl installer whose endpoint now 404s.

## Context
The 2026-08-16 weekly `ci.integration-stress` run ([run 31925258907](https://github.com/stigmer/stigmer/actions/runs/31925258907)) died before running a single test: `go install gotest.tools/gotestsum@v1.12.1` fails to compile under Go 1.25.6 because its pinned `golang.org/x/tools v0.24.0` hits the known `invalid array length -delta * delta` incompatibility. The offline, canary, and seedpack-canary lanes were already on v1.13.0; `ci.integration-providers` carries the identical stale pin and would fail the same way on its next scheduled run — fixed pre-emptively.

A branch dispatch validating the pin bump ([run 31936757352](https://github.com/stigmer/stigmer/actions/runs/31936757352)) then unmasked a SECOND latent break the dead pin had been hiding: `curl -fsSL https://openfga.dev/api/installcli | bash` answers 404, so the lane died at the next step. Replaced with the `go install github.com/openfga/cli/cmd/fga@latest` form the conformance-cloud lane already uses.

## Changes
- `.github/workflows/ci.integration-stress.yaml`: gotestsum pin v1.12.1 → v1.13.0; OpenFGA CLI install switched from the dead curl endpoint to `go install` (matching ci.conformance-cloud). Comments record both whys.
- `.github/workflows/ci.integration-providers.yaml`: gotestsum pin v1.12.1 → v1.13.0.

## Test plan
- v1.13.0 is proven on the identical runner image by the offline/canary/seedpack lanes, and the branch dispatch's "Install gotestsum" step passed.
- A second branch dispatch with both fixes runs the lane end-to-end; the issue's close condition is the lane green (later flake-detection findings comment on the auto-filed issue by design).

## Risks
- Workflow-only change, no production code. Rollback is reverting the pins.

Closes #799