### PR TITLE
test(conformance): cloud-execution target — Class B suites, MCP bridge, and caller-identity headers vs the Java service

### DIFF
--- a/.github/workflows/ci.conformance-cloud.yaml
+++ b/.github/workflows/ci.conformance-cloud.yaml
@@ -1,17 +1,32 @@
 # =============================================================================
-# gRPC Conformance Suite (cloud target)
+# gRPC Conformance Suite (cloud targets)
 # =============================================================================
-# Runs the implementation-agnostic gRPC conformance suite (Class A / CRUD)
-# against the Stigmer Cloud Java service — the suite's whole reason to exist:
-# behavioral drift between the OSS and cloud editions becomes a failing test.
+# Runs the implementation-agnostic gRPC conformance suite against the Stigmer
+# Cloud Java service — the suite's whole reason to exist: behavioral drift
+# between the OSS and cloud editions becomes a failing test.
 #
 # Architecture (mirrors ci.integration-offline):
-#   Job 1 (build-service-jar)   — checks out stigmer-cloud, builds the fat JAR
-#   Job 2 (conformance-cloud)   — the suite's cloud global setup boots the
-#                                 hermetic environment (Testcontainers Postgres/
-#                                 Redis/MinIO/OpenFGA + Temporal dev + the JAR
-#                                 in test security mode with real FGA) via the
-#                                 Go launcher, then runs `npm run test:cloud`.
+#   Job 1 (build-service-jar)             — checks out stigmer-cloud, builds
+#                                           the fat JAR
+#   Job 2 (conformance-cloud)             — Class A (CRUD) + the runner-free
+#                                           schedule-firing suite: the cloud
+#                                           global setup boots the hermetic
+#                                           environment (Testcontainers
+#                                           Postgres/Redis/MinIO/OpenFGA +
+#                                           Temporal dev + the JAR in test
+#                                           security mode with real FGA) via
+#                                           the Go launcher, then runs
+#                                           `npm run test:cloud`.
+#   Job 3 (conformance-cloud-execution)   — Class B (execution): the same
+#                                           environment boot plus the TS
+#                                           runner bootstrapped as a
+#                                           production embedded runner of the
+#                                           primary conformance user
+#                                           (stigmer#202), running
+#                                           `npm run test:cloud-execution`.
+#
+# The two suite jobs share one JAR build but boot separate environments — an
+# execution failure must never poison the Class A signal (or vice versa).
 #
 # The nightly schedule is load-bearing: path triggers in this repo cannot see
 # stigmer-cloud merges, so the cron is what catches cloud-side drift.
@@ -184,13 +199,100 @@ jobs:
           # empty (the #323 class, swept in oss#541).
           include-hidden-files: true
 
+  # ---------------------------------------------------------------------------
+  # Job 3: Run the Class B (execution) conformance suites against the Java
+  # service. Same environment story as Job 2 — the suite's global setup owns
+  # the boot — plus the runner's cold build; each suite file's
+  # CloudExecutionTarget then spawns the TS runner via its production
+  # embedded-runner bootstrap (getRunnerBootstrapConfig as the primary
+  # conformance user).
+  # ---------------------------------------------------------------------------
+  conformance-cloud-execution:
+    name: Conformance (cloud execution)
+    runs-on: ubuntu-latest
+    needs: build-service-jar
+    env:
+      TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: ghcr.io/stigmer/mirror
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download service JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: stigmer-service-jar
+          path: .artifacts
+
+      - name: Download FGA model
+        uses: actions/download-artifact@v4
+        with:
+          name: fga-model
+          path: .artifacts/fga-model
+
+      # Go builds/runs the environment launcher (Testcontainers + service boot).
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install npm workspace dependencies
+        run: npm ci
+
+      # The suite imports the built proto stubs (dist), not their source.
+      # The runner itself is built by the suite's global setup (make
+      # build-runner), keeping one build path for CI and local runs.
+      - name: Build proto stubs
+        run: npm run build -w @stigmer/protos
+
+      - name: Install Temporal CLI
+        uses: temporalio/setup-temporal@v0
+
+      # Transforms the modular FGA DSL into the JSON model the launcher writes
+      # into its OpenFGA container.
+      - name: Install OpenFGA CLI
+        run: |
+          go install github.com/openfga/cli/cmd/fga@latest
+          fga version
+
+      - name: Run conformance suite (cloud execution)
+        env:
+          STIGMER_SERVICE_JAR: ${{ github.workspace }}/.artifacts/stigmer_service_fatjar.jar
+          STIGMER_FGA_MODEL_DIR: ${{ github.workspace }}/.artifacts/fga-model
+        run: npm run test:cloud-execution -w @stigmer/conformance
+
+      # The launcher writes the service log under the integration module's
+      # output dir; surface it when a run goes red.
+      - name: Upload environment logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-cloud-execution-logs
+          path: test/integration/.test-output/logs/
+          retention-days: 14
+          if-no-files-found: ignore
+          # The output dir is dot-prefixed and upload-artifact@v4 excludes
+          # hidden paths by default — without this the artifact is silently
+          # empty (the #323 class, swept in oss#541).
+          include-hidden-files: true
+
   # PR and push failures are attended; the nightly cron is not — and the cron
   # is this lane's load-bearing trigger (path filters cannot see stigmer-cloud
   # merges), so a silent red here means cross-edition drift ships unnoticed
   # (#477). Shared file-or-comment mechanics live in notify-failure.yaml.
   notify-failure:
     name: File Conformance Failure Issue
-    needs: [build-service-jar, conformance-cloud]
+    needs: [build-service-jar, conformance-cloud, conformance-cloud-execution]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -8,6 +8,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cloud": "vitest run -c vitest.cloud.config.ts",
+    "test:cloud-execution": "vitest run -c vitest.cloud-execution.config.ts",
     "test:execution": "vitest run -c vitest.execution.config.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/test/conformance/src/harness/global-setup-cloud-execution.ts
+++ b/test/conformance/src/harness/global-setup-cloud-execution.ts
@@ -1,0 +1,25 @@
+// Vitest global setup for the cloud execution run (Class B vs the Java
+// stigmer-service).
+// Domain: conformance harness (cloud target lifecycle).
+//
+// The environment story is the cloud Class A setup verbatim — one hermetic
+// environment per run, published through the CLOUD_ENV contract (or a
+// pre-provisioned endpoint, skipping the boot) — so it is delegated to
+// global-setup-cloud rather than re-encoded. What Class B adds is the engine's
+// cold build: each suite file's CloudExecutionTarget spawns the TS runner, and
+// paying `make build-runner` once here (like global-setup-execution does for
+// the local engine) keeps it off the per-file hook budget and satisfies the
+// runner's stale-build guard for the from-dist launch.
+import cloudSetup from "./global-setup-cloud";
+import { buildRunner } from "./runner-build";
+
+export default async function setup(): Promise<() => Promise<void>> {
+  const teardown = await cloudSetup();
+  try {
+    await buildRunner();
+  } catch (err) {
+    await teardown();
+    throw err;
+  }
+  return teardown;
+}

--- a/test/conformance/src/harness/mcp-server.ts
+++ b/test/conformance/src/harness/mcp-server.ts
@@ -54,8 +54,31 @@ function buildEchoServer(): McpServer {
   return server;
 }
 
+// One JSON-RPC request as observed by the fixture: the method from the body
+// plus the HTTP headers it arrived with (node lowercases header names). This
+// is the wire-level observation point the caller-identity contract needs
+// (stigmer#382): identity reaches an MCP server ONLY as templated headers, so
+// the receiving server — this fixture — is the one place a test can assert
+// what actually crossed the wire.
+export interface CapturedMcpRequest {
+  method: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
 export class McpToolFixture {
   private server: Server | undefined;
+  private captured: CapturedMcpRequest[] = [];
+
+  // Every JSON-RPC request observed since the last reset, oldest first.
+  // Suites reset in afterEach (the mock-LLM convention) so captures never
+  // leak across tests within a file.
+  capturedRequests(): readonly CapturedMcpRequest[] {
+    return this.captured;
+  }
+
+  resetCaptured(): void {
+    this.captured = [];
+  }
 
   // Binds to an ephemeral loopback port; resolves once listening.
   async start(): Promise<void> {
@@ -104,6 +127,14 @@ export class McpToolFixture {
       return;
     }
 
+    // Buffer and parse the body ourselves so each request can be captured with
+    // its JSON-RPC method (stigmer#382 asserts headers per wire request). The
+    // transport accepts a pre-parsed body for exactly this pattern.
+    const body: unknown = JSON.parse(await readBody(req));
+    for (const method of jsonRpcMethods(body)) {
+      this.captured.push({ method, headers: { ...req.headers } });
+    }
+
     const mcp = buildEchoServer();
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => {
@@ -111,8 +142,24 @@ export class McpToolFixture {
       void mcp.close();
     });
     await mcp.connect(transport);
-    // The transport reads the request body off the stream itself; we deliberately
-    // do not pre-consume it.
-    await transport.handleRequest(req, res);
+    await transport.handleRequest(req, res, body);
   }
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// JSON-RPC over Streamable HTTP is a single message or a batch array; capture
+// one entry per message so batch requests stay individually assertable.
+function jsonRpcMethods(body: unknown): string[] {
+  const messages = Array.isArray(body) ? body : [body];
+  return messages.map((message) => {
+    const method = (message as { method?: unknown } | null)?.method;
+    return typeof method === "string" ? method : "(no method)";
+  });
 }

--- a/test/conformance/src/harness/runner-process.ts
+++ b/test/conformance/src/harness/runner-process.ts
@@ -21,9 +21,10 @@
 // storage would default to `proxy` (presign calls -> setup-time throw) and, in
 // cloud mode, the checkpointer to `http` — so we pin both to local/memory.
 import { spawn } from "node:child_process";
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { runnerDir } from "./runner-build";
 
@@ -51,9 +52,20 @@ export interface RunnerOptions {
   // Absolute path to the runner's compiled entry (dist/main.js).
   entryPath: string;
   // host:port of the live Temporal frontend the runner should connect to.
-  temporalHostPort: string;
-  // http(s) base URL of the Go server's gRPC endpoint, for status streaming.
+  // Mutually exclusive with cloudBootstrap: an explicit address makes the
+  // runner skip its control-plane discovery entirely (bootstrap.ts branch 1).
+  temporalHostPort?: string;
+  // http(s) base URL of the backend's gRPC endpoint, for status streaming.
   backendEndpoint: string;
+  // Cloud engine wiring: boot as a production embedded runner. The token is a
+  // user credential (the primary conformance user); its presence — with NO
+  // explicit Temporal address — triggers the runner's own bootstrap lane
+  // (bootstrap.ts branch 2): getRunnerBootstrapConfig returns the Temporal
+  // coordinates and mints the embedded_runner proxy token, the same door a
+  // desktop embedder walks through. The user identity is what makes cloud
+  // authorization work: runner credentials carry the user as `sub`, so FGA
+  // authorizes the runner as the owner of the executions the suites create.
+  cloudBootstrap?: { token: string };
   // Optional hermetic LLM wiring; present only for agent-execution runs.
   proxy?: RunnerProxyOptions;
   // The server's artifact root + serve URL. When provided (with a proxy), the
@@ -62,6 +74,13 @@ export interface RunnerOptions {
   // fine for runs that never resolve a cross-process artifact.
   artifactDir?: string;
   artifactServeUrl?: string;
+  // When set, the runner's combined stdout/stderr is also streamed to this
+  // file (directory created as needed). The cloud-execution target points it
+  // under test/integration/.test-output/logs/ so a red CI run's uploaded
+  // environment-logs artifact carries the runner's side of the story — the
+  // in-memory logTail() only surfaces on SPAWN failure, which leaves an
+  // execution that failed mid-run undiagnosable after teardown.
+  logFile?: string;
 }
 
 export interface RunningRunner {
@@ -71,6 +90,13 @@ export interface RunningRunner {
 }
 
 export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
+  if ((opts.temporalHostPort === undefined) === (opts.cloudBootstrap === undefined)) {
+    throw new Error(
+      "spawnRunner needs exactly one of temporalHostPort (local engine) or " +
+        "cloudBootstrap (embedded-runner discovery); got " +
+        (opts.temporalHostPort === undefined ? "neither" : "both"),
+    );
+  }
   const workspaceDir = await mkdtemp(join(tmpdir(), "stigmer-conformance-runner-"));
   // Share the server's artifact store when given (#285); otherwise mint a
   // throwaway one. Only a dir we minted here is ours to remove on stop — the
@@ -89,9 +115,19 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
       // STIGMER_RUNNER_MODE intentionally unset -> static (single-queue) mode.
       MODE: "local",
       STIGMER_TASK_QUEUE: "stigmer_runner",
-      TEMPORAL_SERVICE_ADDRESS: opts.temporalHostPort,
-      TEMPORAL_NAMESPACE: "default",
+      // Local engine: pin the Temporal address (skips discovery). Cloud engine:
+      // deliberately UNSET, so the token below triggers the runner's own
+      // bootstrap discovery against the backend (bootstrap.ts branch 2).
+      ...(opts.temporalHostPort !== undefined
+        ? { TEMPORAL_SERVICE_ADDRESS: opts.temporalHostPort, TEMPORAL_NAMESPACE: "default" }
+        : {}),
       STIGMER_BACKEND_ENDPOINT: opts.backendEndpoint,
+      // The runner's one token env var serves control-plane auth AND (until a
+      // token is minted) the proxy bearer. Cloud bootstrap needs the USER
+      // credential here — discovery authenticates with it, and the coordinator
+      // swaps the proxy sink to the minted embedded_runner token afterwards —
+      // so it wins over the proxy's placeholder (which the mock ignores anyway).
+      ...(opts.cloudBootstrap !== undefined ? { STIGMER_TOKEN: opts.cloudBootstrap.token } : {}),
       WORKSPACE_ROOT_DIR: workspaceDir,
       LOG_LEVEL: "info",
       // Avoid a boot-time MCP backfill network call (hermetic test detail).
@@ -105,7 +141,7 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
       ...(opts.proxy !== undefined
         ? {
             STIGMER_PROXY_ENDPOINT: opts.proxy.endpoint,
-            STIGMER_TOKEN: opts.proxy.token,
+            ...(opts.cloudBootstrap === undefined ? { STIGMER_TOKEN: opts.proxy.token } : {}),
             // The mock proxy speaks ONLY Anthropic. Background LLM callers
             // (session titling, #690) route by config.primaryModel, whose
             // baked default is an OpenAI model — without this pin their
@@ -127,11 +163,18 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
     },
   });
 
+  let logSink: WriteStream | undefined;
+  if (opts.logFile !== undefined) {
+    mkdirSync(dirname(opts.logFile), { recursive: true });
+    logSink = createWriteStream(opts.logFile, { flags: "a" });
+  }
+
   let logTail = "";
   let ready = false;
   const appendLog = (chunk: Buffer): void => {
     const text = chunk.toString("utf8");
     logTail = (logTail + text).slice(-LOG_TAIL_BYTES);
+    logSink?.write(chunk);
     if (text.includes(READY_MARKER)) ready = true;
   };
   child.stdout.on("data", appendLog);
@@ -147,6 +190,7 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
     if (exit === null) {
       child.kill("SIGTERM");
     }
+    logSink?.end();
     await rm(workspaceDir, { recursive: true, force: true });
     // Only remove a store we minted; a server-shared dir is the server's to clean.
     if (ownedArtifactDir !== undefined) {

--- a/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
@@ -73,6 +73,11 @@ let clients: ConformanceClients;
 let mock: MockLlmProxy;
 const fixtures = new FixtureTracker();
 
+// Collection-time capability read (the schedule-firing/forwarder pattern):
+// gates the two attachment-materialization cases that require the runner and
+// server to share one artifact store — see the flag's contract in target.ts.
+const sharedArtifactStore = createTarget().capabilities.sharedRunnerArtifactStore;
+
 // Long enough to keep a held execution IN_PROGRESS across the poll-and-act window
 // (tests act within ~1s), well under the runner activity's 2-minute heartbeat and
 // 24-hour start-to-close. A held turn aborts the instant the client disconnects
@@ -647,8 +652,11 @@ describe("AgentExecution conformance — one-call session bootstrap (session_spe
 // store, and the runner — a separate process — must read it back from the SAME
 // directory. Before the fix the two disagreed on the path and this failed; the
 // harness now points both at one root (see server-process.ts / runner-process.ts).
+// The two materialization cases gate on sharedRunnerArtifactStore (a harness
+// limitation on cloud-execution, not edition drift — see target.ts); the
+// presign/foreign-key rejection contract is server-side and runs everywhere.
 describe("AgentExecution conformance — attachments (#285)", () => {
-  it("resolves a storage-key attachment (no local_path) the server wrote to the shared local store", async () => {
+  it.skipIf(!sharedArtifactStore)("resolves a storage-key attachment (no local_path) the server wrote to the shared local store", async () => {
     const { org } = await target.provisionTenancy();
     const agentId = await provisionAgent(org, uniqueName("agent-attach"));
 
@@ -764,7 +772,7 @@ describe("AgentExecution conformance — attachments (#285)", () => {
   // captured request is byte-for-byte what Anthropic would have received
   // (@langchain/anthropic converts the runner's image_url data-URL block into
   // the native base64 source block on the wire).
-  it("delivers an image attachment to the provider as an inline base64 image block (vision, T04)", async () => {
+  it.skipIf(!sharedArtifactStore)("delivers an image attachment to the provider as an inline base64 image block (vision, T04)", async () => {
     const { org } = await target.provisionTenancy();
     const agentId = await provisionAgent(org, uniqueName("agent-vision"));
 

--- a/test/conformance/src/suites-execution/mcp-caller-identity.conformance.test.ts
+++ b/test/conformance/src/suites-execution/mcp-caller-identity.conformance.test.ts
@@ -1,0 +1,224 @@
+// Conformance suite for the MCP caller-identity header contract (Class B).
+// Domain: agentic / agentexecution — the mint → session → execution → headers
+// chain (stigmer#382).
+//
+// The contract under test (docs/guides/integrations/caller-identity-for-mcp-servers.mdx):
+// an McpServer that declares the reserved STIGMER_CALLER_IDENTITY_KIND/_VALUE
+// env keys (`optional: true`) and templates them into its headers receives the
+// platform-verified caller identity on EVERY request — resolved with fixed
+// precedence: channel sender (SessionSpec.metadata, cloud-broker-stamped) →
+// session creator (`stigmer_user` from the session's audit actor) → the
+// anonymous sentinel. A server that never declares the keys never receives
+// identity (opt-in by construction — filterEnvToDeclaredKeys).
+//
+// This chain crosses four components (audit transformer → runner resolver →
+// env filter → header templating) and previously had NO automated test that
+// observes the headers on the wire — #377 and #380 both shipped contract
+// drift caught only by a manual live probe. The observation point here is the
+// receiving server itself: the McpToolFixture records each JSON-RPC request's
+// method + HTTP headers, so the assertions read exactly what crossed the wire
+// on the `tools/call` request that dispatched the tool.
+//
+// Edition-agnostic by derivation, not by forking: the expected creator
+// identity is DERIVED from the session resource's own audit actor via the
+// resolver's documented precedence (email → stigmer_user/email; the "system"
+// placeholder or an absent creator → anonymous). On cloud the creator is the
+// real minted user; on an unconfigured local OSS server it is the "system"
+// sentinel — both are correct outcomes of one contract, so the same assertion
+// pins both editions without a capability flag.
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ConformanceClients } from "../harness/clients";
+import type { CapturedMcpRequest, McpToolFixture } from "../harness/mcp-server";
+import { ECHO_TOOL_NAME } from "../harness/mcp-server";
+import type { MockLlmProxy } from "../harness/mock-llm";
+import { anthropicText, anthropicToolUse } from "../harness/mock-llm";
+import { makeAgent } from "../support/agents";
+import {
+  awaitTerminal,
+  makeAgentExecution,
+  requireLlmProxy,
+  requireMcpFixture,
+} from "../support/agentexecutions";
+import { FixtureTracker } from "../harness/fixtures";
+import { makeHttpMcpServer, type HttpMcpServerOptions } from "../support/mcpservers";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+// The reserved env keys (pinned verbatim to the runner's caller-identity.ts).
+const KIND_ENV_KEY = "STIGMER_CALLER_IDENTITY_KIND";
+const VALUE_ENV_KEY = "STIGMER_CALLER_IDENTITY_VALUE";
+
+// The header names the suite templates. Node lowercases incoming header names,
+// so captures are asserted via the lowercase forms.
+const KIND_HEADER = "x-stigmer-caller-kind";
+const VALUE_HEADER = "x-stigmer-caller-value";
+
+// SessionSpec.metadata keys the cloud broker stamps for channel senders —
+// pinned verbatim to the runner's sender-identity.ts (which pins them to
+// ChannelRuntimeConstants in stigmer-cloud; drift guards exist on both sides).
+const SENDER_IDENTITY_METADATA_KEY = "stigmer.ai/channel-sender-identity";
+const SENDER_KIND_METADATA_KEY = "stigmer.ai/channel-sender-kind";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+let mock: MockLlmProxy;
+let mcp: McpToolFixture;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+  mock = requireLlmProxy(target);
+  mcp = requireMcpFixture(target);
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+  mock.reset();
+  mcp.resetCaptured();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// An McpServer declaring the reserved keys and templating them into headers —
+// the exact shape the docs guide prescribes (rules 1 and 2).
+function identityTemplatingServer(
+  opts: Pick<HttpMcpServerOptions, "org" | "name" | "url">,
+): ReturnType<typeof makeHttpMcpServer> {
+  return makeHttpMcpServer({
+    ...opts,
+    headers: {
+      "X-Stigmer-Caller-Kind": `\${${KIND_ENV_KEY}}`,
+      "X-Stigmer-Caller-Value": `\${${VALUE_ENV_KEY}}`,
+    },
+    env: {
+      [KIND_ENV_KEY]: { optional: true, description: "Injected by the platform" },
+      [VALUE_ENV_KEY]: { optional: true, description: "Injected by the platform" },
+    },
+  });
+}
+
+// Drives one echo-tool run against the given McpServer resource and returns
+// the tools/call requests the fixture observed for it. sessionSpec lets the
+// channel case stamp sender metadata on the auto-created session.
+async function runEchoAndCapture(options: {
+  org: string;
+  server: ReturnType<typeof makeHttpMcpServer>;
+  sessionSpec?: { metadata: Record<string, string> };
+}): Promise<{ toolCalls: CapturedMcpRequest[]; sessionId: string }> {
+  const server = await clients.mcpServerCommand.create(options.server);
+  fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+
+  const agent = await clients.agentCommand.create(
+    makeAgent({
+      org: options.org,
+      name: uniqueName("agent-identity"),
+      mcpServerRefs: [server.metadata!.slug],
+    }),
+  );
+  fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+
+  mock.enqueue(anthropicToolUse("call_echo_identity", ECHO_TOOL_NAME, { text: "ping" }));
+  mock.enqueue(anthropicText("Done."));
+
+  const execution = await clients.agentExecutionCommand.create(
+    makeAgentExecution({
+      org: options.org,
+      name: uniqueName("aex-identity"),
+      agentId: agent.metadata!.id,
+      autoApproveAll: true,
+      ...(options.sessionSpec !== undefined ? { sessionSpec: options.sessionSpec } : {}),
+    }),
+  );
+  const executionId = execution.metadata!.id;
+  fixtures.defer(() => clients.agentExecutionCommand.delete({ value: executionId }));
+
+  const final = await awaitTerminal(clients, executionId);
+  expect(
+    final.status?.phase,
+    `execution ${executionId} should complete; reached ${ExecutionPhase[final.status?.phase ?? 0]}`,
+  ).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+
+  const toolCalls = mcp.capturedRequests().filter((r) => r.method === "tools/call");
+  expect(toolCalls.length, "the echo dispatch reaches the fixture as a tools/call").toBeGreaterThan(0);
+  return { toolCalls: [...toolCalls], sessionId: final.spec?.sessionId ?? "" };
+}
+
+describe("MCP caller-identity headers (mint → session → execution → headers)", () => {
+  it("carries the session creator identity, derived per the resolver's documented precedence", async () => {
+    const { org } = await target.provisionTenancy();
+    const { toolCalls, sessionId } = await runEchoAndCapture({
+      org,
+      server: identityTemplatingServer({ org, name: uniqueName("mcp-identity"), url: mcp.url() }),
+    });
+
+    // Derive the expected identity from the session's own audit actor — the
+    // exact source and precedence the runner resolves from: a creator email
+    // → stigmer_user/<email>; the "system" audit placeholder (or no creator)
+    // is not a principal and resolves to the anonymous sentinel.
+    expect(sessionId, "a completed run carries its auto-created session id").not.toBe("");
+    const session = await clients.sessionQuery.get({ value: sessionId });
+    const creator = session.status?.audit?.specAudit?.createdBy;
+    const email = creator?.email?.trim() ?? "";
+    const creatorId = creator?.id?.trim() ?? "";
+    const expected =
+      email !== ""
+        ? { kind: "stigmer_user", value: email }
+        : creatorId !== "" && creatorId !== "system"
+          ? { kind: "stigmer_user", value: creatorId }
+          : { kind: "anonymous", value: "" };
+
+    for (const call of toolCalls) {
+      expect(call.headers[KIND_HEADER], "the kind header carries the resolved identity kind").toBe(
+        expected.kind,
+      );
+      expect(call.headers[VALUE_HEADER], "the value header carries the resolved identity value").toBe(
+        expected.value,
+      );
+    }
+  });
+
+  it("prefers the channel-stamped sender identity over the session creator", async () => {
+    const { org } = await target.provisionTenancy();
+    const { toolCalls } = await runEchoAndCapture({
+      org,
+      server: identityTemplatingServer({ org, name: uniqueName("mcp-sender"), url: mcp.url() }),
+      // What the cloud broker stamps at session creation for a WhatsApp
+      // conversation — the resolver's highest-precedence source.
+      sessionSpec: {
+        metadata: {
+          [SENDER_KIND_METADATA_KEY]: "whatsapp_phone",
+          [SENDER_IDENTITY_METADATA_KEY]: "15550001111",
+        },
+      },
+    });
+
+    for (const call of toolCalls) {
+      expect(call.headers[KIND_HEADER], "the channel sender kind wins over the creator").toBe(
+        "whatsapp_phone",
+      );
+      expect(call.headers[VALUE_HEADER], "the channel sender value wins over the creator").toBe(
+        "15550001111",
+      );
+    }
+  });
+
+  it("sends no identity headers to a server that never declared the reserved keys", async () => {
+    const { org } = await target.provisionTenancy();
+    const { toolCalls } = await runEchoAndCapture({
+      org,
+      // No env declarations, no templated headers: identity injection is
+      // opt-in, so nothing identity-shaped may reach this server.
+      server: makeHttpMcpServer({ org, name: uniqueName("mcp-plain"), url: mcp.url() }),
+    });
+
+    for (const call of toolCalls) {
+      expect(call.headers[KIND_HEADER], "no declaration → no kind header").toBeUndefined();
+      expect(call.headers[VALUE_HEADER], "no declaration → no value header").toBeUndefined();
+    }
+  });
+});

--- a/test/conformance/src/suites/mcp.conformance.test.ts
+++ b/test/conformance/src/suites/mcp.conformance.test.ts
@@ -1,26 +1,43 @@
 // Conformance slice for the TypeScript MCP server (@stigmer/mcp-server).
-// Domain: MCP protocol bridge over the live OSS Go stigmer-server.
+// Domain: MCP protocol bridge over a live backend (OSS Go server or the cloud
+// Java service).
 //
 // Unlike the other suites — which drive the raw proto controllers via a
-// TargetProfile — this one boots the real Go server and exercises the MCP tool
-// surface end-to-end through an in-memory MCP client. It proves the full path:
-// MCP tool input -> codegen apply projection (toProto) -> gRPC Apply on the real
-// server -> protojson back through the read tool. A small helper (not a
-// TargetProfile) is used because the MCP server exposes tools, not proto clients.
+// TargetProfile — this one exercises the MCP tool surface end-to-end through
+// an in-memory MCP client. It proves the full path: MCP tool input -> codegen
+// apply projection (toProto) -> gRPC Apply on the real server -> protojson
+// back through the read tool. A small backend resolver (not a TargetProfile)
+// is used because the MCP server exposes tools, not proto clients — but it
+// still keys off CONFORMANCE_TARGET so the same assertions pin both editions:
+//   - local (default): boots the OSS Go server, unauthenticated (apiKey "").
+//   - cloud: connects to the CLOUD_ENV-provisioned environment as the primary
+//     conformance user; the bridge's startup apiKey carries the user's JWT
+//     (BackendTarget.apiKey is the stdio credential resolveToken falls back
+//     to), so every tool call traverses real auth + FGA.
 import { createClient } from "@connectrpc/connect";
-import { createGrpcTransport } from "@connectrpc/connect-node";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "@stigmer/mcp-server";
 import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { CLOUD_ENV } from "../harness/cloud-env";
+import { createTransport } from "../harness/clients";
 import { ensureServerBinary } from "../harness/go-build";
-import { spawnServer, type RunningServer } from "../harness/server-process";
+import { spawnServer } from "../harness/server-process";
 import { uniqueName } from "../support/naming";
 
-let server: RunningServer;
-let orgCommand: ReturnType<typeof createClient<typeof OrganizationCommandController>>;
+// What the bridge and the suite need from either edition: gRPC coordinates,
+// the startup credential, one org to work in, and a teardown for whatever the
+// resolver itself booted (nothing, for the pre-provisioned cloud env).
+interface BridgeBackend {
+  serverAddress: string;
+  apiKey: string;
+  orgSlug: string;
+  stop(): Promise<void>;
+}
+
+let backend: BridgeBackend;
 let mcpClient: Client;
 let orgSlug: string;
 
@@ -33,14 +50,13 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<To
   return (await mcpClient.callTool({ name, arguments: args })) as ToolResult;
 }
 
-beforeAll(async () => {
+// Boots the OSS Go server and creates the working org tokenless (single-tenant,
+// no auth). The org create doubles as the gRPC-readiness gate.
+async function resolveLocalBackend(): Promise<BridgeBackend> {
   const binary = await ensureServerBinary();
-  server = await spawnServer(binary);
+  const server = await spawnServer(binary);
+  const orgCommand = createClient(OrganizationCommandController, createTransport(server.baseUrl));
 
-  const transport = createGrpcTransport({ baseUrl: server.baseUrl });
-  orgCommand = createClient(OrganizationCommandController, transport);
-
-  // gRPC-readiness gate: retry org creation until the store is serving.
   const deadline = Date.now() + 15_000;
   let created: Awaited<ReturnType<typeof orgCommand.create>> | undefined;
   let lastErr: unknown;
@@ -58,11 +74,63 @@ beforeAll(async () => {
     }
   }
   if (created === undefined) {
+    await server.stop();
     throw new Error(`server not ready: ${String(lastErr)}\n${server.logTail()}`);
   }
-  orgSlug = created.metadata!.slug;
+  return {
+    serverAddress: `127.0.0.1:${server.port}`,
+    apiKey: "",
+    orgSlug: created.metadata!.slug,
+    stop: () => server.stop(),
+  };
+}
 
-  const mcp = createServer({ serverAddress: `127.0.0.1:${server.port}`, apiKey: "" });
+// Connects to the provisioned cloud environment (the cloud global setup's
+// CLOUD_ENV contract) and creates the working org as the primary conformance
+// user via the production RPC — the same tenancy shape CloudTarget provisions.
+async function resolveCloudBackend(): Promise<BridgeBackend> {
+  const baseUrl = requireEnv(CLOUD_ENV.address);
+  const token = requireEnv(CLOUD_ENV.token);
+  const orgCommand = createClient(
+    OrganizationCommandController,
+    createTransport(baseUrl, { bearerToken: token }),
+  );
+  const created = await orgCommand.create({
+    apiVersion: "tenancy.stigmer.ai/v1",
+    kind: "Organization",
+    metadata: { name: uniqueName("mcp-conf-org") },
+  });
+  return {
+    serverAddress: baseUrl.replace(/^https?:\/\//, ""),
+    apiKey: token,
+    orgSlug: created.metadata!.slug,
+    // The org is this suite's only footprint; the environment belongs to the
+    // global setup.
+    stop: async () => {
+      await orgCommand.delete({ value: created.metadata!.id });
+    },
+  };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(
+      `${name} is not set: the cloud bridge run expects a provisioned environment ` +
+        "(run via `npm run test:cloud`, or set the CLOUD_ENV variables).",
+    );
+  }
+  return value;
+}
+
+beforeAll(async () => {
+  backend =
+    process.env.CONFORMANCE_TARGET === "cloud"
+      ? await resolveCloudBackend()
+      : await resolveLocalBackend();
+  orgSlug = backend.orgSlug;
+
+  const mcp = createServer({ serverAddress: backend.serverAddress, apiKey: backend.apiKey });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   mcpClient = new Client({ name: "mcp-conformance", version: "test" });
   await Promise.all([mcp.connect(serverTransport), mcpClient.connect(clientTransport)]);
@@ -70,10 +138,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await mcpClient?.close();
-  await server?.stop();
+  await backend?.stop();
 });
 
-describe("MCP server conformance (live Go server)", () => {
+describe("MCP server conformance (live backend)", () => {
   it("advertises the full tool roster", async () => {
     const { tools } = await mcpClient.listTools();
     expect(tools.map((t) => t.name)).toEqual(

--- a/test/conformance/src/support/agentexecutions.ts
+++ b/test/conformance/src/support/agentexecutions.ts
@@ -141,26 +141,27 @@ export function awaitTerminal(
 }
 
 // Obtain the mock LLM proxy from an execution target, failing loudly if the
-// active target does not provide one (e.g. a CRUD or cloud target). Agent
-// execution suites must run against local-go-execution.
+// active target does not provide one (e.g. a CRUD-only target). Agent
+// execution suites require an execution target (local-go-execution or
+// cloud-execution).
 export function requireLlmProxy(target: TargetProfile): MockLlmProxy {
   if (target.llmProxy === undefined) {
     throw new Error(
       `target ${target.name} does not provide a mock LLM proxy; ` +
-        "agent execution suites require the local-go-execution target",
+        "agent execution suites require an execution target (local-go-execution or cloud-execution)",
     );
   }
   return target.llmProxy();
 }
 
 // Obtain the HTTP MCP tool fixture from an execution target, failing loudly if
-// the active target does not provide one. Tool-using (HITL) agent suites must
-// run against local-go-execution.
+// the active target does not provide one. Tool-using (HITL) agent suites
+// require an execution target (local-go-execution or cloud-execution).
 export function requireMcpFixture(target: TargetProfile): McpToolFixture {
   if (target.mcpFixture === undefined) {
     throw new Error(
       `target ${target.name} does not provide an MCP tool fixture; ` +
-        "tool-using agent suites require the local-go-execution target",
+        "tool-using agent suites require an execution target (local-go-execution or cloud-execution)",
     );
   }
   return target.mcpFixture();

--- a/test/conformance/src/support/mcpservers.ts
+++ b/test/conformance/src/support/mcpservers.ts
@@ -65,6 +65,15 @@ export interface HttpMcpServerOptions {
   // McpToolFixture.url(). Satisfies the `server_type` oneof via http config.
   url: string;
   description?: string;
+  // HTTP headers sent with every request (spec.http.headers). Values may
+  // template declared env vars — including the reserved caller-identity keys
+  // — with `${VAR}` placeholders; every templated key MUST be declared in
+  // `env` or resolution fails (the docs guide's rule 1).
+  headers?: Record<string, string>;
+  // Env declarations (spec.env). The reserved caller-identity keys must be
+  // declared `optional: true` — their values come from the runner at
+  // execution time, not from an Environment (the docs guide's rule 2).
+  env?: Record<string, { optional?: boolean; isSecret?: boolean; description?: string }>;
 }
 
 // A complete, valid HTTP McpServer resource. Used by the execution suites to
@@ -78,7 +87,11 @@ export function makeHttpMcpServer(opts: HttpMcpServerOptions): MessageInitShape<
     metadata: { name: opts.name, org: opts.org },
     spec: {
       description: opts.description ?? "conformance HTTP MCP fixture",
-      serverType: { case: "http", value: { url: opts.url } },
+      serverType: {
+        case: "http",
+        value: { url: opts.url, ...(opts.headers !== undefined ? { headers: opts.headers } : {}) },
+      },
+      ...(opts.env !== undefined ? { env: opts.env } : {}),
     },
   };
 }

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -1,0 +1,196 @@
+// Cloud execution target: the Java stigmer-service with its execution engine
+// reachable — the Class B twin of `cloud`, and the cloud twin of
+// `local-go-execution`.
+// Domain: conformance targets (execution engine).
+//
+// Composes rather than forks: the connect-only identity/tenancy machinery is
+// delegated to CloudTarget (CLOUD_ENV contract, real orgs, PlatformClient
+// minting), and this target adds exactly what `local-go-execution` adds to
+// `local-go` — the TS-owned engine trio (runner, mock LLM proxy, MCP tool
+// fixture). The fixtures stay TS-pure per DD-002 (no cross-language coupling
+// with the Go integration harness), which is what lets the execution suites
+// program `llmProxy()` per test identically on both editions.
+//
+// The runner boots as a PRODUCTION embedded runner of the primary conformance
+// user: spawnRunner's cloudBootstrap hands it the user's JWT and no Temporal
+// address, so the runner's own bootstrap lane (getRunnerBootstrapConfig)
+// discovers the Temporal coordinates and mints its embedded_runner proxy
+// token — the same single authenticated door a desktop embedder uses. That
+// identity choice is load-bearing: runner credentials carry the user as `sub`
+// (see StigmerTokenType in stigmer-cloud), so FGA authorizes the runner as the
+// owner of every execution the suites create, and the per-execution
+// ExecutionContext decrypt rides the runner's ordinary scoped-token exchange
+// (getRunnerScopedToken, issue #156). Nothing here is test-only plumbing.
+//
+// setup() boot order mirrors local-go-execution: fixtures before the runner
+// (their URLs must be known when it boots); the service itself is already up
+// (the hermetic launcher or a pre-provisioned endpoint owns its lifecycle).
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient, type Client } from "@connectrpc/connect";
+import { BillingCommandController } from "@stigmer/protos/ai/stigmer/billing/v1/command_pb";
+import { CLOUD_ENV } from "../harness/cloud-env";
+import { createTransport, type ConformanceClients } from "../harness/clients";
+import { McpToolFixture } from "../harness/mcp-server";
+import { MockLlmProxy } from "../harness/mock-llm";
+import { ensureRunnerBuilt } from "../harness/runner-build";
+import { spawnRunner, type RunningRunner } from "../harness/runner-process";
+import { CloudTarget } from "./cloud";
+import type { CapabilityFlags, TargetProfile, TenancyContext } from "./target";
+
+// The credit seed for a provisioned execution org, mirroring the integration
+// harness's ProvisionTestBillingAccount ($100 in micro-USD): cloud authorizes
+// billing INSIDE the agent-execution workflow (InvokeAgentExecutionWorkflow →
+// ExecutionBillingService) before any work is dispatched, so the zero-balance
+// account an org create provisions — sufficient for Class A CRUD — denies
+// every Class B run with "Insufficient credits to start execution".
+const TENANCY_SEED_CREDITS_MICROS = 100_000_000n;
+
+// The integration module's log dir — where the hermetic launcher already
+// writes stigmer-service.log, and what the CI lane uploads on failure. Each
+// suite file's runner logs beside it, named for the file so a red run's
+// artifact tells the whole story (repo root is four levels up from
+// test/conformance/src/targets/).
+const RUNNER_LOG_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../..",
+  "test/integration/.test-output/logs",
+);
+
+export class CloudExecutionTarget implements TargetProfile {
+  readonly name = "cloud-execution";
+
+  // Same service, same edition differences: capabilities are delegated to the
+  // inner CloudTarget verbatim (having an engine is not a CapabilityFlag —
+  // the same reasoning local-go-execution records). Notably this makes
+  // workflowChildApprovalForwarding=true reachable for the first time: cloud
+  // is the only edition whose agent-execution workflow emits the
+  // child_approval_required signal (DD-012), and this target is the first
+  // with both that signal and a runner to drive it.
+  private readonly cloud = new CloudTarget();
+
+  private runner: RunningRunner | undefined;
+  private mockLlm: MockLlmProxy | undefined;
+  private mcpTools: McpToolFixture | undefined;
+  private billingCommand: Client<typeof BillingCommandController> | undefined;
+
+  get capabilities(): CapabilityFlags {
+    return this.cloud.capabilities;
+  }
+
+  async setup(): Promise<void> {
+    const runnerEntry = await ensureRunnerBuilt();
+
+    // 1. Connect to the provisioned service first — its address and the
+    //    primary user token are also what the runner bootstraps against.
+    await this.cloud.setup();
+
+    // 2. Fixtures before the runner, so their URLs are known when it boots.
+    this.mockLlm = new MockLlmProxy();
+    await this.mockLlm.start();
+    this.mcpTools = new McpToolFixture();
+    await this.mcpTools.start();
+
+    // 3. Runner last: embedded-runner bootstrap as the primary user (see the
+    //    module doc). The proxy token is a placeholder — cloudBootstrap's user
+    //    JWT wins for STIGMER_TOKEN, and the mock proxy ignores bearers.
+    const backendEndpoint = requireCloudEnv(CLOUD_ENV.address);
+    const primaryToken = requireCloudEnv(CLOUD_ENV.token);
+    // Billing writes authenticate as the primary user — the owner of every
+    // org this target provisions, which is who the integration harness's
+    // org_helpers fund standalone orgs as (ownerConn).
+    this.billingCommand = createClient(
+      BillingCommandController,
+      createTransport(backendEndpoint, { bearerToken: primaryToken }),
+    );
+    this.runner = await spawnRunner({
+      entryPath: runnerEntry,
+      backendEndpoint,
+      cloudBootstrap: { token: primaryToken },
+      proxy: { endpoint: this.mockLlm.url(), token: "conformance-cloud-bootstrap" },
+      logFile: join(RUNNER_LOG_DIR, `conformance-runner-${runnerLogLabel()}.log`),
+    });
+  }
+
+  llmProxy(): MockLlmProxy {
+    if (this.mockLlm === undefined) {
+      throw new Error("CloudExecutionTarget.setup() must be called before llmProxy()");
+    }
+    return this.mockLlm;
+  }
+
+  mcpFixture(): McpToolFixture {
+    if (this.mcpTools === undefined) {
+      throw new Error("CloudExecutionTarget.setup() must be called before mcpFixture()");
+    }
+    return this.mcpTools;
+  }
+
+  clients(): ConformanceClients {
+    return this.cloud.clients();
+  }
+
+  async provisionTenancy(): Promise<TenancyContext> {
+    const context = await this.cloud.provisionTenancy();
+    await this.fundTenancy(context.org);
+    return context;
+  }
+
+  cleanupTenancy(context: TenancyContext): Promise<void> {
+    return this.cloud.cleanupTenancy(context);
+  }
+
+  provisionIdentity(): Promise<ConformanceClients> {
+    return this.cloud.provisionIdentity();
+  }
+
+  async teardown(): Promise<void> {
+    // Reverse boot order: runner, then the fixtures it dials, then the client
+    // connection. The environment itself outlives us (global-setup owns it).
+    await this.runner?.stop();
+    await this.mockLlm?.close();
+    await this.mcpTools?.close();
+    await this.cloud.teardown();
+    this.runner = undefined;
+    this.mockLlm = undefined;
+    this.mcpTools = undefined;
+    this.billingCommand = undefined;
+  }
+
+  // Seeds the fresh org's billing account so the workflow-level billing gate
+  // authorizes runs (see TENANCY_SEED_CREDITS_MICROS). Billing accounts are
+  // keyed by the execution's metadata.org — the slug — which is also what the
+  // integration suite passes. A deliberate zero-credit negative belongs to a
+  // future suite that SKIPS this funding, pinning the denial contract.
+  private async fundTenancy(org: string): Promise<void> {
+    if (this.billingCommand === undefined) {
+      throw new Error("CloudExecutionTarget.setup() must be called before provisionTenancy()");
+    }
+    await this.billingCommand.getOrCreateBillingAccount({ orgId: org });
+    await this.billingCommand.adjustCredits({
+      orgId: org,
+      amountMicros: TENANCY_SEED_CREDITS_MICROS,
+      reason: "conformance execution tenancy seed",
+      idempotencyKey: `conformance-seed-${org}`,
+    });
+  }
+}
+
+// One log per runner spawn. Files run serially (fileParallelism: false) and
+// each file boots its own target, so worker-pid + boot time is a unique,
+// chronologically sortable key — enough to line a log up with a red file.
+function runnerLogLabel(): string {
+  return `${process.pid}-${Date.now()}`;
+}
+
+function requireCloudEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(
+      `${name} is not set: the cloud-execution target expects a provisioned environment. ` +
+        "Run the suite via `npm run test:cloud-execution` (hermetic boot), or set the " +
+        "CLOUD_ENV variables to point at an existing endpoint.",
+    );
+  }
+  return value;
+}

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -52,6 +52,10 @@ export class CloudTarget implements TargetProfile {
     // platform-privileged caller lane (stigmer#547).
     clientReservedLabelWrites: false,
     clientPublicVisibilityWrites: false,
+    // The hermetic cloud service stores attachments in MinIO while the
+    // TS runner (cloud-execution) keeps a local artifact store — a harness
+    // limitation, not edition drift; see the flag's contract in target.ts.
+    sharedRunnerArtifactStore: false,
   };
 
   private grpcBaseUrl: string | undefined;

--- a/test/conformance/src/targets/index.ts
+++ b/test/conformance/src/targets/index.ts
@@ -5,6 +5,7 @@
 // defaulting to the local OSS Go server. The same suite runs unchanged against
 // any registered target.
 import { CloudTarget } from "./cloud";
+import { CloudExecutionTarget } from "./cloud-execution";
 import { LocalGoTarget } from "./local-go";
 import { LocalGoExecutionTarget } from "./local-go-execution";
 import type { TargetProfile } from "./target";
@@ -13,6 +14,7 @@ const TARGET_FACTORIES: Record<string, () => TargetProfile> = {
   "local-go": () => new LocalGoTarget(),
   "local-go-execution": () => new LocalGoExecutionTarget(),
   cloud: () => new CloudTarget(),
+  "cloud-execution": () => new CloudExecutionTarget(),
 };
 
 export function createTarget(): TargetProfile {

--- a/test/conformance/src/targets/local-go-execution.ts
+++ b/test/conformance/src/targets/local-go-execution.ts
@@ -51,6 +51,9 @@ export class LocalGoExecutionTarget implements TargetProfile {
     // (stigmer-cloud#320), so the caller may create labeled candidates.
     clientReservedLabelWrites: true,
     clientPublicVisibilityWrites: true,
+    // The runner shares the server's artifact dir (the #285 wiring in setup),
+    // so server-written storage-key attachments resolve in the runner.
+    sharedRunnerArtifactStore: true,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -26,6 +26,9 @@ export class LocalGoTarget implements TargetProfile {
     // (stigmer-cloud#320), so the caller may create labeled candidates.
     clientReservedLabelWrites: true,
     clientPublicVisibilityWrites: true,
+    // CRUD target: no engine, so the flag is never consulted; true mirrors
+    // the local execution target (one store, one host).
+    sharedRunnerArtifactStore: true,
   };
 
   private server: RunningServer | undefined;

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -100,6 +100,19 @@ export interface CapabilityFlags {
   // retire this flag when the harness gains a platform-privileged caller
   // (stigmer#547) — until then the pin runs OSS-side only.
   clientReservedLabelWrites: boolean;
+  // The execution target's runner shares an artifact store with the server,
+  // so a storage-key attachment the SERVER persisted resolves when the RUNNER
+  // materializes it (the #285 shared-dir wiring on local targets).
+  //
+  // False for cloud-execution — a HARNESS limitation, not an edition
+  // difference: the hermetic cloud service stores attachments in its MinIO,
+  // while the runner is pinned to a local artifact store (the mock LLM proxy
+  // cannot serve the presign calls a proxy-configured artifact store would
+  // make). Attachment-materialization assertions gate on this flag until the
+  // harness gains a presign-capable artifact lane for the cloud engine
+  // (stigmer#803). Attachment REJECTION contracts (foreign keys etc.) are
+  // server-side and run unconditionally.
+  sharedRunnerArtifactStore: boolean;
   // The conformance caller may set a resource's visibility to PUBLIC — the
   // only level that crosses every org boundary (the cross-org "explore"
   // catalog).

--- a/test/conformance/vitest.cloud-execution.config.ts
+++ b/test/conformance/vitest.cloud-execution.config.ts
@@ -1,0 +1,43 @@
+// Vitest configuration for the cloud execution run (Class B vs the Java
+// stigmer-service) — the cloud twin of vitest.execution.config.ts.
+//
+// globalSetup boots the hermetic environment once per run (the Class A cloud
+// story, delegated wholesale) and pays the runner's cold build; each suite
+// file's CloudExecutionTarget then connects and provisions its own engine trio
+// (runner + mock LLM + MCP fixture), mirroring the per-file boot the local
+// execution config documents.
+//
+// Include-list curation (each exclusion deliberate, the vitest.cloud.config.ts
+// convention):
+// - schedule-firing is EXCLUDED: it needs the engine but no runner, so the
+//   Class A cloud run already picks it up (see vitest.cloud.config.ts) —
+//   running it here would only double the nightly signal.
+// - open-computer-use is EXCLUDED: a local-only developer gate (macOS
+//   accessibility + STIGMER_DESKTOP_TESTS opt-in) that can never run in the
+//   headless CI this config exists for.
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/suites-execution/**/*.test.ts"],
+    exclude: [
+      "src/suites-execution/schedule-firing.conformance.test.ts",
+      "src/suites-execution/open-computer-use.conformance.test.ts",
+    ],
+    globalSetup: ["./src/harness/global-setup-cloud-execution.ts"],
+    env: {
+      CONFORMANCE_TARGET: "cloud-execution",
+    },
+    // A real execution spans Temporal dispatch + runner pickup + status
+    // stream, and cloud RPCs additionally traverse real auth + FGA — keep the
+    // local execution budget, which already has headroom for both.
+    testTimeout: 120_000,
+    // Covers the per-file boot: readiness probe against the shared
+    // environment plus the runner's spawn-and-first-poll (its Temporal
+    // workflow bundling dominates).
+    hookTimeout: 180_000,
+    // One multi-tenant service, one global stigmer_runner task queue: files
+    // run serially so N suites never race N runners over shared dispatch.
+    fileParallelism: false,
+  },
+});

--- a/test/conformance/vitest.cloud.config.ts
+++ b/test/conformance/vitest.cloud.config.ts
@@ -6,10 +6,11 @@
 // targets use) and publishes it to workers via env vars; each suite file's
 // CloudTarget then just connects.
 //
-// mcp.conformance.test.ts is excluded deliberately: it is not target-driven —
-// it boots the OSS Go server directly to test the @stigmer/mcp-server bridge —
-// so under CONFORMANCE_TARGET=cloud it would silently test the wrong backend
-// and report a false green.
+// mcp.conformance.test.ts runs here too: its backend resolver keys off
+// CONFORMANCE_TARGET=cloud and points the @stigmer/mcp-server bridge at this
+// environment as the primary conformance user (stigmer#202's bridge-vs-cloud
+// item — it previously booted the OSS Go server unconditionally and had to be
+// excluded to avoid a false green against the wrong backend).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -18,12 +19,12 @@ export default defineConfig({
     // up: firing needs the engine (which this environment boots) but no
     // runner and no LLM (fires target a deleted agent and fail inside the
     // tick), so it is the first Class B behavior assertable against cloud —
-    // and, once the OSS Go clock lands, against both editions.
+    // the full runner-backed Class B suites live in the cloud-execution run
+    // (vitest.cloud-execution.config.ts).
     include: [
       "src/suites/**/*.conformance.test.ts",
       "src/suites-execution/schedule-firing.conformance.test.ts",
     ],
-    exclude: ["src/suites/mcp.conformance.test.ts"],
     globalSetup: ["./src/harness/global-setup-cloud.ts"],
     env: {
       CONFORMANCE_TARGET: "cloud",


### PR DESCRIPTION
## Summary
Implements the `cloud-execution` conformance target — the Class B (execution) twin of the `cloud` target — so the execution suites, the `@stigmer/mcp-server` bridge, and the new MCP caller-identity suite all run against the hermetic Java stigmer-service. Cross-edition drift in executions, approvals, recovery, and MCP identity is now a failing CI test instead of a manual-probe finding.

## Context
The cloud target has been Class A (CRUD) only; every execution-class behavior was OSS-tested but cloud-unverified (stigmer#202's deferred remainder). The caller-identity header contract additionally had no automated wire-level coverage anywhere (stigmer#382 — #377/#380 both shipped drift only a manual live probe caught).

## Changes
- **`cloud-execution` target** (`src/targets/cloud-execution.ts`): composes `CloudTarget`'s tenancy/identity machinery with the TS engine trio (`spawnRunner`, `MockLlmProxy`, `McpToolFixture`, DD-002-pure). The runner boots as a **production embedded runner** of the primary conformance user — `spawnRunner`'s new `cloudBootstrap` option hands it the user JWT and no Temporal address, so the runner's own `getRunnerBootstrapConfig` lane discovers coordinates and mints its `embedded_runner` token; FGA authorizes it as the executions' owner by construction. Provisioned orgs are billing-seeded ($100, the integration harness's `ProvisionTestBillingAccount` semantics) because cloud authorizes billing **inside** the agent-execution workflow.
- **Runner log persistence**: `spawnRunner` gains `logFile`; the cloud-execution target writes each runner's output under `test/integration/.test-output/logs/`, which the CI lane already uploads on failure — a red nightly now carries the runner's side of the story.
- **MCP bridge vs cloud** (`src/suites/mcp.conformance.test.ts`): a two-edition backend resolver replaces the hardwired OSS boot; the suite joins the cloud Class A lane (exclusion removed from `vitest.cloud.config.ts`). Already caught its first drift: stigmer-cloud#501.
- **Caller-identity suite** (`src/suites-execution/mcp-caller-identity.conformance.test.ts`, closes #382): the fixture records each JSON-RPC request's method + headers on the wire; three cases pin creator-derived identity (edition-agnostic by derivation), channel-sender precedence, and opt-in enforcement. Green on BOTH engines.
- **Capability flag `sharedRunnerArtifactStore`**: gates the two attachment-materialization pins on cloud-execution — a harness limitation (MinIO-backed server vs local runner store), tracked in stigmer#803.
- **CI**: `ci.conformance-cloud.yaml` gains a `conformance-cloud-execution` job sharing the existing JAR build, wired into the nightly notify-failure lane.

## First Class B drift scoreboard (the deliverable)
Full hermetic run: **125 tests — 103 passed, 22 failed, 0 skipped.** Every failure triaged to a root cause and filed:
- stigmer-cloud#502 — approval/cancel RPCs validate existence before input shape (11 pins)
- stigmer-cloud#503 — approval accepted against a non-human_input task
- stigmer-cloud#504 — same-name execution create answers AlreadyExists
- stigmer-cloud#505 — cancel reaches CANCELLED without completed_at
- stigmer-cloud#506 — recover accepted-but-inert + refuses the idempotent no-op
- stigmer-cloud#507 — embedded runner gets REDACTED EC values for workflow executions
- stigmer-cloud#508 — session titling never traverses the runner lane
- stigmer-cloud#509 — DD-012 child-approval forwarding happy path fails hermetically
- `getEventLog` unknown-id PermissionDenied: the recorded stigmer#224 ruling family (no new issue)
- 2 attachment pins: harness limitation, gated (stigmer#803)

Also filed from this session: stigmer#801 (integration-harness JVM teardown leak, observed locally).

## Test plan
- Local: `npm run test:cloud` (Class A, 310/313 — the 1 red is filed drift cloud#501), full `npm run test:cloud-execution` (scoreboard above), local engine smokes + caller-identity suite green (5/5), conformance typecheck at the pre-existing 4-error baseline, actionlint clean.
- CI: this PR's paths trigger `ci.conformance-cloud` (both jobs).

## Risks
- Test-infra only, zero production code. The cloud-execution lane stays red on the filed drift by design (the Class A precedent) — reds are signal, each mapped to an issue above.

Closes #202
Closes #382

Made with [Cursor](https://cursor.com)