### PR TITLE
fix(runner): adopt the bootstrap-minted credential in static boot; identity-only child-approval derivation

### DIFF
--- a/backend/services/runner/src/__tests__/golden-e2e.test.ts
+++ b/backend/services/runner/src/__tests__/golden-e2e.test.ts
@@ -76,7 +76,7 @@ function createMockActivities() {
     }),
     RunScript: async (): Promise<unknown> => ({ computed: 4 }),
     RunShell: async (): Promise<unknown> => "hello from shell",
-    UpdateWorkflowTaskApprovalStatus: async (): Promise<void> => {},
+    UpdateWorkflowTaskApprovalStatus: async (): Promise<boolean> => false,
     ClearWorkflowApprovalStatus: async (): Promise<void> => {},
     UpdateWorkflowFileReviewStatus: async (): Promise<void> => {},
     GetAwaitingFileReviewChangeSetIds: async (): Promise<string[]> => [],

--- a/backend/services/runner/src/activities/__tests__/call-agent-status.test.ts
+++ b/backend/services/runner/src/activities/__tests__/call-agent-status.test.ts
@@ -104,17 +104,42 @@ describe("call-agent-status file-review activities", () => {
   });
 
   describe("approval activities are scoped per-child (unify)", () => {
-    it("updateWorkflowTaskApprovalStatus scopes the write to the notifying child", async () => {
-      await updateWorkflowTaskApprovalStatus("wfx_1", "task_a", {
-        executionId: "aex_child",
-        pendingApprovals: [{ toolCallId: "tc_1", toolName: "deploy" } as any],
-      } as any);
+    it("updateWorkflowTaskApprovalStatus derives the gate from the child record and scopes the write to it", async () => {
+      // Identity-only contract (DD-012, stigmer-cloud#509): the activity
+      // receives just the child id and reads the gate from the child's
+      // persisted status — the signal never carries approval details.
+      mockGetExecutionResult = {
+        status: {
+          pendingApprovals: [{ toolCallId: "tc_1", toolName: "deploy" } as any],
+        },
+      };
 
+      const surfaced = await updateWorkflowTaskApprovalStatus("wfx_1", "task_a", "aex_child");
+
+      expect(surfaced).toBe(true);
       expect(capturedUpdates).toHaveLength(1);
       const { status, options } = capturedUpdates[0];
       expect(options.updatePendingApprovals).toBe(true);
       expect(options.pendingUpdateChildAgentExecutionId).toBe("aex_child");
       expect(status.pendingApprovals[0].childAgentExecutionId).toBe("aex_child");
+      expect(status.pendingApprovals[0].approval.toolCallId).toBe("tc_1");
+    });
+
+    it("updateWorkflowTaskApprovalStatus answers false and writes nothing when the child's gate already resolved", async () => {
+      // The child persists its gate before signaling, so an empty read means
+      // the gate resolved in the interim — surfacing it would show a stale
+      // approval card, and the orchestrator deliberately does not retry.
+      mockGetExecutionResult = { status: { pendingApprovals: [] } };
+
+      const surfaced = await updateWorkflowTaskApprovalStatus("wfx_1", "task_a", "aex_child");
+
+      expect(surfaced).toBe(false);
+      expect(capturedUpdates).toHaveLength(0);
+    });
+
+    it("updateWorkflowTaskApprovalStatus is a no-op without a child id", async () => {
+      expect(await updateWorkflowTaskApprovalStatus("wfx_1", "task_a", "")).toBe(false);
+      expect(capturedUpdates).toHaveLength(0);
     });
 
     it("clearWorkflowApprovalStatus scopes the clear to the given child", async () => {

--- a/backend/services/runner/src/activities/call-agent-status.ts
+++ b/backend/services/runner/src/activities/call-agent-status.ts
@@ -16,7 +16,6 @@ import { StigmerClient } from "../client/stigmer-client.js";
 import { loadConfig } from "../config.js";
 import { create } from "@bufbuild/protobuf";
 import { WorkflowExecutionStatusSchema, WorkflowPendingApprovalSchema, WorkflowPendingFileReviewSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
-import type { ChildApprovalNotification } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
 import { ToolCallStatus, FileChangeSetStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 
 function buildClient(): StigmerClient {
@@ -27,22 +26,39 @@ function buildClient(): StigmerClient {
   });
 }
 
+/**
+ * Derives the child's approval gate onto the parent (DD-012: identity-only
+ * signal, derive-from-child). The signal carries only the child execution id;
+ * this activity reads the child's persisted `status.pending_approvals` — the
+ * single source of truth the child's server wrote BEFORE signaling — and
+ * mirrors it onto the parent as reference entries.
+ *
+ * Returns true when a gate was surfaced, false when the child currently has
+ * no pending approvals. The child persists its gate before the signal is
+ * sent (both editions), so an empty read means the gate already resolved
+ * (e.g. approved on the agent surface in the interim) — the caller must NOT
+ * retry: surfacing a resolved gate would show users a stale approval card.
+ */
 export async function updateWorkflowTaskApprovalStatus(
   executionId: string,
   _taskName: string,
-  notification: ChildApprovalNotification,
-): Promise<void> {
-  if (!executionId) return;
+  childExecutionId: string,
+): Promise<boolean> {
+  if (!executionId || !childExecutionId) return false;
 
-  const childExecId = notification.executionId;
   const client = buildClient();
-  const pendingApprovals = (notification.pendingApprovals ?? []).map(
+  const child = await client.getExecution(childExecutionId);
+  const pendingApprovals = (child?.status?.pendingApprovals ?? []).map(
     (approval) =>
       create(WorkflowPendingApprovalSchema, {
         approval,
-        childAgentExecutionId: childExecId,
+        childAgentExecutionId: childExecutionId,
       }),
   );
+
+  if (pendingApprovals.length === 0) {
+    return false;
+  }
 
   const status = create(WorkflowExecutionStatusSchema, {
     pendingApprovals,
@@ -52,8 +68,9 @@ export async function updateWorkflowTaskApprovalStatus(
   // approvals and preserves every parallel sibling's entries.
   await client.updateWorkflowExecutionStatus(executionId, status, {
     updatePendingApprovals: true,
-    pendingUpdateChildAgentExecutionId: childExecId,
+    pendingUpdateChildAgentExecutionId: childExecutionId,
   });
+  return true;
 }
 
 export async function clearWorkflowApprovalStatus(

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -18,7 +18,8 @@ import { homedir, tmpdir } from "node:os";
 import type { Config } from "./config.js";
 import { DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS, DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS, DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS } from "./config.js";
 import type { WorkerActivities } from "./worker.js";
-import { resolveRunnerBootstrap } from "./bootstrap.js";
+import { resolveRunnerBootstrap, refreshRunnerAccessToken } from "./bootstrap.js";
+import { createRunnerTokenCoordinator } from "./runner-token-coordinator.js";
 import { assertLlmBackendsPreflight } from "./preflight.js";
 import {
   captureRunnerSecrets,
@@ -253,11 +254,6 @@ export async function createStigmerRunner(
   // Only the worker connection consumes these coordinates — no activity dials
   // Temporal directly (emit-event, the last one, now routes signals through
   // the server's SendSignal lane; see oss#517).
-  //
-  // The static runner brings its own already-proxy-valid token (harness/CLI),
-  // so it does not consume the minted runner token from the bootstrap response;
-  // that proxy-credential lifecycle lives in createStigmerRunnerManager (the
-  // long-lived desktop host that needs it). Only the coordinates are used here.
   const coordinates = await resolveRunnerBootstrap({
     explicitAddress: options.temporalAddress,
     explicitNamespace: options.temporalNamespace,
@@ -269,11 +265,44 @@ export async function createStigmerRunner(
   // activity clients read the ref per request instead of pinning the boot
   // token for the pod's whole life.
   const tokenRef = { current: baseConfig.stigmerToken };
+
+  // Adopt the bootstrap-minted embedded_runner credential for gRPC runner-class
+  // calls (stigmer-cloud#507). The static path historically discarded it ("the
+  // static token is already proxy-valid") — true for the PROXY lane, but the
+  // ExecutionContext decrypt lane is gated on runner-class token_type
+  // (stigmer-cloud#152/#155): a user-token static runner (conformance harness,
+  // CLI daemon with a cloud token) had its scoped-token exchange refused and
+  // silently read REDACTED secret values. The coordinator owns the mint's TTL
+  // (same module the desktop manager uses — one refresh implementation, not
+  // two); its only sink here is the gRPC runner-credential ref, because the
+  // static host's proxy token is provided by the host and stays untouched.
+  // Servers that mint nothing (explicit-address boots, tokenless OSS, cloud
+  // sandboxes with baked credentials) leave the ref null — byte-identical
+  // behavior to before.
+  const runnerTokenRef: { current: string | null } = { current: null };
+  const runnerTokenCoordinator = createRunnerTokenCoordinator({
+    applyProxyToken: (token) => {
+      runnerTokenRef.current = token;
+    },
+    reMint: () =>
+      refreshRunnerAccessToken({
+        token: tokenRef.current,
+        stigmerEndpoint: baseConfig.stigmerBackendEndpoint,
+      }),
+  });
+  if (coordinates.runnerAccessToken) {
+    runnerTokenCoordinator.adoptMintedToken(
+      coordinates.runnerAccessToken,
+      coordinates.runnerAccessTokenExpiresInSeconds,
+    );
+  }
+
   const config: Config = {
     ...baseConfig,
     temporalAddress: coordinates.temporalAddress,
     temporalNamespace: coordinates.temporalNamespace,
     stigmerTokenRef: tokenRef,
+    stigmerRunnerTokenRef: runnerTokenRef,
   };
   markBoot("bootstrap_resolved");
 
@@ -359,6 +388,7 @@ export async function createStigmerRunner(
     },
     shutdown() {
       tokenRenewal?.stop();
+      runnerTokenCoordinator.stop();
       // Classification first, drain second: an in-flight activity cancelled
       // by the drain must observe the signal already aborted (see
       // shared/worker-shutdown.ts for the ownership contract).

--- a/backend/services/runner/src/workflows/call-agent-orchestrator.ts
+++ b/backend/services/runner/src/workflows/call-agent-orchestrator.ts
@@ -32,13 +32,23 @@ import type { createCallAgentStatusActivities, AgentProgressSummary } from "../a
 import type { createWorkflowEventActivities } from "../activities/workflow-event-activities.js";
 import type { AgentCallConfig, AgentCallResult, WorkflowEventDescriptor } from "../workflow-engine/types.js";
 import { AgentCallError } from "../workflow-engine/types.js";
-import type { ChildApprovalNotification } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
 
 // ─────────────────────────────────────────────────────────────────────
 // Signal Definitions
 // ─────────────────────────────────────────────────────────────────────
 
-export const childApprovalRequired = defineSignal<[ChildApprovalNotification]>(
+/**
+ * Identity-only "go look" trigger (DD-012, stigmer-cloud#509): the child's
+ * server signals just the gated child's execution id, and this workflow
+ * derives the gate from the child's persisted record. The payload MUST stay a
+ * bare string: it crosses the polyglot boundary from the Java server, whose
+ * client serializes proto messages as `json/protobuf` — an encoding this
+ * worker's default converter cannot decode, which poisoned the workflow task
+ * in a permanent retry loop (the original cloud#509 failure). The object
+ * shape is tolerated for a future Go sender's natural `{executionId}` JSON,
+ * mirroring child_execution_started's both-shapes handling below.
+ */
+export const childApprovalRequired = defineSignal<[string | { executionId?: string }]>(
   "child_approval_required",
 );
 
@@ -120,15 +130,27 @@ export async function orchestrateAgentCall(
   let activityDone = false;
   let activityResult: AgentCallResult = {};
   let activityError: unknown = undefined;
-  let pendingNotification: ChildApprovalNotification | undefined;
+  // Child ids whose approval gates await derivation. A set (not a flag)
+  // because one workflow has ONE live handler per signal name: with parallel
+  // agent_call tasks, whichever orchestration registered last receives every
+  // child's signal, and each gate must be derived under its OWN child id for
+  // the per-child status merge to file it correctly.
+  const pendingApprovalChildIds = new Set<string>();
   let childExecId: string | undefined;
   let initialProgressEmitted = false;
 
-  setHandler(childApprovalRequired, (notification: ChildApprovalNotification) => {
-    pendingNotification = notification;
-    if (!childExecId && notification.executionId) {
-      childExecId = notification.executionId;
+  setHandler(childApprovalRequired, (payload: string | { executionId?: string }) => {
+    // Identity-only signal (see the definition above): note the child and
+    // mark its gate for derivation in the main loop — approval details never
+    // travel through the signal itself.
+    const signaledId = typeof payload === "string" ? payload : payload?.executionId;
+    if (!signaledId) {
+      return;
     }
+    if (!childExecId) {
+      childExecId = signaledId;
+    }
+    pendingApprovalChildIds.add(signaledId);
   });
 
   setHandler(childExecutionStarted, (payload: { executionId: string } | string) => {
@@ -221,7 +243,7 @@ export async function orchestrateAgentCall(
     // Wait for a signal, activity completion, or periodic timeout for progress polling.
     // condition() returns false on timeout, true when the predicate became true.
     const conditionMet = await condition(
-      () => activityDone || pendingNotification !== undefined || (!!childExecId && !initialProgressEmitted),
+      () => activityDone || pendingApprovalChildIds.size > 0 || (!!childExecId && !initialProgressEmitted),
       PROGRESS_POLL_INTERVAL,
     );
 
@@ -251,22 +273,36 @@ export async function orchestrateAgentCall(
       await syncFileReviews(childExecId);
     }
 
-    // Handle HITL approval notification
-    if (pendingNotification) {
-      const notification = pendingNotification;
-      pendingNotification = undefined;
+    // Handle HITL approval notifications: derive each signaled child's gate
+    // from its persisted record (identity-only signal, DD-012). The child's
+    // server persists the gate BEFORE signaling, so an empty derivation means
+    // the gate already resolved — the activity answers false and there is
+    // deliberately no retry (see updateWorkflowTaskApprovalStatus).
+    if (pendingApprovalChildIds.size > 0) {
+      // Drain a deterministic snapshot: insertion order is replay-stable, and
+      // ids signaled during the awaits below land in the set for the next pass.
+      const toDerive = [...pendingApprovalChildIds];
+      pendingApprovalChildIds.clear();
 
-      try {
-        await statusProxy.UpdateWorkflowTaskApprovalStatus(
-          input.workflowExecutionId,
-          input.taskName,
-          notification,
-        );
-      } catch (statusErr) {
-        log.warn("Failed to update workflow approval status (non-fatal)", {
-          error: String(statusErr),
-          taskName: input.taskName,
-        });
+      for (const signaledChildId of toDerive) {
+        try {
+          const surfaced = await statusProxy.UpdateWorkflowTaskApprovalStatus(
+            input.workflowExecutionId,
+            input.taskName,
+            signaledChildId,
+          );
+          if (!surfaced) {
+            log.info("Child approval gate already resolved before derivation; nothing surfaced", {
+              taskName: input.taskName,
+              childExecId: signaledChildId,
+            });
+          }
+        } catch (statusErr) {
+          log.warn("Failed to update workflow approval status (non-fatal)", {
+            error: String(statusErr),
+            taskName: input.taskName,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

The OSS halves of the sixty-second drift bundle: the static runner boot path adopts the embedded_runner credential the bootstrap already mints — fixing silently-redacted secret values for every user-token static embedder (Closes stigmer/stigmer-cloud#507) — and the call-agent orchestrator receives the child-approval signal as an identity-only child-execution id, deriving the gate from the child's persisted record per DD-012 (the TS receiver of stigmer-cloud#509's fix; the Java sender ships in stigmer-cloud PR #515).

## Context

The first cloud-execution conformance run filed cloud#507 as "the getRunnerScopedToken workflow arm appears unserved". Diagnosis disproved every layer of that premise — the Java arm, mint claims, claim mapping, and decrypt gate are all correct. The real break: `createStigmerRunner` (static boot) deliberately discarded the minted runner credential ("the static token is already proxy-valid… only the coordinates are used here") — a decision written for the LLM-proxy lane before the ExecutionContext decrypt gate (stigmer-cloud#152/#155) existed. Cloud refuses the exchange for user-class callers by design; the runner treated the refusal as the OSS best-effort lane and silently fell back to the tokenless, redacted read. One run's service log showed 13 refusals: `getRunnerScopedToken requires a runner credential (token_type=embedded_runner)`.

Separately, the `child_approval_required` signal's Java proto payload serialized as `json/protobuf`, which this worker's default converter cannot decode — the parent workflow task failed in a permanent retry loop (`ValueError: Unknown encoding: json/protobuf` at `Activator.signalWorkflow`), so a gated child never surfaced at the parent.

## Changes

- `runner.ts` (static boot): adopts `coordinates.runnerAccessToken` into a `stigmerRunnerTokenRef`, with TTL refresh owned by the existing `RunnerTokenCoordinator` (the same module the desktop manager path uses — one refresh implementation, not two; its only sink here is the gRPC runner-credential ref, since the static host's proxy token is host-provided). Servers that mint nothing (explicit-address boots, tokenless OSS, cloud sandboxes with baked credentials) leave the ref null — byte-identical legacy behavior. Coordinator stopped on shutdown.
- `call-agent-orchestrator.ts`: `childApprovalRequired` is `string | {executionId}` (both-shapes, mirroring the sibling signal); signaled child ids tracked as a SET because one live handler serves every parallel `agent_call`'s signals, and each gate must derive under its own child id for the per-child status merge.
- `call-agent-status.ts`: `updateWorkflowTaskApprovalStatus(executionId, taskName, childExecutionId)` derives the gate from the child's persisted `status.pending_approvals` and answers whether anything was surfaced; an empty derivation means the gate already resolved (the child persists before signaling in both editions) and is deliberately not retried.

## Breaking changes

- None. `updateWorkflowTaskApprovalStatus` is an internal activity; its activity type and ordering are unchanged (replay-safe — local-activity markers don't compare arguments, and old void returns read as falsy in the new code with a log-only effect).

## Test plan

- Runner unit suite: 4706 passed / 22 skipped; typecheck clean.
- Cloud-execution conformance against the companion cloud branch: the envmerge "merged secret reaches the RUNNER decrypted" pin and the child-approval forwarding round-trip pin green for the first time ever; agent-harness smoke green with its titling assertions unmodified; full-lane run shows zero regressions (remaining reds are exactly cloud PR #514's claimed family + the recorded getEventLog pin).

## Risks

- A long-lived static runner whose control-plane token expires cannot re-mint (unchanged from today); the coordinator retries best-effort, and secret-delivery reads fail loudly rather than silently reading junk — the documented exchange contract.

Closes stigmer/stigmer-cloud#507
Companion cloud PR: stigmer/stigmer-cloud#515 (cloud#508 + cloud#509's Java halves).

Made with [Cursor](https://cursor.com)