### PR TITLE
feat(test/conformance): presign-capable artifact lane for the cloud-execution target

### DIFF
--- a/backend/services/runner/src/activities/__tests__/classify-tool-approvals.test.ts
+++ b/backend/services/runner/src/activities/__tests__/classify-tool-approvals.test.ts
@@ -737,6 +737,7 @@ function makeConfig() {
     runnerId: null,
     checkpointerType: "memory" as const,
     checkpointerProxyEndpoint: null,
+    artifactProxyEndpoint: null,
     primaryModel: "gpt-4.1",
     cursorStreamStallTimeoutMs: 180000,
     agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/activities/__tests__/discover-mcp-server.test.ts
+++ b/backend/services/runner/src/activities/__tests__/discover-mcp-server.test.ts
@@ -913,6 +913,7 @@ function makeConfig() {
     runnerId: null,
     checkpointerType: "memory" as const,
     checkpointerProxyEndpoint: null,
+    artifactProxyEndpoint: null,
     primaryModel: "gpt-4.1",
     cursorStreamStallTimeoutMs: 180000,
     agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-reject.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-reject.test.ts
@@ -251,6 +251,7 @@ const httpConfig: Config = {
   cloudModeEnabled: true,
   checkpointerType: "http",
   checkpointerProxyEndpoint: "http://localhost:7234",
+  artifactProxyEndpoint: null,
   primaryModel: "claude-sonnet",
   cursorStreamStallTimeoutMs: 180000,
   agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-approve-all.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-approve-all.test.ts
@@ -296,6 +296,7 @@ const baseConfig: Config = {
   cloudModeEnabled: true,
   checkpointerType: "http",
   checkpointerProxyEndpoint: "http://localhost:7234",
+  artifactProxyEndpoint: null,
   primaryModel: "claude-sonnet",
   cursorStreamStallTimeoutMs: 180000,
   agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-history.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/hitl-resume-history.test.ts
@@ -250,6 +250,7 @@ const baseConfig: Config = {
   cloudModeEnabled: true,
   checkpointerType: "http",
   checkpointerProxyEndpoint: "http://localhost:7234",
+  artifactProxyEndpoint: null,
   primaryModel: "claude-sonnet",
   cursorStreamStallTimeoutMs: 180000,
   agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/index.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/index.test.ts
@@ -47,6 +47,7 @@ describe("ExecuteDeepAgent activity", () => {
     cloudModeEnabled: false,
     checkpointerType: "memory",
     checkpointerProxyEndpoint: null,
+    artifactProxyEndpoint: null,
     primaryModel: "gpt-4.1",
     cursorStreamStallTimeoutMs: 180000,
     agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/sequential-gate-resume.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/sequential-gate-resume.test.ts
@@ -256,6 +256,7 @@ const memoryConfig: Config = {
   cloudModeEnabled: false,
   checkpointerType: "memory",
   checkpointerProxyEndpoint: null,
+  artifactProxyEndpoint: null,
   primaryModel: "claude-sonnet",
   cursorStreamStallTimeoutMs: 180000,
   agentResolveTimeoutMs: 120000,

--- a/backend/services/runner/src/config.ts
+++ b/backend/services/runner/src/config.ts
@@ -96,6 +96,16 @@ export interface Config {
   readonly cloudModeEnabled: boolean;
   readonly checkpointerType: "memory" | "http" | "sqlite";
   readonly checkpointerProxyEndpoint: string | null;
+  /**
+   * Endpoint the proxy artifact store presigns against
+   * (STIGMER_ARTIFACT_PROXY_ENDPOINT), defaulting to {@link proxyEndpoint} —
+   * the checkpointer-override pattern (stigmer#803). Splitting the two lets
+   * artifact traffic target the real control plane while LLM traffic goes
+   * elsewhere (the conformance harness points LLM calls at a mock proxy that
+   * serves no presign routes; embedders can route artifact storage
+   * independently the same way).
+   */
+  readonly artifactProxyEndpoint: string | null;
   readonly primaryModel: string;
   /**
    * No-progress bound for the Cursor harness stream (milliseconds). If no
@@ -197,6 +207,8 @@ export function loadConfig(): Config {
     ?? (mode === "cloud" ? "http" : "sqlite");
   const checkpointerProxyEndpoint = process.env.STIGMER_CHECKPOINTER_PROXY_ENDPOINT
     ?? proxyEndpoint;
+  const artifactProxyEndpoint = process.env.STIGMER_ARTIFACT_PROXY_ENDPOINT
+    ?? proxyEndpoint;
 
   const primaryModel = process.env.STIGMER_PRIMARY_MODEL ?? "gpt-4.1";
 
@@ -228,6 +240,7 @@ export function loadConfig(): Config {
     cloudModeEnabled: process.env.STIGMER_CURSOR_CLOUD_MODE_ENABLED === "true",
     checkpointerType,
     checkpointerProxyEndpoint,
+    artifactProxyEndpoint,
     primaryModel,
     cursorStreamStallTimeoutMs,
     agentResolveTimeoutMs,

--- a/backend/services/runner/src/main.ts
+++ b/backend/services/runner/src/main.ts
@@ -89,6 +89,7 @@ async function runManagerMode(config: import("./config.js").Config): Promise<voi
       primaryModel: config.primaryModel,
       checkpointerType: config.checkpointerType,
       checkpointerProxyEndpoint: config.checkpointerProxyEndpoint ?? undefined,
+      artifactProxyEndpoint: config.artifactProxyEndpoint ?? undefined,
       cloudModeEnabled: config.cloudModeEnabled,
       executionMode: config.mode,
     });
@@ -213,6 +214,7 @@ async function runPoolMode(
     primaryModel: config.primaryModel,
     checkpointerType: config.checkpointerType,
     checkpointerProxyEndpoint: config.checkpointerProxyEndpoint ?? undefined,
+    artifactProxyEndpoint: config.artifactProxyEndpoint ?? undefined,
     cloudModeEnabled: config.cloudModeEnabled,
     executionMode: config.mode,
   });
@@ -338,6 +340,7 @@ async function runStaticMode(config: import("./config.js").Config): Promise<void
     primaryModel: config.primaryModel,
     checkpointerType: config.checkpointerType,
     checkpointerProxyEndpoint: config.checkpointerProxyEndpoint ?? undefined,
+    artifactProxyEndpoint: config.artifactProxyEndpoint ?? undefined,
     cloudModeEnabled: config.cloudModeEnabled,
     // Honor the operator's MODE env (resolved into config.mode) instead of
     // re-deriving execution location from the proxy. This keeps static mode

--- a/backend/services/runner/src/runner-manager.ts
+++ b/backend/services/runner/src/runner-manager.ts
@@ -114,6 +114,9 @@ export interface RunnerManagerOptions {
   /** Checkpointer proxy endpoint. Falls back to proxyEndpoint. */
   readonly checkpointerProxyEndpoint?: string;
 
+  /** Artifact presign endpoint (stigmer#803). Falls back to proxyEndpoint. */
+  readonly artifactProxyEndpoint?: string;
+
   /** Enable Cursor cloud mode. @default false */
   readonly cloudModeEnabled?: boolean;
 
@@ -721,6 +724,8 @@ export function mapManagerOptionsToConfig(
       options.checkpointerType ?? (proxyActive ? "http" : "sqlite"),
     checkpointerProxyEndpoint:
       options.checkpointerProxyEndpoint ?? options.proxyEndpoint ?? null,
+    artifactProxyEndpoint:
+      options.artifactProxyEndpoint ?? options.proxyEndpoint ?? null,
     primaryModel: options.primaryModel ?? "gpt-4.1",
     cursorStreamStallTimeoutMs:
       options.cursorStreamStallTimeoutMs ?? DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS,

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -87,6 +87,9 @@ export interface StigmerRunnerOptions {
   /** Checkpointer proxy endpoint. Falls back to proxyEndpoint. */
   readonly checkpointerProxyEndpoint?: string;
 
+  /** Artifact presign endpoint (stigmer#803). Falls back to proxyEndpoint. */
+  readonly artifactProxyEndpoint?: string;
+
   /** Enable Cursor cloud mode for workspace-less execution. @default false */
   readonly cloudModeEnabled?: boolean;
 
@@ -446,6 +449,9 @@ export function mapOptionsToConfig(options: StigmerRunnerOptions): Config {
     checkpointerType: options.checkpointerType
       ?? (proxyActive ? "http" : "sqlite"),
     checkpointerProxyEndpoint: options.checkpointerProxyEndpoint
+      ?? options.proxyEndpoint
+      ?? null,
+    artifactProxyEndpoint: options.artifactProxyEndpoint
       ?? options.proxyEndpoint
       ?? null,
     primaryModel: options.primaryModel ?? "gpt-4.1",

--- a/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
+++ b/backend/services/runner/src/shared/__tests__/artifact-storage.test.ts
@@ -654,6 +654,7 @@ describe("loadArtifactStorageConfig", () => {
     runnerId: null,
     checkpointerType: "memory" as const,
     checkpointerProxyEndpoint: null,
+    artifactProxyEndpoint: null,
     primaryModel: "gpt-4.1",
     cursorStreamStallTimeoutMs: 180000,
     agentResolveTimeoutMs: 120000,
@@ -672,10 +673,14 @@ describe("loadArtifactStorageConfig", () => {
   });
 
   it("defaults to proxy in cloud mode", () => {
+    // loadConfig derives artifactProxyEndpoint from proxyEndpoint when the
+    // STIGMER_ARTIFACT_PROXY_ENDPOINT override is unset; Config literals here
+    // mirror that invariant.
     const cfg = loadArtifactStorageConfig({
       ...baseConfig,
       mode: "cloud",
       proxyEndpoint: "https://proxy.example.com",
+      artifactProxyEndpoint: "https://proxy.example.com",
       stigmerToken: "tok",
     });
     expect(cfg.type).toBe("proxy");
@@ -689,11 +694,27 @@ describe("loadArtifactStorageConfig", () => {
       ...baseConfig,
       mode: "local",
       proxyEndpoint: "https://localhost:9090",
+      artifactProxyEndpoint: "https://localhost:9090",
       stigmerToken: "tok",
     });
     expect(cfg.type).toBe("proxy");
     expect(cfg.proxyEndpoint).toBe("https://localhost:9090");
     expect(cfg.proxyAuthToken).toBe("tok");
+  });
+
+  it("presigns against the artifact override when split from the LLM proxy endpoint (stigmer#803)", () => {
+    // The conformance harness points LLM traffic at a mock proxy that serves
+    // no presign routes; the artifact override routes storage at the real
+    // control plane independently (the checkpointer-override pattern).
+    process.env.ARTIFACT_STORAGE_TYPE = "proxy";
+    const cfg = loadArtifactStorageConfig({
+      ...baseConfig,
+      proxyEndpoint: "https://mock-llm.example.com",
+      artifactProxyEndpoint: "https://service.example.com",
+      stigmerToken: "tok",
+    });
+    expect(cfg.type).toBe("proxy");
+    expect(cfg.proxyEndpoint).toBe("https://service.example.com");
   });
 
   it("honors ARTIFACT_STORAGE_TYPE=none even when a proxy endpoint is configured", () => {

--- a/backend/services/runner/src/shared/artifact-storage.ts
+++ b/backend/services/runner/src/shared/artifact-storage.ts
@@ -376,19 +376,22 @@ export function loadArtifactStorageConfig(config: Config): ArtifactStorageConfig
   // configured, push artifacts through it (the proxy brokers R2). This holds for
   // both cloud runners and the local desktop runner — the latter executes
   // locally (mode === "local") yet still uploads via the proxy. An explicit
-  // ARTIFACT_STORAGE_TYPE always wins.
+  // ARTIFACT_STORAGE_TYPE always wins. Presigns target artifactProxyEndpoint —
+  // STIGMER_ARTIFACT_PROXY_ENDPOINT when split from the LLM proxy endpoint
+  // (stigmer#803, the checkpointer-override pattern), the plain proxy
+  // endpoint otherwise.
   const envType = process.env.ARTIFACT_STORAGE_TYPE;
   const type: ArtifactStorageType =
     envType === "proxy" ? "proxy" :
     envType === "local" ? "local" :
     envType === "none" ? "none" :
-    config.proxyEndpoint ? "proxy" : "local";
+    config.artifactProxyEndpoint ? "proxy" : "local";
 
   return {
     type,
     localPath: process.env.LOCAL_ARTIFACT_PATH ?? defaultLocalArtifactPath(),
     localServeUrl: process.env.LOCAL_ARTIFACT_SERVE_URL ?? "http://localhost:7235",
-    proxyEndpoint: type === "proxy" ? (config.proxyEndpoint ?? null) : null,
+    proxyEndpoint: type === "proxy" ? (config.artifactProxyEndpoint ?? null) : null,
     // Prefer the live ref: renewal rotates the token in place and uploads
     // must present the current credential, not the boot one.
     proxyAuthToken: type === "proxy"
@@ -408,7 +411,9 @@ export function createArtifactStorage(cfg: ArtifactStorageConfig): ArtifactStora
   }
   if (cfg.type === "proxy") {
     if (!cfg.proxyEndpoint) {
-      throw new Error("Proxy artifact storage requires STIGMER_PROXY_ENDPOINT");
+      throw new Error(
+        "Proxy artifact storage requires STIGMER_ARTIFACT_PROXY_ENDPOINT or STIGMER_PROXY_ENDPOINT",
+      );
     }
     const tokenAtBoot = typeof cfg.proxyAuthToken === "string"
       ? cfg.proxyAuthToken

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -30,6 +30,11 @@ import { uniqueName } from "../support/naming";
 export const CLOUD_ENV = {
   // gRPC base URL of the stigmer-service under test, e.g. http://127.0.0.1:52341.
   address: "STIGMER_CONFORMANCE_CLOUD_ADDRESS",
+  // HTTP (Spring) base URL of the same service — the routes the gRPC port
+  // does not serve, notably the artifact presign endpoints
+  // (/v1/proxy/artifacts/...) the cloud-execution runner's proxy artifact
+  // store targets (stigmer#803).
+  httpAddress: "STIGMER_CONFORMANCE_CLOUD_HTTP_ADDRESS",
   // Stigmer-signed JWT for the primary conformance user; every suite RPC
   // carries it as a Bearer token.
   token: "STIGMER_CONFORMANCE_CLOUD_TOKEN",
@@ -69,6 +74,7 @@ const SHUTDOWN_GRACE_MS = 60_000;
 
 export interface CloudEnvironment {
   readonly grpcBaseUrl: string;
+  readonly httpBaseUrl: string;
   stop(): Promise<void>;
 }
 
@@ -100,9 +106,10 @@ export async function spawnCloudEnvironment(): Promise<CloudEnvironment> {
     stdio: ["ignore", "pipe", "inherit"],
   });
 
-  const grpcAddress = await waitForReadyLine(child);
+  const readyLine = await waitForReadyLine(child);
   return {
-    grpcBaseUrl: `http://${grpcAddress}`,
+    grpcBaseUrl: `http://${readyLine.grpcAddress}`,
+    httpBaseUrl: readyLine.httpAddress,
     stop: () => stopLauncher(child),
   };
 }
@@ -161,19 +168,26 @@ export async function mintCloudUserToken(
   return response.accessToken;
 }
 
-async function waitForReadyLine(child: ChildProcess): Promise<string> {
+interface ReadyLine {
+  readonly grpcAddress: string;
+  readonly httpAddress: string;
+}
+
+async function waitForReadyLine(child: ChildProcess): Promise<ReadyLine> {
   if (child.stdout === null) {
     throw new Error("launcher spawned without a stdout pipe");
   }
   const lines = createInterface({ input: child.stdout });
 
-  const ready = new Promise<string>((resolveReady, rejectReady) => {
+  const ready = new Promise<ReadyLine>((resolveReady, rejectReady) => {
     lines.on("line", (line) => {
       try {
-        const parsed: unknown = JSON.parse(line);
-        const address = (parsed as { grpcAddress?: unknown }).grpcAddress;
-        if (typeof address === "string" && address !== "") {
-          resolveReady(address);
+        const parsed = JSON.parse(line) as { grpcAddress?: unknown; httpAddress?: unknown };
+        if (
+          typeof parsed.grpcAddress === "string" && parsed.grpcAddress !== "" &&
+          typeof parsed.httpAddress === "string" && parsed.httpAddress !== ""
+        ) {
+          resolveReady({ grpcAddress: parsed.grpcAddress, httpAddress: parsed.httpAddress });
         }
       } catch {
         // Not the ready-line; the launcher keeps stdout otherwise silent.

--- a/test/conformance/src/harness/global-setup-cloud.ts
+++ b/test/conformance/src/harness/global-setup-cloud.ts
@@ -31,6 +31,7 @@ export default async function setup(): Promise<() => Promise<void>> {
   try {
     const identity = await bootstrapPrimaryIdentity(environment.grpcBaseUrl);
     process.env[CLOUD_ENV.address] = environment.grpcBaseUrl;
+    process.env[CLOUD_ENV.httpAddress] = environment.httpBaseUrl;
     process.env[CLOUD_ENV.token] = identity.token;
     process.env[CLOUD_ENV.platformClientId] = identity.platformClient.clientId;
     process.env[CLOUD_ENV.platformClientSecret] = identity.platformClient.clientSecret;

--- a/test/conformance/src/harness/runner-process.ts
+++ b/test/conformance/src/harness/runner-process.ts
@@ -16,10 +16,14 @@
 //
 // An AgentExecution, by contrast, runs an LLM loop. When `proxy` is supplied the
 // runner is pointed at the mock LLM proxy (a base-URL override via
-// STIGMER_PROXY_ENDPOINT) and switched to fully local artifacts/checkpointer, so
-// the run stays hermetic. Configuring a proxy flips two runner defaults — artifact
-// storage would default to `proxy` (presign calls -> setup-time throw) and, in
-// cloud mode, the checkpointer to `http` — so we pin both to local/memory.
+// STIGMER_PROXY_ENDPOINT). Configuring a proxy flips two runner defaults —
+// artifact storage would default to `proxy` against the mock (which serves no
+// presign routes -> setup-time throw) and, in cloud mode, the checkpointer to
+// `http` — so the checkpointer is pinned to memory and artifacts default to a
+// local store, UNLESS `artifactProxy` routes them at a real presign-capable
+// endpoint via STIGMER_ARTIFACT_PROXY_ENDPOINT (stigmer#803): the
+// cloud-execution target points artifacts at the hermetic Java service's HTTP
+// port (MinIO-backed) while LLM traffic stays on the mock.
 import { spawn } from "node:child_process";
 import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -74,6 +78,12 @@ export interface RunnerOptions {
   // fine for runs that never resolve a cross-process artifact.
   artifactDir?: string;
   artifactServeUrl?: string;
+  // Presign-capable artifact lane (stigmer#803): base URL of a REAL service
+  // serving /v1/proxy/artifacts/... (the hermetic Java service's HTTP port).
+  // Routes the runner's artifact storage there via
+  // STIGMER_ARTIFACT_PROXY_ENDPOINT while LLM traffic stays on `proxy`.
+  // Mutually exclusive with artifactDir (shared-local vs proxy store).
+  artifactProxy?: { endpoint: string };
   // When set, the runner's combined stdout/stderr is also streamed to this
   // file (directory created as needed). The cloud-execution target points it
   // under test/integration/.test-output/logs/ so a red CI run's uploaded
@@ -135,8 +145,10 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
       // Hermetic LLM wiring, only when an agent execution needs it. Absent for the
       // data-only WorkflowExecution path, which stays fully offline. When present:
       // - STIGMER_PROXY_ENDPOINT/STIGMER_TOKEN route LLM calls to the mock proxy;
-      // - ARTIFACT_STORAGE_TYPE=local keeps artifacts on disk (a configured proxy
-      //   would otherwise default artifacts to presign calls and throw at setup);
+      // - artifacts go to a local on-disk store (a configured proxy would
+      //   otherwise default artifacts to presign calls against the mock and
+      //   throw at setup) — UNLESS artifactProxy routes them at a real
+      //   presign-capable endpoint (stigmer#803);
       // - STIGMER_CHECKPOINTER_TYPE=memory pins the in-memory checkpointer.
       ...(opts.proxy !== undefined
         ? {
@@ -150,13 +162,21 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
             // queued agent turns (#715). Keep every LLM caller on the one
             // provider the mock implements.
             STIGMER_PRIMARY_MODEL: "claude-sonnet-4-6",
-            ARTIFACT_STORAGE_TYPE: "local",
-            LOCAL_ARTIFACT_PATH: artifactDir,
-            // Point blob downloads at the server's artifact file server when we
-            // know it; the runner's own reads go straight to disk regardless.
-            ...(opts.artifactServeUrl !== undefined
-              ? { LOCAL_ARTIFACT_SERVE_URL: opts.artifactServeUrl }
-              : {}),
+            ...(opts.artifactProxy !== undefined
+              ? {
+                  ARTIFACT_STORAGE_TYPE: "proxy",
+                  STIGMER_ARTIFACT_PROXY_ENDPOINT: opts.artifactProxy.endpoint,
+                }
+              : {
+                  ARTIFACT_STORAGE_TYPE: "local",
+                  LOCAL_ARTIFACT_PATH: artifactDir,
+                  // Point blob downloads at the server's artifact file server
+                  // when we know it; the runner's own reads go straight to
+                  // disk regardless.
+                  ...(opts.artifactServeUrl !== undefined
+                    ? { LOCAL_ARTIFACT_SERVE_URL: opts.artifactServeUrl }
+                    : {}),
+                }),
             STIGMER_CHECKPOINTER_TYPE: "memory",
           }
         : {}),

--- a/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
@@ -74,10 +74,6 @@ let mock: MockLlmProxy;
 const fixtures = new FixtureTracker();
 
 // Collection-time capability read (the schedule-firing/forwarder pattern):
-// gates the two attachment-materialization cases that require the runner and
-// server to share one artifact store — see the flag's contract in target.ts.
-const sharedArtifactStore = createTarget().capabilities.sharedRunnerArtifactStore;
-
 // Long enough to keep a held execution IN_PROGRESS across the poll-and-act window
 // (tests act within ~1s), well under the runner activity's 2-minute heartbeat and
 // 24-hour start-to-close. A held turn aborts the instant the client disconnects
@@ -648,15 +644,16 @@ describe("AgentExecution conformance — one-call session bootstrap (session_spe
 });
 
 // The cross-process artifact contract (stigmer/stigmer#285). Nothing else in the
-// suite exercises it: the server writes an uploaded attachment to its local
-// store, and the runner — a separate process — must read it back from the SAME
-// directory. Before the fix the two disagreed on the path and this failed; the
-// harness now points both at one root (see server-process.ts / runner-process.ts).
-// The two materialization cases gate on sharedRunnerArtifactStore (a harness
-// limitation on cloud-execution, not edition drift — see target.ts); the
-// presign/foreign-key rejection contract is server-side and runs everywhere.
+// suite exercises it: the server writes an uploaded attachment to its store,
+// and the runner — a separate process — must read it back from the SAME store.
+// Before the fix the two disagreed on the path and this failed; the harness
+// points local targets at one shared directory (server-process.ts /
+// runner-process.ts) and cloud-execution's runner presigns against the real
+// service's MinIO-backed artifact routes (stigmer#803), so every case here
+// runs unconditionally on every execution target (the retired
+// sharedRunnerArtifactStore gate — see target.ts).
 describe("AgentExecution conformance — attachments (#285)", () => {
-  it.skipIf(!sharedArtifactStore)("resolves a storage-key attachment (no local_path) the server wrote to the shared local store", async () => {
+  it("resolves a storage-key attachment (no local_path) the server wrote to the shared store", async () => {
     const { org } = await target.provisionTenancy();
     const agentId = await provisionAgent(org, uniqueName("agent-attach"));
 
@@ -772,7 +769,7 @@ describe("AgentExecution conformance — attachments (#285)", () => {
   // captured request is byte-for-byte what Anthropic would have received
   // (@langchain/anthropic converts the runner's image_url data-URL block into
   // the native base64 source block on the wire).
-  it.skipIf(!sharedArtifactStore)("delivers an image attachment to the provider as an inline base64 image block (vision, T04)", async () => {
+  it("delivers an image attachment to the provider as an inline base64 image block (vision, T04)", async () => {
     const { org } = await target.provisionTenancy();
     const agentId = await provisionAgent(org, uniqueName("agent-vision"));
 

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -108,6 +108,12 @@ export class CloudExecutionTarget implements TargetProfile {
       backendEndpoint,
       cloudBootstrap: { token: primaryToken },
       proxy: { endpoint: this.mockLlm.url(), token: "conformance-cloud-bootstrap" },
+      // Artifacts presign against the real service's HTTP port (MinIO-backed)
+      // while LLM traffic stays on the mock — the presign-capable artifact
+      // lane (stigmer#803) that lets attachment materialization run against
+      // cloud. The runner authenticates presigns with its adopted
+      // embedded_runner credential (the same lane production runners use).
+      artifactProxy: { endpoint: requireCloudEnv(CLOUD_ENV.httpAddress) },
       logFile: join(RUNNER_LOG_DIR, `conformance-runner-${runnerLogLabel()}.log`),
     });
   }

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -53,9 +53,6 @@ export class CloudTarget implements TargetProfile {
     clientReservedLabelWrites: false,
     clientPublicVisibilityWrites: false,
     // The hermetic cloud service stores attachments in MinIO while the
-    // TS runner (cloud-execution) keeps a local artifact store — a harness
-    // limitation, not edition drift; see the flag's contract in target.ts.
-    sharedRunnerArtifactStore: false,
   };
 
   private grpcBaseUrl: string | undefined;

--- a/test/conformance/src/targets/local-go-execution.ts
+++ b/test/conformance/src/targets/local-go-execution.ts
@@ -51,9 +51,6 @@ export class LocalGoExecutionTarget implements TargetProfile {
     // (stigmer-cloud#320), so the caller may create labeled candidates.
     clientReservedLabelWrites: true,
     clientPublicVisibilityWrites: true,
-    // The runner shares the server's artifact dir (the #285 wiring in setup),
-    // so server-written storage-key attachments resolve in the runner.
-    sharedRunnerArtifactStore: true,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -26,9 +26,6 @@ export class LocalGoTarget implements TargetProfile {
     // (stigmer-cloud#320), so the caller may create labeled candidates.
     clientReservedLabelWrites: true,
     clientPublicVisibilityWrites: true,
-    // CRUD target: no engine, so the flag is never consulted; true mirrors
-    // the local execution target (one store, one host).
-    sharedRunnerArtifactStore: true,
   };
 
   private server: RunningServer | undefined;

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -100,19 +100,15 @@ export interface CapabilityFlags {
   // retire this flag when the harness gains a platform-privileged caller
   // (stigmer#547) — until then the pin runs OSS-side only.
   clientReservedLabelWrites: boolean;
-  // The execution target's runner shares an artifact store with the server,
-  // so a storage-key attachment the SERVER persisted resolves when the RUNNER
-  // materializes it (the #285 shared-dir wiring on local targets).
-  //
-  // False for cloud-execution — a HARNESS limitation, not an edition
-  // difference: the hermetic cloud service stores attachments in its MinIO,
-  // while the runner is pinned to a local artifact store (the mock LLM proxy
-  // cannot serve the presign calls a proxy-configured artifact store would
-  // make). Attachment-materialization assertions gate on this flag until the
-  // harness gains a presign-capable artifact lane for the cloud engine
-  // (stigmer#803). Attachment REJECTION contracts (foreign keys etc.) are
-  // server-side and run unconditionally.
-  sharedRunnerArtifactStore: boolean;
+  // NOTE: there is deliberately no shared-runner-artifact-store capability.
+  // Every execution target's runner resolves storage-key attachments the
+  // server persisted: local targets share the server's on-disk store (the
+  // #285 shared-dir wiring), and cloud-execution presigns against the real
+  // service's MinIO-backed artifact routes via the runner's
+  // STIGMER_ARTIFACT_PROXY_ENDPOINT override (stigmer#803). The flag that
+  // used to gate the attachment-materialization assertions
+  // (sharedRunnerArtifactStore) was retired when that lane landed — the
+  // executionContextSecretRedaction retirement precedent.
   // The conformance caller may set a resource's visibility to PUBLIC — the
   // only level that crosses every org boundary (the cross-org "explore"
   // catalog).

--- a/test/integration/cmd/conformance-cloudenv/main.go
+++ b/test/integration/cmd/conformance-cloudenv/main.go
@@ -37,8 +37,12 @@ const bootTimeout = 10 * time.Minute
 
 // readySignal is the single JSON line printed to stdout once the environment
 // accepts gRPC traffic. The TS global setup parses it to locate the service.
+// The HTTP address carries the Spring routes the gRPC port does not — notably
+// the artifact presign endpoints (/v1/proxy/artifacts/...) the conformance
+// runner's proxy artifact store targets (stigmer#803).
 type readySignal struct {
 	GrpcAddress string `json:"grpcAddress"`
+	HTTPAddress string `json:"httpAddress"`
 }
 
 func main() {
@@ -118,13 +122,17 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("seed base FGA tuples: %w", err)
 	}
 
-	ready, err := json.Marshal(readySignal{GrpcAddress: svc.GRPCAddress()})
+	ready, err := json.Marshal(readySignal{
+		GrpcAddress: svc.GRPCAddress(),
+		HTTPAddress: svc.HTTPAddress(),
+	})
 	if err != nil {
 		return fmt.Errorf("marshal ready signal: %w", err)
 	}
 	fmt.Println(string(ready))
 	logger.Info("conformance cloud environment ready",
 		"grpc_address", svc.GRPCAddress(),
+		"http_address", svc.HTTPAddress(),
 		"service_log", svc.LogPath(),
 	)
 


### PR DESCRIPTION
## Summary
The cloud-execution conformance target's runner now presigns artifacts against the real hermetic Java service (MinIO-backed) instead of being pinned to a throwaway local store, so the two attachment-materialization cases run against cloud. The `sharedRunnerArtifactStore` capability flag retires — every execution target now shares a store with its server.

## Context
The target pinned `ARTIFACT_STORAGE_TYPE=local` because `STIGMER_PROXY_ENDPOINT` points at the MockLlmProxy, which serves no presign routes — so storage-key attachments the server persisted to MinIO could never materialize in the runner (stigmer#803). The Go integration harness already proved the presign lane works against the hermetic service; only the TS conformance harness lacked the plumbing.

## Changes
- Runner: new `STIGMER_ARTIFACT_PROXY_ENDPOINT` override (`artifactProxyEndpoint` in Config and both embedder options surfaces), defaulting to `STIGMER_PROXY_ENDPOINT` — the exact `STIGMER_CHECKPOINTER_PROXY_ENDPOINT` pattern. `ProxyArtifactStorage` presigns against it; behavior is byte-identical when the override is unset.
- Launcher/harness: `conformance-cloudenv` publishes the service's HTTP (Spring) address in its ready-line; `CLOUD_ENV` carries it; `spawnRunner` gains `artifactProxy` which sets `ARTIFACT_STORAGE_TYPE=proxy` + the override; the cloud-execution target wires it. LLM traffic stays on the mock — the MockLlmProxy remains a pure replay fixture.
- Flag retirement: `sharedRunnerArtifactStore` deleted from `CapabilityFlags` with a NOTE recording the retirement (the `executionContextSecretRedaction` precedent); the two `it.skipIf` gates drop and the cases run unconditionally on every execution target.

## Implementation notes
- The runner authenticates presigns with its adopted embedded_runner credential — the same lane production runners use; nothing here is test-only auth.
- Option (a) from the issue (teaching MockLlmProxy to reverse-proxy presign routes) was rejected: it turns a replay fixture into a mini proxy, while the split-endpoint seam follows an established runner-config pattern and is genuinely useful to embedders.

## Test plan
- Runner unit suite: 4723 passed (including new split-endpoint config tests); typecheck clean.
- `npm run test:cloud-execution` (hermetic, service JAR from stigmer-cloud main): 124/125 passed, ZERO skips — both formerly-gated attachment cases (storage-key materialization byte-compare + vision inline base64) ran and passed. The single red is the recorded oss#224-family getEventLog pin — the lane's documented pre-existing residual (tracked by #807), untouched here.
- go vet/gofmt clean on the launcher change.

Closes #803

Made with [Cursor](https://cursor.com)