### PR TITLE
feat(sdk/react): always-visible auto-approve toggle — effective mid-run (the walk-away scenario)

### DIFF
--- a/sdk/react/src/composer/ComposerToolbar.tsx
+++ b/sdk/react/src/composer/ComposerToolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { cn } from "@stigmer/theme";
 import {
   Tooltip,
@@ -7,6 +8,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../internal/tooltip.js";
+import { Switch } from "../switch/Switch.js";
 import { ContextPopover } from "./ContextPopover.js";
 import { ConfigureMenu, type ConfigureMenuItem } from "./ConfigureMenu.js";
 import { ModelSelector } from "../models/ModelSelector.js";
@@ -22,6 +24,18 @@ import {
   StopIcon,
 } from "./icons.js";
 import { SpinnerIcon } from "../internal/SpinnerIcon.js";
+
+/**
+ * Wiring for the always-available "auto-approve tool calls" toggle
+ * (stigmer/stigmer#816). Presence renders the control; omission keeps the
+ * toolbar byte-identical for consumers that don't wire it (DD-011).
+ */
+export interface ComposerAutoApproveProps {
+  /** Whether auto-approve is currently armed for this conversation. */
+  readonly armed: boolean;
+  /** Called with the next value when the user flips the toggle. */
+  readonly onChange: (armed: boolean) => void;
+}
 
 export interface ComposerToolbarProps {
   readonly disabled: boolean;
@@ -46,6 +60,14 @@ export interface ComposerToolbarProps {
   readonly showInteractionModePicker: boolean;
   readonly interactionMode?: InteractionModeOption;
   readonly onInteractionModeChange: (mode: InteractionModeOption) => void;
+
+  /**
+   * Always-available auto-approve toggle (#816). Deliberately NOT bound to
+   * {@link disabled}: the walk-away user flips it exactly while a turn
+   * streams, so it stays interactive under the composer lock — the same
+   * exemption the Stop button carries.
+   */
+  readonly autoApprove?: ComposerAutoApproveProps;
 
   readonly showModelSelector: boolean;
   readonly modelId?: string;
@@ -128,6 +150,7 @@ export function ComposerToolbar({
   showInteractionModePicker,
   interactionMode,
   onInteractionModeChange,
+  autoApprove,
   showModelSelector,
   modelId,
   onModelChange,
@@ -137,6 +160,7 @@ export function ComposerToolbar({
   onThinkingModeChange,
 }: ComposerToolbarProps) {
   const showHarnessSeparate = showHarnessSelector && !showModelSelector;
+  const autoApproveLabelId = useId();
 
   return (
     <div className="stg:flex stg:items-center stg:justify-between stg:gap-2 stg:border-t stg:border-border-muted stg:px-3 stg:py-2">
@@ -172,6 +196,40 @@ export function ComposerToolbar({
             onThinkingModeChange={onThinkingModeChange}
             disabled={disabled}
           />
+        )}
+
+        {/* Auto-approve (#816): primary state like Mode and Model — armed
+            vs gated is something the user glances at before walking away.
+            Never bound to `disabled` (see ComposerAutoApproveProps): the
+            whole point is flipping it while a turn streams. Scoped provider:
+            this tooltip does not share the icon cluster's hover-delay group. */}
+        {autoApprove && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger render={<span className="stg:inline-flex" />}>
+                <span className="stg:flex stg:shrink-0 stg:items-center stg:gap-1.5 stg:px-1">
+                  <label
+                    id={autoApproveLabelId}
+                    htmlFor={`${autoApproveLabelId}-switch`}
+                    className="stg:cursor-pointer stg:select-none stg:text-xs stg:text-muted-foreground"
+                  >
+                    Auto-approve
+                  </label>
+                  <Switch
+                    id={`${autoApproveLabelId}-switch`}
+                    checked={autoApprove.armed}
+                    onCheckedChange={autoApprove.onChange}
+                    aria-labelledby={autoApproveLabelId}
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {autoApprove.armed
+                  ? "Tool calls run without asking — this conversation only. Turn off to be asked again."
+                  : "Run this conversation's tool calls without asking for approval, including the run in progress."}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
       </div>
 

--- a/sdk/react/src/composer/SessionComposer.tsx
+++ b/sdk/react/src/composer/SessionComposer.tsx
@@ -4,7 +4,7 @@ import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo,
 import { cn } from "@stigmer/theme";
 import { getUserMessage, type AttachmentInput, type EnvVarInput, type McpServerUsageInput, type ResourceRef } from "@stigmer/sdk";
 import { useComposer } from "./useComposer.js";
-import { ComposerToolbar } from "./ComposerToolbar.js";
+import { ComposerToolbar, type ComposerAutoApproveProps } from "./ComposerToolbar.js";
 import { type ConfigureMenuItem } from "./ConfigureMenu.js";
 import type { HarnessOption } from "../models/harness.js";
 import { FAST_SERVICE_TIER, type ServiceTierOption } from "../models/service-tier.js";
@@ -299,6 +299,16 @@ export interface SessionComposerProps {
   readonly onModelChange?: (modelId: string) => void;
   /** Show the model selector. @default true */
   readonly showModelSelector?: boolean;
+
+  /**
+   * Always-visible "auto-approve tool calls" toggle in the toolbar
+   * (stigmer/stigmer#816). Presence renders it; omission keeps the composer
+   * byte-identical (DD-011). Stays interactive while the composer is
+   * `disabled` — the walk-away user flips it exactly while a turn streams —
+   * so consumers must only wire it on surfaces whose viewer may submit
+   * approvals (never guest/observer). See {@link ComposerAutoApproveProps}.
+   */
+  readonly autoApprove?: ComposerAutoApproveProps;
 
   /**
    * Workspace state managed by {@link useWorkspaceEntries}.
@@ -617,6 +627,7 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
   defaultModelId,
   onModelChange,
   showModelSelector = true,
+  autoApprove,
   workspace,
   gitHubConnection,
   enableGitHub = true,
@@ -1920,6 +1931,7 @@ const SessionComposerInner = forwardRef<SessionComposerHandle, SessionComposerPr
           interactionMode={interactionMode}
           onInteractionModeChange={handleInteractionModeChange}
           showModelSelector={showModelSelector}
+          autoApprove={autoApprove}
           // The pill renders the effective selection — the same value the
           // submit payload carries (#663), never a fallback of its own.
           modelId={effective.modelId}

--- a/sdk/react/src/composer/__tests__/ComposerToolbar-autoApprove.test.tsx
+++ b/sdk/react/src/composer/__tests__/ComposerToolbar-autoApprove.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ComposerToolbar, type ComposerToolbarProps } from "../ComposerToolbar";
+
+afterEach(cleanup);
+
+function baseProps(overrides: Partial<ComposerToolbarProps> = {}): ComposerToolbarProps {
+  return {
+    disabled: false,
+    isSubmitting: false,
+    canSend: true,
+    onSend: vi.fn(),
+    showHarnessSelector: false,
+    harness: "native",
+    onHarnessChange: vi.fn(),
+    showInteractionModePicker: false,
+    interactionMode: "agent",
+    onInteractionModeChange: vi.fn(),
+    showModelSelector: false,
+    modelId: undefined,
+    onModelChange: vi.fn(),
+    showWorkspace: false,
+    workspaceCount: 0,
+    workspaceContent: null,
+    showAttach: false,
+    attachmentCount: 0,
+    onAttachClick: vi.fn(),
+    configureItems: [],
+    configOpen: false,
+    onConfigOpenChange: vi.fn(),
+    configActivePanel: null,
+    onConfigActivePanelChange: vi.fn(),
+    renderConfigPanel: () => null,
+    ...overrides,
+  };
+}
+
+describe("ComposerToolbar auto-approve toggle (#816)", () => {
+  it("renders nothing when the prop is omitted (DD-011 opt-in)", () => {
+    render(<ComposerToolbar {...baseProps()} />);
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByText("Auto-approve")).toBeNull();
+  });
+
+  it("renders a labeled switch reflecting the armed state", () => {
+    render(
+      <ComposerToolbar
+        {...baseProps({ autoApprove: { armed: true, onChange: vi.fn() } })}
+      />,
+    );
+    const toggle = screen.getByRole("switch", { name: "Auto-approve" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("flipping calls onChange with the next value", () => {
+    const onChange = vi.fn();
+    render(
+      <ComposerToolbar
+        {...baseProps({ autoApprove: { armed: false, onChange } })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("switch", { name: "Auto-approve" }));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("stays interactive while the toolbar is disabled (the walk-away flip)", () => {
+    // The whole point of the toggle is arming DURING a streaming turn, when
+    // the rest of the composer is locked — the Stop-button exemption.
+    const onChange = vi.fn();
+    render(
+      <ComposerToolbar
+        {...baseProps({ disabled: true, autoApprove: { armed: false, onChange } })}
+      />,
+    );
+    const toggle = screen.getByRole("switch", { name: "Auto-approve" });
+    expect(toggle.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+});

--- a/sdk/react/src/composer/index.ts
+++ b/sdk/react/src/composer/index.ts
@@ -7,6 +7,7 @@ export type {
   SessionComposerProps,
   SessionComposerSubmitContext,
 } from "./SessionComposer.js";
+export type { ComposerAutoApproveProps } from "./ComposerToolbar.js";
 
 export { InteractionModePicker } from "./InteractionModePicker.js";
 export type {

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -546,6 +546,7 @@ export type {
   SessionComposerHandle,
   SessionComposerProps,
   SessionComposerSubmitContext,
+  ComposerAutoApproveProps,
   InteractionModePickerProps,
   InteractionModeOption,
 } from "./composer/index.js";

--- a/sdk/react/src/session/NewSessionViewer.tsx
+++ b/sdk/react/src/session/NewSessionViewer.tsx
@@ -6,7 +6,7 @@ import type { UseGitHubConnectionReturn } from "../github/useGitHubConnection.js
 import type { WorkspaceFileLister } from "../workspace/WorkspaceFileLister.js";
 import type { WorkspaceFileReader } from "../workspace/WorkspaceFileReader.js";
 import type { WorkspaceContentSearcher } from "../workspace/WorkspaceContentSearcher.js";
-import type { InteractionModeOption } from "../composer/index.js";
+import type { ComposerAutoApproveProps, InteractionModeOption } from "../composer/index.js";
 import { SessionComposer } from "../composer/index.js";
 import type { HarnessOption } from "../models/harness.js";
 import type { AccountExecutionDefaults } from "../identity-account/useAccountExecutionDefaults.js";
@@ -299,6 +299,19 @@ export function NewSessionViewer({
   // SessionViewer derives (DD-016), gating the chip and the region together.
   const panelEnabled = panelMode !== "none" && !isGuest;
 
+  // Always-visible auto-approve toggle (#816), present before the first
+  // message is ever typed — the walk-away user arms it here and the create
+  // carries spec.auto_approve_all server-side. Guests never get it (the
+  // operator-consent reasoning as the #302 host default). Memoized per
+  // DD-010 — the composer is memo'd and an inline object would defeat it.
+  const autoApprove = useMemo<ComposerAutoApproveProps | undefined>(
+    () =>
+      isGuest
+        ? undefined
+        : { armed: flow.autoApproveAll, onChange: flow.setAutoApproveAll },
+    [isGuest, flow.autoApproveAll, flow.setAutoApproveAll],
+  );
+
   // Guest agent binding is host configuration, not a picker interaction:
   // the composer's agent machinery (picker, env-collection, personal
   // environments — all org reads a guest token cannot make) stays fully
@@ -452,6 +465,7 @@ export function NewSessionViewer({
           onInteractionModeChange={setInteractionMode}
           showInteractionModePicker={!isGuest}
           showModelSelector={modelSelectorVisible}
+          autoApprove={autoApprove}
           enableAttachments={!isGuest}
           defaultModelId={flow.modelId}
           onModelChange={flow.setModelId}

--- a/sdk/react/src/session/SessionViewer.tsx
+++ b/sdk/react/src/session/SessionViewer.tsx
@@ -17,7 +17,7 @@ import {
   WorkspaceSurface,
   type SurfaceVirtualDocument,
 } from "../workspace/WorkspaceSurface.js";
-import type { InteractionModeOption, SessionComposerHandle, SessionComposerSubmitContext } from "../composer/index.js";
+import type { ComposerAutoApproveProps, InteractionModeOption, SessionComposerHandle, SessionComposerSubmitContext } from "../composer/index.js";
 import type { ApplyResourceResult } from "../library/useApplyResource.js";
 import { SessionViewerLayout } from "./SessionViewerLayout.js";
 import { useWorkspaceEditors, isVirtualEntryId } from "../internal/store/index.js";
@@ -824,6 +824,20 @@ const ConversationColumn = memo(function ConversationColumn({
     void conv.stop();
   }, [conv.stop]);
 
+  // Always-visible auto-approve toggle (#816), replacing the old armed-only
+  // indicator banner: the walk-away user needs a way ON before any gate
+  // exists, not just a way off after one. Guests never get it (they don't
+  // inherit the host default and this is the operator's consent surface);
+  // observers have no composer at all. Memoized per DD-010 — the composer
+  // is memo'd and an inline object would defeat it.
+  const autoApprove = useMemo<ComposerAutoApproveProps | undefined>(
+    () =>
+      isGuest
+        ? undefined
+        : { armed: flow.autoApproveAll, onChange: flow.setAutoApproveAll },
+    [isGuest, flow.autoApproveAll, flow.setAutoApproveAll],
+  );
+
   // Edit-and-resubmit: stop the in-flight turn, pre-fill the composer with
   // the original text, and remember which execution is being edited. The
   // append-only execution log is never rewritten — submitting while editing
@@ -948,9 +962,6 @@ const ConversationColumn = memo(function ConversationColumn({
           />
         )}
         {!isObserver && sendError && <SendErrorBanner error={sendError} />}
-        {!isObserver && flow.autoApproveAll && (
-          <AutoApproveIndicator onTurnOff={() => flow.setAutoApproveAll(false)} />
-        )}
         {/* Pending file reviews dock here — pinned above the composer so the
             decision the agent is blocked on can never scroll out of view. The
             thread renders only observational rows (badges) and read-only
@@ -992,6 +1003,7 @@ const ConversationColumn = memo(function ConversationColumn({
             onInteractionModeChange={setInteractionMode}
             showInteractionModePicker={!isGuest}
             showModelSelector={modelSelectorVisible}
+            autoApprove={autoApprove}
             enableAttachments={!isGuest}
             workspace={isGuest ? undefined : flow.workspace}
             gitHubConnection={isGuest ? undefined : gitHubConnection}
@@ -1387,36 +1399,6 @@ function SessionStarting() {
 }
 
 /**
- * Low-weight, always-visible indicator shown while the session-scoped
- * auto-approve preference is active. The "Turn off" control reverts the
- * preference in one click — the safety affordance for "Approve & don't ask
- * again". Visible from the first render when the host pre-armed the
- * preference via `StigmerProvider`'s `approvalDefaults` (#302); otherwise
- * nothing about approvals appears until the user opts in at a gate. Either
- * way the user keeps the last word.
- */
-function AutoApproveIndicator({ onTurnOff }: { onTurnOff: () => void }) {
-  return (
-    <div
-      role="status"
-      className="stg:flex stg:items-center stg:gap-2 stg:border-t stg:border-border-muted stg:px-4 stg:py-1.5 stg:text-xs stg:text-muted-foreground"
-    >
-      <ShieldCheckIcon />
-      <span className="stg:min-w-0 stg:flex-1 stg:truncate">
-        Auto-approving tool calls for this session
-      </span>
-      <button
-        type="button"
-        onClick={onTurnOff}
-        className="stg:shrink-0 stg:rounded stg:font-medium stg:text-foreground stg:underline-offset-2 stg:hover:underline stg:focus-visible:outline-none stg:focus-visible:ring-2 stg:focus-visible:ring-ring"
-      >
-        Turn off
-      </button>
-    </div>
-  );
-}
-
-/**
  * The plan document tab's empty state — reachable only when a streaming plan
  * auto-opened the tab and its turn then ended without publishing (stopped or
  * failed) while the session has no earlier published plan to fall back to.
@@ -1616,11 +1598,3 @@ function LoaderIcon() {
   );
 }
 
-function ShieldCheckIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="stg:shrink-0 stg:text-success" aria-hidden="true">
-      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-      <path d="m9 12 2 2 4-4" />
-    </svg>
-  );
-}

--- a/sdk/react/src/session/__tests__/SessionViewer-autoApproveToggle.test.tsx
+++ b/sdk/react/src/session/__tests__/SessionViewer-autoApproveToggle.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Wiring-contract tests for the always-visible auto-approve toggle
+// (stigmer/stigmer#816): SessionViewer hands the composer the flow's
+// auto-approve state for every audience that may submit approvals
+// (integrator AND endUser — the walk-away persona is an embedder's end
+// user), never for guests, and the old armed-only indicator banner is gone
+// (the toggle IS the indicator now).
+// ---------------------------------------------------------------------------
+
+type CapturedProps = Record<string, unknown>;
+
+const composerProps: CapturedProps[] = [];
+vi.mock("../../composer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../composer")>();
+  return {
+    ...actual,
+    SessionComposer: (props: CapturedProps) => {
+      composerProps.push(props);
+      return <div data-testid="composer-probe" />;
+    },
+  };
+});
+
+vi.mock("../../execution/MessageThread", () => ({
+  MessageThread: () => <div data-testid="thread-probe" />,
+}));
+
+vi.mock("../../execution/FileReviewDock", () => ({
+  FileReviewDock: () => <div data-testid="file-review-dock-probe" />,
+}));
+
+vi.mock("../facets/SetupTab", () => ({
+  SetupTab: () => <div data-testid="setup-probe" />,
+}));
+
+const stubWorkspace = {
+  entries: [],
+  hasEntries: false,
+  toInput: vi.fn().mockReturnValue([]),
+  addGitRepo: vi.fn(),
+  addLocalPath: vi.fn(),
+  removeEntry: vi.fn(),
+  clear: vi.fn(),
+};
+
+const stubConv = {
+  session: { spec: {} } as Record<string, unknown>,
+  isLoading: false,
+  loadError: null,
+  completedExecutions: [],
+  activeStreamExecution: null,
+  activePhase: null,
+  isStreaming: false,
+  isConnecting: false,
+  sendFollowUp: vi.fn(),
+  canSendFollowUp: true,
+  isSending: false,
+  sendError: null,
+  clearSendError: vi.fn(),
+  pendingUserMessage: null,
+  workspaceEntries: [],
+  mcpServerUsages: [],
+  skillRefs: [],
+  pendingApprovals: [],
+  submitApproval: vi.fn(),
+  submittingApprovalIds: new Set<string>(),
+  fileChangeSets: [],
+  submitFileDecision: vi.fn(),
+  submittingFileDecisionKeys: new Set<string>(),
+  fileDecisionErrors: new Map<string, Error>(),
+  streamError: null,
+  reconnectStream: vi.fn(),
+  approvalError: null,
+  retryLastSend: vi.fn(),
+};
+
+const setAutoApproveAll = vi.fn();
+const stubSessionPageFlow = {
+  conv: stubConv,
+  harness: "native" as const,
+  executionTarget: undefined,
+  model: [undefined, vi.fn()] as const,
+  interactionMode: ["agent" as const, vi.fn()] as const,
+  agentRef: { org: "acme", slug: "support-bot" },
+  setAgentRef: vi.fn(),
+  resolution: null,
+  setResolution: vi.fn(),
+  isDefaultAgent: false,
+  mcpServerUsages: [],
+  setMcpServerUsages: vi.fn(),
+  skillRefs: [],
+  setSkillRefs: vi.fn(),
+  workspace: stubWorkspace,
+  sessionVariables: { entries: [], isEmpty: true, clear: vi.fn() },
+  autoApproveAll: false,
+  setAutoApproveAll,
+  submitApproval: vi.fn(),
+  handleSubmit: vi.fn(),
+  submitError: null as Error | null,
+  displayExecution: null,
+  allExecutions: [],
+  sandboxWorkspaceRoot: undefined,
+};
+vi.mock("../useSessionPageFlow", () => ({
+  useSessionPageFlow: () => stubSessionPageFlow,
+}));
+
+vi.mock("../../hooks", () => ({
+  useStigmer: () => ({
+    agentExecution: {
+      uploadAttachment: vi.fn(),
+      getArtifactContent: vi.fn(),
+    },
+  }),
+}));
+
+import { SessionViewer } from "../SessionViewer";
+
+function lastComposerProps(): CapturedProps {
+  expect(composerProps.length).toBeGreaterThan(0);
+  return composerProps.at(-1)!;
+}
+
+beforeEach(() => {
+  composerProps.length = 0;
+  stubConv.session = { spec: {} };
+  stubSessionPageFlow.autoApproveAll = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SessionViewer — auto-approve toggle wiring (#816)", () => {
+  it("hands the composer the flow's auto-approve state (integrator)", () => {
+    render(<SessionViewer sessionId="ses_1" org="acme" />);
+
+    const autoApprove = lastComposerProps().autoApprove as
+      | { armed: boolean; onChange: (v: boolean) => void }
+      | undefined;
+    expect(autoApprove).toBeDefined();
+    expect(autoApprove!.armed).toBe(false);
+    expect(autoApprove!.onChange).toBe(setAutoApproveAll);
+  });
+
+  it("mirrors an armed flow state into the composer", () => {
+    stubSessionPageFlow.autoApproveAll = true;
+    render(<SessionViewer sessionId="ses_1" org="acme" />);
+
+    const autoApprove = lastComposerProps().autoApprove as { armed: boolean };
+    expect(autoApprove.armed).toBe(true);
+  });
+
+  it("endUser gets the toggle — the walk-away persona is an end user", () => {
+    render(<SessionViewer sessionId="ses_1" org="acme" audience="endUser" />);
+
+    expect(lastComposerProps().autoApprove).toBeDefined();
+  });
+
+  it("guests never get the toggle", () => {
+    render(<SessionViewer sessionId="ses_1" org="acme" audience="guest" />);
+
+    expect(lastComposerProps().autoApprove).toBeUndefined();
+  });
+
+  it("the armed-only indicator banner is gone — the toggle is the indicator", () => {
+    stubSessionPageFlow.autoApproveAll = true;
+    render(<SessionViewer sessionId="ses_1" org="acme" />);
+
+    expect(
+      screen.queryByText("Auto-approving tool calls for this session"),
+    ).toBeNull();
+  });
+});

--- a/sdk/react/src/session/__tests__/useNewSessionFlow.test.tsx
+++ b/sdk/react/src/session/__tests__/useNewSessionFlow.test.tsx
@@ -431,6 +431,39 @@ describe("useNewSessionFlow", () => {
       expect(execInput.autoApproveAll).toBe(true);
     });
 
+    it("carries the user's pre-arm toggle into the bootstrap create (#816)", async () => {
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useNewSessionFlow(opts), { wrapper: createWrapper() });
+
+      expect(result.current.autoApproveAll).toBe(false);
+      act(() => result.current.setAutoApproveAll(true));
+      expect(result.current.autoApproveAll).toBe(true);
+
+      await act(async () => {
+        await result.current.submit("Hello");
+      });
+
+      const execInput = mockCreateExecution.mock.calls[0][0];
+      expect(execInput.autoApproveAll).toBe(true);
+    });
+
+    it("the user's toggle-off beats the host approval default (#816)", async () => {
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useNewSessionFlow(opts), {
+        wrapper: createWrapper(undefined, null, { autoApproveAll: true }),
+      });
+
+      expect(result.current.autoApproveAll).toBe(true);
+      act(() => result.current.setAutoApproveAll(false));
+
+      await act(async () => {
+        await result.current.submit("Hello");
+      });
+
+      const execInput = mockCreateExecution.mock.calls[0][0];
+      expect(execInput.autoApproveAll).toBeUndefined();
+    });
+
     it("passes cursor harness in the sessionSpec after switching", async () => {
       const opts = defaultOptions();
       const { result } = renderHook(() => useNewSessionFlow(opts), { wrapper: createWrapper() });

--- a/sdk/react/src/session/__tests__/useSessionPageFlow.autoApprove.test.tsx
+++ b/sdk/react/src/session/__tests__/useSessionPageFlow.autoApprove.test.tsx
@@ -11,11 +11,20 @@ import { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecutio
 const mockSubmitApproval = vi.fn<(t: string, a: ApprovalAction, c?: string) => Promise<void>>();
 const mockSendFollowUp = vi.fn();
 
+/** Loosely-typed conversation stub — individual tests mutate the arming and
+ * gate fields, and restore them in their afterEach. */
 const mockConv = {
-  session: { spec: {} },
+  session: { spec: {} } as {
+    spec: object;
+    metadata?: { labels?: Record<string, string> };
+  },
   isLoading: false,
   completedExecutions: [] as unknown[],
-  activeStreamExecution: null,
+  activeStreamExecution: null as {
+    spec?: { autoApproveAll?: boolean };
+    status?: object;
+  } | null,
+  pendingApprovals: [] as { toolCallId: string }[],
   workspaceEntries: [] as unknown[],
   submitApproval: mockSubmitApproval,
   sendFollowUp: mockSendFollowUp,
@@ -219,5 +228,170 @@ describe("useSessionPageFlow — host-set approval default (#302)", () => {
       wrapper: hostDefaultWrapper(false),
     });
     expect(result.current.autoApproveAll).toBe(false);
+  });
+});
+
+describe("useSessionPageFlow — arming derived from the in-flight run (#816)", () => {
+  afterEach(() => {
+    mockConv.activeStreamExecution = null;
+    mockConv.completedExecutions = [];
+    vi.clearAllMocks();
+  });
+
+  it("reflects an active execution armed at create (launcher handoff)", () => {
+    mockConv.activeStreamExecution = { spec: { autoApproveAll: true }, status: {} };
+    const { result } = renderHook(() => useSessionPageFlow(OPTS));
+    expect(result.current.autoApproveAll).toBe(true);
+  });
+
+  it("the user's explicit OFF beats the armed run for follow-up carry", async () => {
+    mockConv.activeStreamExecution = { spec: { autoApproveAll: true }, status: {} };
+    const { result } = renderHook(() => useSessionPageFlow(OPTS));
+
+    act(() => {
+      result.current.setAutoApproveAll(false);
+    });
+    expect(result.current.autoApproveAll).toBe(false);
+
+    await act(async () => {
+      await result.current.handleSubmit("after explicit off");
+    });
+    const followUpOpts = mockSendFollowUp.mock.calls.at(-1)?.[1];
+    expect(followUpOpts.autoApproveAll).toBeUndefined();
+  });
+
+  it("never derives from PAST executions (the reset-on-reload consent contract)", () => {
+    // A reloaded page whose history contains an armed run must come up at
+    // the host default — deriving from history would make the consent
+    // silently survive reloads.
+    mockConv.completedExecutions = [{ spec: { autoApproveAll: true }, status: {} }];
+    const { result } = renderHook(() => useSessionPageFlow(OPTS));
+    expect(result.current.autoApproveAll).toBe(false);
+  });
+});
+
+describe("useSessionPageFlow — armed responder (#816, the walk-away scenario)", () => {
+  beforeEach(() => {
+    mockSubmitApproval.mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    mockConv.pendingApprovals = [];
+    mockConv.activeStreamExecution = null;
+    mockConv.session = { spec: {} };
+    vi.clearAllMocks();
+  });
+
+  it("releases a gate that appears while armed", async () => {
+    const { rerender } = renderHook(() => useSessionPageFlow(OPTS), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    await act(async () => rerender());
+
+    expect(mockSubmitApproval).toHaveBeenCalledExactlyOnceWith(
+      "tc1",
+      ApprovalAction.APPROVE_ALL,
+    );
+  });
+
+  it("releases a gate already waiting when the toggle flips ON", async () => {
+    mockConv.pendingApprovals = [{ toolCallId: "tc9" }];
+    const { result } = renderHook(() => useSessionPageFlow(OPTS));
+    expect(mockSubmitApproval).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.setAutoApproveAll(true);
+    });
+
+    expect(mockSubmitApproval).toHaveBeenCalledExactlyOnceWith(
+      "tc9",
+      ApprovalAction.APPROVE_ALL,
+    );
+  });
+
+  it("submits once per gate across re-renders", async () => {
+    const { rerender } = renderHook(() => useSessionPageFlow(OPTS), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    await act(async () => rerender());
+    await act(async () => rerender());
+
+    expect(mockSubmitApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it("covers a LATER gate of a different class (lease scope contract)", async () => {
+    // A gate-time APPROVE_ALL grants a class-scoped lease, so a second gate
+    // of another class still parks — the responder must answer it too.
+    const { rerender } = renderHook(() => useSessionPageFlow(OPTS), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    mockConv.pendingApprovals = [{ toolCallId: "tc-shell" }];
+    await act(async () => rerender());
+    mockConv.pendingApprovals = [{ toolCallId: "tc-write" }];
+    await act(async () => rerender());
+
+    expect(mockSubmitApproval).toHaveBeenCalledTimes(2);
+    expect(mockSubmitApproval).toHaveBeenLastCalledWith(
+      "tc-write",
+      ApprovalAction.APPROVE_ALL,
+    );
+  });
+
+  it("does not retry a failed submission (the card stays for manual action)", async () => {
+    mockSubmitApproval.mockRejectedValue(new Error("boom"));
+    const { rerender } = renderHook(() => useSessionPageFlow(OPTS), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    await act(async () => rerender());
+    await act(async () => rerender());
+
+    expect(mockSubmitApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays inert while OFF", async () => {
+    const { rerender } = renderHook(() => useSessionPageFlow(OPTS));
+
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    await act(async () => rerender());
+
+    expect(mockSubmitApproval).not.toHaveBeenCalled();
+  });
+
+  it("never fires for a guest, even when the run itself is armed", async () => {
+    mockConv.activeStreamExecution = { spec: { autoApproveAll: true }, status: {} };
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    renderHook(() => useSessionPageFlow({ ...OPTS, audience: "guest" }), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    expect(mockSubmitApproval).not.toHaveBeenCalled();
+  });
+
+  it("never fires for an observer", async () => {
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    renderHook(() => useSessionPageFlow({ ...OPTS, audience: "observer" }), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    expect(mockSubmitApproval).not.toHaveBeenCalled();
+  });
+
+  it("never fires for a channel-origin session (read-only by construction)", async () => {
+    mockConv.session = {
+      spec: {},
+      metadata: { labels: { "stigmer.ai/channel-id": "ch_1" } },
+    };
+    mockConv.pendingApprovals = [{ toolCallId: "tc1" }];
+    renderHook(() => useSessionPageFlow(OPTS), {
+      wrapper: hostDefaultWrapper(true),
+    });
+
+    expect(mockSubmitApproval).not.toHaveBeenCalled();
   });
 });

--- a/sdk/react/src/session/useNewSessionFlow.ts
+++ b/sdk/react/src/session/useNewSessionFlow.ts
@@ -218,6 +218,18 @@ export interface UseNewSessionFlowReturn {
   /** Session variables (per-execution secrets) manager. */
   readonly sessionVariables: UseSessionVariablesReturn;
 
+  /**
+   * Pre-arm "auto-approve tool calls" for the session this surface will
+   * create (stigmer/stigmer#816, the walk-away scenario). Seeded from the
+   * host's `StigmerProvider` `approvalDefaults` (#302, guests excluded);
+   * the user's toggle wins from then on. Carried into the bootstrap create
+   * as `spec.auto_approve_all` — the whole-run server-side bypass — so the
+   * first run stays covered even if the user closes the tab.
+   */
+  readonly autoApproveAll: boolean;
+  /** Set the user's explicit auto-approve choice for the created session. */
+  readonly setAutoApproveAll: (value: boolean) => void;
+
   /** `true` while the create session + execution flow is in flight. */
   readonly isSubmitting: boolean;
   /** Human-readable error from the last failed submission, or `null`. */
@@ -311,13 +323,18 @@ export function useNewSessionFlow(
   const contextTarget = useExecutionTarget();
   const executionTarget = options.executionTarget ?? contextTarget;
   const adapter = useRunnerAdapter();
-  // Host approval default (#302): pre-arm auto_approve_all on the bootstrap
-  // create when the provider says so. Guests never inherit it — a share-link
-  // visitor is not the operator the host's trust judgment covers (the
-  // GUEST_HARNESS fixed-platform-policy reasoning).
+  // Auto-approve for the session about to be created (#816): the host
+  // approval default (#302) seeds the INITIAL state only; the user's
+  // composer toggle wins from then on. Guests never inherit the default
+  // and never see the toggle — a share-link visitor is not the operator
+  // the host's trust judgment covers (the GUEST_HARNESS
+  // fixed-platform-policy reasoning). Carried into the bootstrap create as
+  // spec.auto_approve_all, the whole-run server-side bypass — the created
+  // run stays covered even if this tab dies before its first gate.
   const approvalDefaults = useApprovalDefaults();
-  const autoApproveAll =
-    (!isGuest && approvalDefaults?.autoApproveAll) || undefined;
+  const [autoApproveAll, setAutoApproveAll] = useState(
+    () => !isGuest && (approvalDefaults?.autoApproveAll ?? false),
+  );
 
   const [harness, setHarnessRaw] = useState<HarnessOption>(() => {
     // Guests get the fixed platform policy (see GUEST_HARNESS) and never
@@ -496,7 +513,9 @@ export function useNewSessionFlow(
             ? (pinnedThinkingMode === "enabled" ? "enabled" : undefined)
             : context?.thinkingMode,
           workspaceFileRefs: context?.workspaceFileRefs,
-          autoApproveAll,
+          // Only an armed state travels; false stays off the wire (the
+          // serviceTier/thinkingMode only-explicit discipline).
+          autoApproveAll: autoApproveAll || undefined,
         };
 
         // Resolve which agent the bootstrapped session runs against: an
@@ -624,6 +643,8 @@ export function useNewSessionFlow(
     setSkillRefs,
     workspace,
     sessionVariables,
+    autoApproveAll,
+    setAutoApproveAll,
     isSubmitting,
     submitError,
     submit,

--- a/sdk/react/src/session/useSessionPageFlow.ts
+++ b/sdk/react/src/session/useSessionPageFlow.ts
@@ -20,6 +20,7 @@ import { useAgentRefFromSession } from "./useAgentRefFromSession.js";
 import { usePersistedModel, type UsePersistedModelReturn } from "./usePersistedModel.js";
 import { toSessionUpdateInput } from "@stigmer/sdk";
 import type { SessionAudience } from "./audience.js";
+import { isChannelOriginSession } from "./channelOrigin.js";
 import { assertValidRunConfig, type SessionRunConfig } from "./run-config.js";
 
 /**
@@ -140,20 +141,33 @@ export interface UseSessionPageFlowReturn {
   readonly sessionVariables: UseSessionVariablesReturn;
 
   /**
-   * Session-scoped "auto-approve tool calls" preference.
+   * Session-scoped "auto-approve tool calls" state (stigmer/stigmer#816).
    *
-   * `false` by default; a host can pre-arm it app-wide via
-   * `StigmerProvider`'s `approvalDefaults` (#302, guests excluded). Flipped
-   * to `true` when the user chooses "Approve & don't ask again" at an
-   * approval gate (see {@link submitApproval}), and carried into every
-   * subsequent follow-up via {@link handleSubmit}. Held in memory only —
-   * reset on reload / new session back to the host default, never persisted
-   * server-side.
+   * `false` by default. `true` when any of its sources arms it — the user's
+   * explicit choice always winning:
+   *
+   * 1. the user's composer toggle ({@link setAutoApproveAll});
+   * 2. "Approve & don't ask again" at an approval gate (see
+   *    {@link submitApproval});
+   * 3. the host's app-wide `StigmerProvider` `approvalDefaults` (#302,
+   *    guests excluded);
+   * 4. the active in-flight execution having been created with
+   *    `spec.auto_approve_all` (e.g. armed on the new-session surface), so
+   *    the state survives the launcher → session-page handoff.
+   *
+   * While `true`, follow-ups carry `auto_approve_all` ({@link handleSubmit})
+   * and gates appearing in the in-flight run are auto-released (never for
+   * guest/observer/channel-origin surfaces). Held in memory only — reset on
+   * reload back to the host default, never persisted server-side.
    */
   readonly autoApproveAll: boolean;
   /**
-   * Toggle the session-scoped auto-approve preference. The reversible "Turn off"
-   * control in the UI calls this with `false`.
+   * Set the user's explicit session-scoped auto-approve choice. Wired to the
+   * composer's always-visible toggle; an explicit `false` wins over the host
+   * default and over an armed in-flight run for everything the client
+   * controls (follow-up carry, gate auto-release) — an already-armed run's
+   * server-side bypass cannot be revoked mid-run, exactly as with today's
+   * gate-time "Approve & don't ask again".
    */
   readonly setAutoApproveAll: (value: boolean) => void;
 
@@ -322,17 +336,34 @@ export function useSessionPageFlow(
   const [skillRefs, setSkillRefs] = useState<ResourceRef[]>([]);
   const initialSyncDone = useRef(false);
 
-  // Session-scoped auto-approve. Armed either at the approval gate ("Approve &
-  // don't ask again") or from the host's provider-level approvalDefaults
-  // (#302) — an app-level trust judgment, so it seeds the INITIAL state only;
-  // the user's in-session "Turn off" always wins from then on. Guests never
-  // inherit the host default (a share-link visitor is not the operator the
-  // host's trust judgment covers). Lives only in memory for the life of this
-  // page — reset on reload re-applies the host default, never a user choice.
+  // Session-scoped auto-approve (#816). Derived like interactionMode above —
+  // the user's explicit in-session decision wins, otherwise the truth is
+  // computed from its sources — never an effect-synced copy:
+  //
+  //   effective = userChoice ?? (hostSeed || runArmed)
+  //
+  // - `userChoice`: the composer toggle, or the gate-time "Approve & don't
+  //   ask again" (which has always escalated the session preference).
+  // - `hostSeed`: the host's provider-level approvalDefaults (#302) — an
+  //   app-level trust judgment. Guests never inherit it (a share-link
+  //   visitor is not the operator the host's trust judgment covers).
+  // - `runArmed`: the ACTIVE execution was created with
+  //   spec.auto_approve_all, so the toggle reflects an armed in-flight run —
+  //   this is what carries the state across the new-session → session-page
+  //   handoff. Deliberately derived from the active execution ONLY, never
+  //   from history: deriving from past executions would silently survive a
+  //   reload and change the reset-on-reload consent contract below.
+  //
+  // Lives only in memory for the life of this page — reset on reload
+  // re-applies the host default, never a user choice.
   const approvalDefaults = useApprovalDefaults();
-  const [autoApproveAll, setAutoApproveAll] = useState(
-    () => !isGuest && (approvalDefaults?.autoApproveAll ?? false),
-  );
+  const [autoApproveChoice, setAutoApproveChoice] = useState<boolean | null>(null);
+  const hostSeed = !isGuest && (approvalDefaults?.autoApproveAll ?? false);
+  const runArmed = conv.activeStreamExecution?.spec?.autoApproveAll === true;
+  const autoApproveAll = autoApproveChoice ?? (hostSeed || runArmed);
+  const setAutoApproveAll = useCallback((value: boolean) => {
+    setAutoApproveChoice(value);
+  }, []);
 
   const submitApproval = useCallback<UseSessionConversationReturn["submitApproval"]>(
     async (toolCallId, action, comment) => {
@@ -341,12 +372,44 @@ export function useSessionPageFlow(
       // plane separately resolves the current execution's remaining gates and
       // the runner skips the gate for the rest of that run.
       if (action === ApprovalAction.APPROVE_ALL) {
-        setAutoApproveAll(true);
+        setAutoApproveChoice(true);
       }
       await conv.submitApproval(toolCallId, action, comment);
     },
     [conv.submitApproval],
   );
+
+  // Armed responder (#816, the walk-away scenario): while auto-approve is ON,
+  // answer each approval gate as it appears in the in-flight run. This must be
+  // a standing responder, not a flip-time one-shot: a gate-time APPROVE_ALL
+  // grants a lease scoped to ONE tool class (see APPROVAL_ACTION_APPROVE_ALL
+  // in agentexecution enum.proto), so a later gate of a different class would
+  // still park the run — the responder covers each class as it surfaces, and
+  // every released call keeps an honest audit decision.
+  //
+  // Read-only surfaces must never auto-submit approvals on a viewer's behalf:
+  // the predicate mirrors SessionViewer's read-only derivation (guest audience,
+  // observer audience, channel-origin session) exactly.
+  const canRespondToGates =
+    !isGuest &&
+    options.audience !== "observer" &&
+    !isChannelOriginSession(conv.session);
+  const respondedToolCallIds = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!autoApproveAll || !canRespondToGates) return;
+    for (const approval of conv.pendingApprovals) {
+      const toolCallId = approval.toolCallId;
+      // Marked before the submit resolves so a re-render mid-flight cannot
+      // double-submit. A failed submission is deliberately NOT retried — the
+      // approval card stays for a manual decision instead of a retry storm.
+      if (!toolCallId || respondedToolCallIds.current.has(toolCallId)) continue;
+      respondedToolCallIds.current.add(toolCallId);
+      void conv.submitApproval(toolCallId, ApprovalAction.APPROVE_ALL).catch(() => {
+        // Swallowed by design (see above); the card's own error surface
+        // reports the failure where the user can act on it.
+      });
+    }
+  }, [autoApproveAll, canRespondToGates, conv.pendingApprovals, conv.submitApproval]);
 
   // -------------------------------------------------------------------------
   // Agent — derive from session, allow mid-session changes


### PR DESCRIPTION
## Summary

Brings back a user-facing auto-approve control ([#816](https://github.com/stigmer/stigmer/issues/816)): a quiet toggle beside the composer input, visible before the first message is ever typed and interactive while a turn streams. Flipping it ON covers the in-flight execution — any waiting approval is released and later gates auto-release — and follow-ups/creates carry `auto_approve_all`.

## Context

The field pattern from the issue: users submit from a landing surface and walk away; minutes later the first gated shell command parks the run in `EXECUTION_WAITING_FOR_APPROVAL`. The gate-time "Approve & don't ask again" structurally cannot serve this user — they are not there when the gate renders. The #302 host default is the host's all-or-nothing judgment; this is each user's own per-conversation choice.

## Changes

- **`useSessionPageFlow`** — arming becomes derived state (the `interactionMode` idiom): `userChoice ?? (hostSeed || runArmed)`. The toggle reflects all three arming sources — gate-time approve-all, the #302 host default, and an in-flight run armed at create (the launcher → session-page handoff) — while keeping the reset-on-reload consent contract (`runArmed` derives from the ACTIVE execution only, never history).
- **Armed responder** (same hook) — while ON, each approval gate appearing in the in-flight run is auto-released with `APPROVAL_ACTION_APPROVE_ALL`, once per `toolCallId`, no retry on failure (the card stays for manual action). A *standing responder*, not a flip-time one-shot: gate-time `APPROVE_ALL` grants a **class-scoped lease** (see `APPROVAL_ACTION_APPROVE_ALL` in the agentexecution proto), so a later gate of a different class would otherwise still park the run. Never fires for guest/observer/channel-origin surfaces — the predicate mirrors the viewer's read-only derivation exactly.
- **`useNewSessionFlow`** — the read-only host-default seed becomes user-flippable state carried into the bootstrap create as `spec.auto_approve_all`, the proto's designated whole-run server-side bypass — the first run stays covered even if the tab closes before its first gate.
- **`SessionComposer` / `ComposerToolbar`** — new opt-in `autoApprove` prop (DD-011; omission is byte-identical) rendering the existing `Switch` in the toolbar's primary-state group, exempt from the composer's streaming lock (the Stop-button precedent, the #283 adjacency). `ComposerAutoApproveProps` exported from the package root.
- **`SessionViewer` / `NewSessionViewer`** — toggle wired for integrator AND endUser audiences (the walk-away persona is an embedder's end user), never guests; the armed-only `AutoApproveIndicator` banner is replaced by the toggle (same semantics, now always reachable). Client apps inherit through the SDK organisms — zero client-app changes (DD-016 by construction).

## Implementation notes

- Mid-run effectiveness for the *current* run is client-side by design: the proto blesses the session-scoped preference as "a client concern, not server-persisted state", and every released call keeps an honest audit decision with lease provenance. New runs use the server-side whole-run bypass (`AUTO_APPROVE_ALL` provenance).
- An explicit OFF beats the host default and an armed run for everything the client controls (follow-up carry, gate auto-release); an already-armed run's server-side bypass cannot be revoked mid-run — exactly as with today's gate-time approve-all.

## Breaking changes

- None. The composer prop is opt-in; all existing auto-approve behaviors (gate-time arming, host default, guest exclusions, follow-up carry) are pinned by the pre-existing tests, which pass unmodified.

## Test plan

- 23 flow pins (11 pre-existing untouched + 12 new: derivation/handoff/consent-contract, responder single-fire, different-class coverage, no-retry, guest/observer/channel-origin exclusion)
- 4 toolbar pins (opt-in absence, labeled switch, onChange, lock exemption)
- 5 viewer wiring pins (integrator/endUser/guest matrix, armed mirroring, indicator retirement) + 2 new-session carry pins
- Full `sdk/react` suite: 437 files / 4722 tests green; lint, typecheck, and the DD-018 ESM specifier gate pass.

Closes #816

Made with [Cursor](https://cursor.com)