### PR TITLE
fix(skill): converge versioning to the repoint, single-holder-tag model

### DIFF
--- a/backend/services/stigmer-server/pkg/domain/skill/controller/list_versions.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/list_versions.go
@@ -19,14 +19,17 @@ const (
 	defaultPageSize = 50
 	maxPageSize     = 100
 
-	listVersionsSkillIDKey = "listVersionsSkillId"
+	listVersionsSkillIDKey  = "listVersionsSkillId"
+	listVersionsHeadHashKey = "listVersionsHeadHash"
 )
 
 // ListVersions returns the version history for a skill, identified by org and slug.
 //
 // The handler resolves the skill by slug, loads all audit records, maps them to
-// SkillVersionEntry protos, and applies cursor-based pagination. The first entry
-// (newest) is marked as is_current=true.
+// SkillVersionEntry protos, and applies cursor-based pagination. The entry whose
+// hash matches the live head is marked is_current=true (see the currency note
+// in LoadAndMapVersionsStep); tags come from the audit tag column, the tag's
+// source of truth under the single-holder model (stigmer/stigmer#475).
 func (c *SkillController) ListVersions(ctx context.Context, req *skillv1.ListSkillVersionsInput) (*skillv1.ListSkillVersionsResponse, error) {
 	reqCtx := pipeline.NewRequestContext(ctx, req)
 
@@ -78,6 +81,11 @@ func (s *ResolveSkillBySlugStep) Execute(ctx *pipeline.RequestContext[*skillv1.L
 	}
 
 	ctx.Set(listVersionsSkillIDKey, skill.Metadata.Id)
+	// The live head's hash decides is_current downstream. Under repoint
+	// semantics (re-pushing archived content re-activates its existing row,
+	// stigmer/stigmer#475) the current version need not be the
+	// newest-archived row, so recency cannot stand in for currency.
+	ctx.Set(listVersionsHeadHashKey, skill.GetStatus().GetVersionHash())
 	return nil
 }
 
@@ -98,18 +106,29 @@ func (s *LoadAndMapVersionsStep) Execute(ctx *pipeline.RequestContext[*skillv1.L
 	req := ctx.Input()
 	skillID := ctx.Get(listVersionsSkillIDKey).(string)
 
-	records, err := s.store.ListAuditHistory(ctx.Context(), apiresourcekind.ApiResourceKind_skill, skillID)
+	records, err := s.store.ListAuditRecords(ctx.Context(), apiresourcekind.ApiResourceKind_skill, skillID)
 	if err != nil {
 		return grpclib.InternalError(err, "failed to load version history")
 	}
 
+	// is_current = the entry whose hash matches the live head, not the newest
+	// row: re-pushing archived content repoints the head at an older archived
+	// version without inserting a new row (stigmer/stigmer#475), so recency
+	// and currency legitimately diverge. Legacy data may hold duplicate-hash
+	// rows (predating the repoint semantics); marking only the first match
+	// keeps exactly-one-current true for them too.
+	headHash, _ := ctx.Get(listVersionsHeadHashKey).(string)
+	currentMarked := false
 	entries := make([]*skillv1.SkillVersionEntry, 0, len(records))
-	for i, data := range records {
+	for _, rec := range records {
 		var skill skillv1.Skill
-		if err := proto.Unmarshal(data, &skill); err != nil {
+		if err := proto.Unmarshal(rec.Data, &skill); err != nil {
 			continue
 		}
-		entries = append(entries, mapSkillToVersionEntry(&skill, i == 0))
+		isCurrent := !currentMarked && headHash != "" && skill.GetStatus().GetVersionHash() == headHash
+		currentMarked = currentMarked || isCurrent
+		// Tag comes from the audit column (source of truth), not the snapshot.
+		entries = append(entries, mapSkillToVersionEntry(&skill, isCurrent, rec.Tag))
 	}
 
 	// Pagination
@@ -161,9 +180,13 @@ func (s *LoadAndMapVersionsStep) Execute(ctx *pipeline.RequestContext[*skillv1.L
 }
 
 // mapSkillToVersionEntry maps an archived Skill proto to a SkillVersionEntry.
-func mapSkillToVersionEntry(skill *skillv1.Skill, isCurrent bool) *skillv1.SkillVersionEntry {
+// The tag comes from the audit tag column (single-holder source of truth),
+// never from the snapshot's spec.tag — snapshots are archived tagless and a
+// legacy snapshot's embedded tag may have moved since it was written.
+func mapSkillToVersionEntry(skill *skillv1.Skill, isCurrent bool, tag string) *skillv1.SkillVersionEntry {
 	entry := &skillv1.SkillVersionEntry{
 		IsCurrent: isCurrent,
+		Tag:       tag,
 	}
 
 	if skill.Status != nil {
@@ -182,10 +205,6 @@ func mapSkillToVersionEntry(skill *skillv1.Skill, isCurrent bool) *skillv1.Skill
 				entry.PushedBy = audit.CreatedBy
 			}
 		}
-	}
-
-	if skill.Spec != nil {
-		entry.Tag = skill.Spec.Tag
 	}
 
 	if skill.Metadata != nil && skill.Metadata.Version != nil {

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/load_skill_by_reference.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/load_skill_by_reference.go
@@ -173,7 +173,11 @@ func (s *LoadSkillByReferenceStep) skillMatchesVersion(skill *skillv1.Skill, ver
 		return skill.Status.VersionHash == version
 	}
 
-	// Otherwise, treat as tag
+	// Otherwise, treat as tag. Matching the live head's spec.tag is honest
+	// under the single-holder tag model (stigmer/stigmer#475): the push
+	// pipeline reconciles the live tag with the audit tag column (assigning
+	// through SetAuditTag, clearing spec.tag if that assignment fails), so a
+	// live head advertising a tag IS that tag's current holder.
 	if skill.Spec != nil && skill.Spec.Tag == version {
 		return true
 	}
@@ -186,7 +190,9 @@ func (s *LoadSkillByReferenceStep) skillMatchesVersion(skill *skillv1.Skill, ver
 //
 // Query strategy:
 //   - If version is a hash: Use GetAuditByHash for O(log n) indexed lookup
-//   - If version is a tag: Use GetAuditByTag which returns most recent by archived_at
+//   - If version is a tag: Use GetAuditByTag, which reads the audit tag
+//     column — under the single-holder model at most one row matches
+//     (newest-wins is only a defensive tiebreaker for legacy multi-holder data)
 func (s *LoadSkillByReferenceStep) findAuditSkillByVersion(ctx context.Context, skillID, version string) (*skillv1.Skill, bool, error) {
 	var skill skillv1.Skill
 

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/push.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/push.go
@@ -2,6 +2,7 @@ package skill
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog/log"
@@ -38,7 +39,8 @@ const (
 // 5. Checks if artifact exists and stores if new (deduplication)
 // 6. Constructs resource ID (org-scoped or platform-scoped)
 // 7. Loads existing skill if it exists
-// 8. Archives previous version if updating
+// 8. Archives the new version (repoint-never-duplicate; tag via the
+//    single-holder audit column — see ArchiveCurrentSkillStep)
 // 9. Updates skill with artifact info and timestamps
 // 10. Persists skill to SQLite
 //
@@ -397,26 +399,31 @@ func (s *CheckAndStoreArtifactStep) Execute(ctx *pipeline.RequestContext[*skillv
 	return nil
 }
 
-// ArchiveCurrentSkillStep archives the NEW skill (after populating fields)
+// ArchiveCurrentSkillStep archives the NEW skill version (after fields are
+// populated), under the content-addressed versioning model shared with
+// workflows (stigmer/stigmer#341, adopted for skills in #475):
 //
-// This step preserves version history by saving a snapshot of the current skill
-// to the dedicated audit table. The archive happens AFTER all fields are populated
-// (including new artifact data).
+//   - Versions are content-addressed identities — one content, one history
+//     row. Re-pushing content that was EVER archived repoints the head to
+//     the existing row instead of inserting a duplicate. A head-only
+//     comparison cannot see the A→B→A case (the hash is the SHA-256 of the
+//     artifact, so re-pushes reproduce it deterministically) and would
+//     duplicate A's row.
+//   - Snapshots are archived TAGLESS: the audit tag COLUMN is the tag's only
+//     home, assigned through the single-holder SetAuditTag primitive, so a
+//     tag names exactly one version and a later tag move never rewrites
+//     immutable snapshot content.
+//   - The tag is assigned even when the content is already archived: skills
+//     have no tagVersion RPC, so re-pushing existing content under a new tag
+//     is the only way to retag — it must reach the audit column.
 //
-// Archival is best-effort - failures are logged but don't stop the push operation.
-//
-// Audit Pattern:
-// - Each push triggers archival (both create and update)
-// - Archived records are immutable (never modified)
-// - Archive contains the CURRENT state (with new artifact data)
-// - Query by tag returns latest version with that tag (sorted by timestamp)
-// - Query by hash returns exact match
-//
-// The audit records are stored in a dedicated resource_audit table with:
-// - resource_id: references the main skill's ID
-// - version_hash: for exact version lookups
-// - tag: for tag-based lookups
-// - archived_at: timestamp for ordering
+// Safe-degradation (the workflow invariant): if archival fails, the version
+// hash is cleared from the in-context skill so the persisted head never
+// references an unresolvable audit entry — the push itself still succeeds,
+// just without version tracking for this apply (StoreSkill, the next step,
+// persists the reverted state). If only the tag assignment fails, the live
+// spec.tag is cleared so the head never advertises a tag the audit column
+// cannot resolve.
 type ArchiveCurrentSkillStep struct {
 	store store.Store
 }
@@ -434,51 +441,89 @@ func (s *ArchiveCurrentSkillStep) Name() string {
 func (s *ArchiveCurrentSkillStep) Execute(ctx *pipeline.RequestContext[*skillv1.PushSkillRequest]) error {
 	skill := ctx.Get(SkillKey).(*skillv1.Skill)
 
-	// Content-addressed change gate: a skill version is the immutable SHA-256 of
-	// its artifact, so re-pushing identical content must NOT append a duplicate
-	// audit row (the inverse of the "only one version" bug — duplicate timeline
-	// entries for the same content). Mirrors the workflow change gate and the
-	// cloud SkillPushHandler. New skills (no existing) always archive.
-	if existing, ok := ctx.Get(ExistingSkillKey).(*skillv1.Skill); ok && existing != nil &&
-		existing.Status != nil && existing.Status.VersionHash == skill.Status.VersionHash {
-		log.Info().
-			Str("skill_id", skill.Metadata.Id).
-			Str("version_hash", skill.Status.VersionHash).
-			Msg("ArchiveCurrentSkill: content unchanged, skipping version archival")
-		return nil
-	}
-
-	// Archive the current skill (with all new data populated)
-	if err := s.archiveSkill(ctx.Context(), skill); err != nil {
-		log.Warn().Err(err).
-			Str("skill_id", skill.Metadata.Id).
-			Msg("ArchiveCurrentSkill: failed to archive skill (best-effort)")
-	}
-
-	return nil
-}
-
-// archiveSkill saves a snapshot to the audit table for version history.
-// The archived skill can be queried by tag or hash.
-func (s *ArchiveCurrentSkillStep) archiveSkill(ctx context.Context, skill *skillv1.Skill) error {
-	// Extract version hash and tag for indexed queries
 	versionHash := ""
-	tag := ""
 	if skill.Status != nil {
 		versionHash = skill.Status.VersionHash
 	}
+	if versionHash == "" {
+		return nil
+	}
+	tag := ""
 	if skill.Spec != nil {
 		tag = skill.Spec.Tag
 	}
+	skillID := skill.Metadata.Id
 
-	// Save snapshot to audit table using the dedicated SaveAudit method
-	// This creates a proper audit record with:
-	// - resource_id: skill.Metadata.Id (for foreign key relationship)
-	// - version_hash: for exact version lookups
-	// - tag: for tag-based lookups
-	// - archived_at: auto-set to current timestamp
-	if err := s.store.SaveAudit(ctx, apiresourcekind.ApiResourceKind_skill, skill.Metadata.Id, skill, versionHash, tag); err != nil {
-		return fmt.Errorf("failed to archive skill: %w", err)
+	// Repoint, never duplicate: if this content was ever archived, the head
+	// simply repoints to the existing row and only the tag assignment below
+	// still runs. An unexpected lookup failure degrades to archiving anyway —
+	// a possible duplicate row beats a failed push (readers resolve
+	// duplicates newest-wins).
+	var existingSnapshot skillv1.Skill
+	lookupErr := s.store.GetAuditByHash(ctx.Context(), apiresourcekind.ApiResourceKind_skill, skillID, versionHash, &existingSnapshot)
+	alreadyArchived := lookupErr == nil
+	if lookupErr != nil && !errors.Is(lookupErr, store.ErrAuditNotFound) {
+		log.Warn().
+			Err(lookupErr).
+			Str("skill_id", skillID).
+			Str("version_hash", versionHash).
+			Msg("Could not check for an existing archived skill version — archiving anyway")
+	}
+
+	if !alreadyArchived {
+		// Archive the snapshot tagless. The tag lives only in the audit tag
+		// column (the source of truth), assigned below through the
+		// single-holder primitive. Snapshot blobs are never the tag's home,
+		// so a later tag move never rewrites this immutable content.
+		if err := s.store.SaveAudit(ctx.Context(), apiresourcekind.ApiResourceKind_skill, skillID, skill, versionHash, ""); err != nil {
+			log.Error().
+				Err(err).
+				Str("skill_id", skillID).
+				Str("version_hash", versionHash).
+				Msg("Failed to archive skill version — reverting the version hash to maintain the audit-resolvability invariant")
+
+			// Revert: the persisted head must never reference an audit entry
+			// that does not exist. The push still succeeds, but without
+			// version tracking for this apply.
+			skill.Status.VersionHash = ""
+			if skill.Metadata != nil && skill.Metadata.Version != nil {
+				skill.Metadata.Version.Id = ""
+			}
+			return nil
+		}
+	}
+
+	// Assign the requested tag through SetAuditTag — the single-holder
+	// primitive — so the head version (freshly archived or repointed-to)
+	// becomes the tag's sole holder; any prior holder is cleared.
+	if tag != "" {
+		if err := s.store.SetAuditTag(ctx.Context(), apiresourcekind.ApiResourceKind_skill, skillID, versionHash, tag); err != nil {
+			log.Error().
+				Err(err).
+				Str("skill_id", skillID).
+				Str("version_hash", versionHash).
+				Str("tag", tag).
+				Msg("Archived skill version but failed to assign its tag — clearing the live tag to stay consistent with the audit column")
+
+			// The audit head is now untagged; keep the live head consistent
+			// so get / getByReference never advertise a tag the store cannot
+			// resolve.
+			skill.Spec.Tag = ""
+		}
+	}
+
+	if alreadyArchived {
+		log.Info().
+			Str("skill_id", skillID).
+			Str("version_hash", versionHash).
+			Str("tag", tag).
+			Msg("Skill version content already archived — repointed head without a new history row")
+	} else {
+		log.Info().
+			Str("skill_id", skillID).
+			Str("version_hash", versionHash).
+			Str("tag", tag).
+			Msg("Archived skill version to audit history")
 	}
 
 	return nil

--- a/backend/services/stigmer-server/pkg/domain/skill/controller/versioning_repoint_test.go
+++ b/backend/services/stigmer-server/pkg/domain/skill/controller/versioning_repoint_test.go
@@ -1,0 +1,168 @@
+package skill
+
+import (
+	"testing"
+
+	skillv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/skill/v1"
+	apiresourcepb "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	"github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource/apiresourcekind"
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/domain/skill/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// These tests pin the content-addressed version identity contract for skills
+// (stigmer/stigmer#475 — the model workflows adopted in #341):
+//
+//   - one content, one history row: re-pushing already-archived content
+//     repoints the head instead of inserting a duplicate (the A→B→A case);
+//   - the audit tag column is the tag's only home, single-holder: a tag names
+//     exactly one version, moving off its prior holder on every assignment;
+//   - is_current follows the live head hash, not row recency — under repoint
+//     the current version need not be the newest-archived row.
+
+// pushSkillArtifact pushes a skill built from the given body under the given
+// tag and returns the resulting skill.
+func pushSkillArtifact(t *testing.T, controller *SkillController, name, body, tag string) *skillv1.Skill {
+	t.Helper()
+	content := storage.ValidSkillContent(name, body)
+	result, err := controller.Push(contextWithSkillKind(), &skillv1.PushSkillRequest{
+		Artifact: storage.CreateTestZip(content),
+		Tag:      tag,
+		Org:      "test-org",
+	})
+	require.NoError(t, err)
+	return result
+}
+
+type skillVersionExpectation struct {
+	hash      string
+	tag       string
+	isCurrent bool
+}
+
+// assertSkillVersionHistory asserts the exact newest-first version history,
+// each entry's column-derived tag, and that exactly one entry is current.
+func assertSkillVersionHistory(t *testing.T, controller *SkillController, slug string, want []skillVersionExpectation) {
+	t.Helper()
+
+	resp, err := controller.ListVersions(contextWithSkillKind(), &skillv1.ListSkillVersionsInput{
+		Org:  "test-org",
+		Slug: slug,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Versions, len(want), "version history row count")
+
+	currentCount := 0
+	for i, entry := range resp.Versions {
+		assert.Equal(t, want[i].hash, entry.VersionHash, "versions[%d].version_hash", i)
+		assert.Equal(t, want[i].tag, entry.Tag, "versions[%d].tag", i)
+		assert.Equal(t, want[i].isCurrent, entry.IsCurrent, "versions[%d].is_current", i)
+		if entry.IsCurrent {
+			currentCount++
+		}
+	}
+	assert.Equal(t, 1, currentCount, "exactly one version must be current")
+}
+
+// TestSkillVersioning_RepushRepointsHead pins the A→B→A contract end to end:
+// re-pushing prior content reproduces its hash (the hash is the SHA-256 of
+// the artifact), the head repoints to the existing audit row without a
+// duplicate, the single-holder tag follows the head, and is_current lands on
+// the repointed-to (older) row.
+func TestSkillVersioning_RepushRepointsHead(t *testing.T) {
+	controller, store := setupTestController(t)
+	defer store.Close()
+
+	atA := pushSkillArtifact(t, controller, "repoint-skill", "# Body A", "stable")
+	hashA := atA.GetStatus().GetVersionHash()
+	require.NotEmpty(t, hashA, "push must compute a version hash")
+	assertSkillVersionHistory(t, controller, atA.Metadata.Slug, []skillVersionExpectation{
+		{hash: hashA, tag: "stable", isCurrent: true},
+	})
+
+	atB := pushSkillArtifact(t, controller, "repoint-skill", "# Body B", "stable")
+	hashB := atB.GetStatus().GetVersionHash()
+	require.NotEqual(t, hashA, hashB, "changed content must change the version hash")
+	// Single-holder: "stable" moved to B; A's row is now untagged.
+	assertSkillVersionHistory(t, controller, atA.Metadata.Slug, []skillVersionExpectation{
+		{hash: hashB, tag: "stable", isCurrent: true},
+		{hash: hashA, tag: "", isCurrent: false},
+	})
+
+	rolledBack := pushSkillArtifact(t, controller, "repoint-skill", "# Body A", "stable")
+	assert.Equal(t, hashA, rolledBack.GetStatus().GetVersionHash(),
+		"re-pushing prior content must repoint the head to its hash")
+	assert.Equal(t, hashB, rolledBack.GetMetadata().GetVersion().GetPreviousVersionId(),
+		"the version chain must record the replaced head")
+	// Still two rows — newest-archived first — with the tag AND currency on
+	// the OLDER row: recency and currency legitimately diverge under repoint.
+	assertSkillVersionHistory(t, controller, atA.Metadata.Slug, []skillVersionExpectation{
+		{hash: hashB, tag: "", isCurrent: false},
+		{hash: hashA, tag: "stable", isCurrent: true},
+	})
+
+	// Tag resolution follows the single holder: skill@stable is content A.
+	resolved, err := controller.GetByReference(contextWithSkillKind(), &apiresourcepb.ApiResourceReference{
+		Kind:    apiresourcekind.ApiResourceKind_skill,
+		Org:     "test-org",
+		Slug:    atA.Metadata.Slug,
+		Version: "stable",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, hashA, resolved.GetStatus().GetVersionHash(), "skill@stable must resolve to the tag's sole holder")
+}
+
+// TestSkillVersioning_SameContentRepushMovesTag pins the retag path: skills
+// have no tagVersion RPC, so re-pushing existing content under a new tag is
+// the only way to retag — it must move the audit column tag without adding a
+// history row, and the old tag must stop resolving.
+func TestSkillVersioning_SameContentRepushMovesTag(t *testing.T) {
+	controller, store := setupTestController(t)
+	defer store.Close()
+
+	atV1 := pushSkillArtifact(t, controller, "retag-skill", "# Same body", "v1")
+	hash := atV1.GetStatus().GetVersionHash()
+	assertSkillVersionHistory(t, controller, atV1.Metadata.Slug, []skillVersionExpectation{
+		{hash: hash, tag: "v1", isCurrent: true},
+	})
+
+	retagged := pushSkillArtifact(t, controller, "retag-skill", "# Same body", "v2")
+	assert.Equal(t, hash, retagged.GetStatus().GetVersionHash(), "identical content must keep its hash")
+	// One content, one row — the tag moved, no duplicate was inserted.
+	assertSkillVersionHistory(t, controller, atV1.Metadata.Slug, []skillVersionExpectation{
+		{hash: hash, tag: "v2", isCurrent: true},
+	})
+
+	// The old tag has no holder anymore.
+	_, err := controller.GetByReference(contextWithSkillKind(), &apiresourcepb.ApiResourceReference{
+		Kind:    apiresourcekind.ApiResourceKind_skill,
+		Org:     "test-org",
+		Slug:    atV1.Metadata.Slug,
+		Version: "v1",
+	})
+	require.Error(t, err, "a moved-away tag must stop resolving")
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestSkillVersioning_LatestTagFollowsHead pins the dominant real-world path:
+// the CLI defaults untagged pushes to the tag "latest", so under the
+// single-holder model "latest" is a moving pointer to the newest push.
+func TestSkillVersioning_LatestTagFollowsHead(t *testing.T) {
+	controller, store := setupTestController(t)
+	defer store.Close()
+
+	atA := pushSkillArtifact(t, controller, "latest-skill", "# First", "latest")
+	hashA := atA.GetStatus().GetVersionHash()
+
+	atB := pushSkillArtifact(t, controller, "latest-skill", "# Second", "latest")
+	hashB := atB.GetStatus().GetVersionHash()
+	require.NotEqual(t, hashA, hashB)
+
+	assertSkillVersionHistory(t, controller, atA.Metadata.Slug, []skillVersionExpectation{
+		{hash: hashB, tag: "latest", isCurrent: true},
+		{hash: hashA, tag: "", isCurrent: false},
+	})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,6 +2919,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3758,6 +3759,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3780,6 +3782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3802,6 +3805,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3818,6 +3822,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3834,6 +3839,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3850,6 +3856,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3866,6 +3873,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3882,6 +3890,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3898,6 +3907,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3914,6 +3924,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3930,6 +3941,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3946,6 +3958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3962,6 +3975,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3984,6 +3998,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4006,6 +4021,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4028,6 +4044,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4050,6 +4067,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4072,6 +4090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4094,6 +4113,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4116,6 +4136,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4138,6 +4159,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4157,6 +4179,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4176,6 +4199,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4195,6 +4219,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16907,12 +16932,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,7 +2919,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3759,7 +3758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3782,7 +3780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3805,7 +3802,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3822,7 +3818,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3839,7 +3834,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3856,7 +3850,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3873,7 +3866,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3890,7 +3882,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3907,7 +3898,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3924,7 +3914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3941,7 +3930,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3958,7 +3946,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3975,7 +3962,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3998,7 +3984,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4021,7 +4006,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4044,7 +4028,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4067,7 +4050,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4090,7 +4072,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4113,7 +4094,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4136,7 +4116,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4159,7 +4138,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4179,7 +4157,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4199,7 +4176,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4219,7 +4195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16932,14 +16907,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/test/conformance/src/suites/skill.conformance.test.ts
+++ b/test/conformance/src/suites/skill.conformance.test.ts
@@ -529,6 +529,86 @@ describe("Skill conformance — listVersions", () => {
   });
 });
 
+// The content-addressed versioning contract (stigmer/stigmer#475 — the model
+// workflows pinned in #341): one content is one history row, re-pushing
+// archived content repoints the head instead of duplicating it, a tag names
+// exactly one version (single-holder, moving on every assignment), and
+// is_current follows the live head rather than row recency.
+describe("Skill conformance — content-addressed versioning (repoint, single-holder tags)", () => {
+  it("A→B→A re-push repoints the head without a duplicate row and the tag follows", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("skill");
+
+    const vA = await pushSkill(org, makeSkillArtifact({ name, body: "# body A" }), { tag: "stable" });
+    const vB = await pushSkill(org, makeSkillArtifact({ name, body: "# body B" }), { tag: "stable", track: false });
+    expect(vB.status?.versionHash).not.toBe(vA.status?.versionHash);
+
+    // Re-push A's content: the artifact hash is deterministic, so this is
+    // hash A again — the head must repoint, not insert a third row.
+    const rolledBack = await pushSkill(org, makeSkillArtifact({ name, body: "# body A" }), {
+      tag: "stable",
+      track: false,
+    });
+    expect(rolledBack.status?.versionHash, "re-pushed prior content keeps its hash").toBe(vA.status?.versionHash);
+
+    const history = await clients.skillQuery.listVersions({ org, slug: name });
+    expect(history.versions, "one content, one history row — no duplicate for the re-push").toHaveLength(2);
+
+    // Newest-archived first (B), but currency and the tag sit on the OLDER
+    // repointed-to row (A): recency and currency legitimately diverge.
+    expect(history.versions[0]?.versionHash).toBe(vB.status?.versionHash);
+    expect(history.versions[0]?.isCurrent).toBe(false);
+    expect(history.versions[0]?.tag, "the moved-away holder is untagged").toBe("");
+    expect(history.versions[1]?.versionHash).toBe(vA.status?.versionHash);
+    expect(history.versions[1]?.isCurrent, "is_current follows the live head, not row recency").toBe(true);
+    expect(history.versions[1]?.tag).toBe("stable");
+
+    const byTag = await clients.skillQuery.getByReference({ org, slug: name, version: "stable" });
+    expect(byTag.status?.versionHash, "the tag resolves to its sole holder").toBe(vA.status?.versionHash);
+  });
+
+  it("re-pushing identical content under a new tag moves the tag without a new row", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("skill");
+
+    const v1 = await pushSkill(org, makeSkillArtifact({ name, body: "# same body" }), { tag: "v1" });
+    const retagged = await pushSkill(org, makeSkillArtifact({ name, body: "# same body" }), {
+      tag: "v2",
+      track: false,
+    });
+    expect(retagged.status?.versionHash, "identical content keeps its hash").toBe(v1.status?.versionHash);
+
+    const history = await clients.skillQuery.listVersions({ org, slug: name });
+    expect(history.versions, "retagging adds no history row").toHaveLength(1);
+    expect(history.versions[0]?.tag, "the tag moved to the new name").toBe("v2");
+
+    const byNewTag = await clients.skillQuery.getByReference({ org, slug: name, version: "v2" });
+    expect(byNewTag.status?.versionHash).toBe(v1.status?.versionHash);
+
+    await expectGrpcCode(
+      () => clients.skillQuery.getByReference({ org, slug: name, version: "v1" }),
+      Code.NotFound,
+      "a moved-away tag stops resolving",
+    );
+  });
+
+  it('"latest" (the CLI default tag) moves to each new push', async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("skill");
+
+    const vA = await pushSkill(org, makeSkillArtifact({ name, body: "# first" }), { tag: "latest" });
+    const vB = await pushSkill(org, makeSkillArtifact({ name, body: "# second" }), { tag: "latest", track: false });
+
+    const history = await clients.skillQuery.listVersions({ org, slug: name });
+    expect(history.versions).toHaveLength(2);
+    expect(history.versions[0]?.versionHash).toBe(vB.status?.versionHash);
+    expect(history.versions[0]?.tag, '"latest" names the newest push').toBe("latest");
+    expect(history.versions[0]?.isCurrent).toBe(true);
+    expect(history.versions[1]?.versionHash).toBe(vA.status?.versionHash);
+    expect(history.versions[1]?.tag, "the prior holder is untagged").toBe("");
+  });
+});
+
 describe("Skill conformance — updateVisibility", () => {
   it("changes an org-default skill to public", async () => {
     // Escalation to PUBLIC is operator-gated in the cloud edition (both


### PR DESCRIPTION
## Summary

Converges skill versioning to the content-addressed model workflows adopted in #341: one content is one history row, re-pushing archived content repoints the head instead of duplicating it, and a tag names exactly one version. Owner-ruled CONVERGE on the issue; the cloud twin (stigmer/stigmer-cloud#334) moves in lockstep in its own PR.

## Context

Re-pushing a skill artifact whose content matches an OLDER version (A→B→A — the hash is the SHA-256 of the ZIP, deterministically reproducible) inserted a duplicate audit row: `ArchiveCurrentSkillStep` gated only on the *head* hash, so it could not see content archived further back. Skills also kept a divergent tag model (archive-time facts inside snapshots, resolved most-recently-archived-wins) that already nearly caused a shipped bug (the cloud#191 session's naive guard) and contradicted the documented contract (`docs/sdk/resources/skill.mdx`: a tag "resolves to THE version with this tag").

## Changes

- `push.go` `ArchiveCurrentSkillStep`: head-only gate replaced with the ever-archived repoint check (mirroring workflow `saveVersionAuditStep`); snapshots archive TAGLESS; the tag is assigned through the single-holder `SetAuditTag` primitive — including on the repoint and identical-content paths, since skills have no tagVersion RPC and re-push-with-new-tag is the only retag lane; adopts the workflow safe-degradation invariant (versionHash revert on archive failure, live-tag clear on tag-assignment failure) replacing fire-and-forget best-effort.
- `list_versions.go`: `is_current` derives from the live head hash (not row recency — under repoint they legitimately diverge); entry tags come from the audit tag column, not the snapshot; legacy duplicate-hash rows tolerated via first-match currency.
- `load_skill_by_reference.go`: comments truthed to the single-holder model (the live-head tag shortcut is now honest by construction; `GetAuditByTag`'s newest-wins is a defensive legacy tiebreaker only).
- New `versioning_repoint_test.go`: A→B→A repoint + chain, same-content retag moves the tag without a new row (old tag stops resolving), and `latest` (the CLI's default tag) as a moving pointer.
- Conformance: new "content-addressed versioning" suite pinning the cross-edition contract (repoint, single-holder tag, head-derived currency, `latest` movement) — these pins define what the cloud twin must match.

## Implementation notes

- No SQLite migration and no unique index — deliberately mirroring the OSS workflow lane: the repoint guard prevents new duplicates, readers tolerate legacy ones (newest-wins tiebreakers already shipped in #474), and "a possible duplicate row beats a failed push".
- The artifact-lane push (`PushFromExecutionArtifact`) delegates to the standard Push pipeline, so one archive step covers both entry points.

## Breaking changes

- Tag semantics are now single-holder: re-pushing content under an existing tag MOVES the tag off its prior holder (previously both rows carried it in their snapshots). This is the documented contract and the ruled convergence; `listVersions` no longer shows duplicate rows for re-pushed content.

## Test plan

- `go test ./backend/services/stigmer-server/pkg/domain/skill/... ./backend/libs/go/store/...` — green, including 3 new repoint pins.
- `make check-go` — full Go gate green.
- Skill conformance suite vs `local-go`: 54 passed / 1 capability-skipped, including the 3 new cross-edition pins.

## Risks

- The new conformance pins run against the cloud target nightly and will be RED until the cloud twin (stigmer/stigmer-cloud#334) merges — a deliberate, brief filed-drift window; merge the cloud PR promptly after this one.

Closes #475

Made with [Cursor](https://cursor.com)