### PR TITLE
fix(sdk/react): un-break gen-react-sdk-docs under npm ci — derive the drag fixture's event type

### DIFF
--- a/docs/sdk/react/version-history.mdx
+++ b/docs/sdk/react/version-history.mdx
@@ -237,7 +237,7 @@ A single line within a diff hunk.
     content: { type: "string", description: "", required: true },
     newLineNumber: { type: "number", description: "" },
     oldLineNumber: { type: "number", description: "" },
-    type: { type: "\"context\" | \"added\" | \"removed\"", description: "", required: true },
+    type: { type: "\"added\" | \"removed\" | \"context\"", description: "", required: true },
   }}
 />
 

--- a/sdk/react/src/workflow/__tests__/useWorkflowCanvas.dirty.test.tsx
+++ b/sdk/react/src/workflow/__tests__/useWorkflowCanvas.dirty.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
-import type { Node } from "@xyflow/react";
+import type { Node, OnNodeDrag } from "@xyflow/react";
 import { useWorkflowCanvas } from "../useWorkflowCanvas";
 
 // Regression tests for oss#609: isDirty was a model-reference comparison
@@ -54,10 +54,12 @@ function renderCanvas() {
 
 type CanvasResult = ReturnType<typeof renderCanvas>["result"];
 
-// React Flow's drag handlers take the NATIVE event (@xyflow types accept
-// MouseEvent | TouchEvent); @types/react >= 19.2.18 no longer lets the
-// synthetic React.MouseEvent stand in for it.
-const DRAG_EVENT = {} as MouseEvent;
+// The drag fixture derives its type from the handler itself, so it tracks
+// whatever event type the installed @xyflow/react declares (the pinned
+// 12.10.2 takes the React synthetic event; newer majors take the native
+// event) — a dependency bump can never strand this cast again (#821's
+// hand-written native-MouseEvent cast did not compile under npm ci).
+const DRAG_EVENT = {} as Parameters<OnNodeDrag>[0];
 
 /** Drives one full drag gesture the way React Flow produces it. */
 function drag(result: CanvasResult, id: string, to: { x: number; y: number }) {

--- a/sdk/react/src/workflow/__tests__/useWorkflowCanvas.drag.test.tsx
+++ b/sdk/react/src/workflow/__tests__/useWorkflowCanvas.drag.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
-import type { Node } from "@xyflow/react";
+import type { Node, OnNodeDrag } from "@xyflow/react";
 import { useWorkflowCanvas } from "../useWorkflowCanvas";
 
 // Regression tests for oss#602: node drags updated only React Flow's copy
@@ -51,10 +51,12 @@ function renderCanvas() {
 
 type CanvasResult = ReturnType<typeof renderCanvas>["result"];
 
-// React Flow's drag handlers take the NATIVE event (@xyflow types accept
-// MouseEvent | TouchEvent); @types/react >= 19.2.18 no longer lets the
-// synthetic React.MouseEvent stand in for it.
-const DRAG_EVENT = {} as MouseEvent;
+// The drag fixture derives its type from the handler itself, so it tracks
+// whatever event type the installed @xyflow/react declares (the pinned
+// 12.10.2 takes the React synthetic event; newer majors take the native
+// event) — a dependency bump can never strand this cast again (#821's
+// hand-written native-MouseEvent cast did not compile under npm ci).
+const DRAG_EVENT = {} as Parameters<OnNodeDrag>[0];
 
 function canvasPosition(result: CanvasResult, id: string): { x: number; y: number } {
   const node = result.current.nodes.find((n) => n.id === id);


### PR DESCRIPTION
## Summary

`make gen-react-sdk-docs` (and its CI check) fails on main for any clean `npm ci` environment since #821: its rides-along test tweak cast the `useWorkflowCanvas` drag fixture to the NATIVE `MouseEvent`, but the pinned `@xyflow/react` 12.10.2 types `OnNodeDrag` with the React SYNTHETIC event — the cast never compiled under the committed lockfile (with `@types/react` 19.2.14 or 19.2.18 alike; #821's comment attributed the change to a types version the lockfile does not carry).

- The fixture now derives its type from the handler itself — `Parameters<OnNodeDrag>[0]` — so it tracks whatever event type the installed `@xyflow/react` declares, and a future dependency bump cannot strand the cast again.
- `docs/sdk/react/version-history.mdx` is the resulting docs regeneration.
- No lockfile change.

## Test plan

- [x] `npm ci` → `make build-ts-stubs` → `make gen-react-sdk-docs` green (was red on main)
- [x] `useWorkflowCanvas.drag.test.tsx` + `useWorkflowCanvas.dirty.test.tsx` — 14 tests pass

Made with [Cursor](https://cursor.com)