### PR TITLE
ci(proto-breaking): activate the dead buf breaking config with a PR gate

### DIFF
--- a/.github/workflows/ci.proto-breaking.yaml
+++ b/.github/workflows/ci.proto-breaking.yaml
@@ -1,0 +1,61 @@
+# =============================================================================
+# Proto Breaking-Change Gate
+# =============================================================================
+# Runs `buf breaking` against main for every PR that touches apis/ — the
+# activation of the `breaking:` config block in apis/buf.yaml, which was
+# committed with the module but never invoked by any Makefile target or
+# workflow (stigmer/stigmer#326).
+#
+# Proto files are the platform's shared contract across two editions, five
+# generated languages, and external SDK consumers; field deletions, type
+# changes, and constraint tightening must not ship ungated.
+#
+# Deliberately NO push-to-main trigger: after a merge, main-vs-main is
+# vacuous (the check would always pass). The gate's value is entirely at
+# PR time; workflow_dispatch covers manual verification.
+# =============================================================================
+
+name: ci.proto-breaking
+
+on:
+  pull_request:
+    paths:
+      - "apis/**"
+      - ".github/workflows/ci.proto-breaking.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: proto-breaking-${{ github.head_ref || github.ref }}
+  # PR pushes cancel superseded runs; dispatch runs queue (stigmer#725 rule).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  buf-breaking:
+    name: buf breaking against main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history: the `--against` git input reads main from this
+          # clone's .git directory.
+          fetch-depth: 0
+
+      # A PR checkout is a detached HEAD with only remote-tracking refs;
+      # buf's `branch=main` git input resolves refs/heads/main, so
+      # materialize it. `|| true` covers dispatch runs ON main, where the
+      # local ref already exists and the refspec is a no-op rejection.
+      - name: Materialize local main ref
+        run: git fetch origin main:main || true
+
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check breaking changes against main
+        working-directory: apis
+        run: buf breaking --against '../.git#branch=main,subdir=apis'


### PR DESCRIPTION
## Summary
Activates the `breaking:` block in `apis/buf.yaml` — configured since the module was committed but never invoked by any Makefile target or workflow — with a new `ci.proto-breaking` workflow that runs `buf breaking` against main on every PR touching `apis/`.

## Context
Proto files are the platform's shared contract across two editions, five generated languages, and external SDK consumers. Field deletions, type changes, and constraint tightening currently ship completely ungated; the #326 report found a #228 constraint change had to be checked with a manual `buf breaking` because no gate exists.

## Changes
- New `.github/workflows/ci.proto-breaking.yaml`: PR-triggered (`apis/**` + the workflow file itself, so this PR self-tests), plus `workflow_dispatch` for manual runs.
- Runs the exact command the issue prescribes: `buf breaking --against '../.git#branch=main,subdir=apis'`.
- House conventions adopted from `ci.frontend.yaml`: banner comment, the #725 concurrency rule, `permissions: contents: read`.

## Implementation notes
- A detached PR checkout carries only remote-tracking refs, and buf's `branch=main` git input resolves `refs/heads/main` — the job materializes the local ref (`git fetch origin main:main`) before the check.
- Deliberately no push-to-main trigger: after a merge, main-vs-main is vacuous. The gate's value is entirely at PR time.
- The `breaking:` config itself (`use: FILE`, `EXTENSION_NO_DELETE` + `FIELD_SAME_DEFAULT` exceptions) is untouched — this PR only makes it live.

## Breaking changes
- None.

## Test plan
- `actionlint` clean on the new workflow.
- The against-main check verified green on current main locally, so the gate lands green and only future breaks trip it.
- This PR touches the workflow file itself, so the new lane runs on this very PR.

## Risks
- A red on a future PR that intentionally breaks proto compatibility is the gate working as designed; the escape hatch is a reviewed edit to the `breaking:` exceptions, not bypassing the lane.

Closes #326

Made with [Cursor](https://cursor.com)