### PR TITLE
feat(runner): time the Cursor SDK token exchange in the fetch interceptor

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/fetch-interceptor.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/fetch-interceptor.test.ts
@@ -171,23 +171,26 @@ describe("fetch-interceptor", () => {
     });
   });
 
-  describe("cursor_models_fetch timing", () => {
+  describe("timed REST path timing", () => {
     beforeEach(() => {
       installFetchInterceptor({ proxyEndpoint: PROXY_ENDPOINT, stigmerToken: STIGMER_TOKEN });
     });
 
     /**
-     * Collect emitted `cursor_models_fetch` timing lines from a console.log
-     * spy, ignoring every other log line (install banner, warnings, other
-     * timelines).
+     * Collect emitted timing lines for one timeline event from a
+     * console.log spy, ignoring every other log line (install banner,
+     * warnings, other timelines).
      */
-    function timingLines(spy: ReturnType<typeof vi.spyOn>): Array<Record<string, unknown>> {
+    function timingLines(
+      spy: ReturnType<typeof vi.spyOn>,
+      event: string,
+    ): Array<Record<string, unknown>> {
       const lines: Array<Record<string, unknown>> = [];
       for (const call of spy.mock.calls) {
         if (typeof call[0] !== "string") continue;
         try {
           const parsed = JSON.parse(call[0]) as Record<string, unknown>;
-          if (parsed.stigmer_timing === "cursor_models_fetch") lines.push(parsed);
+          if (parsed.stigmer_timing === event) lines.push(parsed);
         } catch {
           // Not a JSON log line — ignore.
         }
@@ -195,7 +198,7 @@ describe("fetch-interceptor", () => {
       return lines;
     }
 
-    it("emits one timing line for a Cursor-domain /v1/models call, carrying execution_id", async () => {
+    it("emits one cursor_models_fetch line for a Cursor-domain /v1/models call, carrying execution_id", async () => {
       const spy = vi.spyOn(console, "log").mockImplementation(() => {});
       const executionContext = getExecutionContext();
 
@@ -203,7 +206,7 @@ describe("fetch-interceptor", () => {
         await globalThis.fetch("https://api.cursor.com/v1/models", { method: "GET" });
       });
 
-      const lines = timingLines(spy);
+      const lines = timingLines(spy, "cursor_models_fetch");
       expect(lines).toHaveLength(1);
       expect(lines[0]!.execution_id).toBe("exec-models-1");
       expect(lines[0]!.http_status).toBe(200);
@@ -212,16 +215,46 @@ describe("fetch-interceptor", () => {
       expect(segments.map((s) => s.name)).toEqual(["models_fetch"]);
     });
 
-    it("emits for the proxy-endpoint-targeted /v1/models form too", async () => {
+    it("emits one cursor_token_exchange line for the SDK's token exchange, carrying execution_id (cloud#484)", async () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const executionContext = getExecutionContext();
+
+      await executionContext.run({ executionId: "exec-exchange-1" }, async () => {
+        await globalThis.fetch(
+          "https://api2.cursor.sh/auth/exchange_user_api_key",
+          { method: "POST" },
+        );
+      });
+
+      const lines = timingLines(spy, "cursor_token_exchange");
+      expect(lines).toHaveLength(1);
+      expect(lines[0]!.execution_id).toBe("exec-exchange-1");
+      expect(lines[0]!.http_status).toBe(200);
+      expect(lines[0]!.total_ms).toBeTypeOf("number");
+      const segments = lines[0]!.segments as Array<{ name: string }>;
+      expect(segments.map((s) => s.name)).toEqual(["token_exchange"]);
+      // The exchange emits ONLY its own timeline, never the models one.
+      expect(timingLines(spy, "cursor_models_fetch")).toHaveLength(0);
+    });
+
+    it("emits for the proxy-endpoint-targeted forms too", async () => {
       const spy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       await globalThis.fetch(`${PROXY_ENDPOINT}/v1/models`, { method: "GET" });
+      await globalThis.fetch(
+        `${PROXY_ENDPOINT}/auth/exchange_user_api_key`,
+        { method: "POST" },
+      );
 
-      // The fetch itself was rewritten through the proxy path AND timed.
+      // Both fetches were rewritten through the proxy path AND timed.
       expect(calls[0]!.url).toBe(
         `${PROXY_ENDPOINT}/v1/proxy/cursor/api.cursor.com/v1/models`,
       );
-      expect(timingLines(spy)).toHaveLength(1);
+      expect(calls[1]!.url).toBe(
+        `${PROXY_ENDPOINT}/v1/proxy/cursor/api2.cursor.sh/auth/exchange_user_api_key`,
+      );
+      expect(timingLines(spy, "cursor_models_fetch")).toHaveLength(1);
+      expect(timingLines(spy, "cursor_token_exchange")).toHaveLength(1);
     });
 
     it("omits execution_id (rather than fabricating one) outside an execution context", async () => {
@@ -229,22 +262,23 @@ describe("fetch-interceptor", () => {
 
       await globalThis.fetch("https://api.cursor.com/v1/models", { method: "GET" });
 
-      const lines = timingLines(spy);
+      const lines = timingLines(spy, "cursor_models_fetch");
       expect(lines).toHaveLength(1);
       // undefined context values are dropped by JSON.stringify.
       expect("execution_id" in lines[0]!).toBe(false);
     });
 
-    it("does NOT emit for other rewritten REST paths", async () => {
+    it("does NOT emit for rewritten REST paths outside the timed set", async () => {
       const spy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       await globalThis.fetch(
-        "https://api2.cursor.sh/auth/exchange_user_api_key",
+        "https://api.cursor.com/v1/agents",
         { method: "POST" },
       );
 
       expect(calls).toHaveLength(1);
-      expect(timingLines(spy)).toHaveLength(0);
+      expect(timingLines(spy, "cursor_models_fetch")).toHaveLength(0);
+      expect(timingLines(spy, "cursor_token_exchange")).toHaveLength(0);
     });
   });
 

--- a/backend/services/runner/src/activities/execute-cursor/fetch-interceptor.ts
+++ b/backend/services/runner/src/activities/execute-cursor/fetch-interceptor.ts
@@ -19,15 +19,34 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 import { TimingRecorder, emitTimingLog } from "../../shared/cold-start-timing.js";
 
+/** One REST path's timing identity: the emitted timeline event and its
+ * single segment name. */
+interface TimedRestPath {
+  readonly event: string;
+  readonly segment: string;
+}
+
 /**
- * The one REST path worth timing individually: the Cursor SDK calls
- * GET /v1/models inside Agent.create/Agent.resume purely to validate the
- * model id, and in proxy mode that is a runner → Stigmer → Cursor double
- * hop sitting inside the resolve_agent setup segment (issue #209). The
- * emitted `cursor_models_fetch` timeline splits that network cost out of
- * the segment total without touching the SDK.
+ * REST paths worth timing individually — both sit inside Agent.create/
+ * Agent.resume on the user-visible resolve_agent setup path, and in proxy
+ * mode each is a runner → Stigmer → Cursor double hop. The emitted
+ * timelines split that network cost out of the segment total without
+ * touching the SDK:
+ *
+ * - GET /v1/models (`cursor_models_fetch`): the SDK's model-id validation
+ *   read, ~0.95s of the pre-cache resolve_agent segment (issue #209).
+ * - POST /auth/exchange_user_api_key (`cursor_token_exchange`): the SDK's
+ *   API-key → access-token exchange, the strongest suspect for the
+ *   remaining unexplained 0.6–1.3s inside Agent.create
+ *   (stigmer-cloud#484 — this timeline is that issue's Step 1, measure).
  */
-const MODELS_PATH = "/v1/models";
+const TIMED_REST_PATHS: ReadonlyMap<string, TimedRestPath> = new Map([
+  ["/v1/models", { event: "cursor_models_fetch", segment: "models_fetch" }],
+  [
+    "/auth/exchange_user_api_key",
+    { event: "cursor_token_exchange", segment: "token_exchange" },
+  ],
+]);
 
 const CURSOR_DOMAINS = [
   "api2.cursor.sh",
@@ -258,13 +277,14 @@ async function fetchWithUrlRewrite(
   const rewrittenUrl = rewriteUrl(url, config.proxyEndpoint);
   const rewrittenInit = replaceAuth(init, config);
   const path = extractPath(url);
-  const modelsTiming = path === MODELS_PATH ? new TimingRecorder() : undefined;
+  const timedPath = TIMED_REST_PATHS.get(path);
+  const timing = timedPath ? new TimingRecorder() : undefined;
 
   try {
     const response = await originalFetch(rewrittenUrl, rewrittenInit);
 
-    if (modelsTiming) {
-      emitModelsFetchTiming(modelsTiming, config, response.status);
+    if (timedPath && timing) {
+      emitRestTiming(timedPath, timing, config, response.status);
     }
 
     if (!response.ok) {
@@ -290,22 +310,23 @@ async function fetchWithUrlRewrite(
 }
 
 /**
- * Emit the `cursor_models_fetch` timeline for one proxied GET /v1/models.
+ * Emit the timeline for one proxied REST call on a timed path.
  *
  * `execution_id` comes from the AsyncLocalStorage execution context — the
  * whole ExecuteCursor activity runs inside runWithExecutionContext, so the
  * value is correct even with concurrent activities on one runner process.
- * `recordTimingMetric` deliberately ignores this event (no mapped OTel
- * instrument): it is a forensic stdout line only, joined to the
+ * `recordTimingMetric` deliberately ignores these events (no mapped OTel
+ * instruments): they are forensic stdout lines only, joined to the
  * execution_setup timeline by execution_id in cold-start-baseline analysis.
  */
-function emitModelsFetchTiming(
+function emitRestTiming(
+  timedPath: TimedRestPath,
   timing: TimingRecorder,
   config: ProxyConfig,
   httpStatus: number,
 ): void {
-  timing.mark("models_fetch");
-  emitTimingLog("cursor_models_fetch", {
+  timing.mark(timedPath.segment);
+  emitTimingLog(timedPath.event, {
     execution_id: executionContext.getStore()?.executionId ?? config.executionId,
     http_status: httpStatus,
   }, timing);


### PR DESCRIPTION
## Summary
Adds a `cursor_token_exchange` timing timeline for the SDK's `/auth/exchange_user_api_key` call in the runner's fetch interceptor — Step 1 (measure) of stigmer-cloud#484, targeting the unexplained 0.6–1.3s inside `Agent.create` that survived the #209 latency work.

## Context
#209 cut `resolve_agent` from ~2.4s to ~1.0s median (proxy models cache + pool-boot warm-up) and #215 fixed per-turn executor acquisition. The remaining suspect from the #209 breakdown is the SDK's token exchange, which already routes through the interceptor — but the interceptor's only per-call split today is `cursor_models_fetch`.

## Changes
- `fetch-interceptor.ts`: the single hard-coded timed path becomes a small `TIMED_REST_PATHS` map (`/v1/models` → `cursor_models_fetch`, `/auth/exchange_user_api_key` → `cursor_token_exchange`) feeding one `emitRestTiming` helper; the third timed path (if ever) is one map entry.
- `fetch-interceptor.test.ts`: exchange timing pinned in both URL forms (Cursor-domain and proxy-endpoint-targeted), event isolation pinned (exchange never emits the models timeline), and the stale "does NOT emit for other rewritten REST paths" pin reworked to a genuinely untimed path (`/v1/agents`).

## Implementation notes
- The `cursor_models_fetch` emission is byte-identical (event name, segment name, context keys) — its name is load-bearing in cold-start-baseline analysis.
- The new event inherits the forensic-stdout-only posture by construction: `recordTimingMetric`'s per-event whitelist deliberately ignores unmapped events, so no OTel wiring and no new time series.
- Step 2 (proxy-side exchange cache) stays held for its own review — the exchange is credential-bearing, exactly why #209 excluded it from the models-cache work.

## Breaking changes
- None. Purely additive observability; no request behavior changes.

## Test plan
- Runner typecheck clean; full runner suite 4739 passed / 6 skipped.
- Post-deploy tail (recorded on the issue): read a cold-start-baseline batch with the new timeline to confirm or clear the exchange as the latency suspect.

## Risks
- None beyond one extra stdout JSON line per exchange call; rollback is reverting the commit.

Closes stigmer/stigmer-cloud#484

Made with [Cursor](https://cursor.com)