### PR TITLE
fix(sdk/react): control-flow preview content + de-duplicated card detail (R6-5/R6-6)

### DIFF
--- a/sdk/react/src/workflow/__tests__/task-presentation.test.ts
+++ b/sdk/react/src/workflow/__tests__/task-presentation.test.ts
@@ -286,21 +286,55 @@ describe("per-kind preview lines", () => {
       overrides: { agentSlug: "blog-writer", messagesCount: 12, toolCallsCount: 5 },
       expected: "blog-writer · 12 msgs · 5 tools",
     },
+    {
+      label: "switch_case settled on a target branch (R6-5)",
+      kind: WorkflowTaskKind.switch_case,
+      overrides: { outputSummary: { __flow_directive__: "approved-path" } },
+      expected: "→ approved-path",
+    },
+    {
+      label: "switch_case settled on a termination directive",
+      kind: WorkflowTaskKind.switch_case,
+      overrides: { outputSummary: { __flow_directive__: "exit" } },
+      expected: "→ exit",
+    },
+    {
+      label: "try_catch recovered via catch retry (R6-5)",
+      kind: WorkflowTaskKind.try_catch,
+      overrides: { attemptNumber: 3, outputSummary: { result: "ok" } },
+      expected: "recovered after 3 attempts",
+    },
+    {
+      label: "try_catch settled block result (first-attempt success)",
+      kind: WorkflowTaskKind.try_catch,
+      overrides: { outputSummary: { result: 42 } },
+      expected: "42",
+    },
   ])("$label", ({ kind, overrides, expected }) => {
     const { previewLine } = resolveTaskPreview(state({ taskKind: kind, ...overrides }));
     expect(previewLine).toBe(expected);
   });
 
-  // Kinds that deliberately stay status-only: control flow (branch/fork
-  // detail needs graph topology the thread lacks — deferred), raise_error
-  // (the failure precedence carries the message), the invocation kinds
-  // (no verified output envelope — backend follow-up), and unspecified
-  // (the snapshot fallback).
+  // switch_case degrades to status-only when no case matched: the executor
+  // returns no directive, so there is honestly nothing to say (R6-5).
+  it("switch_case yields an empty line without a flow directive", () => {
+    const { previewLine } = resolveTaskPreview(
+      state({
+        taskKind: WorkflowTaskKind.switch_case,
+        outputSummary: { some: "data" },
+      }),
+    );
+    expect(previewLine).toBe("");
+  });
+
+  // Kinds that deliberately stay status-only: remaining control flow
+  // (for/fork detail needs graph topology the thread lacks — deferred),
+  // raise_error (the failure precedence carries the message; its preview
+  // BODY carries the detail), the invocation kinds (no verified output
+  // envelope — backend follow-up), and unspecified (the snapshot fallback).
   it.each([
-    WorkflowTaskKind.switch_case,
     WorkflowTaskKind.for_each,
     WorkflowTaskKind.fork,
-    WorkflowTaskKind.try_catch,
     WorkflowTaskKind.raise_error,
     WorkflowTaskKind.http_call,
     WorkflowTaskKind.grpc_call,
@@ -396,9 +430,12 @@ type JsonValueLike = Parameters<typeof valueSnippet>[0];
 describe("defaultDisclosureForKind", () => {
   // T05 (DD-T05-5): every kind whose output CAN matter is a preview kind —
   // the showBody gate keeps output-less cards as one-line rows, so preview
-  // disclosure costs nothing until the runner writes real output. Only
-  // genuinely body-less kinds (control flow, wait/listen, unspecified)
-  // remain summary.
+  // disclosure costs nothing until the runner writes real output. R6-5
+  // adds try_catch (its output is the block's settled result) and
+  // raise_error (always fails; the preview body IS the always-visible
+  // failure detail). Only genuinely body-less kinds remain summary —
+  // including switch_case DELIBERATELY: its whole content is the one-word
+  // directive on its preview line; a body would only repeat it.
   it.each([
     [WorkflowTaskKind.transform, "preview"],
     [WorkflowTaskKind.validate, "preview"],
@@ -413,13 +450,13 @@ describe("defaultDisclosureForKind", () => {
     [WorkflowTaskKind.grpc_call, "preview"],
     [WorkflowTaskKind.activity_call, "preview"],
     [WorkflowTaskKind.run_workflow, "preview"],
+    [WorkflowTaskKind.try_catch, "preview"],
+    [WorkflowTaskKind.raise_error, "preview"],
     [WorkflowTaskKind.wait, "summary"],
     [WorkflowTaskKind.switch_case, "summary"],
     [WorkflowTaskKind.fork, "summary"],
-    [WorkflowTaskKind.try_catch, "summary"],
     [WorkflowTaskKind.for_each, "summary"],
     [WorkflowTaskKind.listen, "summary"],
-    [WorkflowTaskKind.raise_error, "summary"],
     [WorkflowTaskKind.workflow_task_kind_unspecified, "summary"],
   ] as const)("kind %d defaults to %s", (kind, expected) => {
     expect(defaultDisclosureForKind(kind)).toBe(expected);

--- a/sdk/react/src/workflow/thread/WorkflowTaskThread.tsx
+++ b/sdk/react/src/workflow/thread/WorkflowTaskThread.tsx
@@ -596,10 +596,11 @@ function ThreadTaskDetail({
   readonly inputIO: TaskDetailIO | null;
   readonly outputIO: TaskDetailIO | null;
 }) {
-  const rows: Array<[string, string]> = [["Status", statusLabel(item.status)]];
-  if (item.durationMs > 0) {
-    rows.push(["Duration", formatMetaChips({ durationMs: item.durationMs }) ?? ""]);
-  }
+  // No Status/Duration rows (R6-6): the card header is the single source
+  // for both — the status glyph and the duration meta chip. The detail
+  // body carries only what the header cannot: attempt count, usage, the
+  // agent slug.
+  const rows: Array<[string, string]> = [];
   if (item.attemptNumber > 1) rows.push(["Attempt", String(item.attemptNumber)]);
   const costChip = formatMetaChips({
     costMicros: item.costMicros,
@@ -612,14 +613,16 @@ function ThreadTaskDetail({
 
   return (
     <div className="stg:flex stg:flex-col stg:gap-2">
-      <dl className="stg:grid stg:grid-cols-[auto_1fr] stg:gap-x-4 stg:gap-y-1 stg:text-xs">
-        {rows.map(([label, value]) => (
-          <div key={label} className="stg:contents">
-            <dt className="stg:text-muted-foreground">{label}</dt>
-            <dd className="stg:text-foreground">{value}</dd>
-          </div>
-        ))}
-      </dl>
+      {rows.length > 0 && (
+        <dl className="stg:grid stg:grid-cols-[auto_1fr] stg:gap-x-4 stg:gap-y-1 stg:text-xs">
+          {rows.map(([label, value]) => (
+            <div key={label} className="stg:contents">
+              <dt className="stg:text-muted-foreground">{label}</dt>
+              <dd className="stg:text-foreground">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
 
       {item.error && (
         <BoundedContent>
@@ -635,25 +638,6 @@ function ThreadTaskDetail({
       {outputIO && <ThreadTaskIOSection label="Output" io={outputIO} />}
     </div>
   );
-}
-
-function statusLabel(status: WorkflowThreadItem["status"]): string {
-  switch (status) {
-    case "waiting_approval":
-      return "Waiting for approval";
-    case "retrying":
-      return "Retrying";
-    case "running":
-      return "Running";
-    case "completed":
-      return "Completed";
-    case "failed":
-      return "Failed";
-    case "skipped":
-      return "Skipped";
-    case "pending":
-      return "Pending";
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/react/src/workflow/thread/task-presentation.ts
+++ b/sdk/react/src/workflow/thread/task-presentation.ts
@@ -124,9 +124,18 @@ export function getTaskPresenter(
  * the output-envelope follow-up standardizes them (DD-T04-3) — stays a
  * clean one-line row with zero cost. `set_vars` earns its place from live
  * data: the runner writes the seeded variables to task output (T05, R2-5).
+ * `try_catch` earns it the same way: its output is the try (or catch.do)
+ * block's settled result — the `transform` class. `raise_error` earns it
+ * from the OTHER `showBody` arm: it always fails, and the preview body
+ * renders the full failure detail without a click (R6-5).
  *
- * Only genuinely body-less kinds (control flow, `wait`/`listen`, and the
- * snapshot fallback's `unspecified`) stay compact summary rows.
+ * Only genuinely body-less kinds stay compact summary rows: `wait`/
+ * `listen`, the snapshot fallback's `unspecified`, and the remaining
+ * control flow — including `switch_case`, DELIBERATELY (an R6-5
+ * refinement): its entire settled content is the one-word flow directive,
+ * carried by its always-visible preview line below; a body would only
+ * re-render the raw `{__flow_directive__}` marker, failing the "does the
+ * body carry content the one-line row cannot?" rule.
  */
 const PREVIEW_KINDS: ReadonlySet<WorkflowTaskKind> = new Set([
   WorkflowTaskKind.transform,
@@ -142,6 +151,8 @@ const PREVIEW_KINDS: ReadonlySet<WorkflowTaskKind> = new Set([
   WorkflowTaskKind.grpc_call,
   WorkflowTaskKind.activity_call,
   WorkflowTaskKind.run_workflow,
+  WorkflowTaskKind.try_catch,
+  WorkflowTaskKind.raise_error,
 ]);
 
 /** Default disclosure mode for a task kind. */
@@ -218,12 +229,17 @@ function defaultPreviewLine(state: DerivedTaskState): string | null {
       return waitLine(state);
     case WorkflowTaskKind.listen:
       return listenLine(state);
+    case WorkflowTaskKind.switch_case:
+      return switchCaseLine(state.outputSummary);
+    case WorkflowTaskKind.try_catch:
+      return tryCatchLine(state);
     default:
-      // Control flow (branch-taken / fork progress need graph topology the
-      // thread does not have — deferred), raise_error (the failure
-      // precedence already shows the message), the invocation kinds
-      // (pending the backend output-envelope follow-up), and the snapshot
-      // fallback's `unspecified` all stay status-only.
+      // Remaining control flow (for_each / fork progress need graph
+      // topology the thread does not have — deferred), raise_error (the
+      // failure precedence already shows the message; its preview body
+      // carries the full detail), the invocation kinds (pending the
+      // backend output-envelope follow-up), and the snapshot fallback's
+      // `unspecified` all stay status-only.
       return null;
   }
 }
@@ -352,6 +368,35 @@ function listenLine(state: DerivedTaskState): string | null {
   if (state.status === "running") return "waiting for signal";
   if (state.status === "completed") return "signal received";
   return null;
+}
+
+/**
+ * `→ approved-path` / `→ exit` — the flow directive the switch settled on
+ * (R6-5). The switch executor's only output is the `__flow_directive__`
+ * marker carrying the matched case's `then` (a target task name, or the
+ * `continue`/`end`/`exit` terminals), and `do-executor` writes raw task
+ * output to the event summary — so the branch taken is already on the
+ * wire. No case matched means no output: status-only, honestly.
+ */
+function switchCaseLine(output: JsonObject | null): string | null {
+  const directive = asString(output?.["__flow_directive__"]);
+  return directive ? `\u2192 ${directive}` : null;
+}
+
+/**
+ * `recovered after 2 attempts` / snippet of the settled block result
+ * (R6-5). The try task's own `task_retrying` events drive
+ * `attemptNumber`, so a completion above attempt 1 IS a catch-retry
+ * recovery. A catch.do-path recovery (no retry configured) is NOT
+ * distinguishable from plain success in the emitted data — deliberately
+ * unmarked: adding a marker to task output would leak presentation into
+ * workflow dataflow (`processTaskOutput` consumes it downstream).
+ */
+function tryCatchLine(state: DerivedTaskState): string | null {
+  if (state.status === "completed" && state.attemptNumber > 1) {
+    return `recovered after ${state.attemptNumber} attempts`;
+  }
+  return state.outputSummary ? valueSnippet(state.outputSummary) : null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The two card-polish items queued when the workflow-execution-ux-parity project closed: control-flow task cards (`switch_case`, `try_catch`, `raise_error`) surface their settled content without a click (R6-5), and the expanded detail's redundant Status/Duration rows are gone (R6-6).

## Context
Owner-ratified Round-6 feedback. The data kinds already show always-visible output; the control-flow kinds collapsed to a bare row, and every expanded detail repeated what the card header (status glyph + duration chip) already says.

## Changes
- `try_catch` → `PREVIEW_KINDS`: its output is the try (or catch.do) block's settled result — exactly the `transform` class. New preview line: `recovered after N attempts` for catch-retry recoveries (derived from the try task's own `task_retrying` events), else a snippet of the settled result.
- `raise_error` → `PREVIEW_KINDS`: it always fails, and the preview body renders the full failure detail always-visible — the entire UX win, zero cost via the existing `showBody` gate.
- `switch_case`: new always-visible header line `→ <target>` / `→ exit`, read from the `__flow_directive__` marker the executor already writes to the event summary (no runner change; the stale "needs graph topology — deferred" comment is truthed).
- `ThreadTaskDetail`: Status and Duration rows deleted; Attempt/Usage/Agent stay; empty detail list guarded; the orphaned `statusLabel` helper removed.

## Implementation notes
- **Deliberate deviation from R6-5's letter for switch_case, honoring its intent**: it stays `summary` disclosure. Its entire settled content is one word — carried by the always-visible header line — and a preview body would only re-render the raw `{__flow_directive__}` struct, failing the card system's own documented rule ("does the body carry content the one-line row cannot?").
- Recorded limitation: a catch.do-path recovery (no retry configured) is not distinguishable from plain success in the emitted data. Marking it would put presentation state into task output, which flows into workflow dataflow (`processTaskOutput`) — not done.
- Observation for a follow-up ruling (on the issue, not implemented here): the Usage detail row duplicates the header's cost/tokens chips — the same redundancy class R6-6 ruled on for Status/Duration.

## Breaking changes
- None for embedders: `defaultDisclosureForKind` return values change for `try_catch`/`raise_error` (documented behavior evolution, overridable per kind via `registerTaskPresenter`).

## Test plan
- New preview-line pins: switch target/termination/no-match, try_catch recovered/settled; disclosure table flipped for the two promoted kinds with the switch refinement documented in place.
- sdk/react: typecheck clean, suite 4765/4765, lint + prefix-classnames, a11y 85/85, tsdoc check.

## Risks
- Pure presentation layer; revert is one commit. The live cloud#267 scroll-on-send session also touches sdk/react thread surfaces — whichever PR merges second may need a trivial rebase (no shared logic).

Closes #780

Made with [Cursor](https://cursor.com)