### PR TITLE
fix(mcp-server): un-break ts-sdk typecheck + wait-for-npm in bridge image

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -47,7 +47,22 @@ WORKDIR /app
 
 # Install the published package globally; this pulls its full runtime dependency
 # tree and exposes the `mcp-server-stigmer` bin on PATH.
-RUN npm install --global --omit=dev "@stigmer/mcp-server@${MCP_SERVER_VERSION}"
+#
+# The install first WAITS for the pinned version to appear on the registry
+# (up to 10 minutes). The prod deploy pipeline fires the moment the tag
+# commit is pushed — ~6 minutes before release.npm-libs finishes publishing
+# that same version — so a bare install raced npm and failed first-try on
+# EVERY release from 3.12.3 through 3.12.8, silently leaving prod on the
+# previous bridge until someone noticed and reran (the v3.12.8 /memory
+# route sat undeployed this way, 2026-08-22). release.mcp-server solves
+# this with a workflow-level wait step; putting the wait here fixes every
+# builder of this file at once.
+RUN for i in $(seq 1 60); do \
+        npm view "@stigmer/mcp-server@${MCP_SERVER_VERSION}" version >/dev/null 2>&1 && break; \
+        echo "attempt $i/60: @stigmer/mcp-server@${MCP_SERVER_VERSION} not on npm yet; retrying in 10s"; \
+        sleep 10; \
+    done \
+    && npm install --global --omit=dev "@stigmer/mcp-server@${MCP_SERVER_VERSION}"
 
 # Run as the non-root user shipped with the node:alpine base.
 USER node

--- a/mcp-server/src/domains/memory/memory.integration.test.ts
+++ b/mcp-server/src/domains/memory/memory.integration.test.ts
@@ -59,8 +59,13 @@ const openSessions = new Set<ServerHttp2Session>();
 /** The next stubbed created record; tests set this. */
 let createResponse: () => Memory;
 
-/** Requests the stub captured (object property for closure narrowing). */
-const captured: { create?: Memory } = {};
+// Requests the stub captured. An array, deliberately: resetting an optional
+// property to undefined narrows its type to `undefined` for the rest of the
+// flow (tsc does not un-narrow across the intervening callTool call), which
+// makes every later `req?.x` a property access on `never` under
+// `npm run typecheck` — the job that, unlike tsconfig.build.json, includes
+// tests. Clearing and reading an array never narrows.
+const capturedCreates: Memory[] = [];
 
 interface ToolResult {
   content: Array<{ type: string; text?: string }>;
@@ -91,7 +96,7 @@ beforeAll(async () => {
   const routes = (router: ConnectRouter) => {
     router.service(MemoryCommandController, {
       create: (req) => {
-        captured.create = req;
+        capturedCreates.push(req);
         return createResponse();
       },
     });
@@ -154,12 +159,12 @@ describe("memory roster (DD-005 D1)", () => {
 describe("argument + capture context → request mapping (DD-005 D2)", () => {
   it("maps the fact and the startup context; subject never travels", async () => {
     createResponse = () => proposedRecord("Prefers concise answers.");
-    captured.create = undefined;
+    capturedCreates.length = 0;
 
     const result = await remember({ fact: "Prefers concise answers." });
 
     expect(result.isError).toBeFalsy();
-    const req = captured.create;
+    const req = capturedCreates.at(-1);
     expect(req?.metadata?.org).toBe("acme");
     expect(req?.metadata?.name).toBe(""); // id-addressed; the server defaults the name
     expect(req?.spec?.content).toBe("Prefers concise answers.");


### PR DESCRIPTION
## Summary
Two small fixes restoring release health after Phase 2 Stage 3 (#824): the `ci.ts-sdk` typecheck regression that has kept main red since the merge, and the npm-publish race that has made the prod bridge deploy fail first-try on every release.

## Context
- `ci.ts-sdk`'s "typecheck (locked resolution)" job has failed on EVERY main commit since #824: `memory.integration.test.ts` resets `captured.create = undefined`, which narrows the optional property to `undefined` for the rest of the flow (tsc does not un-narrow across the intervening `callTool` call), so every later `req?.x` is a property access on `never`. Session 11 missed it because `tsconfig.build.json` excludes tests; only the workspace `typecheck` script (plain `tsconfig.json`) typechecks them.
- The Planton `stigmer-mcp` prod pipeline fires on the tag-commit push, ~6 minutes before `release.npm-libs` finishes publishing that version, so the image build's bare `npm install` raced npm and failed first-try on every release 3.12.3–3.12.8 (`notarget No matching version found`). The v3.12.8 /memory bridge sat undeployed this way until a manual rerun (2026-08-22).

## Changes
- `memory.integration.test.ts`: capture requests into an array (`capturedCreates`) instead of an optional object property — clearing and reading an array never narrows; behavior identical.
- `mcp-server/Dockerfile`: the install step now polls the registry for the pinned version (60×10s, mirroring release.mcp-server's wait step) before `npm install`, so every builder of this file — including the prod deploy pipeline — waits out the publish instead of failing.

## Test plan
- `npm run typecheck -w @stigmer/mcp-server` passes under the locked resolution (previously 8×TS2339); `npx tsc -p mcp-server/tsconfig.build.json --noEmit` still passes.
- Full mcp-server suite: 152/152 passing.
- Retry loop validated inside `public.ecr.aws/docker/library/node:22-alpine` (busybox sh): finds the published version and proceeds to install.

## Risks
- None meaningful: test-only restructure + a bounded pre-install wait. If a version never appears on npm, the final install fails with the same `notarget` error as today, 10 minutes later.

## Checklist
- [x] Tests added/updated (restructured, all passing)
- [x] Backward compatible

Made with [Cursor](https://cursor.com)