### PR TITLE
feat(test/conformance): platform-privileged caller lane for the cloud target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,6 +2919,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3758,6 +3759,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3780,6 +3782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3802,6 +3805,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3818,6 +3822,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3834,6 +3839,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3850,6 +3856,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3866,6 +3873,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3882,6 +3890,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3898,6 +3907,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3914,6 +3924,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3930,6 +3941,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3946,6 +3958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3962,6 +3975,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3984,6 +3998,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4006,6 +4021,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4028,6 +4044,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4050,6 +4067,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4072,6 +4090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4094,6 +4113,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4116,6 +4136,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4138,6 +4159,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4157,6 +4179,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4176,6 +4199,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4195,6 +4219,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16907,12 +16932,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,7 +2919,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3759,7 +3758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3782,7 +3780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3805,7 +3802,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3822,7 +3818,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3839,7 +3834,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3856,7 +3850,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3873,7 +3866,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3890,7 +3882,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3907,7 +3898,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3924,7 +3914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3941,7 +3930,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3958,7 +3946,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3975,7 +3962,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3998,7 +3984,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4021,7 +4006,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4044,7 +4028,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4067,7 +4050,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4090,7 +4072,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4113,7 +4094,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4136,7 +4116,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4159,7 +4138,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4179,7 +4157,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4199,7 +4176,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4219,7 +4195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16932,14 +16907,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -20,6 +20,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { createClient } from "@connectrpc/connect";
+import { IamPolicyCommandController } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/command_pb";
 import { PlatformClientCommandController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/command_pb";
 import { PlatformClientTokenController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/token_pb";
 import { createTransport, makeClients } from "./clients";
@@ -42,6 +43,14 @@ export const CLOUD_ENV = {
   // (CloudTarget.provisionIdentity), used by cross-tenant isolation assertions.
   platformClientId: "STIGMER_CONFORMANCE_CLOUD_PLATFORM_CLIENT_ID",
   platformClientSecret: "STIGMER_CONFORMANCE_CLOUD_PLATFORM_CLIENT_SECRET",
+  // Stigmer-signed JWT for the conf-operator user — a platform operator the
+  // hermetic bootstrap provisions through production RPCs (stigmer#547), used
+  // by CloudTarget.provisionPrivilegedScope for operator-only writes
+  // (reserved labels, the public flip). Deliberately UNSET on
+  // pre-provisioned/deployed endpoints: handing conformance operator
+  // credentials to a real deployment is the permanent skip the stigmer#547
+  // ruling recorded, so privileged-lane assertions skip there.
+  operatorToken: "STIGMER_CONFORMANCE_CLOUD_OPERATOR_TOKEN",
 } as const;
 
 // The org whose FGA ownership tuples the launcher seeds for the synthetic test
@@ -86,6 +95,8 @@ export interface PlatformClientCredentials {
 export interface PrimaryIdentity {
   readonly token: string;
   readonly platformClient: PlatformClientCredentials;
+  // The conf-operator user's JWT (platform operator via bootstrapPolicy).
+  readonly operatorToken: string;
 }
 
 // Builds and spawns the Go launcher, waiting for its single JSON ready-line on
@@ -143,7 +154,51 @@ export async function bootstrapPrimaryIdentity(grpcBaseUrl: string): Promise<Pri
   const platformClient: PlatformClientCredentials = { clientId, clientSecret: created.clientSecret };
 
   const token = await mintCloudUserToken(grpcBaseUrl, platformClient, uniqueName("conf-user"));
-  return { token, platformClient };
+  const operatorToken = await bootstrapOperatorIdentity(grpcBaseUrl, tokenlessTransport, platformClient);
+  return { token, platformClient, operatorToken };
+}
+
+// Provisions the conf-operator identity through production RPCs only
+// (stigmer#547): mint a fresh user via the bootstrap PlatformClient, then
+// grant it `operator` on platform:stigmer with bootstrapPolicy — the exact
+// row + FGA-tuple shape the production BootstrapIdentitySeeder writes for the
+// machine account. The tokenless caller qualifies because the launcher's FGA
+// seeding makes the synthetic test identity a platform operator, which
+// derives can_bootstrap_iam. (The ordinary IamPolicy `create` RPC cannot
+// express this grant: the platform kind declares no grantable_roles and
+// `operator` is not an IamRole — bootstrapPolicy is the sanctioned lane.)
+async function bootstrapOperatorIdentity(
+  grpcBaseUrl: string,
+  tokenlessTransport: ReturnType<typeof createTransport>,
+  platformClient: PlatformClientCredentials,
+): Promise<string> {
+  const operatorToken = await mintCloudUserToken(grpcBaseUrl, platformClient, uniqueName("conf-operator"));
+  const operatorAccountId = jwtSubject(operatorToken);
+
+  const iamPolicyCommand = createClient(IamPolicyCommandController, tokenlessTransport);
+  await iamPolicyCommand.bootstrapPolicy({
+    principal: { kind: "identity_account", id: operatorAccountId },
+    resource: { kind: "platform", id: "stigmer" },
+    relation: "operator",
+  });
+  return operatorToken;
+}
+
+// The minted JWT's `sub` is the JIT-provisioned identity-account id — the
+// principal the operator grant must name (the server chooses it; it is not
+// the userId the mint request carried).
+function jwtSubject(token: string): string {
+  const payloadSegment = token.split(".")[1];
+  if (payloadSegment === undefined) {
+    throw new Error("minted token is not a JWT (no payload segment)");
+  }
+  const payload = JSON.parse(Buffer.from(payloadSegment, "base64url").toString("utf8")) as {
+    sub?: unknown;
+  };
+  if (typeof payload.sub !== "string" || payload.sub === "") {
+    throw new Error("minted token carries no sub claim; cannot grant the operator role");
+  }
+  return payload.sub;
 }
 
 // Mints a Stigmer JWT for the given user id. mintUserToken authenticates via

--- a/test/conformance/src/harness/global-setup-cloud.ts
+++ b/test/conformance/src/harness/global-setup-cloud.ts
@@ -35,6 +35,7 @@ export default async function setup(): Promise<() => Promise<void>> {
     process.env[CLOUD_ENV.token] = identity.token;
     process.env[CLOUD_ENV.platformClientId] = identity.platformClient.clientId;
     process.env[CLOUD_ENV.platformClientSecret] = identity.platformClient.clientSecret;
+    process.env[CLOUD_ENV.operatorToken] = identity.operatorToken;
   } catch (err) {
     await environment.stop();
     throw err;

--- a/test/conformance/src/suites/activity.conformance.test.ts
+++ b/test/conformance/src/suites/activity.conformance.test.ts
@@ -48,9 +48,13 @@ afterAll(async () => {
 // separation, not waiting for async work.
 const separateTimestamps = () => new Promise((resolve) => setTimeout(resolve, 25));
 
-async function provisionAgentInstance(org: string): Promise<string> {
-  const agent = await clients.agentCommand.create(makeAgent({ org, name: uniqueName("agent") }));
-  fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+// Helpers take the caller explicitly: most tests run as the ordinary user,
+// but the runtime-origin exclusion test seeds its lookalike sessions through
+// the privileged scope (reserved-label writes are operator-only on cloud
+// since stigmer-cloud#386, and the recents feed is caller-scoped anyway).
+async function provisionAgentInstance(caller: ConformanceClients, org: string): Promise<string> {
+  const agent = await caller.agentCommand.create(makeAgent({ org, name: uniqueName("agent") }));
+  fixtures.defer(() => caller.agentCommand.delete({ value: agent.metadata!.id }));
   const agentInstanceId = agent.status?.defaultInstanceId;
   if (agentInstanceId === undefined || agentInstanceId === "") {
     throw new Error("agent create did not provision a default instance id");
@@ -59,27 +63,28 @@ async function provisionAgentInstance(org: string): Promise<string> {
 }
 
 async function createSession(
+  caller: ConformanceClients,
   org: string,
   agentInstanceId: string,
   opts: { subject?: string; labels?: Record<string, string> } = {},
 ): Promise<string> {
-  const session = await clients.sessionCommand.create(
+  const session = await caller.sessionCommand.create(
     makeSession({ org, name: uniqueName("session"), agentInstanceId, ...opts }),
   );
-  fixtures.defer(() => clients.sessionCommand.delete({ value: session.metadata!.id }));
+  fixtures.defer(() => caller.sessionCommand.delete({ value: session.metadata!.id }));
   return session.metadata!.id;
 }
 
 describe("Activity conformance — listRecentActivity", () => {
   it("lists created sessions newest-first as projected sidebar entries", async () => {
     const { org } = await target.provisionTenancy();
-    const agentInstanceId = await provisionAgentInstance(org);
+    const agentInstanceId = await provisionAgentInstance(clients, org);
 
-    const first = await createSession(org, agentInstanceId, { subject: "Plan the migration" });
+    const first = await createSession(clients, org, agentInstanceId, { subject: "Plan the migration" });
     await separateTimestamps();
-    const second = await createSession(org, agentInstanceId, { subject: "Review the PR" });
+    const second = await createSession(clients, org, agentInstanceId, { subject: "Review the PR" });
     await separateTimestamps();
-    const third = await createSession(org, agentInstanceId, { subject: "Ship the release" });
+    const third = await createSession(clients, org, agentInstanceId, { subject: "Ship the release" });
 
     const response = await clients.activityQuery.listRecentActivity({ pageSize: 100, org });
     const ids = response.entries.map((entry) => entry.id);
@@ -100,9 +105,9 @@ describe("Activity conformance — listRecentActivity", () => {
 
   it("maps the auto-created sentinel subject to the display placeholder", async () => {
     const { org } = await target.provisionTenancy();
-    const agentInstanceId = await provisionAgentInstance(org);
+    const agentInstanceId = await provisionAgentInstance(clients, org);
 
-    const id = await createSession(org, agentInstanceId, { subject: "Auto-created session" });
+    const id = await createSession(clients, org, agentInstanceId, { subject: "Auto-created session" });
 
     const response = await clients.activityQuery.listRecentActivity({ pageSize: 100, org });
     const entry = response.entries.find((candidate) => candidate.id === id);
@@ -112,34 +117,51 @@ describe("Activity conformance — listRecentActivity", () => {
   });
 
   it("excludes runtime-origin sessions (personal sessions only)", async () => {
-    const { org } = await target.provisionTenancy();
-    const agentInstanceId = await provisionAgentInstance(org);
+    // The runtime-origin lookalikes carry server-stamped reserved keys, which
+    // an ordinary caller can no longer forge on cloud (GuardReservedLabelsStep,
+    // platform-wide since stigmer-cloud#386) — that rejection is itself pinned
+    // in the agent suite. This test therefore seeds them through the
+    // privileged scope (stigmer#547): the local targets' scope IS the ordinary
+    // caller, and the recents feed is caller-scoped, so listing as the same
+    // caller keeps the assertion identical across editions. Deployed endpoints
+    // carry no operator credential by design and skip.
+    if (target.provisionPrivilegedScope === undefined) return;
+    const scope = await target.provisionPrivilegedScope();
 
-    const channelSession = await createSession(org, agentInstanceId, {
-      subject: "Channel conversation",
-      labels: { "stigmer.ai/channel-id": "ach_conformance" },
-    });
-    const scheduleSession = await createSession(org, agentInstanceId, {
-      subject: "Schedule run",
-      labels: { "stigmer.ai/schedule-id": "sch_conformance" },
-    });
-    const consoleSession = await createSession(org, agentInstanceId, { subject: "Console session" });
+    try {
+      const org = scope.context.org;
+      const agentInstanceId = await provisionAgentInstance(scope.clients, org);
 
-    const response = await clients.activityQuery.listRecentActivity({ pageSize: 100, org });
-    const ids = response.entries.map((entry) => entry.id);
+      const channelSession = await createSession(scope.clients, org, agentInstanceId, {
+        subject: "Channel conversation",
+        labels: { "stigmer.ai/channel-id": "ach_conformance" },
+      });
+      const scheduleSession = await createSession(scope.clients, org, agentInstanceId, {
+        subject: "Schedule run",
+        labels: { "stigmer.ai/schedule-id": "sch_conformance" },
+      });
+      const consoleSession = await createSession(scope.clients, org, agentInstanceId, {
+        subject: "Console session",
+      });
 
-    expect(ids).toContain(consoleSession);
-    expect(ids, "channel-originated sessions must not appear in recents").not.toContain(channelSession);
-    expect(ids, "schedule-originated sessions must not appear in recents").not.toContain(scheduleSession);
+      const response = await scope.clients.activityQuery.listRecentActivity({ pageSize: 100, org });
+      const ids = response.entries.map((entry) => entry.id);
+
+      expect(ids).toContain(consoleSession);
+      expect(ids, "channel-originated sessions must not appear in recents").not.toContain(channelSession);
+      expect(ids, "schedule-originated sessions must not appear in recents").not.toContain(scheduleSession);
+    } finally {
+      await scope.cleanup();
+    }
   });
 
   it("trims to page_size, keeping the newest entries", async () => {
     const { org } = await target.provisionTenancy();
-    const agentInstanceId = await provisionAgentInstance(org);
+    const agentInstanceId = await provisionAgentInstance(clients, org);
 
-    await createSession(org, agentInstanceId, { subject: "older" });
+    await createSession(clients, org, agentInstanceId, { subject: "older" });
     await separateTimestamps();
-    const newest = await createSession(org, agentInstanceId, { subject: "newest" });
+    const newest = await createSession(clients, org, agentInstanceId, { subject: "newest" });
 
     const response = await clients.activityQuery.listRecentActivity({ pageSize: 1, org });
 

--- a/test/conformance/src/suites/agent.conformance.test.ts
+++ b/test/conformance/src/suites/agent.conformance.test.ts
@@ -242,26 +242,23 @@ describe("Agent conformance — negative paths", () => {
 describe("Agent conformance — platform default resolution", () => {
   const DEFAULT_AGENT_LABEL = "stigmer.ai/default-agent";
 
-  // Creates a getDefault candidate: an agent carrying the platform default
-  // label, flipped public via updateVisibility (agents create org-visible —
-  // the blueprint default — and public is an explicit opt-in, the same lane
-  // the skill suite pins). The label assert gives a crisp failure if an
-  // edition ever strips labels at create, instead of an opaque NotFound later.
-  //
-  // NOTE: the stigmer.ai/* namespace is now guarded at the cloud write
-  // boundaries (stigmer-cloud#320): only platform operators may introduce
-  // reserved labels there, and the harness has no privileged caller yet —
-  // so this helper runs only where clientReservedLabelWrites holds (the
-  // local OSS targets, deliberately unguarded). stigmer#547 owns the
-  // privileged-caller lane that puts the cloud target back in.
-  async function createDefaultCandidate(org: string) {
-    const agent = await clients.agentCommand.create(
+  // Creates a getDefault candidate as the PRIVILEGED caller: an agent carrying
+  // the platform default label, flipped public via updateVisibility (agents
+  // create org-visible — the blueprint default — and public is an explicit
+  // opt-in). Both writes are operator-gated on cloud (GuardReservedLabelsStep,
+  // stigmer-cloud#320/#386; the public flip behind can_set_public_visibility),
+  // which is exactly why candidates ride the privileged scope (stigmer#547) —
+  // on the local targets that scope IS the ordinary caller. The label assert
+  // gives a crisp failure if an edition ever strips labels at create, instead
+  // of an opaque NotFound later.
+  async function createDefaultCandidate(privileged: ConformanceClients, org: string) {
+    const agent = await privileged.agentCommand.create(
       makeAgent({ org, name: uniqueName("default-cand"), labels: { [DEFAULT_AGENT_LABEL]: "true" } }),
     );
-    fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+    fixtures.defer(() => privileged.agentCommand.delete({ value: agent.metadata!.id }));
     expect(agent.metadata?.labels?.[DEFAULT_AGENT_LABEL], "the default-agent label survives create").toBe("true");
 
-    const updated = await clients.agentCommand.updateVisibility({
+    const updated = await privileged.agentCommand.updateVisibility({
       resourceId: agent.metadata!.id,
       visibility: ApiResourceVisibility.visibility_public,
     });
@@ -270,43 +267,70 @@ describe("Agent conformance — platform default resolution", () => {
   }
 
   it("getDefault resolves the incumbent (first-created) when several public agents carry the label", async () => {
-    // Candidate creation writes a reserved label, which the cloud edition
-    // accepts only from platform operators (stigmer-cloud#320) — see the
-    // capability's doc in targets/target.ts and the helper NOTE above.
-    if (!target.capabilities.clientReservedLabelWrites) return;
+    // Candidate creation needs operator power on cloud; pre-provisioned and
+    // deployed endpoints carry no operator credential BY DESIGN (the
+    // stigmer#547 permanent-skip ruling), so the pin skips only there.
+    if (target.provisionPrivilegedScope === undefined) return;
+    const scope = await target.provisionPrivilegedScope();
+
+    try {
+      // Two labeled public agents is the normal mid-rotation state: the new
+      // default is applied before the old one is retired. The shared contract —
+      // pinned resolver-side on both editions (OSS pkg/domain/agent/defaultagent,
+      // stigmer#356 / PR #458; cloud PostgresAgentRepo.findDefault,
+      // stigmer-cloud#319) — is incumbent-wins: the lowest metadata.id (server
+      // ids are time-ordered ULIDs, so the first-created) keeps serving until
+      // its label is removed. Label removal is the explicit rotation cutover.
+      const incumbent = await createDefaultCandidate(scope.clients, scope.context.org);
+      const rotatedIn = await createDefaultCandidate(scope.clients, scope.context.org);
+
+      // Resolution is PLATFORM-global, so assert from a DIFFERENT, ordinary
+      // tenancy as the ordinary user — the production semantic itself: one
+      // operator-published default served to every org.
+      const { org } = await target.provisionTenancy();
+      const resolved = await clients.agentQuery.getDefault({ org });
+
+      // Two-step assert: first that the winner is one of THIS test's candidates
+      // (a foreign winner means the environment carries a pre-existing default
+      // agent — a broken precondition, reported distinctly), then that it is
+      // specifically the incumbent (the determinism contract under test).
+      expect(
+        [incumbent.metadata!.id, rotatedIn.metadata!.id],
+        "getDefault resolved an agent this test did not create — the environment already carries a default agent",
+      ).toContain(resolved.metadata?.id);
+      expect(resolved.metadata?.id, "the incumbent (lowest id) must win").toBe(incumbent.metadata!.id);
+
+      // getDefault is PLATFORM-global state and the deferred cleanup is
+      // best-effort by design — not enough to stand between this test and a
+      // leaked platform-wide default. Delete both candidates here (as their
+      // owner, the privileged caller) and prove the no-default state is
+      // restored (also what the negative-path pin and the session suite's
+      // no-default case rely on).
+      await scope.clients.agentCommand.delete({ value: rotatedIn.metadata!.id });
+      await scope.clients.agentCommand.delete({ value: incumbent.metadata!.id });
+      await expectGrpcCode(() => clients.agentQuery.getDefault({ org }), Code.NotFound, "getDefault after cleanup");
+    } finally {
+      await scope.cleanup();
+    }
+  });
+
+  it("an ordinary caller introducing a reserved stigmer.ai/* label is rejected where the guard holds", async () => {
+    // The write guard is cloud-only (stigmer-cloud#320, platform-wide since
+    // stigmer-cloud#386); the local OSS targets are deliberately unguarded
+    // (single-tenant, the operator owns the store), so this pin is the
+    // false-branch twin of the capability — where ordinary reserved writes
+    // are allowed there is nothing to reject.
+    if (target.capabilities.clientReservedLabelWrites) return;
 
     const { org } = await target.provisionTenancy();
-
-    // Two labeled public agents is the normal mid-rotation state: the new
-    // default is applied before the old one is retired. The shared contract —
-    // pinned resolver-side on both editions (OSS pkg/domain/agent/defaultagent,
-    // stigmer#356 / PR #458; cloud PostgresAgentRepo.findDefault,
-    // stigmer-cloud#319) — is incumbent-wins: the lowest metadata.id (server
-    // ids are time-ordered ULIDs, so the first-created) keeps serving until
-    // its label is removed. Label removal is the explicit rotation cutover.
-    const incumbent = await createDefaultCandidate(org);
-    const rotatedIn = await createDefaultCandidate(org);
-
-    const resolved = await clients.agentQuery.getDefault({ org });
-
-    // Two-step assert: first that the winner is one of THIS test's candidates
-    // (a foreign winner means the environment carries a pre-existing default
-    // agent — a broken precondition, reported distinctly), then that it is
-    // specifically the incumbent (the determinism contract under test).
-    expect(
-      [incumbent.metadata!.id, rotatedIn.metadata!.id],
-      "getDefault resolved an agent this test did not create — the environment already carries a default agent",
-    ).toContain(resolved.metadata?.id);
-    expect(resolved.metadata?.id, "the incumbent (lowest id) must win").toBe(incumbent.metadata!.id);
-
-    // getDefault is PLATFORM-global state and the deferred cleanup is
-    // best-effort by design — not enough to stand between this test and a
-    // leaked platform-wide default. Delete both candidates here and prove the
-    // no-default state is restored (also what the negative-path pin and the
-    // session suite's no-default case rely on).
-    await clients.agentCommand.delete({ value: rotatedIn.metadata!.id });
-    await clients.agentCommand.delete({ value: incumbent.metadata!.id });
-    await expectGrpcCode(() => clients.agentQuery.getDefault({ org }), Code.NotFound, "getDefault after cleanup");
+    await expectGrpcCode(
+      () =>
+        clients.agentCommand.create(
+          makeAgent({ org, name: uniqueName("forged-default"), labels: { [DEFAULT_AGENT_LABEL]: "true" } }),
+        ),
+      Code.InvalidArgument,
+      "reserved-label introduction by an ordinary caller",
+    );
   });
 });
 

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -15,7 +15,7 @@ import { CLOUD_ENV, mintCloudUserToken } from "../harness/cloud-env";
 import { createTransport, makeClients, type ConformanceClients } from "../harness/clients";
 import { awaitGrpcReady } from "../harness/grpc-ready";
 import { uniqueName, uniqueOrg } from "../support/naming";
-import type { CapabilityFlags, TargetProfile, TenancyContext } from "./target";
+import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } from "./target";
 
 const ORG_API_VERSION = "tenancy.stigmer.ai/v1";
 const ORG_KIND = "Organization";
@@ -47,24 +47,32 @@ export class CloudTarget implements TargetProfile {
     // The hermetic cloud env boots Temporal and the Java service runs the
     // schedule clock (T04 slice 2) — triggers fire for real.
     scheduleFiring: true,
-    // GuardReservedLabelsStep (stigmer-cloud#320) rejects reserved-label
-    // writes from the ordinary conformance user; unguarding requires the
-    // platform-privileged caller lane (stigmer#547).
+    // GuardReservedLabelsStep (stigmer-cloud#320, platform-wide since
+    // stigmer-cloud#386) rejects reserved-label writes from the ordinary
+    // conformance user — the suite pins that rejection where this is false.
+    // Operator-lane assertions run through provisionPrivilegedScope
+    // (stigmer#547) instead.
     clientReservedLabelWrites: false,
     // The primary conformance user is a PlatformClient-minted token —
     // the credential class DD-002 D4 deliberately excludes; the suite
     // pins the create-gate refusal instead (see target.ts).
     firstPartyMemoryCapture: false,
     clientPublicVisibilityWrites: false,
-    // The hermetic cloud service stores attachments in MinIO while the
   };
 
   private grpcBaseUrl: string | undefined;
   private conformanceClients: ConformanceClients | undefined;
+  private operatorClients: ConformanceClients | undefined;
   // Org slug -> resource id, so cleanupTenancy can delete by id without
   // widening TenancyContext beyond the shape the suites share with local
   // targets.
   private readonly provisionedOrgIds = new Map<string, string>();
+
+  // Present only when the environment carries an operator credential — the
+  // hermetic bootstrap always mints one; pre-provisioned/deployed endpoints
+  // deliberately never do (the stigmer#547 permanent-skip ruling), so the
+  // method itself is absent there and privileged-lane assertions skip.
+  provisionPrivilegedScope?: () => Promise<PrivilegedScope>;
 
   async setup(): Promise<void> {
     this.grpcBaseUrl = requireEnv(CLOUD_ENV.address);
@@ -74,6 +82,41 @@ export class CloudTarget implements TargetProfile {
       this.conformanceClients,
       () => "(cloud environment: see the launcher's stderr and stigmer-service-*.log)",
     );
+
+    const operatorToken = process.env[CLOUD_ENV.operatorToken];
+    if (operatorToken !== undefined && operatorToken !== "") {
+      this.operatorClients = makeClients(
+        createTransport(this.grpcBaseUrl, { bearerToken: operatorToken }),
+      );
+      this.provisionPrivilegedScope = () => this.createPrivilegedScope();
+    }
+  }
+
+  // Platform-operator power grants nothing at org level (the FGA model checks
+  // platform capabilities against platform:stigmer only), so the operator
+  // creates AND owns the scope's org; cleanup deletes it.
+  private async createPrivilegedScope(): Promise<PrivilegedScope> {
+    const operatorClients = this.operatorClients;
+    if (operatorClients === undefined) {
+      throw new Error("CloudTarget.setup() must run before provisionPrivilegedScope()");
+    }
+    const created = await operatorClients.organizationCommand.create({
+      apiVersion: ORG_API_VERSION,
+      kind: ORG_KIND,
+      metadata: { name: uniqueOrg() },
+    });
+    const slug = created.metadata?.slug;
+    const id = created.metadata?.id;
+    if (slug === undefined || slug === "" || id === undefined || id === "") {
+      throw new Error("operator organization create returned no slug/id; cannot provision the privileged scope");
+    }
+    return {
+      clients: operatorClients,
+      context: { org: slug },
+      cleanup: async () => {
+        await operatorClients.organizationCommand.delete({ value: id });
+      },
+    };
   }
 
   clients(): ConformanceClients {
@@ -128,6 +171,8 @@ export class CloudTarget implements TargetProfile {
     // it (the cloud global setup for hermetic runs).
     this.grpcBaseUrl = undefined;
     this.conformanceClients = undefined;
+    this.operatorClients = undefined;
+    this.provisionPrivilegedScope = undefined;
     this.provisionedOrgIds.clear();
   }
 }

--- a/test/conformance/src/targets/local-go-execution.ts
+++ b/test/conformance/src/targets/local-go-execution.ts
@@ -27,7 +27,7 @@ import { spawnRunner, type RunningRunner } from "../harness/runner-process";
 import { spawnServer, type RunningServer } from "../harness/server-process";
 import { spawnTemporal, type RunningTemporal } from "../harness/temporal";
 import { uniqueOrg } from "../support/naming";
-import type { CapabilityFlags, TargetProfile, TenancyContext } from "./target";
+import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } from "./target";
 
 export class LocalGoExecutionTarget implements TargetProfile {
   readonly name = "local-go-execution";
@@ -139,6 +139,13 @@ export class LocalGoExecutionTarget implements TargetProfile {
 
   async cleanupTenancy(): Promise<void> {
     // No-op: resources are removed by fixtures and the per-file teardown.
+  }
+
+  // Single-tenant and deliberately unguarded: the one implicit caller IS the
+  // operator, so the ordinary clients and a fresh slug satisfy the privileged
+  // contract (stigmer#547).
+  async provisionPrivilegedScope(): Promise<PrivilegedScope> {
+    return { clients: this.clients(), context: { org: uniqueOrg() }, cleanup: async () => {} };
   }
 
   async teardown(): Promise<void> {

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -9,7 +9,7 @@ import { createTransport, makeClients, type ConformanceClients } from "../harnes
 import { awaitGrpcReady } from "../harness/grpc-ready";
 import { spawnServer, type RunningServer } from "../harness/server-process";
 import { uniqueOrg } from "../support/naming";
-import type { CapabilityFlags, TargetProfile, TenancyContext } from "./target";
+import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } from "./target";
 
 export class LocalGoTarget implements TargetProfile {
   readonly name = "local-go";
@@ -49,6 +49,13 @@ export class LocalGoTarget implements TargetProfile {
   async provisionTenancy(): Promise<TenancyContext> {
     // No auth and no bootstrap org: a unique slug is a fully isolated scope.
     return { org: uniqueOrg() };
+  }
+
+  // Single-tenant and deliberately unguarded: the one implicit caller IS the
+  // operator, so the ordinary clients and a fresh slug satisfy the privileged
+  // contract (stigmer#547).
+  async provisionPrivilegedScope(): Promise<PrivilegedScope> {
+    return { clients: this.clients(), context: { org: uniqueOrg() }, cleanup: async () => {} };
   }
 
   async cleanupTenancy(): Promise<void> {

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -85,20 +85,20 @@ export interface CapabilityFlags {
   // execution is created) — which is what lets this be the first
   // execution-class behavior asserted cross-edition.
   scheduleFiring: boolean;
-  // The conformance caller may write labels in the reserved stigmer.ai/*
-  // namespace (the getDefault determinism pin creates its labeled
-  // candidates through the public API).
+  // The ORDINARY conformance caller may write labels in the reserved
+  // stigmer.ai/* namespace.
   //
   // True for the local OSS targets: single-tenant, deliberately unguarded —
   // the operator owns the store (stigmer-cloud#320 scoped OSS out).
   //
   // False for cloud: GuardReservedLabelsStep rejects non-operator
-  // introductions/changes of reserved labels at the agent write boundaries
-  // (stigmer-cloud#320), and the ordinary conformance user holds no
-  // platform-operator grant. Cloud determinism coverage lives at the
-  // adapter layer meanwhile (AgentRepoCustomQueryContractTest). Flip or
-  // retire this flag when the harness gains a platform-privileged caller
-  // (stigmer#547) — until then the pin runs OSS-side only.
+  // introductions/changes of reserved labels at every client-facing write
+  // boundary (stigmer-cloud#320 for agents, platform-wide since
+  // stigmer-cloud#386). Where false, the suite pins the guard itself: an
+  // ordinary caller introducing a reserved label gets INVALID_ARGUMENT.
+  // The getDefault determinism pin no longer rides this flag — it creates
+  // its labeled candidates through provisionPrivilegedScope (stigmer#547),
+  // so it runs on cloud again.
   clientReservedLabelWrites: boolean;
 // NOTE: there is deliberately no shared-runner-artifact-store capability.
   // Every execution target's runner resolves storage-key attachments the
@@ -154,6 +154,22 @@ export interface TenancyContext {
   org: string;
 }
 
+// A platform-operator caller plus a tenancy that caller may create resources
+// in — the privileged lane assertions that exercise operator-only writes
+// (reserved labels, the public flip) run through (stigmer#547).
+//
+// Platform-operator power deliberately does NOT propagate to organizations
+// (the cloud FGA model checks platform capabilities against platform:stigmer
+// only), so the scope carries its own org: on cloud the operator user creates
+// and owns it; on the local targets — single-tenant, unguarded, the caller IS
+// the operator — the ordinary clients and a unique slug already satisfy the
+// contract.
+export interface PrivilegedScope {
+  readonly clients: ConformanceClients;
+  readonly context: TenancyContext;
+  cleanup(): Promise<void>;
+}
+
 export interface TargetProfile {
   readonly name: string;
   readonly capabilities: CapabilityFlags;
@@ -185,4 +201,13 @@ export interface TargetProfile {
   // targets, where distinct identities exist; local targets have a single
   // implicit caller, so isolation is untestable there by construction.
   provisionIdentity?(): Promise<ConformanceClients>;
+
+  // A platform-operator caller with a tenancy of its own (stigmer#547) — see
+  // PrivilegedScope. Absent where no operator credential exists: hermetic
+  // cloud runs bootstrap one (a conf-operator user granted operator on
+  // platform:stigmer via the production bootstrapPolicy RPC), but
+  // pre-provisioned/deployed endpoints deliberately carry none — operator
+  // credentials against a real deployment is the permanent skip the stigmer#547
+  // ruling recorded — so privileged-lane assertions skip there.
+  provisionPrivilegedScope?(): Promise<PrivilegedScope>;
 }


### PR DESCRIPTION
## Summary
Gives the conformance harness a platform-operator caller on the cloud target, built entirely from production RPCs — the getDefault determinism pin runs on cloud again, and the reserved-label guard gains its own cross-edition rejection pin.

## Context
The cloud#320 guard rejects the ordinary conformance user's `stigmer.ai/default-agent` writes, so the determinism pin early-returned on cloud behind `clientReservedLabelWrites` (coverage held only at the adapter layer). stigmer#547 asked for the privileged-caller lane, a decision on deployed endpoints, and the flag's disposition.

## Changes
- **conf-operator bootstrap** (`cloud-env.ts`): mint a fresh user via the existing `mintUserToken` lane, then grant it `operator` on `platform:stigmer` with **`bootstrapPolicy`** — the tokenless synthetic caller qualifies (`can_bootstrap_iam` derives from the launcher-seeded operator tuple), and the RPC writes the identical policy-row + FGA-tuple shape production's `BootstrapIdentitySeeder` writes. Zero Java and zero Go-harness changes. (The ordinary IamPolicy `create` structurally cannot express this grant: the platform kind declares no grantable roles and `operator` is not an `IamRole` — recorded in the code.)
- **New CLOUD_ENV var** `STIGMER_CONFORMANCE_CLOUD_OPERATOR_TOKEN`, published by the hermetic global setup only.
- **`provisionPrivilegedScope()`** on `TargetProfile` (optional, the `provisionIdentity` precedent): operator clients + an org the operator creates and owns — platform operator deliberately grants nothing at org level. Local targets satisfy the contract with their ordinary caller (single-tenant, the caller IS the operator); the cloud target defines the method only when the operator token is present.
- **Determinism pin un-gated**: candidates created and cleaned by the privileged scope; the assertion moves to a DIFFERENT ordinary tenancy — a strictly stronger pin (one operator-published default served to every org, the production semantic). The pin also now exercises the second operator gate (`can_set_public_visibility`) on the public flip.
- **`clientReservedLabelWrites` kept, false-branch made load-bearing** (the `clientPublicVisibilityWrites` shape, rather than the issue's retire option): a new pin asserts an ordinary caller introducing a reserved label rejects with `INVALID_ARGUMENT` — the first cross-edition pin of the cloud#320/#386 guard itself.
- **Activity suite**: the runtime-origin exclusion test seeds its lookalike sessions through the privileged scope — its old mechanism (client-forged `stigmer.ai/channel-id`) is exactly the hole stigmer-cloud#386 closed, and this run surfaced that as a live rejection. Helpers now take the caller explicitly; the recents feed is caller-scoped so the assertion is unchanged.
- Healed in passing: a dangling truncated comment line in `cloud.ts`'s capability block (main-pre-existing).

## Deployed endpoints — permanent skip (the issue's security question)
Pre-provisioned/deployed CLOUD_ENVs deliberately carry no operator token, so `provisionPrivilegedScope` is absent and privileged-lane assertions skip there. Handing conformance operator credentials to a real deployment is an anti-pattern; adapter-layer determinism coverage (`AgentRepoCustomQueryContractTest`) holds there. Recorded on the issue as the permanent answer.

## Breaking changes
- None. New env var is optional; targets without it behave as before except the pin's skip is now capability-honest rather than edition-hardcoded.

## Test plan
- Hermetic cloud lane (`npm run test:cloud`) against the stigmer-cloud#386 branch JAR: **17 files, 329 passed, 2 skipped** — the determinism pin ran on cloud for the first time since cloud#320, and the run doubles as end-to-end validation of cloud PR #533's guard adoption (allowlist, stamp registry, operator lane all exercised).
- Full local lane (`npm test`): **16 files, 326 passed, 1 skipped**.
- `tsc --noEmit`: no errors in changed files (pre-existing unrelated errors on pristine main verified identical).

## Risks
- Low: conformance-only TS changes; no production code. The operator credential exists only inside hermetic runs and dies with them.

Closes #547

Made with [Cursor](https://cursor.com)