### PR TITLE
feat(runner): semantic memory retriever — threshold-gated top-k selection with injection report

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/build-prompt.test.ts
@@ -12,7 +12,7 @@ import { create } from "@bufbuild/protobuf";
 import { ApprovalAction, InteractionMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { PendingApprovalSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
 
-import { appendStructuredOutputDirective, buildPrompt, isHitlReinvocation, primarySendCarriesImages } from "../index.js";
+import { appendStructuredOutputDirective, buildPrompt, isHitlReinvocation, primarySendCarriesImages, promptCarriesStandingContext } from "../index.js";
 import type { BuildPromptInput } from "../index.js";
 import { buildReinvocationPrompt, formatInteractionModePrefix, formatImplementPlanSection, formatToolApprovalProtocol, buildToolApprovalRuleFile } from "../prompt-builder.js";
 import { PLAN_MODE_DIRECTIVE } from "../../../shared/plan-mode-prompt.js";
@@ -328,6 +328,45 @@ describe("buildPrompt", () => {
     expect(prompt).toContain("<recalled_memories>");
     expect(prompt).toContain("- Prefers OpenTofu.");
     expect(prompt).toContain("APPROVED");
+  });
+
+  it("agrees with promptCarriesStandingContext on every resolution shape — the memory-selection gate can never drift from the routing (DD-008)", () => {
+    // The activity gates the (potentially embedding-backed) memory
+    // selection on this predicate; buildPrompt routes on the same one.
+    // Pin their agreement across the full reason × HITL matrix: memories
+    // reach the prompt exactly when the predicate says the prompt carries
+    // standing context.
+    const reasons: AgentResolutionReason[] = [
+      "created_first_execution",
+      "created_after_resume_failure",
+      "resumed_successfully",
+    ];
+    const hitlDecisions = new Map<string, ApprovalAction>([
+      ["tool-call-1", ApprovalAction.APPROVE],
+    ]);
+    const hitlApprovals = [
+      create(PendingApprovalSchema, {
+        toolCallId: "tool-call-1",
+        toolName: "Write",
+        message: "Write file: gated.txt",
+      }),
+    ];
+
+    for (const reason of reasons) {
+      for (const hitl of [false, true]) {
+        const prompt = buildPrompt(
+          input({
+            resolution: resolution("local", reason),
+            approvalDecisions: hitl ? hitlDecisions : undefined,
+            pendingApprovals: hitl ? hitlApprovals : [],
+            recalledMemories: { facts: ["Prefers OpenTofu."] },
+          }),
+        );
+        expect(prompt.includes("<recalled_memories>")).toBe(
+          promptCarriesStandingContext(reason),
+        );
+      }
+    }
   });
 
   it("uses the reinvocation prompt for a HITL reinvocation (human-meaningful, no opaque ids)", () => {

--- a/backend/services/runner/src/activities/execute-cursor/index.ts
+++ b/backend/services/runner/src/activities/execute-cursor/index.ts
@@ -57,7 +57,8 @@ import {
 } from "../../shared/caller-identity.js";
 import { readSessionContext } from "../../shared/session-context.js";
 import { readDeclaredPreferences } from "../../shared/declared-preferences.js";
-import { readRecalledMemories } from "../../shared/recalled-memories.js";
+import type { RecalledMemoriesContent } from "../../shared/recalled-memories.js";
+import { selectRecalledFacts } from "../../shared/memory-retrieval.js";
 import { withholdSecretContentFromMessages } from "../../shared/tool-row.js";
 import { StallTimeoutError, formatStallFailure } from "../../shared/stall-watchdog.js";
 import { resolveUsableArtifactStorage, loadArtifactStorageConfig, type ArtifactStorage } from "../../shared/artifact-storage.js";
@@ -1182,6 +1183,38 @@ async function executeCursorInner(
     const structuredOutputSchema = spec.executionConfig?.structuredOutputSchema as
       Record<string, unknown> | undefined;
 
+    // Phase 9c: Semantic memory selection (DD-008), memoized to at most one
+    // run per invocation. Deliberately NOT decided by the Phase-10
+    // resolution alone: a resumed-agent primary send carries no memories,
+    // but a mid-send poisoned-handle failure rebuilds on a FRESH agent
+    // whose recovery prompt does — the buildFromPlan drop-hazard class —
+    // so every memory-carrying build site awaits this lazily instead.
+    // Selection runs against the frozen first message's semantics: above
+    // the activation threshold it picks top-k for spec.message, otherwise
+    // (and on any failure) it injects the full candidate set — Phase 2
+    // behavior. The outcome report is stamped on the turn's status ONCE,
+    // picked up by the next persist; a re-invocation replays the report
+    // already persisted on the execution rather than re-selecting (the
+    // written-once rule).
+    let memorySelection: Promise<RecalledMemoriesContent | undefined> | undefined;
+    const selectMemoriesOnce = (): Promise<RecalledMemoriesContent | undefined> => {
+      memorySelection ??= selectRecalledFacts(spec.recalledMemories, spec.message, {
+        proxyEndpoint: config.proxyEndpoint,
+        stigmerToken: config.stigmerToken,
+        executionId,
+        priorReport: execution.status?.recalledMemoriesReport,
+      }).then((selection) => {
+        if (selection.report !== undefined) {
+          status.recalledMemoriesReport = selection.report;
+        }
+        return selection.content;
+      });
+      return memorySelection;
+    };
+    const recalledMemories = promptCarriesStandingContext(resolution.reason)
+      ? await selectMemoriesOnce()
+      : undefined;
+
     // Phase 10: Build the prompt
     const interactionMode = spec.executionConfig?.interactionMode
       ?? InteractionMode.UNSPECIFIED;
@@ -1208,7 +1241,7 @@ async function executeCursorInner(
       senderIdentity: readSenderIdentity(blueprint.sessionSpec.metadata),
       sessionContext: readSessionContext(blueprint.sessionSpec.metadata),
       declaredPreferences: readDeclaredPreferences(spec.declaredPreferences),
-      recalledMemories: readRecalledMemories(spec.recalledMemories),
+      recalledMemories,
       conversationCatchup: readConversationCatchup(spec.conversationCatchup),
       // The turn's recorded transcript, seeded from the persisted execution
       // on a reinvocation (Phase 3). Consumed only by the HITL-recovery
@@ -1916,7 +1949,10 @@ async function executeCursorInner(
             senderIdentity: readSenderIdentity(blueprint.sessionSpec.metadata),
             sessionContext: readSessionContext(blueprint.sessionSpec.metadata),
             declaredPreferences: readDeclaredPreferences(spec.declaredPreferences),
-            recalledMemories: readRecalledMemories(spec.recalledMemories),
+            // Lazily selected: the primary send may have been a resumed-agent
+            // shape that carried no memories, but this fresh agent's prompt
+            // must (see the Phase 9c memoized selection).
+            recalledMemories: await selectMemoriesOnce(),
             conversationCatchup: readConversationCatchup(spec.conversationCatchup),
             // Composed fresh (not reused from Phase 10): the failed primary
             // stream may have appended partial work onto status.messages,
@@ -2607,6 +2643,23 @@ export function primarySendCarriesImages(
 }
 
 /**
+ * Whether a prompt built for this resolution carries the STANDING context —
+ * instructions, skills, declared preferences, recalled memories, session
+ * context. Exactly one resolution shape does not: a successfully RESUMED
+ * agent, whose native conversation already holds the first message's
+ * context (both its prompt shapes — the raw follow-up and the
+ * decisions-only HITL reinvocation — send no standing sections).
+ *
+ * The named authority for that routing property (the
+ * primarySendCarriesImages idiom): buildPrompt's internal routing and the
+ * activity's standing-context preparation (e.g. the memory selection gate)
+ * both consult THIS predicate, so the two can never drift.
+ */
+export function promptCarriesStandingContext(reason: AgentResolutionReason): boolean {
+  return reason !== "resumed_successfully";
+}
+
+/**
  * Append the structured-output contract to a prompt when the execution
  * requests one. A per-turn directive (the buildFromPlan rule): it must ride
  * every prompt this turn sends — the primary send AND the poisoned-handle
@@ -2647,7 +2700,7 @@ export function buildPrompt(input: BuildPromptInput): string {
   // an empty conversation strand the agent with instructions and no story,
   // and the session inherits that amnesia permanently (issue #366).
   if (isHitlReinvocation(approvalDecisions)) {
-    if (resolution.reason !== "resumed_successfully") {
+    if (promptCarriesStandingContext(resolution.reason)) {
       return buildHitlRecoveryPrompt(
         {
           instructions,
@@ -2698,7 +2751,7 @@ export function buildPrompt(input: BuildPromptInput): string {
   // cloud DD-006). Catchup last: it is context, and context sits closest to
   // the task (the enhanced prompt's own ordering doctrine); the input files
   // precede it because they are this turn's payload, not background.
-  if (resolution.reason === "resumed_successfully") {
+  if (!promptCarriesStandingContext(resolution.reason)) {
     const prefixes = [
       formatInteractionModePrefix(interactionMode),
       formatImplementPlanSection(buildFromPlan, attachments),

--- a/backend/services/runner/src/activities/execute-deep-agent/index.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/index.ts
@@ -180,6 +180,16 @@ export function createDeepAgentActivities(config: Config) {
           ? seedStatusFromExecution(setup.execution)
           : create(AgentExecutionStatusSchema, {});
 
+        // The semantic retriever's injection outcome (DD-008 D5), computed at
+        // prompt build in setup Step 8. Stamped here — before the first
+        // persist — because setup predates this status object; the server's
+        // presence-guarded merge preserves it across report-less writes. On a
+        // re-invocation the seeded status already carries the (replayed)
+        // report, so this stamp is idempotent by construction.
+        if (setup.recalledMemoriesReport !== undefined) {
+          initialStatus.recalledMemoriesReport = setup.recalledMemoriesReport;
+        }
+
         const statusBuilder = new StatusBuilder(executionId, initialStatus);
 
         statusBuilder.setApprovalProvider({

--- a/backend/services/runner/src/activities/execute-deep-agent/setup.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/setup.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AgentGraph = any;
 
-import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution, RecalledMemoriesReport } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import type { DynamicStructuredTool } from "@langchain/core/tools";
@@ -33,7 +33,7 @@ import {
 } from "../../shared/caller-identity.js";
 import { readSessionContext } from "../../shared/session-context.js";
 import { readDeclaredPreferences } from "../../shared/declared-preferences.js";
-import { readRecalledMemories } from "../../shared/recalled-memories.js";
+import { selectRecalledFacts } from "../../shared/memory-retrieval.js";
 import { connectMcpServers, type McpConnectionResult } from "../../shared/mcp-manager.js";
 import { mergeMcpServerUsages, resolveMcpServers } from "../../shared/mcp-resolver.js";
 import { resolveMcpTransportPosture } from "../../shared/mcp-transport-guard.js";
@@ -201,6 +201,15 @@ export interface SetupResult {
    * baseline/candidate/reconcile seam (`capture.ts`) and the CAS capture-class.
    */
   readonly gitWorkspace: boolean;
+  /**
+   * The semantic retriever's injection outcome (DD-008 D5), produced at
+   * prompt build (Step 8) — the one place selection runs. The activity
+   * stamps it onto the turn's status proto before the first persist; the
+   * server's presence-guarded merge preserves it across report-less
+   * writes. Undefined when nothing was injected (recall absent, disabled,
+   * or empty) — absent report = wholesale, true by construction.
+   */
+  readonly recalledMemoriesReport: RecalledMemoriesReport | undefined;
 }
 
 export interface SetupDependencies {
@@ -590,7 +599,27 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
     }
     timing.mark("inject_attachments");
 
-    // Step 8: Build enhanced system prompt
+    // Step 8: Build enhanced system prompt.
+    //
+    // Recalled memories go through the semantic retriever (DD-008), not the
+    // raw snapshot read: above the activation threshold it selects the
+    // top-k facts for THIS turn's message (one batched embeddings call);
+    // otherwise — and on any failure — it injects the full candidate set,
+    // exactly the Phase 2 behavior. A re-invocation of this execution
+    // (approval resume) replays the outcome recorded on the execution's
+    // status instead of re-selecting, so the prompt never shifts
+    // mid-execution. The report returned here is stamped onto the turn's
+    // status by the activity (index.ts) — setup has no status object yet.
+    const memorySelection = await selectRecalledFacts(
+      execution.spec!.recalledMemories,
+      execution.spec!.message,
+      {
+        proxyEndpoint: config.proxyEndpoint,
+        stigmerToken: config.stigmerToken,
+        executionId,
+        priorReport: execution.status?.recalledMemoriesReport,
+      },
+    );
     const systemPrompt = buildEnhancedSystemPrompt({
       instructions,
       provisionResults,
@@ -614,9 +643,7 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       declaredPreferences: readDeclaredPreferences(
         execution.spec!.declaredPreferences,
       ),
-      recalledMemories: readRecalledMemories(
-        execution.spec!.recalledMemories,
-      ),
+      recalledMemories: memorySelection.content,
     });
 
     // Step 9: Construct the LLM model. Resolution to the provider API id
@@ -964,6 +991,7 @@ export async function performSetup(deps: SetupDependencies): Promise<SetupResult
       casObserver,
       captureMode,
       gitWorkspace,
+      recalledMemoriesReport: memorySelection.report,
     };
   } catch (err) {
     if (mcpConnection) {

--- a/backend/services/runner/src/shared/__tests__/memory-retrieval.test.ts
+++ b/backend/services/runner/src/shared/__tests__/memory-retrieval.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for the memory-retrieval module (stigmer/stigmer#293 Phase 3a,
+ * DD-008). What is pinned here, path by path:
+ *
+ *  - The activation threshold: selection runs ONLY above RETRIEVAL_K
+ *    candidates; at or below it there is NO embeddings call (most users
+ *    never touch the embeddings API — the DD-008 D3 activation contract).
+ *  - Top-k correctness and the presentation contract: selection is by
+ *    relevance, presentation is snapshot order, ties break toward the
+ *    lower snapshot index (deterministic across invocations).
+ *  - The failure posture: every degraded path — no embedder, embed error,
+ *    malformed response — injects wholesale with an honest
+ *    selection_active=false report, never a throw into prompt build.
+ *  - The written-once replay: a prior report (either polarity) replays
+ *    without an embeddings call, so a re-invocation can never inject a
+ *    different subset than the first invocation did.
+ *  - The report contract: a report exists exactly when facts are injected;
+ *    no injection, no report (absent report = wholesale by construction).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { RecalledMemoriesSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { RecalledMemoriesReportSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import {
+  selectRecalledFacts,
+  RETRIEVAL_K,
+  EMBEDDING_MODEL,
+  QUERY_MAX_CHARS,
+  type EmbedFn,
+} from "../memory-retrieval.js";
+
+const QUERY = "How should I deploy the payments service?";
+
+/** Snapshot of `count` facts: mem_0..mem_{count-1}, "fact 0".."fact N". */
+function snapshot(count: number) {
+  return create(RecalledMemoriesSchema, {
+    enabled: true,
+    facts: Array.from({ length: count }, (_, i) => ({
+      memoryId: `mem_${i}`,
+      content: `fact ${i}`,
+    })),
+  });
+}
+
+/**
+ * A deterministic embedder over 2D unit vectors: the query embeds to
+ * [1, 0]; fact i embeds to an angle that grows with i, so relevance order
+ * is exactly snapshot order (fact 0 most similar) unless a test overrides
+ * per-input vectors.
+ */
+function angularEmbedder(overrides?: Map<string, number[]>): EmbedFn & {
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const fn: EmbedFn = async (inputs) => {
+    calls.push([...inputs]);
+    return inputs.map((input, position) => {
+      const override = overrides?.get(input);
+      if (override) return override;
+      if (position === 0) return [1, 0];
+      const angle = (position / (inputs.length + 1)) * (Math.PI / 2);
+      return [Math.cos(angle), Math.sin(angle)];
+    });
+  };
+  return Object.assign(fn, { calls });
+}
+
+function baseOptions(embed: EmbedFn) {
+  return {
+    proxyEndpoint: null,
+    stigmerToken: null,
+    executionId: "exec_test",
+    embed,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("selectRecalledFacts — no injection, no report", () => {
+  it("answers nothing for an absent snapshot (pre-Phase-2 executions)", async () => {
+    const embed = angularEmbedder();
+    const result = await selectRecalledFacts(undefined, QUERY, baseOptions(embed));
+    expect(result.content).toBeUndefined();
+    expect(result.report).toBeUndefined();
+    expect(embed.calls).toHaveLength(0);
+  });
+
+  it("answers nothing when recall is disabled or enabled-with-zero-facts", async () => {
+    const embed = angularEmbedder();
+    const disabled = create(RecalledMemoriesSchema, {
+      enabled: false,
+      facts: [{ memoryId: "mem_0", content: "fact 0" }],
+    });
+    expect(
+      (await selectRecalledFacts(disabled, QUERY, baseOptions(embed))).report,
+    ).toBeUndefined();
+    const empty = create(RecalledMemoriesSchema, { enabled: true });
+    expect(
+      (await selectRecalledFacts(empty, QUERY, baseOptions(embed))).report,
+    ).toBeUndefined();
+    expect(embed.calls).toHaveLength(0);
+  });
+});
+
+describe("selectRecalledFacts — activation threshold (DD-008 D3)", () => {
+  it("injects wholesale with NO embeddings call at exactly k candidates", async () => {
+    const embed = angularEmbedder();
+    const result = await selectRecalledFacts(
+      snapshot(RETRIEVAL_K),
+      QUERY,
+      baseOptions(embed),
+    );
+
+    expect(embed.calls).toHaveLength(0);
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K);
+    expect(result.report?.selectionActive).toBe(false);
+    expect(result.report?.injectedMemoryIds).toEqual([]);
+    expect(result.report?.embeddingModel).toBe("");
+  });
+
+  it("activates selection at k+1: one batched call, k facts injected", async () => {
+    const embed = angularEmbedder();
+    const result = await selectRecalledFacts(
+      snapshot(RETRIEVAL_K + 1),
+      QUERY,
+      baseOptions(embed),
+    );
+
+    expect(embed.calls).toHaveLength(1);
+    expect(embed.calls[0]).toHaveLength(RETRIEVAL_K + 2); // query + all candidates
+    expect(embed.calls[0][0]).toBe(QUERY);
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K);
+    expect(result.report?.selectionActive).toBe(true);
+    expect(result.report?.injectedMemoryIds).toHaveLength(RETRIEVAL_K);
+    expect(result.report?.embeddingModel).toBe(EMBEDDING_MODEL);
+    // The angular embedder makes the LAST fact least relevant.
+    expect(result.report?.injectedMemoryIds).not.toContain(`mem_${RETRIEVAL_K}`);
+  });
+
+  it("counts only renderable candidates toward the threshold (blank facts dropped, the read-boundary semantics)", async () => {
+    const embed = angularEmbedder();
+    const recalled = create(RecalledMemoriesSchema, {
+      enabled: true,
+      facts: [
+        ...Array.from({ length: RETRIEVAL_K }, (_, i) => ({
+          memoryId: `mem_${i}`,
+          content: `fact ${i}`,
+        })),
+        { memoryId: "mem_blank", content: "   " },
+      ],
+    });
+
+    const result = await selectRecalledFacts(recalled, QUERY, baseOptions(embed));
+
+    expect(embed.calls).toHaveLength(0); // 20 renderable ≤ k → wholesale
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K);
+    expect(result.report?.selectionActive).toBe(false);
+  });
+});
+
+describe("selectRecalledFacts — ranking and presentation", () => {
+  it("selects by relevance but presents in snapshot order, ids parallel to facts", async () => {
+    // Invert relevance: the LAST fact is the most similar, fact 0 the least.
+    const count = RETRIEVAL_K + 5;
+    const overrides = new Map<string, number[]>();
+    for (let i = 0; i < count; i++) {
+      const angle = ((count - i) / (count + 1)) * (Math.PI / 2);
+      overrides.set(`fact ${i}`, [Math.cos(angle), Math.sin(angle)]);
+    }
+    const embed = angularEmbedder(overrides);
+
+    const result = await selectRecalledFacts(
+      snapshot(count),
+      QUERY,
+      baseOptions(embed),
+    );
+
+    // The 5 least relevant under inversion are the FIRST five snapshot facts.
+    const expectedIndices = Array.from({ length: RETRIEVAL_K }, (_, i) => i + 5);
+    expect(result.content?.facts).toEqual(expectedIndices.map((i) => `fact ${i}`));
+    expect(result.report?.injectedMemoryIds).toEqual(
+      expectedIndices.map((i) => `mem_${i}`),
+    );
+  });
+
+  it("breaks ties toward the lower snapshot index — equal scores never reorder across invocations", async () => {
+    // Every input embeds identically: all scores tie.
+    const count = RETRIEVAL_K + 3;
+    const overrides = new Map<string, number[]>([[QUERY, [1, 0]]]);
+    for (let i = 0; i < count; i++) {
+      overrides.set(`fact ${i}`, [1, 0]);
+    }
+    const embed = angularEmbedder(overrides);
+
+    const first = await selectRecalledFacts(snapshot(count), QUERY, baseOptions(embed));
+    const second = await selectRecalledFacts(snapshot(count), QUERY, baseOptions(embed));
+
+    const expected = Array.from({ length: RETRIEVAL_K }, (_, i) => `mem_${i}`);
+    expect(first.report?.injectedMemoryIds).toEqual(expected);
+    expect(second.report?.injectedMemoryIds).toEqual(expected);
+  });
+
+  it("truncates the query at QUERY_MAX_CHARS — a giant paste must not 400 the whole batch", async () => {
+    const embed = angularEmbedder();
+    const giant = "x".repeat(QUERY_MAX_CHARS + 500);
+
+    await selectRecalledFacts(snapshot(RETRIEVAL_K + 1), giant, baseOptions(embed));
+
+    expect(embed.calls[0][0]).toHaveLength(QUERY_MAX_CHARS);
+  });
+});
+
+describe("selectRecalledFacts — failure posture (never worse than Phase 2)", () => {
+  it("degrades to wholesale with an honest report when the embedder throws", async () => {
+    const embed: EmbedFn = async () => {
+      throw new Error("connect ETIMEDOUT");
+    };
+    const result = await selectRecalledFacts(
+      snapshot(RETRIEVAL_K + 1),
+      QUERY,
+      baseOptions(embed),
+    );
+
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K + 1);
+    expect(result.report?.selectionActive).toBe(false);
+    expect(result.report?.injectedMemoryIds).toEqual([]);
+  });
+
+  it("degrades to wholesale when the embedder answers the wrong vector count", async () => {
+    const embed: EmbedFn = async () => [[1, 0]];
+    const result = await selectRecalledFacts(
+      snapshot(RETRIEVAL_K + 1),
+      QUERY,
+      baseOptions(embed),
+    );
+
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K + 1);
+    expect(result.report?.selectionActive).toBe(false);
+  });
+
+  it("injects wholesale when no embedder resolves (no proxy, no OpenAI key — the Anthropic-only OSS posture)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+
+    const result = await selectRecalledFacts(snapshot(RETRIEVAL_K + 1), QUERY, {
+      proxyEndpoint: null,
+      stigmerToken: null,
+      executionId: "exec_test",
+      // No embed injected: the module resolves — and finds — nothing.
+    });
+
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K + 1);
+    expect(result.report?.selectionActive).toBe(false);
+  });
+});
+
+describe("selectRecalledFacts — written-once replay across re-invocations", () => {
+  it("replays a selection-active prior report without an embeddings call", async () => {
+    const embed = angularEmbedder();
+    const prior = create(RecalledMemoriesReportSchema, {
+      selectionActive: true,
+      injectedMemoryIds: ["mem_1", "mem_3"],
+      embeddingModel: EMBEDDING_MODEL,
+    });
+
+    const result = await selectRecalledFacts(snapshot(RETRIEVAL_K + 1), QUERY, {
+      ...baseOptions(embed),
+      priorReport: prior,
+    });
+
+    expect(embed.calls).toHaveLength(0);
+    expect(result.content?.facts).toEqual(["fact 1", "fact 3"]);
+    expect(result.report).toBe(prior);
+  });
+
+  it("replays a wholesale prior report as wholesale — a recorded embed failure is never retried into a different prompt", async () => {
+    const embed = angularEmbedder();
+    const prior = create(RecalledMemoriesReportSchema, { selectionActive: false });
+
+    const result = await selectRecalledFacts(snapshot(RETRIEVAL_K + 1), QUERY, {
+      ...baseOptions(embed),
+      priorReport: prior,
+    });
+
+    expect(embed.calls).toHaveLength(0);
+    expect(result.content?.facts).toHaveLength(RETRIEVAL_K + 1);
+    expect(result.report?.selectionActive).toBe(false);
+  });
+
+  it("re-selects when a recorded id does not resolve against the snapshot (structurally impossible, defended anyway)", async () => {
+    const embed = angularEmbedder();
+    const prior = create(RecalledMemoriesReportSchema, {
+      selectionActive: true,
+      injectedMemoryIds: ["mem_1", "mem_never_existed"],
+      embeddingModel: EMBEDDING_MODEL,
+    });
+
+    const result = await selectRecalledFacts(snapshot(RETRIEVAL_K + 1), QUERY, {
+      ...baseOptions(embed),
+      priorReport: prior,
+    });
+
+    expect(embed.calls).toHaveLength(1);
+    expect(result.report?.selectionActive).toBe(true);
+    expect(result.report?.injectedMemoryIds).toHaveLength(RETRIEVAL_K);
+  });
+});

--- a/backend/services/runner/src/shared/memory-retrieval.ts
+++ b/backend/services/runner/src/shared/memory-retrieval.ts
@@ -1,0 +1,383 @@
+/**
+ * Semantic selection of recalled memories (stigmer/stigmer#293 Phase 3a,
+ * DD-008): when a subject's confirmed-fact set outgrows what wholesale
+ * injection should carry, select the most relevant facts for THIS
+ * execution instead of injecting everything.
+ *
+ * Sibling of recalled-memories.ts (which owns presentation) — this module
+ * owns SELECTION: which subset of the server-composed candidate set
+ * (`spec.recalled_memories`, the auditable snapshot both editions' compose
+ * steps stamp) actually rides the prompt. The compose steps never change;
+ * selection is a runner concern because the runner owns prompt assembly,
+ * provider credentials, and the metered proxy lane (DD-008 D1 — the
+ * titling-convergence doctrine: control-plane-adjacent LLM work runs once,
+ * in the shared runner, for both editions).
+ *
+ * Mechanism (DD-008 D2/D3): embed-on-read, no stored vectors anywhere.
+ * Selection activates ONLY above RETRIEVAL_K candidates; below that,
+ * top-k degenerates to wholesale, so no embeddings call is made and the
+ * shipped Phase 2 path runs untouched. When active: ONE batched
+ * embeddings call (query + all candidates), in-process cosine ranking,
+ * top-k by relevance, presented in snapshot order (relevance order would
+ * carry no information the model needs and would churn the prompt prefix).
+ * The query is the execution's `spec.message` — the current turn.
+ *
+ * The audit contract (DD-008 D5): the selection outcome is recorded in a
+ * runner-owned `RecalledMemoriesReport` on the execution status (the
+ * streaming_usage posture — one writer, written at prompt build). A report
+ * is returned whenever facts are injected, wholesale or selected; when
+ * nothing is injected (recall absent/disabled/empty) there is no report —
+ * absent report = wholesale, true by construction, so pre-3a executions
+ * read identically.
+ *
+ * Written-once across re-invocations: the same execution's prompt is
+ * rebuilt on approval resume (native) and fresh-agent recovery (cursor).
+ * Re-running selection there could pick a DIFFERENT subset mid-execution —
+ * so when the loaded execution already carries a report, this module
+ * REPLAYS it (selected ids resolved against the snapshot, or wholesale
+ * for a selection_active=false report) instead of re-embedding. Selection
+ * is computed at most once per execution, by construction.
+ *
+ * Failure posture: selection is an optimization. ANY failure — no
+ * embedder, HTTP error, timeout, malformed response — degrades to
+ * wholesale injection with a selection_active=false report, never a
+ * failed or degraded execution (DD-008 D3). Deployments with no
+ * embeddings-capable credential (Anthropic-only, Cursor-only OSS) run
+ * Phase 2 behavior unchanged, forever.
+ */
+
+import { create } from "@bufbuild/protobuf";
+import type { RecalledMemories } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import {
+  RecalledMemoriesReportSchema,
+  type RecalledMemoriesReport,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { RecalledMemoriesContent } from "./recalled-memories.js";
+import { resolveProxyBaseUrl, buildProxyHeaders } from "./llm-proxy.js";
+import { checkDirectCredentials } from "./llm-backend.js";
+import { getRunnerSecret } from "./runner-credential-store.js";
+
+/**
+ * Selection activates only when the candidate set EXCEEDS this many facts;
+ * at or below it, top-k degenerates to wholesale and no embeddings call is
+ * made. 20 is comfortably above the dozens-scale where wholesale is fine
+ * (activation is rare) and comfortably below the 100-record cap (activation
+ * is meaningful): at 500-char facts, 20 facts ≈ 10KB of prompt. One
+ * constant, one place, deliberately not adaptive or per-org configurable
+ * in v1 (DD-008 D3).
+ */
+export const RETRIEVAL_K = 20;
+
+/**
+ * The v1 embedder (DD-008 D4). OpenAI-only: resolved through the Stigmer
+ * proxy when one is configured (cloud — platform key, metered), else the
+ * operator's direct OpenAI key (OSS). NOTE: llm-proxy's `inferProvider`
+ * does not know the `text-*` prefix — this module never infers; the
+ * provider is fixed alongside the model.
+ */
+export const EMBEDDING_MODEL = "text-embedding-3-small";
+
+/**
+ * Upper bound on the query text sent to the embedder. Facts are write-time
+ * capped at 500 chars, but the query is `spec.message` — unbounded. A giant
+ * pasted message would blow the embedder's per-input token limit (8192 for
+ * text-embedding-3-small) and 400 the WHOLE batched call, silently forcing
+ * wholesale on exactly the executions where selection matters. 20K chars
+ * sits safely under the limit at worst-case chars-per-token; selection
+ * intent is dominated by the message head, and a truncated query beats no
+ * selection.
+ */
+export const QUERY_MAX_CHARS = 20_000;
+
+/**
+ * Bound on the single embeddings round trip. Generous relative to the
+ * observed 200–400ms typical latency: this exists to keep a hung
+ * connection from stalling prompt build, not to race the provider.
+ */
+const EMBED_TIMEOUT_MS = 15_000;
+
+/** The OpenAI SDK-default base, used only in direct (unproxied) mode. */
+const DIRECT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+/**
+ * One batched embeddings call: one vector per input, in input order.
+ * The seam unit tests inject through, and the boundary a stored-vector
+ * optimization would slot behind if caps ever grow (DD-008 D2).
+ */
+export type EmbedFn = (inputs: readonly string[]) => Promise<number[][]>;
+
+export interface MemoryRetrievalOptions {
+  /** Null/undefined when the deployment has no proxy (direct mode). */
+  readonly proxyEndpoint: string | null | undefined;
+  /** Bearer for proxy mode; unused in direct mode. */
+  readonly stigmerToken: string | null | undefined;
+  /** Scopes the proxied call for FGA authorization and billing attribution. */
+  readonly executionId: string;
+  /**
+   * The report a PREVIOUS invocation of this same execution recorded, if
+   * any (`execution.status.recalled_memories_report`). Presence replays
+   * the recorded outcome instead of re-selecting — the written-once rule.
+   */
+  readonly priorReport?: RecalledMemoriesReport;
+  /** Test seam; defaults to the proxy/direct embedder resolution. */
+  readonly embed?: EmbedFn;
+}
+
+export interface MemorySelectionResult {
+  /**
+   * The facts to inject, in snapshot order — undefined when recall is
+   * absent, disabled, or empty (render nothing, exactly the
+   * readRecalledMemories contract).
+   */
+  readonly content: RecalledMemoriesContent | undefined;
+  /**
+   * The injection outcome to stamp on the execution status. Undefined
+   * exactly when `content` is undefined: no injection, no report.
+   */
+  readonly report: RecalledMemoriesReport | undefined;
+}
+
+/** A candidate fact: the snapshot entry with its audit identity intact. */
+interface Candidate {
+  readonly memoryId: string;
+  readonly content: string;
+}
+
+/**
+ * Select the facts to inject for one execution.
+ *
+ * This is the ONE entry point both harnesses call at prompt build, replacing
+ * their direct `readRecalledMemories` reads on the injection path (the read
+ * function remains the presentation-side authority; this module reads the
+ * proto itself because selection needs `memory_id`, which the render
+ * boundary deliberately strips).
+ *
+ * Never throws: every failure path returns wholesale.
+ */
+export async function selectRecalledFacts(
+  recalled: RecalledMemories | undefined,
+  queryText: string,
+  options: MemoryRetrievalOptions,
+): Promise<MemorySelectionResult> {
+  const candidates = readCandidates(recalled);
+  if (candidates.length === 0) {
+    return { content: undefined, report: undefined };
+  }
+
+  // Written-once: a prior invocation of this execution already decided.
+  if (options.priorReport !== undefined) {
+    const replayed = replayReport(candidates, options.priorReport);
+    if (replayed !== undefined) {
+      return replayed;
+    }
+    // Unreplayable (recorded ids missing from the immutable snapshot —
+    // structurally impossible, defended anyway): fall through and select
+    // fresh rather than inject nothing.
+    log(
+      `prior report for execution ${options.executionId} did not resolve ` +
+      `against the snapshot; re-selecting`,
+    );
+  }
+
+  if (candidates.length <= RETRIEVAL_K) {
+    return wholesale(candidates);
+  }
+
+  const embed = options.embed ?? resolveEmbedder(options);
+  if (embed === undefined) {
+    // No embeddings-capable credential: the recorded no-embedder posture
+    // (DD-008 D4) — Phase 2 behavior, honestly reported.
+    return wholesale(candidates);
+  }
+
+  try {
+    const query = queryText.slice(0, QUERY_MAX_CHARS);
+    const vectors = await embed([query, ...candidates.map((c) => c.content)]);
+    if (vectors.length !== candidates.length + 1) {
+      throw new Error(
+        `embedder returned ${vectors.length} vectors for ` +
+        `${candidates.length + 1} inputs`,
+      );
+    }
+    const [queryVector, ...factVectors] = vectors;
+    const selected = topKBySimilarity(queryVector, factVectors, RETRIEVAL_K);
+    return {
+      content: { facts: selected.map((i) => candidates[i].content) },
+      report: create(RecalledMemoriesReportSchema, {
+        selectionActive: true,
+        injectedMemoryIds: selected.map((i) => candidates[i].memoryId),
+        embeddingModel: EMBEDDING_MODEL,
+      }),
+    };
+  } catch (err) {
+    log(
+      `selection failed for execution ${options.executionId}, degrading to ` +
+      `wholesale: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return wholesale(candidates);
+  }
+}
+
+/**
+ * The snapshot's renderable candidates, in snapshot order. Same semantics
+ * as readRecalledMemories (disabled → none; blank contents dropped
+ * defensively) but keeping `memory_id` — the report's audit link.
+ */
+function readCandidates(recalled: RecalledMemories | undefined): Candidate[] {
+  if (!recalled?.enabled) {
+    return [];
+  }
+  return (recalled.facts ?? [])
+    .map((fact) => ({
+      memoryId: fact.memoryId ?? "",
+      content: fact.content?.trim() ?? "",
+    }))
+    .filter((c) => c.content !== "");
+}
+
+/**
+ * Replay a previously recorded outcome so a re-invocation injects exactly
+ * what the first invocation did. A selection_active=false report replays
+ * as wholesale (including the case where a transient embed failure was
+ * recorded — retrying could select a subset and diverge the prompt).
+ * Returns undefined when a recorded id no longer resolves.
+ */
+function replayReport(
+  candidates: Candidate[],
+  prior: RecalledMemoriesReport,
+): MemorySelectionResult | undefined {
+  if (!prior.selectionActive) {
+    return wholesale(candidates);
+  }
+  const byId = new Map(candidates.map((c) => [c.memoryId, c.content]));
+  const facts: string[] = [];
+  for (const id of prior.injectedMemoryIds) {
+    const content = byId.get(id);
+    if (content === undefined) {
+      return undefined;
+    }
+    facts.push(content);
+  }
+  if (facts.length === 0) {
+    return undefined;
+  }
+  return { content: { facts }, report: prior };
+}
+
+/** Wholesale injection of the full candidate set, honestly reported. */
+function wholesale(candidates: Candidate[]): MemorySelectionResult {
+  return {
+    content: { facts: candidates.map((c) => c.content) },
+    report: create(RecalledMemoriesReportSchema, { selectionActive: false }),
+  };
+}
+
+/**
+ * The credential lanes, in the platform's standing precedence (the
+ * titling-lane idiom): proxy when configured — the runner authenticates
+ * with its Stigmer token and the proxy owns the provider key — else the
+ * operator's direct OpenAI key, else no embedder.
+ */
+function resolveEmbedder(options: MemoryRetrievalOptions): EmbedFn | undefined {
+  if (options.proxyEndpoint) {
+    return fetchEmbedder(
+      resolveProxyBaseUrl(options.proxyEndpoint, "openai"),
+      buildProxyHeaders(options.stigmerToken ?? "", {
+        executionId: options.executionId,
+      }),
+    );
+  }
+  if (checkDirectCredentials("openai") === null) {
+    return fetchEmbedder(DIRECT_OPENAI_BASE_URL, {
+      Authorization: `Bearer ${getRunnerSecret("OPENAI_API_KEY") ?? ""}`,
+    });
+  }
+  return undefined;
+}
+
+/**
+ * The real embedder: one POST {base}/embeddings. A plain typed fetch, not
+ * LangChain's OpenAIEmbeddings — the SDK wrapper discards the response
+ * `usage` block and adds nothing over a single request. Proxy-side
+ * metering reads the JSON usage from the relayed body.
+ */
+function fetchEmbedder(baseUrl: string, headers: Record<string, string>): EmbedFn {
+  return async (inputs) => {
+    const response = await fetch(`${baseUrl}/embeddings`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: EMBEDDING_MODEL, input: inputs }),
+      signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `embeddings request failed: HTTP ${response.status} ${body.slice(0, 300)}`,
+      );
+    }
+    const parsed = (await response.json()) as {
+      data?: Array<{ index?: number; embedding?: number[] }>;
+    };
+    if (!Array.isArray(parsed.data)) {
+      throw new Error("embeddings response carries no data array");
+    }
+    // Place by the response's own index field — the API documents input
+    // order, but the contract names the index as authoritative.
+    const vectors: number[][] = new Array(inputs.length);
+    for (const item of parsed.data) {
+      const index = item.index ?? -1;
+      if (index < 0 || index >= inputs.length || !Array.isArray(item.embedding)) {
+        throw new Error("embeddings response entry is malformed");
+      }
+      vectors[index] = item.embedding;
+    }
+    if (vectors.some((v) => v === undefined)) {
+      throw new Error("embeddings response is missing entries");
+    }
+    return vectors;
+  };
+}
+
+/**
+ * Indices of the top-k facts by cosine similarity to the query, returned
+ * ASCENDING — i.e. re-sorted to snapshot order (DD-008 D3: selection is by
+ * relevance, presentation stays oldest-first). Ties break toward the lower
+ * snapshot index, so equal scores never reorder across invocations.
+ */
+function topKBySimilarity(
+  queryVector: number[],
+  factVectors: number[][],
+  k: number,
+): number[] {
+  return factVectors
+    .map((vector, index) => ({ index, score: cosineSimilarity(queryVector, vector) }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .slice(0, k)
+    .map((entry) => entry.index)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Plain cosine. OpenAI embeddings arrive unit-normalized (a dot product
+ * would suffice today), but normalizing here keeps ranking correct under
+ * any future embedder without a silent provider assumption.
+ */
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function log(msg: string): void {
+  console.warn(`[memory-retrieval] ${msg}`);
+}

--- a/test/conformance/src/suites-execution/agentexecution-memory-retrieval.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution-memory-retrieval.conformance.test.ts
@@ -1,0 +1,175 @@
+// Conformance suite for the semantic memory retriever's deployment posture
+// (stigmer/stigmer#293 Phase 3a, DD-008).
+// Domain: agentic / agentexecution — the runner-side selection of recalled
+// memories, observed through the RecalledMemoriesReport on execution status.
+//
+// The conformance environment runs with NO embeddings-capable provider (the
+// mock proxy speaks only Anthropic and fences every other provider path with
+// a 500), which is exactly the deployment posture DD-008 D4 names for
+// Anthropic-only and Cursor-only OSS operators. The cross-edition property
+// pinned here is therefore CREDENTIAL PRESENCE, not edition: both editions
+// run the same runner code, and without an embedder every execution injects
+// the full candidate set (Phase 2 behavior, unchanged) with an honest
+// selection_active=false report — never a failed or degraded execution.
+//
+// Capability split: seeding memories requires the first-party capture gate
+// (firstPartyMemoryCapture, targets/target.ts) — the cloud conformance user
+// is a PlatformClient-minted token that structurally cannot capture, so the
+// scenario is buildable only on local-go-execution. The capture-gate
+// refusal itself is pinned in the CRUD-level memory suite.
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import type { MockLlmProxy } from "../harness/mock-llm";
+import { anthropicText } from "../harness/mock-llm";
+import { makeAgent } from "../support/agents";
+import {
+  awaitTerminal,
+  makeAgentExecution,
+  requireLlmProxy,
+} from "../support/agentexecutions";
+import { makeMemory } from "../support/memories";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+// Lockstep pin for the runner's activation threshold (RETRIEVAL_K in
+// backend/services/runner/src/shared/memory-retrieval.ts): selection
+// attempts (and here, degrades) only ABOVE this many confirmed facts.
+const RETRIEVAL_ACTIVATION_THRESHOLD = 20;
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+let mock: MockLlmProxy;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+  mock = requireLlmProxy(target);
+});
+
+afterEach(async () => {
+  mock.releaseHolds();
+  await fixtures.cleanup();
+  mock.reset();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// An org with the memory switch ON (org flag alone gates OSS recall — the
+// single-user subject sentinel), plus `count` facts run through the REAL
+// consent lifecycle: captured via create, confirmed via the consent RPC.
+async function provisionOrgWithConfirmedFacts(count: number): Promise<string> {
+  const org = await clients.organizationCommand.create({
+    apiVersion: "tenancy.stigmer.ai/v1",
+    kind: "Organization",
+    metadata: { name: uniqueName("retrorg") },
+    spec: { preferences: { memoryEnabled: true } },
+  });
+  fixtures.defer(() => clients.organizationCommand.delete({ value: org.metadata!.id }));
+  const slug = org.metadata!.slug;
+
+  for (let i = 0; i < count; i += 1) {
+    const memory = await clients.memoryCommand.create(
+      makeMemory(slug, { content: `Durable fact number ${i} about this user.` }),
+    );
+    fixtures.defer(async () => {
+      try {
+        await clients.memoryCommand.delete({ value: memory.metadata!.id });
+      } catch {
+        // Removed with the org.
+      }
+    });
+    await clients.memoryCommand.confirm({ value: memory.metadata!.id });
+  }
+  return slug;
+}
+
+// One completed execution in `org`, with a single scripted agent turn.
+async function runExecution(org: string) {
+  const agent = await clients.agentCommand.create(makeAgent({ org, name: uniqueName("agent") }));
+  fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+
+  mock.enqueue(anthropicText("Done."));
+  const execution = await clients.agentExecutionCommand.create(
+    makeAgentExecution({ org, name: uniqueName("aex"), agentId: agent.metadata!.id }),
+  );
+  fixtures.defer(() => clients.agentExecutionCommand.delete({ value: execution.metadata!.id }));
+
+  const settled = await awaitTerminal(clients, execution.metadata!.id);
+  expect(settled.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+  return settled;
+}
+
+describe("AgentExecution memory retrieval (no-embedder posture)", () => {
+  it("injects wholesale below the threshold with an honest report and no embeddings attempt", async () => {
+    if (!target.capabilities.firstPartyMemoryCapture) return;
+
+    const org = await provisionOrgWithConfirmedFacts(1);
+    const settled = await runExecution(org);
+
+    const snapshot = settled.spec?.recalledMemories;
+    expect(snapshot?.enabled).toBe(true);
+    expect(snapshot?.facts).toHaveLength(1);
+
+    const report = settled.status?.recalledMemoriesReport;
+    expect(report).toBeDefined();
+    expect(report?.selectionActive).toBe(false);
+    expect(report?.injectedMemoryIds ?? []).toHaveLength(0);
+    expect(report?.embeddingModel ?? "").toBe("");
+
+    // Below the threshold the runner must not even TRY to embed.
+    const embedAttempts = mock.requests().filter((r) => r.path.includes("/embeddings"));
+    expect(embedAttempts).toHaveLength(0);
+  });
+
+  it("degrades to wholesale above the threshold when no embedder is reachable — never a failed execution", async () => {
+    if (!target.capabilities.firstPartyMemoryCapture) return;
+
+    const org = await provisionOrgWithConfirmedFacts(RETRIEVAL_ACTIVATION_THRESHOLD + 1);
+    const settled = await runExecution(org);
+
+    // The candidate set is intact on the spec — selection never rewrites
+    // the audit snapshot, and here it could not select at all.
+    expect(settled.spec?.recalledMemories?.facts).toHaveLength(
+      RETRIEVAL_ACTIVATION_THRESHOLD + 1,
+    );
+
+    // The embeddings attempt hit the (embedder-less) proxy and was refused;
+    // the execution completed anyway on the full snapshot, honestly
+    // reported. This is DD-008's no-embedder deployment posture: OSS
+    // operators without an OpenAI credential run Phase 2 behavior forever.
+    const embedAttempts = mock.requests().filter((r) => r.path.includes("/embeddings"));
+    expect(embedAttempts).toHaveLength(1);
+
+    const report = settled.status?.recalledMemoriesReport;
+    expect(report).toBeDefined();
+    expect(report?.selectionActive).toBe(false);
+    expect(report?.injectedMemoryIds ?? []).toHaveLength(0);
+    expect(report?.embeddingModel ?? "").toBe("");
+  });
+
+  it("writes no report when recall is disabled — absent report = wholesale by construction", async () => {
+    if (!target.capabilities.firstPartyMemoryCapture) return;
+
+    // Memory switched OFF: the compose step stamps a disabled snapshot,
+    // the runner injects nothing, and the report field must stay ABSENT so
+    // pre-3a executions and no-injection executions read identically.
+    const org = await clients.organizationCommand.create({
+      apiVersion: "tenancy.stigmer.ai/v1",
+      kind: "Organization",
+      metadata: { name: uniqueName("retrorg") },
+      spec: { preferences: { memoryEnabled: false } },
+    });
+    fixtures.defer(() => clients.organizationCommand.delete({ value: org.metadata!.id }));
+
+    const settled = await runExecution(org.metadata!.slug);
+
+    expect(settled.spec?.recalledMemories?.enabled ?? false).toBe(false);
+    expect(settled.status?.recalledMemoriesReport).toBeUndefined();
+  });
+});

--- a/test/integration-offline/memory_retrieval_offline_test.go
+++ b/test/integration-offline/memory_retrieval_offline_test.go
@@ -1,0 +1,230 @@
+//go:build integration
+
+package offline
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	agentexecv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/agentexecution/v1"
+	memoryv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/memory/v1"
+	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
+	apiresource "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
+	identityaccountv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/identityaccount/v1"
+	organizationv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/tenancy/organization/v1"
+	"github.com/stigmer/stigmer/test/integration/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Lockstep pins for the runner's memory-retrieval module
+// (backend/services/runner/src/shared/memory-retrieval.ts). A drift in
+// either constant fails this suite loudly instead of silently changing the
+// activation boundary or the audited model id.
+const (
+	// RETRIEVAL_K: selection activates only ABOVE this many candidates.
+	retrievalActivationThreshold = 20
+	// EMBEDDING_MODEL: the v1 embedder recorded on selection-active reports.
+	retrievalEmbeddingModel = "text-embedding-3-small"
+)
+
+// TestOffline_MemoryRetrieval proves the Phase 3a semantic retriever
+// (stigmer/stigmer#293, DD-008) end to end through a REAL runner against
+// the mock proxy's deterministic embedder — the full loop from the consent
+// lifecycle (capture + confirm via the front-door RPCs) through prompt
+// build to the report on the persisted execution status:
+//
+//   - at or below the activation threshold the runner injects wholesale,
+//     makes NO embeddings call, and reports selection_active=false;
+//   - above the threshold it makes exactly ONE batched embeddings call
+//     (query first, then every candidate), injects top-k, and reports the
+//     injected subset as ids in snapshot order with the embedding model;
+//   - when recall is disabled (member opt-out) nothing is injected and NO
+//     report is written — absent report = wholesale, true by construction.
+//
+// The mock embedder's similarity decreases with input position (see
+// MockLLMProxyServer.handleEmbeddings), so above-threshold selection is
+// deterministic: exactly the first k snapshot facts.
+func TestOffline_MemoryRetrieval(t *testing.T) {
+	requireEvalPrereqs(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	// One scripted chat response per execution below (the embeddings route
+	// is computed, never scripted — it must not consume these entries).
+	entries := []harness.RecordedLLMEntry{
+		harness.BuildLLMEntry(0, harness.AnthropicTextResponse("Done.", 120, 8)),
+		harness.BuildLLMEntry(1, harness.AnthropicTextResponse("Done.", 120, 8)),
+		harness.BuildLLMEntry(2, harness.AnthropicTextResponse("Done.", 120, 8)),
+	}
+	mockLLM, mgr := startOfflineRunner(t, ctx, entries)
+
+	machineClients := harness.NewClients(grpcConn)
+	harness.RequireServiceHealthy(t, ctx, machineClients)
+
+	// A fresh org with memory ON — the org half of the double opt-in.
+	orgSlug := "retrieval-org-" + uuid.New().String()[:8]
+	org, err := machineClients.OrganizationCommand.Create(ctx, &organizationv1.Organization{
+		ApiVersion: "tenancy.stigmer.ai/v1",
+		Kind:       "Organization",
+		Metadata:   &apiresource.ApiResourceMetadata{Name: orgSlug},
+		Spec: &organizationv1.OrganizationSpec{
+			Preferences: &organizationv1.OrganizationPreferences{MemoryEnabled: true},
+		},
+	})
+	require.NoError(t, err, "create org with memory enabled")
+	orgID := org.GetMetadata().GetId()
+	t.Cleanup(func() {
+		cleanCtx, cancelClean := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancelClean()
+		if _, err := machineClients.OrganizationCommand.Delete(cleanCtx, &organizationv1.OrganizationId{Value: orgID}); err != nil {
+			t.Logf("warning: failed to clean up org %s: %v", orgID, err)
+		}
+	})
+
+	// The user half: a real account opting in via self-service update, with
+	// a plain human JWT — the one credential shape recall admits.
+	account := harness.CreateIdentityAccount(t, ctx, machineClients,
+		"retrieval-human", "retrieval-human@test.stigmer.ai")
+	accountID := account.GetMetadata().GetId()
+
+	humanToken, err := harness.MintStigmerToken(
+		harness.StigmerJWTSigningKeyBase64, "stigmer-signing-key-1", accountID)
+	require.NoError(t, err, "mint plain human JWT")
+	humanConn := harness.GRPCConnWithBearer(t, testHarness.Service.GRPCAddress(), humanToken)
+	humanClients := harness.NewClients(humanConn)
+
+	account.Spec.Preferences = &identityaccountv1.IdentityAccountPreferences{
+		MemoryEnabled: true,
+	}
+	_, err = humanClients.IdentityAccountCommand.Update(ctx, account)
+	require.NoError(t, err, "opt the account into memory")
+
+	harness.GrantOrgRole(t, ctx, machineClients, orgID, accountID,
+		"retrieval-human", "member")
+
+	agent := harness.CreateAgentFull(t, ctx, machineClients, "test-memory-retrieval",
+		"You are a test assistant. Respond briefly.",
+		nil, []harness.AgentCreateOption{harness.WithAgentOrg(orgID)})
+
+	session := harness.CreateTestSessionWithOrg(t, ctx, humanClients,
+		agent.GetStatus().GetDefaultInstanceId(), sessionv1.Harness_HARNESS_NATIVE,
+		[]harness.SessionResourceOption{harness.WithSessionOrg(orgID)})
+	sessionID := session.GetMetadata().GetId()
+
+	_, err = mgr.AddSession(ctx, sessionID)
+	require.NoError(t, err, "AddSession should succeed")
+
+	// captureAndConfirm runs the REAL consent lifecycle for one fact.
+	captureAndConfirm := func(t *testing.T, content string) *memoryv1.Memory {
+		t.Helper()
+		memory, err := humanClients.MemoryCommand.Create(ctx, &memoryv1.Memory{
+			ApiVersion: "agentic.stigmer.ai/v1",
+			Kind:       "Memory",
+			Metadata:   &apiresource.ApiResourceMetadata{Org: org.GetMetadata().GetSlug()},
+			Spec:       &memoryv1.MemorySpec{Content: content},
+		})
+		require.NoError(t, err, "capture memory %q", content)
+		_, err = humanClients.MemoryCommand.Confirm(ctx,
+			&memoryv1.MemoryId{Value: memory.GetMetadata().GetId()})
+		require.NoError(t, err, "confirm memory %q", content)
+		return memory
+	}
+
+	runExecution := func(t *testing.T, name, message string) *agentexecv1.AgentExecution {
+		t.Helper()
+		exec := harness.CreateTestAgentExecutionWithOrg(t, ctx, humanClients,
+			sessionID, message,
+			[]harness.ExecutionResourceOption{harness.WithExecutionOrg(orgID)})
+		waiter := harness.NewAgentExecutionWaiter(humanClients.AgentExecutionQuery, suiteLogger)
+		result, err := waiter.WaitForPhase(ctx, exec.GetMetadata().GetId(),
+			agentexecv1.ExecutionPhase_EXECUTION_COMPLETED, 3*time.Minute)
+		require.NoError(t, err, "%s execution should complete", name)
+		return result
+	}
+
+	// Exactly the threshold count of confirmed facts: top-k degenerates to
+	// wholesale AT the boundary, so this pins k itself, not just "few".
+	for i := 0; i < retrievalActivationThreshold; i++ {
+		captureAndConfirm(t, fmt.Sprintf("Durable fact number %02d about this user.", i))
+	}
+
+	t.Run("at the threshold: wholesale, no embeddings call, honest report", func(t *testing.T) {
+		result := runExecution(t, "wholesale", "What should I deploy today?")
+
+		snapshot := result.GetSpec().GetRecalledMemories()
+		require.True(t, snapshot.GetEnabled(), "recall must be enabled for the opted-in human")
+		require.Len(t, snapshot.GetFacts(), retrievalActivationThreshold,
+			"the compose step stamps the full candidate set")
+
+		report := result.GetStatus().GetRecalledMemoriesReport()
+		require.NotNil(t, report, "an injecting execution always writes a report")
+		assert.False(t, report.GetSelectionActive(),
+			"at k candidates top-k degenerates to wholesale — selection must not activate")
+		assert.Empty(t, report.GetInjectedMemoryIds(), "wholesale reports carry no ids")
+		assert.Empty(t, report.GetEmbeddingModel(), "wholesale reports carry no model")
+
+		assert.Empty(t, mockLLM.EmbeddingsRequests(),
+			"at or below the threshold the runner must make NO embeddings call")
+	})
+
+	// One past the threshold: selection activates.
+	captureAndConfirm(t, "The one fact past the activation threshold.")
+
+	t.Run("above the threshold: one batched call, top-k report in snapshot order", func(t *testing.T) {
+		const query = "Which region do we deploy the payments service to?"
+		result := runExecution(t, "selection", query)
+
+		snapshot := result.GetSpec().GetRecalledMemories()
+		require.Len(t, snapshot.GetFacts(), retrievalActivationThreshold+1,
+			"the candidate set stays wholesale on the spec — selection never rewrites the audit snapshot")
+
+		report := result.GetStatus().GetRecalledMemoriesReport()
+		require.NotNil(t, report, "selection-active executions must write a report")
+		assert.True(t, report.GetSelectionActive())
+		assert.Equal(t, retrievalEmbeddingModel, report.GetEmbeddingModel())
+		require.Len(t, report.GetInjectedMemoryIds(), retrievalActivationThreshold,
+			"exactly k facts injected")
+
+		// The mock's similarity decreases with input position, so top-k is
+		// the first k snapshot facts — and the report presents them in
+		// snapshot (oldest-first) order, ids parallel to the snapshot.
+		for i, id := range report.GetInjectedMemoryIds() {
+			assert.Equal(t, snapshot.GetFacts()[i].GetMemoryId(), id,
+				"injected id %d must be the snapshot's fact %d (snapshot-order presentation)", i, i)
+		}
+
+		embeds := mockLLM.EmbeddingsRequests()
+		require.Len(t, embeds, 1, "exactly one batched embeddings call per selection-active execution")
+		assert.Equal(t, retrievalEmbeddingModel, embeds[0]["model"])
+		inputs, _ := embeds[0]["input"].([]any)
+		require.Len(t, inputs, retrievalActivationThreshold+2,
+			"one batch: the query plus every candidate fact")
+		assert.Equal(t, query, inputs[0],
+			"the query is the execution's message, sent first")
+	})
+
+	t.Run("opted-out member: nothing injected, NO report (absent = wholesale by construction)", func(t *testing.T) {
+		optedOut, err := humanClients.IdentityAccountQuery.Get(ctx,
+			&identityaccountv1.IdentityAccountId{Value: accountID})
+		require.NoError(t, err, "load account for update")
+		optedOut.Spec.Preferences = &identityaccountv1.IdentityAccountPreferences{
+			MemoryEnabled: false,
+		}
+		_, err = humanClients.IdentityAccountCommand.Update(ctx, optedOut)
+		require.NoError(t, err, "opt the account out of memory")
+
+		result := runExecution(t, "opted-out", "hello again")
+
+		assert.False(t, result.GetSpec().GetRecalledMemories().GetEnabled(),
+			"the member's opt-out disables recall")
+		assert.Nil(t, result.GetStatus().GetRecalledMemoriesReport(),
+			"no injection, no report — pre-3a readers and this execution read identically")
+		assert.Len(t, mockLLM.EmbeddingsRequests(), 1,
+			"a disabled snapshot must never trigger an embeddings call")
+	})
+}

--- a/test/integration/harness/mock_llm_proxy.go
+++ b/test/integration/harness/mock_llm_proxy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -54,6 +55,12 @@ type MockLLMProxyServer struct {
 	cursor   int
 	requests []map[string]any
 	registry []map[string]any
+	// Embeddings requests are recorded separately from the sequential chat
+	// entries: the runner's memory retriever (DD-008) makes at most one
+	// batched embeddings call per execution, and tests assert on call count
+	// and inputs rather than scripting responses — the mock computes
+	// deterministic vectors (see handleEmbeddings).
+	embeddingsRequests []map[string]any
 }
 
 // NewMockLLMProxyServer creates a mock server from a fixture file.
@@ -101,6 +108,14 @@ func (m *MockLLMProxyServer) handleRequest(w http.ResponseWriter, r *http.Reques
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]any{"models": reg})
+		return
+	}
+
+	// Embeddings are served by computation, not recorded entries — see
+	// handleEmbeddings. Checked before the sequential LLM handling so an
+	// embeddings call can never consume a scripted chat entry.
+	if pathContains(path, "/embeddings") {
+		m.handleEmbeddings(w, r)
 		return
 	}
 
@@ -422,6 +437,76 @@ func intVal(m map[string]any, key string) int {
 	default:
 		return 0
 	}
+}
+
+// handleEmbeddings answers POST .../embeddings with deterministic 2D unit
+// vectors: input 0 (the retriever sends the query first) embeds to [1, 0],
+// and each later input's angle grows with its position — so cosine
+// similarity to the query strictly DECREASES with input position. Under the
+// retriever's contract (facts sent in snapshot order) top-k selection is
+// therefore exactly the first k facts of the snapshot, which tests assert
+// against the report's injected_memory_ids.
+func (m *MockLLMProxyServer) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body.Close()
+
+	var reqBody map[string]any
+	if len(bodyBytes) > 0 {
+		_ = json.Unmarshal(bodyBytes, &reqBody)
+	}
+
+	m.mu.Lock()
+	if reqBody != nil {
+		m.embeddingsRequests = append(m.embeddingsRequests, reqBody)
+	}
+	m.mu.Unlock()
+
+	inputs := toAnySlice(reqBody["input"])
+	n := len(inputs)
+
+	data := make([]map[string]any, 0, n)
+	totalChars := 0
+	for i := 0; i < n; i++ {
+		if s, ok := inputs[i].(string); ok {
+			totalChars += len(s)
+		}
+		angle := 0.0
+		if n > 1 {
+			angle = (float64(i) / float64(n)) * (math.Pi / 2)
+		}
+		data = append(data, map[string]any{
+			"object":    "embedding",
+			"index":     i,
+			"embedding": []float64{math.Cos(angle), math.Sin(angle)},
+		})
+	}
+
+	// The OpenAI embeddings response shape: JSON (never SSE), usage carries
+	// prompt_tokens/total_tokens only. The rough chars/4 token estimate keeps
+	// metering-shaped consumers honest without a tokenizer.
+	promptTokens := totalChars / 4
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]any{
+		"object": "list",
+		"model":  reqBody["model"],
+		"data":   data,
+		"usage": map[string]any{
+			"prompt_tokens": promptTokens,
+			"total_tokens":  promptTokens,
+		},
+	})
+}
+
+// EmbeddingsRequests returns a copy of every captured embeddings request
+// body, in order. Tests assert call COUNT (the threshold gate: at or below
+// k the retriever must make no call at all) and the batched input shape.
+func (m *MockLLMProxyServer) EmbeddingsRequests() []map[string]any {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]map[string]any, len(m.embeddingsRequests))
+	copy(out, m.embeddingsRequests)
+	return out
 }
 
 // URL returns the base URL of the mock server.


### PR DESCRIPTION
## What this does

Phase 3a Stage 2 of preferences-and-memory (#293, DD-008): when a subject's confirmed-fact set outgrows what wholesale injection should carry, the runner selects the most relevant facts for the current turn instead of injecting everything.

Executions with **more than 20** confirmed candidate facts now get the 20 most relevant injected — one batched embeddings call, in-process cosine ranking, presented in snapshot order — and record exactly what was injected in the `RecalledMemoriesReport` status field that Stage 1 (#833) put on the wire. **Everything else behaves byte-identically to Phase 2**: at or below the threshold, with no embedder configured, or on any failure, the full candidate set is injected and the report says `selection_active=false`.

Both control planes' compose steps are untouched — they still stamp the full auditable candidate set. Selection is a runner concern (DD-008 D1, the titling-convergence doctrine: control-plane-adjacent LLM work runs once, in the shared runner, for both editions).

## Design

New `shared/memory-retrieval.ts`, a sibling of `recalled-memories.ts` (which keeps owning presentation):

- **Embed-on-read, no stored vectors anywhere** (D2). The entire stored-vector problem class — single-writer designation, re-embed on content edit, model-version stamping, migrations in two editions — is deleted rather than solved.
- **Activation only above k=20** (D3). At or below k, top-k degenerates to wholesale, so no embeddings call is made at all: most users never touch the embeddings API, and the retriever activates exactly when retrieval waste begins.
- **Stable presentation.** Selection is by relevance; the selected subset is re-sorted to snapshot order, with a deterministic tie-break by snapshot index — the prompt prefix never churns across turns for nothing.
- **Failure is never worse than Phase 2.** No credential, HTTP error, timeout, malformed response — every path degrades to wholesale with an honest report. Anthropic-only and Cursor-only OSS deployments run Phase 2 behavior forever.

Two hazards closed by construction, both found while reading the code rather than from the design doc:

- **Written-once across re-invocations.** The same execution rebuilds its prompt on approval resume (native re-runs `performSetup`) and on fresh-agent recovery (cursor). Re-selecting there could inject a *different* subset mid-execution, breaking the report's single-writer contract and the prompt-stability property. A prior report on the loaded execution is now **replayed** (pure lookup, no embeddings call) instead of recomputed.
- **Query bound.** Facts are write-time capped at 500 chars, but the query is `spec.message` — unbounded. A giant paste would exceed the embedder's per-input token limit and 400 the *whole* batch, silently forcing wholesale on exactly the executions where selection matters most. The query truncates at a documented `QUERY_MAX_CHARS`.

## Wiring

The selector is async; both prompt builders are pure sync functions. Selection therefore runs at the **activity call sites**, and the builders still receive a ready `RecalledMemoriesContent` — their signatures and every existing prompt-shape pin are untouched.

- **Native**: `setup.ts` step 8 awaits the selector; the report rides `SetupResult` and `index.ts` stamps it onto `initialStatus` before the first persist (setup predates the status object). The server's presence-guarded merge preserves it across later report-less writes.
- **Cursor**: the report is stamped on the turn's shared `status` proto. Selection is gated on a new named predicate, `promptCarriesStandingContext()` — which `buildPrompt` itself now consults for its own routing, so the selection gate and the prompt routing **cannot drift**. This follows the `primarySendCarriesImages` precedent. The memoized selection also feeds the fresh-agent recovery rebuild, the `buildFromPlan` drop-hazard site.

## Tests

- **Module suite** (14 cases, mocked embedder): threshold boundary at k and k+1, top-k correctness on fixed vectors, snapshot-order presentation, deterministic tie-break, embed-failure / wrong-vector-count / no-embedder degradation, exactly one batched call, query truncation, replay in both polarities.
- **`buildPrompt` matrix pin**: memories reach the prompt exactly when the new predicate says so, across the full reason × HITL matrix.
- **Offline integration** (`test/integration-offline/memory_retrieval_offline_test.go`): a real runner against a deterministic mock embedder through the real capture→confirm lifecycle — wholesale at exactly k with **no** embeddings call, selection above k with one batched call and report ids in snapshot order, and no report at all when recall is disabled.
- **Conformance**: pins the no-embedder deployment posture DD-008 D4 names, capability-guarded like every memory pin (the cloud conformance user is PlatformClient-minted and structurally cannot seed memories).

Verification: runner typecheck clean, **4767/4773 runner tests pass** (6 pre-existing skips), `gofmt`/`go vet` clean.

## What this does NOT change

Both compose steps, memory CRUD/consent RPCs, the capture loop, caps, FGA, storage schemas (no migrations), the `RecalledMemories` messages, the preamble and prompt framing, `readRecalledMemories`/`formatRecalledMemoriesText`, both prompt builders' signatures. **No proto changes** — the Stage 1 contract is frozen.

## Sibling

Cloud PR (proxy embeddings lane + JSON usage metering): stigmer/stigmer-cloud#538

Made with [Cursor](https://cursor.com)
