### PR TITLE
test(conformance): close coverage wave 1 — CW-6/8/9/10 suite additions

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -9,8 +9,10 @@ implement the API:
   schedule firing suite: the first execution-class behavior asserted on BOTH
   editions, possible because schedule fires need the engine but no runner).
 
-(A TypeScript server rewrite was once a planned third target; it was
-cancelled 2026-06-14 — the Go server is retained as the OSS backend.)
+(A TypeScript OSS server is in active development as the third target: the
+`local-ts` roster grows per sub-project until it matches the `local-go`
+configuration — that roster equality is the cutover gate. See the
+stigmer-cloud program `20260822.01.oss-ts-server-and-self-hosting`.)
 
 The contract — not any one implementation — is the product. This suite is what
 keeps the implementations honest and makes agentic dual-maintenance safe:

--- a/test/conformance/src/harness/clients.ts
+++ b/test/conformance/src/harness/clients.ts
@@ -33,6 +33,10 @@ import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/a
 import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
 import { WorkflowInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/command_pb";
 import { WorkflowInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/query_pb";
+import { OAuthAppCommandController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/command_pb";
+import { OAuthAppQueryController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/query_pb";
+import { GitHubService } from "@stigmer/protos/ai/stigmer/platform/github/v1/service_pb";
+import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
 import { OrganizationQueryController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/query_pb";
 import { ProjectCommandController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/command_pb";
@@ -70,6 +74,10 @@ export interface ConformanceClients {
   sessionQuery: Client<typeof SessionQueryController>;
   skillCommand: Client<typeof SkillCommandController>;
   skillQuery: Client<typeof SkillQueryController>;
+  platformQuery: Client<typeof PlatformQueryController>;
+  github: Client<typeof GitHubService>;
+  oauthAppCommand: Client<typeof OAuthAppCommandController>;
+  oauthAppQuery: Client<typeof OAuthAppQueryController>;
 }
 
 export interface TransportOptions {
@@ -127,5 +135,9 @@ export function makeClients(transport: Transport): ConformanceClients {
     sessionQuery: createClient(SessionQueryController, transport),
     skillCommand: createClient(SkillCommandController, transport),
     skillQuery: createClient(SkillQueryController, transport),
+    platformQuery: createClient(PlatformQueryController, transport),
+    github: createClient(GitHubService, transport),
+    oauthAppCommand: createClient(OAuthAppCommandController, transport),
+    oauthAppQuery: createClient(OAuthAppQueryController, transport),
   };
 }

--- a/test/conformance/src/harness/server-process.ts
+++ b/test/conformance/src/harness/server-process.ts
@@ -77,6 +77,12 @@ export async function spawnServer(
       TEMPORAL_HOST_PORT: temporalHostPort,
       ENV: "local",
       LOG_LEVEL: "warn",
+      // Hermeticity: the server's background model-registry refresh dials the
+      // public cloud endpoint on boot and would swap the served document
+      // mid-run when the network happens to be up — making any assertion on
+      // the registry lane pass offline and flake online. Conformance servers
+      // always serve the bundled snapshot.
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
       ...(opts.env ?? {}),
     },
   });

--- a/test/conformance/src/suites/activity.conformance.test.ts
+++ b/test/conformance/src/suites/activity.conformance.test.ts
@@ -170,4 +170,44 @@ describe("Activity conformance — listRecentActivity", () => {
     expect(response.entries).toHaveLength(1);
     expect(response.entries[0]?.id, "the trimmed page must keep the newest entry").toBe(newest);
   });
+
+  // The page_size normalization contract. The exact constants (default 30,
+  // cap 100) are pinned byte-identical in both editions' handler unit tests;
+  // what is black-box assertable over the wire — and what a client actually
+  // relies on — is the normalization SHAPE: out-of-range values are folded
+  // into range, never rejected, and never answered with an empty page while
+  // data exists. Proving the exact ceiling would need >100 live fixtures per
+  // run — cost without additional contract signal.
+  it("treats an unspecified page_size as the default page, not an empty one", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentInstanceId = await provisionAgentInstance(clients, org);
+    const session = await createSession(clients, org, agentInstanceId, { subject: "default page" });
+
+    const response = await clients.activityQuery.listRecentActivity({ org });
+
+    expect(
+      response.entries.map((entry) => entry.id),
+      "page_size 0 must mean 'the default page', never 'zero entries'",
+    ).toContain(session);
+  });
+
+  it("normalizes a negative page_size instead of rejecting it", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentInstanceId = await provisionAgentInstance(clients, org);
+    const session = await createSession(clients, org, agentInstanceId, { subject: "negative page" });
+
+    const response = await clients.activityQuery.listRecentActivity({ pageSize: -5, org });
+
+    expect(response.entries.map((entry) => entry.id)).toContain(session);
+  });
+
+  it("caps an oversize page_size instead of rejecting it", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentInstanceId = await provisionAgentInstance(clients, org);
+    const session = await createSession(clients, org, agentInstanceId, { subject: "oversize page" });
+
+    const response = await clients.activityQuery.listRecentActivity({ pageSize: 100_000, org });
+
+    expect(response.entries.map((entry) => entry.id)).toContain(session);
+  });
 });

--- a/test/conformance/src/suites/github.conformance.test.ts
+++ b/test/conformance/src/suites/github.conformance.test.ts
@@ -1,0 +1,79 @@
+// GitHub broker conformance — the OAuth utility service's error contract
+// (Class A).
+// Domain: conformance suites.
+//
+// GitHubService is a platform utility, not a resource domain: it brokers the
+// GitHub OAuth dance (authorize-URL construction + code-for-token exchange)
+// so the frontend never holds the client credentials. What is asserted here
+// is exactly the arm that is TRUE and hermetic on every edition: malformed
+// requests answer InvalidArgument from protovalidate at the transport
+// boundary, before any config or network concern.
+//
+// The broker's other arms are deliberately NOT asserted, each for a
+// discovered, recorded reason:
+//
+//   - "Config-missing FailedPrecondition" is STRUCTURALLY UNREACHABLE on the
+//     OSS server: it ships with the bundled "Stigmer Local" OAuth App
+//     credentials hardcoded as defaults (config.go — the GitHub CLI pattern;
+//     a localhost-only app's secret has negligible value), and the env
+//     override treats an empty value as unset, so no configuration can blank
+//     them. The guard is live only on the cloud edition, whose config
+//     defaults to empty. The editions legitimately diverge here — the
+//     cross-edition disposition of this arm is an owner decision recorded in
+//     the sp.conformance-wave-1 sub-project, not silently encoded by this
+//     suite.
+//   - The exchange happy path and its Unavailable / GitHub-rejection arms
+//     dial github.com FOR REAL on a configured broker — and the OSS broker
+//     is always configured (above). A conformance run must never leave the
+//     host, so those arms stay pinned in the Go controller unit tests.
+//   - The authorize-URL happy path is hermetic (pure URL construction), but
+//     asserting it unconditionally would fail on an unconfigured cloud
+//     environment; it rides the same owner decision as the config-missing
+//     arm.
+import { Code } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+const VALID_REDIRECT = "https://app.example.com/oauth/callback";
+
+describe("GitHub broker conformance — request validation (Layer 1, before config or network)", () => {
+  it("getOAuthAuthorizeUrl rejects an empty redirect_uri with InvalidArgument", () =>
+    expectGrpcCode(
+      () => clients.github.getOAuthAuthorizeUrl({ redirectUri: "" }),
+      Code.InvalidArgument,
+      "getOAuthAuthorizeUrl empty redirect_uri",
+    ));
+
+  it("exchangeOAuthCode rejects each missing required field with InvalidArgument", async () => {
+    await expectGrpcCode(
+      () => clients.github.exchangeOAuthCode({ code: "", state: "s", redirectUri: VALID_REDIRECT }),
+      Code.InvalidArgument,
+      "exchangeOAuthCode empty code",
+    );
+    await expectGrpcCode(
+      () => clients.github.exchangeOAuthCode({ code: "c", state: "", redirectUri: VALID_REDIRECT }),
+      Code.InvalidArgument,
+      "exchangeOAuthCode empty state",
+    );
+    await expectGrpcCode(
+      () => clients.github.exchangeOAuthCode({ code: "c", state: "s", redirectUri: "" }),
+      Code.InvalidArgument,
+      "exchangeOAuthCode empty redirect_uri",
+    );
+  });
+});

--- a/test/conformance/src/suites/oauthapp.conformance.test.ts
+++ b/test/conformance/src/suites/oauthapp.conformance.test.ts
@@ -1,0 +1,308 @@
+// OAuthApp conformance — CRUD, the client-secret contract, and the
+// referential delete-block (Class A).
+// Domain: conformance suites.
+//
+// OAuthApp is the outbound-auth registration with an external vendor: client
+// credentials plus the vendor's OAuth endpoints, referenced by McpServer
+// resources that authenticate via vendor OAuth (McpServerAuth.oauth_app_ref).
+// Three surfaces make the domain distinct, and all three are asserted here:
+//
+//   - The SECRET contract: client_secret is encrypted at rest and REDACTED to
+//     the ***REDACTED*** marker on every read; re-submitting the marker on
+//     apply means "keep the stored secret" (the Environment convention); and
+//     a client-supplied enc:v<N>:-shaped secret is refused with
+//     InvalidArgument on every write door — the prefix is server-reserved, so
+//     a prefixed request value is either forged ciphertext or an attempt to
+//     pin stale ciphertext (the oss#395 boundary, pinned in both editions'
+//     unit tests and held here over the wire).
+//   - The DELETE-BLOCK: deletion is refused with FailedPrecondition while an
+//     McpServer's oauth_app_ref RESOLVES to the app (stigmer#584 — resolution
+//     semantics, not literal field match), because deleting it would sever a
+//     live vendor-OAuth connection. Unreferencing frees the delete.
+//   - There is deliberately NO updateVisibility RPC and no public surface:
+//     an OAuthApp holds credentials, so org-private is the only posture.
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code } from "@connectrpc/connect";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { MCPSERVER_API_VERSION, MCPSERVER_KIND } from "../support/mcpservers";
+import { uniqueName } from "../support/naming";
+import { OAUTHAPP_REDACTED_MARKER, makeOAuthApp } from "../support/oauthapps";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+async function createOAuthAppFixture(org: string, name = uniqueName("oauth-app")) {
+  const app = await clients.oauthAppCommand.create(makeOAuthApp(org, name));
+  fixtures.defer(() => clients.oauthAppCommand.delete({ resourceId: app.metadata!.id }));
+  return app;
+}
+
+// An McpServer whose auth block references the given OAuthApp — the
+// referencing side of the delete-block. Built inline rather than in
+// support/mcpservers.ts: the auth arm exists here only to hold the reference.
+function makeReferencingMcpServer(
+  org: string,
+  appSlug: string,
+): MessageInitShape<typeof McpServerSchema> {
+  return {
+    apiVersion: MCPSERVER_API_VERSION,
+    kind: MCPSERVER_KIND,
+    metadata: { name: uniqueName("mcp-ref"), org },
+    spec: {
+      description: "references an OAuthApp for the delete-block contract",
+      serverType: {
+        case: "stdio",
+        value: { command: "npx", args: ["-y", "@modelcontextprotocol/server-everything"] },
+      },
+      auth: {
+        oauthAppRef: { org, slug: appSlug, kind: ApiResourceKind.oauth_app },
+        targetEnvVar: "VENDOR_TOKEN",
+      },
+    },
+  };
+}
+
+describe("OAuthApp conformance — CRUD & identity", () => {
+  it("create assigns an oapp_ id, echoes the spec, and redacts the secret in the response", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createOAuthAppFixture(org);
+
+    expect(created.metadata?.id).toMatch(/^oapp_/);
+    expect(created.metadata?.org).toBe(org);
+    expect(created.spec?.provider).toBe("ConformanceVendor");
+    expect(created.spec?.clientId).toBe("conformance-client-id");
+    expect(created.spec?.authorizationUrl).toBe("https://vendor.example.com/oauth/authorize");
+    expect(
+      created.spec?.clientSecret,
+      "the stored secret must never travel back — every response redacts it",
+    ).toBe(OAUTHAPP_REDACTED_MARKER);
+  });
+
+  it("get and getByReference resolve the app, both redacted", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createOAuthAppFixture(org);
+
+    const fetched = await clients.oauthAppQuery.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.id).toBe(created.metadata?.id);
+    expect(fetched.spec?.clientSecret).toBe(OAUTHAPP_REDACTED_MARKER);
+
+    const byRef = await clients.oauthAppQuery.getByReference({
+      org,
+      slug: created.metadata!.slug,
+    });
+    expect(byRef.metadata?.id).toBe(created.metadata?.id);
+    expect(byRef.spec?.clientSecret).toBe(OAUTHAPP_REDACTED_MARKER);
+  });
+
+  it("listByOrg returns the org's apps, redacted", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createOAuthAppFixture(org);
+
+    const listed = await clients.oauthAppQuery.listByOrg({ org });
+
+    const match = listed.entries.find((app) => app.metadata?.id === created.metadata?.id);
+    expect(match, "the created app appears in its org's list").toBeDefined();
+    expect(match?.spec?.clientSecret).toBe(OAUTHAPP_REDACTED_MARKER);
+  });
+
+  it("apply creates on first call and updates on second (same name + org)", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("oauth-app");
+
+    const first = await clients.oauthAppCommand.apply(
+      makeOAuthApp(org, name, { provider: "VendorV1" }),
+    );
+    fixtures.defer(() => clients.oauthAppCommand.delete({ resourceId: first.metadata!.id }));
+    expect(first.metadata?.id).toMatch(/^oapp_/);
+
+    const second = await clients.oauthAppCommand.apply(
+      makeOAuthApp(org, name, { provider: "VendorV2" }),
+    );
+
+    expect(second.metadata?.id, "apply must update the same resource").toBe(first.metadata?.id);
+    expect(second.spec?.provider, "apply-as-update replaces the spec").toBe("VendorV2");
+  });
+
+  it("update replaces the spec but preserves id, slug, and org", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createOAuthAppFixture(org);
+
+    const updated = await clients.oauthAppCommand.update({
+      ...makeOAuthApp(org, created.metadata!.name, { clientId: "rotated-client-id" }),
+      metadata: created.metadata,
+    });
+
+    expect(updated.metadata?.id).toBe(created.metadata?.id);
+    expect(updated.metadata?.slug).toBe(created.metadata?.slug);
+    expect(updated.metadata?.org).toBe(org);
+    expect(updated.spec?.clientId).toBe("rotated-client-id");
+    expect(updated.spec?.clientSecret).toBe(OAUTHAPP_REDACTED_MARKER);
+  });
+
+  it("delete removes an unreferenced app", async () => {
+    const { org } = await target.provisionTenancy();
+    // No deferred cleanup: this test deletes the app itself.
+    const created = await clients.oauthAppCommand.create(makeOAuthApp(org, uniqueName("oauth-app")));
+
+    await clients.oauthAppCommand.delete({ resourceId: created.metadata!.id });
+
+    await expectGrpcCode(
+      () => clients.oauthAppQuery.get({ value: created.metadata!.id }),
+      Code.NotFound,
+      "get after delete",
+    );
+  });
+});
+
+describe("OAuthApp conformance — the client-secret contract", () => {
+  it("applying back a fetched app with the redaction marker preserves the stored secret", async () => {
+    // Reads always redact, so preservation is proven behaviorally: the
+    // marker round-trip must succeed and must NOT store the marker itself —
+    // a subsequent read still answers the marker because a real secret is
+    // stored beneath it, and a broken implementation that stored the marker
+    // verbatim would be caught by the ciphertext/secret-shape pins in both
+    // editions' unit tests. What the wire contract owns is that the
+    // round-trip is accepted and stays redacted.
+    const { org } = await target.provisionTenancy();
+    const created = await createOAuthAppFixture(org);
+
+    const fetched = await clients.oauthAppQuery.get({ value: created.metadata!.id });
+    expect(fetched.spec?.clientSecret).toBe(OAUTHAPP_REDACTED_MARKER);
+
+    const reapplied = await clients.oauthAppCommand.apply(fetched);
+
+    expect(reapplied.metadata?.id).toBe(created.metadata?.id);
+    expect(reapplied.spec?.clientSecret).toBe(OAUTHAPP_REDACTED_MARKER);
+  });
+
+  it("rejects a ciphertext-shaped client_secret on create (InvalidArgument), across the whole enc:v<N>: family", async () => {
+    const { org } = await target.provisionTenancy();
+
+    for (const smuggled of ["enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=", "enc:v2:ZnV0dXJlLXZlcnNpb24="]) {
+      await expectGrpcCode(
+        () =>
+          clients.oauthAppCommand.create(
+            makeOAuthApp(org, uniqueName("oauth-app"), { clientSecret: smuggled }),
+          ),
+        Code.InvalidArgument,
+        `create with ciphertext-shaped client_secret ${smuggled}`,
+      );
+    }
+  });
+
+  it("rejects a ciphertext-shaped client_secret on update (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createOAuthAppFixture(org);
+
+    await expectGrpcCode(
+      () =>
+        clients.oauthAppCommand.update({
+          ...makeOAuthApp(org, created.metadata!.name, {
+            clientSecret: "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=",
+          }),
+          metadata: created.metadata,
+        }),
+      Code.InvalidArgument,
+      "update with ciphertext-shaped client_secret",
+    );
+  });
+});
+
+describe("OAuthApp conformance — referential delete-block", () => {
+  it("refuses to delete an app an McpServer references, then allows it once unreferenced", async () => {
+    const { org } = await target.provisionTenancy();
+    const app = await clients.oauthAppCommand.create(makeOAuthApp(org, uniqueName("oauth-app")));
+
+    const mcpServer = await clients.mcpServerCommand.create(
+      makeReferencingMcpServer(org, app.metadata!.slug),
+    );
+
+    // Referenced: deleting the app would sever a live vendor-OAuth
+    // connection, so the guard refuses.
+    await expectGrpcCode(
+      () => clients.oauthAppCommand.delete({ resourceId: app.metadata!.id }),
+      Code.FailedPrecondition,
+      "delete an OAuthApp a live McpServer references",
+    );
+
+    // Unreference by deleting the McpServer; the app is now free to go.
+    await clients.mcpServerCommand.delete({ resourceId: mcpServer.metadata!.id });
+    const deleted = await clients.oauthAppCommand.delete({ resourceId: app.metadata!.id });
+    expect(deleted.metadata?.id).toBe(app.metadata?.id);
+  });
+});
+
+describe("OAuthApp conformance — negative paths", () => {
+  it("get of a missing id returns NotFound", () =>
+    expectGrpcCode(
+      () => clients.oauthAppQuery.get({ value: "oapp_01conformancemissing" }),
+      Code.NotFound,
+      "get missing oauth app",
+    ));
+
+  it("getByReference of an unknown slug returns NotFound", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () => clients.oauthAppQuery.getByReference({ org, slug: "does-not-exist" }),
+      Code.NotFound,
+      "getByReference unknown slug",
+    );
+  });
+
+  it("rejects a create with an empty client_id (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () =>
+        clients.oauthAppCommand.create(
+          makeOAuthApp(org, uniqueName("oauth-app"), { clientId: "" }),
+        ),
+      Code.InvalidArgument,
+      "create with empty client_id",
+    );
+  });
+
+  it("rejects a create with an empty client_secret (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () =>
+        clients.oauthAppCommand.create(
+          makeOAuthApp(org, uniqueName("oauth-app"), { clientSecret: "" }),
+        ),
+      Code.InvalidArgument,
+      "create with empty client_secret",
+    );
+  });
+
+  it("rejects a create with a malformed authorization_url (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () =>
+        clients.oauthAppCommand.create(
+          makeOAuthApp(org, uniqueName("oauth-app"), { authorizationUrl: "not-a-url" }),
+        ),
+      Code.InvalidArgument,
+      "create with malformed authorization_url",
+    );
+  });
+});

--- a/test/conformance/src/suites/platform.conformance.test.ts
+++ b/test/conformance/src/suites/platform.conformance.test.ts
@@ -1,0 +1,98 @@
+// Platform conformance — server identity and runner bootstrap (Class A).
+// Domain: conformance suites.
+//
+// PlatformQueryController is not a resource domain: it is the server's
+// self-description surface. getServerInfo is what clients call on startup to
+// learn the edition and version instead of guessing from the URL, and
+// getRunnerBootstrapConfig is the one authenticated door an embedded runner
+// self-bootstraps through. The contract asserted here is the response SHAPE
+// both editions must honor:
+//
+//   - getServerInfo names a real edition (never unspecified) and a non-empty
+//     version.
+//   - getRunnerBootstrapConfig always carries reachable Temporal coordinates,
+//     and its token/key fields follow the PRESENCE-BASED contract: an empty
+//     token means "not minted" (OSS has no Cursor proxy; a cloud server may
+//     lack a signing key), and the companion fields (token_type,
+//     expires_in_seconds, key ids) are present exactly when their principal
+//     is — never half-populated. Clients branch on presence, so a
+//     half-populated response is a broken contract even when every field is
+//     individually well-formed.
+//
+// getRunnerScopedToken is deliberately NOT covered here: its arms are gated
+// on runner-class credentials (embedded_runner / pool_sandbox / sandbox
+// token types) that only exist mid-execution, so it belongs to the
+// execution-lifecycle slice.
+import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ConformanceClients } from "../harness/clients";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+describe("Platform conformance — getServerInfo", () => {
+  it("names a real edition and a non-empty version", async () => {
+    const info = await clients.platformQuery.getServerInfo({});
+
+    expect(
+      info.edition,
+      "edition is the deployment-mode signal clients branch on — unspecified is a broken server",
+    ).not.toBe(ServerEdition.server_edition_unspecified);
+    expect([ServerEdition.oss, ServerEdition.cloud]).toContain(info.edition);
+    expect(info.version, "version must identify the build").not.toBe("");
+  });
+
+  it("is stable across calls — server identity does not drift within a run", async () => {
+    const first = await clients.platformQuery.getServerInfo({});
+    const second = await clients.platformQuery.getServerInfo({});
+
+    expect(second.edition).toBe(first.edition);
+    expect(second.version).toBe(first.version);
+  });
+});
+
+describe("Platform conformance — getRunnerBootstrapConfig", () => {
+  it("carries Temporal coordinates and presence-consistent token fields", async () => {
+    const config = await clients.platformQuery.getRunnerBootstrapConfig({});
+
+    expect(config.temporalAddress, "a runner cannot bootstrap without an address").not.toBe("");
+    expect(config.temporalAddress, "address is host:port").toMatch(/^.+:\d+$/);
+    expect(config.temporalNamespace, "a runner cannot bootstrap without a namespace").not.toBe("");
+
+    // The presence-based token contract: all-or-nothing, never half-populated.
+    if (config.runnerAccessToken === "") {
+      expect(config.tokenType, "no token means no token_type").toBe("");
+      expect(
+        config.runnerAccessTokenExpiresInSeconds,
+        "no token means no expiry countdown",
+      ).toBe(0);
+    } else {
+      expect(config.tokenType, "a minted token is a Bearer token").toBe("Bearer");
+      expect(
+        config.runnerAccessTokenExpiresInSeconds,
+        "a minted token carries its lifetime",
+      ).toBeGreaterThan(0);
+    }
+
+    // The payload-encryption key pairs follow the same presence coupling.
+    expect(
+      config.payloadEncryptionKeyId === "",
+      "key id is present exactly when the key is",
+    ).toBe(config.payloadEncryptionKey === "");
+    expect(
+      config.payloadEncryptionSecondaryKeyId === "",
+      "secondary key id is present exactly when the secondary key is",
+    ).toBe(config.payloadEncryptionSecondaryKey === "");
+  });
+});

--- a/test/conformance/src/suites/registry-proxy.conformance.test.ts
+++ b/test/conformance/src/suites/registry-proxy.conformance.test.ts
@@ -1,0 +1,130 @@
+// Registry proxy conformance — the OSS server's plain-HTTP registry lanes
+// (Class A; the suite's first non-gRPC tests).
+// Domain: conformance suites.
+//
+// The unified port serves two unauthenticated, cacheable JSON proxies that
+// route AROUND the gRPC stack: /v1/proxy/task-kind-registry (the workflow
+// task palette) and /v1/proxy/model-registry (canonical model ids for
+// tokenless local runners and the web console). They are what lets the OSS
+// console work without an authenticated fetch from the hosted API, and the
+// future TS server must serve them byte-compatibly — this suite is the gate
+// the transport scaffold's proxy lanes are built against.
+//
+// The asserted contract, sourced from the Go server's routing block and
+// registryCORS wrapper (oss#571):
+//   - GET answers 200, Content-Type application/json, Cache-Control
+//     public/max-age, and a parseable document of the expected shape.
+//   - Every response carries Access-Control-Allow-Origin: * (the proxies
+//     bypass the gRPC-Web wrapper's CORS, so they own their own headers —
+//     without them the console's task palette and model pickers never load).
+//   - OPTIONS preflight answers 204 with the GET/OPTIONS allow-list — even
+//     for unregistered endpoints the browser probes.
+//   - Non-GET methods answer 405.
+//   - Unknown paths fall through the proxy lanes to the router's 404.
+//   - EMBEDDED FALLBACK: the model registry serves its bundled build-time
+//     snapshot without any network — the harness pins the background
+//     upstream refresh off (STIGMER_MODEL_REGISTRY_REFRESH=off, see
+//     server-process.ts), so the served document IS the embedded one and the
+//     assertion is deterministic offline and online alike.
+//
+// Gated on the target exposing an httpBaseUrl (the local OSS targets): the
+// cloud edition serves registries through its own authenticated routes — a
+// different contract — so this file reports SKIPPED there rather than a
+// false green (the DD-012 posture).
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTarget, type TargetProfile } from "../targets";
+
+// Collection-time gate: whether the SELECTED target class exposes the HTTP
+// lane. The URL itself is only known after setup() in beforeAll.
+const hasHttpLane = createTarget().httpBaseUrl !== undefined;
+
+let target: TargetProfile;
+let baseUrl: string;
+
+describe.skipIf(!hasHttpLane)("Registry proxy conformance — HTTP lanes", () => {
+  beforeAll(async () => {
+    target = createTarget();
+    await target.setup();
+    baseUrl = target.httpBaseUrl!();
+  });
+
+  afterAll(async () => {
+    await target?.teardown();
+  });
+
+  const routes = [
+    { path: "/v1/proxy/task-kind-registry", topLevelKey: "descriptors" },
+    { path: "/v1/proxy/model-registry", topLevelKey: "models" },
+  ] as const;
+
+  for (const { path, topLevelKey } of routes) {
+    describe(`GET ${path}`, () => {
+      it("answers cacheable JSON with allow-all CORS", async () => {
+        const response = await fetch(baseUrl + path);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("application/json");
+        expect(
+          response.headers.get("cache-control"),
+          "the registries are static and cacheable",
+        ).toContain("max-age");
+        expect(
+          response.headers.get("access-control-allow-origin"),
+          "cross-origin console fetches need allow-all CORS (oss#571)",
+        ).toBe("*");
+
+        const document = (await response.json()) as Record<string, unknown>;
+        expect(
+          document[topLevelKey],
+          `the served document carries its ${topLevelKey} catalog`,
+        ).toBeDefined();
+      });
+
+      it("answers the OPTIONS preflight with 204 and the GET allow-list", async () => {
+        const response = await fetch(baseUrl + path, {
+          method: "OPTIONS",
+          headers: {
+            Origin: "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+          },
+        });
+
+        expect(response.status).toBe(204);
+        expect(response.headers.get("access-control-allow-origin")).toBe("*");
+        expect(response.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+        expect(response.headers.get("access-control-allow-headers")).toBe(
+          "Authorization, Content-Type",
+        );
+      });
+
+      it("refuses non-GET methods with 405", async () => {
+        const response = await fetch(baseUrl + path, { method: "POST" });
+        expect(response.status).toBe(405);
+      });
+    });
+  }
+
+  it("model registry serves the embedded snapshot deterministically (no network behind it)", async () => {
+    // The harness pins the upstream refresh off, so this is the bundled
+    // build-time document — the offline-install contract: a server with no
+    // outbound network still answers a complete, valid registry.
+    const first = await fetch(baseUrl + "/v1/proxy/model-registry");
+    const second = await fetch(baseUrl + "/v1/proxy/model-registry");
+
+    const firstBody = await first.text();
+    const secondBody = await second.text();
+    expect(secondBody, "the embedded document is stable across reads").toBe(firstBody);
+
+    const document = JSON.parse(firstBody) as { models?: unknown[] };
+    expect(Array.isArray(document.models), "the bundled catalog is a models array").toBe(true);
+    expect(
+      (document.models as unknown[]).length,
+      "the bundled catalog is non-empty — an empty fallback would blank every model picker",
+    ).toBeGreaterThan(0);
+  });
+
+  it("unknown /v1/proxy paths fall through to the router's 404", async () => {
+    const response = await fetch(baseUrl + "/v1/proxy/does-not-exist");
+    expect(response.status).toBe(404);
+  });
+});

--- a/test/conformance/src/suites/schedule.conformance.test.ts
+++ b/test/conformance/src/suites/schedule.conformance.test.ts
@@ -5,10 +5,16 @@
 // clock, no runner. The trigger/resume refusal matrix (DD-014 D-B) is part of
 // the contract even where nothing can fire yet — the OSS Go server enforces
 // it ahead of its clock precisely so these negatives hold on both editions.
-// The FIRING contract (a trigger records last_fire_at, failed fires
-// accumulate into the platform auto-pause, resume + re-trigger fires again)
-// lives in suites-execution/schedule-firing.conformance.test.ts, gated on
-// the scheduleFiring capability.
+// Coverage spans the full CRUD + query surface: create/delete, apply
+// create/update branching, update spec replacement with the immutable
+// agent_ref (repointing would bypass the create-time consent bar on the
+// referenced agent — the AgentChannel rule), getByReference, the
+// agent-id-keyed getByAgent (unknown agent answers an empty list, not an
+// error), and the org-scoped list. The FIRING contract (a trigger records
+// last_fire_at, failed fires accumulate into the platform auto-pause, resume
+// + re-trigger fires again) and the run-history surface (listRuns) live in
+// suites-execution/schedule-firing.conformance.test.ts, gated on the
+// scheduleFiring capability.
 import { Code } from "@connectrpc/connect";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
@@ -39,13 +45,15 @@ afterAll(async () => {
 
 // Creates the referenced agent first: the schedule create's consent bar is
 // edit rights on the REFERENCED agent, so the agent must exist and belong to
-// the caller on both editions.
-async function createAgentFixture(org: string): Promise<string> {
+// the caller on both editions. Returns both handles a schedule surface uses:
+// the slug (what spec.agent.agent_ref carries) and the id (what getByAgent
+// is keyed on).
+async function createAgentFixture(org: string): Promise<{ id: string; slug: string }> {
   const agent = await clients.agentCommand.create(
     makeAgent({ org, name: uniqueName("sched-target") }),
   );
   fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
-  return agent.metadata!.slug;
+  return { id: agent.metadata!.id, slug: agent.metadata!.slug };
 }
 
 async function createScheduleFixture(
@@ -63,7 +71,7 @@ async function createScheduleFixture(
 describe("Schedule CRUD contract", () => {
   it("create round-trips the spec and starts with a clean firing status", async () => {
     const { org } = await target.provisionTenancy();
-    const agentSlug = await createAgentFixture(org);
+    const { slug: agentSlug } = await createAgentFixture(org);
 
     const created = await createScheduleFixture(org, agentSlug);
 
@@ -82,7 +90,7 @@ describe("Schedule CRUD contract", () => {
 
   it("delete removes the schedule", async () => {
     const { org } = await target.provisionTenancy();
-    const agentSlug = await createAgentFixture(org);
+    const { slug: agentSlug } = await createAgentFixture(org);
     const created = await createScheduleFixture(org, agentSlug);
 
     await clients.scheduleCommand.delete({ value: created.metadata!.id });
@@ -106,7 +114,7 @@ describe("Schedule trigger refusal matrix (DD-014 D-B — unconditional on every
 
   it("triggering a disabled schedule refuses with the exact teaching copy", async () => {
     const { org } = await target.provisionTenancy();
-    const agentSlug = await createAgentFixture(org);
+    const { slug: agentSlug } = await createAgentFixture(org);
     const disabled = await createScheduleFixture(org, agentSlug, { enabled: false });
 
     const err = await expectGrpcCode(
@@ -125,7 +133,7 @@ describe("Schedule trigger refusal matrix (DD-014 D-B — unconditional on every
 describe("Schedule resume contract (unconditional on every edition)", () => {
   it("resuming an unpaused schedule succeeds and changes nothing", async () => {
     const { org } = await target.provisionTenancy();
-    const agentSlug = await createAgentFixture(org);
+    const { slug: agentSlug } = await createAgentFixture(org);
     const created = await createScheduleFixture(org, agentSlug);
 
     const resumed = await clients.scheduleCommand.resume({ value: created.metadata!.id });
@@ -136,7 +144,7 @@ describe("Schedule resume contract (unconditional on every edition)", () => {
 
   it("a disabled schedule stays disabled through a resume — the latch and the switch are independent levers", async () => {
     const { org } = await target.provisionTenancy();
-    const agentSlug = await createAgentFixture(org);
+    const { slug: agentSlug } = await createAgentFixture(org);
     const disabled = await createScheduleFixture(org, agentSlug, { enabled: false });
 
     const resumed = await clients.scheduleCommand.resume({ value: disabled.metadata!.id });
@@ -154,4 +162,178 @@ describe("Schedule resume contract (unconditional on every edition)", () => {
       "resume a missing schedule",
     );
   });
+});
+
+describe("Schedule apply contract", () => {
+  it("apply creates on first call and updates on second (same name + org)", async () => {
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const name = uniqueName("sched-apply");
+
+    const first = await clients.scheduleCommand.apply(
+      makeSchedule(org, name, agentSlug, { cron: "0 9 * * *" }),
+    );
+    fixtures.defer(() => clients.scheduleCommand.delete({ value: first.metadata!.id }));
+    expect(first.metadata?.id).toMatch(/^sch_/);
+
+    const second = await clients.scheduleCommand.apply(
+      makeSchedule(org, name, agentSlug, { cron: "30 18 * * *" }),
+    );
+
+    expect(second.metadata?.id, "apply must update the same resource").toBe(first.metadata?.id);
+    expect(second.spec?.cron, "apply-as-update replaces the spec").toBe("30 18 * * *");
+  });
+
+  it("apply-as-update cannot repoint the agent target (FailedPrecondition)", async () => {
+    // The agent_ref is immutable on every update path — the create-time
+    // consent bar is edit rights on the REFERENCED agent, and a repoint
+    // would bypass it (the AgentChannel rule). Apply routes through update
+    // when the schedule exists, so the refusal must hold here too.
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const { slug: otherAgentSlug } = await createAgentFixture(org);
+    const name = uniqueName("sched-repoint");
+
+    const created = await clients.scheduleCommand.apply(makeSchedule(org, name, agentSlug));
+    fixtures.defer(() => clients.scheduleCommand.delete({ value: created.metadata!.id }));
+
+    await expectGrpcCode(
+      () => clients.scheduleCommand.apply(makeSchedule(org, name, otherAgentSlug)),
+      Code.FailedPrecondition,
+      "apply that repoints the schedule's agent",
+    );
+  });
+});
+
+describe("Schedule update contract", () => {
+  it("update replaces the spec but preserves id, slug, and org", async () => {
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const created = await createScheduleFixture(org, agentSlug);
+
+    const updated = await clients.scheduleCommand.update({
+      apiVersion: created.apiVersion,
+      kind: created.kind,
+      metadata: created.metadata,
+      spec: { ...created.spec!, cron: "15 6 * * 1", timeZone: "UTC" },
+    });
+
+    expect(updated.metadata?.id).toBe(created.metadata?.id);
+    expect(updated.metadata?.slug).toBe(created.metadata?.slug);
+    expect(updated.metadata?.org).toBe(org);
+    expect(updated.spec?.cron).toBe("15 6 * * 1");
+    expect(updated.spec?.timeZone).toBe("UTC");
+  });
+
+  it("update cannot change the agent_ref (FailedPrecondition)", async () => {
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const { slug: otherAgentSlug } = await createAgentFixture(org);
+    const created = await createScheduleFixture(org, agentSlug);
+
+    // Target the existing row (update loads by metadata.id) but carry a
+    // different agent in the spec.
+    const repointed = makeSchedule(org, created.metadata!.name, otherAgentSlug);
+    await expectGrpcCode(
+      () => clients.scheduleCommand.update({ ...repointed, metadata: created.metadata }),
+      Code.FailedPrecondition,
+      "update that repoints the schedule's agent",
+    );
+  });
+
+  it("update of a missing schedule is NotFound", async () => {
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const name = uniqueName("sched-missing");
+
+    // A valid schedule shape whose metadata.id points at nothing.
+    const missing = makeSchedule(org, name, agentSlug);
+    missing.metadata = { name, org, id: "sch_01conformancemissing" };
+    await expectGrpcCode(
+      () => clients.scheduleCommand.update(missing),
+      Code.NotFound,
+      "update a missing schedule",
+    );
+  });
+});
+
+describe("Schedule queries", () => {
+  it("getByReference resolves by org and slug", async () => {
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const created = await createScheduleFixture(org, agentSlug);
+
+    const fetched = await clients.scheduleQuery.getByReference({
+      org,
+      slug: created.metadata!.slug,
+    });
+    expect(fetched.metadata?.id).toBe(created.metadata?.id);
+  });
+
+  it("getByReference of an unknown slug returns NotFound", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () => clients.scheduleQuery.getByReference({ org, slug: "does-not-exist" }),
+      Code.NotFound,
+      "getByReference unknown slug",
+    );
+  });
+
+  it("getByAgent returns only the agent's schedules, keyed by agent id", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const otherAgent = await createAgentFixture(org);
+
+    const mine = await createScheduleFixture(org, agent.slug);
+    await createScheduleFixture(org, otherAgent.slug);
+
+    const list = await clients.scheduleQuery.getByAgent({ agentId: agent.id });
+
+    const ids = list.items.map((s) => s.metadata?.id);
+    expect(ids, "the agent's schedule is present").toContain(mine.metadata?.id);
+    for (const item of list.items) {
+      const targetArm = item.spec?.target;
+      expect(targetArm?.case, "every returned schedule targets an agent").toBe("agent");
+      expect(
+        targetArm?.case === "agent" ? targetArm.value.agentRef?.slug : undefined,
+        "getByAgent must not leak another agent's schedules",
+      ).toBe(agent.slug);
+    }
+    expect(list.totalCount).toBe(list.items.length);
+  });
+
+  it("getByAgent of an unknown agent returns an empty list, not an error", async () => {
+    // "No schedules" is the useful answer for an operational surface
+    // whether the agent is unknown or merely schedule-less.
+    const list = await clients.scheduleQuery.getByAgent({
+      agentId: "agent_01conformancemissing",
+    });
+    expect(list.items).toHaveLength(0);
+    expect(list.totalCount ?? 0).toBe(0);
+  });
+
+  it("getByAgent rejects an empty agent_id with InvalidArgument", () =>
+    expectGrpcCode(
+      () => clients.scheduleQuery.getByAgent({ agentId: "" }),
+      Code.InvalidArgument,
+      "getByAgent empty agent_id",
+    ));
+
+  it("list returns the org's schedules", async () => {
+    const { org } = await target.provisionTenancy();
+    const { slug: agentSlug } = await createAgentFixture(org);
+    const created = await createScheduleFixture(org, agentSlug);
+
+    const list = await clients.scheduleQuery.list({ org });
+
+    expect(list.items.map((s) => s.metadata?.id)).toContain(created.metadata?.id);
+    expect(list.totalCount).toBe(list.items.length);
+  });
+
+  it("list rejects an empty org with InvalidArgument", () =>
+    expectGrpcCode(
+      () => clients.scheduleQuery.list({ org: "" }),
+      Code.InvalidArgument,
+      "list empty org",
+    ));
 });

--- a/test/conformance/src/suites/session.conformance.test.ts
+++ b/test/conformance/src/suites/session.conformance.test.ts
@@ -302,6 +302,72 @@ describe("Session conformance — queries", () => {
       Code.InvalidArgument,
       "listByAgentInstance empty agent_instance_id",
     ));
+
+  it("listByChannel answers an empty list for a channel with no sessions — ordinary sessions never leak into a channel view", async () => {
+    // Channel sessions are created by the cloud channel runtime, which stamps
+    // the stigmer.ai/channel-id label at create time. The OSS runtime has no
+    // channel broker, so nothing ever stamps it there — the empty answer IS
+    // the OSS contract. Creating an ordinary session first makes this a real
+    // filter assertion rather than a vacuous empty-store read: a broken
+    // filter that returned unlabeled sessions would fail here.
+    const { org } = await target.provisionTenancy();
+    const agentInstanceId = await provisionAgentInstance(org);
+    await createSession(org, uniqueName("session"), agentInstanceId);
+
+    const listed = await clients.sessionQuery.listByChannel({ channelId: uniqueName("ach") });
+
+    expect(listed.entries).toHaveLength(0);
+  });
+
+  it("listByChannel returns exactly the sessions stamped with the channel's label", async () => {
+    // The positive arm: the filter must key on the stigmer.ai/channel-id
+    // label, not on emptiness. The label is a server-stamped reserved key an
+    // ordinary caller cannot forge on cloud (GuardReservedLabelsStep), so the
+    // channel-originated session is seeded through the privileged scope
+    // (stigmer#547) — the activity suite's runtime-origin seeding pattern.
+    // Deployed endpoints carry no operator credential by design and skip.
+    if (target.provisionPrivilegedScope === undefined) return;
+    const scope = await target.provisionPrivilegedScope();
+
+    try {
+      const org = scope.context.org;
+      const agent = await scope.clients.agentCommand.create(
+        makeAgent({ org, name: uniqueName("agent") }),
+      );
+      const agentInstanceId = agent.status!.defaultInstanceId;
+      const channelId = uniqueName("ach");
+
+      const channelSession = await scope.clients.sessionCommand.create(
+        makeSession({
+          org,
+          name: uniqueName("session"),
+          agentInstanceId,
+          labels: { "stigmer.ai/channel-id": channelId },
+        }),
+      );
+      await scope.clients.sessionCommand.create(
+        makeSession({ org, name: uniqueName("session"), agentInstanceId }),
+      );
+
+      const listed = await scope.clients.sessionQuery.listByChannel({ channelId });
+      const ids = listed.entries.map((s) => s.metadata?.id);
+
+      expect(ids, "the channel-stamped session is the one result").toEqual([
+        channelSession.metadata?.id,
+      ]);
+
+      await scope.clients.agentCommand.delete({ value: agent.metadata!.id });
+    } finally {
+      await scope.cleanup();
+    }
+  });
+
+  it("listByChannel rejects an empty channel_id with InvalidArgument", () =>
+    expectGrpcCode(
+      () => clients.sessionQuery.listByChannel({ channelId: "" }),
+      Code.InvalidArgument,
+      "listByChannel empty channel_id",
+    ));
 });
 
 describe("Session conformance — negative paths", () => {

--- a/test/conformance/src/suites/workflow.conformance.test.ts
+++ b/test/conformance/src/suites/workflow.conformance.test.ts
@@ -613,3 +613,77 @@ describe("Workflow conformance — tagVersion", () => {
     );
   });
 });
+
+describe("Workflow conformance — updateVisibility", () => {
+  it("changes an org-default workflow to public", async () => {
+    // Escalation to PUBLIC is operator-gated in the cloud edition (both
+    // write doors require can_set_public_visibility on platform:stigmer),
+    // and the ordinary conformance user holds no operator grant — see the
+    // capability's doc in targets/target.ts. The gate itself is pinned by
+    // the PermissionDenied case below; this happy path runs where the
+    // caller may publish (the local OSS targets, deliberately unguarded).
+    if (!target.capabilities.clientPublicVisibilityWrites) return;
+
+    const { org } = await target.provisionTenancy();
+    const created = await createWorkflow(org, uniqueName("wf"));
+    expect(created.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+
+    const updated = await clients.workflowCommand.updateVisibility({
+      resourceId: created.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+    expect(updated.metadata?.visibility).toBe(ApiResourceVisibility.visibility_public);
+
+    // The change is durable and observable via a fresh read.
+    const fetched = await clients.workflowQuery.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.visibility).toBe(ApiResourceVisibility.visibility_public);
+
+    // Cross-edition audit-slot contract (stigmer#540): a visibility flip is
+    // a lifecycle change, not a definition change, so the live workflow's
+    // spec_audit.updated_at — what search recency and version history read
+    // as "definition changed" — must not move from its post-create value.
+    const createdSpecUpdatedAt = created.status?.audit?.specAudit?.updatedAt;
+    expect(createdSpecUpdatedAt, "create stamps spec_audit.updated_at").toBeDefined();
+    expect(fetched.status?.audit?.specAudit?.updatedAt).toEqual(createdSpecUpdatedAt);
+  });
+
+  it("rejects escalation to public from a non-operator (PermissionDenied) and leaves the stored level untouched", async () => {
+    // The inverse pin of the happy path above: where the caller holds no
+    // operator grant (the cloud edition), escalation to PUBLIC is a
+    // curation decision the platform team makes — the visibility write door
+    // answers PermissionDenied and the stored level must not move. Skipped
+    // where publishing is self-service (the local OSS targets).
+    if (target.capabilities.clientPublicVisibilityWrites) return;
+
+    const { org } = await target.provisionTenancy();
+    const created = await createWorkflow(org, uniqueName("wf"));
+    expect(created.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+
+    await expectGrpcCode(
+      () =>
+        clients.workflowCommand.updateVisibility({
+          resourceId: created.metadata!.id,
+          visibility: ApiResourceVisibility.visibility_public,
+        }),
+      Code.PermissionDenied,
+      "update workflow visibility to public as a non-operator",
+    );
+
+    const stored = await clients.workflowQuery.get({ value: created.metadata!.id });
+    expect(stored.metadata?.visibility, "the rejected escalation must not change the stored level").toBe(
+      ApiResourceVisibility.visibility_org,
+    );
+  });
+
+  it("returns NotFound for an unknown workflow", async () => {
+    await expectGrpcCode(
+      () =>
+        clients.workflowCommand.updateVisibility({
+          resourceId: "wfl_doesnotexist",
+          visibility: ApiResourceVisibility.visibility_public,
+        }),
+      Code.NotFound,
+      "updateVisibility unknown id",
+    );
+  });
+});

--- a/test/conformance/src/support/oauthapps.ts
+++ b/test/conformance/src/support/oauthapps.ts
@@ -1,0 +1,57 @@
+// Canonical valid OAuthApp fixtures for the conformance suite.
+// Domain: conformance support.
+//
+// OAuthApp is the outbound-auth registration with an external vendor (the
+// mirror image of IdentityProvider's inbound trust): client credentials plus
+// the vendor's OAuth endpoints. Its spec carries a real secret
+// (client_secret), which the contract encrypts at rest and REDACTS on every
+// read — the suites assert the redaction marker, never a stored value.
+//
+// Negative cases (missing client_id/client_secret, malformed endpoint URLs,
+// ciphertext-shaped secrets) are written inline in the suite, matching the
+// support/agents.ts convention: this module is validity by construction.
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+
+export const OAUTHAPP_API_VERSION = "iam.stigmer.ai/v1";
+export const OAUTHAPP_KIND = "OAuthApp";
+
+// The redaction sentinel every read surface substitutes for the stored
+// client_secret. A CROSS-EDITION CONTRACT STRING: the Go steps package and
+// the Java handler each pin it in their own unit tests; the suite asserts it
+// over the wire on both. Re-submitting it on apply/update means "keep the
+// stored secret" (the Environment redaction-marker convention).
+export const OAUTHAPP_REDACTED_MARKER = "***REDACTED***";
+
+export interface OAuthAppOptions {
+  // Vendor display name; defaults to a stable placeholder.
+  provider?: string;
+  // OAuth client credentials; default to obviously-fake fixture values.
+  clientId?: string;
+  clientSecret?: string;
+  // Vendor endpoint URLs; default to a well-formed fixture vendor.
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  scopes?: string[];
+}
+
+// A complete, valid OAuthApp resource ready to hand to create/apply/update.
+export function makeOAuthApp(
+  org: string,
+  name: string,
+  options: OAuthAppOptions = {},
+): MessageInitShape<typeof OAuthAppSchema> {
+  return {
+    apiVersion: OAUTHAPP_API_VERSION,
+    kind: OAUTHAPP_KIND,
+    metadata: { name, org },
+    spec: {
+      provider: options.provider ?? "ConformanceVendor",
+      clientId: options.clientId ?? "conformance-client-id",
+      clientSecret: options.clientSecret ?? "conformance-client-secret",
+      authorizationUrl: options.authorizationUrl ?? "https://vendor.example.com/oauth/authorize",
+      tokenUrl: options.tokenUrl ?? "https://vendor.example.com/oauth/token",
+      scopes: options.scopes ?? ["read", "write"],
+    },
+  };
+}

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -46,6 +46,15 @@ export class LocalGoTarget implements TargetProfile {
     return this.conformanceClients;
   }
 
+  // The spawned server's unified port also serves the plain-HTTP lanes (the
+  // registry proxies) — expose it so those suites can drive them directly.
+  httpBaseUrl(): string {
+    if (this.server === undefined) {
+      throw new Error("LocalGoTarget.setup() must be called before httpBaseUrl()");
+    }
+    return this.server.baseUrl;
+  }
+
   async provisionTenancy(): Promise<TenancyContext> {
     // No auth and no bootstrap org: a unique slug is a fully isolated scope.
     return { org: uniqueOrg() };

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -202,6 +202,15 @@ export interface TargetProfile {
   // implicit caller, so isolation is untestable there by construction.
   provisionIdentity?(): Promise<ConformanceClients>;
 
+  // Base URL of the server's unified HTTP port, for the plain-HTTP lanes that
+  // route AROUND gRPC (the registry proxies). Present only on targets whose
+  // OSS-lane HTTP surface is under test: the local targets own their spawned
+  // server's port; the cloud edition serves registries through its own
+  // authenticated routes (a different contract), so the method is absent
+  // there and the registry-proxy suite reports SKIPPED — the DD-012
+  // "genuinely skipped, not false green" posture. Valid only after setup().
+  httpBaseUrl?(): string;
+
   // A platform-operator caller with a tenancy of its own (stigmer#547) — see
   // PrivilegedScope. Absent where no operator credential exists: hermetic
   // cloud runs bootstrap one (a conf-operator user granted operator on


### PR DESCRIPTION
## Summary

First wave of conformance coverage work items (CW-6, CW-8, CW-9, CW-10) — suite-only additions proven against the Go server, closing the small coverage gaps before their domains port to the TS server (the DD-002 coverage-before-port rule). D4 entry #2 of the OSS TS-server program.

## Context

The TS-server rewrite ships domain by domain against the conformance gate. Four small coverage gaps in already-covered or small domains must close BEFORE those domains port, so the gate is complete when the port arrives. No production code is touched.

## Changes

- **CW-6 (schedule)**: `apply` create/update branching, `update` spec replacement with the immutable `agent_ref` (repointing would bypass the create-time consent bar on the referenced agent), `getByReference`, the agent-id-keyed `getByAgent` (unknown agent answers an empty list, not an error), and org-scoped `list`.
- **CW-8 (three new suites + client registration)**:
  - `platform` — `getServerInfo` shape (real edition, non-empty version) and `getRunnerBootstrapConfig`'s presence-based token/key contract.
  - `github` — Layer-1 validation negatives (see Implementation notes for the discovered scope change).
  - `oauthapp` — CRUD & identity, client-secret redaction on every read, `enc:v<N>:`-shaped secret rejection on every write door (oss#395), redaction-marker apply round-trip, and the referential delete-block (stigmer#584) exercised over the wire against a real referencing McpServer.
- **CW-9 (gap-fills)**: `Workflow.updateVisibility` (happy path + cloud PermissionDenied inverse + the stigmer#540 spec-audit pin), `Session.listByChannel` (ordinary sessions never leak into a channel view; the positive label-filter arm via the privileged scope), activity `page_size` normalization (zero / negative / oversize never error, never answer an empty page while data exists).
- **CW-10 (registry proxy)**: the suite's first plain-HTTP tests — both `/v1/proxy/*` routes, CORS preflight (oss#571), 405/404 lanes, and the embedded-fallback contract. New optional `TargetProfile.httpBaseUrl?()` (the `llmProxy?()`/`mcpFixture?()` precedent); the file reports SKIPPED where the method is absent (cloud) rather than false-greening.
- **Harness hermeticity**: conformance servers now boot with `STIGMER_MODEL_REGISTRY_REFRESH=off`, so the registry lane serves the bundled snapshot deterministically and no suite run dials the network.
- **README**: replaced the stale "TS rewrite cancelled 2026-06-14" copy — the rewrite is the program in flight.

## Implementation notes

- **GitHub broker scope change (recorded surprise)**: the D4 brief scoped "config-missing FailedPrecondition" for the broker, but the OSS server ships bundled "Stigmer Local" OAuth App credentials as hardcoded defaults (`config.go`, the GitHub CLI pattern) and treats an empty env override as unset — the unconfigured state is structurally unreachable on `local-go` (and the exchange happy path dials github.com for real). The suite therefore carries only the arms that are true and hermetic on every edition; the cross-edition disposition of the config-missing arm is an owner decision tracked in the `sp.conformance-wave-1` sub-project.
- `Schedule.listRuns` deliberately stays out of CW-6 — it is firing-coupled and covered by the Class B firing suite.

## Breaking changes

- None (tests and harness only).

## Test plan

- `make test-conformance` (local-go): 20 files, 375 passed, 1 pre-existing skip — includes all four new suites and every extended one.
- Workspace typecheck: no new errors from this change (pre-existing errors in `mcp-server/`, `sdk/typescript/`, and two untouched suite files remain).
- The four new suites failed meaningfully during development (wrong oneof path, wrong delete input shape, the GitHub discovery) before converging — they are not tautological.

## Risks

- New Class A suites run against the Java cloud service in the nightly; the CW-8 surfaces are implemented there (verified in source) and the registry-proxy suite skips by design. If the nightly surfaces a genuine cloud deviation, it goes through the known-deviation registry protocol.
- Rollback: revert the single commit; no production code is affected.

## Checklist

- [x] Docs updated (conformance README)
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)