### PR TITLE
feat(client-apps/cli): add --harness flag and honor account default_harness

### DIFF
--- a/client-apps/cli/docs/commands/draft.mdx
+++ b/client-apps/cli/docs/commands/draft.mdx
@@ -36,6 +36,11 @@ Each draft command:
 
 The generated files follow Stigmer's best practices for the resource type.
 
+Draft sessions always run on the native harness, even when your account
+declares a cursor default — the creator agents are built for the native
+engine. Pass `--harness cursor` explicitly if you want a draft to run on
+the Cursor engine anyway.
+
 ### Supported resource types
 
 | Subcommand | Creates | System agent |

--- a/client-apps/cli/docs/commands/run.mdx
+++ b/client-apps/cli/docs/commands/run.mdx
@@ -120,6 +120,7 @@ stigmer run my-agent --detach -m "Generate weekly report"
 | Flag | Purpose |
 |------|---------|
 | `--model` | Override the LLM model (e.g., `claude-sonnet-4-6`) |
+| `--harness` | Choose the execution engine for the new session (`native` or `cursor`) |
 | `--auto-approve` | Approve all tool executions without prompting (bypasses approval policies) |
 | `--approve-default` | Auto-resolve approval prompts in non-interactive mode (`approve`, `skip`, `reject`) |
 | `--verbose`, `-v` | Show execution IDs and phase transitions in the TUI transcript |
@@ -131,6 +132,30 @@ stigmer run my-agent --model claude-opus-4.6 -m "Analyze this codebase"
 # Skip all approval prompts (use with caution)
 stigmer run my-agent --auto-approve -m "Deploy to staging"
 ```
+
+### Choosing a harness
+
+The harness is the engine that executes your session: `native` (Stigmer's
+own runtime, the default) or `cursor` (the Cursor engine, billed at its
+premium tier). A session keeps its harness for life — `stigmer resume`
+always continues on the engine the session started with.
+
+You rarely need the flag. If your account declares a default harness
+(Account settings → Execution defaults, or `default_harness` on your
+identity account), `stigmer run` applies it automatically on Stigmer Cloud,
+and an omitted `--model` fills from your default model for that harness.
+The flag is the per-run override:
+
+```bash
+# Start a cursor-harness session explicitly
+stigmer run code-reviewer --harness cursor -w . -m "Review my changes"
+
+# Force one native run without changing your cursor account default
+stigmer run my-agent --harness native -m "Quick question"
+```
+
+When a session starts on the cursor harness, the session header says so —
+you always see the engine before output streams.
 
 ## Examples
 

--- a/client-apps/cli/src/commands/agent-exec-flags.ts
+++ b/client-apps/cli/src/commands/agent-exec-flags.ts
@@ -3,7 +3,7 @@
 // execution flag is added here once and both surfaces pick it up.
 
 import type { Command } from "commander";
-import type { AgentExecFlags, RunMode, ServiceTierFlag, ThinkingFlag } from "../resources/run/prepare.js";
+import type { AgentExecFlags, HarnessFlag, RunMode, ServiceTierFlag, ThinkingFlag } from "../resources/run/prepare.js";
 
 /** Commander collector for repeatable string options. */
 export const collect = (value: string, previous: string[]): string[] => [...previous, value];
@@ -27,6 +27,7 @@ export interface AgentExecOptions {
   mode?: string;
   serviceTier?: string;
   thinking?: string;
+  harness?: string;
 }
 
 /**
@@ -54,7 +55,8 @@ export function addAgentExecFlags(command: Command, requireMessage = false): Com
     .option("--auto-approve", "automatically approve all tool executions")
     .option("--mode <mode>", 'interaction mode: "agent" (default) or "plan" (read-only)')
     .option("--service-tier <tier>", 'model service tier: "standard" (default) or "fast" (requires --model naming a model with a fast tier; billed at fast rates)')
-    .option("--thinking <mode>", 'extended reasoning: "disabled" (default) or "enabled" (requires --model naming a thinking-capable model; billed at base rates, uses more output tokens)');
+    .option("--thinking <mode>", 'extended reasoning: "disabled" (default) or "enabled" (requires --model naming a thinking-capable model; billed at base rates, uses more output tokens)')
+    .option("--harness <harness>", 'execution harness for the new session: "native" (default) or "cursor"');
 }
 
 /** Map parsed commander options onto the shared {@link AgentExecFlags} shape. */
@@ -77,5 +79,6 @@ export function toAgentExecFlags(options: AgentExecOptions): AgentExecFlags {
     mode: (options.mode ?? "") as RunMode,
     serviceTier: (options.serviceTier ?? "") as ServiceTierFlag,
     thinking: (options.thinking ?? "") as ThinkingFlag,
+    harness: (options.harness ?? "") as HarnessFlag,
   };
 }

--- a/client-apps/cli/src/commands/run.ts
+++ b/client-apps/cli/src/commands/run.ts
@@ -173,6 +173,9 @@ async function runResolvedAgent(
 
   const prepared = await prepareAgentExec(toAgentExecFlags(options), client.stigmer, org, stderrProgress(), {
     cloudBackend: isCloudMode(client.config),
+    // run opts into the account default_harness fill; draft deliberately
+    // does not (see the option's doc comment for the D5 rationale).
+    applyAccountHarnessDefault: true,
   });
   await executeResolvedAgent({
     agent,

--- a/client-apps/cli/src/resources/run/agent-exec.test.ts
+++ b/client-apps/cli/src/resources/run/agent-exec.test.ts
@@ -11,6 +11,7 @@ import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
 import {
   LocalPathSourceSchema,
   WorkspaceEntrySchema,
@@ -48,6 +49,7 @@ function makePrepared(overrides: Partial<PreparedRun> = {}): PreparedRun {
     mode: "",
     serviceTier: "",
     thinking: "",
+    harness: "",
     ...overrides,
   };
 }
@@ -126,5 +128,28 @@ describe("executeResolvedAgent", () => {
     expect(sent).toHaveLength(1);
     expect(sent[0]?.spec?.sessionSpec).toBeUndefined();
     expect(sent[0]?.spec?.agentId).toBe("agt_1");
+  });
+
+  it("threads the resolved harness onto the wire and surfaces it in the header (oss#293)", async () => {
+    // The revert-detection seam: if the prepared→create threading is ever
+    // dropped, this wire assertion fails — not just a flag-parsing test.
+    const { client, creates } = fakeBackend();
+
+    await executeResolvedAgent({
+      agent: makeAgent(),
+      prepared: makePrepared({ harness: "cursor" }),
+      org: "acme",
+      downloadDir: "",
+      outputMode: "inline",
+      client,
+    });
+
+    const sent = creates();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.spec?.sessionSpec?.harness).toBe(Harness.CURSOR);
+    // D2 visibility: a cursor session must announce itself before streaming —
+    // whether the flag or the account preference selected it.
+    expect(stderrLines.join("")).toContain("Harness:");
+    expect(stderrLines.join("")).toContain("Cursor");
   });
 });

--- a/client-apps/cli/src/resources/run/agent-exec.ts
+++ b/client-apps/cli/src/resources/run/agent-exec.ts
@@ -45,6 +45,7 @@ export async function executeResolvedAgent(input: ResolvedAgentExecInput): Promi
     serviceTier: prepared.serviceTier,
     thinking: prepared.thinking,
     autoApproveAll: prepared.autoApproveAll,
+    harness: prepared.harness,
   });
 
   // The backend owns the canonical session id: it creates the session and
@@ -56,6 +57,7 @@ export async function executeResolvedAgent(input: ResolvedAgentExecInput): Promi
     sessionId,
     model: prepared.model,
     mode: prepared.mode,
+    harness: prepared.harness,
     workspaces: workspaceNames(prepared.workspaceEntries),
   };
 

--- a/client-apps/cli/src/resources/run/create.test.ts
+++ b/client-apps/cli/src/resources/run/create.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 import { InteractionMode, ServiceTier, ThinkingMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { create } from "@bufbuild/protobuf";
+import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
 import {
   LocalPathSourceSchema,
   WorkspaceEntrySchema,
@@ -43,6 +44,7 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "",
       autoApproveAll: true,
+      harness: "",
     });
 
     expect(exec.kind).toBe("AgentExecution");
@@ -72,6 +74,7 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.message).toBe("hi");
     expect(exec.spec?.executionConfig).toBeUndefined();
@@ -92,6 +95,7 @@ describe("createAgentExecution", () => {
       serviceTier: "fast",
       thinking: "",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.executionConfig?.serviceTier).toBe(ServiceTier.FAST);
   });
@@ -113,6 +117,7 @@ describe("createAgentExecution", () => {
       serviceTier: "standard",
       thinking: "",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.executionConfig?.serviceTier).toBe(ServiceTier.STANDARD);
   });
@@ -132,6 +137,7 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "enabled",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.executionConfig?.thinkingMode).toBe(ThinkingMode.ENABLED);
   });
@@ -153,6 +159,7 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "disabled",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.executionConfig?.thinkingMode).toBe(ThinkingMode.DISABLED);
   });
@@ -172,6 +179,7 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.sessionId).toBe("ses_1");
     expect(exec.spec?.executionConfig?.interactionMode).toBe(InteractionMode.UNSPECIFIED);
@@ -199,6 +207,7 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "",
       autoApproveAll: false,
+      harness: "",
     });
 
     expect(exec.spec?.sessionId).toBe("");
@@ -206,9 +215,16 @@ describe("createAgentExecution", () => {
     // Subject stays empty so the server defaults its sentinel and the async
     // title activity generates a real one.
     expect(exec.spec?.sessionSpec?.subject).toBe("");
+    // No harness opinion: the field stays UNSPECIFIED so the server default
+    // (native) applies — a workspace-only run is byte-identical to before
+    // the --harness flag existed.
+    expect(exec.spec?.sessionSpec?.harness).toBe(Harness.UNSPECIFIED);
   });
 
-  it("omits session_spec when there are no workspace entries", async () => {
+  it("omits session_spec when there are no workspace entries and no harness (wire-shape regression pin)", async () => {
+    // The pre---harness wire shape for a plain run: NO embedded session_spec
+    // at all. If this pin fails, plain runs have started carrying a spec they
+    // never carried before — a silent contract change, not a feature.
     const { fn } = fakeController();
     const exec = await createAgentExecution(fn, {
       agentId: "agt_1",
@@ -223,8 +239,83 @@ describe("createAgentExecution", () => {
       serviceTier: "",
       thinking: "",
       autoApproveAll: false,
+      harness: "",
     });
     expect(exec.spec?.sessionSpec).toBeUndefined();
+  });
+
+  it("stamps cursor harness on a session_spec created just for it (oss#293)", async () => {
+    const { fn } = fakeController();
+    const exec = await createAgentExecution(fn, {
+      agentId: "agt_1",
+      orgId: "acme",
+      message: "hi",
+      runtimeEnv: {},
+      attachments: [],
+      workspaceFileRefs: [],
+      workspaceEntries: [],
+      model: "",
+      mode: "",
+      serviceTier: "",
+      thinking: "",
+      autoApproveAll: false,
+      harness: "cursor",
+    });
+    // Harness alone justifies the embedded spec: the server clones it onto
+    // the auto-created session (the one-call bootstrap contract).
+    expect(exec.spec?.sessionSpec?.harness).toBe(Harness.CURSOR);
+    expect(exec.spec?.sessionSpec?.workspaceEntries).toEqual([]);
+  });
+
+  it("stamps an explicit native harness rather than leaving it unspecified", async () => {
+    // "native" may be a deliberate per-run escape from the account's
+    // default_harness preference — it must survive on the wire so it beats
+    // any future change to the server-side default (D3).
+    const { fn } = fakeController();
+    const exec = await createAgentExecution(fn, {
+      agentId: "agt_1",
+      orgId: "acme",
+      message: "hi",
+      runtimeEnv: {},
+      attachments: [],
+      workspaceFileRefs: [],
+      workspaceEntries: [],
+      model: "",
+      mode: "",
+      serviceTier: "",
+      thinking: "",
+      autoApproveAll: false,
+      harness: "native",
+    });
+    expect(exec.spec?.sessionSpec?.harness).toBe(Harness.NATIVE);
+  });
+
+  it("carries harness and workspace entries together on one session_spec", async () => {
+    const entry = create(WorkspaceEntrySchema, {
+      name: "repo",
+      source: create(WorkspaceSourceSchema, {
+        source: { case: "localPath", value: create(LocalPathSourceSchema, { path: "/home/user/repo" }) },
+      }),
+    });
+
+    const { fn } = fakeController();
+    const exec = await createAgentExecution(fn, {
+      agentId: "agt_1",
+      orgId: "acme",
+      message: "hi",
+      runtimeEnv: {},
+      attachments: [],
+      workspaceFileRefs: [],
+      workspaceEntries: [entry],
+      model: "",
+      mode: "",
+      serviceTier: "",
+      thinking: "",
+      autoApproveAll: false,
+      harness: "cursor",
+    });
+    expect(exec.spec?.sessionSpec?.harness).toBe(Harness.CURSOR);
+    expect(exec.spec?.sessionSpec?.workspaceEntries).toEqual([entry]);
   });
 });
 

--- a/client-apps/cli/src/resources/run/create.ts
+++ b/client-apps/cli/src/resources/run/create.ts
@@ -18,7 +18,8 @@ import {
   ExecutionConfigSchema,
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
-import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import { type SessionSpec, SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
 import type { WorkspaceEntry } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import {
   type WorkflowExecution,
@@ -29,7 +30,7 @@ import { WorkflowExecutionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/
 import { ExecutionValueSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
 import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
 import type { RuntimeEnv } from "./env.js";
-import type { RunMode, ServiceTierFlag, ThinkingFlag } from "./prepare.js";
+import type { HarnessFlag, RunMode, ServiceTierFlag, ThinkingFlag } from "./prepare.js";
 
 const API_VERSION = "agentic.stigmer.ai/v1";
 
@@ -60,6 +61,7 @@ export interface CreateAgentExecutionInput {
   readonly serviceTier: ServiceTierFlag;
   readonly thinking: ThinkingFlag;
   readonly autoApproveAll: boolean;
+  readonly harness: HarnessFlag;
 }
 
 /** Create an agent execution. Mirrors Go's createAgentExecution. */
@@ -81,10 +83,7 @@ export async function createAgentExecution(
       agentId: input.agentId ?? "",
       // Subject is left empty: the server defaults its sentinel and the async
       // title activity replaces it, same as any auto-created session.
-      sessionSpec:
-        input.workspaceEntries.length > 0
-          ? create(SessionSpecSchema, { workspaceEntries: [...input.workspaceEntries] })
-          : undefined,
+      sessionSpec: buildSessionSpec(input.workspaceEntries, input.harness),
       executionConfig: buildExecutionConfig(input.model, input.mode, input.serviceTier, input.thinking),
     }),
   });
@@ -119,6 +118,26 @@ export async function createWorkflowExecution(
     }),
   });
   return controller(WorkflowExecutionCommandController).create(execution);
+}
+
+// Build the embedded session spec for the one-call bootstrap
+// (stigmer/stigmer#249), or undefined when there is nothing to carry — the
+// pre-existing wire shape for a plain run must stay byte-identical. A resolved
+// harness is stamped explicitly, including "native": the value may be a
+// deliberate per-run escape from the account's default_harness preference, so
+// it must survive any future change to the server-side default. Empty means
+// "no opinion" and stays off the wire (server defaults to native). The server
+// clones this spec onto the auto-created session and then clears it from the
+// persisted execution — the Session resource stays the single source of truth.
+function buildSessionSpec(
+  workspaceEntries: readonly WorkspaceEntry[],
+  harness: HarnessFlag,
+): SessionSpec | undefined {
+  if (workspaceEntries.length === 0 && harness === "") return undefined;
+  const spec = create(SessionSpecSchema, { workspaceEntries: [...workspaceEntries] });
+  if (harness === "cursor") spec.harness = Harness.CURSOR;
+  else if (harness === "native") spec.harness = Harness.NATIVE;
+  return spec;
 }
 
 // Build ExecutionConfig, or undefined when no flag is set so the backend

--- a/client-apps/cli/src/resources/run/header.test.ts
+++ b/client-apps/cli/src/resources/run/header.test.ts
@@ -31,6 +31,24 @@ describe("renderSessionHeader", () => {
     expect(agent.text()).not.toContain("Mode:");
   });
 
+  it("surfaces the cursor harness but not native/default (oss#293 D2 visibility)", () => {
+    // A cursor session may have been selected by the account preference, not
+    // a flag — the header is the CLI's only pre-stream channel to say so.
+    const cursor = capture();
+    renderSessionHeader(cursor.out, { agentName: "", sessionId: "s", model: "", mode: "", harness: "cursor", workspaces: [] });
+    expect(cursor.text()).toContain("Harness:");
+    expect(cursor.text()).toContain("Cursor");
+
+    // Native (explicit or defaulted) stays implicit, like agent mode.
+    const native = capture();
+    renderSessionHeader(native.out, { agentName: "", sessionId: "s", model: "", mode: "", harness: "native", workspaces: [] });
+    expect(native.text()).not.toContain("Harness:");
+
+    const unset = capture();
+    renderSessionHeader(unset.out, { agentName: "", sessionId: "s", model: "", mode: "", workspaces: [] });
+    expect(unset.text()).not.toContain("Harness:");
+  });
+
   it("indents extra workspaces under the first", () => {
     const { out, text } = capture();
     renderSessionHeader(out, {

--- a/client-apps/cli/src/resources/run/header.ts
+++ b/client-apps/cli/src/resources/run/header.ts
@@ -11,7 +11,7 @@
 
 import type { WorkspaceEntry } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import { shouldColorize, styler } from "../../output/style.js";
-import type { RunMode } from "./prepare.js";
+import type { HarnessFlag, RunMode } from "./prepare.js";
 
 export interface SessionHeaderInfo {
   readonly agentName: string;
@@ -20,6 +20,14 @@ export interface SessionHeaderInfo {
   readonly subject?: string;
   readonly model: string;
   readonly mode: RunMode;
+  /**
+   * Resolved harness for the session. Surfaced only when it is "cursor":
+   * a harness switch changes the toolset, conversation-state model, and
+   * billing tier, and it may come from the account preference rather than
+   * a flag — a cursor session must never start silently (the CLI
+   * counterpart of the web composer's harness selector).
+   */
+  readonly harness?: HarnessFlag;
   readonly workspaces: readonly string[];
 }
 
@@ -39,6 +47,8 @@ export function renderSessionHeader(out: { write(chunk: string): unknown; isTTY?
   if (info.sessionId !== "") lines.push(row(s, "Session", info.sessionId));
   if ((info.subject ?? "") !== "") lines.push(row(s, "Subject", info.subject ?? ""));
   if (info.model !== "") lines.push(row(s, "Model", info.model));
+  // Only "cursor" is surfaced; native/"" is the default and stays implicit.
+  if (info.harness === "cursor") lines.push(row(s, "Harness", "Cursor"));
   // Only "plan" is surfaced; "agent"/"" is the default and stays implicit.
   if (info.mode === "plan") lines.push(row(s, "Mode", "Plan (read-only)"));
   if (info.workspaces.length > 0) {

--- a/client-apps/cli/src/resources/run/prepare.test.ts
+++ b/client-apps/cli/src/resources/run/prepare.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "vitest";
 import { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import type { Stigmer } from "@stigmer/sdk";
-import { type AgentExecFlags, parseApprovalAction, prepareAgentExec, validateMode, validateServiceTier, validateThinking } from "./prepare.js";
+import { type AgentExecFlags, parseApprovalAction, prepareAgentExec, validateHarness, validateMode, validateServiceTier, validateThinking } from "./prepare.js";
 
 describe("parseApprovalAction", () => {
   it("maps each accepted value (case-insensitive)", () => {
@@ -59,6 +59,24 @@ describe("validateThinking", () => {
   });
 });
 
+describe("validateHarness", () => {
+  it("accepts empty, native, and cursor", () => {
+    expect(() => validateHarness("")).not.toThrow();
+    expect(() => validateHarness("native")).not.toThrow();
+    expect(() => validateHarness("cursor")).not.toThrow();
+  });
+
+  it("rejects anything else before a network round trip", () => {
+    expect(() => validateHarness("turbo")).toThrow(/must be "native" or "cursor"/);
+  });
+
+  it("rejects UI-only harness names that have no proto mapping", () => {
+    // copilot/codex/etc. exist in display metadata but not on the wire —
+    // accepting them here would stamp UNSPECIFIED and silently run native.
+    expect(() => validateHarness("copilot")).toThrow(/must be "native" or "cursor"/);
+  });
+});
+
 const BASE_FLAGS: AgentExecFlags = {
   message: "hi",
   attach: [],
@@ -77,21 +95,33 @@ const BASE_FLAGS: AgentExecFlags = {
   mode: "",
   serviceTier: "",
   thinking: "",
+  harness: "",
 };
 
 // prepareAgentExec only touches client.agentExecution for attachment uploads;
 // with no attachments a bare stub suffices.
 const STUB_CLIENT = { agentExecution: {} } as unknown as Stigmer;
 
-/** Stub whose whoAmI resolves an account carrying the given preference. */
-function clientWithPreference(defaultNativeModel: string): Stigmer {
+/** The shape of IdentityAccountPreferences the stubs below expose. */
+interface StubPreferences {
+  readonly defaultHarness?: string;
+  readonly defaultNativeModel?: string;
+  readonly defaultCursorModel?: string;
+}
+
+/** Stub whose whoAmI resolves an account carrying the given preferences. */
+function clientWithPreferences(preferences: StubPreferences): Stigmer {
   return {
     agentExecution: {},
     identityAccount: {
-      whoAmI: () =>
-        Promise.resolve({ spec: { preferences: { defaultNativeModel } } }),
+      whoAmI: () => Promise.resolve({ spec: { preferences } }),
     },
   } as unknown as Stigmer;
+}
+
+/** Back-compat shorthand for the original native-model-only stub. */
+function clientWithPreference(defaultNativeModel: string): Stigmer {
+  return clientWithPreferences({ defaultNativeModel });
 }
 
 /** Stub whose whoAmI rejects (auth failure, backend without the RPC, ...). */
@@ -103,6 +133,24 @@ function clientWithFailingWhoAmI(): Stigmer {
     },
   } as unknown as Stigmer;
 }
+
+/** Preference stub that also counts whoAmI invocations (round-trip pin). */
+function countingClient(preferences: StubPreferences): { client: Stigmer; calls: () => number } {
+  let calls = 0;
+  const client = {
+    agentExecution: {},
+    identityAccount: {
+      whoAmI: () => {
+        calls += 1;
+        return Promise.resolve({ spec: { preferences } });
+      },
+    },
+  } as unknown as Stigmer;
+  return { client, calls: () => calls };
+}
+
+/** prepareAgentExec options as `run` passes them: cloud + harness opt-in. */
+const CLOUD_RUN_OPTIONS = { cloudBackend: true, applyAccountHarnessDefault: true } as const;
 
 describe("prepareAgentExec env injection", () => {
   it("injects STIGMER_ORG_ID when absent", async () => {
@@ -194,5 +242,199 @@ describe("prepareAgentExec account-preference model fill (oss#293 Phase 1.5)", (
       { cloudBackend: true },
     );
     expect(prepared.model).toBe("");
+  });
+});
+
+describe("prepareAgentExec harness resolution (oss#293)", () => {
+  it("fills an omitted --harness from the account preference on cloud when the caller opts in (run)", async () => {
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithPreferences({ defaultHarness: "cursor" }),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.harness).toBe("cursor");
+  });
+
+  it("an explicit --harness always outranks the account preference", async () => {
+    // The per-run escape hatch: a cursor-preference user can still force a
+    // native run without touching their settings.
+    const prepared = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "native" },
+      clientWithPreferences({ defaultHarness: "cursor" }),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.harness).toBe("native");
+  });
+
+  it("ignores the preference when the caller has not opted in (draft, D5)", async () => {
+    // draft runs the seedpack's system creator agents — a utility flow that
+    // must not be silently rerouted onto the cursor engine by a preference
+    // meant for the user's own sessions (owner-ratified D5).
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithPreferences({ defaultHarness: "cursor" }),
+      "acme",
+      undefined,
+      { cloudBackend: true },
+    );
+    expect(prepared.harness).toBe("");
+  });
+
+  it("an explicit --harness still resolves for a non-opted-in caller (draft escape hatch)", async () => {
+    const prepared = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "cursor" },
+      STUB_CLIENT,
+      "acme",
+      undefined,
+      { cloudBackend: false },
+    );
+    expect(prepared.harness).toBe("cursor");
+  });
+
+  it("treats a malformed persisted harness as undeclared", async () => {
+    // A client must not trust stored data it did not write: anything outside
+    // the shipped allowlist resolves as if no preference existed.
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithPreferences({ defaultHarness: "devin" }),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.harness).toBe("");
+  });
+
+  it("resolves empty when whoAmI fails — a missing preference never fails a run", async () => {
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithFailingWhoAmI(),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.harness).toBe("");
+    expect(prepared.model).toBe("");
+  });
+
+  it("never consults identity on a local backend, even with the opt-in", async () => {
+    // The failing stub doubles as a call detector, as in the model-fill suite.
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithFailingWhoAmI(),
+      "acme",
+      undefined,
+      { cloudBackend: false, applyAccountHarnessDefault: true },
+    );
+    expect(prepared.harness).toBe("");
+  });
+
+  it("resolves empty when nothing is declared anywhere", async () => {
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithPreferences({}),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.harness).toBe("");
+  });
+});
+
+describe("prepareAgentExec harness-aware model fill (oss#293)", () => {
+  const BOTH_MODELS: StubPreferences = {
+    defaultNativeModel: "claude-sonnet-4.6",
+    defaultCursorModel: "composer-2.5",
+  };
+
+  it("fills the cursor model when the explicit harness is cursor", async () => {
+    const prepared = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "cursor" },
+      clientWithPreferences(BOTH_MODELS),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.model).toBe("composer-2.5");
+  });
+
+  it("fills the cursor model when the preference resolves the harness to cursor", async () => {
+    const prepared = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithPreferences({ ...BOTH_MODELS, defaultHarness: "cursor" }),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.harness).toBe("cursor");
+    expect(prepared.model).toBe("composer-2.5");
+  });
+
+  it("fills the native model when the harness resolves native or empty", async () => {
+    const explicit = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "native" },
+      clientWithPreferences(BOTH_MODELS),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(explicit.model).toBe("claude-sonnet-4.6");
+
+    const unset = await prepareAgentExec(
+      BASE_FLAGS,
+      clientWithPreferences(BOTH_MODELS),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(unset.model).toBe("claude-sonnet-4.6");
+  });
+
+  it("an explicit --model outranks the harness-matched preference", async () => {
+    const prepared = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "cursor", model: "gpt-5.3" },
+      clientWithPreferences(BOTH_MODELS),
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(prepared.model).toBe("gpt-5.3");
+  });
+
+  it("draft with an explicit --harness cursor fills the cursor model despite no harness opt-in (D5)", async () => {
+    // D5 scopes only the silent preference fill; the model fill follows
+    // whatever harness the user explicitly chose.
+    const prepared = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "cursor" },
+      clientWithPreferences(BOTH_MODELS),
+      "acme",
+      undefined,
+      { cloudBackend: true },
+    );
+    expect(prepared.harness).toBe("cursor");
+    expect(prepared.model).toBe("composer-2.5");
+  });
+
+  it("serves both fills from one whoAmI round trip, and none when both flags are explicit", async () => {
+    const single = countingClient({ ...BOTH_MODELS, defaultHarness: "cursor" });
+    const filled = await prepareAgentExec(BASE_FLAGS, single.client, "acme", undefined, CLOUD_RUN_OPTIONS);
+    expect(filled.harness).toBe("cursor");
+    expect(filled.model).toBe("composer-2.5");
+    expect(single.calls(), "harness + model fills share one whoAmI").toBe(1);
+
+    const skipped = countingClient(BOTH_MODELS);
+    const explicit = await prepareAgentExec(
+      { ...BASE_FLAGS, harness: "native", model: "gpt-5.3" },
+      skipped.client,
+      "acme",
+      undefined,
+      CLOUD_RUN_OPTIONS,
+    );
+    expect(explicit.harness).toBe("native");
+    expect(explicit.model).toBe("gpt-5.3");
+    expect(skipped.calls(), "explicit flags leave nothing to fill — no round trip").toBe(0);
   });
 });

--- a/client-apps/cli/src/resources/run/prepare.ts
+++ b/client-apps/cli/src/resources/run/prepare.ts
@@ -32,6 +32,15 @@ export type ServiceTierFlag = "" | "standard" | "fast";
  */
 export type ThinkingFlag = "" | "disabled" | "enabled";
 
+/**
+ * The `--harness` flag's value space (oss#293): empty means unset — the
+ * account preference may fill it (see {@link prepareAgentExec}), and when
+ * nothing resolves the server defaults the session to native. Deliberately
+ * only the two shipped engines, mirroring the proto validation on
+ * `IdentityAccountPreferences.default_harness`.
+ */
+export type HarnessFlag = "" | "native" | "cursor";
+
 /** Raw agent-execution flags shared by `run` and `draft` (Go's agentExecFlags). */
 export interface AgentExecFlags {
   readonly message: string;
@@ -51,6 +60,7 @@ export interface AgentExecFlags {
   readonly mode: RunMode;
   readonly serviceTier: ServiceTierFlag;
   readonly thinking: ThinkingFlag;
+  readonly harness: HarnessFlag;
 }
 
 /**
@@ -71,6 +81,13 @@ export interface PreparedRun {
   readonly mode: RunMode;
   readonly serviceTier: ServiceTierFlag;
   readonly thinking: ThinkingFlag;
+  /**
+   * The RESOLVED harness for the new session: the explicit flag, else the
+   * account preference (when the caller opted in), else "" — which stays off
+   * the wire so the server default (native) applies. Also drives the header's
+   * visibility row: a cursor session is never entered silently.
+   */
+  readonly harness: HarnessFlag;
 }
 
 /** Optional behavior switches for {@link prepareAgentExec}. */
@@ -78,11 +95,24 @@ export interface PrepareAgentExecOptions {
   /**
    * When `true` (the caller's backend is Stigmer Cloud) and `--model` is
    * omitted, the model is filled from the caller's account preference
-   * (`IdentityAccountPreferences.default_native_model`) via `whoAmI()`.
-   * Local mode has no IdentityAccount, so callers pass `false` there and
-   * the omitted model keeps resolving to the platform default.
+   * (`IdentityAccountPreferences.default_*_model` for the resolved harness)
+   * via `whoAmI()`. Local mode has no IdentityAccount, so callers pass
+   * `false` there and the omitted model keeps resolving to the platform
+   * default.
    */
   readonly cloudBackend?: boolean;
+  /**
+   * When `true` and `--harness` is omitted, the harness is filled from the
+   * caller's account preference (`IdentityAccountPreferences.default_harness`)
+   * on cloud. `run` opts in; `draft` deliberately does not: draft executes the
+   * seedpack's system creator agents (a utility flow, not the user's own
+   * conversation), which are built and exercised on the native harness —
+   * silently rerouting them onto the cursor engine (different toolset,
+   * premium billing tier) would fail the least-surprise test. An explicit
+   * `--harness` on draft still wins; only the silent preference fill is
+   * scoped out. Owner-ratified (D5, 2026-08-23).
+   */
+  readonly applyAccountHarnessDefault?: boolean;
 }
 
 /**
@@ -100,16 +130,28 @@ export async function prepareAgentExec(
   validateMode(flags.mode);
   validateServiceTier(flags.serviceTier);
   validateThinking(flags.thinking);
+  validateHarness(flags.harness);
 
-  // Layered model seed (oss#293 Phase 1.5): an explicit --model always wins;
-  // an omitted one fills from the account preference on cloud. `run` and
-  // `draft` always create a NEW session (threading lives in `resume`, which
-  // does not pass through here), so the fill never injects a native model
-  // into an existing cursor-harness session.
-  const model =
-    flags.model === "" && options?.cloudBackend === true
-      ? await resolveModelFromAccountPreference(client)
-      : flags.model;
+  // Layered seeds (oss#293, DD-003): explicit flag > account preference
+  // (cloud only) > platform default. Harness resolves first because the model
+  // fill is harness-aware: a cursor session fills from default_cursor_model,
+  // everything else from default_native_model. `run` and `draft` always
+  // create a NEW session (threading lives in `resume`, which does not pass
+  // through here), so neither fill can ever contradict an existing session's
+  // immutable harness. One whoAmI round trip serves both fills, and it is
+  // skipped entirely when explicit flags leave nothing to fill.
+  const wantsHarnessFill = flags.harness === "" && options?.applyAccountHarnessDefault === true;
+  const wantsModelFill = flags.model === "";
+  const accountDefaults =
+    options?.cloudBackend === true && (wantsHarnessFill || wantsModelFill)
+      ? await resolveAccountExecutionDefaults(client)
+      : NO_ACCOUNT_DEFAULTS;
+  const harness = flags.harness !== "" ? flags.harness : wantsHarnessFill ? accountDefaults.harness : "";
+  const model = wantsModelFill
+    ? harness === "cursor"
+      ? accountDefaults.cursorModel
+      : accountDefaults.nativeModel
+    : flags.model;
 
   const workspaceEntries = parseWorkspaceEntries(flags.workspace, flags.branch, flags.commit);
 
@@ -144,23 +186,43 @@ export async function prepareAgentExec(
     mode: flags.mode,
     serviceTier: flags.serviceTier,
     thinking: flags.thinking,
+    harness,
   };
 }
 
+/** The account's execution defaults, "" for anything undeclared. */
+interface AccountExecutionDefaults {
+  readonly harness: HarnessFlag;
+  readonly nativeModel: string;
+  readonly cursorModel: string;
+}
+
+const NO_ACCOUNT_DEFAULTS: AccountExecutionDefaults = { harness: "", nativeModel: "", cursorModel: "" };
+
 /**
- * Best-effort read of the caller's default model for native-harness runs
- * (CLI sessions are native — there is no --harness flag yet, so the cursor
- * default is deliberately not consulted). Any failure — network, auth, a
- * backend without IdentityAccount — resolves to "" and the run proceeds
- * exactly as an unfilled --model does today: a missing preference must
- * never fail a run.
+ * Best-effort read of the caller's execution defaults
+ * (`IdentityAccountPreferences.default_harness` / `default_*_model`) in one
+ * whoAmI round trip. Any failure — network, auth, a backend without
+ * IdentityAccount — resolves to no defaults and the run proceeds exactly as
+ * unfilled flags do today: a missing preference must never fail a run.
+ *
+ * The persisted harness value is allowlist-guarded to the shipped engines
+ * (the same guard the web launcher's useAccountExecutionDefaults applies):
+ * a client must not trust stored data it did not write, so anything outside
+ * native/cursor is treated as undeclared rather than stamped on the wire.
  */
-async function resolveModelFromAccountPreference(client: Stigmer): Promise<string> {
+async function resolveAccountExecutionDefaults(client: Stigmer): Promise<AccountExecutionDefaults> {
   try {
     const account = await client.identityAccount.whoAmI();
-    return account.spec?.preferences?.defaultNativeModel ?? "";
+    const prefs = account.spec?.preferences;
+    const declared = prefs?.defaultHarness;
+    return {
+      harness: declared === "native" || declared === "cursor" ? declared : "",
+      nativeModel: prefs?.defaultNativeModel ?? "",
+      cursorModel: prefs?.defaultCursorModel ?? "",
+    };
   } catch {
-    return "";
+    return NO_ACCOUNT_DEFAULTS;
   }
 }
 
@@ -224,6 +286,22 @@ export function validateThinking(mode: string): asserts mode is ThinkingFlag {
   if (mode !== "" && mode !== "disabled" && mode !== "enabled") {
     throw new UsageError(
       `invalid --thinking value "${mode}": must be "disabled" or "enabled"`,
+    );
+  }
+}
+
+/**
+ * Validate the `--harness` flag. Empty means "use default": the account
+ * preference when the caller opted in, else the platform default (native).
+ * Only the shipped engines are accepted — other harness names that appear in
+ * UI metadata (copilot, codex, ...) have no proto mapping yet, so rejecting
+ * them here is honest, and this check catches spelling errors before a
+ * network round trip.
+ */
+export function validateHarness(harness: string): asserts harness is HarnessFlag {
+  if (harness !== "" && harness !== "native" && harness !== "cursor") {
+    throw new UsageError(
+      `invalid --harness value "${harness}": must be "native" or "cursor"`,
     );
   }
 }

--- a/docs/cli/commands/draft.mdx
+++ b/docs/cli/commands/draft.mdx
@@ -47,6 +47,11 @@ Each draft command:
 
 The generated files follow Stigmer's best practices for the resource type.
 
+Draft sessions always run on the native harness, even when your account declares
+a cursor default — the creator agents are built for the native engine. Pass
+`--harness cursor` explicitly if you want a draft to run on the Cursor engine
+anyway.
+
 ### Supported resource types
 
 | Subcommand         | Creates                     | System agent       |
@@ -96,6 +101,7 @@ stigmer draft agent [flags]
 | `--detach`          | `bool`   |         | start execution and return immediately without streaming                                                                                                |
 | `--env`             | `string` |         | runtime env var KEY=VALUE (repeatable)                                                                                                                  |
 | `--env-file`        | `string` |         | load env from file (repeatable, later override earlier)                                                                                                 |
+| `--harness`         | `string` |         | execution harness for the new session: "native" (default) or "cursor"                                                                                   |
 | `--json`            | `bool`   |         | stream events as newline-delimited JSON                                                                                                                 |
 | `--message`, `-m`   | `string` |         | initial message/prompt for execution                                                                                                                    |
 | `--mode`            | `string` |         | interaction mode: "agent" (default) or "plan" (read-only)                                                                                               |
@@ -126,6 +132,7 @@ stigmer draft mcp-server [flags]
 | `--detach`          | `bool`   |         | start execution and return immediately without streaming                                                                                                |
 | `--env`             | `string` |         | runtime env var KEY=VALUE (repeatable)                                                                                                                  |
 | `--env-file`        | `string` |         | load env from file (repeatable, later override earlier)                                                                                                 |
+| `--harness`         | `string` |         | execution harness for the new session: "native" (default) or "cursor"                                                                                   |
 | `--json`            | `bool`   |         | stream events as newline-delimited JSON                                                                                                                 |
 | `--message`, `-m`   | `string` |         | initial message/prompt for execution                                                                                                                    |
 | `--mode`            | `string` |         | interaction mode: "agent" (default) or "plan" (read-only)                                                                                               |
@@ -156,6 +163,7 @@ stigmer draft skill [flags]
 | `--detach`          | `bool`   |         | start execution and return immediately without streaming                                                                                                |
 | `--env`             | `string` |         | runtime env var KEY=VALUE (repeatable)                                                                                                                  |
 | `--env-file`        | `string` |         | load env from file (repeatable, later override earlier)                                                                                                 |
+| `--harness`         | `string` |         | execution harness for the new session: "native" (default) or "cursor"                                                                                   |
 | `--json`            | `bool`   |         | stream events as newline-delimited JSON                                                                                                                 |
 | `--message`, `-m`   | `string` |         | initial message/prompt for execution                                                                                                                    |
 | `--mode`            | `string` |         | interaction mode: "agent" (default) or "plan" (read-only)                                                                                               |

--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -55,6 +55,7 @@ stigmer run my-agent -m "Summarize the Q4 earnings report"
 | `--download`        | `string` |         | download artifacts to directory when complete                                                                                                           |
 | `--env`             | `string` |         | runtime env var KEY=VALUE (repeatable)                                                                                                                  |
 | `--env-file`        | `string` |         | load env from file (repeatable, later override earlier)                                                                                                 |
+| `--harness`         | `string` |         | execution harness for the new session: "native" (default) or "cursor"                                                                                   |
 | `--json`            | `bool`   |         | stream events as newline-delimited JSON                                                                                                                 |
 | `--message`, `-m`   | `string` |         | initial message/prompt for execution                                                                                                                    |
 | `--mode`            | `string` |         | interaction mode: "agent" (default) or "plan" (read-only)                                                                                               |
@@ -154,6 +155,7 @@ stigmer run my-agent --detach -m "Generate weekly report"
 | Flag                | Purpose                                                                             |
 | ------------------- | ----------------------------------------------------------------------------------- |
 | `--model`           | Override the LLM model (e.g., `claude-sonnet-4-6`)                                  |
+| `--harness`         | Choose the execution engine for the new session (`native` or `cursor`)              |
 | `--auto-approve`    | Approve all tool executions without prompting (bypasses approval policies)          |
 | `--approve-default` | Auto-resolve approval prompts in non-interactive mode (`approve`, `skip`, `reject`) |
 | `--verbose`, `-v`   | Show execution IDs and phase transitions in the TUI transcript                      |
@@ -165,6 +167,30 @@ stigmer run my-agent --model claude-opus-4.6 -m "Analyze this codebase"
 # Skip all approval prompts (use with caution)
 stigmer run my-agent --auto-approve -m "Deploy to staging"
 ```
+
+### Choosing a harness
+
+The harness is the engine that executes your session: `native` (Stigmer's own
+runtime, the default) or `cursor` (the Cursor engine, billed at its premium
+tier). A session keeps its harness for life — `stigmer resume` always continues
+on the engine the session started with.
+
+You rarely need the flag. If your account declares a default harness (Account
+settings → Execution defaults, or `default_harness` on your identity account),
+`stigmer run` applies it automatically on Stigmer Cloud, and an omitted
+`--model` fills from your default model for that harness. The flag is the
+per-run override:
+
+```bash
+# Start a cursor-harness session explicitly
+stigmer run code-reviewer --harness cursor -w . -m "Review my changes"
+
+# Force one native run without changing your cursor account default
+stigmer run my-agent --harness native -m "Quick question"
+```
+
+When a session starts on the cursor harness, the session header says so — you
+always see the engine before output streams.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
Adds a `--harness <native|cursor>` flag to `stigmer run` and `stigmer draft`, and honors the account preference `IdentityAccountPreferences.default_harness` on Stigmer Cloud when the flag is omitted (`run` only). The `--model` account fill becomes harness-aware: a cursor-harness run fills an omitted model from `default_cursor_model` instead of `default_native_model`.

## Context
The harness choice has existed on the web and desktop launchers since oss#293 Phase 1.5, and the Account settings page lets users declare `default_harness` — but the CLI ignored both: a cursor-preference user had to leave the terminal to start a session. The CLI code itself recorded the gap ("there is no --harness flag yet" in `prepare.ts`). This closes it. Part of #293.

## Changes
- `commands/agent-exec-flags.ts` — `--harness` registered once in the shared flag set; `run` and `draft` pick it up in lockstep.
- `resources/run/prepare.ts` — `HarnessFlag` type + `validateHarness()` (the `validateMode`/`validateServiceTier` pattern); one best-effort `whoAmI()` read (`resolveAccountExecutionDefaults`) serves both the harness and the harness-aware model fill; new `applyAccountHarnessDefault` option scopes the silent preference fill to `run`.
- `resources/run/create.ts` — `buildSessionSpec()`: the embedded one-call-bootstrap `session_spec` now carries the resolved harness; created when workspace entries exist OR a harness is stamped. No flag + no workspaces keeps producing NO `session_spec` (wire shape byte-identical to before).
- `resources/run/header.ts` / `agent-exec.ts` — the session header prints `Harness: Cursor` whenever the effective harness is cursor, whether the flag or the preference chose it; native stays implicit (like the `mode` row).
- Docs — flag table regenerated by `gen-cli-docs`; hand-written template enrichment: a "Choosing a harness" section on `run`, and a note on `draft` that the account harness preference is not auto-applied.

## Implementation notes
- Layered-seed precedence (DD-003): explicit `--harness` > account `default_harness` (cloud only) > unset (server defaults native). Explicit `native` is stamped on the wire so the per-run escape from a cursor account default survives any future server-side default change.
- The preference auto-fill is `run`-only (owner-ratified D5): `draft` executes the seedpack's system creator agents — a utility flow that must not be silently rerouted onto the cursor engine (different toolset, premium billing tier) by a preference meant for the user's own sessions. An explicit `--harness` on draft still wins.
- Persisted preference values are allowlist-guarded to `native|cursor` (the same guard `useAccountExecutionDefaults` applies): a client must not trust stored data it did not write.
- Server-side no change was needed: both editions' create bootstrap already clones a caller `session_spec` — harness included — onto the auto-created session (pinned by the existing `create_session_bootstrap_test.go`). `resume` never passes through `prepareAgentExec`, so session-harness immutability holds by construction.

## Breaking changes
- None. Existing runs produce byte-identical requests (pinned by a wire-shape regression test).

## Test plan
- 20 new unit tests across the four touched suites: flag validation (incl. UI-only names like `copilot` rejected), the full precedence matrix, D5 scoping, harness-aware model fill, single-round-trip pin (a counting stub proves one `whoAmI` serves both fills and zero calls when both flags are explicit), `whoAmI`-failure degradation, malformed-preference guard, wire-shape stamping for cursor/explicit-native/harness-only, the no-spec regression pin, and the header visibility row.
- Full CLI suite: 943/943 green. `tsc --noEmit` clean. `make gen-cli-docs-check` green.
- Not verified manually against a live backend in this session.

## Risks
- Low: client-only, no protos, no server, no runner, no sdk/react changes. Rollback = revert the single commit.
- A local-mode `--harness cursor` run depends on the user's Cursor auth, as on desktop; the failure path is runner-owned and unchanged.

## Checklist
- [x] Docs updated (generated + template enrichment)
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)