### PR TITLE
fix(runner): include @stigmer/temporal-codecs in the sandbox image build

### DIFF
--- a/backend/services/runner/Dockerfile.sandbox
+++ b/backend/services/runner/Dockerfile.sandbox
@@ -36,8 +36,17 @@ RUN cd apis/stubs/ts && npm install --ignore-scripts
 COPY apis/stubs/ts/ apis/stubs/ts/
 RUN cd apis/stubs/ts && npm run build
 
+# Build @stigmer/temporal-codecs (file: dependency of the runner) — the
+# shared Temporal payload-codec lib extracted from the runner. Same
+# treatment as the proto stubs: install, copy source, build dist.
+COPY backend/libs/ts/temporal-codecs/package.json backend/libs/ts/temporal-codecs/
+RUN cd backend/libs/ts/temporal-codecs && npm install --ignore-scripts
+COPY backend/libs/ts/temporal-codecs/ backend/libs/ts/temporal-codecs/
+RUN cd backend/libs/ts/temporal-codecs && npm run build
+
 # Install runner production dependencies.
-# The directory layout preserves the file:../../../apis/stubs/ts reference.
+# The directory layout preserves the file:../../../apis/stubs/ts and
+# file:../../libs/ts/temporal-codecs references.
 COPY backend/services/runner/package.json backend/services/runner/package-lock.json backend/services/runner/
 WORKDIR /build/backend/services/runner
 RUN npm ci --legacy-peer-deps
@@ -46,14 +55,17 @@ RUN npm ci --legacy-peer-deps
 COPY backend/services/runner/ .
 RUN npm run build
 
-# Strip dev dependencies and resolve the @stigmer/protos symlink into a
-# real copy so the runtime stage doesn't need the stubs directory tree.
+# Strip dev dependencies and resolve the @stigmer/protos and
+# @stigmer/temporal-codecs symlinks into real copies so the runtime stage
+# doesn't need the stubs/libs directory trees.
 RUN npm prune --omit=dev --legacy-peer-deps && \
-    if [ -L node_modules/@stigmer/protos ]; then \
-      target="$(readlink -f node_modules/@stigmer/protos)" && \
-      rm node_modules/@stigmer/protos && \
-      cp -r "$target" node_modules/@stigmer/protos; \
-    fi
+    for dep in protos temporal-codecs; do \
+      if [ -L "node_modules/@stigmer/$dep" ]; then \
+        target="$(readlink -f "node_modules/@stigmer/$dep")" && \
+        rm "node_modules/@stigmer/$dep" && \
+        cp -r "$target" "node_modules/@stigmer/$dep"; \
+      fi; \
+    done
 
 # ---------- Runtime ----------
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
Fixes the cloud sandbox image build, broken since #836: the runner depends on `@stigmer/temporal-codecs` via `file:../../libs/ts/temporal-codecs`, but `Dockerfile.sandbox` never copied that folder into the build context, so `npm run build` failed with TS2307 on every real `release.sandbox-cloud` build.

## Context
#836 extracted the Temporal payload codecs from the runner into the shared lib `backend/libs/ts/temporal-codecs`. Every `release.sandbox-cloud` run that actually rebuilt the image since then failed at the runner `tsc` step (`aa4a517e1`, `86fbbba85`, `f44d94f47`); later green runs were path-filtered skips. `ghcr.io/stigmer/runner:prod` is consequently pinned at `75622a63d` (#833) — cloud sandboxes are missing the semantic memory retriever (#837) and everything after it.

## Changes
- `Dockerfile.sandbox`: build `@stigmer/temporal-codecs` before the runner `npm ci`, mirroring the existing `@stigmer/protos` stubs pattern (copy manifest → install → copy source → build dist).
- Generalize the final symlink-resolution step to resolve BOTH `file:` deps (`protos`, `temporal-codecs`) into real directories, so the runtime stage carries no dangling symlinks.

## Breaking changes
- None.

## Test plan
- Full local `docker build -f backend/services/runner/Dockerfile.sandbox .` from repo root: succeeds (previously failed at `RUN npm run build` with TS2307).
- Container check on the built image: `/runner/node_modules/@stigmer/temporal-codecs` is a real directory and `import("@stigmer/temporal-codecs")` resolves (exports `EncryptionPayloadCodec`, `ClaimcheckPayloadCodec`, config loaders).

## Risks
- Low: Dockerfile-only. The merge push triggers a real `release.sandbox-cloud` build whose smoke test gates the `:prod` bless — a bad image cannot be blessed.

Made with [Cursor](https://cursor.com)