### PR TITLE
feat(backend/stigmer-server-ts): port encryption, runnerauth, and the environment domain

### DIFF
--- a/backend/services/stigmer-server-ts/scripts/regen-go-ciphertext-fixture.sh
+++ b/backend/services/stigmer-server-ts/scripts/regen-go-ciphertext-fixture.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regenerates src/encryption/__tests__/fixtures/go-ciphertext.json — the
+# cross-edition compatibility fixture (sub-project DD-001): enc:v1: values
+# produced by the REAL Go encryption code (pkg/encryption) under a fixed
+# test key. The TS unit suite decrypts every entry and must recover the
+# exact plaintext, proving the AES-256-GCM layout (nonce || ct || tag,
+# standard Base64, enc:v1: prefix) is byte-compatible across editions.
+#
+# Ciphertext is nonce-random, so regeneration rewrites the file with
+# different bytes — that is fine; the CONTRACT is that whatever Go emits,
+# TS decrypts. Requires: go (the repo toolchain). Run from anywhere.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+service_dir="$repo_root/backend/services/stigmer-server-ts"
+gen_dir="$repo_root/backend/services/stigmer-server/fixturegen-tmp"
+out_file="$service_dir/src/encryption/__tests__/fixtures/go-ciphertext.json"
+
+cleanup() {
+  rm -rf "$gen_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$gen_dir" "$(dirname "$out_file")"
+
+cat > "$gen_dir/main.go" <<'EOF'
+// Throwaway fixture generator (written by regen-go-ciphertext-fixture.sh,
+// never committed): encrypts a set of plaintexts through the REAL Go
+// SecretService under a fixed test key and emits JSON on stdout.
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/stigmer/stigmer/backend/services/stigmer-server/pkg/encryption"
+)
+
+type entry struct {
+	Name       string `json:"name"`
+	Plaintext  string `json:"plaintext"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type fixture struct {
+	// The fixed 32-byte test key (Base64). A committed key is safe here:
+	// it encrypts only these fixture strings and guards a format contract.
+	KeyBase64 string  `json:"keyBase64"`
+	Entries   []entry `json:"entries"`
+}
+
+func main() {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1) // 0x01..0x20 — fixed, reviewable, obviously non-production
+	}
+
+	svc, err := encryption.NewSecretService(key)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	plaintexts := map[string]string{
+		"simple":       "hello world",
+		"empty":        "",
+		"single-byte":  "x",
+		"api-key-like": "sk-proj-AbCdEf0123456789_secretSECRET-9876543210fedcba",
+		"unicode":      "秘密のパスワード🔐 — ключ",
+		"multiline":    "line one\nline two\r\n\ttabbed",
+		"long":         string(make500()),
+	}
+
+	fx := fixture{KeyBase64: base64.StdEncoding.EncodeToString(key)}
+	for _, name := range []string{"simple", "empty", "single-byte", "api-key-like", "unicode", "multiline", "long"} {
+		pt := plaintexts[name]
+		ct, err := svc.Encrypt(pt)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fx.Entries = append(fx.Entries, entry{Name: name, Plaintext: pt, Ciphertext: ct})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(fx); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func make500() []byte {
+	b := make([]byte, 500)
+	for i := range b {
+		b[i] = byte('a' + i%26)
+	}
+	return b
+}
+EOF
+
+echo "Generating Go ciphertext fixture ..."
+(cd "$repo_root" && go run "$gen_dir/main.go") > "$out_file"
+
+echo "Wrote $out_file"

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -17,8 +17,11 @@
  */
 import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
 
+import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
+import { SecretService } from "../encryption/encryption.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
+import { RunnerAuthService } from "../runnerauth/runnerauth.js";
 import { SqliteStore } from "../store/sqlite/store.js";
 import type { Store } from "../store/interface.js";
 import { HealthState, registerHealthService } from "../transport/health.js";
@@ -31,6 +34,12 @@ export interface ComposedServer {
   healthState: HealthState;
   /** The persistence layer (exposed for tests; domain code gets it injected). */
   store: Store;
+  /**
+   * The runner-token service (exposed for its future consumers' wiring —
+   * the platform exchange RPC and the executioncontext decrypt lane land
+   * with their own sub-projects — and for boot tests).
+   */
+  runnerAuthService: RunnerAuthService;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
   start(): Promise<number>;
   /** NOT_SERVING first, stop background work, drain connections. */
@@ -58,6 +67,31 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // identity seam deliberately is not.
   const store: Store = SqliteStore.open(config.dbPath, logger);
 
+  // Stage: keys — the ratified fail-loud boot ASYMMETRY (D2 cross-domain
+  // invariants; Go server.go:277-293):
+  //
+  //   - Encryption key failure → WARN and continue with a keyless
+  //     pass-through service. Plaintext at rest is tolerable (the write
+  //     steps WARN per request, oss#394); refusing to boot over it is not.
+  //   - Runner-token key failure → FATAL (throw). The EC read RPCs redact
+  //     by default, so a server that cannot mint runner tokens would hand
+  //     every execution redaction markers instead of its secrets — the
+  //     exact silent-junk failure the oss#405 fail-loud doctrine forbids.
+  //     (Its consumers — the platform exchange RPC, the EC decrypt lane —
+  //     arrive with their sub-projects; the boot posture is wired now so
+  //     their wiring PRs never restructure boot.)
+  let secretService: SecretService;
+  try {
+    secretService = SecretService.fromEnv();
+  } catch (error) {
+    logger.warn(
+      "Failed to initialize encryption - secret values will be stored in plaintext",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+    secretService = SecretService.create(undefined);
+  }
+  const runnerAuthService = RunnerAuthService.fromEnv();
+
   // Stage: temporal — seam (execution cluster sub-projects).
 
   // Stage: controllers + routes.
@@ -73,6 +107,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     routes: (router) => {
       registerHealthService(router, healthState);
       registerOrganizationServices(router, { store, logger });
+      registerEnvironmentServices(router, { store, logger, secretService });
     },
     interceptors: buildInterceptorChain(logger),
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
@@ -82,6 +117,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   return {
     healthState,
     store,
+    runnerAuthService,
 
     async start(): Promise<number> {
       // Wiring complete → SERVING → background refresh → bind. The port

--- a/backend/services/stigmer-server-ts/src/domain/environment/__tests__/environment.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/__tests__/environment.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Pins the environment domain against Go's environment_controller_test.go
+ * + environment_encryption_test.go + update_visibility_test.go — through
+ * the REAL stack: a composed server on an ephemeral port, a native gRPC
+ * client, the full interceptor chain.
+ *
+ * The load-bearing pins the conformance suite CANNOT cover (it is a black
+ * box; these need direct store access or key control):
+ *   - secrets rest as enc:v1: CIPHERTEXT in the store, never plaintext;
+ *   - the marker round-trip re-persists the IDENTICAL ciphertext (no
+ *     double encryption — the sentinels→encrypt ordering proof);
+ *   - the keyless WARN-degrade path (invalid explicit key config) stores
+ *     plaintext, still redacts on read, and reveal of a stranded
+ *     ciphertext row fails LOUD (Internal), never returns junk.
+ *
+ * Keys are injected via env (vi.stubEnv) so the ladder short-circuits
+ * before its file steps — the real ~/.stigmer is never touched (DD-002).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { EnvironmentCommandController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/command_pb";
+import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { ENCRYPTED_PREFIX, isCiphertextShaped } from "../../../encryption/encryption.js";
+import { REDACTED_MARKER } from "../constants.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const TEST_KEY_B64 = Buffer.alloc(32, 7).toString("base64");
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "Environment";
+const ORG = "acme";
+
+type CommandClient = Client<typeof EnvironmentCommandController>;
+type QueryClient = Client<typeof EnvironmentQueryController>;
+
+interface TestServer {
+  server: ComposedServer;
+  command: CommandClient;
+  query: QueryClient;
+  dir: string;
+}
+
+async function startServer(env: Record<string, string>): Promise<TestServer> {
+  const dir = mkdtempSync(path.join(tmpdir(), "env-domain-test-"));
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+  const server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  return {
+    server,
+    command: createClient(EnvironmentCommandController, transport),
+    query: createClient(EnvironmentQueryController, transport),
+    dir,
+  };
+}
+
+async function stopServer(ts: TestServer): Promise<void> {
+  await ts.server.shutdown();
+  rmSync(ts.dir, { recursive: true, force: true });
+}
+
+let counter = 0;
+function envInput(overrides?: {
+  name?: string;
+  org?: string;
+  labels?: Record<string, string>;
+  data?: Record<string, { value: string; isSecret?: boolean; description?: string }>;
+}) {
+  counter += 1;
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      name: overrides?.name ?? `Env ${counter}`,
+      org: overrides?.org ?? ORG,
+      labels: overrides?.labels ?? {},
+    },
+    spec: {
+      description: "created by the domain test",
+      data: Object.fromEntries(
+        Object.entries(overrides?.data ?? {}).map(([k, v]) => [
+          k,
+          { value: v.value, isSecret: v.isSecret ?? false, description: v.description ?? "" },
+        ]),
+      ),
+    },
+  };
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Encryption-enabled server (the production shape).
+// ---------------------------------------------------------------------------
+
+describe("environment domain (encryption enabled)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({
+      STIGMER_ENCRYPTION_KEY: TEST_KEY_B64,
+      STIGMER_RUNNER_TOKEN_KEY: Buffer.alloc(32, 8).toString("base64"),
+    });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+    vi.unstubAllEnvs();
+  });
+
+  describe("create + redaction doctrine", () => {
+    it("mints an env_ id, redacts secrets in the response, and leaves non-secrets readable", async () => {
+      const created = await ts.command.create(
+        envInput({
+          data: {
+            API_KEY: { value: "sk-secret-1", isSecret: true, description: "the key" },
+            REGION: { value: "us-east-1" },
+          },
+        }),
+      );
+      expect(created.metadata?.id).toMatch(/^env_[0-9a-z]{26}$/);
+      expect(created.spec?.data["API_KEY"]?.value).toBe(REDACTED_MARKER);
+      expect(created.spec?.data["API_KEY"]?.isSecret).toBe(true);
+      expect(created.spec?.data["API_KEY"]?.description).toBe("the key");
+      expect(created.spec?.data["REGION"]?.value).toBe("us-east-1");
+    });
+
+    it("stores enc:v1: CIPHERTEXT at rest — never the plaintext, never the marker", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { TOKEN: { value: "super-secret", isSecret: true } } }),
+      );
+      const stored = await ts.server.store.getResource(
+        ApiResourceKind.environment,
+        created.metadata?.id ?? "",
+        EnvironmentSchema,
+      );
+      const atRest = stored.spec?.data["TOKEN"]?.value ?? "";
+      expect(isCiphertextShaped(atRest)).toBe(true);
+      expect(atRest).not.toContain("super-secret");
+    });
+
+    it("leaves an EMPTY secret declaration empty — no false marker", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { PENDING: { value: "", isSecret: true } } }),
+      );
+      expect(created.spec?.data["PENDING"]?.value).toBe("");
+    });
+  });
+
+  describe("getSecretValue (the reveal path)", () => {
+    it("reveals the decrypted plaintext with is_secret and description intact", async () => {
+      const created = await ts.command.create(
+        envInput({
+          data: { DB_PASS: { value: "p@ss w0rd", isSecret: true, description: "db" } },
+        }),
+      );
+      const revealed = await ts.query.getSecretValue({
+        environmentId: created.metadata?.id ?? "",
+        key: "DB_PASS",
+      });
+      expect(revealed.value).toBe("p@ss w0rd");
+      expect(revealed.isSecret).toBe(true);
+      expect(revealed.description).toBe("db");
+    });
+
+    it("returns a non-secret value as-is", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { REGION: { value: "eu-west-1" } } }),
+      );
+      const value = await ts.query.getSecretValue({
+        environmentId: created.metadata?.id ?? "",
+        key: "REGION",
+      });
+      expect(value.value).toBe("eu-west-1");
+      expect(value.isSecret).toBe(false);
+    });
+
+    it("answers NotFound with the pinned copy for a missing key", async () => {
+      const created = await ts.command.create(envInput());
+      const error = await grpcError(() =>
+        ts.query.getSecretValue({
+          environmentId: created.metadata?.id ?? "",
+          key: "GHOST",
+        }),
+      );
+      expect(error.code).toBe(Code.NotFound);
+      expect(error.rawMessage).toBe("environment key not found: GHOST");
+    });
+  });
+
+  describe("the marker round-trip (sentinels → encrypt ordering)", () => {
+    it("update with the marker preserves the stored secret — ciphertext IDENTICAL (no double encryption)", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { API_KEY: { value: "keep-me", isSecret: true } } }),
+      );
+      const id = created.metadata?.id ?? "";
+      const before = await ts.server.store.getResource(
+        ApiResourceKind.environment,
+        id,
+        EnvironmentSchema,
+      );
+      const cipherBefore = before.spec?.data["API_KEY"]?.value ?? "";
+
+      // Full-resource update echoing the redacted read back (the client
+      // round-trip shape), plus a spec change.
+      const updated = await ts.command.update(
+        create(EnvironmentSchema, {
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: created.metadata,
+          spec: {
+            description: "updated description",
+            data: {
+              API_KEY: { value: REDACTED_MARKER, isSecret: true, description: "" },
+            },
+          },
+        }),
+      );
+      expect(updated.spec?.data["API_KEY"]?.value).toBe(REDACTED_MARKER);
+
+      const after = await ts.server.store.getResource(
+        ApiResourceKind.environment,
+        id,
+        EnvironmentSchema,
+      );
+      expect(after.spec?.data["API_KEY"]?.value).toBe(cipherBefore);
+
+      const revealed = await ts.query.getSecretValue({ environmentId: id, key: "API_KEY" });
+      expect(revealed.value).toBe("keep-me");
+    });
+
+    it("rejects the marker on create with the pinned copy (nothing to preserve)", async () => {
+      const error = await grpcError(() =>
+        ts.command.create(
+          envInput({ data: { API_KEY: { value: REDACTED_MARKER, isSecret: true } } }),
+        ),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+      expect(error.rawMessage).toBe(
+        "variable 'API_KEY': cannot use the redaction marker as a secret value",
+      );
+    });
+
+    it("rejects the marker on update for a key that had no prior secret", async () => {
+      const created = await ts.command.create(envInput());
+      const error = await grpcError(() =>
+        ts.command.update(
+          create(EnvironmentSchema, {
+            apiVersion: API_VERSION,
+            kind: KIND,
+            metadata: created.metadata,
+            spec: {
+              data: { NEW_KEY: { value: REDACTED_MARKER, isSecret: true } },
+            },
+          }),
+        ),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+      expect(error.rawMessage).toBe(
+        "variable 'NEW_KEY': cannot use the redaction marker as a secret value",
+      );
+    });
+  });
+
+  describe("forged-ciphertext rejection (oss#395)", () => {
+    const FORGED = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
+    const PINNED_MESSAGE =
+      "variable 'EVIL' must be plaintext — values carrying the 'enc:' " +
+      "encryption prefix are not accepted from clients";
+
+    it("rejects a ciphertext-shaped SECRET on create, any version prefix", async () => {
+      for (const forged of [FORGED, "enc:v2:whatever"]) {
+        const error = await grpcError(() =>
+          ts.command.create(
+            envInput({ data: { EVIL: { value: forged, isSecret: true } } }),
+          ),
+        );
+        expect(error.code).toBe(Code.InvalidArgument);
+        expect(error.rawMessage).toBe(PINNED_MESSAGE);
+      }
+    });
+
+    it("rejects a ciphertext-shaped secret on updateVariables", async () => {
+      const created = await ts.command.create(envInput());
+      const error = await grpcError(() =>
+        ts.command.updateVariables({
+          environmentId: created.metadata?.id ?? "",
+          variables: { EVIL: { value: FORGED, isSecret: true, description: "" } },
+        }),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+      expect(error.rawMessage).toBe(PINNED_MESSAGE);
+    });
+
+    it("passes a ciphertext-shaped NON-secret through — the pinned exemption (inert value)", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { DOC_EXAMPLE: { value: FORGED } } }),
+      );
+      expect(created.spec?.data["DOC_EXAMPLE"]?.value).toBe(FORGED);
+    });
+  });
+
+  describe("personal-environment uniqueness (per org, create-only)", () => {
+    const personal = { "stigmer.ai/personal": "true" };
+
+    it("allows one personal env per org, rejects the second with the pinned copy", async () => {
+      const first = await ts.command.create(
+        envInput({ org: "personal-org-a", labels: personal }),
+      );
+      const error = await grpcError(() =>
+        ts.command.create(envInput({ org: "personal-org-a", labels: personal })),
+      );
+      expect(error.code).toBe(Code.AlreadyExists);
+      expect(error.rawMessage).toBe(
+        `a personal environment already exists for this organization: ${first.metadata?.id}`,
+      );
+    });
+
+    it("scopes the check per org — another org gets its own personal env", async () => {
+      await ts.command.create(envInput({ org: "personal-org-b", labels: personal }));
+      const other = await ts.command.create(
+        envInput({ org: "personal-org-c", labels: personal }),
+      );
+      expect(other.metadata?.id).toMatch(/^env_/);
+    });
+
+    it("update of the personal env never matches itself (create-only check)", async () => {
+      const created = await ts.command.create(
+        envInput({ org: "personal-org-d", labels: personal }),
+      );
+      const updated = await ts.command.update(
+        create(EnvironmentSchema, {
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: created.metadata,
+          spec: { description: "still unique" },
+        }),
+      );
+      expect(updated.spec?.description).toBe("still unique");
+    });
+  });
+
+  describe("updateVisibility (ceiling: org; share restrictions)", () => {
+    it("widens a normal environment to org and stamps the status audit", async () => {
+      const created = await ts.command.create(envInput());
+      const updated = await ts.command.updateVisibility({
+        resourceId: created.metadata?.id ?? "",
+        visibility: ApiResourceVisibility.visibility_org,
+      });
+      expect(updated.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+      expect(updated.status?.audit?.statusAudit?.event).toBe("updated");
+    });
+
+    it("rejects org sharing of a personal env with the pinned FailedPrecondition copy", async () => {
+      const created = await ts.command.create(
+        envInput({ org: "vis-org-a", labels: { "stigmer.ai/personal": "true" } }),
+      );
+      const error = await grpcError(() =>
+        ts.command.updateVisibility({
+          resourceId: created.metadata?.id ?? "",
+          visibility: ApiResourceVisibility.visibility_org,
+        }),
+      );
+      expect(error.code).toBe(Code.FailedPrecondition);
+      expect(error.rawMessage).toBe(
+        "personal environments cannot be shared with the organization - " +
+          "create a dedicated environment with only the credentials the agent needs",
+      );
+    });
+
+    it("rejects org sharing of an OAuth-managed env", async () => {
+      const created = await ts.command.create(
+        envInput({ labels: { "stigmer.ai/managed": "true" } }),
+      );
+      const error = await grpcError(() =>
+        ts.command.updateVisibility({
+          resourceId: created.metadata?.id ?? "",
+          visibility: ApiResourceVisibility.visibility_org,
+        }),
+      );
+      expect(error.code).toBe(Code.FailedPrecondition);
+      expect(error.rawMessage).toBe(
+        "OAuth-managed environments cannot be shared with the organization - " +
+          "OAuth tokens are per-user credentials",
+      );
+    });
+
+    it("always allows restoring a share-restricted env to private (only widening is gated)", async () => {
+      const created = await ts.command.create(
+        envInput({ org: "vis-org-b", labels: { "stigmer.ai/personal": "true" } }),
+      );
+      const restored = await ts.command.updateVisibility({
+        resourceId: created.metadata?.id ?? "",
+        visibility: ApiResourceVisibility.visibility_private,
+      });
+      expect(restored.metadata?.visibility).toBe(
+        ApiResourceVisibility.visibility_private,
+      );
+    });
+
+    it("NOT_FOUND wins over a bad level for an unknown id (cross-edition precedence)", async () => {
+      const error = await grpcError(() =>
+        ts.command.updateVisibility({
+          resourceId: "env_does_not_exist",
+          visibility: ApiResourceVisibility.visibility_public,
+        }),
+      );
+      expect(error.code).toBe(Code.NotFound);
+    });
+  });
+
+  describe("incremental variable management", () => {
+    it("updateVariables merges: request keys overwrite, absent keys preserved, secrets encrypted", async () => {
+      const created = await ts.command.create(
+        envInput({
+          data: {
+            KEEP: { value: "kept" },
+            OVERWRITE: { value: "old" },
+          },
+        }),
+      );
+      const id = created.metadata?.id ?? "";
+      const updated = await ts.command.updateVariables({
+        environmentId: id,
+        variables: {
+          OVERWRITE: { value: "new", isSecret: false, description: "" },
+          ADDED_SECRET: { value: "shh", isSecret: true, description: "" },
+        },
+      });
+      expect(updated.spec?.data["KEEP"]?.value).toBe("kept");
+      expect(updated.spec?.data["OVERWRITE"]?.value).toBe("new");
+      expect(updated.spec?.data["ADDED_SECRET"]?.value).toBe(REDACTED_MARKER);
+
+      const stored = await ts.server.store.getResource(
+        ApiResourceKind.environment,
+        id,
+        EnvironmentSchema,
+      );
+      expect(
+        (stored.spec?.data["ADDED_SECRET"]?.value ?? "").startsWith(ENCRYPTED_PREFIX),
+      ).toBe(true);
+    });
+
+    it("updateVariables preserves an existing secret sent back as the marker", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { TOKEN: { value: "original", isSecret: true } } }),
+      );
+      const id = created.metadata?.id ?? "";
+      await ts.command.updateVariables({
+        environmentId: id,
+        variables: { TOKEN: { value: REDACTED_MARKER, isSecret: true, description: "" } },
+      });
+      const revealed = await ts.query.getSecretValue({ environmentId: id, key: "TOKEN" });
+      expect(revealed.value).toBe("original");
+    });
+
+    it("removeVariables deletes named keys and silently ignores unknown ones", async () => {
+      const created = await ts.command.create(
+        envInput({ data: { A: { value: "1" }, B: { value: "2" } } }),
+      );
+      const updated = await ts.command.removeVariables({
+        environmentId: created.metadata?.id ?? "",
+        keys: ["A", "GHOST"],
+      });
+      expect(updated.spec?.data["A"]).toBeUndefined();
+      expect(updated.spec?.data["B"]?.value).toBe("2");
+    });
+
+    it("rejects an empty removeVariables key list at the protovalidate boundary", async () => {
+      const created = await ts.command.create(envInput());
+      const error = await grpcError(() =>
+        ts.command.removeVariables({
+          environmentId: created.metadata?.id ?? "",
+          keys: [],
+        }),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+    });
+
+    it("answers NotFound for variable operations on an unknown environment", async () => {
+      const error = await grpcError(() =>
+        ts.command.updateVariables({
+          environmentId: "env_ghost",
+          variables: { X: { value: "1", isSecret: false, description: "" } },
+        }),
+      );
+      expect(error.code).toBe(Code.NotFound);
+      expect(error.rawMessage).toBe("environment not found: env_ghost");
+    });
+  });
+
+  describe("list", () => {
+    it("filters by org + AND-labels, redacts every item, sorts newest first", async () => {
+      const org = "list-org";
+      const a = await ts.command.create(
+        envInput({
+          org,
+          labels: { tier: "prod" },
+          data: { S: { value: "secret", isSecret: true } },
+        }),
+      );
+      const b = await ts.command.create(envInput({ org, labels: { tier: "prod", extra: "y" } }));
+      await ts.command.create(envInput({ org, labels: { tier: "dev" } }));
+      await ts.command.create(envInput({ org: "other-org", labels: { tier: "prod" } }));
+
+      const all = await ts.query.list({ org });
+      expect(all.totalCount).toBe(3);
+      // Newest first: b was created after a.
+      const ids = all.items.map((e) => e.metadata?.id);
+      expect(ids.indexOf(b.metadata?.id ?? "")).toBeLessThan(
+        ids.indexOf(a.metadata?.id ?? ""),
+      );
+      const withSecret = all.items.find((e) => e.metadata?.id === a.metadata?.id);
+      expect(withSecret?.spec?.data["S"]?.value).toBe(REDACTED_MARKER);
+
+      const prodOnly = await ts.query.list({ org, labels: { tier: "prod" } });
+      expect(prodOnly.totalCount).toBe(2);
+
+      const narrow = await ts.query.list({ org, labels: { tier: "prod", extra: "y" } });
+      expect(narrow.totalCount).toBe(1);
+      expect(narrow.items[0]?.metadata?.id).toBe(b.metadata?.id);
+    });
+  });
+
+  describe("get / getByReference / delete return redacted resources", () => {
+    it("get and getByReference redact; delete returns the redacted parting copy", async () => {
+      const created = await ts.command.create(
+        envInput({ org: "read-org", data: { K: { value: "v", isSecret: true } } }),
+      );
+      const id = created.metadata?.id ?? "";
+
+      const got = await ts.query.get({ value: id });
+      expect(got.spec?.data["K"]?.value).toBe(REDACTED_MARKER);
+
+      const byRef = await ts.query.getByReference({
+        slug: created.metadata?.slug ?? "",
+        org: "read-org",
+        kind: ApiResourceKind.environment,
+      });
+      expect(byRef.metadata?.id).toBe(id);
+      expect(byRef.spec?.data["K"]?.value).toBe(REDACTED_MARKER);
+
+      const deleted = await ts.command.delete({ resourceId: id });
+      expect(deleted.spec?.data["K"]?.value).toBe(REDACTED_MARKER);
+
+      const error = await grpcError(() => ts.query.get({ value: id }));
+      expect(error.code).toBe(Code.NotFound);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyless server (the WARN-degrade path): an INVALID explicit key makes
+// compose fall back to the disabled pass-through service.
+// ---------------------------------------------------------------------------
+
+describe("environment domain (encryption degraded to plaintext)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({
+      STIGMER_ENCRYPTION_KEY: "not!!valid@@base64",
+      STIGMER_RUNNER_TOKEN_KEY: Buffer.alloc(32, 8).toString("base64"),
+    });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+    vi.unstubAllEnvs();
+  });
+
+  it("stores secrets as PLAINTEXT (degraded), still redacts on read, reveal works", async () => {
+    const created = await ts.command.create(
+      envInput({ data: { S: { value: "plain-secret", isSecret: true } } }),
+    );
+    const id = created.metadata?.id ?? "";
+    expect(created.spec?.data["S"]?.value).toBe(REDACTED_MARKER);
+
+    const stored = await ts.server.store.getResource(
+      ApiResourceKind.environment,
+      id,
+      EnvironmentSchema,
+    );
+    expect(stored.spec?.data["S"]?.value).toBe("plain-secret");
+
+    const revealed = await ts.query.getSecretValue({ environmentId: id, key: "S" });
+    expect(revealed.value).toBe("plain-secret");
+  });
+
+  it("still rejects forged enc:v<N>: input — the guard is unconditional on keyless deployments", async () => {
+    const error = await grpcError(() =>
+      ts.command.create(
+        envInput({ data: { EVIL: { value: "enc:v1:Zm9yZ2Vk", isSecret: true } } }),
+      ),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+  });
+
+  it("fails LOUD (Internal) revealing a stranded ciphertext row — never returns ciphertext", async () => {
+    // Seed a row holding real ciphertext (as if the key file were lost).
+    const seeded = create(EnvironmentSchema, {
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: { id: "env_stranded", name: "Stranded", slug: "stranded", org: ORG },
+      spec: {
+        data: {
+          LOST: { value: "enc:v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", isSecret: true },
+        },
+      },
+    });
+    await ts.server.store.saveResource(
+      ApiResourceKind.environment,
+      "env_stranded",
+      EnvironmentSchema,
+      seeded,
+    );
+
+    const error = await grpcError(() =>
+      ts.query.getSecretValue({ environmentId: "env_stranded", key: "LOST" }),
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe("failed to decrypt secret value");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/environment/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/constants.ts
@@ -1,0 +1,63 @@
+/**
+ * Environment domain constants — the byte-pinned wire copy and label
+ * contract shared with the Go server and the cloud edition. Every string
+ * here is asserted by clients, the conformance suite, or the cross-edition
+ * error contract; none is editable without an owner-ratified wire change.
+ */
+
+/**
+ * The sentinel replacing every non-empty is_secret value at every
+ * Environment-returning boundary — Go steps.RedactedMarker, pinned by the
+ * conformance suite and mirrored by the cloud edition. A client sending it
+ * BACK on a write means "keep the existing secret" (the round-trip
+ * contract; see preserveRedactedSecrets).
+ */
+export const REDACTED_MARKER = "***REDACTED***";
+
+/** Label marking a user's personal environment — Go personalLabelKey. */
+export const PERSONAL_LABEL_KEY = "stigmer.ai/personal";
+export const PERSONAL_LABEL_VALUE = "true";
+
+/** Label marking a system-created OAuth-token holder — Go managedLabelKey. */
+export const MANAGED_LABEL_KEY = "stigmer.ai/managed";
+export const MANAGED_LABEL_VALUE = "true";
+
+/**
+ * InvalidArgument copy for a redaction marker with nothing to preserve
+ * (create, or an update key that had no prior secret) — Go
+ * preserve_redacted_secrets.go, byte-pinned.
+ */
+export function markerRejectionMessage(key: string): string {
+  return `variable '${key}': cannot use the redaction marker as a secret value`;
+}
+
+/**
+ * InvalidArgument copy for client-supplied enc:v<N>: input (oss#395) — Go
+ * preserve_redacted_secrets.go / merge_variables_and_persist.go, byte-pinned.
+ */
+export function forgedCiphertextMessage(key: string): string {
+  return (
+    `variable '${key}' must be plaintext — values carrying the 'enc:' ` +
+    "encryption prefix are not accepted from clients"
+  );
+}
+
+/**
+ * AlreadyExists copy for a second personal environment in an org — Go
+ * enforce_personal_uniqueness.go, byte-pinned (regression guard for
+ * stigmer#193 in the conformance suite).
+ */
+export function personalEnvironmentExistsMessage(existingId: string): string {
+  return `a personal environment already exists for this organization: ${existingId}`;
+}
+
+/**
+ * FailedPrecondition reasons for share-restricted environments — Go
+ * share_restricted.go, byte-pinned; both editions enforce identically.
+ */
+export const PERSONAL_SHARE_RESTRICTION =
+  "personal environments cannot be shared with the organization - " +
+  "create a dedicated environment with only the credentials the agent needs";
+export const MANAGED_SHARE_RESTRICTION =
+  "OAuth-managed environments cannot be shared with the organization - " +
+  "OAuth tokens are per-user credentials";

--- a/backend/services/stigmer-server-ts/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/controller.ts
@@ -1,0 +1,677 @@
+/**
+ * Environment controller — ports pkg/domain/environment (command + query
+ * sides): the first secret-bearing domain, executing the redaction
+ * doctrine end-to-end. Environments provide variable bindings and
+ * configuration context for agent executions; is_secret values rest
+ * encrypted (enc:v1:, oss#405), leave the server as ***REDACTED***
+ * markers, and are revealed only through getSecretValue (single-key by
+ * design: limited blast radius, per-key audit, the industry "reveal" UX).
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by environment.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/environment.test.ts.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies,
+ * FGA-tuple, and Publish steps (no multi-tenant auth, IAM/FGA, or event
+ * publishing here); the visibility ceiling (org — secrets never resolve
+ * across the org boundary) and share restrictions run in BOTH editions
+ * from the same proto config, keeping the error contract identical.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+
+import { EnvironmentCommandController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/command_pb";
+import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { EnvironmentListSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import type {
+  EnvironmentList,
+  EnvironmentSecretValueInput,
+  ListEnvironmentsRequest,
+  RemoveEnvironmentVariablesRequest,
+  UpdateEnvironmentVariablesRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import type { EnvironmentValue } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type {
+  ApiResourceDeleteInput,
+  ApiResourceId,
+  ApiResourceReference,
+  UpdateVisibilityInput,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import {
+  failedPreconditionError,
+  internalError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  RESOURCE_ID_KEY,
+  newDeleteResourceStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import {
+  newValidateVisibilityStep,
+  newValidateVisibilityUpdateStep,
+} from "../../pipeline/steps/validate-visibility.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import { redactEnvironmentSecrets, shareRestrictionReason } from "./redact.js";
+import { environmentSearchExtractor } from "./search-extractor.js";
+import {
+  SECRET_VALUE_KEY,
+  UPDATED_ENVIRONMENT_KEY,
+  newEncryptSecretValuesStep,
+  newEnforcePersonalUniquenessStep,
+  newExtractAndDecryptSingleKeyStep,
+  newLoadEnvironmentByIdStep,
+  newMergeVariablesAndPersistStep,
+  newPreserveRedactedSecretsStep,
+  newRemoveVariableKeysAndPersistStep,
+} from "./steps.js";
+
+export interface EnvironmentControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly secretService: SecretService;
+}
+
+/** Registers both environment services on the router (routes stage). */
+export function registerEnvironmentServices(
+  router: ConnectRouter,
+  deps: EnvironmentControllerDeps,
+): void {
+  router.service(EnvironmentCommandController, {
+    apply: (env, ctx) => apply(deps, env, ctx),
+    create: (env, ctx) => createEnvironment(deps, env, ctx),
+    update: (env, ctx) => update(deps, env, ctx),
+    updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
+    delete: (input, ctx) => deleteEnvironment(deps, input, ctx),
+    updateVariables: (req, ctx) => updateVariables(deps, req, ctx),
+    removeVariables: (req, ctx) => removeVariables(deps, req, ctx),
+  });
+  router.service(EnvironmentQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getSecretValue: (input, ctx) => getSecretValue(deps, input, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. Redaction runs AFTER
+ * Persist: the store keeps ciphertext, the response carries markers
+ * (never ciphertext — clients cannot round-trip it past the enc: prefix
+ * guard, and it is server-internal by design).
+ */
+async function createEnvironment(
+  deps: EnvironmentControllerDeps,
+  env: Environment,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(EnvironmentSchema, env, kindOf(ctx));
+  await newPipeline<typeof EnvironmentSchema>("environment-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newEnforcePersonalUniquenessStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newPreserveRedactedSecretsStep())
+    .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  redactEnvironmentSecrets(reqCtx.newState);
+  return reqCtx.newState;
+}
+
+/** Update — chain per Go buildUpdatePipeline; redact after persist. */
+async function update(
+  deps: EnvironmentControllerDeps,
+  env: Environment,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(EnvironmentSchema, env, kindOf(ctx));
+  await newPipeline<typeof EnvironmentSchema>("environment-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newPreserveRedactedSecretsStep())
+    .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  redactEnvironmentSecrets(reqCtx.newState);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
+ * existence, then delegates to Create or Update with the ORIGINAL request
+ * message (Go delegates `environment`, not the pipeline's mutated clone).
+ */
+async function apply(
+  deps: EnvironmentControllerDeps,
+  env: Environment,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(EnvironmentSchema, env, kindOf(ctx));
+  await newPipeline<typeof EnvironmentSchema>("environment-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate
+    ? createEnvironment(deps, env, ctx)
+    : update(deps, env, ctx);
+}
+
+/**
+ * Delete — returns the deleted environment REDACTED (the audit-trail
+ * convention; even a parting response never carries secrets). The id is
+ * seeded into context manually because ApiResourceDeleteInput carries
+ * resource_id, not the `value` field ExtractResourceId expects (Go does
+ * the same manual seed).
+ */
+async function deleteEnvironment(
+  deps: EnvironmentControllerDeps,
+  input: ApiResourceDeleteInput,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(
+    EnvironmentCommandController.method.delete.input,
+    input,
+    kindOf(ctx),
+  );
+  reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
+  await newPipeline<typeof EnvironmentCommandController.method.delete.input>(
+    "environment-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, EnvironmentSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted environment not found in context"),
+      "deleted environment not found in context",
+    );
+  }
+  const env = deleted as Environment;
+  redactEnvironmentSecrets(env);
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// updateVisibility — Go update_visibility.go: a targeted metadata update
+// (only metadata.visibility changes; spec/status untouched). Environments
+// cap out at org visibility (the kind's VisibilityConfig — secret values
+// must never be resolvable across the org boundary); personal and
+// OAuth-managed environments reject org sharing entirely.
+// ---------------------------------------------------------------------------
+
+const UPDATE_VISIBILITY_ENVIRONMENT_KEY = "updateVisibilityEnvironment";
+
+type UpdateVisibilityDesc =
+  typeof EnvironmentCommandController.method.updateVisibility.input;
+
+async function updateVisibility(
+  deps: EnvironmentControllerDeps,
+  input: UpdateVisibilityInput,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(
+    EnvironmentCommandController.method.updateVisibility.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<UpdateVisibilityDesc>(
+    "environment-update-visibility",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadEnvironmentForVisibilityUpdateStep(deps.store))
+    // After load, per the cross-edition error precedence: unknown id +
+    // bad level = NOT_FOUND on both editions.
+    .addStep(newValidateVisibilityUpdateStep())
+    .addStep(newValidateEnvironmentShareRestrictionStep())
+    .addStep(newSetEnvironmentVisibilityStep())
+    .addStep(newPersistEnvironmentForVisibilityUpdateStep(deps.store))
+    .addStep(newIndexEnvironmentAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const env = reqCtx.get(UPDATE_VISIBILITY_ENVIRONMENT_KEY) as Environment;
+  redactEnvironmentSecrets(env);
+  return env;
+}
+
+/** Loads the environment by resource_id; ANY load failure → NotFound. */
+function newLoadEnvironmentForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "LoadEnvironmentForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const input = ctx.input;
+      let env: Environment;
+      try {
+        env = await store.getResource(
+          ctx.apiResourceKind,
+          input.resourceId,
+          EnvironmentSchema,
+        );
+      } catch {
+        throw notFoundError("environment", input.resourceId);
+      }
+      ctx.set(UPDATE_VISIBILITY_ENVIRONMENT_KEY, env);
+    },
+  };
+}
+
+/**
+ * Rejects org sharing on personal and OAuth-managed environments BEFORE
+ * any state changes. Only gates the transitions that WIDEN access —
+ * restoring a share-restricted environment to private must always be
+ * possible. Level support is validated by the shared
+ * ValidateVisibilityUpdate composed just before this one.
+ */
+function newValidateEnvironmentShareRestrictionStep(): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "ValidateEnvironmentShareRestriction",
+    execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
+      if (ctx.input.visibility !== ApiResourceVisibility.visibility_org) {
+        return;
+      }
+      const env = ctx.get(UPDATE_VISIBILITY_ENVIRONMENT_KEY) as Environment;
+      const reason = shareRestrictionReason(env.metadata);
+      if (reason !== "") {
+        throw failedPreconditionError(reason);
+      }
+    },
+  };
+}
+
+/** Sets metadata.visibility and stamps the StatusAudit slot (#540). */
+function newSetEnvironmentVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "SetVisibility",
+    execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
+      const env = ctx.get(UPDATE_VISIBILITY_ENVIRONMENT_KEY) as Environment;
+      if (env.metadata !== undefined) {
+        env.metadata.visibility = ctx.input.visibility;
+      }
+      // Go wraps a stamping failure as a PLAIN error (not grpclib) — the
+      // wire then carries the sanitized "internal server error", exactly
+      // what the pipeline's non-Connect fallback produces here.
+      setAuditFieldsForUpdate(EnvironmentSchema, env, "status_audit");
+    },
+  };
+}
+
+/** Persists the visibility change. */
+function newPersistEnvironmentForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "PersistEnvironmentForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const env = ctx.get(UPDATE_VISIBILITY_ENVIRONMENT_KEY) as Environment;
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          env.metadata?.id ?? "",
+          EnvironmentSchema,
+          env,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to save environment");
+      }
+    },
+  };
+}
+
+/**
+ * Re-indexes after the visibility change (visibility is an indexed
+ * field). Domain-local because the shared IndexSearch reads newState,
+ * which is the UpdateVisibilityInput here, not the environment.
+ * Best-effort by contract, as in Go.
+ */
+function newIndexEnvironmentAfterVisibilityUpdateStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "IndexEnvironmentAfterVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const env = ctx.get(UPDATE_VISIBILITY_ENVIRONMENT_KEY) as Environment;
+      const entry = environmentSearchExtractor.getSearchIndexEntry(env);
+      if (entry === undefined) {
+        logger.warn(
+          "IndexEnvironmentAfterVisibilityUpdate: extractor returned nil, skipping",
+          { id: env.metadata?.id ?? "" },
+        );
+        return;
+      }
+      try {
+        await store.upsertSearchIndex(
+          ctx.apiResourceKind,
+          env.metadata?.id ?? "",
+          entry,
+        );
+      } catch (error) {
+        logger.warn(
+          "IndexEnvironmentAfterVisibilityUpdate: failed (best-effort)",
+          {
+            id: env.metadata?.id ?? "",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    },
+  };
+}
+
+/**
+ * UpdateVariables — server-side merge: request keys overwrite, absent
+ * keys are preserved. Avoids the read-modify-write secret destruction
+ * problem inherent in the full-resource Update RPC.
+ */
+async function updateVariables(
+  deps: EnvironmentControllerDeps,
+  req: UpdateEnvironmentVariablesRequest,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(
+    EnvironmentCommandController.method.updateVariables.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof EnvironmentCommandController.method.updateVariables.input>(
+    "environment-update-variables",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadEnvironmentByIdStep(deps.store))
+    .addStep(
+      newMergeVariablesAndPersistStep(deps.store, deps.secretService, deps.logger),
+    )
+    .build()
+    .execute(reqCtx);
+
+  const updated = reqCtx.get(UPDATED_ENVIRONMENT_KEY) as Environment;
+  redactEnvironmentSecrets(updated);
+  return updated;
+}
+
+/** RemoveVariables — named keys deleted; unknown keys silently ignored. */
+async function removeVariables(
+  deps: EnvironmentControllerDeps,
+  req: RemoveEnvironmentVariablesRequest,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(
+    EnvironmentCommandController.method.removeVariables.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof EnvironmentCommandController.method.removeVariables.input>(
+    "environment-remove-variables",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadEnvironmentByIdStep(deps.store))
+    .addStep(newRemoveVariableKeysAndPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const updated = reqCtx.get(UPDATED_ENVIRONMENT_KEY) as Environment;
+  redactEnvironmentSecrets(updated);
+  return updated;
+}
+
+/** Get — LoadTarget by id; the response is redacted (oss#405). */
+async function get(
+  deps: EnvironmentControllerDeps,
+  id: ApiResourceId,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(
+    EnvironmentQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof EnvironmentQueryController.method.get.input>(
+    "environment-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, EnvironmentSchema))
+    .build()
+    .execute(reqCtx);
+  const env = reqCtx.get(TARGET_RESOURCE_KEY) as Environment;
+  redactEnvironmentSecrets(env);
+  return env;
+}
+
+/** GetByReference — slug+org lookup; the response is redacted. */
+async function getByReference(
+  deps: EnvironmentControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<Environment> {
+  const reqCtx = new RequestContext(
+    EnvironmentQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof EnvironmentQueryController.method.getByReference.input>(
+    "environment-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, EnvironmentSchema))
+    .build()
+    .execute(reqCtx);
+  const env = reqCtx.get(TARGET_RESOURCE_KEY) as Environment;
+  redactEnvironmentSecrets(env);
+  return env;
+}
+
+/**
+ * GetSecretValue — the sanctioned single-key reveal path; the ONE
+ * Environment surface that returns an unredacted value.
+ */
+async function getSecretValue(
+  deps: EnvironmentControllerDeps,
+  input: EnvironmentSecretValueInput,
+  ctx: HandlerContext,
+): Promise<EnvironmentValue> {
+  const reqCtx = new RequestContext(
+    EnvironmentQueryController.method.getSecretValue.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof EnvironmentQueryController.method.getSecretValue.input>(
+    "environment-get-secret-value",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadEnvironmentByIdStep(deps.store))
+    .addStep(newExtractAndDecryptSingleKeyStep(deps.secretService, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(SECRET_VALUE_KEY) as EnvironmentValue;
+}
+
+const LIST_RESULT_KEY = "listResult";
+
+/**
+ * List — org + labels filter with per-item redaction. Versus Cloud, OSS
+ * excludes authorization filtering AND pagination (returns all matches),
+ * exactly as Go's list.go records.
+ */
+async function list(
+  deps: EnvironmentControllerDeps,
+  req: ListEnvironmentsRequest,
+  ctx: HandlerContext,
+): Promise<EnvironmentList> {
+  const reqCtx = new RequestContext(
+    EnvironmentQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof EnvironmentQueryController.method.list.input>(
+    "environment-list",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgAndLabelsStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("environment list not found in context"),
+      "environment list not found in context",
+    );
+  }
+  return result as EnvironmentList;
+}
+
+/**
+ * ListByOrgAndLabels — Go list.go's domain step: full scan, malformed
+ * rows skipped, org equality + AND-label filtering, per-item redaction,
+ * sorted by spec-audit created_at descending (seconds then nanos;
+ * timestamped entries before untimestamped ones).
+ */
+function newListByOrgAndLabelsStep(
+  store: Store,
+): PipelineStep<typeof EnvironmentQueryController.method.list.input> {
+  return {
+    name: "ListByOrgAndLabels",
+    async execute(
+      ctx: RequestContext<typeof EnvironmentQueryController.method.list.input>,
+    ): Promise<void> {
+      const { org, labels: filterLabels } = ctx.input;
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ctx.apiResourceKind);
+      } catch (error) {
+        throw internalError(error, "failed to list environments");
+      }
+
+      const environments: Environment[] = [];
+      for (const bytes of rows) {
+        let env: Environment;
+        try {
+          env = fromBinary(EnvironmentSchema, bytes);
+        } catch {
+          continue; // skip malformed rows, as Go does
+        }
+        if ((env.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        if (!matchesAllLabels(env.metadata?.labels ?? {}, filterLabels)) {
+          continue;
+        }
+        redactEnvironmentSecrets(env);
+        environments.push(env);
+      }
+
+      environments.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(EnvironmentListSchema, {
+          totalCount: environments.length,
+          items: environments,
+        }),
+      );
+    },
+  };
+}
+
+/** True when resourceLabels contains every filter entry (empty = all). */
+function matchesAllLabels(
+  resourceLabels: Record<string, string>,
+  filterLabels: Record<string, string>,
+): boolean {
+  return Object.entries(filterLabels).every(
+    ([key, value]) => resourceLabels[key] === value,
+  );
+}
+
+/** Go's sort.Slice comparator: newest first; nil timestamps last. */
+function compareCreatedAtDesc(
+  a: Timestamp | undefined,
+  b: Timestamp | undefined,
+): number {
+  if (a === undefined || b === undefined) {
+    if (a === undefined && b === undefined) {
+      return 0;
+    }
+    return a !== undefined ? -1 : 1;
+  }
+  if (a.seconds !== b.seconds) {
+    return a.seconds > b.seconds ? -1 : 1;
+  }
+  if (a.nanos !== b.nanos) {
+    return a.nanos > b.nanos ? -1 : 1;
+  }
+  return 0;
+}

--- a/backend/services/stigmer-server-ts/src/domain/environment/redact.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/redact.ts
@@ -1,0 +1,75 @@
+/**
+ * Redaction + share-restriction helpers — port
+ * pkg/domain/environment/controller/steps/{redact_secret_values,
+ * share_restricted}.go. Deliberately NOT pipeline steps: redaction runs
+ * post-pipeline at every Environment-returning boundary, and the share
+ * restriction is a predicate the visibility pipeline consumes.
+ */
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { ApiResourceMetadata } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+
+import {
+  MANAGED_LABEL_KEY,
+  MANAGED_LABEL_VALUE,
+  MANAGED_SHARE_RESTRICTION,
+  PERSONAL_LABEL_KEY,
+  PERSONAL_LABEL_VALUE,
+  PERSONAL_SHARE_RESTRICTION,
+  REDACTED_MARKER,
+} from "./constants.js";
+
+/**
+ * Go RedactEnvironmentSecrets: replaces every NON-EMPTY is_secret value
+ * with the marker — called at every controller boundary that returns an
+ * Environment (get, getByReference, list, create, update, updateVariables,
+ * removeVariables, updateVisibility, delete; apply inherits via
+ * delegation). getSecretValue is the sanctioned single-key reveal path and
+ * stays unredacted; server-internal consumers go through the
+ * RuntimeResolutionService, never the RPC surface.
+ *
+ * is_secret and description are preserved so clients know a hidden value
+ * exists; EMPTY secret declarations stay empty (a marker would falsely
+ * signal a stored value). Mutates in place: callers hold either a fresh
+ * store unmarshal (reads) or the already-persisted new state (writes), so
+ * the redaction never reaches the store. Runs strictly AFTER Persist on
+ * write paths.
+ */
+export function redactEnvironmentSecrets(env: Environment | undefined): void {
+  const data = env?.spec?.data;
+  if (data === undefined) {
+    return;
+  }
+  for (const value of Object.values(data)) {
+    if (value.isSecret && value.value !== "") {
+      value.value = REDACTED_MARKER;
+    }
+  }
+}
+
+/**
+ * Go ShareRestrictionReason: why an environment must never leave private
+ * visibility, or "" when no restriction applies.
+ *
+ * Two classes are share-restricted by construction:
+ *   - Personal (stigmer.ai/personal=true): the user's whole credential
+ *     fallback bag — org-sharing it would expose every credential the user
+ *     ever stored, not a deliberately scoped set.
+ *   - Managed (stigmer.ai/managed=true): system-created holders of
+ *     per-user OAuth tokens. Sharing OAuth grants needs its own identity
+ *     and refresh design (tracked follow-up), so it is rejected rather
+ *     than silently half-working.
+ *
+ * Both editions enforce this identically — the error copy is shared.
+ */
+export function shareRestrictionReason(
+  metadata: ApiResourceMetadata | undefined,
+): string {
+  const labels = metadata?.labels ?? {};
+  if (labels[PERSONAL_LABEL_KEY] === PERSONAL_LABEL_VALUE) {
+    return PERSONAL_SHARE_RESTRICTION;
+  }
+  if (labels[MANAGED_LABEL_KEY] === MANAGED_LABEL_VALUE) {
+    return MANAGED_SHARE_RESTRICTION;
+  }
+  return "";
+}

--- a/backend/services/stigmer-server-ts/src/domain/environment/resolution/__tests__/resolution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/resolution/__tests__/resolution.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Pins the runtime resolution service against Go's
+ * runtime_resolution_test.go: RPC-identical lookup semantics (slug+org,
+ * org required for this org-scoped kind, kind-mismatch rejection), decrypt
+ * in place on the loaded copy (the store is never touched), the per-key
+ * WARN-and-drop for undecryptable ciphertext, and the fail-loud
+ * propagation of the keyless-with-ciphertext state.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../../boot/logger.js";
+import { SecretService } from "../../../../encryption/encryption.js";
+import { SqliteStore } from "../../../../store/sqlite/store.js";
+import type { Store } from "../../../../store/interface.js";
+import { RuntimeResolutionService } from "../resolution.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const KEY = Buffer.alloc(32, 7);
+
+let dir: string;
+let store: Store;
+let secretService: SecretService;
+let service: RuntimeResolutionService;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "env-resolution-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"), silentLogger);
+  secretService = SecretService.create(KEY);
+  service = new RuntimeResolutionService(store, secretService, silentLogger);
+
+  await seed("resolved", "acme", {
+    API_KEY: { value: secretService.encrypt("real-key"), isSecret: true },
+    LEGACY: { value: "pre-oss405-plaintext", isSecret: true },
+    REGION: { value: "us-east-1", isSecret: false },
+  });
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function seed(
+  slug: string,
+  org: string,
+  data: Record<string, { value: string; isSecret: boolean }>,
+): Promise<string> {
+  const id = `env_${slug}`;
+  const env = create(EnvironmentSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "Environment",
+    metadata: { id, name: slug, slug, org },
+    spec: {
+      data: Object.fromEntries(
+        Object.entries(data).map(([k, v]) => [
+          k,
+          { value: v.value, isSecret: v.isSecret, description: "" },
+        ]),
+      ),
+    },
+  });
+  await store.saveResource(ApiResourceKind.environment, id, EnvironmentSchema, env);
+  return id;
+}
+
+async function connectError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+function ref(slug: string, org: string, kind = ApiResourceKind.environment) {
+  return { slug, org, kind } as Parameters<
+    RuntimeResolutionService["resolveByReference"]
+  >[0];
+}
+
+describe("resolveByReference", () => {
+  it("decrypts is_secret values in place; legacy plaintext and non-secrets pass through", async () => {
+    const env = await service.resolveByReference(ref("resolved", "acme"));
+    expect(env.spec?.data["API_KEY"]?.value).toBe("real-key");
+    expect(env.spec?.data["LEGACY"]?.value).toBe("pre-oss405-plaintext");
+    expect(env.spec?.data["REGION"]?.value).toBe("us-east-1");
+  });
+
+  it("never touches the store — the persisted row keeps its ciphertext", async () => {
+    await service.resolveByReference(ref("resolved", "acme"));
+    const stored = await store.getResource(
+      ApiResourceKind.environment,
+      "env_resolved",
+      EnvironmentSchema,
+    );
+    expect(stored.spec?.data["API_KEY"]?.value.startsWith("enc:v1:")).toBe(true);
+  });
+
+  it("accepts an unspecified kind (unknown = no assertion), rejects a wrong one", async () => {
+    const viaUnknown = await service.resolveByReference(
+      ref("resolved", "acme", ApiResourceKind.api_resource_kind_unknown),
+    );
+    expect(viaUnknown.metadata?.id).toBe("env_resolved");
+
+    const error = await connectError(() =>
+      service.resolveByReference(ref("resolved", "acme", ApiResourceKind.agent)),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+    expect(error.rawMessage).toBe("kind mismatch: expected environment, got agent");
+  });
+
+  it("requires a slug and an org (org-scoped kind — no cross-tenant resolution)", async () => {
+    const noSlug = await connectError(() => service.resolveByReference(ref("", "acme")));
+    expect(noSlug.code).toBe(Code.InvalidArgument);
+    expect(noSlug.rawMessage).toBe("environment reference with slug is required");
+
+    const noOrg = await connectError(() => service.resolveByReference(ref("resolved", "")));
+    expect(noOrg.code).toBe(Code.InvalidArgument);
+  });
+
+  it("answers NotFound for an unresolvable reference (authoring error, never a silent run)", async () => {
+    const error = await connectError(() =>
+      service.resolveByReference(ref("ghost", "acme")),
+    );
+    expect(error.code).toBe(Code.NotFound);
+    expect(error.rawMessage).toBe("environment not found: ghost");
+  });
+
+  it("WARNs and DROPS an undecryptable key, keeping the rest (per-key skip)", async () => {
+    await seed("partially-broken", "acme", {
+      GOOD: { value: secretService.encrypt("good-value"), isSecret: true },
+      BROKEN: { value: "enc:v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", isSecret: true },
+    });
+    const env = await service.resolveByReference(ref("partially-broken", "acme"));
+    expect(env.spec?.data["GOOD"]?.value).toBe("good-value");
+    expect(env.spec?.data["BROKEN"]).toBeUndefined();
+  });
+
+  it("fails LOUD when ciphertext exists but no key is configured (never a credential-less run)", async () => {
+    await seed("keyless-victim", "acme", {
+      SEALED: { value: secretService.encrypt("sealed"), isSecret: true },
+    });
+    const keyless = new RuntimeResolutionService(
+      store,
+      SecretService.create(undefined),
+      silentLogger,
+    );
+    const error = await connectError(() =>
+      keyless.resolveByReference(ref("keyless-victim", "acme")),
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe(
+      "environment env_keyless-victim holds encrypted secret 'SEALED' but no encryption key is configured",
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/environment/resolution/resolution.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/resolution/resolution.ts
@@ -1,0 +1,150 @@
+/**
+ * Runtime environment resolution — ports
+ * pkg/domain/environment/resolution/runtime_resolution.go, the OSS twin of
+ * the cloud edition's EnvironmentRuntimeResolutionService.
+ *
+ * Runtime resolution and human reveal are two DISTINCT operations: the
+ * environment RPC surface redacts secret values in every response
+ * (oss#405, getSecretValue being the single-key reveal path), while an
+ * execution needs the full map decrypted. This service is the sanctioned
+ * internal path for the latter. It deliberately does not ride the gRPC
+ * surface: the RPC responses are redacted by design, and this single-user
+ * edition has no caller identity that could gate an "unredacted" RPC.
+ *
+ * Called cross-domain by the execution-context builders (the
+ * agentexecution and workflowexecution sub-projects, D4 #15/#17/#20) — a
+ * deliberate, documented boundary crossing in the style of the cloud
+ * edition's EnvironmentMergeService dependency. OSS omits the cloud's
+ * OrgSharedEnvironmentPolicy gate: single-user, no trust boundary.
+ *
+ * Returned values are PLAINTEXT, for execution-context builds only. Never
+ * surface them in an API response, log, or error message.
+ */
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import { EncryptionDisabledError } from "../../../encryption/encryption.js";
+import type { SecretService } from "../../../encryption/encryption.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../../pipeline/errors.js";
+import {
+  findResourceBySlug,
+  requireOrgForReference,
+} from "../../../pipeline/steps/helpers.js";
+import { apiResourceKindName } from "../../../store/sqlite/proto-fields.js";
+import type { Store } from "../../../store/interface.js";
+
+/**
+ * Resolves environments with secret values decrypted, for merging into an
+ * ExecutionContext.
+ */
+export class RuntimeResolutionService {
+  constructor(
+    private readonly store: Store,
+    private readonly secretService: SecretService,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Go ResolveByReference: loads the referenced environment and decrypts
+   * its is_secret values in place on the freshly-loaded copy (the store is
+   * never touched). Lookup semantics match the getByReference RPC exactly
+   * — same slug+org matching and the same org requirement for this
+   * org-scoped kind — so a ref that resolves through the RPC surface
+   * resolves identically here, and vice versa.
+   *
+   * Error doctrine (the cloud service's, in this edition's taxonomy):
+   *   - Undecryptable ciphertext (tampered/truncated/wrong-key) is scoped
+   *     to one value: WARN and drop that key (the cloud's per-key skip).
+   *   - EncryptionDisabledError propagates: the stored ciphertext may be
+   *     perfectly valid (key file lost), and skipping it would start the
+   *     execution silently missing a credential — a confusing downstream
+   *     failure instead of a clear one here.
+   *   - An unresolvable reference is NotFound, same as the RPC path — the
+   *     execution-context builders treat that as an authoring error that
+   *     fails the create (never a silent run without credentials).
+   */
+  async resolveByReference(
+    ref: ApiResourceReference | undefined,
+  ): Promise<Environment> {
+    if (ref === undefined || ref.slug === "") {
+      throw invalidArgumentError("environment reference with slug is required");
+    }
+    if (
+      ref.kind !== ApiResourceKind.api_resource_kind_unknown &&
+      ref.kind !== ApiResourceKind.environment
+    ) {
+      throw invalidArgumentError(
+        `kind mismatch: expected environment, got ${apiResourceKindName(ref.kind)}`,
+      );
+    }
+    requireOrgForReference(ApiResourceKind.environment, ref.org);
+
+    let env: Environment | undefined;
+    try {
+      env = await findResourceBySlug(
+        this.store,
+        ApiResourceKind.environment,
+        EnvironmentSchema,
+        ref.slug,
+        ref.org,
+      );
+    } catch (error) {
+      throw internalError(
+        error,
+        "failed to look up environment for runtime resolution",
+      );
+    }
+    if (env === undefined) {
+      throw notFoundError("environment", ref.slug);
+    }
+
+    this.decryptSecretValues(env);
+    return env;
+  }
+
+  /**
+   * Decrypts every encrypted is_secret value in place. Plaintext legacy
+   * rows pass through decrypt unchanged, so pre-oss#405 stores resolve
+   * without migration.
+   */
+  private decryptSecretValues(env: Environment): void {
+    const data = env.spec?.data;
+    if (data === undefined || Object.keys(data).length === 0) {
+      return;
+    }
+
+    const environmentId = env.metadata?.id ?? "";
+    for (const [key, value] of Object.entries(data)) {
+      if (!value.isSecret || !this.secretService.isEncrypted(value.value)) {
+        continue;
+      }
+
+      try {
+        value.value = this.secretService.decrypt(value.value);
+      } catch (error) {
+        if (error instanceof EncryptionDisabledError) {
+          throw internalError(
+            error,
+            `environment ${environmentId} holds encrypted secret '${key}' but no encryption key is configured`,
+          );
+        }
+        this.logger.warn(
+          "Undecryptable ciphertext in environment — dropping this value from runtime resolution",
+          {
+            key,
+            environmentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        delete data[key];
+      }
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/environment/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/search-extractor.ts
@@ -1,0 +1,37 @@
+/**
+ * Environment search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/environment_extractor.go (the search summary
+ * is spec.description). Secret DATA is deliberately never indexed — only
+ * name, description, tags, org, and visibility reach FTS5. The query side
+ * of the extractor contract arrives with the search service sub-project
+ * (#13), exactly as the organization extractor's header records.
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const environmentSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const env = resource as unknown as Environment;
+    const metadata = env.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      description: env.spec?.description ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        env.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/environment/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/steps.ts
@@ -1,0 +1,515 @@
+/**
+ * Environment domain steps — port
+ * pkg/domain/environment/controller/steps/ (the create/update sentinel
+ * guard, the encrypt-at-rest step, personal-environment uniqueness, the
+ * single-key reveal extractor, the environment_id loader, and the two
+ * self-contained write-boundary steps for incremental variable management).
+ *
+ * The ordering contracts these steps embody (the cloud "sentinels →
+ * encrypt" doc, oss#395/oss#405):
+ *   1. PreserveRedactedSecrets runs BEFORE EncryptSecretValues — the
+ *      marker arm restores stored ciphertext, whose idempotent encrypt
+ *      pass-through must leave it unchanged (never double-encrypted).
+ *   2. Within the guard, the marker arm runs BEFORE the forged-ciphertext
+ *      arm — after preservation, legitimate stored ciphertext is present
+ *      by design and must not hit the forgery rejection.
+ *   3. Redaction (redact.ts) runs AFTER Persist, outside the pipeline.
+ *
+ * Proven by environment.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/environment.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import {
+  EnvironmentSpecSchema,
+  EnvironmentValueSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { EnvironmentValue } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type {
+  EnvironmentSecretValueInputSchema,
+  RemoveEnvironmentVariablesRequestSchema,
+  UpdateEnvironmentVariablesRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { isCiphertextShaped } from "../../encryption/encryption.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { findResourceByLabelAndOrg } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import type { Store } from "../../store/interface.js";
+import {
+  PERSONAL_LABEL_KEY,
+  PERSONAL_LABEL_VALUE,
+  forgedCiphertextMessage,
+  markerRejectionMessage,
+  personalEnvironmentExistsMessage,
+  REDACTED_MARKER,
+} from "./constants.js";
+
+/** Context key for the decrypted single-key result — Go SecretValueKey. */
+export const SECRET_VALUE_KEY = "secretValue";
+
+/**
+ * Context key for the modified environment after a merge/remove variables
+ * operation — Go UpdatedEnvironmentKey.
+ */
+export const UPDATED_ENVIRONMENT_KEY = "updatedEnvironment";
+
+/**
+ * PreserveRedactedSecrets — Go preserve_redacted_secrets.go. Handles
+ * client-supplied secret SENTINELS on write, serving both the create and
+ * full-resource update pipelines:
+ *
+ *   - A secret whose incoming value is the ***REDACTED*** marker is
+ *     restored from the existing resource (update). When there is nothing
+ *     to preserve — a create, or an update for a key that had no prior
+ *     secret — the marker is meaningless and rejected with
+ *     INVALID_ARGUMENT rather than stored literally.
+ *   - A secret carrying the ciphertext-shaped enc:v<N>: prefix is rejected
+ *     with INVALID_ARGUMENT (oss#395): the prefix is server-reserved. The
+ *     marker arm must run FIRST — after preservation, legitimate stored
+ *     ciphertext is present by design and must not hit this arm.
+ *   - Non-secret values pass through untouched. They are exempt from the
+ *     prefix rejection deliberately: every decrypt path gates on
+ *     is_secret && isEncrypted, so a non-secret prefixed string is inert,
+ *     and flipping it to secret later re-enters this guard.
+ *
+ * Runs while spec.data is still raw client input: after BuildUpdateState
+ * (update; requires LoadExisting) or after BuildNewState (create, where
+ * EXISTING_RESOURCE_KEY is absent and every marker is rejected).
+ */
+export function newPreserveRedactedSecretsStep(): PipelineStep<
+  typeof EnvironmentSchema
+> {
+  return {
+    name: "PreserveRedactedSecrets",
+    execute(ctx: RequestContext<typeof EnvironmentSchema>): void {
+      const data = ctx.newState.spec?.data;
+      if (data === undefined || Object.keys(data).length === 0) {
+        return;
+      }
+
+      // Absent existing resource (the create pipeline) means there is
+      // nothing to preserve: fall through with an empty map so every
+      // marker is rejected instead of silently skipping the guards.
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as
+        | Environment
+        | undefined;
+      const existingData = existing?.spec?.data ?? {};
+
+      for (const [key, value] of Object.entries(data)) {
+        if (!value.isSecret) {
+          continue;
+        }
+
+        if (value.value === REDACTED_MARKER) {
+          const existingEntry = existingData[key];
+          if (existingEntry !== undefined && existingEntry.isSecret) {
+            data[key] = existingEntry;
+            continue;
+          }
+          throw invalidArgumentError(markerRejectionMessage(key));
+        }
+
+        // Unconditional (not gated on encryption being enabled): the
+        // prefix is server-reserved regardless of key state.
+        if (isCiphertextShaped(value.value)) {
+          throw invalidArgumentError(forgedCiphertextMessage(key));
+        }
+      }
+    },
+  };
+}
+
+/**
+ * EncryptSecretValues — Go encrypt_secret_values.go: encrypts every
+ * is_secret value in spec.data before persistence (oss#405 — environment
+ * secrets rested plaintext while oauthapp/channelapp secrets were
+ * encrypted in the same store).
+ *
+ * MUST run after PreserveRedactedSecrets ("sentinels → encrypt"): by this
+ * point every secret value is either fresh client plaintext (encrypt it)
+ * or marker-restored stored ciphertext (the idempotent pass-through leaves
+ * it unchanged, so a round-tripped secret is never double-encrypted).
+ *
+ * Keyless mode: values pass through plaintext with one WARN per request,
+ * emitted only when a non-empty secret would actually rest plaintext (the
+ * oss#394 convention shared with oauthapp and channelapp). Non-secret
+ * values are never touched: the decrypt paths gate on is_secret, so
+ * encrypting a non-secret value would strand it as unreadable ciphertext.
+ */
+export function newEncryptSecretValuesStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof EnvironmentSchema> {
+  return {
+    name: "EncryptSecretValues",
+    execute(ctx: RequestContext<typeof EnvironmentSchema>): void {
+      const env = ctx.newState;
+      const data = env.spec?.data;
+      if (data === undefined || Object.keys(data).length === 0) {
+        return;
+      }
+
+      if (!secretService.isEnabled()) {
+        if (hasNonEmptySecret(data)) {
+          logger.warn(
+            "Encryption disabled: environment secret values will be stored in plaintext",
+            { environmentId: env.metadata?.id ?? "" },
+          );
+        }
+        return;
+      }
+
+      for (const [key, value] of Object.entries(data)) {
+        if (!value.isSecret || value.value === "") {
+          continue;
+        }
+        try {
+          value.value = secretService.encrypt(value.value);
+        } catch (error) {
+          throw internalError(
+            error,
+            `failed to encrypt secret value for variable '${key}'`,
+          );
+        }
+      }
+    },
+  };
+}
+
+/** Whether any entry would have been encrypted — keeps the WARN honest. */
+function hasNonEmptySecret(
+  data: Record<string, EnvironmentValue>,
+): boolean {
+  return Object.values(data).some((v) => v.isSecret && v.value !== "");
+}
+
+/**
+ * EnforcePersonalEnvUniqueness — Go enforce_personal_uniqueness.go: at
+ * most one personal environment (stigmer.ai/personal=true) per ORG →
+ * ALREADY_EXISTS. Non-personal environments are a no-op.
+ *
+ * Contract note: cloud enforces per (org, owner) — it also scopes by the
+ * creating identity. OSS has no caller identity yet (audit created_by is
+ * the "system" actor), so per-(org, owner) collapses to per-org here — a
+ * faithful specialization of the shared contract, not a divergence.
+ *
+ * Create-time only, before the resource has an id, so it never matches
+ * the in-flight resource against itself; update deliberately omits it.
+ */
+export function newEnforcePersonalUniquenessStep(
+  store: Store,
+): PipelineStep<typeof EnvironmentSchema> {
+  return {
+    // The Go step's registered name — note "Env", not the type name.
+    name: "EnforcePersonalEnvUniqueness",
+    async execute(
+      ctx: RequestContext<typeof EnvironmentSchema>,
+    ): Promise<void> {
+      const metadata = ctx.newState.metadata;
+      if (metadata === undefined) {
+        return;
+      }
+      if (metadata.labels[PERSONAL_LABEL_KEY] !== PERSONAL_LABEL_VALUE) {
+        return;
+      }
+
+      let existing: Environment | undefined;
+      try {
+        existing = await findResourceByLabelAndOrg(
+          store,
+          ctx.apiResourceKind,
+          EnvironmentSchema,
+          PERSONAL_LABEL_KEY,
+          PERSONAL_LABEL_VALUE,
+          metadata.org,
+        );
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to check personal environment uniqueness",
+        );
+      }
+
+      if (existing !== undefined) {
+        // Go raises this via status.Errorf(codes.AlreadyExists, "<copy>"),
+        // NOT the grpclib helper's "%s already exists: %s" format — the
+        // wire message is the bare pinned copy, so the ConnectError is
+        // constructed directly rather than through alreadyExistsError().
+        throw new ConnectError(
+          personalEnvironmentExistsMessage(existing.metadata?.id ?? ""),
+          Code.AlreadyExists,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * LoadEnvironmentByID — Go load_environment_by_id.go: loads by the
+ * environment_id field (the standard LoadTarget expects a `value` id
+ * field, but EnvironmentSecretValueInput / Update-/RemoveEnvironment-
+ * VariablesRequest carry `environment_id`). Stores under
+ * TARGET_RESOURCE_KEY.
+ */
+export function newLoadEnvironmentByIdStep<Desc extends DescMessage>(
+  store: Store,
+): PipelineStep<Desc> {
+  return {
+    name: "LoadEnvironmentByID",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const environmentId = (
+        ctx.input as { environmentId?: unknown }
+      ).environmentId;
+      if (typeof environmentId !== "string" || environmentId === "") {
+        throw invalidArgumentError("environment_id is required");
+      }
+
+      let env: Environment;
+      try {
+        env = await store.getResource(
+          ctx.apiResourceKind,
+          environmentId,
+          EnvironmentSchema,
+        );
+      } catch {
+        // Go maps EVERY load failure to NotFound here (store errors
+        // included) — ported as-is.
+        throw notFoundError("environment", environmentId);
+      }
+
+      ctx.set(TARGET_RESOURCE_KEY, env);
+    },
+  };
+}
+
+/**
+ * ExtractAndDecryptSingleKey — Go extract_and_decrypt_single_key.go: the
+ * getSecretValue reveal path. Missing key → NotFound; non-secret → the
+ * value as-is; secret → decrypted via the SecretService (a decrypt failure
+ * — including keyless-with-ciphertext — is Internal; the loud path, never
+ * a silent marker).
+ */
+export function newExtractAndDecryptSingleKeyStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof EnvironmentSecretValueInputSchema> {
+  return {
+    name: "ExtractAndDecryptSingleKey",
+    execute(
+      ctx: RequestContext<typeof EnvironmentSecretValueInputSchema>,
+    ): void {
+      const key = ctx.input.key;
+
+      const env = ctx.get(TARGET_RESOURCE_KEY) as Environment | undefined;
+      if (env === undefined) {
+        throw internalError(
+          new Error("targetResource missing or wrong type"),
+          "environment not loaded in context",
+        );
+      }
+
+      const envValue = env.spec?.data[key];
+      if (envValue === undefined) {
+        throw notFoundError("environment key", key);
+      }
+
+      if (envValue.isSecret && envValue.value !== "") {
+        let decrypted: string;
+        try {
+          decrypted = secretService.decrypt(envValue.value);
+        } catch (error) {
+          logger.error("Failed to decrypt secret value", {
+            key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw internalError(error, "failed to decrypt secret value");
+        }
+        ctx.set(
+          SECRET_VALUE_KEY,
+          create(EnvironmentValueSchema, {
+            value: decrypted,
+            isSecret: true,
+            description: envValue.description,
+          }),
+        );
+        return;
+      }
+
+      ctx.set(SECRET_VALUE_KEY, envValue);
+    },
+  };
+}
+
+/**
+ * MergeVariablesAndPersist — Go merge_variables_and_persist.go: merges
+ * incoming variables into the loaded environment's spec.data and persists.
+ * Request keys overwrite; absent keys are preserved.
+ *
+ * This step is its OWN write boundary (sentinel guard, merge, encrypt, and
+ * persist all live here — same ordering contract as create/update:
+ * sentinels first, then encrypt). This is the path OAuth-managed vendor
+ * tokens take, so they rest encrypted too. Deliberately NO search
+ * re-index: variables are not indexed fields (mirror, don't fix).
+ *
+ * Requires LoadEnvironmentByID first (reads TARGET_RESOURCE_KEY); stores
+ * the modified environment under UPDATED_ENVIRONMENT_KEY. Stamps the
+ * SpecAudit slot (#540 — a definition change).
+ */
+export function newMergeVariablesAndPersistStep(
+  store: Store,
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof UpdateEnvironmentVariablesRequestSchema> {
+  return {
+    name: "MergeVariablesAndPersist",
+    async execute(
+      ctx: RequestContext<typeof UpdateEnvironmentVariablesRequestSchema>,
+    ): Promise<void> {
+      const env = ctx.get(TARGET_RESOURCE_KEY) as Environment | undefined;
+      if (env === undefined) {
+        throw internalError(
+          new Error("targetResource missing or wrong type"),
+          "environment not loaded in context",
+        );
+      }
+
+      if (env.spec === undefined) {
+        env.spec = create(EnvironmentSpecSchema, {});
+      }
+
+      const incoming = ctx.input.variables;
+      for (const [key, incomingValue] of Object.entries(incoming)) {
+        let value = incomingValue;
+        if (value.isSecret && value.value === REDACTED_MARKER) {
+          const existing = env.spec.data[key];
+          if (existing !== undefined && existing.isSecret) {
+            continue; // preserved — the round-trip contract
+          }
+          throw invalidArgumentError(markerRejectionMessage(key));
+        }
+        // Ciphertext-shaped client input is rejected at every secret write
+        // boundary (oss#395); see newPreserveRedactedSecretsStep for the
+        // full rationale. Non-secret values are deliberately exempt.
+        if (value.isSecret && isCiphertextShaped(value.value)) {
+          throw invalidArgumentError(forgedCiphertextMessage(key));
+        }
+        if (value.isSecret && value.value !== "") {
+          if (!secretService.isEnabled()) {
+            logger.warn(
+              "Encryption disabled: environment secret value will be stored in plaintext",
+              { key },
+            );
+          } else {
+            let encrypted: string;
+            try {
+              encrypted = secretService.encrypt(value.value);
+            } catch (error) {
+              throw internalError(
+                error,
+                `failed to encrypt secret value for variable '${key}'`,
+              );
+            }
+            value = create(EnvironmentValueSchema, {
+              value: encrypted,
+              isSecret: true,
+              description: value.description,
+            });
+          }
+        }
+        env.spec.data[key] = value;
+      }
+
+      try {
+        setAuditFieldsForUpdate(EnvironmentSchema, env, "spec_audit");
+      } catch (error) {
+        throw internalError(error, "failed to set audit fields");
+      }
+
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          env.metadata?.id ?? "",
+          EnvironmentSchema,
+          env,
+        );
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to persist environment after merging variables",
+        );
+      }
+
+      ctx.set(UPDATED_ENVIRONMENT_KEY, env);
+    },
+  };
+}
+
+/**
+ * RemoveVariableKeysAndPersist — Go remove_variable_keys_and_persist.go:
+ * deletes the named keys from spec.data (unknown keys silently ignored)
+ * and persists. Requires LoadEnvironmentByID first; stores the modified
+ * environment under UPDATED_ENVIRONMENT_KEY; stamps SpecAudit. No search
+ * re-index, as in Go.
+ */
+export function newRemoveVariableKeysAndPersistStep(
+  store: Store,
+): PipelineStep<typeof RemoveEnvironmentVariablesRequestSchema> {
+  return {
+    name: "RemoveVariableKeysAndPersist",
+    async execute(
+      ctx: RequestContext<typeof RemoveEnvironmentVariablesRequestSchema>,
+    ): Promise<void> {
+      const env = ctx.get(TARGET_RESOURCE_KEY) as Environment | undefined;
+      if (env === undefined) {
+        throw internalError(
+          new Error("targetResource missing or wrong type"),
+          "environment not loaded in context",
+        );
+      }
+
+      const keys = ctx.input.keys;
+      if (env.spec?.data !== undefined) {
+        for (const key of keys) {
+          delete env.spec.data[key];
+        }
+      }
+
+      try {
+        setAuditFieldsForUpdate(EnvironmentSchema, env, "spec_audit");
+      } catch (error) {
+        throw internalError(error, "failed to set audit fields");
+      }
+
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          env.metadata?.id ?? "",
+          EnvironmentSchema,
+          env,
+        );
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to persist environment after removing variables",
+        );
+      }
+
+      ctx.set(UPDATED_ENVIRONMENT_KEY, env);
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/encryption/__tests__/encryption.test.ts
+++ b/backend/services/stigmer-server-ts/src/encryption/__tests__/encryption.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Pins the SecretService's cross-edition contract: the enc:v1: format
+ * (proven against the Go-generated fixture, DD-001), the keyless
+ * pass-through/fail-loud asymmetry, encrypt idempotence (the marker
+ * round-trip's foundation), the error taxonomy (invalid ciphertext vs
+ * decryption failed vs disabled), and the fail-closed handling of
+ * future-version prefixes. Ports pkg/encryption/encryption_test.go and
+ * adds the adversarial arms the T01 plan lists.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  DecryptionFailedError,
+  ENCRYPTED_PREFIX,
+  EncryptionDisabledError,
+  GCM_NONCE_SIZE,
+  GCM_TAG_SIZE,
+  InvalidCiphertextError,
+  SecretService,
+  isCiphertextShaped,
+} from "../encryption.js";
+
+const KEY = Buffer.alloc(32, 7);
+const OTHER_KEY = Buffer.alloc(32, 8);
+
+function enabled(): SecretService {
+  return SecretService.create(KEY);
+}
+
+function disabled(): SecretService {
+  return SecretService.create(undefined);
+}
+
+describe("SecretService round-trip", () => {
+  it("encrypts and decrypts back to the plaintext", () => {
+    const svc = enabled();
+    const plaintexts = [
+      "hello world",
+      "",
+      "x",
+      "秘密のパスワード🔐 — ключ",
+      "line one\nline two\r\n\ttabbed",
+      "a".repeat(10_000),
+    ];
+    for (const pt of plaintexts) {
+      const ct = svc.encrypt(pt);
+      expect(ct.startsWith(ENCRYPTED_PREFIX)).toBe(true);
+      expect(svc.decrypt(ct)).toBe(pt);
+    }
+  });
+
+  it("produces a unique nonce per encryption (same plaintext, different ciphertext)", () => {
+    const svc = enabled();
+    expect(svc.encrypt("same input")).not.toBe(svc.encrypt("same input"));
+  });
+
+  it("emits the exact sealed layout: base64(nonce || ct || tag)", () => {
+    const svc = enabled();
+    const ct = svc.encrypt("abc");
+    const sealed = Buffer.from(ct.slice(ENCRYPTED_PREFIX.length), "base64");
+    expect(sealed.length).toBe(GCM_NONCE_SIZE + 3 + GCM_TAG_SIZE);
+  });
+
+  it("is idempotent on already-prefixed input (the marker-restore round-trip)", () => {
+    const svc = enabled();
+    const ct = svc.encrypt("stored secret");
+    expect(svc.encrypt(ct)).toBe(ct);
+  });
+});
+
+describe("SecretService disabled (keyless) semantics", () => {
+  it("reports disabled and passes plaintext through encrypt unchanged", () => {
+    const svc = disabled();
+    expect(svc.isEnabled()).toBe(false);
+    expect(svc.encrypt("plain")).toBe("plain");
+  });
+
+  it("passes unprefixed values through decrypt (legacy plaintext rows)", () => {
+    expect(disabled().decrypt("legacy plaintext")).toBe("legacy plaintext");
+  });
+
+  it("fails LOUD decrypting a prefixed value — never returns ciphertext as-is", () => {
+    const ct = enabled().encrypt("secret");
+    expect(() => disabled().decrypt(ct)).toThrow(EncryptionDisabledError);
+  });
+
+  it("treats an empty key buffer as disabled, like Go's len(key) == 0", () => {
+    expect(SecretService.create(Buffer.alloc(0)).isEnabled()).toBe(false);
+  });
+});
+
+describe("SecretService error taxonomy", () => {
+  it("rejects a wrong-size key at construction", () => {
+    expect(() => SecretService.create(Buffer.alloc(16))).toThrow(
+      "encryption key must be exactly 32 bytes",
+    );
+  });
+
+  it("fails with DecryptionFailedError on a tampered ciphertext byte", () => {
+    const svc = enabled();
+    const ct = svc.encrypt("tamper me");
+    const sealed = Buffer.from(ct.slice(ENCRYPTED_PREFIX.length), "base64");
+    sealed[GCM_NONCE_SIZE] ^= 0xff; // flip one ciphertext bit
+    const tampered = ENCRYPTED_PREFIX + sealed.toString("base64");
+    expect(() => svc.decrypt(tampered)).toThrow(DecryptionFailedError);
+  });
+
+  it("fails with DecryptionFailedError under the wrong key", () => {
+    const ct = enabled().encrypt("keyed secret");
+    expect(() => SecretService.create(OTHER_KEY).decrypt(ct)).toThrow(
+      DecryptionFailedError,
+    );
+  });
+
+  it("fails with InvalidCiphertextError on corrupted base64", () => {
+    expect(() => enabled().decrypt("enc:v1:!!!not-base64!!!")).toThrow(
+      InvalidCiphertextError,
+    );
+  });
+
+  it("fails with InvalidCiphertextError on truncated sealed bytes", () => {
+    const short = Buffer.alloc(GCM_NONCE_SIZE + GCM_TAG_SIZE - 1, 1);
+    expect(() =>
+      enabled().decrypt(ENCRYPTED_PREFIX + short.toString("base64")),
+    ).toThrow(InvalidCiphertextError);
+  });
+
+  it("fails CLOSED on future-version prefixes instead of decrypting them as v1", () => {
+    // enc:v2: is isEncrypted-matched (fail-open-as-plaintext would be the
+    // bug) but not decryptable by this build — Go's TrimPrefix leaves the
+    // prefix in place and the strict base64 check rejects it.
+    const v1 = enabled().encrypt("future");
+    const v2 = v1.replace("enc:v1:", "enc:v2:");
+    expect(() => enabled().decrypt(v2)).toThrow(InvalidCiphertextError);
+  });
+});
+
+describe("isCiphertextShaped (the oss#395 boundary guard)", () => {
+  it("matches every enc:v<N>: version, not just v1", () => {
+    expect(isCiphertextShaped("enc:v1:abc")).toBe(true);
+    expect(isCiphertextShaped("enc:v2:abc")).toBe(true);
+    expect(isCiphertextShaped("enc:v99:x")).toBe(true);
+  });
+
+  it("does not match plaintext, near-misses, or mid-string prefixes", () => {
+    expect(isCiphertextShaped("plain")).toBe(false);
+    expect(isCiphertextShaped("enc:vX:abc")).toBe(false);
+    expect(isCiphertextShaped("enc:v:abc")).toBe(false);
+    expect(isCiphertextShaped(" enc:v1:abc")).toBe(false);
+    expect(isCiphertextShaped("xenc:v1:abc")).toBe(false);
+    expect(isCiphertextShaped("")).toBe(false);
+  });
+
+  it("agrees with the instance dispatch (same regex, different intent)", () => {
+    const svc = enabled();
+    expect(svc.isEncrypted("enc:v3:whatever")).toBe(true);
+    expect(svc.isEncrypted("whatever")).toBe(false);
+  });
+});
+
+describe("cross-edition compatibility (Go-generated fixture, DD-001)", () => {
+  interface FixtureEntry {
+    name: string;
+    plaintext: string;
+    ciphertext: string;
+  }
+  interface Fixture {
+    keyBase64: string;
+    entries: FixtureEntry[];
+  }
+
+  const fixturePath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "fixtures",
+    "go-ciphertext.json",
+  );
+  const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as Fixture;
+
+  it("decrypts every ciphertext the Go implementation produced", () => {
+    const svc = SecretService.create(
+      Buffer.from(fixture.keyBase64, "base64"),
+    );
+    expect(fixture.entries.length).toBeGreaterThanOrEqual(7);
+    for (const entry of fixture.entries) {
+      expect(svc.decrypt(entry.ciphertext), entry.name).toBe(entry.plaintext);
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/encryption/__tests__/fixtures/go-ciphertext.json
+++ b/backend/services/stigmer-server-ts/src/encryption/__tests__/fixtures/go-ciphertext.json
@@ -1,0 +1,40 @@
+{
+  "keyBase64": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
+  "entries": [
+    {
+      "name": "simple",
+      "plaintext": "hello world",
+      "ciphertext": "enc:v1:jupEOoxuQVw/iL3XziK9WOz6HVlbEeEzCZRoSBtnqemWrSvw8tcM"
+    },
+    {
+      "name": "empty",
+      "plaintext": "",
+      "ciphertext": "enc:v1:E81ikcSKFZ33STrromvZVgIsmL8OSGviFjLrQw=="
+    },
+    {
+      "name": "single-byte",
+      "plaintext": "x",
+      "ciphertext": "enc:v1:yR3smYjaVfMHtzVxk21uDJ0+D7iioyKdLg1jzNw="
+    },
+    {
+      "name": "api-key-like",
+      "plaintext": "sk-proj-AbCdEf0123456789_secretSECRET-9876543210fedcba",
+      "ciphertext": "enc:v1:GTgZKvd3fFHQ+0Q5n7ACp7jpTnv1wknpfG7ZY+QZ4snH45EdX5LzGUARsNfW5BNb3gC0ccP3Grc2f8RcTqWGAyD/LqqjsdI0vsNF7q52ZAr0MQ=="
+    },
+    {
+      "name": "unicode",
+      "plaintext": "秘密のパスワード🔐 — ключ",
+      "ciphertext": "enc:v1:dkjLnurtg1n5xNQLeHGh1+WLoKpWgDGRTFgCyZPAkMHLbhmo4hI1Nmm9l1oPicrXgwA40uGMPtQ7476b9PdmhgkZIphj"
+    },
+    {
+      "name": "multiline",
+      "plaintext": "line one\nline two\r\n\ttabbed",
+      "ciphertext": "enc:v1:LVuS/7HghJSoMyXSLujV3y4PUO6DlVCQjAgtU+YSiJRIe7+l7HjT0hcdjRZMpPBKcP18Yy9l"
+    },
+    {
+      "name": "long",
+      "plaintext": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+      "ciphertext": "enc:v1:98zB4kVU8pKT2nuwY3+V1wX9AwVsz6EptgFS0YdTJOUOVeI1BK6TUpkvGLfOUQDDyv1Kd1KVLuBsDJy7e5RGpn1ZVyObU1LOUmy5SDxXtf2cQbkCchH97/hOV7Iwk17uNF0QJLanh5r1OAaZGPpyDefc96l+fW/m2bBdhJca+/27DFNA5V8X8tgxX6AmdKMdFfdhCRdU3TnUxaNV3JF7zyk7EJlJwc8OL/d5ZIegIrShifzk87OaZ27przBvTZdPmEG523hcKMs/WbMOFgTcxfGyo/v9sa5NkznnanY5EnDSVXdBClO6KaG0k4R9E64HY0h+AEp8S4aIl6eiZtUDtWV0N1DeCdcaiesK0x5u3ADO4EfBPVOzgTZuHUL0LACzmMxmlJcPDR7w1FM6pOadYqTSj0RR/qSf8xEXxwIU00oGUV+nIy6wNND6d4USNNz4zTCyPQu3Q5Iz5L5K2+68Anjvn6tgTS6SoYEHmBWKIEnjtRpC6gEWXqdDlNBufShDXdY+DLH3Glbi0AC+dgOgSpcUOeZ+5QkAlgj0iuODtCPwZRh8Af9ZnDSW+AFmqGjobIgU6cFOikJAzobmA18crG+I8AkzvuOvuwPecUVdmtCh7Ir+HZrk7bSnDY8VNR8gNF7o/E8f44PFBVSu8ZNg8KGu6XANnJN8fQ7jQV/jJqG5aiu+XOsX+6wOHscRi/8R"
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/encryption/__tests__/key-manager.test.ts
+++ b/backend/services/stigmer-server-ts/src/encryption/__tests__/key-manager.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Pins the key ladder (env var → key file → auto-generate), the strict
+ * env-key validation (explicit misconfiguration errors, never degrades),
+ * the 0600 permission gate on key files, and persistence of auto-generated
+ * keys. All tests run against an injected temp home (DD-002) — the real
+ * ~/.stigmer is never touched.
+ */
+import { mkdtempSync, chmodSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  KEY_FILE_PERMISSIONS,
+  KEY_SIZE,
+  getOrCreateNamedKey,
+  namedKeyFilePath,
+} from "../key-manager.js";
+
+const ENV_VAR = "STIGMER_TEST_KEY";
+const FILE_NAME = "test.key";
+
+const tempHomes: string[] = [];
+
+function tempHome(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "stigmer-keymgr-"));
+  tempHomes.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempHomes.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("key ladder priority", () => {
+  it("prefers a valid env key over an existing key file", () => {
+    const homeDir = tempHome();
+    const fileKey = Buffer.alloc(KEY_SIZE, 1);
+    const keyPath = namedKeyFilePath(FILE_NAME, { homeDir });
+    mkdirSync(path.dirname(keyPath), { recursive: true, mode: 0o700 });
+    writeFileSync(keyPath, fileKey, { mode: KEY_FILE_PERMISSIONS });
+
+    const envKey = Buffer.alloc(KEY_SIZE, 2);
+    const key = getOrCreateNamedKey(ENV_VAR, FILE_NAME, {
+      env: { [ENV_VAR]: envKey.toString("base64") },
+      homeDir,
+    });
+    expect(key.equals(envKey)).toBe(true);
+  });
+
+  it("loads an existing 0600 key file when no env key is set", () => {
+    const homeDir = tempHome();
+    const fileKey = Buffer.alloc(KEY_SIZE, 3);
+    const keyPath = namedKeyFilePath(FILE_NAME, { homeDir });
+    mkdirSync(path.dirname(keyPath), { recursive: true, mode: 0o700 });
+    writeFileSync(keyPath, fileKey, { mode: KEY_FILE_PERMISSIONS });
+
+    const key = getOrCreateNamedKey(ENV_VAR, FILE_NAME, { env: {}, homeDir });
+    expect(key.equals(fileKey)).toBe(true);
+  });
+
+  it("auto-generates and persists (0600) when neither source exists", () => {
+    const homeDir = tempHome();
+    const key = getOrCreateNamedKey(ENV_VAR, FILE_NAME, { env: {}, homeDir });
+    expect(key.length).toBe(KEY_SIZE);
+
+    const keyPath = namedKeyFilePath(FILE_NAME, { homeDir });
+    expect(readFileSync(keyPath).equals(key)).toBe(true);
+    expect(statSync(keyPath).mode & 0o777).toBe(KEY_FILE_PERMISSIONS);
+
+    // A second load adopts the persisted key (stable across boots).
+    const again = getOrCreateNamedKey(ENV_VAR, FILE_NAME, { env: {}, homeDir });
+    expect(again.equals(key)).toBe(true);
+  });
+});
+
+describe("explicit env misconfiguration errors (never degrades)", () => {
+  it("rejects invalid Base64", () => {
+    expect(() =>
+      getOrCreateNamedKey(ENV_VAR, FILE_NAME, {
+        env: { [ENV_VAR]: "not!!valid@@base64" },
+        homeDir: tempHome(),
+      }),
+    ).toThrow(`invalid Base64 encoding in ${ENV_VAR}`);
+  });
+
+  it("rejects a wrong-length key with the exact byte count", () => {
+    expect(() =>
+      getOrCreateNamedKey(ENV_VAR, FILE_NAME, {
+        env: { [ENV_VAR]: Buffer.alloc(16, 1).toString("base64") },
+        homeDir: tempHome(),
+      }),
+    ).toThrow(
+      `${ENV_VAR} must be exactly 32 bytes (256 bits) when decoded, got 16 bytes`,
+    );
+  });
+});
+
+describe("key file load gates (fall through to auto-generate, as Go does)", () => {
+  it.skipIf(process.platform === "win32")(
+    "never adopts a key file with insecure permissions",
+    () => {
+      const homeDir = tempHome();
+      const insecureKey = Buffer.alloc(KEY_SIZE, 4);
+      const keyPath = namedKeyFilePath(FILE_NAME, { homeDir });
+      mkdirSync(path.dirname(keyPath), { recursive: true, mode: 0o700 });
+      writeFileSync(keyPath, insecureKey);
+      chmodSync(keyPath, 0o644);
+
+      const key = getOrCreateNamedKey(ENV_VAR, FILE_NAME, { env: {}, homeDir });
+      expect(key.equals(insecureKey)).toBe(false);
+    },
+  );
+
+  it("never adopts a wrong-size key file", () => {
+    const homeDir = tempHome();
+    const keyPath = namedKeyFilePath(FILE_NAME, { homeDir });
+    mkdirSync(path.dirname(keyPath), { recursive: true, mode: 0o700 });
+    writeFileSync(keyPath, Buffer.alloc(16, 5), { mode: KEY_FILE_PERMISSIONS });
+
+    const key = getOrCreateNamedKey(ENV_VAR, FILE_NAME, { env: {}, homeDir });
+    expect(key.length).toBe(KEY_SIZE);
+    expect(key.subarray(0, 16).equals(Buffer.alloc(16, 5))).toBe(false);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/encryption/encryption.ts
+++ b/backend/services/stigmer-server-ts/src/encryption/encryption.ts
@@ -1,0 +1,232 @@
+/**
+ * Secret encryption service — ports pkg/encryption/encryption.go, the Go
+ * twin of the cloud edition's Java EnvironmentSecretService. Cross-edition
+ * wire contract: ciphertext produced by any edition decrypts in the others
+ * (proven by the Go-generated fixture, sub-project DD-001).
+ *
+ * Format: enc:v1:<base64(nonce || ciphertext || tag)>
+ *   - AES-256-GCM, 12-byte crypto-random nonce (unique per encryption),
+ *     16-byte GCM tag, standard padded Base64.
+ *
+ * Keyless ("disabled") semantics are load-bearing and asymmetric:
+ *   - encrypt() passes plaintext through (the WARN-degrade posture — the
+ *     write steps own the per-request warning, oss#394);
+ *   - decrypt() of a PREFIXED value fails loud (EncryptionDisabledError):
+ *     stored ciphertext with no key must never be returned as-is;
+ *   - decrypt() of an unprefixed value passes through (legacy plaintext
+ *     rows, pre-oss#405).
+ *
+ * NOT ported: pkg/encryption/payloadcodec — that is the Temporal payload
+ * lane, already extracted to backend/libs/ts/temporal-codecs (D4 #1); the
+ * server's decode side arrives with the worker sub-projects.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+import { KEY_SIZE, getOrCreateNamedKey } from "./key-manager.js";
+import type { KeyLoaderOptions } from "./key-manager.js";
+
+/** Nonce size for AES-GCM (12 bytes = 96 bits, NIST) — Go GCMNonceSize. */
+export const GCM_NONCE_SIZE = 12;
+
+/** GCM authentication tag size (128 bits) — Go's gcm.Overhead(). */
+export const GCM_TAG_SIZE = 16;
+
+/** Version prefix for encrypted values — Go EncryptedPrefix. */
+export const ENCRYPTED_PREFIX = "enc:v1:";
+
+/** Env var configuring the secrets key (Base64 32B) — Go EnvKeyName. */
+export const ENCRYPTION_KEY_ENV_VAR = "STIGMER_ENCRYPTION_KEY";
+
+/** Key file under ~/.stigmer — Go KeyFileName. */
+export const ENCRYPTION_KEY_FILE_NAME = "encryption.key";
+
+/**
+ * Matches ciphertext in ANY supported-or-future version of the enc:v<N>:
+ * family. Matching all versions (not just v1) is load-bearing: an
+ * unmatched version would be treated as plaintext at every dispatch site
+ * and fail open (returned or re-encrypted as if it were a real value).
+ * Mirrors the cloud edition's SecretEncryptionService.VERSIONED_PREFIX.
+ */
+const VERSIONED_PREFIX = /^enc:v\d+:/;
+
+/** Go ErrInvalidCiphertext — malformed input (bad base64, too short). */
+export class InvalidCiphertextError extends Error {
+  constructor(detail: string) {
+    super(`invalid ciphertext format: ${detail}`);
+    this.name = "InvalidCiphertextError";
+  }
+}
+
+/** Go ErrDecryptionFailed — wrong key or tampered data. */
+export class DecryptionFailedError extends Error {
+  constructor(cause: unknown) {
+    super("decryption failed - wrong key or tampered data");
+    this.name = "DecryptionFailedError";
+    this.cause = cause;
+  }
+}
+
+/** Go ErrEncryptionDisabled — decrypting a prefixed value with no key. */
+export class EncryptionDisabledError extends Error {
+  constructor() {
+    super("encryption is not enabled - no key configured");
+    this.name = "EncryptionDisabledError";
+  }
+}
+
+/**
+ * Go IsCiphertextShaped: whether a value merely has the SHAPE of
+ * ciphertext — the enc:v<N>: prefix — regardless of whether it is genuine.
+ *
+ * This is the request-boundary provenance test (oss#395, the Go twin of
+ * cloud#229): the prefix is a server-reserved sentinel, so client-supplied
+ * values matching it must be rejected with INVALID_ARGUMENT before they
+ * reach encrypt(), whose idempotent pass-through would otherwise persist
+ * them verbatim (letting a client store forged ciphertext that
+ * getSecretValue later decrypts with the deployment key). Module-level,
+ * like the redaction-marker constant, so boundary steps need no service
+ * instance and the rejection stays unconditional on keyless deployments.
+ */
+export function isCiphertextShaped(value: string): boolean {
+  return VERSIONED_PREFIX.test(value);
+}
+
+/**
+ * Encryption/decryption for environment (and other domain) secrets. Safe
+ * for concurrent use; construct via one of the factories below.
+ */
+export class SecretService {
+  private readonly key: Buffer | undefined;
+
+  private constructor(key: Buffer | undefined) {
+    this.key = key;
+  }
+
+  /**
+   * Go NewSecretService: nil/empty key → disabled (pass-through) service;
+   * a present key must be exactly 32 bytes.
+   */
+  static create(key: Buffer | undefined): SecretService {
+    if (key === undefined || key.length === 0) {
+      return new SecretService(undefined);
+    }
+    if (key.length !== KEY_SIZE) {
+      throw new Error(
+        `encryption key must be exactly 32 bytes (256 bits): got ${key.length} bytes`,
+      );
+    }
+    return new SecretService(key);
+  }
+
+  /**
+   * Go NewSecretServiceFromEnv: key via the shared ladder (env var → key
+   * file → auto-generate). Throws only on unusable explicit configuration;
+   * the composition root maps that to the WARN-degrade posture.
+   */
+  static fromEnv(options: KeyLoaderOptions = {}): SecretService {
+    const key = getOrCreateNamedKey(
+      ENCRYPTION_KEY_ENV_VAR,
+      ENCRYPTION_KEY_FILE_NAME,
+      options,
+    );
+    return SecretService.create(key);
+  }
+
+  /** Go IsEnabled: whether a key is configured. */
+  isEnabled(): boolean {
+    return this.key !== undefined;
+  }
+
+  /**
+   * Go IsEncrypted — dispatch on STORED values (decrypt, preserve,
+   * re-encrypt). For CLIENT-SUPPLIED input at a request boundary use the
+   * module-level isCiphertextShaped — same test, different intent.
+   */
+  isEncrypted(value: string): boolean {
+    return isCiphertextShaped(value);
+  }
+
+  /**
+   * Go Encrypt: enc:v1:<base64(nonce || ct || tag)>; disabled → plaintext
+   * unchanged; already-prefixed input → unchanged.
+   *
+   * The idempotent pass-through TRUSTS its callers: it exists for
+   * store-restored ciphertext (the ***REDACTED*** round-trip copies stored
+   * values back into the new state before this runs), which must survive a
+   * second pass unchanged. It is NOT a safe place to validate provenance —
+   * only the request pipeline knows whether a prefixed value came from the
+   * store or from a client. Client-supplied enc:v<N>: input is rejected at
+   * every write boundary via isCiphertextShaped (oss#395); do not "fix"
+   * smuggling here, it would break the marker round-trip.
+   */
+  encrypt(plaintext: string): string {
+    if (this.key === undefined) {
+      return plaintext;
+    }
+    if (this.isEncrypted(plaintext)) {
+      return plaintext;
+    }
+    const nonce = randomBytes(GCM_NONCE_SIZE);
+    const cipher = createCipheriv("aes-256-gcm", this.key, nonce);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext, "utf8"),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    // Layout matches Go's gcm.Seal(nonce, nonce, plaintext, nil):
+    // nonce || ciphertext || tag, then standard Base64.
+    const sealed = Buffer.concat([nonce, ciphertext, tag]);
+    return ENCRYPTED_PREFIX + sealed.toString("base64");
+  }
+
+  /**
+   * Go Decrypt: unprefixed values pass through (legacy plaintext
+   * compatibility); prefixed values decrypt or fail with the taxonomy the
+   * callers branch on (invalid-ciphertext / decryption-failed /
+   * encryption-disabled).
+   */
+  decrypt(encrypted: string): string {
+    if (!this.isEncrypted(encrypted)) {
+      return encrypted;
+    }
+    if (this.key === undefined) {
+      throw new EncryptionDisabledError();
+    }
+
+    // Go TrimPrefix semantics: only the LITERAL enc:v1: prefix is
+    // stripped. A future-version value (enc:v2:…) is matched by
+    // isEncrypted but keeps its prefix here, fails the strict Base64
+    // check below, and surfaces as invalid ciphertext — exactly Go's
+    // fail-closed handling of versions this build cannot decrypt.
+    const base64Data = encrypted.startsWith(ENCRYPTED_PREFIX)
+      ? encrypted.slice(ENCRYPTED_PREFIX.length)
+      : encrypted;
+    const sealed = Buffer.from(base64Data, "base64");
+    // Node's lenient decoder never throws; the round-trip check restores
+    // Go's strict-decode error for corrupted Base64.
+    if (sealed.toString("base64") !== base64Data) {
+      throw new InvalidCiphertextError("invalid base64 encoding");
+    }
+    if (sealed.length < GCM_NONCE_SIZE + GCM_TAG_SIZE) {
+      throw new InvalidCiphertextError("ciphertext too short");
+    }
+
+    const nonce = sealed.subarray(0, GCM_NONCE_SIZE);
+    const ciphertext = sealed.subarray(
+      GCM_NONCE_SIZE,
+      sealed.length - GCM_TAG_SIZE,
+    );
+    const tag = sealed.subarray(sealed.length - GCM_TAG_SIZE);
+
+    const decipher = createDecipheriv("aes-256-gcm", this.key, nonce);
+    decipher.setAuthTag(tag);
+    try {
+      return Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]).toString("utf8");
+    } catch (error) {
+      throw new DecryptionFailedError(error);
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/encryption/key-manager.ts
+++ b/backend/services/stigmer-server-ts/src/encryption/key-manager.ts
@@ -1,0 +1,156 @@
+/**
+ * Named-key loader — ports pkg/encryption/keymanager.go.
+ *
+ * One convention for every 32-byte key the server holds (sub-project
+ * DD-002): env var (Base64) → ~/.stigmer/<file> (raw bytes, 0600) →
+ * auto-generate and persist. The loader is generalized over the env var
+ * and file name so sibling key material (the runner-token signing key,
+ * oss#535) rides the same ladder instead of growing a divergent loader.
+ *
+ * Ladder semantics, exactly Go's:
+ *   - An EXPLICITLY configured env key that is unusable (bad Base64, wrong
+ *     length) is an ERROR, never a degrade — silently ignoring deliberate
+ *     configuration would be worse than refusing to boot.
+ *   - A key file that fails its load checks (permissions other than 0600,
+ *     wrong size) is never adopted; the ladder FALLS THROUGH to
+ *     auto-generate, which overwrites the file's content — Go's shipped
+ *     behavior (loadKeyFromFile error → generate → save), ported as-is.
+ *   - Auto-generation persists for future boots; a persist FAILURE is a
+ *     stderr warning only — the key is still usable for this process.
+ *
+ * `env` and `homeDir` are injectable with process defaults — the
+ * loadConfig(env = process.env) idiom (boot/config.ts) — so unit tests
+ * stay hermetic and never touch the real ~/.stigmer (DD-002). The key env
+ * vars deliberately do NOT ride ServerConfig: Go's pkg/config never sees
+ * them either, and config.ts's contract is that no entry exists before
+ * the code that reads it.
+ */
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** AES-256 / HMAC-SHA256 key size (32 bytes = 256 bits) — Go KeySize. */
+export const KEY_SIZE = 32;
+
+/** Directory under home for key files — Go KeyFileDir. */
+export const KEY_FILE_DIR = ".stigmer";
+
+/** Key file permissions (owner read/write only) — Go KeyFilePermissions. */
+export const KEY_FILE_PERMISSIONS = 0o600;
+
+/** Key directory permissions — Go KeyDirPermissions. */
+export const KEY_DIR_PERMISSIONS = 0o700;
+
+export interface KeyLoaderOptions {
+  /** Environment map; defaults to the live process env. */
+  readonly env?: NodeJS.ProcessEnv;
+  /** Home directory for ~/.stigmer; defaults to os.homedir(). */
+  readonly homeDir?: string;
+}
+
+/**
+ * Go GetOrCreateNamedKey: env var → key file → auto-generate. Throws only
+ * on unusable EXPLICIT configuration (bad env value) or when no key can be
+ * produced at all.
+ */
+export function getOrCreateNamedKey(
+  envVar: string,
+  fileName: string,
+  options: KeyLoaderOptions = {},
+): Buffer {
+  const env = options.env ?? process.env;
+
+  // 1. Environment variable (highest priority) — Base64-encoded 32 bytes.
+  const envValue = env[envVar];
+  if (envValue !== undefined && envValue !== "") {
+    return decodeEnvKey(envVar, envValue);
+  }
+
+  // 2. Local key file — raw 32 bytes, refused on insecure permissions.
+  const keyPath = namedKeyFilePath(fileName, options);
+  const fromFile = loadKeyFromFile(keyPath);
+  if (fromFile !== undefined) {
+    return fromFile;
+  }
+
+  // 3. Auto-generate (local development); persist for future boots.
+  const key = randomBytes(KEY_SIZE);
+  try {
+    saveKeyToFile(keyPath, key);
+  } catch (error) {
+    // Warn but don't fail — the key is still usable (Go's posture).
+    process.stderr.write(
+      `Warning: could not save key to ${keyPath}: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+  }
+  return key;
+}
+
+/** Strict Base64 decode + length check for an env-configured key. */
+function decodeEnvKey(envVar: string, value: string): Buffer {
+  const key = Buffer.from(value, "base64");
+  // Node's base64 decoder is lenient (skips invalid characters, accepts
+  // missing padding) and never throws; Go's StdEncoding errors on any
+  // non-canonical input. Round-tripping — Buffer always re-emits the
+  // canonical padded form — restores Go's strictness.
+  if (key.toString("base64") !== value) {
+    throw new Error(`invalid Base64 encoding in ${envVar}`);
+  }
+  if (key.length !== KEY_SIZE) {
+    throw new Error(
+      `${envVar} must be exactly 32 bytes (256 bits) when decoded, got ${key.length} bytes`,
+    );
+  }
+  return key;
+}
+
+/** Path to a named key file under <home>/.stigmer. */
+export function namedKeyFilePath(
+  fileName: string,
+  options: KeyLoaderOptions = {},
+): string {
+  const home = options.homeDir ?? os.homedir();
+  return path.join(home, KEY_FILE_DIR, fileName);
+}
+
+/**
+ * Reads raw key bytes, mirroring Go loadKeyFromFile: missing file →
+ * undefined (fall through the ladder); present-but-wrong (insecure
+ * permissions, wrong size) also falls through — exactly Go's behavior,
+ * where any load error falls to auto-generate. The 0600 check is skipped
+ * on Windows, where POSIX modes are not meaningful.
+ */
+function loadKeyFromFile(keyPath: string): Buffer | undefined {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(keyPath);
+  } catch {
+    return undefined;
+  }
+  if (process.platform !== "win32") {
+    const mode = stat.mode & 0o777;
+    if (mode !== KEY_FILE_PERMISSIONS) {
+      return undefined;
+    }
+  }
+  let key: Buffer;
+  try {
+    key = fs.readFileSync(keyPath);
+  } catch {
+    return undefined;
+  }
+  if (key.length !== KEY_SIZE) {
+    return undefined;
+  }
+  return key;
+}
+
+/** Writes the key with secure permissions (dir 0700, file 0600). */
+function saveKeyToFile(keyPath: string, key: Buffer): void {
+  fs.mkdirSync(path.dirname(keyPath), {
+    recursive: true,
+    mode: KEY_DIR_PERMISSIONS,
+  });
+  fs.writeFileSync(keyPath, key, { mode: KEY_FILE_PERMISSIONS });
+}

--- a/backend/services/stigmer-server-ts/src/runnerauth/__tests__/runnerauth.test.ts
+++ b/backend/services/stigmer-server-ts/src/runnerauth/__tests__/runnerauth.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Pins the runner-token contract: mint/verify round-trip with the exact
+ * claim names (wire contract with the runner's token-claims.ts), the
+ * single-error fail-closed verify (every failure = InvalidTokenError, no
+ * reason leakage), alg-confusion refusal via the encoded-header pin,
+ * constant-time signature comparison including the Node length-mismatch
+ * guard, and the `now >= exp` expiry boundary. Ports
+ * pkg/runnerauth/runnerauth_test.go plus the T01 plan's adversarial arms.
+ */
+import { createHmac } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_TTL_SECONDS,
+  InvalidTokenError,
+  MintingDisabledError,
+  RunnerAuthService,
+  TOKEN_TYPE_EXECUTION_SCOPED,
+} from "../runnerauth.js";
+
+const KEY = Buffer.alloc(32, 9);
+const OTHER_KEY = Buffer.alloc(32, 10);
+
+function service(): RunnerAuthService {
+  return RunnerAuthService.create(KEY);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("mint", () => {
+  it("round-trips: a minted token verifies to its execution id", () => {
+    const svc = service();
+    const { token, ttlSeconds } = svc.mint("agx_01exec");
+    expect(ttlSeconds).toBe(DEFAULT_TTL_SECONDS);
+    expect(svc.verify(token)).toBe("agx_01exec");
+  });
+
+  it("carries the exact wire-contract claim names and values", () => {
+    const { token } = service().mint("wfx_01exec", 120);
+    const parts = token.split(".");
+    expect(parts).toHaveLength(3);
+    const header = JSON.parse(
+      Buffer.from(parts[0] as string, "base64url").toString("utf8"),
+    ) as Record<string, string>;
+    expect(header).toEqual({ alg: "HS256", typ: "JWT" });
+    const claims = JSON.parse(
+      Buffer.from(parts[1] as string, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    expect(claims["token_type"]).toBe(TOKEN_TYPE_EXECUTION_SCOPED);
+    expect(claims["execution_id"]).toBe("wfx_01exec");
+    expect(claims["exp"]).toBe((claims["iat"] as number) + 120);
+  });
+
+  it("applies the default TTL when ttl <= 0", () => {
+    expect(service().mint("id", 0).ttlSeconds).toBe(DEFAULT_TTL_SECONDS);
+    expect(service().mint("id", -5).ttlSeconds).toBe(DEFAULT_TTL_SECONDS);
+  });
+
+  it("requires a non-empty execution id", () => {
+    expect(() => service().mint("")).toThrow(
+      "execution id is required to mint a runner token",
+    );
+  });
+
+  it("fails with MintingDisabledError on a keyless service", () => {
+    expect(() => RunnerAuthService.create(undefined).mint("id")).toThrow(
+      MintingDisabledError,
+    );
+  });
+});
+
+describe("verify (every failure collapses to InvalidTokenError)", () => {
+  it("rejects everything on a keyless service (fail closed)", () => {
+    const token = service().mint("id").token;
+    expect(() => RunnerAuthService.create(undefined).verify(token)).toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  it("rejects malformed tokens (wrong part count)", () => {
+    const svc = service();
+    for (const bad of ["", "a", "a.b", "a.b.c.d"]) {
+      expect(() => svc.verify(bad)).toThrow(InvalidTokenError);
+    }
+  });
+
+  it("refuses alg confusion via the encoded-header pin (alg:none)", () => {
+    const svc = service();
+    const { token } = svc.mint("id");
+    const [, payload, sig] = token.split(".");
+    const noneHeader = Buffer.from('{"alg":"none","typ":"JWT"}').toString(
+      "base64url",
+    );
+    expect(() => svc.verify(`${noneHeader}.${payload}.${sig}`)).toThrow(
+      InvalidTokenError,
+    );
+    // Even a semantically identical header with different key order is
+    // refused — the compare is on the ENCODED form, never parsed JSON.
+    const reordered = Buffer.from('{"typ":"JWT","alg":"HS256"}').toString(
+      "base64url",
+    );
+    expect(() => svc.verify(`${reordered}.${payload}.${sig}`)).toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  it("rejects a token signed with a different key", () => {
+    const foreign = RunnerAuthService.create(OTHER_KEY).mint("id").token;
+    expect(() => service().verify(foreign)).toThrow(InvalidTokenError);
+  });
+
+  it("rejects a tampered payload (signature binds the exact bytes)", () => {
+    const svc = service();
+    const { token } = svc.mint("id");
+    const [header, , sig] = token.split(".");
+    const forged = Buffer.from(
+      JSON.stringify({
+        token_type: TOKEN_TYPE_EXECUTION_SCOPED,
+        execution_id: "someone-elses-execution",
+        iat: 0,
+        exp: 9999999999,
+      }),
+    ).toString("base64url");
+    expect(() => svc.verify(`${header}.${forged}.${sig}`)).toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  it("survives a length-mismatched signature (Node timingSafeEqual guard)", () => {
+    const svc = service();
+    const { token } = svc.mint("id");
+    const [header, payload] = token.split(".");
+    // Without the length guard this would THROW a RangeError out of
+    // timingSafeEqual instead of the contract's InvalidTokenError.
+    expect(() => svc.verify(`${header}.${payload}.abc`)).toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  it("rejects a wrong token_type and an empty execution_id", () => {
+    const svc = service();
+    // Forge claims and re-sign with the REAL key via a same-key service —
+    // only the claim checks can reject these.
+    const forge = (claims: Record<string, unknown>): string => {
+      const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString(
+        "base64url",
+      );
+      const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+      const sig = createHmac("sha256", KEY)
+        .update(`${header}.${payload}`)
+        .digest("base64url");
+      return `${header}.${payload}.${sig}`;
+    };
+    const now = Math.floor(Date.now() / 1000);
+    expect(() =>
+      svc.verify(
+        forge({ token_type: "sandbox", execution_id: "id", iat: now, exp: now + 60 }),
+      ),
+    ).toThrow(InvalidTokenError);
+    expect(() =>
+      svc.verify(
+        forge({
+          token_type: TOKEN_TYPE_EXECUTION_SCOPED,
+          execution_id: "",
+          iat: now,
+          exp: now + 60,
+        }),
+      ),
+    ).toThrow(InvalidTokenError);
+  });
+
+  it("expires at the boundary: now >= exp is invalid", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:00Z"));
+    const svc = service();
+    const { token } = svc.mint("id", 60);
+
+    vi.setSystemTime(new Date("2026-08-23T12:00:59Z"));
+    expect(svc.verify(token)).toBe("id"); // one second before exp — valid
+
+    vi.setSystemTime(new Date("2026-08-23T12:01:00Z"));
+    expect(() => svc.verify(token)).toThrow(InvalidTokenError); // exp second — invalid
+  });
+});

--- a/backend/services/stigmer-server-ts/src/runnerauth/runnerauth.ts
+++ b/backend/services/stigmer-server-ts/src/runnerauth/runnerauth.ts
@@ -1,0 +1,246 @@
+/**
+ * Execution-scoped runner tokens — ports pkg/runnerauth/runnerauth.go
+ * (oss#535), the lane that gates the ExecutionContext decrypt path.
+ *
+ * WHY: since oss#535 the EC read RPCs redact is_secret values for every
+ * caller — the same contract the cloud edition enforces — but the runner
+ * still needs the real values to serve executions. Cloud distinguishes the
+ * runner by the token_type claim of its platform-minted credential; OSS
+ * has no authentication at all, so this module supplies the minimal
+ * equivalent: the platform exchange mints a short-lived token bound to ONE
+ * execution, and the EC handler decrypts only for a token whose binding
+ * matches the requested ExecutionContext.
+ *
+ * A LANE DISCRIMINATOR, NOT A TRUST BOUNDARY (DD-004): single-user OSS has
+ * no identity to verify — anyone who can reach the server can mint. What
+ * the token buys is the redaction-by-default read contract converging with
+ * cloud, on top of oss#405's encryption at rest.
+ *
+ * Token shape (field names are wire contract — the runner's
+ * token-claims.ts reads token_type by name):
+ *   {"token_type":"execution_scoped","execution_id":"<id>","iat":…,"exp":…}
+ *
+ * Consumers arrive with their own domains: the platform exchange RPC
+ * (mint) and the executioncontext resolve step (verify). This module lands
+ * with the encryption sub-project because its signing key rides the shared
+ * key ladder and its boot posture is a ratified cross-domain invariant
+ * (fatal — see compose.ts).
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { getOrCreateNamedKey } from "../encryption/key-manager.js";
+import type { KeyLoaderOptions } from "../encryption/key-manager.js";
+
+/**
+ * The token_type claim of every OSS-minted runner token — Go
+ * TokenTypeExecutionScoped. Deliberately distinct from the cloud sandbox
+ * vocabulary (sandbox / workflow_sandbox / connect_sandbox): borrowing
+ * "sandbox" while carrying different claims would mislead anyone debugging
+ * across editions. One honest type with a direct execution_id binding.
+ */
+export const TOKEN_TYPE_EXECUTION_SCOPED = "execution_scoped";
+
+/** Env var for the signing key (Base64 32B) — Go EnvKeyName. */
+export const RUNNER_TOKEN_KEY_ENV_VAR = "STIGMER_RUNNER_TOKEN_KEY";
+
+/** Auto-generated key file under ~/.stigmer — Go KeyFileName. */
+export const RUNNER_TOKEN_KEY_FILE_NAME = "runner-token.key";
+
+/**
+ * Default token lifetime — Go DefaultTTL (1 hour). Tokens are minted
+ * immediately before each ExecutionContext read (or carried in a connect
+ * workflow's dispatch payload), so the TTL only needs to cover one unit of
+ * dispatched work including its Temporal retries: generous without being
+ * an effectively-permanent credential in Temporal history.
+ */
+export const DEFAULT_TTL_SECONDS = 3600;
+
+/**
+ * Go ErrInvalidToken: ANY verification failure — forged signature, wrong
+ * algorithm, expired, wrong type, empty binding — collapses to this one
+ * error. Callers fail closed to redaction on it; a finer-grained reason
+ * would just invite branching on it.
+ */
+export class InvalidTokenError extends Error {
+  constructor() {
+    super("invalid runner token");
+    this.name = "InvalidTokenError";
+  }
+}
+
+/**
+ * Go ErrMintingDisabled: minting with no signing key (keyless deployments,
+ * effectively test-only — fromEnv auto-generates). The exchange RPC maps
+ * it to the presence-based "not minted" response the runner handles.
+ */
+export class MintingDisabledError extends Error {
+  constructor() {
+    super("runner token minting is disabled - no signing key configured");
+    this.name = "MintingDisabledError";
+  }
+}
+
+/**
+ * The constant JWT header: HS256 is the only algorithm this module ever
+ * produces or accepts — Verify refuses alg-confusion inputs by comparing
+ * the ENCODED header, without parsing attacker-controlled JSON.
+ */
+const JWT_HEADER = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString(
+  "base64url",
+);
+
+/** JWT payload shape — field names are wire contract. */
+interface TokenClaims {
+  readonly token_type: string;
+  readonly execution_id: string;
+  readonly iat: number;
+  readonly exp: number;
+}
+
+/** A minted token with its lifetime in whole seconds (the RPC's shape). */
+export interface MintedToken {
+  readonly token: string;
+  readonly ttlSeconds: number;
+}
+
+/**
+ * Mints and verifies execution-scoped runner tokens with a single
+ * HMAC-SHA256 key. Stateless and safe for concurrent use.
+ */
+export class RunnerAuthService {
+  private readonly key: Buffer | undefined;
+
+  private constructor(key: Buffer | undefined) {
+    this.key = key;
+  }
+
+  /**
+   * Go NewService: nil/empty key → disabled service (Mint fails with
+   * MintingDisabledError, Verify rejects everything — fail closed: without
+   * a key no token can be genuine).
+   */
+  static create(key: Buffer | undefined): RunnerAuthService {
+    if (key === undefined || key.length === 0) {
+      return new RunnerAuthService(undefined);
+    }
+    return new RunnerAuthService(key);
+  }
+
+  /**
+   * Go NewServiceFromEnv: key via the shared ladder (env var → key file →
+   * auto-generate). Errors only on unusable explicit configuration; the
+   * composition root maps that to the BOOT-FATAL posture (the ratified D2
+   * asymmetry: a server that cannot mint runner tokens would hand every
+   * execution redaction markers instead of its secrets — the silent-junk
+   * failure the oss#405 fail-loud doctrine forbids).
+   */
+  static fromEnv(options: KeyLoaderOptions = {}): RunnerAuthService {
+    const key = getOrCreateNamedKey(
+      RUNNER_TOKEN_KEY_ENV_VAR,
+      RUNNER_TOKEN_KEY_FILE_NAME,
+      options,
+    );
+    return RunnerAuthService.create(key);
+  }
+
+  /** Go IsEnabled: whether the service holds a signing key. */
+  isEnabled(): boolean {
+    return this.key !== undefined;
+  }
+
+  /**
+   * Go Mint: a token bound to executionId, valid for ttlSeconds
+   * (DEFAULT_TTL_SECONDS when <= 0).
+   */
+  mint(executionId: string, ttlSeconds: number = 0): MintedToken {
+    if (this.key === undefined) {
+      throw new MintingDisabledError();
+    }
+    if (executionId === "") {
+      throw new Error("execution id is required to mint a runner token");
+    }
+    const ttl = ttlSeconds > 0 ? ttlSeconds : DEFAULT_TTL_SECONDS;
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const claims: TokenClaims = {
+      token_type: TOKEN_TYPE_EXECUTION_SCOPED,
+      execution_id: executionId,
+      iat: nowSeconds,
+      exp: nowSeconds + ttl,
+    };
+    const signingInput =
+      JWT_HEADER + "." + Buffer.from(JSON.stringify(claims)).toString("base64url");
+    return {
+      token: signingInput + "." + this.sign(signingInput),
+      ttlSeconds: ttl,
+    };
+  }
+
+  /**
+   * Go Verify: checks signature, algorithm, expiry, and token type, and
+   * returns the execution id the token is bound to. Any failure throws the
+   * one InvalidTokenError — the caller's only correct reaction is to fall
+   * closed to redaction.
+   *
+   * Check order mirrors Go: enabled → three parts → exact encoded-header
+   * compare → constant-time HMAC → payload decode → claims. The expiry
+   * boundary is `now >= exp` (a token in its expiring second is invalid).
+   */
+  verify(token: string): string {
+    if (this.key === undefined) {
+      throw new InvalidTokenError();
+    }
+
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      throw new InvalidTokenError();
+    }
+    if (parts[0] !== JWT_HEADER) {
+      throw new InvalidTokenError();
+    }
+
+    const signingInput = parts[0] + "." + parts[1];
+    const expected = Buffer.from(this.sign(signingInput));
+    const provided = Buffer.from(parts[2] as string);
+    // Go's hmac.Equal returns false on length mismatch; Node's
+    // timingSafeEqual THROWS on it, so the length guard comes first (the
+    // signature length is not secret — no timing channel is opened).
+    if (
+      expected.length !== provided.length ||
+      !timingSafeEqual(expected, provided)
+    ) {
+      throw new InvalidTokenError();
+    }
+
+    let claims: TokenClaims;
+    try {
+      claims = JSON.parse(
+        Buffer.from(parts[1] as string, "base64url").toString("utf8"),
+      ) as TokenClaims;
+    } catch {
+      throw new InvalidTokenError();
+    }
+
+    if (
+      claims.token_type !== TOKEN_TYPE_EXECUTION_SCOPED ||
+      typeof claims.execution_id !== "string" ||
+      claims.execution_id === "" ||
+      typeof claims.exp !== "number" ||
+      Math.floor(Date.now() / 1000) >= claims.exp
+    ) {
+      throw new InvalidTokenError();
+    }
+
+    return claims.execution_id;
+  }
+
+  /** base64url HMAC-SHA256 of the signing input — Go sign(). */
+  private sign(signingInput: string): string {
+    if (this.key === undefined) {
+      throw new InvalidTokenError();
+    }
+    return createHmac("sha256", this.key)
+      .update(signingInput)
+      .digest("base64url");
+  }
+}

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -10,6 +10,8 @@
 // Roster history:
 //   - organization + registry-proxy — sub-project #4 (storage + pipeline;
 //     registry-proxy exercises the #3 transport lanes, DD-003).
+//   - environment — sub-project #5 (encryption + runnerauth + the
+//     Environment domain; the first secret-bearing suite).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -17,6 +19,7 @@ export default defineConfig({
     include: [
       "src/suites/organization.conformance.test.ts",
       "src/suites/registry-proxy.conformance.test.ts",
+      "src/suites/environment.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

D4 entry #5 of the TS server rewrite (program 20260822.01): the encryption subsystem, the runnerauth subsystem, and the Environment domain with its internal runtime-resolution service — secrets handling at full parity BEFORE any secret-bearing domain ports (oauthapp, mcpserver-OAuth, executioncontext all build on this). First secret-bearing suite on the `local-ts` roster.

## Context

The Environment domain is the redaction doctrine's home: `is_secret` values rest encrypted (`enc:v1:`, oss#405), leave the server as `***REDACTED***` markers, round-trip on writes, and reveal only through `getSecretValue`. Encryption and the runner-token lane are cross-cutting subsystems the later execution sub-projects (#15/#17/#20) consume; landing them here keeps those PRs purely additive.

## Changes

- **`src/encryption/`** — `enc:v1:<base64(nonce||ct||tag)>` AES-256-GCM secret service, byte-compatible with Go and the cloud Java service — proven by a fixture generated by the REAL Go encryptor and decrypted in the TS unit suite (sub-project DD-001; regen via `scripts/regen-go-ciphertext-fixture.sh`). Shared named-key ladder (`STIGMER_ENCRYPTION_KEY` → `~/.stigmer/encryption.key` → auto-generate) with injectable env/home for hermetic tests (DD-002). Keyless = warn-degrade: encrypt passes through, decrypt of ciphertext fails loud.
- **`src/runnerauth/`** — HS256 execution-scoped tokens (oss#535): constant JWT header pinned in encoded form (alg-confusion refused unparsed), constant-time HMAC compare, every verify failure collapsing to one error, `now >= exp` boundary. Key rides the shared ladder (`STIGMER_RUNNER_TOKEN_KEY`). Boot-fatal in `compose.ts` per the ratified D2 asymmetry; its consumers (platform exchange RPC, EC decrypt lane) arrive with their own sub-projects.
- **`src/domain/environment/`** — all 11 RPCs with Go's exact pipelines: the sentinels→encrypt ordering (marker restore BEFORE forged-ciphertext rejection BEFORE encrypt), redaction AFTER persist at every Environment-returning boundary (including delete), forged `enc:v<N>:` input rejected unconditionally (oss#395) with the non-secret exemption preserved, per-org personal-env uniqueness (create-only), share restrictions gating only WIDENING visibility transitions, `updateVariables`/`removeVariables` as self-contained write boundaries (SpecAudit slot, deliberately no search re-index), in-memory `list` (org + AND-labels, created_at desc, no pagination). Search extractor indexes name/description/tags/org/visibility — never secret data.
- **`src/domain/environment/resolution/`** — the internal decrypt-for-execution service (never on the RPC surface): RPC-identical lookup, WARN-and-drop per undecryptable key, fail-loud propagation of keyless-with-ciphertext, NotFound on unresolved refs.
- **`compose.ts`** — the new keys stage between storage and controllers (encryption WARN-degrade → runnerauth boot-fatal), environment registration.
- **Conformance** — `environment.conformance.test.ts` added to the `local-ts` roster.

## Implementation notes (parity disclosures for the register)

No wire-visible divergence was found — the environment suite passed unchanged on the first local-ts run, including every byte-pinned error message and the protovalidate InvalidArgument negatives. Implementation-level notes:

1. **HMAC length guard**: Go's `hmac.Equal` returns false on length-mismatched signatures; Node's `timingSafeEqual` throws — a length guard precedes the compare (behavior identical: `ErrInvalidToken`).
2. **Strict Base64 restoration**: Node's lenient decoder never throws; round-trip checks restore Go's strict-decode errors for corrupted key/ciphertext input.
3. **Future-version ciphertext**: Go's `TrimPrefix` leaves `enc:v2:…` intact so it fails closed as invalid ciphertext; the TS decrypt preserves those exact semantics (a naive prefix-length slice would have decrypted v2 payloads as v1).
4. **Key loader testability**: injectable `env`/`homeDir` parameters (defaulting to process values, the `loadConfig` idiom) so unit tests never touch the real `~/.stigmer`. Production call sites pass nothing; ladder semantics are Go's, including the fall-through-and-overwrite on unloadable key files.

## Breaking changes

- None. The Go server is untouched; the TS server is not yet the served binary.

## Test plan

- Unit: 232 tests green (`npm test`) — encryption incl. the Go-generated cross-edition fixture, tamper/wrong-key/forged-version arms; runnerauth incl. alg-confusion, forged-claims, expiry-boundary, length-mismatch arms; environment through the REAL stack (composed server + gRPC client) incl. ciphertext-at-rest, no-double-encryption, and the keyless degrade path; resolution per-key drop + fail-loud.
- Conformance: `make test-conformance-ts` — 57/57 (environment 38/38); `make test-conformance` (local-go) — 375 passed, regression-free.
- `npm run typecheck` clean; `verify:dist` and `verify:slim` boot gates green.

## Risks

- Low: purely additive (no shared-pipeline or store changes). Rollback = revert; no schema or wire impact.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Conformance green on both targets

Made with [Cursor](https://cursor.com)