### PR TITLE
test(conformance): add wave-2 suites — CW-2/3/4/5/7 (agentshare, channels, artifact, search, execution read surfaces)

### DIFF
--- a/test/conformance/src/harness/clients.ts
+++ b/test/conformance/src/harness/clients.ts
@@ -9,10 +9,22 @@ import { createGrpcTransport } from "@connectrpc/connect-node";
 import { ActivityQueryController } from "@stigmer/protos/ai/stigmer/activity/v1/query_pb";
 import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
 import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { AgentChannelCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/command_pb";
+import { ChannelConversationCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_command_pb";
+import { ChannelConversationQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_query_pb";
+import { ChannelMessageCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_command_pb";
+import { ChannelMessageQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_query_pb";
+import { AgentChannelQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/query_pb";
 import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
 import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
 import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
 import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { AgentShareCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/command_pb";
+import { AgentShareQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/query_pb";
+import { ArtifactCommandController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/command_pb";
+import { ArtifactQueryController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/query_pb";
+import { ChannelAppCommandController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/command_pb";
+import { ChannelAppQueryController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/query_pb";
 import { EnvironmentCommandController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/command_pb";
 import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
 import { ExecutionContextCommandController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/command_pb";
@@ -37,6 +49,7 @@ import { OAuthAppCommandController } from "@stigmer/protos/ai/stigmer/iam/oautha
 import { OAuthAppQueryController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/query_pb";
 import { GitHubService } from "@stigmer/protos/ai/stigmer/platform/github/v1/service_pb";
 import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import { SearchService } from "@stigmer/protos/ai/stigmer/search/v1/query_pb";
 import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
 import { OrganizationQueryController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/query_pb";
 import { ProjectCommandController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/command_pb";
@@ -44,6 +57,19 @@ import { ProjectQueryController } from "@stigmer/protos/ai/stigmer/tenancy/proje
 
 export interface ConformanceClients {
   activityQuery: Client<typeof ActivityQueryController>;
+  agentChannelCommand: Client<typeof AgentChannelCommandController>;
+  agentChannelQuery: Client<typeof AgentChannelQueryController>;
+  agentShareCommand: Client<typeof AgentShareCommandController>;
+  agentShareQuery: Client<typeof AgentShareQueryController>;
+  artifactCommand: Client<typeof ArtifactCommandController>;
+  artifactQuery: Client<typeof ArtifactQueryController>;
+  channelAppCommand: Client<typeof ChannelAppCommandController>;
+  channelAppQuery: Client<typeof ChannelAppQueryController>;
+  channelConversationCommand: Client<typeof ChannelConversationCommandController>;
+  channelConversationQuery: Client<typeof ChannelConversationQueryController>;
+  channelMessageCommand: Client<typeof ChannelMessageCommandController>;
+  channelMessageQuery: Client<typeof ChannelMessageQueryController>;
+  search: Client<typeof SearchService>;
   projectCommand: Client<typeof ProjectCommandController>;
   projectQuery: Client<typeof ProjectQueryController>;
   organizationCommand: Client<typeof OrganizationCommandController>;
@@ -105,6 +131,19 @@ export function createTransport(baseUrl: string, options: TransportOptions = {})
 export function makeClients(transport: Transport): ConformanceClients {
   return {
     activityQuery: createClient(ActivityQueryController, transport),
+    agentChannelCommand: createClient(AgentChannelCommandController, transport),
+    agentChannelQuery: createClient(AgentChannelQueryController, transport),
+    agentShareCommand: createClient(AgentShareCommandController, transport),
+    agentShareQuery: createClient(AgentShareQueryController, transport),
+    artifactCommand: createClient(ArtifactCommandController, transport),
+    artifactQuery: createClient(ArtifactQueryController, transport),
+    channelAppCommand: createClient(ChannelAppCommandController, transport),
+    channelAppQuery: createClient(ChannelAppQueryController, transport),
+    channelConversationCommand: createClient(ChannelConversationCommandController, transport),
+    channelConversationQuery: createClient(ChannelConversationQueryController, transport),
+    channelMessageCommand: createClient(ChannelMessageCommandController, transport),
+    channelMessageQuery: createClient(ChannelMessageQueryController, transport),
+    search: createClient(SearchService, transport),
     projectCommand: createClient(ProjectCommandController, transport),
     projectQuery: createClient(ProjectQueryController, transport),
     organizationCommand: createClient(OrganizationCommandController, transport),

--- a/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
@@ -45,7 +45,11 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { create } from "@bufbuild/protobuf";
 import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
-import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  ExecutionPhase,
+  FileDecisionAction,
+  FileDecisionScope,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { UploadAttachmentRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
 import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
 import { Code } from "@connectrpc/connect";
@@ -57,6 +61,7 @@ import { FixtureTracker } from "../harness/fixtures";
 import type { MockLlmProxy } from "../harness/mock-llm";
 import { anthropicText } from "../harness/mock-llm";
 import { makeAgent } from "../support/agents";
+import { collectStream } from "../support/collect-stream";
 import {
   AGENT_EXECUTION_API_VERSION,
   AGENT_EXECUTION_KIND,
@@ -842,5 +847,97 @@ describe("AgentExecution conformance — attachments (#285)", () => {
       },
       expect.objectContaining({ type: "text", text: "What is in this image?" }),
     ]);
+  });
+});
+
+// --- CW-7: the subscribe lane and the read surfaces a real run populates ----
+//
+// Streams are consumed through collectStream, the bounded reader that keeps
+// the S4 idle-forever quirk (pinned below) from hanging the suite.
+
+describe("AgentExecution conformance — subscribe & populated read surfaces (CW-7)", () => {
+  it("subscribe on a LIVE run streams the snapshot, its updates, and closes on the terminal one", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentId = await provisionAgent(org);
+    const created = await createExecution(org, agentId);
+
+    // Subscribed while the run is in flight: the lane's contract is
+    // snapshot-first, then full-snapshot updates, then a clean server close
+    // when an UPDATE reaches a terminal phase.
+    const stream = await collectStream((signal) =>
+      clients.agentExecutionQuery.subscribe({ value: created.metadata!.id }, { signal }),
+    );
+    expect(stream.outcome, "the server closes on the terminal update").toBe("closed");
+    expect(stream.messages.length, "at least the snapshot plus the terminal update").toBeGreaterThanOrEqual(2);
+    expect(stream.messages[0]?.metadata?.id).toBe(created.metadata?.id);
+    expect(stream.messages.at(-1)?.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+  });
+
+  it("subscribe sends the snapshot but never closes on an already-terminal run (the pinned S4 quirk)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentId = await provisionAgent(org);
+    const created = await createExecution(org, agentId);
+    await awaitTerminal(clients, created.metadata!.id);
+
+    // The terminal-close check fires only on broker UPDATES, never on the
+    // initial snapshot — a subscription to a finished run receives the
+    // snapshot and then idles forever. Pinned deliberately (wave-2 S4): the
+    // TS port must reproduce it consciously or fix it in both editions.
+    const stream = await collectStream(
+      (signal) => clients.agentExecutionQuery.subscribe({ value: created.metadata!.id }, { signal }),
+      { timeoutMs: 3_000 },
+    );
+    expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
+    expect(stream.messages).toHaveLength(1);
+    expect(stream.messages[0]?.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+  });
+
+  it("a completed run's usage report answers the zero-valued aggregate (this edition records no usage)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentId = await provisionAgent(org);
+    const created = await createExecution(org, agentId);
+    await awaitTerminal(clients, created.metadata!.id);
+
+    // The strongest form of the zero-shapes contract: the execution EXISTS
+    // (the NotFound arm is Class A), yet the aggregate is still a
+    // structurally complete zero report — OSS deliberately aggregates no
+    // usage data at all.
+    const report = await clients.agentExecutionQuery.getExecutionUsageReport({
+      executionId: created.metadata!.id,
+    });
+    expect(report.aggregate, "the aggregate is always present").toBeDefined();
+    expect(report.aggregate?.totalTokens).toBe(0n);
+    expect(report.aggregate?.inputTokens).toBe(0n);
+    expect(report.aggregate?.outputTokens).toBe(0n);
+    expect(report.modelBreakdown).toHaveLength(0);
+  });
+
+  it("submitFileDecision refuses a run with no actionable file change sets (FailedPrecondition)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agentId = await provisionAgent(org);
+    const created = await createExecution(org, agentId);
+    await awaitTerminal(clients, created.metadata!.id);
+
+    // A text-only completed run has an empty file-review stream AND a
+    // terminal phase — both fold into the same precondition refusal (there
+    // is deliberately no separate wrong-phase arm). The deeper arms (digest
+    // mismatch, unknown change set) need file-edit choreography and land
+    // with #17. Message prefix only: the copy embeds the phase enum's
+    // rendering, which is the Go formatter's, not a contract.
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentExecutionCommand.submitFileDecision({
+          agentExecutionId: created.metadata!.id,
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.FailedPrecondition,
+      "submitFileDecision on a run that produced no file changes",
+    );
+    expect(err.rawMessage).toContain(
+      `execution ${created.metadata!.id} has no actionable file change sets`,
+    );
   });
 });

--- a/test/conformance/src/suites-execution/workflowexecution-approval.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution-approval.conformance.test.ts
@@ -145,6 +145,16 @@ describe("WorkflowExecution submitWorkflowTaskApproval — gate & resolution", (
       ExecutionPhase.EXECUTION_IN_PROGRESS,
     );
 
+    // The gate is also the listPendingApprovals populated arm (CW-7): the
+    // read scans per-task status projections, and the entry carries the
+    // TASK NAME (deliberately not the composite task id — the value
+    // submitWorkflowTaskApproval accepts).
+    const pending = await clients.workflowExecutionQuery.listPendingApprovals({ org });
+    expect(pending.totalCount).toBe(1);
+    expect(pending.entries).toHaveLength(1);
+    expect(pending.entries[0]?.executionId).toBe(executionId);
+    expect(pending.entries[0]?.taskName).toBe(HUMAN_INPUT_TASK_NAME);
+
     // Settle so the run terminates cleanly.
     await clients.workflowExecutionCommand.submitWorkflowTaskApproval({
       executionId,
@@ -153,6 +163,11 @@ describe("WorkflowExecution submitWorkflowTaskApproval — gate & resolution", (
       reviewer: "conformance",
     });
     await awaitTerminal(clients, executionId);
+
+    // Resolved gates leave the pending view — the read reflects live task
+    // state, not a ledger of past gates.
+    const drained = await clients.workflowExecutionQuery.listPendingApprovals({ org });
+    expect(drained.totalCount).toBe(0);
   });
 
   it("approve resolves the gate; the execution completes and the downstream task runs", async () => {

--- a/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
@@ -23,14 +23,17 @@
 //   contracts ARE asserted; their success paths await the human-input slice.
 // - updateStatus is the runner's internal status-merge RPC, exercised implicitly
 //   by every completion rather than as a user-facing contract.
+import { FileDecisionAction, FileDecisionScope } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
 import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { WorkflowEventType, type WorkflowExecutionEvent } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
 import { Code } from "@connectrpc/connect";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
+import { collectStream } from "../support/collect-stream";
 import { uniqueName } from "../support/naming";
 import {
   WORKFLOW_EXECUTION_API_VERSION,
@@ -447,6 +450,125 @@ describe("WorkflowExecution conformance — create negative paths", () => {
         }),
       Code.InvalidArgument,
       "create without name",
+    );
+  });
+});
+
+// --- CW-7: the event log's cursor pagination and the streaming lanes --------
+//
+// A completed single-task set_vars run emits exactly FOUR events
+// (execution_started, task_started, task_completed, execution_completed) —
+// small enough to be cheap, rich enough to walk a real has_more/
+// latest_sequence cursor with page_size 1. Streams are consumed through
+// collectStream, the bounded reader that keeps the S4 idle-forever quirk
+// (pinned below) from hanging the suite.
+
+describe("WorkflowExecution conformance — event log pagination & streaming (CW-7)", () => {
+  it("getEventLog walks the after_sequence cursor: page_size 1, has_more, exhaustion", async () => {
+    const { org } = await target.provisionTenancy();
+    const workflowId = await provisionWorkflow(org);
+    const created = await createExecution(org, workflowId);
+    await awaitTerminal(clients, created.metadata!.id);
+    const executionId = created.metadata!.id;
+
+    // Walk the whole log one event at a time — real cursor semantics, no
+    // manufactured event floods.
+    const walked: WorkflowExecutionEvent[] = [];
+    let afterSequence = 0n;
+    for (;;) {
+      const page = await clients.workflowExecutionQuery.getEventLog({
+        executionId,
+        afterSequence,
+        pageSize: 1,
+      });
+      if (page.events.length === 0) break;
+      expect(page.events, "page_size 1 is honored").toHaveLength(1);
+      walked.push(page.events[0]!);
+      // has_more reflects records beyond this page; the cursor is the
+      // page's latest sequence, strictly-greater-than on the next read.
+      expect(page.hasMore).toBe(walked.length < 4);
+      expect(page.latestSequence).toBe(page.events[0]!.sequenceNumber);
+      afterSequence = page.latestSequence;
+      if (!page.hasMore) break;
+    }
+
+    // The four-event shape of a single-task run, sequences dense from 1.
+    expect(walked).toHaveLength(4);
+    expect(walked.map((e) => e.sequenceNumber)).toEqual([1n, 2n, 3n, 4n]);
+    expect(walked[0]?.eventType).toBe(WorkflowEventType.execution_started);
+    expect(walked[3]?.eventType).toBe(WorkflowEventType.execution_completed);
+
+    // One unpaginated read returns the same log with has_more exhausted.
+    const full = await clients.workflowExecutionQuery.getEventLog({ executionId });
+    expect(full.events.map((e) => e.eventId)).toEqual(walked.map((e) => e.eventId));
+    expect(full.hasMore).toBe(false);
+    expect(full.latestSequence).toBe(4n);
+  });
+
+  it("subscribeEvents replays a terminal run's whole log and closes cleanly", async () => {
+    const { org } = await target.provisionTenancy();
+    const workflowId = await provisionWorkflow(org);
+    const created = await createExecution(org, workflowId);
+    await awaitTerminal(clients, created.metadata!.id);
+
+    // Replay-then-close: on an already-terminal execution the stream sends
+    // every persisted event and ends on its own — the deterministic way to
+    // prove the lane without racing a live run.
+    const stream = await collectStream((signal) =>
+      clients.workflowExecutionQuery.subscribeEvents(
+        { executionId: created.metadata!.id },
+        { signal },
+      ),
+    );
+    expect(stream.outcome, "the server closes after draining a terminal run").toBe("closed");
+    expect(stream.messages.map((e) => e.sequenceNumber)).toEqual([1n, 2n, 3n, 4n]);
+    expect(stream.messages[3]?.eventType).toBe(WorkflowEventType.execution_completed);
+  });
+
+  it("subscribe sends the snapshot but never closes on an already-terminal run (the pinned S4 quirk)", async () => {
+    const { org } = await target.provisionTenancy();
+    const workflowId = await provisionWorkflow(org);
+    const created = await createExecution(org, workflowId);
+    await awaitTerminal(clients, created.metadata!.id);
+
+    // The terminal-close check fires only on broker UPDATES, never on the
+    // initial snapshot — so a subscription to a finished run receives the
+    // snapshot and then idles forever. Pinned deliberately (wave-2 S4): the
+    // TS port must reproduce it consciously or fix it in both editions.
+    const stream = await collectStream(
+      (signal) =>
+        clients.workflowExecutionQuery.subscribe({ executionId: created.metadata!.id }, { signal }),
+      { timeoutMs: 3_000 },
+    );
+    expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
+    expect(stream.messages).toHaveLength(1);
+    expect(stream.messages[0]?.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+  });
+
+  it("submitFileDecision refuses an execution with no pending file reviews (FailedPrecondition)", async () => {
+    const { org } = await target.provisionTenancy();
+    const workflowId = await provisionWorkflow(org);
+    const created = await createExecution(org, workflowId);
+    await awaitTerminal(clients, created.metadata!.id);
+
+    // The deeper file-review arms (digest mismatch, unknown change set)
+    // need mock-LLM file-edit choreography and land with the execution
+    // ports (#17/#20) — this pins the reachable precondition arm.
+    const err = await expectGrpcCode(
+      () =>
+        clients.workflowExecutionCommand.submitFileDecision({
+          executionId: created.metadata!.id,
+          childAgentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.FailedPrecondition,
+      "submitFileDecision on a run that never produced file reviews",
+    );
+    expect(err.rawMessage).toBe(
+      `workflow execution ${created.metadata!.id} has no pending file reviews`,
     );
   });
 });

--- a/test/conformance/src/suites/agentchannel.conformance.test.ts
+++ b/test/conformance/src/suites/agentchannel.conformance.test.ts
@@ -222,6 +222,34 @@ describe("AgentChannel conformance — create validation", () => {
     expect(err.rawMessage).toBe("Agent not found: no-such-agent");
   });
 
+  it("the pin-REQUIRED rule is edition-split: OSS stores an unpinned channel, cloud refuses it (#362)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const unpinned = makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug, {
+      modelName: null,
+    });
+
+    if (target.capabilities.channelMessaging) {
+      // The edition that SERVES channels refuses an unpinned one at write
+      // time: its channel execution profile runs the Cursor harness, where
+      // no pin means billing as Auto.
+      const err = await expectGrpcCode(
+        () => clients.agentChannelCommand.create(unpinned),
+        Code.InvalidArgument,
+        "unpinned channel where the channel runtime serves Cursor",
+      );
+      expect(err.rawMessage).toContain(
+        "spec.run_config.model_name must name a pinned model when the run would use the Cursor harness",
+      );
+    } else {
+      // The edition that only STORES channels accepts the unpinned spec —
+      // there is no serving profile to bill against.
+      const created = await clients.agentChannelCommand.create(unpinned);
+      fixtures.defer(() => clients.agentChannelCommand.delete({ value: created.metadata!.id }));
+      expect(created.spec?.runConfig?.modelName ?? "").toBe("");
+    }
+  });
+
   it("rejects an unknown model pin (InvalidArgument, stable message prefix)", async () => {
     const { org } = await target.provisionTenancy();
     const agent = await createAgentFixture(org);
@@ -405,35 +433,45 @@ describe("AgentChannel conformance — the install lanes", () => {
 });
 
 describe("AgentChannel conformance — conversation lanes", () => {
-  it("discovery reads answer truthful emptiness (both editions, no traffic exists)", async () => {
+  // The reads probe a REAL channel of the caller's own org: on cloud a
+  // fabricated channel id fails closed in authorization (PermissionDenied,
+  // no existence leak) before any handler runs, so only an owned channel
+  // reaches the shared truthful-emptiness contract on both editions.
+  it("discovery reads answer truthful emptiness (no conversation traffic exists)", async () => {
     const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const channel = await createChannelFixture(org, agent.metadata!.slug);
 
     const conversations = await clients.channelConversationQuery.listConversations({ org });
     expect(conversations.totalCount).toBe(0);
     expect(conversations.items).toHaveLength(0);
 
     const timeline = await clients.channelConversationQuery.getTimeline({
-      agentChannelId: "ach_01confmissing",
+      agentChannelId: channel.metadata!.id,
       conversationKey: "conf-conversation",
     });
     expect(timeline.items ?? []).toHaveLength(0);
   });
 
   it("single-row reads answer uniform NotFound (no local probing, no existence leak)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const channel = await createChannelFixture(org, agent.metadata!.slug);
+
     await expectGrpcCode(
       () =>
         clients.channelConversationQuery.getConversation({
-          agentChannelId: "ach_01confmissing",
+          agentChannelId: channel.metadata!.id,
           conversationKey: "conf-conversation",
         }),
       Code.NotFound,
-      "getConversation — this edition never materializes conversations",
+      "getConversation on a channel with no conversations",
     );
 
     const media = await expectGrpcCode(
       () =>
         clients.channelConversationQuery.getMediaDownloadUrl({
-          agentChannelId: "ach_01confmissing",
+          agentChannelId: channel.metadata!.id,
           conversationKey: "conf-conversation",
           itemId: "conf-item",
         }),
@@ -486,11 +524,24 @@ describe("AgentChannel conformance — conversation lanes", () => {
 });
 
 describe("AgentChannel conformance — messaging lanes", () => {
-  it("listMessagingChannels answers truthful emptiness (both editions — a capability-DISCOVERY read)", async () => {
-    // The runner issues this read on every agent execution to decide
-    // whether to attach the send tool; "none" is the honest answer wherever
-    // no proactive-enabled installed channel exists — which is everywhere a
-    // fresh conformance run looks.
+  it("listMessagingChannels answers truthful emptiness on the storing edition, a refusal on the serving one", async () => {
+    if (target.capabilities.channelMessaging) {
+      // The serving edition resolves this read from an agent SESSION (the
+      // runner's identity), so a bare direct call is refused with guidance
+      // toward the resource surface — a verified edition divergence,
+      // pinned two-armed rather than skipped.
+      const err = await expectGrpcCode(
+        () => clients.channelMessageQuery.listMessagingChannels({}),
+        Code.InvalidArgument,
+        "direct listMessagingChannels where the channel runtime serves",
+      );
+      expect(err.rawMessage).toContain("resolves from an agent session");
+      return;
+    }
+    // The storing edition answers "none" for everyone: the runner issues
+    // this read on every agent execution to decide whether to attach the
+    // send tool, and an expected-error path in that hot loop would be
+    // noise.
     const channels = await clients.channelMessageQuery.listMessagingChannels({});
     expect(channels.entries ?? []).toHaveLength(0);
   });

--- a/test/conformance/src/suites/agentchannel.conformance.test.ts
+++ b/test/conformance/src/suites/agentchannel.conformance.test.ts
@@ -1,0 +1,529 @@
+// AgentChannel conformance — CRUD + validation, the install/conversation/
+// messaging runtime postures, and the same-org invariants (Class A).
+// Domain: conformance suites.
+//
+// An AgentChannel binds one agent to one external messaging workspace. The
+// resource CRUD surface is fully served by both editions; the RUNTIME lanes
+// split by edition and are pinned by posture (channel-integrations T02 §0-b
+// and the conversation/messaging decisions, all documented in the Go
+// controllers):
+//
+//   - COMMANDS that ask to DO a cloud-only thing refuse FailedPrecondition
+//     with per-surface copy — byte-pinned here where channelMessaging is
+//     false (the OSS contract the TS port must reproduce): installs
+//     ("channel installs require Stigmer Cloud"), conversation participation
+//     ("conversation participation requires Stigmer Cloud"), proactive
+//     messaging ("proactive channel messaging requires Stigmer Cloud").
+//   - DISCOVERY reads answer truthful emptiness on both editions (empty
+//     lists; uniform NotFound for single-row reads) — asserted
+//     unconditionally: a fresh conformance fixture has no conversation
+//     traffic on either edition.
+//   - INPUT VALIDATION runs before every refusal (the controllers validate
+//     first precisely so the InvalidArgument contract matches cloud) —
+//     asserted unconditionally.
+//
+// Deliberate exclusions, disclosed in the wave-2 PR:
+//   - The app_ref freeze-while-installed rule is structurally unreachable on
+//     OSS (install_state never reaches `installed` — the install lane is the
+//     refusal above). The reachable half of the same rule IS asserted: a
+//     pending channel rebinds its app freely.
+//   - The install/conversation/messaging lanes' full CLOUD behavior needs
+//     live provider workspaces; it stays covered by cloud's integration
+//     tests (see the channelMessaging flag comment in targets/target.ts).
+import { Code } from "@connectrpc/connect";
+import { AgentChannelInstallState } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/status_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { makeAgent } from "../support/agents";
+import {
+  makeSlackAgentChannel,
+  makeWhatsAppAgentChannel,
+} from "../support/agentchannels";
+import { makeSlackChannelApp } from "../support/channelapps";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// An agent for channels to reference — every channel needs one, and the
+// same-org invariant is about ITS org.
+async function createAgentFixture(org: string) {
+  const agent = await clients.agentCommand.create(
+    makeAgent({ org, name: uniqueName("channel-agent") }),
+  );
+  fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+  return agent;
+}
+
+async function createChannelFixture(org: string, agentSlug: string, name = uniqueName("channel")) {
+  const channel = await clients.agentChannelCommand.create(
+    makeSlackAgentChannel(org, name, agentSlug),
+  );
+  fixtures.defer(() => clients.agentChannelCommand.delete({ value: channel.metadata!.id }));
+  return channel;
+}
+
+describe("AgentChannel conformance — CRUD & identity", () => {
+  it("create assigns an ach_ id, echoes the spec, and initializes install_state to pending_install", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    expect(created.metadata?.id).toMatch(/^ach_/);
+    expect(created.metadata?.org).toBe(org);
+    expect(created.spec?.providerConfig?.case).toBe("slack");
+    // The relative agent_ref was normalized to an absolute one.
+    expect(created.spec?.agentRef?.org).toBe(org);
+    expect(created.spec?.agentRef?.slug).toBe(agent.metadata?.slug);
+    // System-managed install lifecycle starts at pending_install — set
+    // AFTER the create pipeline's status wipe, so its presence proves the
+    // ordering contract too.
+    expect(created.status?.installState).toBe(AgentChannelInstallState.pending_install);
+  });
+
+  it("get, getByReference, and list resolve the channel", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    const fetched = await clients.agentChannelQuery.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.id).toBe(created.metadata?.id);
+
+    const byRef = await clients.agentChannelQuery.getByReference({
+      org,
+      slug: created.metadata!.slug,
+    });
+    expect(byRef.metadata?.id).toBe(created.metadata?.id);
+
+    const listed = await clients.agentChannelQuery.list({ org });
+    expect(listed.items.some((c) => c.metadata?.id === created.metadata?.id)).toBe(true);
+  });
+
+  it("getByAgent returns the agent's channels; an unknown agent id yields an empty list, not an error", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    const channels = await clients.agentChannelQuery.getByAgent({ agentId: agent.metadata!.id });
+    expect(channels.items.some((c) => c.metadata?.id === created.metadata?.id)).toBe(true);
+
+    // "No channels" is the useful answer for the integrations surface
+    // whether the agent is unknown or merely channel-less.
+    const none = await clients.agentChannelQuery.getByAgent({ agentId: "agent_01confmissing" });
+    expect(none.totalCount).toBe(0);
+    expect(none.items).toHaveLength(0);
+  });
+
+  it("update flips mutable fields (enabled) and preserves identity", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    const updated = await clients.agentChannelCommand.update({
+      ...makeSlackAgentChannel(org, created.metadata!.name, agent.metadata!.slug, {
+        enabled: false,
+      }),
+      metadata: created.metadata,
+    });
+
+    expect(updated.metadata?.id).toBe(created.metadata?.id);
+    expect(updated.spec?.enabled).toBe(false);
+    // Status (install lifecycle) is system-managed and survives updates.
+    expect(updated.status?.installState).toBe(AgentChannelInstallState.pending_install);
+  });
+
+  it("delete removes the channel", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    // No deferred cleanup: this test deletes the channel itself.
+    const created = await clients.agentChannelCommand.create(
+      makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug),
+    );
+
+    await clients.agentChannelCommand.delete({ value: created.metadata!.id });
+
+    await expectGrpcCode(
+      () => clients.agentChannelQuery.get({ value: created.metadata!.id }),
+      Code.NotFound,
+      "get after delete",
+    );
+  });
+});
+
+describe("AgentChannel conformance — create validation", () => {
+  it("requires metadata.org (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.create(
+          makeSlackAgentChannel("", uniqueName("channel"), agent.metadata!.slug),
+        ),
+      Code.InvalidArgument,
+      "create without metadata.org",
+    );
+    expect(err.rawMessage).toBe("metadata.org is required for an agent channel");
+  });
+
+  it("rejects a cross-org agent_ref (FailedPrecondition — channels have no cross-org arm)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const { org: otherOrg } = await target.provisionTenancy();
+
+    // NOTE the deliberate as-is pin: the same-org rule here answers
+    // FailedPrecondition while ChannelApp's provider rule answers
+    // InvalidArgument — the cross-domain inconsistency recorded in the
+    // wave-2 PR for post-cutover harmonization.
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.create(
+          makeSlackAgentChannel(otherOrg, uniqueName("channel"), agent.metadata!.slug, {
+            agentRefOrg: org,
+          }),
+        ),
+      Code.FailedPrecondition,
+      "create with agent_ref pointing at another org",
+    );
+    expect(err.rawMessage).toContain("spec.agent_ref.org must match metadata.org");
+  });
+
+  it("rejects an unknown agent with the same NotFound a direct lookup produces", async () => {
+    const { org } = await target.provisionTenancy();
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.create(
+          makeSlackAgentChannel(org, uniqueName("channel"), "no-such-agent"),
+        ),
+      Code.NotFound,
+      "create referencing a nonexistent agent",
+    );
+    // Byte-identical with the direct agent lookup's refusal (the
+    // indistinguishability contract the defaults resolver documents).
+    expect(err.rawMessage).toBe("Agent not found: no-such-agent");
+  });
+
+  it("rejects an unknown model pin (InvalidArgument, stable message prefix)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.create(
+          makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug, {
+            modelName: "surely-not-a-real-model-xyz",
+          }),
+        ),
+      Code.InvalidArgument,
+      "create with a model pin the registry does not know",
+    );
+    // Prefix only, never the full string: the refusal appends a
+    // did-you-mean suffix whose content depends on the registry snapshot.
+    expect(err.rawMessage).toContain(
+      "spec.run_config.model_name: model 'surely-not-a-real-model-xyz' is not in the model registry",
+    );
+  });
+
+  it("requires app_ref for WhatsApp channels (InvalidArgument — BYO-only provider)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.create(
+          makeWhatsAppAgentChannel(org, uniqueName("channel"), agent.metadata!.slug),
+        ),
+      Code.InvalidArgument,
+      "create a WhatsApp channel without an app_ref",
+    );
+    expect(err.rawMessage).toBe(
+      "spec.app_ref is required for WhatsApp channels — register your Meta app as a channel app and reference it",
+    );
+  });
+
+  it("rejects a cross-org app_ref (FailedPrecondition — secrets never cross orgs)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const { org: otherOrg } = await target.provisionTenancy();
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.create(
+          makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug, {
+            appRefSlug: "some-app",
+            appRefOrg: otherOrg,
+          }),
+        ),
+      Code.FailedPrecondition,
+      "create with app_ref pointing at another org's app",
+    );
+    expect(err.rawMessage).toContain("spec.app_ref.org must match metadata.org");
+  });
+
+  it("rejects a create with no provider arm (InvalidArgument — required oneof)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+
+    const spec = makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug);
+    delete (spec.spec as { providerConfig?: unknown }).providerConfig;
+
+    await expectGrpcCode(
+      () => clients.agentChannelCommand.create(spec),
+      Code.InvalidArgument,
+      "create with an empty provider_config oneof",
+    );
+  });
+});
+
+describe("AgentChannel conformance — update immutability", () => {
+  it("rejects re-pointing agent_ref (FailedPrecondition — a channel serves ONE agent)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const otherAgent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.update({
+          ...makeSlackAgentChannel(org, created.metadata!.name, otherAgent.metadata!.slug),
+          metadata: created.metadata,
+        }),
+      Code.FailedPrecondition,
+      "update re-pointing the channel at a different agent",
+    );
+    expect(err.rawMessage).toContain("spec.agent_ref is immutable");
+  });
+
+  it("rejects flipping the provider arm (FailedPrecondition — install state is provider-shaped)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.update({
+          ...makeWhatsAppAgentChannel(org, created.metadata!.name, agent.metadata!.slug, {
+            appRefSlug: "some-app",
+          }),
+          metadata: created.metadata,
+        }),
+      Code.FailedPrecondition,
+      "update flipping slack → whatsapp",
+    );
+    expect(err.rawMessage).toContain("spec provider is immutable (channel provider is slack)");
+  });
+
+  it("allows rebinding app_ref while the channel is pending (the reachable half of the freeze rule)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const app = await clients.channelAppCommand.create(
+      makeSlackChannelApp(org, uniqueName("channel-app")),
+    );
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+    // The channel must unbind before cleanup deletes the app (delete-block).
+    fixtures.defer(() => clients.channelAppCommand.delete({ resourceId: app.metadata!.id }));
+
+    // pending_install channels rebind freely — the freeze applies only to
+    // installed channels, a state this edition never reaches (the install
+    // lane is a refusal; see the suite header's disclosed exclusion).
+    const bound = await clients.agentChannelCommand.update({
+      ...makeSlackAgentChannel(org, created.metadata!.name, agent.metadata!.slug, {
+        appRefSlug: app.metadata!.slug,
+      }),
+      metadata: created.metadata,
+    });
+    expect(bound.spec?.appRef?.slug).toBe(app.metadata?.slug);
+
+    const unbound = await clients.agentChannelCommand.update({
+      ...makeSlackAgentChannel(org, created.metadata!.name, agent.metadata!.slug),
+      metadata: created.metadata,
+    });
+    expect(unbound.spec?.appRef?.slug ?? "").toBe("");
+  });
+});
+
+describe("AgentChannel conformance — the install lanes", () => {
+  it("initiateInstall on an unknown channel answers the LoadChannel NotFound (both editions)", async () => {
+    const err = await expectGrpcCode(
+      () => clients.agentChannelCommand.initiateInstall({ resourceId: "ach_01confmissing" }),
+      Code.NotFound,
+      "initiateInstall on a nonexistent channel",
+    );
+    // The load-then-refuse contract: NOT_FOUND is deliberately identical to
+    // the cloud edition's LoadChannel step, so only the final (documented)
+    // step diverges by edition.
+    expect(err.rawMessage).toBe("AgentChannel not found: ach_01confmissing");
+  });
+
+  it("refuses installs where no channel runtime exists (the pinned OSS posture)", async (ctx) => {
+    // Cloud serves real installs; their behavior needs a live provider
+    // workspace — covered by cloud's integration tests, not pinnable here
+    // (the skill transfer-lane skip precedent: no observable opposite arm).
+    if (target.capabilities.channelMessaging) return ctx.skip();
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createChannelFixture(org, agent.metadata!.slug);
+
+    const initiate = await expectGrpcCode(
+      () => clients.agentChannelCommand.initiateInstall({ resourceId: created.metadata!.id }),
+      Code.FailedPrecondition,
+      "initiateInstall on this edition",
+    );
+    expect(initiate.rawMessage).toBe("channel installs require Stigmer Cloud");
+
+    const complete = await expectGrpcCode(
+      () =>
+        clients.agentChannelCommand.completeInstall({
+          resourceId: created.metadata!.id,
+          state: "conformance-state-token",
+          code: "conformance-oauth-code",
+        }),
+      Code.FailedPrecondition,
+      "completeInstall on this edition",
+    );
+    expect(complete.rawMessage).toBe("channel installs require Stigmer Cloud");
+  });
+});
+
+describe("AgentChannel conformance — conversation lanes", () => {
+  it("discovery reads answer truthful emptiness (both editions, no traffic exists)", async () => {
+    const { org } = await target.provisionTenancy();
+
+    const conversations = await clients.channelConversationQuery.listConversations({ org });
+    expect(conversations.totalCount).toBe(0);
+    expect(conversations.items).toHaveLength(0);
+
+    const timeline = await clients.channelConversationQuery.getTimeline({
+      agentChannelId: "ach_01confmissing",
+      conversationKey: "conf-conversation",
+    });
+    expect(timeline.items ?? []).toHaveLength(0);
+  });
+
+  it("single-row reads answer uniform NotFound (no local probing, no existence leak)", async () => {
+    await expectGrpcCode(
+      () =>
+        clients.channelConversationQuery.getConversation({
+          agentChannelId: "ach_01confmissing",
+          conversationKey: "conf-conversation",
+        }),
+      Code.NotFound,
+      "getConversation — this edition never materializes conversations",
+    );
+
+    const media = await expectGrpcCode(
+      () =>
+        clients.channelConversationQuery.getMediaDownloadUrl({
+          agentChannelId: "ach_01confmissing",
+          conversationKey: "conf-conversation",
+          itemId: "conf-item",
+        }),
+      Code.NotFound,
+      "getMediaDownloadUrl uniform miss",
+    );
+    // Byte-identical with the cloud handler's uniform miss (which covers
+    // every cause the same way so a prober cannot learn which items exist).
+    expect(media.rawMessage).toBe("no downloadable media at this timeline item");
+  });
+
+  it("validation runs before any refusal (InvalidArgument matches cloud)", async () => {
+    // Empty conversation_key fails proto validation on BOTH editions —
+    // proving the controllers validate before the edition split.
+    await expectGrpcCode(
+      () => clients.channelConversationCommand.takeOver({ agentChannelId: "ach_x", conversationKey: "" }),
+      Code.InvalidArgument,
+      "takeOver with an empty conversation_key",
+    );
+    await expectGrpcCode(
+      () => clients.channelConversationCommand.escalate({ reason: "" }),
+      Code.InvalidArgument,
+      "escalate with an empty reason",
+    );
+  });
+
+  it("refuses participation commands where no runtime exists (the pinned OSS posture)", async (ctx) => {
+    if (target.capabilities.channelMessaging) return ctx.skip();
+    const refusal = "conversation participation requires Stigmer Cloud";
+    const control = { agentChannelId: "ach_01confmissing", conversationKey: "conf-conversation" };
+
+    for (const [label, call] of [
+      [
+        "reply",
+        () =>
+          clients.channelConversationCommand.reply({
+            ...control,
+            payload: { kind: { case: "text", value: { body: "hello" } } },
+          }),
+      ],
+      ["takeOver", () => clients.channelConversationCommand.takeOver(control)],
+      ["handBack", () => clients.channelConversationCommand.handBack(control)],
+      ["clearAttention", () => clients.channelConversationCommand.clearAttention(control)],
+      ["escalate", () => clients.channelConversationCommand.escalate({ reason: "needs a human" })],
+    ] as const) {
+      const err = await expectGrpcCode(call, Code.FailedPrecondition, `${label} on this edition`);
+      expect(err.rawMessage, `${label} refusal copy`).toBe(refusal);
+    }
+  });
+});
+
+describe("AgentChannel conformance — messaging lanes", () => {
+  it("listMessagingChannels answers truthful emptiness (both editions — a capability-DISCOVERY read)", async () => {
+    // The runner issues this read on every agent execution to decide
+    // whether to attach the send tool; "none" is the honest answer wherever
+    // no proactive-enabled installed channel exists — which is everywhere a
+    // fresh conformance run looks.
+    const channels = await clients.channelMessageQuery.listMessagingChannels({});
+    expect(channels.entries ?? []).toHaveLength(0);
+  });
+
+  it("validation runs before any refusal (InvalidArgument matches cloud)", async () => {
+    await expectGrpcCode(
+      () => clients.channelMessageCommand.sendMessage({ channel: "c", recipient: "" }),
+      Code.InvalidArgument,
+      "sendMessage with an empty recipient",
+    );
+  });
+
+  it("refuses proactive messaging where no runtime exists (the pinned OSS posture)", async (ctx) => {
+    if (target.capabilities.channelMessaging) return ctx.skip();
+    const refusal = "proactive channel messaging requires Stigmer Cloud";
+
+    const send = await expectGrpcCode(
+      () =>
+        clients.channelMessageCommand.sendMessage({
+          channel: "conf-channel",
+          recipient: "15551234567",
+          payload: { kind: { case: "text", value: { body: "hello" } } },
+        }),
+      Code.FailedPrecondition,
+      "sendMessage on this edition",
+    );
+    expect(send.rawMessage).toBe(refusal);
+
+    const templates = await expectGrpcCode(
+      () => clients.channelMessageQuery.listTemplates({ channel: "conf-channel" }),
+      Code.FailedPrecondition,
+      "listTemplates on this edition",
+    );
+    expect(templates.rawMessage).toBe(refusal);
+  });
+});

--- a/test/conformance/src/suites/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites/agentexecution.conformance.test.ts
@@ -186,7 +186,12 @@ describe("AgentExecution conformance — thinking-mode fail-closed validation (#
 // populated arms live in suites-execution/.
 
 describe("AgentExecution conformance — the engine gate (CW-7)", () => {
-  it("create refuses Unavailable before any side effect when no engine is connected", async () => {
+  it("create refuses Unavailable before any side effect when no engine is connected", async (ctx) => {
+    // Only the engineless local CRUD targets observe this boundary —
+    // scheduleFiring doubles as "a Temporal engine backs this target", and
+    // the cloud CRUD target serves a live engine (and resolves the agent
+    // reference before its gate).
+    if (target.capabilities.scheduleFiring) return ctx.skip();
     const { org } = await target.provisionTenancy();
     // agt_fake passes the reference-presence guard; existence is resolved
     // AFTER the engine gate (default-instance creation), so the refusal
@@ -224,6 +229,9 @@ describe("AgentExecution conformance — zero-record read surfaces (CW-7)", () =
       Code.InvalidArgument,
       "execution usage report without an id",
     );
+    // Single-user arm: the multi-tenant edition's authorization fails
+    // closed on an unresolvable id (PermissionDenied, no existence leak).
+    if (target.capabilities.multiTenant) return;
     await expectGrpcCode(
       () =>
         clients.agentExecutionQuery.getExecutionUsageReport({
@@ -234,7 +242,11 @@ describe("AgentExecution conformance — zero-record read surfaces (CW-7)", () =
     );
   });
 
-  it("the session/agent/org usage reports answer zero-valued SHAPES with no existence check", async () => {
+  it("the session/agent/org usage reports answer zero-valued SHAPES with no existence check", async (ctx) => {
+    // Single-user posture only: where orgs are real, an unauthorized scope
+    // answers PermissionDenied instead of a zero report — the aggregation
+    // reads are authorization-gated per scope on the multi-tenant edition.
+    if (target.capabilities.multiTenant) return ctx.skip();
     // The zero-shapes contract: these aggregation reads never error for
     // "nothing to aggregate" — they answer structurally complete,
     // zero-valued reports (OSS deliberately records no usage data at all,
@@ -296,6 +308,9 @@ describe("AgentExecution conformance — zero-record read surfaces (CW-7)", () =
       Code.InvalidArgument,
       "subscribe with an empty id",
     );
+    // Single-user arm: the multi-tenant edition answers PermissionDenied
+    // for an unresolvable id (authorization fail-closed, no existence leak).
+    if (target.capabilities.multiTenant) return;
     await expectGrpcCode(
       () =>
         collectStream((signal) =>
@@ -308,7 +323,12 @@ describe("AgentExecution conformance — zero-record read surfaces (CW-7)", () =
 });
 
 describe("AgentExecution conformance — submitFileDecision negatives (CW-7)", () => {
-  it("rejects structurally invalid inputs before any load (InvalidArgument)", async () => {
+  // Single-user-posture arms: the multi-tenant edition's authorization
+  // interceptor resolves the execution BEFORE proto validation, so invalid
+  // or unknown ids surface as NotFound/PermissionDenied there instead — the
+  // ordering divergence disclosed in the wave-2 PR.
+  it("rejects structurally invalid inputs before any load (InvalidArgument)", async (ctx) => {
+    if (target.capabilities.multiTenant) return ctx.skip();
     await expectGrpcCode(
       () =>
         clients.agentExecutionCommand.submitFileDecision({
@@ -335,7 +355,8 @@ describe("AgentExecution conformance — submitFileDecision negatives (CW-7)", (
     );
   });
 
-  it("an unknown execution answers NotFound", async () => {
+  it("an unknown execution answers NotFound", async (ctx) => {
+    if (target.capabilities.multiTenant) return ctx.skip();
     await expectGrpcCode(
       () =>
         clients.agentExecutionCommand.submitFileDecision({

--- a/test/conformance/src/suites/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites/agentexecution.conformance.test.ts
@@ -16,11 +16,17 @@
 // single-source-of-truth clearing) needs a live engine and stays in the
 // execution suite.
 import { Code } from "@connectrpc/connect";
-import { ServiceTier, ThinkingMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
-import { afterAll, beforeAll, describe, it } from "vitest";
+import {
+  FileDecisionAction,
+  FileDecisionScope,
+  ServiceTier,
+  ThinkingMode,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { expectGrpcCode } from "../contract/errors";
 import type { ConformanceClients } from "../harness/clients";
 import { makeAgentExecution } from "../support/agentexecutions";
+import { collectStream } from "../support/collect-stream";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
 
@@ -168,6 +174,179 @@ describe("AgentExecution conformance — thinking-mode fail-closed validation (#
         ),
       Code.InvalidArgument,
       "create with thinking_mode enabled on a model without the capability",
+    );
+  });
+});
+
+// --- CW-7: the engineless read surfaces -------------------------------------
+//
+// No execution record can exist on this target (create's engine gate below),
+// so every read RPC is asserted in its zero-record / validation arm — the
+// truthful answers a fresh server owes before anything has ever run. The
+// populated arms live in suites-execution/.
+
+describe("AgentExecution conformance — the engine gate (CW-7)", () => {
+  it("create refuses Unavailable before any side effect when no engine is connected", async () => {
+    const { org } = await target.provisionTenancy();
+    // agt_fake passes the reference-presence guard; existence is resolved
+    // AFTER the engine gate (default-instance creation), so the refusal
+    // proves the gate itself.
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentExecutionCommand.create(
+          makeAgentExecution({ org, name: uniqueName("aex-gate"), agentId: "agt_fake" }),
+        ),
+      Code.Unavailable,
+      "create with no execution engine behind the server",
+    );
+    expect(err.rawMessage).toBe(
+      "The execution engine is temporarily unavailable. Please try again shortly.",
+    );
+  });
+});
+
+describe("AgentExecution conformance — zero-record read surfaces (CW-7)", () => {
+  it("getExecutionSummary answers the pinned zero shape — no cost fields by design", async () => {
+    const { org } = await target.provisionTenancy();
+    const summary = await clients.agentExecutionQuery.getExecutionSummary({ org });
+
+    expect(summary.activeCount).toBe(0);
+    expect(summary.phaseCounts).toEqual({});
+    // An average over nothing is absence, not 0; and unlike the workflow
+    // summary there are deliberately NO cost fields on this shape at all.
+    expect(summary.avgDuration).toBeUndefined();
+    expect(summary.topFailingAgents).toHaveLength(0);
+  });
+
+  it("the execution-scoped usage report validates and checks existence (the ONE report that 404s)", async () => {
+    await expectGrpcCode(
+      () => clients.agentExecutionQuery.getExecutionUsageReport({ executionId: "" }),
+      Code.InvalidArgument,
+      "execution usage report without an id",
+    );
+    await expectGrpcCode(
+      () =>
+        clients.agentExecutionQuery.getExecutionUsageReport({
+          executionId: "aexec_01conformancemissing",
+        }),
+      Code.NotFound,
+      "execution usage report for an unknown execution",
+    );
+  });
+
+  it("the session/agent/org usage reports answer zero-valued SHAPES with no existence check", async () => {
+    // The zero-shapes contract: these aggregation reads never error for
+    // "nothing to aggregate" — they answer structurally complete,
+    // zero-valued reports (OSS deliberately records no usage data at all,
+    // so on this edition even populated executions aggregate to zero).
+    const session = await clients.agentExecutionQuery.getSessionUsageReport({
+      sessionId: "ses_01conformancemissing",
+    });
+    expect(session.sessionId).toBe("ses_01conformancemissing");
+    expect(session.executionCount).toBe(0);
+    expect(session.totalUsage, "the aggregate is always present, zero-valued").toBeDefined();
+    expect(session.executions).toHaveLength(0);
+    expect(session.modelBreakdown).toHaveLength(0);
+    expect(session.firstExecutionAt).toBe("");
+    expect(session.lastExecutionAt).toBe("");
+
+    const agent = await clients.agentExecutionQuery.getAgentUsageReport({
+      agentId: "agt_01conformancemissing",
+      orgId: "conf-org-missing",
+    });
+    // The name resolves only when the org has executions; until then the
+    // id is echoed — pinned so clients know not to treat it as a name.
+    expect(agent.agentName).toBe("agt_01conformancemissing");
+    expect(agent.totalUsage).toBeDefined();
+    expect(agent.sessions).toHaveLength(0);
+    expect(agent.totalSessions).toBe(0);
+    expect(agent.totalExecutions).toBe(0);
+
+    const orgReport = await clients.agentExecutionQuery.getOrgUsageReport({
+      orgId: "conf-org-missing",
+      fromDate: "2026-01-01",
+      toDate: "2026-01-31",
+    });
+    expect(orgReport.orgId).toBe("conf-org-missing");
+    expect(orgReport.totalAgents).toBe(0);
+    expect(orgReport.totalSessions).toBe(0);
+    expect(orgReport.totalExecutions).toBe(0);
+    expect(orgReport.modelBreakdown).toHaveLength(0);
+    expect(orgReport.topAgentsByCost).toHaveLength(0);
+    expect(orgReport.dailyCosts).toHaveLength(0);
+  });
+
+  it("the agent/org usage reports refuse missing scope fields (InvalidArgument)", async () => {
+    await expectGrpcCode(
+      () => clients.agentExecutionQuery.getAgentUsageReport({ agentId: "agt_x" }),
+      Code.InvalidArgument,
+      "agent usage report without org_id",
+    );
+    await expectGrpcCode(
+      () => clients.agentExecutionQuery.getOrgUsageReport({ orgId: "conf-org" }),
+      Code.InvalidArgument,
+      "org usage report without the date range",
+    );
+  });
+
+  it("subscribe refuses an empty id (InvalidArgument) and an unknown id (NotFound)", async () => {
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) => clients.agentExecutionQuery.subscribe({ value: "" }, { signal })),
+      Code.InvalidArgument,
+      "subscribe with an empty id",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          clients.agentExecutionQuery.subscribe({ value: "aexec_01conformancemissing" }, { signal }),
+        ),
+      Code.NotFound,
+      "subscribe to an unknown execution",
+    );
+  });
+});
+
+describe("AgentExecution conformance — submitFileDecision negatives (CW-7)", () => {
+  it("rejects structurally invalid inputs before any load (InvalidArgument)", async () => {
+    await expectGrpcCode(
+      () =>
+        clients.agentExecutionCommand.submitFileDecision({
+          agentExecutionId: "",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.InvalidArgument,
+      "submitFileDecision without an execution id",
+    );
+    await expectGrpcCode(
+      () =>
+        clients.agentExecutionCommand.submitFileDecision({
+          agentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.UNSPECIFIED,
+        }),
+      Code.InvalidArgument,
+      "submitFileDecision with an unspecified action",
+    );
+  });
+
+  it("an unknown execution answers NotFound", async () => {
+    await expectGrpcCode(
+      () =>
+        clients.agentExecutionCommand.submitFileDecision({
+          agentExecutionId: "aexec_01conformancemissing",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.NotFound,
+      "submitFileDecision on a nonexistent agent execution",
     );
   });
 });

--- a/test/conformance/src/suites/agentshare.conformance.test.ts
+++ b/test/conformance/src/suites/agentshare.conformance.test.ts
@@ -1,0 +1,534 @@
+// AgentShare conformance — CRUD, the rotatable link token, the anonymous
+// resolution lane's uniform-refusal contract, and the cross-org
+// public-dependency rules (Class A).
+// Domain: conformance suites.
+//
+// An AgentShare is the hosted-chat channel for one agent. Four surfaces
+// make the domain distinct, all asserted here:
+//
+//   - The CANONICAL-SHARE default: creating a share with neither name nor
+//     slug adopts the agent's own slug (the /chat/<org>/<agent-slug> URL),
+//     and create stamps status.agent_id — the server-owned rebind pin that
+//     keeps a stale share from attaching to whatever agent later claims
+//     the slug.
+//   - The ANONYMOUS resolution lane (getSharedProfile): every miss — share
+//     absent, share disabled, locked link with a wrong or missing token,
+//     dangling or rebound agent — answers ONE byte-identical NotFound that
+//     deliberately says "Agent", so a public URL leaks nothing about which
+//     internal state produced the refusal (the constant-time token compare
+//     behind it is unit-level; the wire contract is the uniformity).
+//   - The ROTATABLE link token: rotateShareLink is status.share_link_token's
+//     sole writer; after rotation the plain URL dies, the tokened URL
+//     resolves, and a stale token on an UNLOCKED link stays harmless.
+//   - The CROSS-ORG contract (decision 013): sharing another org's agent
+//     requires the agent public, the audience public, and every declared
+//     dependency public — with the blocker-naming refusal pinned. Gated on
+//     clientPublicVisibilityWrites (the happy paths need a public agent,
+//     which only the local single-tenant targets let an ordinary caller
+//     mint); the same-org surface runs everywhere.
+//
+// OD-1 exclusion (parent blueprint): the agentshare boot migration is
+// asserted separately, never here.
+import { Code } from "@connectrpc/connect";
+import { AgentShareAudience } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/spec_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { makeAgent } from "../support/agents";
+import { makeAgentShare } from "../support/agentshares";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+async function createAgentFixture(org: string, opts: { public?: boolean } = {}) {
+  const agent = await clients.agentCommand.create(
+    makeAgent({ org, name: uniqueName("shared-agent") }),
+  );
+  fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+  if (opts.public === true) {
+    await clients.agentCommand.updateVisibility({
+      resourceId: agent.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+  }
+  return agent;
+}
+
+async function createShareFixture(
+  org: string,
+  agentSlug: string,
+  options: Parameters<typeof makeAgentShare>[2] = {},
+) {
+  const share = await clients.agentShareCommand.create(makeAgentShare(org, agentSlug, options));
+  fixtures.defer(() => clients.agentShareCommand.delete({ value: share.metadata!.id }));
+  return share;
+}
+
+// The uniform public refusal — deliberately "Agent", never "AgentShare":
+// the visitor asked for an agent's chat page; the share resource is an
+// internal modeling detail a public error must not teach.
+function sharedNotFoundMessage(slug: string): string {
+  return `Agent not found: ${slug}`;
+}
+
+describe("AgentShare conformance — CRUD & identity", () => {
+  it("the canonical share adopts the agent's slug and stamps the rebind pin", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createShareFixture(org, agent.metadata!.slug);
+
+    expect(created.metadata?.id).toMatch(/^ash_/);
+    expect(created.metadata?.org).toBe(org);
+    // No name, no slug in the create → the share lives at the agent's own
+    // hosted URL.
+    expect(created.metadata?.slug).toBe(agent.metadata?.slug);
+    // The system-managed rebind pin: the immutable ID of the agent the ref
+    // resolved to at creation, surviving the create pipeline's status wipe.
+    expect(created.status?.agentId).toBe(agent.metadata?.id);
+    // The relative agent_ref was normalized to an absolute one.
+    expect(created.spec?.agentRef?.org).toBe(org);
+  });
+
+  it("a named share gets its own slug beside the canonical one", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const named = await createShareFixture(org, agent.metadata!.slug, {
+      name: uniqueName("campaign-link"),
+    });
+
+    expect(named.metadata?.slug).not.toBe(agent.metadata?.slug);
+    expect(named.metadata?.slug).toContain("campaign-link");
+  });
+
+  it("get, getByReference, getByAgent, and list resolve the share", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await createShareFixture(org, agent.metadata!.slug);
+
+    const fetched = await clients.agentShareQuery.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.id).toBe(created.metadata?.id);
+
+    const byRef = await clients.agentShareQuery.getByReference({
+      org,
+      slug: created.metadata!.slug,
+    });
+    expect(byRef.metadata?.id).toBe(created.metadata?.id);
+
+    const byAgent = await clients.agentShareQuery.getByAgent({ agentId: agent.metadata!.id });
+    expect(byAgent.items.some((s) => s.metadata?.id === created.metadata?.id)).toBe(true);
+
+    const listed = await clients.agentShareQuery.list({ org });
+    expect(listed.items.some((s) => s.metadata?.id === created.metadata?.id)).toBe(true);
+  });
+
+  it("update flips mutable fields but refuses re-pointing agent_ref (FailedPrecondition)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const otherAgent = await createAgentFixture(org);
+    const created = await createShareFixture(org, agent.metadata!.slug, {
+      name: uniqueName("share"),
+    });
+
+    const updated = await clients.agentShareCommand.update({
+      ...makeAgentShare(org, agent.metadata!.slug, {
+        name: created.metadata!.name,
+        enabled: false,
+      }),
+      metadata: created.metadata,
+    });
+    expect(updated.spec?.enabled).toBe(false);
+    // The rebind pin is status and survives updates wholesale.
+    expect(updated.status?.agentId).toBe(agent.metadata?.id);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentShareCommand.update({
+          ...makeAgentShare(org, otherAgent.metadata!.slug, { name: created.metadata!.name }),
+          metadata: created.metadata,
+        }),
+      Code.FailedPrecondition,
+      "update re-pointing the share at a different agent",
+    );
+    expect(err.rawMessage).toContain("spec.agent_ref is immutable");
+  });
+
+  it("delete removes the share", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const created = await clients.agentShareCommand.create(
+      makeAgentShare(org, agent.metadata!.slug),
+    );
+
+    await clients.agentShareCommand.delete({ value: created.metadata!.id });
+
+    await expectGrpcCode(
+      () => clients.agentShareQuery.get({ value: created.metadata!.id }),
+      Code.NotFound,
+      "get after delete",
+    );
+  });
+});
+
+describe("AgentShare conformance — create validation", () => {
+  it("requires metadata.org (InvalidArgument)", async () => {
+    const err = await expectGrpcCode(
+      () => clients.agentShareCommand.create(makeAgentShare("", "some-agent")),
+      Code.InvalidArgument,
+      "create without metadata.org",
+    );
+    expect(err.rawMessage).toBe("metadata.org is required for an agent share");
+  });
+
+  it("rejects an unknown agent with the same NotFound a direct lookup produces", async () => {
+    const { org } = await target.provisionTenancy();
+    const err = await expectGrpcCode(
+      () => clients.agentShareCommand.create(makeAgentShare(org, "no-such-agent")),
+      Code.NotFound,
+      "create referencing a nonexistent agent",
+    );
+    expect(err.rawMessage).toBe("Agent not found: no-such-agent");
+  });
+
+  it("rejects environment_refs on an org-audience share (InvalidArgument — the CEL rule)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+
+    const share = makeAgentShare(org, agent.metadata!.slug, {
+      audience: AgentShareAudience.org,
+    });
+    (share.spec as { environmentRefs?: unknown[] }).environmentRefs = [
+      { slug: "some-env", kind: 53 },
+    ];
+
+    await expectGrpcCode(
+      () => clients.agentShareCommand.create(share),
+      Code.InvalidArgument,
+      "org-audience share carrying environment_refs",
+    );
+  });
+});
+
+describe("AgentShare conformance — the anonymous resolution lane", () => {
+  it("resolves an enabled share to the trimmed profile (share identity + agent display)", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    await createShareFixture(org, agent.metadata!.slug);
+
+    const profile = await clients.agentShareQuery.getSharedProfile({
+      org,
+      slug: agent.metadata!.slug,
+    });
+
+    // URL identity from the SHARE; display fields from the AGENT — never
+    // the full Agent resource (its spec carries the system prompt).
+    expect(profile.org).toBe(org);
+    expect(profile.slug).toBe(agent.metadata?.slug);
+    expect(profile.name).toBe(agent.metadata?.name);
+    expect(profile.defaultInstanceId).toBe(agent.status?.defaultInstanceId);
+  });
+
+  it("requires org (InvalidArgument — cross-org slug matching would enable enumeration)", async () => {
+    const err = await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfile({ org: "", slug: "anything" }),
+      Code.InvalidArgument,
+      "getSharedProfile without org",
+    );
+    expect(err.rawMessage).toBe("org is required for shared agent lookup");
+  });
+
+  it("answers ONE byte-identical NotFound for absent, disabled, and dangling shares", async () => {
+    const { org } = await target.provisionTenancy();
+    const slug = uniqueName("uniform");
+
+    // Absent share.
+    const absent = await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfile({ org, slug }),
+      Code.NotFound,
+      "getSharedProfile on a nonexistent share",
+    );
+    expect(absent.rawMessage).toBe(sharedNotFoundMessage(slug));
+
+    // Disabled share: existing-but-disabled must be indistinguishable.
+    const agent = await createAgentFixture(org);
+    await createShareFixture(org, agent.metadata!.slug, { enabled: false });
+    const disabled = await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfile({ org, slug: agent.metadata!.slug }),
+      Code.NotFound,
+      "getSharedProfile on a disabled share",
+    );
+    expect(disabled.rawMessage).toBe(sharedNotFoundMessage(agent.metadata!.slug));
+
+    // Dangling agent_ref: a channel to a deleted agent must look exactly
+    // like no channel. (Deleting the agent directly; the share outlives it.)
+    const dangling = await createAgentFixture(org);
+    await createShareFixture(org, dangling.metadata!.slug);
+    await clients.agentCommand.delete({ value: dangling.metadata!.id });
+    const afterDelete = await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfile({ org, slug: dangling.metadata!.slug }),
+      Code.NotFound,
+      "getSharedProfile after the referenced agent was deleted",
+    );
+    expect(afterDelete.rawMessage).toBe(sharedNotFoundMessage(dangling.metadata!.slug));
+  });
+
+  it("a stale token on an UNLOCKED link stays harmless", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    await createShareFixture(org, agent.metadata!.slug);
+
+    // No live token → whatever the caller presented is ignored, so an old
+    // bookmarked ?k= keeps working after an unlock-by-recreate.
+    const profile = await clients.agentShareQuery.getSharedProfile({
+      org,
+      slug: agent.metadata!.slug,
+      linkToken: "stale-token-from-an-old-bookmark",
+    });
+    expect(profile.slug).toBe(agent.metadata?.slug);
+  });
+});
+
+describe("AgentShare conformance — the rotatable link token", () => {
+  it("rotation kills the plain URL, admits the tokened one, and refuses the wrong token uniformly", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    const share = await createShareFixture(org, agent.metadata!.slug);
+
+    const rotated = await clients.agentShareCommand.rotateShareLink({
+      resourceId: share.metadata!.id,
+    });
+    const token = rotated.status?.shareLinkToken ?? "";
+    // 20 bytes of server entropy → 27 url-safe base64 characters.
+    expect(token).toMatch(/^[A-Za-z0-9_-]{27}$/);
+
+    // The plain URL is dead — and the refusal is byte-identical with a
+    // nonexistent share's, so a killed link looks like one that never was.
+    const plain = await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfile({ org, slug: share.metadata!.slug }),
+      Code.NotFound,
+      "plain URL after rotation",
+    );
+    expect(plain.rawMessage).toBe(sharedNotFoundMessage(share.metadata!.slug));
+
+    // A wrong token refuses the same way — never a distinct "wrong token".
+    const wrong = await expectGrpcCode(
+      () =>
+        clients.agentShareQuery.getSharedProfile({
+          org,
+          slug: share.metadata!.slug,
+          linkToken: "not-the-token-that-was-minted",
+        }),
+      Code.NotFound,
+      "wrong token after rotation",
+    );
+    expect(wrong.rawMessage).toBe(sharedNotFoundMessage(share.metadata!.slug));
+
+    // The minted token resolves.
+    const profile = await clients.agentShareQuery.getSharedProfile({
+      org,
+      slug: share.metadata!.slug,
+      linkToken: token,
+    });
+    expect(profile.slug).toBe(share.metadata?.slug);
+
+    // Rotating again kills the previous token immediately.
+    await clients.agentShareCommand.rotateShareLink({ resourceId: share.metadata!.id });
+    await expectGrpcCode(
+      () =>
+        clients.agentShareQuery.getSharedProfile({
+          org,
+          slug: share.metadata!.slug,
+          linkToken: token,
+        }),
+      Code.NotFound,
+      "previous token after a second rotation",
+    );
+  });
+
+  it("rotateShareLink on an unknown share returns NotFound", async () => {
+    const err = await expectGrpcCode(
+      () => clients.agentShareCommand.rotateShareLink({ resourceId: "ash_01confmissing" }),
+      Code.NotFound,
+      "rotateShareLink on a nonexistent share",
+    );
+    expect(err.rawMessage).toBe("AgentShare not found: ash_01confmissing");
+  });
+});
+
+describe("AgentShare conformance — the member resolution lane", () => {
+  it("resolves enabled shares and requires org, like the anonymous lane", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    await createShareFixture(org, agent.metadata!.slug);
+
+    const profile = await clients.agentShareQuery.getSharedProfileForMember({
+      org,
+      slug: agent.metadata!.slug,
+    });
+    expect(profile.slug).toBe(agent.metadata?.slug);
+
+    await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfileForMember({ org: "", slug: "anything" }),
+      Code.InvalidArgument,
+      "member lookup without org",
+    );
+  });
+
+  it("refuses a token-locked PUBLIC share on the tokenless member path, but not an org-audience one", async () => {
+    const { org } = await target.provisionTenancy();
+
+    // Public-audience + rotated: this tokenless path must not reveal a
+    // killed link's profile.
+    const publicAgent = await createAgentFixture(org);
+    const publicShare = await createShareFixture(org, publicAgent.metadata!.slug);
+    await clients.agentShareCommand.rotateShareLink({ resourceId: publicShare.metadata!.id });
+    const refused = await expectGrpcCode(
+      () =>
+        clients.agentShareQuery.getSharedProfileForMember({
+          org,
+          slug: publicShare.metadata!.slug,
+        }),
+      Code.NotFound,
+      "member path on a token-locked public share",
+    );
+    expect(refused.rawMessage).toBe(sharedNotFoundMessage(publicShare.metadata!.slug));
+
+    // Org-audience + rotated: the gate is membership, not the link token —
+    // the member path still resolves.
+    const orgAgent = await createAgentFixture(org);
+    const orgShare = await createShareFixture(org, orgAgent.metadata!.slug, {
+      audience: AgentShareAudience.org,
+    });
+    await clients.agentShareCommand.rotateShareLink({ resourceId: orgShare.metadata!.id });
+    const resolved = await clients.agentShareQuery.getSharedProfileForMember({
+      org,
+      slug: orgShare.metadata!.slug,
+    });
+    expect(resolved.slug).toBe(orgShare.metadata?.slug);
+  });
+});
+
+describe("AgentShare conformance — the cross-org contract (decision 013)", () => {
+  it("refuses to share another org's non-public agent with the enumeration-safe NotFound", async () => {
+    const { org: originOrg } = await target.provisionTenancy();
+    const { org: sharingOrg } = await target.provisionTenancy();
+    const privateAgent = await createAgentFixture(originOrg);
+
+    // For the sharing org, another org's private agent does not exist —
+    // this create path must not become an existence probe.
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentShareCommand.create(
+          makeAgentShare(sharingOrg, privateAgent.metadata!.slug, { agentRefOrg: originOrg }),
+        ),
+      Code.NotFound,
+      "cross-org share of a private agent",
+    );
+    expect(err.rawMessage).toBe(sharedNotFoundMessage(privateAgent.metadata!.slug));
+  });
+
+  it("shares a public agent cross-org, refusing the org audience with the pinned copy", async (ctx) => {
+    // The happy path needs a PUBLIC agent, which only the unguarded local
+    // targets let the ordinary caller mint (the workflow/skill suites'
+    // gating precedent).
+    if (!target.capabilities.clientPublicVisibilityWrites) return ctx.skip();
+    const { org: originOrg } = await target.provisionTenancy();
+    const { org: sharingOrg } = await target.provisionTenancy();
+    const publicAgent = await createAgentFixture(originOrg, { public: true });
+
+    // Org-audience semantics don't carry across the org boundary.
+    const orgAudience = await expectGrpcCode(
+      () =>
+        clients.agentShareCommand.create(
+          makeAgentShare(sharingOrg, publicAgent.metadata!.slug, {
+            agentRefOrg: originOrg,
+            audience: AgentShareAudience.org,
+          }),
+        ),
+      Code.FailedPrecondition,
+      "cross-org share with an org audience",
+    );
+    expect(orgAudience.rawMessage).toBe(
+      `a cross-org share must have a public audience — org-audience shares are limited to the agent's own organization (${originOrg})`,
+    );
+
+    // Public audience + public dependency-free agent: the share resolves
+    // for anonymous visitors under the SHARING org's URL.
+    const share = await createShareFixture(sharingOrg, publicAgent.metadata!.slug, {
+      agentRefOrg: originOrg,
+    });
+    const profile = await clients.agentShareQuery.getSharedProfile({
+      org: sharingOrg,
+      slug: share.metadata!.slug,
+    });
+    expect(profile.org).toBe(sharingOrg);
+    expect(profile.name).toBe(publicAgent.metadata?.name);
+  });
+
+  it("names every non-public dependency in the blocker refusal", async (ctx) => {
+    if (!target.capabilities.clientPublicVisibilityWrites) return ctx.skip();
+    const { org: originOrg } = await target.provisionTenancy();
+    const { org: sharingOrg } = await target.provisionTenancy();
+
+    // A public agent whose declared MCP dependency is NOT public — guests
+    // could resolve the agent but its tools would silently vanish, so the
+    // create refuses and names exactly what to publish.
+    const mcpServer = await clients.mcpServerCommand.create({
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "McpServer",
+      metadata: { name: uniqueName("private-dep"), org: originOrg },
+      spec: {
+        description: "non-public dependency for the cross-org blocker pin",
+        serverType: {
+          case: "stdio",
+          value: { command: "npx", args: ["-y", "@modelcontextprotocol/server-everything"] },
+        },
+      },
+    });
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: mcpServer.metadata!.id }));
+
+    const agent = await clients.agentCommand.create(
+      makeAgent({
+        org: originOrg,
+        name: uniqueName("shared-agent"),
+        mcpServerRefs: [mcpServer.metadata!.slug],
+      }),
+    );
+    fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+    await clients.agentCommand.updateVisibility({
+      resourceId: agent.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentShareCommand.create(
+          makeAgentShare(sharingOrg, agent.metadata!.slug, { agentRefOrg: originOrg }),
+        ),
+      Code.FailedPrecondition,
+      "cross-org share of an agent with a non-public dependency",
+    );
+    expect(err.rawMessage).toBe(
+      `cannot share ${originOrg}/${agent.metadata!.slug} across organizations: ` +
+        `it references resources that are not public: mcp_server ${originOrg}/${mcpServer.metadata!.slug}`,
+    );
+  });
+});

--- a/test/conformance/src/suites/artifact.conformance.test.ts
+++ b/test/conformance/src/suites/artifact.conformance.test.ts
@@ -62,8 +62,25 @@ afterAll(async () => {
 // behavior this suite pins), so "cleanup" would only flip states. Rows live
 // in the per-file server's throwaway state dir and vanish at teardown.
 
+// Most of this suite runs on the single-user targets only (a verified
+// edition split, disclosed in the wave-2 PR): OSS derives the artifact's
+// org from its source execution BEST-EFFORT — fabricated ids are accepted
+// and fall back to an empty org, which is what makes the domain
+// standalone-testable — while the multi-tenant edition REQUIRES the source
+// execution to exist and carry an org (FailedPrecondition otherwise: an
+// org-less artifact would be unownable where orgs are real). Cloud-side
+// artifact behavior is covered by its integration tests against real runs.
+function requiresSingleUserArtifacts(ctx: { skip: () => void }): boolean {
+  if (target.capabilities.multiTenant) {
+    ctx.skip();
+    return true;
+  }
+  return false;
+}
+
 describe("Artifact conformance — create & content addressing", () => {
-  it("create assigns an art_ id and stamps the content-addressed status", async () => {
+  it("create assigns an art_ id and stamps the content-addressed status", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const created = await clients.artifactCommand.create(makeArtifactInput());
 
     expect(created.metadata?.id).toMatch(/^art_/);
@@ -75,7 +92,8 @@ describe("Artifact conformance — create & content addressing", () => {
     expect(created.status?.storageState).toBe(ArtifactStorageState.storage_state_stored);
   });
 
-  it("expires_at defaults to ~30 days out; ttl_days -1 means permanent", async () => {
+  it("expires_at defaults to ~30 days out; ttl_days -1 means permanent", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const defaulted = await clients.artifactCommand.create(makeArtifactInput());
     const expiresAt = Date.parse(defaulted.status?.expiresAt ?? "");
     const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
@@ -86,7 +104,8 @@ describe("Artifact conformance — create & content addressing", () => {
     expect(permanent.status?.expiresAt, "-1 is the never-expires marker").toBe("");
   });
 
-  it("accepts a fabricated execution id and falls back to an empty org (the OSS posture)", async () => {
+  it("accepts a fabricated execution id and falls back to an empty org (the OSS posture)", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     // Org derivation is best-effort by design: the create path must not
     // fail an artifact write because its producing execution is unknown.
     const created = await clients.artifactCommand.create(
@@ -95,18 +114,23 @@ describe("Artifact conformance — create & content addressing", () => {
     expect(created.metadata?.org).toBe("");
   });
 
-  it("rejects a create without content or without an execution source (InvalidArgument)", async () => {
-    // Codes only, never copy: the empty-content arm fires in the proto
-    // validation layer (buf.validate) BEFORE the handler's own check, so
-    // the handler's message is unreachable from the wire — which layer
-    // names the refusal is an implementation detail both editions share
-    // the interceptor for.
+  it("rejects a create with empty content (InvalidArgument, both editions)", async () => {
+    // Code only, never copy: the arm fires in the proto validation layer
+    // (buf.validate) BEFORE the handler's own check, so the handler's
+    // message is unreachable from the wire.
     await expectGrpcCode(
       () => clients.artifactCommand.create(makeArtifactInput({ content: new Uint8Array(0) })),
       Code.InvalidArgument,
       "create with empty content",
     );
+  });
 
+  it("rejects a create without an execution source (InvalidArgument — single-user posture)", async (ctx) => {
+    // Edition split, disclosed in the wave-2 PR: the multi-tenant edition
+    // resolves the source BEFORE the emptiness check and answers
+    // FailedPrecondition ("source execution not found or carries no org"),
+    // so only the single-user InvalidArgument arm is pinned here.
+    if (requiresSingleUserArtifacts(ctx)) return;
     const input = makeArtifactInput();
     (input.spec as { source?: unknown }).source = {};
     await expectGrpcCode(
@@ -118,7 +142,8 @@ describe("Artifact conformance — create & content addressing", () => {
 });
 
 describe("Artifact conformance — read surfaces", () => {
-  it("get and listByExecution resolve the artifact by id and by source", async () => {
+  it("get and listByExecution resolve the artifact by id and by source", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const executionId = `wexec_01${uniqueName("run").replace(/-/g, "")}`.slice(0, 30);
     const created = await clients.artifactCommand.create(
       makeArtifactInput({ workflowExecutionId: executionId }),
@@ -149,7 +174,8 @@ describe("Artifact conformance — read surfaces", () => {
     );
   });
 
-  it("getContent returns the bytes, truncating to max_bytes with the full size reported", async () => {
+  it("getContent returns the bytes, truncating to max_bytes with the full size reported", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const content = new TextEncoder().encode("0123456789".repeat(100)); // 1000 bytes
     const created = await clients.artifactCommand.create(makeArtifactInput({ content }));
 
@@ -170,7 +196,8 @@ describe("Artifact conformance — read surfaces", () => {
     expect(truncated.content).toHaveLength(100);
   });
 
-  it("getDownloadUrl answers the pinned ttl_seconds constant and the blob facts (P3)", async () => {
+  it("getDownloadUrl answers the pinned ttl_seconds constant and the blob facts (P3)", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const created = await clients.artifactCommand.create(makeArtifactInput());
 
     const download = await clients.artifactQuery.getDownloadUrl({
@@ -184,7 +211,8 @@ describe("Artifact conformance — read surfaces", () => {
     expect(download.contentType).toBe("text/plain");
   });
 
-  it("unknown ids answer NotFound across the read surfaces", async () => {
+  it("unknown ids answer NotFound across the read surfaces", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const get = await expectGrpcCode(
       () => clients.artifactQuery.get({ value: "art_01conformancemissing" }),
       Code.NotFound,
@@ -206,7 +234,8 @@ describe("Artifact conformance — read surfaces", () => {
 });
 
 describe("Artifact conformance — the soft-delete lifecycle", () => {
-  it("delete transitions storage_state; metadata survives; blob reads refuse FailedPrecondition", async () => {
+  it("delete transitions storage_state; metadata survives; blob reads refuse FailedPrecondition", async (ctx) => {
+    if (requiresSingleUserArtifacts(ctx)) return;
     const created = await clients.artifactCommand.create(makeArtifactInput());
 
     const deleted = await clients.artifactCommand.delete({ value: created.metadata!.id });

--- a/test/conformance/src/suites/artifact.conformance.test.ts
+++ b/test/conformance/src/suites/artifact.conformance.test.ts
@@ -1,0 +1,265 @@
+// Artifact conformance — content-addressed create, the read surfaces, the
+// soft-delete lifecycle, and the local file-server disposition lane
+// (Class A).
+// Domain: conformance suites.
+//
+// Artifact is the execution-output store: a metadata resource plus a blob
+// keyed by its SHA-256. Create is a direct handler taking spec + content
+// bytes — it derives org from the producing execution best-effort and never
+// checks the execution exists, which is what makes the domain standalone-
+// testable on a bare server. The distinct surfaces asserted here:
+//
+//   - CONTENT ADDRESSING: status.content_hash is the content's SHA-256,
+//     size_bytes the byte count, storage_state stored.
+//   - TTL: expires_at defaults to ~30 days out; retention.ttl_days = -1
+//     means permanent (expires_at empty).
+//   - SOFT DELETE: delete is a storage_state transition, never a row
+//     removal — get still resolves the metadata (the audit trail), while
+//     getDownloadUrl/getContent refuse FailedPrecondition on the deleted
+//     blob.
+//   - The OVERSIZE boundary (disposition S1, AMENDED during execution and
+//     recorded in the sub-project's wrong-assumptions): NEITHER cap is
+//     cleanly black-box-assertable. The domain's 50MB check sits behind the
+//     transport's 10MB message cap, and an over-cap send from the reference
+//     TS client does not surface a graceful ResourceExhausted — the server
+//     answers with a connection-level HTTP/2 ENHANCE_YOUR_CALM that poisons
+//     the shared channel for unrelated RPCs. That is an HTTP/2 artifact,
+//     not a wire contract, so the suite deliberately asserts NO oversize
+//     arm; both caps stay unit-level in each edition (the #13 port carries
+//     them as unit tests).
+//   - getDownloadUrl reports ttl_seconds 604800 unconditionally (ratified
+//     P3): local URLs never actually expire — pinned as the wire contract,
+//     with the semantic mismatch disclosed in the wave-2 PR.
+//   - The FILE-SERVER lane (local artifact storage only): the download URL
+//     serves the bytes inline; appending ?download=<name> adds the
+//     attachment Content-Disposition. Runs only where the target exposes
+//     the lane (artifactHttpBaseUrl — absent on cloud, whose artifact bytes
+//     travel authenticated presigned routes instead).
+import { createHash } from "node:crypto";
+import { Code } from "@connectrpc/connect";
+import { ArtifactStorageState } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/enum_pb";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { ARTIFACT_DEFAULT_CONTENT, makeArtifactInput } from "../support/artifacts";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// No FixtureTracker here: artifact delete is a soft state transition (a
+// behavior this suite pins), so "cleanup" would only flip states. Rows live
+// in the per-file server's throwaway state dir and vanish at teardown.
+
+describe("Artifact conformance — create & content addressing", () => {
+  it("create assigns an art_ id and stamps the content-addressed status", async () => {
+    const created = await clients.artifactCommand.create(makeArtifactInput());
+
+    expect(created.metadata?.id).toMatch(/^art_/);
+    expect(created.metadata?.name).toBe("conformance-artifact.txt");
+    expect(created.status?.contentHash).toBe(
+      createHash("sha256").update(ARTIFACT_DEFAULT_CONTENT).digest("hex"),
+    );
+    expect(created.status?.sizeBytes).toBe(BigInt(ARTIFACT_DEFAULT_CONTENT.byteLength));
+    expect(created.status?.storageState).toBe(ArtifactStorageState.storage_state_stored);
+  });
+
+  it("expires_at defaults to ~30 days out; ttl_days -1 means permanent", async () => {
+    const defaulted = await clients.artifactCommand.create(makeArtifactInput());
+    const expiresAt = Date.parse(defaulted.status?.expiresAt ?? "");
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    expect(expiresAt - Date.now()).toBeGreaterThan(thirtyDaysMs - 60_000);
+    expect(expiresAt - Date.now()).toBeLessThan(thirtyDaysMs + 60_000);
+
+    const permanent = await clients.artifactCommand.create(makeArtifactInput({ ttlDays: -1 }));
+    expect(permanent.status?.expiresAt, "-1 is the never-expires marker").toBe("");
+  });
+
+  it("accepts a fabricated execution id and falls back to an empty org (the OSS posture)", async () => {
+    // Org derivation is best-effort by design: the create path must not
+    // fail an artifact write because its producing execution is unknown.
+    const created = await clients.artifactCommand.create(
+      makeArtifactInput({ agentExecutionId: "aexec_01neverexisted" }),
+    );
+    expect(created.metadata?.org).toBe("");
+  });
+
+  it("rejects a create without content or without an execution source (InvalidArgument)", async () => {
+    // Codes only, never copy: the empty-content arm fires in the proto
+    // validation layer (buf.validate) BEFORE the handler's own check, so
+    // the handler's message is unreachable from the wire — which layer
+    // names the refusal is an implementation detail both editions share
+    // the interceptor for.
+    await expectGrpcCode(
+      () => clients.artifactCommand.create(makeArtifactInput({ content: new Uint8Array(0) })),
+      Code.InvalidArgument,
+      "create with empty content",
+    );
+
+    const input = makeArtifactInput();
+    (input.spec as { source?: unknown }).source = {};
+    await expectGrpcCode(
+      () => clients.artifactCommand.create(input),
+      Code.InvalidArgument,
+      "create without an execution source",
+    );
+  });
+});
+
+describe("Artifact conformance — read surfaces", () => {
+  it("get and listByExecution resolve the artifact by id and by source", async () => {
+    const executionId = `wexec_01${uniqueName("run").replace(/-/g, "")}`.slice(0, 30);
+    const created = await clients.artifactCommand.create(
+      makeArtifactInput({ workflowExecutionId: executionId }),
+    );
+
+    const fetched = await clients.artifactQuery.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.id).toBe(created.metadata?.id);
+    expect(fetched.status?.contentHash).toBe(created.status?.contentHash);
+
+    const listed = await clients.artifactQuery.listByExecution({
+      workflowExecutionId: executionId,
+    });
+    expect(listed.entries).toHaveLength(1);
+    expect(listed.entries[0]?.metadata?.id).toBe(created.metadata?.id);
+
+    // The other source arm does not match.
+    const other = await clients.artifactQuery.listByExecution({
+      agentExecutionId: executionId,
+    });
+    expect(other.entries).toHaveLength(0);
+  });
+
+  it("listByExecution requires an execution filter (InvalidArgument)", async () => {
+    await expectGrpcCode(
+      () => clients.artifactQuery.listByExecution({}),
+      Code.InvalidArgument,
+      "listByExecution without any filter",
+    );
+  });
+
+  it("getContent returns the bytes, truncating to max_bytes with the full size reported", async () => {
+    const content = new TextEncoder().encode("0123456789".repeat(100)); // 1000 bytes
+    const created = await clients.artifactCommand.create(makeArtifactInput({ content }));
+
+    const full = await clients.artifactQuery.getContent({
+      artifactId: created.metadata!.id,
+    });
+    expect(full.truncated).toBe(false);
+    expect(full.totalSizeBytes).toBe(1000n);
+    expect(full.contentType).toBe("text/plain");
+    expect(new Uint8Array(full.content)).toEqual(content);
+
+    const truncated = await clients.artifactQuery.getContent({
+      artifactId: created.metadata!.id,
+      maxBytes: 100n,
+    });
+    expect(truncated.truncated).toBe(true);
+    expect(truncated.totalSizeBytes, "total size reports the FULL blob").toBe(1000n);
+    expect(truncated.content).toHaveLength(100);
+  });
+
+  it("getDownloadUrl answers the pinned ttl_seconds constant and the blob facts (P3)", async () => {
+    const created = await clients.artifactCommand.create(makeArtifactInput());
+
+    const download = await clients.artifactQuery.getDownloadUrl({
+      value: created.metadata!.id,
+    });
+    expect(download.url).toContain(created.status!.contentHash);
+    // 7 days in seconds, reported unconditionally — local URLs never
+    // actually expire (the disclosed P3 semantic mismatch).
+    expect(download.ttlSeconds).toBe(604800);
+    expect(download.sizeBytes).toBe(created.status?.sizeBytes);
+    expect(download.contentType).toBe("text/plain");
+  });
+
+  it("unknown ids answer NotFound across the read surfaces", async () => {
+    const get = await expectGrpcCode(
+      () => clients.artifactQuery.get({ value: "art_01conformancemissing" }),
+      Code.NotFound,
+      "get missing artifact",
+    );
+    expect(get.rawMessage).toBe("Artifact not found: art_01conformancemissing");
+
+    await expectGrpcCode(
+      () => clients.artifactQuery.getDownloadUrl({ value: "art_01conformancemissing" }),
+      Code.NotFound,
+      "getDownloadUrl missing artifact",
+    );
+    await expectGrpcCode(
+      () => clients.artifactQuery.getContent({ artifactId: "art_01conformancemissing" }),
+      Code.NotFound,
+      "getContent missing artifact",
+    );
+  });
+});
+
+describe("Artifact conformance — the soft-delete lifecycle", () => {
+  it("delete transitions storage_state; metadata survives; blob reads refuse FailedPrecondition", async () => {
+    const created = await clients.artifactCommand.create(makeArtifactInput());
+
+    const deleted = await clients.artifactCommand.delete({ value: created.metadata!.id });
+    expect(deleted.status?.storageState).toBe(ArtifactStorageState.storage_state_deleted);
+
+    // Soft delete: the metadata row remains readable — the audit trail of
+    // what an execution produced outlives the blob.
+    const fetched = await clients.artifactQuery.get({ value: created.metadata!.id });
+    expect(fetched.status?.storageState).toBe(ArtifactStorageState.storage_state_deleted);
+
+    // The blob lanes fail closed on the deleted state.
+    const download = await expectGrpcCode(
+      () => clients.artifactQuery.getDownloadUrl({ value: created.metadata!.id }),
+      Code.FailedPrecondition,
+      "getDownloadUrl after delete",
+    );
+    expect(download.rawMessage).toBe(
+      `artifact blob has been deleted: ${created.metadata!.id}`,
+    );
+    await expectGrpcCode(
+      () => clients.artifactQuery.getContent({ artifactId: created.metadata!.id }),
+      Code.FailedPrecondition,
+      "getContent after delete",
+    );
+  });
+});
+
+describe("Artifact conformance — the local file-server lane", () => {
+  it("serves the blob inline, and ?download=<name> adds the attachment disposition", async (ctx) => {
+    // Only local artifact storage has this lane; cloud serves artifact
+    // bytes through authenticated presigned routes (a different contract),
+    // so the accessor is absent there and this reports SKIPPED.
+    if (target.artifactHttpBaseUrl === undefined) return ctx.skip();
+    const content = new TextEncoder().encode("file-server conformance body\n");
+    const created = await clients.artifactCommand.create(makeArtifactInput({ content }));
+
+    const download = await clients.artifactQuery.getDownloadUrl({
+      value: created.metadata!.id,
+    });
+
+    // Inline serve: the URL getDownloadUrl mints (no download param — the
+    // inline disposition is this RPC's documented behavior).
+    const inline = await fetch(download.url);
+    expect(inline.status).toBe(200);
+    expect(inline.headers.get("content-disposition")).toBeNull();
+    expect(new Uint8Array(await inline.arrayBuffer())).toEqual(content);
+
+    // Attachment disposition: the ?download= query the file server reads,
+    // mirroring the R2 backend's signed disposition.
+    const attachment = await fetch(`${download.url}?download=report.txt`);
+    expect(attachment.status).toBe(200);
+    expect(attachment.headers.get("content-disposition")).toBe(
+      'attachment; filename="report.txt"',
+    );
+  });
+});

--- a/test/conformance/src/suites/channelapp.conformance.test.ts
+++ b/test/conformance/src/suites/channelapp.conformance.test.ts
@@ -1,0 +1,311 @@
+// ChannelApp conformance — CRUD, the per-field secret contract, and the
+// referential delete-block (Class A).
+// Domain: conformance suites.
+//
+// A ChannelApp registers a customer-owned messaging-platform app (Slack or
+// Meta/WhatsApp) whose credentials agent channels install through. Three
+// surfaces make the domain distinct, all asserted here:
+//
+//   - The PER-FIELD secret contract: every secret in the provider arm
+//     (Slack: client_secret + signing_secret; WhatsApp: app_secret +
+//     access_token + verify_token) is encrypted at rest and REDACTED to the
+//     platform marker on every read; re-submitting the marker on update
+//     preserves that field's stored value INDEPENDENTLY of its siblings —
+//     one request can rotate one secret and keep the rest (the OAuthApp
+//     contract generalized to multi-secret arms). Ciphertext-shaped values
+//     are refused on every write door (oss#395), and the marker itself is
+//     refused on create (nothing to preserve yet).
+//   - PROVIDER immutability: the provider oneof arm cannot change on update
+//     — every referencing channel's install state and webhook verification
+//     path are provider-shaped. NOTE the deliberate as-is pin: ChannelApp
+//     answers InvalidArgument here while its sibling AgentChannel answers
+//     FailedPrecondition for ITS provider rule — a verified cross-domain
+//     inconsistency, pinned exactly (parity doctrine; harmonization is a
+//     post-cutover both-editions candidate, recorded in the wave-2 PR).
+//   - The DELETE-BLOCK: deletion is refused with FailedPrecondition while
+//     any AgentChannel's spec.app_ref resolves to the app — a deleted app
+//     would break the referencing channels' webhook verification and any
+//     future re-install. Unreferencing frees the delete.
+import { Code } from "@connectrpc/connect";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { makeAgent } from "../support/agents";
+import { makeSlackAgentChannel } from "../support/agentchannels";
+import {
+  CHANNELAPP_REDACTED_MARKER,
+  makeSlackChannelApp,
+  makeWhatsAppChannelApp,
+} from "../support/channelapps";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+async function createSlackAppFixture(org: string, name = uniqueName("channel-app")) {
+  const app = await clients.channelAppCommand.create(makeSlackChannelApp(org, name));
+  fixtures.defer(() => clients.channelAppCommand.delete({ resourceId: app.metadata!.id }));
+  return app;
+}
+
+describe("ChannelApp conformance — CRUD & identity", () => {
+  it("create assigns a chapp_ id, echoes the public config, and redacts every secret", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createSlackAppFixture(org);
+
+    expect(created.metadata?.id).toMatch(/^chapp_/);
+    expect(created.metadata?.org).toBe(org);
+    expect(created.spec?.providerConfig?.case).toBe("slack");
+    const slack = created.spec?.providerConfig?.case === "slack" ? created.spec.providerConfig.value : undefined;
+    // client_id is public app identity and travels back verbatim; both
+    // secrets must never travel back at all.
+    expect(slack?.clientId).toBe("conformance-slack-client-id");
+    expect(slack?.clientSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+    expect(slack?.signingSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+  });
+
+  it("get, getByReference, and listByOrg resolve the app, all redacted", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createSlackAppFixture(org);
+
+    const fetched = await clients.channelAppQuery.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.id).toBe(created.metadata?.id);
+    const fetchedSlack =
+      fetched.spec?.providerConfig?.case === "slack" ? fetched.spec.providerConfig.value : undefined;
+    expect(fetchedSlack?.clientSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+    expect(fetchedSlack?.signingSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+
+    const byRef = await clients.channelAppQuery.getByReference({
+      org,
+      slug: created.metadata!.slug,
+    });
+    expect(byRef.metadata?.id).toBe(created.metadata?.id);
+
+    const listed = await clients.channelAppQuery.listByOrg({ org });
+    const match = listed.entries.find((app) => app.metadata?.id === created.metadata?.id);
+    expect(match, "the created app appears in its org's list").toBeDefined();
+    const listedSlack =
+      match?.spec?.providerConfig?.case === "slack" ? match.spec.providerConfig.value : undefined;
+    expect(listedSlack?.clientSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+  });
+
+  it("apply creates on first call and updates on second (same name + org)", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("channel-app");
+
+    const first = await clients.channelAppCommand.apply(
+      makeSlackChannelApp(org, name, { clientId: "app-v1" }),
+    );
+    fixtures.defer(() => clients.channelAppCommand.delete({ resourceId: first.metadata!.id }));
+    expect(first.metadata?.id).toMatch(/^chapp_/);
+
+    const second = await clients.channelAppCommand.apply(
+      makeSlackChannelApp(org, name, { clientId: "app-v2" }),
+    );
+
+    expect(second.metadata?.id, "apply must update the same resource").toBe(first.metadata?.id);
+    const slack = second.spec?.providerConfig?.case === "slack" ? second.spec.providerConfig.value : undefined;
+    expect(slack?.clientId, "apply-as-update replaces the spec").toBe("app-v2");
+  });
+
+  it("delete removes an unreferenced app", async () => {
+    const { org } = await target.provisionTenancy();
+    // No deferred cleanup: this test deletes the app itself.
+    const created = await clients.channelAppCommand.create(
+      makeSlackChannelApp(org, uniqueName("channel-app")),
+    );
+
+    const deleted = await clients.channelAppCommand.delete({ resourceId: created.metadata!.id });
+    // The deleted resource is returned for audit — redacted like any read.
+    const slack = deleted.spec?.providerConfig?.case === "slack" ? deleted.spec.providerConfig.value : undefined;
+    expect(slack?.clientSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+
+    await expectGrpcCode(
+      () => clients.channelAppQuery.get({ value: created.metadata!.id }),
+      Code.NotFound,
+      "get after delete",
+    );
+  });
+});
+
+describe("ChannelApp conformance — the per-field secret contract", () => {
+  it("update with the marker on one secret rotates the other independently", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createSlackAppFixture(org);
+
+    // Rotate signing_secret while preserving client_secret via the marker —
+    // the per-field independence the multi-secret arm exists for. Reads
+    // always redact, so preservation is proven behaviorally: the update is
+    // accepted and every subsequent read still answers the marker.
+    const updated = await clients.channelAppCommand.update({
+      ...makeSlackChannelApp(org, created.metadata!.name, {
+        clientSecret: CHANNELAPP_REDACTED_MARKER,
+        signingSecret: "rotated-signing-secret",
+      }),
+      metadata: created.metadata,
+    });
+
+    expect(updated.metadata?.id).toBe(created.metadata?.id);
+    const slack = updated.spec?.providerConfig?.case === "slack" ? updated.spec.providerConfig.value : undefined;
+    expect(slack?.clientSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+    expect(slack?.signingSecret).toBe(CHANNELAPP_REDACTED_MARKER);
+  });
+
+  it("rejects the redaction marker as a secret on create (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () =>
+        clients.channelAppCommand.create(
+          makeSlackChannelApp(org, uniqueName("channel-app"), {
+            clientSecret: CHANNELAPP_REDACTED_MARKER,
+          }),
+        ),
+      Code.InvalidArgument,
+      "create with the redaction marker as client_secret",
+    );
+  });
+
+  it("rejects a ciphertext-shaped secret on create and update (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+
+    await expectGrpcCode(
+      () =>
+        clients.channelAppCommand.create(
+          makeSlackChannelApp(org, uniqueName("channel-app"), {
+            signingSecret: "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=",
+          }),
+        ),
+      Code.InvalidArgument,
+      "create with ciphertext-shaped signing_secret",
+    );
+
+    const created = await createSlackAppFixture(org);
+    await expectGrpcCode(
+      () =>
+        clients.channelAppCommand.update({
+          ...makeSlackChannelApp(org, created.metadata!.name, {
+            clientSecret: "enc:v2:ZnV0dXJlLXZlcnNpb24=",
+          }),
+          metadata: created.metadata,
+        }),
+      Code.InvalidArgument,
+      "update with ciphertext-shaped client_secret",
+    );
+  });
+
+  it("rejects a create with an empty secret field (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () =>
+        clients.channelAppCommand.create(
+          makeSlackChannelApp(org, uniqueName("channel-app"), { signingSecret: "" }),
+        ),
+      Code.InvalidArgument,
+      "create with empty signing_secret",
+    );
+  });
+});
+
+describe("ChannelApp conformance — provider immutability", () => {
+  it("rejects an update that flips the provider arm (InvalidArgument — the pinned as-is code)", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createSlackAppFixture(org);
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.channelAppCommand.update({
+          ...makeWhatsAppChannelApp(org, created.metadata!.name),
+          metadata: created.metadata,
+        }),
+      // Deliberately InvalidArgument, not FailedPrecondition — see the
+      // suite header's as-is pin note.
+      Code.InvalidArgument,
+      "update flipping slack → whatsapp",
+    );
+    expect(err.rawMessage).toBe("the provider of a channel app cannot be changed");
+  });
+});
+
+describe("ChannelApp conformance — referential delete-block", () => {
+  it("refuses to delete an app a channel references, then allows it once unreferenced", async () => {
+    const { org } = await target.provisionTenancy();
+    const app = await clients.channelAppCommand.create(
+      makeSlackChannelApp(org, uniqueName("channel-app")),
+    );
+
+    // The referencing side: an agent (channels must reference one) and a
+    // channel bound to the app via spec.app_ref.
+    const agent = await clients.agentCommand.create(
+      makeAgent({ org, name: uniqueName("channel-agent") }),
+    );
+    fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+    const channel = await clients.agentChannelCommand.create(
+      makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug, {
+        appRefSlug: app.metadata!.slug,
+      }),
+    );
+
+    // Referenced: deleting the app would break the channel's webhook
+    // verification, so the guard refuses.
+    await expectGrpcCode(
+      () => clients.channelAppCommand.delete({ resourceId: app.metadata!.id }),
+      Code.FailedPrecondition,
+      "delete a ChannelApp a live channel references",
+    );
+
+    // Unreference by deleting the channel; the app is now free to go.
+    await clients.agentChannelCommand.delete({ value: channel.metadata!.id });
+    const deleted = await clients.channelAppCommand.delete({ resourceId: app.metadata!.id });
+    expect(deleted.metadata?.id).toBe(app.metadata?.id);
+  });
+});
+
+describe("ChannelApp conformance — negative paths", () => {
+  it("get of a missing id returns NotFound", () =>
+    expectGrpcCode(
+      () => clients.channelAppQuery.get({ value: "chapp_01conformancemissing" }),
+      Code.NotFound,
+      "get missing channel app",
+    ));
+
+  it("getByReference of an unknown slug returns NotFound", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () => clients.channelAppQuery.getByReference({ org, slug: "does-not-exist" }),
+      Code.NotFound,
+      "getByReference unknown slug",
+    );
+  });
+
+  it("rejects a create with no provider arm (InvalidArgument — required oneof)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () =>
+        clients.channelAppCommand.create({
+          apiVersion: "agentic.stigmer.ai/v1",
+          kind: "ChannelApp",
+          metadata: { name: uniqueName("channel-app"), org },
+          spec: {},
+        }),
+      Code.InvalidArgument,
+      "create with an empty provider_config oneof",
+    );
+  });
+});

--- a/test/conformance/src/suites/search.conformance.test.ts
+++ b/test/conformance/src/suites/search.conformance.test.ts
@@ -1,0 +1,284 @@
+// Search conformance — the unified list/search/discover RPC: mode selection,
+// org and visibility scoping, kind filtering (#440), and pagination
+// clamping (Class A).
+// Domain: conformance suites.
+//
+// SearchService.search is one RPC whose behavior forks on its parameters:
+// empty query = list mode (created_at ordering, score pinned 1.0), non-empty
+// query = full-text search (relevance ordering), empty kinds = discover
+// across every searchable kind. The suite asserts MEMBERSHIP and
+// stable-property contracts only — never BM25 scores or relative ranking,
+// which are implementation-tunable (D1's explicit instruction).
+//
+// Error arms are pinned by CODE only (ratified guard P2): the Go
+// controller maps handler errors by string-matching and sanitizes
+// everything unmatched to a generic Internal (#478), so message text is
+// deliberately not part of the wire contract here.
+//
+// Indexing is synchronous on resource writes in both editions' stores, so
+// create-then-search needs no polling — a deliberate property this suite
+// silently relies on (a flaky pass here would smell of an async index).
+import { Code } from "@connectrpc/connect";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { makeAgent } from "../support/agents";
+import { uniqueName } from "../support/naming";
+import { makeWorkflow } from "../support/workflows";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// A single FTS-safe token (no hyphens — the porter unicode61 tokenizer
+// splits on them) unique per call, embedded in resource names so text
+// queries hit exactly the fixtures that carry it.
+function uniqueToken(): string {
+  return `conf${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function createAgentNamed(org: string, name: string) {
+  const agent = await clients.agentCommand.create(makeAgent({ org, name }));
+  fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+  return agent;
+}
+
+describe("Search conformance — list mode (empty query)", () => {
+  it("returns the org's resources of the kind with the pinned list-mode properties", async () => {
+    const { org } = await target.provisionTenancy();
+    const first = await createAgentNamed(org, uniqueName("list-agent"));
+    const second = await createAgentNamed(org, uniqueName("list-agent"));
+
+    const response = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org,
+    });
+
+    const ids = response.entries.map((e) => e.id);
+    expect(ids).toContain(first.metadata?.id);
+    expect(ids).toContain(second.metadata?.id);
+    expect(response.totalCount).toBe(2);
+    expect(response.countsByKind).toEqual({ agent: 2 });
+    expect(response.totalPages).toBe(1);
+
+    for (const entry of response.entries) {
+      // List mode pins score to exactly 1.0 — relevance is meaningless
+      // without a query.
+      expect(entry.score).toBe(1);
+      expect(entry.kind).toBe(ApiResourceKind.agent);
+      expect(entry.org).toBe(org);
+      expect(entry.qualifiedSlug).toBe(`${org}/${entry.slug}`);
+    }
+  });
+});
+
+describe("Search conformance — search mode (text query)", () => {
+  it("finds resources by a name token with a positive relevance score", async () => {
+    const { org } = await target.provisionTenancy();
+    const token = uniqueToken();
+    const match = await createAgentNamed(org, `needle-${token}`);
+    await createAgentNamed(org, uniqueName("chaff-agent"));
+
+    const response = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org,
+      query: token,
+    });
+
+    // Membership only: exactly the token-carrying agent, with SOME
+    // positive score — never a pinned value or ranking (D1).
+    expect(response.entries).toHaveLength(1);
+    expect(response.entries[0]?.id).toBe(match.metadata?.id);
+    expect(response.entries[0]?.score).toBeGreaterThan(0);
+  });
+
+  it("discover mode (empty kinds) spans searchable kinds — including the default instances", async () => {
+    const { org } = await target.provisionTenancy();
+    const token = uniqueToken();
+    await createAgentNamed(org, `disc-${token}-agent`);
+    const workflow = await clients.workflowCommand.create(
+      makeWorkflow({ org, name: `disc-${token}-flow` }),
+    );
+    fixtures.defer(() => clients.workflowCommand.delete({ value: workflow.metadata!.id }));
+
+    const response = await clients.search.search({ query: token, org });
+
+    // Four hits from two creates: agent and workflow creates each spawn a
+    // system-managed default INSTANCE named for its parent, and instances
+    // are search-indexed by kind_meta — discover truthfully surfaces all
+    // of them. Pinning the full set documents that behavior.
+    expect(response.totalCount).toBe(4);
+    expect(response.countsByKind).toEqual({
+      agent: 1,
+      agent_instance: 1,
+      workflow: 1,
+      workflow_instance: 1,
+    });
+  });
+
+  it("naming ONLY non-searchable kinds returns empty — never a discover fallback (#440)", async () => {
+    const { org } = await target.provisionTenancy();
+    const token = uniqueToken();
+    await createAgentNamed(org, `nofallback-${token}`);
+
+    // agent_channel is not_search_indexed by proto kind_meta in BOTH
+    // editions — a request naming only it must answer emptiness, not
+    // silently widen to every searchable kind.
+    const response = await clients.search.search({
+      kinds: [ApiResourceKind.agent_channel],
+      org,
+      query: token,
+    });
+
+    expect(response.entries).toHaveLength(0);
+    expect(response.totalCount).toBe(0);
+  });
+});
+
+describe("Search conformance — org & visibility scoping", () => {
+  it("a strict org filter never leaks another org's private resources", async () => {
+    const { org: orgA } = await target.provisionTenancy();
+    const { org: orgB } = await target.provisionTenancy();
+    const token = uniqueToken();
+    const mine = await createAgentNamed(orgA, `scoped-${token}-a`);
+    await createAgentNamed(orgB, `scoped-${token}-b`);
+
+    // Strict filter (cross_org_public unset): only orgA's resource.
+    const strict = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org: orgA,
+      query: token,
+    });
+    expect(strict.entries.map((e) => e.id)).toEqual([mine.metadata?.id]);
+
+    // cross_org_public widens to PUBLIC resources of other orgs — orgB's
+    // agent is private, so nothing changes.
+    const widened = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org: orgA,
+      query: token,
+      crossOrgPublic: true,
+    });
+    expect(widened.entries.map((e) => e.id)).toEqual([mine.metadata?.id]);
+  });
+
+  it("cross_org_public admits other orgs' PUBLIC resources; exclude_public removes them", async (ctx) => {
+    // Minting a public resource needs the unguarded local write door (the
+    // agentshare suite's gating precedent).
+    if (!target.capabilities.clientPublicVisibilityWrites) return ctx.skip();
+    const { org: orgA } = await target.provisionTenancy();
+    const { org: orgB } = await target.provisionTenancy();
+    const token = uniqueToken();
+    const mine = await createAgentNamed(orgA, `vis-${token}-mine`);
+    const theirs = await createAgentNamed(orgB, `vis-${token}-public`);
+    await clients.agentCommand.updateVisibility({
+      resourceId: theirs.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+
+    // The "All" library scope: my org's resources plus the marketplace.
+    const widened = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org: orgA,
+      query: token,
+      crossOrgPublic: true,
+    });
+    expect(new Set(widened.entries.map((e) => e.id))).toEqual(
+      new Set([mine.metadata?.id, theirs.metadata?.id]),
+    );
+
+    // Strict org filter: the public foreign resource disappears.
+    const strict = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org: orgA,
+      query: token,
+    });
+    expect(strict.entries.map((e) => e.id)).toEqual([mine.metadata?.id]);
+
+    // exclude_public is an independent subtraction on top of any scope.
+    const excluded = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      query: token,
+      excludePublic: true,
+    });
+    expect(excluded.entries.map((e) => e.id)).toEqual([mine.metadata?.id]);
+  });
+});
+
+describe("Search conformance — pagination clamping", () => {
+  it("pages by size with totals, clamping oversize and zero values instead of erroring", async () => {
+    const { org } = await target.provisionTenancy();
+    const token = uniqueToken();
+    for (let i = 0; i < 3; i++) {
+      await createAgentNamed(org, `page-${token}-${i}`);
+    }
+
+    const firstPage = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org,
+      query: token,
+      page: { num: 1, size: 2 },
+    });
+    expect(firstPage.entries).toHaveLength(2);
+    expect(firstPage.totalCount).toBe(3);
+    expect(firstPage.totalPages).toBe(2);
+
+    const secondPage = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org,
+      query: token,
+      page: { num: 2, size: 2 },
+    });
+    expect(secondPage.entries).toHaveLength(1);
+    // The two pages partition the result set.
+    const seen = new Set([...firstPage.entries, ...secondPage.entries].map((e) => e.id));
+    expect(seen.size).toBe(3);
+
+    // Clamping, not refusal: size above the 100 cap and num 0 both
+    // normalize (size→100, num→1) — the request still succeeds.
+    const clamped = await clients.search.search({
+      kinds: [ApiResourceKind.agent],
+      org,
+      query: token,
+      page: { num: 0, size: 1000 },
+    });
+    expect(clamped.entries).toHaveLength(3);
+    expect(clamped.totalPages).toBe(1);
+  });
+});
+
+describe("Search conformance — validation arms (codes only, P2)", () => {
+  it("rejects an over-length query (InvalidArgument)", async () => {
+    await expectGrpcCode(
+      () => clients.search.search({ query: "x".repeat(501) }),
+      Code.InvalidArgument,
+      "query above the 500-character cap",
+    );
+  });
+
+  it("rejects a malformed org slug (InvalidArgument — the proto pattern)", async () => {
+    await expectGrpcCode(
+      () => clients.search.search({ org: "NotASlug" }),
+      Code.InvalidArgument,
+      "org violating the slug pattern",
+    );
+  });
+});

--- a/test/conformance/src/suites/search.conformance.test.ts
+++ b/test/conformance/src/suites/search.conformance.test.ts
@@ -124,9 +124,15 @@ describe("Search conformance — search mode (text query)", () => {
     // Four hits from two creates: agent and workflow creates each spawn a
     // system-managed default INSTANCE named for its parent, and instances
     // are search-indexed by kind_meta — discover truthfully surfaces all
-    // of them. Pinning the full set documents that behavior.
+    // of them. Compared on the NON-ZERO entries: whether zero-count kinds
+    // appear in the map is an edition presentation difference (the
+    // multi-tenant edition enumerates every kind at 0; local omits them),
+    // while the non-zero membership is the shared contract.
     expect(response.totalCount).toBe(4);
-    expect(response.countsByKind).toEqual({
+    const nonZeroCounts = Object.fromEntries(
+      Object.entries(response.countsByKind).filter(([, count]) => count > 0),
+    );
+    expect(nonZeroCounts).toEqual({
       agent: 1,
       agent_instance: 1,
       workflow: 1,

--- a/test/conformance/src/suites/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites/workflowexecution.conformance.test.ts
@@ -60,7 +60,12 @@ afterAll(async () => {
 });
 
 describe("WorkflowExecution conformance — the engine gate (Class A)", () => {
-  it("create refuses Unavailable before any side effect when no engine is connected", async () => {
+  it("create refuses Unavailable before any side effect when no engine is connected", async (ctx) => {
+    // Only the engineless local CRUD targets can observe this boundary —
+    // scheduleFiring doubles as "a Temporal engine backs this target" (its
+    // local-CRUD value documents 'no Temporal behind this target at all'),
+    // and the cloud CRUD target serves a live engine.
+    if (target.capabilities.scheduleFiring) return ctx.skip();
     const { org } = await target.provisionTenancy();
     // A real workflow: the engine gate sits AFTER reference validation, so
     // the refusal proves the gate specifically, not an earlier miss.
@@ -97,13 +102,22 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
     expect(summary.activeCount).toBe(0);
     expect(summary.phaseCounts).toEqual({});
     expect(summary.totalCount).toBe(0);
-    // -1 is the "no terminal runs yet" sentinel — deliberately not 0,
-    // which would read as a real 0% success rate.
-    expect(summary.successRate).toBe(-1);
-    // The cost summary is ALWAYS present, zero-valued — consumers never
-    // null-check it.
-    expect(summary.totalCost).toBeDefined();
-    expect(summary.totalCost?.totalCostUsd ?? 0).toBe(0);
+    // The zero-record success rate is a VERIFIED cross-edition
+    // inconsistency, pinned as-is per edition (the wave-2 PR records the
+    // harmonization candidate): OSS answers the -1 "no terminal runs yet"
+    // sentinel — deliberately distinguishable from a real 0% — while the
+    // multi-tenant edition answers a plain 0.
+    expect(summary.successRate).toBe(target.capabilities.multiTenant ? 0 : -1);
+    // The zero-record cost summary is the second shape inconsistency
+    // pinned as-is per edition (same PR record): OSS ALWAYS materializes a
+    // zero-valued summary so consumers never null-check it; the
+    // multi-tenant edition omits the message entirely when nothing ran.
+    if (target.capabilities.multiTenant) {
+      expect(summary.totalCost).toBeUndefined();
+    } else {
+      expect(summary.totalCost).toBeDefined();
+      expect(summary.totalCost?.totalCostUsd ?? 0).toBe(0);
+    }
     // An average over nothing is absence, not 0.
     expect(summary.avgDuration).toBeUndefined();
     expect(summary.topFailingWorkflows).toHaveLength(0);
@@ -126,14 +140,18 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
       "getEventLog without an execution id",
     );
 
-    // No existence check by design: the event log of a never-seen id is
-    // truthfully empty, and has_more/latest_sequence are zero-valued.
-    const page = await clients.workflowExecutionQuery.getEventLog({
-      executionId: "wfe_01conformancemissing",
-    });
-    expect(page.events).toHaveLength(0);
-    expect(page.hasMore).toBe(false);
-    expect(page.latestSequence).toBe(0n);
+    // The unknown-id arm is single-user-posture only: the multi-tenant
+    // edition's authorization fails closed on an unresolvable id
+    // (PermissionDenied — no existence leak), never reaching the handler's
+    // no-existence-check behavior.
+    if (!target.capabilities.multiTenant) {
+      const page = await clients.workflowExecutionQuery.getEventLog({
+        executionId: "wfe_01conformancemissing",
+      });
+      expect(page.events).toHaveLength(0);
+      expect(page.hasMore).toBe(false);
+      expect(page.latestSequence).toBe(0n);
+    }
   });
 
   it("the subscribe lanes refuse empty ids (InvalidArgument) and unknown ids (NotFound)", async () => {
@@ -151,6 +169,20 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
     await expectGrpcCode(
       () =>
         collectStream((signal) =>
+          clients.workflowExecutionQuery.subscribeEvents({ executionId: "" }, { signal }),
+        ),
+      Code.InvalidArgument,
+      "subscribeEvents with an empty id",
+    );
+
+    // The unknown-id NotFound arms hold where the caller can see everything
+    // (single-user); the multi-tenant edition answers PermissionDenied for
+    // an unresolvable id instead (authorization fail-closed, no existence
+    // leak) — the same split as getEventLog above.
+    if (target.capabilities.multiTenant) return;
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
           clients.workflowExecutionQuery.subscribe(
             { executionId: "wfe_01conformancemissing" },
             { signal },
@@ -158,14 +190,6 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
         ),
       Code.NotFound,
       "subscribe to an unknown execution",
-    );
-    await expectGrpcCode(
-      () =>
-        collectStream((signal) =>
-          clients.workflowExecutionQuery.subscribeEvents({ executionId: "" }, { signal }),
-        ),
-      Code.InvalidArgument,
-      "subscribeEvents with an empty id",
     );
     await expectGrpcCode(
       () =>
@@ -182,7 +206,13 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
 });
 
 describe("WorkflowExecution conformance — submitFileDecision negatives (Class A)", () => {
-  it("rejects structurally invalid inputs before any load (InvalidArgument)", async () => {
+  // Single-user-posture arms: the multi-tenant edition's authorization
+  // interceptor resolves the execution BEFORE proto validation, so
+  // structurally invalid or unknown ids surface as NotFound/PermissionDenied
+  // there instead — a verified ordering divergence, disclosed in the wave-2
+  // PR for the parity register.
+  it("rejects structurally invalid inputs before any load (InvalidArgument)", async (ctx) => {
+    if (target.capabilities.multiTenant) return ctx.skip();
     // Proto-validation arms: min_len on the ids/digest, defined-and-nonzero
     // on the enums — all fire before the execution load, so a fake id is
     // never touched.
@@ -227,7 +257,8 @@ describe("WorkflowExecution conformance — submitFileDecision negatives (Class 
     );
   });
 
-  it("an unknown execution answers NotFound", async () => {
+  it("an unknown execution answers NotFound", async (ctx) => {
+    if (target.capabilities.multiTenant) return ctx.skip();
     await expectGrpcCode(
       () =>
         clients.workflowExecutionCommand.submitFileDecision({

--- a/test/conformance/src/suites/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites/workflowexecution.conformance.test.ts
@@ -1,0 +1,245 @@
+// WorkflowExecution conformance — the ENGINELESS surface (Class A): the
+// create-time engine gate and every read RPC's zero-record/validation
+// contract.
+// Domain: conformance suites.
+//
+// This target runs no Temporal, so no execution record can ever exist here
+// — the create pipeline's EnsureEngineAvailable step (step 4, deliberately
+// BEFORE any side effect) refuses with Unavailable, which is itself the
+// first pin: the acknowledged boundary the Class B suite explicitly scopes
+// out (its target always has an engine). Everything else asserts what the
+// read surfaces truthfully answer when NOTHING has ever run:
+//
+//   - getExecutionSummary's zero shape, including the success_rate -1
+//     sentinel ("no terminal runs yet" — distinguishable from a real 0%),
+//     the ALWAYS-present zero cost summary, and avg_duration's deliberate
+//     absence (an average over nothing is not 0).
+//   - listPendingApprovals' empty page.
+//   - getEventLog's asymmetry: empty id refuses InvalidArgument, but an
+//     UNKNOWN id answers an empty page — NOT NotFound (no existence check
+//     by design; the Class B suite pins the same arm engine-side).
+//   - The subscribe lanes' error arms, driven through the bounded
+//     collectStream consumer: empty id InvalidArgument; unknown id
+//     NotFound (subscribeEvents and subscribe both check existence before
+//     streaming — the opposite of getEventLog).
+//   - submitFileDecision's engineless negatives: proto-validation arms and
+//     the unknown-execution NotFound. The deeper arms (digest mismatch,
+//     unknown change set) need a live file review and land with the
+//     execution-domain ports (#17/#20 — disclosed in the wave-2 PR).
+//
+// The populated arms of every one of these RPCs are Class B and live in
+// suites-execution/.
+import { Code } from "@connectrpc/connect";
+import { FileDecisionAction, FileDecisionScope } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { collectStream } from "../support/collect-stream";
+import { uniqueName } from "../support/naming";
+import { makeWorkflow } from "../support/workflows";
+import { makeWorkflowExecution } from "../support/workflowexecutions";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+describe("WorkflowExecution conformance — the engine gate (Class A)", () => {
+  it("create refuses Unavailable before any side effect when no engine is connected", async () => {
+    const { org } = await target.provisionTenancy();
+    // A real workflow: the engine gate sits AFTER reference validation, so
+    // the refusal proves the gate specifically, not an earlier miss.
+    const workflow = await clients.workflowCommand.create(
+      makeWorkflow({ org, name: uniqueName("gate-flow") }),
+    );
+    fixtures.defer(() => clients.workflowCommand.delete({ value: workflow.metadata!.id }));
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.workflowExecutionCommand.create(
+          makeWorkflowExecution({
+            org,
+            name: uniqueName("gate-exec"),
+            workflowId: workflow.metadata!.id,
+          }),
+        ),
+      Code.Unavailable,
+      "create with no execution engine behind the server",
+    );
+    // The user-facing copy both domains share — a transient-shaped message
+    // because the engine may legitimately still be connecting at boot.
+    expect(err.rawMessage).toBe(
+      "The execution engine is temporarily unavailable. Please try again shortly.",
+    );
+  });
+});
+
+describe("WorkflowExecution conformance — zero-record read surfaces (Class A)", () => {
+  it("getExecutionSummary answers the pinned zero shape", async () => {
+    const { org } = await target.provisionTenancy();
+    const summary = await clients.workflowExecutionQuery.getExecutionSummary({ org });
+
+    expect(summary.activeCount).toBe(0);
+    expect(summary.phaseCounts).toEqual({});
+    expect(summary.totalCount).toBe(0);
+    // -1 is the "no terminal runs yet" sentinel — deliberately not 0,
+    // which would read as a real 0% success rate.
+    expect(summary.successRate).toBe(-1);
+    // The cost summary is ALWAYS present, zero-valued — consumers never
+    // null-check it.
+    expect(summary.totalCost).toBeDefined();
+    expect(summary.totalCost?.totalCostUsd ?? 0).toBe(0);
+    // An average over nothing is absence, not 0.
+    expect(summary.avgDuration).toBeUndefined();
+    expect(summary.topFailingWorkflows).toHaveLength(0);
+    expect(summary.costByWorkflow).toHaveLength(0);
+  });
+
+  it("listPendingApprovals answers the empty page", async () => {
+    const { org } = await target.provisionTenancy();
+    const approvals = await clients.workflowExecutionQuery.listPendingApprovals({ org });
+    expect(approvals.entries).toHaveLength(0);
+    expect(approvals.totalCount).toBe(0);
+  });
+
+  it("getEventLog: empty id refuses; an UNKNOWN id answers an empty page, not NotFound", async () => {
+    // Code only: the proto validation layer fires before the handler's own
+    // required-id check, so the message is the interceptor's, not a pin.
+    await expectGrpcCode(
+      () => clients.workflowExecutionQuery.getEventLog({ executionId: "" }),
+      Code.InvalidArgument,
+      "getEventLog without an execution id",
+    );
+
+    // No existence check by design: the event log of a never-seen id is
+    // truthfully empty, and has_more/latest_sequence are zero-valued.
+    const page = await clients.workflowExecutionQuery.getEventLog({
+      executionId: "wfe_01conformancemissing",
+    });
+    expect(page.events).toHaveLength(0);
+    expect(page.hasMore).toBe(false);
+    expect(page.latestSequence).toBe(0n);
+  });
+
+  it("the subscribe lanes refuse empty ids (InvalidArgument) and unknown ids (NotFound)", async () => {
+    // Unlike getEventLog, both streaming lanes CHECK existence before
+    // streaming — a long-lived subscription to a typo'd id must fail
+    // loudly, not idle forever on an empty poll loop.
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          clients.workflowExecutionQuery.subscribe({ executionId: "" }, { signal }),
+        ),
+      Code.InvalidArgument,
+      "subscribe with an empty id",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          clients.workflowExecutionQuery.subscribe(
+            { executionId: "wfe_01conformancemissing" },
+            { signal },
+          ),
+        ),
+      Code.NotFound,
+      "subscribe to an unknown execution",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          clients.workflowExecutionQuery.subscribeEvents({ executionId: "" }, { signal }),
+        ),
+      Code.InvalidArgument,
+      "subscribeEvents with an empty id",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          clients.workflowExecutionQuery.subscribeEvents(
+            { executionId: "wfe_01conformancemissing" },
+            { signal },
+          ),
+        ),
+      Code.NotFound,
+      "subscribeEvents on an unknown execution",
+    );
+  });
+});
+
+describe("WorkflowExecution conformance — submitFileDecision negatives (Class A)", () => {
+  it("rejects structurally invalid inputs before any load (InvalidArgument)", async () => {
+    // Proto-validation arms: min_len on the ids/digest, defined-and-nonzero
+    // on the enums — all fire before the execution load, so a fake id is
+    // never touched.
+    await expectGrpcCode(
+      () =>
+        clients.workflowExecutionCommand.submitFileDecision({
+          executionId: "",
+          childAgentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.InvalidArgument,
+      "submitFileDecision without a workflow execution id",
+    );
+    await expectGrpcCode(
+      () =>
+        clients.workflowExecutionCommand.submitFileDecision({
+          executionId: "wfe_x",
+          childAgentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.UNSPECIFIED,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.InvalidArgument,
+      "submitFileDecision with an unspecified scope",
+    );
+    await expectGrpcCode(
+      () =>
+        clients.workflowExecutionCommand.submitFileDecision({
+          executionId: "wfe_x",
+          childAgentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          expectedDigest: "",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.REJECT,
+        }),
+      Code.InvalidArgument,
+      "submitFileDecision without the digest guard",
+    );
+  });
+
+  it("an unknown execution answers NotFound", async () => {
+    await expectGrpcCode(
+      () =>
+        clients.workflowExecutionCommand.submitFileDecision({
+          executionId: "wfe_01conformancemissing",
+          childAgentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          expectedDigest: "digest",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+        }),
+      Code.NotFound,
+      "submitFileDecision on a nonexistent workflow execution",
+    );
+  });
+});

--- a/test/conformance/src/support/agentchannels.ts
+++ b/test/conformance/src/support/agentchannels.ts
@@ -1,0 +1,91 @@
+// Canonical valid AgentChannel fixtures for the conformance suite.
+// Domain: conformance support.
+//
+// An AgentChannel binds one agent to one external messaging workspace
+// (Slack or WhatsApp). The spec is deliberately small — which agent serves,
+// whether serving is enabled, the provider arm, and credential wiring —
+// because workspace identity lives in status, produced by the install flow
+// (which the OSS edition refuses; see the agentchannel suite header).
+//
+// The same-org invariant is structural: agent_ref.org and app_ref.org must
+// both equal metadata.org (channels have no cross-org arm — the channel's
+// org is the billing and credentials org). Builders leave ref orgs empty by
+// default so the server's relative-reference normalization is exercised;
+// negatives set them explicitly.
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+export const AGENTCHANNEL_API_VERSION = "agentic.stigmer.ai/v1";
+export const AGENTCHANNEL_KIND = "AgentChannel";
+
+export interface SlackAgentChannelOptions {
+  // Explicit agent_ref org, for the cross-org negative; empty means
+  // same-org (the platform's relative-reference convention).
+  agentRefOrg?: string;
+  enabled?: boolean;
+  // ChannelApp binding (BYO app). Optional for Slack — absent means the
+  // shared platform app.
+  appRefSlug?: string;
+  appRefOrg?: string;
+  // Per-channel model pin, for the model-registry existence rule (#774).
+  modelName?: string;
+}
+
+// A complete, valid Slack AgentChannel for the given agent. Slack's provider
+// arm is an empty message by design (`slack: {}` — workspace identity is
+// OAuth-observed into status, never declared).
+export function makeSlackAgentChannel(
+  org: string,
+  name: string,
+  agentSlug: string,
+  options: SlackAgentChannelOptions = {},
+): MessageInitShape<typeof AgentChannelSchema> {
+  return {
+    apiVersion: AGENTCHANNEL_API_VERSION,
+    kind: AGENTCHANNEL_KIND,
+    metadata: { name, org },
+    spec: {
+      agentRef: {
+        slug: agentSlug,
+        kind: ApiResourceKind.agent,
+        ...(options.agentRefOrg !== undefined ? { org: options.agentRefOrg } : {}),
+      },
+      enabled: options.enabled ?? true,
+      providerConfig: { case: "slack", value: {} },
+      ...(options.appRefSlug !== undefined
+        ? {
+            appRef: {
+              slug: options.appRefSlug,
+              kind: ApiResourceKind.channel_app,
+              ...(options.appRefOrg !== undefined ? { org: options.appRefOrg } : {}),
+            },
+          }
+        : {}),
+      ...(options.modelName !== undefined ? { runConfig: { modelName: options.modelName } } : {}),
+    },
+  };
+}
+
+// A complete WhatsApp AgentChannel. WhatsApp is BYO-only (DD-WA-2): app_ref
+// is required, which is exactly the arm the suite's negative drops.
+export function makeWhatsAppAgentChannel(
+  org: string,
+  name: string,
+  agentSlug: string,
+  options: { appRefSlug?: string } = {},
+): MessageInitShape<typeof AgentChannelSchema> {
+  return {
+    apiVersion: AGENTCHANNEL_API_VERSION,
+    kind: AGENTCHANNEL_KIND,
+    metadata: { name, org },
+    spec: {
+      agentRef: { slug: agentSlug, kind: ApiResourceKind.agent },
+      enabled: true,
+      providerConfig: { case: "whatsapp", value: { phoneNumberId: "106540352242922" } },
+      ...(options.appRefSlug !== undefined
+        ? { appRef: { slug: options.appRefSlug, kind: ApiResourceKind.channel_app } }
+        : {}),
+    },
+  };
+}

--- a/test/conformance/src/support/agentchannels.ts
+++ b/test/conformance/src/support/agentchannels.ts
@@ -19,6 +19,14 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 export const AGENTCHANNEL_API_VERSION = "agentic.stigmer.ai/v1";
 export const AGENTCHANNEL_KIND = "AgentChannel";
 
+// The default model pin every channel fixture carries. Cloud REQUIRES a
+// pinned model on channel writes (its channel execution profile serves the
+// Cursor harness, where an unpinned run would bill as Auto —
+// stigmer/stigmer#362); OSS merely validates a pin that is present. One
+// registry-valid pin keeps every fixture accepted by both editions; the
+// pin-REQUIRED divergence itself is pinned two-armed in the suite.
+export const CHANNEL_FIXTURE_MODEL = "composer-2.5";
+
 export interface SlackAgentChannelOptions {
   // Explicit agent_ref org, for the cross-org negative; empty means
   // same-org (the platform's relative-reference convention).
@@ -28,8 +36,10 @@ export interface SlackAgentChannelOptions {
   // shared platform app.
   appRefSlug?: string;
   appRefOrg?: string;
-  // Per-channel model pin, for the model-registry existence rule (#774).
-  modelName?: string;
+  // Per-channel model pin. Defaults to CHANNEL_FIXTURE_MODEL (see its
+  // comment); pass an unknown name for the existence-rule negative (#774)
+  // or `null` to omit the pin entirely (the two-armed #362 divergence).
+  modelName?: string | null;
 }
 
 // A complete, valid Slack AgentChannel for the given agent. Slack's provider
@@ -62,7 +72,9 @@ export function makeSlackAgentChannel(
             },
           }
         : {}),
-      ...(options.modelName !== undefined ? { runConfig: { modelName: options.modelName } } : {}),
+      ...(options.modelName !== null
+        ? { runConfig: { modelName: options.modelName ?? CHANNEL_FIXTURE_MODEL } }
+        : {}),
     },
   };
 }
@@ -83,6 +95,7 @@ export function makeWhatsAppAgentChannel(
       agentRef: { slug: agentSlug, kind: ApiResourceKind.agent },
       enabled: true,
       providerConfig: { case: "whatsapp", value: { phoneNumberId: "106540352242922" } },
+      runConfig: { modelName: CHANNEL_FIXTURE_MODEL },
       ...(options.appRefSlug !== undefined
         ? { appRef: { slug: options.appRefSlug, kind: ApiResourceKind.channel_app } }
         : {}),

--- a/test/conformance/src/support/agentshares.ts
+++ b/test/conformance/src/support/agentshares.ts
@@ -1,0 +1,50 @@
+// Canonical valid AgentShare fixtures for the conformance suite.
+// Domain: conformance support.
+//
+// An AgentShare is the hosted-chat distribution channel for one agent: the
+// /chat/<org>/<slug> URL identity, its audience, and an optional rotatable
+// link token (server-owned, in status). The canonical share carries the
+// agent's own slug — created by omitting BOTH metadata.name and slug, which
+// the defaults resolver fills from the referenced agent — so the builder
+// makes the name optional on purpose.
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { AgentShareSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import { AgentShareAudience } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+export const AGENTSHARE_API_VERSION = "agentic.stigmer.ai/v1";
+export const AGENTSHARE_KIND = "AgentShare";
+
+export interface AgentShareOptions {
+  // Omit for the canonical share (slug + name default from the agent);
+  // set for a deliberately distinct link.
+  name?: string;
+  // Explicit agent_ref org, for cross-org shares; empty means same-org.
+  agentRefOrg?: string;
+  enabled?: boolean;
+  // Unspecified deliberately means PUBLIC (the proto's documented default) —
+  // set org for the member-gated audience.
+  audience?: AgentShareAudience;
+}
+
+// A complete, valid AgentShare for the given agent.
+export function makeAgentShare(
+  org: string,
+  agentSlug: string,
+  options: AgentShareOptions = {},
+): MessageInitShape<typeof AgentShareSchema> {
+  return {
+    apiVersion: AGENTSHARE_API_VERSION,
+    kind: AGENTSHARE_KIND,
+    metadata: { org, ...(options.name !== undefined ? { name: options.name } : {}) },
+    spec: {
+      agentRef: {
+        slug: agentSlug,
+        kind: ApiResourceKind.agent,
+        ...(options.agentRefOrg !== undefined ? { org: options.agentRefOrg } : {}),
+      },
+      enabled: options.enabled ?? true,
+      ...(options.audience !== undefined ? { audience: options.audience } : {}),
+    },
+  };
+}

--- a/test/conformance/src/support/artifacts.ts
+++ b/test/conformance/src/support/artifacts.ts
@@ -1,0 +1,48 @@
+// Canonical valid Artifact create inputs for the conformance suite.
+// Domain: conformance support.
+//
+// Artifact is the execution-output store: a metadata resource plus a
+// content-addressed blob. Create is NOT a standard resource write — the
+// input is spec + raw content bytes, and the org derives from the producing
+// execution (falling back to empty when the execution id is unknown, the
+// OSS single-user posture) — so the builder shapes CreateArtifactInput
+// rather than a resource message.
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { CreateArtifactInputSchema } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/io_pb";
+
+export interface ArtifactInputOptions {
+  displayName?: string;
+  contentType?: string;
+  content?: Uint8Array;
+  // Exactly one execution source is the create contract; agent-execution
+  // sourced by default, workflow via this override.
+  workflowExecutionId?: string;
+  agentExecutionId?: string;
+  // Retention TTL in days; -1 means permanent (expires_at stays empty).
+  ttlDays?: number;
+}
+
+export const ARTIFACT_DEFAULT_CONTENT = new TextEncoder().encode(
+  "conformance artifact content\n",
+);
+
+// A complete, valid CreateArtifactInput sourced from a (fabricated) agent
+// execution id — accepted by construction: create derives org best-effort
+// and never validates the execution's existence.
+export function makeArtifactInput(
+  options: ArtifactInputOptions = {},
+): MessageInitShape<typeof CreateArtifactInputSchema> {
+  const source =
+    options.workflowExecutionId !== undefined
+      ? { workflowExecutionId: options.workflowExecutionId }
+      : { agentExecutionId: options.agentExecutionId ?? "aexec_01conformancefixture" };
+  return {
+    spec: {
+      displayName: options.displayName ?? "conformance-artifact.txt",
+      contentType: options.contentType ?? "text/plain",
+      source,
+      ...(options.ttlDays !== undefined ? { retention: { ttlDays: options.ttlDays } } : {}),
+    },
+    content: options.content ?? ARTIFACT_DEFAULT_CONTENT,
+  };
+}

--- a/test/conformance/src/support/channelapps.ts
+++ b/test/conformance/src/support/channelapps.ts
@@ -1,0 +1,76 @@
+// Canonical valid ChannelApp fixtures for the conformance suite.
+// Domain: conformance support.
+//
+// A ChannelApp is a customer-owned messaging-platform app (a Slack app or a
+// Meta/WhatsApp app) that agent channels install through instead of the
+// shared platform app. Its spec is a required provider oneof whose arms
+// carry real secrets — encrypted at rest, redacted to the platform marker on
+// every read, rotated per field via the marker convention (the OAuthApp
+// secret contract generalized to multiple secrets per arm).
+//
+// Negative cases (missing secrets, ciphertext-shaped values, provider flips)
+// are written inline in the suite: this module is validity by construction.
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { ChannelAppSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+
+export const CHANNELAPP_API_VERSION = "agentic.stigmer.ai/v1";
+export const CHANNELAPP_KIND = "ChannelApp";
+
+// The redaction sentinel every read surface substitutes for stored secrets.
+// A CROSS-EDITION CONTRACT STRING (the oauthapp/environment marker); sending
+// it back on update means "keep the stored value" — independently per field,
+// which is what makes single-secret rotation possible.
+export const CHANNELAPP_REDACTED_MARKER = "***REDACTED***";
+
+export interface SlackChannelAppOptions {
+  clientId?: string;
+  clientSecret?: string;
+  signingSecret?: string;
+}
+
+// A complete, valid Slack ChannelApp ready to hand to create/apply/update.
+export function makeSlackChannelApp(
+  org: string,
+  name: string,
+  options: SlackChannelAppOptions = {},
+): MessageInitShape<typeof ChannelAppSchema> {
+  return {
+    apiVersion: CHANNELAPP_API_VERSION,
+    kind: CHANNELAPP_KIND,
+    metadata: { name, org },
+    spec: {
+      providerConfig: {
+        case: "slack",
+        value: {
+          clientId: options.clientId ?? "conformance-slack-client-id",
+          clientSecret: options.clientSecret ?? "conformance-slack-client-secret",
+          signingSecret: options.signingSecret ?? "conformance-slack-signing-secret",
+        },
+      },
+    },
+  };
+}
+
+// A complete, valid WhatsApp ChannelApp — the second provider arm, used by
+// the provider-immutability negatives and the WhatsApp-specific rules.
+export function makeWhatsAppChannelApp(
+  org: string,
+  name: string,
+): MessageInitShape<typeof ChannelAppSchema> {
+  return {
+    apiVersion: CHANNELAPP_API_VERSION,
+    kind: CHANNELAPP_KIND,
+    metadata: { name, org },
+    spec: {
+      providerConfig: {
+        case: "whatsapp",
+        value: {
+          appId: "1234567890",
+          appSecret: "conformance-wa-app-secret",
+          accessToken: "conformance-wa-access-token",
+          verifyToken: "conformance-wa-verify-token",
+        },
+      },
+    },
+  };
+}

--- a/test/conformance/src/support/collect-stream.ts
+++ b/test/conformance/src/support/collect-stream.ts
@@ -1,0 +1,86 @@
+// Bounded collection of server-streaming RPC responses.
+// Domain: conformance support (streaming lanes).
+//
+// The subscribe lanes (AgentExecution.subscribe, WorkflowExecution.subscribe/
+// subscribeEvents) return long-lived streams that only sometimes close on
+// their own — the server ends them on a terminal-phase UPDATE, but a stream
+// opened against an already-terminal execution replays its snapshot/events
+// and then idles forever (a verified quirk of both editions' pollers, pinned
+// deliberately by the suites). A bare `for await` over such a stream would
+// hang the test, so every conformance consumption of a stream goes through
+// this helper: collect until a predicate is satisfied or a deadline passes,
+// then abort the call and report what was gathered.
+//
+// The shape mirrors the poll-don't-sleep core (execution-poll.ts): the caller
+// owns the predicate and the meaning of the collected messages; this module
+// owns only the bounded-consumption rhythm. The streamFactory receives the
+// AbortSignal because Connect-ES binds cancellation per call — the same
+// `(signal) => AsyncIterable` seam the CLI's stream drivers use.
+import { Code, ConnectError } from "@connectrpc/connect";
+
+export const DEFAULT_STREAM_TIMEOUT_MS = 30_000;
+
+export interface CollectStreamOptions<T> {
+  // Stop collecting (successfully) once this returns true for the messages
+  // gathered so far. Omit it to collect until the SERVER closes the stream —
+  // only safe where the server is known to close (e.g. subscribeEvents on a
+  // terminal execution); the timeout still backstops a hang.
+  until?: (messages: T[]) => boolean;
+  timeoutMs?: number;
+}
+
+export interface CollectedStream<T> {
+  messages: T[];
+  // How consumption ended:
+  //   "until"  — the predicate was satisfied (the stream was then aborted);
+  //   "closed" — the server ended the stream on its own;
+  //   "timeout" — the deadline passed first. Deliberately NOT an error:
+  //     some pinned contracts (the idle-forever snapshot replay) are proven
+  //     BY the timeout arm, so the caller asserts on the outcome instead of
+  //     catching.
+  outcome: "until" | "closed" | "timeout";
+}
+
+// Consumes a server stream until the predicate, server close, or deadline —
+// whichever comes first — and returns everything received. Abort-induced
+// stream termination (Code.Canceled) is the helper's own doing and never
+// surfaces; every other stream error propagates untouched, so error-contract
+// assertions (NotFound on an unknown id) still see the real ConnectError.
+export async function collectStream<T>(
+  streamFactory: (signal: AbortSignal) => AsyncIterable<T>,
+  options: CollectStreamOptions<T> = {},
+): Promise<CollectedStream<T>> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_STREAM_TIMEOUT_MS;
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+
+  const messages: T[] = [];
+  let outcome: CollectedStream<T>["outcome"] = "closed";
+  try {
+    for await (const message of streamFactory(abort.signal)) {
+      messages.push(message);
+      if (options.until?.(messages) === true) {
+        outcome = "until";
+        abort.abort();
+        break;
+      }
+    }
+  } catch (err) {
+    // Our own abort ends the iterable with Canceled; translate it to the
+    // outcome it represents rather than failing the caller.
+    if (err instanceof ConnectError && err.code === Code.Canceled && abort.signal.aborted) {
+      outcome = outcome === "until" ? "until" : "timeout";
+    } else {
+      throw err;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // A predicate satisfied on the same tick the server closed reports "until":
+  // the caller got what it asked for; how the stream ended is incidental.
+  if (outcome === "closed" && abort.signal.aborted) {
+    outcome = "timeout";
+  }
+  return { messages, outcome };
+}

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -58,6 +58,10 @@ export class CloudTarget implements TargetProfile {
     // pins the create-gate refusal instead (see target.ts).
     firstPartyMemoryCapture: false,
     clientPublicVisibilityWrites: false,
+    // The cloud channel runtime serves installs, conversation participation,
+    // and proactive messaging for real — the OSS refusal pins are gated off
+    // here (their full behavior needs live provider workspaces; see target.ts).
+    channelMessaging: true,
   };
 
   private grpcBaseUrl: string | undefined;

--- a/test/conformance/src/targets/local-go-execution.ts
+++ b/test/conformance/src/targets/local-go-execution.ts
@@ -52,6 +52,10 @@ export class LocalGoExecutionTarget implements TargetProfile {
     clientReservedLabelWrites: true,
     firstPartyMemoryCapture: true,
     clientPublicVisibilityWrites: true,
+    // No channel runtime in this edition (T02 §0-b): the engine this target
+    // provisions is the agent/workflow execution engine, not a channel
+    // delivery runtime — the refusal posture is identical to local-go.
+    channelMessaging: false,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -27,6 +27,9 @@ export class LocalGoTarget implements TargetProfile {
     clientReservedLabelWrites: true,
     firstPartyMemoryCapture: true,
     clientPublicVisibilityWrites: true,
+    // No channel runtime in this edition (T02 §0-b) — the suite pins the
+    // documented refusal copy on every runtime lane.
+    channelMessaging: false,
   };
 
   private server: RunningServer | undefined;
@@ -53,6 +56,16 @@ export class LocalGoTarget implements TargetProfile {
       throw new Error("LocalGoTarget.setup() must be called before httpBaseUrl()");
     }
     return this.server.baseUrl;
+  }
+
+  // The artifact file server's own port (local artifact storage only) — the
+  // harness already pins it for the runner's serve URL; the artifact suite
+  // drives its download-disposition contract through the same address.
+  artifactHttpBaseUrl(): string {
+    if (this.server === undefined) {
+      throw new Error("LocalGoTarget.setup() must be called before artifactHttpBaseUrl()");
+    }
+    return this.server.artifactServeUrl;
   }
 
   async provisionTenancy(): Promise<TenancyContext> {

--- a/test/conformance/src/targets/local-ts.ts
+++ b/test/conformance/src/targets/local-ts.ts
@@ -35,6 +35,9 @@ export class LocalTsTarget implements TargetProfile {
     clientReservedLabelWrites: true,
     firstPartyMemoryCapture: true,
     clientPublicVisibilityWrites: true,
+    // No channel runtime in this edition (T02 §0-b) — the suite pins the
+    // documented refusal copy on every runtime lane.
+    channelMessaging: false,
   };
 
   private server: RunningServer | undefined;
@@ -63,6 +66,16 @@ export class LocalTsTarget implements TargetProfile {
       throw new Error("LocalTsTarget.setup() must be called before httpBaseUrl()");
     }
     return this.server.baseUrl;
+  }
+
+  // The artifact file server's own port (local artifact storage only) — the
+  // harness already pins it for the runner's serve URL; the artifact suite
+  // drives its download-disposition contract through the same address.
+  artifactHttpBaseUrl(): string {
+    if (this.server === undefined) {
+      throw new Error("LocalTsTarget.setup() must be called before artifactHttpBaseUrl()");
+    }
+    return this.server.artifactServeUrl;
   }
 
   async provisionTenancy(): Promise<TenancyContext> {

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -126,6 +126,34 @@ export interface CapabilityFlags {
   // FGA tuples) and the Java handler unit tests — the same coverage
   // split ComposeDeclaredPreferencesStep has.
   firstPartyMemoryCapture: boolean;
+  // The channel RUNTIME lanes exist here: provider installs
+  // (initiateInstall/completeInstall), conversation participation
+  // (reply/takeOver/handBack/clearAttention/escalate), and proactive
+  // messaging (sendMessage/listTemplates).
+  //
+  // False for the local OSS targets — BY DOCUMENTED DESIGN, not a gap
+  // (channel-integrations T02 §0-b and its siblings): this edition has no
+  // webhook receiver, no delivery runtime, and no participation state
+  // machine, so every runtime command refuses with FAILED_PRECONDITION and
+  // per-surface copy ("channel installs require Stigmer Cloud" /
+  // "conversation participation requires Stigmer Cloud" / "proactive
+  // channel messaging requires Stigmer Cloud"). Where false, the suite
+  // byte-pins those refusals — they are the OSS contract, and the TS port
+  // must reproduce them exactly.
+  //
+  // True for cloud, whose channel runtime serves these lanes for real.
+  // The refusal pins are gated OFF there; the lanes' full cloud behavior
+  // needs live provider workspaces (a real Slack install), which no
+  // hermetic target can provision — it stays covered by cloud's own
+  // integration tests, the same coverage split ComposeDeclaredPreferences
+  // has. What runs unconditionally on both editions: input validation
+  // (INVALID_ARGUMENT — the Go controllers deliberately validate before
+  // refusing so this contract matches cloud), the install lanes'
+  // load-then-NOT_FOUND for unknown channels, and the discovery reads'
+  // truthful-emptiness postures (empty lists / uniform NOT_FOUND), which
+  // hold wherever no conversation traffic exists — exactly the state a
+  // fresh conformance fixture is in on either edition.
+  channelMessaging: boolean;
   // The conformance caller may set a resource's visibility to PUBLIC — the
   // only level that crosses every org boundary (the cross-org "explore"
   // catalog).
@@ -210,6 +238,17 @@ export interface TargetProfile {
   // there and the registry-proxy suite reports SKIPPED — the DD-012
   // "genuinely skipped, not false green" posture. Valid only after setup().
   httpBaseUrl?(): string;
+
+  // Base URL of the server's artifact HTTP file server — the ONE lane that
+  // deliberately lives on its own port beside the unified one (D1: plain
+  // FileServer over the artifact base path, served only when artifact
+  // storage is local). Present only on the local managed targets, whose
+  // spawned server pins the port (ARTIFACT_HTTP_PORT); absent on cloud,
+  // where artifact bytes travel through the service's own authenticated,
+  // presigned routes (a different contract) — the artifact suite's
+  // file-server block then reports SKIPPED at collection time, the
+  // registry-proxy posture. Valid only after setup().
+  artifactHttpBaseUrl?(): string;
 
   // A platform-operator caller with a tenancy of its own (stigmer#547) — see
   // PrivilegedScope. Absent where no operator credential exists: hermetic


### PR DESCRIPTION
## Summary

Conformance wave 2 (stigmer-cloud program `20260822.01`, D4 entry #10): suite-only coverage for the five remaining uncovered surfaces, proven against the Go server on `main` and against the hermetic cloud target. No production code is touched. These suites pin today's behavior before their domains port to the TS server (#12/#13/#14/#17/#20 in the D4 sequence).

- **CW-2 `agentshare`**: canonical-share slug default + the `status.agent_id` rebind pin, the anonymous lane's uniform-refusal doctrine (absent/disabled/dangling/rotated-away/wrong-token all answer one byte-identical `Agent not found`), `rotateShareLink`'s full lifecycle, the member lane's token-locked-public exception with the org-audience carve-out, and the decision-013 cross-org contract with the blocker-naming refusal.
- **CW-3 `agentchannel` + `channelapp`**: CRUD with the `pending_install` lifecycle, same-org invariants, model-pin existence (#774), WhatsApp's BYO `app_ref` rule, provider immutability on both resources, per-field secret rotation with the platform redaction marker, the referential delete-block, and the runtime-lane postures (byte-pinned `FailedPrecondition` refusal copy where `channelMessaging` is false; truthful-emptiness discovery reads and validation-first `InvalidArgument` arms cross-edition).
- **CW-4 `artifact`**: content-addressed create, the TTL contract (30-day default, `-1` permanent), `getContent` truncation, the soft-delete lifecycle (metadata survives; blob lanes refuse), `listByExecution` filtering, and the local file-server `?download=` disposition over the new `artifactHttpBaseUrl` target accessor.
- **CW-5 `search`**: list/search/discover modes, the #440 no-fallback kind rule, strict-org vs `cross_org_public` vs `exclude_public` scoping, pagination clamping, membership-stable assertions only (never BM25 values).
- **CW-7 execution read surfaces**: the shared create-time `EnsureEngineAvailable` boundary, both `getExecutionSummary` zero shapes, the four usage reports' contract, `getEventLog`'s `after_sequence` cursor walked at `page_size: 1`, `subscribeEvents` replay-then-close, the live `subscribe` snapshot→updates→terminal-close contract, `listPendingApprovals`' populated arm at the `human_input` gate, and `submitFileDecision`'s reachable negatives on both controllers.
- **Harness**: clients for the five domains, the `channelMessaging` capability flag (S6), `artifactHttpBaseUrl?()`, and `collectStream` — the bounded server-stream consumer (the `execution-poll.ts` idiom applied to streams).

## Ratified dispositions & parity-register disclosures

Approved at the sub-project plan gate (stigmer-cloud `20260823.09.sp.conformance-wave-2`); items marked **(amended)** were refined by execution-time evidence and are recorded in the sub-project's wrong-assumptions:

- **S1 (amended)** — the artifact oversize arm is not wire-assertable at ANY boundary: the 50MB domain cap hides behind the 10MB transport cap, and an over-cap send from the reference client surfaces as a connection-level HTTP/2 `ENHANCE_YOUR_CALM` GOAWAY (poisoning the shared channel), not a gRPC status. The suite asserts no oversize arm; both caps stay unit-level (ported with #13).
- **S2** — the `app_ref` freeze-while-installed rule is structurally unreachable where installs refuse; the reachable half (pending channels rebind freely) is pinned instead.
- **S3** — sibling error-code inconsistency pinned as-is: ChannelApp provider-immutability answers `InvalidArgument` where AgentChannel's answers `FailedPrecondition`. Post-cutover both-editions harmonization candidate.
- **S4** — `subscribe` on an already-terminal execution sends the snapshot and never closes (both domains; terminal-close fires only on updates). Pinned deliberately via bounded collection; #17/#20 must reproduce it consciously or fix it in both editions.
- **S5** — `getEventLog.has_more` can overreport under multi-event-type filters (lookahead precedes the in-memory filter). Single-type pagination pinned; the quirk disclosed, not asserted.
- **S6** — new `channelMessaging` capability flag (false on local targets, true on cloud); local-go/local-ts matrices stay byte-identical, so the D4 cutover gate is unaffected.
- **P1–P3** — message-fragility guards: model-pin refusals pinned by prefix (variable did-you-mean suffix); search errors pinned by code only (string-matched mapping, #478 sanitization); `getDownloadUrl` pins `ttl_seconds: 604800` although local URLs never expire.

**Verified edition splits from the pre-PR cloud run** (each pinned two-armed or capability-gated, none skipped silently):

- Cloud REQUIRES `run_config.model_name` on channel writes (#362); OSS stores unpinned specs — pinned two-armed; fixtures carry a registry-valid default pin.
- Fabricated ids never reach cloud handlers: FGA fails closed with `PermissionDenied` (no existence leak), so unknown-id `NotFound`/empty-page arms are single-user-posture pins (gated on `multiTenant`).
- Artifact standalone-testability is single-user-only: cloud requires the source execution to exist and carry an org.
- `submitFileDecision` validation ordering: cloud resolves the execution before proto validation.
- `listMessagingChannels`: cloud refuses direct calls (session-resolved); OSS answers the runner's empty list.
- Two zero-shape inconsistencies pinned as-is for the register: workflow summary `success_rate` (OSS `-1` sentinel vs cloud `0`) and the always-present-vs-omitted zero `total_cost`.
- Discover `counts_by_kind`: cloud enumerates every kind at 0; local omits zero-count kinds — compared on non-zero entries.

**Deliberately deferred**: the deep `submitFileDecision` arms (digest mismatch, unknown change-set/file, approve-blocked) need mock-LLM file-edit choreography and land with the execution-domain ports (#17/#20).

## Test plan

- [x] `local-go` full roster: 26 files, **468 passed**, 1 pre-existing skip (wave-1 baseline: 375)
- [x] `local-go-execution` full roster: **139 passed**, 2 pre-existing DD-012 skips
- [x] `local-ts` roster regression: **57/57** (wave 2 adds nothing to it)
- [x] Hermetic cloud run (fresh fat JAR from stigmer-cloud main): **every wave-2 suite green**; the 4 remaining failures are wave-1 files untouched by this branch (github broker Layer-1 arms, session listByChannel — cross-repo lag between today's wave-1 merge and the Java service)
- [x] `tsc --noEmit`: zero NEW errors vs the identical pre-existing local-environment baseline on `main` (19 errors in sdk/mcp-server files, reproduced bit-for-bit on a pristine main checkout; CI is green there)

Made with [Cursor](https://cursor.com)