### PR TITLE
feat(backend/stigmer-server-ts): port the agent family (agent, agentinstance, session, memory)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -15,10 +15,17 @@
  * that — the CLI's serverGate TCP probe treats port-bind as readiness.
  * Shutdown is the reverse (grpc lib Stop): NOT_SERVING first, then drain.
  */
+import type { ConnectRouter } from "@connectrpc/connect";
+
 import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
 
+import { registerAgentServices } from "../domain/agent/controller.js";
+import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
+import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
+import { registerMemoryServices } from "../domain/memory/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
+import { registerSessionServices } from "../domain/session/controller.js";
 import { SecretService } from "../encryption/encryption.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
@@ -28,6 +35,8 @@ import { HealthState, registerHealthService } from "../transport/health.js";
 import { createRegistryLanes } from "../transport/registry/lanes.js";
 import { createUnifiedPortServer } from "../transport/server.js";
 import type { ServerConfig } from "./config.js";
+import { createInProcessClients } from "./inprocess.js";
+import type { InProcessClients } from "./inprocess.js";
 import type { Logger } from "./logger.js";
 
 export interface ComposedServer {
@@ -95,6 +104,12 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // Stage: temporal — seam (execution cluster sub-projects).
 
   // Stage: controllers + routes.
+  // The agent-execution temporal config is env-derived strings only — the
+  // temporal seam stays empty. It lives here (not with the seam) because
+  // the session update pipeline's execution-target immutability step must
+  // resolve UNSPECIFIED through the SAME default dispatch will use — one
+  // definition, so policy and dispatch can never disagree (oss#397).
+  const temporalConfig = newConfigFromEnv();
   const healthState = new HealthState();
   const registryLanes = createRegistryLanes({
     modelRegistryUpstream: config.modelRegistryUpstream,
@@ -102,13 +117,51 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     logger,
     fetchImpl: options.fetchImpl,
   });
+  // The SAME `routes` function registers every service on BOTH the serving
+  // router and the in-process router transport (createInProcessClients).
+  // Handlers are stateless over the same store, so the two routers behave
+  // as one server — Go's single-server bufconn shape. Chain traversal on
+  // internal calls is the point (DD-002): an in-process apply/get is
+  // validated, logged, and kind-tagged exactly like an external one.
+  //
+  // requireInProcess breaks the routes↔clients definition cycle: the lazy
+  // domain providers are only invoked at request time, after boot
+  // completes, so the throw is the composition-root loudness idiom — never
+  // expected to fire.
+  let inProcess: InProcessClients | undefined;
+  function requireInProcess(): InProcessClients {
+    if (inProcess === undefined) {
+      throw new Error("in-process clients not wired (boot ordering bug)");
+    }
+    return inProcess;
+  }
+  const routes = (router: ConnectRouter): void => {
+    registerHealthService(router, healthState);
+    registerOrganizationServices(router, { store, logger });
+    registerEnvironmentServices(router, { store, logger, secretService });
+    registerAgentServices(router, {
+      store,
+      logger,
+      agentInstanceApplier: () => requireInProcess().agentInstanceApplier,
+    });
+    registerAgentInstanceServices(router, {
+      store,
+      logger,
+      parentAgentLoader: () => requireInProcess().parentAgentLoader,
+    });
+    registerSessionServices(router, {
+      store,
+      logger,
+      temporalConfig,
+      agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
+    });
+    registerMemoryServices(router, { store, logger });
+  };
+  inProcess = createInProcessClients(routes, logger);
+
   const server = createUnifiedPortServer({
     logger,
-    routes: (router) => {
-      registerHealthService(router, healthState);
-      registerOrganizationServices(router, { store, logger });
-      registerEnvironmentServices(router, { store, logger, secretService });
-    },
+    routes,
     interceptors: buildInterceptorChain(logger),
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
     modelRegistryLane: registryLanes.modelRegistryLane,

--- a/backend/services/stigmer-server-ts/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server-ts/src/boot/inprocess.ts
@@ -1,0 +1,77 @@
+/**
+ * In-process ConnectRPC clients — the TS twin of Go's pkg/downstream/*
+ * packages (agent, agentinstance), which serve cross-domain calls through
+ * the same *grpc.Server over an in-memory bufconn so EVERY interceptor
+ * executes: an internal call is validated, logged, and kind-tagged exactly
+ * like an external one. Here the bufconn equivalent is ConnectRPC's
+ * `createRouterTransport` built from the SAME routes registration function
+ * the unified-port server uses, with the SAME interceptor chain — proven by
+ * spike SP-B (src/pipeline/__tests__/router-transport.test.ts): every
+ * interceptor runs, in registration order, and a chain rejection
+ * short-circuits with a ConnectError the in-process caller sees (DD-002).
+ *
+ * The agent↔agentinstance true cycle is broken at the CONSUMERS with lazy
+ * providers (`() => client`) resolved at call time; this module only
+ * supplies the client objects those providers close over.
+ */
+import { createClient, createRouterTransport } from "@connectrpc/connect";
+import type { ConnectRouter } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { AgentIdSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
+import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
+
+import type { AgentInstanceApplier } from "../domain/agent/steps.js";
+import type { ParentAgentLoader } from "../domain/agentinstance/steps.js";
+import type { AgentInstanceCreator } from "../domain/session/steps.js";
+import { buildInterceptorChain } from "../pipeline/chain.js";
+import type { Logger } from "./logger.js";
+
+/** The narrow in-process surfaces the domains consume (DD-002). */
+export interface InProcessClients {
+  readonly agentInstanceApplier: AgentInstanceApplier;
+  readonly agentInstanceCreator: AgentInstanceCreator;
+  readonly parentAgentLoader: ParentAgentLoader;
+}
+
+/**
+ * Builds the in-process clients over a router transport that registers the
+ * SAME routes and runs the SAME interceptor chain as the serving router —
+ * validation parity is the point, exactly Go's bufconn shape.
+ */
+export function createInProcessClients(
+  routes: (router: ConnectRouter) => void,
+  logger: Logger,
+): InProcessClients {
+  const transport = createRouterTransport(routes, {
+    router: { interceptors: buildInterceptorChain(logger) },
+  });
+
+  const agentInstanceCommand = createClient(
+    AgentInstanceCommandController,
+    transport,
+  );
+  const agentQuery = createClient(AgentQueryController, transport);
+
+  return {
+    // Go's ApplyAsSystem is the Apply RPC with no extra identity attached:
+    // the audit actor comes from the process-global operator identity
+    // (installed once by main.ts, #400), so a plain apply IS the
+    // system-actor apply in this edition.
+    agentInstanceApplier: {
+      applyAsSystem: (instance) => agentInstanceCommand.apply(instance),
+    },
+    // Go's CreateAsSystem is the Create RPC under the same process-global
+    // operator identity; session create's resolve step uses CREATE (not
+    // apply) so a duplicate default-instance slug surfaces as
+    // AlreadyExists instead of silently updating.
+    agentInstanceCreator: {
+      createAsSystem: (instance) => agentInstanceCommand.create(instance),
+    },
+    parentAgentLoader: {
+      get: (agentId) =>
+        agentQuery.get(create(AgentIdSchema, { value: agentId })),
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agent/__tests__/agent.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/__tests__/agent.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Pins the agent domain against Go's pkg/domain/agent tests — through the
+ * REAL stack: a composed server on an ephemeral port, a native gRPC
+ * client, the full interceptor chain, and the DD-002 in-process
+ * agentinstance edge (agent create applies its default instance through
+ * the router transport, traversing the whole chain).
+ *
+ * The load-bearing pins:
+ *   - default-agent resolution (stigmer/stigmer#356): NotFound copy when
+ *     nothing is labeled; FailedPrecondition copy when labeled agents
+ *     exist but none is public; incumbent-wins (LOWEST metadata.id) among
+ *     public labeled candidates — an older non-public labeled agent never
+ *     wins;
+ *   - MCP env-merge semantics: agent-declared entries win, among servers
+ *     first-encountered wins, only declaration fields are copied;
+ *   - enabled-tools validation (#402): byte-pinned INVALID_ARGUMENT copy
+ *     for unknown tools and for resource-template names; empty
+ *     enabled_tools and unconnected servers skip validation;
+ *   - cascade delete (oss#611): ALL instances of the agent are swept by
+ *     spec.agent_id — including a cross-ORG instance — same-org shares are
+ *     deleted, cross-org shares of the same agent SURVIVE, and a
+ *     bystander agent's instances are untouched.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
+import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { AgentShareSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { ResourceNotFoundError } from "../../../store/interface.js";
+import {
+  DEFAULT_AGENT_LABEL,
+  DEFAULT_AGENT_LABEL_VALUE,
+} from "../defaultagent.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "acme";
+
+let dir: string;
+let server: ComposedServer;
+let transport: Transport;
+let command: Client<typeof AgentCommandController>;
+let query: Client<typeof AgentQueryController>;
+let instanceCommand: Client<typeof AgentInstanceCommandController>;
+let instanceQuery: Client<typeof AgentInstanceQueryController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "agent-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  command = createClient(AgentCommandController, transport);
+  query = createClient(AgentQueryController, transport);
+  instanceCommand = createClient(AgentInstanceCommandController, transport);
+  instanceQuery = createClient(AgentInstanceQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let agentCounter = 0;
+function agentInput(overrides?: {
+  name?: string;
+  org?: string;
+  visibility?: ApiResourceVisibility;
+  labels?: Record<string, string>;
+  usages?: Array<{ slug: string; enabledTools?: string[] }>;
+  env?: Record<
+    string,
+    { description?: string; isSecret?: boolean; optional?: boolean }
+  >;
+}) {
+  agentCounter += 1;
+  return {
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: {
+      name: overrides?.name ?? `Test Agent ${agentCounter}`,
+      org: overrides?.org ?? ORG,
+      visibility:
+        overrides?.visibility ??
+        ApiResourceVisibility.api_resource_visibility_unspecified,
+      labels: overrides?.labels ?? {},
+    },
+    spec: {
+      instructions: "You are a helpful agent used by the domain tests.",
+      mcpServerUsages: (overrides?.usages ?? []).map((usage) => ({
+        // The spec's CEL rule pins kind == mcp_server; org stays empty so
+        // NormalizeReferences resolves it from the agent's own org.
+        mcpServerRef: { kind: ApiResourceKind.mcp_server, slug: usage.slug },
+        enabledTools: usage.enabledTools ?? [],
+      })),
+      env: overrides?.env ?? {},
+    },
+  };
+}
+
+/**
+ * Seeds an MCP server straight into the store — the mcpserver controller
+ * arrives with sub-project #9, and the agent pipelines only need the row.
+ */
+async function seedMcpServer(opts: {
+  id: string;
+  slug: string;
+  org?: string;
+  env?: Record<
+    string,
+    { description?: string; isSecret?: boolean; optional?: boolean }
+  >;
+  tools?: string[];
+  resourceTemplates?: string[];
+}): Promise<void> {
+  const connected =
+    opts.tools !== undefined || opts.resourceTemplates !== undefined;
+  const mcpServer = create(McpServerSchema, {
+    apiVersion: API_VERSION,
+    kind: "McpServer",
+    metadata: {
+      id: opts.id,
+      name: opts.slug,
+      slug: opts.slug,
+      org: opts.org ?? ORG,
+    },
+    spec: { env: opts.env ?? {} },
+    status: connected
+      ? {
+          discoveredCapabilities: {
+            tools: (opts.tools ?? []).map((name) => ({ name })),
+            resourceTemplates: (opts.resourceTemplates ?? []).map((name) => ({
+              name,
+            })),
+          },
+        }
+      : undefined,
+  });
+  await server.store.saveResource(
+    ApiResourceKind.mcp_server,
+    opts.id,
+    McpServerSchema,
+    mcpServer,
+  );
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// The getDefault tests are order-dependent within this describe: the
+// platform default is a GLOBAL singleton, so the empty state must be
+// asserted before any labeled agent exists.
+describe("agent getDefault (platform default resolution, #356)", () => {
+  it("answers NotFound with the configured-hint copy when nothing carries the label", async () => {
+    // org is required for authorization scoping only; resolution is global.
+    const error = await grpcError(() => query.getDefault({ org: ORG }));
+    expect(error.code).toBe(Code.NotFound);
+    expect(error.rawMessage).toBe(
+      "No default agent available. Ensure an agent with label " +
+        "stigmer.ai/default-agent=true and visibility_public exists: " +
+        "no agent labeled stigmer.ai/default-agent=true",
+    );
+  });
+
+  it("answers FailedPrecondition when labeled agents exist but none is public", async () => {
+    await command.create(
+      agentInput({
+        name: "Labeled But Org Visible",
+        labels: { [DEFAULT_AGENT_LABEL]: DEFAULT_AGENT_LABEL_VALUE },
+      }),
+    );
+
+    const error = await grpcError(() => query.getDefault({ org: ORG }));
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(
+      "Default agent exists but is not visibility_public: agents labeled " +
+        "stigmer.ai/default-agent=true exist but none is visibility_public",
+    );
+  });
+
+  it("serves the incumbent — the LOWEST metadata.id among PUBLIC labeled candidates", async () => {
+    const first = await command.create(
+      agentInput({
+        name: "Public Default One",
+        visibility: ApiResourceVisibility.visibility_public,
+        labels: { [DEFAULT_AGENT_LABEL]: DEFAULT_AGENT_LABEL_VALUE },
+      }),
+    );
+    const second = await command.create(
+      agentInput({
+        name: "Public Default Two",
+        visibility: ApiResourceVisibility.visibility_public,
+        labels: { [DEFAULT_AGENT_LABEL]: DEFAULT_AGENT_LABEL_VALUE },
+      }),
+    );
+
+    const firstId = first.metadata!.id;
+    const secondId = second.metadata!.id;
+    const incumbentId = firstId < secondId ? firstId : secondId;
+
+    // The older NON-public labeled agent (previous test) has a lower id
+    // than both public candidates; incumbent-wins must skip it.
+    // A DIFFERENT org resolves the same singleton — resolution is global.
+    const resolved = await query.getDefault({ org: "globex" });
+    expect(resolved.metadata?.id).toBe(incumbentId);
+  });
+});
+
+describe("agent MCP env merge (merge_mcp_env_specs)", () => {
+  it("merges declarations: agent-declared wins, first-encountered server wins, declaration fields copied", async () => {
+    await seedMcpServer({
+      id: "mcp_env_one",
+      slug: "env-srv-one",
+      env: {
+        SHARED_VAR: { description: "shared from one", isSecret: true },
+        ONLY_ONE: { description: "one only", optional: true },
+      },
+    });
+    await seedMcpServer({
+      id: "mcp_env_two",
+      slug: "env-srv-two",
+      env: {
+        SHARED_VAR: { description: "shared from two" },
+        ONLY_TWO: { description: "two only" },
+      },
+    });
+
+    const created = await command.create(
+      agentInput({
+        name: "Env Merge Agent",
+        usages: [{ slug: "env-srv-one" }, { slug: "env-srv-two" }],
+        env: {
+          AGENT_VAR: { description: "declared on the agent", isSecret: true },
+          ONLY_TWO: {
+            description: "agent wins",
+            isSecret: true,
+            optional: true,
+          },
+        },
+      }),
+    );
+
+    const env = created.spec!.env;
+    // Agent-declared entries always win over server declarations.
+    expect(env.AGENT_VAR?.description).toBe("declared on the agent");
+    expect(env.ONLY_TWO?.description).toBe("agent wins");
+    expect(env.ONLY_TWO?.isSecret).toBe(true);
+    expect(env.ONLY_TWO?.optional).toBe(true);
+    // Among servers, first-encountered (usage order) wins for overlaps.
+    expect(env.SHARED_VAR?.description).toBe("shared from one");
+    expect(env.SHARED_VAR?.isSecret).toBe(true);
+    // Declaration fields are copied verbatim from the server's spec.
+    expect(env.ONLY_ONE?.description).toBe("one only");
+    expect(env.ONLY_ONE?.isSecret).toBe(false);
+    expect(env.ONLY_ONE?.optional).toBe(true);
+  });
+});
+
+describe("agent enabled-tools validation (#402)", () => {
+  beforeAll(async () => {
+    await seedMcpServer({
+      id: "mcp_connected",
+      slug: "conn-srv",
+      tools: ["search_docs", "create_ticket"],
+      resourceTemplates: ["customer-record"],
+    });
+    await seedMcpServer({ id: "mcp_unconnected", slug: "unconn-srv" });
+  });
+
+  it("rejects an unknown tool with the byte-pinned copy listing discovered tools", async () => {
+    const error = await grpcError(() =>
+      command.create(
+        agentInput({
+          name: "Unknown Tool Agent",
+          usages: [{ slug: "conn-srv", enabledTools: ["serach_docs"] }],
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+    expect(error.rawMessage).toBe(
+      "MCP server 'conn-srv' (org: acme): enabled_tools names tool(s) the " +
+        "server does not expose: 'serach_docs'. Discovered tools: " +
+        "'search_docs', 'create_ticket'. If the server's toolset changed, " +
+        "run 'stigmer connect' on it to refresh discovered capabilities.",
+    );
+  });
+
+  it("rejects a resource-template name with the template-specific copy", async () => {
+    const error = await grpcError(() =>
+      command.create(
+        agentInput({
+          name: "Template Tool Agent",
+          usages: [{ slug: "conn-srv", enabledTools: ["customer-record"] }],
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+    expect(error.rawMessage).toBe(
+      "MCP server 'conn-srv' (org: acme): enabled_tools names resource " +
+        "template(s): 'customer-record' — resource templates are read-only " +
+        "data endpoints, not callable tools, and must not appear in " +
+        "enabled_tools. Discovered tools: 'search_docs', 'create_ticket'. " +
+        "If the server's toolset changed, run 'stigmer connect' on it to " +
+        "refresh discovered capabilities.",
+    );
+  });
+
+  it("skips validation for empty enabled_tools (use the server's defaults)", async () => {
+    const created = await command.create(
+      agentInput({
+        name: "Empty Tools Agent",
+        usages: [{ slug: "conn-srv" }],
+      }),
+    );
+    expect(created.metadata?.id).not.toBe("");
+  });
+
+  it("skips validation for a server without discovered capabilities (not yet connected)", async () => {
+    const created = await command.create(
+      agentInput({
+        name: "Unconnected Server Agent",
+        usages: [{ slug: "unconn-srv", enabledTools: ["anything-goes"] }],
+      }),
+    );
+    expect(created.metadata?.id).not.toBe("");
+  });
+});
+
+describe("agent cascade delete (oss#611)", () => {
+  it("sweeps ALL instances by spec.agent_id (cross-org included), deletes same-org shares, keeps cross-org shares", async () => {
+    const agent = await command.create(
+      agentInput({
+        name: "Cascade Target",
+        visibility: ApiResourceVisibility.visibility_public,
+      }),
+    );
+    const agentId = agent.metadata!.id;
+    const agentSlug = agent.metadata!.slug;
+    // Agent create provisioned the default instance through the
+    // in-process edge and recorded the pointer (DD-002 choreography).
+    const defaultInstanceId = agent.status!.defaultInstanceId;
+    expect(defaultInstanceId).not.toBe("");
+
+    const personal = await instanceCommand.create({
+      apiVersion: API_VERSION,
+      kind: "AgentInstance",
+      metadata: { name: "Cascade Personal", org: ORG },
+      spec: { agentId },
+    });
+    // Cross-org instance of the same agent — allowed by design in OSS
+    // (an agent is a shareable blueprint; no same-org rule on create).
+    const crossOrg = await instanceCommand.create({
+      apiVersion: API_VERSION,
+      kind: "AgentInstance",
+      metadata: { name: "Cascade Cross Org", org: "globex" },
+      spec: { agentId },
+    });
+
+    // A bystander agent whose instance must survive the sweep untouched.
+    const bystander = await command.create(agentInput({ name: "Bystander" }));
+
+    // Shares are seeded directly (the agentshare controller arrives with
+    // its own sub-project); the cascade matches spec.agent_ref.
+    const sameOrgShare = create(AgentShareSchema, {
+      metadata: { id: "ash_same_org", name: "same-org-share", org: ORG },
+      spec: {
+        agentRef: { kind: ApiResourceKind.agent, org: ORG, slug: agentSlug },
+      },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_share,
+      "ash_same_org",
+      AgentShareSchema,
+      sameOrgShare,
+    );
+    const crossOrgShare = create(AgentShareSchema, {
+      metadata: { id: "ash_cross_org", name: "cross-org-share", org: "globex" },
+      spec: {
+        agentRef: { kind: ApiResourceKind.agent, org: ORG, slug: agentSlug },
+      },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_share,
+      "ash_cross_org",
+      AgentShareSchema,
+      crossOrgShare,
+    );
+
+    const before = await instanceQuery.getByAgent({ agentId, org: "" });
+    expect(before.totalCount).toBe(3); // default + personal + cross-org
+
+    const deleted = await command.delete({ value: agentId });
+    expect(deleted.metadata?.id).toBe(agentId);
+
+    // Every instance of the agent is gone — the cross-ORG one included.
+    const after = await instanceQuery.getByAgent({ agentId, org: "" });
+    expect(after.totalCount).toBe(0);
+    for (const instanceId of [
+      defaultInstanceId,
+      personal.metadata!.id,
+      crossOrg.metadata!.id,
+    ]) {
+      const error = await grpcError(() =>
+        instanceQuery.get({ value: instanceId }),
+      );
+      expect(error.code).toBe(Code.NotFound);
+    }
+
+    // Same-org share deleted; the cross-org share of the SAME agent
+    // survives — it is another org's resource and fails closed instead.
+    await expect(
+      server.store.getResource(
+        ApiResourceKind.agent_share,
+        "ash_same_org",
+        AgentShareSchema,
+      ),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+    const survivor = await server.store.getResource(
+      ApiResourceKind.agent_share,
+      "ash_cross_org",
+      AgentShareSchema,
+    );
+    expect(survivor.metadata?.id).toBe("ash_cross_org");
+
+    // The bystander agent's default instance was not swept.
+    const bystanderInstances = await instanceQuery.getByAgent({
+      agentId: bystander.metadata!.id,
+      org: "",
+    });
+    expect(bystanderInstances.totalCount).toBe(1);
+  });
+});
+
+describe("agent create — CreateDefaultInstance failure wire contract (oss#852)", () => {
+  it("answers the inner code with Go's %w-wrapped transport-formatted message", async () => {
+    // Pre-occupy the deterministic default-instance slug with an instance
+    // bound to a DIFFERENT (nonexistent) agent: the in-process Apply
+    // routes to UPDATE and ValidateInstanceUpdate fires the immutability
+    // guard. Go wraps that FailedPrecondition with fmt.Errorf("%w"), so
+    // the wire message embeds grpc-go's `rpc error: code = X desc = ...`
+    // rendering of the inner error — the leak filed as stigmer/stigmer#852,
+    // mirrored byte-for-byte until the both-editions post-cutover fix.
+    const occupier = create(AgentInstanceSchema, {
+      apiVersion: API_VERSION,
+      kind: "AgentInstance",
+      metadata: {
+        id: "ain_wrap_occupier",
+        name: "wrapped-error-agent-default",
+        slug: "wrapped-error-agent-default",
+        org: ORG,
+      },
+      spec: { agentId: "agt_wrap_nonexistent" },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_instance,
+      "ain_wrap_occupier",
+      AgentInstanceSchema,
+      occupier,
+    );
+
+    const error = await grpcError(() =>
+      command.create(agentInput({ name: "Wrapped Error Agent" })),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(
+      "failed to apply default instance: rpc error: " +
+        "code = FailedPrecondition desc = spec.agent_id is immutable " +
+        "(instance instantiates agent agt_wrap_nonexistent) — create a new " +
+        "instance for a different agent",
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agent/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/controller.ts
@@ -1,0 +1,433 @@
+/**
+ * Agent controller — ports pkg/domain/agent/controller (command + query
+ * sides): the agent BLUEPRINT surface. Create provisions the agent's
+ * default instance through the in-process agentinstance client (the
+ * agent↔agentinstance mutual edge, wired as a lazy provider in the
+ * composition root — sub-project DD-002); delete cascades ALL instances
+ * (oss#611) and same-org shares before the agent row; GetDefault serves
+ * the platform default-agent resolution (defaultagent.ts).
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by agent.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/agent.test.ts.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies, and
+ * Publish steps (no multi-tenant auth, IAM/FGA, or event publishing here).
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { AgentId, GetDefaultAgentRequest } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
+import type {
+  ApiResourceReference,
+  UpdateVisibilityInput,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError, notFoundError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  newNormalizeReferencesStep,
+  newValidateReferencesStep,
+} from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import {
+  newValidateVisibilityStep,
+  newValidateVisibilityUpdateStep,
+} from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import { agentSearchExtractor } from "./search-extractor.js";
+import {
+  newCascadeDeleteInstancesStep,
+  newCascadeDeleteSharesStep,
+  newCreateDefaultInstanceStep,
+  newLoadDefaultAgentStep,
+  newMergeMcpServerEnvSpecsStep,
+  newUpdateAgentStatusWithDefaultInstanceStep,
+  newValidateEnabledToolsStep,
+} from "./steps.js";
+import type { AgentInstanceApplierProvider } from "./steps.js";
+
+export interface AgentControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  /**
+   * The agentinstance in-process edge — a lazy provider because
+   * agent↔agentinstance is a true dependency cycle (DD-002; the ratified
+   * DI story breaks cycles with `() => client` closures resolved at call
+   * time, never at construction).
+   */
+  readonly agentInstanceApplier: AgentInstanceApplierProvider;
+}
+
+/** Registers both agent services on the router (routes stage). */
+export function registerAgentServices(
+  router: ConnectRouter,
+  deps: AgentControllerDeps,
+): void {
+  router.service(AgentCommandController, {
+    apply: (agent, ctx) => apply(deps, agent, ctx),
+    create: (agent, ctx) => createAgent(deps, agent, ctx),
+    update: (agent, ctx) => update(deps, agent, ctx),
+    updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
+    delete: (id, ctx) => deleteAgent(deps, id, ctx),
+  });
+  router.service(AgentQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getDefault: (req, ctx) => getDefault(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline: the default instance is
+ * applied AFTER Persist (children need the parent's id), then the agent's
+ * status.default_instance_id is written in an explicit second persist.
+ */
+async function createAgent(
+  deps: AgentControllerDeps,
+  agent: Agent,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(AgentSchema, agent, kindOf(ctx));
+  await newPipeline<typeof AgentSchema>("agent-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newValidateReferencesStep(deps.store))
+    .addStep(newValidateEnabledToolsStep(deps.store))
+    .addStep(newMergeMcpServerEnvSpecsStep(deps.store, deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .addStep(newCreateDefaultInstanceStep(deps.agentInstanceApplier, deps.logger))
+    .addStep(newUpdateAgentStatusWithDefaultInstanceStep(deps.store, deps.logger))
+    .addStep(newIndexSearchStep(deps.store, agentSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/** Update — chain per Go buildUpdatePipeline. */
+async function update(
+  deps: AgentControllerDeps,
+  agent: Agent,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(AgentSchema, agent, kindOf(ctx));
+  await newPipeline<typeof AgentSchema>("agent-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newValidateReferencesStep(deps.store))
+    .addStep(newValidateEnabledToolsStep(deps.store))
+    .addStep(newMergeMcpServerEnvSpecsStep(deps.store, deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, agentSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
+ * existence, then delegates to Create or Update with the ORIGINAL request
+ * message (Go delegates `agent`, not the pipeline's mutated clone).
+ */
+async function apply(
+  deps: AgentControllerDeps,
+  agent: Agent,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(AgentSchema, agent, kindOf(ctx));
+  await newPipeline<typeof AgentSchema>("agent-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate ? createAgent(deps, agent, ctx) : update(deps, agent, ctx);
+}
+
+/**
+ * Delete — cascades children before the parent (delete_cascade.go):
+ * ALL instances, then same-org shares, then the agent row and its index
+ * entry. Returns the deleted agent (the audit-trail convention).
+ */
+async function deleteAgent(
+  deps: AgentControllerDeps,
+  agentId: AgentId,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(
+    AgentCommandController.method.delete.input,
+    agentId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentCommandController.method.delete.input>(
+    "agent-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, AgentSchema))
+    .addStep(newCascadeDeleteInstancesStep(deps.store, deps.logger))
+    .addStep(newCascadeDeleteSharesStep(deps.store, deps.logger))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted agent not found in context"),
+      "deleted agent not found in context",
+    );
+  }
+  return deleted as Agent;
+}
+
+// ---------------------------------------------------------------------------
+// updateVisibility — update_visibility.go: a targeted metadata update (only
+// metadata.visibility changes; spec/status untouched). The level check runs
+// AFTER load, preserving the cross-edition error precedence: unknown id +
+// bad level = NOT_FOUND on both editions.
+// ---------------------------------------------------------------------------
+
+const UPDATE_VISIBILITY_AGENT_KEY = "updateVisibilityAgent";
+
+type UpdateVisibilityDesc =
+  typeof AgentCommandController.method.updateVisibility.input;
+
+async function updateVisibility(
+  deps: AgentControllerDeps,
+  input: UpdateVisibilityInput,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(
+    AgentCommandController.method.updateVisibility.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<UpdateVisibilityDesc>(
+    "agent-update-visibility",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadAgentForVisibilityUpdateStep(deps.store))
+    .addStep(newValidateVisibilityUpdateStep())
+    .addStep(newSetAgentVisibilityStep())
+    .addStep(newPersistAgentForVisibilityUpdateStep(deps.store))
+    .addStep(newIndexAgentAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  return reqCtx.get(UPDATE_VISIBILITY_AGENT_KEY) as Agent;
+}
+
+/** Loads the agent by resource_id; ANY load failure → NotFound. */
+function newLoadAgentForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "LoadAgentForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const input = ctx.input;
+      let agent: Agent;
+      try {
+        agent = await store.getResource(
+          ApiResourceKind.agent,
+          input.resourceId,
+          AgentSchema,
+        );
+      } catch {
+        throw notFoundError("agent", input.resourceId);
+      }
+      ctx.set(UPDATE_VISIBILITY_AGENT_KEY, agent);
+    },
+  };
+}
+
+/** Sets metadata.visibility and stamps the StatusAudit slot (#540). */
+function newSetAgentVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "SetAgentVisibility",
+    execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
+      const agent = ctx.get(UPDATE_VISIBILITY_AGENT_KEY) as Agent;
+      if (agent.metadata !== undefined) {
+        agent.metadata.visibility = ctx.input.visibility;
+      }
+      setAuditFieldsForUpdate(AgentSchema, agent, "status_audit");
+    },
+  };
+}
+
+/** Persists the visibility change. */
+function newPersistAgentForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "PersistAgentForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const agent = ctx.get(UPDATE_VISIBILITY_AGENT_KEY) as Agent;
+      try {
+        await store.saveResource(
+          ApiResourceKind.agent,
+          agent.metadata?.id ?? "",
+          AgentSchema,
+          agent,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to save agent");
+      }
+    },
+  };
+}
+
+/**
+ * Re-indexes after the visibility change (visibility is an indexed field).
+ * Domain-local because the shared IndexSearch reads newState, which is the
+ * UpdateVisibilityInput here, not the agent. Best-effort by contract.
+ */
+function newIndexAgentAfterVisibilityUpdateStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "IndexAgentAfterVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const agent = ctx.get(UPDATE_VISIBILITY_AGENT_KEY) as Agent;
+      const entry = agentSearchExtractor.getSearchIndexEntry(agent);
+      if (entry === undefined) {
+        logger.warn(
+          "IndexAgentAfterVisibilityUpdate: extractor returned nil, skipping",
+          { id: agent.metadata?.id ?? "" },
+        );
+        return;
+      }
+      try {
+        await store.upsertSearchIndex(
+          ApiResourceKind.agent,
+          agent.metadata?.id ?? "",
+          entry,
+        );
+      } catch (error) {
+        logger.warn("IndexAgentAfterVisibilityUpdate: failed (best-effort)", {
+          id: agent.metadata?.id ?? "",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}
+
+/** Get — LoadTarget by id (Go's chain has no ExtractResourceId here). */
+async function get(
+  deps: AgentControllerDeps,
+  id: AgentId,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(
+    AgentQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentQueryController.method.get.input>(
+    "agent-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, AgentSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Agent;
+}
+
+/** GetByReference — slug+org lookup. */
+async function getByReference(
+  deps: AgentControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(
+    AgentQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentQueryController.method.getByReference.input>(
+    "agent-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, AgentSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Agent;
+}
+
+/**
+ * GetDefault — the platform default agent (label + visibility_public,
+ * incumbent-wins). Used by frontends for the session-first UX where users
+ * start a conversation without explicitly selecting an agent.
+ */
+async function getDefault(
+  deps: AgentControllerDeps,
+  req: GetDefaultAgentRequest,
+  ctx: HandlerContext,
+): Promise<Agent> {
+  const reqCtx = new RequestContext(
+    AgentQueryController.method.getDefault.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentQueryController.method.getDefault.input>(
+    "agent-get-default",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadDefaultAgentStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Agent;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agent/defaultagent.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/defaultagent.ts
@@ -1,0 +1,135 @@
+/**
+ * Platform default-agent resolution — ports
+ * pkg/domain/agent/defaultagent/defaultagent.go: the single resolution
+ * implementation behind Agent.GetDefault, AgentExecution create (#17), and
+ * Session create.
+ *
+ * The default agent is a platform-level singleton: the agent labeled
+ * stigmer.ai/default-agent: "true" with visibility_public, seeded in the
+ * system org and served to callers of every org. Resolution is deliberately
+ * GLOBAL — GetDefaultAgentRequest.org exists for authorization scoping only
+ * (see apis/ai/stigmer/agentic/agent/v1/io.proto). It powers the
+ * session-first UX where a user starts a conversation without picking an
+ * agent. The cloud twin is AgentRepo.findDefault(); keep the two in sync.
+ *
+ * Determinism contract (stigmer/stigmer#356): multiple labeled agents is a
+ * reachable state, not an error — safe label rotation applies the new
+ * default before retiring the old one. Among public candidates the winner
+ * is the one with the LOWEST metadata.id — the incumbent. Rejected
+ * alternatives (recorded in the Go package doc): first-match depends on row
+ * insertion order; newest-wins lets any newly labeled public agent capture
+ * the platform-wide default (nothing guards the reserved stigmer.ai/*
+ * namespace at OSS write boundaries); creation time is not trustworthy as
+ * an ordering key (pre-#453 rows may carry rewritten timestamps).
+ * metadata.id never changes and is time-ordered for server-generated ULIDs.
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { Store } from "../../store/interface.js";
+
+/** Marks the platform default agent; the value must be DEFAULT_AGENT_LABEL_VALUE. */
+export const DEFAULT_AGENT_LABEL = "stigmer.ai/default-agent";
+
+/** The only value of DEFAULT_AGENT_LABEL that marks an agent as the default. */
+export const DEFAULT_AGENT_LABEL_VALUE = "true";
+
+/**
+ * No agent carries the default-agent label. Call sites map this to
+ * NotFound with their own caller-facing copy (Go ErrNotConfigured).
+ */
+export class DefaultAgentNotConfiguredError extends Error {
+  constructor() {
+    super(
+      `no agent labeled ${DEFAULT_AGENT_LABEL}=${DEFAULT_AGENT_LABEL_VALUE}`,
+    );
+    this.name = "DefaultAgentNotConfiguredError";
+  }
+}
+
+/**
+ * Labeled agents exist but none is visibility_public. Call sites map this
+ * to FailedPrecondition — a deliberate divergence from the cloud edition,
+ * whose SQL predicate collapses this state into "not found": the distinct
+ * code tells a self-hosting operator the label is present but the
+ * visibility is wrong (Go ErrNotPublic).
+ */
+export class DefaultAgentNotPublicError extends Error {
+  constructor() {
+    super(
+      `agents labeled ${DEFAULT_AGENT_LABEL}=${DEFAULT_AGENT_LABEL_VALUE} exist but none is visibility_public`,
+    );
+    this.name = "DefaultAgentNotPublicError";
+  }
+}
+
+/**
+ * Resolves the platform default agent per the module contract: candidates
+ * are all agents labeled DEFAULT_AGENT_LABEL=true, only visibility_public
+ * candidates are eligible, and among those the lowest metadata.id wins.
+ *
+ * Throws DefaultAgentNotConfiguredError when nothing carries the label,
+ * DefaultAgentNotPublicError when labeled agents exist but none is public,
+ * and lets store/decode failures propagate (a store failure is an internal
+ * fault, not a "no default agent" condition — callers must not map it to
+ * NotFound).
+ */
+export async function findDefaultAgent(
+  store: Store,
+  logger: Logger,
+): Promise<Agent> {
+  const raws = await store.findAllByLabel(
+    ApiResourceKind.agent,
+    DEFAULT_AGENT_LABEL,
+    DEFAULT_AGENT_LABEL_VALUE,
+    AgentSchema,
+  );
+  if (raws.length === 0) {
+    throw new DefaultAgentNotConfiguredError();
+  }
+
+  let publicCount = 0;
+  let winner: Agent | undefined;
+  for (const raw of raws) {
+    // findAllByLabel already unmarshaled every returned row to match the
+    // label, so a decode failure here is store corruption. Fail loudly
+    // (propagate): skipping a row could silently change which agent wins.
+    const candidate = fromBinary(AgentSchema, raw);
+    if (
+      candidate.metadata?.visibility !==
+      ApiResourceVisibility.visibility_public
+    ) {
+      continue;
+    }
+    publicCount++;
+    if (
+      winner === undefined ||
+      (candidate.metadata?.id ?? "") < (winner.metadata?.id ?? "")
+    ) {
+      winner = candidate;
+    }
+  }
+  if (winner === undefined) {
+    throw new DefaultAgentNotPublicError();
+  }
+
+  if (publicCount > 1) {
+    // Expected briefly mid-rotation; persistent duplicates mean someone
+    // forgot to retire the old label after applying the new default.
+    logger.warn(
+      "Multiple public agents carry the default-agent label; serving the incumbent (lowest id). Retire the stale label to complete rotation.",
+      {
+        publicLabeledAgents: publicCount,
+        winnerId: winner.metadata?.id ?? "",
+        winnerName: winner.metadata?.name ?? "",
+      },
+    );
+  }
+
+  return winner;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agent/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/search-extractor.ts
@@ -1,0 +1,47 @@
+/**
+ * Agent search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/agent_extractor.go. The search summary uses
+ * spec.description if available, falling back to instructions (the system
+ * prompt) — the common pattern where older agents may not have a dedicated
+ * description field, but all agents have instructions. The query side of
+ * the extractor contract arrives with the search service sub-project
+ * (#13), exactly as the organization extractor's header records.
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const agentSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const agent = resource as unknown as Agent;
+    const metadata = agent.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      description: agentSearchSummary(agent),
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        agent.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};
+
+/** Go AgentExtractor.GetSearchSummary: description, else instructions. */
+function agentSearchSummary(agent: Agent): string {
+  const spec = agent.spec;
+  if (spec === undefined) {
+    return "";
+  }
+  return spec.description !== "" ? spec.description : spec.instructions;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agent/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/steps.ts
@@ -1,0 +1,665 @@
+/**
+ * Agent domain-local pipeline steps — port the inline steps of
+ * pkg/domain/agent/controller/ (create.go, delete_cascade.go,
+ * get_default.go, merge_mcp_env_specs.go, validate_enabled_tools.go).
+ * Shared steps stay in src/pipeline/steps/; these exist because they
+ * embody agent-specific contracts: the default-instance choreography, the
+ * cascade rules, MCP env merging, and enabled-tools validation.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { AgentStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/status_pb";
+import type {
+  Agent,
+  AgentSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentShareSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import { EnvVarDeclarationSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { EnvVarDeclaration } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { DiscoveredCapabilities } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  classify,
+  isValidClassification,
+  quoteJoin,
+  toolNames,
+} from "../mcpserver/enabledtools/enabledtools.js";
+import {
+  goWrappedStatusError,
+  internalError,
+  invalidArgumentError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import type { Store } from "../../store/interface.js";
+import { buildDefaultInstanceRequest } from "../agentinstance/defaultinstance.js";
+import {
+  DefaultAgentNotConfiguredError,
+  DefaultAgentNotPublicError,
+  findDefaultAgent,
+} from "./defaultagent.js";
+
+/** Context key carrying the applied default instance's id (Go DefaultInstanceIDKey). */
+const DEFAULT_INSTANCE_ID_KEY = "default_instance_id";
+
+type AgentDesc = typeof AgentSchema;
+
+/**
+ * The narrow in-process surface the agent domain needs from agentinstance —
+ * consumer-defined so the dependency reads at the domain boundary (the Go
+ * twin is pkg/downstream/agentinstance.Client). Calls ride the in-process
+ * router transport, traversing the full interceptor chain (DD-002).
+ */
+export interface AgentInstanceApplier {
+  applyAsSystem(instance: AgentInstance): Promise<AgentInstance>;
+}
+
+/**
+ * Lazy provider for the agent↔agentinstance true cycle — resolved at call
+ * time, never at construction (the ratified DI story, D2 §2).
+ */
+export type AgentInstanceApplierProvider = () => AgentInstanceApplier;
+
+// ---------------------------------------------------------------------------
+// ValidateEnabledTools — validate_enabled_tools.go: rejects agent manifests
+// whose McpServerUsage.enabled_tools name tools the referenced MCP server
+// does not expose (issue #402). Runtime enforcement (runner
+// shared/mcp-enabled-tools.ts, issue #350) is deliberately lenient — warn
+// and drop — so a manifest typo silently narrows the agent's toolset; this
+// step is the apply-time half of that owner decision: reject the typo where
+// the operator can see it, with the server's real tool names in the error.
+//
+// Deliberate skips: empty enabled_tools ("use the server's
+// default_enabled_tools"); referenced server not found (ValidateReferences,
+// earlier in the pipeline, already rejects with its own actionable error);
+// server without discovered_capabilities (not yet connected — no
+// authoritative toolset; the runner's warn-and-intersect remains the safety
+// net for that window).
+//
+// Pipeline position: AFTER ValidateReferences, BEFORE Persist.
+// ---------------------------------------------------------------------------
+
+export function newValidateEnabledToolsStep(
+  store: Store,
+): PipelineStep<AgentDesc> {
+  return {
+    name: "ValidateEnabledTools",
+    async execute(ctx: RequestContext<AgentDesc>): Promise<void> {
+      const agent = ctx.newState;
+
+      for (const usage of agent.spec?.mcpServerUsages ?? []) {
+        if (usage.enabledTools.length === 0) {
+          continue;
+        }
+
+        const ref = usage.mcpServerRef;
+        const slug = ref?.slug ?? "";
+        if (slug === "") {
+          continue;
+        }
+        let org = ref?.org ?? "";
+        if (org === "") {
+          org = agent.metadata?.org ?? "";
+        }
+
+        let mcpServer: McpServer | undefined;
+        try {
+          mcpServer = await findResourceBySlug(
+            store,
+            ApiResourceKind.mcp_server,
+            McpServerSchema,
+            slug,
+            org,
+          );
+        } catch (error) {
+          // Go wraps as a plain error → the pipeline's Internal fallback.
+          throw new Error(
+            `failed to look up MCP server '${slug}' (org: ${org}) for enabled_tools validation: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        if (mcpServer === undefined) {
+          continue;
+        }
+
+        const caps = mcpServer.status?.discoveredCapabilities;
+        if (caps === undefined) {
+          continue;
+        }
+
+        const classification = classify(caps, usage.enabledTools);
+        if (!isValidClassification(classification)) {
+          throw invalidEnabledToolsError(slug, org, classification, caps);
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Go invalidEnabledToolsError: the operator-facing INVALID_ARGUMENT. It
+ * names the offending entries, distinguishes resource-template names from
+ * plain typos, and lists the discovered tool names so the fix is one edit
+ * away. The refresh hint covers the honest failure mode where the server's
+ * toolset changed after the last discovery. Byte-pinned copy.
+ */
+function invalidEnabledToolsError(
+  slug: string,
+  org: string,
+  c: ReturnType<typeof classify>,
+  caps: DiscoveredCapabilities,
+): ConnectError {
+  const problems: string[] = [];
+  if (c.unknown.length > 0) {
+    problems.push(
+      `enabled_tools names tool(s) the server does not expose: ${quoteJoin(c.unknown)}`,
+    );
+  }
+  if (c.resourceTemplates.length > 0) {
+    problems.push(
+      `enabled_tools names resource template(s): ${quoteJoin(c.resourceTemplates)} — resource templates are read-only data endpoints, not callable tools, and must not appear in enabled_tools`,
+    );
+  }
+
+  return invalidArgumentError(
+    `MCP server '${slug}' (org: ${org}): ${problems.join("; ")}. ` +
+      `Discovered tools: ${quoteJoin(toolNames(caps))}. ` +
+      "If the server's toolset changed, run 'stigmer connect' on it to refresh discovered capabilities.",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MergeMcpServerEnvSpecs — merge_mcp_env_specs.go: merges env DECLARATIONS
+// from referenced MCP servers into the agent's env at create/update time,
+// so the UI/CLI can show what the agent needs, AgentInstance configuration
+// knows which vars to supply, and execution-time validation has the
+// complete schema.
+//
+// Merge semantics: agent-declared entries always take precedence (user
+// intent is preserved); among MCP servers, first-encountered wins for
+// overlapping keys; only declaration fields (description, is_secret,
+// optional) are merged — actual values come from
+// AgentInstance.environment_refs at runtime.
+//
+// Lenient by design: a server that cannot be found (not yet created,
+// different org, …) logs a warning and is skipped. The authoritative
+// fail-fast check remains McpEnvironmentValidator at execution creation.
+//
+// Pipeline position: AFTER NormalizeReferences (needs resolved org),
+// BEFORE Persist.
+// ---------------------------------------------------------------------------
+
+export function newMergeMcpServerEnvSpecsStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<AgentDesc> {
+  return {
+    name: "MergeMcpServerEnvSpecs",
+    async execute(ctx: RequestContext<AgentDesc>): Promise<void> {
+      const agent = ctx.newState;
+
+      const usages = agent.spec?.mcpServerUsages ?? [];
+      if (usages.length === 0) {
+        return;
+      }
+
+      const mcpEnvVars: Record<string, EnvVarDeclaration> = {};
+      for (const usage of usages) {
+        const ref = usage.mcpServerRef;
+
+        const slug = ref?.slug ?? "";
+        if (slug === "") {
+          continue;
+        }
+
+        let org = ref?.org ?? "";
+        if (org === "") {
+          org = agent.metadata?.org ?? "";
+        }
+        if (org === "") {
+          continue;
+        }
+
+        let mcpServer: McpServer | undefined;
+        try {
+          mcpServer = await findResourceBySlug(
+            store,
+            ApiResourceKind.mcp_server,
+            McpServerSchema,
+            slug,
+            org,
+          );
+        } catch (error) {
+          logger.warn("Failed to look up MCP server for env merge", {
+            mcpServerSlug: slug,
+            org,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+        if (mcpServer === undefined) {
+          logger.warn(
+            "MCP server not found — skipping env merge for this server",
+            { mcpServerSlug: slug, org },
+          );
+          continue;
+        }
+
+        const serverEnv = mcpServer.spec?.env ?? {};
+        for (const [varName, decl] of Object.entries(serverEnv)) {
+          if (!(varName in mcpEnvVars)) {
+            mcpEnvVars[varName] = create(EnvVarDeclarationSchema, {
+              description: decl.description,
+              isSecret: decl.isSecret,
+              optional: decl.optional,
+            });
+          }
+        }
+      }
+
+      if (Object.keys(mcpEnvVars).length === 0) {
+        return;
+      }
+
+      const spec = agent.spec;
+      if (spec === undefined) {
+        return;
+      }
+
+      const existingEnv = spec.env;
+      const merged: Record<string, EnvVarDeclaration> = { ...mcpEnvVars };
+      for (const [k, v] of Object.entries(existingEnv)) {
+        merged[k] = v;
+      }
+      spec.env = merged;
+
+      const mergedCount =
+        Object.keys(merged).length - Object.keys(existingEnv).length;
+      if (mergedCount > 0) {
+        logger.info("Merged MCP server env declarations into agent env", {
+          injectedCount: mergedCount,
+          totalCount: Object.keys(merged).length,
+          agent: agent.metadata?.slug ?? "",
+        });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CreateDefaultInstance + UpdateAgentStatusWithDefaultInstance — create.go's
+// post-persist choreography. Split in two so the second database persist is
+// explicit in the chain (Go's stated rationale).
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies (not creates — idempotency) the agent's default instance through
+ * the in-process client. Agent delete cascades the default instance, so
+ * this normally routes to CREATE; the UPDATE route remains as self-heal for
+ * pre-cascade legacy orphans (self-hosters upgrading across the T08
+ * release), which Apply recovers by re-pointing agent_id at the new agent.
+ *
+ * Versus Go: no nil-client skip — the provider is a required dependency
+ * (the staged composition root eliminates the nil-then-inject window whose
+ * silent no-op the domain inventory flags).
+ */
+export function newCreateDefaultInstanceStep(
+  applierProvider: AgentInstanceApplierProvider,
+  logger: Logger,
+): PipelineStep<AgentDesc> {
+  return {
+    name: "CreateDefaultInstance",
+    async execute(ctx: RequestContext<AgentDesc>): Promise<void> {
+      const agent = ctx.newState;
+      const metadata = agent.metadata;
+      if (metadata === undefined) {
+        throw internalError(
+          new Error("agent metadata is nil after persist"),
+          "agent metadata is nil after persist",
+        );
+      }
+
+      logger.info("Creating default instance for agent", {
+        agentId: metadata.id,
+        slug: metadata.slug,
+        org: metadata.org,
+      });
+
+      const instanceRequest = buildDefaultInstanceRequest(metadata);
+
+      // Go create.go:124-127 wraps the downstream error with fmt.Errorf
+      // ("failed to apply default instance: %w") and PipelineError
+      // .GRPCStatus's errors.As branch keeps the inner CODE but rewrites
+      // the wire MESSAGE to the wrapped text — transport formatting
+      // (`rpc error: code = X desc = ...`) included. Mirrored byte-for-
+      // byte via goWrappedStatusError; the leak is stigmer/stigmer#852
+      // (both-editions post-cutover fix). Unstatused failures fall to the
+      // pipeline's Internal fallback, exactly Go's plain-error path.
+      let applied: AgentInstance;
+      try {
+        applied = await applierProvider().applyAsSystem(instanceRequest);
+      } catch (error) {
+        if (error instanceof ConnectError) {
+          throw goWrappedStatusError("failed to apply default instance", error);
+        }
+        throw new Error(
+          `failed to apply default instance: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      logger.info("Successfully applied default instance for agent", {
+        instanceId: applied.metadata?.id ?? "",
+        agentId: metadata.id,
+      });
+
+      ctx.set(DEFAULT_INSTANCE_ID_KEY, applied.metadata?.id ?? "");
+    },
+  };
+}
+
+/**
+ * Writes status.default_instance_id onto the just-persisted agent and
+ * re-persists. Reads the id from context (set by CreateDefaultInstance).
+ */
+export function newUpdateAgentStatusWithDefaultInstanceStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<AgentDesc> {
+  return {
+    name: "UpdateAgentStatusWithDefaultInstance",
+    async execute(ctx: RequestContext<AgentDesc>): Promise<void> {
+      const agent = ctx.newState;
+      const agentId = agent.metadata?.id ?? "";
+
+      const defaultInstanceId = ctx.get(DEFAULT_INSTANCE_ID_KEY);
+      if (typeof defaultInstanceId !== "string" || defaultInstanceId === "") {
+        // Unreachable with the required provider (Go's skip existed for its
+        // nil-client test mode); loud beats silent per the boot idiom.
+        throw internalError(
+          new Error(
+            "no default instance id in context (CreateDefaultInstance must run first)",
+          ),
+          "no default instance id in context (CreateDefaultInstance must run first)",
+        );
+      }
+
+      if (agent.status === undefined) {
+        agent.status = create(AgentStatusSchema, {});
+      }
+      agent.status.defaultInstanceId = defaultInstanceId;
+
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          agentId,
+          ctx.schema,
+          agent,
+        );
+      } catch (error) {
+        logger.error("Failed to persist agent with default_instance_id", {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw new Error(
+          `failed to persist agent with default instance: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      ctx.setNewState(agent);
+
+      logger.info(
+        "Successfully updated agent status with default_instance_id",
+        {
+          defaultInstanceId,
+          agentId,
+        },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cascade steps — delete_cascade.go. Children before parent, so a
+// mid-failure retry converges. What deliberately SURVIVES an agent delete,
+// and must never be swept into this cascade: sessions and agent executions
+// (historical record, the #582 posture — they reference agent and instance
+// by immutable IDs) and resource_audit rows (surviving sessions and
+// executions render their historical state from them).
+// ---------------------------------------------------------------------------
+
+/**
+ * Deletes EVERY instance of the agent (row + search-index entry) before the
+ * agent is deleted — the system-managed default AND members' personal ones
+ * (owner ruling stigmer/stigmer#611, extending the workflow ruling #592:
+ * instances are configuration OF the agent, meaningless without it, and an
+ * orphan occupies its org-scoped slug forever with no UI left to delete
+ * it). Matched by spec.agent_id — a required, validated field on every
+ * instance — so a single ID sweep covers the default instance too,
+ * including legacy rows that predate the status.default_instance_id
+ * pointer.
+ */
+export function newCascadeDeleteInstancesStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "CascadeDeleteInstances",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const agent = ctx.get(EXISTING_RESOURCE_KEY) as Agent | undefined;
+      if (agent === undefined) {
+        throw internalError(
+          new Error(
+            "agent not found in context (LoadExistingForDelete must run first)",
+          ),
+          "agent not found in context (LoadExistingForDelete must run first)",
+        );
+      }
+      const agentId = agent.metadata?.id ?? "";
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_instance);
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to list agent instances for cascade delete",
+        );
+      }
+
+      let deleted = 0;
+      for (const data of rows) {
+        let instance: AgentInstance;
+        try {
+          instance = fromBinary(AgentInstanceSchema, data);
+        } catch {
+          continue;
+        }
+        if ((instance.spec?.agentId ?? "") !== agentId) {
+          continue;
+        }
+        const instanceId = instance.metadata?.id ?? "";
+        try {
+          await store.deleteResource(
+            ApiResourceKind.agent_instance,
+            instanceId,
+          );
+        } catch (error) {
+          throw internalError(
+            error,
+            `failed to cascade-delete instance ${instanceId} of agent ${agentId}`,
+          );
+        }
+
+        // Best-effort, matching DeleteSearchIndex: a stale index entry is a
+        // cosmetic search artifact, not a correctness problem.
+        try {
+          await store.deleteSearchIndex(
+            ApiResourceKind.agent_instance,
+            instanceId,
+          );
+        } catch (error) {
+          logger.warn(
+            "CascadeDeleteInstances: failed to remove search index entry (best-effort)",
+            {
+              instanceId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+        deleted++;
+      }
+
+      if (deleted > 0) {
+        logger.info("Cascade-deleted instances of agent", {
+          count: deleted,
+          agentId,
+        });
+      }
+    },
+  };
+}
+
+/**
+ * Deletes the agent's SAME-ORG AgentShares before the agent is deleted.
+ * Shares reference the agent by org+slug (spec.agent_ref), so a stale share
+ * would silently rebind — audience, link token, and bound credentials
+ * included — to whatever agent is later created at that slug. Matching by
+ * spec.agent_ref finds them all regardless of each share's own slug (a
+ * renamed share stays covered). Cross-org shares (another org sharing this
+ * marketplace-public agent) are NOT cascaded: they are that org's
+ * resources, and deleting them here would make agent delete a
+ * cross-principal destructive action — they fail closed instead, via the
+ * dangling-ref check and the status.agent_id pin every share-resolution
+ * gate verifies. AgentShare is not search-indexed, so there is no index
+ * entry to clean.
+ */
+export function newCascadeDeleteSharesStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "CascadeDeleteShares",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const agent = ctx.get(EXISTING_RESOURCE_KEY) as Agent | undefined;
+      if (agent === undefined) {
+        throw internalError(
+          new Error(
+            "agent not found in context (LoadExistingForDelete must run first)",
+          ),
+          "agent not found in context (LoadExistingForDelete must run first)",
+        );
+      }
+      const agentOrg = agent.metadata?.org ?? "";
+      const agentSlug = agent.metadata?.slug ?? "";
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_share);
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to list agent shares for cascade delete",
+        );
+      }
+
+      let deleted = 0;
+      for (const data of rows) {
+        let share;
+        try {
+          share = fromBinary(AgentShareSchema, data);
+        } catch {
+          continue;
+        }
+        const ref = share.spec?.agentRef;
+        if ((ref?.org ?? "") !== agentOrg || (ref?.slug ?? "") !== agentSlug) {
+          continue;
+        }
+        if ((share.metadata?.org ?? "") !== agentOrg) {
+          // A cross-org share — another org's resource. Fails closed via
+          // the agent-id pin instead of being deleted here.
+          continue;
+        }
+        const shareId = share.metadata?.id ?? "";
+        try {
+          await store.deleteResource(ApiResourceKind.agent_share, shareId);
+        } catch (error) {
+          throw internalError(
+            error,
+            `failed to cascade-delete share ${shareId} of agent ${agentOrg}/${agentSlug}`,
+          );
+        }
+        deleted++;
+      }
+
+      if (deleted > 0) {
+        logger.info("Cascade-deleted shares of agent", {
+          count: deleted,
+          agent: `${agentOrg}/${agentSlug}`,
+        });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// LoadDefaultAgent — get_default.go's step: resolve via defaultagent and
+// map its sentinels to the wire contract. Go builds the wire message with
+// WrapError ("%s: %v"), so the sentinel's text RIDES the message — both
+// strings are cross-edition conformance surface.
+// ---------------------------------------------------------------------------
+
+export function newLoadDefaultAgentStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "LoadDefaultAgent",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      logger.info("Resolving platform default agent");
+
+      let agent: Agent;
+      try {
+        agent = await findDefaultAgent(store, logger);
+      } catch (error) {
+        if (error instanceof DefaultAgentNotConfiguredError) {
+          throw new ConnectError(
+            `No default agent available. Ensure an agent with label stigmer.ai/default-agent=true and visibility_public exists: ${error.message}`,
+            Code.NotFound,
+          );
+        }
+        if (error instanceof DefaultAgentNotPublicError) {
+          throw new ConnectError(
+            `Default agent exists but is not visibility_public: ${error.message}`,
+            Code.FailedPrecondition,
+          );
+        }
+        // Store/decode failure — an internal fault, not "no default agent".
+        // InternalError keeps the cause off the wire (stigmer/stigmer#478).
+        logger.error("Failed to resolve platform default agent", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw internalError(
+          error,
+          "failed to resolve the platform default agent",
+        );
+      }
+
+      logger.info("Resolved platform default agent", {
+        agentId: agent.metadata?.id ?? "",
+        agentName: agent.metadata?.name ?? "",
+      });
+
+      ctx.set(TARGET_RESOURCE_KEY, agent);
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/temporal/config.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/temporal/config.ts
@@ -1,0 +1,119 @@
+/**
+ * Agent-execution Temporal config — ports
+ * pkg/domain/agentexecution/temporal/config.go: the queue names, routing
+ * mode, and default execution target for agent-execution dispatch.
+ *
+ * resolveExecutionTarget is the SINGLE definition of the
+ * UNSPECIFIED-resolution rule (oss#397) — dispatch (the agentexecution
+ * domain, #17/#18) and policy enforcement (the session update pipeline's
+ * execution-target immutability step) must both use it rather than
+ * re-deriving the default, so they can never disagree about where an
+ * execution runs. Mirrors the cloud edition's
+ * AgentExecutionTemporalConfig.resolveExecutionTarget.
+ *
+ * This module is the first resident of the agentexecution domain directory
+ * (the domain itself is a later sub-project); the tree corresponds to Go's,
+ * same precedent as src/domain/mcpserver/enabledtools/.
+ */
+import { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+
+/**
+ * Routes all activities to the shared global queue (runnerQueue, default
+ * stigmer_runner) — the default for OSS local development where a single
+ * runner polls one queue for all sessions (Go RoutingGlobal).
+ */
+export const ROUTING_GLOBAL = "global";
+
+/**
+ * Derives a per-session task queue (session:{session_id}) for each
+ * execution — for deployments where each session has a dedicated runner
+ * (desktop app with embedded runners, or cloud sandboxes; Go
+ * RoutingSession).
+ */
+export const ROUTING_SESSION = "session";
+
+/**
+ * Resolves UNSPECIFIED to LOCAL — OSS/self-hosted deployments (Go
+ * DefaultExecutionTargetLocal).
+ */
+export const DEFAULT_EXECUTION_TARGET_LOCAL = "local";
+
+/**
+ * Resolves UNSPECIFIED to CLOUD — the managed cloud service (Go
+ * DefaultExecutionTargetCloud).
+ */
+export const DEFAULT_EXECUTION_TARGET_CLOUD = "cloud";
+
+/**
+ * Configuration for agent-execution Temporal workers (Go temporal.Config).
+ *
+ * Queue architecture:
+ *   - stigmerQueue: server workflows on agent_execution_stigmer
+ *   - runnerQueue: unified-runner activities on stigmer_runner (global) or
+ *     session:{id} (per-session)
+ */
+export class AgentExecutionTemporalConfig {
+  constructor(
+    /** Task queue for server workflows. Default: agent_execution_stigmer. */
+    readonly stigmerQueue: string,
+    /**
+     * Default task queue for runner activities (stigmer_runner). In global
+     * routing mode all activities route here; in session routing mode it is
+     * the fallback when the session id is empty.
+     */
+    readonly runnerQueue: string,
+    /** ROUTING_GLOBAL or ROUTING_SESSION. */
+    readonly activityRouting: string,
+    /**
+     * Resolves EXECUTION_TARGET_UNSPECIFIED on sessions:
+     * DEFAULT_EXECUTION_TARGET_LOCAL (client's runner polls the queue) or
+     * DEFAULT_EXECUTION_TARGET_CLOUD (server provisions a sandbox).
+     */
+    readonly defaultExecutionTarget: string,
+  ) {}
+
+  /**
+   * Resolves a session's execution_target to its effective target:
+   * UNSPECIFIED becomes the configured default (LOCAL on OSS/self-hosted,
+   * CLOUD on the managed cloud service); explicit values pass through
+   * unchanged (Go Config.ResolveExecutionTarget).
+   */
+  resolveExecutionTarget(target: ExecutionTarget): ExecutionTarget {
+    if (target !== ExecutionTarget.UNSPECIFIED) {
+      return target;
+    }
+    if (this.defaultExecutionTarget === DEFAULT_EXECUTION_TARGET_CLOUD) {
+      return ExecutionTarget.CLOUD;
+    }
+    return ExecutionTarget.LOCAL;
+  }
+}
+
+/**
+ * Builds the config from environment variables with Go NewConfig's
+ * defaults. Env-derived strings only — no Temporal connection is made
+ * here (the temporal seam stays empty until the execution cluster
+ * sub-projects land).
+ */
+export function newConfigFromEnv(): AgentExecutionTemporalConfig {
+  return new AgentExecutionTemporalConfig(
+    valueOrDefault(
+      process.env.TEMPORAL_AGENT_EXECUTION_STIGMER_TASK_QUEUE,
+      "agent_execution_stigmer",
+    ),
+    valueOrDefault(
+      process.env.TEMPORAL_AGENT_EXECUTION_RUNNER_TASK_QUEUE,
+      "stigmer_runner",
+    ),
+    valueOrDefault(process.env.STIGMER_ACTIVITY_ROUTING, ROUTING_GLOBAL),
+    valueOrDefault(
+      process.env.STIGMER_DEFAULT_EXECUTION_TARGET,
+      DEFAULT_EXECUTION_TARGET_LOCAL,
+    ),
+  );
+}
+
+/** Go's `if v == "" { v = default }` idiom for env reads. */
+function valueOrDefault(value: string | undefined, fallback: string): string {
+  return value === undefined || value === "" ? fallback : value;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/__tests__/agentinstance.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/__tests__/agentinstance.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Pins the agentinstance domain against Go's pkg/domain/agentinstance
+ * tests — through the REAL stack: a composed server on an ephemeral port,
+ * a native gRPC client, the full interceptor chain, and the DD-002
+ * in-process parent-agent edge (instance create loads its agent through
+ * the router transport).
+ *
+ * The load-bearing pins:
+ *   - the defaultinstance factory names the instance from the agent's
+ *     SLUG, never the display name (stigmer/stigmer#355), stamps both
+ *     reserved labels, and binds spec.agent_id to metadata.id;
+ *   - create rejects an unknown spec.agent_id with NotFound (oss#645);
+ *   - update enforces the immutable spec.agent_id with the exact
+ *     FAILED_PRECONDITION copy (oss#646); a same-id update passes;
+ *   - the default-instance visibility guard (stigmer/stigmer#556) rejects
+ *     on the LABEL branch and on the parent-POINTER branch (no label
+ *     needed), while an orphan instance and an ordinary personal instance
+ *     pass through.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/status_pb";
+import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
+import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import {
+  DEFAULT_INSTANCE_LABEL,
+  RESERVED_LABEL_TRUE,
+  SYSTEM_MANAGED_LABEL,
+} from "../../../pipeline/apiresource-labels.js";
+import {
+  buildDefaultInstanceRequest,
+  defaultInstanceSlug,
+} from "../defaultinstance.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "acme";
+
+const DEFAULT_INSTANCE_VISIBILITY_REFUSAL =
+  "Default instances do not have their own visibility - access always " +
+  "follows the parent blueprint. Change the blueprint's visibility instead.";
+
+let dir: string;
+let server: ComposedServer;
+let transport: Transport;
+let agentCommand: Client<typeof AgentCommandController>;
+let command: Client<typeof AgentInstanceCommandController>;
+let query: Client<typeof AgentInstanceQueryController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "agentinstance-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  agentCommand = createClient(AgentCommandController, transport);
+  command = createClient(AgentInstanceCommandController, transport);
+  query = createClient(AgentInstanceQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function createAgent(name: string) {
+  return agentCommand.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org: ORG },
+    spec: {
+      instructions: "You are a helpful agent used by the instance tests.",
+    },
+  });
+}
+
+function instanceInput(name: string, agentId: string, org: string = ORG) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "AgentInstance",
+    metadata: { name, org },
+    spec: { agentId },
+  };
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+describe("defaultinstance factory (the #355 pin)", () => {
+  it("names the instance from the agent's SLUG, not the display name", () => {
+    const metadata = create(ApiResourceMetadataSchema, {
+      id: "agt_factory_test",
+      name: "Fancy Display Name",
+      slug: "real-slug",
+      org: ORG,
+    });
+
+    const request = buildDefaultInstanceRequest(metadata);
+
+    // The wrong-field mistake (metadata.name) held together only while
+    // GenerateSlug(name + "-default") happened to re-derive the slug.
+    expect(request.metadata?.name).toBe("real-slug-default");
+    expect(defaultInstanceSlug("real-slug")).toBe("real-slug-default");
+    expect(request.metadata?.org).toBe(ORG);
+    // Both reserved marker labels are stamped.
+    expect(request.metadata?.labels[DEFAULT_INSTANCE_LABEL]).toBe(
+      RESERVED_LABEL_TRUE,
+    );
+    expect(request.metadata?.labels[SYSTEM_MANAGED_LABEL]).toBe(
+      RESERVED_LABEL_TRUE,
+    );
+    // The parent binding comes from metadata.id.
+    expect(request.spec?.agentId).toBe("agt_factory_test");
+    // Default instances carry no visibility of their own.
+    expect(request.metadata?.visibility).toBe(
+      ApiResourceVisibility.api_resource_visibility_unspecified,
+    );
+  });
+});
+
+describe("agent instance create (parent edge, oss#645)", () => {
+  it("rejects an unknown spec.agent_id with NotFound instead of persisting a dangling instance", async () => {
+    const error = await grpcError(() =>
+      command.create(instanceInput("Dangling Instance", "agt_does_not_exist")),
+    );
+    expect(error.code).toBe(Code.NotFound);
+    expect(error.rawMessage).toBe("Agent not found: agt_does_not_exist");
+  });
+});
+
+describe("agent instance update (immutable agent_id, oss#646)", () => {
+  it("rejects a differing spec.agent_id with the exact FailedPrecondition copy", async () => {
+    const agent = await createAgent("Update Guard Agent");
+    const agentId = agent.metadata!.id;
+    const instance = await command.create(
+      instanceInput("Update Guard Instance", agentId),
+    );
+
+    const error = await grpcError(() =>
+      command.update({
+        apiVersion: API_VERSION,
+        kind: "AgentInstance",
+        metadata: {
+          id: instance.metadata!.id,
+          name: instance.metadata!.name,
+          slug: instance.metadata!.slug,
+          org: instance.metadata!.org,
+        },
+        spec: { agentId: "agt_a_different_agent" },
+      }),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(
+      `spec.agent_id is immutable (instance instantiates agent ${agentId}) — create a new instance for a different agent`,
+    );
+  });
+
+  it("passes an update that keeps the same agent_id", async () => {
+    const agent = await createAgent("Update Pass Agent");
+    const agentId = agent.metadata!.id;
+    const instance = await command.create(
+      instanceInput("Update Pass Instance", agentId),
+    );
+
+    const updated = await command.update({
+      apiVersion: API_VERSION,
+      kind: "AgentInstance",
+      metadata: {
+        id: instance.metadata!.id,
+        name: instance.metadata!.name,
+        slug: instance.metadata!.slug,
+        org: instance.metadata!.org,
+      },
+      spec: { agentId, description: "updated by the domain test" },
+    });
+    expect(updated.spec?.description).toBe("updated by the domain test");
+    expect(updated.status?.audit?.specAudit?.event).toBe("updated");
+  });
+});
+
+describe("default-instance visibility guard (stigmer/stigmer#556)", () => {
+  it("rejects via the LABEL branch on the agent's system-managed default instance", async () => {
+    const agent = await createAgent("Label Branch Agent");
+    const defaultInstanceId = agent.status!.defaultInstanceId;
+    expect(defaultInstanceId).not.toBe("");
+
+    // The auto-created default instance carries the reserved label and the
+    // slug convention (the factory shape, persisted end-to-end).
+    const defaultInstance = await query.get({ value: defaultInstanceId });
+    expect(defaultInstance.metadata?.labels[DEFAULT_INSTANCE_LABEL]).toBe(
+      RESERVED_LABEL_TRUE,
+    );
+    expect(defaultInstance.metadata?.slug).toBe(
+      defaultInstanceSlug(agent.metadata!.slug),
+    );
+
+    const error = await grpcError(() =>
+      command.updateVisibility({
+        resourceId: defaultInstanceId,
+        visibility: ApiResourceVisibility.visibility_org,
+      }),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(DEFAULT_INSTANCE_VISIBILITY_REFUSAL);
+  });
+
+  it("rejects via the parent-POINTER branch even without the label", async () => {
+    const agent = await createAgent("Pointer Branch Agent");
+    const agentId = agent.metadata!.id;
+    const personal = await command.create(
+      instanceInput("Pointer Branch Instance", agentId),
+    );
+    const personalId = personal.metadata!.id;
+    expect(personal.metadata?.labels[DEFAULT_INSTANCE_LABEL]).toBeUndefined();
+
+    // Repoint the parent's server-owned record at the unlabeled instance
+    // — the pre-label legacy-row shape the pointer branch exists to cover.
+    const stored = await server.store.getResource(
+      ApiResourceKind.agent,
+      agentId,
+      AgentSchema,
+    );
+    if (stored.status === undefined) {
+      stored.status = create(AgentStatusSchema, {});
+    }
+    stored.status.defaultInstanceId = personalId;
+    await server.store.saveResource(
+      ApiResourceKind.agent,
+      agentId,
+      AgentSchema,
+      stored,
+    );
+
+    const error = await grpcError(() =>
+      command.updateVisibility({
+        resourceId: personalId,
+        visibility: ApiResourceVisibility.visibility_org,
+      }),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(DEFAULT_INSTANCE_VISIBILITY_REFUSAL);
+  });
+
+  it("passes through for an orphan instance whose parent no longer exists", async () => {
+    // Seeded directly: an orphan predating the delete cascade — nothing
+    // marks it default, so the one operation it supports must work.
+    const orphan = create(AgentInstanceSchema, {
+      apiVersion: API_VERSION,
+      kind: "AgentInstance",
+      metadata: {
+        id: "ain_orphan_test",
+        name: "Orphan Instance",
+        slug: "orphan-instance",
+        org: ORG,
+      },
+      spec: { agentId: "agt_long_gone" },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_instance,
+      "ain_orphan_test",
+      AgentInstanceSchema,
+      orphan,
+    );
+
+    const updated = await command.updateVisibility({
+      resourceId: "ain_orphan_test",
+      visibility: ApiResourceVisibility.visibility_org,
+    });
+    expect(updated.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_org,
+    );
+  });
+
+  it("passes through for an ordinary personal instance and persists the change", async () => {
+    const agent = await createAgent("Non Default Agent");
+    const personal = await command.create(
+      instanceInput("Non Default Instance", agent.metadata!.id),
+    );
+    const personalId = personal.metadata!.id;
+
+    const updated = await command.updateVisibility({
+      resourceId: personalId,
+      visibility: ApiResourceVisibility.visibility_org,
+    });
+    expect(updated.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_org,
+    );
+
+    const fetched = await query.get({ value: personalId });
+    expect(fetched.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_org,
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/controller.ts
@@ -1,0 +1,492 @@
+/**
+ * AgentInstance controller — ports pkg/domain/agentinstance/controller
+ * (command + query sides): configured materializations of an agent
+ * blueprint. Create validates the parent agent through the in-process
+ * agent client (the agent↔agentinstance mutual edge — sub-project DD-002);
+ * update enforces the immutable spec.agent_id (oss#646); updateVisibility
+ * refuses default instances outright (stigmer/stigmer#556).
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by agentinstance.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentinstance.test.ts.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize (FGA
+ * can_create_instance on the parent agent), CreateIamPolicies, and Publish
+ * steps. Deliberately NO same-org rule on create, unlike WorkflowInstance:
+ * an agent is a shareable blueprint, and one agent legitimately has
+ * instances in several orgs (the marketplace case) — cloud governs
+ * cross-org creation with FGA on the parent agent; OSS has no
+ * authorization layer, so cross-org creation is allowed.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
+import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type {
+  AgentInstanceId,
+  AgentInstanceList,
+  GetAgentInstancesByAgentRequest,
+  ListAgentInstancesRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/io_pb";
+import type {
+  ApiResourceReference,
+  UpdateVisibilityInput,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError, notFoundError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import {
+  newBuildNewStateStep,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import {
+  newValidateVisibilityStep,
+  newValidateVisibilityUpdateStep,
+} from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import { agentInstanceSearchExtractor } from "./search-extractor.js";
+import {
+  INSTANCE_LIST_KEY,
+  LIST_RESULT_KEY,
+  UPDATE_VISIBILITY_INSTANCE_KEY,
+  newListByOrgAndLabelsStep,
+  newLoadByAgentStep,
+  newLoadParentAgentStep,
+  newRejectDefaultInstanceVisibilityUpdateStep,
+  newValidateInstanceUpdateStep,
+} from "./steps.js";
+import type { ParentAgentLoaderProvider } from "./steps.js";
+
+export interface AgentInstanceControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  /**
+   * The agent in-process edge — a lazy provider because
+   * agent↔agentinstance is a true dependency cycle (DD-002; the ratified
+   * DI story breaks cycles with `() => client` closures resolved at call
+   * time, never at construction).
+   */
+  readonly parentAgentLoader: ParentAgentLoaderProvider;
+}
+
+/** Registers both agentinstance services on the router (routes stage). */
+export function registerAgentInstanceServices(
+  router: ConnectRouter,
+  deps: AgentInstanceControllerDeps,
+): void {
+  router.service(AgentInstanceCommandController, {
+    apply: (instance, ctx) => apply(deps, instance, ctx),
+    create: (instance, ctx) => createInstance(deps, instance, ctx),
+    update: (instance, ctx) => update(deps, instance, ctx),
+    updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
+    delete: (id, ctx) => deleteInstance(deps, id, ctx),
+  });
+  router.service(AgentInstanceQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByAgent: (req, ctx) => getByAgent(deps, req, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline: the parent agent is loaded
+ * (and an unknown spec.agent_id rejected, oss#645) BEFORE the duplicate
+ * check, exactly Go's order.
+ */
+async function createInstance(
+  deps: AgentInstanceControllerDeps,
+  instance: AgentInstance,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(AgentInstanceSchema, instance, kindOf(ctx));
+  await newPipeline<typeof AgentInstanceSchema>(
+    "agent-instance-create",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadParentAgentStep(deps.parentAgentLoader, deps.logger))
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(deps.store, agentInstanceSearchExtractor, deps.logger),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/** Update — chain per Go buildUpdatePipeline (agent_id immutable). */
+async function update(
+  deps: AgentInstanceControllerDeps,
+  instance: AgentInstance,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(AgentInstanceSchema, instance, kindOf(ctx));
+  await newPipeline<typeof AgentInstanceSchema>(
+    "agent-instance-update",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateInstanceUpdateStep())
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(deps.store, agentInstanceSearchExtractor, deps.logger),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update; delegates with the ORIGINAL
+ * request message. The create route is the default-instance path (the
+ * agent controller's CreateDefaultInstance applies through here); the
+ * update route is the self-heal for pre-cascade legacy orphans.
+ */
+async function apply(
+  deps: AgentInstanceControllerDeps,
+  instance: AgentInstance,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(AgentInstanceSchema, instance, kindOf(ctx));
+  await newPipeline<typeof AgentInstanceSchema>(
+    "agent-instance-apply",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate
+    ? createInstance(deps, instance, ctx)
+    : update(deps, instance, ctx);
+}
+
+/** Delete — no cascade of its own; returns the deleted instance. */
+async function deleteInstance(
+  deps: AgentInstanceControllerDeps,
+  instanceId: AgentInstanceId,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(
+    AgentInstanceCommandController.method.delete.input,
+    instanceId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentInstanceCommandController.method.delete.input>(
+    "agent-instance-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, AgentInstanceSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted agent instance not found in context"),
+      "deleted agent instance not found in context",
+    );
+  }
+  return deleted as AgentInstance;
+}
+
+// ---------------------------------------------------------------------------
+// updateVisibility — update_visibility.go. Step order is contract: the
+// default-instance guard runs FIRST after load (FAILED_PRECONDITION wins
+// over the level check, as in Cloud), then the shared level validation
+// (after load: NOT_FOUND wins, as in Cloud).
+// ---------------------------------------------------------------------------
+
+type UpdateVisibilityDesc =
+  typeof AgentInstanceCommandController.method.updateVisibility.input;
+
+async function updateVisibility(
+  deps: AgentInstanceControllerDeps,
+  input: UpdateVisibilityInput,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(
+    AgentInstanceCommandController.method.updateVisibility.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<UpdateVisibilityDesc>(
+    "agent-instance-update-visibility",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadInstanceForVisibilityUpdateStep(deps.store))
+    .addStep(newRejectDefaultInstanceVisibilityUpdateStep(deps.store))
+    .addStep(newValidateVisibilityUpdateStep())
+    .addStep(newSetInstanceVisibilityStep())
+    .addStep(newPersistInstanceForVisibilityUpdateStep(deps.store))
+    .addStep(newIndexInstanceAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  return reqCtx.get(UPDATE_VISIBILITY_INSTANCE_KEY) as AgentInstance;
+}
+
+/** Loads the agent instance by resource_id; ANY load failure → NotFound. */
+function newLoadInstanceForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "LoadInstanceForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const input = ctx.input;
+      let instance: AgentInstance;
+      try {
+        instance = await store.getResource(
+          ApiResourceKind.agent_instance,
+          input.resourceId,
+          AgentInstanceSchema,
+        );
+      } catch {
+        throw notFoundError("agent instance", input.resourceId);
+      }
+      ctx.set(UPDATE_VISIBILITY_INSTANCE_KEY, instance);
+    },
+  };
+}
+
+/** Sets metadata.visibility and stamps the StatusAudit slot (#540). */
+function newSetInstanceVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "SetInstanceVisibility",
+    execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
+      const instance = ctx.get(UPDATE_VISIBILITY_INSTANCE_KEY) as AgentInstance;
+      if (instance.metadata !== undefined) {
+        instance.metadata.visibility = ctx.input.visibility;
+      }
+      setAuditFieldsForUpdate(AgentInstanceSchema, instance, "status_audit");
+    },
+  };
+}
+
+/** Persists the visibility change. */
+function newPersistInstanceForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "PersistInstanceForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const instance = ctx.get(UPDATE_VISIBILITY_INSTANCE_KEY) as AgentInstance;
+      try {
+        await store.saveResource(
+          ApiResourceKind.agent_instance,
+          instance.metadata?.id ?? "",
+          AgentInstanceSchema,
+          instance,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to save agent instance");
+      }
+    },
+  };
+}
+
+/**
+ * Re-indexes after the visibility change (visibility is an indexed field).
+ * Domain-local because the shared IndexSearch reads newState, which is the
+ * UpdateVisibilityInput here, not the instance. Best-effort by contract.
+ */
+function newIndexInstanceAfterVisibilityUpdateStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "IndexInstanceAfterVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const instance = ctx.get(UPDATE_VISIBILITY_INSTANCE_KEY) as AgentInstance;
+      const entry = agentInstanceSearchExtractor.getSearchIndexEntry(instance);
+      if (entry === undefined) {
+        logger.warn(
+          "IndexInstanceAfterVisibilityUpdate: extractor returned nil, skipping",
+          { id: instance.metadata?.id ?? "" },
+        );
+        return;
+      }
+      try {
+        await store.upsertSearchIndex(
+          ApiResourceKind.agent_instance,
+          instance.metadata?.id ?? "",
+          entry,
+        );
+      } catch (error) {
+        logger.warn(
+          "IndexInstanceAfterVisibilityUpdate: failed (best-effort)",
+          {
+            id: instance.metadata?.id ?? "",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    },
+  };
+}
+
+/** Get — ExtractResourceId + LoadTarget, exactly Go's (3-step) chain. */
+async function get(
+  deps: AgentInstanceControllerDeps,
+  id: AgentInstanceId,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(
+    AgentInstanceQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentInstanceQueryController.method.get.input>(
+    "agent-instance-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadTargetStep(deps.store, AgentInstanceSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentInstance;
+}
+
+/** GetByReference — slug+org lookup. */
+async function getByReference(
+  deps: AgentInstanceControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<AgentInstance> {
+  const reqCtx = new RequestContext(
+    AgentInstanceQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof AgentInstanceQueryController.method.getByReference.input
+  >("agent-instance-get-by-reference", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, AgentInstanceSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentInstance;
+}
+
+/** GetByAgent — all instances of one agent, optionally org-scoped. */
+async function getByAgent(
+  deps: AgentInstanceControllerDeps,
+  req: GetAgentInstancesByAgentRequest,
+  ctx: HandlerContext,
+): Promise<AgentInstanceList> {
+  const reqCtx = new RequestContext(
+    AgentInstanceQueryController.method.getByAgent.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof AgentInstanceQueryController.method.getByAgent.input
+  >("agent-instance-get-by-agent", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByAgentStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(INSTANCE_LIST_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("instance list not found in context"),
+      "instance list not found in context",
+    );
+  }
+  return result as AgentInstanceList;
+}
+
+/** List — org + labels filter (AND semantics), newest first. */
+async function list(
+  deps: AgentInstanceControllerDeps,
+  req: ListAgentInstancesRequest,
+  ctx: HandlerContext,
+): Promise<AgentInstanceList> {
+  const reqCtx = new RequestContext(
+    AgentInstanceQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentInstanceQueryController.method.list.input>(
+    "agent-instance-list",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgAndLabelsStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("agent instance list not found in context"),
+      "agent instance list not found in context",
+    );
+  }
+  return result as AgentInstanceList;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/defaultinstance.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/defaultinstance.ts
@@ -1,0 +1,87 @@
+/**
+ * Default-instance factory — ports
+ * pkg/domain/agentinstance/defaultinstance/defaultinstance.go (the OSS twin
+ * of the cloud edition's DefaultAgentInstanceFactory; keep the two in sync).
+ *
+ * Every agent has exactly one default instance: an empty shell with no
+ * custom configuration that serves as the fallback when the user has no
+ * personal instance. This module is the single source of its naming
+ * convention and request shape, shared by every flow that creates one
+ * (agent create, session create's self-heal) — in Go, previously four
+ * hand-rolled copies that could drift.
+ *
+ * Default instances carry no visibility of their own: their access always
+ * follows the parent agent. metadata.visibility is deliberately left unset
+ * here, and visibility updates on default instances are rejected by the
+ * agentinstance controller's RejectDefaultInstanceVisibilityUpdate step.
+ *
+ * Default instances are tagged with two reserved labels (see
+ * src/pipeline/apiresource-labels.ts). The labels are descriptive markers
+ * matching the cloud edition's stored shape — restrict-shaped decisions
+ * must also key on the parent's status.default_instance_id, which is
+ * server-owned (labels are client-suppliable, and instances created before
+ * this factory existed carry none).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { ApiResourceMetadata } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+
+import {
+  DEFAULT_INSTANCE_LABEL,
+  RESERVED_LABEL_TRUE,
+  SYSTEM_MANAGED_LABEL,
+} from "../../pipeline/apiresource-labels.js";
+
+// apiVersion / kind match what every creation flow (and the cloud
+// edition's resolvers) put on AgentInstance requests.
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "AgentInstance";
+
+const SLUG_SUFFIX = "-default";
+const DESCRIPTION = "Default instance (auto-created, no custom configuration)";
+
+/**
+ * The deterministic slug of an agent's default instance
+ * (<agent-slug>-default) — the single source of the naming convention.
+ */
+export function defaultInstanceSlug(agentSlug: string): string {
+  return `${agentSlug}${SLUG_SUFFIX}`;
+}
+
+/**
+ * Builds the AgentInstance proto for a default-instance creation request
+ * from the parent agent's metadata. Callers hand it to the agentinstance
+ * in-process client (applyAsSystem), which owns persistence and validation.
+ *
+ * Taking the metadata rather than loose strings is deliberate: the instance
+ * is named from the agent's SLUG — the kebab-case identity — never from the
+ * free-form display name. Every historical Go call site passed
+ * metadata.name for the slug parameter, which held together only while
+ * GenerateSlug(name + "-default") happened to re-derive slug + "-default"
+ * (stigmer/stigmer#355); reading the slug at this single source makes the
+ * wrong-field mistake unwritable. All callers see a populated slug: create
+ * pipelines run after ResolveSlug, and the self-heal paths load an
+ * already-persisted parent.
+ */
+export function buildDefaultInstanceRequest(
+  agent: ApiResourceMetadata,
+): AgentInstance {
+  return create(AgentInstanceSchema, {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      name: defaultInstanceSlug(agent.slug),
+      org: agent.org,
+      labels: {
+        [DEFAULT_INSTANCE_LABEL]: RESERVED_LABEL_TRUE,
+        [SYSTEM_MANAGED_LABEL]: RESERVED_LABEL_TRUE,
+      },
+    },
+    spec: {
+      agentId: agent.id,
+      description: DESCRIPTION,
+    },
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/search-extractor.ts
@@ -1,0 +1,36 @@
+/**
+ * AgentInstance search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/agent_instance_extractor.go. Agent instances
+ * are configured incarnations of an agent blueprint; the summary is
+ * spec.description. The query side of the extractor contract arrives with
+ * the search service sub-project (#13).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const agentInstanceSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const instance = resource as unknown as AgentInstance;
+    const metadata = instance.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      description: instance.spec?.description ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        instance.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/steps.ts
@@ -1,0 +1,352 @@
+/**
+ * AgentInstance domain-local pipeline steps — port the inline steps of
+ * pkg/domain/agentinstance/controller/ (create.go, update.go,
+ * update_visibility.go, list.go, get_by_agent.go). Shared steps stay in
+ * src/pipeline/steps/; these exist because they embody instance-specific
+ * contracts: the parent-agent edge, the immutable agent_id, the
+ * default-instance visibility guard, and the org/label list filters.
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentInstanceListSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/io_pb";
+import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { isDefaultInstance } from "../../pipeline/apiresource-labels.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import {
+  compareCreatedAtDesc,
+  matchesAllLabels,
+} from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { rejectDefaultInstanceVisibilityUpdate } from "../../pipeline/steps/validate-visibility.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * The narrow in-process surface the agentinstance domain needs from agent —
+ * consumer-defined so the dependency reads at the domain boundary (the Go
+ * twin is pkg/downstream/agent.Client). Calls ride the in-process router
+ * transport, traversing the full interceptor chain (DD-002).
+ */
+export interface ParentAgentLoader {
+  get(agentId: string): Promise<Agent>;
+}
+
+/**
+ * Lazy provider for the agent↔agentinstance true cycle — resolved at call
+ * time, never at construction (the ratified DI story, D2 §2).
+ */
+export type ParentAgentLoaderProvider = () => ParentAgentLoader;
+
+/**
+ * LoadParentAgent — create.go: an unknown spec.agent_id is rejected with
+ * NotFound instead of persisting a dangling instance (oss#645), converging
+ * on cloud's LoadParentAgent step and this server's own WorkflowInstance
+ * create pipeline.
+ *
+ * Unlike its WorkflowInstance twin, the loaded agent is NOT stored in the
+ * request context: nothing downstream consumes it (cloud's consumer is the
+ * FGA authorize step, which OSS excludes; the WorkflowInstance twin's
+ * consumer is the same-org rule, which agent instances deliberately do not
+ * have — an agent is a shareable blueprint, and one agent legitimately has
+ * instances in several orgs: the marketplace case).
+ */
+export function newLoadParentAgentStep(
+  agentLoader: ParentAgentLoaderProvider,
+  logger: Logger,
+): PipelineStep<typeof AgentInstanceSchema> {
+  return {
+    name: "LoadParentAgent",
+    async execute(
+      ctx: RequestContext<typeof AgentInstanceSchema>,
+    ): Promise<void> {
+      const agentId = ctx.input.spec?.agentId ?? "";
+
+      logger.info("Loading parent agent", { agentId });
+
+      let parentAgent: Agent;
+      try {
+        parentAgent = await agentLoader().get(agentId);
+      } catch (error) {
+        logger.warn("Parent agent not found", {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw notFoundError("Agent", agentId);
+      }
+
+      logger.debug("Loaded parent agent", {
+        agentId,
+        org: parentAgent.metadata?.org ?? "",
+      });
+    },
+  };
+}
+
+/**
+ * ValidateInstanceUpdate — update.go: enforces the instance's immutable
+ * identity on update — spec.agent_id must keep referencing the same agent.
+ * An instance is a configured materialization OF one agent; repointing it
+ * would silently change what its executions run while keeping the
+ * instance's identity, history, and references intact — create a new
+ * instance instead (oss#646).
+ *
+ * Rejecting (rather than silently preserving, as BuildUpdateState does for
+ * metadata.visibility) is deliberate: visibility has a legitimate second
+ * door — the guarded updateVisibility RPC — so stale manifests carrying an
+ * old level are routine and must not fail the update. The parent ref has NO
+ * other door; no manifest with a different agent_id was ever valid, so a
+ * differing value is always a client error and deserves a loud failure.
+ *
+ * Runs after LoadExisting. Apply delegates to Update for existing
+ * resources, so this guard covers the apply door too. An EMPTY request
+ * agent_id never reaches this step — protovalidate pins min_len=1.
+ */
+export function newValidateInstanceUpdateStep(): PipelineStep<
+  typeof AgentInstanceSchema
+> {
+  return {
+    name: "ValidateInstanceUpdate",
+    execute(ctx: RequestContext<typeof AgentInstanceSchema>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as
+        | AgentInstance
+        | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing agent instance not found in context"),
+          "existing agent instance not found in context",
+        );
+      }
+
+      if ((ctx.input.spec?.agentId ?? "") !== (existing.spec?.agentId ?? "")) {
+        throw failedPreconditionError(
+          `spec.agent_id is immutable (instance instantiates agent ${existing.spec?.agentId ?? ""}) — create a new instance for a different agent`,
+        );
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RejectDefaultInstanceVisibilityUpdate — update_visibility.go: rejects
+// visibility updates on an agent's system-managed default instance — the
+// OSS half of the guard the cloud edition applies in its
+// ValidateVisibilityUpdateStep. Default instances carry no visibility of
+// their own: their access always follows the parent agent, and a level
+// stamped here would persist state the cloud edition considers structurally
+// invalid (stigmer/stigmer#556).
+//
+// An instance counts as the default when EITHER holds: metadata carries the
+// stigmer.ai/default-instance label (cloud's key — stamped at create by the
+// defaultinstance factory), or the parent agent's status.default_instance_id
+// points at it (the authoritative, server-owned record; covers instances
+// created before OSS stamped the label, and cannot be dropped by a client
+// update the way the label can — OSS has no reserved-label write guard).
+//
+// Deliberate divergence from cloud (label-only): the pointer branch makes
+// the guard hold for pre-label legacy rows without a backfill migration.
+// Deliberate non-goal: UpdateExecutionVisibility (spec.execution_visibility,
+// run observability) is NOT guarded — cloud allows it on default instances.
+// Do not "fix" that.
+//
+// A missing parent (orphan instance) passes through: nothing marks the
+// instance default, and inventing a failure mode here would break the one
+// legitimate operation an orphan supports. Any other store failure is
+// INTERNAL — a transient fault must not silently open the guard.
+// ---------------------------------------------------------------------------
+
+/** Context key for the instance under visibility update. */
+export const UPDATE_VISIBILITY_INSTANCE_KEY = "updateVisibilityInstance";
+
+export function newRejectDefaultInstanceVisibilityUpdateStep<
+  Desc extends DescMessage,
+>(store: Store): PipelineStep<Desc> {
+  return {
+    name: "RejectDefaultInstanceVisibilityUpdate",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const instance = ctx.get(UPDATE_VISIBILITY_INSTANCE_KEY) as AgentInstance;
+
+      if (isDefaultInstance(instance.metadata)) {
+        rejectDefaultInstanceVisibilityUpdate();
+      }
+
+      const parentId = instance.spec?.agentId ?? "";
+      if (parentId === "") {
+        return;
+      }
+      let parent: Agent;
+      try {
+        parent = await store.getResource(
+          ApiResourceKind.agent,
+          parentId,
+          AgentSchema,
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          return;
+        }
+        throw internalError(
+          error,
+          "failed to load parent agent for default-instance check",
+        );
+      }
+      if (parent.status?.defaultInstanceId === (instance.metadata?.id ?? "")) {
+        rejectDefaultInstanceVisibilityUpdate();
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// List filters — list.go and get_by_agent.go. Full scans with client-side
+// filtering, exactly Go (no pagination, no authorization filtering in OSS).
+// ---------------------------------------------------------------------------
+
+/** Context key for the list result (Go listResultKey). */
+export const LIST_RESULT_KEY = "listResult";
+
+/** Context key for the get-by-agent result (Go "instanceList"). */
+export const INSTANCE_LIST_KEY = "instanceList";
+
+/**
+ * ListByOrgAndLabels — org equality + AND-label filtering, sorted by
+ * spec-audit created_at descending (seconds then nanos; timestamped
+ * entries before untimestamped ones).
+ */
+export function newListByOrgAndLabelsStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof AgentInstanceQueryController.method.list.input> {
+  return {
+    name: "ListByOrgAndLabels",
+    async execute(
+      ctx: RequestContext<
+        typeof AgentInstanceQueryController.method.list.input
+      >,
+    ): Promise<void> {
+      const { org, labels: filterLabels } = ctx.input;
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_instance);
+      } catch (error) {
+        throw internalError(error, "failed to list agent instances");
+      }
+
+      const instances: AgentInstance[] = [];
+      for (const data of rows) {
+        let instance: AgentInstance;
+        try {
+          instance = fromBinary(AgentInstanceSchema, data);
+        } catch (error) {
+          logger.warn("Failed to unmarshal agent instance, skipping", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+
+        if ((instance.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        if (!matchesAllLabels(instance.metadata?.labels ?? {}, filterLabels)) {
+          continue;
+        }
+        instances.push(instance);
+      }
+
+      instances.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      logger.info("Listed agent instances", {
+        org,
+        matchCount: instances.length,
+        labelFilters: Object.keys(filterLabels).length,
+      });
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(AgentInstanceListSchema, {
+          totalCount: instances.length,
+          items: instances,
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * LoadByAgent — all instances of one agent (spec.agent_id match), scoped to
+ * one org when the request carries one. The org filter is contract parity,
+ * not authorization: a multi-org caller asking for one org's instances must
+ * not see another org's instances of the same agent.
+ */
+export function newLoadByAgentStep(
+  store: Store,
+): PipelineStep<typeof AgentInstanceQueryController.method.getByAgent.input> {
+  return {
+    name: "LoadByAgent",
+    async execute(
+      ctx: RequestContext<
+        typeof AgentInstanceQueryController.method.getByAgent.input
+      >,
+    ): Promise<void> {
+      const req = ctx.input;
+      const agentId = req.agentId;
+
+      if (agentId === "") {
+        throw invalidArgumentError("agent_id is required");
+      }
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_instance);
+      } catch (error) {
+        throw internalError(error, "failed to list agent instances");
+      }
+
+      const instances: AgentInstance[] = [];
+      for (const data of rows) {
+        let instance: AgentInstance;
+        try {
+          instance = fromBinary(AgentInstanceSchema, data);
+        } catch {
+          continue;
+        }
+
+        if ((instance.spec?.agentId ?? "") !== agentId) {
+          continue;
+        }
+        if (req.org !== "" && (instance.metadata?.org ?? "") !== req.org) {
+          continue;
+        }
+        instances.push(instance);
+      }
+
+      ctx.set(
+        INSTANCE_LIST_KEY,
+        create(AgentInstanceListSchema, {
+          totalCount: instances.length,
+          items: instances,
+        }),
+      );
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/controller.ts
@@ -19,8 +19,6 @@
  */
 import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
 import { create, fromBinary } from "@bufbuild/protobuf";
-import type { Timestamp } from "@bufbuild/protobuf/wkt";
-
 import { EnvironmentCommandController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/command_pb";
 import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
 import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
@@ -66,6 +64,7 @@ import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
+import { compareCreatedAtDesc, matchesAllLabels } from "../../pipeline/steps/helpers.js";
 import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
 import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
@@ -644,34 +643,4 @@ function newListByOrgAndLabelsStep(
       );
     },
   };
-}
-
-/** True when resourceLabels contains every filter entry (empty = all). */
-function matchesAllLabels(
-  resourceLabels: Record<string, string>,
-  filterLabels: Record<string, string>,
-): boolean {
-  return Object.entries(filterLabels).every(
-    ([key, value]) => resourceLabels[key] === value,
-  );
-}
-
-/** Go's sort.Slice comparator: newest first; nil timestamps last. */
-function compareCreatedAtDesc(
-  a: Timestamp | undefined,
-  b: Timestamp | undefined,
-): number {
-  if (a === undefined || b === undefined) {
-    if (a === undefined && b === undefined) {
-      return 0;
-    }
-    return a !== undefined ? -1 : 1;
-  }
-  if (a.seconds !== b.seconds) {
-    return a.seconds > b.seconds ? -1 : 1;
-  }
-  if (a.nanos !== b.nanos) {
-    return a.nanos > b.nanos ? -1 : 1;
-  }
-  return 0;
 }

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/enabledtools/__tests__/enabledtools.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/enabledtools/__tests__/enabledtools.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Pins the enabled-tools classification (enabledtools.ts, ports
+ * pkg/domain/mcpserver/enabledtools): discovered tools pass, discovered
+ * resource-template names are classified SEPARATELY from plainly unknown
+ * names (the two get different error copy at the call sites, #402), and
+ * both partitions preserve the requested order so error messages are
+ * deterministic.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { DiscoveredCapabilitiesSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+
+import {
+  classify,
+  isValidClassification,
+  quoteJoin,
+  toolNames,
+} from "../enabledtools.js";
+
+const caps = create(DiscoveredCapabilitiesSchema, {
+  tools: [{ name: "search_docs" }, { name: "create_ticket" }],
+  resourceTemplates: [{ name: "customer-record" }, { name: "invoice" }],
+});
+
+describe("classify", () => {
+  it("passes names that resolve to discovered tools", () => {
+    const c = classify(caps, ["search_docs", "create_ticket"]);
+    expect(c.unknown).toEqual([]);
+    expect(c.resourceTemplates).toEqual([]);
+    expect(isValidClassification(c)).toBe(true);
+  });
+
+  it("classifies resource-template names separately from unknown names", () => {
+    const c = classify(caps, ["customer-record"]);
+    expect(c.resourceTemplates).toEqual(["customer-record"]);
+    expect(c.unknown).toEqual([]);
+    expect(isValidClassification(c)).toBe(false);
+  });
+
+  it("collects plainly unknown names", () => {
+    const c = classify(caps, ["serach_docs"]);
+    expect(c.unknown).toEqual(["serach_docs"]);
+    expect(c.resourceTemplates).toEqual([]);
+    expect(isValidClassification(c)).toBe(false);
+  });
+
+  it("preserves the requested order within each partition", () => {
+    const c = classify(caps, [
+      "zzz-unknown",
+      "invoice",
+      "search_docs",
+      "aaa-unknown",
+      "customer-record",
+    ]);
+    expect(c.unknown).toEqual(["zzz-unknown", "aaa-unknown"]);
+    expect(c.resourceTemplates).toEqual(["invoice", "customer-record"]);
+  });
+
+  it("matching is exact and case-sensitive", () => {
+    const c = classify(caps, ["Search_Docs"]);
+    expect(c.unknown).toEqual(["Search_Docs"]);
+  });
+});
+
+describe("error-message helpers", () => {
+  it("toolNames returns discovered tool names in discovery order", () => {
+    expect(toolNames(caps)).toEqual(["search_docs", "create_ticket"]);
+  });
+
+  it("quoteJoin renders 'a', 'b', 'c'", () => {
+    expect(quoteJoin(["a", "b", "c"])).toBe("'a', 'b', 'c'");
+    expect(quoteJoin([])).toBe("");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/enabledtools/enabledtools.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/enabledtools/enabledtools.ts
@@ -1,0 +1,93 @@
+/**
+ * Enabled-tools classification — ports
+ * pkg/domain/mcpserver/enabledtools/enabledtools.go: classifies
+ * enabled-tools selections against an MCP server's discovered capabilities.
+ *
+ * It is the shared core of the apply-time validation added for issue #402:
+ * the agent controller checks McpServerUsage.enabled_tools and the
+ * mcpserver controller (arriving with sub-project #9 — this module is its
+ * first resident, placed here so the tree keeps corresponding to Go's)
+ * checks McpServerSpec.default_enabled_tools, and both must agree on what
+ * counts as a valid tool name. Keeping the classification here — in the
+ * domain that owns capability semantics — prevents the two error paths
+ * from drifting.
+ *
+ * The classification deliberately distinguishes resource templates from
+ * plainly unknown names: a resource-template name in an enabled-tools list
+ * is a specific, documented mistake (templates are read-only data
+ * endpoints, not callable tools — see DiscoveredCapabilities in
+ * mcpserver/v1/status.proto), and the error message should say so instead
+ * of implying a typo.
+ */
+import type { DiscoveredCapabilities } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+
+/**
+ * Partitions the requested-but-invalid names of an enabled-tools list.
+ * Names present in the server's discovered tools appear in neither array.
+ * Order follows the requested list (stable, deterministic error messages).
+ */
+export interface Classification {
+  /**
+   * Names the server exposes neither as a tool nor as a resource template
+   * — almost always typos or stale entries.
+   */
+  readonly unknown: string[];
+  /**
+   * Names that match a discovered resource template: real names on the
+   * server, but never callable as tools.
+   */
+  readonly resourceTemplates: string[];
+}
+
+/** Whether every requested name resolved to a discovered tool. */
+export function isValidClassification(c: Classification): boolean {
+  return c.unknown.length === 0 && c.resourceTemplates.length === 0;
+}
+
+/**
+ * Checks each requested name against the discovered capabilities. Matching
+ * is exact and case-sensitive — tool names must match what the server
+ * reports via tools/list (see McpServerUsage.enabled_tools docs).
+ *
+ * Callers are expected to skip validation entirely when capabilities are
+ * absent (server not yet connected); classifying against absent
+ * capabilities would mark every name unknown, which is not a statement the
+ * platform can honestly make before the first discovery.
+ */
+export function classify(
+  caps: DiscoveredCapabilities,
+  requested: readonly string[],
+): Classification {
+  const tools = new Set(caps.tools.map((tool) => tool.name));
+  const templates = new Set(caps.resourceTemplates.map((tmpl) => tmpl.name));
+
+  const unknown: string[] = [];
+  const resourceTemplates: string[] = [];
+  for (const name of requested) {
+    if (tools.has(name)) {
+      continue;
+    }
+    if (templates.has(name)) {
+      resourceTemplates.push(name);
+      continue;
+    }
+    unknown.push(name);
+  }
+  return { unknown, resourceTemplates };
+}
+
+/**
+ * The discovered tool names in discovery order, for error messages that
+ * tell the operator what IS valid.
+ */
+export function toolNames(caps: DiscoveredCapabilities): string[] {
+  return caps.tools.map((tool) => tool.name);
+}
+
+/**
+ * Renders a name list as 'a', 'b', 'c' for error messages — shared so the
+ * agent and mcpserver error texts quote tool names identically.
+ */
+export function quoteJoin(names: readonly string[]): string {
+  return names.map((n) => `'${n}'`).join(", ");
+}

--- a/backend/services/stigmer-server-ts/src/domain/memory/__tests__/memory.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/memory/__tests__/memory.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Pins the memory domain against Go's pkg/domain/memory tests — through
+ * the REAL stack: a composed server on an ephemeral port, a native gRPC
+ * client, and the full interceptor chain.
+ *
+ * The load-bearing pins:
+ *   - create starts the consent lifecycle at proposed with
+ *     state_changed_at set; the subject is forced to the OSS single-user
+ *     sentinel "" (DD-005 D2); provenance is stored as supplied with
+ *     tool_call_id force-cleared (the Stage 3 contract); an unnamed
+ *     create defaults its name from the minted mem_ id; a missing org is
+ *     the exact InvalidArgument copy;
+ *   - enablement fails CLOSED: org switch off is the exact formatted
+ *     FailedPrecondition copy, an unknown org is NotFound;
+ *   - the 100-per-subject-per-org ceiling refuses the 101st record with
+ *     the exact copy and never blocks another org;
+ *   - confirm/reject are one contract with opposite verdicts: idempotent
+ *     re-decisions write NOTHING (no audit bump), cross-decisions are
+ *     refused with the pinned copy;
+ *   - update grafts metadata+spec+status.audit onto the LIVE row: the
+ *     lifecycle survives a content edit by MECHANISM, subject/provenance
+ *     edits are refused with the exact copy, and a client-sent lifecycle
+ *     on update is ignored;
+ *   - delete works from every lifecycle state (the any-state guarantee).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { MemoryCommandController } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/command_pb";
+import { MemoryQueryController } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/query_pb";
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import type { Memory } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { MemoryLifecycleState } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { generateId } from "../../../pipeline/steps/defaults.js";
+import {
+  MAX_MEMORIES_PER_SUBJECT,
+  MEMORY_CONFIRM_REJECTED_MESSAGE,
+  MEMORY_FULL_MESSAGE,
+  MEMORY_PROVENANCE_IMMUTABLE_MESSAGE,
+  MEMORY_REJECT_CONFIRMED_MESSAGE,
+  MEMORY_SUBJECT_IMMUTABLE_MESSAGE,
+  memoryDisabledMessage,
+} from "../constants.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const MEMORY_API_VERSION = "agentic.stigmer.ai/v1";
+const MEMORY_KIND = "Memory";
+const ORG_API_VERSION = "tenancy.stigmer.ai/v1";
+const ORG_KIND = "Organization";
+
+let dir: string;
+let server: ComposedServer;
+let transport: Transport;
+let orgCommand: Client<typeof OrganizationCommandController>;
+let command: Client<typeof MemoryCommandController>;
+let query: Client<typeof MemoryQueryController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "memory-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  orgCommand = createClient(OrganizationCommandController, transport);
+  command = createClient(MemoryCommandController, transport);
+  query = createClient(MemoryQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let orgCounter = 0;
+/**
+ * Provisions an org with the memory switch in the requested position (the
+ * memory conformance suite's pattern). Organization id equals slug — the
+ * tenancy-root addressing rule.
+ */
+async function createOrg(memoryEnabled: boolean): Promise<string> {
+  orgCounter += 1;
+  const org = await orgCommand.create({
+    apiVersion: ORG_API_VERSION,
+    kind: ORG_KIND,
+    metadata: { name: `Memory Test Org ${orgCounter}` },
+    spec: { preferences: { memoryEnabled } },
+  });
+  return org.metadata!.slug;
+}
+
+let memoryCounter = 0;
+async function createMemory(org: string, content?: string): Promise<Memory> {
+  memoryCounter += 1;
+  return command.create({
+    apiVersion: MEMORY_API_VERSION,
+    kind: MEMORY_KIND,
+    metadata: { org },
+    spec: { content: content ?? `Remembered fact ${memoryCounter}.` },
+  });
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+describe("memory create", () => {
+  it("starts proposed with state_changed_at set and server-writes every owned field", async () => {
+    const org = await createOrg(true);
+    // Forge the server-owned fields; all of them must come back
+    // server-written.
+    const created = await command.create({
+      apiVersion: MEMORY_API_VERSION,
+      kind: MEMORY_KIND,
+      metadata: { org },
+      spec: {
+        content: "Deploys to us-east-1.",
+        subjectIdentityAccountId: "ida_forged",
+      },
+      status: {
+        lifecycleState: MemoryLifecycleState.lifecycle_state_confirmed,
+      },
+    });
+
+    expect(created.metadata?.id).toMatch(/^mem_/);
+    expect(created.spec?.content).toBe("Deploys to us-east-1.");
+    expect(created.spec?.subjectIdentityAccountId).toBe("");
+    expect(created.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_proposed,
+    );
+    expect(created.status?.stateChangedAt).toBeDefined();
+  });
+
+  it("stores capture-path provenance with tool_call_id force-cleared", async () => {
+    const org = await createOrg(true);
+    const created = await command.create({
+      apiVersion: MEMORY_API_VERSION,
+      kind: MEMORY_KIND,
+      metadata: { org },
+      spec: {
+        content: "Works primarily in Go.",
+        provenance: {
+          agentId: "agt_1",
+          sessionId: "ses_1",
+          agentExecutionId: "aex_1",
+          toolCallId: "call_invented",
+        },
+      },
+    });
+
+    expect(created.spec?.provenance?.agentId).toBe("agt_1");
+    expect(created.spec?.provenance?.sessionId).toBe("ses_1");
+    expect(created.spec?.provenance?.agentExecutionId).toBe("aex_1");
+    expect(created.spec?.provenance?.toolCallId ?? "").toBe("");
+  });
+
+  it("defaults an unnamed record's name from its own minted mem_ id", async () => {
+    const org = await createOrg(true);
+    const created = await createMemory(org);
+    expect(created.metadata?.id).toMatch(/^mem_/);
+    expect(created.metadata?.name).toBe(created.metadata?.id);
+  });
+
+  it("requires metadata.org with the exact InvalidArgument copy", async () => {
+    const error = await grpcError(() =>
+      command.create({
+        apiVersion: MEMORY_API_VERSION,
+        kind: MEMORY_KIND,
+        metadata: { name: "Orgless Memory" },
+        spec: { content: "A fact without a home." },
+      }),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+    expect(error.rawMessage).toBe("metadata.org is required for a memory");
+  });
+});
+
+describe("memory enablement (fail-closed)", () => {
+  it("refuses a create while the org has memory disabled, with the exact formatted copy", async () => {
+    const org = await createOrg(false);
+    const error = await grpcError(() => createMemory(org));
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(memoryDisabledMessage(org));
+  });
+
+  it("answers NotFound for an unknown org — the check fails closed", async () => {
+    const error = await grpcError(() => createMemory("no-such-org"));
+    expect(error.code).toBe(Code.NotFound);
+    expect(error.rawMessage).toBe("Organization not found: no-such-org");
+  });
+});
+
+describe("memory cap", () => {
+  it("refuses the record past the per-subject ceiling, visibly, without blocking other orgs", async () => {
+    const org = await createOrg(true);
+    const otherOrg = await createOrg(true);
+
+    // Seed the ceiling directly through the store (the RPC path would be
+    // needlessly slow at 100 creates); the refused create goes through
+    // the RPC. Seeded rows carry the sentinel subject "" the create path
+    // would derive.
+    for (let i = 0; i < MAX_MEMORIES_PER_SUBJECT; i++) {
+      const id = generateId("mem");
+      const seeded = create(MemorySchema, {
+        apiVersion: MEMORY_API_VERSION,
+        kind: MEMORY_KIND,
+        metadata: { id, name: id, slug: id, org },
+        spec: { content: `Seeded fact ${i}.`, subjectIdentityAccountId: "" },
+      });
+      await server.store.saveResource(
+        ApiResourceKind.memory,
+        id,
+        MemorySchema,
+        seeded,
+      );
+    }
+
+    const error = await grpcError(() => createMemory(org, "One too many."));
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(MEMORY_FULL_MESSAGE);
+
+    // A different org's subject is not blocked by this org's ceiling.
+    const unblocked = await createMemory(
+      otherOrg,
+      "Different org, plenty of room.",
+    );
+    expect(unblocked.metadata?.id).toMatch(/^mem_/);
+  });
+});
+
+describe("memory confirm/reject", () => {
+  it("confirms a proposal; re-confirm is an idempotent no-op with no audit bump", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+    const id = { value: memory.metadata!.id };
+
+    const confirmed = await command.confirm(id);
+    expect(confirmed.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_confirmed,
+    );
+
+    // Idempotent no-op: same decision timestamp, same audit stamp — the
+    // sentinel abort wrote nothing.
+    const again = await command.confirm(id);
+    expect(again.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_confirmed,
+    );
+    expect(again.status?.stateChangedAt).toEqual(
+      confirmed.status?.stateChangedAt,
+    );
+    expect(again.status?.audit?.statusAudit?.updatedAt).toEqual(
+      confirmed.status?.audit?.statusAudit?.updatedAt,
+    );
+  });
+
+  it("refuses reject-after-confirm with the pinned copy", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+    const id = { value: memory.metadata!.id };
+    await command.confirm(id);
+
+    const error = await grpcError(() => command.reject(id));
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(MEMORY_REJECT_CONFIRMED_MESSAGE);
+  });
+
+  it("rejects a proposal idempotently and refuses confirm-after-reject with the pinned copy", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+    const id = { value: memory.metadata!.id };
+
+    const rejected = await command.reject(id);
+    expect(rejected.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_rejected,
+    );
+
+    const again = await command.reject(id);
+    expect(again.status?.stateChangedAt).toEqual(
+      rejected.status?.stateChangedAt,
+    );
+
+    const error = await grpcError(() => command.confirm(id));
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(MEMORY_CONFIRM_REJECTED_MESSAGE);
+  });
+
+  it("answers NotFound for an unknown id", async () => {
+    const ghost = { value: "mem_00000000000000000000000000" };
+    for (const run of [
+      () => command.confirm(ghost),
+      () => command.reject(ghost),
+    ]) {
+      const error = await grpcError(run);
+      expect(error.code).toBe(Code.NotFound);
+    }
+  });
+});
+
+describe("memory update", () => {
+  function updateInput(
+    memory: Memory,
+    spec: MessageInitShape<typeof MemorySchema>["spec"],
+  ): MessageInitShape<typeof MemorySchema> {
+    return {
+      apiVersion: memory.apiVersion,
+      kind: memory.kind,
+      metadata: memory.metadata,
+      spec,
+    };
+  }
+
+  it("edits content and answers with the LIVE lifecycle — the graft pin", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+    const id = memory.metadata!.id;
+    await command.confirm({ value: id });
+
+    // A wholesale spec replacement editing content only (status wiped, as
+    // generated update mappers send it): the decision must survive by
+    // mechanism, in the response AND the stored row.
+    const updated = await command.update(
+      updateInput(memory, {
+        content: "Deploys to eu-west-1.",
+        subjectIdentityAccountId: memory.spec!.subjectIdentityAccountId,
+        provenance: memory.spec!.provenance,
+      }),
+    );
+    expect(updated.spec?.content).toBe("Deploys to eu-west-1.");
+    expect(updated.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_confirmed,
+    );
+
+    const stored = await query.get({ value: id });
+    expect(stored.spec?.content).toBe("Deploys to eu-west-1.");
+    expect(stored.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_confirmed,
+    );
+  });
+
+  it("refuses a subject change with the pinned copy", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+
+    const error = await grpcError(() =>
+      command.update(
+        updateInput(memory, {
+          content: "x",
+          subjectIdentityAccountId: "ida_someone_else",
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(MEMORY_SUBJECT_IMMUTABLE_MESSAGE);
+  });
+
+  it("refuses a provenance change with the pinned copy", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+
+    const error = await grpcError(() =>
+      command.update(
+        updateInput(memory, {
+          content: "x",
+          subjectIdentityAccountId: memory.spec!.subjectIdentityAccountId,
+          provenance: { agentId: "agt_invented" },
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(MEMORY_PROVENANCE_IMMUTABLE_MESSAGE);
+  });
+
+  it("ignores a client-sent lifecycle on update — consent is not rewritable through a spec edit", async () => {
+    const org = await createOrg(true);
+    const memory = await createMemory(org);
+    const id = memory.metadata!.id;
+    await command.confirm({ value: id });
+
+    const updated = await command.update({
+      apiVersion: memory.apiVersion,
+      kind: memory.kind,
+      metadata: memory.metadata,
+      spec: {
+        content: "Still the subject's fact.",
+        subjectIdentityAccountId: memory.spec!.subjectIdentityAccountId,
+      },
+      status: {
+        lifecycleState: MemoryLifecycleState.lifecycle_state_rejected,
+      },
+    });
+    expect(updated.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_confirmed,
+    );
+
+    const stored = await query.get({ value: id });
+    expect(stored.status?.lifecycleState).toBe(
+      MemoryLifecycleState.lifecycle_state_confirmed,
+    );
+  });
+});
+
+describe("memory delete", () => {
+  it("works from proposed, confirmed, and rejected states — never refused on lifecycle grounds", async () => {
+    const org = await createOrg(true);
+
+    const proposed = await createMemory(org, "Proposed fact.");
+    const confirmed = await createMemory(org, "Confirmed fact.");
+    await command.confirm({ value: confirmed.metadata!.id });
+    const rejected = await createMemory(org, "Rejected fact.");
+    await command.reject({ value: rejected.metadata!.id });
+
+    for (const record of [proposed, confirmed, rejected]) {
+      const id = { value: record.metadata!.id };
+      const deleted = await command.delete(id);
+      expect(deleted.metadata?.id).toBe(record.metadata?.id);
+
+      const error = await grpcError(() => query.get(id));
+      expect(error.code).toBe(Code.NotFound);
+    }
+  });
+});
+
+describe("memory list", () => {
+  it("is org-scoped", async () => {
+    const org = await createOrg(true);
+    const other = await createOrg(true);
+    const mine = await createMemory(org, "First fact.");
+    await createMemory(other, "Another org's fact.");
+
+    const listed = await query.list({ org });
+    expect(listed.totalCount).toBe(listed.items.length);
+    expect(listed.items.map((m) => m.metadata?.id)).toContain(
+      mine.metadata?.id,
+    );
+    for (const item of listed.items) {
+      expect(item.metadata?.org).toBe(org);
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/memory/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/memory/constants.ts
@@ -1,0 +1,60 @@
+/**
+ * Memory domain constants — the byte-pinned cross-edition contract copy,
+ * ported character-for-character from Go
+ * pkg/domain/memory/controller/steps.go. Every string here is pinned by
+ * the conformance suite and mirrored byte-identically by the cloud
+ * edition's handlers; none is editable without an owner-ratified wire
+ * change. Refusals are visible and actionable — never silent eviction
+ * (the ChatGPT Memory-Full pattern, DD-006 D5).
+ */
+
+/**
+ * The per-subject-per-org record ceiling, counted across ALL lifecycle
+ * states — proposed clutter counts, which pressures honest rejection over
+ * letting proposals pile up (DD-006 D5). Go MaxMemoriesPerSubject.
+ */
+export const MAX_MEMORIES_PER_SUBJECT = 100;
+
+/**
+ * Refuses a create once the subject's ceiling is reached — Go
+ * MemoryFullMessage.
+ */
+export const MEMORY_FULL_MESSAGE =
+  "memory is full — review and delete existing memories";
+
+/**
+ * Refuses a create while the organization has not enabled memory — Go
+ * MemoryDisabledMessageFmt, taking the org slug.
+ */
+export function memoryDisabledMessage(org: string): string {
+  return `memory is not enabled for organization ${org} — an organization admin can enable it in organization preferences`;
+}
+
+/**
+ * Refuses confirming a rejected memory: the decision is auditable and
+ * stands; a fresh proposal is the way back. Go
+ * MemoryConfirmRejectedMessage.
+ */
+export const MEMORY_CONFIRM_REJECTED_MESSAGE =
+  "memory was rejected — delete it and let the agent propose it again";
+
+/**
+ * Refuses rejecting a confirmed memory: deletion IS the revocation of a
+ * confirmed fact (DD-006). Go MemoryRejectConfirmedMessage.
+ */
+export const MEMORY_REJECT_CONFIRMED_MESSAGE =
+  "memory was confirmed — delete it to stop it from being recalled";
+
+/**
+ * Refuses an update that changes the subject: an editable subject would
+ * re-aim the record at another person. Go MemorySubjectImmutableMessage.
+ */
+export const MEMORY_SUBJECT_IMMUTABLE_MESSAGE =
+  "spec.subject_identity_account_id is immutable — it is derived from the capturing credential at create";
+
+/**
+ * Refuses an update that changes provenance: attribution that can be
+ * edited is not attribution. Go MemoryProvenanceImmutableMessage.
+ */
+export const MEMORY_PROVENANCE_IMMUTABLE_MESSAGE =
+  "spec.provenance is immutable — it records where the fact came from";

--- a/backend/services/stigmer-server-ts/src/domain/memory/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/memory/controller.ts
@@ -1,0 +1,412 @@
+/**
+ * Memory controller — ports pkg/domain/memory/controller (command + query
+ * sides): agent-proposed, user-confirmed facts the platform remembers
+ * about a person (decisions DD-004/DD-005/DD-006 of the
+ * preferences-and-memory project, stigmer/stigmer#293).
+ *
+ * A memory is system-generated: an agent proposes it (Phase 2 Stage 3's
+ * remember tool calls the create RPC), and it becomes recallable only
+ * after the person it is about confirms it. There is deliberately no
+ * apply RPC — nobody authors a memory manifest. The kind belongs to the
+ * Session/AgentExecution/Artifact family: records the platform creates
+ * that users inspect and manage.
+ *
+ * Field ownership (DD-004, provenance revised by the Stage 3 decision,
+ * owner-ratified 2026-08-22): spec.content is the subject's after capture
+ * (editable via update); spec.subject_identity_account_id is
+ * server-derived at create and immutable forever; spec.provenance is
+ * capture-path-supplied at create (the remember tool threads it; direct
+ * creates leave it empty; tool_call_id force-cleared in v1) and immutable
+ * forever after — attribution that can be edited is not attribution;
+ * status.lifecycle_state is written ONLY by create (initial proposed) and
+ * the confirm/reject commands. Updates graft metadata+spec+status.audit
+ * onto the live row and never touch the lifecycle — consent must not be
+ * rewritable through a spec edit.
+ *
+ * Consent posture (DD-005 D3): confirm/reject enforced at the control
+ * plane is the ENTIRE consent mechanism. Client-side approval flows are
+ * never trusted with retention — three shipped HITL bypasses are the
+ * recorded evidence (see DD-005).
+ *
+ * Caps (DD-006 D5): content length via protovalidate (500 chars); a
+ * 100-records-per-subject-per-org ceiling across ALL lifecycle states
+ * (proposed clutter counts, which pressures honest rejection), enforced
+ * at create with a visible FAILED_PRECONDITION — never silent eviction.
+ *
+ * Authorization posture (OSS): this edition is single-user and local, so
+ * handlers perform no authorization — a documented no-op, not a silent
+ * divergence. The subject is the empty-string sentinel (the OAuth grant
+ * store convention); enablement is the org flag alone (the user scope
+ * collapses — DD-002 D1). The cloud edition derives the subject from the
+ * calling credential, enforces the strict first-party-human gate, checks
+ * both memory_enabled flags, and gates every RPC through FGA (subject-only
+ * can_view/can_edit/can_delete).
+ *
+ * Memory is deliberately NOT search-indexed (privacy — subject-only
+ * content must not surface in org-visible search): no search-extractor,
+ * no IndexSearch/DeleteSearchIndex steps anywhere in this domain.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by memory.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/memory.test.ts.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { MemoryCommandController } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/command_pb";
+import { MemoryQueryController } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/query_pb";
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import type { Memory } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { MemoryLifecycleState } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/enum_pb";
+import { MemoryIdSchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/io_pb";
+import type {
+  ListMemoriesRequest,
+  MemoryId,
+  MemoryList,
+} from "@stigmer/protos/ai/stigmer/agentic/memory/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import {
+  MEMORY_CONFIRM_REJECTED_MESSAGE,
+  MEMORY_REJECT_CONFIRMED_MESSAGE,
+} from "./constants.js";
+import {
+  LIST_RESULT_KEY,
+  newCheckMemoryCapStep,
+  newCheckMemoryEnablementStep,
+  newInitializeMemoryLifecycleStep,
+  newListMemoriesByOrgStep,
+  newPersistMemoryUpdateStep,
+  newResolveMemoryDefaultsStep,
+  newTransitionMemoryLifecycleStep,
+  newValidateMemoryUpdateStep,
+} from "./steps.js";
+
+export interface MemoryControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+/** Registers both memory services on the router (routes stage). */
+export function registerMemoryServices(
+  router: ConnectRouter,
+  deps: MemoryControllerDeps,
+): void {
+  router.service(MemoryCommandController, {
+    create: (memory, ctx) => createMemory(deps, memory, ctx),
+    update: (memory, ctx) => update(deps, memory, ctx),
+    delete: (id, ctx) => deleteMemory(deps, id, ctx),
+    confirm: (id, ctx) => confirm(deps, id, ctx),
+    reject: (id, ctx) => reject(deps, id, ctx),
+  });
+  router.service(MemoryQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline: a new memory in the proposed
+ * state (DD-005 D2). ResolveMemoryDefaults mints the id BEFORE
+ * BuildNewState so an unnamed record can default its name from its own
+ * identity; InitializeMemoryLifecycle runs AFTER BuildNewState so the
+ * status wipe cannot undo it.
+ *
+ * No search-index step: memory is not_search_indexed by design (privacy —
+ * content is subject-only and must not surface in org-visible search).
+ *
+ * Note: Unlike Stigmer Cloud, OSS excludes the strict
+ * first-party-human-operator gate and the caller's own memory_enabled
+ * check (no per-request user identity — the user scope collapses, DD-006
+ * D1) and creates no FGA tuples.
+ */
+async function createMemory(
+  deps: MemoryControllerDeps,
+  memory: Memory,
+  ctx: HandlerContext,
+): Promise<Memory> {
+  const reqCtx = new RequestContext(MemorySchema, memory, kindOf(ctx));
+  await newPipeline<typeof MemorySchema>("memory-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveMemoryDefaultsStep())
+    .addStep(newCheckMemoryEnablementStep(deps.store))
+    .addStep(newCheckMemoryCapStep(deps.store))
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newInitializeMemoryLifecycleStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline: edits the fact text only
+ * (DD-004: the content is the subject's; everything else on the record is
+ * not up for editing). The spec is replaced wholesale (declarative
+ * semantics), but only content may actually change: subject and
+ * provenance are immutable (validate step), and the consent lifecycle is
+ * protected by MECHANISM — PersistMemoryUpdate grafts
+ * metadata+spec+status.audit onto the LIVE row inside one atomic
+ * read-modify-write, so status.lifecycle_state stays exactly as its
+ * owners (create, confirm, reject) last wrote it, even against a
+ * concurrent confirm landing between this pipeline's load and persist.
+ *
+ * Note: Unlike Stigmer Cloud, OSS excludes the authorization step (cloud
+ * requires can_edit on the memory — FGA subject-only).
+ */
+async function update(
+  deps: MemoryControllerDeps,
+  memory: Memory,
+  ctx: HandlerContext,
+): Promise<Memory> {
+  const reqCtx = new RequestContext(MemorySchema, memory, kindOf(ctx));
+  await newPipeline<typeof MemorySchema>("memory-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateMemoryUpdateStep())
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newPersistMemoryUpdateStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Confirm — Go confirm.go: moves a proposed memory to confirmed — the
+ * consent act (DD-005 D3). From the next eligible execution on, the fact
+ * is recalled as background context.
+ *
+ * Confirming an already-confirmed memory is an idempotent no-op.
+ * Confirming a rejected memory is refused with FAILED_PRECONDITION: the
+ * rejection stands as an auditable decision — delete the record and let
+ * the agent propose again.
+ *
+ * This RPC and reject are the ONLY writers of status.lifecycle_state.
+ * Consent is enforced here, at the control plane — never delegated to
+ * client-side approval mechanisms (DD-005 D3 records the three shipped
+ * HITL bypasses that make any client-side gate untrustworthy for
+ * retention).
+ */
+async function confirm(
+  deps: MemoryControllerDeps,
+  memoryId: MemoryId,
+  ctx: HandlerContext,
+): Promise<Memory> {
+  return runTransition(
+    deps,
+    memoryId,
+    ctx,
+    "memory-confirm",
+    MemoryLifecycleState.lifecycle_state_confirmed,
+    MEMORY_CONFIRM_REJECTED_MESSAGE,
+  );
+}
+
+/**
+ * Reject — Go reject.go: moves a proposed memory to rejected. A rejected
+ * memory is never recalled; the record is kept rather than deleted so the
+ * decision is auditable and an identical re-proposal is visible as such
+ * (DD-005).
+ *
+ * Rejecting an already-rejected memory is an idempotent no-op. Rejecting
+ * a confirmed memory is refused with FAILED_PRECONDITION: deleting a
+ * confirmed memory IS its revocation (DD-006) — a reject that pretended
+ * to revoke would leave a misleading audit record.
+ *
+ * Rejection is deliberately one click on every surface — expensive review
+ * teaches users to ignore the proposal queue (DD-005 D4).
+ */
+async function reject(
+  deps: MemoryControllerDeps,
+  memoryId: MemoryId,
+  ctx: HandlerContext,
+): Promise<Memory> {
+  return runTransition(
+    deps,
+    memoryId,
+    ctx,
+    "memory-reject",
+    MemoryLifecycleState.lifecycle_state_rejected,
+    MEMORY_REJECT_CONFIRMED_MESSAGE,
+  );
+}
+
+/**
+ * The shared confirm/reject pipeline — Go buildTransitionPipeline +
+ * runTransition: one contract with opposite verdicts (DD-005 D3),
+ * answering with the post-image row.
+ *
+ * Note: Unlike Stigmer Cloud, OSS excludes the authorization step (cloud
+ * requires can_edit on the memory — FGA subject-only, loading before
+ * authorizing so a missing memory answers NOT_FOUND, #224).
+ */
+async function runTransition(
+  deps: MemoryControllerDeps,
+  memoryId: MemoryId,
+  ctx: HandlerContext,
+  name: string,
+  target: MemoryLifecycleState,
+  blockedMessage: string,
+): Promise<Memory> {
+  const reqCtx = new RequestContext(MemoryIdSchema, memoryId, kindOf(ctx));
+  await newPipeline<typeof MemoryIdSchema>(name, deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, MemorySchema))
+    .addStep(
+      newTransitionMemoryLifecycleStep(deps.store, target, blockedMessage),
+    )
+    .build()
+    .execute(reqCtx);
+
+  const transitioned = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (transitioned === undefined) {
+    throw internalError(
+      new Error("transitioned memory not found in context"),
+      "transitioned memory not found in context",
+    );
+  }
+  return transitioned as Memory;
+}
+
+/**
+ * Delete — Go delete.go: deletes a memory permanently, in ANY lifecycle
+ * state — the any-state guarantee is load-bearing for the trust story:
+ * "delete this one" must never be refused on lifecycle grounds (DD-004).
+ * Deleting a confirmed memory is how consent is revoked; past executions
+ * keep their immutable recalled_memories snapshots (DD-006 D6).
+ *
+ * No search-index cleanup: memory is not_search_indexed.
+ *
+ * Note: Unlike Stigmer Cloud, OSS excludes the authorization step (cloud
+ * requires can_delete on the memory — FGA subject-only).
+ *
+ * The deleted memory is returned for audit trail purposes (gRPC
+ * convention).
+ */
+async function deleteMemory(
+  deps: MemoryControllerDeps,
+  memoryId: MemoryId,
+  ctx: HandlerContext,
+): Promise<Memory> {
+  const reqCtx = new RequestContext(MemoryIdSchema, memoryId, kindOf(ctx));
+  await newPipeline<typeof MemoryIdSchema>("memory-delete", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, MemorySchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted memory not found in context"),
+      "deleted memory not found in context",
+    );
+  }
+  return deleted as Memory;
+}
+
+/**
+ * Get — chain per Go buildGetPipeline (ExtractResourceId → LoadTarget).
+ *
+ * Note: Unlike Stigmer Cloud, OSS excludes the authorization step (cloud
+ * requires can_view — FGA subject-only: only the person a memory is about
+ * can read it).
+ */
+async function get(
+  deps: MemoryControllerDeps,
+  memoryId: MemoryId,
+  ctx: HandlerContext,
+): Promise<Memory> {
+  const reqCtx = new RequestContext(MemoryIdSchema, memoryId, kindOf(ctx));
+  await newPipeline<typeof MemoryIdSchema>("memory-get", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadTargetStep(deps.store, MemorySchema))
+    .build()
+    .execute(reqCtx);
+
+  const target = reqCtx.get(TARGET_RESOURCE_KEY);
+  if (target === undefined) {
+    throw internalError(
+      new Error("target memory not found in context"),
+      "target memory not found in context",
+    );
+  }
+  return target as Memory;
+}
+
+/**
+ * List — Go list.go: memories in an organization, newest first. Ordering
+ * is chronological only; grouping pending proposals first is the
+ * console's presentation concern (DD-005 D4), deliberately not an RPC
+ * parameter at the kind's dozens-of-records scale.
+ *
+ * Note: Unlike Stigmer Cloud, OSS excludes:
+ *   - Authorization filtering (single user — every record is the
+ *     caller's; cloud filters to can_view via FGA, which resolves to the
+ *     subject)
+ *   - Pagination (returns all matching results)
+ */
+async function list(
+  deps: MemoryControllerDeps,
+  req: ListMemoriesRequest,
+  ctx: HandlerContext,
+): Promise<MemoryList> {
+  const reqCtx = new RequestContext(
+    MemoryQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof MemoryQueryController.method.list.input>(
+    "memory-list",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListMemoriesByOrgStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("memory list not found in context"),
+      "memory list not found in context",
+    );
+  }
+  return result as MemoryList;
+}

--- a/backend/services/stigmer-server-ts/src/domain/memory/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/memory/steps.ts
@@ -1,0 +1,547 @@
+/**
+ * Memory domain steps — port pkg/domain/memory/controller/steps.go,
+ * update.go's graft persist, transition.go's atomic decided-state write,
+ * and list.go's org filter.
+ *
+ * The consent doctrine these steps embody (DD-004/DD-005/DD-006): a
+ * memory is agent-proposed and user-confirmed; the server claims every
+ * field it owns at create (subject sentinel, provenance tool_call_id);
+ * updates graft only what the request path owns onto the LIVE row so a
+ * spec edit can never rewrite a consent decision; confirm/reject are the
+ * ONLY writers of status.lifecycle_state.
+ *
+ * Deliberately NO search-extractor and NO index steps anywhere in this
+ * domain: memory is not_search_indexed by design (privacy — content is
+ * subject-only and must not surface in org-visible search).
+ *
+ * Proven by memory.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/memory.test.ts.
+ */
+import { create, equals, fromBinary } from "@bufbuild/protobuf";
+import { timestampNow } from "@bufbuild/protobuf/wkt";
+import type { ConnectError } from "@connectrpc/connect";
+
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import type { Memory } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { MemoryLifecycleState } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/enum_pb";
+import type { MemoryIdSchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/io_pb";
+import type { ListMemoriesRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/io_pb";
+import { MemoryListSchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/io_pb";
+import { MemoryProvenanceSchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/spec_pb";
+import { MemoryStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import {
+  generateId,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
+import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import {
+  MAX_MEMORIES_PER_SUBJECT,
+  MEMORY_FULL_MESSAGE,
+  MEMORY_PROVENANCE_IMMUTABLE_MESSAGE,
+  MEMORY_SUBJECT_IMMUTABLE_MESSAGE,
+  memoryDisabledMessage,
+} from "./constants.js";
+
+/** Context key for the list result — Go listResultKey. */
+export const LIST_RESULT_KEY = "listResult";
+
+/**
+ * ResolveMemoryDefaults — Go resolveMemoryDefaultsStep: prepares a memory
+ * for creation — the server claiming every field it owns, before anything
+ * persists:
+ *
+ *  1. Requires metadata.org — memory records are org-scoped (DD-004), so
+ *     the org can never be inferred.
+ *  2. Mints metadata.id here (not in BuildNewState) when absent, so an
+ *     unnamed record can default its name/slug from its own identity:
+ *     memories are id-addressed records (the remember tool sends content
+ *     only), and the platform's slug machinery requires a name. A
+ *     client-supplied name still wins — the default only fills absence.
+ *  3. Overwrites spec.subject_identity_account_id with the empty-string
+ *     sentinel — the OSS single-user subject (the OAuth grant store
+ *     convention). Server-derived, never client-supplied (DD-005 D2):
+ *     the cloud edition writes the caller's identity account here.
+ *  4. Stores spec.provenance as supplied (Stage 3 provenance decision,
+ *     owner-ratified 2026-08-22): the capture path — the remember tool
+ *     via the runner-synthesized attachment — threads the agent/session/
+ *     execution triple, and in OSS single-user local mode every caller
+ *     IS the trusted local operator, so supplied attribution is stored
+ *     rather than cleared. A direct create simply supplies none and the
+ *     field stays empty. tool_call_id is force-cleared: MCP cannot carry
+ *     the harness's tool-call identity in v1, so a supplied value could
+ *     only be an invention. The cloud edition is stricter — it accepts
+ *     the triple only from a session-sandbox credential and overrides
+ *     session/org with the token's own claims. Post-create the field is
+ *     immutable either way (ValidateMemoryUpdate): attribution that can
+ *     be edited is not attribution.
+ */
+export function newResolveMemoryDefaultsStep(): PipelineStep<
+  typeof MemorySchema
+> {
+  return {
+    name: "ResolveMemoryDefaults",
+    execute(ctx: RequestContext<typeof MemorySchema>): void {
+      const memory = ctx.newState;
+      const metadata = memory.metadata;
+
+      if ((metadata?.org ?? "") === "") {
+        throw invalidArgumentError("metadata.org is required for a memory");
+      }
+      // Narrowing only: a defined org implies defined metadata.
+      if (metadata === undefined) {
+        throw internalError(new Error("metadata is nil"), "metadata is nil");
+      }
+
+      if (metadata.id === "") {
+        metadata.id = generateId("mem");
+      }
+      if (metadata.name === "" && metadata.slug === "") {
+        metadata.name = metadata.id;
+      }
+
+      // Go dereferences spec unconditionally (a nil spec panics into
+      // Internal); the explicit throw keeps the same wire code.
+      const spec = memory.spec;
+      if (spec === undefined) {
+        throw internalError(
+          new Error("memory spec is nil"),
+          "memory spec is nil",
+        );
+      }
+
+      // The subject stays server-owned (DD-005 D2): the OSS sentinel; the
+      // cloud edition derives it from the calling credential.
+      spec.subjectIdentityAccountId = "";
+
+      // Provenance is capture-path-supplied (see the step doc, point 4);
+      // only tool_call_id is force-cleared — unreachable via MCP in v1, so
+      // a supplied value could only be an invention.
+      if (spec.provenance !== undefined) {
+        spec.provenance.toolCallId = "";
+      }
+    },
+  };
+}
+
+/**
+ * CheckMemoryEnablement — Go checkMemoryEnablementStep: enforces the
+ * org's memory_enabled switch at write time, FAIL-CLOSED (DD-005 D2): a
+ * write that cannot verify enablement refuses. This deliberately inverts
+ * the recall compose step's best-effort posture — an execution must start
+ * without its optional preferences, but a memory must never be stored
+ * without verified consent to store it.
+ *
+ * The runner-side remember-tool attachment is convenience, never
+ * authorization: "the label is not authorization; the server refuses"
+ * (the conversation-attachment doctrine, applied verbatim).
+ *
+ * OSS checks the org flag alone — the user scope collapses in single-user
+ * local mode (DD-006 D1). The cloud edition additionally requires the
+ * caller's own memory_enabled and the strict first-party-human gate.
+ *
+ * Reads the Organization row directly from the store, matching Go — no
+ * cross-domain client.
+ */
+export function newCheckMemoryEnablementStep(
+  store: Store,
+): PipelineStep<typeof MemorySchema> {
+  return {
+    name: "CheckMemoryEnablement",
+    async execute(ctx: RequestContext<typeof MemorySchema>): Promise<void> {
+      const orgID = ctx.newState.metadata?.org ?? "";
+
+      let org;
+      try {
+        org = await store.getResource(
+          ApiResourceKind.organization,
+          orgID,
+          OrganizationSchema,
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError("Organization", orgID);
+        }
+        throw internalError(
+          error,
+          "failed to load organization for memory enablement check",
+        );
+      }
+
+      if (org.spec?.preferences?.memoryEnabled !== true) {
+        throw failedPreconditionError(memoryDisabledMessage(orgID));
+      }
+    },
+  };
+}
+
+/**
+ * CheckMemoryCap — Go checkMemoryCapStep: enforces the
+ * per-subject-per-org record ceiling at create (DD-006 D5). Counted
+ * across all lifecycle states. A full-scan count matches the store's
+ * local/OSS posture at the kind's dozens-of-records scale (the schedule
+ * list precedent); the cloud edition counts through an indexed
+ * repository query.
+ */
+export function newCheckMemoryCapStep(
+  store: Store,
+): PipelineStep<typeof MemorySchema> {
+  return {
+    name: "CheckMemoryCap",
+    async execute(ctx: RequestContext<typeof MemorySchema>): Promise<void> {
+      const newState = ctx.newState;
+      const org = newState.metadata?.org ?? "";
+      const subject = newState.spec?.subjectIdentityAccountId ?? "";
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.memory);
+      } catch (error) {
+        throw internalError(error, "failed to count memories for cap check");
+      }
+
+      let count = 0;
+      for (const bytes of rows) {
+        const existing = unmarshalMemory(bytes);
+        if (existing === undefined) {
+          continue;
+        }
+        if ((existing.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        if ((existing.spec?.subjectIdentityAccountId ?? "") !== subject) {
+          continue;
+        }
+        count++;
+      }
+
+      if (count >= MAX_MEMORIES_PER_SUBJECT) {
+        throw failedPreconditionError(MEMORY_FULL_MESSAGE);
+      }
+    },
+  };
+}
+
+/**
+ * InitializeMemoryLifecycle — Go initializeMemoryLifecycleStep: stamps
+ * the initial consent state after BuildNewState wiped client-provided
+ * status: every memory starts proposed (DD-005 D2) — nothing is
+ * recallable until the subject confirms. Runs after BuildNewState so the
+ * wipe cannot undo it and the audit block it set is preserved.
+ */
+export function newInitializeMemoryLifecycleStep(): PipelineStep<
+  typeof MemorySchema
+> {
+  return {
+    name: "InitializeMemoryLifecycle",
+    execute(ctx: RequestContext<typeof MemorySchema>): void {
+      const memory = ctx.newState;
+      if (memory.status === undefined) {
+        memory.status = create(MemoryStatusSchema, {});
+      }
+      memory.status.lifecycleState =
+        MemoryLifecycleState.lifecycle_state_proposed;
+      memory.status.stateChangedAt = timestampNow();
+    },
+  };
+}
+
+/**
+ * ValidateMemoryUpdate — Go validateMemoryUpdateStep: enforces the
+ * memory's immutable identity on update (the Schedule agent_ref pattern):
+ *
+ *   - spec.subject_identity_account_id must not change: an editable
+ *     subject would re-aim the record at another person, silently
+ *     defeating the subject-only visibility model.
+ *   - spec.provenance must not change, byte for byte: provenance is
+ *     attribution, displayed beside the fact everywhere — attribution
+ *     that can be edited is not attribution (DD-004).
+ *
+ * Update replaces the spec wholesale (declarative semantics), so callers
+ * carry the loaded values — the generated toMemoryUpdateInput mapper does
+ * this by construction. metadata.slug/org immutability needs no step
+ * here: the generic BuildUpdateState preserves both. The lifecycle state
+ * is protected by MECHANISM, not validation: PersistMemoryUpdate grafts
+ * only metadata+spec+status.audit onto the live row.
+ *
+ * Runs after LoadExisting so the existing state is available.
+ */
+export function newValidateMemoryUpdateStep(): PipelineStep<
+  typeof MemorySchema
+> {
+  return {
+    name: "ValidateMemoryUpdate",
+    execute(ctx: RequestContext<typeof MemorySchema>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as Memory | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing memory not found in context"),
+          "existing memory not found in context",
+        );
+      }
+      const newState = ctx.newState;
+
+      if (
+        (newState.spec?.subjectIdentityAccountId ?? "") !==
+        (existing.spec?.subjectIdentityAccountId ?? "")
+      ) {
+        throw failedPreconditionError(MEMORY_SUBJECT_IMMUTABLE_MESSAGE);
+      }
+
+      // Go proto.Equal on nils: both nil → equal; one nil (even against an
+      // empty message) → not equal. protobuf-es equals requires two
+      // messages, so the undefined arms branch explicitly.
+      const newProvenance = newState.spec?.provenance;
+      const existingProvenance = existing.spec?.provenance;
+      const provenanceEqual =
+        newProvenance === undefined || existingProvenance === undefined
+          ? newProvenance === existingProvenance
+          : equals(MemoryProvenanceSchema, newProvenance, existingProvenance);
+      if (!provenanceEqual) {
+        throw failedPreconditionError(MEMORY_PROVENANCE_IMMUTABLE_MESSAGE);
+      }
+    },
+  };
+}
+
+/**
+ * PersistMemoryUpdate — Go persistMemoryUpdateStep (update.go): persists
+ * an update as a graft of exactly what the request path owns —
+ * apiVersion/kind/metadata/spec plus the audit bump BuildUpdateState
+ * stamped — onto the LIVE row, inside one store.updateResource closure.
+ * NOT the generic Persist: memory status has other writers
+ * (confirm/reject), and a full-row save of the load-time snapshot could
+ * silently revert a consent decision made between this pipeline's load
+ * and its persist. The schedule domain's persistScheduleUpdateStep is the
+ * direct template (DD-015 D-C shape).
+ *
+ * The graft never resurrects a concurrently deleted row: updateResource
+ * answers not-found, relayed as NOT_FOUND — the delete won, honestly.
+ */
+export function newPersistMemoryUpdateStep(
+  store: Store,
+): PipelineStep<typeof MemorySchema> {
+  return {
+    name: "PersistMemoryUpdate",
+    async execute(ctx: RequestContext<typeof MemorySchema>): Promise<void> {
+      const newState = ctx.newState;
+      const memoryId = newState.metadata?.id ?? "";
+
+      let live: Memory;
+      try {
+        live = await store.updateResource(
+          ApiResourceKind.memory,
+          memoryId,
+          MemorySchema,
+          (row) => {
+            row.apiVersion = newState.apiVersion;
+            row.kind = newState.kind;
+            row.metadata = newState.metadata;
+            row.spec = newState.spec;
+            // The one status subtree the request path owns: its own audit
+            // bump. The lifecycle leaves stay exactly as their owners
+            // (create/confirm/reject) last wrote them.
+            if (newState.status?.audit !== undefined) {
+              if (row.status === undefined) {
+                row.status = create(MemoryStatusSchema, {});
+              }
+              row.status.audit = newState.status.audit;
+            }
+          },
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError("Memory", memoryId);
+        }
+        throw internalError(error, "failed to persist memory update");
+      }
+
+      // Answer with the persisted post-image: the new spec plus the LIVE
+      // status — honest about any consent decision that landed mid-request.
+      ctx.setNewState(live);
+    },
+  };
+}
+
+/**
+ * TransitionMemoryLifecycle — Go transitionMemoryLifecycleStep: moves a
+ * memory's consent lifecycle to a target decided state in ONE
+ * store.updateResource closure on the freshly-read row — confirm and
+ * reject share this step because they are one contract with opposite
+ * verdicts (DD-005 D3).
+ *
+ * Transition matrix (see MemoryLifecycleState's doc):
+ *   - proposed (or unspecified, defensively) → target: written, with
+ *     state_changed_at and a StatusAudit bump.
+ *   - already the target → idempotent success, no write, no audit bump
+ *     (Go aborts the write by returning a sentinel error from the
+ *     closure; here the sentinel throw rolls the transaction back — the
+ *     same no-write property).
+ *   - the OPPOSITE decided state → FAILED_PRECONDITION with the
+ *     cross-edition copy: decisions do not flip — deletion is the way out
+ *     of confirmed (revocation) and out of rejected (making room for a
+ *     fresh proposal).
+ *
+ * The atomic closure is adopted from schedule's clearSchedulePauseStep:
+ * memory has no concurrent status writer yet in Stage 1, but Stage 2's
+ * recall reads and any future writer get the discipline for free, and a
+ * concurrent delete is already answered honestly (NOT_FOUND — the delete
+ * won).
+ *
+ * Answers with the post-image row: EXISTING_RESOURCE_KEY is set to the
+ * live row on both the transitioned and idempotent paths.
+ */
+export function newTransitionMemoryLifecycleStep(
+  store: Store,
+  target: MemoryLifecycleState,
+  blockedMessage: string,
+): PipelineStep<typeof MemoryIdSchema> {
+  return {
+    name: "TransitionMemoryLifecycle",
+    async execute(ctx: RequestContext<typeof MemoryIdSchema>): Promise<void> {
+      const loaded = ctx.get(EXISTING_RESOURCE_KEY) as Memory;
+      const memoryId = loaded.metadata?.id ?? "";
+
+      // Aborts the atomic write on the idempotent path — the record is
+      // already in the target state, so nothing is written and no audit
+      // bumps (Go errTransitionNoOp).
+      const transitionNoOp = new Error("memory already in target state");
+      let blocked: ConnectError | undefined;
+      let live: Memory | undefined;
+      try {
+        live = await store.updateResource(
+          ApiResourceKind.memory,
+          memoryId,
+          MemorySchema,
+          (row) => {
+            // Capture the freshly-read row so the idempotent abort still
+            // answers with the untouched post-image.
+            live = row;
+            const current =
+              row.status?.lifecycleState ??
+              MemoryLifecycleState.lifecycle_state_unspecified;
+            if (current === target) {
+              throw transitionNoOp;
+            }
+            if (
+              current !== MemoryLifecycleState.lifecycle_state_proposed &&
+              current !== MemoryLifecycleState.lifecycle_state_unspecified
+            ) {
+              // The opposite decided state: refuse without writing.
+              blocked = failedPreconditionError(blockedMessage);
+              throw blocked;
+            }
+            if (row.status === undefined) {
+              row.status = create(MemoryStatusSchema, {});
+            }
+            row.status.lifecycleState = target;
+            row.status.stateChangedAt = timestampNow();
+            setAuditFieldsForUpdate(MemorySchema, row, "status_audit");
+          },
+        );
+      } catch (error) {
+        if (error !== transitionNoOp) {
+          if (blocked !== undefined && error === blocked) {
+            throw blocked;
+          }
+          if (error instanceof ResourceNotFoundError) {
+            // Deleted between load and transition: the delete won.
+            throw notFoundError("Memory", memoryId);
+          }
+          throw internalError(error, "failed to transition memory lifecycle");
+        }
+      }
+      if (live === undefined) {
+        // Unreachable: every surviving path assigned the freshly-read row.
+        throw internalError(
+          new Error("transition closure did not observe the row"),
+          "failed to transition memory lifecycle",
+        );
+      }
+
+      // live holds the post-image (transitioned, or the untouched row on
+      // the idempotent path) — the honest response either way.
+      ctx.set(EXISTING_RESOURCE_KEY, live);
+    },
+  };
+}
+
+/**
+ * ListMemoriesByOrg — Go listMemoriesByOrgStep (list.go): loads all
+ * memories and filters by org, sorted by created_at descending (newest
+ * first) — the schedule list posture. Ordering is chronological only;
+ * grouping pending proposals first is the console's presentation concern
+ * (DD-005 D4), deliberately not an RPC parameter at the kind's
+ * dozens-of-records scale.
+ */
+export function newListMemoriesByOrgStep(
+  store: Store,
+): PipelineStep<typeof ListMemoriesRequestSchema> {
+  return {
+    name: "ListMemoriesByOrg",
+    async execute(
+      ctx: RequestContext<typeof ListMemoriesRequestSchema>,
+    ): Promise<void> {
+      const org = ctx.input.org;
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.memory);
+      } catch (error) {
+        throw internalError(error, "failed to list memories");
+      }
+
+      const memories: Memory[] = [];
+      for (const bytes of rows) {
+        const memory = unmarshalMemory(bytes);
+        if (memory === undefined) {
+          continue;
+        }
+        if ((memory.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        memories.push(memory);
+      }
+
+      memories.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(MemoryListSchema, {
+          totalCount: memories.length,
+          items: memories,
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * Decodes a stored memory, skipping invalid entries (should not happen in
+ * normal operation) — Go unmarshalMemory.
+ */
+function unmarshalMemory(data: Uint8Array): Memory | undefined {
+  try {
+    return fromBinary(MemorySchema, data);
+  } catch {
+    return undefined;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/session/__tests__/session.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/__tests__/session.test.ts
@@ -1,0 +1,769 @@
+/**
+ * Pins the session domain against Go's pkg/domain/session tests — through
+ * the REAL stack: a composed server on an ephemeral port, a native gRPC
+ * client, the full interceptor chain, and the DD-002 in-process
+ * agentinstance CREATE edge (session create's default-instance self-heal
+ * runs through the router transport).
+ *
+ * The load-bearing pins:
+ *   - ResolveDefaultAgentInstance fills the session's agent_instance_id
+ *     from the platform default agent (newState, not input — the persisted
+ *     session carries it); the on-the-fly default-instance creation path
+ *     writes the agent's status.default_instance_id; the not-configured /
+ *     not-public arms carry Go WrapError's exact double-wrapped copy;
+ *   - harness immutability locks only once harness_state_id is non-empty,
+ *     with UNSPECIFIED==NATIVE equivalence in both directions and the
+ *     exact FAILED_PRECONDITION copy;
+ *   - execution-target immutability resolves UNSPECIFIED through the
+ *     deployment default on BOTH sides (oss#397) — a no-op round-trip
+ *     passes on a local-default config, a real change is refused with the
+ *     exact copy (Go enum value names + the config string), and a
+ *     cloud-default config flips which transitions count as changes;
+ *   - harness_state_id_history is server-owned: appended on replace, never
+ *     duplicated, client-sent values discarded;
+ *   - updateSubject is a field-level RMW that stamps ONLY the spec_audit
+ *     slot (#540) and leaves the status slot untouched;
+ *   - delete is refused while any of the four active execution phases
+ *     exists (exact count copy), terminal phases don't block, and the
+ *     cascade removes exactly the session's own executions.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { SessionCommandController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/command_pb";
+import { SessionQueryController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/query_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type { SessionSpec } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import {
+  ExecutionTarget,
+  Harness,
+} from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { EXISTING_RESOURCE_KEY } from "../../../pipeline/steps/load-existing.js";
+import { ResourceNotFoundError } from "../../../store/interface.js";
+import {
+  AgentExecutionTemporalConfig,
+  DEFAULT_EXECUTION_TARGET_CLOUD,
+  DEFAULT_EXECUTION_TARGET_LOCAL,
+  ROUTING_GLOBAL,
+  newConfigFromEnv,
+} from "../../agentexecution/temporal/config.js";
+import {
+  DEFAULT_AGENT_LABEL,
+  DEFAULT_AGENT_LABEL_VALUE,
+} from "../../agent/defaultagent.js";
+import { newValidateExecutionTargetImmutabilityStep } from "../steps.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "acme";
+
+const HARNESS_IMMUTABILITY_REFUSAL =
+  "session harness cannot be changed after the first execution — each harness owns its conversation state independently";
+
+let dir: string;
+let server: ComposedServer;
+let transport: Transport;
+let agentCommand: Client<typeof AgentCommandController>;
+let instanceQuery: Client<typeof AgentInstanceQueryController>;
+let command: Client<typeof SessionCommandController>;
+let query: Client<typeof SessionQueryController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "session-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  agentCommand = createClient(AgentCommandController, transport);
+  instanceQuery = createClient(AgentInstanceQueryController, transport);
+  command = createClient(SessionCommandController, transport);
+  query = createClient(SessionQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function createAgent(name: string) {
+  return agentCommand.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org: ORG },
+    spec: {
+      instructions: "You are a helpful agent used by the session tests.",
+    },
+  });
+}
+
+/**
+ * Stamps the default-agent label (and optionally visibility_public)
+ * directly on the stored agent row — the reserved stigmer.ai/* label is
+ * operator-seeded state, not something the OSS write path guards, and the
+ * direct write keeps the test independent of create-time visibility rules.
+ */
+async function markDefaultAgent(
+  agentId: string,
+  opts: { public: boolean },
+): Promise<void> {
+  const stored = await server.store.getResource(
+    ApiResourceKind.agent,
+    agentId,
+    AgentSchema,
+  );
+  stored.metadata!.labels[DEFAULT_AGENT_LABEL] = DEFAULT_AGENT_LABEL_VALUE;
+  if (opts.public) {
+    stored.metadata!.visibility = ApiResourceVisibility.visibility_public;
+  }
+  await server.store.saveResource(
+    ApiResourceKind.agent,
+    agentId,
+    AgentSchema,
+    stored,
+  );
+}
+
+let sessionCounter = 0;
+async function createSession(
+  spec: Partial<Omit<SessionSpec, "$typeName">> = {},
+): Promise<Session> {
+  sessionCounter += 1;
+  return command.create({
+    apiVersion: API_VERSION,
+    kind: "Session",
+    metadata: { name: `Session ${sessionCounter}`, org: ORG },
+    spec,
+  });
+}
+
+function updateInput(
+  session: Session,
+  spec: Partial<Omit<SessionSpec, "$typeName">>,
+) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "Session",
+    metadata: {
+      id: session.metadata!.id,
+      name: session.metadata!.name,
+      slug: session.metadata!.slug,
+      org: session.metadata!.org,
+    },
+    spec,
+  };
+}
+
+/** Simulates a completed first execution: sets the immutability sentinel. */
+async function markSessionUsed(
+  sessionId: string,
+  harnessStateId: string,
+): Promise<void> {
+  const stored = await server.store.getResource(
+    ApiResourceKind.session,
+    sessionId,
+    SessionSchema,
+  );
+  stored.spec!.harnessStateId = harnessStateId;
+  await server.store.saveResource(
+    ApiResourceKind.session,
+    sessionId,
+    SessionSchema,
+    stored,
+  );
+}
+
+let executionCounter = 0;
+async function seedExecution(
+  sessionId: string,
+  phase: ExecutionPhase,
+): Promise<string> {
+  executionCounter += 1;
+  const id = `aex_sessiontest_${executionCounter}`;
+  const execution = create(AgentExecutionSchema, {
+    apiVersion: API_VERSION,
+    kind: "AgentExecution",
+    metadata: { id, name: `Execution ${executionCounter}`, org: ORG },
+    spec: { sessionId },
+    status: { phase },
+  });
+  await server.store.saveResource(
+    ApiResourceKind.agent_execution,
+    id,
+    AgentExecutionSchema,
+    execution,
+  );
+  return id;
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// The resolve tests run FIRST: the not-configured arm requires that no
+// agent carries the default-agent label yet, and later tests only create
+// unlabeled agents (or clean their labeled ones up).
+describe("session create — ResolveDefaultAgentInstance", () => {
+  it("rejects a create with no default agent configured (exact NotFound copy, Go's double wrap)", async () => {
+    const error = await grpcError(() => createSession({}));
+    expect(error.code).toBe(Code.NotFound);
+    expect(error.rawMessage).toBe(
+      "No default agent available. Ensure an agent with label " +
+        "stigmer.ai/default-agent=true and visibility_public exists: " +
+        "no default agent available on this platform: " +
+        "no agent labeled stigmer.ai/default-agent=true",
+    );
+  });
+
+  it("rejects when the labeled default agent is not visibility_public (exact FailedPrecondition copy)", async () => {
+    const agent = await createAgent("Non Public Default Agent");
+    await markDefaultAgent(agent.metadata!.id, { public: false });
+    try {
+      const error = await grpcError(() => createSession({}));
+      expect(error.code).toBe(Code.FailedPrecondition);
+      expect(error.rawMessage).toBe(
+        "Default agent exists but is not visibility_public: " +
+          "agents labeled stigmer.ai/default-agent=true exist but none is visibility_public",
+      );
+    } finally {
+      await agentCommand.delete({ value: agent.metadata!.id });
+    }
+  });
+
+  it("fills the persisted session's agent_instance_id from the default agent's existing default instance", async () => {
+    const agent = await createAgent("Configured Default Agent");
+    const defaultInstanceId = agent.status!.defaultInstanceId;
+    expect(defaultInstanceId).not.toBe("");
+    await markDefaultAgent(agent.metadata!.id, { public: true });
+    try {
+      const session = await createSession({});
+      // The resolve step wrote newState.spec (the clone Persist saves) —
+      // the id survives the round trip to storage.
+      expect(session.spec?.agentInstanceId).toBe(defaultInstanceId);
+      const fetched = await query.get({ value: session.metadata!.id });
+      expect(fetched.spec?.agentInstanceId).toBe(defaultInstanceId);
+      await command.delete({ value: session.metadata!.id });
+    } finally {
+      await agentCommand.delete({ value: agent.metadata!.id });
+    }
+  });
+
+  it("creates the default instance on the fly and writes the agent's status.default_instance_id", async () => {
+    // Seeded directly: a labeled public agent with NO default instance —
+    // the legacy shape the self-heal path exists for.
+    const agentId = "agt_sessiontest_selfheal";
+    const seeded = create(AgentSchema, {
+      apiVersion: API_VERSION,
+      kind: "Agent",
+      metadata: {
+        id: agentId,
+        name: "Self Heal Default Agent",
+        slug: "self-heal-default-agent",
+        org: ORG,
+        visibility: ApiResourceVisibility.visibility_public,
+        labels: { [DEFAULT_AGENT_LABEL]: DEFAULT_AGENT_LABEL_VALUE },
+      },
+      spec: { instructions: "seeded for the self-heal path" },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent,
+      agentId,
+      AgentSchema,
+      seeded,
+    );
+    try {
+      const session = await createSession({});
+      const resolvedId = session.spec?.agentInstanceId ?? "";
+      expect(resolvedId).not.toBe("");
+
+      // The created instance is real (rode the in-process CREATE edge and
+      // its full pipeline) and follows the defaultinstance factory shape.
+      const instance = await instanceQuery.get({ value: resolvedId });
+      expect(instance.spec?.agentId).toBe(agentId);
+      expect(instance.metadata?.slug).toBe("self-heal-default-agent-default");
+
+      // The agent's server-owned pointer was persisted (explicit agent
+      // kind — the pipeline's own ctx kind is session).
+      const storedAgent = await server.store.getResource(
+        ApiResourceKind.agent,
+        agentId,
+        AgentSchema,
+      );
+      expect(storedAgent.status?.defaultInstanceId).toBe(resolvedId);
+
+      await command.delete({ value: session.metadata!.id });
+    } finally {
+      await agentCommand.delete({ value: agentId });
+    }
+  });
+
+  it("is a no-op when agent_instance_id is provided (no default agent needed)", async () => {
+    // No labeled agent exists at this point; an explicit id must not
+    // trigger resolution.
+    const session = await createSession({ agentInstanceId: "ain_explicit" });
+    expect(session.spec?.agentInstanceId).toBe("ain_explicit");
+    await command.delete({ value: session.metadata!.id });
+  });
+});
+
+describe("session update — harness immutability", () => {
+  it("allows a harness change while harness_state_id is empty (session not yet used)", async () => {
+    const session = await createSession({
+      agentInstanceId: "ain_h1",
+      harness: Harness.NATIVE,
+    });
+
+    const updated = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_h1",
+        harness: Harness.CURSOR,
+      }),
+    );
+    expect(updated.spec?.harness).toBe(Harness.CURSOR);
+  });
+
+  it("rejects a harness change after the first execution with the exact copy", async () => {
+    const session = await createSession({
+      agentInstanceId: "ain_h2",
+      harness: Harness.NATIVE,
+    });
+    await markSessionUsed(session.metadata!.id, "thread-1");
+
+    const error = await grpcError(() =>
+      command.update(
+        updateInput(session, {
+          agentInstanceId: "ain_h2",
+          harness: Harness.CURSOR,
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(HARNESS_IMMUTABILITY_REFUSAL);
+  });
+
+  it("treats UNSPECIFIED as NATIVE: existing NATIVE + input UNSPECIFIED passes", async () => {
+    const session = await createSession({
+      agentInstanceId: "ain_h3",
+      harness: Harness.NATIVE,
+    });
+    await markSessionUsed(session.metadata!.id, "thread-3");
+
+    const updated = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_h3",
+        subject: "still native",
+      }),
+    );
+    expect(updated.spec?.subject).toBe("still native");
+  });
+
+  it("treats UNSPECIFIED as NATIVE: existing UNSPECIFIED + input NATIVE passes; CURSOR is refused", async () => {
+    const session = await createSession({ agentInstanceId: "ain_h4" });
+    await markSessionUsed(session.metadata!.id, "thread-4");
+
+    const updated = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_h4",
+        harness: Harness.NATIVE,
+      }),
+    );
+    expect(updated.spec?.harness).toBe(Harness.NATIVE);
+
+    // Re-arm the sentinel (the passing update replaced the spec).
+    await markSessionUsed(session.metadata!.id, "thread-4");
+    const error = await grpcError(() =>
+      command.update(
+        updateInput(session, {
+          agentInstanceId: "ain_h4",
+          harness: Harness.CURSOR,
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(HARNESS_IMMUTABILITY_REFUSAL);
+  });
+});
+
+describe("session update — execution-target immutability (oss#397)", () => {
+  it("passes an unset→unset round-trip on the local-default deployment (both resolve LOCAL)", async () => {
+    const session = await createSession({ agentInstanceId: "ain_t1" });
+    await markSessionUsed(session.metadata!.id, "thread-t1");
+
+    const updated = await command.update(
+      updateInput(session, { agentInstanceId: "ain_t1", subject: "no move" }),
+    );
+    expect(updated.spec?.subject).toBe("no move");
+  });
+
+  it("passes unset→LOCAL on the local-default deployment (no dispatch change)", async () => {
+    const session = await createSession({ agentInstanceId: "ain_t2" });
+    await markSessionUsed(session.metadata!.id, "thread-t2");
+
+    const updated = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_t2",
+        executionTarget: ExecutionTarget.LOCAL,
+      }),
+    );
+    expect(updated.spec?.executionTarget).toBe(ExecutionTarget.LOCAL);
+  });
+
+  it("refuses unset→CLOUD with the exact copy (Go enum names + the config default string)", async () => {
+    const session = await createSession({ agentInstanceId: "ain_t3" });
+    await markSessionUsed(session.metadata!.id, "thread-t3");
+
+    const error = await grpcError(() =>
+      command.update(
+        updateInput(session, {
+          agentInstanceId: "ain_t3",
+          executionTarget: ExecutionTarget.CLOUD,
+        }),
+      ),
+    );
+    expect(error.code).toBe(Code.FailedPrecondition);
+    expect(error.rawMessage).toBe(
+      "session execution_target cannot be changed after the first execution " +
+        "(EXECUTION_TARGET_LOCAL → EXECUTION_TARGET_CLOUD; unset resolves to the " +
+        "deployment default, local) — workspace state may not be portable " +
+        "between local and cloud environments",
+    );
+  });
+
+  it("resolves through a cloud-default config: unset==CLOUD passes, LOCAL is refused (step-level)", () => {
+    const cloudConfig = new AgentExecutionTemporalConfig(
+      "agent_execution_stigmer",
+      "stigmer_runner",
+      ROUTING_GLOBAL,
+      DEFAULT_EXECUTION_TARGET_CLOUD,
+    );
+    const step = newValidateExecutionTargetImmutabilityStep(cloudConfig);
+
+    const existing = create(SessionSchema, {
+      spec: {
+        harnessStateId: "thread-x",
+        executionTarget: ExecutionTarget.UNSPECIFIED,
+      },
+    });
+
+    // unset existing + explicit CLOUD input: both resolve CLOUD — passes.
+    const passCtx = new RequestContext(
+      SessionSchema,
+      create(SessionSchema, {
+        spec: { executionTarget: ExecutionTarget.CLOUD },
+      }),
+      ApiResourceKind.session,
+    );
+    passCtx.set(EXISTING_RESOURCE_KEY, existing);
+    expect(() => step.execute(passCtx)).not.toThrow();
+
+    // unset existing + LOCAL input: CLOUD → LOCAL is a real move — refused,
+    // with the cloud default string in the copy.
+    const failCtx = new RequestContext(
+      SessionSchema,
+      create(SessionSchema, {
+        spec: { executionTarget: ExecutionTarget.LOCAL },
+      }),
+      ApiResourceKind.session,
+    );
+    failCtx.set(EXISTING_RESOURCE_KEY, existing);
+    let thrown: unknown;
+    try {
+      step.execute(failCtx);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConnectError);
+    expect((thrown as ConnectError).code).toBe(Code.FailedPrecondition);
+    expect((thrown as ConnectError).rawMessage).toBe(
+      "session execution_target cannot be changed after the first execution " +
+        "(EXECUTION_TARGET_CLOUD → EXECUTION_TARGET_LOCAL; unset resolves to the " +
+        "deployment default, cloud) — workspace state may not be portable " +
+        "between local and cloud environments",
+    );
+  });
+
+  it("newConfigFromEnv defaults resolve UNSPECIFIED to LOCAL and pass explicit values through", () => {
+    const config = newConfigFromEnv();
+    expect(config.defaultExecutionTarget).toBe(DEFAULT_EXECUTION_TARGET_LOCAL);
+    expect(config.resolveExecutionTarget(ExecutionTarget.UNSPECIFIED)).toBe(
+      ExecutionTarget.LOCAL,
+    );
+    expect(config.resolveExecutionTarget(ExecutionTarget.CLOUD)).toBe(
+      ExecutionTarget.CLOUD,
+    );
+  });
+});
+
+describe("session update — server-owned harness_state_id_history", () => {
+  it("appends the replaced id, never duplicates, and discards client-sent history", async () => {
+    const session = await createSession({ agentInstanceId: "ain_hist" });
+    await markSessionUsed(session.metadata!.id, "hs-1");
+
+    // Replace hs-1 with hs-2: the replaced id lands in the history.
+    const first = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_hist",
+        harnessStateId: "hs-2",
+      }),
+    );
+    expect(first.spec?.harnessStateId).toBe("hs-2");
+    expect(first.spec?.harnessStateIdHistory).toEqual(["hs-1"]);
+
+    // Same id again, with client-forged history: no duplicate append and
+    // the forged entry is discarded (server-owned field).
+    const second = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_hist",
+        harnessStateId: "hs-2",
+        harnessStateIdHistory: ["client-forged"],
+      }),
+    );
+    expect(second.spec?.harnessStateId).toBe("hs-2");
+    expect(second.spec?.harnessStateIdHistory).toEqual(["hs-1"]);
+
+    // A second replacement appends behind the first.
+    const third = await command.update(
+      updateInput(session, {
+        agentInstanceId: "ain_hist",
+        harnessStateId: "hs-3",
+      }),
+    );
+    expect(third.spec?.harnessStateIdHistory).toEqual(["hs-1", "hs-2"]);
+
+    // The persisted row agrees with the wire answer.
+    const fetched = await query.get({ value: session.metadata!.id });
+    expect(fetched.spec?.harnessStateIdHistory).toEqual(["hs-1", "hs-2"]);
+  });
+});
+
+describe("session updateSubject — field-level RMW (#540 spec_audit slot)", () => {
+  it("updates only the subject, stamps spec_audit, and leaves status_audit untouched", async () => {
+    const session = await createSession({
+      agentInstanceId: "ain_subj",
+      subject: "original",
+      harness: Harness.NATIVE,
+    });
+    const statusAuditBefore = session.status!.audit!.statusAudit!;
+
+    const updated = await command.updateSubject({
+      id: session.metadata!.id,
+      subject: "renamed thread",
+    });
+
+    expect(updated.spec?.subject).toBe("renamed thread");
+    // Every other spec field survives the RMW.
+    expect(updated.spec?.agentInstanceId).toBe("ain_subj");
+    expect(updated.spec?.harness).toBe(Harness.NATIVE);
+
+    // The SPEC slot took the update stamp...
+    expect(updated.status?.audit?.specAudit?.event).toBe("updated");
+    // ...and the STATUS slot is byte-identical to before (not rewritten).
+    const statusAuditAfter = updated.status?.audit?.statusAudit;
+    expect(statusAuditAfter?.event).toBe("created");
+    expect(statusAuditAfter?.updatedAt?.seconds).toBe(
+      statusAuditBefore.updatedAt?.seconds,
+    );
+    expect(statusAuditAfter?.updatedAt?.nanos).toBe(
+      statusAuditBefore.updatedAt?.nanos,
+    );
+  });
+
+  it("returns NotFound for an unknown session id", async () => {
+    const error = await grpcError(() =>
+      command.updateSubject({ id: "ses_doesnotexist", subject: "anything" }),
+    );
+    expect(error.code).toBe(Code.NotFound);
+    expect(error.rawMessage).toBe("session not found: ses_doesnotexist");
+  });
+});
+
+describe("session delete — active-execution guard and cascade", () => {
+  const activePhases: ReadonlyArray<[string, ExecutionPhase]> = [
+    ["EXECUTION_PENDING", ExecutionPhase.EXECUTION_PENDING],
+    ["EXECUTION_IN_PROGRESS", ExecutionPhase.EXECUTION_IN_PROGRESS],
+    [
+      "EXECUTION_WAITING_FOR_APPROVAL",
+      ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+    ],
+    ["EXECUTION_PAUSED", ExecutionPhase.EXECUTION_PAUSED],
+  ];
+
+  for (const [name, phase] of activePhases) {
+    it(`blocks delete while an execution is ${name} (exact count copy)`, async () => {
+      const session = await createSession({ agentInstanceId: "ain_guard" });
+      const executionId = await seedExecution(session.metadata!.id, phase);
+
+      const error = await grpcError(() =>
+        command.delete({ value: session.metadata!.id }),
+      );
+      expect(error.code).toBe(Code.FailedPrecondition);
+      expect(error.rawMessage).toBe(
+        "session has 1 active execution(s); cancel them or wait for completion before deleting",
+      );
+
+      // The refused delete left everything in place.
+      await expect(
+        query.get({ value: session.metadata!.id }),
+      ).resolves.toBeDefined();
+
+      // Unblock and converge: the retried delete succeeds and cascades.
+      await server.store.deleteResource(
+        ApiResourceKind.agent_execution,
+        executionId,
+      );
+      await command.delete({ value: session.metadata!.id });
+    });
+  }
+
+  it("terminal executions don't block; the cascade removes exactly the session's own executions", async () => {
+    const doomed = await createSession({ agentInstanceId: "ain_cascade" });
+    const survivor = await createSession({ agentInstanceId: "ain_cascade" });
+
+    const completedId = await seedExecution(
+      doomed.metadata!.id,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    );
+    const failedId = await seedExecution(
+      doomed.metadata!.id,
+      ExecutionPhase.EXECUTION_FAILED,
+    );
+    const survivorExecutionId = await seedExecution(
+      survivor.metadata!.id,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    );
+
+    const deleted = await command.delete({ value: doomed.metadata!.id });
+    expect(deleted.metadata?.id).toBe(doomed.metadata?.id);
+
+    // The doomed session's executions are gone (children before parent)...
+    await expect(
+      server.store.getResource(
+        ApiResourceKind.agent_execution,
+        completedId,
+        AgentExecutionSchema,
+      ),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+    await expect(
+      server.store.getResource(
+        ApiResourceKind.agent_execution,
+        failedId,
+        AgentExecutionSchema,
+      ),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+
+    // ...while the other session's execution is untouched.
+    const untouched = await server.store.getResource(
+      ApiResourceKind.agent_execution,
+      survivorExecutionId,
+      AgentExecutionSchema,
+    );
+    expect(untouched.spec?.sessionId).toBe(survivor.metadata?.id);
+
+    await command.delete({ value: survivor.metadata!.id });
+  });
+});
+
+describe("session create — CreateAsSystem failure wire contract (oss#852)", () => {
+  it("answers the inner code with Go's %w-wrapped transport-formatted message", async () => {
+    // A labeled public default agent with NO status.default_instance_id
+    // (the self-heal shape) whose deterministic default-instance slug is
+    // already occupied: the in-process CreateAsSystem hits CheckDuplicate's
+    // AlreadyExists. Go wraps that error with fmt.Errorf("%w"), so the
+    // wire message embeds grpc-go's `rpc error: code = X desc = ...`
+    // rendering of the inner error — the leak filed as stigmer/stigmer#852,
+    // mirrored byte-for-byte until the both-editions post-cutover fix.
+    const agentId = "agt_wrap_session";
+    const seeded = create(AgentSchema, {
+      apiVersion: API_VERSION,
+      kind: "Agent",
+      metadata: {
+        id: agentId,
+        name: "Wrap Mirror Default Agent",
+        slug: "wrap-mirror-default-agent",
+        org: ORG,
+        visibility: ApiResourceVisibility.visibility_public,
+        labels: { [DEFAULT_AGENT_LABEL]: DEFAULT_AGENT_LABEL_VALUE },
+      },
+      spec: { instructions: "seeded for the wrapped-error mirror test" },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent,
+      agentId,
+      AgentSchema,
+      seeded,
+    );
+    const occupier = create(AgentInstanceSchema, {
+      apiVersion: API_VERSION,
+      kind: "AgentInstance",
+      metadata: {
+        id: "ain_wrap_occupied",
+        name: "wrap-mirror-default-agent-default",
+        slug: "wrap-mirror-default-agent-default",
+        org: ORG,
+      },
+      spec: { agentId },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_instance,
+      "ain_wrap_occupied",
+      AgentInstanceSchema,
+      occupier,
+    );
+
+    try {
+      const error = await grpcError(() => createSession({}));
+      expect(error.code).toBe(Code.AlreadyExists);
+      expect(error.rawMessage).toBe(
+        "failed to create default instance for default agent: rpc error: " +
+          "code = AlreadyExists desc = AgentInstance already exists: slug " +
+          "'wrap-mirror-default-agent-default' in org 'acme' " +
+          "(id: ain_wrap_occupied)",
+      );
+    } finally {
+      // The cascade sweeps the occupying instance (spec.agent_id match)
+      // and removes the default-agent label with the agent.
+      await agentCommand.delete({ value: agentId });
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/controller.ts
@@ -1,0 +1,442 @@
+/**
+ * Session controller — ports pkg/domain/session/controller (command +
+ * query sides): the runtime conversation thread that runs against an
+ * AgentInstance. Create resolves the platform default agent instance when
+ * none is provided (the session-first UX, via the in-process agentinstance
+ * CREATE edge); update enforces the harness and execution-target
+ * immutability sentinels and maintains the server-owned
+ * harness_state_id_history; delete blocks while executions are active and
+ * cascades the session's agent executions; updateSubject is a field-level
+ * read-modify-write.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by session.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/session.test.ts.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies, and
+ * Publish steps (no multi-tenant auth, IAM/FGA, or event publishing here)
+ * and the FGA-authorized list filtering.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { SessionCommandController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/command_pb";
+import { SessionQueryController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/query_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type {
+  ListSessionsByAgentInstanceRequest,
+  ListSessionsByChannelRequest,
+  ListSessionsRequest,
+  SessionId,
+  SessionList,
+  UpdateSessionSubjectRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/session/v1/io_pb";
+import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { create } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import type { AgentExecutionTemporalConfig } from "../agentexecution/temporal/config.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import {
+  newBuildNewStateStep,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import { sessionSearchExtractor } from "./search-extractor.js";
+import {
+  LIST_RESULT_KEY,
+  newCascadeDeleteAgentExecutionsStep,
+  newFilterByAgentInstanceStep,
+  newFilterByChannelStep,
+  newListAllSessionsStep,
+  newRecordHarnessStateHistoryStep,
+  newRejectDeleteWithActiveExecutionsStep,
+  newResolveDefaultAgentInstanceStep,
+  newValidateExecutionTargetImmutabilityStep,
+  newValidateHarnessImmutabilityStep,
+} from "./steps.js";
+import type { AgentInstanceCreatorProvider } from "./steps.js";
+
+export interface SessionControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  /**
+   * The agent-execution temporal config — the update pipeline's
+   * execution-target immutability step resolves UNSPECIFIED through the
+   * same deployment default dispatch uses (oss#397).
+   */
+  readonly temporalConfig: AgentExecutionTemporalConfig;
+  /**
+   * The agentinstance in-process CREATE edge — a lazy provider because the
+   * routes↔clients definition cycle resolves at request time (the ratified
+   * DI story, DD-002).
+   */
+  readonly agentInstanceCreator: AgentInstanceCreatorProvider;
+}
+
+/** Registers both session services on the router (routes stage). */
+export function registerSessionServices(
+  router: ConnectRouter,
+  deps: SessionControllerDeps,
+): void {
+  router.service(SessionCommandController, {
+    apply: (session, ctx) => apply(deps, session, ctx),
+    create: (session, ctx) => createSession(deps, session, ctx),
+    update: (session, ctx) => update(deps, session, ctx),
+    updateSubject: (req) => updateSubject(deps, req),
+    delete: (id, ctx) => deleteSession(deps, id, ctx),
+  });
+  router.service(SessionQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+    listByAgentInstance: (req, ctx) => listByAgentInstance(deps, req, ctx),
+    listByChannel: (req, ctx) => listByChannel(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. ResolveDefaultAgentInstance
+ * runs BEFORE ValidateProto: when agent_instance_id is omitted, the
+ * resolution fills it in before validation sees the spec.
+ */
+async function createSession(
+  deps: SessionControllerDeps,
+  session: Session,
+  ctx: HandlerContext,
+): Promise<Session> {
+  const reqCtx = new RequestContext(SessionSchema, session, kindOf(ctx));
+  await newPipeline<typeof SessionSchema>("session-create", deps.logger)
+    .addStep(
+      newResolveDefaultAgentInstanceStep(
+        deps.store,
+        deps.agentInstanceCreator,
+        deps.logger,
+      ),
+    )
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(deps.store, sessionSearchExtractor, deps.logger),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline: the immutability sentinels
+ * run after LoadExisting, the server-owned history append after
+ * BuildUpdateState (it mutates the merged state).
+ */
+async function update(
+  deps: SessionControllerDeps,
+  session: Session,
+  ctx: HandlerContext,
+): Promise<Session> {
+  const reqCtx = new RequestContext(SessionSchema, session, kindOf(ctx));
+  await newPipeline<typeof SessionSchema>("session-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateHarnessImmutabilityStep())
+    .addStep(newValidateExecutionTargetImmutabilityStep(deps.temporalConfig))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newRecordHarnessStateHistoryStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(deps.store, sessionSearchExtractor, deps.logger),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
+ * existence, then delegates to Create or Update with the ORIGINAL request
+ * message (Go delegates `session`, not the pipeline's mutated clone).
+ */
+async function apply(
+  deps: SessionControllerDeps,
+  session: Session,
+  ctx: HandlerContext,
+): Promise<Session> {
+  const reqCtx = new RequestContext(SessionSchema, session, kindOf(ctx));
+  await newPipeline<typeof SessionSchema>("session-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate
+    ? createSession(deps, session, ctx)
+    : update(deps, session, ctx);
+}
+
+/**
+ * Delete — blocks while any execution in the session is active, then
+ * cascades the session's agent executions before the session row
+ * (children before parent, so a mid-failure retry converges). Returns the
+ * deleted session (the audit-trail convention).
+ */
+async function deleteSession(
+  deps: SessionControllerDeps,
+  sessionId: SessionId,
+  ctx: HandlerContext,
+): Promise<Session> {
+  const reqCtx = new RequestContext(
+    SessionCommandController.method.delete.input,
+    sessionId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SessionCommandController.method.delete.input>(
+    "session-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, SessionSchema))
+    .addStep(newRejectDeleteWithActiveExecutionsStep(deps.store, deps.logger))
+    .addStep(newCascadeDeleteAgentExecutionsStep(deps.store, deps.logger))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted session not found in context"),
+      "deleted session not found in context",
+    );
+  }
+  return deleted as Session;
+}
+
+/**
+ * UpdateSubject — update_subject.go: a field-level read-modify-write, NO
+ * pipeline. The server loads the current session, modifies only the
+ * subject field, stamps the SPEC audit slot (a definition change, unlike
+ * the visibility RPCs' status slot), persists, and refreshes the search
+ * index best-effort. Because the read-modify-write happens entirely on
+ * the server, concurrent callers (e.g., GenerateSessionSubject and
+ * sandbox_manager) cannot overwrite each other's unrelated fields.
+ */
+async function updateSubject(
+  deps: SessionControllerDeps,
+  req: UpdateSessionSubjectRequest,
+): Promise<Session> {
+  // Field validation is guaranteed at the transport boundary by the
+  // protovalidate interceptor; this guard covers the direct-call path
+  // (unit tests) with the same InvalidArgument contract.
+  if (req.id === "") {
+    throw invalidArgumentError("id is required");
+  }
+
+  const kind = ApiResourceKind.session;
+
+  let session: Session;
+  try {
+    session = await deps.store.getResource(kind, req.id, SessionSchema);
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      throw notFoundError("session", req.id);
+    }
+    throw internalError(error, "failed to load session");
+  }
+
+  if (session.spec === undefined) {
+    session.spec = create(SessionSpecSchema, {});
+  }
+  session.spec.subject = req.subject;
+
+  setAuditFieldsForUpdate(SessionSchema, session, "spec_audit");
+
+  try {
+    await deps.store.saveResource(kind, req.id, SessionSchema, session);
+  } catch (error) {
+    throw internalError(error, "failed to persist session");
+  }
+
+  await indexSessionSearch(deps, kind, session);
+
+  return session;
+}
+
+/**
+ * Refreshes the FTS5 search index for a session. Best-effort: logs on
+ * failure but does not propagate (Go indexSessionSearch — an undefined
+ * entry returns silently, without the shared step's warn).
+ */
+async function indexSessionSearch(
+  deps: SessionControllerDeps,
+  kind: ApiResourceKind,
+  session: Session,
+): Promise<void> {
+  const entry = sessionSearchExtractor.getSearchIndexEntry(session);
+  if (entry === undefined) {
+    return;
+  }
+  try {
+    await deps.store.upsertSearchIndex(kind, session.metadata?.id ?? "", entry);
+  } catch (error) {
+    deps.logger.warn(
+      "UpdateSubject: failed to update search index (best-effort)",
+      {
+        id: session.metadata?.id ?? "",
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+/** Get — LoadTarget by id (Go's chain has no ExtractResourceId here). */
+async function get(
+  deps: SessionControllerDeps,
+  id: SessionId,
+  ctx: HandlerContext,
+): Promise<Session> {
+  const reqCtx = new RequestContext(
+    SessionQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SessionQueryController.method.get.input>(
+    "session-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, SessionSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Session;
+}
+
+/** List — all sessions, newest first. */
+async function list(
+  deps: SessionControllerDeps,
+  req: ListSessionsRequest,
+  ctx: HandlerContext,
+): Promise<SessionList> {
+  const reqCtx = new RequestContext(
+    SessionQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SessionQueryController.method.list.input>(
+    "session-list",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListAllSessionsStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return requireListResult(reqCtx.get(LIST_RESULT_KEY));
+}
+
+/** ListByAgentInstance — spec.agent_instance_id equality filter. */
+async function listByAgentInstance(
+  deps: SessionControllerDeps,
+  req: ListSessionsByAgentInstanceRequest,
+  ctx: HandlerContext,
+): Promise<SessionList> {
+  const reqCtx = new RequestContext(
+    SessionQueryController.method.listByAgentInstance.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof SessionQueryController.method.listByAgentInstance.input
+  >("session-list-by-agent-instance", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newFilterByAgentInstanceStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return requireListResult(reqCtx.get(LIST_RESULT_KEY));
+}
+
+/** ListByChannel — stigmer.ai/channel-id label filter (contract parity). */
+async function listByChannel(
+  deps: SessionControllerDeps,
+  req: ListSessionsByChannelRequest,
+  ctx: HandlerContext,
+): Promise<SessionList> {
+  const reqCtx = new RequestContext(
+    SessionQueryController.method.listByChannel.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SessionQueryController.method.listByChannel.input>(
+    "session-list-by-channel",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newFilterByChannelStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return requireListResult(reqCtx.get(LIST_RESULT_KEY));
+}
+
+function requireListResult(result: unknown): SessionList {
+  if (result === undefined) {
+    throw internalError(
+      new Error("session list not found in context"),
+      "session list not found in context",
+    );
+  }
+  return result as SessionList;
+}

--- a/backend/services/stigmer-server-ts/src/domain/session/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/search-extractor.ts
@@ -1,0 +1,36 @@
+/**
+ * Session search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/session_extractor.go. Sessions are
+ * conversation threads between a user and an agent instance; the summary
+ * is spec.subject (the conversation topic). The query side of the
+ * extractor contract arrives with the search service sub-project (#13).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const sessionSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const session = resource as unknown as Session;
+    const metadata = session.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      description: session.spec?.subject ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        session.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/session/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/steps.ts
@@ -1,0 +1,791 @@
+/**
+ * Session domain-local pipeline steps — port the inline steps of
+ * pkg/domain/session/controller/ (create.go, delete.go, list.go,
+ * validate_harness_immutability.go,
+ * validate_execution_target_immutability.go,
+ * record_harness_state_history.go) and its steps/ package
+ * (filter_by_agent_instance.go, filter_by_channel.go). Shared steps stay
+ * in src/pipeline/steps/; these exist because they embody
+ * session-specific contracts: the default-agent-instance resolution, the
+ * harness/execution-target immutability sentinels, the server-owned
+ * harness-state history, the active-execution delete guard with its
+ * execution cascade, and the list filters.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/status_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import {
+  ExecutionTarget,
+  Harness,
+} from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import { SessionListSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/io_pb";
+import { SessionQueryController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/query_pb";
+import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { AgentExecutionTemporalConfig } from "../agentexecution/temporal/config.js";
+import {
+  failedPreconditionError,
+  goWrappedStatusError,
+  internalError,
+  invalidArgumentError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { RESOURCE_ID_KEY } from "../../pipeline/steps/delete.js";
+import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+import { buildDefaultInstanceRequest } from "../agentinstance/defaultinstance.js";
+import {
+  DefaultAgentNotConfiguredError,
+  DefaultAgentNotPublicError,
+  findDefaultAgent,
+} from "../agent/defaultagent.js";
+
+type SessionDesc = typeof SessionSchema;
+
+/** Context key for the list result (Go listResultKey). */
+export const LIST_RESULT_KEY = "listResult";
+
+/**
+ * The session label the channel runtime stamps at create time to record
+ * which agent channel originated the conversation. Mirrors
+ * ChannelRuntimeConstants.CHANNEL_ID_METADATA_KEY in Stigmer Cloud.
+ */
+const CHANNEL_ID_LABEL_KEY = "stigmer.ai/channel-id";
+
+/**
+ * The narrow in-process surface the session domain needs from
+ * agentinstance — consumer-defined so the dependency reads at the domain
+ * boundary (the Go twin is pkg/downstream/agentinstance.Client). This is
+ * the CREATE RPC (Go CreateAsSystem), not apply: the resolve step only
+ * reaches it when the default instance is known to be missing, and a
+ * duplicate-slug collision must surface as AlreadyExists, not silently
+ * update. Calls ride the in-process router transport, traversing the full
+ * interceptor chain (DD-002).
+ */
+export interface AgentInstanceCreator {
+  createAsSystem(instance: AgentInstance): Promise<AgentInstance>;
+}
+
+/**
+ * Lazy provider for the in-process agentinstance edge — resolved at call
+ * time, never at construction (the ratified DI story, D2 §2).
+ */
+export type AgentInstanceCreatorProvider = () => AgentInstanceCreator;
+
+// ---------------------------------------------------------------------------
+// ResolveDefaultAgentInstance — create.go:62-182: when agent_instance_id is
+// not provided, resolve the platform default agent (shared defaultagent
+// implementation: label stigmer.ai/default-agent=true, visibility_public,
+// deterministic incumbent-wins tie-break), get or create its default
+// instance, and set agent_instance_id on the session spec. This enables the
+// session-first UX where users create a session (with workspace entries)
+// without knowing the agent instance — the backend resolves it
+// automatically.
+//
+// Runs FIRST in the create chain, before ValidateProto — resolution must
+// fill agent_instance_id before validation sees the spec.
+//
+// The id lands on ctx.newState.spec, NEVER on input: the pipeline cloned
+// input into newState at construction and Persist saves newState, so
+// mutating input does not propagate (Go's documented clone gotcha,
+// create.go:168-170).
+// ---------------------------------------------------------------------------
+
+export function newResolveDefaultAgentInstanceStep(
+  store: Store,
+  creator: AgentInstanceCreatorProvider,
+  logger: Logger,
+): PipelineStep<SessionDesc> {
+  return {
+    name: "ResolveDefaultAgentInstance",
+    async execute(ctx: RequestContext<SessionDesc>): Promise<void> {
+      if ((ctx.input.spec?.agentInstanceId ?? "") !== "") {
+        return;
+      }
+
+      logger.info(
+        "agent_instance_id not provided on session, resolving platform default agent",
+      );
+
+      // 1. Resolve the default agent. The error copy is Go WrapError's
+      // "%s: %v" — the sentinel's text RIDES the wire message, and the
+      // NotFound arm carries Go's DOUBLE wrap (fmt.Errorf("no default
+      // agent available on this platform: %w", err) inside WrapError).
+      // Byte-pinned.
+      let defaultAgent: Agent;
+      try {
+        defaultAgent = await findDefaultAgent(store, logger);
+      } catch (error) {
+        if (error instanceof DefaultAgentNotConfiguredError) {
+          logger.error("No platform default agent configured", {
+            error: error.message,
+          });
+          throw new ConnectError(
+            `No default agent available. Ensure an agent with label stigmer.ai/default-agent=true and visibility_public exists: no default agent available on this platform: ${error.message}`,
+            Code.NotFound,
+          );
+        }
+        if (error instanceof DefaultAgentNotPublicError) {
+          logger.error("Default agent is not visibility_public", {
+            error: error.message,
+          });
+          throw new ConnectError(
+            `Default agent exists but is not visibility_public: ${error.message}`,
+            Code.FailedPrecondition,
+          );
+        }
+        // Store/decode failure — an internal fault, not "no default
+        // agent". InternalError keeps the cause off the wire
+        // (stigmer/stigmer#478).
+        logger.error("Failed to resolve platform default agent", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw internalError(
+          error,
+          "failed to resolve the platform default agent",
+        );
+      }
+
+      const metadata = defaultAgent.metadata;
+      if (metadata === undefined) {
+        // Unreachable: findDefaultAgent only returns public-visibility
+        // candidates, whose metadata is necessarily set.
+        throw internalError(
+          new Error("default agent metadata is nil"),
+          "failed to resolve the platform default agent",
+        );
+      }
+      const agentId = metadata.id;
+      logger.info("Resolved platform default agent", {
+        agentId,
+        agentName: metadata.name,
+      });
+
+      // 2. Get or create the default instance.
+      let defaultInstanceId = defaultAgent.status?.defaultInstanceId ?? "";
+      if (defaultInstanceId === "") {
+        logger.info("Default instance missing, creating one", { agentId });
+
+        const instanceRequest = buildDefaultInstanceRequest(metadata);
+
+        // Go create.go:144-148 wraps the downstream error with fmt.Errorf
+        // ("failed to create default instance for default agent: %w") and
+        // PipelineError.GRPCStatus's errors.As branch keeps the inner
+        // CODE but rewrites the wire MESSAGE to the wrapped text —
+        // transport formatting (`rpc error: code = X desc = ...`)
+        // included. Mirrored byte-for-byte via goWrappedStatusError; the
+        // leak is stigmer/stigmer#852 (both-editions post-cutover fix).
+        // Unstatused failures fall to the pipeline's Internal fallback,
+        // exactly Go's plain-error path.
+        let createdInstance: AgentInstance;
+        try {
+          createdInstance = await creator().createAsSystem(instanceRequest);
+        } catch (error) {
+          logger.error("Failed to create default instance", {
+            agentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          if (error instanceof ConnectError) {
+            throw goWrappedStatusError(
+              "failed to create default instance for default agent",
+              error,
+            );
+          }
+          throw new Error(
+            `failed to create default instance for default agent: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+
+        defaultInstanceId = createdInstance.metadata?.id ?? "";
+
+        // Persist default_instance_id on the agent — EXPLICITLY the agent
+        // kind: this pipeline's ctx kind is session (Go hardcodes
+        // ApiResourceKind_agent here too).
+        if (defaultAgent.status === undefined) {
+          defaultAgent.status = create(AgentStatusSchema, {});
+        }
+        defaultAgent.status.defaultInstanceId = defaultInstanceId;
+        try {
+          await store.saveResource(
+            ApiResourceKind.agent,
+            agentId,
+            AgentSchema,
+            defaultAgent,
+          );
+        } catch (error) {
+          logger.error("Failed to persist agent with default_instance_id", {
+            agentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          // Go wraps as a plain error → the pipeline's Internal fallback.
+          throw new Error(
+            `failed to persist agent with default instance: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+
+        logger.info("Created default instance for default agent", {
+          instanceId: defaultInstanceId,
+          agentId,
+        });
+      }
+
+      // 3. Set agent_instance_id on the session's newState (not input) —
+      // see the module-level clone gotcha note.
+      const newState = ctx.newState;
+      if (newState.spec === undefined) {
+        newState.spec = create(SessionSpecSchema, {});
+      }
+      newState.spec.agentInstanceId = defaultInstanceId;
+
+      logger.info(
+        "Set agent_instance_id on session from platform default agent",
+        {
+          agentInstanceId: defaultInstanceId,
+        },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ValidateHarnessImmutability — validate_harness_immutability.go: rejects
+// session updates that attempt to change the harness after the session has
+// been used for execution. Each harness owns its conversation state
+// independently (LangGraph uses Stigmer checkpoints via harness_state_id;
+// Cursor uses a Cursor-hosted Agent via cursor_agent_id in
+// harness_state_id); switching harness mid-session would silently discard
+// conversation history. A session counts as "used" when its
+// harness_state_id is non-empty — set after the first execution completes.
+// ---------------------------------------------------------------------------
+
+export function newValidateHarnessImmutabilityStep(): PipelineStep<SessionDesc> {
+  return {
+    name: "ValidateHarnessImmutability",
+    execute(ctx: RequestContext<SessionDesc>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as Session | undefined;
+      if (existing === undefined) {
+        return;
+      }
+
+      const existingSpec = existing.spec;
+      if (existingSpec === undefined) {
+        return;
+      }
+
+      // Session has not been used yet — harness can still change.
+      if (existingSpec.harnessStateId === "") {
+        return;
+      }
+
+      const inputSpec = ctx.input.spec;
+      if (inputSpec === undefined) {
+        return;
+      }
+
+      // Treat UNSPECIFIED as NATIVE for comparison.
+      let existingHarness = existingSpec.harness;
+      let inputHarness = inputSpec.harness;
+      if (existingHarness === Harness.UNSPECIFIED) {
+        existingHarness = Harness.NATIVE;
+      }
+      if (inputHarness === Harness.UNSPECIFIED) {
+        inputHarness = Harness.NATIVE;
+      }
+
+      if (inputHarness !== existingHarness) {
+        throw failedPreconditionError(
+          "session harness cannot be changed after the first execution — each harness owns its conversation state independently",
+        );
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ValidateExecutionTargetImmutability —
+// validate_execution_target_immutability.go: rejects session updates that
+// attempt to change execution_target after the session has been used for
+// execution — workspace state may not be portable between local and cloud
+// environments.
+//
+// UNSPECIFIED is compared by what dispatch would actually do with it: both
+// the existing and the input target are resolved through the same
+// deployment default dispatch uses (resolveExecutionTarget — LOCAL on OSS,
+// CLOUD on hosted deployments), so "no effective change" and "no dispatch
+// change" are the same predicate on every deployment. Hardcoding
+// UNSPECIFIED to a fixed target here would refuse round-trips that change
+// nothing on cloud-defaulting deployments and wave through updates that
+// really do move the session (oss#397).
+//
+// Uses the same sentinel as harness immutability: harness_state_id is
+// non-empty after the first execution completes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Go's ExecutionTarget.String() names, reproduced explicitly: protobuf-es
+ * strips the shared EXECUTION_TARGET_ prefix from the TS enum members
+ * (ExecutionTarget[1] yields "LOCAL"), but the refusal copy carries the
+ * full proto value names — cross-edition wire contract.
+ */
+const EXECUTION_TARGET_GO_NAMES: Readonly<Record<ExecutionTarget, string>> = {
+  [ExecutionTarget.UNSPECIFIED]: "EXECUTION_TARGET_UNSPECIFIED",
+  [ExecutionTarget.LOCAL]: "EXECUTION_TARGET_LOCAL",
+  [ExecutionTarget.CLOUD]: "EXECUTION_TARGET_CLOUD",
+};
+
+export function newValidateExecutionTargetImmutabilityStep(
+  temporalConfig: AgentExecutionTemporalConfig,
+): PipelineStep<SessionDesc> {
+  return {
+    name: "ValidateExecutionTargetImmutability",
+    execute(ctx: RequestContext<SessionDesc>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as Session | undefined;
+      if (existing === undefined) {
+        return;
+      }
+
+      const existingSpec = existing.spec;
+      if (existingSpec === undefined) {
+        return;
+      }
+
+      if (existingSpec.harnessStateId === "") {
+        return;
+      }
+
+      const inputSpec = ctx.input.spec;
+      if (inputSpec === undefined) {
+        return;
+      }
+
+      const existingTarget = temporalConfig.resolveExecutionTarget(
+        existingSpec.executionTarget,
+      );
+      const inputTarget = temporalConfig.resolveExecutionTarget(
+        inputSpec.executionTarget,
+      );
+
+      if (inputTarget !== existingTarget) {
+        throw failedPreconditionError(
+          `session execution_target cannot be changed after the first execution (${EXECUTION_TARGET_GO_NAMES[existingTarget]} → ${EXECUTION_TARGET_GO_NAMES[inputTarget]}; unset resolves to the deployment default, ${temporalConfig.defaultExecutionTarget}) — workspace state may not be portable between local and cloud environments`,
+        );
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RecordHarnessStateHistory — record_harness_state_history.go: maintains
+// the server-owned harness_state_id_history on the merged update state.
+//
+// A session can span multiple harness-side conversations: when the
+// cursor-runner's resume fails, it creates a fresh Cursor agent and
+// replaces harness_state_id via a normal session update. The replaced id
+// must not be destroyed — billing reconciliation joins Cursor ledger
+// events on the union of current + prior ids, and every turn that ran
+// under a replaced id would otherwise become an orphaned ledger event.
+//
+// The history is computed here, from the observed harness_state_id
+// transition, and never taken from client input: BuildUpdateState performs
+// full spec replacement, so a stale client resending an old spec would
+// silently clobber a client-writable history. Resetting it from the
+// existing record makes the server the single writer of this field.
+//
+// Must run after BuildUpdateState (it mutates the merged state) and
+// before Persist.
+// ---------------------------------------------------------------------------
+
+export function newRecordHarnessStateHistoryStep(): PipelineStep<SessionDesc> {
+  return {
+    name: "RecordHarnessStateHistory",
+    execute(ctx: RequestContext<SessionDesc>): void {
+      const mergedSpec = ctx.newState.spec;
+      if (mergedSpec === undefined) {
+        return;
+      }
+
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as Session | undefined;
+      if (existing === undefined || existing.spec === undefined) {
+        return;
+      }
+      const existingSpec = existing.spec;
+
+      // Server-owned: the merged state carries whatever the client sent
+      // for this field — discard it and rebuild from the stored history.
+      const history = [...existingSpec.harnessStateIdHistory];
+
+      const previousId = existingSpec.harnessStateId;
+      if (
+        previousId !== "" &&
+        previousId !== mergedSpec.harnessStateId &&
+        !history.includes(previousId)
+      ) {
+        history.push(previousId);
+      }
+
+      mergedSpec.harnessStateIdHistory = history;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Delete guard + cascade — delete.go. Children before parent, so a
+// mid-failure retry converges (already-deleted executions are simply no
+// longer found; the reverse order would orphan executions permanently).
+// The cross-kind access to agent_execution rows (#17's kind) is RATIFIED
+// (project T01 brief) — the session owns its executions' lifecycle.
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether an execution phase counts as active for the session-delete
+ * guard: pending, in progress, waiting for approval, or paused.
+ * WAITING_FOR_APPROVAL and PAUSED are deliberately included — the
+ * execution is logically alive and expected to resume. Mirrors the Cloud
+ * AgentExecutionRepo.countActiveBySessionId phase set (Go
+ * isActiveExecutionPhase, default-false switch).
+ */
+function isActiveExecutionPhase(phase: ExecutionPhase): boolean {
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_PENDING:
+    case ExecutionPhase.EXECUTION_IN_PROGRESS:
+    case ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL:
+    case ExecutionPhase.EXECUTION_PAUSED:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Loads every agent execution whose spec.session_id matches the given
+ * session; malformed rows warn and are skipped. Shared by the guard and
+ * cascade steps (Go listExecutionsBySession).
+ */
+async function listExecutionsBySession(
+  store: Store,
+  logger: Logger,
+  sessionId: string,
+): Promise<AgentExecution[]> {
+  let rows: Uint8Array[];
+  try {
+    rows = await store.listResources(ApiResourceKind.agent_execution);
+  } catch (error) {
+    throw internalError(error, "failed to list agent executions");
+  }
+
+  const executions: AgentExecution[] = [];
+  for (const data of rows) {
+    let execution: AgentExecution;
+    try {
+      execution = fromBinary(AgentExecutionSchema, data);
+    } catch (error) {
+      logger.warn("Failed to unmarshal execution, skipping", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    if ((execution.spec?.sessionId ?? "") === sessionId) {
+      executions.push(execution);
+    }
+  }
+  return executions;
+}
+
+/**
+ * RejectDeleteWithActiveExecutions — rejects deletion while any agent
+ * execution in the session is still active. Deleting a session mid-run
+ * would strand a live execution whose conversation no longer exists; the
+ * caller must cancel the execution or wait for it to finish. Error
+ * contract matches Stigmer Cloud's
+ * SessionDeleteHandler.RejectDeleteWithActiveExecutionsStep.
+ */
+export function newRejectDeleteWithActiveExecutionsStep<
+  Desc extends DescMessage,
+>(store: Store, logger: Logger): PipelineStep<Desc> {
+  return {
+    name: "RejectDeleteWithActiveExecutions",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const sessionId = requireSessionId(ctx);
+      const executions = await listExecutionsBySession(
+        store,
+        logger,
+        sessionId,
+      );
+
+      let activeCount = 0;
+      for (const execution of executions) {
+        if (
+          isActiveExecutionPhase(
+            execution.status?.phase ??
+              ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+          )
+        ) {
+          activeCount++;
+        }
+      }
+
+      if (activeCount > 0) {
+        throw failedPreconditionError(
+          `session has ${activeCount} active execution(s); cancel them or wait for completion before deleting`,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * CascadeDeleteAgentExecutions — deletes the session's agent executions
+ * before the session row itself. Billing/usage data is unaffected — usage
+ * records are immutable and carry their own copies of session/execution
+ * identifiers. Search-index removal per execution is best-effort,
+ * matching DeleteSearchIndexStep's convention.
+ */
+export function newCascadeDeleteAgentExecutionsStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "CascadeDeleteAgentExecutions",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const sessionId = requireSessionId(ctx);
+      const executions = await listExecutionsBySession(
+        store,
+        logger,
+        sessionId,
+      );
+      if (executions.length === 0) {
+        return;
+      }
+
+      for (const execution of executions) {
+        const executionId = execution.metadata?.id ?? "";
+        try {
+          await store.deleteResource(
+            ApiResourceKind.agent_execution,
+            executionId,
+          );
+        } catch (error) {
+          throw internalError(
+            error,
+            `failed to cascade-delete execution ${executionId} of session ${sessionId}`,
+          );
+        }
+        try {
+          await store.deleteSearchIndex(
+            ApiResourceKind.agent_execution,
+            executionId,
+          );
+        } catch (error) {
+          logger.warn(
+            "CascadeDeleteAgentExecutions: failed to remove search index entry (best-effort)",
+            {
+              executionId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      }
+
+      logger.info("Cascade-deleted executions of session", {
+        sessionId,
+        count: executions.length,
+      });
+    },
+  };
+}
+
+/** The delete pipeline's extracted session id (ExtractResourceId runs first). */
+function requireSessionId<Desc extends DescMessage>(
+  ctx: RequestContext<Desc>,
+): string {
+  const sessionId = ctx.get(RESOURCE_ID_KEY);
+  if (typeof sessionId !== "string" || sessionId === "") {
+    throw internalError(
+      new Error(
+        "session id not found in context (ExtractResourceId must run first)",
+      ),
+      "session id not found in context (ExtractResourceId must run first)",
+    );
+  }
+  return sessionId;
+}
+
+// ---------------------------------------------------------------------------
+// List steps — list.go and the steps/ package. Full scans with client-side
+// filtering, exactly Go (no pagination, no authorization filtering in OSS).
+// ---------------------------------------------------------------------------
+
+/**
+ * ListAllSessions — all sessions, newest first by spec-audit created_at
+ * (seconds then nanos; timestamped entries before untimestamped ones).
+ * Malformed rows warn and are skipped.
+ */
+export function newListAllSessionsStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof SessionQueryController.method.list.input> {
+  return {
+    name: "ListAllSessions",
+    async execute(
+      ctx: RequestContext<typeof SessionQueryController.method.list.input>,
+    ): Promise<void> {
+      const sessions = await loadAllSessions(
+        store,
+        logger,
+        ctx.apiResourceKind,
+      );
+
+      sessions.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      logger.info("Loaded sessions from database", { count: sessions.length });
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(SessionListSchema, { entries: sessions }),
+      );
+    },
+  };
+}
+
+/**
+ * FilterByAgentInstance — steps/filter_by_agent_instance.go: sessions
+ * whose spec.agent_instance_id matches. No sorting (Go doesn't sort here).
+ */
+export function newFilterByAgentInstanceStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<
+  typeof SessionQueryController.method.listByAgentInstance.input
+> {
+  return {
+    name: "FilterByAgentInstance",
+    async execute(
+      ctx: RequestContext<
+        typeof SessionQueryController.method.listByAgentInstance.input
+      >,
+    ): Promise<void> {
+      const agentInstanceId = ctx.input.agentInstanceId;
+      if (agentInstanceId === "") {
+        throw invalidArgumentError("agent_instance_id is required");
+      }
+
+      const sessions = await loadAllSessions(
+        store,
+        logger,
+        ctx.apiResourceKind,
+      );
+      const filtered = sessions.filter(
+        (session) => (session.spec?.agentInstanceId ?? "") === agentInstanceId,
+      );
+
+      logger.info("Filtered sessions by agent instance", {
+        agentInstanceId,
+        totalSessions: sessions.length,
+        filteredSessions: filtered.length,
+      });
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(SessionListSchema, { entries: filtered }),
+      );
+    },
+  };
+}
+
+/**
+ * FilterByChannel — steps/filter_by_channel.go: sessions whose
+ * metadata.labels carry the channel's stigmer.ai/channel-id stamp. No
+ * sorting. Channel sessions are created by the cloud channel runtime
+ * (Slack/WhatsApp inbound turns), which stamps the label at create time;
+ * the OSS runtime has no channel broker, so this filter typically matches
+ * nothing — the RPC exists for contract parity with Stigmer Cloud (which
+ * additionally gates on can_view of the agent_channel and intersects with
+ * FGA-authorized session IDs).
+ */
+export function newFilterByChannelStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof SessionQueryController.method.listByChannel.input> {
+  return {
+    name: "FilterByChannel",
+    async execute(
+      ctx: RequestContext<
+        typeof SessionQueryController.method.listByChannel.input
+      >,
+    ): Promise<void> {
+      const channelId = ctx.input.channelId;
+      if (channelId === "") {
+        throw invalidArgumentError("channel_id is required");
+      }
+
+      const sessions = await loadAllSessions(
+        store,
+        logger,
+        ctx.apiResourceKind,
+      );
+      const filtered = sessions.filter(
+        (session) =>
+          (session.metadata?.labels ?? {})[CHANNEL_ID_LABEL_KEY] === channelId,
+      );
+
+      logger.info("Filtered sessions by channel", {
+        channelId,
+        totalSessions: sessions.length,
+        filteredSessions: filtered.length,
+      });
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(SessionListSchema, { entries: filtered }),
+      );
+    },
+  };
+}
+
+/** Full-scan session load shared by the list steps; malformed rows warn + skip. */
+async function loadAllSessions(
+  store: Store,
+  logger: Logger,
+  kind: ApiResourceKind,
+): Promise<Session[]> {
+  let rows: Uint8Array[];
+  try {
+    rows = await store.listResources(kind);
+  } catch (error) {
+    throw internalError(error, "failed to list sessions");
+  }
+
+  const sessions: Session[] = [];
+  for (const data of rows) {
+    let session: Session;
+    try {
+      session = fromBinary(SessionSchema, data);
+    } catch (error) {
+      logger.warn("Failed to unmarshal session, skipping", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    sessions.push(session);
+  }
+  return sessions;
+}

--- a/backend/services/stigmer-server-ts/src/pipeline/__tests__/apiresource-labels.test.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/__tests__/apiresource-labels.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pins the reserved-label predicates (apiresource-labels.ts, the TS twin
+ * of backend/libs/go/apiresource/labels.go): isDefaultInstance is true
+ * ONLY for the exact DEFAULT_INSTANCE_LABEL key with the exact "true"
+ * value — any other value is inert (matching cloud's "true".equals(...))
+ * and missing metadata is undefined-safe.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+
+import {
+  DEFAULT_INSTANCE_LABEL,
+  RESERVED_LABEL_TRUE,
+  isDefaultInstance,
+} from "../apiresource-labels.js";
+
+function metadataWithLabels(labels: Record<string, string>) {
+  return create(ApiResourceMetadataSchema, {
+    id: "ain_test",
+    name: "Test Instance",
+    org: "acme",
+    labels,
+  });
+}
+
+describe("isDefaultInstance", () => {
+  it("is true for the exact label key and the exact 'true' value", () => {
+    expect(
+      isDefaultInstance(
+        metadataWithLabels({ [DEFAULT_INSTANCE_LABEL]: RESERVED_LABEL_TRUE }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for any other value of the label — other values are inert", () => {
+    expect(
+      isDefaultInstance(
+        metadataWithLabels({ [DEFAULT_INSTANCE_LABEL]: "false" }),
+      ),
+    ).toBe(false);
+    expect(
+      isDefaultInstance(
+        metadataWithLabels({ [DEFAULT_INSTANCE_LABEL]: "TRUE" }),
+      ),
+    ).toBe(false);
+    expect(
+      isDefaultInstance(metadataWithLabels({ [DEFAULT_INSTANCE_LABEL]: "" })),
+    ).toBe(false);
+  });
+
+  it("is false when the label is missing entirely", () => {
+    expect(isDefaultInstance(metadataWithLabels({}))).toBe(false);
+    expect(
+      isDefaultInstance(
+        metadataWithLabels({
+          "stigmer.ai/system-managed": RESERVED_LABEL_TRUE,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false (not a crash) for undefined metadata", () => {
+    expect(isDefaultInstance(undefined)).toBe(false);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/pipeline/__tests__/steps.test.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/__tests__/steps.test.ts
@@ -11,6 +11,7 @@
  * spec carries ApiResourceReference fields) as vehicles.
  */
 import { create, clone } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Code, ConnectError } from "@connectrpc/connect";
 
@@ -39,6 +40,7 @@ import {
   newLoadExistingForDeleteStep,
   RESOURCE_ID_KEY,
 } from "../steps/delete.js";
+import { compareCreatedAtDesc, matchesAllLabels } from "../steps/helpers.js";
 import { newIndexSearchStep } from "../steps/index-search.js";
 import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../steps/load-existing.js";
 import {
@@ -477,5 +479,53 @@ describe("references (agent spec as the vehicle)", () => {
     expect((error as ConnectError).rawMessage).toContain(
       "referenced MCP server(s) not found: 'ghost' (org: acme)",
     );
+  });
+});
+
+describe("list helpers (consolidated from the per-domain Go copies)", () => {
+  function ts(seconds: number, nanos = 0) {
+    return create(TimestampSchema, { seconds: BigInt(seconds), nanos });
+  }
+
+  describe("compareCreatedAtDesc", () => {
+    it("answers 0 when both timestamps are missing", () => {
+      expect(compareCreatedAtDesc(undefined, undefined)).toBe(0);
+    });
+
+    it("orders a timestamped entry before an untimestamped one", () => {
+      expect(compareCreatedAtDesc(ts(1), undefined)).toBe(-1);
+      expect(compareCreatedAtDesc(undefined, ts(1))).toBe(1);
+    });
+
+    it("orders by seconds descending (newest first)", () => {
+      expect(compareCreatedAtDesc(ts(20), ts(10))).toBe(-1);
+      expect(compareCreatedAtDesc(ts(10), ts(20))).toBe(1);
+    });
+
+    it("breaks a seconds tie by nanos descending", () => {
+      expect(compareCreatedAtDesc(ts(10, 500), ts(10, 100))).toBe(-1);
+      expect(compareCreatedAtDesc(ts(10, 100), ts(10, 500))).toBe(1);
+    });
+
+    it("answers 0 on a full tie", () => {
+      expect(compareCreatedAtDesc(ts(10, 100), ts(10, 100))).toBe(0);
+    });
+  });
+
+  describe("matchesAllLabels", () => {
+    it("matches everything when the filter is empty", () => {
+      expect(matchesAllLabels({}, {})).toBe(true);
+      expect(matchesAllLabels({ a: "1" }, {})).toBe(true);
+    });
+
+    it("requires EVERY filter entry to match (AND semantics)", () => {
+      const labels = { a: "1", b: "2" };
+      expect(matchesAllLabels(labels, { a: "1", b: "2" })).toBe(true);
+      expect(matchesAllLabels(labels, { a: "1", c: "3" })).toBe(false);
+    });
+
+    it("rejects a value mismatch on a present key", () => {
+      expect(matchesAllLabels({ a: "1" }, { a: "2" })).toBe(false);
+    });
   });
 });

--- a/backend/services/stigmer-server-ts/src/pipeline/apiresource-labels.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/apiresource-labels.ts
@@ -1,0 +1,60 @@
+/**
+ * Well-known stigmer.ai/* metadata labels — ports
+ * backend/libs/go/apiresource/labels.go (itself the Go twin of the cloud
+ * edition's SystemManagedLabels). Keep the three in sync.
+ *
+ * Trust boundary: labels are client-suppliable, so they may be used to
+ * RESTRICT what a request may do (e.g. reject visibility updates on default
+ * instances) but never to GRANT anything. Where a grant-shaped decision is
+ * needed, key it on server-owned state instead (e.g. the parent blueprint's
+ * status.default_instance_id, written only by the create/self-heal flows).
+ * The cloud edition additionally guards the whole reserved namespace at its
+ * write boundaries (GuardReservedLabelsStep); OSS has no such guard, which
+ * is one of the reasons OSS predicates must not trust these labels alone.
+ */
+import type { ApiResourceMetadata } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+
+/**
+ * The platform-reserved label key namespace. Keys under this prefix carry
+ * platform semantics (default-agent resolution, personal-environment
+ * uniqueness, default-instance marking) and are written by the server —
+ * never introduced by ordinary client requests on the cloud edition.
+ */
+export const RESERVED_LABEL_PREFIX = "stigmer.ai/";
+
+/**
+ * Marks a blueprint's one auto-created default instance (the empty config
+ * shell the runner resolves when a user has no personal instance). Default
+ * instances carry no visibility of their own: their access always follows
+ * the parent blueprint.
+ */
+export const DEFAULT_INSTANCE_LABEL = `${RESERVED_LABEL_PREFIX}default-instance`;
+
+/**
+ * Marks a resource whose lifecycle (creation, naming, visibility) is
+ * system-managed; user mutations of the managed aspects are rejected.
+ */
+export const SYSTEM_MANAGED_LABEL = `${RESERVED_LABEL_PREFIX}system-managed`;
+
+/**
+ * The only value that activates a reserved marker label; any other value is
+ * inert (matching cloud's "true".equals(...)). Stamped by the flows that
+ * create system-managed resources (e.g. the defaultinstance factories) and
+ * read by the predicates here.
+ */
+export const RESERVED_LABEL_TRUE = "true";
+
+/**
+ * Whether the metadata carries the DEFAULT_INSTANCE_LABEL marker
+ * (undefined-safe) — Go IsDefaultInstance.
+ *
+ * Because OSS has no reserved-label write guard, callers making a
+ * restrict-shaped decision should combine this with the authoritative
+ * parent pointer (blueprint status.default_instance_id) — the label alone
+ * misses pre-labeling legacy rows and can be dropped by a client update.
+ */
+export function isDefaultInstance(
+  metadata: ApiResourceMetadata | undefined,
+): boolean {
+  return metadata?.labels[DEFAULT_INSTANCE_LABEL] === RESERVED_LABEL_TRUE;
+}

--- a/backend/services/stigmer-server-ts/src/pipeline/errors.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/errors.ts
@@ -54,3 +54,53 @@ export function unavailableError(message: string): ConnectError {
 export function internalError(cause: unknown, message: string): ConnectError {
   return new ConnectError(message, Code.Internal, undefined, undefined, cause);
 }
+
+/**
+ * grpc-go's codes.Code.String() names, keyed by the connect Code enum.
+ * Record<Code, string> keeps the map compile-time exhaustive: a new code
+ * in the enum fails typecheck here instead of rendering "undefined" on
+ * the wire.
+ */
+const GRPC_CODE_NAMES: Readonly<Record<Code, string>> = {
+  [Code.Canceled]: "Canceled",
+  [Code.Unknown]: "Unknown",
+  [Code.InvalidArgument]: "InvalidArgument",
+  [Code.DeadlineExceeded]: "DeadlineExceeded",
+  [Code.NotFound]: "NotFound",
+  [Code.AlreadyExists]: "AlreadyExists",
+  [Code.PermissionDenied]: "PermissionDenied",
+  [Code.ResourceExhausted]: "ResourceExhausted",
+  [Code.FailedPrecondition]: "FailedPrecondition",
+  [Code.Aborted]: "Aborted",
+  [Code.OutOfRange]: "OutOfRange",
+  [Code.Unimplemented]: "Unimplemented",
+  [Code.Internal]: "Internal",
+  [Code.Unavailable]: "Unavailable",
+  [Code.DataLoss]: "DataLoss",
+  [Code.Unauthenticated]: "Unauthenticated",
+};
+
+/**
+ * Reproduces the wire message grpc-go's status.FromError manufactures for
+ * %w-wrapped status errors: when Go wraps a downstream in-process client
+ * error with fmt.Errorf("%s: %w", ...), PipelineError.GRPCStatus's
+ * errors.As branch keeps the INNER code but rewrites the message to the
+ * full wrapped text — and the inner client error's Error() renders as
+ * `rpc error: code = <CodeName> desc = <message>`. Byte-parity with Go on
+ * the two arms that hit this (agent create's CreateDefaultInstance,
+ * session create's ResolveDefaultAgentInstance). The transport-formatting
+ * leak is filed as stigmer/stigmer#852 for a both-editions post-cutover
+ * fix; until then this shim IS the wire contract.
+ *
+ * rawMessage is the code-prefix-free message — ConnectError.message
+ * prepends "[code_name] ", which must not ride the manufactured desc.
+ */
+export function goWrappedStatusError(
+  prefix: string,
+  error: ConnectError,
+): ConnectError {
+  return new ConnectError(
+    `${prefix}: rpc error: code = ${GRPC_CODE_NAMES[error.code]} desc = ${error.rawMessage}`,
+    error.code,
+  );
+}

--- a/backend/services/stigmer-server-ts/src/pipeline/steps/helpers.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/steps/helpers.ts
@@ -5,6 +5,7 @@
  */
 import { fromBinary } from "@bufbuild/protobuf";
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
 
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { AuthorizationScopeType } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/authorization_config_pb";
@@ -115,4 +116,39 @@ export function requireOrgForReference(
   if (scopeType === AuthorizationScopeType.ORGANIZATION) {
     throw invalidArgumentError(`org is required for ${kindName} lookup`);
   }
+}
+
+// The two list-step helpers below are duplicated per package in Go (each
+// controller carries its own copy); the TS tree consolidates them here
+// because the shared-steps guideline promotes a helper on its second
+// consumer.
+
+/** Go's sort.Slice comparator: newest first; nil timestamps last. */
+export function compareCreatedAtDesc(
+  a: Timestamp | undefined,
+  b: Timestamp | undefined,
+): number {
+  if (a === undefined || b === undefined) {
+    if (a === undefined && b === undefined) {
+      return 0;
+    }
+    return a !== undefined ? -1 : 1;
+  }
+  if (a.seconds !== b.seconds) {
+    return a.seconds > b.seconds ? -1 : 1;
+  }
+  if (a.nanos !== b.nanos) {
+    return a.nanos > b.nanos ? -1 : 1;
+  }
+  return 0;
+}
+
+/** True when resourceLabels contains every filter entry (empty = all). */
+export function matchesAllLabels(
+  resourceLabels: Record<string, string>,
+  filterLabels: Record<string, string>,
+): boolean {
+  return Object.entries(filterLabels).every(
+    ([key, value]) => resourceLabels[key] === value,
+  );
 }

--- a/test/conformance/src/suites/agent-mcpserver-references.conformance.test.ts
+++ b/test/conformance/src/suites/agent-mcpserver-references.conformance.test.ts
@@ -1,0 +1,119 @@
+// Conformance suite for the Agent -> McpServer cross-aggregate reference
+// invariant.
+// Domain: agentic / agent — a flat (non-versioned) blueprint resource.
+//
+// Pins the agent McpServer-reference normalization contract: the accept path
+// for an agent referencing an EXISTING McpServer (the reference round-trips on
+// the agent and an empty reference org is normalized to the agent's org by
+// NormalizeReferences), plus the FailedPrecondition rejection of a reference
+// to a non-existent McpServer.
+//
+// WHY this is a separate file: the accept-path test creates/deletes an
+// McpServer as a fixture, so the suite requires the McpServer service —
+// which the TS server (stigmer-server-ts) only gains at D4 entry #9
+// (McpServer CRUD). This block was split out of agent.conformance.test.ts by
+// sub-project decision DD-001 (sp.agent-family) so the main agent suite can
+// roster on local-ts now; this file stays on the Go-target rosters (picked up
+// by vitest.config.ts's suites/ glob) and rosters on local-ts when entry #9
+// lands.
+//
+// Note: the missing-reference rejection test below does NOT need the
+// McpServer fixture (it only calls agentCommand.create), and that rejection
+// is already TS-implemented and unit-tested in the server (the shared
+// ValidateReferences test in src/pipeline/__tests__/steps.test.ts, which
+// pins the FailedPrecondition code and Go's copy) — so no behavior goes
+// unproven
+// while this file waits for entry #9. The whole describe block moves anyway:
+// DD-001's split criterion is the describe block, keeping the diff reviewable.
+import { Code } from "@connectrpc/connect";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { makeAgent } from "../support/agents";
+import { makeMcpServer } from "../support/mcpservers";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+async function createAgent(
+  org: string,
+  name: string,
+  opts: { description?: string; mcpServerRefs?: string[] } = {},
+) {
+  const agent = await clients.agentCommand.create(
+    makeAgent({ org, name, ...opts }),
+  );
+  fixtures.defer(() =>
+    clients.agentCommand.delete({ value: agent.metadata!.id }),
+  );
+  return agent;
+}
+
+describe("Agent conformance — McpServer references", () => {
+  it("accepts an agent referencing an existing McpServer and normalizes the reference org", async () => {
+    const { org } = await target.provisionTenancy();
+    const mcpServer = await clients.mcpServerCommand.create(
+      makeMcpServer({ org, name: uniqueName("tools") }),
+    );
+    fixtures.defer(() =>
+      clients.mcpServerCommand.delete({ resourceId: mcpServer.metadata!.id }),
+    );
+    const mcpSlug = mcpServer.metadata!.slug;
+
+    const agent = await createAgent(org, uniqueName("agent"), {
+      mcpServerRefs: [mcpSlug],
+    });
+
+    const usages = agent.spec?.mcpServerUsages ?? [];
+    expect(
+      usages,
+      "the referenced MCP server is preserved on the agent",
+    ).toHaveLength(1);
+    expect(usages[0]?.mcpServerRef?.slug).toBe(mcpSlug);
+    // The request left org empty; NormalizeReferences resolves it to the agent's org.
+    expect(
+      usages[0]?.mcpServerRef?.org,
+      "the empty reference org is normalized to the agent's org",
+    ).toBe(org);
+  });
+
+  it("rejects an agent referencing a non-existent McpServer (FailedPrecondition)", async () => {
+    const { org } = await target.provisionTenancy();
+    const missingSlug = "ghost-mcp-server";
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.agentCommand.create(
+          makeAgent({
+            org,
+            name: uniqueName("agent"),
+            mcpServerRefs: [missingSlug],
+          }),
+        ),
+      Code.FailedPrecondition,
+      "create agent with missing MCP server reference",
+    );
+    expect(
+      err.message,
+      "the error names the missing MCP server slug",
+    ).toContain(missingSlug);
+  });
+});

--- a/test/conformance/src/suites/agent.conformance.test.ts
+++ b/test/conformance/src/suites/agent.conformance.test.ts
@@ -4,8 +4,9 @@
 // Drives AgentCommandController + AgentQueryController through the raw proto
 // stubs and asserts the contract: CRUD round-trips, apply create/update
 // branching, immutable identity fields, default-instance provisioning, reference
-// resolution, slug semantics, spec-first negative paths, and — the headline of
-// this slice — the cross-aggregate Agent->McpServer reference invariant.
+// resolution, slug semantics, and spec-first negative paths. The cross-aggregate
+// Agent->McpServer reference invariant lives in
+// agent-mcpserver-references.conformance.test.ts (split out by DD-001).
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import { Code } from "@connectrpc/connect";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
@@ -17,7 +18,6 @@ import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
 import { AGENT_API_VERSION, AGENT_KIND, makeAgent, makeAgentSpec } from "../support/agents";
 import { makeAgentInstance } from "../support/agentinstances";
-import { makeMcpServer } from "../support/mcpservers";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
 
@@ -550,34 +550,5 @@ describe("Agent conformance — plain-update visibility door (stigmer#573)", () 
 
     const stored = await clients.agentInstanceQuery.get({ value: defaultInstanceId! });
     expect(stored.metadata?.visibility, "the stored level is untouched").toBe(storedLevel);
-  });
-});
-
-describe("Agent conformance — McpServer references", () => {
-  it("accepts an agent referencing an existing McpServer and normalizes the reference org", async () => {
-    const { org } = await target.provisionTenancy();
-    const mcpServer = await clients.mcpServerCommand.create(makeMcpServer({ org, name: uniqueName("tools") }));
-    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: mcpServer.metadata!.id }));
-    const mcpSlug = mcpServer.metadata!.slug;
-
-    const agent = await createAgent(org, uniqueName("agent"), { mcpServerRefs: [mcpSlug] });
-
-    const usages = agent.spec?.mcpServerUsages ?? [];
-    expect(usages, "the referenced MCP server is preserved on the agent").toHaveLength(1);
-    expect(usages[0]?.mcpServerRef?.slug).toBe(mcpSlug);
-    // The request left org empty; NormalizeReferences resolves it to the agent's org.
-    expect(usages[0]?.mcpServerRef?.org, "the empty reference org is normalized to the agent's org").toBe(org);
-  });
-
-  it("rejects an agent referencing a non-existent McpServer (FailedPrecondition)", async () => {
-    const { org } = await target.provisionTenancy();
-    const missingSlug = "ghost-mcp-server";
-
-    const err = await expectGrpcCode(
-      () => clients.agentCommand.create(makeAgent({ org, name: uniqueName("agent"), mcpServerRefs: [missingSlug] })),
-      Code.FailedPrecondition,
-      "create agent with missing MCP server reference",
-    );
-    expect(err.message, "the error names the missing MCP server slug").toContain(missingSlug);
   });
 });

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -12,6 +12,11 @@
 //     registry-proxy exercises the #3 transport lanes, DD-003).
 //   - environment — sub-project #5 (encryption + runnerauth + the
 //     Environment domain; the first secret-bearing suite).
+//   - agent + agentinstance + session + memory — sub-project #6
+//     (sp.agent-family; the agent aggregate and its satellite domains).
+//     agent-mcpserver-references.conformance.test.ts (split out of the
+//     agent suite by sub-project DD-001) will roster here when entry #9
+//     (McpServer CRUD) lands; until then it runs only on the Go rosters.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -20,6 +25,10 @@ export default defineConfig({
       "src/suites/organization.conformance.test.ts",
       "src/suites/registry-proxy.conformance.test.ts",
       "src/suites/environment.conformance.test.ts",
+      "src/suites/agent.conformance.test.ts",
+      "src/suites/agentinstance.conformance.test.ts",
+      "src/suites/session.conformance.test.ts",
+      "src/suites/memory.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

D4 entry #6 of the TS server rewrite (program 20260822.01): the agent-side CRUD cluster — **agent**, **agentinstance**, **session**, and **memory** — ported to the TS server, together with the supporting modules the cluster needs (apiresource-labels, enabledtools, agentexecution temporal config, in-process clients, search extractors). The `local-ts` conformance roster grows from 3 suites/57 tests to 7 suites/148 tests, all green on the first rostered run.

## Context

These four domains are the agent-side heart of the server and are tightly interdependent: agent creation fabricates a default instance, sessions resolve agents and instances before validation, and memory hangs off the agent+user pair. They land as one entry so the cross-domain wiring — Go's bufconn-shaped in-process clients — arrives with all of its consumers.

## Changes

- **`src/domain/agent/`** — 8 RPCs incl. GetDefault's incumbent-wins resolution and cascade delete of instances/sessions/memory per oss#611.
- **`src/domain/agentinstance/`** — 9 RPCs incl. the default-instance factory, the oss#645 parent-agent existence check, oss#646 `agent_id` immutability, and the stigmer#556 default-instance visibility guard.
- **`src/domain/session/`** — 9 RPCs incl. resolve-before-validation create, oss#397 execution-target immutability, server-owned harness history, pipeline-less `updateSubject`, and the delete guard + execution cascade.
- **`src/domain/memory/`** — 7 RPCs (no apply): the consent lifecycle with atomic transitions, the 100-entry cap, fail-closed enablement, and graft persist.
- **Supporting modules** — `pipeline/apiresource-labels`; `mcpserver/enabledtools` (first resident of mcpserver's directory); `agentexecution/temporal/config` (first resident of entry #17's directory, oss#397); search extractors for the three indexed kinds.
- **`src/boot/inprocess.ts`** — in-process router-transport clients (sub-project DD-002): the same routes and interceptor chain as the serving router — Go's bufconn shape; the agent↔agentinstance dependency cycle is broken with lazy providers.
- **Conformance suite change (sub-project DD-001)** — the two-test "McpServer references" block moved verbatim from `agent.conformance.test.ts` to `agent-mcpserver-references.conformance.test.ts`: its fixture needs McpServer CRUD, which arrives at entry #9. It stays on the Go rosters and joins `local-ts` at #9.

## Implementation notes (parity disclosures for the register)

1. **Wrapped-downstream-error wire messages** mirrored byte-for-byte, including the `rpc error: code = X desc = ...` transport-formatting leak Go's `status.FromError` manufactures on `%w`-wrapped errors (the agent-create default-instance arm; the session-create CreateAsSystem arm) — owner-ratified; both-editions cleanup filed as #852.
2. **Enum-name prefix**: protobuf-es strips the `EXECUTION_TARGET_` prefix from enum names, so the execution-target immutability copy uses an explicit map reproducing Go's `String()` names (pinned by tests).
3. **Faithfully ported latent Go bug** (disclosed, not fixed): the documented apply "self-heal" for orphaned default instances cannot actually re-point `spec.agent_id` — the immutability guard refuses in BOTH editions.
4. **Sort stability**: Go's `sort.Slice` is unstable, TS sort is stable — exact `created_at` ties may order differently. Not wire-assertable; Go's own tie order is arbitrary.
5. **Memory semantics**: the transition idempotency maps Go's sentinel-abort to the TS store's throw-rollback (re-confirm keeps the decision timestamp; pinned by tests); protobuf-es `equals()` nil-branching mirrors `proto.Equal`; Go's nil-spec panic→Internal is an explicit internalError with the same wire code; memory get includes ExtractResourceId per Go (agent get does not — both match Go).
6. **Deliberate structure divergences**: no nil-client no-op in `CreateDefaultInstance` (the required lazy provider per the ratified DI story); `compareCreatedAtDesc`/`matchesAllLabels` consolidated into `pipeline/steps/helpers.ts` on the second-consumer rule (Go duplicates them per package).

## Breaking changes

- None. The Go server is untouched; the TS server is not yet the served binary.

## Test plan

- `make test-conformance-ts` — 148/148 across 7 suites: agent (25), agentinstance (25), session (28), memory (13) all green on the first rostered run.
- `make test-conformance` (local-go) — 375 passed, regression-free (+1 pre-existing skill-suite skip).
- `npm run typecheck && npm test` — 309 unit tests green.
- `verify:dist` and `verify:slim` boot gates green.

## Risks

- Low: purely additive on the TS side plus a verbatim test relocation on the conformance side. Rollback = revert; no schema or wire impact.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Conformance green on both targets

Made with [Cursor](https://cursor.com)