### PR TITLE
feat(backend/stigmer-server-ts): port the executioncontext domain with the runner-token decrypt lane

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -23,6 +23,7 @@ import { registerAgentServices } from "../domain/agent/controller.js";
 import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
+import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
 import { registerMemoryServices } from "../domain/memory/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
@@ -52,9 +53,10 @@ export interface ComposedServer {
   /** The persistence layer (exposed for tests; domain code gets it injected). */
   store: Store;
   /**
-   * The runner-token service (exposed for its future consumers' wiring —
-   * the platform exchange RPC and the executioncontext decrypt lane land
-   * with their own sub-projects — and for boot tests).
+   * The runner-token service (exposed for boot tests and for the
+   * executioncontext decrypt-lane tests, which mint scope-bound tokens
+   * against the SAME key the server verifies with; the platform exchange
+   * RPC — the mint side — lands with its own sub-project).
    */
   runnerAuthService: RunnerAuthService;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
@@ -94,9 +96,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   //     by default, so a server that cannot mint runner tokens would hand
   //     every execution redaction markers instead of its secrets — the
   //     exact silent-junk failure the oss#405 fail-loud doctrine forbids.
-  //     (Its consumers — the platform exchange RPC, the EC decrypt lane —
-  //     arrive with their sub-projects; the boot posture is wired now so
-  //     their wiring PRs never restructure boot.)
+  //     (The verify side is live: the executioncontext decrypt lane. The
+  //     mint side — the platform exchange RPC — arrives with its
+  //     sub-project.)
   let secretService: SecretService;
   try {
     secretService = SecretService.fromEnv();
@@ -160,6 +162,12 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     registerHealthService(router, healthState);
     registerOrganizationServices(router, { store, logger });
     registerEnvironmentServices(router, { store, logger, secretService });
+    registerExecutionContextServices(router, {
+      store,
+      logger,
+      secretService,
+      runnerAuthService,
+    });
     registerAgentServices(router, {
       store,
       logger,

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/__tests__/executioncontext.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/__tests__/executioncontext.test.ts
@@ -1,0 +1,778 @@
+/**
+ * Pins the executioncontext domain against Go's
+ * executioncontext_controller_test.go + executioncontext_secrets_test.go —
+ * through the REAL stack: a composed server on an ephemeral port, a native
+ * gRPC client, the full interceptor chain.
+ *
+ * The load-bearing pins the conformance suite CANNOT cover (its harness
+ * authenticates as a user and asserts redaction unconditionally; these
+ * need direct store access, key control, or a runner token):
+ *   - secrets rest as enc:v1: CIPHERTEXT in the store, never plaintext;
+ *   - the decrypt-lane dispatch matrix: only a valid, unexpired token
+ *     bound to THIS execution decrypts — every other credential state
+ *     (absent, malformed, forged, expired, wrong scheme, wrong execution)
+ *     falls closed to redaction AS A SUCCESS, never an error;
+ *   - the decrypt error doctrine: tampered ciphertext drops the one key
+ *     while the read succeeds; an encrypted row on a keyless server fails
+ *     LOUD (Internal, pinned copy), never returns junk;
+ *   - the keyless WARN-degrade write path (legacy plaintext rows) still
+ *     redacts user reads and passes through on the runner lane;
+ *   - the DeleteExecutionContext activity seam: idempotent, best-effort,
+ *     never throws.
+ *
+ * Keys are injected via env (vi.stubEnv) so the ladder short-circuits
+ * before its file steps — the real ~/.stigmer is never touched (DD-002).
+ * Adversarial tokens (expired, forged) are HAND-CRAFTED HS256 JWTs, not
+ * sleeps or timer games — determinism is non-negotiable.
+ */
+import { createHmac } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ExecutionContextCommandController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/command_pb";
+import { ExecutionContextQueryController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import {
+  ENCRYPTED_PREFIX,
+  SecretService,
+} from "../../../encryption/encryption.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import { REDACTED_MARKER } from "../../environment/constants.js";
+import {
+  DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME,
+  deleteExecutionContextForExecution,
+} from "../temporal/delete-execution-context.js";
+import { executionContextSearchExtractor } from "../search-extractor.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const ENCRYPTION_KEY = Buffer.alloc(32, 7);
+const RUNNER_KEY = Buffer.alloc(32, 8);
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "ExecutionContext";
+const ORG = "acme";
+
+type CommandClient = Client<typeof ExecutionContextCommandController>;
+type QueryClient = Client<typeof ExecutionContextQueryController>;
+
+interface TestServer {
+  server: ComposedServer;
+  command: CommandClient;
+  query: QueryClient;
+  dir: string;
+}
+
+async function startServer(env: Record<string, string>): Promise<TestServer> {
+  const dir = mkdtempSync(path.join(tmpdir(), "ectx-domain-test-"));
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+  const server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  return {
+    server,
+    command: createClient(ExecutionContextCommandController, transport),
+    query: createClient(ExecutionContextQueryController, transport),
+    dir,
+  };
+}
+
+/**
+ * Failure-path safe: ts is undefined when startServer threw in beforeAll —
+ * the env stubs must STILL be cleared or they leak into the next describe
+ * (the keyless suite stubs an invalid encryption key on purpose).
+ */
+async function stopServer(ts: TestServer | undefined): Promise<void> {
+  try {
+    if (ts !== undefined) {
+      await ts.server.shutdown();
+      rmSync(ts.dir, { recursive: true, force: true });
+    }
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+let counter = 0;
+function ecInput(overrides?: {
+  name?: string;
+  org?: string;
+  executionId?: string;
+  data?: Record<string, { value: string; isSecret?: boolean }>;
+}) {
+  counter += 1;
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      name: overrides?.name ?? `Ectx ${counter}`,
+      org: overrides?.org ?? ORG,
+    },
+    spec: {
+      executionId: overrides?.executionId ?? `aex_test_${counter}`,
+      data: Object.fromEntries(
+        Object.entries(
+          overrides?.data ?? {
+            API_TOKEN: { value: "super-secret-token", isSecret: true },
+            REGION: { value: "us-east-1" },
+            EMPTY_SEC: { value: "", isSecret: true },
+          },
+        ).map(([k, v]) => [
+          k,
+          { value: v.value, isSecret: v.isSecret ?? false },
+        ]),
+      ),
+    },
+  };
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+/** Reads the raw stored row — the at-rest truth redaction must never touch. */
+async function storedRow(
+  ts: TestServer,
+  id: string,
+): Promise<ExecutionContext> {
+  return await ts.server.store.getResource(
+    ApiResourceKind.execution_context,
+    id,
+    ExecutionContextSchema,
+  );
+}
+
+function bearerHeaders(token: string): { authorization: string } {
+  return { authorization: `Bearer ${token}` };
+}
+
+/**
+ * Hand-crafts an HS256 runner token — the adversarial arms (expired,
+ * forged key) that RunnerAuthService.mint refuses to produce.
+ */
+function craftToken(
+  key: Buffer,
+  claims: {
+    token_type?: string;
+    execution_id?: string;
+    iat?: number;
+    exp?: number;
+  },
+): string {
+  const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString(
+    "base64url",
+  );
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signingInput = `${header}.${payload}`;
+  const signature = createHmac("sha256", key)
+    .update(signingInput)
+    .digest("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+// ---------------------------------------------------------------------------
+// Encryption + runner key enabled (the production shape).
+// ---------------------------------------------------------------------------
+
+describe("executioncontext domain (encryption + runner auth enabled)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({
+      STIGMER_ENCRYPTION_KEY: ENCRYPTION_KEY.toString("base64"),
+      STIGMER_RUNNER_TOKEN_KEY: RUNNER_KEY.toString("base64"),
+    });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+  });
+
+  describe("secrets rest encrypted (Go TestSecrets_EncryptedAtRest)", () => {
+    it("stores is_secret values as enc:v1: ciphertext, non-secrets plaintext, empty secrets empty", async () => {
+      const created = await ts.command.create(
+        ecInput({ executionId: "aex_atrest" }),
+      );
+
+      const stored = await storedRow(ts, created.metadata!.id);
+      const secret = stored.spec!.data["API_TOKEN"]!;
+      expect(secret.value, "is_secret value must rest encrypted").toMatch(
+        new RegExp(`^${ENCRYPTED_PREFIX}`),
+      );
+      expect(secret.value).not.toContain("super-secret-token");
+      expect(secret.isSecret).toBe(true);
+      expect(
+        stored.spec!.data["REGION"]!.value,
+        "non-secret values rest plaintext",
+      ).toBe("us-east-1");
+      expect(
+        stored.spec!.data["EMPTY_SEC"]!.value,
+        "empty secret declarations stay empty",
+      ).toBe("");
+    });
+  });
+
+  describe("user-shaped reads redact (Go TestSecrets_UserShapedReadsRedact)", () => {
+    it("presents the identical contract on all five boundaries: create echo, get, getByReference, tokenless getByExecutionId, delete echo", async () => {
+      const created = await ts.command.create(
+        ecInput({ executionId: "aex_redact" }),
+      );
+
+      const reads: Array<[string, () => Promise<ExecutionContext>]> = [
+        ["create echo", () => Promise.resolve(created)],
+        ["get", () => ts.query.get({ value: created.metadata!.id })],
+        [
+          "getByReference",
+          () =>
+            ts.query.getByReference({
+              kind: ApiResourceKind.execution_context,
+              slug: created.metadata!.slug,
+            }),
+        ],
+        [
+          "getByExecutionId without token",
+          () => ts.query.getByExecutionId({ executionId: "aex_redact" }),
+        ],
+        // Runs last: it removes the row.
+        [
+          "delete echo",
+          () => ts.command.delete({ resourceId: created.metadata!.id }),
+        ],
+      ];
+
+      for (const [name, read] of reads) {
+        const ec = await read();
+        const data = ec.spec!.data;
+        expect(
+          data["API_TOKEN"]!.value,
+          `${name}: non-empty secret must be the marker`,
+        ).toBe(REDACTED_MARKER);
+        expect(
+          data["API_TOKEN"]!.isSecret,
+          `${name}: is_secret preserved`,
+        ).toBe(true);
+        expect(
+          data["REGION"]!.value,
+          `${name}: non-secrets never redacted`,
+        ).toBe("us-east-1");
+        expect(
+          data["EMPTY_SEC"]!.value,
+          `${name}: empty secrets stay empty (a marker would fake a stored value)`,
+        ).toBe("");
+      }
+    });
+
+    it("redaction never reaches the store (Go TestSecrets_RedactionNeverReachesTheStore)", async () => {
+      const created = await ts.command.create(
+        ecInput({ executionId: "aex_immut" }),
+      );
+      await ts.query.get({ value: created.metadata!.id });
+
+      const stored = await storedRow(ts, created.metadata!.id);
+      expect(
+        stored.spec!.data["API_TOKEN"]!.value,
+        "the store must never hold the redaction marker",
+      ).toMatch(new RegExp(`^${ENCRYPTED_PREFIX}`));
+    });
+  });
+
+  describe("decrypt-lane dispatch (Go TestSecrets_GetByExecutionIdDispatch + adversarial arms)", () => {
+    const EXEC_ID = "aex_dispatch";
+
+    beforeAll(async () => {
+      await ts.command.create(ecInput({ executionId: EXEC_ID }));
+    });
+
+    async function read(
+      headers?: Record<string, string>,
+    ): Promise<ExecutionContext> {
+      return await ts.query.getByExecutionId(
+        { executionId: EXEC_ID },
+        { headers },
+      );
+    }
+
+    it("a scope-bound token decrypts; is_secret survives decryption; empty secrets stay empty", async () => {
+      const { token } = ts.server.runnerAuthService.mint(EXEC_ID);
+      const ec = await read(bearerHeaders(token));
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe("super-secret-token");
+      expect(
+        ec.spec!.data["API_TOKEN"]!.isSecret,
+        "is_secret survives decryption",
+      ).toBe(true);
+      expect(ec.spec!.data["REGION"]!.value).toBe("us-east-1");
+      expect(
+        ec.spec!.data["EMPTY_SEC"]!.value,
+        "empty secret declarations pass through the decrypt walk untouched",
+      ).toBe("");
+    });
+
+    it("repeated authorization headers honor the FIRST value (Go metadata.Get semantics)", async () => {
+      // Node joins repeated headers with ", " before Connect sees them —
+      // this pre-joined shape is exactly what a two-header request
+      // presents to the server. Go reads values[0] and decrypts.
+      const { token } = ts.server.runnerAuthService.mint(EXEC_ID);
+      const ec = await read({
+        authorization: `Bearer ${token}, Bearer junk-second-credential`,
+      });
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe("super-secret-token");
+    });
+
+    it("a token for another execution redacts (WARN, not error)", async () => {
+      const { token } = ts.server.runnerAuthService.mint("aex_someone_else");
+      const ec = await read(bearerHeaders(token));
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+    });
+
+    it("a malformed token redacts", async () => {
+      const ec = await read(bearerHeaders("not-a-real-token"));
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+    });
+
+    it("a non-Bearer authorization scheme redacts", async () => {
+      const { token } = ts.server.runnerAuthService.mint(EXEC_ID);
+      const ec = await read({ authorization: `Basic ${token}` });
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+    });
+
+    it("no authorization header at all redacts", async () => {
+      const ec = await read();
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+    });
+
+    it("an EXPIRED scope-bound token redacts (crafted, no sleeps)", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const expired = craftToken(RUNNER_KEY, {
+        token_type: "execution_scoped",
+        execution_id: EXEC_ID,
+        iat: now - 120,
+        exp: now - 60,
+      });
+      const ec = await read(bearerHeaders(expired));
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+    });
+
+    it("a token forged with a DIFFERENT key redacts", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const forged = craftToken(Buffer.alloc(32, 9), {
+        token_type: "execution_scoped",
+        execution_id: EXEC_ID,
+        iat: now,
+        exp: now + 3600,
+      });
+      const ec = await read(bearerHeaders(forged));
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+    });
+
+    it("bearer prefix matching is case-insensitive (Go strings.EqualFold)", async () => {
+      const { token } = ts.server.runnerAuthService.mint(EXEC_ID);
+      const ec = await read({ authorization: `bearer ${token}` });
+      expect(ec.spec!.data["API_TOKEN"]!.value).toBe("super-secret-token");
+    });
+  });
+
+  describe("decrypt error doctrine", () => {
+    it("tampered stored ciphertext drops the ONE key while the read succeeds; intact keys decrypt", async () => {
+      const created = await ts.command.create(
+        ecInput({
+          executionId: "aex_tampered",
+          data: {
+            GOOD_SECRET: { value: "good-value", isSecret: true },
+            BAD_SECRET: { value: "will-be-tampered", isSecret: true },
+          },
+        }),
+      );
+
+      // Corrupt one ciphertext directly in the store: valid prefix, junk
+      // payload — the tampered/truncated/wrong-key class.
+      const stored = await storedRow(ts, created.metadata!.id);
+      stored.spec!.data["BAD_SECRET"]!.value =
+        ENCRYPTED_PREFIX +
+        Buffer.from("garbage-not-a-ciphertext").toString("base64");
+      await ts.server.store.saveResource(
+        ApiResourceKind.execution_context,
+        created.metadata!.id,
+        ExecutionContextSchema,
+        stored,
+      );
+
+      const { token } = ts.server.runnerAuthService.mint("aex_tampered");
+      const ec = await ts.query.getByExecutionId(
+        { executionId: "aex_tampered" },
+        { headers: bearerHeaders(token) },
+      );
+      expect(
+        ec.spec!.data["GOOD_SECRET"]!.value,
+        "intact keys still decrypt",
+      ).toBe("good-value");
+      expect(
+        ec.spec!.data["BAD_SECRET"],
+        "the undecryptable key is DROPPED from the runner read, not errored",
+      ).toBeUndefined();
+    });
+  });
+
+  describe("write-boundary guard (Go TestSecrets_ForgedCiphertextInputRejected)", () => {
+    it("rejects ciphertext-shaped SECRET input with the pinned copy", async () => {
+      const error = await grpcError(() =>
+        ts.command.create(
+          ecInput({
+            data: {
+              API_TOKEN: { value: "enc:v1:Zm9yZ2VkLWJsb2I=", isSecret: true },
+            },
+          }),
+        ),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+      expect(error.rawMessage).toBe(
+        "value for 'API_TOKEN' looks like stored ciphertext (enc:v<N>: prefix); supply the plaintext value",
+      );
+    });
+
+    it("rejects ciphertext-shaped NON-secret input too (the prefix is server-reserved)", async () => {
+      const error = await grpcError(() =>
+        ts.command.create(
+          ecInput({ data: { PLAIN: { value: "enc:v1:Zm9yZ2VkLWJsb2I=" } } }),
+        ),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+    });
+
+    it("rejects FUTURE ciphertext versions (enc:v2:) — the guard fails closed on unknown versions", async () => {
+      const error = await grpcError(() =>
+        ts.command.create(
+          ecInput({
+            data: {
+              API_TOKEN: { value: "enc:v2:Zm9yZ2VkLWJsb2I=", isSecret: true },
+            },
+          }),
+        ),
+      );
+      expect(error.code).toBe(Code.InvalidArgument);
+    });
+  });
+
+  describe("pinned wire copy conformance asserts only by code", () => {
+    it("apply over an existing slug returns Go's exact AlreadyExists copy (metadata.NAME, not slug)", async () => {
+      const name = "Apply Twice";
+      await ts.command.apply(ecInput({ name, executionId: "aex_apply_1" }));
+      const error = await grpcError(() =>
+        ts.command.apply(ecInput({ name, executionId: "aex_apply_2" })),
+      );
+      expect(error.code).toBe(Code.AlreadyExists);
+      expect(error.rawMessage).toBe(`ExecutionContext already exists: ${name}`);
+    });
+
+    it("getByExecutionId of an unknown execution returns Go's exact NotFound copy", async () => {
+      const error = await grpcError(() =>
+        ts.query.getByExecutionId({ executionId: "aex_never_created" }),
+      );
+      expect(error.code).toBe(Code.NotFound);
+      expect(error.rawMessage).toBe(
+        "execution_context not found: execution_id=aex_never_created",
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyless encryption (WARN-degrade — the legacy plaintext shape).
+// ---------------------------------------------------------------------------
+
+describe("executioncontext domain (encryption keyless, runner auth enabled)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({
+      // Unusable explicit key config → SecretService.fromEnv throws →
+      // compose WARN-degrades to the keyless pass-through service.
+      STIGMER_ENCRYPTION_KEY: "definitely-not-a-valid-key",
+      STIGMER_RUNNER_TOKEN_KEY: RUNNER_KEY.toString("base64"),
+    });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+  });
+
+  it("legacy plaintext rows: rest plaintext, redact on user reads, pass through on the runner lane (Go TestSecrets_LegacyPlaintextRows...)", async () => {
+    const created = await ts.command.create(
+      ecInput({ executionId: "aex_legacy" }),
+    );
+
+    const stored = await storedRow(ts, created.metadata!.id);
+    expect(
+      stored.spec!.data["API_TOKEN"]!.value,
+      "precondition: rests plaintext",
+    ).toBe("super-secret-token");
+
+    const fetched = await ts.query.get({ value: created.metadata!.id });
+    expect(
+      fetched.spec!.data["API_TOKEN"]!.value,
+      "user read still redacts",
+    ).toBe(REDACTED_MARKER);
+
+    const { token } = ts.server.runnerAuthService.mint("aex_legacy");
+    const ec = await ts.query.getByExecutionId(
+      { executionId: "aex_legacy" },
+      { headers: bearerHeaders(token) },
+    );
+    expect(
+      ec.spec!.data["API_TOKEN"]!.value,
+      "runner lane passes legacy plaintext through unchanged",
+    ).toBe("super-secret-token");
+  });
+
+  it("an ENCRYPTED row on the keyless server fails LOUD with the pinned Internal copy (never silent junk)", async () => {
+    // Plant a row whose secret is genuine ciphertext (produced with a real
+    // key this server does not hold) — the key-file-lost scenario.
+    const keyed = SecretService.create(ENCRYPTION_KEY);
+    const created = await ts.command.create(
+      ecInput({
+        executionId: "aex_keyloss",
+        data: { HELD_SECRET: { value: "placeholder", isSecret: true } },
+      }),
+    );
+    const stored = await storedRow(ts, created.metadata!.id);
+    stored.spec!.data["HELD_SECRET"]!.value = keyed.encrypt(
+      "the-real-credential",
+    );
+    await ts.server.store.saveResource(
+      ApiResourceKind.execution_context,
+      created.metadata!.id,
+      ExecutionContextSchema,
+      stored,
+    );
+
+    const { token } = ts.server.runnerAuthService.mint("aex_keyloss");
+    const error = await grpcError(() =>
+      ts.query.getByExecutionId(
+        { executionId: "aex_keyloss" },
+        { headers: bearerHeaders(token) },
+      ),
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe(
+      "execution context for aex_keyloss holds encrypted secret 'HELD_SECRET' but no encryption key is configured",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The DeleteExecutionContext activity seam (store-direct, no server).
+// ---------------------------------------------------------------------------
+
+describe("DeleteExecutionContext activity seam", () => {
+  it("exports Go's registration name byte-identically", () => {
+    expect(DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME).toBe(
+      "DeleteExecutionContext",
+    );
+  });
+
+  it("deletes the EC for an execution and is a no-op when none exists (idempotent)", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ectx-activity-test-"));
+    const store = SqliteStore.open(path.join(dir, "stigmer.db"), silentLogger);
+    try {
+      const ec = ecInput({ executionId: "aex_cleanup" });
+      const message = create(ExecutionContextSchema, {
+        ...ec,
+        metadata: { ...ec.metadata, id: "ectx_cleanup" },
+      });
+      await store.saveResource(
+        ApiResourceKind.execution_context,
+        "ectx_cleanup",
+        ExecutionContextSchema,
+        message,
+      );
+
+      await deleteExecutionContextForExecution(
+        store,
+        silentLogger,
+        "aex_cleanup",
+      );
+      await expect(
+        store.getResource(
+          ApiResourceKind.execution_context,
+          "ectx_cleanup",
+          ExecutionContextSchema,
+        ),
+      ).rejects.toThrow();
+
+      // Second run: the row is gone — best-effort means no throw, ever.
+      await expect(
+        deleteExecutionContextForExecution(store, silentLogger, "aex_cleanup"),
+      ).resolves.toBeUndefined();
+    } finally {
+      await store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("swallows QUERY failures (closed store: findByField throws before the delete is reached)", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ectx-activity-closed-"));
+    const store = SqliteStore.open(path.join(dir, "stigmer.db"), silentLogger);
+    await store.close();
+    try {
+      await expect(
+        deleteExecutionContextForExecution(store, silentLogger, "aex_whatever"),
+      ).resolves.toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("swallows DELETE failures (row found, delete throws → WARN, row left in place, no throw)", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ectx-activity-delfail-"));
+    const store = SqliteStore.open(path.join(dir, "stigmer.db"), silentLogger);
+    try {
+      const ec = ecInput({ executionId: "aex_delfail" });
+      await store.saveResource(
+        ApiResourceKind.execution_context,
+        "ectx_delfail",
+        ExecutionContextSchema,
+        create(ExecutionContextSchema, {
+          ...ec,
+          metadata: { ...ec.metadata, id: "ectx_delfail" },
+        }),
+      );
+
+      // A delegating stub that fails ONLY the delete — exercises the
+      // second best-effort branch (find succeeds, delete throws).
+      const failingStore = {
+        findByField: store.findByField.bind(store),
+        deleteResource: () =>
+          Promise.reject(new Error("simulated delete failure")),
+      } as unknown as Parameters<typeof deleteExecutionContextForExecution>[0];
+
+      await expect(
+        deleteExecutionContextForExecution(
+          failingStore,
+          silentLogger,
+          "aex_delfail",
+        ),
+      ).resolves.toBeUndefined();
+
+      const survivor = await store.getResource(
+        ApiResourceKind.execution_context,
+        "ectx_delfail",
+        ExecutionContextSchema,
+      );
+      expect(survivor.metadata?.id, "the row survives a failed delete").toBe(
+        "ectx_delfail",
+      );
+    } finally {
+      await store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Search extractor (metadata only — secrets never reach FTS).
+// ---------------------------------------------------------------------------
+
+describe("search extractor", () => {
+  it("indexes name/tags/org/visibility with an EMPTY description (no spec field is indexed)", () => {
+    const ec = create(ExecutionContextSchema, {
+      metadata: {
+        name: "Indexed",
+        org: ORG,
+        tags: ["a", "b"],
+      },
+      spec: {
+        executionId: "aex_idx",
+        data: { API_TOKEN: { value: "must-never-be-indexed", isSecret: true } },
+      },
+    });
+    const entry = executionContextSearchExtractor.getSearchIndexEntry(ec);
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe("Indexed");
+    expect(
+      entry!.description,
+      "EC has no description; Go's summary is empty",
+    ).toBe("");
+    expect(entry!.tags).toBe("a b");
+    expect(entry!.org).toBe(ORG);
+    expect(JSON.stringify(entry)).not.toContain("must-never-be-indexed");
+  });
+
+  it("returns undefined without metadata (Go's nil guard)", () => {
+    const ec = create(ExecutionContextSchema, {});
+    expect(
+      executionContextSearchExtractor.getSearchIndexEntry(ec),
+    ).toBeUndefined();
+  });
+});
+
+// Bearer extraction precision — the two parsing arms the dispatch matrix
+// above does not isolate: Go's length guard ("Bearer " with an empty
+// remainder) and strings.TrimSpace on the extracted token.
+describe("bearer header edge shapes (through the enabled server)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({
+      STIGMER_ENCRYPTION_KEY: ENCRYPTION_KEY.toString("base64"),
+      STIGMER_RUNNER_TOKEN_KEY: RUNNER_KEY.toString("base64"),
+    });
+    await ts.command.create(ecInput({ executionId: "aex_edges" }));
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+  });
+
+  it("'Bearer' with an empty remainder redacts (Go's length guard)", async () => {
+    const ec = await ts.query.getByExecutionId(
+      { executionId: "aex_edges" },
+      { headers: { authorization: "Bearer " } },
+    );
+    expect(ec.spec!.data["API_TOKEN"]!.value).toBe(REDACTED_MARKER);
+  });
+
+  it("surrounding whitespace around the token is trimmed (Go strings.TrimSpace)", async () => {
+    const { token } = ts.server.runnerAuthService.mint("aex_edges");
+    const ec = await ts.query.getByExecutionId(
+      { executionId: "aex_edges" },
+      { headers: { authorization: `Bearer   ${token}  ` } },
+    );
+    expect(ec.spec!.data["API_TOKEN"]!.value).toBe("super-secret-token");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/constants.ts
@@ -1,0 +1,49 @@
+/**
+ * ExecutionContext domain constants — the byte-pinned wire copy shared
+ * with the Go server. Every string here reaches clients verbatim (the
+ * conformance suite and the runner's error surfaces read them), so none
+ * is editable without an owner-ratified wire change.
+ *
+ * The redaction marker itself is NOT defined here: it is imported from
+ * the environment domain's constants (the single source of truth both Go
+ * domains share — Go's redact_secret_values.go imports
+ * envsteps.RedactedMarker the same way).
+ */
+
+/**
+ * InvalidArgument copy for client-supplied enc:v<N>: input — Go
+ * encrypt_secret_values.go's rejectCiphertextShapedStep, byte-pinned.
+ * Note the copy differs from the environment domain's forged-ciphertext
+ * message: each domain pins its own Go string.
+ */
+export function ciphertextShapedMessage(key: string): string {
+  return (
+    `value for '${key}' looks like stored ciphertext (enc:v<N>: prefix); ` +
+    "supply the plaintext value"
+  );
+}
+
+/**
+ * Internal copy for an encrypt failure at write — Go
+ * encrypt_secret_values.go (no "variable" wording, unlike environment).
+ */
+export function encryptFailureMessage(key: string): string {
+  return `failed to encrypt secret value for '${key}'`;
+}
+
+/**
+ * Internal copy for the fail-loud decrypt arm: the row holds ciphertext
+ * but the server has no key (key file lost). Dropping the value would
+ * start the execution silently missing a credential — a confusing
+ * downstream failure instead of a clear one here (the oss#405 doctrine).
+ * Go resolve_values_for_caller.go, byte-pinned.
+ */
+export function encryptionKeyMissingMessage(
+  executionId: string,
+  key: string,
+): string {
+  return (
+    `execution context for ${executionId} holds encrypted secret '${key}' ` +
+    "but no encryption key is configured"
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/controller.ts
@@ -1,0 +1,337 @@
+/**
+ * ExecutionContext controller — ports pkg/domain/executioncontext
+ * (command + query sides): the create-only, secret-bearing resource the
+ * execution engine mints to carry one run's merged runtime configuration
+ * and secrets, deleted when the execution completes.
+ *
+ * The domain diverges from the other flat domains in two
+ * contract-significant ways:
+ *   - There is NO update RPC and NO list RPC. Reads are by id, by
+ *     reference (org + slug), or by the parent execution_id.
+ *   - apply is create-or-FAIL: applying over an existing slug returns a
+ *     real AlreadyExists, not an update.
+ *
+ * Secret handling (oss#535, the stigmer-cloud#152 contract ported):
+ * is_secret values rest encrypted (enc:v1:), leave the server as
+ * ***REDACTED*** markers on EVERY user-shaped boundary — get,
+ * getByReference, the create/apply and delete echoes — and are revealed
+ * only through getByExecutionId to a caller presenting an
+ * execution-scoped runner token bound to this very EC (see
+ * resolve-values-for-caller.ts).
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by executioncontext.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and __tests__/executioncontext.test.ts
+ * (the decrypt-lane matrix conformance deliberately never exercises —
+ * its harness authenticates as a user).
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies,
+ * and Publish steps (no multi-tenant auth, IAM/FGA, or event publishing
+ * here); the redaction and decrypt-lane contracts run in BOTH editions,
+ * keeping the error contract identical.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ExecutionContextCommandController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/command_pb";
+import { ExecutionContextQueryController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/query_pb";
+import type {
+  ExecutionContextExecutionIdInput,
+  ExecutionContextId,
+} from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type {
+  ApiResourceDeleteInput,
+  ApiResourceReference,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { alreadyExistsError, internalError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import {
+  RESOURCE_ID_KEY,
+  newDeleteResourceStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import type { Store } from "../../store/interface.js";
+import { redactExecutionContextSecrets } from "./redact.js";
+import { resolveValuesForCaller } from "./resolve-values-for-caller.js";
+import { executionContextSearchExtractor } from "./search-extractor.js";
+import {
+  newEncryptSecretValuesStep,
+  newLoadByExecutionIdStep,
+  newRejectCiphertextShapedStep,
+} from "./steps.js";
+
+export interface ExecutionContextControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  /**
+   * Shared with the Environment/OAuthApp controllers so the
+   * encrypt-on-write / decrypt-on-read key pair always matches.
+   */
+  readonly secretService: SecretService;
+  /**
+   * Verifies the execution-scoped tokens that gate getByExecutionId's
+   * decrypt lane. REQUIRED: the composition root always constructs one
+   * (boot-fatal otherwise); the keyless state — verify rejects every
+   * token, every read redacts — is the modeled "disabled" arm, the TS
+   * shape of Go's nil-service check.
+   */
+  readonly runnerAuthService: RunnerAuthService;
+}
+
+/** Registers both executioncontext services on the router (routes stage). */
+export function registerExecutionContextServices(
+  router: ConnectRouter,
+  deps: ExecutionContextControllerDeps,
+): void {
+  router.service(ExecutionContextCommandController, {
+    apply: (ec, ctx) => apply(deps, ec, ctx),
+    create: (ec, ctx) => createExecutionContext(deps, ec, ctx),
+    delete: (input, ctx) => deleteExecutionContext(deps, input, ctx),
+  });
+  router.service(ExecutionContextQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getByExecutionId: (input, ctx) => getByExecutionId(deps, input, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. The response echo is
+ * redacted AFTER the pipeline: the persisted resource is echoed back, and
+ * without redaction the echo would leak either the plaintext the caller
+ * just sent or the stored ciphertext. The internal builders (agent
+ * execution, workflow execution, MCP connect — they arrive with #17/#19/
+ * #20) only read metadata.id from the echo, so they are unaffected.
+ */
+async function createExecutionContext(
+  deps: ExecutionContextControllerDeps,
+  ec: ExecutionContext,
+  ctx: HandlerContext,
+): Promise<ExecutionContext> {
+  const reqCtx = new RequestContext(ExecutionContextSchema, ec, kindOf(ctx));
+  await newPipeline<typeof ExecutionContextSchema>(
+    "execution-context-create",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newRejectCiphertextShapedStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        executionContextSearchExtractor,
+        deps.logger,
+      ),
+    )
+    .build()
+    .execute(reqCtx);
+  redactExecutionContextSecrets(reqCtx.newState);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — Go apply.go: declarative create-or-FAIL (ExecutionContext has
+ * no update). A minimal probe pipeline decides existence, then delegates
+ * to Create with the ORIGINAL request message or returns AlreadyExists
+ * with Go's exact copy — note it carries metadata.NAME, while the
+ * duplicate arm inside the delegated create emits CheckDuplicate's
+ * slug-shaped message; both are wire contract, reached via different
+ * entry paths.
+ */
+async function apply(
+  deps: ExecutionContextControllerDeps,
+  ec: ExecutionContext,
+  ctx: HandlerContext,
+): Promise<ExecutionContext> {
+  const reqCtx = new RequestContext(ExecutionContextSchema, ec, kindOf(ctx));
+  await newPipeline<typeof ExecutionContextSchema>(
+    "execution-context-apply",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  if (shouldCreate) {
+    return createExecutionContext(deps, ec, ctx);
+  }
+  deps.logger.warn("ExecutionContext already exists - UPDATE not supported", {
+    slug: ec.metadata?.name ?? "",
+    id: ec.metadata?.id ?? "",
+  });
+  throw alreadyExistsError("ExecutionContext", ec.metadata?.name ?? "");
+}
+
+/**
+ * Delete — returns the deleted execution context REDACTED (oss#535):
+ * without it, delete would be the one path that leaks the stored
+ * representation — ciphertext today, actual plaintext for legacy
+ * pre-encryption rows. The id is seeded into context manually because
+ * ApiResourceDeleteInput carries resource_id, not the `value` field
+ * ExtractResourceId expects (Go does the same manual seed).
+ */
+async function deleteExecutionContext(
+  deps: ExecutionContextControllerDeps,
+  input: ApiResourceDeleteInput,
+  ctx: HandlerContext,
+): Promise<ExecutionContext> {
+  const reqCtx = new RequestContext(
+    ExecutionContextCommandController.method.delete.input,
+    input,
+    kindOf(ctx),
+  );
+  reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
+  await newPipeline<
+    typeof ExecutionContextCommandController.method.delete.input
+  >("execution-context-delete", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, ExecutionContextSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted execution context not found in context"),
+      "deleted execution context not found in context",
+    );
+  }
+  const ec = deleted as ExecutionContext;
+  redactExecutionContextSecrets(ec);
+  return ec;
+}
+
+/** Get — LoadTarget by id; the response is redacted (oss#535). */
+async function get(
+  deps: ExecutionContextControllerDeps,
+  id: ExecutionContextId,
+  ctx: HandlerContext,
+): Promise<ExecutionContext> {
+  const reqCtx = new RequestContext(
+    ExecutionContextQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ExecutionContextQueryController.method.get.input>(
+    "execution-context-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, ExecutionContextSchema))
+    .build()
+    .execute(reqCtx);
+  const ec = reqCtx.get(TARGET_RESOURCE_KEY) as ExecutionContext;
+  redactExecutionContextSecrets(ec);
+  return ec;
+}
+
+/** GetByReference — slug+org lookup; the response is redacted. */
+async function getByReference(
+  deps: ExecutionContextControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<ExecutionContext> {
+  const reqCtx = new RequestContext(
+    ExecutionContextQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof ExecutionContextQueryController.method.getByReference.input
+  >("execution-context-get-by-reference", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, ExecutionContextSchema))
+    .build()
+    .execute(reqCtx);
+  const ec = reqCtx.get(TARGET_RESOURCE_KEY) as ExecutionContext;
+  redactExecutionContextSecrets(ec);
+  return ec;
+}
+
+/**
+ * GetByExecutionId — the runner's secret-delivery path: the unified TS
+ * runner fetches the merged environment variables here before executing
+ * an agent or workflow (and during MCP connect discovery). The
+ * execution_id corresponds to a WorkflowExecution ID, AgentExecution ID,
+ * or connect-flow execution id.
+ *
+ * The response carries DECRYPTED is_secret values only when the caller
+ * presents an execution-scoped runner token whose binding matches this
+ * EC — see resolve-values-for-caller.ts. Every other caller receives the
+ * same redaction as get/getByReference, as a SUCCESS.
+ */
+async function getByExecutionId(
+  deps: ExecutionContextControllerDeps,
+  input: ExecutionContextExecutionIdInput,
+  ctx: HandlerContext,
+): Promise<ExecutionContext> {
+  const reqCtx = new RequestContext(
+    ExecutionContextQueryController.method.getByExecutionId.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof ExecutionContextQueryController.method.getByExecutionId.input
+  >("execution-context-get-by-execution-id", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByExecutionIdStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  // Resolve secret values by presented credential: decrypt for a
+  // scope-bound runner token, redact for everyone else. Both transforms
+  // mutate the fresh store unmarshal, never the stored row.
+  const ec = reqCtx.get(TARGET_RESOURCE_KEY) as ExecutionContext;
+  resolveValuesForCaller(deps, ctx, ec);
+  return ec;
+}

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/redact.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/redact.ts
@@ -1,0 +1,42 @@
+/**
+ * Redaction helper — ports
+ * pkg/domain/executioncontext/controller/redact_secret_values.go.
+ * Deliberately NOT a pipeline step: redaction runs post-pipeline at every
+ * ExecutionContext-returning boundary outside the runner lane.
+ */
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+
+import { REDACTED_MARKER } from "../environment/constants.js";
+
+/**
+ * Go RedactExecutionContextSecrets: replaces every NON-EMPTY is_secret
+ * value with the marker — called at every controller boundary that
+ * returns an ExecutionContext to a caller outside the runner lane: get,
+ * getByReference, the create/apply response echo, the delete response
+ * echo, and getByExecutionId for callers without a scope-bound runner
+ * token. The EC twin of the environment domain's redaction (oss#535); the
+ * marker is imported from that domain so the sentinel has a single source
+ * of truth, the same move both Go domains make.
+ *
+ * is_secret is preserved so clients know a hidden value exists; EMPTY
+ * secret declarations stay empty (a marker would falsely signal a stored
+ * value). Redaction is representation-agnostic: it replaces whatever is
+ * stored (ciphertext or legacy pre-oss#535 plaintext). Mutates in place —
+ * callers hold either a fresh store unmarshal (reads) or the
+ * already-persisted new state (create echo), so redaction never reaches
+ * the store. Runs strictly AFTER Persist and IndexSearch on the create
+ * path.
+ */
+export function redactExecutionContextSecrets(
+  ec: ExecutionContext | undefined,
+): void {
+  const data = ec?.spec?.data;
+  if (data === undefined) {
+    return;
+  }
+  for (const value of Object.values(data)) {
+    if (value.isSecret && value.value !== "") {
+      value.value = REDACTED_MARKER;
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/resolve-values-for-caller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/resolve-values-for-caller.ts
@@ -1,0 +1,188 @@
+/**
+ * resolveValuesForCaller — ports
+ * pkg/domain/executioncontext/controller/resolve_values_for_caller.go:
+ * decides, by presented credential, whether a getByExecutionId response
+ * carries decrypted or redacted secret values, and applies the transform
+ * in place. The OSS mirror of the cloud edition's
+ * ResolveExecutionContextValuesForCaller (oss#535, porting the
+ * stigmer-cloud#152 contract: no read RPC hands plaintext secrets to a
+ * caller outside the runner lane).
+ *
+ * # The lane
+ *
+ * getByExecutionId is the runner's secret-delivery path. OSS has no
+ * caller identity, so the runner distinguishes itself with an
+ * execution-scoped token minted by getRunnerScopedToken and presented as
+ * a Bearer authorization header (the same header shape a cloud runner
+ * uses for its sandbox credential). Decrypt requires the FULL binding: a
+ * valid, unexpired token whose execution_id claim equals this EC's
+ * spec.execution_id. Everything else — no header, malformed or expired
+ * token, or a token minted for a different execution — falls closed to
+ * the same redaction get/getByReference apply, as a SUCCESSFUL response,
+ * not an error.
+ *
+ * Bearer verification lives HERE, in the domain, not in the interceptor
+ * chain: the auth interceptor stays a pass-through seam (phase-3 server
+ * mode), and this is the one RPC that reads the header — exactly the
+ * consumer the runnerauth module header reserves ("the executioncontext
+ * resolve step").
+ *
+ * # Decrypt error doctrine (the oss#405 runtime-resolution doctrine)
+ *
+ *   - Undecryptable ciphertext (tampered/truncated/wrong-key) is scoped
+ *     to one value: WARN and drop that key rather than failing the read.
+ *   - EncryptionDisabledError fails the request: the stored ciphertext
+ *     may be perfectly valid (key file lost), and dropping it would start
+ *     the execution silently missing a credential — a confusing
+ *     downstream failure instead of a clear one here.
+ *   - Legacy pre-oss#535 plaintext rows pass through undecorated (decrypt
+ *     only runs on isEncrypted values), so old stores serve without
+ *     migration.
+ */
+import type { HandlerContext } from "@connectrpc/connect";
+
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { EncryptionDisabledError } from "../../encryption/encryption.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { internalError } from "../../pipeline/errors.js";
+import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import { encryptionKeyMissingMessage } from "./constants.js";
+import { redactExecutionContextSecrets } from "./redact.js";
+
+export interface ResolveValuesDeps {
+  readonly logger: Logger;
+  readonly secretService: SecretService;
+  readonly runnerAuthService: RunnerAuthService;
+}
+
+/**
+ * Applies the credential-dispatched transform in place: decrypt for a
+ * scope-bound runner token, redact for everyone else. Both transforms
+ * mutate the fresh store unmarshal, never the stored row.
+ */
+export function resolveValuesForCaller(
+  deps: ResolveValuesDeps,
+  ctx: HandlerContext,
+  ec: ExecutionContext,
+): void {
+  const executionId = verifyRunnerToken(deps, ctx, ec);
+  if (executionId !== undefined) {
+    deps.logger.debug(
+      "Scope-bound runner token presented - decrypting execution context secrets",
+      { executionId },
+    );
+    decryptSecretValues(deps, ec);
+    return;
+  }
+  redactExecutionContextSecrets(ec);
+}
+
+/**
+ * Go verifyRunnerToken: the execution id the token is bound to when the
+ * caller presented a valid runner token bound to exactly this execution
+ * context; undefined otherwise. Every failure mode answers undefined —
+ * the caller falls closed to redaction — with the mismatch case
+ * WARN-logged because a runner reading across executions indicates a bug,
+ * while an absent header is just an ordinary user-shaped read. A keyless
+ * RunnerAuthService rejects every token (verify throws), the TS shape of
+ * Go's nil-service arm: without a key no token can be genuine.
+ */
+function verifyRunnerToken(
+  deps: ResolveValuesDeps,
+  ctx: HandlerContext,
+  ec: ExecutionContext,
+): string | undefined {
+  const token = bearerToken(ctx);
+  if (token === "") {
+    return undefined;
+  }
+
+  let tokenExecutionId: string;
+  try {
+    tokenExecutionId = deps.runnerAuthService.verify(token);
+  } catch {
+    deps.logger.debug(
+      "Presented runner token failed verification - redacting execution context secrets",
+    );
+    return undefined;
+  }
+
+  if (tokenExecutionId !== (ec.spec?.executionId ?? "")) {
+    deps.logger.warn(
+      "Runner token is not scope-bound to this execution context - redacting secrets",
+      {
+        tokenExecutionId,
+        executionId: ec.spec?.executionId ?? "",
+      },
+    );
+    return undefined;
+  }
+
+  return tokenExecutionId;
+}
+
+/**
+ * Go bearerToken: the Bearer credential from the request's authorization
+ * header; empty when absent or differently shaped. Ports Go's exact
+ * shape: case-insensitive "bearer " prefix match, the remainder must be
+ * non-empty before trimming, trailing/leading whitespace trimmed.
+ *
+ * Repeated headers: Go's metadata.Get returns a slice and the Go server
+ * reads values[0]; Node's http2 layer joins repeated headers with ", "
+ * before Connect ever sees them, so the first comma segment IS Go's
+ * first value — a genuine token (base64url segments joined by dots) can
+ * never contain a comma, so the split is lossless for every legitimate
+ * shape.
+ */
+function bearerToken(ctx: HandlerContext): string {
+  const joined = ctx.requestHeader.get("authorization") ?? "";
+  const header = joined.split(",")[0] ?? "";
+  const prefix = "bearer ";
+  if (
+    header.length <= prefix.length ||
+    header.slice(0, prefix.length).toLowerCase() !== prefix
+  ) {
+    return "";
+  }
+  return header.slice(prefix.length).trim();
+}
+
+/**
+ * Go decryptSecretValues: walks spec.data and decrypts every encrypted
+ * is_secret value in place, per the doctrine documented on the module
+ * header.
+ */
+function decryptSecretValues(
+  deps: ResolveValuesDeps,
+  ec: ExecutionContext,
+): void {
+  const executionId = ec.spec?.executionId ?? "";
+  const data = ec.spec?.data ?? {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!value.isSecret || !deps.secretService.isEncrypted(value.value)) {
+      continue;
+    }
+
+    try {
+      value.value = deps.secretService.decrypt(value.value);
+    } catch (error) {
+      if (error instanceof EncryptionDisabledError) {
+        throw internalError(
+          error,
+          encryptionKeyMissingMessage(executionId, key),
+        );
+      }
+      deps.logger.warn(
+        "Undecryptable ciphertext in execution context — dropping this value from the runner read",
+        {
+          key,
+          executionId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      delete data[key];
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/search-extractor.ts
@@ -1,0 +1,37 @@
+/**
+ * ExecutionContext search extractor — ports the GetSearchIndexEntry side
+ * of pkg/query/search/extractor/execution_context_extractor.go. Execution
+ * contexts have no description field, so the summary is empty — and
+ * secret DATA is deliberately never indexed: only name, tags, org, and
+ * visibility reach FTS5. The query side of the extractor contract
+ * (ToSearchResult) arrives with the search service sub-project (#14
+ * sp.search-and-activity).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const executionContextSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const ec = resource as unknown as ExecutionContext;
+    const metadata = ec.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      // No description field on the spec; Go's GetSearchSummary returns "".
+      description: "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(ec.status?.audit?.specAudit?.createdAt?.seconds ?? 0n),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/steps.ts
@@ -1,0 +1,180 @@
+/**
+ * ExecutionContext domain steps — port the domain-local steps of
+ * pkg/domain/executioncontext/controller/ (the write-boundary ciphertext
+ * guard, the encrypt-at-rest step, and the execution_id loader).
+ *
+ * The ordering contract these steps embody (oss#535, the EC flavor of the
+ * environment domain's "sentinels → encrypt" doc):
+ *   1. RejectCiphertextShapedValues runs BEFORE EncryptSecretValues.
+ *      ExecutionContext is create-only with NO redaction round-trip
+ *      (unlike Environment, whose PreserveRedactedSecrets restores
+ *      ***REDACTED*** markers on update), so this guard is the WHOLE
+ *      write boundary: every legitimate creator — the agent/workflow
+ *      builders, the MCP connect handler, an SDK caller — supplies
+ *      plaintext, and nothing with an enc:v<N>: prefix reaches the store
+ *      except server-produced ciphertext. That is what keeps the decrypt
+ *      lane safe from forged or replayed blobs.
+ *   2. Redaction (redact.ts) runs AFTER Persist, outside the pipeline.
+ *
+ * Proven by executioncontext.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and __tests__/executioncontext.test.ts.
+ */
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionContextExecutionIdInput } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/io_pb";
+import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import type { ExecutionContextQueryController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/query_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { isCiphertextShaped } from "../../encryption/encryption.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import { ciphertextShapedMessage, encryptFailureMessage } from "./constants.js";
+
+/**
+ * RejectCiphertextShapedValues — Go rejectCiphertextShapedStep: refuses
+ * client-supplied values that look like stored ciphertext (the enc:v<N>:
+ * prefix family, ANY version — an unknown future version fails closed) —
+ * the EC flavor of the oss#395 / cloud#229 write-boundary guard. Without
+ * it, the encrypt step's idempotent pass-through would let a caller
+ * smuggle a forged or replayed ciphertext blob into the store, where the
+ * runner lane would later try to decrypt it.
+ *
+ * Checks ALL of spec.data — secret and non-secret alike, exactly as Go
+ * does: the prefix is server-reserved regardless of the is_secret flag.
+ * Reads the immutable input (Go ctx.Input()), the request as the client
+ * sent it.
+ */
+export function newRejectCiphertextShapedStep(): PipelineStep<
+  typeof ExecutionContextSchema
+> {
+  return {
+    name: "RejectCiphertextShapedValues",
+    execute(ctx: RequestContext<typeof ExecutionContextSchema>): void {
+      const data = ctx.input.spec?.data ?? {};
+      for (const [key, value] of Object.entries(data)) {
+        if (isCiphertextShaped(value.value)) {
+          throw invalidArgumentError(ciphertextShapedMessage(key));
+        }
+      }
+    },
+  };
+}
+
+/**
+ * EncryptSecretValues — Go encryptSecretValuesStep: encrypts every
+ * non-empty is_secret value in spec.data before persistence — the EC twin
+ * of the environment domain's step of the same name, closing the at-rest
+ * half of oss#535 (the merged EC — decrypted environment secrets,
+ * runtime_env overrides, injected OAuth tokens — rested plaintext for
+ * each run's duration, the same backup-exposure class oss#405 closed for
+ * environments).
+ *
+ * Runs after RejectCiphertextShapedValues, so every secret value reaching
+ * it is client plaintext; encrypt's idempotent pass-through is therefore
+ * never exercised by design, but keeps a double application harmless.
+ *
+ * Keyless mode: values pass through plaintext with one WARN per request,
+ * emitted only when a non-empty secret would actually rest plaintext (the
+ * oss#394 convention). Non-secret values are never touched: the read
+ * paths gate decryption on is_secret, so encrypting a non-secret value
+ * would strand it as unreadable ciphertext.
+ */
+export function newEncryptSecretValuesStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof ExecutionContextSchema> {
+  return {
+    name: "EncryptSecretValues",
+    execute(ctx: RequestContext<typeof ExecutionContextSchema>): void {
+      const ec = ctx.newState;
+      const data = ec.spec?.data;
+      if (data === undefined || Object.keys(data).length === 0) {
+        return;
+      }
+
+      if (!secretService.isEnabled()) {
+        if (hasNonEmptySecret(data)) {
+          logger.warn(
+            "Encryption disabled: execution context secret values will be stored in plaintext",
+            { executionId: ec.spec?.executionId ?? "" },
+          );
+        }
+        return;
+      }
+
+      for (const [key, value] of Object.entries(data)) {
+        if (!value.isSecret || value.value === "") {
+          continue;
+        }
+        try {
+          value.value = secretService.encrypt(value.value);
+        } catch (error) {
+          throw internalError(error, encryptFailureMessage(key));
+        }
+      }
+    },
+  };
+}
+
+/** Whether any entry would have been encrypted — keeps the WARN honest. */
+function hasNonEmptySecret(data: Record<string, ExecutionValue>): boolean {
+  return Object.values(data).some((v) => v.isSecret && v.value !== "");
+}
+
+type GetByExecutionIdDesc =
+  typeof ExecutionContextQueryController.method.getByExecutionId.input;
+
+/**
+ * LoadByExecutionId — Go loadByExecutionIdStep: loads an ExecutionContext
+ * by querying the spec.executionId FIELD (protobuf JSON naming), not the
+ * resource id — the runner's lookup key is the parent execution's id.
+ * findByField is a full scan of the kind with first-match semantics, the
+ * Go-parity behavior the store interface documents.
+ *
+ * The empty-input guard is unreachable behind ValidateProto (min_len 1 on
+ * execution_id) but ports Go's in-step defense verbatim so the chains
+ * correspond step-for-step.
+ */
+export function newLoadByExecutionIdStep(
+  store: Store,
+): PipelineStep<GetByExecutionIdDesc> {
+  return {
+    name: "LoadByExecutionId",
+    async execute(ctx: RequestContext<GetByExecutionIdDesc>): Promise<void> {
+      const input: ExecutionContextExecutionIdInput = ctx.input;
+      if (input.executionId === "") {
+        throw invalidArgumentError("execution_id is required");
+      }
+
+      let executionContext: ExecutionContext;
+      try {
+        executionContext = await store.findByField(
+          ctx.apiResourceKind,
+          "spec.executionId",
+          input.executionId,
+          ExecutionContextSchema,
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError(
+            "execution_context",
+            `execution_id=${input.executionId}`,
+          );
+        }
+        throw internalError(error, "failed to query execution context");
+      }
+
+      ctx.set(TARGET_RESOURCE_KEY, executionContext);
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/temporal/delete-execution-context.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/temporal/delete-execution-context.ts
@@ -1,0 +1,96 @@
+/**
+ * DeleteExecutionContext activity seam — ports
+ * pkg/domain/executioncontext/temporal/activities/delete_execution_context.go.
+ *
+ * The ExecutionContext is an ephemeral resource containing the
+ * fully-merged environment (environment_refs values overridden by
+ * runtime_env, filtered to the blueprint's declared env keys), including
+ * secrets. It must be cleaned up when the execution finishes so sensitive
+ * data does not persist beyond the execution lifetime.
+ *
+ * A SEAM, deliberately unregistered: this module has no Temporal SDK
+ * dependency — it is the plain store-direct function the agent-execution
+ * and workflow-execution workers (D4 #18/#21) will register as a local
+ * activity under DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME, shared by both
+ * workflows exactly as in Go.
+ *
+ * Behavior (Go parity):
+ *   - Idempotent: no-op if the ExecutionContext does not exist.
+ *   - Best-effort: logs failures but never throws — cleanup failure must
+ *     not affect the workflow outcome. A failed delete leaves the row in
+ *     place with its secret values still encrypted at rest (oss#535);
+ *     nothing retries it later, so the WARN is the operator's signal.
+ *   - Security-aware: logs the variable count, never names or values.
+ */
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import { ResourceNotFoundError } from "../../../store/interface.js";
+import type { Store } from "../../../store/interface.js";
+
+/** The activity name for worker registration — Go's constant, byte-pinned. */
+export const DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME = "DeleteExecutionContext";
+
+/**
+ * Finds and deletes the ExecutionContext for the given execution ID
+ * (an AgentExecution or WorkflowExecution id — the lookup uses the
+ * spec.executionId field).
+ */
+export async function deleteExecutionContextForExecution(
+  store: Store,
+  logger: Logger,
+  executionId: string,
+): Promise<void> {
+  logger.debug("Cleaning up ExecutionContext for execution", { executionId });
+
+  let ec: ExecutionContext;
+  try {
+    ec = await store.findByField(
+      ApiResourceKind.execution_context,
+      "spec.executionId",
+      executionId,
+      ExecutionContextSchema,
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      logger.debug(
+        "No ExecutionContext found for execution -- nothing to clean up",
+        { executionId },
+      );
+      return;
+    }
+    logger.warn(
+      "Failed to query ExecutionContext -- leaving cleanup to the operator",
+      {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+
+  const contextId = ec.metadata?.id ?? "";
+  const dataCount = Object.keys(ec.spec?.data ?? {}).length;
+
+  try {
+    await store.deleteResource(ApiResourceKind.execution_context, contextId);
+  } catch (error) {
+    logger.warn(
+      "Failed to delete ExecutionContext -- leaving cleanup to the operator",
+      {
+        executionId,
+        contextId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+
+  logger.info("Deleted ExecutionContext for execution", {
+    executionId,
+    contextId,
+    variables: dataCount,
+  });
+}

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -20,6 +20,10 @@
 //   - workflow + workflowinstance — sub-project #7 (sp.workflow-family;
 //     authoring/validation/versioning incl. the #341 head-repoint and the
 //     CW-9 updateVisibility block).
+//   - executioncontext — sub-project #15 (sp.executioncontext; the
+//     create-only secret-delivery domain. The suite is user-shaped by
+//     design — the runner-token decrypt lane is proven by the domain's
+//     own __tests__/executioncontext.test.ts).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -34,6 +38,7 @@ export default defineConfig({
       "src/suites/memory.conformance.test.ts",
       "src/suites/workflow.conformance.test.ts",
       "src/suites/workflowinstance.conformance.test.ts",
+      "src/suites/executioncontext.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the ExecutionContext domain — the create-only, secret-bearing resource the execution engine mints per run — to the TS server (D4 entry #15, program 20260822.01). Ships the full RPC surface (create/apply/delete + get/getByReference/getByExecutionId), the Bearer runner-token decrypt lane, and the `DeleteExecutionContext` activity seam. The `local-ts` conformance roster grows 9 suites/208 → **10 suites/231**.

## Context

Entry #15 is the sole remaining blocker for #17 `sp.agentexecution-domain`: the agent-execution create pipeline persists its merged environment through this domain, and the runner reads it back through `getByExecutionId`. The domain executes the oss#535 secret contract on the TS edition: encrypt at write, redact every user-shaped read, decrypt only for a scope-bound execution token.

## Changes

- `src/domain/executioncontext/` — controller (6 RPCs, pipelines mirroring Go's chains character-for-character), domain steps (`RejectCiphertextShapedValues`, `EncryptSecretValues`, `LoadByExecutionId`), redaction helper (marker imported from the environment domain's single source of truth, as Go does), search extractor (metadata only; empty summary — secrets never reach FTS), and `resolve-values-for-caller.ts` (the decrypt lane).
- `temporal/delete-execution-context.ts` — the store-direct, idempotent, best-effort cleanup activity as an unregistered seam (no Temporal SDK dependency); #18/#21 register it under the byte-pinned `"DeleteExecutionContext"` name.
- `src/boot/compose.ts` — registers the domain; the runner-auth comments now record the verify side as live.
- `test/conformance/vitest.local-ts.config.ts` — rosters `executioncontext.conformance.test.ts` (23 tests, unchanged).
- 28 co-located tests through the real composed server, mirroring Go's `executioncontext_secrets_test.go` case-for-case plus adversarial arms Go lacks (expired token, forged-key token, tampered stored ciphertext, encrypted-row-on-keyless-server, repeated authorization headers).

## Implementation notes

- **Bearer verification lives in the domain handler** (reading the ConnectRPC `HandlerContext` header), not the interceptor chain — fulfilling the seam the runnerauth module header and compose.ts reserved for "the executioncontext resolve step". The auth interceptor stays a pass-through.
- **Decrypt-lane proof strategy**: the conformance suite is user-shaped by design (asserts redaction unconditionally), so the security-critical path is proven by the domain's own composed-server tests: valid scope-bound token → plaintext; absent/malformed/expired/forged/wrong-execution/wrong-scheme → redaction-as-SUCCESS; tampered ciphertext → key dropped, read succeeds; encrypted row + keyless encryption → Internal with the pinned copy.
- **`runnerAuthService` is a REQUIRED dependency** (vs Go's nilable service): the composition root always constructs one (boot-fatal otherwise), so keyless-disabled is the modeled state — per the guidelines' "optional infrastructure is an explicit modeled state, never a nullable".
- **Repeated `authorization` headers**: Go reads `metadata.Get(...)[0]`; Node joins repeated headers with `", "` before Connect sees them. The port takes the first comma segment, restoring Go's first-value semantics exactly (a genuine token can never contain a comma). Found by the adversarial parity review; covered by a dedicated test.
- Two-reviewer adversarial panel ran pre-PR: 1 wire-visible finding (the header join, fixed as above) + 4 minor findings (all applied: delete-failure branch test, guarded test cleanup, empty-secret decrypt assertion, extractor header correction).

## Parity nuances disclosed (for the register)

1. **Dropped Go narration logs** (non-wire): apply's "delegating to CREATE" Info, the encrypt step's `encryptedCount` Debug, and LoadByExecutionId's before/after Debugs are omitted, matching the house convention set by the environment port.
2. **Delete-activity log copy reworded** (non-wire): Go logs "will rely on TTL cleanup", citing a TTL backup index that does not exist (it is listed only under future enhancements in Go's own README); the TS copy says honestly "leaving cleanup to the operator". Behavior is byte-faithful: idempotent, never throws, logs variable count only. The stale Go claim is a candidate OSS issue (owner decision pending).
3. **`EncryptionDisabledError` key naming**: with several encrypted secrets, Go's map iteration picks a nondeterministic key for the Internal message; TS is deterministic (insertion order) — always within Go's behavior envelope, noted in case a future suite pins the key name.
4. **Unicode trim/fold edges in bearer parsing** (unreachable): Go `strings.TrimSpace`/`EqualFold` vs JS `trim()`/`toLowerCase` differ on exotic code points that cannot appear in conforming ASCII HTTP headers.
5. **Stale proto comment (pre-existing, not touched)**: `apis/ai/stigmer/agentic/executioncontext/v1/query.proto` still says OSS returns secrets "in plaintext" — pre-#535 wording; flagged to the owner for a docs-only fix.

## Test plan

- `npm run typecheck` + `npm test` in stigmer-server-ts: 39 files / **433 tests green** (28 new).
- `make test-conformance-ts`: **10 suites / 231 tests green** on the first rostered run.
- `make test-conformance`: local-go **468 passed / 1 skipped** — regression-free.

## Risks

- Low: additive domain registration; no store or migration changes (kind `execution_context` already mapped). Rollback is reverting the single commit.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Conformance roster updated (the cutover-gate mechanism)

Made with [Cursor](https://cursor.com)