### PR TITLE
feat(backend/stigmer-server-ts): port the agentexecution domain (D4 #17)

### DIFF
--- a/backend/services/stigmer-server-ts/package-lock.json
+++ b/backend/services/stigmer-server-ts/package-lock.json
@@ -14,6 +14,7 @@
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
+        "fflate": "^0.8.3",
         "js-yaml": "^4.3.1",
         "ulidx": "2.4.1"
       },
@@ -1260,6 +1261,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",

--- a/backend/services/stigmer-server-ts/package.json
+++ b/backend/services/stigmer-server-ts/package.json
@@ -30,6 +30,7 @@
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
     "@stigmer/protos": "file:../../../apis/stubs/ts",
+    "fflate": "^0.8.3",
     "js-yaml": "^4.3.1",
     "ulidx": "2.4.1"
   },

--- a/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/artifact-storage.test.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/artifact-storage.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Ports storage/local_storage_test.go + disposition_test.go case-for-case:
+ * the containment guard (every escaping key refused on every operation,
+ * contained dot-segment keys allowed), the #285 no-implicit-segment
+ * layout contract, the local signed-URL shape, and the
+ * Content-Disposition builder. Adds the factory's r2/unknown refusals
+ * (Go's are boot asserted; here they're the disclosed deferral).
+ */
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  LocalArtifactStorage,
+  contentDispositionAttachment,
+  newArtifactStorage,
+} from "../artifact-storage.js";
+
+// Keys that, once cleaned, resolve outside the artifact root — the
+// containment guard must refuse every one of them.
+const escapingKeys = [
+  "../evil.txt",
+  "../../evil.txt",
+  "attachments/x/../../../../evil.txt",
+  "attachments/../../evil.txt",
+  "a/b/../../../escape",
+];
+
+// Keys that clean to a location still inside the root — the guard
+// rejects escapes, not the mere presence of a `..` segment.
+const containedKeys = [
+  "attachments/01ABC/plan.md",
+  "artifacts/exec-1/out.txt",
+  "attachments/x/../y/file.txt",
+  "name.with.dots.txt",
+];
+
+describe("LocalArtifactStorage", () => {
+  let parent: string;
+  let base: string;
+  let storage: LocalArtifactStorage;
+
+  beforeEach(() => {
+    parent = mkdtempSync(path.join(tmpdir(), "artifact-test-"));
+    base = path.join(parent, "store");
+    storage = new LocalArtifactStorage(base, "http://localhost:7235");
+  });
+
+  afterEach(() => {
+    rmSync(parent, { recursive: true, force: true });
+  });
+
+  function assertNoEscape(name: string): void {
+    expect(
+      existsSync(path.join(parent, name)),
+      `file escaped the artifact root to ${path.join(parent, name)}`,
+    ).toBe(false);
+  }
+
+  describe("upload rejects path traversal", () => {
+    for (const key of escapingKeys) {
+      it(key, async () => {
+        await expect(
+          storage.upload(key, Buffer.from("owned"), "text/plain"),
+        ).rejects.toThrow("resolves outside the artifact storage root");
+        assertNoEscape("evil.txt");
+        assertNoEscape("escape");
+      });
+    }
+  });
+
+  describe("download rejects path traversal", () => {
+    for (const key of escapingKeys) {
+      it(key, async () => {
+        // Plant a file just outside the root that a traversal key would
+        // otherwise reach.
+        writeFileSync(path.join(parent, "secret.txt"), "top secret");
+        await expect(storage.download(key)).rejects.toThrow(
+          "resolves outside the artifact storage root",
+        );
+      });
+    }
+  });
+
+  describe("exists and delete reject path traversal", () => {
+    for (const key of escapingKeys) {
+      it(`exists/${key}`, async () => {
+        await expect(storage.exists(key)).rejects.toThrow(
+          "resolves outside the artifact storage root",
+        );
+      });
+      it(`delete/${key}`, async () => {
+        await expect(storage.delete(key)).rejects.toThrow(
+          "resolves outside the artifact storage root",
+        );
+      });
+    }
+  });
+
+  // Pins the layout contract after unification (#285): the configured
+  // base path IS the artifact root, so a key K lands at <base>/<K> with
+  // no implicit "artifacts" segment — what lets the runner, whose
+  // LOCAL_ARTIFACT_PATH points at the same directory, read back exactly
+  // what the server wrote.
+  it("stores key at root without implicit segment", async () => {
+    const key = "attachments/01ABC/plan.md";
+    await storage.upload(key, Buffer.from("the plan"), "text/markdown");
+    expect(existsSync(path.join(base, key))).toBe(true);
+    expect(existsSync(path.join(base, "artifacts", key))).toBe(false);
+  });
+
+  describe("allows contained keys with dot segments", () => {
+    for (const key of containedKeys) {
+      it(key, async () => {
+        await storage.upload(key, Buffer.from("ok"), "text/plain");
+        const data = await storage.download(key);
+        expect(Buffer.from(data).toString()).toBe("ok");
+      });
+    }
+  });
+
+  it("signed URL: inline has no query, download carries url-encoded filename", async () => {
+    const key = "artifacts/aex_1/plan.md";
+    const inline = await storage.getSignedUrl(key, 3600_000, "");
+    expect(inline).toBe(`http://localhost:7235/${key}`);
+
+    const download = await storage.getSignedUrl(
+      key,
+      3600_000,
+      "my plan.plan.md",
+    );
+    // Space encodes as '+' (Go url.Values.Encode).
+    expect(download).toBe(
+      `http://localhost:7235/${key}?download=my+plan.plan.md`,
+    );
+  });
+
+  it("delete removes the artifact and prunes empty parents, never the root", async () => {
+    const key = "attachments/01DEL/file.txt";
+    await storage.upload(key, Buffer.from("x"), "text/plain");
+    await storage.delete(key);
+    expect(existsSync(path.join(base, key))).toBe(false);
+    expect(existsSync(path.join(base, "attachments", "01DEL"))).toBe(false);
+    expect(existsSync(base)).toBe(true);
+  });
+
+  it("health probes the root writable", async () => {
+    await expect(storage.health()).resolves.toBeUndefined();
+    expect(existsSync(path.join(base, ".health_check"))).toBe(false);
+  });
+});
+
+describe("newArtifactStorage factory", () => {
+  it("empty type defaults to local", () => {
+    const parent = mkdtempSync(path.join(tmpdir(), "artifact-factory-"));
+    try {
+      const s = newArtifactStorage({
+        type: "",
+        localBasePath: path.join(parent, "store"),
+        localServeUrl: "http://localhost:7235",
+      });
+      expect(s).toBeInstanceOf(LocalArtifactStorage);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("r2 refuses with the deferral message", () => {
+    expect(() =>
+      newArtifactStorage({ type: "r2", localBasePath: "", localServeUrl: "" }),
+    ).toThrow("ARTIFACT_STORAGE_TYPE=r2 is not yet supported by the TS server");
+  });
+
+  it("unknown type refuses", () => {
+    expect(() =>
+      newArtifactStorage({ type: "s3", localBasePath: "", localServeUrl: "" }),
+    ).toThrow("unknown storage type: s3 (must be 'local' or 'r2')");
+  });
+});
+
+describe("contentDispositionAttachment", () => {
+  const cases = [
+    {
+      name: "plain ascii filename",
+      filename: "plan_card_ux_cleanup.plan.md",
+      want: 'attachment; filename="plan_card_ux_cleanup.plan.md"',
+    },
+    {
+      name: "embedded quote is escaped, not broken out of",
+      filename: 'evil".md',
+      want: 'attachment; filename="evil\\".md"',
+    },
+    {
+      name: "non-ascii adds an RFC 5987 filename* fallback",
+      filename: "café.md",
+      want: "attachment; filename=\"caf_.md\"; filename*=UTF-8''caf%C3%A9.md",
+    },
+  ];
+  for (const tt of cases) {
+    it(tt.name, () => {
+      expect(contentDispositionAttachment(tt.filename)).toBe(tt.want);
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/artifact-storage.test.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/artifact-storage.test.ts
@@ -134,6 +134,11 @@ describe("LocalArtifactStorage", () => {
     expect(download).toBe(
       `http://localhost:7235/${key}?download=my+plan.plan.md`,
     );
+
+    // Go url.QueryEscape byte-exactness on the two characters where
+    // URLSearchParams disagrees: '~' stays bare, '*' percent-encodes.
+    const exotic = await storage.getSignedUrl(key, 3600_000, "a~b*c.md");
+    expect(exotic).toBe(`http://localhost:7235/${key}?download=a~b%2Ac.md`);
   });
 
   it("delete removes the artifact and prunes empty parents, never the root", async () => {

--- a/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
@@ -131,11 +131,7 @@ export class LocalArtifactStorage implements ArtifactStorage {
     }
     let url = `${this.serveUrl}/${key}`;
     if (downloadFilename !== "") {
-      // URLSearchParams matches Go url.Values.Encode (space → '+').
-      const query = new URLSearchParams({
-        [LOCAL_DOWNLOAD_QUERY_PARAM]: downloadFilename,
-      });
-      url += `?${query.toString()}`;
+      url += `?${LOCAL_DOWNLOAD_QUERY_PARAM}=${goQueryEscape(downloadFilename)}`;
     }
     return url;
   }
@@ -225,6 +221,27 @@ export class LocalArtifactStorage implements ArtifactStorage {
     }
     await this.cleanupEmptyDirs(path.dirname(dir));
   }
+}
+
+/**
+ * Go url.QueryEscape, byte-exact: unreserved [A-Za-z0-9-_.~] pass, space
+ * becomes '+', everything else percent-encodes. URLSearchParams differs
+ * on two characters ('~' escaped, '*' bare), so the stdlib encoder would
+ * break URL byte parity for filenames carrying them.
+ */
+function goQueryEscape(s: string): string {
+  let out = "";
+  for (const byte of Buffer.from(s, "utf-8")) {
+    const c = String.fromCharCode(byte);
+    if (/[A-Za-z0-9\-_.~]/.test(c)) {
+      out += c;
+    } else if (c === " ") {
+      out += "+";
+    } else {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
 }
 
 /**

--- a/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
@@ -1,0 +1,296 @@
+/**
+ * Artifact storage — ports pkg/domain/artifact/storage/{storage.go,
+ * local_storage.go,disposition.go}: the execution-output/attachment blob
+ * store SHARED (D1) by agentexecution attachments (#17), the artifact
+ * domain + its port+1 file server (#13), and skill's
+ * pushFromExecutionArtifact (#8). Cross-cutting home, like
+ * src/encryption/ (the ratified sub-project DD).
+ *
+ * The LOCAL backend is the OSS default: the configured base path IS the
+ * artifact root — a key K stores at <basePath>/<K> with no implicit
+ * segment, so the server and the runner (LOCAL_ARTIFACT_PATH) share one
+ * store by construction (#285).
+ *
+ * The R2 backend (S3-compatible, AWS SDK) is DEFERRED to #13 per the
+ * owner-ratified plan decision: it would drag the AWS SDK into this
+ * package's dependency surface and its presigned-URL semantics are
+ * asserted on #13's RPC surface. Until then ARTIFACT_STORAGE_TYPE=r2
+ * boot-fails with an explicit message — a disclosed, temporary
+ * coexistence divergence (the Go server serves r2 today).
+ */
+import { mkdirSync } from "node:fs";
+import {
+  mkdir,
+  readFile,
+  rm,
+  rmdir,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+/** Query key carrying the desired download filename on local URLs; the
+ * artifact file server (#13) reads it to set Content-Disposition. */
+export const LOCAL_DOWNLOAD_QUERY_PARAM = "download";
+
+export interface ArtifactStorage {
+  /** Stores artifact data under the key. */
+  upload(key: string, data: Uint8Array, contentType: string): Promise<void>;
+  /** Retrieves artifact data by key. */
+  download(key: string): Promise<Uint8Array>;
+  /**
+   * A time-limited download URL. downloadFilename, when non-empty, bakes
+   * a browser-download disposition into the URL (browsers ignore the HTML
+   * `download` attribute cross-origin); empty serves inline.
+   */
+  getSignedUrl(
+    key: string,
+    expiresInMs: number,
+    downloadFilename: string,
+  ): Promise<string>;
+  /** Removes the artifact; missing is not an error. */
+  delete(key: string): Promise<void>;
+  /** Whether an artifact with the key exists. */
+  exists(key: string): Promise<boolean>;
+  /** Storage connectivity/writability probe (boot health check). */
+  health(): Promise<void>;
+}
+
+export interface ArtifactStorageConfig {
+  /** "local" or "r2" ("" defaults to local — Go NewArtifactStorage). */
+  readonly type: string;
+  readonly localBasePath: string;
+  readonly localServeUrl: string;
+}
+
+/** Factory mirroring Go NewArtifactStorage; r2 is the deferred arm. */
+export function newArtifactStorage(
+  config: ArtifactStorageConfig,
+): ArtifactStorage {
+  const storageType = config.type === "" ? "local" : config.type;
+  switch (storageType) {
+    case "local":
+      return new LocalArtifactStorage(
+        config.localBasePath,
+        config.localServeUrl,
+      );
+    case "r2":
+      // Deferred to #13 (owner-ratified): fail loud at boot rather than
+      // serving a silently different artifact store than configured.
+      throw new Error(
+        "ARTIFACT_STORAGE_TYPE=r2 is not yet supported by the TS server; " +
+          "the R2 backend arrives with the artifact domain sub-project (D4 #13). " +
+          "Use the Go server for r2-backed deployments during coexistence.",
+      );
+    default:
+      throw new Error(
+        `unknown storage type: ${storageType} (must be 'local' or 'r2')`,
+      );
+  }
+}
+
+export class LocalArtifactStorage implements ArtifactStorage {
+  constructor(
+    private readonly basePath: string,
+    private readonly serveUrl: string,
+  ) {
+    // Ensure the artifact root exists (Go NewLocalStorage MkdirAll).
+    mkdirSync(this.root(), { recursive: true });
+  }
+
+  async upload(
+    key: string,
+    data: Uint8Array,
+    _contentType: string,
+  ): Promise<void> {
+    const filePath = this.resolveWithinRoot(key);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    // Restricted permissions, matching Go's 0600.
+    await writeFile(filePath, data, { mode: 0o600 });
+  }
+
+  async download(key: string): Promise<Uint8Array> {
+    const filePath = this.resolveWithinRoot(key);
+    try {
+      return await readFile(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`artifact not found: ${key}`);
+      }
+      throw error;
+    }
+  }
+
+  async getSignedUrl(
+    key: string,
+    _expiresInMs: number,
+    downloadFilename: string,
+  ): Promise<string> {
+    if (this.serveUrl === "") {
+      throw new Error("local serve URL not configured");
+    }
+    let url = `${this.serveUrl}/${key}`;
+    if (downloadFilename !== "") {
+      // URLSearchParams matches Go url.Values.Encode (space → '+').
+      const query = new URLSearchParams({
+        [LOCAL_DOWNLOAD_QUERY_PARAM]: downloadFilename,
+      });
+      url += `?${query.toString()}`;
+    }
+    return url;
+  }
+
+  async delete(key: string): Promise<void> {
+    const filePath = this.resolveWithinRoot(key);
+    await rm(filePath, { force: true });
+    await this.cleanupEmptyDirs(path.dirname(filePath));
+  }
+
+  async exists(key: string): Promise<boolean> {
+    const filePath = this.resolveWithinRoot(key);
+    try {
+      await stat(filePath);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async health(): Promise<void> {
+    const info = await stat(this.root()).catch((error: unknown) => {
+      throw new Error(
+        `artifacts directory not accessible: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    if (!info.isDirectory()) {
+      throw new Error("artifacts path is not a directory");
+    }
+    const testFile = path.join(this.root(), ".health_check");
+    await writeFile(testFile, "ok", { mode: 0o600 }).catch(
+      (error: unknown) => {
+        throw new Error(
+          `artifacts directory not writable: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    );
+    await rm(testFile, { force: true });
+  }
+
+  /**
+   * The single directory every key resolves under — the base path itself
+   * (#285): the key→path mapping, the health probe, and the cleanup floor
+   * can never disagree about where the store lives.
+   */
+  private root(): string {
+    return this.basePath;
+  }
+
+  /**
+   * Maps a storage key to an absolute path, guaranteeing the result stays
+   * inside the artifact root. Keys carry caller-influenced segments (an
+   * attachment's original filename rides in the key) and path.join CLEANS
+   * `..` rather than rejecting it — without this guard a crafted key
+   * escapes the store. A key resolving outside the root is refused with a
+   * descriptive, non-path error.
+   */
+  private resolveWithinRoot(key: string): string {
+    const root = this.root();
+    const full = path.join(root, key);
+    if (!isWithin(root, full)) {
+      throw new Error(
+        `storage key ${JSON.stringify(key)} resolves outside the artifact storage root`,
+      );
+    }
+    return full;
+  }
+
+  /**
+   * Removes empty parent directories up to (but never including) the
+   * artifact root; stops at the first non-empty directory.
+   */
+  private async cleanupEmptyDirs(dir: string): Promise<void> {
+    const root = this.root();
+    if (!isWithin(root, dir) || path.resolve(dir) === path.resolve(root)) {
+      return;
+    }
+    try {
+      // rmdir fails on non-empty directories — exactly the stop signal
+      // (Go os.Remove semantics).
+      await rmdir(dir);
+    } catch {
+      return;
+    }
+    await this.cleanupEmptyDirs(path.dirname(dir));
+  }
+}
+
+/**
+ * Whether `p` is `root` itself or a descendant — cleaned-path comparison
+ * with a trailing separator so a sibling sharing a name prefix (`/a/bc`
+ * vs `/a/b`) is correctly excluded (Go isWithin).
+ */
+function isWithin(root: string, p: string): boolean {
+  const cleanRoot = path.resolve(root);
+  const cleanPath = path.resolve(p);
+  return (
+    cleanPath === cleanRoot || cleanPath.startsWith(cleanRoot + path.sep)
+  );
+}
+
+/**
+ * Content-Disposition header value instructing a browser to save the
+ * response as a download named filename (Go
+ * ContentDispositionAttachment): a plain quoted `filename="..."`
+ * (ASCII-sanitized fallback) plus, when the name carries non-ASCII, the
+ * RFC 5987 `filename*=UTF-8''...` parameter modern browsers prefer. The
+ * fallback escapes embedded quotes and backslashes, so a crafted name can
+ * never break out of the header value. Consumed by #13's file server;
+ * defined with the storage it describes.
+ */
+export function contentDispositionAttachment(filename: string): string {
+  const ascii = sanitizeAsciiFilename(filename);
+  const quoted = `"${ascii.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+  let disposition = `attachment; filename=${quoted}`;
+  if (ascii !== filename) {
+    disposition += `; filename*=UTF-8''${rfc5987Encode(filename)}`;
+  }
+  return disposition;
+}
+
+/** Bytes outside printable ASCII (and controls) become '_' (Go twin). */
+function sanitizeAsciiFilename(filename: string): string {
+  let out = "";
+  for (const r of filename) {
+    const code = r.codePointAt(0) ?? 0;
+    out += code < 0x20 || code > 0x7e ? "_" : r;
+  }
+  return out;
+}
+
+/** Percent-encodes per RFC 5987 ext-value, attr-chars unescaped. */
+function rfc5987Encode(filename: string): string {
+  const bytes = Buffer.from(filename, "utf-8");
+  let out = "";
+  for (const c of bytes) {
+    if (isRfc5987AttrChar(c)) {
+      out += String.fromCharCode(c);
+    } else {
+      out += `%${c.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+function isRfc5987AttrChar(c: number): boolean {
+  if (
+    (c >= 0x41 && c <= 0x5a) || // A-Z
+    (c >= 0x61 && c <= 0x7a) || // a-z
+    (c >= 0x30 && c <= 0x39) // 0-9
+  ) {
+    return true;
+  }
+  return "!#$&+-.^_`|~".includes(String.fromCharCode(c));
+}

--- a/backend/services/stigmer-server-ts/src/boot/__tests__/compose.test.ts
+++ b/backend/services/stigmer-server-ts/src/boot/__tests__/compose.test.ts
@@ -35,9 +35,12 @@ const silentLogger = createLogger({
 function compose() {
   // Each composed server gets a throwaway database — the storage stage
   // opens DB_PATH for real (never the developer's ~/.stigmer).
+  const testDir = mkdtempSync(path.join(tmpdir(), "compose-test-"));
   const config = loadConfig({
     STIGMER_MODEL_REGISTRY_REFRESH: "off",
-    DB_PATH: path.join(mkdtempSync(path.join(tmpdir(), "compose-test-")), "stigmer.db"),
+    DB_PATH: path.join(testDir, "stigmer.db"),
+    // Keep the artifact store inside the test dir (never ~/.stigmer).
+    ARTIFACT_LOCAL_BASE_PATH: path.join(testDir, "artifacts"),
   });
   return composeServer({
     config,

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -22,6 +22,7 @@ import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/pro
 import { registerAgentServices } from "../domain/agent/controller.js";
 import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
 import { registerAgentExecutionServices } from "../domain/agentexecution/controller.js";
+import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
@@ -60,6 +61,12 @@ export interface ComposedServer {
    * RPC — the mint side — lands with its own sub-project).
    */
   runnerAuthService: RunnerAuthService;
+  /**
+   * The agentexecution broadcast fabric (exposed for tests and, with #18,
+   * the Temporal worker's recovery broadcasts — Go's GetStreamBroker).
+   * UpdateStatus is the production writer.
+   */
+  agentExecutionStreamBroker: StreamBroker;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
   start(): Promise<number>;
   /** NOT_SERVING first, stop background work, drain connections. */
@@ -141,6 +148,10 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // per validation call, keeping validation and the served pickers in
   // lockstep (DD-004).
   const workflowValidator = new InProcessValidator(modelRegistryStore, logger);
+  // ONE broker spans both routers: #18's Temporal activities update
+  // status through the in-process client, and those broadcasts must reach
+  // externally-connected subscribe streams (Go's GetStreamBroker seam).
+  const agentExecutionStreamBroker = new StreamBroker(logger);
   // The SAME `routes` function registers every service on BOTH the serving
   // router and the in-process router transport (createInProcessClients).
   // Handlers are stateless over the same store, so the two routers behave
@@ -186,7 +197,11 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
     });
     registerMemoryServices(router, { store, logger });
-    registerAgentExecutionServices(router, { store, logger });
+    registerAgentExecutionServices(router, {
+      store,
+      logger,
+      broker: agentExecutionStreamBroker,
+    });
     registerWorkflowServices(router, {
       store,
       logger,
@@ -213,6 +228,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     healthState,
     store,
     runnerAuthService,
+    agentExecutionStreamBroker,
 
     async start(): Promise<number> {
       // Wiring complete → SERVING → background refresh → bind. The port

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -22,6 +22,7 @@ import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/pro
 import { registerAgentServices } from "../domain/agent/controller.js";
 import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
 import { registerAgentExecutionServices } from "../domain/agentexecution/controller.js";
+import { ENGINE_DISCONNECTED } from "../domain/agentexecution/engine.js";
 import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
@@ -201,6 +202,10 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       store,
       logger,
       broker: agentExecutionStreamBroker,
+      // Permanently disconnected until #18 lands the worker infra; the
+      // provider shape lets its TemporalManager flip availability at
+      // runtime without controller changes.
+      engineState: () => ENGINE_DISCONNECTED,
     });
     registerWorkflowServices(router, {
       store,

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -21,6 +21,7 @@ import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/pro
 
 import { registerAgentServices } from "../domain/agent/controller.js";
 import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
+import { registerAgentExecutionServices } from "../domain/agentexecution/controller.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
@@ -185,6 +186,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
     });
     registerMemoryServices(router, { store, logger });
+    registerAgentExecutionServices(router, { store, logger });
     registerWorkflowServices(router, {
       store,
       logger,

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -22,8 +22,11 @@ import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/pro
 import { registerAgentServices } from "../domain/agent/controller.js";
 import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
 import { registerAgentExecutionServices } from "../domain/agentexecution/controller.js";
+import { newArtifactStorage } from "../artifactstorage/artifact-storage.js";
 import { ENGINE_DISCONNECTED } from "../domain/agentexecution/engine.js";
 import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
+import { RuntimeResolutionService } from "../domain/environment/resolution/resolution.js";
+import { ManagedEnvironmentService } from "../domain/mcpserver/oauth/managed-env.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
@@ -153,6 +156,32 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // status through the in-process client, and those broadcasts must reach
   // externally-connected subscribe streams (Go's GetStreamBroker seam).
   const agentExecutionStreamBroker = new StreamBroker(logger);
+  // The artifact blob store (Go server.go 349: shared by agentexecution
+  // attachments now, the artifact domain + skill push later). Construction
+  // boot-fails on ARTIFACT_STORAGE_TYPE=r2 (the ratified #13 deferral);
+  // the health probe runs in start(), matching Go's boot check.
+  const artifactStorage = newArtifactStorage({
+    type: config.artifactStorageType,
+    localBasePath: config.artifactLocalBasePath,
+    localServeUrl: config.artifactLocalServeUrl,
+  });
+  // The environment runtime-resolution service (#5) — the decrypt-for-
+  // execution path the EC builder uses to resolve environment_refs (the
+  // RPC surface redacts secret values, oss#405).
+  const environmentResolution = new RuntimeResolutionService(
+    store,
+    secretService,
+    logger,
+  );
+  // OAuth-managed token access for the EC builder's injection (server.go
+  // 732–735); rides the environment in-process client so encryption,
+  // validation, and audit ride the environment pipeline.
+  const managedEnvService = new ManagedEnvironmentService({
+    getSecretValue: (input) =>
+      requireInProcess().executionEnvironmentReader.getSecretValue(input),
+    updateVariables: (request) =>
+      requireInProcess().executionEnvironmentReader.updateVariables(request),
+  });
   // The SAME `routes` function registers every service on BOTH the serving
   // router and the in-process router transport (createInProcessClients).
   // Handlers are stateless over the same store, so the two routers behave
@@ -206,6 +235,26 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       // provider shape lets its TemporalManager flip availability at
       // runtime without controller changes.
       engineState: () => ENGINE_DISCONNECTED,
+      modelRegistry: modelRegistryStore,
+      artifactStorage,
+      agentLoader: () => requireInProcess().executionAgentLoader,
+      agentInstanceCreator: () =>
+        requireInProcess().executionAgentInstanceCreator,
+      sessionCreator: () => requireInProcess().executionSessionCreator,
+      executionContextBuilder: {
+        store,
+        logger,
+        agentLoader: () => requireInProcess().executionAgentLoader,
+        agentInstanceLoader: () =>
+          requireInProcess().executionAgentInstanceLoader,
+        sessionLoader: () => requireInProcess().executionSessionLoader,
+        environmentReader: () =>
+          requireInProcess().executionEnvironmentReader,
+        environmentResolution,
+        executionContextCreator: () =>
+          requireInProcess().executionContextCreator,
+        managedEnvService,
+      },
     });
     registerWorkflowServices(router, {
       store,
@@ -236,6 +285,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     agentExecutionStreamBroker,
 
     async start(): Promise<number> {
+      // Artifact storage must be reachable and writable before the server
+      // answers (Go server.go boots-fatal on the same probe).
+      await artifactStorage.health();
       // Wiring complete → SERVING → background refresh → bind. The port
       // must be the LAST observable effect (serverGate contract).
       healthState.setOverall(ServingStatus.SERVING);

--- a/backend/services/stigmer-server-ts/src/boot/config.ts
+++ b/backend/services/stigmer-server-ts/src/boot/config.ts
@@ -41,6 +41,20 @@ export interface ServerConfig {
    */
   readonly operatorEmail: string;
   readonly operatorName: string;
+  /**
+   * Artifact blob storage (attachments + execution outputs; Go
+   * config.ArtifactStorage). "local" is the OSS default; "r2" boot-fails
+   * on this server until #13 (the owner-ratified deferral).
+   */
+  readonly artifactStorageType: string;
+  /** The artifact root — shared with the runner's LOCAL_ARTIFACT_PATH (#285). */
+  readonly artifactLocalBasePath: string;
+  /**
+   * Base URL for local artifact download URLs — the port+1 artifact file
+   * server (#13); no trailing path segment (the storage key carries the
+   * full path).
+   */
+  readonly artifactLocalServeUrl: string;
 }
 
 /** Default unified port; the CLI's env contract pins the same value. */
@@ -51,8 +65,22 @@ export const DEFAULT_MODEL_REGISTRY_UPSTREAM = "https://api.stigmer.ai";
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   const { operatorEmail, operatorName } = loadOperatorIdentity(env);
+  const grpcPort = envInt(env, "GRPC_PORT", DEFAULT_GRPC_PORT);
+  // Go: ARTIFACT_HTTP_PORT defaults to the gRPC port + 1.
+  const artifactHttpPort = envInt(env, "ARTIFACT_HTTP_PORT", grpcPort + 1);
   return {
-    grpcPort: envInt(env, "GRPC_PORT", DEFAULT_GRPC_PORT),
+    grpcPort,
+    artifactStorageType: envString(env, "ARTIFACT_STORAGE_TYPE", "local"),
+    artifactLocalBasePath: envString(
+      env,
+      "ARTIFACT_LOCAL_BASE_PATH",
+      defaultArtifactPath(),
+    ),
+    artifactLocalServeUrl: envString(
+      env,
+      "ARTIFACT_LOCAL_SERVE_URL",
+      `http://localhost:${artifactHttpPort}`,
+    ),
     logLevel: envString(env, "LOG_LEVEL", "info"),
     env: envString(env, "ENV", "local"),
     modelRegistryUpstream: envString(
@@ -76,6 +104,15 @@ function defaultDbPath(): string {
     return path.join(os.homedir(), ".stigmer", "stigmer.db");
   } catch {
     return "./stigmer.db";
+  }
+}
+
+/** Go defaultArtifactPath: ~/.stigmer/data/artifacts, ./artifacts without a home. */
+function defaultArtifactPath(): string {
+  try {
+    return path.join(os.homedir(), ".stigmer", "data", "artifacts");
+  } catch {
+    return "./artifacts";
   }
 }
 

--- a/backend/services/stigmer-server-ts/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server-ts/src/boot/inprocess.ts
@@ -21,12 +21,32 @@ import { create } from "@bufbuild/protobuf";
 import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
 import { AgentIdSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
 import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
+import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
+import { AgentInstanceIdSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/io_pb";
+import { EnvironmentCommandController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/command_pb";
+import { EnvironmentQueryController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/query_pb";
+import { ExecutionContextCommandController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/command_pb";
+import { SessionCommandController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/command_pb";
+import { SessionQueryController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/query_pb";
+import { SessionIdSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/io_pb";
 import { WorkflowQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/query_pb";
 import { WorkflowIdSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/io_pb";
 import { WorkflowInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/command_pb";
 
 import type { AgentInstanceApplier } from "../domain/agent/steps.js";
 import type { ParentAgentLoader } from "../domain/agentinstance/steps.js";
+import type {
+  AgentLoader,
+  ExecutionAgentInstanceCreator,
+  SessionCreator,
+} from "../domain/agentexecution/create-steps.js";
+import type {
+  AgentInstanceLoader,
+  EnvironmentReader,
+  ExecutionContextCreator,
+  SessionLoader,
+} from "../domain/agentexecution/create-execution-context-step.js";
+import type { ManagedEnvironmentClient } from "../domain/mcpserver/oauth/managed-env.js";
 import type { AgentInstanceCreator } from "../domain/session/steps.js";
 import type { WorkflowInstanceCreator } from "../domain/workflow/steps.js";
 import type { ParentWorkflowLoader } from "../domain/workflowinstance/steps.js";
@@ -40,6 +60,22 @@ export interface InProcessClients {
   readonly parentAgentLoader: ParentAgentLoader;
   readonly workflowInstanceCreator: WorkflowInstanceCreator;
   readonly parentWorkflowLoader: ParentWorkflowLoader;
+  // The agentexecution create/EC-builder edges (server.go 565–566: the
+  // controller's agent/agentinstance/session/environment/executioncontext
+  // in-process clients).
+  readonly executionAgentLoader: AgentLoader;
+  readonly executionAgentInstanceLoader: AgentInstanceLoader;
+  readonly executionAgentInstanceCreator: ExecutionAgentInstanceCreator;
+  readonly executionSessionLoader: SessionLoader;
+  readonly executionSessionCreator: SessionCreator;
+  /**
+   * Reads for the EC builder plus the secret rewrite the OAuth pre-flight
+   * refresh needs (ManagedEnvironmentClient) — one surface, every call
+   * through the full chain.
+   */
+  readonly executionEnvironmentReader: EnvironmentReader &
+    ManagedEnvironmentClient;
+  readonly executionContextCreator: ExecutionContextCreator;
 }
 
 /**
@@ -59,7 +95,22 @@ export function createInProcessClients(
     AgentInstanceCommandController,
     transport,
   );
+  const agentInstanceQuery = createClient(
+    AgentInstanceQueryController,
+    transport,
+  );
   const agentQuery = createClient(AgentQueryController, transport);
+  const sessionCommand = createClient(SessionCommandController, transport);
+  const sessionQuery = createClient(SessionQueryController, transport);
+  const environmentCommand = createClient(
+    EnvironmentCommandController,
+    transport,
+  );
+  const environmentQuery = createClient(EnvironmentQueryController, transport);
+  const executionContextCommand = createClient(
+    ExecutionContextCommandController,
+    transport,
+  );
   const workflowInstanceCommand = createClient(
     WorkflowInstanceCommandController,
     transport,
@@ -98,6 +149,36 @@ export function createInProcessClients(
     parentWorkflowLoader: {
       get: (workflowId) =>
         workflowQuery.get(create(WorkflowIdSchema, { value: workflowId })),
+    },
+    // The agentexecution edges. CreateAsSystem semantics per the agent
+    // edge above: create under the process-global operator identity.
+    executionAgentLoader: {
+      get: (agentId) =>
+        agentQuery.get(create(AgentIdSchema, { value: agentId })),
+    },
+    executionAgentInstanceLoader: {
+      get: (instanceId) =>
+        agentInstanceQuery.get(
+          create(AgentInstanceIdSchema, { value: instanceId }),
+        ),
+    },
+    executionAgentInstanceCreator: {
+      createAsSystem: (instance) => agentInstanceCommand.create(instance),
+    },
+    executionSessionLoader: {
+      get: (sessionId) =>
+        sessionQuery.get(create(SessionIdSchema, { value: sessionId })),
+    },
+    executionSessionCreator: {
+      create: (session) => sessionCommand.create(session),
+    },
+    executionEnvironmentReader: {
+      list: (request) => environmentQuery.list(request),
+      getSecretValue: (input) => environmentQuery.getSecretValue(input),
+      updateVariables: (request) => environmentCommand.updateVariables(request),
+    },
+    executionContextCreator: {
+      create: (ec) => executionContextCommand.create(ec),
     },
   };
 }

--- a/backend/services/stigmer-server-ts/src/domain/agent/__tests__/agent.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/__tests__/agent.test.ts
@@ -74,6 +74,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Pins the agentexecution Phase-1 surfaces against Go's controller —
+ * through the REAL stack: a composed server on an ephemeral port, a
+ * native gRPC client, the full interceptor chain. Executions cannot be
+ * created through the RPC surface here (the engine gate refuses without
+ * Temporal — exactly the production posture until #18), so records are
+ * seeded directly through the store, the same way Go's controller tests
+ * seed with SaveResource.
+ *
+ * Load-bearing pins the conformance suite cannot cover:
+ *   - the MANGLED unknown-execution message on getExecutionUsageReport,
+ *     byte-for-byte (sub-project DD-001: faithful-port + OSS issue);
+ *   - getAgentUsageReport org scoping (oss#389) incl. the no-name-oracle
+ *     rule (Go get_agent_usage_report_test.go case-for-case);
+ *   - list/listBySession filter semantics over seeded rows and the
+ *     total_pages placeholder;
+ *   - update's status-clearing standard build and delete's audit-trail
+ *     return, over the wire;
+ *   - the populated getExecutionSummary arm (phase counts, active count,
+ *     avg duration, failure ranks) that the zero-record conformance arm
+ *     cannot reach.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { executionUsageReportNotFoundMessage } from "../constants.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "AgentExecution";
+const ORG = "acme";
+
+type CommandClient = Client<typeof AgentExecutionCommandController>;
+type QueryClient = Client<typeof AgentExecutionQueryController>;
+
+let server: ComposedServer;
+let dir: string;
+let command: CommandClient;
+let query: QueryClient;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "aexec-domain-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
+  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(AgentExecutionCommandController, transport);
+  query = createClient(AgentExecutionQueryController, transport);
+});
+
+afterAll(async () => {
+  try {
+    await server?.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
+let counter = 0;
+function seedInput(overrides?: {
+  id?: string;
+  org?: string;
+  sessionId?: string;
+  agentId?: string;
+  phase?: ExecutionPhase;
+  startedAt?: string;
+  completedAt?: string;
+}): MessageInitShape<typeof AgentExecutionSchema> & { metadata: { id: string } } {
+  counter += 1;
+  const id = overrides?.id ?? `aexec_test_${counter}`;
+  const slug = `exec-${id.replaceAll("_", "-")}`;
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      id,
+      name: slug,
+      slug,
+      org: overrides?.org ?? ORG,
+    },
+    spec: {
+      sessionId: overrides?.sessionId ?? `ses_test_${counter}`,
+      agentId: overrides?.agentId ?? `agt_test_${counter}`,
+      message: "Say hello.",
+    },
+    status: {
+      phase: overrides?.phase ?? ExecutionPhase.EXECUTION_COMPLETED,
+      startedAt: overrides?.startedAt ?? "",
+      completedAt: overrides?.completedAt ?? "",
+    },
+  };
+}
+
+async function seed(
+  init: MessageInitShape<typeof AgentExecutionSchema> & {
+    metadata: { id: string };
+  },
+): Promise<string> {
+  await server.store.saveResource(
+    ApiResourceKind.agent_execution,
+    init.metadata.id,
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, init),
+  );
+  return init.metadata.id;
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    const connectError = error as ConnectError;
+    expect(connectError.code).toBe(code);
+    return connectError;
+  }
+  throw new Error(`expected code ${Code[code]}, call succeeded`);
+}
+
+describe("get / list / listBySession over the wire", () => {
+  it("get answers NotFound for an unknown id and the record for a seeded one", async () => {
+    await expectCode(
+      () => query.get({ value: "aexec_missing" }),
+      Code.NotFound,
+    );
+
+    const id = await seed(seedInput());
+    const got = await query.get({ value: id });
+    expect(got.metadata?.id).toBe(id);
+    expect(got.spec?.message).toBe("Say hello.");
+  });
+
+  it("list returns every row with the total_pages placeholder, filtered by phase on request", async () => {
+    const completed = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    const failed = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_FAILED }),
+    );
+
+    const all = await query.list({});
+    expect(all.totalPages).toBe(1);
+    const ids = all.entries.map((e) => e.metadata?.id);
+    expect(ids).toContain(completed);
+    expect(ids).toContain(failed);
+
+    const failedOnly = await query.list({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+    });
+    const failedIds = failedOnly.entries.map((e) => e.metadata?.id);
+    expect(failedIds).toContain(failed);
+    expect(failedIds).not.toContain(completed);
+  });
+
+  it("listBySession requires session_id and filters by it", async () => {
+    await expectCode(
+      () => query.listBySession({ sessionId: "" }),
+      Code.InvalidArgument,
+    );
+
+    const inSession = await seed(seedInput({ sessionId: "ses_shared" }));
+    const outOfSession = await seed(seedInput({ sessionId: "ses_other" }));
+
+    const result = await query.listBySession({ sessionId: "ses_shared" });
+    expect(result.totalPages).toBe(1);
+    const ids = result.entries.map((e) => e.metadata?.id);
+    expect(ids).toContain(inSession);
+    expect(ids).not.toContain(outOfSession);
+  });
+});
+
+describe("update / delete over the wire", () => {
+  it("update rewrites the spec through the standard build (status cleared per the shared pattern)", async () => {
+    const init = seedInput({ phase: ExecutionPhase.EXECUTION_FAILED });
+    const id = await seed(init);
+
+    const updated = await command.update({
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: init.metadata,
+      spec: {
+        sessionId: init.spec?.sessionId,
+        agentId: init.spec?.agentId,
+        message: "Say goodbye.",
+      },
+    });
+    expect(updated.metadata?.id).toBe(id);
+    expect(updated.spec?.message).toBe("Say goodbye.");
+
+    // The standard BuildUpdateState clears caller-supplied status; the
+    // persisted record reflects the update response.
+    const got = await query.get({ value: id });
+    expect(got.spec?.message).toBe("Say goodbye.");
+  });
+
+  it("delete returns the deleted record (audit-trail convention) and removes it", async () => {
+    const id = await seed(seedInput());
+
+    const deleted = await command.delete({ value: id });
+    expect(deleted.metadata?.id).toBe(id);
+
+    await expectCode(() => query.get({ value: id }), Code.NotFound);
+  });
+
+  it("delete answers NotFound for an unknown id", async () => {
+    await expectCode(
+      () => command.delete({ value: "aexec_missing" }),
+      Code.NotFound,
+    );
+  });
+});
+
+describe("usage reports over the wire", () => {
+  it("getExecutionUsageReport pins the mangled NotFound copy byte-for-byte (DD-001)", async () => {
+    await expectCode(
+      () => query.getExecutionUsageReport({ executionId: "" }),
+      Code.InvalidArgument,
+    );
+
+    const err = await expectCode(
+      () => query.getExecutionUsageReport({ executionId: "aexec_missing" }),
+      Code.NotFound,
+    );
+    expect(err.rawMessage).toBe(
+      executionUsageReportNotFoundMessage("aexec_missing"),
+    );
+    expect(err.rawMessage).toBe(
+      "agent execution '%s' not found not found: aexec_missing",
+    );
+  });
+
+  it("getExecutionUsageReport answers the zero aggregate for a seeded execution", async () => {
+    const id = await seed(seedInput());
+    const report = await query.getExecutionUsageReport({ executionId: id });
+    expect(report.aggregate).toBeDefined();
+    expect(report.aggregate?.totalTokens).toBe(0n);
+  });
+
+  it("getAgentUsageReport scopes to the requested org (oss#389)", async () => {
+    await seed(
+      seedInput({
+        agentId: "agt_scoped",
+        org: "org-a",
+        sessionId: "ses_a1",
+        startedAt: "2026-03-10T10:00:00Z",
+      }),
+    );
+    await seed(
+      seedInput({
+        agentId: "agt_scoped",
+        org: "org-a",
+        sessionId: "ses_a2",
+        startedAt: "2026-03-11T10:00:00Z",
+      }),
+    );
+    await seed(
+      seedInput({
+        agentId: "agt_scoped",
+        org: "org-b",
+        sessionId: "ses_b1",
+        startedAt: "2026-03-10T10:00:00Z",
+      }),
+    );
+
+    const orgA = await query.getAgentUsageReport({
+      agentId: "agt_scoped",
+      orgId: "org-a",
+    });
+    expect(orgA.totalExecutions).toBe(2);
+    expect(orgA.totalSessions).toBe(2);
+    for (const session of orgA.sessions) {
+      expect(session.sessionId, "org-b session must not leak").not.toBe(
+        "ses_b1",
+      );
+    }
+
+    const orgB = await query.getAgentUsageReport({
+      agentId: "agt_scoped",
+      orgId: "org-b",
+    });
+    expect(orgB.totalExecutions).toBe(1);
+  });
+
+  it("getAgentUsageReport resolves the display name only when the org used the agent (no id-to-name oracle)", async () => {
+    await server.store.saveResource(
+      ApiResourceKind.agent,
+      "agt_named",
+      AgentSchema,
+      create(AgentSchema, {
+        metadata: { id: "agt_named", name: "PR Reviewer", org: "org-a" },
+      }),
+    );
+    await seed(
+      seedInput({
+        agentId: "agt_named",
+        org: "org-a",
+        startedAt: "2026-03-10T10:00:00Z",
+      }),
+    );
+
+    const used = await query.getAgentUsageReport({
+      agentId: "agt_named",
+      orgId: "org-a",
+    });
+    expect(used.agentName).toBe("PR Reviewer");
+
+    const unused = await query.getAgentUsageReport({
+      agentId: "agt_named",
+      orgId: "org-never-used",
+    });
+    expect(unused.agentName, "the raw id, not the name").toBe("agt_named");
+  });
+
+  it("the scope-field refusals: agent report without org_id, org report without dates", async () => {
+    await expectCode(
+      () => query.getAgentUsageReport({ agentId: "agt_x" }),
+      Code.InvalidArgument,
+    );
+    await expectCode(
+      () => query.getAgentUsageReport({ orgId: "org-a" }),
+      Code.InvalidArgument,
+    );
+    await expectCode(
+      () => query.getOrgUsageReport({ orgId: "org-a" }),
+      Code.InvalidArgument,
+    );
+  });
+
+  it("getOrgUsageReport aggregates the org's executions in range with zero costs", async () => {
+    await seed(
+      seedInput({
+        agentId: "agt_org_report",
+        org: "org-report",
+        sessionId: "ses_r1",
+        startedAt: "2026-04-10T10:00:00Z",
+      }),
+    );
+    await seed(
+      seedInput({
+        agentId: "agt_org_report",
+        org: "org-report",
+        sessionId: "ses_r2",
+        startedAt: "2026-04-11T10:00:00Z",
+      }),
+    );
+
+    const report = await query.getOrgUsageReport({
+      orgId: "org-report",
+      fromDate: "2026-04-01",
+      toDate: "2026-04-30",
+    });
+    expect(report.totalExecutions).toBe(2);
+    expect(report.totalAgents).toBe(1);
+    expect(report.totalSessions).toBe(2);
+    expect(report.dailyCosts).toHaveLength(2);
+    expect(report.dailyCosts[0]?.date).toBe("2026-04-10");
+    expect(report.topAgentsByCost).toHaveLength(1);
+    expect(report.topAgentsByCost[0]?.billableCostMicros).toBe(0n);
+  });
+
+  it("getSessionUsageReport orders per-execution summaries chronologically", async () => {
+    await seed(
+      seedInput({
+        sessionId: "ses_report_order",
+        startedAt: "2026-05-02T10:00:00Z",
+      }),
+    );
+    await seed(
+      seedInput({
+        sessionId: "ses_report_order",
+        startedAt: "2026-05-01T10:00:00Z",
+      }),
+    );
+
+    const report = await query.getSessionUsageReport({
+      sessionId: "ses_report_order",
+    });
+    expect(report.executionCount).toBe(2);
+    expect(report.executions[0]?.startedAt).toBe("2026-05-01T10:00:00Z");
+    expect(report.executions[1]?.startedAt).toBe("2026-05-02T10:00:00Z");
+    expect(report.firstExecutionAt).toBe("2026-05-01T10:00:00Z");
+    expect(report.lastExecutionAt).toBe("2026-05-02T10:00:00Z");
+  });
+});
+
+describe("getExecutionSummary — the populated arm", () => {
+  it("counts phases, actives, completion durations, and failure ranks", async () => {
+    // Seeded records carry no audit timestamps, so the window cutoff
+    // never skips them (Go: a zero created_at disables the skip).
+    await seed(
+      seedInput({
+        org: "org-summary",
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        startedAt: "2026-06-01T10:00:00Z",
+        completedAt: "2026-06-01T11:00:00Z",
+      }),
+    );
+    await seed(
+      seedInput({
+        org: "org-summary",
+        agentId: "agt_failing",
+        phase: ExecutionPhase.EXECUTION_FAILED,
+      }),
+    );
+    await seed(
+      seedInput({
+        org: "org-summary",
+        phase: ExecutionPhase.EXECUTION_PENDING,
+      }),
+    );
+
+    const summary = await query.getExecutionSummary({ org: "org-summary" });
+
+    // The org field is a no-op on this single-tenant edition; earlier
+    // suites' seeds are counted too — assert at-least semantics on the
+    // shared counters and exact semantics on this suite's own markers.
+    expect(
+      summary.phaseCounts[ExecutionPhase.EXECUTION_PENDING] ?? 0,
+    ).toBeGreaterThanOrEqual(1);
+    expect(summary.activeCount).toBeGreaterThanOrEqual(1);
+
+    expect(summary.avgDuration, "one completed pair exists").toBeDefined();
+    expect(Number(summary.avgDuration?.seconds ?? 0n)).toBeGreaterThan(0);
+
+    const failing = summary.topFailingAgents.find(
+      (rank) => rank.agentSlug === "agt_failing",
+    );
+    expect(failing, "the failed execution ranks its agent").toBeDefined();
+    expect(failing?.failureCount).toBe(1);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -65,6 +65,7 @@ import type {
 import { EngineWorkflowNotFoundError } from "../engine.js";
 import { aggregateDigest, fileDigest } from "../filereview/digest.js";
 import { submitApproval } from "../submit-approval.js";
+import { stubConnectedEngine } from "./engine-stub.js";
 
 const silentLogger = createLogger({
   level: "error",
@@ -92,6 +93,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,
@@ -983,11 +987,13 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
       }),
     );
     const signalled: string[] = [];
-    const deps = stubDeps({
-      signalApprovalGateResolved: async (executionId) => {
-        signalled.push(executionId);
-      },
-    });
+    const deps = stubDeps(
+      stubConnectedEngine({
+        signalApprovalGateResolved: async (executionId) => {
+          signalled.push(executionId);
+        },
+      }),
+    );
 
     // First decision: a different-class call stays gated → no signal.
     await submitApproval(deps,
@@ -1012,11 +1018,13 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
 
   it("a vanished workflow reconciles the execution to FAILED with settled tool calls (pinned copy)", async () => {
     const id = await seed(gatedSeed({ toolCalls: [{ id: "tc-1", name: "Write" }] }));
-    const deps = stubDeps({
-      signalApprovalGateResolved: async (executionId) => {
-        throw new EngineWorkflowNotFoundError(executionId);
-      },
-    });
+    const deps = stubDeps(
+      stubConnectedEngine({
+        signalApprovalGateResolved: async (executionId) => {
+          throw new EngineWorkflowNotFoundError(executionId);
+        },
+      }),
+    );
 
     const err = await expectCode(
       () =>

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -34,7 +34,22 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
-import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  ApprovalAction,
+  ApprovalEventType,
+  DiffCompleteness,
+  ExecutionPhase,
+  FileChangeKind,
+  FileChangeSetStatus,
+  FileDecisionAction,
+  FileDecisionOrigin,
+  FileDecisionScope,
+  FileReviewEventType,
+  MessageType,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { CapturedFileChangeSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import { SubmitApprovalInputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
 import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
@@ -43,6 +58,13 @@ import { composeServer } from "../../../boot/compose.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
 import { executionUsageReportNotFoundMessage } from "../constants.js";
+import type {
+  ConnectedExecutionEngine,
+  ExecutionEngineState,
+} from "../engine.js";
+import { EngineWorkflowNotFoundError } from "../engine.js";
+import { aggregateDigest, fileDigest } from "../filereview/digest.js";
+import { submitApproval } from "../submit-approval.js";
 
 const silentLogger = createLogger({
   level: "error",
@@ -558,6 +580,628 @@ describe("subscribe — the first domain stream through the real transport", () 
         timeout: 2000,
       })
       .toBe(0);
+  });
+});
+
+function gatedSeed(overrides?: {
+  id?: string;
+  toolCalls?: Array<{
+    id: string;
+    name: string;
+    mcpServerSlug?: string;
+  }>;
+}): MessageInitShape<typeof AgentExecutionSchema> & {
+  metadata: { id: string };
+} {
+  counter += 1;
+  const id = overrides?.id ?? `aexec_gated_${counter}`;
+  const slug = `exec-${id.replaceAll("_", "-")}`;
+  const toolCalls = overrides?.toolCalls ?? [{ id: "tc-1", name: "Write" }];
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: { id, name: slug, slug, org: ORG },
+    spec: { sessionId: `ses_${id}`, agentId: `agt_${id}`, message: "Say hello." },
+    status: {
+      phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+      messages: [
+        {
+          toolCalls: toolCalls.map((tc) => ({
+            id: tc.id,
+            name: tc.name,
+            status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+            requiresApproval: true,
+            ...(tc.mcpServerSlug !== undefined
+              ? { mcpServerSlug: tc.mcpServerSlug }
+              : {}),
+          })),
+        },
+      ],
+    },
+  };
+}
+
+describe("updateStatus over the wire (ADR 011 write path)", () => {
+  it("answers NotFound for an unknown execution and InvalidArgument without a status", async () => {
+    await expectCode(
+      () =>
+        command.updateStatus({
+          executionId: "aexec_missing",
+          status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+        }),
+      Code.NotFound,
+    );
+    await expectCode(
+      () => command.updateStatus({ executionId: "aexec_missing" }),
+      Code.InvalidArgument,
+    );
+  });
+
+  it("persists the merge and broadcasts to a live subscriber in one write path", async () => {
+    const init = seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS });
+    const id = await seed(init);
+
+    // A live subscriber; the snapshot arrives first.
+    const controller = new AbortController();
+    const frames: ExecutionPhase[] = [];
+    let sawFrame: (() => void) | undefined;
+    const consuming = (async () => {
+      try {
+        for await (const frame of query.subscribe(
+          { value: id },
+          { signal: controller.signal },
+        )) {
+          frames.push(
+            frame.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+          );
+          sawFrame?.();
+        }
+      } catch (error) {
+        if (!(error instanceof ConnectError && error.code === Code.Canceled)) {
+          throw error;
+        }
+      }
+    })();
+    await new Promise<void>((resolve) => {
+      if (frames.length >= 1) {
+        resolve();
+        return;
+      }
+      sawFrame = () => {
+        sawFrame = undefined;
+        resolve();
+      };
+    });
+
+    // The runner's terminal persist: merged, persisted, broadcast.
+    await command.updateStatus({
+      executionId: id,
+      status: {
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        completedAt: "2026-08-24T10:00:00Z",
+        messages: [{ content: "done" }],
+      },
+    });
+
+    const reloaded = await query.get({ value: id });
+    expect(reloaded.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    expect(reloaded.status?.messages[0]?.content).toBe("done");
+
+    // The broadcast reached the subscriber and, being terminal, closed the
+    // stream server-side.
+    await consuming;
+    expect(frames).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    ]);
+  });
+});
+
+describe("submitApproval over the wire (submit_approval_contract_test.go arms)", () => {
+  it("records the decision, empties the gate, and authors the event pair", async () => {
+    const init = gatedSeed();
+    const id = await seed(init);
+
+    const result = await command.submitApproval({
+      agentExecutionId: id,
+      toolCallId: "tc-1",
+      action: ApprovalAction.APPROVE,
+      comment: "go ahead",
+    });
+
+    const tc = result.status?.messages[0]?.toolCalls[0];
+    expect(tc?.approvalAction).toBe(ApprovalAction.APPROVE);
+    expect(tc?.approvalDecidedAt).not.toBe("");
+    expect(result.status?.pendingApprovals).toHaveLength(0);
+
+    // The append-only stream carries exactly one REQUESTED + one APPROVED,
+    // the decision with the user's comment.
+    const events = result.status?.approvalEventStream?.events ?? [];
+    const mine = events.filter((ev) => ev.approvalRequestId === "tc-1");
+    expect(mine.map((ev) => ev.eventType).sort()).toEqual(
+      [ApprovalEventType.REQUESTED, ApprovalEventType.APPROVED].sort(),
+    );
+    const decided = mine.find(
+      (ev) => ev.eventType === ApprovalEventType.APPROVED,
+    );
+    expect(
+      decided?.payload.case === "decided" ? decided.payload.value.comment : "",
+    ).toBe("go ahead");
+  });
+
+  it("is idempotent for a repeated identical submit and refuses a conflicting change", async () => {
+    const id = await seed(gatedSeed());
+
+    await command.submitApproval({
+      agentExecutionId: id,
+      toolCallId: "tc-1",
+      action: ApprovalAction.SKIP,
+    });
+    // Same action again: a no-op answering current state.
+    const repeat = await command.submitApproval({
+      agentExecutionId: id,
+      toolCallId: "tc-1",
+      action: ApprovalAction.SKIP,
+    });
+    expect(repeat.status?.messages[0]?.toolCalls[0]?.approvalAction).toBe(
+      ApprovalAction.SKIP,
+    );
+    // A different action on a decided call refuses.
+    await expectCode(
+      () =>
+        command.submitApproval({
+          agentExecutionId: id,
+          toolCallId: "tc-1",
+          action: ApprovalAction.REJECT,
+        }),
+      Code.FailedPrecondition,
+    );
+  });
+
+  it("refuses non-approvable phases, unknown tool calls, and unknown executions", async () => {
+    const terminal = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    await expectCode(
+      () =>
+        command.submitApproval({
+          agentExecutionId: terminal,
+          toolCallId: "tc-1",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.FailedPrecondition,
+    );
+
+    const gated = await seed(gatedSeed());
+    await expectCode(
+      () =>
+        command.submitApproval({
+          agentExecutionId: gated,
+          toolCallId: "tc-unknown",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.InvalidArgument,
+    );
+
+    await expectCode(
+      () =>
+        command.submitApproval({
+          agentExecutionId: "aexec_missing",
+          toolCallId: "tc-1",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.NotFound,
+    );
+  });
+
+  it("APPROVE_ALL bulk-approves only the clicked tool's lease class", async () => {
+    const id = await seed(
+      gatedSeed({
+        toolCalls: [
+          { id: "tc-shell-1", name: "shell" },
+          { id: "tc-shell-2", name: "bash" },
+          { id: "tc-write", name: "Write" },
+        ],
+      }),
+    );
+
+    const result = await command.submitApproval({
+      agentExecutionId: id,
+      toolCallId: "tc-shell-1",
+      action: ApprovalAction.APPROVE_ALL,
+    });
+
+    const calls = result.status?.messages[0]?.toolCalls ?? [];
+    const byId = new Map(calls.map((tc) => [tc.id, tc]));
+    // The clicked tool carries APPROVE_ALL (the user's escalation point).
+    expect(byId.get("tc-shell-1")?.approvalAction).toBe(
+      ApprovalAction.APPROVE_ALL,
+    );
+    // The same-class co-pending call carries a plain APPROVE.
+    expect(byId.get("tc-shell-2")?.approvalAction).toBe(ApprovalAction.APPROVE);
+    // The different-class call stays gated — pending_approvals still
+    // lists it, so the gate stays open.
+    expect(byId.get("tc-write")?.approvalAction).toBe(
+      ApprovalAction.UNSPECIFIED,
+    );
+    expect(result.status?.pendingApprovals).toHaveLength(1);
+    expect(result.status?.pendingApprovals[0]?.toolCallId).toBe("tc-write");
+  });
+
+  it("the approve-all resume round-trip preserves earlier thinking and the first tool call (transcript test)", async () => {
+    counter += 1;
+    const id = `aexec_resume_${counter}`;
+    const slug = `exec-${id.replaceAll("_", "-")}`;
+    await seed({
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: { id, name: slug, slug, org: ORG },
+      spec: { message: "Say hello." },
+      status: {
+        phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+        messages: [
+          {
+            type: MessageType.MESSAGE_THINKING,
+            content: "planning the self-DM",
+          },
+          {
+            type: MessageType.MESSAGE_AI,
+            toolCalls: [
+              {
+                id: "tc-getappstate",
+                name: "getAppState",
+                status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+                requiresApproval: true,
+                mcpServerSlug: "open-computer-use",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await command.submitApproval({
+      agentExecutionId: id,
+      toolCallId: "tc-getappstate",
+      action: ApprovalAction.APPROVE_ALL,
+    });
+
+    // The durable-checkpoint resume sends a regressed transcript: leading
+    // thinking + getAppState gone, later leased tools appended.
+    await command.updateStatus({
+      executionId: id,
+      status: {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        messages: [
+          {
+            type: MessageType.MESSAGE_AI,
+            toolCalls: [
+              { id: "tc-click", name: "click", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+            ],
+          },
+          {
+            type: MessageType.MESSAGE_AI,
+            toolCalls: [
+              { id: "tc-scroll", name: "scroll", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+            ],
+          },
+          { type: MessageType.MESSAGE_AI, content: "done" },
+        ],
+      },
+    });
+
+    const final = await query.get({ value: id });
+    const hasThinking = final.status?.messages.some(
+      (m) =>
+        m.type === MessageType.MESSAGE_THINKING &&
+        m.content === "planning the self-DM",
+    );
+    expect(
+      hasThinking,
+      "the leading thinking block survives the resume round-trip",
+    ).toBe(true);
+    const gated = final.status?.messages
+      .flatMap((m) => m.toolCalls)
+      .find((tc) => tc.id === "tc-getappstate");
+    expect(gated, "the first tool call survives").toBeDefined();
+    expect(
+      gated?.approvalAction,
+      "the recorded APPROVE_ALL decision survives",
+    ).toBe(ApprovalAction.APPROVE_ALL);
+  });
+
+  it("a racing heartbeat never clobbers the decision, and REQUESTED never duplicates", async () => {
+    // The designed overlap window (update_status_concurrency_test.go):
+    // both paths persist via the lock-serialized atomic updateResource.
+    for (let i = 0; i < 20; i++) {
+      const id = await seed(gatedSeed());
+      const heartbeat = command.updateStatus({
+        executionId: id,
+        status: {
+          phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+          messages: [
+            {
+              toolCalls: [
+                {
+                  id: "tc-1",
+                  name: "Write",
+                  status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+                  requiresApproval: true,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const approval = command.submitApproval({
+        agentExecutionId: id,
+        toolCallId: "tc-1",
+        action: ApprovalAction.APPROVE,
+      });
+      await Promise.all([heartbeat, approval]);
+
+      const final = await query.get({ value: id });
+      const tc = final.status?.messages
+        .flatMap((m) => m.toolCalls)
+        .find((c) => c.id === "tc-1");
+      expect(tc?.approvalAction, `iteration ${i}: decision lost`).toBe(
+        ApprovalAction.APPROVE,
+      );
+      const events = (
+        final.status?.approvalEventStream?.events ?? []
+      ).filter((ev) => ev.approvalRequestId === "tc-1");
+      expect(
+        events.filter((ev) => ev.eventType === ApprovalEventType.REQUESTED),
+        `iteration ${i}: REQUESTED duplicated`,
+      ).toHaveLength(1);
+      expect(
+        events.filter((ev) => ev.eventType === ApprovalEventType.APPROVED),
+        `iteration ${i}: decision event lost`,
+      ).toHaveLength(1);
+    }
+  });
+});
+
+describe("the engine-connected signal arms (stubbed engine, direct calls)", () => {
+  function stubDeps(engine: ConnectedExecutionEngine) {
+    return {
+      store: server.store,
+      logger: silentLogger,
+      broker: server.agentExecutionStreamBroker,
+      engineState: () =>
+        ({ connected: true, engine }) as ExecutionEngineState,
+    };
+  }
+
+  it("signals approvalGateResolved exactly once, only when the unified gate clears", async () => {
+    const id = await seed(
+      gatedSeed({
+        toolCalls: [
+          { id: "tc-shell", name: "shell" },
+          { id: "tc-write", name: "Write" },
+        ],
+      }),
+    );
+    const signalled: string[] = [];
+    const deps = stubDeps({
+      signalApprovalGateResolved: async (executionId) => {
+        signalled.push(executionId);
+      },
+    });
+
+    // First decision: a different-class call stays gated → no signal.
+    await submitApproval(deps,
+      create(SubmitApprovalInputSchema, {
+        agentExecutionId: id,
+        toolCallId: "tc-shell",
+        action: ApprovalAction.APPROVE,
+      }),
+    );
+    expect(signalled).toHaveLength(0);
+
+    // Second decision clears the gate → exactly one signal.
+    await submitApproval(deps,
+      create(SubmitApprovalInputSchema, {
+        agentExecutionId: id,
+        toolCallId: "tc-write",
+        action: ApprovalAction.REJECT,
+      }),
+    );
+    expect(signalled).toEqual([id]);
+  });
+
+  it("a vanished workflow reconciles the execution to FAILED with settled tool calls (pinned copy)", async () => {
+    const id = await seed(gatedSeed({ toolCalls: [{ id: "tc-1", name: "Write" }] }));
+    const deps = stubDeps({
+      signalApprovalGateResolved: async (executionId) => {
+        throw new EngineWorkflowNotFoundError(executionId);
+      },
+    });
+
+    const err = await expectCode(
+      () =>
+        submitApproval(deps,
+          create(SubmitApprovalInputSchema, {
+            agentExecutionId: id,
+            toolCallId: "tc-1",
+            action: ApprovalAction.APPROVE,
+          }),
+        ),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(
+      `workflow not running for execution ${id} - the backing workflow has terminated unexpectedly and the execution has been marked as failed`,
+    );
+
+    const final = await query.get({ value: id });
+    expect(final.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
+    expect(final.status?.error).toBe(
+      "Workflow backing this execution is no longer running. Execution has been marked as failed.",
+    );
+    // The system message is appended and in-flight calls settle (#207).
+    expect(
+      final.status?.messages.at(-1)?.type,
+    ).toBe(MessageType.MESSAGE_SYSTEM);
+    const tc = final.status?.messages
+      .flatMap((m) => m.toolCalls)
+      .find((c) => c.id === "tc-1");
+    expect(tc?.status).toBe(ToolCallStatus.TOOL_CALL_INTERRUPTED);
+    // The ledger is preserved for the audit trail; the projection is empty
+    // (terminal).
+    expect(
+      (final.status?.approvalEventStream?.events ?? []).length,
+    ).toBeGreaterThan(0);
+    expect(final.status?.pendingApprovals).toHaveLength(0);
+  });
+});
+
+describe("submitFileDecision over the wire", () => {
+  function ledgerSeed(): {
+    init: MessageInitShape<typeof AgentExecutionSchema> & {
+      metadata: { id: string };
+    };
+    changeSetId: string;
+    change: ReturnType<typeof buildChange>;
+    aggregate: string;
+  } {
+    counter += 1;
+    const id = `aexec_review_${counter}`;
+    const slug = `exec-${id.replaceAll("_", "-")}`;
+    const changeSetId = `cs_${counter}`;
+    const change = buildChange();
+    const aggregate = aggregateDigest([change]);
+    return {
+      init: {
+        apiVersion: API_VERSION,
+        kind: KIND,
+        metadata: { id, name: slug, slug, org: ORG },
+        spec: { message: "Say hello." },
+        status: {
+          phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+          fileReviewEventStream: {
+            executionId: id,
+            events: [
+              {
+                eventId: `${changeSetId}:${changeSetId}:BASELINE`,
+                changeSetId,
+                eventType: FileReviewEventType.BASELINE_CAPTURED,
+                actor: "runner",
+                payload: {
+                  case: "baselineCaptured",
+                  value: { turnId: "turn-1", harnessId: "harness-1" },
+                },
+              },
+              {
+                eventId: `${changeSetId}:${changeSetId}:CANDIDATE`,
+                changeSetId,
+                eventType: FileReviewEventType.CANDIDATE_CAPTURED,
+                actor: "runner",
+                payload: {
+                  case: "candidateCaptured",
+                  value: {
+                    changes: [change],
+                    aggregateDigest: aggregate,
+                    diffCompleteness: DiffCompleteness.COMPLETE,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      changeSetId,
+      change,
+      aggregate,
+    };
+  }
+
+  function buildChange() {
+    const change = create(CapturedFileChangeSchema, {
+      id: "fc-1",
+      pathBefore: "src/a.ts",
+      pathAfter: "src/a.ts",
+      kind: FileChangeKind.MODIFY,
+      beforeSha256: "a".repeat(64),
+      afterSha256: "b".repeat(64),
+      diffComplete: true,
+    });
+    change.fileDigest = fileDigest(change);
+    return change;
+  }
+
+  it("records a CHANGE_SET keep, projects DECIDED, and is idempotent on resubmit", async () => {
+    const { init, changeSetId, aggregate } = ledgerSeed();
+    const id = await seed(init);
+
+    const result = await command.submitFileDecision({
+      agentExecutionId: id,
+      changeSetId,
+      scope: FileDecisionScope.CHANGE_SET,
+      action: FileDecisionAction.APPROVE,
+      expectedDigest: aggregate,
+    });
+    const cs = result.status?.fileChangeSets.find((c) => c.id === changeSetId);
+    expect(cs?.status).toBe(FileChangeSetStatus.DECIDED);
+    expect(cs?.decisions).toHaveLength(1);
+    expect(cs?.decisions[0]?.origin).toBe(FileDecisionOrigin.USER);
+
+    // Idempotent resubmit: the same deterministic event id — no error, no
+    // duplicate decision.
+    const repeat = await command.submitFileDecision({
+      agentExecutionId: id,
+      changeSetId,
+      scope: FileDecisionScope.CHANGE_SET,
+      action: FileDecisionAction.APPROVE,
+      expectedDigest: aggregate,
+    });
+    const csRepeat = repeat.status?.fileChangeSets.find(
+      (c) => c.id === changeSetId,
+    );
+    expect(csRepeat?.decisions).toHaveLength(1);
+  });
+
+  it("refuses a stale digest, an unknown change set, and FILE scope without an id", async () => {
+    const { init, changeSetId } = ledgerSeed();
+    const id = await seed(init);
+
+    const staleErr = await expectCode(
+      () =>
+        command.submitFileDecision({
+          agentExecutionId: id,
+          changeSetId,
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+          expectedDigest: "0".repeat(64),
+        }),
+      Code.InvalidArgument,
+    );
+    expect(staleErr.rawMessage).toBe(
+      `expected_digest mismatch for change set ${changeSetId}: the captured content changed since it was reviewed`,
+    );
+
+    await expectCode(
+      () =>
+        command.submitFileDecision({
+          agentExecutionId: id,
+          changeSetId: "cs_unknown",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+          expectedDigest: "0".repeat(64),
+        }),
+      Code.FailedPrecondition,
+    );
+
+    await expectCode(
+      () =>
+        command.submitFileDecision({
+          agentExecutionId: id,
+          changeSetId,
+          scope: FileDecisionScope.FILE,
+          action: FileDecisionAction.APPROVE,
+          expectedDigest: "0".repeat(64),
+        }),
+      Code.InvalidArgument,
+    );
   });
 });
 

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -422,6 +422,145 @@ describe("usage reports over the wire", () => {
   });
 });
 
+describe("subscribe — the first domain stream through the real transport", () => {
+  /**
+   * Collects frames from a live subscribe stream. `done` resolves when
+   * the server ends the stream; the caller aborts for the
+   * client-disconnect arms.
+   */
+  function openStream(id: string) {
+    const controller = new AbortController();
+    const frames: string[] = [];
+    let sawFrame: (() => void) | undefined;
+    const done = (async () => {
+      try {
+        for await (const frame of query.subscribe(
+          { value: id },
+          { signal: controller.signal },
+        )) {
+          frames.push(frame.status?.error ?? "");
+          sawFrame?.();
+        }
+        return "server-ended" as const;
+      } catch (error) {
+        if (
+          error instanceof ConnectError &&
+          error.code === Code.Canceled
+        ) {
+          return "client-cancelled" as const;
+        }
+        throw error;
+      }
+    })();
+    // Deterministic wait: resolves once frames.length >= n (no sleeps).
+    const untilFrames = (n: number) =>
+      new Promise<void>((resolve) => {
+        if (frames.length >= n) {
+          resolve();
+          return;
+        }
+        sawFrame = () => {
+          if (frames.length >= n) {
+            sawFrame = undefined;
+            resolve();
+          }
+        };
+      });
+    return { controller, frames, done, untilFrames };
+  }
+
+  it("refuses an empty id (InvalidArgument) and an unknown id (NotFound, pinned copy)", async () => {
+    const emptyErr = await expectCode(async () => {
+      for await (const frame of query.subscribe({ value: "" })) {
+        void frame;
+      }
+    }, Code.InvalidArgument);
+    // The protovalidate STREAM interceptor fires before the handler in
+    // both editions (Go StreamServerInterceptor); the handler's inline
+    // guard is the direct-call defense. protovalidate-go and
+    // protovalidate-es render this violation byte-identically (the #7
+    // probe).
+    expect(emptyErr.rawMessage).toBe("value: value is required [required]");
+
+    const unknownErr = await expectCode(async () => {
+      for await (const frame of query.subscribe({ value: "aexec_missing" })) {
+        void frame;
+      }
+    }, Code.NotFound);
+    expect(unknownErr.rawMessage).toBe(
+      "AgentExecution not found: aexec_missing",
+    );
+  });
+
+  it("streams snapshot → live update → terminal close, suppressing duplicate frames", async () => {
+    const init = seedInput({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    const id = await seed(init);
+
+    const stream = openStream(id);
+    await stream.untilFrames(1); // the snapshot
+
+    // The overlap frame: byte-equal to the snapshot — must be suppressed.
+    server.agentExecutionStreamBroker.broadcast(
+      create(AgentExecutionSchema, init),
+    );
+    // A genuinely new frame follows; its arrival proves the equal frame
+    // was dropped (ordered queue — had it been delivered, it would appear
+    // before this one).
+    const progressed = create(AgentExecutionSchema, {
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: init.metadata,
+      spec: init.spec,
+      status: {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        error: "marker-live-update",
+      },
+    });
+    server.agentExecutionStreamBroker.broadcast(progressed);
+    await stream.untilFrames(2);
+    expect(stream.frames).toEqual(["", "marker-live-update"]);
+
+    // A terminal broadcast ends the stream server-side.
+    server.agentExecutionStreamBroker.broadcast(
+      create(AgentExecutionSchema, {
+        apiVersion: API_VERSION,
+        kind: KIND,
+        metadata: init.metadata,
+        spec: init.spec,
+        status: {
+          phase: ExecutionPhase.EXECUTION_COMPLETED,
+          error: "marker-terminal",
+        },
+      }),
+    );
+    await expect(stream.done).resolves.toBe("server-ended");
+    expect(stream.frames).toEqual(["", "marker-live-update", "marker-terminal"]);
+    expect(server.agentExecutionStreamBroker.getSubscriberCount(id)).toBe(0);
+  });
+
+  it("a terminal SNAPSHOT leaves the stream open until the client disconnects (faithful port)", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+
+    const stream = openStream(id);
+    await stream.untilFrames(1);
+    expect(server.agentExecutionStreamBroker.getSubscriberCount(id)).toBe(1);
+
+    stream.controller.abort();
+    await expect(stream.done).resolves.toBe("client-cancelled");
+    // The generator's finally runs server-side after the client observes
+    // the cancellation — poll (bounded, no sleeps) for the unsubscribe.
+    await expect
+      .poll(() => server.agentExecutionStreamBroker.getSubscriberCount(id), {
+        timeout: 2000,
+      })
+      .toBe(0);
+  });
+});
+
 describe("getExecutionSummary — the populated arm", () => {
   it("counts phases, actives, completion durations, and failure ranks", async () => {
     // Seeded records carry no audit timestamps, so the window cutoff

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -24,7 +24,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { create } from "@bufbuild/protobuf";
+import { create, fromBinary } from "@bufbuild/protobuf";
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { Code, ConnectError, createClient } from "@connectrpc/connect";
 import type { Client, Transport } from "@connectrpc/connect";
@@ -46,6 +46,7 @@ import {
   FileDecisionScope,
   FileReviewEventType,
   MessageType,
+  ServiceTier,
   ToolCallStatus,
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { CapturedFileChangeSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
@@ -181,6 +182,83 @@ async function expectCode(
   }
   throw new Error(`expected code ${Code[code]}, call succeeded`);
 }
+
+describe("create over the wire (engine gate)", () => {
+  it("valid create refuses Unavailable at the engine gate, BEFORE any side effect", async () => {
+    // Seed an agent the request references, so target resolution and
+    // validation pass and the refusal is provably the engine gate.
+    await server.store.saveResource(
+      ApiResourceKind.agent,
+      "agt_create_gate",
+      AgentSchema,
+      create(AgentSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Agent",
+        metadata: { id: "agt_create_gate", name: "gate-agent", org: ORG },
+      }),
+    );
+
+    const err = await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "gated-exec", org: ORG },
+          spec: { agentId: "agt_create_gate", message: "hello" },
+        }),
+      Code.Unavailable,
+    );
+    expect(err.rawMessage).toBe(
+      "The execution engine is temporarily unavailable. Please try again shortly.",
+    );
+
+    // The gate ran before the side-effecting steps: nothing persisted.
+    const executions = await server.store.listResources(
+      ApiResourceKind.agent_execution,
+    );
+    const sessions = await server.store.listResources(ApiResourceKind.session);
+    for (const data of executions) {
+      const row = fromBinary(AgentExecutionSchema, data);
+      expect(row.metadata?.name).not.toBe("gated-exec");
+    }
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("validation runs before the gate: a tier without a model answers InvalidArgument", async () => {
+    const err = await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "bad-tier-exec", org: ORG },
+          spec: {
+            agentId: "agt_create_gate",
+            message: "hello",
+            executionConfig: { serviceTier: ServiceTier.FAST },
+          },
+        }),
+      Code.InvalidArgument,
+    );
+    expect(err.rawMessage).toContain("requires execution_config.model_name");
+  });
+
+  it("session_id and session_spec together refuse at proto validation", async () => {
+    await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "both-exec", org: ORG },
+          spec: {
+            message: "hello",
+            sessionId: "ses_1",
+            sessionSpec: { agentInstanceId: "inst_1" },
+          },
+        }),
+      Code.InvalidArgument,
+    );
+  });
+});
 
 describe("get / list / listBySession over the wire", () => {
   it("get answers NotFound for an unknown id and the record for a seeded one", async () => {

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -52,6 +52,7 @@ import {
 import { CapturedFileChangeSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
 import { SubmitApprovalInputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
 import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import { loadConfig } from "../../../boot/config.js";
@@ -213,15 +214,22 @@ describe("create over the wire (engine gate)", () => {
     );
 
     // The gate ran before the side-effecting steps: nothing persisted.
+    // Both checks filter to THIS request's artifacts rather than
+    // asserting global emptiness, so future seeding elsewhere in the
+    // file can never make them order-dependent.
     const executions = await server.store.listResources(
       ApiResourceKind.agent_execution,
     );
-    const sessions = await server.store.listResources(ApiResourceKind.session);
     for (const data of executions) {
       const row = fromBinary(AgentExecutionSchema, data);
       expect(row.metadata?.name).not.toBe("gated-exec");
     }
-    expect(sessions).toHaveLength(0);
+    const sessions = await server.store.listResources(ApiResourceKind.session);
+    for (const data of sessions) {
+      const row = fromBinary(SessionSchema, data);
+      expect(row.spec?.agentInstanceId ?? "").not.toContain("agt_create_gate");
+      expect(row.spec?.subject).not.toBe("Auto-created session");
+    }
   });
 
   it("validation runs before the gate: a tier without a model answers InvalidArgument", async () => {
@@ -253,6 +261,28 @@ describe("create over the wire (engine gate)", () => {
             message: "hello",
             sessionId: "ses_1",
             sessionSpec: { agentInstanceId: "inst_1" },
+          },
+        }),
+      Code.InvalidArgument,
+    );
+  });
+
+  it("a forged server-owned harness_state_id in session_spec refuses at proto validation", async () => {
+    // Go create_session_bootstrap_test.go: harness_state_id is
+    // server-owned — a caller seeding thread state must be rejected by
+    // the CEL rule, not silently honored.
+    await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "forged-exec", org: ORG },
+          spec: {
+            message: "hello",
+            sessionSpec: {
+              agentInstanceId: "inst_1",
+              harnessStateId: "thread-forged",
+            },
           },
         }),
       Code.InvalidArgument,

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Attachment + artifact RPC tests — ports upload_attachment_test.go,
+ * get_artifact_content_test.go, and get_artifact_download_url_test.go
+ * case-for-case over a real SQLite store and a real local-filesystem
+ * artifact backend (the same direct-call shape as Go's controller tests).
+ */
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { zipSync } from "fflate";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  GetArtifactContentRequestSchema,
+  GetArtifactDownloadUrlRequestSchema,
+  UploadAttachmentRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { LocalArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+
+import type { ArtifactRpcDeps } from "../artifacts.js";
+import {
+  detectContentType,
+  getArtifactContent,
+  getArtifactDownloadUrl,
+  uploadAttachment,
+} from "../artifacts.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: Store;
+let deps: ArtifactRpcDeps;
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "aexec-artifacts-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"));
+  deps = {
+    store,
+    logger: silentLogger,
+    artifactStorage: new LocalArtifactStorage(
+      path.join(dir, "artifacts"),
+      "http://localhost:7235",
+    ),
+  };
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function seedExecution(
+  executionId: string,
+  attachmentKey?: string,
+): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.agent_execution,
+    executionId,
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, {
+      metadata: { id: executionId, name: "artifact-test" },
+      spec:
+        attachmentKey === undefined
+          ? {}
+          : {
+              attachments: [
+                {
+                  filename: "notes.png",
+                  storageKey: attachmentKey,
+                  contentType: "image/png",
+                },
+              ],
+            },
+    }),
+  );
+}
+
+function sha256Hex(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+// The exact CAS blob key shape the runner writes: when the stored bytes
+// differ from content, the key's embedded address no longer matches the
+// served bytes (the tamper case).
+function casBlobKeyFor(executionId: string, content: Uint8Array): string {
+  return `artifacts/${executionId}/filereview/cas/blobs/${sha256Hex(content)}`;
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(connectError.code).toBe(code);
+    return connectError;
+  }
+  throw new Error(`expected code ${Code[code]}, call succeeded`);
+}
+
+describe("uploadAttachment", () => {
+  // The service boundary refuses a filename that would smuggle path
+  // separators or `..` segments into the storage key — backstopping the
+  // buf.validate constraint so a bypassed constraint still fails closed.
+  const badFilenames = [
+    "../evil.txt",
+    "../../evil.txt",
+    "a/b.txt",
+    "dir/../../escape",
+    "..",
+    ".",
+    "..\\evil.txt",
+    "sub\\file.txt",
+  ];
+  for (const name of badFilenames) {
+    it(`rejects traversal filename ${JSON.stringify(name)}`, async () => {
+      await expectCode(
+        () =>
+          uploadAttachment(
+            deps,
+            create(UploadAttachmentRequestSchema, {
+              filename: name,
+              content: Buffer.from("payload"),
+            }),
+          ),
+        Code.InvalidArgument,
+      );
+    });
+  }
+
+  // The guard must not over-reject: ordinary filenames (dots inside the
+  // name, spaces, unicode) upload and produce the documented key shape.
+  const goodFilenames = [
+    "dataset.csv",
+    "report.final.v2.pdf",
+    "my report.txt",
+    "contrat-français.pdf",
+  ];
+  for (const name of goodFilenames) {
+    it(`accepts plain filename ${JSON.stringify(name)}`, async () => {
+      const resp = await uploadAttachment(
+        deps,
+        create(UploadAttachmentRequestSchema, {
+          filename: name,
+          content: Buffer.from("payload"),
+        }),
+      );
+      expect(resp.storageKey.startsWith("attachments/")).toBe(true);
+      expect(resp.storageKey.endsWith(`/${name}`)).toBe(true);
+    });
+  }
+
+  it("rejects empty filename and empty content", async () => {
+    await expectCode(
+      () =>
+        uploadAttachment(
+          deps,
+          create(UploadAttachmentRequestSchema, {
+            filename: "",
+            content: Buffer.from("x"),
+          }),
+        ),
+      Code.InvalidArgument,
+    );
+    await expectCode(
+      () =>
+        uploadAttachment(
+          deps,
+          create(UploadAttachmentRequestSchema, {
+            filename: "ok.txt",
+            content: new Uint8Array(),
+          }),
+        ),
+      Code.InvalidArgument,
+    );
+  });
+});
+
+describe("getArtifactContent CAS blob integrity", () => {
+  const execId = "aex_artifact";
+
+  async function upload(key: string, data: Uint8Array): Promise<void> {
+    await deps.artifactStorage.upload(key, data, "application/octet-stream");
+  }
+
+  it("matching CAS blob is served", async () => {
+    await seedExecution(execId);
+    const body = Buffer.from("gitignored file bytes");
+    const key = casBlobKeyFor(execId, body);
+    await upload(key, body);
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+      }),
+    );
+    expect(Buffer.from(resp.content).toString()).toBe(
+      "gitignored file bytes",
+    );
+    expect(resp.contentType).toBe("application/octet-stream");
+  });
+
+  it("tampered CAS blob fails closed with DATA_LOSS", async () => {
+    await seedExecution(execId);
+    // Key addresses the hash of the original bytes; store different bytes.
+    const key = casBlobKeyFor(
+      execId,
+      Buffer.from("original bytes the runner captured"),
+    );
+    await upload(key, Buffer.from("corrupted bytes"));
+
+    await expectCode(
+      () =>
+        getArtifactContent(
+          deps,
+          create(GetArtifactContentRequestSchema, {
+            executionId: execId,
+            storageKey: key,
+          }),
+        ),
+      Code.DataLoss,
+    );
+  });
+
+  it("CAS blob key of another execution is rejected", async () => {
+    await seedExecution(execId);
+    const otherKey = casBlobKeyFor("aex_someone_else", Buffer.from("x"));
+    await expectCode(
+      () =>
+        getArtifactContent(
+          deps,
+          create(GetArtifactContentRequestSchema, {
+            executionId: execId,
+            storageKey: otherKey,
+          }),
+        ),
+      Code.InvalidArgument,
+    );
+  });
+
+  it("manifest is served unverified", async () => {
+    await seedExecution(execId);
+    const manifestKey = `artifacts/${execId}/filereview/cas/${execId}_0.manifest.json`;
+    const manifest = Buffer.from(
+      `{"changeSetId":"${execId}:0","files":[]}`,
+    );
+    await upload(manifestKey, manifest);
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: manifestKey,
+      }),
+    );
+    expect(Buffer.from(resp.content).toString()).toBe(manifest.toString());
+    expect(resp.contentType).toBe("application/json");
+  });
+
+  it("blob exactly at max_bytes is verified", async () => {
+    await seedExecution(execId);
+    const body = Buffer.from("0123456789");
+    const key = casBlobKeyFor(execId, body);
+    await upload(key, body);
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+        maxBytes: BigInt(body.length),
+      }),
+    );
+    expect(resp.truncated).toBe(false);
+  });
+
+  it("truncated read skips verification (no false DATA_LOSS)", async () => {
+    await seedExecution(execId);
+    // A tampered blob larger than max_bytes: the partial read cannot
+    // full-hash-verify, so it must be served (truncated), not rejected.
+    const key = casBlobKeyFor(
+      execId,
+      Buffer.from("the original object bytes"),
+    );
+    const stored = Buffer.from(
+      "corrupted but served because the read is truncated",
+    );
+    await upload(key, stored);
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+        maxBytes: BigInt(stored.length - 1),
+      }),
+    );
+    expect(resp.truncated).toBe(true);
+  });
+
+  it("unknown execution answers NotFound", async () => {
+    await expectCode(
+      () =>
+        getArtifactContent(
+          deps,
+          create(GetArtifactContentRequestSchema, {
+            executionId: "aex_never_seeded",
+            storageKey: "artifacts/aex_never_seeded/out.txt",
+          }),
+        ),
+      Code.NotFound,
+    );
+  });
+
+  it("extracts a single entry from a ZIP artifact with entry-derived content type", async () => {
+    await seedExecution(execId);
+    const zipped = zipSync({
+      "report/summary.md": Buffer.from("# Summary"),
+      "report/data.csv": Buffer.from("a,b\n1,2"),
+    });
+    const key = `artifacts/${execId}/report.zip`;
+    await upload(key, zipped);
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+        entryPath: "report/summary.md",
+      }),
+    );
+    expect(Buffer.from(resp.content).toString()).toBe("# Summary");
+    expect(resp.contentType).toBe("text/markdown");
+
+    await expectCode(
+      () =>
+        getArtifactContent(
+          deps,
+          create(GetArtifactContentRequestSchema, {
+            executionId: execId,
+            storageKey: key,
+            entryPath: "missing/entry.txt",
+          }),
+        ),
+      Code.NotFound,
+    );
+  });
+});
+
+describe("getArtifactDownloadUrl", () => {
+  const execId = "aex_download";
+  const key = `artifacts/${execId}/plan_card_ux_cleanup.plan.md`;
+
+  it("inline by default (no disposition)", async () => {
+    await seedExecution(execId);
+    const resp = await getArtifactDownloadUrl(
+      deps,
+      create(GetArtifactDownloadUrlRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+      }),
+    );
+    expect(resp.downloadUrl).not.toContain("download=");
+    expect(resp.expiresAt).not.toBe("");
+  });
+
+  it("as_attachment names the download after the artifact", async () => {
+    await seedExecution(execId);
+    const resp = await getArtifactDownloadUrl(
+      deps,
+      create(GetArtifactDownloadUrlRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+        asAttachment: true,
+      }),
+    );
+    expect(resp.downloadUrl).toContain(
+      "download=plan_card_ux_cleanup.plan.md",
+    );
+  });
+
+  describe("spec.attachments key arm", () => {
+    const attachExecId = "aex_attach_presign";
+    const attachmentKey = "attachments/01JXULIDULIDULIDULIDULIDXX/notes.png";
+
+    it("key listed in spec.attachments is accepted", async () => {
+      await seedExecution(attachExecId, attachmentKey);
+      const resp = await getArtifactDownloadUrl(
+        deps,
+        create(GetArtifactDownloadUrlRequestSchema, {
+          executionId: attachExecId,
+          storageKey: attachmentKey,
+        }),
+      );
+      expect(resp.downloadUrl).not.toBe("");
+    });
+
+    it("as_attachment names the download after the attachment file", async () => {
+      await seedExecution(attachExecId, attachmentKey);
+      const resp = await getArtifactDownloadUrl(
+        deps,
+        create(GetArtifactDownloadUrlRequestSchema, {
+          executionId: attachExecId,
+          storageKey: attachmentKey,
+          asAttachment: true,
+        }),
+      );
+      expect(resp.downloadUrl).toContain("download=notes.png");
+    });
+
+    it("artifact-prefixed key still accepted alongside attachments", async () => {
+      await seedExecution(attachExecId, attachmentKey);
+      const resp = await getArtifactDownloadUrl(
+        deps,
+        create(GetArtifactDownloadUrlRequestSchema, {
+          executionId: attachExecId,
+          storageKey: `artifacts/${attachExecId}/report.md`,
+        }),
+      );
+      expect(resp.downloadUrl).not.toBe("");
+    });
+
+    it("attachment key not in spec is rejected", async () => {
+      await seedExecution(attachExecId, attachmentKey);
+      await expectCode(
+        () =>
+          getArtifactDownloadUrl(
+            deps,
+            create(GetArtifactDownloadUrlRequestSchema, {
+              executionId: attachExecId,
+              storageKey: "attachments/01JXOTHERULIDULIDULIDULIDX/other.png",
+            }),
+          ),
+        Code.InvalidArgument,
+      );
+    });
+
+    it("execution without the spec entry rejects the same key", async () => {
+      // A second execution that never referenced attachmentKey must not
+      // presign it — membership is per-execution, not global.
+      await seedExecution("aex_other");
+      await expectCode(
+        () =>
+          getArtifactDownloadUrl(
+            deps,
+            create(GetArtifactDownloadUrlRequestSchema, {
+              executionId: "aex_other",
+              storageKey: attachmentKey,
+            }),
+          ),
+        Code.InvalidArgument,
+      );
+    });
+  });
+});
+
+describe("detectContentType", () => {
+  it("prefers the artifact-relevant table, falls back per Go", () => {
+    expect(detectContentType("artifacts/x/report.yaml")).toBe("text/yaml");
+    expect(detectContentType("artifacts/x/data.json")).toBe(
+      "application/json",
+    );
+    expect(detectContentType("artifacts/x/image.png")).toBe("image/png");
+    expect(detectContentType("artifacts/x/unknown.zzz")).toBe(
+      "application/octet-stream",
+    );
+    expect(detectContentType("artifacts/x/no-extension")).toBe(
+      "application/octet-stream",
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
@@ -32,6 +32,7 @@ import {
   detectContentType,
   getArtifactContent,
   getArtifactDownloadUrl,
+  osMimeTypeByExtension,
   uploadAttachment,
 } from "../artifacts.js";
 
@@ -497,10 +498,33 @@ describe("detectContentType", () => {
       "application/json",
     );
     expect(detectContentType("artifacts/x/image.png")).toBe("image/png");
+    // Go's mime builtins carry charset qualifiers for text types the
+    // KNOWN table doesn't intercept (.css falls through; .html does not).
+    expect(detectContentType("artifacts/x/style.css")).toBe(
+      "text/css; charset=utf-8",
+    );
+    expect(detectContentType("artifacts/x/page.html")).toBe("text/html");
     expect(detectContentType("artifacts/x/unknown.zzz")).toBe(
       "application/octet-stream",
     );
     expect(detectContentType("artifacts/x/no-extension")).toBe(
+      "application/octet-stream",
+    );
+  });
+});
+
+describe("osMimeTypeByExtension (the upload path's detection)", () => {
+  it("consults only the mime-builtin table — never the artifact table", () => {
+    // Go's upload path uses mime.TypeByExtension alone: .yaml is NOT a
+    // Go mime builtin, so an uploaded YAML stores octet-stream even
+    // though the READ path reports text/yaml (edition-identical object
+    // metadata for #13's R2 backend).
+    expect(osMimeTypeByExtension("values.yaml")).toBe(
+      "application/octet-stream",
+    );
+    expect(osMimeTypeByExtension("photo.png")).toBe("image/png");
+    expect(osMimeTypeByExtension("doc.pdf")).toBe("application/pdf");
+    expect(osMimeTypeByExtension("no-extension")).toBe(
       "application/octet-stream",
     );
   });

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
@@ -315,6 +315,25 @@ describe("getArtifactContent CAS blob integrity", () => {
     expect(resp.truncated).toBe(true);
   });
 
+  it("max_bytes <= 0 falls back to the 512KB default (fail-safe)", async () => {
+    await seedExecution(execId);
+    const body = Buffer.from("small body");
+    const key = casBlobKeyFor(execId, body);
+    await upload(key, body);
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: key,
+        maxBytes: BigInt(-1),
+      }),
+    );
+    // The default (512KB) applies, so the whole small object is served.
+    expect(resp.truncated).toBe(false);
+    expect(Buffer.from(resp.content).toString()).toBe("small body");
+  });
+
   it("unknown execution answers NotFound", async () => {
     await expectCode(
       () =>

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/artifacts.test.ts
@@ -335,6 +335,42 @@ describe("getArtifactContent CAS blob integrity", () => {
     expect(Buffer.from(resp.content).toString()).toBe("small body");
   });
 
+  it("a `..` key that clean-resolves into ANOTHER execution's prefix is rejected", async () => {
+    // stigmer/stigmer#858: the raw key starts with the caller's own
+    // prefix, but path-cleaning resolves it into the victim's artifacts —
+    // the ownership check must run on the normalized form. Deliberate
+    // fail-closed divergence from Go until #858 lands there.
+    await seedExecution(execId);
+    const victimBody = Buffer.from("victim's secret");
+    await upload(`artifacts/aex_victim/secret.txt`, victimBody);
+
+    await expectCode(
+      () =>
+        getArtifactContent(
+          deps,
+          create(GetArtifactContentRequestSchema, {
+            executionId: execId,
+            storageKey: `artifacts/${execId}/../aex_victim/secret.txt`,
+          }),
+        ),
+      Code.InvalidArgument,
+    );
+  });
+
+  it("a `..` key that stays within the caller's own prefix remains allowed", async () => {
+    await seedExecution(execId);
+    await upload(`artifacts/${execId}/y.txt`, Buffer.from("mine"));
+
+    const resp = await getArtifactContent(
+      deps,
+      create(GetArtifactContentRequestSchema, {
+        executionId: execId,
+        storageKey: `artifacts/${execId}/x/../y.txt`,
+      }),
+    );
+    expect(Buffer.from(resp.content).toString()).toBe("mine");
+  });
+
   it("unknown execution answers NotFound", async () => {
     await expectCode(
       () =>
@@ -466,6 +502,22 @@ describe("getArtifactDownloadUrl", () => {
             create(GetArtifactDownloadUrlRequestSchema, {
               executionId: attachExecId,
               storageKey: "attachments/01JXOTHERULIDULIDULIDULIDX/other.png",
+            }),
+          ),
+        Code.InvalidArgument,
+      );
+    });
+
+    it("a `..` key clean-resolving into another execution's prefix is rejected (presign)", async () => {
+      // stigmer/stigmer#858, the presign arm.
+      await seedExecution(attachExecId, attachmentKey);
+      await expectCode(
+        () =>
+          getArtifactDownloadUrl(
+            deps,
+            create(GetArtifactDownloadUrlRequestSchema, {
+              executionId: attachExecId,
+              storageKey: `artifacts/${attachExecId}/../aex_victim/secret.txt`,
             }),
           ),
         Code.InvalidArgument,

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-execution-context-step.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-execution-context-step.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { afterAll, beforeAll, expect, it } from "vitest";
 
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
@@ -48,6 +49,82 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(dir, { recursive: true, force: true });
+});
+
+it("an unresolvable environment ref surfaces the inner status code with Go's wrap chain", async () => {
+  // Go wraps the typed resolution status with %w — a deleted environment
+  // answers NotFound (caller-fixable), never an opaque Internal.
+  const deps: ExecutionContextBuilderDeps = {
+    store,
+    logger: silentLogger,
+    agentLoader: () => ({
+      get: async () =>
+        create(AgentSchema, { metadata: { id: "agt_x", org: "acme" } }),
+    }),
+    agentInstanceLoader: () => ({
+      get: async (instanceId) =>
+        create(AgentInstanceSchema, {
+          metadata: { id: instanceId, org: "acme" },
+          spec: {
+            agentId: "agt_x",
+            environmentRefs: [
+              {
+                kind: ApiResourceKind.environment,
+                org: "acme",
+                slug: "deleted-env",
+              },
+            ],
+          },
+        }),
+    }),
+    sessionLoader: () => ({
+      get: async (sessionId) =>
+        create(SessionSchema, {
+          metadata: { id: sessionId, org: "acme" },
+          spec: { agentInstanceId: "agi_x" },
+        }),
+    }),
+    environmentReader: () => ({
+      list: async () => {
+        throw new Error("unreached");
+      },
+      getSecretValue: async () => {
+        throw new Error("unreached");
+      },
+    }),
+    environmentResolution: {
+      resolveByReference: async () => {
+        throw new ConnectError(
+          "environment not found: deleted-env",
+          Code.NotFound,
+        );
+      },
+    } as unknown as ExecutionContextBuilderDeps["environmentResolution"],
+    executionContextCreator: () => ({
+      create: async (ec) => ec,
+    }),
+    managedEnvService: {
+      readSecretValue: async () => "",
+      updateSecrets: async () => {},
+    } as unknown as ManagedEnvironmentService,
+  };
+
+  const execution = create(AgentExecutionSchema, {
+    metadata: { id: "aexec_ref_gone", org: "acme" },
+    spec: { sessionId: "ses_x", message: "hi" },
+  });
+
+  try {
+    await buildAndPersistExecutionContext(deps, execution, "");
+    expect.unreachable("expected NotFound");
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(connectError.code).toBe(Code.NotFound);
+    expect(connectError.rawMessage).toBe(
+      "resolve environment ref (org=acme, slug=deleted-env): " +
+        "rpc error: code = NotFound desc = environment not found: deleted-env",
+    );
+  }
 });
 
 it("assembles merge → filter → OAuth injection → EC persist over a non-empty environment", async () => {

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-execution-context-step.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-execution-context-step.test.ts
@@ -1,0 +1,209 @@
+/**
+ * The EC builder ASSEMBLY test — panel finding (Reviewer B #3): the
+ * pieces (envmerge, refresh, filter) are unit-tested standalone, but the
+ * composition — resolve refs → merge layers → least-privilege filter →
+ * OAuth injection with inline pre-flight refresh → EC persist — needs one
+ * test driving a NON-EMPTY environment and a real token injection through
+ * buildAndPersistExecutionContext. Go has no unit twin (its coverage is
+ * the execution conformance suites); this pin is TS-only by design.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { afterAll, beforeAll, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { EnvironmentValue } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+import type { ManagedEnvironmentService } from "../../mcpserver/oauth/managed-env.js";
+
+import type { ExecutionContextBuilderDeps } from "../create-execution-context-step.js";
+import { buildAndPersistExecutionContext } from "../create-execution-context-step.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: Store;
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "aexec-ecbuilder-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+it("assembles merge → filter → OAuth injection → EC persist over a non-empty environment", async () => {
+  const ORG = "acme";
+  const EXEC_ID = "aexec_ec_assembly";
+  const now = Math.floor(Date.now() / 1000);
+
+  // An MCP server with spec.auth, an EXPIRED grant against it, and a
+  // managed environment holding the refresh token — the full injection
+  // chain including the inline pre-flight refresh.
+  await store.saveResource(
+    ApiResourceKind.mcp_server,
+    "mcps_vendor",
+    McpServerSchema,
+    create(McpServerSchema, {
+      metadata: { id: "mcps_vendor", org: ORG, slug: "vendor" },
+      spec: { auth: {} },
+    }),
+  );
+  await store.oauthGrants.upsert({
+    identityAccountId: "",
+    resourceId: "mcps_vendor",
+    resourceKind: "mcp_server",
+    orgId: ORG,
+    accessTokenExpiresAt: now - 10, // expired → refresh must run
+    clientId: "client-1",
+    authMethod: "mcp_oauth",
+    tokenEndpoint: "https://vendor.example/token",
+    accessTokenEnvVar: "VENDOR_TOKEN",
+    refreshTokenEnvVar: "VENDOR_REFRESH_TOKEN",
+    environmentId: "env_managed",
+    createdAt: 0,
+    updatedAt: 0,
+  });
+
+  // The managed environment as a live map: the refresh writes rotated
+  // tokens through updateSecrets, and the injection reads the access
+  // token back — proving write-then-read, not two isolated stubs.
+  const managedSecrets = new Map<string, string>([
+    ["VENDOR_REFRESH_TOKEN", "rt-old"],
+  ]);
+  const managedEnvService = {
+    readSecretValue: async (_envId: string, key: string) =>
+      managedSecrets.get(key) ?? "",
+    updateSecrets: async (
+      _envId: string,
+      variables: { [key: string]: EnvironmentValue },
+    ) => {
+      for (const [key, value] of Object.entries(variables)) {
+        managedSecrets.set(key, value.value);
+      }
+    },
+  } as unknown as ManagedEnvironmentService;
+
+  const environment = create(EnvironmentSchema, {
+    metadata: { id: "env_1", org: ORG, slug: "shared-secrets" },
+    spec: {
+      data: {
+        API_KEY: { value: "key-123", isSecret: true },
+        EXTRA: { value: "not-declared", isSecret: false },
+      },
+    },
+  });
+
+  const agent = create(AgentSchema, {
+    metadata: { id: "agt_ec", org: ORG, slug: "ec-agent" },
+    spec: {
+      // Least-privilege: only API_KEY is declared — EXTRA must be
+      // filtered out of the merge.
+      env: { API_KEY: { isSecret: true } },
+      mcpServerUsages: [{ mcpServerRef: { slug: "vendor", org: ORG } }],
+    },
+  });
+
+  const createdEcs: ExecutionContext[] = [];
+  const deps: ExecutionContextBuilderDeps = {
+    store,
+    logger: silentLogger,
+    agentLoader: () => ({ get: async () => agent }),
+    agentInstanceLoader: () => ({
+      get: async (instanceId) =>
+        create(AgentInstanceSchema, {
+          metadata: { id: instanceId, org: ORG },
+          spec: {
+            agentId: "agt_ec",
+            environmentRefs: [
+              {
+                kind: ApiResourceKind.environment,
+                org: ORG,
+                slug: "shared-secrets",
+              },
+            ],
+          },
+        }),
+    }),
+    sessionLoader: () => ({
+      get: async (sessionId) =>
+        create(SessionSchema, {
+          metadata: { id: sessionId, org: ORG },
+          spec: { agentInstanceId: "agi_ec" },
+        }),
+    }),
+    environmentReader: () => ({
+      list: async () => {
+        throw new Error("personal-env lookup not needed in this test");
+      },
+      getSecretValue: async () => {
+        throw new Error("personal-env lookup not needed in this test");
+      },
+    }),
+    environmentResolution: {
+      resolveByReference: async () => environment,
+    } as unknown as ExecutionContextBuilderDeps["environmentResolution"],
+    executionContextCreator: () => ({
+      create: async (ec) => {
+        createdEcs.push(ec);
+        return ec;
+      },
+    }),
+    managedEnvService,
+    // The vendor's token endpoint: rotates the refresh token and issues
+    // a fresh access token.
+    fetchImpl: async () =>
+      new Response(
+        '{"access_token":"at-fresh","refresh_token":"rt-new","expires_in":3600}',
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+  };
+
+  const execution = create(AgentExecutionSchema, {
+    metadata: { id: EXEC_ID, org: ORG },
+    spec: {
+      sessionId: "ses_ec",
+      message: "hi",
+      // runtime_env overrides the environment layer for declared keys.
+      runtimeEnv: { API_KEY: { value: "runtime-wins", isSecret: true } },
+    },
+  });
+
+  await buildAndPersistExecutionContext(deps, execution, "");
+
+  expect(createdEcs).toHaveLength(1);
+  const data = createdEcs[0]?.spec?.data ?? {};
+
+  // Merge priority: runtime_env beat the environment layer.
+  expect(data["API_KEY"]?.value).toBe("runtime-wins");
+  expect(data["API_KEY"]?.isSecret).toBe(true);
+  // Least-privilege filter: the undeclared key never reaches the EC.
+  expect(data["EXTRA"]).toBeUndefined();
+  // OAuth injection: the freshly-refreshed token, marked secret.
+  expect(data["VENDOR_TOKEN"]?.value).toBe("at-fresh");
+  expect(data["VENDOR_TOKEN"]?.isSecret).toBe(true);
+
+  // The refresh wrote the rotated tokens back to the managed environment...
+  expect(managedSecrets.get("VENDOR_REFRESH_TOKEN")).toBe("rt-new");
+  // ...and the grant's expiry was advanced past the old one.
+  const grant = await store.oauthGrants.find("", "mcps_vendor", ORG);
+  expect(grant?.accessTokenExpiresAt ?? 0).toBeGreaterThan(now);
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-steps.test.ts
@@ -285,6 +285,30 @@ it("createDefaultInstanceIfNeeded skips for a bootstrap instance", async () => {
   expect(ctx.get(DEFAULT_INSTANCE_ID_KEY)).toBeUndefined();
 });
 
+// Go wraps the in-process create with %w — the inner status code reaches
+// the wire (a session_spec failing session validation answers
+// InvalidArgument, never Internal), with the wrapped #852 message shape.
+it("createSessionIfNeeded surfaces the inner status code of a failed session create", async () => {
+  const step = newCreateSessionIfNeededStep({
+    logger: silentLogger,
+    sessionCreator: () => ({
+      create: async () => {
+        throw new ConnectError(
+          "session subject too long",
+          Code.InvalidArgument,
+        );
+      },
+    }),
+  });
+  const execution = newExecution("", "agt_1");
+  const ctx = newContext(execution);
+  ctx.set(DEFAULT_INSTANCE_ID_KEY, "inst_1");
+  const err = await expectCode(() => step.execute(ctx), Code.InvalidArgument);
+  expect(err.rawMessage).toBe(
+    "failed to create session: rpc error: code = InvalidArgument desc = session subject too long",
+  );
+});
+
 // The unchanged skip contract: an existing session_id bypasses
 // auto-creation entirely.
 it("createSessionIfNeeded skips when a session is provided", async () => {
@@ -544,7 +568,7 @@ async function seedMemory(init: {
   subject?: string;
   content: string;
   state: MemoryLifecycleState;
-  createdAt: Date;
+  createdAt: Date | undefined;
 }): Promise<void> {
   await store.saveResource(
     ApiResourceKind.memory,
@@ -560,9 +584,12 @@ async function seedMemory(init: {
       },
       status: {
         lifecycleState: init.state,
-        audit: {
-          specAudit: { createdAt: timestampFromDate(init.createdAt) },
-        },
+        audit:
+          init.createdAt === undefined
+            ? undefined
+            : {
+                specAudit: { createdAt: timestampFromDate(init.createdAt) },
+              },
       },
     }),
   );
@@ -577,7 +604,8 @@ describe("newComposeRecalledMemoriesStep", () => {
     subject?: string;
     content: string;
     state: MemoryLifecycleState;
-    offsetMinutes: number;
+    /** undefined = untimestamped row (sorts first, Go's nil-first). */
+    offsetMinutes: number | undefined;
   }
 
   const cases: Array<{
@@ -613,6 +641,30 @@ describe("newComposeRecalledMemoriesStep", () => {
       ],
       wantEnabled: true,
       wantMemoryIds: ["mem_older", "mem_newer"],
+    },
+    {
+      name: "untimestamped memory sorts first even when seeded after a timestamped one",
+      // Exercises the (timestamped, untimestamped) comparator arm — Go's
+      // nil-first ordering is symmetric.
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      memories: [
+        {
+          id: "mem_stamped",
+          content: "stamped",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 0,
+        },
+        {
+          id: "mem_unstamped",
+          content: "unstamped",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: undefined,
+        },
+      ],
+      wantEnabled: true,
+      wantMemoryIds: ["mem_unstamped", "mem_stamped"],
     },
     {
       name: "proposed and rejected records are never injected",
@@ -734,7 +786,10 @@ describe("newComposeRecalledMemoriesStep", () => {
           subject: m.subject ?? "",
           content: m.content,
           state: m.state,
-          createdAt: minutes(m.offsetMinutes),
+          createdAt:
+            m.offsetMinutes === undefined
+              ? undefined
+              : minutes(m.offsetMinutes),
         });
       }
       let stepStore = store;

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/create-steps.test.ts
@@ -1,0 +1,859 @@
+/**
+ * Create pipeline step tests — ports create_target_resolution_test.go,
+ * create_session_bootstrap_test.go, compose_declared_preferences_step_test.go,
+ * compose_recalled_memories_step_test.go, and
+ * create_execution_context_workflow_refs_test.go case-for-case, over a
+ * real SQLite store and the real pipeline RequestContext (the same
+ * direct-step shape as Go). Go's nil-client skip proofs map to throwing
+ * providers — reaching the client would fail the test just as a nil
+ * dereference would panic Go.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create, clone, toJson } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import type { JsonObject } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  DeclaredPreferencesSchema,
+  RecalledMemoriesSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { MemoryLifecycleState } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/enum_pb";
+import type { SessionSpec } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import {
+  ExecutionTarget,
+  Harness,
+} from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowTaskKind } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+
+import { agentCallTaskEnvironmentRefs } from "../create-execution-context-step.js";
+import {
+  AUTO_CREATED_SESSION_SUBJECT,
+  DEFAULT_INSTANCE_ID_KEY,
+  buildAutoCreateSessionSpec,
+  newComposeDeclaredPreferencesStep,
+  newComposeRecalledMemoriesStep,
+  newCreateDefaultInstanceIfNeededStep,
+  newCreateSessionIfNeededStep,
+  newEnsureSessionOrAgentResolvedStep,
+  newResolveDefaultAgentStep,
+} from "../create-steps.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: Store;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "aexec-create-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function newExecution(sessionId: string, agentId: string): AgentExecution {
+  return create(AgentExecutionSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "AgentExecution",
+    metadata: { name: "exec", org: "test-org" },
+    spec: { sessionId, agentId, message: "hi" },
+  });
+}
+
+function newContext(
+  execution: AgentExecution,
+): RequestContext<typeof AgentExecutionSchema> {
+  return new RequestContext(
+    AgentExecutionSchema,
+    execution,
+    ApiResourceKind.agent_execution,
+  );
+}
+
+async function seedDefaultAgent(
+  id: string,
+  visibility: ApiResourceVisibility,
+): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.agent,
+    id,
+    AgentSchema,
+    create(AgentSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Agent",
+      metadata: {
+        id,
+        name: "assistant",
+        org: "stigmer",
+        visibility,
+        labels: { "stigmer.ai/default-agent": "true" },
+      },
+    }),
+  );
+}
+
+async function expectCode(
+  fn: () => Promise<unknown> | unknown,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(connectError.code).toBe(code);
+    return connectError;
+  }
+  throw new Error(`expected code ${Code[code]}, call succeeded`);
+}
+
+// The post-resolution invariant guard: a resolved reference passes; an
+// unresolved one is an Internal invariant violation (never
+// InvalidArgument — issue #196).
+describe("newEnsureSessionOrAgentResolvedStep", () => {
+  const step = newEnsureSessionOrAgentResolvedStep(silentLogger);
+
+  const cases: Array<{
+    name: string;
+    sessionId?: string;
+    agentId?: string;
+    specInstanceId?: string;
+    wantCode?: Code;
+  }> = [
+    { name: "session_id resolved -> pass", sessionId: "ses_1" },
+    { name: "agent_id resolved -> pass", agentId: "agt_1" },
+    {
+      name: "both resolved -> pass",
+      sessionId: "ses_1",
+      agentId: "agt_1",
+    },
+    {
+      name: "session_spec instance resolved -> pass",
+      specInstanceId: "inst_1",
+    },
+    {
+      name: "none resolved -> Internal invariant violation",
+      wantCode: Code.Internal,
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, async () => {
+      const execution = newExecution(tt.sessionId ?? "", tt.agentId ?? "");
+      if (tt.specInstanceId !== undefined) {
+        execution.spec!.sessionSpec = create(SessionSpecSchema, {
+          agentInstanceId: tt.specInstanceId,
+        });
+      }
+      const ctx = newContext(execution);
+      if (tt.wantCode === undefined) {
+        await step.execute(ctx);
+      } else {
+        await expectCode(() => step.execute(ctx), tt.wantCode);
+      }
+    });
+  }
+});
+
+// The reachable contract of default-agent resolution: NotFound when
+// unseeded, resolution onto newState when a public default exists, and
+// FailedPrecondition when the default is not visibility_public.
+describe("newResolveDefaultAgentStep", () => {
+  it("no default agent seeded -> NotFound", async () => {
+    const step = newResolveDefaultAgentStep(store, silentLogger);
+    await expectCode(
+      () => step.execute(newContext(newExecution("", ""))),
+      Code.NotFound,
+    );
+  });
+
+  it("public default agent -> resolves agent_id onto newState", async () => {
+    await seedDefaultAgent("agt_default", ApiResourceVisibility.visibility_public);
+    const step = newResolveDefaultAgentStep(store, silentLogger);
+    const ctx = newContext(newExecution("", ""));
+
+    await step.execute(ctx);
+
+    expect(ctx.newState.spec?.agentId).toBe("agt_default");
+    // The original request must remain immutable.
+    expect(ctx.input.spec?.agentId).toBe("");
+  });
+
+  it("non-public default agent -> FailedPrecondition", async () => {
+    await seedDefaultAgent(
+      "agt_private",
+      ApiResourceVisibility.visibility_private,
+    );
+    const step = newResolveDefaultAgentStep(store, silentLogger);
+    await expectCode(
+      () => step.execute(newContext(newExecution("", ""))),
+      Code.FailedPrecondition,
+    );
+  });
+
+  // The oss#356 defect through this step's lens: a first-match lookup
+  // could land on the non-public labeled agent and fail even though a
+  // valid public default existed. Both insertion orders must resolve the
+  // public agent.
+  for (const [name, ids] of Object.entries({
+    "private inserted first": ["agt_0private", "agt_1public"],
+    "public inserted first": ["agt_1public", "agt_0private"],
+  })) {
+    it(`non-public labeled agent alongside a public one -> public wins (${name})`, async () => {
+      for (const id of ids) {
+        await seedDefaultAgent(
+          id,
+          id === "agt_1public"
+            ? ApiResourceVisibility.visibility_public
+            : ApiResourceVisibility.visibility_private,
+        );
+      }
+      const step = newResolveDefaultAgentStep(store, silentLogger);
+      const ctx = newContext(newExecution("", ""));
+      await step.execute(ctx);
+      expect(ctx.newState.spec?.agentId).toBe("agt_1public");
+    });
+  }
+
+  it("reference already provided -> no-op", async () => {
+    const step = newResolveDefaultAgentStep(store, silentLogger);
+    const ctx = newContext(newExecution("", "agt_explicit"));
+    await step.execute(ctx);
+    expect(ctx.newState.spec?.agentId).toBe("agt_explicit");
+  });
+
+  it("session_spec instance provided -> no-op even with a seeded default agent", async () => {
+    // A one-call bootstrap naming an explicit instance must NOT resolve
+    // the platform default agent: doing so would stamp misleading
+    // metadata pointing at an agent the session does not run against.
+    await seedDefaultAgent("agt_default", ApiResourceVisibility.visibility_public);
+    const step = newResolveDefaultAgentStep(store, silentLogger);
+    const execution = newExecution("", "");
+    execution.spec!.sessionSpec = create(SessionSpecSchema, {
+      agentInstanceId: "inst_explicit",
+    });
+    const ctx = newContext(execution);
+    await step.execute(ctx);
+    expect(ctx.newState.spec?.agentId).toBe("");
+  });
+});
+
+// The one-call bootstrap skip: when session_spec names an instance, the
+// step must return before any agent lookup — the throwing providers
+// prove it (Go's nil clients would panic).
+it("createDefaultInstanceIfNeeded skips for a bootstrap instance", async () => {
+  const step = newCreateDefaultInstanceIfNeededStep({
+    store,
+    logger: silentLogger,
+    agentLoader: () => {
+      throw new Error("agent loader must not be reached");
+    },
+    agentInstanceCreator: () => {
+      throw new Error("instance creator must not be reached");
+    },
+  });
+  const execution = newExecution("", "");
+  execution.spec!.sessionSpec = create(SessionSpecSchema, {
+    agentInstanceId: "inst_explicit",
+  });
+  const ctx = newContext(execution);
+  await step.execute(ctx);
+  expect(ctx.get(DEFAULT_INSTANCE_ID_KEY)).toBeUndefined();
+});
+
+// The unchanged skip contract: an existing session_id bypasses
+// auto-creation entirely.
+it("createSessionIfNeeded skips when a session is provided", async () => {
+  const step = newCreateSessionIfNeededStep({
+    logger: silentLogger,
+    sessionCreator: () => {
+      throw new Error("session creator must not be reached");
+    },
+  });
+  const ctx = newContext(newExecution("ses_existing", ""));
+  await step.execute(ctx);
+  expect(ctx.newState.spec?.sessionId).toBe("ses_existing");
+});
+
+// The spec-forwarding contract of the one-call session bootstrap
+// (stigmer/stigmer#249): caller fields survive, defaults fill only gaps,
+// and the caller's message is never mutated.
+describe("buildAutoCreateSessionSpec", () => {
+  const workspaceEntries = [
+    {
+      name: "repo",
+      source: {
+        source: {
+          case: "localPath" as const,
+          value: { path: "/home/user/repo" },
+        },
+      },
+    },
+  ];
+
+  const cases: Array<{
+    name: string;
+    callerSpec: SessionSpec | undefined;
+    defaultInstanceId: string;
+    want: SessionSpec;
+  }> = [
+    {
+      name: "undefined spec -> minimal default (pre-bootstrap behavior)",
+      callerSpec: undefined,
+      defaultInstanceId: "inst_default",
+      want: create(SessionSpecSchema, {
+        agentInstanceId: "inst_default",
+        subject: AUTO_CREATED_SESSION_SUBJECT,
+      }),
+    },
+    {
+      name: "full bootstrap spec -> forwarded verbatim, no defaults applied",
+      callerSpec: create(SessionSpecSchema, {
+        agentInstanceId: "inst_explicit",
+        subject: "Customize the landing page",
+        workspaceEntries,
+        harness: Harness.NATIVE,
+        executionTarget: ExecutionTarget.LOCAL,
+      }),
+      // defaultInstanceId intentionally empty: CreateDefaultInstanceIfNeeded
+      // skips resolution when the spec names an instance.
+      defaultInstanceId: "",
+      want: create(SessionSpecSchema, {
+        agentInstanceId: "inst_explicit",
+        subject: "Customize the landing page",
+        workspaceEntries,
+        harness: Harness.NATIVE,
+        executionTarget: ExecutionTarget.LOCAL,
+      }),
+    },
+    {
+      name: "spec without instance or subject -> both defaulted, rest forwarded",
+      callerSpec: create(SessionSpecSchema, {
+        workspaceEntries,
+        executionTarget: ExecutionTarget.CLOUD,
+      }),
+      defaultInstanceId: "inst_resolved",
+      want: create(SessionSpecSchema, {
+        agentInstanceId: "inst_resolved",
+        subject: AUTO_CREATED_SESSION_SUBJECT,
+        workspaceEntries,
+        executionTarget: ExecutionTarget.CLOUD,
+      }),
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, () => {
+      const got = buildAutoCreateSessionSpec(
+        tt.callerSpec,
+        tt.defaultInstanceId,
+      );
+      expect(toJson(SessionSpecSchema, got)).toEqual(
+        toJson(SessionSpecSchema, tt.want),
+      );
+    });
+  }
+
+  it("returns a deep clone: mutation never writes through to the caller", () => {
+    const callerSpec = create(SessionSpecSchema, { workspaceEntries });
+    const original = clone(SessionSpecSchema, callerSpec);
+
+    const got = buildAutoCreateSessionSpec(callerSpec, "inst_resolved");
+    got.workspaceEntries[0]!.name = "mutated";
+
+    expect(toJson(SessionSpecSchema, callerSpec)).toEqual(
+      toJson(SessionSpecSchema, original),
+    );
+    expect(callerSpec.agentInstanceId).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ComposeDeclaredPreferences (compose_declared_preferences_step_test.go).
+// ---------------------------------------------------------------------------
+
+async function seedOrg(orgId: string, standingContext: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.organization,
+    orgId,
+    OrganizationSchema,
+    create(OrganizationSchema, {
+      apiVersion: "tenancy.stigmer.ai/v1",
+      kind: "Organization",
+      metadata: { id: orgId, name: orgId, org: orgId },
+      spec:
+        standingContext !== ""
+          ? { preferences: { standingContext } }
+          : undefined,
+    }),
+  );
+}
+
+/** Wraps the real store but fails every getResource (the store-fault arm). */
+function failingGetStore(): Store {
+  return new Proxy(store, {
+    get(target, prop, receiver) {
+      if (prop === "getResource") {
+        return async () => {
+          throw new Error("simulated store fault");
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+/** Wraps the real store but fails every listResources (the scan-fault arm). */
+function failingListStore(): Store {
+  return new Proxy(store, {
+    get(target, prop, receiver) {
+      if (prop === "listResources") {
+        return async () => {
+          throw new Error("simulated store fault");
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+describe("newComposeDeclaredPreferencesStep", () => {
+  const cases: Array<{
+    name: string;
+    orgId: string;
+    seedContext?: string;
+    seedOrg?: boolean;
+    failingStore?: boolean;
+    wantOrgContext: string;
+  }> = [
+    {
+      name: "org with standing context -> snapshotted verbatim",
+      orgId: "test-org",
+      seedOrg: true,
+      seedContext: "We deploy to us-east-1.",
+      wantOrgContext: "We deploy to us-east-1.",
+    },
+    {
+      name: "org without preferences -> empty snapshot",
+      orgId: "test-org",
+      seedOrg: true,
+      wantOrgContext: "",
+    },
+    {
+      name: "org not found -> empty snapshot, create unaffected",
+      orgId: "ghost-org",
+      wantOrgContext: "",
+    },
+    {
+      name: "no org on metadata -> empty snapshot, create unaffected",
+      orgId: "",
+      wantOrgContext: "",
+    },
+    {
+      name: "store fault -> empty snapshot, create unaffected (best-effort)",
+      orgId: "test-org",
+      seedOrg: true,
+      seedContext: "never reached",
+      failingStore: true,
+      wantOrgContext: "",
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, async () => {
+      if (tt.seedOrg) {
+        await seedOrg(tt.orgId, tt.seedContext ?? "");
+      }
+      const step = newComposeDeclaredPreferencesStep(
+        tt.failingStore ? failingGetStore() : store,
+        silentLogger,
+      );
+
+      const execution = newExecution("ses_1", "agt_1");
+      execution.metadata!.org = tt.orgId;
+      // The injection attempt: a caller-supplied value must never survive
+      // — the field is server-owned (DD-002 D2).
+      execution.spec!.declaredPreferences = create(
+        DeclaredPreferencesSchema,
+        {
+          orgContext: "injected org context",
+          userContext: "injected user context",
+        },
+      );
+      const ctx = newContext(execution);
+
+      await step.execute(ctx);
+
+      const got = ctx.newState.spec?.declaredPreferences;
+      expect(got, "server-owned field must be stamped on every path").toBeDefined();
+      expect(got?.orgContext).toBe(tt.wantOrgContext);
+      // user_context must stay empty in OSS (no per-request user identity).
+      expect(got?.userContext).toBe("");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ComposeRecalledMemories (compose_recalled_memories_step_test.go).
+// ---------------------------------------------------------------------------
+
+async function seedMemoryOrg(
+  orgId: string,
+  memoryEnabled: boolean,
+): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.organization,
+    orgId,
+    OrganizationSchema,
+    create(OrganizationSchema, {
+      apiVersion: "tenancy.stigmer.ai/v1",
+      kind: "Organization",
+      metadata: { id: orgId, name: orgId, org: orgId },
+      spec: { preferences: { memoryEnabled } },
+    }),
+  );
+}
+
+async function seedMemory(init: {
+  id: string;
+  orgId: string;
+  subject?: string;
+  content: string;
+  state: MemoryLifecycleState;
+  createdAt: Date;
+}): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.memory,
+    init.id,
+    MemorySchema,
+    create(MemorySchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Memory",
+      metadata: { id: init.id, name: init.id, org: init.orgId },
+      spec: {
+        content: init.content,
+        subjectIdentityAccountId: init.subject ?? "",
+      },
+      status: {
+        lifecycleState: init.state,
+        audit: {
+          specAudit: { createdAt: timestampFromDate(init.createdAt) },
+        },
+      },
+    }),
+  );
+}
+
+describe("newComposeRecalledMemoriesStep", () => {
+  const baseTime = new Date("2026-08-22T10:00:00Z");
+  const minutes = (n: number) => new Date(baseTime.getTime() + n * 60_000);
+
+  interface SeededMemory {
+    id: string;
+    subject?: string;
+    content: string;
+    state: MemoryLifecycleState;
+    offsetMinutes: number;
+  }
+
+  const cases: Array<{
+    name: string;
+    orgId: string;
+    seedOrg?: boolean;
+    memoryEnabled?: boolean;
+    memories?: SeededMemory[];
+    failingGet?: boolean;
+    failingList?: boolean;
+    wantEnabled: boolean;
+    wantMemoryIds: string[];
+  }> = [
+    {
+      name: "confirmed memories recalled oldest-first, verbatim",
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      memories: [
+        // Seeded newest-first to prove the sort does the ordering.
+        {
+          id: "mem_newer",
+          content: "Prefers OpenTofu.",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 60,
+        },
+        {
+          id: "mem_older",
+          content: "Deploys to us-east-1.",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 0,
+        },
+      ],
+      wantEnabled: true,
+      wantMemoryIds: ["mem_older", "mem_newer"],
+    },
+    {
+      name: "proposed and rejected records are never injected",
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      memories: [
+        {
+          id: "mem_proposed",
+          content: "unconfirmed",
+          state: MemoryLifecycleState.lifecycle_state_proposed,
+          offsetMinutes: 0,
+        },
+        {
+          id: "mem_rejected",
+          content: "rejected",
+          state: MemoryLifecycleState.lifecycle_state_rejected,
+          offsetMinutes: 1,
+        },
+        {
+          id: "mem_confirmed",
+          content: "confirmed",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 2,
+        },
+      ],
+      wantEnabled: true,
+      wantMemoryIds: ["mem_confirmed"],
+    },
+    {
+      name: "other org's and non-sentinel-subject records are filtered out",
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      memories: [
+        {
+          id: "mem_mine",
+          content: "mine",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 0,
+        },
+        // A cloud-style subject-keyed record (e.g. from a restored backup)
+        // must not leak into the OSS sentinel's recall.
+        {
+          id: "mem_subject",
+          subject: "ia_someone",
+          content: "not mine",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 1,
+        },
+      ],
+      wantEnabled: true,
+      wantMemoryIds: ["mem_mine"],
+    },
+    {
+      name: "org flag on with zero confirmed facts -> enabled=true, no facts (remember-tool signal)",
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      wantEnabled: true,
+      wantMemoryIds: [],
+    },
+    {
+      name: "org flag off -> disabled snapshot (default-off design)",
+      orgId: "test-org",
+      seedOrg: true,
+      memories: [
+        {
+          id: "mem_confirmed",
+          content: "confirmed",
+          state: MemoryLifecycleState.lifecycle_state_confirmed,
+          offsetMinutes: 0,
+        },
+      ],
+      wantEnabled: false,
+      wantMemoryIds: [],
+    },
+    {
+      name: "org not found -> disabled snapshot, create unaffected",
+      orgId: "ghost-org",
+      wantEnabled: false,
+      wantMemoryIds: [],
+    },
+    {
+      name: "no org on metadata -> disabled snapshot, create unaffected",
+      orgId: "",
+      wantEnabled: false,
+      wantMemoryIds: [],
+    },
+    {
+      name: "org load fault -> disabled snapshot, create unaffected (best-effort)",
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      failingGet: true,
+      wantEnabled: false,
+      wantMemoryIds: [],
+    },
+    {
+      name: "memory scan fault -> DISABLED, never enabled-with-zero-facts",
+      orgId: "test-org",
+      seedOrg: true,
+      memoryEnabled: true,
+      failingList: true,
+      wantEnabled: false,
+      wantMemoryIds: [],
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, async () => {
+      if (tt.seedOrg) {
+        await seedMemoryOrg(tt.orgId, tt.memoryEnabled ?? false);
+      }
+      for (const m of tt.memories ?? []) {
+        await seedMemory({
+          id: m.id,
+          orgId: tt.orgId,
+          subject: m.subject ?? "",
+          content: m.content,
+          state: m.state,
+          createdAt: minutes(m.offsetMinutes),
+        });
+      }
+      let stepStore = store;
+      if (tt.failingGet) {
+        stepStore = failingGetStore();
+      }
+      if (tt.failingList) {
+        stepStore = failingListStore();
+      }
+      const step = newComposeRecalledMemoriesStep(stepStore, silentLogger);
+
+      const execution = newExecution("ses_1", "agt_1");
+      execution.metadata!.org = tt.orgId;
+      // The injection attempt: caller-supplied recalled_memories never
+      // survive — the field is server-owned (DD-006 D2).
+      execution.spec!.recalledMemories = create(RecalledMemoriesSchema, {
+        enabled: true,
+        facts: [{ memoryId: "mem_injected", content: "injected fact" }],
+      });
+      const ctx = newContext(execution);
+
+      await step.execute(ctx);
+
+      // The step's contract is SPEC-ONLY: status.recalled_memories_report
+      // is runner-owned with a single writer (DD-008 D5).
+      expect(
+        ctx.newState.status?.recalledMemoriesReport,
+        "the compose step must never write status.recalled_memories_report",
+      ).toBeUndefined();
+
+      const got = ctx.newState.spec?.recalledMemories;
+      expect(got, "server-owned field must be stamped on every path").toBeDefined();
+      expect(got?.enabled).toBe(tt.wantEnabled);
+      expect(got?.facts.map((f) => f.memoryId)).toEqual(tt.wantMemoryIds);
+      for (const fact of got?.facts ?? []) {
+        expect(fact.content).not.toBe("");
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// agentCallTaskEnvironmentRefs (create_execution_context_workflow_refs_test.go).
+// ---------------------------------------------------------------------------
+
+describe("agentCallTaskEnvironmentRefs", () => {
+  function makeWorkflow(
+    taskName: string,
+    kind: WorkflowTaskKind,
+    config: JsonObject,
+  ): Workflow {
+    return create(WorkflowSchema, {
+      spec: { tasks: [{ name: taskName, kind, taskConfig: config }] },
+    });
+  }
+
+  const agentCallConfig: JsonObject = {
+    agent: "triage",
+    message: "classify",
+    environment_refs: [
+      { slug: "shared-secrets" },
+      { org: "acme", slug: "other" },
+    ],
+  };
+
+  it("returns the named task's refs", () => {
+    const workflow = makeWorkflow(
+      "review",
+      WorkflowTaskKind.agent_call,
+      agentCallConfig,
+    );
+    const refs = agentCallTaskEnvironmentRefs(silentLogger, workflow, "review");
+    expect(refs).toHaveLength(2);
+    expect(refs[0]?.slug).toBe("shared-secrets");
+    expect(refs[1]?.org).toBe("acme");
+  });
+
+  it("renamed task answers empty", () => {
+    const workflow = makeWorkflow(
+      "review",
+      WorkflowTaskKind.agent_call,
+      agentCallConfig,
+    );
+    expect(
+      agentCallTaskEnvironmentRefs(silentLogger, workflow, "old_name"),
+    ).toHaveLength(0);
+  });
+
+  it("same-named non-agent_call task answers empty", () => {
+    const workflow = makeWorkflow("review", WorkflowTaskKind.llm_call, {
+      model: "some-model",
+      prompt: "classify",
+    });
+    expect(
+      agentCallTaskEnvironmentRefs(silentLogger, workflow, "review"),
+    ).toHaveLength(0);
+  });
+
+  it("unparsable config answers empty", () => {
+    // A config with a key the current proto does not declare no longer
+    // parses (strict JSON) — the binding degrades rather than failing
+    // the run.
+    const workflow = makeWorkflow("review", WorkflowTaskKind.agent_call, {
+      agent: "triage",
+      message: "classify",
+      legacy_knob: true,
+    });
+    expect(
+      agentCallTaskEnvironmentRefs(silentLogger, workflow, "review"),
+    ).toHaveLength(0);
+  });
+
+  it("task without refs answers empty", () => {
+    const workflow = makeWorkflow("review", WorkflowTaskKind.agent_call, {
+      agent: "triage",
+      message: "classify",
+    });
+    expect(
+      agentCallTaskEnvironmentRefs(silentLogger, workflow, "review"),
+    ).toHaveLength(0);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine-stub.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine-stub.ts
@@ -1,0 +1,20 @@
+/**
+ * Test stub for the connected execution engine: every operation resolves
+ * as a no-op unless overridden, so a test asserts exactly the seam calls
+ * it cares about (#18 provides the real implementation).
+ */
+import type { ConnectedExecutionEngine } from "../engine.js";
+
+export function stubConnectedEngine(
+  overrides: Partial<ConnectedExecutionEngine> = {},
+): ConnectedExecutionEngine {
+  return {
+    signalApprovalGateResolved: async () => {},
+    startInvokeWorkflow: async () => {},
+    signalPause: async () => {},
+    signalResume: async () => {},
+    cancelWorkflow: async () => {},
+    terminateWorkflow: async () => {},
+    ...overrides,
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine.test.ts
@@ -44,7 +44,7 @@ describe("the execution-engine seam", () => {
   });
 
   it("passes while connected", () => {
-    const connected: ExecutionEngineState = { connected: true, engine: {} };
+    const connected: ExecutionEngineState = { connected: true, engine: { signalApprovalGateResolved: async () => {} } };
     const step = newEnsureEngineAvailableStep(() => connected);
     expect(() => step.execute(contextFor())).not.toThrow();
   });
@@ -55,7 +55,7 @@ describe("the execution-engine seam", () => {
 
     expect(() => step.execute(contextFor())).toThrow(ConnectError);
 
-    state = { connected: true, engine: {} };
+    state = { connected: true, engine: { signalApprovalGateResolved: async () => {} } };
     expect(() => step.execute(contextFor())).not.toThrow();
   });
 });

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Pins the execution-engine seam: the modeled availability state and the
+ * EnsureEngineAvailable gate (create.go ensureEngineAvailableStep). The
+ * disconnected refusal copy is byte-pinned by the conformance engine-gate
+ * test too; this pins the seam mechanics — the provider is consulted at
+ * EXECUTION time (a reconnect between requests must be observed, Go's
+ * SetWorkflowCreator re-injection).
+ */
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { ENGINE_UNAVAILABLE_MESSAGE } from "../constants.js";
+import {
+  ENGINE_DISCONNECTED,
+  newEnsureEngineAvailableStep,
+} from "../engine.js";
+import type { ExecutionEngineState } from "../engine.js";
+
+function contextFor(): RequestContext<typeof AgentExecutionSchema> {
+  return new RequestContext(
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, {}),
+    ApiResourceKind.agent_execution,
+  );
+}
+
+describe("the execution-engine seam", () => {
+  it("refuses Unavailable with the pinned copy while disconnected", () => {
+    const step = newEnsureEngineAvailableStep(() => ENGINE_DISCONNECTED);
+    try {
+      step.execute(contextFor());
+      throw new Error("expected the engine gate to refuse");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectError);
+      const connectError = error as ConnectError;
+      expect(connectError.code).toBe(Code.Unavailable);
+      expect(connectError.rawMessage).toBe(ENGINE_UNAVAILABLE_MESSAGE);
+    }
+  });
+
+  it("passes while connected", () => {
+    const connected: ExecutionEngineState = { connected: true, engine: {} };
+    const step = newEnsureEngineAvailableStep(() => connected);
+    expect(() => step.execute(contextFor())).not.toThrow();
+  });
+
+  it("observes the CURRENT state at execution time (reconnect semantics)", () => {
+    let state: ExecutionEngineState = ENGINE_DISCONNECTED;
+    const step = newEnsureEngineAvailableStep(() => state);
+
+    expect(() => step.execute(contextFor())).toThrow(ConnectError);
+
+    state = { connected: true, engine: {} };
+    expect(() => step.execute(contextFor())).not.toThrow();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/engine.test.ts
@@ -20,6 +20,7 @@ import {
   newEnsureEngineAvailableStep,
 } from "../engine.js";
 import type { ExecutionEngineState } from "../engine.js";
+import { stubConnectedEngine } from "./engine-stub.js";
 
 function contextFor(): RequestContext<typeof AgentExecutionSchema> {
   return new RequestContext(
@@ -44,7 +45,10 @@ describe("the execution-engine seam", () => {
   });
 
   it("passes while connected", () => {
-    const connected: ExecutionEngineState = { connected: true, engine: { signalApprovalGateResolved: async () => {} } };
+    const connected: ExecutionEngineState = {
+      connected: true,
+      engine: stubConnectedEngine(),
+    };
     const step = newEnsureEngineAvailableStep(() => connected);
     expect(() => step.execute(contextFor())).not.toThrow();
   });
@@ -55,7 +59,7 @@ describe("the execution-engine seam", () => {
 
     expect(() => step.execute(contextFor())).toThrow(ConnectError);
 
-    state = { connected: true, engine: { signalApprovalGateResolved: async () => {} } };
+    state = { connected: true, engine: stubConnectedEngine() };
     expect(() => step.execute(contextFor())).not.toThrow();
   });
 });

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/lifecycle.test.ts
@@ -1,0 +1,783 @@
+/**
+ * Lifecycle RPC tests — ports lifecycle_cancel_cascade_test.go,
+ * lifecycle_concurrency_test.go, and terminate_existing_workflow_step_test.go,
+ * plus the pipeline-level behavior Go asserts through conformance:
+ *
+ *   - applyLifecyclePhaseTransition: the pure mutation inside the atomic
+ *     persist closure — terminal cascade (sub-agents, tool-call settle
+ *     #207, pending clear), PAUSED non-terminality, recover's error clear;
+ *   - the five pipelines over a real SQLite store with a stub engine:
+ *     phase refusals, idempotent already-in-target, NotFound, the
+ *     disconnected-engine refusal, warn-and-proceed on workflow-not-found,
+ *     and recover's full terminate → EC-recreate → fresh-start chain;
+ *   - the pause/decision-append race: the lifecycle persist rides
+ *     store.updateResource under the write lock, so a concurrent approval
+ *     append is never clobbered (the Go 50-iteration regression).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ApprovalAction,
+  ApprovalEventType,
+  ExecutionPhase,
+  SubAgentStatus,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  CancelAgentExecutionInput,
+  PauseAgentExecutionInput,
+  RecoverAgentExecutionInput,
+  ResumeAgentExecutionInput,
+  TerminateAgentExecutionInput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import {
+  CancelAgentExecutionInputSchema,
+  PauseAgentExecutionInputSchema,
+  RecoverAgentExecutionInputSchema,
+  ResumeAgentExecutionInputSchema,
+  TerminateAgentExecutionInputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { SubAgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+import type { ManagedEnvironmentService } from "../../mcpserver/oauth/managed-env.js";
+
+import {
+  ensureApprovalRequests,
+  recordDecisionEvent,
+} from "../approval/author.js";
+import type { ExecutionContextBuilderDeps } from "../create-execution-context-step.js";
+import type {
+  ConnectedExecutionEngine,
+  ExecutionEngineState,
+} from "../engine.js";
+import { EngineWorkflowNotFoundError } from "../engine.js";
+import type { LifecycleDeps } from "../lifecycle.js";
+import {
+  applyLifecyclePhaseTransition,
+  cancelInProgressSubAgents,
+  cancelExecution,
+  pauseExecution,
+  recoverExecution,
+  resumeExecution,
+  terminateExecution,
+} from "../lifecycle.js";
+import { StreamBroker } from "../stream-broker.js";
+import { stubConnectedEngine } from "./engine-stub.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: Store;
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "aexec-lifecycle-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function subAgent(init: {
+  id: string;
+  status: SubAgentStatus;
+  completedAt?: string;
+}): SubAgentExecution {
+  return create(SubAgentExecutionSchema, init);
+}
+
+describe("cancelInProgressSubAgents", () => {
+  it("cascades in-flight, preserves terminal and preexisting timestamps", () => {
+    const subAgents = [
+      subAgent({ id: "a", status: SubAgentStatus.SUB_AGENT_IN_PROGRESS }),
+      subAgent({ id: "b", status: SubAgentStatus.SUB_AGENT_PENDING }),
+      subAgent({
+        id: "c",
+        status: SubAgentStatus.SUB_AGENT_COMPLETED,
+        completedAt: "2026-01-01T00:00:00Z",
+      }),
+      subAgent({
+        id: "d",
+        status: SubAgentStatus.SUB_AGENT_IN_PROGRESS,
+        completedAt: "preexisting",
+      }),
+    ];
+
+    cancelInProgressSubAgents(subAgents, "2026-06-05T00:00:00Z");
+
+    // IN_PROGRESS -> CANCELLED, completed_at filled in.
+    expect(subAgents[0]?.status).toBe(SubAgentStatus.SUB_AGENT_CANCELLED);
+    expect(subAgents[0]?.completedAt).toBe("2026-06-05T00:00:00Z");
+    // PENDING -> CANCELLED.
+    expect(subAgents[1]?.status).toBe(SubAgentStatus.SUB_AGENT_CANCELLED);
+    // COMPLETED is terminal — untouched.
+    expect(subAgents[2]?.status).toBe(SubAgentStatus.SUB_AGENT_COMPLETED);
+    expect(subAgents[2]?.completedAt).toBe("2026-01-01T00:00:00Z");
+    // Cancelled but the preexisting timestamp is preserved.
+    expect(subAgents[3]?.status).toBe(SubAgentStatus.SUB_AGENT_CANCELLED);
+    expect(subAgents[3]?.completedAt).toBe("preexisting");
+  });
+
+  it("is safe on an empty list", () => {
+    expect(() =>
+      cancelInProgressSubAgents([], "2026-06-05T00:00:00Z"),
+    ).not.toThrow();
+  });
+});
+
+// An IN_PROGRESS execution carrying every field the transition can touch,
+// so each case asserts both what changes and what is left alone.
+function newTransitionFixture(): AgentExecution {
+  return create(AgentExecutionSchema, {
+    status: {
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      completedAt: "2026-01-01T00:00:00Z",
+      error: "preexisting error",
+      messages: [
+        {
+          toolCalls: [
+            { id: "tc-running", status: ToolCallStatus.TOOL_CALL_RUNNING },
+            { id: "tc-done", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+          ],
+        },
+      ],
+      subAgentExecutions: [
+        { id: "s1", status: SubAgentStatus.SUB_AGENT_IN_PROGRESS },
+        { id: "s2", status: SubAgentStatus.SUB_AGENT_COMPLETED },
+      ],
+      pendingApprovals: [{}],
+    },
+  });
+}
+
+describe("applyLifecyclePhaseTransition", () => {
+  it("pause: non-terminal, keeps completed_at/pending/sub-agents/error", () => {
+    const exec = newTransitionFixture();
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_PAUSED,
+      false,
+      false,
+      "",
+    );
+
+    expect(exec.status?.phase).toBe(ExecutionPhase.EXECUTION_PAUSED);
+    // PAUSED is not terminal; completed_at untouched.
+    expect(exec.status?.completedAt).toBe("2026-01-01T00:00:00Z");
+    expect(exec.status?.error).toBe("preexisting error");
+    // Pending must survive a pause (it can resume).
+    expect(exec.status?.pendingApprovals).toHaveLength(1);
+    expect(exec.status?.subAgentExecutions[0]?.status).toBe(
+      SubAgentStatus.SUB_AGENT_IN_PROGRESS,
+    );
+    // PAUSED is not terminal; in-flight tool calls untouched.
+    expect(exec.status?.messages[0]?.toolCalls[0]?.status).toBe(
+      ToolCallStatus.TOOL_CALL_RUNNING,
+    );
+  });
+
+  it("resume: IN_PROGRESS clears completed_at, keeps error and pending", () => {
+    const exec = newTransitionFixture();
+    exec.status!.phase = ExecutionPhase.EXECUTION_PAUSED;
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      false,
+      false,
+      "",
+    );
+
+    expect(exec.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(exec.status?.completedAt).toBe("");
+    // Resume does not clear error.
+    expect(exec.status?.error).toBe("preexisting error");
+    expect(exec.status?.pendingApprovals).toHaveLength(1);
+  });
+
+  it("recover: IN_PROGRESS clears completed_at and error", () => {
+    const exec = newTransitionFixture();
+    exec.status!.phase = ExecutionPhase.EXECUTION_FAILED;
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      false,
+      true,
+      "",
+    );
+
+    expect(exec.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(exec.status?.completedAt).toBe("");
+    expect(exec.status?.error).toBe("");
+  });
+
+  it("cancel: terminal sets completed_at, cascades, clears pending", () => {
+    const exec = newTransitionFixture();
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_CANCELLED,
+      false,
+      false,
+      "",
+    );
+
+    expect(exec.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+    expect(exec.status?.completedAt).not.toBe("");
+    // A terminal execution carries no pending approvals.
+    expect(exec.status?.pendingApprovals).toHaveLength(0);
+    // In-flight sub-agent cascaded to CANCELLED.
+    expect(exec.status?.subAgentExecutions[0]?.status).toBe(
+      SubAgentStatus.SUB_AGENT_CANCELLED,
+    );
+    expect(exec.status?.subAgentExecutions[0]?.completedAt).not.toBe("");
+    // Already-COMPLETED sub-agent preserved.
+    expect(exec.status?.subAgentExecutions[1]?.status).toBe(
+      SubAgentStatus.SUB_AGENT_COMPLETED,
+    );
+    // Cancel does not set error.
+    expect(exec.status?.error).toBe("preexisting error");
+    // In-flight tool call settled to INTERRUPTED (#207).
+    expect(exec.status?.messages[0]?.toolCalls[0]?.status).toBe(
+      ToolCallStatus.TOOL_CALL_INTERRUPTED,
+    );
+    expect(exec.status?.messages[0]?.toolCalls[0]?.completedAt).not.toBe("");
+    // Already-terminal tool call preserved.
+    expect(exec.status?.messages[0]?.toolCalls[1]?.status).toBe(
+      ToolCallStatus.TOOL_CALL_COMPLETED,
+    );
+  });
+
+  it("terminate: sets error from reason, cascades, clears pending", () => {
+    const exec = newTransitionFixture();
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_TERMINATED,
+      true,
+      false,
+      "disk full",
+    );
+
+    expect(exec.status?.phase).toBe(ExecutionPhase.EXECUTION_TERMINATED);
+    expect(exec.status?.completedAt).not.toBe("");
+    expect(exec.status?.pendingApprovals).toHaveLength(0);
+    expect(exec.status?.subAgentExecutions[0]?.status).toBe(
+      SubAgentStatus.SUB_AGENT_CANCELLED,
+    );
+    expect(exec.status?.error).toBe("Terminated: disk full");
+    // Force-kill settles in-flight tool calls.
+    expect(exec.status?.messages[0]?.toolCalls[0]?.status).toBe(
+      ToolCallStatus.TOOL_CALL_INTERRUPTED,
+    );
+  });
+
+  it("terminate: empty reason falls back to default error", () => {
+    const exec = newTransitionFixture();
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_TERMINATED,
+      true,
+      false,
+      "",
+    );
+    expect(exec.status?.error).toBe("Terminated by user");
+  });
+
+  it("missing status is initialized", () => {
+    const exec = create(AgentExecutionSchema, {});
+    applyLifecyclePhaseTransition(
+      exec,
+      ExecutionPhase.EXECUTION_PAUSED,
+      false,
+      false,
+      "",
+    );
+    expect(exec.status).toBeDefined();
+    expect(exec.status?.phase).toBe(ExecutionPhase.EXECUTION_PAUSED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The pipelines over a real store.
+// ---------------------------------------------------------------------------
+
+let counter = 0;
+
+function gatedExecution(id: string, toolCallId: string): AgentExecution {
+  return create(AgentExecutionSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "AgentExecution",
+    metadata: { id, name: id },
+    spec: {},
+    status: {
+      phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+      messages: [
+        {
+          toolCalls: [
+            {
+              id: toolCallId,
+              name: "Write",
+              status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+              requiresApproval: true,
+            },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+async function seedExecution(init: {
+  phase: ExecutionPhase;
+  sessionId?: string;
+  error?: string;
+}): Promise<string> {
+  counter += 1;
+  const id = `aexec_lifecycle_${counter}`;
+  await store.saveResource(
+    ApiResourceKind.agent_execution,
+    id,
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "AgentExecution",
+      metadata: { id, name: id, org: "acme" },
+      spec: { sessionId: init.sessionId ?? "", message: "hi" },
+      status: { phase: init.phase, error: init.error ?? "" },
+    }),
+  );
+  return id;
+}
+
+/**
+ * The EC-builder deps recover consumes, stubbed at the in-process edges
+ * (the builder logic itself is real). The store is the shared SQLite
+ * store, so schedule/workflow label lookups run for real (and find
+ * nothing here).
+ */
+function stubBuilderDeps(overrides?: {
+  onEcCreate?: (ec: ExecutionContext) => void;
+}): ExecutionContextBuilderDeps {
+  const agent: Agent = create(AgentSchema, {
+    metadata: { id: "agt_lc", org: "acme", slug: "lc-agent" },
+    spec: {},
+  });
+  return {
+    store,
+    logger: silentLogger,
+    agentLoader: () => ({ get: async () => agent }),
+    agentInstanceLoader: () => ({
+      get: async (instanceId) =>
+        create(AgentInstanceSchema, {
+          metadata: { id: instanceId, org: "acme" },
+          spec: { agentId: "agt_lc" },
+        }),
+    }),
+    sessionLoader: () => ({
+      get: async (sessionId) =>
+        create(SessionSchema, {
+          metadata: { id: sessionId, org: "acme" },
+          spec: { agentInstanceId: "agi_lc" },
+        }),
+    }),
+    environmentReader: () => ({
+      list: async () => {
+        throw new Error("no environments in this test");
+      },
+      getSecretValue: async () => {
+        throw new Error("no secrets in this test");
+      },
+    }),
+    environmentResolution: {
+      resolveByReference: async () => {
+        throw new Error("no environment refs in this test");
+      },
+      // Only resolveByReference is consumed by the builder.
+    } as unknown as ExecutionContextBuilderDeps["environmentResolution"],
+    executionContextCreator: () => ({
+      create: async (ec) => {
+        overrides?.onEcCreate?.(ec);
+        return ec;
+      },
+    }),
+    managedEnvService: {
+      readSecretValue: async () => "",
+      updateSecrets: async () => {},
+    } as unknown as ManagedEnvironmentService,
+  };
+}
+
+function lifecycleDeps(engineState: ExecutionEngineState): LifecycleDeps {
+  return {
+    store,
+    logger: silentLogger,
+    broker: new StreamBroker(silentLogger),
+    engineState: () => engineState,
+    executionContextBuilder: stubBuilderDeps(),
+  };
+}
+
+const DISCONNECTED: ExecutionEngineState = { connected: false };
+
+function connected(engine: ConnectedExecutionEngine): ExecutionEngineState {
+  return { connected: true, engine };
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(connectError.code).toBe(code);
+    return connectError;
+  }
+  throw new Error(`expected code ${Code[code]}, call succeeded`);
+}
+
+function cancelInput(id: string): CancelAgentExecutionInput {
+  return create(CancelAgentExecutionInputSchema, { id });
+}
+function terminateInput(
+  id: string,
+  reason = "",
+): TerminateAgentExecutionInput {
+  return create(TerminateAgentExecutionInputSchema, { id, reason });
+}
+function pauseInput(id: string, reason = ""): PauseAgentExecutionInput {
+  return create(PauseAgentExecutionInputSchema, { id, reason });
+}
+function resumeInput(id: string): ResumeAgentExecutionInput {
+  return create(ResumeAgentExecutionInputSchema, { id });
+}
+function recoverInput(id: string): RecoverAgentExecutionInput {
+  return create(RecoverAgentExecutionInputSchema, { id });
+}
+
+describe("lifecycle pipelines", () => {
+  it("empty id refuses InvalidArgument before any load", async () => {
+    const deps = lifecycleDeps(DISCONNECTED);
+    const err = await expectCode(
+      () => cancelExecution(deps, cancelInput("")),
+      Code.InvalidArgument,
+    );
+    expect(err.rawMessage).toBe("execution id is required");
+  });
+
+  it("unknown id answers NotFound", async () => {
+    const deps = lifecycleDeps(DISCONNECTED);
+    await expectCode(
+      () => cancelExecution(deps, cancelInput("aexec_missing")),
+      Code.NotFound,
+    );
+  });
+
+  it("disconnected engine refuses FailedPrecondition after phase validation", async () => {
+    const deps = lifecycleDeps(DISCONNECTED);
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    const err = await expectCode(
+      () => cancelExecution(deps, cancelInput(id)),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe("Temporal is not available");
+  });
+
+  it("wrong phase refuses FailedPrecondition with the per-verb copy", async () => {
+    const deps = lifecycleDeps(DISCONNECTED);
+    const completed = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_COMPLETED,
+    });
+    const cases: Array<[() => Promise<unknown>, string]> = [
+      [
+        () => cancelExecution(deps, cancelInput(completed)),
+        "cannot cancel execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be cancelled",
+      ],
+      [
+        () => terminateExecution(deps, terminateInput(completed)),
+        "cannot terminate execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be terminated",
+      ],
+      [
+        () => pauseExecution(deps, pauseInput(completed)),
+        "cannot pause execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be paused",
+      ],
+      [
+        () => resumeExecution(deps, resumeInput(completed)),
+        "cannot resume execution in phase EXECUTION_COMPLETED; only PAUSED executions can be resumed",
+      ],
+      [
+        () => recoverExecution(deps, recoverInput(completed)),
+        "cannot recover execution in phase EXECUTION_COMPLETED; only FAILED executions can be recovered",
+      ],
+    ];
+    for (const [fn, message] of cases) {
+      const err = await expectCode(fn, Code.FailedPrecondition);
+      expect(err.rawMessage).toBe(message);
+    }
+  });
+
+  it("already in target phase is idempotent success without touching the engine", async () => {
+    let engineCalls = 0;
+    const deps = lifecycleDeps(
+      connected(
+        stubConnectedEngine({
+          cancelWorkflow: async () => {
+            engineCalls += 1;
+          },
+        }),
+      ),
+    );
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_CANCELLED,
+    });
+    const result = await cancelExecution(deps, cancelInput(id));
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+    expect(engineCalls).toBe(0);
+  });
+
+  it("cancel with a connected engine persists CANCELLED and broadcasts", async () => {
+    const cancelled: string[] = [];
+    const deps = lifecycleDeps(
+      connected(
+        stubConnectedEngine({
+          cancelWorkflow: async (executionId) => {
+            cancelled.push(executionId);
+          },
+        }),
+      ),
+    );
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    const result = await cancelExecution(deps, cancelInput(id));
+    expect(cancelled).toEqual([id]);
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+    expect(result.status?.completedAt).not.toBe("");
+
+    const persisted = await store.getResource(
+      ApiResourceKind.agent_execution,
+      id,
+      AgentExecutionSchema,
+    );
+    expect(persisted.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+  });
+
+  it("workflow-not-found is warn-and-proceed: the state update still lands", async () => {
+    const deps = lifecycleDeps(
+      connected(
+        stubConnectedEngine({
+          cancelWorkflow: async (executionId) => {
+            throw new EngineWorkflowNotFoundError(executionId);
+          },
+        }),
+      ),
+    );
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    const result = await cancelExecution(deps, cancelInput(id));
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+  });
+
+  it("terminate stamps the resolved reason into status.error", async () => {
+    const deps = lifecycleDeps(connected(stubConnectedEngine()));
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    const result = await terminateExecution(
+      deps,
+      terminateInput(id, "disk full"),
+    );
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_TERMINATED);
+    expect(result.status?.error).toBe("Terminated: disk full");
+  });
+
+  it("resume from PAUSED clears completed_at and returns IN_PROGRESS", async () => {
+    const resumed: string[] = [];
+    const deps = lifecycleDeps(
+      connected(
+        stubConnectedEngine({
+          signalResume: async (executionId) => {
+            resumed.push(executionId);
+          },
+        }),
+      ),
+    );
+    const id = await seedExecution({ phase: ExecutionPhase.EXECUTION_PAUSED });
+    const result = await resumeExecution(deps, resumeInput(id));
+    expect(resumed).toEqual([id]);
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(result.status?.completedAt).toBe("");
+  });
+
+  it("recover runs terminate → EC recreate → fresh start → clears error", async () => {
+    const terminations: Array<{ executionId: string; reason: string }> = [];
+    const starts: string[] = [];
+    const createdEcs: ExecutionContext[] = [];
+    const deps: LifecycleDeps = {
+      store,
+      logger: silentLogger,
+      broker: new StreamBroker(silentLogger),
+      engineState: () =>
+        connected(
+          stubConnectedEngine({
+            terminateWorkflow: async (executionId, reason) => {
+              terminations.push({ executionId, reason });
+            },
+            startInvokeWorkflow: async (params) => {
+              starts.push(params.executionId);
+            },
+          }),
+        ),
+      executionContextBuilder: stubBuilderDeps({
+        onEcCreate: (ec) => createdEcs.push(ec),
+      }),
+    };
+
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      sessionId: "ses_lc",
+      error: "runner exploded",
+    });
+    const result = await recoverExecution(deps, recoverInput(id));
+
+    expect(terminations).toEqual([
+      {
+        executionId: id,
+        reason: "Recovery: terminating before fresh workflow start",
+      },
+    ]);
+    expect(createdEcs).toHaveLength(1);
+    expect(createdEcs[0]?.spec?.executionId).toBe(id);
+    expect(createdEcs[0]?.metadata?.name).toBe(`exec-ctx-${id}`);
+    expect(starts).toEqual([id]);
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(result.status?.error).toBe("");
+    expect(result.status?.completedAt).toBe("");
+  });
+
+  it("recover with a disconnected engine refuses before any side effect", async () => {
+    const deps = lifecycleDeps(DISCONNECTED);
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      sessionId: "ses_lc",
+    });
+    const err = await expectCode(
+      () => recoverExecution(deps, recoverInput(id)),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe("Temporal is not available");
+
+    const persisted = await store.getResource(
+      ApiResourceKind.agent_execution,
+      id,
+      AgentExecutionSchema,
+    );
+    expect(persisted.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
+  });
+});
+
+// The append-only invariant on the lifecycle path: a pause and an
+// approval-decision append race on the same gated execution. Because the
+// lifecycle persist re-reads fresh under the store's write lock inside
+// store.updateResource, it can never clobber a decision a concurrent
+// writer appended (Go's 50-iteration regression, appended through the
+// same real approval helpers).
+describe("lifecycle pause racing a decision append", () => {
+  it("keeps both the decision and the pause across 50 races", async () => {
+    const toolCallId = "tc-1";
+    const deps = lifecycleDeps(connected(stubConnectedEngine()));
+
+    for (let i = 0; i < 50; i++) {
+      const id = `aexec_pause_race_${i}`;
+      await store.saveResource(
+        ApiResourceKind.agent_execution,
+        id,
+        AgentExecutionSchema,
+        gatedExecution(id, toolCallId),
+      );
+
+      // Go seeds WAITING_FOR_APPROVAL; pause requires PENDING/IN_PROGRESS,
+      // so flip to IN_PROGRESS while keeping the gated call — the overlap
+      // window the plan describes.
+      await store.updateResource(
+        ApiResourceKind.agent_execution,
+        id,
+        AgentExecutionSchema,
+        (loaded) => {
+          loaded.status!.phase = ExecutionPhase.EXECUTION_IN_PROGRESS;
+        },
+      );
+
+      await Promise.all([
+        pauseExecution(deps, pauseInput(id)),
+        store.updateResource(
+          ApiResourceKind.agent_execution,
+          id,
+          AgentExecutionSchema,
+          (loaded) => {
+            ensureApprovalRequests(loaded.status, id);
+            const tc = loaded.status?.messages[0]?.toolCalls[0];
+            if (tc === undefined) {
+              throw new Error(`tool call ${toolCallId} not found`);
+            }
+            tc.approvalAction = ApprovalAction.APPROVE;
+            tc.approvalDecidedAt = new Date()
+              .toISOString()
+              .replace(/\.\d{3}Z$/, "Z");
+            recordDecisionEvent(loaded.status, tc, "", "");
+          },
+        ),
+      ]);
+
+      const final = await store.getResource(
+        ApiResourceKind.agent_execution,
+        id,
+        AgentExecutionSchema,
+      );
+
+      let requested = 0;
+      let approved = 0;
+      for (const ev of final.status?.approvalEventStream?.events ?? []) {
+        if (ev.approvalRequestId !== toolCallId) {
+          continue;
+        }
+        if (ev.eventType === ApprovalEventType.REQUESTED) {
+          requested += 1;
+        }
+        if (ev.eventType === ApprovalEventType.APPROVED) {
+          approved += 1;
+        }
+      }
+      expect(requested, `iteration ${i}: REQUESTED count`).toBe(1);
+      expect(approved, `iteration ${i}: APPROVED decision lost`).toBe(1);
+      // The pause transition must also have landed.
+      expect(final.status?.phase, `iteration ${i}: phase`).toBe(
+        ExecutionPhase.EXECUTION_PAUSED,
+      );
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/lifecycle.test.ts
@@ -804,6 +804,41 @@ describe("lifecycle pipelines", () => {
     expect(engineCalls).toBe(0);
   });
 
+  it("recover surfaces the inner status code when the EC rebuild fails (never Internal)", async () => {
+    // Go's recreate step wraps with %w: a NotFound session load (or the
+    // FailedPrecondition OAuth refusal) keeps its code on the wire with
+    // the recover prefix — the caller-actionable copy must not collapse
+    // into an opaque 500.
+    const builderDeps = stubBuilderDeps();
+    const deps: LifecycleDeps = {
+      store,
+      logger: silentLogger,
+      broker: new StreamBroker(silentLogger),
+      engineState: () => connected(stubConnectedEngine()),
+      executionContextBuilder: {
+        ...builderDeps,
+        sessionLoader: () => ({
+          get: async () => {
+            throw new ConnectError("session not found: ses_gone", Code.NotFound);
+          },
+        }),
+      },
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      sessionId: "ses_gone",
+    });
+    const err = await expectCode(
+      () => recoverExecution(deps, recoverInput(id)),
+      Code.NotFound,
+    );
+    expect(err.rawMessage).toBe(
+      `recreate execution context for recovered execution ${id}: ` +
+        "resolve agent instance: load session ses_gone: " +
+        "rpc error: code = NotFound desc = session not found: ses_gone",
+    );
+  });
+
   it("recover with a disconnected engine refuses before any side effect", async () => {
     const deps = lifecycleDeps(DISCONNECTED);
     const id = await seedExecution({

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/lifecycle.test.ts
@@ -140,9 +140,15 @@ describe("cancelInProgressSubAgents", () => {
     expect(subAgents[3]?.completedAt).toBe("preexisting");
   });
 
-  it("is safe on an empty list", () => {
+  it("is safe on an empty list and on undefined elements (Go NilSafe)", () => {
     expect(() =>
       cancelInProgressSubAgents([], "2026-06-05T00:00:00Z"),
+    ).not.toThrow();
+    expect(() =>
+      cancelInProgressSubAgents(
+        [undefined] as unknown as SubAgentExecution[],
+        "2026-06-05T00:00:00Z",
+      ),
     ).not.toThrow();
   });
 });
@@ -679,6 +685,125 @@ describe("lifecycle pipelines", () => {
     expect(result.status?.completedAt).toBe("");
   });
 
+  it("recover proceeds when the previous workflow is already gone (NotFound = success)", async () => {
+    // Go terminate_existing_workflow_step_test.go NotFound_Succeeds: a
+    // FAILED execution's workflow has normally already completed; the
+    // recreate + fresh start must still run.
+    const starts: string[] = [];
+    const createdEcs: ExecutionContext[] = [];
+    const deps: LifecycleDeps = {
+      store,
+      logger: silentLogger,
+      broker: new StreamBroker(silentLogger),
+      engineState: () =>
+        connected(
+          stubConnectedEngine({
+            terminateWorkflow: async (executionId) => {
+              throw new EngineWorkflowNotFoundError(executionId);
+            },
+            startInvokeWorkflow: async (params) => {
+              starts.push(params.executionId);
+            },
+          }),
+        ),
+      executionContextBuilder: stubBuilderDeps({
+        onEcCreate: (ec) => createdEcs.push(ec),
+      }),
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      sessionId: "ses_lc",
+      error: "runner exploded",
+    });
+    const result = await recoverExecution(deps, recoverInput(id));
+    expect(createdEcs).toHaveLength(1);
+    expect(starts).toEqual([id]);
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+  });
+
+  it("recover aborts when the terminate fails with a real error — nothing re-started", async () => {
+    // Go terminate_existing_workflow_step_test.go TerminateFails: the
+    // workflow ID must be terminal before the fresh start reuses it, so a
+    // genuine terminate failure gates the whole recovery.
+    const starts: string[] = [];
+    const createdEcs: ExecutionContext[] = [];
+    const deps: LifecycleDeps = {
+      store,
+      logger: silentLogger,
+      broker: new StreamBroker(silentLogger),
+      engineState: () =>
+        connected(
+          stubConnectedEngine({
+            terminateWorkflow: async () => {
+              throw new Error("temporal unavailable");
+            },
+            startInvokeWorkflow: async (params) => {
+              starts.push(params.executionId);
+            },
+          }),
+        ),
+      executionContextBuilder: stubBuilderDeps({
+        onEcCreate: (ec) => createdEcs.push(ec),
+      }),
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      sessionId: "ses_lc",
+      error: "runner exploded",
+    });
+    const err = await expectCode(
+      () => recoverExecution(deps, recoverInput(id)),
+      Code.Internal,
+    );
+    expect(err.rawMessage).toBe(
+      "failed to terminate previous workflow during recovery",
+    );
+    expect(createdEcs).toHaveLength(0);
+    expect(starts).toHaveLength(0);
+    // The execution stays FAILED (recover can be retried).
+    const persisted = await store.getResource(
+      ApiResourceKind.agent_execution,
+      id,
+      AgentExecutionSchema,
+    );
+    expect(persisted.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
+    expect(persisted.status?.error).toBe("runner exploded");
+  });
+
+  it("recover already IN_PROGRESS is idempotent success without touching the engine", async () => {
+    // Go terminate_existing_workflow_step_test.go
+    // SkipsWhenAlreadyInTargetState, driven through the full pipeline.
+    let engineCalls = 0;
+    const deps: LifecycleDeps = {
+      store,
+      logger: silentLogger,
+      broker: new StreamBroker(silentLogger),
+      engineState: () =>
+        connected(
+          stubConnectedEngine({
+            terminateWorkflow: async () => {
+              engineCalls += 1;
+            },
+            startInvokeWorkflow: async () => {
+              engineCalls += 1;
+            },
+          }),
+        ),
+      executionContextBuilder: stubBuilderDeps({
+        onEcCreate: () => {
+          engineCalls += 1;
+        },
+      }),
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      sessionId: "ses_lc",
+    });
+    const result = await recoverExecution(deps, recoverInput(id));
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(engineCalls).toBe(0);
+  });
+
   it("recover with a disconnected engine refuses before any side effect", async () => {
     const deps = lifecycleDeps(DISCONNECTED);
     const id = await seedExecution({
@@ -698,6 +823,86 @@ describe("lifecycle pipelines", () => {
     );
     expect(persisted.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
   });
+});
+
+// The lifecycle persist must go through the atomic store.updateResource,
+// never the whole-resource saveResource it replaced (Go
+// TestLifecyclePersist_UsesUpdateResource): a saveResource here is the
+// regression that lets a concurrent SubmitApproval append be clobbered.
+// The mechanism pin complements the race test below — it pinpoints the
+// regression without depending on interleaving.
+describe("lifecycle persist uses the atomic updateResource", () => {
+  const cases: Array<{
+    name: string;
+    run: (deps: LifecycleDeps, id: string) => Promise<unknown>;
+    fromPhase: ExecutionPhase;
+    wantPhase: ExecutionPhase;
+  }> = [
+    {
+      name: "pause",
+      run: (deps, id) => pauseExecution(deps, pauseInput(id)),
+      fromPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      wantPhase: ExecutionPhase.EXECUTION_PAUSED,
+    },
+    {
+      name: "cancel",
+      run: (deps, id) => cancelExecution(deps, cancelInput(id)),
+      fromPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      wantPhase: ExecutionPhase.EXECUTION_CANCELLED,
+    },
+    {
+      name: "terminate",
+      run: (deps, id) => terminateExecution(deps, terminateInput(id)),
+      fromPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      wantPhase: ExecutionPhase.EXECUTION_TERMINATED,
+    },
+  ];
+
+  for (const tc of cases) {
+    it(tc.name, async () => {
+      let updateCalls = 0;
+      let saveCalls = 0;
+      const countingStore = new Proxy(store, {
+        get(target, prop, receiver) {
+          if (prop === "updateResource") {
+            return (...args: Parameters<Store["updateResource"]>) => {
+              updateCalls += 1;
+              return target.updateResource(...args);
+            };
+          }
+          if (prop === "saveResource") {
+            return (...args: Parameters<Store["saveResource"]>) => {
+              saveCalls += 1;
+              return target.saveResource(...args);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+      const deps: LifecycleDeps = {
+        store: countingStore,
+        logger: silentLogger,
+        broker: new StreamBroker(silentLogger),
+        engineState: () => connected(stubConnectedEngine()),
+        executionContextBuilder: stubBuilderDeps(),
+      };
+
+      // Seed through the RAW store so the seed write is not counted.
+      const id = await seedExecution({ phase: tc.fromPhase });
+
+      await tc.run(deps, id);
+
+      expect(updateCalls, "exactly 1 atomic updateResource").toBe(1);
+      expect(saveCalls, "0 whole-resource saveResource").toBe(0);
+
+      const final = await store.getResource(
+        ApiResourceKind.agent_execution,
+        id,
+        AgentExecutionSchema,
+      );
+      expect(final.status?.phase).toBe(tc.wantPhase);
+    });
+  }
 });
 
 // The append-only invariant on the lifecycle path: a pause and an

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/stream-broker.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/stream-broker.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pins the StreamBroker delivery semantics (stream_broker.go): bounded
+ * per-subscriber buffering with drop-on-full (never blocking a
+ * broadcast), notify-on-push, idempotent unsubscribe with close
+ * signaling, and per-execution isolation.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  StreamBroker,
+  SUBSCRIBER_BUFFER_CAPACITY,
+} from "../stream-broker.js";
+
+function capturingLogger() {
+  const lines: Array<{ level: string; message: string }> = [];
+  return {
+    lines,
+    logger: createLogger({
+      level: "debug",
+      pretty: false,
+      write: (line) =>
+        lines.push(JSON.parse(line) as { level: string; message: string }),
+    }),
+  };
+}
+
+function frame(id: string, error = "") {
+  return create(AgentExecutionSchema, {
+    metadata: { id },
+    status: { error },
+  });
+}
+
+describe("StreamBroker", () => {
+  it("delivers to every subscriber of the execution, none of another's", () => {
+    const { logger } = capturingLogger();
+    const broker = new StreamBroker(logger);
+    const a1 = broker.subscribe("aexec_a");
+    const a2 = broker.subscribe("aexec_a");
+    const b = broker.subscribe("aexec_b");
+
+    broker.broadcast(frame("aexec_a"));
+
+    expect(a1.queue).toHaveLength(1);
+    expect(a2.queue).toHaveLength(1);
+    expect(b.queue).toHaveLength(0);
+    expect(broker.getSubscriberCount("aexec_a")).toBe(2);
+  });
+
+  it("wakes a parked consumer exactly once per push", () => {
+    const { logger } = capturingLogger();
+    const broker = new StreamBroker(logger);
+    const sub = broker.subscribe("aexec_x");
+
+    let woken = 0;
+    sub.notify = () => {
+      woken += 1;
+    };
+    broker.broadcast(frame("aexec_x"));
+
+    expect(woken).toBe(1);
+    // The broker clears the hook after firing (one-shot, like the
+    // generator re-arms it per wait).
+    expect(sub.notify).toBeUndefined();
+  });
+
+  it("drops the frame for a full subscriber and warns (never blocks)", () => {
+    const { logger, lines } = capturingLogger();
+    const broker = new StreamBroker(logger);
+    const sub = broker.subscribe("aexec_full");
+
+    for (let i = 0; i < SUBSCRIBER_BUFFER_CAPACITY; i++) {
+      broker.broadcast(frame("aexec_full", `frame-${i}`));
+    }
+    expect(sub.queue).toHaveLength(SUBSCRIBER_BUFFER_CAPACITY);
+
+    broker.broadcast(frame("aexec_full", "overflow"));
+    expect(sub.queue).toHaveLength(SUBSCRIBER_BUFFER_CAPACITY);
+    expect(sub.queue.at(-1)?.status?.error).toBe(
+      `frame-${SUBSCRIBER_BUFFER_CAPACITY - 1}`,
+    );
+    expect(
+      lines.some((l) => l.message.includes("Subscriber channel full")),
+    ).toBe(true);
+  });
+
+  it("unsubscribe closes, wakes, cleans the map, and is idempotent", () => {
+    const { logger } = capturingLogger();
+    const broker = new StreamBroker(logger);
+    const sub = broker.subscribe("aexec_gone");
+
+    let woken = false;
+    sub.notify = () => {
+      woken = true;
+    };
+    broker.unsubscribe("aexec_gone", sub);
+
+    expect(sub.closed).toBe(true);
+    expect(woken, "a parked consumer observes the close").toBe(true);
+    expect(broker.getSubscriberCount("aexec_gone")).toBe(0);
+
+    // Idempotent; a post-close broadcast reaches nobody and throws nothing.
+    broker.unsubscribe("aexec_gone", sub);
+    broker.broadcast(frame("aexec_gone"));
+    expect(sub.queue).toHaveLength(0);
+  });
+
+  it("ignores frames without a metadata id (Go's nil guard)", () => {
+    const { logger } = capturingLogger();
+    const broker = new StreamBroker(logger);
+    const sub = broker.subscribe("");
+    broker.broadcast(create(AgentExecutionSchema, {}));
+    expect(sub.queue).toHaveLength(0);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/update-status.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/update-status.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Pins the updateStatus merge engine against Go's
+ * update_status_guard_test.go and
+ * update_status_recalled_memories_report_test.go case-for-case: the
+ * transcript regression guard (shrink + front-truncation-with-append +
+ * the terminal exemption), the equal-length approval finalize, and the
+ * presence-guarded runner-owned field pattern (recalled_memories_report).
+ * These exercise applyUpdateStatusMerge directly on a clone — mirroring
+ * the freshly-loaded resource the merge mutates in place inside the
+ * updateResource write lock.
+ */
+import { clone, create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ApprovalAction,
+  ExecutionPhase,
+  MessageType,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { AgentExecutionUpdateStatusInputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { findToolCallInExecution } from "../submit-approval.js";
+import { applyUpdateStatusMerge } from "../update-status.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+/**
+ * Applies the merge to a clone of the existing execution and returns the
+ * merged result (Go runBuildStep).
+ */
+function runBuildStep(
+  existing: AgentExecution,
+  incoming: MessageInitShape<typeof AgentExecutionStatusSchema>,
+): AgentExecution {
+  const input = create(AgentExecutionUpdateStatusInputSchema, {
+    executionId: existing.metadata?.id ?? "",
+    status: incoming,
+  });
+  const merged = clone(AgentExecutionSchema, existing);
+  applyUpdateStatusMerge(merged, input, silentLogger);
+  return merged;
+}
+
+function messages(...contents: string[]): AgentMessage[] {
+  return contents.map((c) => create(AgentMessageSchema, { content: c }));
+}
+
+function existingWith(
+  phase: ExecutionPhase,
+  ...msgs: string[]
+): AgentExecution {
+  return create(AgentExecutionSchema, {
+    metadata: { id: "exec-guard", name: "exec-guard" },
+    spec: {},
+    status: { phase, messages: msgs.map((c) => ({ content: c })) },
+  });
+}
+
+describe("the transcript regression guard (update_status_guard_test.go)", () => {
+  it("rejects a shrinking transcript for a non-terminal execution", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL, "m1", "m2", "m3"),
+      {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        messages: [{ content: "only-one" }],
+      },
+    );
+    expect(merged.status?.messages).toHaveLength(3);
+    expect(merged.status?.messages[0]?.content).toBe("m1");
+  });
+
+  it("accepts the equal-length approval finalize (narration blanked in place) and projects the gate", () => {
+    const existing = create(AgentExecutionSchema, {
+      metadata: { id: "exec-guard", name: "exec-guard" },
+      spec: {},
+      status: {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        messages: [
+          { content: "let me create the file" },
+          {
+            toolCalls: [
+              {
+                id: "tc-write",
+                name: "Write",
+                status: ToolCallStatus.TOOL_CALL_FAILED,
+                requiresApproval: true,
+              },
+            ],
+          },
+          { content: "I could not write the file; approve it when prompted" },
+        ],
+      },
+    });
+    const merged = runBuildStep(existing, {
+      phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+      messages: [
+        { content: "let me create the file" },
+        {
+          toolCalls: [
+            {
+              id: "tc-write",
+              name: "Write",
+              status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+              requiresApproval: true,
+            },
+          ],
+        },
+        { content: "" },
+      ],
+    });
+
+    expect(
+      merged.status?.messages,
+      "append-only finalize keeps all 3 messages (narration blanked, not removed)",
+    ).toHaveLength(3);
+    expect(merged.status?.messages[2]?.content).toBe("");
+    expect(
+      merged.status?.pendingApprovals,
+      "the gated WAITING_APPROVAL call projects exactly one pending approval",
+    ).toHaveLength(1);
+    expect(merged.status?.pendingApprovals[0]?.toolCallId).toBe("tc-write");
+  });
+
+  it("rejects a shrinking WAITING_FOR_APPROVAL finalize (no phase carve-out)", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_IN_PROGRESS, "m1", "m2", "m3"),
+      {
+        phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+        messages: [{ content: "m1" }, { content: "m2" }],
+      },
+    );
+    expect(merged.status?.messages).toHaveLength(3);
+  });
+
+  it("accepts a growing transcript (the normal streaming case)", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_IN_PROGRESS, "m1", "m2"),
+      {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        messages: [{ content: "m1" }, { content: "m2" }, { content: "m3" }],
+      },
+    );
+    expect(merged.status?.messages).toHaveLength(3);
+  });
+
+  it("accepts an equal-length replacement (in-place mutation of the same turns)", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_IN_PROGRESS, "m1", "m2"),
+      {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        messages: [{ content: "m1-updated" }, { content: "m2-updated" }],
+      },
+    );
+    expect(merged.status?.messages).toHaveLength(2);
+    expect(merged.status?.messages[0]?.content).toBe("m1-updated");
+  });
+
+  it("rejects front-truncation-with-append (the gap a count-only guard cannot see)", () => {
+    const existing = create(AgentExecutionSchema, {
+      metadata: { id: "exec-guard", name: "exec-guard" },
+      spec: {},
+      status: {
+        phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+        messages: [
+          {
+            type: MessageType.MESSAGE_THINKING,
+            content: "planning the self-DM",
+          },
+          {
+            type: MessageType.MESSAGE_AI,
+            toolCalls: [
+              {
+                id: "tc-getappstate",
+                name: "getAppState",
+                status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+                requiresApproval: true,
+                approvalAction: ApprovalAction.APPROVE_ALL,
+                mcpServerSlug: "open-computer-use",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    // Regressed resume transcript: leading thinking + getAppState gone,
+    // later leased tools appended. len(incoming)=3 >= existing=2, so a
+    // count-only guard would not fire.
+    const merged = runBuildStep(existing, {
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      messages: [
+        {
+          type: MessageType.MESSAGE_AI,
+          toolCalls: [
+            { id: "tc-click", name: "click", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+          ],
+        },
+        {
+          type: MessageType.MESSAGE_AI,
+          toolCalls: [
+            { id: "tc-scroll", name: "scroll", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+          ],
+        },
+        { type: MessageType.MESSAGE_AI, content: "done" },
+      ],
+    });
+
+    const hasThinking = merged.status?.messages.some(
+      (m) =>
+        m.type === MessageType.MESSAGE_THINKING &&
+        m.content === "planning the self-DM",
+    );
+    expect(
+      hasThinking,
+      "the leading thinking block must survive a front-truncated-but-appended update",
+    ).toBe(true);
+    expect(
+      findToolCallInExecution(merged, "tc-getappstate"),
+      "the first tool call must survive a front-truncated-but-appended update",
+    ).toBeDefined();
+  });
+
+  it("allows a shrink for a terminal execution (administrative correction)", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_COMPLETED, "m1", "m2", "m3"),
+      {
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        messages: [{ content: "single" }],
+      },
+    );
+    expect(merged.status?.messages).toHaveLength(1);
+  });
+
+  it("keeps the TERMINATED transcript guarded (the narrow transcript-terminal set)", () => {
+    // TERMINATED is deliberately absent from the transcript guard's
+    // terminal set (phases.ts) — a terminated execution's committed
+    // transcript stays protected from free rewrites.
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_TERMINATED, "m1", "m2", "m3"),
+      {
+        phase: ExecutionPhase.EXECUTION_TERMINATED,
+        messages: [{ content: "single" }],
+      },
+    );
+    expect(merged.status?.messages).toHaveLength(3);
+  });
+});
+
+describe("the phase latch and terminal settle", () => {
+  it("latches a terminal phase against a straggler IN_PROGRESS persist and re-settles its rows", () => {
+    const existing = create(AgentExecutionSchema, {
+      metadata: { id: "exec-latch", name: "exec-latch" },
+      spec: {},
+      status: {
+        phase: ExecutionPhase.EXECUTION_TERMINATED,
+        completedAt: "2026-08-24T10:00:00Z",
+        messages: [{ content: "m1" }],
+      },
+    });
+    // The straggler carries a live phase and a RUNNING tool call appended
+    // to an equal-or-longer transcript.
+    const merged = runBuildStep(existing, {
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      messages: [
+        { content: "m1" },
+        {
+          toolCalls: [
+            { id: "tc-live", name: "shell", status: ToolCallStatus.TOOL_CALL_RUNNING },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      merged.status?.phase,
+      "the terminal phase is final (Recover is the sanctioned un-terminalizer)",
+    ).toBe(ExecutionPhase.EXECUTION_TERMINATED);
+    const straggler = findToolCallInExecution(merged, "tc-live");
+    expect(
+      straggler?.status,
+      "the straggler's RUNNING row re-settles in the same merge (#207)",
+    ).toBe(ToolCallStatus.TOOL_CALL_INTERRUPTED);
+    expect(straggler?.completedAt).toBe("2026-08-24T10:00:00Z");
+  });
+
+  it("clears completed_at when the merged phase is non-terminal (resume defense-in-depth)", () => {
+    const existing = create(AgentExecutionSchema, {
+      metadata: { id: "exec-resume", name: "exec-resume" },
+      spec: {},
+      status: {
+        phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+        completedAt: "2026-08-24T10:00:00Z",
+        messages: [{ content: "m1" }],
+      },
+    });
+    const merged = runBuildStep(existing, {
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      messages: [{ content: "m1" }],
+    });
+    expect(merged.status?.completedAt).toBe("");
+  });
+});
+
+describe("the presence-guarded runner-owned field pattern (recalled_memories_report)", () => {
+  function selectionReport(...ids: string[]) {
+    return {
+      selectionActive: true,
+      injectedMemoryIds: ids,
+      embeddingModel: "text-embedding-3-small",
+    };
+  }
+
+  it("stores a runner-sent report", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_IN_PROGRESS, "m1"),
+      {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        messages: [{ content: "m1" }],
+        recalledMemoriesReport: selectionReport("mem_a", "mem_b"),
+      },
+    );
+    const report = merged.status?.recalledMemoriesReport;
+    expect(report).toBeDefined();
+    expect(report?.selectionActive).toBe(true);
+    expect(report?.injectedMemoryIds).toEqual(["mem_a", "mem_b"]);
+    expect(report?.embeddingModel).toBe("text-embedding-3-small");
+  });
+
+  it("preserves the stored report across report-less writes (incl. the terminal persist)", () => {
+    const existing = existingWith(ExecutionPhase.EXECUTION_IN_PROGRESS, "m1");
+    (existing.status as AgentExecutionStatus).recalledMemoriesReport = create(
+      AgentExecutionStatusSchema,
+      { recalledMemoriesReport: selectionReport("mem_a") },
+    ).recalledMemoriesReport;
+
+    const merged = runBuildStep(existing, {
+      phase: ExecutionPhase.EXECUTION_COMPLETED,
+      messages: [{ content: "m1" }, { content: "m2" }],
+    });
+    expect(merged.status?.recalledMemoriesReport?.injectedMemoryIds).toEqual([
+      "mem_a",
+    ]);
+  });
+
+  it("never invents a report (runner-owned, single writer)", () => {
+    const merged = runBuildStep(
+      existingWith(ExecutionPhase.EXECUTION_IN_PROGRESS, "m1"),
+      {
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        messages: [{ content: "m1" }, { content: "m2" }],
+      },
+    );
+    expect(merged.status?.recalledMemoriesReport).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/usage.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/usage.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Pins the usage aggregation helpers against Go's usage_aggregation_test.go
+ * case-for-case: the OSS zero-value posture (no llm_call_usage_record
+ * collection here — every aggregate is structurally valid and zero), the
+ * date/org/agent filters, grouping, distinct sets, daily entries, and the
+ * top-agents cap.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { AgentUsageSummarySchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+
+import {
+  aggregateUsageReport,
+  buildDailyCostEntries,
+  buildExecutionSummary,
+  buildSessionSummary,
+  earliestStartedAt,
+  extractDate,
+  filterByDateRange,
+  filterByOrg,
+  groupByDate,
+  groupBySessionId,
+  latestStartedAt,
+  mergeModelBreakdowns,
+  topAgentsByCost,
+} from "../usage.js";
+
+function makeExecution(
+  id: string,
+  sessionId: string,
+  agentId: string,
+  org: string,
+  startedAt: string,
+  subAgentCount = 0,
+): AgentExecution {
+  return create(AgentExecutionSchema, {
+    metadata: { id, name: `exec-${id}`, org },
+    spec: { sessionId, agentId },
+    status: {
+      startedAt,
+      completedAt: startedAt,
+      phase: ExecutionPhase.EXECUTION_COMPLETED,
+      subAgentExecutions: Array.from({ length: subAgentCount }, () => ({})),
+    },
+  });
+}
+
+describe("usage aggregation (OSS zero-value posture)", () => {
+  it("aggregateUsageReport returns zero", () => {
+    const agg = aggregateUsageReport();
+    expect(agg.inputTokens).toBe(0n);
+    expect(agg.outputTokens).toBe(0n);
+    expect(agg.totalTokens).toBe(0n);
+    expect(agg.llmCallCount).toBe(0);
+    expect(agg.billableCostMicros).toBe(0n);
+  });
+
+  it("mergeModelBreakdowns returns empty", () => {
+    expect(mergeModelBreakdowns()).toHaveLength(0);
+  });
+
+  it("buildExecutionSummary projects identity fields with zero usage", () => {
+    const summary = buildExecutionSummary(
+      makeExecution("e1", "s1", "a1", "org", "2026-03-10T10:00:00Z", 1),
+    );
+    expect(summary.executionId).toBe("e1");
+    expect(summary.startedAt).toBe("2026-03-10T10:00:00Z");
+    expect(summary.subAgentCount).toBe(1);
+    expect(summary.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    expect(summary.inputTokens, "OSS has no usage data").toBe(0n);
+    expect(summary.billableCostMicros, "OSS has no usage data").toBe(0n);
+  });
+
+  it("filterByDateRange applies inclusive string bounds", () => {
+    const executions = [
+      makeExecution("e1", "s1", "a1", "org", "2026-03-01T10:00:00Z"),
+      makeExecution("e2", "s1", "a1", "org", "2026-03-05T10:00:00Z"),
+      makeExecution("e3", "s1", "a1", "org", "2026-03-10T10:00:00Z"),
+      makeExecution("e4", "s1", "a1", "org", "2026-03-15T10:00:00Z"),
+    ];
+    expect(filterByDateRange(executions, "2026-03-03", "2026-03-12")).toHaveLength(2);
+    expect(filterByDateRange(executions, "2026-03-10", "")).toHaveLength(2);
+    expect(filterByDateRange(executions, "", "2026-03-05T10:00:00Z")).toHaveLength(2);
+    expect(filterByDateRange(executions, "", "")).toHaveLength(4);
+  });
+
+  it("groupBySessionId groups by spec.session_id", () => {
+    const groups = groupBySessionId([
+      makeExecution("e1", "s1", "a1", "org", ""),
+      makeExecution("e2", "s1", "a1", "org", ""),
+      makeExecution("e3", "s2", "a1", "org", ""),
+    ]);
+    expect(groups.size).toBe(2);
+    expect(groups.get("s1")).toHaveLength(2);
+    expect(groups.get("s2")).toHaveLength(1);
+  });
+
+  it("groupByDate groups by the YYYY-MM-DD prefix", () => {
+    const groups = groupByDate([
+      makeExecution("e1", "s1", "a1", "org", "2026-03-10T08:00:00Z"),
+      makeExecution("e2", "s1", "a1", "org", "2026-03-10T14:00:00Z"),
+      makeExecution("e3", "s1", "a1", "org", "2026-03-11T09:00:00Z"),
+    ]);
+    expect(groups.size).toBe(2);
+    expect(groups.get("2026-03-10")).toHaveLength(2);
+  });
+
+  it("buildSessionSummary carries the time span with zero usage", () => {
+    const summary = buildSessionSummary("s1", [
+      makeExecution("e1", "s1", "a1", "org", "2026-03-10T08:00:00Z"),
+      makeExecution("e2", "s1", "a1", "org", "2026-03-10T14:00:00Z"),
+    ]);
+    expect(summary.sessionId).toBe("s1");
+    expect(summary.executionCount).toBe(2);
+    expect(summary.totalTokens, "OSS has no usage data").toBe(0n);
+    expect(summary.billableCostMicros, "OSS has no usage data").toBe(0n);
+    expect(summary.firstExecutionAt).toBe("2026-03-10T08:00:00Z");
+  });
+
+  it("buildDailyCostEntries sorts chronologically with zero cost", () => {
+    const entries = buildDailyCostEntries([
+      makeExecution("e1", "s1", "a1", "org", "2026-03-10T08:00:00Z"),
+      makeExecution("e2", "s1", "a1", "org", "2026-03-10T14:00:00Z"),
+      makeExecution("e3", "s1", "a1", "org", "2026-03-11T09:00:00Z"),
+    ]);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.date).toBe("2026-03-10");
+    expect(entries[0]?.executionCount).toBe(2);
+    expect(entries[0]?.totalTokens, "OSS has no usage data").toBe(0n);
+    expect(entries[1]?.date).toBe("2026-03-11");
+  });
+
+  it("topAgentsByCost ranks descending and caps", () => {
+    const top = topAgentsByCost(
+      [
+        create(AgentUsageSummarySchema, { agentId: "a1", billableCostMicros: 1_000_000n }),
+        create(AgentUsageSummarySchema, { agentId: "a2", billableCostMicros: 5_000_000n }),
+        create(AgentUsageSummarySchema, { agentId: "a3", billableCostMicros: 500_000n }),
+        create(AgentUsageSummarySchema, { agentId: "a4", billableCostMicros: 3_000_000n }),
+      ],
+      2,
+    );
+    expect(top).toHaveLength(2);
+    expect(top[0]?.agentId).toBe("a2");
+    expect(top[1]?.agentId).toBe("a4");
+  });
+
+  it("filterByOrg matches case-insensitively", () => {
+    const executions = [
+      makeExecution("e1", "s1", "a1", "org-a", ""),
+      makeExecution("e2", "s1", "a1", "org-b", ""),
+      makeExecution("e3", "s1", "a1", "org-a", ""),
+    ];
+    expect(filterByOrg(executions, "org-a")).toHaveLength(2);
+    // Go strings.EqualFold semantics.
+    expect(filterByOrg(executions, "ORG-A")).toHaveLength(2);
+  });
+
+  it("extractDate takes the 10-char prefix or nothing", () => {
+    expect(extractDate("2026-03-10T08:00:00Z")).toBe("2026-03-10");
+    expect(extractDate("2026-03-10")).toBe("2026-03-10");
+    expect(extractDate("short")).toBe("");
+    expect(extractDate("")).toBe("");
+  });
+
+  it("earliest/latestStartedAt skip empties and compare as strings", () => {
+    const executions = [
+      makeExecution("e1", "s1", "a1", "org", "2026-03-10T14:00:00Z"),
+      makeExecution("e2", "s1", "a1", "org", "2026-03-05T09:00:00Z"),
+      makeExecution("e3", "s1", "a1", "org", "2026-03-12T08:00:00Z"),
+    ];
+    expect(earliestStartedAt(executions)).toBe("2026-03-05T09:00:00Z");
+    expect(latestStartedAt(executions)).toBe("2026-03-12T08:00:00Z");
+  });
+
+  it("empty inputs answer zero shapes everywhere", () => {
+    expect(aggregateUsageReport().totalTokens).toBe(0n);
+    expect(mergeModelBreakdowns()).toHaveLength(0);
+    expect(buildDailyCostEntries([])).toHaveLength(0);
+    expect(earliestStartedAt([])).toBe("");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/validate-service-tier.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/validate-service-tier.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Pins validate-service-tier.ts against Go's validate_service_tier_test.go
+ * case-for-case: fail-closed create-time validation of
+ * ExecutionConfig.service_tier (#357) against the BUNDLED registry
+ * (composer-2.5 prices a fast variant; claude-sonnet-4.6 is native with
+ * none). Both editions must refuse the same request with the same
+ * message — the conformance tier suite asserts the codes on every target;
+ * these tests additionally pin the message fragments.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ServiceTier } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ExecutionConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { bundledModelRegistryDocument } from "../../workflow/registry/bundled.js";
+import { ModelRegistryStore } from "../../workflow/registry/model-registry-store.js";
+import { newValidateServiceTierStep } from "../validate-service-tier.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const registry = new ModelRegistryStore({
+  bundledDocument: bundledModelRegistryDocument(),
+  upstreamOrigin: "http://unused.test",
+  refreshEnabled: false,
+  logger: silentLogger,
+});
+
+const step = newValidateServiceTierStep(registry);
+
+function contextFor(
+  config: MessageInitShape<typeof ExecutionConfigSchema> | undefined,
+): RequestContext<typeof AgentExecutionSchema> {
+  return new RequestContext(
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, {
+      spec: {
+        message: "hello",
+        ...(config === undefined ? {} : { executionConfig: config }),
+      },
+    }),
+    ApiResourceKind.agent_execution,
+  );
+}
+
+function refusal(config: MessageInitShape<typeof ExecutionConfigSchema>): ConnectError {
+  try {
+    step.execute(contextFor(config));
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    return error as ConnectError;
+  }
+  throw new Error("expected a fail-closed refusal, step passed");
+}
+
+describe("ValidateServiceTier (#357, bundled registry)", () => {
+  it("no execution_config passes", () => {
+    expect(() => step.execute(contextFor(undefined))).not.toThrow();
+  });
+
+  it("explicit STANDARD passes without a model", () => {
+    expect(() =>
+      step.execute(contextFor({ serviceTier: ServiceTier.STANDARD })),
+    ).not.toThrow();
+  });
+
+  it("FAST with a fast-priced model passes", () => {
+    expect(() =>
+      step.execute(
+        contextFor({
+          modelName: "composer-2.5",
+          serviceTier: ServiceTier.FAST,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("FAST without model_name fails closed (no FAST-on-Auto)", () => {
+    const err = refusal({ serviceTier: ServiceTier.FAST });
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("requires execution_config.model_name");
+    // Fast-capable suggestions ride along.
+    expect(err.rawMessage).toContain("composer-2.5");
+  });
+
+  it("FAST on a native model with no fast variant fails closed", () => {
+    const err = refusal({
+      modelName: "claude-sonnet-4.6",
+      serviceTier: ServiceTier.FAST,
+    });
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("no fast variant");
+    expect(err.rawMessage).toContain("claude-sonnet-4.6");
+  });
+
+  it("FAST on an unknown model fails closed", () => {
+    const err = refusal({
+      modelName: "not-a-model",
+      serviceTier: ServiceTier.FAST,
+    });
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/validate-thinking-mode.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/validate-thinking-mode.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Pins validate-thinking-mode.ts against Go's
+ * validate_thinking_mode_test.go case-for-case: fail-closed create-time
+ * validation of ExecutionConfig.thinking_mode (#772) against the BUNDLED
+ * registry. Capability-gated and cursor-harness-scoped: claude-opus-4-6
+ * declares capabilities.thinking on its cursor entry; composer-2.5's
+ * cursor entry declares thinking=false; claude-sonnet-4.6 declares the
+ * capability but only on its NATIVE entry, which has no thinking wire
+ * mapping in v1 and must refuse.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ServiceTier,
+  ThinkingMode,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ExecutionConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { bundledModelRegistryDocument } from "../../workflow/registry/bundled.js";
+import { ModelRegistryStore } from "../../workflow/registry/model-registry-store.js";
+import { newValidateThinkingModeStep } from "../validate-thinking-mode.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const registry = new ModelRegistryStore({
+  bundledDocument: bundledModelRegistryDocument(),
+  upstreamOrigin: "http://unused.test",
+  refreshEnabled: false,
+  logger: silentLogger,
+});
+
+const step = newValidateThinkingModeStep(registry);
+
+function contextFor(
+  config: MessageInitShape<typeof ExecutionConfigSchema> | undefined,
+): RequestContext<typeof AgentExecutionSchema> {
+  return new RequestContext(
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, {
+      spec: {
+        message: "hello",
+        ...(config === undefined ? {} : { executionConfig: config }),
+      },
+    }),
+    ApiResourceKind.agent_execution,
+  );
+}
+
+function refusal(config: MessageInitShape<typeof ExecutionConfigSchema>): ConnectError {
+  try {
+    step.execute(contextFor(config));
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    return error as ConnectError;
+  }
+  throw new Error("expected a fail-closed refusal, step passed");
+}
+
+describe("ValidateThinkingMode (#772, bundled registry)", () => {
+  it("no execution_config passes", () => {
+    expect(() => step.execute(contextFor(undefined))).not.toThrow();
+  });
+
+  it("explicit DISABLED passes without a model", () => {
+    expect(() =>
+      step.execute(contextFor({ thinkingMode: ThinkingMode.DISABLED })),
+    ).not.toThrow();
+  });
+
+  it("ENABLED with a thinking-capable cursor model passes", () => {
+    expect(() =>
+      step.execute(
+        contextFor({
+          modelName: "claude-opus-4-6",
+          thinkingMode: ThinkingMode.ENABLED,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("ENABLED combines freely with FAST — the combination bills as the fast variant", () => {
+    expect(() =>
+      step.execute(
+        contextFor({
+          modelName: "claude-opus-4-6",
+          serviceTier: ServiceTier.FAST,
+          thinkingMode: ThinkingMode.ENABLED,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("ENABLED without model_name fails closed (no thinking-on-Auto)", () => {
+    const err = refusal({ thinkingMode: ThinkingMode.ENABLED });
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("requires execution_config.model_name");
+    // Thinking-capable suggestions ride along.
+    expect(err.rawMessage).toContain("claude-opus-4-6");
+  });
+
+  it("ENABLED on a cursor model without the capability fails closed", () => {
+    const err = refusal({
+      modelName: "composer-2.5",
+      thinkingMode: ThinkingMode.ENABLED,
+    });
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("no thinking capability");
+    expect(err.rawMessage).toContain("composer-2.5");
+  });
+
+  it("ENABLED on a native-only model fails closed (no native wire mapping in v1)", () => {
+    const err = refusal({
+      modelName: "claude-sonnet-4.6",
+      thinkingMode: ThinkingMode.ENABLED,
+    });
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("cursor");
+    expect(err.rawMessage).toContain("claude-sonnet-4.6");
+  });
+
+  it("ENABLED on an unknown model fails closed", () => {
+    const err = refusal({
+      modelName: "not-a-model",
+      thinkingMode: ThinkingMode.ENABLED,
+    });
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/corpus-support.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/corpus-support.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared-corpus test support — the TS-server edition of Go's
+ * corpus_path_test.go + fixtures_test.go decode helpers. Locates the
+ * cross-edition HITL corpus (apis/testdata/hitl) through this file's
+ * compiled-in source path, decodes raw protojson bodies with the
+ * generated schemas (a malformed fixture fails loudly, never silently
+ * skips), and diffs pending-approval sets order-independently by
+ * tool_call_id.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { equals, fromJson } from "@bufbuild/protobuf";
+import type { JsonValue } from "@bufbuild/protobuf";
+
+import type { PendingApproval } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import { PendingApprovalSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+import { SubAgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+
+/**
+ * The corpus root: this file lives at
+ * backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/,
+ * eight directories above which is the repo root; the corpus lives under
+ * apis/testdata/hitl.
+ */
+export function hitlCorpusDir(): string {
+  return path.join(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "../../../../../../../..",
+    "apis/testdata/hitl",
+  );
+}
+
+/** The corpus .json files of a subdirectory, schema.json excluded. */
+export function corpusFiles(subdir: string): string[] {
+  const dir = path.join(hitlCorpusDir(), subdir);
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".json") && name !== "schema.json")
+    .map((name) => path.join(dir, name));
+}
+
+export function readCorpusJson(filePath: string): JsonValue {
+  return JSON.parse(readFileSync(filePath, "utf-8")) as JsonValue;
+}
+
+export function decodeMessages(raws: JsonValue[] | undefined): AgentMessage[] {
+  return (raws ?? []).map((raw) => fromJson(AgentMessageSchema, raw));
+}
+
+export function decodeSubAgents(
+  raws: JsonValue[] | undefined,
+): SubAgentExecution[] {
+  return (raws ?? []).map((raw) => fromJson(SubAgentExecutionSchema, raw));
+}
+
+export function decodePendingApprovals(
+  raws: JsonValue[] | undefined,
+): PendingApproval[] {
+  const out = (raws ?? []).map((raw) => fromJson(PendingApprovalSchema, raw));
+  out.sort((a, b) => (a.toolCallId < b.toolCallId ? -1 : 1));
+  return out;
+}
+
+/**
+ * Order-independent diff by tool_call_id (the test-side twin of the
+ * production seam's cross-check diff); "" when semantically equal.
+ */
+export function diffPendingApprovals(
+  want: PendingApproval[],
+  got: PendingApproval[],
+): string {
+  const wantById = new Map(want.map((pa) => [pa.toolCallId, pa]));
+  const gotById = new Map(got.map((pa) => [pa.toolCallId, pa]));
+  if (wantById.size !== want.length || gotById.size !== got.length) {
+    return "duplicate tool_call_id within a projection set";
+  }
+
+  const diffs: string[] = [];
+  for (const [id, pa] of wantById) {
+    const other = gotById.get(id);
+    if (other === undefined) {
+      diffs.push(`missing:${id}`);
+      continue;
+    }
+    if (!equals(PendingApprovalSchema, pa, other)) {
+      diffs.push(`field-mismatch:${id}`);
+    }
+  }
+  for (const id of gotById.keys()) {
+    if (!wantById.has(id)) {
+      diffs.push(`unexpected:${id}`);
+    }
+  }
+  diffs.sort();
+  return diffs.join(",");
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/lease-scope-corpus.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/lease-scope-corpus.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The TS-server half of the cross-edition lease-scope parity gate
+ * (apis/testdata/hitl/lease-scope) — ports lease_scope_corpus_test.go +
+ * lease_scope_test.go: every vector derives through deriveLeaseScope and
+ * must equal the expected scope. The runner (TS) and Cloud (Java)
+ * editions load the same file, so a drift fails one of the suites.
+ */
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { ToolCallSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import { deriveLeaseScope, sameLeaseScope } from "../lease-scope.js";
+import { hitlCorpusDir, readCorpusJson } from "./corpus-support.js";
+
+interface LeaseScopeVector {
+  name: string;
+  input: { toolName?: string; mcpServerSlug?: string };
+  expected: { category?: string; server?: string } | null;
+}
+
+describe("shared lease-scope corpus", () => {
+  const doc = readCorpusJson(
+    path.join(hitlCorpusDir(), "lease-scope", "vectors.json"),
+  ) as unknown as { vectors: LeaseScopeVector[] };
+
+  // Guard the guard (Go asserts >= 10 too).
+  it("discovers the corpus", () => {
+    expect(doc.vectors.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const v of doc.vectors) {
+    it(v.name, () => {
+      const tc = create(ToolCallSchema, {
+        name: v.input.toolName ?? "",
+        mcpServerSlug: v.input.mcpServerSlug ?? "",
+      });
+      const scope = deriveLeaseScope(tc);
+
+      if (v.expected === null) {
+        expect(scope, "expected no leasable scope").toBeUndefined();
+        return;
+      }
+      expect(scope, "expected a leasable scope").toBeDefined();
+      expect(
+        sameLeaseScope(scope as NonNullable<typeof scope>, {
+          category: v.expected.category ?? "",
+          server: v.expected.server ?? "",
+        }),
+      ).toBe(true);
+    });
+  }
+});
+
+describe("deriveLeaseScope unit pins (lease_scope_test.go)", () => {
+  it("an MCP slug takes precedence over any category lookup", () => {
+    const scope = deriveLeaseScope(
+      create(ToolCallSchema, { name: "shell", mcpServerSlug: "github" }),
+    );
+    expect(scope).toEqual({ category: "", server: "github" });
+  });
+
+  it("a gated built-in derives its category", () => {
+    const scope = deriveLeaseScope(create(ToolCallSchema, { name: "Write" }));
+    expect(scope).toEqual({ category: "write", server: "" });
+  });
+
+  it("a read-only or unknown tool has no leasable scope", () => {
+    expect(
+      deriveLeaseScope(create(ToolCallSchema, { name: "read_file" })),
+    ).toBeUndefined();
+    expect(
+      deriveLeaseScope(create(ToolCallSchema, { name: "" })),
+    ).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/policy-source-corpus.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/policy-source-corpus.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The TS-server half of the cross-edition authorization-provenance parity
+ * gate (apis/testdata/hitl/policy-source) — ports
+ * policy_source_corpus_test.go: every vector's proto enum name must
+ * resolve, through the generated ApprovalPolicySource descriptor, to the
+ * pinned number, and the reverse mapping must agree. A renumbering in any
+ * edition fails one of the suites.
+ */
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ApprovalPolicySourceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import { hitlCorpusDir, readCorpusJson } from "./corpus-support.js";
+
+interface PolicySourceVector {
+  name: string;
+  name_proto: string;
+  number: number;
+}
+
+describe("shared policy-source corpus", () => {
+  const doc = readCorpusJson(
+    path.join(hitlCorpusDir(), "policy-source", "vectors.json"),
+  ) as unknown as { vectors: PolicySourceVector[] };
+
+  // Guard the guard: the corpus must cover every enum value, so a
+  // silently truncated file cannot pass for the wrong reason.
+  it("covers every enum value", () => {
+    expect(doc.vectors.length).toBe(ApprovalPolicySourceSchema.values.length);
+  });
+
+  for (const v of doc.vectors) {
+    it(v.name, () => {
+      const byName = ApprovalPolicySourceSchema.values.find(
+        (value) => value.name === v.name_proto,
+      );
+      expect(byName, `enum name ${v.name_proto} exists`).toBeDefined();
+      expect(byName?.number).toBe(v.number);
+
+      // The reverse map must agree, locking the name<->number pairing.
+      const byNumber = ApprovalPolicySourceSchema.values.find(
+        (value) => value.number === v.number,
+      );
+      expect(byNumber?.name).toBe(v.name_proto);
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/scenarios-corpus.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/scenarios-corpus.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The TS-server half of the cross-edition HITL scenario corpus
+ * (apis/testdata/hitl/scenarios) — ports fixtures_test.go: every scenario
+ * is projected BOTH ways (message scan and shadow event stream) and both
+ * must equal the expected pending_approvals. The Go and Java editions
+ * load the same files, so a behavioral drift in any edition fails one of
+ * the suites.
+ */
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { computePendingApprovals } from "../compute.js";
+import { computePendingApprovalsFromEvents } from "../compute-from-events.js";
+import { emitApprovalEvents } from "../emit.js";
+import {
+  corpusFiles,
+  decodeMessages,
+  decodePendingApprovals,
+  decodeSubAgents,
+  diffPendingApprovals,
+  readCorpusJson,
+} from "./corpus-support.js";
+
+interface ScenarioFixture {
+  name: string;
+  input: {
+    messages?: unknown[];
+    sub_agent_executions?: unknown[];
+  };
+  expected: {
+    pending_approvals?: unknown[];
+  };
+}
+
+describe("shared HITL scenario corpus", () => {
+  const files = corpusFiles("scenarios");
+
+  // Guard the guard: a silently empty corpus would pass for the wrong
+  // reason. The plan mandates >= 10 scenarios (Go asserts the same).
+  it("discovers the corpus", () => {
+    expect(files.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const file of files) {
+    it(path.basename(file), () => {
+      const fx = readCorpusJson(file) as unknown as ScenarioFixture;
+
+      const messages = decodeMessages(fx.input.messages as never);
+      const subAgents = decodeSubAgents(fx.input.sub_agent_executions as never);
+      const want = decodePendingApprovals(
+        fx.expected.pending_approvals as never,
+      );
+
+      // Path 1: the message scan.
+      const fromScan = computePendingApprovals(messages, subAgents);
+      expect(
+        diffPendingApprovals(want, fromScan),
+        "message-scan projection != expected",
+      ).toBe("");
+
+      // Path 2: the event-stream projection over the shadow seed must
+      // agree with the same expectation — the parity the corpus enforces.
+      const fromEvents = computePendingApprovalsFromEvents(
+        emitApprovalEvents(messages, subAgents),
+      );
+      expect(
+        diffPendingApprovals(want, fromEvents),
+        "event-stream projection != expected",
+      ).toBe("");
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/sequence-corpus.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/__tests__/sequence-corpus.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The TS-server half of the cross-edition sequence corpus
+ * (apis/testdata/hitl/sequences) — ports sequence_corpus_test.go. Where
+ * the scenario corpus locks a single input → pending_approvals
+ * projection, this replays the stateful, persisted-append path: each
+ * sequence is a series of write sites over a carried-forward
+ * approval_event_stream, and after EVERY step (1) the seam result equals
+ * expected.pending_approvals, (2) for a live execution the two
+ * projections agree (the equality-at-every-write-site property the
+ * source-of-truth flip rides on), and (3) the authored lifecycle matches
+ * expected.stream_events. The divergence counter must not move across a
+ * well-formed sequence.
+ */
+import path from "node:path";
+
+import { create, enumFromJson, enumToJson } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type {
+  ApprovalEvent,
+  ApprovalEventStream,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import {
+  ApprovalAction,
+  ApprovalActionSchema,
+  ApprovalEventType,
+  ApprovalEventTypeSchema,
+  ApprovalRetractionReasonSchema,
+  ExecutionPhase,
+  ExecutionPhaseSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import { createLogger } from "../../../../boot/logger.js";
+import { ensureApprovalRequests, recordDecisionEvent } from "../author.js";
+import { computePendingApprovals, isTerminalExecution } from "../compute.js";
+import { computePendingApprovalsFromEvents } from "../compute-from-events.js";
+import { isGatedToolCall } from "../emit.js";
+import {
+  pendingApprovalDivergenceCount,
+  projectPendingApprovals,
+} from "../project.js";
+import {
+  corpusFiles,
+  decodeMessages,
+  decodePendingApprovals,
+  decodeSubAgents,
+  diffPendingApprovals,
+  readCorpusJson,
+} from "./corpus-support.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+interface SequenceFile {
+  name: string;
+  execution_id: string;
+  steps: SequenceStep[];
+}
+
+interface SequenceStep {
+  name: string;
+  status: {
+    phase?: string;
+    messages?: unknown[];
+    sub_agent_executions?: unknown[];
+  };
+  decisions?: SequenceDecision[];
+  expected: {
+    pending_approvals?: unknown[];
+    stream_events?: StreamEventView[];
+  };
+}
+
+interface SequenceDecision {
+  tool_call_id: string;
+  action: string;
+  decided_by: string;
+  comment: string;
+  decided_at: string;
+}
+
+/**
+ * The normalized cross-edition event view: transition type, correlation
+ * id, and (for a retraction) its reason — deliberately NOT the internal
+ * event_id/timestamp/actor (locked by per-edition unit tests).
+ */
+interface StreamEventView {
+  approval_request_id: string;
+  event_type: string;
+  reason?: string;
+}
+
+function parsePhase(s: string | undefined): ExecutionPhase {
+  if (s === undefined || s === "") {
+    return ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+  }
+  return enumFromJson(ExecutionPhaseSchema, s);
+}
+
+function parseAction(s: string): ApprovalAction {
+  return enumFromJson(ApprovalActionSchema, s);
+}
+
+function findToolCall(
+  status: AgentExecutionStatus,
+  id: string,
+): ToolCall | undefined {
+  for (const msg of status.messages) {
+    for (const tc of msg.toolCalls) {
+      if (tc.id === id) {
+        return tc;
+      }
+    }
+  }
+  for (const sa of status.subAgentExecutions) {
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        if (tc.id === id) {
+          return tc;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizeStreamEvent(ev: ApprovalEvent): string {
+  const type = enumToJson(ApprovalEventTypeSchema, ev.eventType) as string;
+  let reason = "";
+  if (
+    ev.eventType === ApprovalEventType.RETRACTED &&
+    ev.payload.case === "retracted"
+  ) {
+    reason = enumToJson(
+      ApprovalRetractionReasonSchema,
+      ev.payload.value.reason,
+    ) as string;
+  }
+  return `${ev.approvalRequestId}|${type}|${reason}`;
+}
+
+/** Order-independent multiset diff of normalized stream-event views. */
+function diffStreamEvents(
+  want: StreamEventView[],
+  stream: ApprovalEventStream | undefined,
+): string {
+  const wantCounts = new Map<string, number>();
+  for (const e of want) {
+    const key = `${e.approval_request_id}|${e.event_type}|${e.reason ?? ""}`;
+    wantCounts.set(key, (wantCounts.get(key) ?? 0) + 1);
+  }
+  const gotCounts = new Map<string, number>();
+  for (const ev of stream?.events ?? []) {
+    const key = normalizeStreamEvent(ev);
+    gotCounts.set(key, (gotCounts.get(key) ?? 0) + 1);
+  }
+
+  const diffs: string[] = [];
+  for (const [key, n] of gotCounts) {
+    if ((wantCounts.get(key) ?? 0) !== n) {
+      diffs.push(`unexpected:${key}`);
+    }
+  }
+  for (const [key, n] of wantCounts) {
+    if ((gotCounts.get(key) ?? 0) !== n) {
+      diffs.push(`missing:${key}`);
+    }
+  }
+  diffs.sort();
+  return diffs.join(",");
+}
+
+describe("shared HITL sequence corpus", () => {
+  const files = corpusFiles("sequences");
+
+  // Guard the guard: a silently empty corpus would pass for the wrong
+  // reason (Go asserts >= 6 too).
+  it("discovers the corpus", () => {
+    expect(files.length).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const file of files) {
+    it(path.basename(file), () => {
+      const seq = readCorpusJson(file) as unknown as SequenceFile;
+      expect(seq.steps.length).toBeGreaterThan(0);
+
+      // The carried-forward stream is the only state threaded across
+      // steps — exactly what production persists.
+      let stream: ApprovalEventStream | undefined;
+
+      const divergenceBefore = pendingApprovalDivergenceCount();
+
+      for (const step of seq.steps) {
+        const messages = decodeMessages(step.status.messages as never);
+        const subAgents = decodeSubAgents(
+          step.status.sub_agent_executions as never,
+        );
+        const phase = parsePhase(step.status.phase);
+
+        const status = create(AgentExecutionStatusSchema, {
+          phase,
+          messages,
+          subAgentExecutions: subAgents,
+        });
+        if (stream !== undefined) {
+          status.approvalEventStream = stream;
+        }
+
+        // Reproduce the production authoring for the step's write-site
+        // type. A decision target must be pre-decision gated, or the
+        // corpus would model a state the handler never produces.
+        for (const d of step.decisions ?? []) {
+          const tc = findToolCall(status, d.tool_call_id);
+          expect(tc, `decision target ${d.tool_call_id} in status`).toBeDefined();
+          expect(
+            isGatedToolCall(tc as ToolCall) &&
+              (tc as ToolCall).approvalAction === ApprovalAction.UNSPECIFIED,
+            `decision target ${d.tool_call_id} pre-decision gated`,
+          ).toBe(true);
+        }
+
+        ensureApprovalRequests(status, seq.execution_id);
+
+        for (const d of step.decisions ?? []) {
+          const tc = findToolCall(status, d.tool_call_id) as ToolCall;
+          tc.approvalAction = parseAction(d.action);
+          tc.approvalDecidedAt = d.decided_at;
+          tc.approvedBy = d.decided_by;
+          recordDecisionEvent(status, tc, d.decided_by, d.comment);
+        }
+
+        stream = status.approvalEventStream;
+
+        // (1) Value contract: the real seam, as production calls it.
+        const got = projectPendingApprovals(
+          phase,
+          messages,
+          subAgents,
+          stream,
+          silentLogger,
+        );
+        const want = decodePendingApprovals(
+          step.expected.pending_approvals as never,
+        );
+        expect(
+          diffPendingApprovals(want, got),
+          `step ${step.name}: seam pending_approvals`,
+        ).toBe("");
+
+        // (2) Equality-at-every-write-site for live executions.
+        if (!isTerminalExecution(phase)) {
+          const fromScan = computePendingApprovals(messages, subAgents);
+          const fromEvents = computePendingApprovalsFromEvents(stream);
+          expect(
+            diffPendingApprovals(fromScan, fromEvents),
+            `step ${step.name}: equality-at-write-site`,
+          ).toBe("");
+        }
+
+        // (3) Lifecycle: the authored stream's normalized event view.
+        expect(
+          diffStreamEvents(step.expected.stream_events ?? [], stream),
+          `step ${step.name}: stream_events`,
+        ).toBe("");
+      }
+
+      expect(
+        pendingApprovalDivergenceCount(),
+        "divergence counter must not move across a well-formed sequence",
+      ).toBe(divergenceBefore);
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/author.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/author.ts
@@ -1,0 +1,280 @@
+/**
+ * Authors the PERSISTED approval-event stream
+ * (AgentExecutionStatus.approval_event_stream) — ports approval/author.go.
+ *
+ * Two commands, one writer per event type:
+ *   - ensureApprovalRequests authors REQUESTED events (the UpdateStatus
+ *     handlers own it; it also seeds the stream once for executions that
+ *     predate the field) and, on the same pass, authors RETRACTED events
+ *     for in-flight orphans so the lifecycle is total.
+ *   - recordDecisionEvent authors a single decision event (the
+ *     SubmitApproval handler owns it, carrying decided_by + the user's
+ *     comment).
+ *
+ * Every append is keyed by the deterministic ApprovalEvent.event_id, so
+ * both commands are idempotent under retries and a rich decision event —
+ * written in the same operation that records the decision on the message
+ * scan — can never be duplicated or clobbered by the coarse decision the
+ * seed derives. The projection seam (project.ts) stays a pure read over
+ * whatever these commands have written.
+ */
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { ApprovalEventStream } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import { create } from "@bufbuild/protobuf";
+import { ApprovalEventStreamSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import {
+  ApprovalEventType,
+  ApprovalRetractionReason,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  AgentMessage,
+  ToolCall,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import {
+  computePendingApprovals,
+  isTerminalExecution,
+  isTerminalSubAgent,
+} from "./compute.js";
+import { isResolvingEvent } from "./compute-from-events.js";
+import {
+  buildDecisionEvent,
+  buildRequestedEvent,
+  buildRetractionEvent,
+  emitApprovalEvents,
+  isGatedToolCall,
+} from "./emit.js";
+
+/**
+ * Records a REQUESTED event for every tool call currently in the approval
+ * gate, mutating status.approval_event_stream in place. The sole writer
+ * of REQUESTED events; called at every UpdateStatus site and at the start
+ * of the SubmitApproval transaction (before the decision is recorded, so
+ * a request always precedes its decision).
+ *
+ * When the stream is empty it is seeded once from the authoritative
+ * message scan (emitApprovalEvents): for a new execution that is just the
+ * REQUESTED events; for an execution predating the field it is REQUESTED
+ * plus the coarse decisions already recorded on the scan, so the ledger
+ * is consistent from first touch without spurious projection-divergence
+ * warnings. Thereafter only REQUESTED events are appended (decisions are
+ * authored by recordDecisionEvent), keeping the parity check a real
+ * cross-writer guard rather than a tautology.
+ *
+ * executionId stamps the stream's identity on first seed; informational,
+ * never used for correlation. Correlation is by approval_request_id,
+ * which equals tool_call_id by a deliberate, documented decision.
+ */
+export function ensureApprovalRequests(
+  status: AgentExecutionStatus | undefined,
+  executionId: string,
+): void {
+  if (status === undefined) {
+    return;
+  }
+
+  const stream = status.approvalEventStream;
+  if (stream === undefined || stream.events.length === 0) {
+    const seeded = emitApprovalEvents(
+      status.messages,
+      status.subAgentExecutions,
+    );
+    seeded.executionId = executionId;
+    status.approvalEventStream = seeded;
+    return;
+  }
+
+  const seen = eventIdSet(stream);
+  appendRequestedIfAbsent(stream, seen, status.messages, false, "", "");
+  for (const sa of status.subAgentExecutions) {
+    // Mirror the scan and the seed: a terminal sub-agent's gated tool
+    // calls are orphans and must not surface, so never author requests
+    // for them.
+    if (isTerminalSubAgent(sa.status)) {
+      continue;
+    }
+    appendRequestedIfAbsent(stream, seen, sa.messages, true, sa.name, sa.subject);
+  }
+
+  reconcileRetractions(status, stream, seen);
+}
+
+/**
+ * Completes the approval lifecycle by authoring a RETRACTED event for
+ * every in-flight per-call orphan: a REQUESTED whose gated call has left
+ * the gate WITHOUT a user decision while the execution is still live (its
+ * sub-agent reached a terminal state, or the harness superseded the call
+ * on resume). Without this, the append-only stream would keep the orphan
+ * REQUESTED forever and the event-stream projection would report a
+ * phantom pending approval the message scan already dropped.
+ *
+ * It is the mirror image of the message scan's two non-decision exits;
+ * two invariants keep it from ever OVER-retracting (which would crash a
+ * parked execution to FAILED via the WAITING ⟺ ≥1 pending fail-fast):
+ *   - Terminal executions are skipped entirely — they project to empty
+ *     via the phase-aware seam, so a dangling REQUESTED on a dead
+ *     execution is explained by the phase, not an orphan to retract.
+ *   - A call still in the gate (present in the scan) or already resolved
+ *     (a decision or prior retraction exists) is never retracted. In
+ *     particular, the SubmitApproval pre-decision ensure runs while the
+ *     clicked and APPROVE_ALL co-pending calls are still gated, so they
+ *     are never false-retracted.
+ */
+function reconcileRetractions(
+  status: AgentExecutionStatus,
+  stream: ApprovalEventStream,
+  seen: Set<string>,
+): void {
+  if (isTerminalExecution(status.phase)) {
+    return;
+  }
+
+  const gated = gatedToolCallIds(status);
+  const resolved = resolvedRequestIds(stream);
+
+  // Snapshot the events: retractions are appended below, and iterating a
+  // snapshot keeps the pass from considering its own output.
+  const original = [...stream.events];
+  for (const ev of original) {
+    if (ev.eventType !== ApprovalEventType.REQUESTED) {
+      continue;
+    }
+    const reqId = ev.approvalRequestId;
+    if (gated.has(reqId)) {
+      continue;
+    }
+    if (resolved.has(reqId)) {
+      continue;
+    }
+    const event = buildRetractionEvent(reqId, retractionReason(status, reqId));
+    if (seen.has(event.eventId)) {
+      continue;
+    }
+    stream.events.push(event);
+    seen.add(event.eventId);
+  }
+}
+
+/**
+ * The set of tool_call_ids still in the approval gate per the
+ * authoritative message scan — i.e. the REQUESTED events that must NOT be
+ * retracted. reconcileRetractions only runs for non-terminal executions,
+ * where the scan is the exact live gate set.
+ */
+function gatedToolCallIds(status: AgentExecutionStatus): Set<string> {
+  const pending = computePendingApprovals(
+    status.messages,
+    status.subAgentExecutions,
+  );
+  return new Set(pending.map((pa) => pa.toolCallId));
+}
+
+/**
+ * The set of approval_request_ids already carrying a terminal event — a
+ * user decision (APPROVED/REJECTED/SKIPPED) or a prior RETRACTED — so
+ * reconcileRetractions never double-resolves an approval.
+ */
+function resolvedRequestIds(stream: ApprovalEventStream): Set<string> {
+  const resolved = new Set<string>();
+  for (const ev of stream.events) {
+    if (isResolvingEvent(ev.eventType)) {
+      resolved.add(ev.approvalRequestId);
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Classifies why an in-flight request was orphaned, for the audit trail
+ * only. A call still located inside a now-terminal sub-agent was orphaned
+ * by that sub-agent finishing; anything else (a root call, or a call
+ * whose status advanced off WAITING_APPROVAL) was superseded.
+ */
+function retractionReason(
+  status: AgentExecutionStatus,
+  requestId: string,
+): ApprovalRetractionReason {
+  for (const sa of status.subAgentExecutions) {
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        if (tc.id === requestId) {
+          if (isTerminalSubAgent(sa.status)) {
+            return ApprovalRetractionReason.SUB_AGENT_TERMINAL;
+          }
+          return ApprovalRetractionReason.SUPERSEDED;
+        }
+      }
+    }
+  }
+  return ApprovalRetractionReason.SUPERSEDED;
+}
+
+function appendRequestedIfAbsent(
+  stream: ApprovalEventStream,
+  seen: Set<string>,
+  messages: AgentMessage[],
+  fromSubAgent: boolean,
+  subAgentName: string,
+  subAgentSubject: string,
+): void {
+  for (const msg of messages) {
+    for (const tc of msg.toolCalls) {
+      if (!isGatedToolCall(tc)) {
+        continue;
+      }
+      const event = buildRequestedEvent(
+        tc,
+        fromSubAgent,
+        subAgentName,
+        subAgentSubject,
+      );
+      if (seen.has(event.eventId)) {
+        continue;
+      }
+      stream.events.push(event);
+      seen.add(event.eventId);
+    }
+  }
+}
+
+/**
+ * Appends the decision event for a single decided tool call, carrying
+ * decided_by and the user's comment. The sole writer of decision events
+ * (the SubmitApproval handler), called once for the clicked tool call
+ * (with the comment) and once per co-pending tool call an APPROVE_ALL
+ * bulk-approves (with an empty comment — the escalation comment belongs
+ * to the clicked tool).
+ *
+ * A no-op when the tool call carries no decision, and append-if-absent by
+ * event_id so a repeated submit or a later coarse seed never
+ * double-records.
+ */
+export function recordDecisionEvent(
+  status: AgentExecutionStatus | undefined,
+  tc: ToolCall,
+  decidedBy: string,
+  comment: string,
+): void {
+  if (status === undefined) {
+    return;
+  }
+  const event = buildDecisionEvent(tc, decidedBy, comment);
+  if (event === undefined) {
+    return;
+  }
+
+  let stream = status.approvalEventStream;
+  if (stream === undefined) {
+    stream = create(ApprovalEventStreamSchema);
+    status.approvalEventStream = stream;
+  }
+  if (stream.events.some((ev) => ev.eventId === event.eventId)) {
+    return;
+  }
+  stream.events.push(event);
+}
+
+/** Indexes a stream's events by event_id for append-if-absent checks. */
+function eventIdSet(stream: ApprovalEventStream): Set<string> {
+  return new Set(stream.events.map((ev) => ev.eventId));
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/compute-from-events.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/compute-from-events.ts
@@ -1,0 +1,92 @@
+/**
+ * The pending-approvals EVENT-STREAM projection — ports
+ * approval/compute_from_events.go: every REQUESTED event whose approval
+ * has not been resolved by a later terminal event — a user decision
+ * (APPROVED/REJECTED/SKIPPED) or a system RETRACTED.
+ *
+ * This is the AUTHORITATIVE projection: projectPendingApprovals returns
+ * its result. For a given execution it must produce the same set as the
+ * retained message-scan cross-check; project.ts asserts that equality in
+ * production and the shared HITL corpus asserts it in CI. The RETRACTED
+ * resolution is what lets the two agree for the in-flight orphan exits
+ * the scan handles structurally — see reconcileRetractions (author.ts).
+ * Terminal-execution gate-exits are handled one level up, by the
+ * phase-aware seam, not here. Correlation is by approval_request_id
+ * (today, the tool_call_id).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type {
+  ApprovalEventStream,
+  ApprovalRequest,
+  PendingApproval,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import { PendingApprovalSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import { ApprovalEventType } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+export function computePendingApprovalsFromEvents(
+  stream: ApprovalEventStream | undefined,
+): PendingApproval[] {
+  if (stream === undefined) {
+    return [];
+  }
+
+  const resolved = new Set<string>();
+  for (const ev of stream.events) {
+    if (isResolvingEvent(ev.eventType)) {
+      resolved.add(ev.approvalRequestId);
+    }
+  }
+
+  const result: PendingApproval[] = [];
+  for (const ev of stream.events) {
+    if (ev.eventType !== ApprovalEventType.REQUESTED) {
+      continue;
+    }
+    if (resolved.has(ev.approvalRequestId)) {
+      continue;
+    }
+    if (ev.payload.case === "requested") {
+      result.push(pendingApprovalFromRequest(ev.payload.value));
+    }
+  }
+  return result;
+}
+
+/**
+ * Whether an event type terminally resolves a REQUESTED: the three user
+ * decisions plus the system RETRACTED. A resolved request never appears
+ * in the pending projection.
+ */
+export function isResolvingEvent(t: ApprovalEventType): boolean {
+  switch (t) {
+    case ApprovalEventType.APPROVED:
+    case ApprovalEventType.REJECTED:
+    case ApprovalEventType.SKIPPED:
+    case ApprovalEventType.RETRACTED:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Reconstructs a PendingApproval from a REQUESTED event's payload.
+ * ApprovalRequest intentionally carries the same display fields as
+ * PendingApproval so this projection needs no join back to the ToolCall.
+ */
+function pendingApprovalFromRequest(req: ApprovalRequest): PendingApproval {
+  return create(PendingApprovalSchema, {
+    toolCallId: req.toolCallId,
+    toolName: req.toolName,
+    message: req.message,
+    argsPreview: req.argsPreview,
+    requestedAt: req.requestedAt,
+    fromSubAgent: req.fromSubAgent,
+    subAgentName: req.subAgentName,
+    subAgentSubject: req.subAgentSubject,
+    mcpServerSlug: req.mcpServerSlug,
+    toolKind: req.toolKind,
+    approvalPolicySource: req.approvalPolicySource,
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/compute.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/compute.ts
@@ -1,0 +1,143 @@
+/**
+ * The pending-approvals MESSAGE SCAN — ports approval/compute.go.
+ *
+ * A tool call qualifies as pending when:
+ *   - status == TOOL_CALL_WAITING_APPROVAL
+ *   - requires_approval == true
+ *   - approval_action == UNSPECIFIED (no decision recorded yet)
+ *
+ * Since the source-of-truth flip this is the retained CROSS-CHECK, not
+ * the returned result: projectPendingApprovals (project.ts) returns the
+ * event-stream projection and runs this scan only to assert the two
+ * agree. It is recomputed from the tool-call state in messages, which the
+ * runner still writes authoritatively.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  SubAgentStatus,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { PendingApproval } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import { PendingApprovalSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import type {
+  AgentMessage,
+  ToolCall,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+
+export function computePendingApprovals(
+  messages: AgentMessage[],
+  subAgentExecutions: SubAgentExecution[],
+): PendingApproval[] {
+  const result: PendingApproval[] = [];
+
+  for (const msg of messages) {
+    for (const tc of msg.toolCalls) {
+      const pa = projectToolCall(tc, false, "", "");
+      if (pa !== undefined) {
+        result.push(pa);
+      }
+    }
+  }
+
+  for (const sa of subAgentExecutions) {
+    if (isTerminalSubAgent(sa.status)) {
+      continue;
+    }
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        const pa = projectToolCall(tc, true, sa.name, sa.subject);
+        if (pa !== undefined) {
+          result.push(pa);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Whether the execution has reached a final phase. A terminal execution
+ * has no actionable pending approvals — the workflow that would resume a
+ * gated call no longer exists — so the projection seam collapses
+ * pending_approvals to empty for these phases regardless of stale
+ * tool-call state left in the transcript. This makes every
+ * terminal-execution gate-exit (cancel / fail / terminate) correct
+ * without authoring a per-call retraction event, and closes the
+ * pre-existing edition split where OSS cleared a failed-at-gate
+ * execution's pending_approvals via an incidental message wipe while
+ * Cloud retained them.
+ */
+export function isTerminalExecution(phase: ExecutionPhase): boolean {
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_COMPLETED:
+    case ExecutionPhase.EXECUTION_FAILED:
+    case ExecutionPhase.EXECUTION_CANCELLED:
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Sub-agents that have reached a final lifecycle state. Any
+ * WAITING_APPROVAL tool calls left inside a terminal sub-agent are
+ * orphans and must not appear in pending_approvals.
+ */
+export function isTerminalSubAgent(status: SubAgentStatus): boolean {
+  switch (status) {
+    case SubAgentStatus.SUB_AGENT_COMPLETED:
+    case SubAgentStatus.SUB_AGENT_FAILED:
+    case SubAgentStatus.SUB_AGENT_CANCELLED:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function projectToolCall(
+  tc: ToolCall,
+  fromSubAgent: boolean,
+  subAgentName: string,
+  subAgentSubject: string,
+): PendingApproval | undefined {
+  if (tc.status !== ToolCallStatus.TOOL_CALL_WAITING_APPROVAL) {
+    return undefined;
+  }
+  if (!tc.requiresApproval) {
+    return undefined;
+  }
+  if (tc.approvalAction !== ApprovalAction.UNSPECIFIED) {
+    return undefined;
+  }
+
+  return create(PendingApprovalSchema, {
+    toolCallId: tc.id,
+    toolName: tc.name,
+    message: tc.approvalMessage,
+    argsPreview: tc.argsPreview,
+    requestedAt: tc.approvalRequestedAt,
+    fromSubAgent,
+    subAgentName,
+    // Mirrors Java PendingApprovalComputer: the sub-agent's task subject
+    // lets approval surfaces label the card with the task instead of the
+    // generic agent type. Empty for root tool calls.
+    subAgentSubject,
+    mcpServerSlug: tc.mcpServerSlug,
+    // Denormalized for approval surfaces (like mcpServerSlug) so the
+    // approval UI classifies the tool without re-deriving it.
+    toolKind: tc.toolKind,
+    // Denormalized (like toolKind) so the approval surface can explain
+    // WHY the tool is gated without re-deriving the policy. Runner-written
+    // on the ToolCall; copied through verbatim. The authoritative
+    // event-stream projection copies it too (emit.ts /
+    // compute-from-events.ts) so projectPendingApprovals fromEvents ==
+    // fromScan holds (this scan is the retained cross-check).
+    approvalPolicySource: tc.approvalPolicySource,
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/emit.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/emit.ts
@@ -1,0 +1,274 @@
+/**
+ * Approval-event construction + the shadow seed — ports approval/emit.go.
+ *
+ * emitApprovalEvents derives a complete append-only approval-event stream
+ * from the same authoritative tool-call state the message scan reads. It
+ * is the SEED for the persisted stream: ensureApprovalRequests
+ * (author.ts) calls it once when an execution's stream is empty, so a new
+ * execution starts with its REQUESTED events and an execution that
+ * predates the persisted field gets a consistent ledger (REQUESTED plus
+ * the coarse decisions already on the scan) without spurious
+ * projection-divergence warnings. The decisions it derives are coarse
+ * (no decided_by/comment); the rich decision is authored separately by
+ * recordDecisionEvent and wins via append-if-absent.
+ *
+ * Event ids are PERSISTED and must be byte-identical to Go's
+ * `requestID + ":" + eventType.String()` — Go's String() renders the
+ * FULL proto enum value name (e.g. "APPROVAL_EVENT_TYPE_REQUESTED"),
+ * which protobuf-es exposes via enumToJson, NOT via the prefix-stripped
+ * TS member name.
+ */
+import { create, enumToJson } from "@bufbuild/protobuf";
+
+import type {
+  ApprovalEvent,
+  ApprovalEventStream,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import {
+  ApprovalEventSchema,
+  ApprovalEventStreamSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import {
+  ApprovalAction,
+  ApprovalEventType,
+  ApprovalEventTypeSchema,
+  ApprovalRetractionReason,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  AgentMessage,
+  ToolCall,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+
+import { isTerminalSubAgent } from "./compute.js";
+
+/**
+ * Actors for approval events. REQUESTED is raised by the platform when a
+ * gated tool call appears; decisions are attributed to the user.
+ */
+export const ACTOR_SYSTEM = "system";
+export const ACTOR_USER = "user";
+
+export function emitApprovalEvents(
+  messages: AgentMessage[],
+  subAgentExecutions: SubAgentExecution[],
+): ApprovalEventStream {
+  const stream = create(ApprovalEventStreamSchema);
+
+  for (const msg of messages) {
+    for (const tc of msg.toolCalls) {
+      appendToolCallEvents(stream, tc, false, "", "");
+    }
+  }
+
+  for (const sa of subAgentExecutions) {
+    // Mirror the message scan: a terminal sub-agent's WAITING_APPROVAL
+    // tool calls are orphans and must not produce events either.
+    if (isTerminalSubAgent(sa.status)) {
+      continue;
+    }
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        appendToolCallEvents(stream, tc, true, sa.name, sa.subject);
+      }
+    }
+  }
+
+  return stream;
+}
+
+function appendToolCallEvents(
+  stream: ApprovalEventStream,
+  tc: ToolCall,
+  fromSubAgent: boolean,
+  subAgentName: string,
+  subAgentSubject: string,
+): void {
+  // Only tool calls that actually entered the approval gate produce
+  // events — a call that never required approval is invisible to the
+  // stream, exactly as it is to the message scan.
+  if (!isGatedToolCall(tc)) {
+    return;
+  }
+
+  stream.events.push(
+    buildRequestedEvent(tc, fromSubAgent, subAgentName, subAgentSubject),
+  );
+
+  // The shadow seed carries a coarse decision (no decided_by/comment);
+  // the authoritative rich decision is authored by SubmitApproval via
+  // recordDecisionEvent (author.ts). Append-if-absent by event_id
+  // guarantees the rich one, written in the same op that records the
+  // decision, always wins.
+  const decided = buildDecisionEvent(tc, "", "");
+  if (decided !== undefined) {
+    stream.events.push(decided);
+  }
+}
+
+/**
+ * Whether a tool call has entered the approval gate — the single
+ * condition under which it produces approval events. The exact gate the
+ * message scan uses (compute.ts projectToolCall), minus the decision
+ * check: a gated call produces a REQUESTED event whether or not a
+ * decision has since been recorded.
+ */
+export function isGatedToolCall(tc: ToolCall): boolean {
+  return (
+    tc.status === ToolCallStatus.TOOL_CALL_WAITING_APPROVAL &&
+    tc.requiresApproval
+  );
+}
+
+/**
+ * The REQUESTED event for a gated tool call. Callers must have confirmed
+ * isGatedToolCall(tc).
+ *
+ * approval_request_id equals the harness tool_call_id by a deliberate,
+ * documented decision (the "approval-request-id-equals-tool-call-id" HITL
+ * design decision): tool_call_id is already a stable, run-unique
+ * correlation key, so a separately minted id would be parallel state with
+ * no reader. It is never a content hash. The ApprovalRequest payload
+ * carries the same display fields as PendingApproval so the event-stream
+ * projection reconstructs the identical PendingApproval the message scan
+ * does, without joining back to the ToolCall.
+ */
+export function buildRequestedEvent(
+  tc: ToolCall,
+  fromSubAgent: boolean,
+  subAgentName: string,
+  subAgentSubject: string,
+): ApprovalEvent {
+  const requestId = tc.id;
+  return create(ApprovalEventSchema, {
+    eventId: eventId(requestId, ApprovalEventType.REQUESTED),
+    approvalRequestId: requestId,
+    eventType: ApprovalEventType.REQUESTED,
+    timestamp: tc.approvalRequestedAt,
+    actor: ACTOR_SYSTEM,
+    payload: {
+      case: "requested",
+      value: {
+        approvalRequestId: requestId,
+        toolCallId: tc.id,
+        requestedAt: tc.approvalRequestedAt,
+        toolName: tc.name,
+        message: tc.approvalMessage,
+        argsPreview: tc.argsPreview,
+        fromSubAgent,
+        subAgentName,
+        subAgentSubject,
+        mcpServerSlug: tc.mcpServerSlug,
+        toolKind: tc.toolKind,
+        // Carried so the authoritative event-stream projection
+        // reconstructs the same PendingApproval the message-scan
+        // cross-check does — keeps fromEvents == fromScan.
+        approvalPolicySource: tc.approvalPolicySource,
+      },
+    },
+  });
+}
+
+/**
+ * The decision event for a tool call carrying an approval_action, or
+ * undefined when no decision has been recorded.
+ *
+ * decidedBy and comment are the audit metadata the flat ToolCall fields
+ * cannot hold; the shadow seed passes them empty, while SubmitApproval
+ * passes the real decider and the user's comment (author.ts). The coarse
+ * event_type buckets APPROVE_ALL as APPROVED; the precise action survives
+ * on the payload's ApprovalDecision.action.
+ */
+export function buildDecisionEvent(
+  tc: ToolCall,
+  decidedBy: string,
+  comment: string,
+): ApprovalEvent | undefined {
+  const action = tc.approvalAction;
+  if (action === ApprovalAction.UNSPECIFIED) {
+    return undefined;
+  }
+
+  const requestId = tc.id;
+  const eventType = decisionEventType(action);
+  return create(ApprovalEventSchema, {
+    eventId: eventId(requestId, eventType),
+    approvalRequestId: requestId,
+    eventType,
+    timestamp: tc.approvalDecidedAt,
+    actor: ACTOR_USER,
+    payload: {
+      case: "decided",
+      value: {
+        approvalRequestId: requestId,
+        action,
+        decidedAt: tc.approvalDecidedAt,
+        decidedBy,
+        comment,
+      },
+    },
+  });
+}
+
+/**
+ * The terminal RETRACTED event for an in-flight orphaned request (see
+ * reconcileRetractions, author.ts). Reconciler-authored, not derived from
+ * a tool-call field, so it carries no source timestamp: retracted_at is
+ * left empty and ordering is conveyed by the event's position after its
+ * REQUESTED in the append-only stream. An empty timestamp is also what
+ * keeps the event byte-for-byte identical across editions for the shared
+ * HITL corpus — a clock would diverge them. The deterministic event_id
+ * (request_id:RETRACTED) makes authoring idempotent.
+ */
+export function buildRetractionEvent(
+  requestId: string,
+  reason: ApprovalRetractionReason,
+): ApprovalEvent {
+  return create(ApprovalEventSchema, {
+    eventId: eventId(requestId, ApprovalEventType.RETRACTED),
+    approvalRequestId: requestId,
+    eventType: ApprovalEventType.RETRACTED,
+    actor: ACTOR_SYSTEM,
+    payload: {
+      case: "retracted",
+      value: {
+        approvalRequestId: requestId,
+        reason,
+      },
+    },
+  });
+}
+
+/**
+ * Maps a precise ApprovalAction to the coarse lifecycle bucket carried on
+ * ApprovalEvent.event_type; APPROVE_ALL buckets as APPROVED (the precise
+ * action survives on ApprovalDecision.action).
+ */
+export function decisionEventType(action: ApprovalAction): ApprovalEventType {
+  switch (action) {
+    case ApprovalAction.APPROVE:
+    case ApprovalAction.APPROVE_ALL:
+      return ApprovalEventType.APPROVED;
+    case ApprovalAction.SKIP:
+      return ApprovalEventType.SKIPPED;
+    case ApprovalAction.REJECT:
+      return ApprovalEventType.REJECTED;
+    default:
+      return ApprovalEventType.UNSPECIFIED;
+  }
+}
+
+/**
+ * Deterministic event id from (request_id, type) — the permanent
+ * idempotency anchor for append-only authoring: a single approval has at
+ * most one event per type, so (request_id, type) is unique and
+ * re-authoring never duplicates an event. The type renders as the FULL
+ * proto enum value name, byte-identical to Go's eventType.String().
+ */
+export function eventId(
+  requestId: string,
+  eventType: ApprovalEventType,
+): string {
+  return `${requestId}:${enumToJson(ApprovalEventTypeSchema, eventType) as string}`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/lease-scope.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/lease-scope.ts
@@ -1,0 +1,53 @@
+/**
+ * LeaseScope — ports approval/lease_scope.go: the class of actions a
+ * single APPROVE_ALL decision covers (the server edition of the runner's
+ * ActiveLeases scope; see deriveActiveLeases in
+ * backend/services/runner/src/shared/approval-policy.ts).
+ *
+ * An APPROVE_ALL ("approve all of this kind") is not an all-or-nothing
+ * gate bypass: it grants a run-lifetime lease scoped to ONE class of
+ * action — the clicked tool's built-in category (write/delete/shell) for
+ * a built-in, or its MCP server for an MCP tool. Two tool calls belong to
+ * the same scope when their derived scopes are equal (compare with
+ * sameLeaseScope — TS has no comparable-struct ==).
+ *
+ * Exactly one of category/server is non-empty for a derivable scope; the
+ * derivation returns undefined when the tool has no scope (a read-only
+ * built-in, an unknown name) — callers treat that as matching nothing.
+ */
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import { toolApprovalCategory } from "./tool-category.js";
+
+export interface LeaseScope {
+  /** Built-in approval category (write/delete/shell); empty for MCP. */
+  readonly category: string;
+  /** MCP server slug; empty for a built-in. */
+  readonly server: string;
+}
+
+/**
+ * Reduces a tool call to the scope its APPROVE_ALL would lease. MCP
+ * server slug takes precedence over the built-in category lookup,
+ * matching the runner's deriveActiveLeases ordering byte-for-byte (a
+ * real built-in never carries a server slug and a real MCP tool never
+ * resolves to a category, so the order is parity insurance, not a
+ * behavioral choice). Returns undefined for a tool with no leasable
+ * scope (Go's ok=false).
+ */
+export function deriveLeaseScope(tc: ToolCall): LeaseScope | undefined {
+  const slug = tc.mcpServerSlug;
+  if (slug !== "") {
+    return { category: "", server: slug };
+  }
+  const category = toolApprovalCategory(tc.name);
+  if (category !== undefined) {
+    return { category, server: "" };
+  }
+  return undefined;
+}
+
+/** Value equality for lease scopes (Go compares the struct with ==). */
+export function sameLeaseScope(a: LeaseScope, b: LeaseScope): boolean {
+  return a.category === b.category && a.server === b.server;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/preserve.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/preserve.ts
@@ -1,0 +1,88 @@
+/**
+ * PreserveApprovalFields — ports approval/preserve.go: copies
+ * SubmitApproval-owned fields from existing (DB-loaded) tool calls onto
+ * incoming (runner-sent) tool calls that have UNSPECIFIED
+ * approval_action. This prevents updateStatus from overwriting approval
+ * decisions that were atomically recorded by SubmitApproval — the runner
+ * always sends UNSPECIFIED for these fields.
+ *
+ * The three preserved fields: approval_action, approval_decided_at,
+ * approved_by. Tool call IDs are unique across root and sub-agent
+ * messages, so a flat index is used. Incoming tool calls that already
+ * carry a non-UNSPECIFIED approval_action are left untouched.
+ */
+import { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+
+interface ApprovalSnapshot {
+  readonly action: ApprovalAction;
+  readonly decidedAt: string;
+  readonly approvedBy: string;
+}
+
+export function preserveApprovalFields(
+  incomingMessages: AgentMessage[],
+  incomingSubAgents: SubAgentExecution[],
+  existingMessages: AgentMessage[],
+  existingSubAgents: SubAgentExecution[],
+): void {
+  const index = buildApprovalIndex(existingMessages, existingSubAgents);
+  if (index.size === 0) {
+    return;
+  }
+
+  applyApprovalFields(incomingMessages, index);
+  for (const sa of incomingSubAgents) {
+    applyApprovalFields(sa.messages, index);
+  }
+}
+
+function buildApprovalIndex(
+  messages: AgentMessage[],
+  subAgentExecutions: SubAgentExecution[],
+): Map<string, ApprovalSnapshot> {
+  const index = new Map<string, ApprovalSnapshot>();
+  collectFromMessages(messages, index);
+  for (const sa of subAgentExecutions) {
+    collectFromMessages(sa.messages, index);
+  }
+  return index;
+}
+
+function collectFromMessages(
+  messages: AgentMessage[],
+  index: Map<string, ApprovalSnapshot>,
+): void {
+  for (const msg of messages) {
+    for (const tc of msg.toolCalls) {
+      if (tc.approvalAction !== ApprovalAction.UNSPECIFIED) {
+        index.set(tc.id, {
+          action: tc.approvalAction,
+          decidedAt: tc.approvalDecidedAt,
+          approvedBy: tc.approvedBy,
+        });
+      }
+    }
+  }
+}
+
+function applyApprovalFields(
+  messages: AgentMessage[],
+  index: Map<string, ApprovalSnapshot>,
+): void {
+  for (const msg of messages) {
+    for (const tc of msg.toolCalls) {
+      const snap = index.get(tc.id);
+      if (snap === undefined) {
+        continue;
+      }
+      if (tc.approvalAction !== ApprovalAction.UNSPECIFIED) {
+        continue;
+      }
+      tc.approvalAction = snap.action;
+      tc.approvalDecidedAt = snap.decidedAt;
+      tc.approvedBy = snap.approvedBy;
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/project.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/project.ts
@@ -1,0 +1,139 @@
+/**
+ * The pending-approvals projection SEAM — ports approval/project.go.
+ *
+ * projectPendingApprovals is the single entry point every caller uses to
+ * recompute pending_approvals: the persisted approval-event stream is the
+ * source of truth, and the same call runs the message scan as a
+ * cross-check and asserts the two agree.
+ *
+ * It is a PURE read — it never mutates the stream. Authoring is the job
+ * of the ensureApprovalRequests / recordDecisionEvent commands
+ * (author.ts), which callers run before this projection so the passed
+ * stream is current. That author-then-project ordering is the seam's
+ * contract.
+ *
+ * "Pending" is execution-phase-aware: a terminal execution has no
+ * actionable approvals (the workflow that would resume a gated call is
+ * gone), so the seam returns empty for a terminal phase — both
+ * projections collapse identically.
+ *
+ * The retained message scan is a cross-check, not the result: on any
+ * disagreement it bumps the process-lifetime divergence counter and emits
+ * the structured warning monitoring alerts on, without ever altering the
+ * returned value.
+ */
+import { equals } from "@bufbuild/protobuf";
+
+import type { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  ApprovalEventStream,
+  PendingApproval,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import { PendingApprovalSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/approval_pb";
+import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import { computePendingApprovals, isTerminalExecution } from "./compute.js";
+import { computePendingApprovalsFromEvents } from "./compute-from-events.js";
+
+/**
+ * Process-lifetime count of seam divergences — times the authoritative
+ * event-stream projection disagreed with the legacy message scan. The OSS
+ * regression backstop: a monotonic counter that must stay zero, readable
+ * by tests. It NEVER gates runtime — the seam always returns the
+ * event-stream result; a non-zero value is a bug to investigate, not a
+ * fallback that kicks in.
+ */
+let pendingApprovalDivergence = 0;
+
+/** The divergence total; reading it has no side effects. */
+export function pendingApprovalDivergenceCount(): number {
+  return pendingApprovalDivergence;
+}
+
+export function projectPendingApprovals(
+  phase: ExecutionPhase,
+  messages: AgentMessage[],
+  subAgentExecutions: SubAgentExecution[],
+  stream: ApprovalEventStream | undefined,
+  logger: Logger,
+): PendingApproval[] {
+  if (isTerminalExecution(phase)) {
+    return [];
+  }
+
+  const fromEvents = computePendingApprovalsFromEvents(stream);
+  const fromScan = computePendingApprovals(messages, subAgentExecutions);
+
+  const diff = diffPendingApprovals(fromScan, fromEvents);
+  if (diff !== "") {
+    // Bump the monotonic regression counter, then emit the structured
+    // signal monitoring alerts on. Behavior is never gated on either
+    // projection — fromEvents (the source of truth) is always returned.
+    pendingApprovalDivergence += 1;
+    logger.warn(
+      "pending_approvals event-stream source of truth diverged from the message-scan cross-check",
+      {
+        signal: "hitl_pending_approvals_projection_divergence",
+        scanCount: fromScan.length,
+        eventsCount: fromEvents.length,
+        divergenceTotal: pendingApprovalDivergence,
+        diff,
+      },
+    );
+  }
+
+  return fromEvents;
+}
+
+/**
+ * Compares two pending-approval sets order-independently by tool_call_id
+ * and returns a short, stable description of the differences, or "" when
+ * they are semantically equal. Used only to populate the divergence
+ * warning; never affects the projection result.
+ */
+function diffPendingApprovals(
+  scan: PendingApproval[],
+  events: PendingApproval[],
+): string {
+  const scanById = indexByToolCallId(scan);
+  const eventsById = indexByToolCallId(events);
+
+  // A collision means a set carried the same tool_call_id twice — itself
+  // a divergence-worthy bug, since pending approvals are a set keyed by
+  // call id.
+  if (scanById.size !== scan.length || eventsById.size !== events.length) {
+    return "duplicate tool_call_id within a projection set";
+  }
+
+  const diffs: string[] = [];
+  for (const [id, pa] of scanById) {
+    const other = eventsById.get(id);
+    if (other === undefined) {
+      diffs.push(`only-in-scan:${id}`);
+      continue;
+    }
+    if (!equals(PendingApprovalSchema, pa, other)) {
+      diffs.push(`field-mismatch:${id}`);
+    }
+  }
+  for (const id of eventsById.keys()) {
+    if (!scanById.has(id)) {
+      diffs.push(`only-in-events:${id}`);
+    }
+  }
+
+  diffs.sort();
+  return diffs.join(",");
+}
+
+function indexByToolCallId(
+  list: PendingApproval[],
+): Map<string, PendingApproval> {
+  const m = new Map<string, PendingApproval>();
+  for (const pa of list) {
+    m.set(pa.toolCallId, pa);
+  }
+  return m;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/tool-category.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/approval/tool-category.ts
@@ -1,0 +1,58 @@
+/**
+ * Coarse, cross-taxonomy approval category of a gated built-in tool —
+ * ports approval/tool_category.go (itself the Go edition of
+ * toolApprovalCategory in backend/services/runner/src/shared/tool-kind.ts).
+ *
+ * FILE_WRITE and FILE_EDIT both collapse to "write" on purpose: the
+ * Cursor preToolUse hook reports every file mutation (create or edit) as
+ * `Write`, while the SDK stream names them `edit`/`write`. The category
+ * is therefore the only tool identity stable across the hook and stream
+ * taxonomies. This table must stay in lockstep with the runner's
+ * TOOL_NAME_TO_KIND map (the machine-checked contract for the full
+ * classification lives in the runner's classification.json fixture; the
+ * subset reproduced here is only the gated, mutating names the category
+ * needs).
+ */
+
+/**
+ * Built-in tool name (either harness's naming) → approval category. Only
+ * mutating built-ins appear; everything else (read-only built-ins, MCP
+ * tools, unknown names) has no category and is matched by other means.
+ */
+const TOOL_NAME_TO_CATEGORY: ReadonlyMap<string, string> = new Map([
+  // FILE_WRITE + FILE_EDIT collapse to "write".
+  ["write", "write"],
+  ["write_file", "write"],
+  ["create_file", "write"],
+  ["overwrite_file", "write"],
+  ["Write", "write"],
+  ["edit", "write"],
+  ["edit_file", "write"],
+  ["str_replace_editor", "write"],
+  ["StrReplace", "write"],
+  ["EditNotebook", "write"],
+
+  // FILE_DELETE.
+  ["delete", "delete"],
+  ["delete_file", "delete"],
+  ["remove_file", "delete"],
+  ["Delete", "delete"],
+
+  // SHELL.
+  ["shell", "shell"],
+  ["bash", "shell"],
+  ["execute", "shell"],
+  ["execute_command", "shell"],
+  ["run_command", "shell"],
+  ["terminal", "shell"],
+  ["Shell", "shell"],
+]);
+
+/**
+ * The approval category ("write"/"delete"/"shell") of a gated built-in
+ * tool; undefined for tools not gated by category (read-only built-ins,
+ * MCP tools, unknown names). Go returns (category, ok).
+ */
+export function toolApprovalCategory(name: string): string | undefined {
+  return TOOL_NAME_TO_CATEGORY.get(name);
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
@@ -97,24 +97,30 @@ const KNOWN_CONTENT_TYPES: ReadonlyMap<string, string> = new Map([
 ]);
 
 /**
- * The fallback extension table standing in for Go's mime.TypeByExtension
- * (Node has no OS MIME database binding): the common web/media types the
- * OS table would answer. Everything else falls to octet-stream, exactly
- * Go's final default.
+ * The stand-in for Go's mime.TypeByExtension (Node has no OS MIME
+ * database binding): Go's mime package BUILTIN table verbatim, including
+ * its charset-qualified text types — the deterministic subset both
+ * editions agree on. Go additionally consults the OS mime.types database
+ * for other extensions; that residue is an accepted, recorded parity gap
+ * (everything else falls to octet-stream, Go's final default).
  */
 const OS_MIME_FALLBACK: ReadonlyMap<string, string> = new Map([
-  [".png", "image/png"],
-  [".jpg", "image/jpeg"],
-  [".jpeg", "image/jpeg"],
+  [".avif", "image/avif"],
+  [".css", "text/css; charset=utf-8"],
   [".gif", "image/gif"],
-  [".svg", "image/svg+xml"],
-  [".webp", "image/webp"],
+  [".htm", "text/html; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".jpeg", "image/jpeg"],
+  [".jpg", "image/jpeg"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json"],
+  [".mjs", "text/javascript; charset=utf-8"],
   [".pdf", "application/pdf"],
-  [".css", "text/css"],
-  [".htm", "text/html"],
-  [".mp4", "video/mp4"],
-  [".mp3", "audio/mpeg"],
-  [".wav", "audio/wav"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".wasm", "application/wasm"],
+  [".webp", "image/webp"],
+  [".xml", "text/xml; charset=utf-8"],
 ]);
 
 // ---------------------------------------------------------------------------
@@ -138,7 +144,12 @@ export async function uploadAttachment(
   const uploadId = ulid();
   let contentType = req.contentType;
   if (contentType === "") {
-    contentType = detectContentType(req.filename);
+    // Go's UPLOAD path consults ONLY mime.TypeByExtension — never the
+    // artifact-relevant knownContentTypes table, which is a read-path
+    // (detectContentType) concern. Mirrored so stored object metadata
+    // stays edition-identical when the R2 backend (#13) starts carrying
+    // it.
+    contentType = osMimeTypeByExtension(req.filename);
   }
 
   const storageKey = `attachments/${uploadId}/${req.filename}`;
@@ -327,20 +338,36 @@ function extractZipEntry(
  * OS-table stand-in second, octet-stream last (Go detectContentType).
  */
 export function detectContentType(storageKey: string): string {
-  const dot = storageKey.lastIndexOf(".");
-  const slash = Math.max(
-    storageKey.lastIndexOf("/"),
-    storageKey.lastIndexOf("\\"),
-  );
-  if (dot <= slash || dot === -1) {
+  const ext = fileExtension(storageKey);
+  if (ext === "") {
     return "application/octet-stream";
   }
-  const ext = storageKey.slice(dot).toLowerCase();
   return (
     KNOWN_CONTENT_TYPES.get(ext) ??
     OS_MIME_FALLBACK.get(ext) ??
     "application/octet-stream"
   );
+}
+
+/**
+ * The upload path's MIME detection (Go mime.TypeByExtension +
+ * octet-stream fallback — see uploadAttachment).
+ */
+export function osMimeTypeByExtension(filename: string): string {
+  const ext = fileExtension(filename);
+  if (ext === "") {
+    return "application/octet-stream";
+  }
+  return OS_MIME_FALLBACK.get(ext) ?? "application/octet-stream";
+}
+
+function fileExtension(name: string): string {
+  const dot = name.lastIndexOf(".");
+  const slash = Math.max(name.lastIndexOf("/"), name.lastIndexOf("\\"));
+  if (dot <= slash || dot === -1) {
+    return "";
+  }
+  return name.slice(dot).toLowerCase();
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
@@ -302,6 +302,11 @@ export async function getArtifactContent(
  * Reads a single file from an in-memory ZIP archive (Go extractZipEntry
  * over archive/zip; here fflate's unzipSync with a name filter so only
  * the requested entry inflates). undefined = not found / unreadable.
+ *
+ * The max_bytes guard applies AFTER inflation (both editions): a crafted
+ * entry inflates fully in memory first. Acceptable under the current
+ * trust boundary — ZIP artifacts are runner-written, and single-user OSS
+ * has no hostile tenant — revisit if artifacts ever become user-supplied.
  */
 function extractZipEntry(
   zipData: Uint8Array,

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
@@ -22,6 +22,8 @@
  * lands with #13 — the URL is correctly shaped before then, with nothing
  * serving it on THIS server.
  */
+import path from "node:path";
+
 import { ulid } from "ulidx";
 import { unzipSync } from "fflate";
 import { Code, ConnectError } from "@connectrpc/connect";
@@ -212,8 +214,14 @@ export async function getArtifactContent(
     throw invalidArgumentError("storage_key is required");
   }
 
+  // Ownership is checked on the NORMALIZED key and the normalized key is
+  // what gets served: the storage layer path-cleans `.`/`..` segments, so
+  // a raw-key prefix check would let `artifacts/{mine}/../{other}/f` pass
+  // yet resolve into another execution's artifacts. Deliberate fail-closed
+  // divergence from Go until stigmer/stigmer#858 lands there.
+  const storageKey = path.posix.normalize(req.storageKey);
   const expectedPrefix = `artifacts/${req.executionId}/`;
-  if (!req.storageKey.startsWith(expectedPrefix)) {
+  if (!storageKey.startsWith(expectedPrefix)) {
     deps.logger.warn(
       "Storage key does not belong to execution - potential path traversal attempt",
       {
@@ -246,7 +254,7 @@ export async function getArtifactContent(
 
   let data: Uint8Array;
   try {
-    data = await deps.artifactStorage.download(req.storageKey);
+    data = await deps.artifactStorage.download(storageKey);
   } catch (error) {
     throw internalError(error, "failed to read artifact content");
   }
@@ -254,7 +262,7 @@ export async function getArtifactContent(
   // Serve-time integrity for CAS blobs — only over the COMPLETE object
   // (untruncated, no entry extraction); non-CAS keys fail open.
   if (req.entryPath === "" && data.length <= maxBytes) {
-    const reason = casBlobContentMismatch(req.storageKey, data);
+    const reason = casBlobContentMismatch(storageKey, data);
     if (reason !== "") {
       deps.logger.error("CAS blob failed content-address integrity check", {
         executionId: req.executionId,
@@ -288,7 +296,7 @@ export async function getArtifactContent(
     truncated = true;
   }
 
-  const contentKey = req.entryPath !== "" ? req.entryPath : req.storageKey;
+  const contentKey = req.entryPath !== "" ? req.entryPath : storageKey;
   const contentType = detectContentType(contentKey);
 
   deps.logger.info("Successfully read artifact content", {
@@ -401,10 +409,15 @@ export async function getArtifactDownloadUrl(
     );
   }
 
+  // Same normalize-before-check posture as getArtifactContent
+  // (stigmer/stigmer#858); spec.attachments membership also compares the
+  // normalized form — stored attachment keys are always clean, so a
+  // dot-segment-carrying alias of a listed key matches its verbatim row.
+  const storageKey = path.posix.normalize(req.storageKey);
   const expectedPrefix = `artifacts/${req.executionId}/`;
   if (
-    !req.storageKey.startsWith(expectedPrefix) &&
-    !isSpecAttachmentKey(execution, req.storageKey)
+    !storageKey.startsWith(expectedPrefix) &&
+    !isSpecAttachmentKey(execution, storageKey)
   ) {
     deps.logger.warn(
       "Storage key does not belong to execution - potential path traversal attempt",
@@ -423,13 +436,13 @@ export async function getArtifactDownloadUrl(
   // A browser download saves under the key's basename (already validated
   // to be scoped to this execution); empty serves inline.
   const downloadFilename = req.asAttachment
-    ? (req.storageKey.split("/").pop() ?? "")
+    ? (storageKey.split("/").pop() ?? "")
     : "";
 
   let downloadUrl: string;
   try {
     downloadUrl = await deps.artifactStorage.getSignedUrl(
-      req.storageKey,
+      storageKey,
       expiresInMs,
       downloadFilename,
     );

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/artifacts.ts
@@ -1,0 +1,437 @@
+/**
+ * Attachment upload + artifact read surfaces — ports
+ * upload_attachment.go, get_artifact_content.go, and
+ * get_artifact_download_url.go.
+ *
+ * uploadAttachment pre-uploads files (>4MB inline limit) before create;
+ * the returned storage_key acts as a capability token. Keys are
+ * attachments/{ulid}/{filename} with strict bare-filename validation (a
+ * name carrying path structure is a directory-traversal vector).
+ *
+ * getArtifactContent returns bytes through the API (no CORS concerns for
+ * SDK consumers): key-prefix ownership check, CAS-blob serve-time
+ * integrity (DATA_LOSS on mismatch, only over the complete object),
+ * single-entry ZIP extraction (fflate — the ratified dependency; Node has
+ * no stdlib ZIP), 512KB default truncation.
+ *
+ * getArtifactDownloadUrl returns a time-limited direct-download URL;
+ * ownership is the artifacts/{execution_id}/ prefix OR a key listed
+ * verbatim in spec.attachments (attachment keys carry no execution id, so
+ * membership is the proof). COEXISTENCE NOTE (disclosed in the plan): on
+ * local storage the URL points at the port+1 artifact file server, which
+ * lands with #13 — the URL is correctly shaped before then, with nothing
+ * serving it on THIS server.
+ */
+import { ulid } from "ulidx";
+import { unzipSync } from "fflate";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type {
+  GetArtifactContentRequest,
+  GetArtifactContentResponse,
+  GetArtifactDownloadUrlRequest,
+  GetArtifactDownloadUrlResponse,
+  UploadAttachmentRequest,
+  UploadAttachmentResponse,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import {
+  GetArtifactContentResponseSchema,
+  GetArtifactDownloadUrlResponseSchema,
+  UploadAttachmentResponseSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { create } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import {
+  internalError,
+  invalidArgumentError,
+} from "../../pipeline/errors.js";
+import type { Store } from "../../store/interface.js";
+import { casBlobContentMismatch } from "./filereview/cas-blob.js";
+
+export interface ArtifactRpcDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly artifactStorage: ArtifactStorage;
+}
+
+/**
+ * Default size limit when max_bytes is unset: the first 512 KB with
+ * truncated=true when the full content exceeds it (Go
+ * DefaultMaxArtifactContentBytes).
+ */
+export const DEFAULT_MAX_ARTIFACT_CONTENT_BYTES = 512 * 1024;
+
+/**
+ * Default expiration for artifact download URLs — R2's presigned-URL
+ * maximum (Go DefaultArtifactURLExpiration).
+ */
+export const DEFAULT_ARTIFACT_URL_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Artifact-relevant extensions commonly missing from OS MIME databases
+ * (Go knownContentTypes); checked before the generic table below.
+ */
+const KNOWN_CONTENT_TYPES: ReadonlyMap<string, string> = new Map([
+  [".yaml", "text/yaml"],
+  [".yml", "text/yaml"],
+  [".json", "application/json"],
+  [".md", "text/markdown"],
+  [".txt", "text/plain"],
+  [".csv", "text/csv"],
+  [".xml", "application/xml"],
+  [".html", "text/html"],
+  [".zip", "application/zip"],
+  [".tar", "application/x-tar"],
+  [".gz", "application/gzip"],
+  [".py", "text/x-python"],
+  [".go", "text/x-go"],
+  [".js", "text/javascript"],
+  [".ts", "text/typescript"],
+  [".sh", "text/x-shellscript"],
+  [".toml", "application/toml"],
+]);
+
+/**
+ * The fallback extension table standing in for Go's mime.TypeByExtension
+ * (Node has no OS MIME database binding): the common web/media types the
+ * OS table would answer. Everything else falls to octet-stream, exactly
+ * Go's final default.
+ */
+const OS_MIME_FALLBACK: ReadonlyMap<string, string> = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".gif", "image/gif"],
+  [".svg", "image/svg+xml"],
+  [".webp", "image/webp"],
+  [".pdf", "application/pdf"],
+  [".css", "text/css"],
+  [".htm", "text/html"],
+  [".mp4", "video/mp4"],
+  [".mp3", "audio/mpeg"],
+  [".wav", "audio/wav"],
+]);
+
+// ---------------------------------------------------------------------------
+// uploadAttachment
+// ---------------------------------------------------------------------------
+
+export async function uploadAttachment(
+  deps: ArtifactRpcDeps,
+  req: UploadAttachmentRequest,
+): Promise<UploadAttachmentResponse> {
+  // Field validation mirrors the proto's buf.validate constraints so a
+  // bypassed constraint still fails closed at the service boundary.
+  if (req.filename === "") {
+    throw invalidArgumentError("filename is required");
+  }
+  validateAttachmentFilename(req.filename);
+  if (req.content.length === 0) {
+    throw invalidArgumentError("content is required");
+  }
+
+  const uploadId = ulid();
+  let contentType = req.contentType;
+  if (contentType === "") {
+    contentType = detectContentType(req.filename);
+  }
+
+  const storageKey = `attachments/${uploadId}/${req.filename}`;
+  deps.logger.info("Uploading attachment to artifact storage", {
+    storageKey,
+    filename: req.filename,
+    contentType,
+    sizeBytes: req.content.length,
+  });
+
+  try {
+    await deps.artifactStorage.upload(storageKey, req.content, contentType);
+  } catch (error) {
+    throw internalError(error, "failed to upload attachment");
+  }
+
+  deps.logger.info("Successfully uploaded attachment to storage", {
+    storageKey,
+    filename: req.filename,
+    sizeBytes: req.content.length,
+  });
+
+  return create(UploadAttachmentResponseSchema, { storageKey });
+}
+
+/**
+ * Enforces that a filename is a single bare path component: no directory
+ * separators (either flavor), no `.`/`..` traversal segments, no NUL —
+ * the name becomes part of the storage key and, on the local backend, an
+ * on-disk path (Go validateAttachmentFilename).
+ */
+export function validateAttachmentFilename(name: string): void {
+  if (name.includes("/") || name.includes("\\")) {
+    throw invalidArgumentError(
+      `filename ${JSON.stringify(name)} must not contain path separators; send a bare filename such as "report.pdf"`,
+    );
+  }
+  if (name.includes("\0")) {
+    throw invalidArgumentError("filename must not contain NUL bytes");
+  }
+  if (name === "." || name === "..") {
+    throw invalidArgumentError(
+      `filename ${JSON.stringify(name)} must be a bare filename, not a traversal segment`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getArtifactContent
+// ---------------------------------------------------------------------------
+
+export async function getArtifactContent(
+  deps: ArtifactRpcDeps,
+  req: GetArtifactContentRequest,
+): Promise<GetArtifactContentResponse> {
+  if (req.executionId === "") {
+    throw invalidArgumentError("execution_id is required");
+  }
+  if (req.storageKey === "") {
+    throw invalidArgumentError("storage_key is required");
+  }
+
+  const expectedPrefix = `artifacts/${req.executionId}/`;
+  if (!req.storageKey.startsWith(expectedPrefix)) {
+    deps.logger.warn(
+      "Storage key does not belong to execution - potential path traversal attempt",
+      {
+        executionId: req.executionId,
+        storageKey: req.storageKey,
+        expectedPrefix,
+      },
+    );
+    throw invalidArgumentError("storage_key does not belong to this execution");
+  }
+
+  // Existence check (Go answers NotFound for any load failure here).
+  try {
+    await deps.store.getResource(
+      ApiResourceKind.agent_execution,
+      req.executionId,
+      AgentExecutionSchema,
+    );
+  } catch {
+    throw new ConnectError(
+      `execution not found: ${req.executionId}`,
+      Code.NotFound,
+    );
+  }
+
+  let maxBytes = Number(req.maxBytes);
+  if (maxBytes <= 0) {
+    maxBytes = DEFAULT_MAX_ARTIFACT_CONTENT_BYTES;
+  }
+
+  let data: Uint8Array;
+  try {
+    data = await deps.artifactStorage.download(req.storageKey);
+  } catch (error) {
+    throw internalError(error, "failed to read artifact content");
+  }
+
+  // Serve-time integrity for CAS blobs — only over the COMPLETE object
+  // (untruncated, no entry extraction); non-CAS keys fail open.
+  if (req.entryPath === "" && data.length <= maxBytes) {
+    const reason = casBlobContentMismatch(req.storageKey, data);
+    if (reason !== "") {
+      deps.logger.error("CAS blob failed content-address integrity check", {
+        executionId: req.executionId,
+        storageKey: req.storageKey,
+      });
+      throw new ConnectError(reason, Code.DataLoss);
+    }
+  }
+
+  // Single-entry ZIP extraction for directory artifacts.
+  if (req.entryPath !== "") {
+    const entryData = extractZipEntry(data, req.entryPath);
+    if (entryData === undefined) {
+      deps.logger.warn("Failed to extract entry from ZIP artifact", {
+        executionId: req.executionId,
+        storageKey: req.storageKey,
+        entryPath: req.entryPath,
+      });
+      throw new ConnectError(
+        `entry ${JSON.stringify(req.entryPath)} not found in archive`,
+        Code.NotFound,
+      );
+    }
+    data = entryData;
+  }
+
+  const totalSize = data.length;
+  let truncated = false;
+  if (totalSize > maxBytes) {
+    data = data.slice(0, maxBytes);
+    truncated = true;
+  }
+
+  const contentKey = req.entryPath !== "" ? req.entryPath : req.storageKey;
+  const contentType = detectContentType(contentKey);
+
+  deps.logger.info("Successfully read artifact content", {
+    executionId: req.executionId,
+    storageKey: req.storageKey,
+    entryPath: req.entryPath,
+    totalSizeBytes: totalSize,
+    returnedBytes: data.length,
+    truncated,
+    contentType,
+  });
+
+  return create(GetArtifactContentResponseSchema, {
+    content: data,
+    contentType,
+    totalSizeBytes: BigInt(totalSize),
+    truncated,
+  });
+}
+
+/**
+ * Reads a single file from an in-memory ZIP archive (Go extractZipEntry
+ * over archive/zip; here fflate's unzipSync with a name filter so only
+ * the requested entry inflates). undefined = not found / unreadable.
+ */
+function extractZipEntry(
+  zipData: Uint8Array,
+  entryPath: string,
+): Uint8Array | undefined {
+  try {
+    const extracted = unzipSync(zipData, {
+      filter: (file) => file.name === entryPath,
+    });
+    return extracted[entryPath];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * MIME type from the extension: the artifact-relevant table first, the
+ * OS-table stand-in second, octet-stream last (Go detectContentType).
+ */
+export function detectContentType(storageKey: string): string {
+  const dot = storageKey.lastIndexOf(".");
+  const slash = Math.max(
+    storageKey.lastIndexOf("/"),
+    storageKey.lastIndexOf("\\"),
+  );
+  if (dot <= slash || dot === -1) {
+    return "application/octet-stream";
+  }
+  const ext = storageKey.slice(dot).toLowerCase();
+  return (
+    KNOWN_CONTENT_TYPES.get(ext) ??
+    OS_MIME_FALLBACK.get(ext) ??
+    "application/octet-stream"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// getArtifactDownloadUrl
+// ---------------------------------------------------------------------------
+
+export async function getArtifactDownloadUrl(
+  deps: ArtifactRpcDeps,
+  req: GetArtifactDownloadUrlRequest,
+): Promise<GetArtifactDownloadUrlResponse> {
+  if (req.executionId === "") {
+    throw invalidArgumentError("execution_id is required");
+  }
+  if (req.storageKey === "") {
+    throw invalidArgumentError("storage_key is required");
+  }
+
+  // Load BEFORE the key check: the attachment arm needs spec.attachments,
+  // and this doubles as the existence check.
+  let execution: AgentExecution;
+  try {
+    execution = await deps.store.getResource(
+      ApiResourceKind.agent_execution,
+      req.executionId,
+      AgentExecutionSchema,
+    );
+  } catch {
+    throw new ConnectError(
+      `execution not found: ${req.executionId}`,
+      Code.NotFound,
+    );
+  }
+
+  const expectedPrefix = `artifacts/${req.executionId}/`;
+  if (
+    !req.storageKey.startsWith(expectedPrefix) &&
+    !isSpecAttachmentKey(execution, req.storageKey)
+  ) {
+    deps.logger.warn(
+      "Storage key does not belong to execution - potential path traversal attempt",
+      {
+        executionId: req.executionId,
+        storageKey: req.storageKey,
+        expectedPrefix,
+      },
+    );
+    throw invalidArgumentError("storage_key does not belong to this execution");
+  }
+
+  const expiresInMs = DEFAULT_ARTIFACT_URL_EXPIRATION_MS;
+  const expiresAt = new Date(Date.now() + expiresInMs);
+
+  // A browser download saves under the key's basename (already validated
+  // to be scoped to this execution); empty serves inline.
+  const downloadFilename = req.asAttachment
+    ? (req.storageKey.split("/").pop() ?? "")
+    : "";
+
+  let downloadUrl: string;
+  try {
+    downloadUrl = await deps.artifactStorage.getSignedUrl(
+      req.storageKey,
+      expiresInMs,
+      downloadFilename,
+    );
+  } catch (error) {
+    throw internalError(error, "failed to generate download URL");
+  }
+
+  deps.logger.info(
+    "Successfully generated presigned download URL for artifact",
+    {
+      executionId: req.executionId,
+      storageKey: req.storageKey,
+      expiresAt: expiresAt.toISOString(),
+    },
+  );
+
+  return create(GetArtifactDownloadUrlResponseSchema, {
+    downloadUrl,
+    // RFC3339 seconds precision, Go's time.RFC3339 Format.
+    expiresAt: expiresAt.toISOString().replace(/\.\d{3}Z$/, "Z"),
+  });
+}
+
+/**
+ * Whether storageKey appears verbatim in spec.attachments — the ownership
+ * proof for submitted inputs (attachment keys carry no execution id;
+ * ULID-unique per upload, so membership cannot reference another
+ * execution's files).
+ */
+function isSpecAttachmentKey(
+  execution: AgentExecution,
+  storageKey: string,
+): boolean {
+  return (execution.spec?.attachments ?? []).some(
+    (attachment) => attachment.storageKey === storageKey,
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/constants.ts
@@ -1,0 +1,30 @@
+/**
+ * AgentExecution byte-pinned wire copy — every string a client can observe
+ * from this domain, copied character-for-character from the Go controller
+ * (pkg/domain/agentexecution/controller). Coexistence rule: the Go server
+ * is the behavioral reference; do not "improve" copy here (guidelines §2).
+ */
+
+/**
+ * create's engine-gate refusal (create.go engineUnavailableMessage) —
+ * kept identical across AgentExecution and WorkflowExecution so both
+ * domains present one symmetric create-boundary contract. Pinned by the
+ * conformance engine-gate test (CW-7).
+ */
+export const ENGINE_UNAVAILABLE_MESSAGE =
+  "The execution engine is temporarily unavailable. Please try again shortly.";
+
+/**
+ * getExecutionUsageReport's unknown-execution refusal. Go
+ * (get_execution_usage_report.go) calls
+ * NotFoundError("agent execution '%s' not found", executionID) — but that
+ * helper's signature is (resource, id) rendering "%s not found: %s", so
+ * the literal '%s' and the doubled "not found" reach the wire. Ported
+ * byte-faithfully per sub-project DD-001 (owner-ratified 2026-08-24);
+ * the both-editions fix ships through the OSS issue filed at wrap-up.
+ */
+export function executionUsageReportNotFoundMessage(
+  executionId: string,
+): string {
+  return `agent execution '%s' not found not found: ${executionId}`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/constants.ts
@@ -21,7 +21,7 @@ export const ENGINE_UNAVAILABLE_MESSAGE =
  * helper's signature is (resource, id) rendering "%s not found: %s", so
  * the literal '%s' and the doubled "not found" reach the wire. Ported
  * byte-faithfully per sub-project DD-001 (owner-ratified 2026-08-24);
- * the both-editions fix ships through the OSS issue filed at wrap-up.
+ * the both-editions fix is stigmer/stigmer#859.
  */
 export function executionUsageReportNotFoundMessage(
   executionId: string,

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
@@ -4,14 +4,6 @@
  * controller implements both services; this module mirrors that with one
  * deps object and one registration function.
  *
- * Ported in phases within sub-project #17 (D4). This phase carries the
- * read/write surfaces without engine coupling: get/list/listBySession,
- * the update and delete pipelines, the four usage reports and the
- * dashboard summary. The create pipeline, updateStatus merge engine,
- * approval/file-review ledgers, subscribe stream, attachments, and
- * lifecycle RPCs land in the following phases of the same PR; ConnectRPC
- * answers Unimplemented for them until their phase.
- *
  * Pipeline per RPC mirrors the Go step chains character-for-character.
  * Proven by agentexecution.conformance.test.ts
  * (CONFORMANCE_TARGET=local-ts) and __tests__/.
@@ -65,13 +57,51 @@ import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
+import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+
+import {
+  getArtifactContent,
+  getArtifactDownloadUrl,
+  uploadAttachment,
+} from "./artifacts.js";
+import type {
+  AgentLoaderProvider,
+  ExecutionAgentInstanceCreatorProvider,
+  SessionCreatorProvider,
+} from "./create-steps.js";
+import {
+  newComposeDeclaredPreferencesStep,
+  newComposeRecalledMemoriesStep,
+  newCreateDefaultInstanceIfNeededStep,
+  newCreateSessionIfNeededStep,
+  newEnsureSessionOrAgentResolvedStep,
+  newProcessAttachmentsStep,
+  newResolveDefaultAgentStep,
+  newSetInitialPhaseStep,
+  newStartWorkflowStep,
+} from "./create-steps.js";
+import type { ExecutionContextBuilderDeps } from "./create-execution-context-step.js";
+import { newCreateExecutionContextStep } from "./create-execution-context-step.js";
 import type { ExecutionEngineStateProvider } from "./engine.js";
+import { newEnsureEngineAvailableStep } from "./engine.js";
+import {
+  cancelExecution,
+  pauseExecution,
+  recoverExecution,
+  resumeExecution,
+  terminateExecution,
+} from "./lifecycle.js";
 import { agentExecutionSearchExtractor } from "./search-extractor.js";
 import type { StreamBroker } from "./stream-broker.js";
 import { submitApproval } from "./submit-approval.js";
 import { submitFileDecision } from "./submit-file-decision.js";
 import { subscribeExecution } from "./subscribe.js";
 import { updateStatus } from "./update-status.js";
+import { newValidateServiceTierStep } from "./validate-service-tier.js";
+import { newValidateThinkingModeStep } from "./validate-thinking-mode.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
   EXECUTION_LIST_KEY,
   newApplyPhaseFilterStep,
@@ -102,9 +132,27 @@ export interface AgentExecutionControllerDeps {
   /**
    * The execution-engine seam (engine.ts): permanently disconnected until
    * #18's TemporalManager flips it. Consumed by the engine gate, the
-   * lifecycle RPCs, and the two HITL signal steps.
+   * lifecycle RPCs, the create/recover workflow starts, and the two HITL
+   * signal steps.
    */
   readonly engineState: ExecutionEngineStateProvider;
+  /**
+   * The bundled+refreshed model registry (the composition root's single
+   * instance, DD-004) — the #357/#772 tier and thinking-mode validators
+   * read it at create.
+   */
+  readonly modelRegistry: ModelRegistryStore;
+  /** The shared artifact blob store (attachments + artifact reads). */
+  readonly artifactStorage: ArtifactStorage;
+  /**
+   * The in-process edges the create pipeline consumes (lazy providers —
+   * the routes↔clients cycle resolves at request time, DD-002).
+   */
+  readonly agentLoader: AgentLoaderProvider;
+  readonly agentInstanceCreator: ExecutionAgentInstanceCreatorProvider;
+  readonly sessionCreator: SessionCreatorProvider;
+  /** The shared EC-builder deps (create's step 16 + recover's recreate). */
+  readonly executionContextBuilder: ExecutionContextBuilderDeps;
 }
 
 /** Registers both agentexecution services on the router (routes stage). */
@@ -112,11 +160,30 @@ export function registerAgentExecutionServices(
   router: ConnectRouter,
   deps: AgentExecutionControllerDeps,
 ): void {
+  const lifecycleDeps = {
+    store: deps.store,
+    logger: deps.logger,
+    broker: deps.broker,
+    engineState: deps.engineState,
+    executionContextBuilder: deps.executionContextBuilder,
+  };
+  const artifactDeps = {
+    store: deps.store,
+    logger: deps.logger,
+    artifactStorage: deps.artifactStorage,
+  };
   router.service(AgentExecutionCommandController, {
+    create: (execution, ctx) => createExecution(deps, execution, ctx),
     update: (execution, ctx) => update(deps, execution, ctx),
     updateStatus: (input) => updateStatus(deps, input),
     submitApproval: (input) => submitApproval(deps, input),
     submitFileDecision: (input) => submitFileDecision(deps, input),
+    cancel: (input) => cancelExecution(lifecycleDeps, input),
+    terminate: (input) => terminateExecution(lifecycleDeps, input),
+    recover: (input) => recoverExecution(lifecycleDeps, input),
+    pause: (input) => pauseExecution(lifecycleDeps, input),
+    resume: (input) => resumeExecution(lifecycleDeps, input),
+    uploadAttachment: (req) => uploadAttachment(artifactDeps, req),
     delete: (id, ctx) => deleteExecution(deps, id, ctx),
   });
   router.service(AgentExecutionQueryController, {
@@ -124,12 +191,88 @@ export function registerAgentExecutionServices(
     list: (req, ctx) => list(deps, req, ctx),
     listBySession: (req, ctx) => listBySession(deps, req, ctx),
     subscribe: (id, ctx) => subscribeExecution(deps, id, ctx),
+    getArtifactDownloadUrl: (req) => getArtifactDownloadUrl(artifactDeps, req),
+    getArtifactContent: (req) => getArtifactContent(artifactDeps, req),
     getExecutionUsageReport: (req) => getExecutionUsageReport(deps, req),
     getSessionUsageReport: (req) => getSessionUsageReport(deps, req),
     getAgentUsageReport: (req) => getAgentUsageReport(deps, req),
     getOrgUsageReport: (req) => getOrgUsageReport(deps, req),
     getExecutionSummary: (req) => getExecutionSummary(deps, req),
   });
+}
+
+/**
+ * Create — create.go buildCreatePipeline, step-for-step: validation
+ * (proto → visibility → tier #357 → thinking #772) → target resolution
+ * (default agent → invariant guard) → the standard build → the engine
+ * gate (fail fast BEFORE the first side effect, so a down engine orphans
+ * nothing) → the side-effecting steps (default instance, session
+ * bootstrap, preference/memory snapshots, initial phase, the
+ * ExecutionContext with merged env, attachment validation) → Persist →
+ * IndexSearch → StartWorkflow (after persist; a start failure marks the
+ * execution FAILED, recoverable via Recover).
+ */
+async function createExecution(
+  deps: AgentExecutionControllerDeps,
+  execution: AgentExecution,
+  ctx: HandlerContext,
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    AgentExecutionSchema,
+    execution,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentExecutionSchema>(
+    "agent-execution-create",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newValidateServiceTierStep(deps.modelRegistry))
+    .addStep(newValidateThinkingModeStep(deps.modelRegistry))
+    .addStep(newResolveDefaultAgentStep(deps.store, deps.logger))
+    .addStep(newEnsureSessionOrAgentResolvedStep(deps.logger))
+    .addStep(newResolveSlugStep())
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newEnsureEngineAvailableStep(deps.engineState))
+    .addStep(
+      newCreateDefaultInstanceIfNeededStep({
+        store: deps.store,
+        logger: deps.logger,
+        agentLoader: deps.agentLoader,
+        agentInstanceCreator: deps.agentInstanceCreator,
+      }),
+    )
+    .addStep(
+      newCreateSessionIfNeededStep({
+        logger: deps.logger,
+        sessionCreator: deps.sessionCreator,
+      }),
+    )
+    .addStep(newComposeDeclaredPreferencesStep(deps.store, deps.logger))
+    .addStep(newComposeRecalledMemoriesStep(deps.store, deps.logger))
+    .addStep(newSetInitialPhaseStep())
+    .addStep(newCreateExecutionContextStep(deps.executionContextBuilder))
+    .addStep(newProcessAttachmentsStep(deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        agentExecutionSearchExtractor,
+        deps.logger,
+      ),
+    )
+    .addStep(
+      newStartWorkflowStep({
+        store: deps.store,
+        logger: deps.logger,
+        engineState: deps.engineState,
+      }),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
 }
 
 function kindOf(ctx: HandlerContext): ApiResourceKind {

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
@@ -1,0 +1,269 @@
+/**
+ * AgentExecution controller — ports pkg/domain/agentexecution/controller
+ * (command + query sides): the deepest domain's request surface. One Go
+ * controller implements both services; this module mirrors that with one
+ * deps object and one registration function.
+ *
+ * Ported in phases within sub-project #17 (D4). This phase carries the
+ * read/write surfaces without engine coupling: get/list/listBySession,
+ * the update and delete pipelines, the four usage reports and the
+ * dashboard summary. The create pipeline, updateStatus merge engine,
+ * approval/file-review ledgers, subscribe stream, attachments, and
+ * lifecycle RPCs land in the following phases of the same PR; ConnectRPC
+ * answers Unimplemented for them until their phase.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by agentexecution.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and __tests__/.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies,
+ * Publish, PublishToRedis, and TransformResponse steps (no multi-tenant
+ * auth, IAM/FGA, event publishing, or Redis here — subscribe streams ride
+ * in-memory channels per ADR 011).
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import type {
+  AgentExecutionId,
+  AgentExecutionList,
+  ListAgentExecutionsBySessionRequest,
+  ListAgentExecutionsRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+import type { ApiResourceId } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import type { Store } from "../../store/interface.js";
+
+import { agentExecutionSearchExtractor } from "./search-extractor.js";
+import {
+  EXECUTION_LIST_KEY,
+  newApplyPhaseFilterStep,
+  newBuildExecutionListResponseStep,
+  newQueryAllExecutionsStep,
+  newQueryExecutionsBySessionStep,
+  newValidateListBySessionRequestStep,
+  newValidateListRequestStep,
+} from "./steps.js";
+import {
+  getAgentUsageReport,
+  getExecutionSummary,
+  getExecutionUsageReport,
+  getOrgUsageReport,
+  getSessionUsageReport,
+} from "./usage.js";
+
+export interface AgentExecutionControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+/** Registers both agentexecution services on the router (routes stage). */
+export function registerAgentExecutionServices(
+  router: ConnectRouter,
+  deps: AgentExecutionControllerDeps,
+): void {
+  router.service(AgentExecutionCommandController, {
+    update: (execution, ctx) => update(deps, execution, ctx),
+    delete: (id, ctx) => deleteExecution(deps, id, ctx),
+  });
+  router.service(AgentExecutionQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+    listBySession: (req, ctx) => listBySession(deps, req, ctx),
+    getExecutionUsageReport: (req) => getExecutionUsageReport(deps, req),
+    getSessionUsageReport: (req) => getSessionUsageReport(deps, req),
+    getAgentUsageReport: (req) => getAgentUsageReport(deps, req),
+    getOrgUsageReport: (req) => getOrgUsageReport(deps, req),
+    getExecutionSummary: (req) => getExecutionSummary(deps, req),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Update — update.go buildUpdatePipeline: USER-initiated spec updates
+ * (status updates from the runner use UpdateStatus instead). Standard
+ * chain; BuildUpdateState clears status per the shared pattern.
+ */
+async function update(
+  deps: AgentExecutionControllerDeps,
+  execution: AgentExecution,
+  ctx: HandlerContext,
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    AgentExecutionSchema,
+    execution,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentExecutionSchema>(
+    "agent-execution-update",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        agentExecutionSearchExtractor,
+        deps.logger,
+      ),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Delete — delete.go buildDeletePipeline; returns the deleted execution
+ * for the audit trail (gRPC convention).
+ */
+async function deleteExecution(
+  deps: AgentExecutionControllerDeps,
+  id: ApiResourceId,
+  ctx: HandlerContext,
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    AgentExecutionCommandController.method.delete.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentExecutionCommandController.method.delete.input>(
+    "agent-execution-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, AgentExecutionSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted execution not found in context"),
+      "deleted execution not found in context",
+    );
+  }
+  return deleted as AgentExecution;
+}
+
+/** Get — get.go buildGetPipeline: ValidateProto → LoadTarget. */
+async function get(
+  deps: AgentExecutionControllerDeps,
+  id: AgentExecutionId,
+  ctx: HandlerContext,
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentExecutionQueryController.method.get.input>(
+    "agent-execution-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, AgentExecutionSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+}
+
+/**
+ * List — list.go: full scan, optional phase filter, no sorting, no
+ * pagination (total_pages placeholder 1); the request org field is a
+ * deliberate no-op on this single-tenant edition.
+ */
+async function list(
+  deps: AgentExecutionControllerDeps,
+  req: ListAgentExecutionsRequest,
+  ctx: HandlerContext,
+): Promise<AgentExecutionList> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentExecutionQueryController.method.list.input>(
+    "agent-execution-list",
+    deps.logger,
+  )
+    .addStep(newValidateListRequestStep())
+    .addStep(newQueryAllExecutionsStep(deps.store, deps.logger))
+    .addStep(newApplyPhaseFilterStep(deps.logger))
+    .addStep(newBuildExecutionListResponseStep())
+    .build()
+    .execute(reqCtx);
+  return requireListResult(reqCtx.get(EXECUTION_LIST_KEY));
+}
+
+/** ListBySession — list_by_session.go: spec.session_id equality filter. */
+async function listBySession(
+  deps: AgentExecutionControllerDeps,
+  req: ListAgentExecutionsBySessionRequest,
+  ctx: HandlerContext,
+): Promise<AgentExecutionList> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.listBySession.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof AgentExecutionQueryController.method.listBySession.input
+  >("agent-execution-list-by-session", deps.logger)
+    .addStep(newValidateListBySessionRequestStep())
+    .addStep(newQueryExecutionsBySessionStep(deps.store, deps.logger))
+    .addStep(newBuildExecutionListResponseStep())
+    .build()
+    .execute(reqCtx);
+  return requireListResult(reqCtx.get(EXECUTION_LIST_KEY));
+}
+
+function requireListResult(result: unknown): AgentExecutionList {
+  if (result === undefined || Array.isArray(result)) {
+    throw internalError(
+      new Error("execution list not found in context"),
+      "execution list not found in context",
+    );
+  }
+  return result as AgentExecutionList;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
@@ -66,6 +66,8 @@ import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
 import { agentExecutionSearchExtractor } from "./search-extractor.js";
+import type { StreamBroker } from "./stream-broker.js";
+import { subscribeExecution } from "./subscribe.js";
 import {
   EXECUTION_LIST_KEY,
   newApplyPhaseFilterStep,
@@ -86,6 +88,13 @@ import {
 export interface AgentExecutionControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /**
+   * The shared broadcast fabric for subscribe streams. ONE instance spans
+   * both routers (serving + in-process) — see stream-broker.ts; the
+   * composition root owns it (Go: NewStreamBroker in the controller
+   * constructor + GetStreamBroker for the Temporal activities).
+   */
+  readonly broker: StreamBroker;
 }
 
 /** Registers both agentexecution services on the router (routes stage). */
@@ -101,6 +110,7 @@ export function registerAgentExecutionServices(
     get: (id, ctx) => get(deps, id, ctx),
     list: (req, ctx) => list(deps, req, ctx),
     listBySession: (req, ctx) => listBySession(deps, req, ctx),
+    subscribe: (id, ctx) => subscribeExecution(deps, id, ctx),
     getExecutionUsageReport: (req) => getExecutionUsageReport(deps, req),
     getSessionUsageReport: (req) => getSessionUsageReport(deps, req),
     getAgentUsageReport: (req) => getAgentUsageReport(deps, req),

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/controller.ts
@@ -65,9 +65,13 @@ import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
+import type { ExecutionEngineStateProvider } from "./engine.js";
 import { agentExecutionSearchExtractor } from "./search-extractor.js";
 import type { StreamBroker } from "./stream-broker.js";
+import { submitApproval } from "./submit-approval.js";
+import { submitFileDecision } from "./submit-file-decision.js";
 import { subscribeExecution } from "./subscribe.js";
+import { updateStatus } from "./update-status.js";
 import {
   EXECUTION_LIST_KEY,
   newApplyPhaseFilterStep,
@@ -95,6 +99,12 @@ export interface AgentExecutionControllerDeps {
    * constructor + GetStreamBroker for the Temporal activities).
    */
   readonly broker: StreamBroker;
+  /**
+   * The execution-engine seam (engine.ts): permanently disconnected until
+   * #18's TemporalManager flips it. Consumed by the engine gate, the
+   * lifecycle RPCs, and the two HITL signal steps.
+   */
+  readonly engineState: ExecutionEngineStateProvider;
 }
 
 /** Registers both agentexecution services on the router (routes stage). */
@@ -104,6 +114,9 @@ export function registerAgentExecutionServices(
 ): void {
   router.service(AgentExecutionCommandController, {
     update: (execution, ctx) => update(deps, execution, ctx),
+    updateStatus: (input) => updateStatus(deps, input),
+    submitApproval: (input) => submitApproval(deps, input),
+    submitFileDecision: (input) => submitFileDecision(deps, input),
     delete: (id, ctx) => deleteExecution(deps, id, ctx),
   });
   router.service(AgentExecutionQueryController, {

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/create-execution-context-step.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/create-execution-context-step.ts
@@ -56,13 +56,18 @@ import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/a
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { MessageInitShape } from "@bufbuild/protobuf";
 
+import { ConnectError } from "@connectrpc/connect";
+
 import type { Logger } from "../../boot/logger.js";
 import {
   filterByDeclaredKeys,
   mergeEnvironmentLayers,
   validateRequiredKeys,
 } from "../../envmerge/envmerge.js";
-import { failedPreconditionError } from "../../pipeline/errors.js";
+import {
+  failedPreconditionError,
+  goWrappedStatusError,
+} from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
@@ -202,17 +207,42 @@ export async function buildAndPersistExecutionContext(
   const executionOrg = execution.metadata?.org ?? "";
 
   // 1. Resolve agent_instance_id.
-  const agentInstanceId = await resolveAgentInstanceId(
-    deps,
-    execution,
-    preResolvedInstanceId,
-  );
+  let agentInstanceId: string;
+  try {
+    agentInstanceId = await resolveAgentInstanceId(
+      deps,
+      execution,
+      preResolvedInstanceId,
+    );
+  } catch (error) {
+    chainError("resolve agent instance", error);
+  }
 
   // 2.–3. Load the instance (environment_refs + agent_id), then the
-  // agent (env declarations) — in-process, full chain traversal.
-  const instance = await deps.agentInstanceLoader().get(agentInstanceId);
+  // agent (env declarations) — in-process, full chain traversal. Load
+  // failures keep the inner status code with Go's wrap prefix.
+  let instance: AgentInstance;
+  try {
+    instance = await deps.agentInstanceLoader().get(agentInstanceId);
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      throw goWrappedStatusError(
+        `load agent instance ${agentInstanceId}`,
+        error,
+      );
+    }
+    chainError(`load agent instance ${agentInstanceId}`, error);
+  }
   const agentId = instance.spec?.agentId ?? "";
-  const agentResource = await deps.agentLoader().get(agentId);
+  let agentResource: Agent;
+  try {
+    agentResource = await deps.agentLoader().get(agentId);
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      throw goWrappedStatusError(`load agent ${agentId}`, error);
+    }
+    chainError(`load agent ${agentId}`, error);
+  }
 
   // 4. Resolve environments from instance environment_refs.
   let environments = await resolveEnvironments(
@@ -355,13 +385,42 @@ export async function buildAndPersistExecutionContext(
       data: Object.fromEntries(filtered),
     },
   });
-  const created = await deps.executionContextCreator().create(ec);
+  let created: ExecutionContext;
+  try {
+    created = await deps.executionContextCreator().create(ec);
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      throw goWrappedStatusError(
+        `create execution context for ${executionId}`,
+        error,
+      );
+    }
+    chainError(`create execution context for ${executionId}`, error);
+  }
 
   deps.logger.info("Successfully created execution context", {
     executionContextId: created.metadata?.id ?? "",
     executionId,
     dataEntries: filtered.size,
   });
+}
+
+/**
+ * Go's %w wrap chains, mirrored: the INNERMOST status boundary renders
+ * through goWrappedStatusError ("prefix: rpc error: code = X desc = …");
+ * every OUTER wrap prepends plain text while preserving the inner code —
+ * exactly how nested fmt.Errorf("%s: %w") chains reach the wire through
+ * the pipeline's errors.As branch (the #852 leak). Plain errors chain as
+ * plain errors and land on the pipeline's Internal fallback, Go's
+ * non-status path.
+ */
+function chainError(prefix: string, error: unknown): never {
+  if (error instanceof ConnectError) {
+    throw new ConnectError(`${prefix}: ${error.rawMessage}`, error.code);
+  }
+  throw new Error(
+    `${prefix}: ${error instanceof Error ? error.message : String(error)}`,
+  );
 }
 
 /** Path A/Path B instance resolution (Go resolveAgentInstanceID). */
@@ -379,7 +438,17 @@ async function resolveAgentInstanceId(
       "neither a pre-resolved instance id nor session_id on execution",
     );
   }
-  const session = await deps.sessionLoader().get(sessionId);
+  let session: Session;
+  try {
+    session = await deps.sessionLoader().get(sessionId);
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      throw goWrappedStatusError(`load session ${sessionId}`, error);
+    }
+    throw new Error(
+      `load session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   const agentInstanceId = session.spec?.agentInstanceId ?? "";
   if (agentInstanceId === "") {
     throw new Error(`session ${sessionId} has no agent_instance_id`);
@@ -407,8 +476,18 @@ async function resolveEnvironments(
     try {
       environments.push(await deps.environmentResolution.resolveByReference(ref));
     } catch (error) {
-      throw new Error(
-        `resolve environment ref (org=${ref.org}, slug=${ref.slug}): ${error instanceof Error ? error.message : String(error)}`,
+      // The resolution service throws typed statuses (NotFound for a
+      // deleted environment) — the inner code must reach the wire so a
+      // caller-fixable authoring error never masquerades as a 500.
+      if (error instanceof ConnectError) {
+        throw goWrappedStatusError(
+          `resolve environment ref (org=${ref.org}, slug=${ref.slug})`,
+          error,
+        );
+      }
+      chainError(
+        `resolve environment ref (org=${ref.org}, slug=${ref.slug})`,
+        error,
       );
     }
   }
@@ -474,9 +553,7 @@ async function resolveScheduleEnvironments(
   try {
     return await resolveEnvironments(deps, resolved);
   } catch (error) {
-    throw new Error(
-      `resolve schedule ${scheduleId} environment_refs: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    chainError(`resolve schedule ${scheduleId} environment_refs`, error);
   }
 }
 
@@ -590,8 +667,9 @@ async function resolveWorkflowTaskEnvironments(
   try {
     return await resolveEnvironments(deps, resolved);
   } catch (error) {
-    throw new Error(
-      `resolve workflow ${workflowId} task "${taskName}" environment_refs: ${error instanceof Error ? error.message : String(error)}`,
+    chainError(
+      `resolve workflow ${workflowId} task "${taskName}" environment_refs`,
+      error,
     );
   }
 }
@@ -735,8 +813,9 @@ async function injectFromPersonalEnvironment(
   let injected = false;
   for (const key of missing) {
     // The personal env's spec.data keys are present even when redacted,
-    // so existence is checkable before the GetSecretValue call.
-    if (!(key in (personalEnv.spec?.data ?? {}))) {
+    // so existence is checkable before the GetSecretValue call. Own-key
+    // membership (Go map semantics — never the prototype chain).
+    if (!Object.hasOwn(personalEnv.spec?.data ?? {}, key)) {
       continue;
     }
     let secretValue: EnvironmentValue;

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/create-execution-context-step.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/create-execution-context-step.ts
@@ -602,7 +602,7 @@ async function resolveWorkflowTaskEnvironments(
  * config all answer empty — the binding no longer exists in the current
  * revision, the degrade-not-fail case (Go agentCallTaskEnvironmentRefs).
  */
-function agentCallTaskEnvironmentRefs(
+export function agentCallTaskEnvironmentRefs(
   logger: Logger,
   workflow: Workflow,
   taskName: string,

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/create-execution-context-step.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/create-execution-context-step.ts
@@ -1,0 +1,1015 @@
+/**
+ * The ExecutionContext builder — ports create_execution_context_step.go:
+ * builds and persists an ExecutionContext with a fully-merged environment
+ * for an agent execution. Shared by the create pipeline
+ * (newCreateExecutionContextStep) and the recover pipeline
+ * (lifecycle.ts's recreate step): recovery must rebuild the EC because
+ * the failed run's workflow cleanup deleted it, and re-resolving from the
+ * CURRENT agent/instance/environment configuration is the desired
+ * semantics ("fix the API key, then recover").
+ *
+ * Resolution chain:
+ *   - Path A (preResolvedInstanceId): agentInstanceLoader → agentLoader
+ *   - Path B (session_id): sessionLoader → session.agent_instance_id →
+ *     agentInstanceLoader → agentLoader
+ *
+ * Merge priority (lowest to highest): schedule/workflow-task
+ * environment_refs (the share/channel/schedule/agent_call layering) →
+ * instance environment_refs (via the environment RuntimeResolutionService
+ * — decrypted, the RPC surface redacts, oss#405) → spec.runtime_env.
+ * Then the declared-key least-privilege filter, the
+ * workspace-provisioning re-injection + personal-environment fallback,
+ * the MCP OAuth injection with inline pre-flight refresh, and the
+ * required-keys warning.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { McpServerUsage } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { EnvironmentList } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import {
+  EnvironmentSecretValueInputSchema,
+  ListEnvironmentsRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import { EnvironmentValueSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { EnvironmentValue } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import { ExecutionValueSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowTaskKind } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/enum_pb";
+import type { AgentCallTaskConfig } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/tasks/agent_call_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  filterByDeclaredKeys,
+  mergeEnvironmentLayers,
+  validateRequiredKeys,
+} from "../../envmerge/envmerge.js";
+import { failedPreconditionError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { OAuthGrant, Store } from "../../store/interface.js";
+import type { RuntimeResolutionService } from "../environment/resolution/resolution.js";
+import type { ManagedEnvironmentService } from "../mcpserver/oauth/managed-env.js";
+import { refreshTokenIfExpired } from "../mcpserver/oauth/refresh.js";
+import { unmarshalTaskConfig } from "../workflow/converter/unmarshal.js";
+
+import { DEFAULT_INSTANCE_ID_KEY } from "./create-steps.js";
+
+/**
+ * The audit link stamped on every schedule-created execution by the run
+ * starter — the environment-resolution key here. Pinned locally with its
+ * lineage (Go scheduletemporal.ScheduleIDLabelKey; the schedule domain is
+ * #22): the enabledtools/temporal-config precedent for pre-porting a
+ * cross-domain constant the consumer needs first.
+ */
+export const SCHEDULE_ID_LABEL_KEY = "stigmer.ai/schedule-id";
+
+/**
+ * Workflow provenance labels, stamped by the workflow runner's CallAgent
+ * activity on every execution it creates. Consumed as the
+ * environment-resolution key — OSS has no caller tokens to carry a claim,
+ * and this single-user edition has no trust boundary the labels could
+ * widen (the DD-015 divergence posture).
+ */
+export const WORKFLOW_EXECUTION_ID_LABEL_KEY =
+  "stigmer.ai/workflow-execution-id";
+export const WORKFLOW_TASK_LABEL_KEY = "stigmer.ai/workflow-task";
+
+/**
+ * Environment variable keys the agent-runner needs for workspace
+ * provisioning, re-injected after env_spec filtering when the session has
+ * git_repo workspace entries (GITHUB_TOKEN is a session-level workspace
+ * concern, not an agent-declared tool dependency).
+ */
+export const WORKSPACE_PROVISIONING_KEYS = ["GITHUB_TOKEN"];
+
+/** The well-known label identifying a user's personal environment. */
+export const PERSONAL_ENV_LABEL = "stigmer.ai/personal";
+
+// ---------------------------------------------------------------------------
+// The narrow in-process edges the builder consumes (DD-002 lazy providers).
+// ---------------------------------------------------------------------------
+
+export interface AgentInstanceLoader {
+  get(instanceId: string): Promise<AgentInstance>;
+}
+export interface SessionLoader {
+  get(sessionId: string): Promise<Session>;
+}
+export interface EnvironmentReader {
+  list(
+    request: MessageInitShape<typeof ListEnvironmentsRequestSchema>,
+  ): Promise<EnvironmentList>;
+  getSecretValue(
+    input: MessageInitShape<typeof EnvironmentSecretValueInputSchema>,
+  ): Promise<EnvironmentValue>;
+}
+export interface ExecutionContextCreator {
+  create(ec: ExecutionContext): Promise<ExecutionContext>;
+}
+
+export interface ExecutionContextBuilderDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly agentLoader: () => { get(agentId: string): Promise<Agent> };
+  readonly agentInstanceLoader: () => AgentInstanceLoader;
+  readonly sessionLoader: () => SessionLoader;
+  readonly environmentReader: () => EnvironmentReader;
+  readonly environmentResolution: RuntimeResolutionService;
+  readonly executionContextCreator: () => ExecutionContextCreator;
+  readonly managedEnvService: ManagedEnvironmentService;
+  /** Test seam forwarded to the OAuth token-endpoint refresh. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * CreateExecutionContext — the create pipeline's step: runs the shared
+ * builder, then clears the consumed runtime_env from the execution — a
+ * create-only concern (recover has no runtime_env to clear). Clearing
+ * ensures secrets never appear in the persisted execution or in Temporal
+ * workflow history.
+ */
+export function newCreateExecutionContextStep(
+  deps: ExecutionContextBuilderDeps,
+): PipelineStep<typeof AgentExecutionSchema> {
+  return {
+    name: "CreateExecutionContext",
+    async execute(ctx) {
+      const execution = ctx.newState;
+
+      // Path A: the instance resolved by CreateDefaultInstanceIfNeeded,
+      // when the request came in by agent_id. Empty for session-first
+      // requests, which the builder resolves via the session (Path B).
+      const resolved = ctx.get(DEFAULT_INSTANCE_ID_KEY);
+      const preResolvedInstanceId =
+        typeof resolved === "string" ? resolved : "";
+
+      await buildAndPersistExecutionContext(
+        deps,
+        execution,
+        preResolvedInstanceId,
+      );
+
+      if (Object.keys(execution.spec?.runtimeEnv ?? {}).length > 0) {
+        deps.logger.debug(
+          "Clearing runtime_env from execution (consumed into ExecutionContext)",
+          {
+            executionId: execution.metadata?.id ?? "",
+            clearedEntries: Object.keys(execution.spec?.runtimeEnv ?? {})
+              .length,
+          },
+        );
+        const spec = (execution.spec ??= create(AgentExecutionSpecSchema));
+        spec.runtimeEnv = {};
+      }
+    },
+  };
+}
+
+/**
+ * Resolves the environment for the execution and persists a fresh
+ * ExecutionContext (Go buildAndPersist). preResolvedInstanceId
+ * short-circuits instance resolution; "" resolves via the execution's
+ * session_id (the only path recover needs). Failures throw — the create
+ * pipeline surfaces them as-is; the wrapping context matches Go's %w
+ * chains in the logged (never wire) message.
+ */
+export async function buildAndPersistExecutionContext(
+  deps: ExecutionContextBuilderDeps,
+  execution: AgentExecution,
+  preResolvedInstanceId: string,
+): Promise<void> {
+  const executionId = execution.metadata?.id ?? "";
+  const executionOrg = execution.metadata?.org ?? "";
+
+  // 1. Resolve agent_instance_id.
+  const agentInstanceId = await resolveAgentInstanceId(
+    deps,
+    execution,
+    preResolvedInstanceId,
+  );
+
+  // 2.–3. Load the instance (environment_refs + agent_id), then the
+  // agent (env declarations) — in-process, full chain traversal.
+  const instance = await deps.agentInstanceLoader().get(agentInstanceId);
+  const agentId = instance.spec?.agentId ?? "";
+  const agentResource = await deps.agentLoader().get(agentId);
+
+  // 4. Resolve environments from instance environment_refs.
+  let environments = await resolveEnvironments(
+    deps,
+    instance.spec?.environmentRefs ?? [],
+  );
+
+  // 4.5 Schedule-created executions: the schedule's own environment_refs
+  // merge BELOW instance refs (lowest priority — the AgentShare/
+  // AgentChannel layering, DD-017). This is how a tool-using agent
+  // becomes schedulable: the schedule binds the credentials its
+  // unattended runs need without touching the agent or its instance.
+  const scheduleEnvironments = await resolveScheduleEnvironments(
+    deps,
+    execution,
+  );
+  if (scheduleEnvironments.length > 0) {
+    environments = [...scheduleEnvironments, ...environments];
+  }
+
+  // 4.6 Workflow-created executions (agent_call): the task's own
+  // environment_refs, same lowest-priority layering — fourth in the
+  // share/channel/schedule lineage (issue #358 Phase 2). At most one of
+  // 4.5/4.6 applies: an execution is created by a schedule fire or by a
+  // workflow task, never both.
+  const workflowEnvironments = await resolveWorkflowTaskEnvironments(
+    deps,
+    execution,
+  );
+  if (workflowEnvironments.length > 0) {
+    environments = [...workflowEnvironments, ...environments];
+  }
+
+  // 5. Merge all layers.
+  const merged = mergeEnvironmentLayers(
+    environments,
+    execution.spec?.runtimeEnv ?? {},
+  );
+
+  // 6. Least-privilege whitelist: agents only receive variables they
+  // explicitly declared; nil/empty declarations pass everything through.
+  const agentEnvDecls = agentResource.spec?.env ?? {};
+  const filterResult = filterByDeclaredKeys(merged, agentEnvDecls);
+  let filtered = filterResult.filtered;
+  if (filterResult.excludedKeys.length > 0) {
+    deps.logger.warn("Filtered env vars not declared in agent env", {
+      executionId,
+      agentId,
+      excludedKeys: filterResult.excludedKeys,
+    });
+  }
+
+  // 6.5 Re-inject workspace-provisioning keys excluded by the filter,
+  // and fall back to the caller's personal environment for keys never in
+  // the merge chain at all. Session load failures are non-fatal.
+  const sessionId = execution.spec?.sessionId ?? "";
+  let session: Session | undefined;
+  if (sessionId !== "") {
+    try {
+      session = await deps.sessionLoader().get(sessionId);
+    } catch (error) {
+      deps.logger.warn(
+        "Failed to load session for workspace provisioning key injection (non-fatal)",
+        {
+          executionId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+    if (session !== undefined) {
+      filtered = injectWorkspaceProvisioningKeys(
+        deps.logger,
+        filtered,
+        merged,
+        session,
+        executionId,
+      );
+      filtered = await injectFromPersonalEnvironment(
+        deps,
+        filtered,
+        session,
+        executionOrg,
+        executionId,
+      );
+    }
+  }
+
+  // 6.7 Inject OAuth-managed MCP variables from managed environments,
+  // over the merged agent + session MCP usages so session-level servers
+  // (added at runtime) get their tokens too. Refresh failures are FATAL
+  // (FailedPrecondition): an expired token must prevent execution rather
+  // than fail opaquely mid-run with a 401.
+  const mergedMcpUsages = mergeAgentAndSessionMcpUsages(
+    agentResource,
+    session,
+  );
+  try {
+    filtered = await injectMcpOAuthFromManagedEnvironment(
+      deps,
+      filtered,
+      mergedMcpUsages,
+      executionOrg,
+      executionId,
+    );
+  } catch (error) {
+    throw failedPreconditionError(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  // 6.9 Warn on missing required declared vars — the downstream
+  // execution fails with a clearer error if truly needed.
+  const missingRequired = validateRequiredKeys(filtered, agentEnvDecls);
+  if (missingRequired.length > 0) {
+    deps.logger.warn(
+      "Required env vars missing after environment merge — execution may fail",
+      { executionId, agentId, missingRequired },
+    );
+  }
+
+  deps.logger.info("Merged environment layers for execution context", {
+    executionId,
+    mergedCount: merged.size,
+    filteredCount: filtered.size,
+    environmentRefsCount: instance.spec?.environmentRefs.length ?? 0,
+  });
+
+  // 7. Build and persist the ExecutionContext through the in-process
+  // client (the executioncontext create pipeline owns encryption,
+  // ciphertext rejection, and indexing).
+  const ec = create(ExecutionContextSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "ExecutionContext",
+    metadata: {
+      name: `exec-ctx-${executionId}`,
+      org: executionOrg,
+    },
+    spec: {
+      executionId,
+      data: Object.fromEntries(filtered),
+    },
+  });
+  const created = await deps.executionContextCreator().create(ec);
+
+  deps.logger.info("Successfully created execution context", {
+    executionContextId: created.metadata?.id ?? "",
+    executionId,
+    dataEntries: filtered.size,
+  });
+}
+
+/** Path A/Path B instance resolution (Go resolveAgentInstanceID). */
+async function resolveAgentInstanceId(
+  deps: ExecutionContextBuilderDeps,
+  execution: AgentExecution,
+  preResolvedInstanceId: string,
+): Promise<string> {
+  if (preResolvedInstanceId !== "") {
+    return preResolvedInstanceId;
+  }
+  const sessionId = execution.spec?.sessionId ?? "";
+  if (sessionId === "") {
+    throw new Error(
+      "neither a pre-resolved instance id nor session_id on execution",
+    );
+  }
+  const session = await deps.sessionLoader().get(sessionId);
+  const agentInstanceId = session.spec?.agentInstanceId ?? "";
+  if (agentInstanceId === "") {
+    throw new Error(`session ${sessionId} has no agent_instance_id`);
+  }
+  return agentInstanceId;
+}
+
+/**
+ * Fetches each referenced Environment in order via the runtime-resolution
+ * service, NOT the GetByReference RPC: the RPC surface redacts secret
+ * values (oss#405); this internal path returns them decrypted for the
+ * execution-context merge. An unresolvable ref fails the create — an
+ * authoring error must surface as a deterministic refusal, never a silent
+ * run without credentials.
+ */
+async function resolveEnvironments(
+  deps: ExecutionContextBuilderDeps,
+  refs: ApiResourceReference[],
+): Promise<Environment[]> {
+  if (refs.length === 0) {
+    return [];
+  }
+  const environments: Environment[] = [];
+  for (const ref of refs) {
+    try {
+      environments.push(await deps.environmentResolution.resolveByReference(ref));
+    } catch (error) {
+      throw new Error(
+        `resolve environment ref (org=${ref.org}, slug=${ref.slug}): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return environments;
+}
+
+/**
+ * Resolves the environment_refs of the schedule that created this
+ * execution (the stigmer.ai/schedule-id label). No label — the common
+ * case — answers empty at the cost of one map lookup; a DELETED schedule
+ * degrades to no schedule environments; an unresolvable REF fails the
+ * create (Go resolveScheduleEnvironments).
+ */
+async function resolveScheduleEnvironments(
+  deps: ExecutionContextBuilderDeps,
+  execution: AgentExecution,
+): Promise<Environment[]> {
+  const scheduleId =
+    execution.metadata?.labels[SCHEDULE_ID_LABEL_KEY] ?? "";
+  if (scheduleId === "") {
+    return [];
+  }
+
+  let schedule;
+  try {
+    schedule = await deps.store.getResource(
+      ApiResourceKind.schedule,
+      scheduleId,
+      ScheduleSchema,
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      deps.logger.warn(
+        "Schedule-labeled execution's schedule row is gone — running without schedule environments",
+        { scheduleId, executionId: execution.metadata?.id ?? "" },
+      );
+      return [];
+    }
+    throw new Error(
+      `load schedule ${scheduleId} for environment resolution: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const target = schedule.spec?.target;
+  const refs =
+    target?.case === "agent" ? (target.value.environmentRefs ?? []) : [];
+  if (refs.length === 0) {
+    return [];
+  }
+
+  // A manifest ref may omit the org (relative to the schedule's own —
+  // the same-org invariant pins agent_ref.org == metadata.org).
+  const resolved = refs.map((ref) =>
+    ref.org === ""
+      ? create(ApiResourceReferenceSchema, {
+          kind: ref.kind,
+          org: schedule.metadata?.org ?? "",
+          slug: ref.slug,
+        })
+      : ref,
+  );
+
+  try {
+    return await resolveEnvironments(deps, resolved);
+  } catch (error) {
+    throw new Error(
+      `resolve schedule ${scheduleId} environment_refs: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Resolves the environment_refs of the agent_call task that created this
+ * execution (the workflow-provenance labels). Missing labels — every
+ * non-workflow execution — answer empty; a deleted/renamed workflow
+ * execution, workflow, or task degrades to no workflow environments; an
+ * unresolvable REF fails the create (Go resolveWorkflowTaskEnvironments).
+ */
+async function resolveWorkflowTaskEnvironments(
+  deps: ExecutionContextBuilderDeps,
+  execution: AgentExecution,
+): Promise<Environment[]> {
+  const labels = execution.metadata?.labels ?? {};
+  const workflowExecutionId = labels[WORKFLOW_EXECUTION_ID_LABEL_KEY] ?? "";
+  const taskName = labels[WORKFLOW_TASK_LABEL_KEY] ?? "";
+  if (workflowExecutionId === "" || taskName === "") {
+    return [];
+  }
+  const executionId = execution.metadata?.id ?? "";
+
+  let workflowExecution;
+  try {
+    workflowExecution = await deps.store.getResource(
+      ApiResourceKind.workflow_execution,
+      workflowExecutionId,
+      WorkflowExecutionSchema,
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      deps.logger.warn(
+        "Workflow-labeled execution's workflow execution row is gone — running without workflow environments",
+        { workflowExecutionId, executionId },
+      );
+      return [];
+    }
+    throw new Error(
+      `load workflow execution ${workflowExecutionId} for environment resolution: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let workflowId = workflowExecution.spec?.workflowId ?? "";
+  if (workflowId === "") {
+    // Instance-first executions carry only the instance id.
+    const instanceId = workflowExecution.spec?.workflowInstanceId ?? "";
+    if (instanceId === "") {
+      return [];
+    }
+    try {
+      const instance = await deps.store.getResource(
+        ApiResourceKind.workflow_instance,
+        instanceId,
+        WorkflowInstanceSchema,
+      );
+      workflowId = instance.spec?.workflowId ?? "";
+    } catch (error) {
+      if (error instanceof ResourceNotFoundError) {
+        deps.logger.warn(
+          "Workflow-labeled execution's instance row is gone — running without workflow environments",
+          { workflowInstanceId: instanceId, executionId },
+        );
+        return [];
+      }
+      throw new Error(
+        `load workflow instance ${instanceId} for environment resolution: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  if (workflowId === "") {
+    return [];
+  }
+
+  let workflow: Workflow;
+  try {
+    workflow = await deps.store.getResource(
+      ApiResourceKind.workflow,
+      workflowId,
+      WorkflowSchema,
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      deps.logger.warn(
+        "Workflow-labeled execution's workflow row is gone — running without workflow environments",
+        { workflowId, executionId },
+      );
+      return [];
+    }
+    throw new Error(
+      `load workflow ${workflowId} for environment resolution: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const refs = agentCallTaskEnvironmentRefs(deps.logger, workflow, taskName);
+  if (refs.length === 0) {
+    return [];
+  }
+
+  // A ref may omit the org (relative form); resolution follows the
+  // workflow's org — also the execution's billing org.
+  const resolved = refs.map((ref) =>
+    ref.org === ""
+      ? create(ApiResourceReferenceSchema, {
+          kind: ref.kind,
+          org: workflow.metadata?.org ?? "",
+          slug: ref.slug,
+        })
+      : ref,
+  );
+
+  try {
+    return await resolveEnvironments(deps, resolved);
+  } catch (error) {
+    throw new Error(
+      `resolve workflow ${workflowId} task "${taskName}" environment_refs: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Extracts the environment_refs of the named agent_call task. A missing/
+ * renamed task, a non-agent_call task under that name, or an unparsable
+ * config all answer empty — the binding no longer exists in the current
+ * revision, the degrade-not-fail case (Go agentCallTaskEnvironmentRefs).
+ */
+function agentCallTaskEnvironmentRefs(
+  logger: Logger,
+  workflow: Workflow,
+  taskName: string,
+): ApiResourceReference[] {
+  for (const task of workflow.spec?.tasks ?? []) {
+    if (task.name !== taskName || task.kind !== WorkflowTaskKind.agent_call) {
+      continue;
+    }
+    let msg;
+    try {
+      msg = unmarshalTaskConfig(task.kind, task.taskConfig);
+    } catch (error) {
+      logger.warn(
+        "agent_call task config no longer parses — running without workflow environments",
+        {
+          taskName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return [];
+    }
+    const cfg = msg as AgentCallTaskConfig;
+    return cfg.environmentRefs;
+  }
+  return [];
+}
+
+/**
+ * Re-injects provisioning keys excluded by the declared-key filter, only
+ * when the session actually has git_repo workspace entries (Go
+ * injectWorkspaceProvisioningKeys; the copy-on-write is preserved so the
+ * caller's maps are never mutated).
+ */
+function injectWorkspaceProvisioningKeys(
+  logger: Logger,
+  filtered: Map<string, ExecutionValue>,
+  merged: Map<string, ExecutionValue>,
+  session: Session,
+  executionId: string,
+): Map<string, ExecutionValue> {
+  const hasGitRepo = (session.spec?.workspaceEntries ?? []).some(
+    (entry) => entry.source?.source.case === "gitRepo",
+  );
+  if (!hasGitRepo) {
+    return filtered;
+  }
+
+  let out = filtered;
+  let injected = false;
+  for (const key of WORKSPACE_PROVISIONING_KEYS) {
+    if (out.has(key)) {
+      continue;
+    }
+    const val = merged.get(key);
+    if (val === undefined) {
+      continue;
+    }
+    if (!injected) {
+      out = new Map(out);
+      injected = true;
+    }
+    out.set(key, val);
+    logger.info(
+      "Re-injected workspace-provisioning key after env_spec filter (session has git_repo entries)",
+      { executionId, key },
+    );
+  }
+  return out;
+}
+
+/**
+ * The fallback for provisioning keys absent from the merge chain
+ * entirely: looks up the caller's personal environment (org +
+ * stigmer.ai/personal=true) and injects the decrypted secret. ALL
+ * failures are non-fatal — the downstream git clone fails with a clear
+ * auth error if the token is truly required (Go
+ * injectFromPersonalEnvironment).
+ */
+async function injectFromPersonalEnvironment(
+  deps: ExecutionContextBuilderDeps,
+  filtered: Map<string, ExecutionValue>,
+  session: Session,
+  executionOrg: string,
+  executionId: string,
+): Promise<Map<string, ExecutionValue>> {
+  const hasGitRepo = (session.spec?.workspaceEntries ?? []).some(
+    (entry) => entry.source?.source.case === "gitRepo",
+  );
+  if (!hasGitRepo) {
+    return filtered;
+  }
+
+  const missing = WORKSPACE_PROVISIONING_KEYS.filter(
+    (key) => !filtered.has(key),
+  );
+  if (missing.length === 0) {
+    return filtered;
+  }
+
+  let listResponse: EnvironmentList;
+  try {
+    listResponse = await deps.environmentReader().list(
+      create(ListEnvironmentsRequestSchema, {
+        org: executionOrg,
+        labels: { [PERSONAL_ENV_LABEL]: "true" },
+      }),
+    );
+  } catch (error) {
+    deps.logger.warn(
+      "Failed to list personal environments for provisioning key injection (non-fatal)",
+      {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return filtered;
+  }
+  if (listResponse.totalCount === 0 || listResponse.items.length === 0) {
+    deps.logger.debug(
+      "No personal environment found — skipping provisioning key injection from personal env",
+      { executionId, org: executionOrg },
+    );
+    return filtered;
+  }
+
+  const personalEnv = listResponse.items[0] as Environment;
+  const personalEnvId = personalEnv.metadata?.id ?? "";
+
+  let out = filtered;
+  let injected = false;
+  for (const key of missing) {
+    // The personal env's spec.data keys are present even when redacted,
+    // so existence is checkable before the GetSecretValue call.
+    if (!(key in (personalEnv.spec?.data ?? {}))) {
+      continue;
+    }
+    let secretValue: EnvironmentValue;
+    try {
+      secretValue = await deps.environmentReader().getSecretValue(
+        create(EnvironmentSecretValueInputSchema, {
+          environmentId: personalEnvId,
+          key,
+        }),
+      );
+    } catch (error) {
+      deps.logger.warn(
+        "Failed to retrieve secret from personal environment (non-fatal)",
+        {
+          executionId,
+          key,
+          personalEnvId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      continue;
+    }
+    if (secretValue.value === "") {
+      continue;
+    }
+    if (!injected) {
+      out = new Map(out);
+      injected = true;
+    }
+    out.set(
+      key,
+      create(ExecutionValueSchema, { value: secretValue.value, isSecret: true }),
+    );
+    deps.logger.info(
+      "Injected workspace-provisioning key from caller's personal environment",
+      { executionId, key, personalEnvId },
+    );
+  }
+  return out;
+}
+
+/**
+ * Combines MCP server usages from the agent and session, deduplicating by
+ * slug with agent-level usages taking priority — so servers added at the
+ * session level (e.g. via the UI at runtime) are included in OAuth token
+ * injection too (Go mergeAgentAndSessionMcpUsages).
+ */
+export function mergeAgentAndSessionMcpUsages(
+  agentResource: Agent | undefined,
+  session: Session | undefined,
+): McpServerUsage[] {
+  const merged = new Map<string, McpServerUsage>();
+  // Session usages first (lower priority).
+  for (const usage of session?.spec?.mcpServerUsages ?? []) {
+    const slug = usage.mcpServerRef?.slug ?? "";
+    if (slug !== "") {
+      merged.set(slug, usage);
+    }
+  }
+  // Agent usages override (higher priority).
+  for (const usage of agentResource?.spec?.mcpServerUsages ?? []) {
+    const slug = usage.mcpServerRef?.slug ?? "";
+    if (slug !== "") {
+      merged.set(slug, usage);
+    }
+  }
+  return [...merged.values()];
+}
+
+/**
+ * Reads OAuth-managed access tokens from managed environments for MCP
+ * servers with spec.auth: grant lookup by (identity="", server_id, org) —
+ * OSS single-user — then inline pre-flight refresh if expired, then the
+ * token read. Refresh failures THROW (fatal; the caller maps to
+ * FailedPrecondition); read failures are non-fatal skips (Go
+ * injectMcpOAuthFromManagedEnvironment).
+ */
+async function injectMcpOAuthFromManagedEnvironment(
+  deps: ExecutionContextBuilderDeps,
+  filtered: Map<string, ExecutionValue>,
+  mcpServerUsages: McpServerUsage[],
+  executionOrg: string,
+  executionId: string,
+): Promise<Map<string, ExecutionValue>> {
+  if (mcpServerUsages.length === 0) {
+    return filtered;
+  }
+
+  let out = filtered;
+  let injected = false;
+  for (const usage of mcpServerUsages) {
+    const ref = usage.mcpServerRef;
+    const slug = ref?.slug ?? "";
+    if (slug === "") {
+      continue;
+    }
+    let serverOrg = ref?.org ?? "";
+    if (serverOrg === "") {
+      serverOrg = executionOrg;
+    }
+    if (serverOrg === "") {
+      continue;
+    }
+
+    let mcpServer;
+    try {
+      mcpServer = await findResourceBySlug(
+        deps.store,
+        ApiResourceKind.mcp_server,
+        McpServerSchema,
+        slug,
+        serverOrg,
+      );
+    } catch {
+      continue;
+    }
+    if (mcpServer === undefined || mcpServer.spec?.auth === undefined) {
+      continue;
+    }
+
+    const mcpServerId = mcpServer.metadata?.id ?? "";
+    const grant = await deps.store.oauthGrants
+      .find("", mcpServerId, serverOrg)
+      .catch(() => undefined);
+    if (grant === undefined) {
+      continue;
+    }
+
+    const oauthKey = grant.accessTokenEnvVar;
+    if (oauthKey === "") {
+      continue;
+    }
+    if (out.has(oauthKey)) {
+      continue;
+    }
+
+    const managedEnvId = grant.environmentId;
+    if (managedEnvId === "") {
+      deps.logger.warn(
+        "OAuth grant has no managed environment ID — skipping token injection",
+        { mcpServerId, executionId },
+      );
+      continue;
+    }
+
+    // Inline pre-flight refresh if expired; failures are fatal — an
+    // expired token must not be silently injected.
+    let refreshResult;
+    try {
+      refreshResult = await inlineRefreshIfExpired(deps, grant, managedEnvId);
+    } catch (error) {
+      throw new Error(
+        `OAuth token refresh failed for MCP server '${mcpServerId}': ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (refreshResult !== undefined && refreshResult.refreshed) {
+      try {
+        await deps.store.oauthGrants.upsert({
+          ...grant,
+          accessTokenExpiresAt: refreshResult.newExpiresAt,
+        });
+      } catch (error) {
+        deps.logger.warn(
+          "Failed to update OAuth grant after inline refresh (non-fatal)",
+          {
+            mcpServerId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
+    let tokenValue: string;
+    try {
+      tokenValue = await deps.managedEnvService.readSecretValue(
+        managedEnvId,
+        oauthKey,
+      );
+    } catch (error) {
+      deps.logger.warn(
+        "Failed to read OAuth token from managed environment (non-fatal)",
+        {
+          mcpServerId,
+          oauthKey,
+          managedEnvId,
+          executionId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      continue;
+    }
+    if (tokenValue === "") {
+      deps.logger.warn(
+        "Failed to read OAuth token from managed environment (non-fatal)",
+        { mcpServerId, oauthKey, managedEnvId, executionId },
+      );
+      continue;
+    }
+
+    if (!injected) {
+      out = new Map(out);
+      injected = true;
+    }
+    out.set(
+      oauthKey,
+      create(ExecutionValueSchema, { value: tokenValue, isSecret: true }),
+    );
+    deps.logger.info("Injected OAuth token from managed environment", {
+      executionId,
+      mcpServerId,
+      oauthKey,
+      managedEnvId,
+    });
+  }
+  return out;
+}
+
+/**
+ * Reads the refresh token from the managed environment and refreshes if
+ * the access token is expired; undefined when the refresh token is
+ * unavailable (Go inlineRefreshIfExpired). No client_secret resolution on
+ * this path — DCR/public clients work without it, and vendor OAuth's
+ * connect pre-flight (#19) owns the OAuthApp lookup; no secret means no
+ * token-endpoint auth method either.
+ */
+async function inlineRefreshIfExpired(
+  deps: ExecutionContextBuilderDeps,
+  grant: OAuthGrant,
+  managedEnvId: string,
+): Promise<import("../mcpserver/oauth/refresh.js").RefreshResult | undefined> {
+  let currentRefreshToken: string;
+  try {
+    currentRefreshToken = await deps.managedEnvService.readSecretValue(
+      managedEnvId,
+      grant.refreshTokenEnvVar,
+    );
+  } catch {
+    return undefined;
+  }
+  if (currentRefreshToken === "") {
+    return undefined;
+  }
+
+  const result = await refreshTokenIfExpired(
+    grant,
+    currentRefreshToken,
+    "",
+    "",
+    deps.logger,
+    deps.fetchImpl ?? fetch,
+  );
+  if (!result.refreshed) {
+    return result;
+  }
+
+  const tokenVariables: { [key: string]: EnvironmentValue } = {
+    [grant.accessTokenEnvVar]: create(EnvironmentValueSchema, {
+      value: result.newAccessToken,
+      isSecret: true,
+    }),
+  };
+  if (result.newRefreshToken !== currentRefreshToken) {
+    tokenVariables[grant.refreshTokenEnvVar] = create(EnvironmentValueSchema, {
+      value: result.newRefreshToken,
+      isSecret: true,
+    });
+  }
+  try {
+    await deps.managedEnvService.updateSecrets(managedEnvId, tokenVariables);
+  } catch (error) {
+    throw new Error(
+      `failed to write refreshed tokens to managed environment: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return result;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/create-steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/create-steps.ts
@@ -35,6 +35,7 @@ import { clone } from "@bufbuild/protobuf";
 import type { Logger } from "../../boot/logger.js";
 import {
   failedPreconditionError,
+  goWrappedStatusError,
   internalError,
   invalidArgumentError,
   notFoundError,
@@ -286,6 +287,11 @@ export function newCreateDefaultInstanceIfNeededStep(
           "internal server error",
         );
       }
+      // Go create.go wraps the downstream error with %w and the pipeline's
+      // errors.As branch keeps the inner CODE with the wrapped text on the
+      // wire (the #852 leak, mirrored via goWrappedStatusError, exactly as
+      // the agent domain's apply-default-instance arm). Unstatused
+      // failures fall to the pipeline's Internal fallback.
       let createdId: string;
       try {
         const created = await deps
@@ -293,13 +299,20 @@ export function newCreateDefaultInstanceIfNeededStep(
           .createAsSystem(buildDefaultInstanceRequest(metadata));
         createdId = created.metadata?.id ?? "";
       } catch (error) {
-        throw internalError(error, "failed to create default instance");
+        if (error instanceof ConnectError) {
+          throw goWrappedStatusError("failed to create default instance", error);
+        }
+        throw new Error(
+          `failed to create default instance: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
 
       // 3. Update agent status with default_instance_id — direct store
       // save (matching Java agentRepo.save), bypassing the Update
       // pipeline; the AGENT kind is explicit since the pipeline's kind is
-      // agent_execution.
+      // agent_execution. A store failure is a plain (non-status) error in
+      // Go, so both editions land on the pipeline's Internal fallback
+      // ("internal server error" — the #478 sanitization posture).
       const status = (agent.status ??= create(AgentStatusSchema));
       status.defaultInstanceId = createdId;
       try {
@@ -310,9 +323,8 @@ export function newCreateDefaultInstanceIfNeededStep(
           agent,
         );
       } catch (error) {
-        throw internalError(
-          error,
-          "failed to persist agent with default instance",
+        throw new Error(
+          `failed to update agent with default instance: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
 
@@ -425,12 +437,20 @@ export function newCreateSessionIfNeededStep(
         spec: buildAutoCreateSessionSpec(callerSpec, defaultInstanceId),
       });
 
-      // 4. Create via in-process gRPC (single source of truth).
+      // 4. Create via in-process gRPC (single source of truth). Go wraps
+      // with %w — the inner code survives to the wire (a session_spec
+      // failing session validation answers InvalidArgument, not
+      // Internal); goWrappedStatusError mirrors the #852 wire shape.
       let createdSession: Session;
       try {
         createdSession = await deps.sessionCreator().create(sessionRequest);
       } catch (error) {
-        throw internalError(error, "failed to create session");
+        if (error instanceof ConnectError) {
+          throw goWrappedStatusError("failed to create session", error);
+        }
+        throw new Error(
+          `failed to create session: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
       sessionId = createdSession.metadata?.id ?? "";
       deps.logger.info("Successfully auto-created session", {
@@ -658,7 +678,12 @@ async function loadConfirmedFacts(store: Store, orgId: string) {
     const ta = a.status?.audit?.specAudit?.createdAt;
     const tb = b.status?.audit?.specAudit?.createdAt;
     if (ta === undefined || tb === undefined) {
-      return tb !== undefined ? -1 : 0;
+      // Nil-first, symmetrically (Go: `return tj != nil` sorts an
+      // untimestamped row before a timestamped one from EITHER side).
+      if (ta === tb) {
+        return 0;
+      }
+      return ta === undefined ? -1 : 1;
     }
     if (ta.seconds !== tb.seconds) {
       return ta.seconds < tb.seconds ? -1 : 1;

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/create-steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/create-steps.ts
@@ -1,0 +1,843 @@
+/**
+ * The create pipeline's domain steps — ports create.go,
+ * compose_declared_preferences_step.go, and
+ * compose_recalled_memories_step.go. The chain itself is assembled in
+ * controller.ts, mirroring Go buildCreatePipeline order exactly.
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/status_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import {
+  DeclaredPreferencesSchema,
+  RecalledMemoriesSchema,
+  RecalledMemoryFactSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { MemoryLifecycleState } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/enum_pb";
+import type { Memory } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type { SessionSpec } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { clone } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { ConnectError, Code } from "@connectrpc/connect";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import {
+  DefaultAgentNotConfiguredError,
+  DefaultAgentNotPublicError,
+  findDefaultAgent,
+} from "../agent/defaultagent.js";
+import { buildDefaultInstanceRequest } from "../agentinstance/defaultinstance.js";
+
+import type {
+  ExecutionEngineStateProvider,
+} from "./engine.js";
+import { EngineDispatchError } from "./engine.js";
+import { ENGINE_UNAVAILABLE_MESSAGE } from "./constants.js";
+import { unavailableError } from "../../pipeline/errors.js";
+
+type CreateDesc = typeof AgentExecutionSchema;
+
+// Context keys for inter-step communication — Go's key strings, verbatim.
+export const DEFAULT_INSTANCE_ID_KEY = "default_instance_id";
+export const CREATED_SESSION_ID_KEY = "created_session_id";
+
+/**
+ * The sentinel subject written on auto-created sessions. The
+ * GenerateSessionSubject activity replaces it with an LLM-generated
+ * title; display paths filter it (PENDING_SUBJECT in the TS SDK,
+ * ResolvedSubject in the Go CLI).
+ */
+export const AUTO_CREATED_SESSION_SUBJECT = "Auto-created session";
+
+// ---------------------------------------------------------------------------
+// The in-process edges the create pipeline consumes (lazy providers per
+// the ratified DI story — the routes↔clients cycle resolves at request
+// time, DD-002).
+// ---------------------------------------------------------------------------
+
+export interface AgentLoader {
+  get(agentId: string): Promise<Agent>;
+}
+export type AgentLoaderProvider = () => AgentLoader;
+
+export interface SessionCreator {
+  create(session: Session): Promise<Session>;
+}
+export type SessionCreatorProvider = () => SessionCreator;
+
+// ---------------------------------------------------------------------------
+// ResolveDefaultAgent — create.go resolveDefaultAgentStep.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the platform's public default agent when neither session_id
+ * nor agent_id (nor a session_spec instance) is provided — the
+ * session-first UX, a VALID request shape, not an input error. Resolution
+ * (candidate set, visibility preference, deterministic incumbent-wins
+ * tie-break) is owned by the defaultagent module, shared with the
+ * Agent.GetDefault RPC and session create.
+ */
+export function newResolveDefaultAgentStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<CreateDesc> {
+  return {
+    name: "ResolveDefaultAgent",
+    async execute(ctx) {
+      const spec = ctx.input.spec;
+      if (
+        (spec?.sessionId ?? "") !== "" ||
+        (spec?.agentId ?? "") !== "" ||
+        (spec?.sessionSpec?.agentInstanceId ?? "") !== ""
+      ) {
+        return;
+      }
+
+      logger.info(
+        "Neither session_id nor agent_id provided, resolving platform default agent",
+      );
+
+      let defaultAgent: Agent;
+      try {
+        defaultAgent = await findDefaultAgent(store, logger);
+      } catch (error) {
+        if (error instanceof DefaultAgentNotConfiguredError) {
+          // Caller-actionable message: the create caller can fix this by
+          // supplying a reference — deliberately different from the
+          // Agent.GetDefault RPC's message, whose caller cannot.
+          throw new ConnectError(
+            "No default agent is configured on this platform. Provide session_id or agent_id explicitly, or seed an agent labeled stigmer.ai/default-agent=true with visibility_public",
+            Code.NotFound,
+          );
+        }
+        if (error instanceof DefaultAgentNotPublicError) {
+          throw failedPreconditionError(
+            "Default agent exists but is not visibility_public",
+          );
+        }
+        // Store/decode failure — an internal fault, not "no default
+        // agent". The sanitized wire copy keeps the cause off the wire
+        // (stigmer/stigmer#478).
+        throw internalError(
+          error,
+          "failed to resolve the platform default agent",
+        );
+      }
+
+      const resolvedId = defaultAgent.metadata?.id ?? "";
+      logger.info("Resolved platform default agent", {
+        agentId: resolvedId,
+        agentName: defaultAgent.metadata?.name ?? "",
+      });
+
+      // Set agent_id on newState (not input): later steps and Persist
+      // operate on newState.
+      const newState = ctx.newState;
+      const newSpec = (newState.spec ??= create(AgentExecutionSpecSchema));
+      newSpec.agentId = resolvedId;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// EnsureSessionOrAgentResolved — the invariant guard.
+// ---------------------------------------------------------------------------
+
+/**
+ * Asserts the post-condition that a session, agent, or
+ * embedded-session-spec instance reference has been resolved. An
+ * invariant guard, NOT input validation: ResolveDefaultAgent runs first
+ * and guarantees one of the three or an error, so reaching this step with
+ * none set is a server-side programming error — hence Internal, not
+ * InvalidArgument. Deliberately diverges from WorkflowExecution's
+ * validateWorkflowOrInstanceStep (InvalidArgument), whose check is
+ * genuinely reachable (issue #196) — do not "harmonize" the two.
+ */
+export function newEnsureSessionOrAgentResolvedStep(
+  logger: Logger,
+): PipelineStep<CreateDesc> {
+  return {
+    name: "EnsureSessionOrAgentResolved",
+    execute(ctx) {
+      const spec = ctx.newState.spec;
+      const hasSessionId = (spec?.sessionId ?? "") !== "";
+      const hasAgentId = (spec?.agentId ?? "") !== "";
+      const hasSpecInstanceId =
+        (spec?.sessionSpec?.agentInstanceId ?? "") !== "";
+      if (!hasSessionId && !hasAgentId && !hasSpecInstanceId) {
+        logger.error(
+          "Invariant violated: no session, agent, or session_spec instance reference resolved after ResolveDefaultAgent",
+        );
+        throw internalError(
+          new Error(
+            "neither session_id, agent_id, nor session_spec.agent_instance_id set after ResolveDefaultAgent",
+          ),
+          "execution target not resolved",
+        );
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// EnsureEngineAvailable lives in engine.ts (Phase 1); re-exported by the
+// controller for chain assembly.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// CreateDefaultInstanceIfNeeded — create.go createDefaultInstanceIfNeededStep.
+// ---------------------------------------------------------------------------
+
+/** The narrow agentinstance CREATE edge (Go agentInstanceClient.CreateAsSystem). */
+export interface ExecutionAgentInstanceCreator {
+  createAsSystem(instance: AgentInstance): Promise<AgentInstance>;
+}
+export type ExecutionAgentInstanceCreatorProvider =
+  () => ExecutionAgentInstanceCreator;
+
+/**
+ * Ensures the referenced agent has a default instance: skips when a
+ * session or explicit session_spec instance names the target; loads the
+ * agent via the in-process client, creates the default instance when the
+ * status lacks one, saves the agent status DIRECTLY to the store
+ * (matching Go/Java: repo save, not the Update pipeline), and stores the
+ * instance id in the context for the next step.
+ */
+export function newCreateDefaultInstanceIfNeededStep(
+  deps: {
+    store: Store;
+    logger: Logger;
+    agentLoader: AgentLoaderProvider;
+    agentInstanceCreator: ExecutionAgentInstanceCreatorProvider;
+  },
+): PipelineStep<CreateDesc> {
+  return {
+    name: "CreateDefaultInstanceIfNeeded",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      const sessionId = execution.spec?.sessionId ?? "";
+      const agentId = execution.spec?.agentId ?? "";
+
+      if (sessionId !== "") {
+        deps.logger.debug(
+          "Session ID already provided, skipping default instance check",
+          { sessionId },
+        );
+        return;
+      }
+      // An explicit session_spec instance fully specifies the target — no
+      // agent load or default-instance creation needed (a default-agent
+      // lookup would stamp misleading metadata).
+      const specInstanceId = execution.spec?.sessionSpec?.agentInstanceId ?? "";
+      if (specInstanceId !== "") {
+        deps.logger.debug(
+          "session_spec carries an explicit agent instance, skipping default instance check",
+          { agentInstanceId: specInstanceId },
+        );
+        return;
+      }
+
+      // 1. Load agent via in-process gRPC (single source of truth).
+      const agent = await deps.agentLoader().get(agentId);
+
+      const defaultInstanceId = agent.status?.defaultInstanceId ?? "";
+      if (defaultInstanceId !== "") {
+        deps.logger.debug("Agent already has default instance", {
+          defaultInstanceId,
+          agentId,
+        });
+        ctx.set(DEFAULT_INSTANCE_ID_KEY, defaultInstanceId);
+        return;
+      }
+
+      // 2. Default instance missing — create it via the in-process edge
+      // (system credentials = the process-global operator identity). The
+      // request builder reads the agent's SLUG at its single source
+      // (defaultinstance.ts, stigmer/stigmer#355).
+      deps.logger.info("Agent missing default instance, creating one", {
+        agentId,
+      });
+      const metadata = agent.metadata;
+      if (metadata === undefined) {
+        throw internalError(
+          new Error(`agent ${agentId} has no metadata`),
+          "internal server error",
+        );
+      }
+      let createdId: string;
+      try {
+        const created = await deps
+          .agentInstanceCreator()
+          .createAsSystem(buildDefaultInstanceRequest(metadata));
+        createdId = created.metadata?.id ?? "";
+      } catch (error) {
+        throw internalError(error, "failed to create default instance");
+      }
+
+      // 3. Update agent status with default_instance_id — direct store
+      // save (matching Java agentRepo.save), bypassing the Update
+      // pipeline; the AGENT kind is explicit since the pipeline's kind is
+      // agent_execution.
+      const status = (agent.status ??= create(AgentStatusSchema));
+      status.defaultInstanceId = createdId;
+      try {
+        await deps.store.saveResource(
+          ApiResourceKind.agent,
+          agentId,
+          AgentSchema,
+          agent,
+        );
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to persist agent with default instance",
+        );
+      }
+
+      ctx.set(DEFAULT_INSTANCE_ID_KEY, createdId);
+      deps.logger.info("Successfully ensured default instance exists", {
+        instanceId: createdId,
+        agentId,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CreateSessionIfNeeded — create.go createSessionIfNeededStep.
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the spec for an auto-created session (Go
+ * buildAutoCreateSessionSpec): a caller-provided spec (the one-call
+ * bootstrap, stigmer/stigmer#249) is CLONED and forwarded so the session
+ * carries workspace_entries, harness, execution_target, MCP servers, and
+ * skills from a single create call; defaults fill in the instance (when
+ * the spec names none) and the subject sentinel (when empty).
+ */
+export function buildAutoCreateSessionSpec(
+  callerSpec: SessionSpec | undefined,
+  defaultInstanceId: string,
+): SessionSpec {
+  const spec =
+    callerSpec !== undefined
+      ? clone(SessionSpecSchema, callerSpec)
+      : create(SessionSpecSchema);
+  if (spec.agentInstanceId === "") {
+    spec.agentInstanceId = defaultInstanceId;
+  }
+  if (spec.subject === "") {
+    spec.subject = AUTO_CREATED_SESSION_SUBJECT;
+  }
+  return spec;
+}
+
+/**
+ * Auto-creates the session when session_id is absent: forwards the
+ * caller's session_spec, fills the instance from the previous step's
+ * context key when needed, owns the session under the CALLER's org (never
+ * the agent's — cross-org public agents stay usable), updates the
+ * execution with the created id, and CLEARS session_spec (the Session
+ * resource is the single source of truth; the persisted execution never
+ * carries a second copy that could drift).
+ */
+export function newCreateSessionIfNeededStep(
+  deps: {
+    logger: Logger;
+    sessionCreator: SessionCreatorProvider;
+  },
+): PipelineStep<CreateDesc> {
+  return {
+    name: "CreateSessionIfNeeded",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      let sessionId = execution.spec?.sessionId ?? "";
+      const agentId = execution.spec?.agentId ?? "";
+
+      if (sessionId !== "") {
+        deps.logger.debug("Session ID already provided, skipping auto-creation", {
+          sessionId,
+        });
+        return;
+      }
+
+      const callerSpec = execution.spec?.sessionSpec;
+      deps.logger.info("Session ID not provided, auto-creating session", {
+        agentId,
+        hasSessionSpec: callerSpec !== undefined,
+      });
+
+      // 1. Resolve the instance when the caller's spec does not name one.
+      // The previous step resolved it and only skips when the spec
+      // carries an explicit instance, so the key is present exactly when
+      // needed.
+      let defaultInstanceId = "";
+      if ((callerSpec?.agentInstanceId ?? "") === "") {
+        const resolved = ctx.get(DEFAULT_INSTANCE_ID_KEY);
+        if (typeof resolved !== "string" || resolved === "") {
+          deps.logger.error("DEFAULT_INSTANCE_ID not found in context", {
+            agentId,
+          });
+          throw internalError(
+            new Error("default instance ID not found in context"),
+            "internal server error",
+          );
+        }
+        defaultInstanceId = resolved;
+      }
+
+      // 2.–3. Build the session request: the caller's org from the
+      // execution metadata (not the agent's org).
+      let orgId = execution.metadata?.org ?? "";
+      if (orgId === "") {
+        orgId = ctx.input.metadata?.org ?? "";
+      }
+      const sessionRequest = create(SessionSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Session",
+        metadata: {
+          // Auto-generated name (Go's session-%d millisecond stamp).
+          name: `session-${Date.now()}`,
+          org: orgId,
+        },
+        spec: buildAutoCreateSessionSpec(callerSpec, defaultInstanceId),
+      });
+
+      // 4. Create via in-process gRPC (single source of truth).
+      let createdSession: Session;
+      try {
+        createdSession = await deps.sessionCreator().create(sessionRequest);
+      } catch (error) {
+        throw internalError(error, "failed to create session");
+      }
+      sessionId = createdSession.metadata?.id ?? "";
+      deps.logger.info("Successfully auto-created session", {
+        sessionId,
+        agentId,
+      });
+
+      // 5. Update the execution and clear the embedded spec (single
+      // source of truth — see the step doc).
+      execution.spec ??= create(AgentExecutionSpecSchema);
+      execution.spec.sessionId = sessionId;
+      execution.spec.sessionSpec = undefined;
+
+      // 6. Track the created session for observability.
+      ctx.set(CREATED_SESSION_ID_KEY, sessionId);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ComposeDeclaredPreferences — compose_declared_preferences_step.go.
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshots the organization's declared standing context onto the
+ * execution spec (DD-002, stigmer/stigmer#293). SERVER-OWNED: stamped
+ * unconditionally, overwriting anything the caller supplied. OSS composes
+ * org_context only (the local server has no per-request user identity).
+ * BEST-EFFORT: an execution must never fail to start because its optional
+ * preferences could not load — genuine failures log at ERROR (quiet
+ * degradation of a should-work path must stay visible) and degrade to an
+ * empty snapshot. Snapshot-at-create is the point: preferences are
+ * mutable, executions are immutable audit records.
+ */
+export function newComposeDeclaredPreferencesStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<CreateDesc> {
+  return {
+    name: "ComposeDeclaredPreferences",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      execution.spec ??= create(AgentExecutionSpecSchema);
+      // Claim the server-owned field first, before any load can fail.
+      execution.spec.declaredPreferences = create(DeclaredPreferencesSchema);
+
+      let orgId = execution.metadata?.org ?? "";
+      if (orgId === "") {
+        orgId = ctx.input.metadata?.org ?? "";
+      }
+      if (orgId === "") {
+        logger.debug(
+          "No org on execution metadata, composing no declared preferences",
+        );
+        return;
+      }
+
+      let org: Organization;
+      try {
+        org = await store.getResource(
+          ApiResourceKind.organization,
+          orgId,
+          OrganizationSchema,
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          logger.debug(
+            "Org not found in store, composing no declared preferences",
+            { orgId },
+          );
+          return;
+        }
+        logger.error(
+          "Failed to load org for declared preferences - degrading to none (best-effort contract)",
+          {
+            orgId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      // Verbatim per DD-002 D2: the server stamps content only;
+      // blank-is-absent is the runner's read-side convention.
+      execution.spec.declaredPreferences.orgContext =
+        org.spec?.preferences?.standingContext ?? "";
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ComposeRecalledMemories — compose_recalled_memories_step.go.
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshots the subject's CONFIRMED memories onto the execution spec
+ * (DD-006, stigmer/stigmer#293 Phase 2 Stage 2) — the recall half of the
+ * memory loop, sibling of ComposeDeclaredPreferences in every invariant:
+ * server-owned (enabled=false stamped on every ineligible/degraded path),
+ * best-effort (degrading to DISABLED, never enabled-with-zero-facts, so a
+ * broken recall never falsely offers the remember tool). OSS gates on the
+ * org flag alone with the empty-string subject sentinel; confirmed-only
+ * (the consent gate is meaningless otherwise); no compose-time truncation
+ * (the runner's retriever selects at prompt build, recorded on
+ * status.recalled_memories_report). Facts order oldest-first on
+ * created_at — identical prompt order in both editions. The Organization
+ * is loaded independently of the preferences step: step independence over
+ * one saved read.
+ */
+export function newComposeRecalledMemoriesStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<CreateDesc> {
+  return {
+    name: "ComposeRecalledMemories",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      execution.spec ??= create(AgentExecutionSpecSchema);
+      // Claim the server-owned field first.
+      execution.spec.recalledMemories = create(RecalledMemoriesSchema);
+
+      let orgId = execution.metadata?.org ?? "";
+      if (orgId === "") {
+        orgId = ctx.input.metadata?.org ?? "";
+      }
+      if (orgId === "") {
+        logger.debug(
+          "No org on execution metadata, composing no recalled memories",
+        );
+        return;
+      }
+
+      let org: Organization;
+      try {
+        org = await store.getResource(
+          ApiResourceKind.organization,
+          orgId,
+          OrganizationSchema,
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          logger.debug(
+            "Org not found in store, composing no recalled memories",
+            { orgId },
+          );
+          return;
+        }
+        logger.error(
+          "Failed to load org for recalled memories - degrading to disabled (best-effort contract)",
+          {
+            orgId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      if (!(org.spec?.preferences?.memoryEnabled ?? false)) {
+        // Default-off is the design — a disabled snapshot is normal
+        // operation, not degradation; no log.
+        return;
+      }
+
+      let facts;
+      try {
+        facts = await loadConfirmedFacts(store, orgId);
+      } catch (error) {
+        // Enabled stays false: a broken recall must not offer the
+        // remember tool (the enabled bit doubles as the tool signal).
+        logger.error(
+          "Failed to load memories for recall - degrading to disabled (best-effort contract)",
+          {
+            orgId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      execution.spec.recalledMemories.enabled = true;
+      execution.spec.recalledMemories.facts = facts;
+      logger.debug("Composed recalled memories snapshot", {
+        orgId,
+        factCount: facts.length,
+      });
+    },
+  };
+}
+
+/**
+ * Scans the memory kind for the OSS single-user subject's (the ""
+ * sentinel) confirmed records in the org, oldest-first. Facts carry only
+ * memory_id + content (the id is the transparency link back to the
+ * addressable record). Undecodable rows are skipped — one bad record must
+ * not take recall down.
+ */
+async function loadConfirmedFacts(store: Store, orgId: string) {
+  const rows = await store.listResources(ApiResourceKind.memory);
+  const memories: Memory[] = [];
+  for (const data of rows) {
+    let memory: Memory;
+    try {
+      memory = fromBinary(MemorySchema, data);
+    } catch {
+      continue;
+    }
+    if ((memory.metadata?.org ?? "") !== orgId) {
+      continue;
+    }
+    if ((memory.spec?.subjectIdentityAccountId ?? "") !== "") {
+      continue;
+    }
+    if (
+      memory.status?.lifecycleState !==
+      MemoryLifecycleState.lifecycle_state_confirmed
+    ) {
+      continue;
+    }
+    memories.push(memory);
+  }
+
+  // Oldest-first on created_at (seconds then nanos; untimestamped rows
+  // first) — mirrors the cloud repo's ORDER BY created_at ASC.
+  memories.sort((a, b) => {
+    const ta = a.status?.audit?.specAudit?.createdAt;
+    const tb = b.status?.audit?.specAudit?.createdAt;
+    if (ta === undefined || tb === undefined) {
+      return tb !== undefined ? -1 : 0;
+    }
+    if (ta.seconds !== tb.seconds) {
+      return ta.seconds < tb.seconds ? -1 : 1;
+    }
+    return ta.nanos - tb.nanos;
+  });
+
+  return memories.map((memory) =>
+    create(RecalledMemoryFactSchema, {
+      memoryId: memory.metadata?.id ?? "",
+      content: memory.spec?.content ?? "",
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SetInitialPhase — create.go setInitialPhaseStep.
+// ---------------------------------------------------------------------------
+
+/**
+ * Sets the execution phase to PENDING so the frontend can show a thinking
+ * indicator immediately, before the agent worker begins processing.
+ */
+export function newSetInitialPhaseStep(): PipelineStep<CreateDesc> {
+  return {
+    name: "SetInitialPhase",
+    execute(ctx) {
+      const execution = ctx.newState;
+      execution.status ??= create(AgentExecutionStatusSchema);
+      execution.status.phase = ExecutionPhase.EXECUTION_PENDING;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ProcessAttachments — create.go processAttachmentsStep.
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates every attachment carries a storage_key — all attachments must
+ * be pre-uploaded via the uploadAttachment RPC.
+ */
+export function newProcessAttachmentsStep(
+  logger: Logger,
+): PipelineStep<CreateDesc> {
+  return {
+    name: "ProcessAttachments",
+    execute(ctx) {
+      const attachments = ctx.newState.spec?.attachments ?? [];
+      if (attachments.length === 0) {
+        return;
+      }
+      for (const attachment of attachments) {
+        if (attachment.storageKey === "") {
+          logger.error(
+            "Attachment missing storage_key - all attachments must be pre-uploaded via uploadAttachment RPC",
+            { filename: attachment.filename },
+          );
+          throw invalidArgumentError(
+            `attachment '${attachment.filename}' missing storage_key: all attachments must be pre-uploaded via uploadAttachment RPC`,
+          );
+        }
+      }
+      logger.info("All attachments validated successfully", {
+        attachmentCount: attachments.length,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// StartWorkflow — create.go startWorkflowStep (behind the engine seam).
+// ---------------------------------------------------------------------------
+
+/**
+ * Starts the Temporal workflow AFTER the execution is persisted. Engine
+ * availability was guaranteed by the EnsureEngineAvailable gate, so a
+ * failure here is a live/transient error: a dispatch-resolution failure
+ * maps to FailedPrecondition (Go's ResolveActivityTaskQueue boundary);
+ * any other start failure marks the execution FAILED and persists it
+ * (whole-resource save is intentional and exempt from the atomic
+ * UpdateStatus path: this is the creation path marking a brand-new
+ * execution whose workflow never started — no approval gate has ever
+ * existed, so there is no event stream to preserve and no concurrent
+ * appender to lose a write to), then answers Internal.
+ */
+export function newStartWorkflowStep(
+  deps: {
+    store: Store;
+    logger: Logger;
+    engineState: ExecutionEngineStateProvider;
+  },
+): PipelineStep<CreateDesc> {
+  return {
+    name: "StartWorkflow",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      const executionId = execution.metadata?.id ?? "";
+
+      const engine = deps.engineState();
+      if (!engine.connected) {
+        // Unreachable behind the gate; kept as the loud belt-and-braces
+        // arm the gate's contract promises (a reconnect flap between the
+        // gate and this step surfaces as the same pinned refusal).
+        throw unavailableError(ENGINE_UNAVAILABLE_MESSAGE);
+      }
+
+      // Log callback token presence (async activity completion pattern —
+      // the token handshake ADR); Base64 preview only, never the bytes.
+      const callbackToken = execution.spec?.callbackToken ?? new Uint8Array();
+      if (callbackToken.length > 0) {
+        const tokenBase64 = Buffer.from(callbackToken).toString("base64");
+        deps.logger.info(
+          "📝 Callback token present - workflow will complete external activity on finish",
+          {
+            executionId,
+            tokenPreview:
+              tokenBase64.length > 20
+                ? `${tokenBase64.slice(0, 20)}...`
+                : tokenBase64,
+            tokenLength: callbackToken.length,
+          },
+        );
+      }
+
+      try {
+        await engine.engine.startInvokeWorkflow({
+          executionId,
+          sessionId: execution.spec?.sessionId ?? "",
+          agentId: execution.spec?.agentId ?? "",
+          callbackToken,
+          autoApproveAll: execution.spec?.autoApproveAll ?? false,
+          parentWorkflowId: execution.spec?.parentWorkflowId ?? "",
+          activityTaskQueueOverride: execution.spec?.activityTaskQueue ?? "",
+        });
+      } catch (error) {
+        if (error instanceof EngineDispatchError) {
+          deps.logger.warn("Activity dispatch failed", {
+            executionId,
+            error: error.message,
+          });
+          throw failedPreconditionError(error.message);
+        }
+
+        deps.logger.error(
+          "Failed to start Temporal workflow - marking execution as FAILED",
+          {
+            executionId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        execution.status ??= create(AgentExecutionStatusSchema);
+        execution.status.phase = ExecutionPhase.EXECUTION_FAILED;
+        execution.status.error = `Failed to start Temporal workflow: ${error instanceof Error ? error.message : String(error)}`;
+
+        try {
+          await deps.store.saveResource(
+            ctx.apiResourceKind,
+            executionId,
+            AgentExecutionSchema,
+            execution as AgentExecution,
+          );
+        } catch (updateError) {
+          throw internalError(
+            updateError,
+            "failed to start workflow and failed to update status",
+          );
+        }
+        throw internalError(error, "failed to start workflow");
+      }
+
+      deps.logger.info("Temporal workflow started successfully", {
+        executionId,
+      });
+    },
+  };
+}
+
+/** Unknown-execution NotFound with Go's kind naming for these paths. */
+export function agentExecutionNotFound(executionId: string): ConnectError {
+  return notFoundError("agent_execution", executionId);
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/engine.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/engine.ts
@@ -46,6 +46,60 @@ export interface ConnectedExecutionEngine {
    * then reconciles the stale execution to FAILED.
    */
   signalApprovalGateResolved(executionId: string): Promise<void>;
+
+  /**
+   * Starts the invoke-agent-execution workflow (Go's dispatch resolution
+   * — ResolveActivityTaskQueue over the session + config — plus
+   * workflowCreator.Create, both temporal-slice code that lands with
+   * #18). Throws EngineDispatchError for dispatch-resolution failures
+   * (the create step maps them to FailedPrecondition, exactly Go's
+   * boundary); any other throw marks the execution FAILED.
+   */
+  startInvokeWorkflow(input: StartInvokeWorkflowInput): Promise<void>;
+
+  /**
+   * The lifecycle client operations (Go temporalClient.SignalWorkflow /
+   * CancelWorkflow / TerminateWorkflow against the byte-pinned workflow
+   * id). Each throws EngineWorkflowNotFoundError when the workflow no
+   * longer exists — the lifecycle steps treat that as
+   * warn-and-proceed (the local state update still applies).
+   */
+  signalPause(executionId: string, reason: string): Promise<void>;
+  signalResume(executionId: string): Promise<void>;
+  cancelWorkflow(executionId: string): Promise<void>;
+  terminateWorkflow(executionId: string, reason: string): Promise<void>;
+}
+
+/**
+ * The slim workflow-start input (Go
+ * workflows.InvokeAgentExecutionWorkflowInput plus the dispatch
+ * coordinates the engine resolves): only orchestration coordinates —
+ * secrets (runtime_env) were already consumed into the ExecutionContext.
+ */
+export interface StartInvokeWorkflowInput {
+  readonly executionId: string;
+  readonly sessionId: string;
+  readonly agentId: string;
+  readonly callbackToken: Uint8Array;
+  readonly autoApproveAll: boolean;
+  readonly parentWorkflowId: string;
+  /**
+   * The spec's activity_task_queue override; "" lets the engine
+   * re-resolve routing from the session (the recover path always passes
+   * "" — see StartFreshWorkflowStep's rationale).
+   */
+  readonly activityTaskQueueOverride: string;
+}
+
+/**
+ * Dispatch-resolution failure sentinel: the create/recover steps map it
+ * to FailedPrecondition (Go's ResolveActivityTaskQueue error boundary).
+ */
+export class EngineDispatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EngineDispatchError";
+  }
 }
 
 /**

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/engine.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/engine.ts
@@ -19,10 +19,11 @@
  * and submitApproval records the decision but skips the resolved-gate
  * signal with a WARN (submit_approval.go signalWorkflowStep).
  *
- * The connected variant's operation surface is deliberately EMPTY here:
- * #18 owns its shape (workflow creator + lifecycle client + signals), and
- * pre-declaring it would be an architecture decision made outside that
- * sub-project's plan gate.
+ * The connected variant's surface carries exactly the operations THIS
+ * controller consumes (the seam Go defines through
+ * workflowCreator/temporalClient method calls); #18 owns the
+ * implementations. Operations the controller does not consume are not
+ * pre-declared — #18's worker internals are its own plan's business.
  */
 import type { RequestContext } from "../../pipeline/request-context.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
@@ -36,7 +37,28 @@ import { ENGINE_UNAVAILABLE_MESSAGE } from "./constants.js";
  * Populated by #18 (sp.agentexecution-orchestration); empty by design
  * until then — see the module header.
  */
-export interface ConnectedExecutionEngine {}
+export interface ConnectedExecutionEngine {
+  /**
+   * Sends the approvalGateResolved signal to the execution's running
+   * workflow (Go InvokeAgentExecutionWorkflowCreator.
+   * SignalApprovalGateResolved). Throws EngineWorkflowNotFoundError when
+   * the backing workflow no longer runs — SubmitApproval's signal step
+   * then reconciles the stale execution to FAILED.
+   */
+  signalApprovalGateResolved(executionId: string): Promise<void>;
+}
+
+/**
+ * The engine's "workflow not found" sentinel (Go
+ * agentexecutiontemporal.ErrWorkflowNotFound). #18's implementation maps
+ * Temporal's not-found onto it; tests construct it directly.
+ */
+export class EngineWorkflowNotFoundError extends Error {
+  constructor(executionId: string) {
+    super(`workflow not found for execution ${executionId}`);
+    this.name = "EngineWorkflowNotFoundError";
+  }
+}
 
 /** Engine availability as an explicit modeled state (guidelines §4). */
 export type ExecutionEngineState =

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/engine.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/engine.ts
@@ -1,0 +1,80 @@
+/**
+ * The execution-engine seam — the ONE place the agentexecution controller
+ * touches Temporal-shaped behavior before sub-project #18 lands the real
+ * worker infrastructure.
+ *
+ * Go models engine availability as two separately-injected nilable fields
+ * on the controller (workflowCreator for create/signal/recover,
+ * temporalClient for the lifecycle RPCs), re-injected by TemporalManager
+ * on every reconnect. The TS guidelines forbid nullable modeling of
+ * optional infrastructure, so availability is an explicit two-variant
+ * state instead; #18's TemporalManager will flip the provider between the
+ * variants on connect/disconnect, exactly where Go calls
+ * SetWorkflowCreator/SetTemporalClient.
+ *
+ * Until #18, the composition root wires ENGINE_DISCONNECTED permanently —
+ * byte-identical behavior to the Go server running without Temporal:
+ * create refuses Unavailable at the gate (create.go
+ * ensureEngineAvailableStep), lifecycle RPCs refuse FailedPrecondition,
+ * and submitApproval records the decision but skips the resolved-gate
+ * signal with a WARN (submit_approval.go signalWorkflowStep).
+ *
+ * The connected variant's operation surface is deliberately EMPTY here:
+ * #18 owns its shape (workflow creator + lifecycle client + signals), and
+ * pre-declaring it would be an architecture decision made outside that
+ * sub-project's plan gate.
+ */
+import type { RequestContext } from "../../pipeline/request-context.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { unavailableError } from "../../pipeline/errors.js";
+import type { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import { ENGINE_UNAVAILABLE_MESSAGE } from "./constants.js";
+
+/**
+ * The engine operations the controller consumes once Temporal is wired.
+ * Populated by #18 (sp.agentexecution-orchestration); empty by design
+ * until then — see the module header.
+ */
+export interface ConnectedExecutionEngine {}
+
+/** Engine availability as an explicit modeled state (guidelines §4). */
+export type ExecutionEngineState =
+  | { readonly connected: true; readonly engine: ConnectedExecutionEngine }
+  | { readonly connected: false };
+
+/**
+ * The permanent pre-#18 state: no Temporal behind this server. A frozen
+ * singleton so identity comparisons in tests stay meaningful.
+ */
+export const ENGINE_DISCONNECTED: ExecutionEngineState = Object.freeze({
+  connected: false,
+});
+
+/**
+ * A provider rather than a value: #18's TemporalManager re-injects on
+ * every reconnect (Go's SetWorkflowCreator), so consumers must observe
+ * the CURRENT state at request time, never a boot-time snapshot.
+ */
+export type ExecutionEngineStateProvider = () => ExecutionEngineState;
+
+/**
+ * EnsureEngineAvailable — create.go ensureEngineAvailableStep: rejects the
+ * create fast — before any persistence or side effect — when the engine is
+ * not connected. Placed after input validation but before the first
+ * side-effecting step, so a malformed request still gets InvalidArgument
+ * first and a down engine orphans nothing (no default instance, no
+ * auto-created session, no ExecutionContext, no execution record).
+ */
+export function newEnsureEngineAvailableStep(
+  engineState: ExecutionEngineStateProvider,
+): PipelineStep<typeof AgentExecutionSchema> {
+  return {
+    name: "EnsureEngineAvailable",
+    execute(_ctx: RequestContext<typeof AgentExecutionSchema>): void {
+      if (!engineState().connected) {
+        throw unavailableError(ENGINE_UNAVAILABLE_MESSAGE);
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/__tests__/file-review-corpus.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/__tests__/file-review-corpus.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The TS-server half of the cross-edition file-review projection corpus
+ * (apis/testdata/hitl/file-review) — ports filereview/corpus_test.go:
+ * replays a persisted file_review ledger through projectFileChangeSets
+ * and asserts the normalized projected summary (derived status, ordered
+ * change ids, decision count, aggregate digest, approved-snapshot
+ * presence; diff_completeness / blocked_reasons / acknowledged ids where
+ * the fixture declares them). Also pins the file-digest vector corpus
+ * (apis/testdata/hitl/file-digest) against fileDigest/aggregateDigest.
+ */
+import path from "node:path";
+
+import { create, enumFromJson, enumToJson, fromJson } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import {
+  FileReviewBlockReasonSchema,
+  DiffCompletenessSchema,
+  ExecutionPhase,
+  ExecutionPhaseSchema,
+  FileChangeSetStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { FileChangeSet } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import {
+  CapturedFileChangeSchema,
+  FileReviewEventSchema,
+  FileReviewEventStreamSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+
+import { aggregateDigest, fileDigest } from "../digest.js";
+import { projectFileChangeSets } from "../project.js";
+import {
+  corpusFiles,
+  hitlCorpusDir,
+  readCorpusJson,
+} from "../../approval/__tests__/corpus-support.js";
+
+interface FileReviewFixture {
+  name: string;
+  execution_id: string;
+  phase: string;
+  events: unknown[];
+  expected: FileChangeSetSummary[];
+}
+
+interface FileChangeSetSummary {
+  id: string;
+  status: string;
+  diff_completeness?: string;
+  change_ids: string[];
+  blocked_reasons?: string[];
+  acknowledged_change_ids?: string[];
+  decision_count: number;
+  aggregate_digest: string;
+  has_approved_snapshot: boolean;
+}
+
+function summarize(cs: FileChangeSet): FileChangeSetSummary {
+  return {
+    id: cs.id,
+    status: enumToJson(FileChangeSetStatusSchema, cs.status) as string,
+    diff_completeness: enumToJson(
+      DiffCompletenessSchema,
+      cs.diffCompleteness,
+    ) as string,
+    change_ids: cs.changes.map((c) => c.id),
+    blocked_reasons: cs.changes.map(
+      (c) => enumToJson(FileReviewBlockReasonSchema, c.blockedReason) as string,
+    ),
+    acknowledged_change_ids: cs.decisions
+      .filter((d) => d.acknowledgeUnreviewable)
+      .map((d) => d.fileChangeId),
+    decision_count: cs.decisions.length,
+    aggregate_digest: cs.aggregateDigest,
+    has_approved_snapshot: cs.approvedSnapshot !== undefined,
+  };
+}
+
+describe("shared file-review projection corpus", () => {
+  const files = corpusFiles("file-review");
+
+  // Guard the guard (Go asserts >= 5 too).
+  it("discovers the corpus", () => {
+    expect(files.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const file of files) {
+    it(path.basename(file), () => {
+      const fx = readCorpusJson(file) as unknown as FileReviewFixture;
+
+      const stream = create(FileReviewEventStreamSchema, {
+        executionId: fx.execution_id,
+      });
+      for (const raw of fx.events) {
+        stream.events.push(fromJson(FileReviewEventSchema, raw as never));
+      }
+
+      const phase =
+        fx.phase === undefined || fx.phase === ""
+          ? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED
+          : enumFromJson(ExecutionPhaseSchema, fx.phase);
+      const got = projectFileChangeSets(phase, stream);
+
+      expect(got.length, "projected change-set count").toBe(fx.expected.length);
+      for (const [i, want] of fx.expected.entries()) {
+        const summary = summarize(got[i] as FileChangeSet);
+        expect(summary.id, `set[${i}] id`).toBe(want.id);
+        expect(summary.status, `set[${i}] status`).toBe(want.status);
+        // Optional assertions: only when the fixture declares them, so a
+        // vector never has to enumerate the usually-default values.
+        if (want.diff_completeness !== undefined && want.diff_completeness !== "") {
+          expect(summary.diff_completeness, `set[${i}] diff_completeness`).toBe(
+            want.diff_completeness,
+          );
+        }
+        expect(summary.decision_count, `set[${i}] decision_count`).toBe(
+          want.decision_count,
+        );
+        expect(summary.aggregate_digest, `set[${i}] aggregate_digest`).toBe(
+          want.aggregate_digest,
+        );
+        expect(
+          summary.has_approved_snapshot,
+          `set[${i}] has_approved_snapshot`,
+        ).toBe(want.has_approved_snapshot);
+        expect(summary.change_ids, `set[${i}] change_ids`).toEqual(
+          want.change_ids,
+        );
+        if ((want.blocked_reasons ?? []).length > 0) {
+          expect(summary.blocked_reasons, `set[${i}] blocked_reasons`).toEqual(
+            want.blocked_reasons,
+          );
+        }
+        if ((want.acknowledged_change_ids ?? []).length > 0) {
+          expect(
+            summary.acknowledged_change_ids,
+            `set[${i}] acknowledged_change_ids`,
+          ).toEqual(want.acknowledged_change_ids);
+        }
+      }
+    });
+  }
+});
+
+interface FileDigestCase {
+  name: string;
+  path_before: string;
+  path_after: string;
+  kind: string;
+  before_sha256: string;
+  after_sha256: string;
+  file_digest: string;
+}
+
+interface FileDigestAggregate {
+  name: string;
+  change_names: string[];
+  aggregate_digest: string;
+}
+
+describe("shared file-digest corpus", () => {
+  const doc = readCorpusJson(
+    path.join(hitlCorpusDir(), "file-digest", "vectors.json"),
+  ) as unknown as {
+    cases: FileDigestCase[];
+    aggregates: FileDigestAggregate[];
+  };
+
+  const changeOf = (c: FileDigestCase) =>
+    fromJson(CapturedFileChangeSchema, {
+      pathBefore: c.path_before,
+      pathAfter: c.path_after,
+      kind: c.kind,
+      beforeSha256: c.before_sha256,
+      afterSha256: c.after_sha256,
+    } as never);
+
+  it("discovers the corpus", () => {
+    expect(doc.cases.length).toBeGreaterThanOrEqual(4);
+    expect(doc.aggregates.length).toBeGreaterThanOrEqual(3);
+  });
+
+  for (const c of doc.cases) {
+    it(`file_digest: ${c.name}`, () => {
+      expect(fileDigest(changeOf(c))).toBe(c.file_digest);
+    });
+  }
+
+  for (const agg of doc.aggregates) {
+    it(`aggregate_digest: ${agg.name}`, () => {
+      const byName = new Map(doc.cases.map((c) => [c.name, c]));
+      const changes = agg.change_names.map((name) =>
+        changeOf(byName.get(name) as FileDigestCase),
+      );
+      expect(aggregateDigest(changes)).toBe(agg.aggregate_digest);
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/author.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/author.ts
@@ -1,0 +1,338 @@
+/**
+ * File-review ledger authoring — ports filereview/author.go: the
+ * deterministic event ids, the human-decision builder, the FILE_DECIDED
+ * append (the backend-owned writer), the runner-event fold, and the
+ * digest/completeness enforcement predicates SubmitFileDecision checks
+ * before authoring a decision.
+ */
+import { create, enumToJson } from "@bufbuild/protobuf";
+
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  DiffCompleteness,
+  FileDecisionAction,
+  FileDecisionOrigin,
+  FileDecisionScope,
+  FileReviewEventType,
+  FileReviewEventTypeSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  CapturedFileChange,
+  FileChangeSet,
+  FileDecision,
+  FileReviewEventStream,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import {
+  FileDecisionSchema,
+  FileReviewEventSchema,
+  FileReviewEventStreamSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+
+export const ACTOR_USER = "user";
+
+/**
+ * Stamps events authored by a platform policy (the DD-28 approved-command
+ * auto-keep) — never attributed to the user, so the audit trail always
+ * shows WHO decided.
+ */
+export const ACTOR_POLICY = "policy";
+
+/**
+ * The deterministic idempotency key for a file-review event:
+ * changeSetId:scopeId:eventType (the type rendered as the FULL proto enum
+ * value name, byte-identical to Go's .String()). Authoring is
+ * append-if-absent on this key, so re-deriving or retrying never
+ * duplicates an event.
+ */
+export function eventId(
+  changeSetId: string,
+  scopeId: string,
+  eventType: FileReviewEventType,
+): string {
+  return `${changeSetId}:${scopeId}:${enumToJson(FileReviewEventTypeSchema, eventType) as string}`;
+}
+
+/**
+ * The scope discriminator inside a decision's event id: the file change
+ * id for FILE scope, the change set id for CHANGE_SET scope — lets a set
+ * carry both one set-wide decision and per-file decisions without
+ * event-id collisions.
+ */
+export function decisionScopeId(d: FileDecision): string {
+  if (d.scope === FileDecisionScope.FILE) {
+    return d.fileChangeId;
+  }
+  return d.changeSetId;
+}
+
+/**
+ * Assembles a FileDecision from a validated SubmitFileDecision request
+ * plus server-supplied identity. The id is deterministic
+ * (changeSetId:scopeId) so a resubmit yields the same decision and the
+ * same event id — idempotent by construction. Origin is always USER (the
+ * policy auto-keep has its own constructor in autokeep.ts).
+ */
+export function buildFileDecision(
+  changeSetId: string,
+  fileChangeId: string,
+  scope: FileDecisionScope,
+  action: FileDecisionAction,
+  expectedDigest: string,
+  reviewerId: string,
+  decidedAt: string,
+  reason: string,
+  acknowledgeUnreviewable: boolean,
+): FileDecision {
+  const decision = create(FileDecisionSchema, {
+    changeSetId,
+    fileChangeId,
+    scope,
+    action,
+    expectedDigest,
+    reviewerId,
+    decidedAt,
+    reason,
+    acknowledgeUnreviewable,
+    origin: FileDecisionOrigin.USER,
+  });
+  decision.id = `${changeSetId}:${decisionScopeId(decision)}`;
+  return decision;
+}
+
+/**
+ * Authors a FILE_DECIDED event for the decision and appends it to the
+ * execution's file_review stream, idempotently by event id. The
+ * backend-owned writer (the runner authors capture/reconcile events).
+ * Run inside the store's write lock on a freshly-loaded stream so the
+ * append can never clobber a concurrent write.
+ */
+export function recordFileDecisionEvent(
+  status: AgentExecutionStatus | undefined,
+  executionId: string,
+  decision: FileDecision | undefined,
+): void {
+  recordFileDecisionEventWithActor(status, executionId, decision, ACTOR_USER);
+}
+
+/**
+ * The single FILE_DECIDED append: the human path stamps ACTOR_USER, the
+ * auto-keep policy stamps ACTOR_POLICY. Both share the deterministic
+ * event id, so whichever authority decides first wins and a
+ * retry/resubmit never duplicates.
+ */
+export function recordFileDecisionEventWithActor(
+  status: AgentExecutionStatus | undefined,
+  executionId: string,
+  decision: FileDecision | undefined,
+  actor: string,
+): void {
+  if (status === undefined || decision === undefined) {
+    return;
+  }
+  let stream = status.fileReviewEventStream;
+  if (stream === undefined) {
+    stream = create(FileReviewEventStreamSchema, { executionId });
+    status.fileReviewEventStream = stream;
+  }
+  const event = create(FileReviewEventSchema, {
+    eventId: eventId(
+      decision.changeSetId,
+      decisionScopeId(decision),
+      FileReviewEventType.FILE_DECIDED,
+    ),
+    changeSetId: decision.changeSetId,
+    eventType: FileReviewEventType.FILE_DECIDED,
+    timestamp: decision.decidedAt,
+    actor,
+    payload: { case: "fileDecided", value: decision },
+  });
+  if (hasEvent(stream, event.eventId)) {
+    return;
+  }
+  stream.events.push(event);
+}
+
+/**
+ * Folds the capture/reconcile events the runner authored on its
+ * UpdateStatus payload into the execution's server-owned file_review
+ * stream, append-only and idempotent by event_id — the file-review
+ * analogue of ensureApprovalRequests: the runner contributes events, the
+ * server owns the stream.
+ *
+ * Two invariants are enforced here, not merely documented:
+ *   - One writer per event type. FILE_DECIDED is authored exclusively by
+ *     SubmitFileDecision; a runner-sent FILE_DECIDED is dropped, so the
+ *     runner can never forge a human decision.
+ *   - Append-only. An event whose deterministic event_id already exists
+ *     is skipped, so a re-sent heartbeat or a Temporal retry never
+ *     duplicates (or overwrites) an event.
+ *
+ * Must run inside the store write lock on the freshly-loaded stream so
+ * the appends cannot clobber a concurrent SubmitFileDecision.
+ */
+export function appendRunnerEvents(
+  status: AgentExecutionStatus | undefined,
+  executionId: string,
+  requestStatus: AgentExecutionStatus | undefined,
+): void {
+  if (status === undefined || requestStatus === undefined) {
+    return;
+  }
+  const incoming = requestStatus.fileReviewEventStream?.events ?? [];
+  if (incoming.length === 0) {
+    return;
+  }
+
+  let stream = status.fileReviewEventStream;
+  if (stream === undefined) {
+    stream = create(FileReviewEventStreamSchema, { executionId });
+    status.fileReviewEventStream = stream;
+  }
+
+  for (const ev of incoming) {
+    // Decisions are server-owned (SubmitFileDecision). Never accept one
+    // from the runner — defense in depth against a forged human verdict.
+    if (ev.eventType === FileReviewEventType.FILE_DECIDED) {
+      continue;
+    }
+    if (ev.eventId === "" || ev.changeSetId === "") {
+      continue;
+    }
+    if (hasEvent(stream, ev.eventId)) {
+      continue;
+    }
+    stream.events.push(ev);
+  }
+}
+
+function hasEvent(stream: FileReviewEventStream, id: string): boolean {
+  return stream.events.some((ev) => ev.eventId === id);
+}
+
+/** The projected change set with the given id, or undefined. */
+export function findChangeSet(
+  changeSets: FileChangeSet[],
+  changeSetId: string,
+): FileChangeSet | undefined {
+  return changeSets.find((cs) => cs.id === changeSetId);
+}
+
+/** The captured change with the given id within a set, or undefined. */
+export function findChange(
+  cs: FileChangeSet,
+  fileChangeId: string,
+): CapturedFileChange | undefined {
+  return cs.changes.find((c) => c.id === fileChangeId);
+}
+
+/**
+ * The digest a decision's expected_digest is checked against: the file's
+ * file_digest for FILE scope, the set's aggregate_digest for CHANGE_SET
+ * scope. Enforcement only — never used to correlate.
+ */
+export function targetDigest(
+  cs: FileChangeSet,
+  scope: FileDecisionScope,
+  fileChangeId: string,
+): string {
+  if (scope === FileDecisionScope.FILE) {
+    return findChange(cs, fileChangeId)?.fileDigest ?? "";
+  }
+  return cs.aggregateDigest;
+}
+
+/**
+ * Why an APPROVE of the decision's target must be refused because its
+ * diff is not fully reviewable, or "" when the approve may proceed — the
+ * completeness sibling of targetDigest; the second precondition
+ * SubmitFileDecision enforces before authoring a decision.
+ *
+ * The report rule: a non-COMPLETE diff can never be kept as if complete,
+ * so an unreviewable target is not approvable. Applied to APPROVE only —
+ * REJECT is never gated, so an unreviewable change stays discardable and
+ * the turn can still resume (liveness). FILE scope turns on the one
+ * file's diff_complete; CHANGE_SET scope on the set's diff_completeness,
+ * so a complete file inside a PARTIAL_BLOCKED set is still approvable on
+ * its own. Fail-closed: an UNSPECIFIED completeness, an absent change, or
+ * an absent set are all not approvable.
+ *
+ * The binary-acknowledgment carve-out (DD-16 / DD-17): a BINARY file has
+ * no text diff but its exact bytes are captured and byte-true
+ * reconcilable, so acknowledged==true relaxes the completeness gate for
+ * binaries — the ONLY relaxation: binary only (never a secret-withheld /
+ * size-elided / uncapturable file, which have no keepable bytes), and it
+ * never touches the expected_digest gate. The CHANGE_SET carve-out
+ * re-derives "binary-only" from the actual changes, never from the
+ * diff_completeness rollup, so a stale or mislabeled rollup can never
+ * widen what may be kept.
+ */
+export function approveBlockedReason(
+  cs: FileChangeSet | undefined,
+  scope: FileDecisionScope,
+  fileChangeId: string,
+  acknowledged: boolean,
+): string {
+  if (cs === undefined) {
+    return "change set is not reviewable";
+  }
+  if (scope === FileDecisionScope.FILE) {
+    const c = findChange(cs, fileChangeId);
+    if (c === undefined) {
+      return `file change ${fileChangeId} is not reviewable`;
+    }
+    if (!c.diffComplete) {
+      // A binary file the user consciously acknowledged is keepable: no
+      // text diff, but exact reconcilable bytes. Every other
+      // incompleteness has no keepable bytes, so acknowledgment does not
+      // unblock it.
+      if (acknowledged && isBinaryChange(c)) {
+        return "";
+      }
+      return `file change ${fileChangeId} cannot be approved: its diff is not fully reviewable (incomplete or binary); reject it to discard, or wait for a complete capture`;
+    }
+    return "";
+  }
+  // CHANGE_SET scope: a COMPLETE set is approvable as-is. Otherwise the
+  // only one-shot keep allowed is a set whose every incompleteness is
+  // binary, and only when the user consciously acknowledged it ("Keep
+  // all", DD-17). Re-derived from the actual changes, never the rollup,
+  // so a stale label cannot let a non-binary file ride along.
+  if (cs.diffCompleteness === DiffCompleteness.COMPLETE) {
+    return "";
+  }
+  if (acknowledged && everyIncompleteChangeIsBinary(cs)) {
+    return "";
+  }
+  return `change set ${cs.id} cannot be approved: at least one file's diff is not fully reviewable (incomplete or binary); reject the affected files or the whole set, or wait for a complete capture`;
+}
+
+/**
+ * Whether either side of a captured change is binary — the single signal
+ * for "reviewable as bytes but not as a text diff" (binary is conveyed by
+ * FileContent.is_binary, never blocked_reason).
+ */
+export function isBinaryChange(c: CapturedFileChange): boolean {
+  return (c.before?.isBinary ?? false) || (c.after?.isBinary ?? false);
+}
+
+/**
+ * Whether the set has at least one incomplete change and every incomplete
+ * change is binary — the "keep-all is safe" condition (DD-17). The
+ * enforcement boundary for a CHANGE_SET-scoped acknowledged approve:
+ * re-deriving from the changes means a secret-withheld / size-elided file
+ * (absent content → not binary) always blocks the bulk keep, whatever the
+ * diff_completeness rollup claims.
+ */
+export function everyIncompleteChangeIsBinary(cs: FileChangeSet): boolean {
+  let sawIncomplete = false;
+  for (const c of cs.changes) {
+    if (c.diffComplete) {
+      continue;
+    }
+    sawIncomplete = true;
+    if (!isBinaryChange(c)) {
+      return false;
+    }
+  }
+  return sawIncomplete;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/autokeep.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/autokeep.ts
@@ -1,0 +1,249 @@
+/**
+ * The approved-command auto-keep policy (DD-28) — ports
+ * filereview/autokeep.go.
+ *
+ * A turn whose ONLY mutation source was shell commands the human
+ * explicitly authorized (per-command approval, APPROVE_ALL category
+ * lease, or the pre-armed spec.auto_approve_all) must not re-gate its
+ * file effects at the turn-boundary review — the user consented to the
+ * command, and the command's file effects are the consented outcome. One
+ * consent, one gate.
+ *
+ * TRUST MODEL. The runner asserts the turn FACTS on the candidate event
+ * (TurnCommandProvenance) — the same trust level as the captured bytes.
+ * The CONSENT is verified HERE against records only the server writes:
+ * every cited row's approval_action was authored by SubmitApproval (and
+ * is preserved against runner writes), and the auto_approve_all flag is
+ * checked against the spec. A runner can therefore never mint
+ * authorization it was never given.
+ *
+ * The decision is a REAL FILE_DECIDED event (origin
+ * POLICY_APPROVED_COMMAND, actor "policy", digest-bound to the reviewed
+ * aggregate) — not a projection shortcut — so the fold keeps one
+ * semantics, the audit trail shows who decided, and the runner reconciles
+ * it exactly like a human keep-all.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  FileChangeSetStatus,
+  FileDecisionAction,
+  FileDecisionOrigin,
+  FileDecisionScope,
+  FileReviewEventType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  FileChangeSet,
+  FileDecision,
+  TurnCommandProvenance,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import { FileDecisionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import {
+  ACTOR_POLICY,
+  approveBlockedReason,
+  decisionScopeId,
+  findChangeSet,
+  recordFileDecisionEventWithActor,
+} from "./author.js";
+import { projectFileChangeSets } from "./project.js";
+
+/**
+ * The audit-trail text on a policy decision. The UI label derives from
+ * FileDecision.origin; this is for the record itself.
+ */
+const AUTO_KEEP_REASON =
+  "Kept automatically: every change in this turn was produced by a command the user approved";
+
+/**
+ * Evaluates every undecided AWAITING_REVIEW change set whose candidate
+ * carries TurnCommandProvenance and — when the consent verifies and the
+ * set is fully reviewable — authors the policy APPROVE. Returns how many
+ * sets were auto-kept.
+ *
+ * Idempotent: the deterministic decision/event id makes re-evaluation on
+ * every status write a no-op once decided, and a racing human decision
+ * wins by first-append. Fail-closed: any verification miss leaves the set
+ * awaiting manual review, exactly as if no provenance existed.
+ *
+ * Must run inside the store write lock (with appendRunnerEvents, before
+ * the projection) so the authored decision lands in the same write as the
+ * candidate that qualified it — the workflow's gate check then never sees
+ * a transient AWAITING_REVIEW for an auto-kept set.
+ */
+export function autoKeepApprovedCommandSets(
+  status: AgentExecutionStatus,
+  executionId: string,
+  autoApproveAll: boolean,
+  logger: Logger,
+): number {
+  const stream = status.fileReviewEventStream;
+  if (stream === undefined || stream.events.length === 0) {
+    return 0;
+  }
+  const changeSets = projectFileChangeSets(status.phase, stream);
+  if (changeSets.length === 0) {
+    return 0;
+  }
+
+  let kept = 0;
+  for (const ev of stream.events) {
+    if (ev.eventType !== FileReviewEventType.CANDIDATE_CAPTURED) {
+      continue;
+    }
+    const provenance =
+      ev.payload.case === "candidateCaptured"
+        ? ev.payload.value.commandProvenance
+        : undefined;
+    if (provenance === undefined) {
+      continue;
+    }
+    const cs = findChangeSet(changeSets, ev.changeSetId);
+    if (
+      cs === undefined ||
+      cs.status !== FileChangeSetStatus.AWAITING_REVIEW
+    ) {
+      continue;
+    }
+    if (cs.decisions.length > 0) {
+      // A (possibly partial) human decision exists — the human owns this
+      // set.
+      continue;
+    }
+    // The same fail-closed completeness gate a human APPROVE passes, with
+    // NO binary acknowledgment: an unreviewable or binary-blocked set is
+    // never auto-kept — it falls back to manual review.
+    const blockedReason = approveBlockedReason(
+      cs,
+      FileDecisionScope.CHANGE_SET,
+      "",
+      false,
+    );
+    if (blockedReason !== "") {
+      logger.info("Auto-keep skipped: set not fully reviewable — manual review", {
+        executionId,
+        changeSetId: cs.id,
+        blockedReason,
+      });
+      continue;
+    }
+    if (!verifyCommandConsent(status, provenance, autoApproveAll)) {
+      logger.warn(
+        "Auto-keep skipped: claimed consent did not verify against server-authored approvals — manual review",
+        {
+          executionId,
+          changeSetId: cs.id,
+          consentToolCallIds: provenance.consentToolCallIds,
+        },
+      );
+      continue;
+    }
+
+    const decision = buildPolicyAutoKeepDecision(cs);
+    recordFileDecisionEventWithActor(
+      status,
+      executionId,
+      decision,
+      ACTOR_POLICY,
+    );
+    kept++;
+    logger.info(
+      "Auto-kept change set: every change produced by an approved command (DD-28)",
+      {
+        executionId,
+        changeSetId: cs.id,
+        consentToolCallIds: provenance.consentToolCallIds,
+        authorizedByAutoApproveAll: provenance.authorizedByAutoApproveAll,
+      },
+    );
+  }
+  return kept;
+}
+
+/**
+ * The policy twin of buildFileDecision: a CHANGE_SET-scoped APPROVE bound
+ * to the aggregate digest the runner captured, origin
+ * POLICY_APPROVED_COMMAND, no reviewer (the actor is "policy"). Shares
+ * the deterministic id space, so a concurrent human decision on the same
+ * set collapses to whichever was appended first.
+ */
+function buildPolicyAutoKeepDecision(cs: FileChangeSet): FileDecision {
+  const decision = create(FileDecisionSchema, {
+    changeSetId: cs.id,
+    scope: FileDecisionScope.CHANGE_SET,
+    action: FileDecisionAction.APPROVE,
+    expectedDigest: cs.aggregateDigest,
+    decidedAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    reason: AUTO_KEEP_REASON,
+    origin: FileDecisionOrigin.POLICY_APPROVED_COMMAND,
+  });
+  decision.id = `${cs.id}:${decisionScopeId(decision)}`;
+  return decision;
+}
+
+/**
+ * Checks the runner's consent claims against the records only the server
+ * writes. Every cited tool call must exist and carry a
+ * SubmitApproval-authored APPROVE or APPROVE_ALL; the auto_approve_all
+ * claim must match the spec-owned flag. At least one consent source is
+ * required — an empty claim authorizes nothing.
+ */
+function verifyCommandConsent(
+  status: AgentExecutionStatus,
+  provenance: TurnCommandProvenance,
+  autoApproveAll: boolean,
+): boolean {
+  if (provenance.authorizedByAutoApproveAll && !autoApproveAll) {
+    return false;
+  }
+  const ids = provenance.consentToolCallIds;
+  if (ids.length === 0 && !provenance.authorizedByAutoApproveAll) {
+    return false;
+  }
+  for (const id of ids) {
+    const tc = findToolCall(status, id);
+    if (tc === undefined) {
+      return false;
+    }
+    switch (tc.approvalAction) {
+      case ApprovalAction.APPROVE:
+      case ApprovalAction.APPROVE_ALL:
+        // Server-authored consent — verified.
+        break;
+      default:
+        return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Locates a tool call by id across the transcript and sub-agent
+ * transcripts (a lease-granting APPROVE_ALL row may live in either).
+ */
+function findToolCall(
+  status: AgentExecutionStatus,
+  id: string,
+): ToolCall | undefined {
+  for (const msg of status.messages) {
+    for (const tc of msg.toolCalls) {
+      if (tc.id === id) {
+        return tc;
+      }
+    }
+  }
+  for (const sa of status.subAgentExecutions) {
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        if (tc.id === id) {
+          return tc;
+        }
+      }
+    }
+  }
+  return undefined;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/cas-blob.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/cas-blob.ts
@@ -1,0 +1,52 @@
+/**
+ * CAS-blob content-integrity verification — ports filereview/cas_blob.go.
+ * The runner content-addresses gitignored/non-git before/after bytes
+ * under artifacts/{execution_id}/filereview/cas/blobs/{sha256}; the
+ * trailing 64-char lowercase-hex segment IS the SHA-256 of the stored
+ * bytes, making the key self-verifying.
+ */
+import { sha256HexBytes } from "./digest.js";
+
+/**
+ * Strict lowercase hex to match the producer; an off-convention key is
+ * treated as non-CAS (skipped), never as a failure.
+ */
+const CAS_BLOB_KEY_PATTERN =
+  /^artifacts\/[^/]+\/filereview\/cas\/blobs\/([0-9a-f]{64})$/;
+
+/**
+ * The single, static, user-facing reason when a CAS blob's served bytes
+ * do not match the content address in its key — intentionally free of
+ * interpolated hashes or keys (safe to surface; diagnostics go to the
+ * caller's structured log; a static string lets the edition mirror
+ * tables assert exact equality).
+ */
+export const CAS_BLOB_CONTENT_MISMATCH_REASON =
+  "artifact content failed integrity verification: the stored bytes do not match the content address in the storage key";
+
+/**
+ * Why served bytes fail the content-address integrity check embedded in a
+ * CAS blob storage key, or "" when the read may be served. A pure,
+ * transport-free predicate whose non-empty reason the caller maps to a
+ * DATA_LOSS status.
+ *
+ * Fail-open on anything that is not a CAS blob key: git-substrate
+ * offloads, tool-call outputs, attachments, the CAS manifest, or any
+ * future convention all return "" and are served untouched. The caller
+ * MUST pass the COMPLETE object bytes (a truncated read cannot be
+ * full-hash-verified, so the caller skips verification in that case).
+ * Enforcement only, never a correlation key.
+ */
+export function casBlobContentMismatch(
+  storageKey: string,
+  content: Uint8Array,
+): string {
+  const m = CAS_BLOB_KEY_PATTERN.exec(storageKey);
+  if (m === null) {
+    return "";
+  }
+  if (sha256HexBytes(content) === m[1]) {
+    return "";
+  }
+  return CAS_BLOB_CONTENT_MISMATCH_REASON;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/digest.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/digest.ts
@@ -1,0 +1,58 @@
+/**
+ * The canonical file-change digests — ports filereview/digest.go. The
+ * filereview module is the backend half of the apply-then-review
+ * file-change subsystem: it owns the canonical change digests, authors
+ * FILE_DECIDED events on the append-only file_review ledger, and projects
+ * FileChangeSet from that ledger — the approval package's append-only
+ * discipline instantiated for a second lifecycle.
+ *
+ * FileDigest is the enforcement key the runner's reconcile checks before
+ * applying a decision ("what you approve is what gets applied"); NEVER a
+ * correlation key (correlation is by CapturedFileChange.id). The
+ * canonical form digests the content HASHES, not raw bytes, so the string
+ * is pure ASCII with no encoding ambiguity across editions. kind renders
+ * as the proto enum value name (Go .String() / Java name()). The format
+ * is locked by apis/testdata/hitl/file-digest/vectors.json.
+ */
+import { createHash } from "node:crypto";
+
+import { enumToJson } from "@bufbuild/protobuf";
+
+import { FileChangeKindSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { CapturedFileChange } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+
+export function fileDigest(c: CapturedFileChange): string {
+  const canonical = [
+    c.pathBefore,
+    c.pathAfter,
+    enumToJson(FileChangeKindSchema, c.kind) as string,
+    c.beforeSha256,
+    c.afterSha256,
+  ].join("\n");
+  return sha256Hex(canonical);
+}
+
+/**
+ * The canonical digest over a change set's whole manifest. Per-file
+ * digests are sorted so the result is independent of input order (a
+ * change set is an unordered set of files for identity). The empty set
+ * hashes the empty string. Enforcement only, never a correlation key.
+ */
+export function aggregateDigest(changes: CapturedFileChange[]): string {
+  const digests = changes.map(fileDigest);
+  digests.sort();
+  return sha256Hex(digests.join("\n"));
+}
+
+function sha256Hex(s: string): string {
+  return createHash("sha256").update(s, "utf-8").digest("hex");
+}
+
+/**
+ * The raw-bytes content address CAS blobs are keyed by (Node
+ * createHash("sha256").digest("hex") — lowercase hex, exactly Go's
+ * hex.EncodeToString).
+ */
+export function sha256HexBytes(b: Uint8Array): string {
+  return createHash("sha256").update(b).digest("hex");
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/gate.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/gate.ts
@@ -1,0 +1,68 @@
+/**
+ * The unified HITL resume gate — ports filereview/gate.go. Two lifecycles
+ * can block a single turn: tool approvals (pending_approvals) and file
+ * review (file_change_sets awaiting a human decision); a turn is
+ * unblocked only when BOTH are clear. These helpers are the one place
+ * that truth is computed, so the workflow's wake condition,
+ * SubmitApproval's signal, and SubmitFileDecision's signal can never
+ * disagree about whether the turn may resume.
+ */
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { FileChangeSetStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { FileChangeSet } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+
+/**
+ * How many change sets still wait on a human decision (AWAITING_REVIEW).
+ * A CAPTURING set is mid-turn (the runner has not returned yet) and a
+ * DECIDED/RECONCILED/FAILED set no longer blocks the gate, so neither
+ * counts.
+ */
+export function countAwaitingReview(changeSets: FileChangeSet[]): number {
+  let n = 0;
+  for (const cs of changeSets) {
+    if (cs.status === FileChangeSetStatus.AWAITING_REVIEW) {
+      n++;
+    }
+  }
+  return n;
+}
+
+/** Whether the file-review sub-gate is clear. */
+export function noChangeSetAwaitingReview(
+  status: AgentExecutionStatus,
+): boolean {
+  return countAwaitingReview(status.fileChangeSets) === 0;
+}
+
+/**
+ * The size of the combined HITL gate: tool calls still awaiting approval
+ * plus change sets still awaiting review. The workflow waits while this
+ * is > 0 and re-invokes the runner once it reaches 0.
+ */
+export function unresolvedGateCount(status: AgentExecutionStatus): number {
+  return (
+    status.pendingApprovals.length +
+    countAwaitingReview(status.fileChangeSets)
+  );
+}
+
+/** Whether the combined HITL gate is fully clear — the turn may resume. */
+export function gateResolved(status: AgentExecutionStatus): boolean {
+  return unresolvedGateCount(status) === 0;
+}
+
+/**
+ * Whether some change set is DECIDED — verdicts recorded, runner
+ * reconcile still owed. The workflow's wait loop uses this to tell a
+ * LEGITIMATE empty gate from a broken one (a set decided before the gate
+ * check — the DD-28 auto-keep or a fast human — leaves phase
+ * WAITING_FOR_APPROVAL with a zero gate count; the correct response is an
+ * immediate re-invoke to reconcile, never the empty-gate anomaly path).
+ */
+export function hasDecidedAwaitingReconcile(
+  status: AgentExecutionStatus,
+): boolean {
+  return status.fileChangeSets.some(
+    (cs) => cs.status === FileChangeSetStatus.DECIDED,
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/progress.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/progress.ts
@@ -1,0 +1,51 @@
+/**
+ * ReconcileFileChangeProgress — ports filereview/progress.go: the
+ * defense-in-depth clear for the transient
+ * AgentExecutionStatus.file_change_progress field (mid-run live capture,
+ * DD-32).
+ *
+ * Progress is a runner-owned, latest-snapshot DISPLAY field (the
+ * file-review analogue of setup_progress), NOT part of the append-only
+ * ledger. The runner overwrites it on each mid-run persist while its
+ * change set is CAPTURING; this seam clears it once that set leaves
+ * CAPTURING, so a stale mid-run delta never outlives the turn.
+ *
+ * It runs AFTER projectFileChangeSets so it reads the just-folded
+ * projection: progress is KEPT only while a CAPTURING change set with the
+ * matching change_set_id exists. A terminal execution is subsumed — the
+ * projection is empty there. Keying on change_set_id (not merely "any
+ * CAPTURING set") is what makes resume correct: a new turn's new set id
+ * no longer matches the stale prior-turn progress, which clears.
+ */
+import { FileChangeSetStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  FileChangeProgress,
+  FileChangeSet,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+
+export function reconcileFileChangeProgress(
+  sets: FileChangeSet[],
+  progress: FileChangeProgress | undefined,
+): FileChangeProgress | undefined {
+  if (progress === undefined) {
+    return undefined;
+  }
+  if (hasCapturingSet(sets, progress.changeSetId)) {
+    return progress;
+  }
+  return undefined;
+}
+
+function hasCapturingSet(
+  sets: FileChangeSet[],
+  changeSetId: string,
+): boolean {
+  if (changeSetId === "") {
+    return false;
+  }
+  return sets.some(
+    (cs) =>
+      cs.id === changeSetId &&
+      cs.status === FileChangeSetStatus.CAPTURING,
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/project.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/filereview/project.ts
@@ -1,0 +1,171 @@
+/**
+ * The file-change-set projection SEAM — ports filereview/project.go.
+ *
+ * projectFileChangeSets is the single entry point every status writer
+ * uses to recompute AgentExecutionStatus.file_change_sets from the
+ * append-only file_review ledger — exactly as projectPendingApprovals is
+ * for approvals. A PURE read: authoring is the capture/reconcile
+ * activities' and recordFileDecisionEvent's job, run before this
+ * projection.
+ *
+ * Unlike the approval seam there is NO scan cross-check and NO divergence
+ * counter: file review is a greenfield, single-source ledger (no legacy
+ * second representation exists to disagree with). The cross-edition
+ * parity guard is the shared corpus.
+ *
+ * "Actionable" is execution-phase-aware: a terminal execution has no
+ * actionable review (the workflow that would reconcile is gone), so the
+ * seam returns empty for a terminal phase. The durable audit trail lives
+ * in the ledger, always preserved regardless of phase.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  FileChangeSetStatus,
+  FileDecisionScope,
+  FileReviewEventType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  FileChangeSet,
+  FileReviewEvent,
+  FileReviewEventStream,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import { FileChangeSetSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+
+export function projectFileChangeSets(
+  phase: ExecutionPhase,
+  stream: FileReviewEventStream | undefined,
+): FileChangeSet[] {
+  if (isTerminalExecution(phase)) {
+    return [];
+  }
+  if (stream === undefined || stream.events.length === 0) {
+    return [];
+  }
+
+  const order: string[] = [];
+  const byId = new Map<string, FileChangeSet>();
+  for (const ev of stream.events) {
+    const csId = ev.changeSetId;
+    if (csId === "") {
+      continue;
+    }
+    let cs = byId.get(csId);
+    if (cs === undefined) {
+      cs = create(FileChangeSetSchema, { id: csId });
+      byId.set(csId, cs);
+      order.push(csId);
+    }
+    applyEvent(cs, ev);
+  }
+
+  return order.map((id) => byId.get(id) as FileChangeSet);
+}
+
+/**
+ * Folds a single ledger event into the change set being built. Event
+ * order is the ledger order; terminal events (RECONCILED / FAILED) set a
+ * terminal status that later non-terminal recomputation does not
+ * override.
+ */
+function applyEvent(cs: FileChangeSet, ev: FileReviewEvent): void {
+  switch (ev.eventType) {
+    case FileReviewEventType.BASELINE_CAPTURED: {
+      if (ev.payload.case === "baselineCaptured") {
+        const b = ev.payload.value;
+        cs.turnId = b.turnId;
+        cs.harnessId = b.harnessId;
+        cs.baselineSnapshot = b.baselineSnapshot;
+      }
+      cs.status = FileChangeSetStatus.CAPTURING;
+      break;
+    }
+    case FileReviewEventType.CANDIDATE_CAPTURED: {
+      if (ev.payload.case === "candidateCaptured") {
+        const c = ev.payload.value;
+        cs.candidateSnapshot = c.candidateSnapshot;
+        cs.changes = c.changes;
+        cs.aggregateDigest = c.aggregateDigest;
+        cs.diffCompleteness = c.diffCompleteness;
+      }
+      cs.status = deriveStatusAfterCandidate(cs);
+      break;
+    }
+    case FileReviewEventType.FILE_DECIDED: {
+      if (ev.payload.case === "fileDecided") {
+        cs.decisions.push(ev.payload.value);
+      }
+      cs.status = deriveStatusAfterCandidate(cs);
+      break;
+    }
+    case FileReviewEventType.RECONCILED: {
+      if (ev.payload.case === "reconciled") {
+        cs.approvedSnapshot = ev.payload.value.approvedSnapshot;
+      }
+      cs.status = FileChangeSetStatus.RECONCILED;
+      break;
+    }
+    case FileReviewEventType.FAILED: {
+      cs.status = FileChangeSetStatus.FAILED;
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+/**
+ * The non-terminal status once a candidate exists: DECIDED when every
+ * change is decided, otherwise AWAITING_REVIEW (partially-decided sets
+ * stay actionable). Never downgrades a terminal status.
+ */
+function deriveStatusAfterCandidate(cs: FileChangeSet): FileChangeSetStatus {
+  switch (cs.status) {
+    case FileChangeSetStatus.RECONCILED:
+    case FileChangeSetStatus.FAILED:
+      return cs.status;
+    default:
+      break;
+  }
+  if (isFullyDecided(cs)) {
+    return FileChangeSetStatus.DECIDED;
+  }
+  return FileChangeSetStatus.AWAITING_REVIEW;
+}
+
+/**
+ * Whether every change in the set has a verdict: either a
+ * CHANGE_SET-scoped decision (covers all), or a FILE decision per change.
+ */
+function isFullyDecided(cs: FileChangeSet): boolean {
+  if (cs.changes.length === 0) {
+    return false;
+  }
+  const decidedFiles = new Set<string>();
+  for (const d of cs.decisions) {
+    if (d.scope === FileDecisionScope.CHANGE_SET) {
+      return true;
+    }
+    if (d.scope === FileDecisionScope.FILE) {
+      decidedFiles.add(d.fileChangeId);
+    }
+  }
+  return cs.changes.every((c) => decidedFiles.has(c.id));
+}
+
+/**
+ * Mirrors the approval package's terminal-phase set exactly, so the two
+ * projections collapse identically on a dead execution.
+ */
+export function isTerminalExecution(phase: ExecutionPhase): boolean {
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_COMPLETED:
+    case ExecutionPhase.EXECUTION_FAILED:
+    case ExecutionPhase.EXECUTION_CANCELLED:
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/lifecycle.ts
@@ -284,6 +284,11 @@ export function cancelInProgressSubAgents(
   completedAt: string,
 ): void {
   for (const sa of subAgents) {
+    // Go skips nil elements (lifecycle_cancel_cascade_test.go NilSafe);
+    // the defensive twin for a hole smuggled past the type system.
+    if (sa === undefined) {
+      continue;
+    }
     if (
       sa.status === SubAgentStatus.SUB_AGENT_IN_PROGRESS ||
       sa.status === SubAgentStatus.SUB_AGENT_PENDING

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/lifecycle.ts
@@ -1,0 +1,797 @@
+/**
+ * The lifecycle RPCs — ports cancel.go, terminate.go, pause.go,
+ * resume.go, recover.go, recreate_execution_context_step.go, and
+ * lifecycle_steps.go: the five phase-transition commands over one shared
+ * step vocabulary.
+ *
+ * Every Temporal touchpoint rides the engine seam. With the engine
+ * disconnected (pre-#18) the Temporal steps refuse
+ * FailedPrecondition("Temporal is not available") — Go's nil-client arm,
+ * asserted by the Class A conformance lifecycle negatives. With a
+ * connected engine, workflow-not-found is warn-and-proceed (the local
+ * state update still applies; the workflow may simply have completed).
+ *
+ * The phase transition + persist is ONE atomic read-modify-write under
+ * the store's per-resource write lock — the lifecycle counterpart of the
+ * UpdateStatus merge chokepoint (pause/cancel/terminate are reachable
+ * from WAITING_FOR_APPROVAL, so the concurrent-SubmitApproval window is
+ * real); lifecycle simply authors no approval events.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import {
+  ExecutionPhase,
+  ExecutionPhaseSchema,
+  SubAgentStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  CancelAgentExecutionInput,
+  PauseAgentExecutionInput,
+  RecoverAgentExecutionInput,
+  ResumeAgentExecutionInput,
+  TerminateAgentExecutionInput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import { enumToJson } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+import type {
+  ExecutionContextBuilderDeps,
+} from "./create-execution-context-step.js";
+import { buildAndPersistExecutionContext } from "./create-execution-context-step.js";
+import type { ExecutionEngineStateProvider } from "./engine.js";
+import {
+  EngineDispatchError,
+  EngineWorkflowNotFoundError,
+} from "./engine.js";
+import { settleInterruptedToolCalls } from "./tool-call-settle.js";
+import type { StreamBroker } from "./stream-broker.js";
+
+// Context keys — Go's key strings, verbatim.
+const LOADED_EXECUTION_KEY = "loadedExecution";
+const REASON_KEY = "reason";
+const ALREADY_IN_TARGET_STATE_KEY = "alreadyInTargetState";
+
+/** The pinned no-engine refusal (Go "Temporal is not available"). */
+export const TEMPORAL_UNAVAILABLE_MESSAGE = "Temporal is not available";
+
+export interface LifecycleDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+  readonly engineState: ExecutionEngineStateProvider;
+  /** The shared EC-builder deps, consumed by recover's recreate step. */
+  readonly executionContextBuilder: ExecutionContextBuilderDeps;
+}
+
+/** Inputs that carry an execution id (Go LifecycleInput). */
+interface LifecycleInputShape {
+  id: string;
+}
+/** Inputs that also carry a reason (Go LifecycleInputWithReason). */
+interface LifecycleInputWithReasonShape extends LifecycleInputShape {
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared steps (lifecycle_steps.go).
+// ---------------------------------------------------------------------------
+
+function newLoadExecutionByIdStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "LoadExecutionById",
+    async execute(ctx) {
+      const executionId = (ctx.newState as unknown as LifecycleInputShape).id;
+      if (executionId === "") {
+        throw invalidArgumentError("execution id is required");
+      }
+      let execution: AgentExecution;
+      try {
+        execution = await deps.store.getResource(
+          ApiResourceKind.agent_execution,
+          executionId,
+          AgentExecutionSchema,
+        );
+      } catch {
+        // Go converts every load failure here to the same NotFound.
+        throw notFoundError("agent_execution", executionId);
+      }
+      ctx.set(LOADED_EXECUTION_KEY, execution);
+    },
+  };
+}
+
+function loadedExecution<Desc extends DescMessage>(
+  ctx: RequestContext<Desc>,
+): AgentExecution {
+  return ctx.get(LOADED_EXECUTION_KEY) as AgentExecution;
+}
+
+function phaseName(phase: ExecutionPhase): string {
+  return enumToJson(ExecutionPhaseSchema, phase) as string;
+}
+
+/**
+ * The five phase-validation steps share one shape: an already-in-target
+ * phase is idempotent success (skips the remaining steps), a phase
+ * outside the allowed set refuses FailedPrecondition with the pinned
+ * per-verb copy.
+ */
+function newValidatePhaseStep<Desc extends DescMessage>(config: {
+  name: string;
+  targetPhase: ExecutionPhase;
+  allowed: ExecutionPhase[];
+  refusal: (phase: ExecutionPhase) => string;
+  logger: Logger;
+}): PipelineStep<Desc> {
+  return {
+    name: config.name,
+    execute(ctx) {
+      const execution = loadedExecution(ctx);
+      const phase =
+        execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+      if (phase === config.targetPhase) {
+        config.logger.debug(
+          "Execution already in target state, returning success (idempotent)",
+          { executionId: execution.metadata?.id ?? "" },
+        );
+        ctx.set(ALREADY_IN_TARGET_STATE_KEY, true);
+        return;
+      }
+      if (!config.allowed.includes(phase)) {
+        throw failedPreconditionError(config.refusal(phase));
+      }
+    },
+  };
+}
+
+/**
+ * The engine-facing lifecycle steps: skip when already in target state,
+ * refuse FailedPrecondition when disconnected (Go's nil temporalClient),
+ * warn-and-proceed on workflow-not-found (the workflow may have already
+ * completed; the local state update still applies).
+ */
+function newEngineLifecycleStep<Desc extends DescMessage>(config: {
+  name: string;
+  deps: LifecycleDeps;
+  invoke: (
+    engine: Extract<
+      ReturnType<ExecutionEngineStateProvider>,
+      { connected: true }
+    >,
+    executionId: string,
+    ctx: RequestContext<Desc>,
+  ) => Promise<void>;
+  failureMessage: string;
+}): PipelineStep<Desc> {
+  return {
+    name: config.name,
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const engine = config.deps.engineState();
+      if (!engine.connected) {
+        throw failedPreconditionError(TEMPORAL_UNAVAILABLE_MESSAGE);
+      }
+      const execution = loadedExecution(ctx);
+      const executionId = execution.metadata?.id ?? "";
+      try {
+        await config.invoke(engine, executionId, ctx);
+      } catch (error) {
+        if (error instanceof EngineWorkflowNotFoundError) {
+          config.deps.logger.warn(
+            "Temporal workflow not found, may have already completed",
+            { executionId },
+          );
+          return;
+        }
+        throw internalError(error, config.failureMessage);
+      }
+    },
+  };
+}
+
+/**
+ * Applies a lifecycle phase transition in place: target phase +
+ * phase-dependent fields (completed_at, error, the terminal sub-agent
+ * cascade, the terminal tool-call settle #207, the terminal
+ * pending_approvals clear). The body run inside the updateResource
+ * closure — the transition is computed against the very snapshot that
+ * will be persisted (Go applyLifecyclePhaseTransition, exercised directly
+ * by the lifecycle unit tests).
+ */
+export function applyLifecyclePhaseTransition(
+  execution: AgentExecution,
+  targetPhase: ExecutionPhase,
+  setError: boolean,
+  clearError: boolean,
+  reason: string,
+): void {
+  execution.status ??= create(AgentExecutionStatusSchema);
+  const status = execution.status;
+  status.phase = targetPhase;
+
+  // completed_at for terminal phases; PAUSED is NOT terminal.
+  if (
+    targetPhase === ExecutionPhase.EXECUTION_CANCELLED ||
+    targetPhase === ExecutionPhase.EXECUTION_TERMINATED
+  ) {
+    const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    status.completedAt = now;
+
+    // Cascade to in-flight sub-agents: a cancelled/terminated parent
+    // leaves no live delegation, so IN_PROGRESS/PENDING sub-agents move
+    // to CANCELLED — never a permanent "Running" zombie. Authoritative
+    // here: the runner's own cancellation persist is best-effort and can
+    // be lost to the cancellation race.
+    cancelInProgressSubAgents(status.subAgentExecutions, now);
+
+    // Same cascade for in-flight tool calls (issue #207) — authoritative
+    // for force-kill, where the runner never gets a finalize.
+    settleInterruptedToolCalls(status, now);
+
+    // A terminal execution has no actionable approvals; this blind clear
+    // keeps the invariant on the bypass paths too, edition-consistently
+    // with the Cloud terminal handlers (the graceful-cancel case is also
+    // cleared later by the workflow cleanup running the seam).
+    status.pendingApprovals = [];
+  }
+
+  // Clear completed_at for recovery / resume back to IN_PROGRESS.
+  if (targetPhase === ExecutionPhase.EXECUTION_IN_PROGRESS) {
+    status.completedAt = "";
+  }
+
+  if (setError) {
+    status.error = reason !== "" ? `Terminated: ${reason}` : "Terminated by user";
+  }
+  if (clearError) {
+    status.error = "";
+  }
+}
+
+/**
+ * Transitions non-terminal sub-agents (IN_PROGRESS/PENDING) to CANCELLED
+ * with a completion timestamp (only when empty, preserving any
+ * runner-recorded one) — Go cancelInProgressSubAgents.
+ */
+export function cancelInProgressSubAgents(
+  subAgents: SubAgentExecution[],
+  completedAt: string,
+): void {
+  for (const sa of subAgents) {
+    if (
+      sa.status === SubAgentStatus.SUB_AGENT_IN_PROGRESS ||
+      sa.status === SubAgentStatus.SUB_AGENT_PENDING
+    ) {
+      sa.status = SubAgentStatus.SUB_AGENT_CANCELLED;
+      if (sa.completedAt === "") {
+        sa.completedAt = completedAt;
+      }
+    }
+  }
+}
+
+/**
+ * The atomic phase-transition persist (Go
+ * UpdateExecutionPhaseAndPersistStep): one read-modify-write under the
+ * per-resource write lock, so an approval event a concurrent
+ * SubmitApproval appends between the earlier load and this persist can
+ * never be lost. UpdateResource requires existence (no upsert): a
+ * lifecycle op racing a delete returns NOT_FOUND rather than resurrecting
+ * a half-built document.
+ */
+function newUpdateExecutionPhaseAndPersistStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+  targetPhase: ExecutionPhase,
+  setError: boolean,
+  clearError: boolean,
+): PipelineStep<Desc> {
+  return {
+    name: "UpdateExecutionPhaseAndPersist",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const execution = loadedExecution(ctx);
+      const executionId = execution.metadata?.id ?? "";
+      const reasonValue = ctx.get(REASON_KEY);
+      const reason = typeof reasonValue === "string" ? reasonValue : "";
+
+      let updated: AgentExecution;
+      try {
+        updated = await deps.store.updateResource(
+          ApiResourceKind.agent_execution,
+          executionId,
+          AgentExecutionSchema,
+          (loaded) => {
+            applyLifecyclePhaseTransition(
+              loaded,
+              targetPhase,
+              setError,
+              clearError,
+              reason,
+            );
+          },
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError("agent_execution", executionId);
+        }
+        throw internalError(error, "failed to persist execution");
+      }
+      // Hand the persisted result to the broadcast step and the handler's
+      // return value (both read the same key).
+      ctx.set(LOADED_EXECUTION_KEY, updated);
+    },
+  };
+}
+
+/** Publishes the transition to live subscribers (Go LifecycleBroadcastStep). */
+function newLifecycleBroadcastStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "LifecycleBroadcast",
+    execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      deps.broker.broadcast(loadedExecution(ctx));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The five RPCs.
+// ---------------------------------------------------------------------------
+
+async function runLifecyclePipeline<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+  pipelineName: string,
+  schema: Desc,
+  input: MessageShape<Desc>,
+  steps: PipelineStep<Desc>[],
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    schema,
+    input,
+    ApiResourceKind.agent_execution,
+  );
+  const builder = newPipeline<Desc>(pipelineName, deps.logger);
+  for (const step of steps) {
+    builder.addStep(step);
+  }
+  await builder.build().execute(reqCtx);
+
+  const execution = reqCtx.get(LOADED_EXECUTION_KEY);
+  if (execution === undefined) {
+    throw internalError(
+      new Error(`execution not found in context after ${pipelineName}`),
+      `execution not found in context after ${pipelineName.replace("agentexecution-", "")} pipeline`,
+    );
+  }
+  return execution as AgentExecution;
+}
+
+/**
+ * Cancel — graceful cancellation via the workflow's cancel signal; the
+ * agent can save checkpoint and clean up before CANCELLED.
+ */
+export async function cancelExecution(
+  deps: LifecycleDeps,
+  input: CancelAgentExecutionInput,
+): Promise<AgentExecution> {
+  type Desc = typeof AgentExecutionCommandController.method.cancel.input;
+  deps.logger.info("Cancel agent execution request", {
+    executionId: input.id,
+    reason: input.reason,
+  });
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "agentexecution-cancel",
+    AgentExecutionCommandController.method.cancel.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep({
+        name: "ValidateCancellable",
+        targetPhase: ExecutionPhase.EXECUTION_CANCELLED,
+        allowed: [
+          ExecutionPhase.EXECUTION_PENDING,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+        ],
+        refusal: (phase) =>
+          `cannot cancel execution in phase ${phaseName(phase)}; only PENDING or IN_PROGRESS can be cancelled`,
+        logger: deps.logger,
+      }),
+      newEngineLifecycleStep({
+        name: "CancelTemporalWorkflow",
+        deps,
+        invoke: (engine, executionId) =>
+          engine.engine.cancelWorkflow(executionId),
+        failureMessage: "failed to cancel Temporal workflow",
+      }),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_CANCELLED,
+        false,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/** Terminate — the forceful sibling: terminates the workflow, sets error. */
+export async function terminateExecution(
+  deps: LifecycleDeps,
+  input: TerminateAgentExecutionInput,
+): Promise<AgentExecution> {
+  type Desc = typeof AgentExecutionCommandController.method.terminate.input;
+  deps.logger.info("Terminate agent execution request", {
+    executionId: input.id,
+    reason: input.reason,
+  });
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "agentexecution-terminate",
+    AgentExecutionCommandController.method.terminate.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep({
+        name: "ValidateTerminable",
+        targetPhase: ExecutionPhase.EXECUTION_TERMINATED,
+        allowed: [
+          ExecutionPhase.EXECUTION_PENDING,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+        ],
+        refusal: (phase) =>
+          `cannot terminate execution in phase ${phaseName(phase)}; only PENDING or IN_PROGRESS can be terminated`,
+        logger: deps.logger,
+      }),
+      newEngineLifecycleStep({
+        name: "TerminateTemporalWorkflow",
+        deps,
+        invoke: async (engine, executionId, ctx) => {
+          const reason =
+            (ctx.newState as unknown as LifecycleInputWithReasonShape)
+              .reason || "Terminated by user";
+          await engine.engine.terminateWorkflow(executionId, reason);
+          // Store the resolved reason for the phase update's error text.
+          ctx.set(REASON_KEY, reason);
+        },
+        failureMessage: "failed to terminate Temporal workflow",
+      }),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_TERMINATED,
+        true,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/** Pause — signals the workflow's pause gate; PAUSED is resumable. */
+export async function pauseExecution(
+  deps: LifecycleDeps,
+  input: PauseAgentExecutionInput,
+): Promise<AgentExecution> {
+  type Desc = typeof AgentExecutionCommandController.method.pause.input;
+  deps.logger.info("Pause agent execution request", {
+    executionId: input.id,
+    reason: input.reason,
+  });
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "agentexecution-pause",
+    AgentExecutionCommandController.method.pause.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep({
+        name: "ValidatePausable",
+        targetPhase: ExecutionPhase.EXECUTION_PAUSED,
+        allowed: [
+          ExecutionPhase.EXECUTION_PENDING,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+        ],
+        refusal: (phase) =>
+          `cannot pause execution in phase ${phaseName(phase)}; only PENDING or IN_PROGRESS can be paused`,
+        logger: deps.logger,
+      }),
+      newEngineLifecycleStep({
+        name: "SignalPauseToTemporal",
+        deps,
+        invoke: async (engine, executionId, ctx) => {
+          const reason =
+            (ctx.newState as unknown as LifecycleInputWithReasonShape)
+              .reason || "Paused by user";
+          await engine.engine.signalPause(executionId, reason);
+          ctx.set(REASON_KEY, reason);
+        },
+        failureMessage: "failed to send pause signal to Temporal workflow",
+      }),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_PAUSED,
+        false,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/** Resume — signals the pause gate open; PAUSED → IN_PROGRESS. */
+export async function resumeExecution(
+  deps: LifecycleDeps,
+  input: ResumeAgentExecutionInput,
+): Promise<AgentExecution> {
+  type Desc = typeof AgentExecutionCommandController.method.resume.input;
+  deps.logger.info("Resume agent execution request", {
+    executionId: input.id,
+  });
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "agentexecution-resume",
+    AgentExecutionCommandController.method.resume.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep({
+        name: "ValidateResumable",
+        targetPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        allowed: [ExecutionPhase.EXECUTION_PAUSED],
+        refusal: (phase) =>
+          `cannot resume execution in phase ${phaseName(phase)}; only PAUSED executions can be resumed`,
+        logger: deps.logger,
+      }),
+      newEngineLifecycleStep({
+        name: "SignalResumeToTemporal",
+        deps,
+        invoke: (engine, executionId) =>
+          engine.engine.signalResume(executionId),
+        failureMessage: "failed to send resume signal to Temporal workflow",
+      }),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        false,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/**
+ * Recover — terminate-and-start-fresh for FAILED executions (deliberately
+ * NOT Temporal reset: the runner activity RETURNS its FAILED result, so a
+ * reset replays the preserved failure instead of re-dispatching, issue
+ * #200; continuity is carried by the harness state, not Temporal
+ * history). Order rationale: terminate BEFORE EC recreation (a still-live
+ * old workflow's cleanup must not delete the new EC); recreate EC BEFORE
+ * workflow start (the runner's setup needs env); start BEFORE the phase
+ * update (a failed start leaves the execution FAILED — recover retries).
+ */
+export async function recoverExecution(
+  deps: LifecycleDeps,
+  input: RecoverAgentExecutionInput,
+): Promise<AgentExecution> {
+  type Desc = typeof AgentExecutionCommandController.method.recover.input;
+  deps.logger.info("Recover agent execution request", {
+    executionId: input.id,
+  });
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "agentexecution-recover",
+    AgentExecutionCommandController.method.recover.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep({
+        name: "ValidateRecoverable",
+        targetPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        allowed: [ExecutionPhase.EXECUTION_FAILED],
+        refusal: (phase) =>
+          `cannot recover execution in phase ${phaseName(phase)}; only FAILED executions can be recovered`,
+        logger: deps.logger,
+      }),
+      // TerminateExistingWorkflow: a FAILED execution's workflow has
+      // normally already completed (NOT_FOUND = success); termination
+      // matters for the rarer DB-says-FAILED-but-workflow-live state —
+      // the workflow ID must be terminal before the fresh start reuses
+      // it.
+      newEngineLifecycleStep({
+        name: "TerminateExistingWorkflow",
+        deps,
+        invoke: (engine, executionId) =>
+          engine.engine.terminateWorkflow(
+            executionId,
+            "Recovery: terminating before fresh workflow start",
+          ),
+        failureMessage:
+          "failed to terminate previous workflow during recovery",
+      }),
+      newRecreateExecutionContextStep(deps),
+      newStartFreshWorkflowStep(deps),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        false,
+        true, // clear error on recovery
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/**
+ * Rebuilds the ExecutionContext for a recovered execution (Go
+ * recreateExecutionContextStep): the failed run's workflow cleanup
+ * deleted the EC, so a fresh start would hydrate with an empty
+ * environment. Re-resolving from CURRENT configuration is the point
+ * ("fix the API key, then recover"). DELIBERATE divergence from
+ * WorkflowExecution's graceful recreate: a failure here FAILS the
+ * recover RPC — the agent EC carries OAuth tokens and declared env vars
+ * the run genuinely needs; the execution stays FAILED and recover can be
+ * retried. Stale-EC delete first (best-effort): the failure-path cleanup
+ * is itself best-effort, and the EC name derives from the execution id.
+ */
+function newRecreateExecutionContextStep(
+  deps: LifecycleDeps,
+): PipelineStep<typeof AgentExecutionCommandController.method.recover.input> {
+  return {
+    name: "RecreateExecutionContext",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const execution = loadedExecution(ctx);
+      const executionId = execution.metadata?.id ?? "";
+
+      await deleteStaleExecutionContext(deps, executionId);
+
+      // No pre-resolved instance id on the recover path: a persisted
+      // execution always carries session_id (the create pipeline
+      // guarantees it), so the builder resolves via the session.
+      try {
+        await buildAndPersistExecutionContext(
+          deps.executionContextBuilder,
+          execution,
+          "",
+        );
+      } catch (error) {
+        if (error instanceof EngineDispatchError) {
+          throw failedPreconditionError(error.message);
+        }
+        throw internalError(
+          error,
+          "internal server error",
+        );
+      }
+    },
+  };
+}
+
+/** Best-effort stale-EC removal before recreation. */
+async function deleteStaleExecutionContext(
+  deps: LifecycleDeps,
+  executionId: string,
+): Promise<void> {
+  let existing;
+  try {
+    existing = await deps.store.findByField(
+      ApiResourceKind.execution_context,
+      "spec.executionId",
+      executionId,
+      ExecutionContextSchema,
+    );
+  } catch {
+    return;
+  }
+  const ecId = existing.metadata?.id ?? "";
+  if (ecId === "") {
+    return;
+  }
+  deps.logger.info("Deleting stale ExecutionContext before recreation", {
+    executionContextId: ecId,
+    executionId,
+  });
+  try {
+    await deps.store.deleteResource(ApiResourceKind.execution_context, ecId);
+  } catch (error) {
+    deps.logger.warn(
+      "Failed to delete stale ExecutionContext (proceeding anyway)",
+      {
+        executionContextId: ecId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+/**
+ * Starts a brand-new workflow for the recovered execution (Go
+ * StartFreshWorkflowStep): Temporal allows workflow-id reuse after the
+ * previous run reached a terminal state. Dispatch is re-resolved with an
+ * EMPTY activity_task_queue override and the parent-coupled coordinates
+ * (callback_token, parent_workflow_id) are deliberately NOT carried — a
+ * recovered execution is a standalone rerun (the single-use token was
+ * already completed with the failure; the parent already observed the
+ * failure; the parent's sandbox queue loses its poller when the parent
+ * completes). Known documented limitation: a durable (http) LangGraph
+ * checkpointer would duplicate the user message; the OSS default memory
+ * checkpointer replays from scratch, so this is moot here.
+ */
+function newStartFreshWorkflowStep(
+  deps: LifecycleDeps,
+): PipelineStep<typeof AgentExecutionCommandController.method.recover.input> {
+  return {
+    name: "StartFreshWorkflow",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const engine = deps.engineState();
+      if (!engine.connected) {
+        throw failedPreconditionError(
+          "Temporal is not available (workflow creator not set)",
+        );
+      }
+      const execution = loadedExecution(ctx);
+      const executionId = execution.metadata?.id ?? "";
+      try {
+        await engine.engine.startInvokeWorkflow({
+          executionId,
+          sessionId: execution.spec?.sessionId ?? "",
+          agentId: execution.spec?.agentId ?? "",
+          callbackToken: new Uint8Array(),
+          autoApproveAll: execution.spec?.autoApproveAll ?? false,
+          parentWorkflowId: "",
+          activityTaskQueueOverride: "",
+        });
+      } catch (error) {
+        if (error instanceof EngineDispatchError) {
+          throw failedPreconditionError(error.message);
+        }
+        throw internalError(
+          error,
+          "failed to start fresh Temporal workflow for recovered execution",
+        );
+      }
+      deps.logger.info(
+        "Started fresh Temporal workflow for recovered execution",
+        { executionId },
+      );
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/lifecycle.ts
@@ -18,6 +18,7 @@
  * real); lifecycle simply authors no approval events.
  */
 import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
 
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import {
@@ -687,7 +688,11 @@ function newRecreateExecutionContextStep(
 
       // No pre-resolved instance id on the recover path: a persisted
       // execution always carries session_id (the create pipeline
-      // guarantees it), so the builder resolves via the session.
+      // guarantees it), so the builder resolves via the session. Go wraps
+      // with %w — the inner status code survives to the wire (notably the
+      // FailedPrecondition OAuth pre-flight refusal and NotFound loads,
+      // exactly as the same failure surfaces on the create path); plain
+      // errors chain to the pipeline's Internal fallback.
       try {
         await buildAndPersistExecutionContext(
           deps.executionContextBuilder,
@@ -695,12 +700,14 @@ function newRecreateExecutionContextStep(
           "",
         );
       } catch (error) {
-        if (error instanceof EngineDispatchError) {
-          throw failedPreconditionError(error.message);
+        if (error instanceof ConnectError) {
+          throw new ConnectError(
+            `recreate execution context for recovered execution ${executionId}: ${error.rawMessage}`,
+            error.code,
+          );
         }
-        throw internalError(
-          error,
-          "internal server error",
+        throw new Error(
+          `recreate execution context for recovered execution ${executionId}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     },

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/phases.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/phases.ts
@@ -1,0 +1,39 @@
+/**
+ * The domain's TWO deliberately-distinct terminal-phase predicates —
+ * package-level functions in Go (subscribe.go / tool_call_settle.go),
+ * shared here so every consumer names the same sets.
+ *
+ * isTerminalExecutionPhase answers "will this execution ever run again?"
+ * — COMPLETED / FAILED / CANCELLED / TERMINATED. TERMINATED executions
+ * will not run, so their in-flight tool calls must settle and their
+ * phase latches.
+ *
+ * isTranscriptTerminalPhase (Go subscribe.go isTerminalPhase) OMITS
+ * TERMINATED: the transcript regression guard uses it so a terminated
+ * execution's committed transcript stays protected from free rewrites,
+ * and the subscribe stream uses it as its close set (the disclosed
+ * never-closes-on-TERMINATED quirk, ported faithfully). Do NOT
+ * "harmonize" the two — the difference is deliberate and documented in
+ * Go.
+ */
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+export function isTerminalExecutionPhase(phase: ExecutionPhase): boolean {
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_COMPLETED:
+    case ExecutionPhase.EXECUTION_FAILED:
+    case ExecutionPhase.EXECUTION_CANCELLED:
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isTranscriptTerminalPhase(phase: ExecutionPhase): boolean {
+  return (
+    phase === ExecutionPhase.EXECUTION_COMPLETED ||
+    phase === ExecutionPhase.EXECUTION_FAILED ||
+    phase === ExecutionPhase.EXECUTION_CANCELLED
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/search-extractor.ts
@@ -1,0 +1,39 @@
+/**
+ * AgentExecution search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/agent_execution_extractor.go. Agent
+ * executions are individual invocation records; they have no description
+ * field, so the FTS description stays empty and the name is the summary.
+ * The query side of the extractor contract arrives with the search
+ * service sub-project (#14).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const agentExecutionSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const execution = resource as unknown as AgentExecution;
+    const metadata = execution.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      // No description field on executions (Go leaves entry.Description
+      // at its zero value).
+      description: "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        execution.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/steps.ts
@@ -1,0 +1,193 @@
+/**
+ * AgentExecution domain steps — the list-side chains from list.go and
+ * list_by_session.go, plus the full-scan load helper the usage reports
+ * share.
+ *
+ * List semantics ported verbatim: no sorting (unlike the session domain's
+ * newest-first list), no pagination (total_pages pinned to 1 — Go's
+ * placeholder), the request `org` field a deliberate no-op (single-tenant
+ * edition), and phase filtering only when a phase is specified.
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { AgentExecutionListSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * Inter-step key for the working execution list AND the final
+ * AgentExecutionList — Go reuses one key ("execution_list") for both, and
+ * the controller reads the final response from it.
+ */
+export const EXECUTION_LIST_KEY = "execution_list";
+
+type ListDesc = typeof AgentExecutionQueryController.method.list.input;
+type ListBySessionDesc =
+  typeof AgentExecutionQueryController.method.listBySession.input;
+
+/**
+ * Full-scan agent-execution load shared by the list steps and the usage
+ * reports; malformed rows warn + skip (Go's proto.Unmarshal-continue).
+ */
+export async function loadAllAgentExecutions(
+  store: Store,
+  logger: Logger,
+): Promise<AgentExecution[]> {
+  let rows: Uint8Array[];
+  try {
+    rows = await store.listResources(ApiResourceKind.agent_execution);
+  } catch (error) {
+    throw internalError(error, "failed to list agent executions");
+  }
+
+  const executions: AgentExecution[] = [];
+  for (const data of rows) {
+    let execution: AgentExecution;
+    try {
+      execution = fromBinary(AgentExecutionSchema, data);
+    } catch (error) {
+      logger.warn("Failed to unmarshal execution, skipping", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    executions.push(execution);
+  }
+  return executions;
+}
+
+/** ValidateListRequest — list.go: no required fields today (a no-op). */
+export function newValidateListRequestStep(): PipelineStep<ListDesc> {
+  return {
+    name: "ValidateListRequest",
+    execute() {
+      // Go validates nothing here yet; pagination validation would land
+      // in both editions together.
+    },
+  };
+}
+
+/** QueryAllExecutions — list.go: full scan into the context. */
+export function newQueryAllExecutionsStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<ListDesc> {
+  return {
+    name: "QueryAllExecutions",
+    async execute(ctx) {
+      const executions = await loadAllAgentExecutions(store, logger);
+      logger.debug("Successfully queried executions", {
+        count: executions.length,
+      });
+      ctx.set(EXECUTION_LIST_KEY, executions);
+    },
+  };
+}
+
+/**
+ * ApplyPhaseFilter — list.go: status.phase equality filter, skipped when
+ * the request carries no phase.
+ */
+export function newApplyPhaseFilterStep(
+  logger: Logger,
+): PipelineStep<ListDesc> {
+  return {
+    name: "ApplyPhaseFilter",
+    execute(ctx) {
+      const executions = requireExecutions(ctx.get(EXECUTION_LIST_KEY));
+      if (ctx.input.phase === ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) {
+        logger.debug("No phase filter specified, skipping");
+        return;
+      }
+      const filtered = executions.filter(
+        (execution) =>
+          (execution.status?.phase ??
+            ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) === ctx.input.phase,
+      );
+      logger.debug("Phase filter applied", {
+        originalCount: executions.length,
+        filteredCount: filtered.length,
+      });
+      ctx.set(EXECUTION_LIST_KEY, filtered);
+    },
+  };
+}
+
+/**
+ * ValidateListBySessionRequest — list_by_session.go: session_id required.
+ */
+export function newValidateListBySessionRequestStep(): PipelineStep<ListBySessionDesc> {
+  return {
+    name: "ValidateListBySessionRequest",
+    execute(ctx) {
+      if (ctx.input.sessionId === "") {
+        throw invalidArgumentError("session_id is required");
+      }
+    },
+  };
+}
+
+/**
+ * QueryExecutionsBySession — list_by_session.go: full scan +
+ * spec.session_id equality filter.
+ */
+export function newQueryExecutionsBySessionStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<ListBySessionDesc> {
+  return {
+    name: "QueryExecutionsBySession",
+    async execute(ctx) {
+      const all = await loadAllAgentExecutions(store, logger);
+      const executions = all.filter(
+        (execution) =>
+          (execution.spec?.sessionId ?? "") === ctx.input.sessionId,
+      );
+      logger.debug("Successfully queried executions by session", {
+        sessionId: ctx.input.sessionId,
+        count: executions.length,
+      });
+      ctx.set(EXECUTION_LIST_KEY, executions);
+    },
+  };
+}
+
+/**
+ * BuildExecutionListResponse — both list files: wraps the working list
+ * into AgentExecutionList with the total_pages placeholder pinned to 1.
+ */
+export function newBuildExecutionListResponseStep<
+  Desc extends ListDesc | ListBySessionDesc,
+>(): PipelineStep<Desc> {
+  return {
+    name: "BuildExecutionListResponse",
+    execute(ctx) {
+      const executions = requireExecutions(ctx.get(EXECUTION_LIST_KEY));
+      ctx.set(
+        EXECUTION_LIST_KEY,
+        create(AgentExecutionListSchema, {
+          totalPages: 1,
+          entries: executions,
+        }),
+      );
+    },
+  };
+}
+
+function requireExecutions(value: unknown): AgentExecution[] {
+  if (!Array.isArray(value)) {
+    throw internalError(
+      new Error("execution list not found in context"),
+      "execution list not found in context",
+    );
+  }
+  return value as AgentExecution[];
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/stream-broker.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/stream-broker.ts
@@ -1,0 +1,126 @@
+/**
+ * StreamBroker — ports controller/stream_broker.go: the in-memory
+ * broadcast fabric for real-time execution updates (ADR 011's "Stream
+ * Broker" responsibility; the OSS stand-in for cloud's Redis streams).
+ *
+ * Go's shape is a map of executionID → buffered channels (capacity 100)
+ * under an RWMutex: Broadcast is non-blocking — a full buffer drops the
+ * frame for that subscriber (they catch up on the next one) — and
+ * Unsubscribe closes the channel. The TS port keeps the exact delivery
+ * semantics on the queue-plus-notify idiom the transport already proved
+ * for streams (transport/health.ts watch): each subscription owns a
+ * bounded FIFO queue the subscribe generator drains, and a notify hook
+ * wakes the drain loop. Node's single-threaded event loop replaces the
+ * mutex; the bounded queue replaces the channel buffer.
+ *
+ * ONE instance serves both routers (serving + in-process): #18's Temporal
+ * activities update status through the in-process client, and those
+ * broadcasts must reach externally-connected subscribers — the same
+ * reason Go exposes GetStreamBroker to its activities. The composition
+ * root owns the instance.
+ */
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import type { Logger } from "../../boot/logger.js";
+
+/**
+ * Go's channel buffer size: bursts up to this many undelivered frames per
+ * subscriber are absorbed; beyond it, broadcasts drop for that subscriber
+ * (stream_broker.go's `make(chan ..., 100)` + non-blocking send).
+ */
+export const SUBSCRIBER_BUFFER_CAPACITY = 100;
+
+/**
+ * One subscriber's delivery state. The subscribe stream loop drains
+ * `queue` and parks on `notify`; the broker pushes and wakes. `closed`
+ * flips on unsubscribe (Go's close(ch)) so a parked or late consumer
+ * observes the end instead of waiting forever.
+ */
+export interface BrokerSubscription {
+  readonly queue: AgentExecution[];
+  notify: (() => void) | undefined;
+  closed: boolean;
+}
+
+export class StreamBroker {
+  private readonly subscribers = new Map<string, Set<BrokerSubscription>>();
+
+  constructor(private readonly logger: Logger) {}
+
+  /**
+   * Registers a new subscriber for the execution. The caller MUST
+   * unsubscribe when done (the subscribe generator's `finally`) — Go's
+   * "caller MUST call Unsubscribe" contract, enforced there by defer.
+   */
+  subscribe(executionId: string): BrokerSubscription {
+    const subscription: BrokerSubscription = {
+      queue: [],
+      notify: undefined,
+      closed: false,
+    };
+    const set = this.subscribers.get(executionId) ?? new Set();
+    set.add(subscription);
+    this.subscribers.set(executionId, set);
+    this.logger.debug("New subscriber registered", {
+      executionId,
+      totalSubscribers: set.size,
+    });
+    return subscription;
+  }
+
+  /** Removes and closes a subscription; idempotent (Go Unsubscribe). */
+  unsubscribe(executionId: string, subscription: BrokerSubscription): void {
+    const set = this.subscribers.get(executionId);
+    if (set === undefined || !set.has(subscription)) {
+      return;
+    }
+    set.delete(subscription);
+    subscription.closed = true;
+    subscription.notify?.();
+    subscription.notify = undefined;
+    this.logger.debug("Subscriber unregistered", {
+      executionId,
+      remainingSubscribers: set.size,
+    });
+    if (set.size === 0) {
+      this.subscribers.delete(executionId);
+    }
+  }
+
+  /**
+   * Delivers an execution update to every active subscriber of its id.
+   * Non-blocking by construction: a subscriber at buffer capacity drops
+   * THIS frame (it catches up on the next broadcast) — Go's select/default
+   * arm, warn included.
+   */
+  broadcast(execution: AgentExecution): void {
+    const executionId = execution.metadata?.id ?? "";
+    if (executionId === "") {
+      return;
+    }
+    const set = this.subscribers.get(executionId);
+    if (set === undefined || set.size === 0) {
+      return;
+    }
+    this.logger.debug("Broadcasting execution update", {
+      executionId,
+      subscribers: set.size,
+    });
+    for (const subscription of set) {
+      if (subscription.queue.length >= SUBSCRIBER_BUFFER_CAPACITY) {
+        this.logger.warn("Subscriber channel full, dropping update", {
+          executionId,
+        });
+        continue;
+      }
+      subscription.queue.push(execution);
+      subscription.notify?.();
+      subscription.notify = undefined;
+    }
+  }
+
+  /** Active subscriber count for an execution (Go GetSubscriberCount). */
+  getSubscriberCount(executionId: string): number {
+    return this.subscribers.get(executionId)?.size ?? 0;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/submit-approval.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/submit-approval.ts
@@ -1,0 +1,546 @@
+/**
+ * SubmitApproval — ports controller/submit_approval.go: the HITL approval
+ * decision writer.
+ *
+ * Chain per Go: ValidateProto → LoadExisting → ValidateApproval →
+ * RecordApprovalDecision → SignalWorkflow → BuildResponse.
+ *
+ * Behavior by action: APPROVE executes the tool; SKIP feeds a skip
+ * message to the LLM; REJECT denies ONE tool call and continues the run
+ * (never fails it — the runner feeds the objection back to the model);
+ * APPROVE_ALL approves the clicked tool AND auto-approves co-pending
+ * calls of the SAME lease class (the clicked tool's built-in category or
+ * its MCP server — deriveLeaseScope), leaving other classes gated.
+ *
+ * The decision recording is one atomic read-modify-write under the store
+ * write lock, with a TOCTOU re-check (a concurrent submit that won the
+ * race surfaces as Internal, exactly Go's closure error). Idempotency: a
+ * repeated identical submit is a no-op answering current state.
+ *
+ * The approvalGateResolved signal fires ONLY when the unified HITL gate
+ * fully clears — no pending approval AND no change set awaiting review.
+ * With the engine disconnected (pre-#18) the signal is skipped with a
+ * WARN and the decision still persists (Go's nil-creator arm).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import {
+  ApprovalAction,
+  ApprovalActionSchema,
+  ExecutionPhase,
+  ExecutionPhaseSchema,
+  MessageType,
+  ToolCallStatus,
+  ToolCallStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { SubmitApprovalInput } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { enumToJson } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+import { ensureApprovalRequests, recordDecisionEvent } from "./approval/author.js";
+import { deriveLeaseScope, sameLeaseScope } from "./approval/lease-scope.js";
+import { projectPendingApprovals } from "./approval/project.js";
+import type {
+  ExecutionEngineStateProvider,
+} from "./engine.js";
+import { EngineWorkflowNotFoundError } from "./engine.js";
+import { countAwaitingReview } from "./filereview/gate.js";
+import { settleInterruptedToolCalls } from "./tool-call-settle.js";
+import type { StreamBroker } from "./stream-broker.js";
+
+export interface SubmitApprovalDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+  readonly engineState: ExecutionEngineStateProvider;
+}
+
+type SubmitApprovalDesc =
+  typeof AgentExecutionCommandController.method.submitApproval.input;
+
+// Context keys for inter-step communication — Go's key strings, verbatim.
+const IS_IDEMPOTENT_REQUEST_KEY = "isIdempotentRequest";
+const TARGET_RESOURCE_KEY = "targetResource";
+
+export async function submitApproval(
+  deps: SubmitApprovalDeps,
+  input: SubmitApprovalInput,
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    AgentExecutionCommandController.method.submitApproval.input,
+    input,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<SubmitApprovalDesc>(
+    "agent-execution-submit-approval",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep({
+      name: "LoadExisting",
+      async execute(ctx) {
+        const executionId = ctx.input.agentExecutionId;
+        if (executionId === "") {
+          throw invalidArgumentError("agent_execution_id is required");
+        }
+        let execution: AgentExecution;
+        try {
+          execution = await deps.store.getResource(
+            ApiResourceKind.agent_execution,
+            executionId,
+            AgentExecutionSchema,
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            throw notFoundError("agent_execution", executionId);
+          }
+          throw internalError(error, "failed to load agent execution");
+        }
+        ctx.set(TARGET_RESOURCE_KEY, execution);
+      },
+    })
+    .addStep({
+      name: "ValidateApproval",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+        const executionId = execution.metadata?.id ?? "";
+        const requestedToolCallId = ctx.input.toolCallId;
+        const requestedAction = ctx.input.action;
+        const currentPhase =
+          execution.status?.phase ??
+          ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+
+        // Approval is accepted during active execution phases where tool
+        // calls may await decisions; terminal and pre-start phases refuse.
+        if (
+          currentPhase !== ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL &&
+          currentPhase !== ExecutionPhase.EXECUTION_IN_PROGRESS
+        ) {
+          throw failedPreconditionError(
+            `execution ${executionId} is in phase ${protoName(ExecutionPhaseSchema, currentPhase)}, approval requires EXECUTION_WAITING_FOR_APPROVAL or EXECUTION_IN_PROGRESS`,
+          );
+        }
+
+        // The ToolCall in messages is the single source of truth.
+        const tc = findToolCallInExecution(execution, requestedToolCallId);
+        if (tc === undefined) {
+          throw invalidArgumentError(
+            `tool_call_id ${requestedToolCallId} not found in messages for execution ${executionId}`,
+          );
+        }
+
+        // Idempotency: a decision already recorded on the ToolCall.
+        const existingAction = tc.approvalAction;
+        if (existingAction !== ApprovalAction.UNSPECIFIED) {
+          if (existingAction === requestedAction) {
+            deps.logger.info(
+              "IDEMPOTENT: ToolCall already has matching approval action",
+              {
+                executionId,
+                toolCallId: requestedToolCallId,
+                action: protoName(ApprovalActionSchema, requestedAction),
+              },
+            );
+            ctx.set(IS_IDEMPOTENT_REQUEST_KEY, true);
+            return;
+          }
+          throw failedPreconditionError(
+            `tool call ${requestedToolCallId} already has approval action ${protoName(ApprovalActionSchema, existingAction)}, cannot change to ${protoName(ApprovalActionSchema, requestedAction)}`,
+          );
+        }
+
+        if (tc.status !== ToolCallStatus.TOOL_CALL_WAITING_APPROVAL) {
+          throw failedPreconditionError(
+            `tool call ${requestedToolCallId} has status ${protoName(ToolCallStatusSchema, tc.status)}, expected TOOL_CALL_WAITING_APPROVAL`,
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "RecordApprovalDecision",
+      async execute(ctx) {
+        if (ctx.get(IS_IDEMPOTENT_REQUEST_KEY) === true) {
+          deps.logger.debug(
+            "Skipping approval decision recording for idempotent request",
+          );
+          return;
+        }
+        const executionId = ctx.input.agentExecutionId;
+        const toolCallId = ctx.input.toolCallId;
+        const action = ctx.input.action;
+        const comment = ctx.input.comment;
+        const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+        // Decider identity for the approval ledger. OSS is single-user
+        // with no multi-tenant auth context, so the principal is empty;
+        // the Cloud edition populates it from the authenticated caller.
+        const decidedBy = "";
+
+        let updated: AgentExecution;
+        try {
+          updated = await deps.store.updateResource(
+            ApiResourceKind.agent_execution,
+            executionId,
+            AgentExecutionSchema,
+            (execution) => {
+              // Re-check under the write lock: TOCTOU guard against a
+              // concurrent request that recorded a decision between our
+              // validation step and this locked update.
+              const tc = findToolCallInExecution(execution, toolCallId);
+              if (tc === undefined) {
+                throw new Error(
+                  `tool call ${toolCallId} no longer exists in execution ${executionId}`,
+                );
+              }
+              if (tc.approvalAction !== ApprovalAction.UNSPECIFIED) {
+                throw new Error(
+                  `tool call ${toolCallId} already has approval action ${protoName(ApprovalActionSchema, tc.approvalAction)} (concurrent approval won the race)`,
+                );
+              }
+
+              if (execution.status === undefined) {
+                execution.status = create(AgentExecutionStatusSchema);
+              }
+
+              // Author REQUESTED events BEFORE recording the decision,
+              // while every gated tool call is still WAITING — seeds the
+              // stream for executions predating the field, so a decision
+              // event always has a preceding request.
+              ensureApprovalRequests(execution.status, executionId);
+
+              tc.approvalAction = action;
+              tc.approvalDecidedAt = now;
+              tc.approvedBy = decidedBy;
+              // The rich decision event (decided_by + the user's comment)
+              // in the same locked write that records the decision on the
+              // scan, so it can never be duplicated or clobbered.
+              recordDecisionEvent(execution.status, tc, decidedBy, comment);
+
+              // APPROVE_ALL grants a run-lifetime lease scoped to the
+              // clicked tool's class; co-pending calls of the SAME class
+              // are auto-approved with a plain APPROVE and no comment (the
+              // escalation comment belongs to the clicked tool).
+              if (action === ApprovalAction.APPROVE_ALL) {
+                for (const bulkTc of bulkApproveCoPendingToolCalls(
+                  execution,
+                  toolCallId,
+                  now,
+                  decidedBy,
+                )) {
+                  recordDecisionEvent(execution.status, bulkTc, decidedBy, "");
+                }
+              }
+
+              // Recompute pending_approvals — the approved entry
+              // disappears because its approval_action is now set.
+              execution.status.pendingApprovals = projectPendingApprovals(
+                execution.status.phase,
+                execution.status.messages,
+                execution.status.subAgentExecutions,
+                execution.status.approvalEventStream,
+                deps.logger,
+              );
+            },
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            throw notFoundError("agent_execution", executionId);
+          }
+          throw internalError(error, "failed to persist approval decision");
+        }
+
+        deps.logger.info(
+          "Recorded approval decision on ToolCall, recomputed pending_approvals",
+          {
+            executionId,
+            toolCallId,
+            action: protoName(ApprovalActionSchema, action),
+            pendingApprovalsRemaining:
+              updated.status?.pendingApprovals.length ?? 0,
+          },
+        );
+
+        deps.broker.broadcast(updated);
+        ctx.set(TARGET_RESOURCE_KEY, updated);
+      },
+    })
+    .addStep({
+      name: "SignalWorkflow",
+      async execute(ctx) {
+        if (ctx.get(IS_IDEMPOTENT_REQUEST_KEY) === true) {
+          deps.logger.debug("Skipping workflow signal for idempotent request");
+          return;
+        }
+
+        const engine = deps.engineState();
+        if (!engine.connected) {
+          // Go's nil-creator arm: the decision persists; the signal is
+          // skipped until #18 connects an engine.
+          deps.logger.warn(
+            "Workflow creator not available - skipping Temporal signal",
+          );
+          return;
+        }
+
+        const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+        const executionId = execution.metadata?.id ?? "";
+        const pendingRemaining =
+          execution.status?.pendingApprovals.length ?? 0;
+        const awaitingReview = countAwaitingReview(
+          execution.status?.fileChangeSets ?? [],
+        );
+
+        // The HITL gate is unified: a turn resumes only when BOTH
+        // sub-gates clear. Clearing the last approval while file review is
+        // still pending must NOT resume the turn. REJECT is not special:
+        // it resolves exactly one gate, like SKIP.
+        if (!(pendingRemaining === 0 && awaitingReview === 0)) {
+          deps.logger.info(
+            "Approval recorded, HITL gate not yet resolved — waiting",
+            {
+              executionId,
+              toolCallId: ctx.input.toolCallId,
+              pendingApprovalsRemaining: pendingRemaining,
+              changeSetsAwaitingReview: awaitingReview,
+            },
+          );
+          return;
+        }
+
+        try {
+          await engine.engine.signalApprovalGateResolved(executionId);
+        } catch (error) {
+          if (error instanceof EngineWorkflowNotFoundError) {
+            deps.logger.warn(
+              "Workflow not found - reconciling stale execution status to FAILED",
+              { executionId },
+            );
+            await reconcileStaleExecution(deps, execution);
+            throw failedPreconditionError(
+              `workflow not running for execution ${executionId} - the backing workflow has terminated unexpectedly and the execution has been marked as failed`,
+            );
+          }
+          throw unavailableError(
+            `failed to signal workflow: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        deps.logger.info(
+          "Successfully sent approvalGateResolved signal to workflow",
+          { executionId },
+        );
+      },
+    })
+    .addStep({
+      name: "BuildResponse",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+        // Audit log the approval decision (caller identity arrives with
+        // the cloud edition's auth context).
+        const tc = findToolCallInExecution(execution, ctx.input.toolCallId);
+        deps.logger.info("AUDIT: Approval decision submitted", {
+          executionId: execution.metadata?.id ?? "",
+          org: execution.metadata?.org ?? "",
+          toolCallId: ctx.input.toolCallId,
+          toolName: tc?.name ?? "unknown",
+          action: protoName(ApprovalActionSchema, ctx.input.action),
+          comment: ctx.input.comment,
+        });
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+}
+
+/**
+ * Terminalizes an execution stuck in WAITING_FOR_APPROVAL because the
+ * backing workflow no longer runs (Go reconcileStaleExecution).
+ * Best-effort: a failed persist is logged and the caller still surfaces
+ * the WorkflowNotFound refusal. The approval-event ledger is preserved
+ * verbatim for the audit trail; pending_approvals is deliberately left
+ * empty (a FAILED execution has no actionable approvals). Whole-resource
+ * save is intentional: this writes a TERMINAL state with no live appender
+ * racing the stream.
+ */
+async function reconcileStaleExecution(
+  deps: SubmitApprovalDeps,
+  execution: AgentExecution,
+): Promise<void> {
+  const executionId = execution.metadata?.id ?? "";
+
+  const reconciled = create(AgentExecutionSchema, {
+    apiVersion: execution.apiVersion,
+    kind: execution.kind,
+    metadata: execution.metadata,
+    spec: execution.spec,
+    status: {
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      error:
+        "Workflow backing this execution is no longer running. Execution has been marked as failed.",
+      messages: execution.status?.messages ?? [],
+      audit: execution.status?.audit,
+      approvalEventStream: execution.status?.approvalEventStream,
+    },
+  });
+
+  // A system message explaining what happened.
+  reconciled.status?.messages.push(
+    create(AgentMessageSchema, {
+      type: MessageType.MESSAGE_SYSTEM,
+      content:
+        "The workflow backing this execution is no longer running. This can happen due to infrastructure issues or manual termination. The execution has been marked as failed.",
+    }),
+  );
+
+  // The gated call that brought the user here — plus any other in-flight
+  // call — is still non-terminal; this write terminalizes the execution,
+  // so settle them (issue #207).
+  settleInterruptedToolCalls(
+    reconciled.status,
+    new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+  );
+
+  try {
+    await deps.store.saveResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+      reconciled,
+    );
+  } catch (error) {
+    deps.logger.error(
+      "Failed to reconcile stale execution status - execution will remain in WAITING_FOR_APPROVAL until next attempt",
+      {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+
+  deps.logger.info(
+    "RECONCILIATION: Updated stale execution status to FAILED",
+    { executionId },
+  );
+}
+
+/**
+ * The gate-resolving half of an APPROVE_ALL decision, SCOPED to the
+ * clicked tool's lease class (Go bulkApproveCoPendingToolCalls): every
+ * co-pending call (still WAITING_APPROVAL, no decision) of the SAME lease
+ * scope is set to a plain APPROVE (the audit trail stays unambiguous —
+ * exactly one tool carries APPROVE_ALL, the user's escalation point);
+ * calls of a DIFFERENT class stay WAITING_APPROVAL so the gate keeps
+ * waiting for them. Returns the calls it approved so the caller authors a
+ * decision event for each.
+ */
+export function bulkApproveCoPendingToolCalls(
+  execution: AgentExecution,
+  clickedToolCallId: string,
+  decidedAt: string,
+  decidedBy: string,
+): ToolCall[] {
+  const clicked = findToolCallInExecution(execution, clickedToolCallId);
+  if (clicked === undefined) {
+    return [];
+  }
+  const clickedScope = deriveLeaseScope(clicked);
+  if (clickedScope === undefined) {
+    // The clicked tool has no leasable scope (an unknown/ungated name
+    // that somehow carried APPROVE_ALL). Nothing else can match it.
+    // Defensive — a gated tool always has a scope.
+    return [];
+  }
+
+  const approved: ToolCall[] = [];
+  const approveIfWaitingInScope = (tc: ToolCall): void => {
+    if (tc.id === clickedToolCallId) {
+      return;
+    }
+    if (tc.status !== ToolCallStatus.TOOL_CALL_WAITING_APPROVAL) {
+      return;
+    }
+    if (tc.approvalAction !== ApprovalAction.UNSPECIFIED) {
+      return;
+    }
+    const scope = deriveLeaseScope(tc);
+    if (scope === undefined || !sameLeaseScope(scope, clickedScope)) {
+      return;
+    }
+    tc.approvalAction = ApprovalAction.APPROVE;
+    tc.approvalDecidedAt = decidedAt;
+    tc.approvedBy = decidedBy;
+    approved.push(tc);
+  };
+
+  for (const msg of execution.status?.messages ?? []) {
+    for (const tc of msg.toolCalls) {
+      approveIfWaitingInScope(tc);
+    }
+  }
+  for (const sa of execution.status?.subAgentExecutions ?? []) {
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        approveIfWaitingInScope(tc);
+      }
+    }
+  }
+  return approved;
+}
+
+/**
+ * Searches for a ToolCall by ID in messages (root and sub-agent). Tool
+ * calls live exclusively in messages[].tool_calls.
+ */
+export function findToolCallInExecution(
+  execution: AgentExecution,
+  toolCallId: string,
+): ToolCall | undefined {
+  for (const msg of execution.status?.messages ?? []) {
+    for (const tc of msg.toolCalls) {
+      if (tc.id === toolCallId) {
+        return tc;
+      }
+    }
+  }
+  for (const sa of execution.status?.subAgentExecutions ?? []) {
+    for (const msg of sa.messages) {
+      for (const tc of msg.toolCalls) {
+        if (tc.id === toolCallId) {
+          return tc;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+/** The full proto enum value name — Go's .String() rendering. */
+function protoName(
+  schema: Parameters<typeof enumToJson>[0],
+  value: number,
+): string {
+  return enumToJson(schema, value) as string;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/submit-file-decision.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/submit-file-decision.ts
@@ -1,0 +1,451 @@
+/**
+ * SubmitFileDecision — ports controller/submit_file_decision.go: the
+ * backend-owned writer of FILE_DECIDED events on the append-only
+ * file_review stream (apply-then-review HITL). FileChangeSet.decisions is
+ * the derived projection; the runner's reconcile applies the approved
+ * bytes — this RPC records the decision and enforces that
+ * expected_digest still matches the captured content the user reviewed
+ * ("what you approve is what gets applied").
+ *
+ * Chain mirrors the approval pipeline: ValidateProto → LoadExisting →
+ * ValidateDecision → RecordFileDecision → SignalWorkflow →
+ * BuildResponse. The signal is the SAME approvalGateResolved — the HITL
+ * gate is unified, so a turn blocked on file review (and possibly tool
+ * approvals too) resumes through one signal and one wait. Unlike
+ * approvals, a file REJECT has no immediate-resume shortcut — every file
+ * in the set must be decided (or one CHANGE_SET-scoped decision cover
+ * them) before the runner reconciles.
+ *
+ * Idempotency: a decision with the same deterministic event id already on
+ * the stream is a no-op answering current state.
+ */
+import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import {
+  ExecutionPhase,
+  ExecutionPhaseSchema,
+  FileDecisionAction,
+  FileDecisionActionSchema,
+  FileDecisionScope,
+  FileDecisionScopeSchema,
+  FileReviewEventType,
+  MessageType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { FileReviewEventStream } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import type { SubmitFileDecisionInput } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { enumToJson } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+import type { ExecutionEngineStateProvider } from "./engine.js";
+import { EngineWorkflowNotFoundError } from "./engine.js";
+import {
+  buildFileDecision,
+  eventId as fileReviewEventId,
+  findChange,
+  findChangeSet,
+  approveBlockedReason,
+  recordFileDecisionEvent,
+  targetDigest,
+} from "./filereview/author.js";
+import { countAwaitingReview, gateResolved } from "./filereview/gate.js";
+import { projectFileChangeSets } from "./filereview/project.js";
+import { settleInterruptedToolCalls } from "./tool-call-settle.js";
+import type { StreamBroker } from "./stream-broker.js";
+
+export interface SubmitFileDecisionDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+  readonly engineState: ExecutionEngineStateProvider;
+}
+
+type SubmitFileDecisionDesc =
+  typeof AgentExecutionCommandController.method.submitFileDecision.input;
+
+// Go's key strings, verbatim.
+const FILE_DECISION_IDEMPOTENT_KEY = "isIdempotentFileDecision";
+const TARGET_RESOURCE_KEY = "targetResource";
+
+export async function submitFileDecision(
+  deps: SubmitFileDecisionDeps,
+  input: SubmitFileDecisionInput,
+): Promise<AgentExecution> {
+  const reqCtx = new RequestContext(
+    AgentExecutionCommandController.method.submitFileDecision.input,
+    input,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<SubmitFileDecisionDesc>(
+    "agent-execution-submit-file-decision",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep({
+      name: "LoadExisting",
+      async execute(ctx) {
+        const executionId = ctx.input.agentExecutionId;
+        if (executionId === "") {
+          throw invalidArgumentError("agent_execution_id is required");
+        }
+        let execution: AgentExecution;
+        try {
+          execution = await deps.store.getResource(
+            ApiResourceKind.agent_execution,
+            executionId,
+            AgentExecutionSchema,
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            throw notFoundError("agent_execution", executionId);
+          }
+          throw internalError(error, "failed to load agent execution");
+        }
+        ctx.set(TARGET_RESOURCE_KEY, execution);
+      },
+    })
+    .addStep({
+      name: "ValidateDecision",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+        validateFileDecisionTarget(execution, ctx.input);
+
+        // Idempotency: the same deterministic event id already on the
+        // stream means this exact decision was recorded.
+        if (
+          streamHasFileDecision(
+            execution.status?.fileReviewEventStream,
+            ctx.input,
+          )
+        ) {
+          deps.logger.info("IDEMPOTENT: file decision already recorded", {
+            executionId: execution.metadata?.id ?? "",
+            changeSetId: ctx.input.changeSetId,
+            fileChangeId: ctx.input.fileChangeId,
+          });
+          ctx.set(FILE_DECISION_IDEMPOTENT_KEY, true);
+        }
+      },
+    })
+    .addStep({
+      name: "RecordFileDecision",
+      async execute(ctx) {
+        if (ctx.get(FILE_DECISION_IDEMPOTENT_KEY) === true) {
+          return;
+        }
+        const executionId = ctx.input.agentExecutionId;
+        const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+        // OSS is single-user with no multi-tenant auth context, so the
+        // reviewer is empty; the Cloud edition populates reviewer_id from
+        // the authenticated caller.
+        const reviewerId = "";
+
+        let updated: AgentExecution;
+        try {
+          updated = await deps.store.updateResource(
+            ApiResourceKind.agent_execution,
+            executionId,
+            AgentExecutionSchema,
+            (execution) => {
+              // Re-validate under the write lock against the
+              // freshly-loaded state (guards against a capture/decision
+              // that landed between the pre-lock validation and this
+              // update).
+              validateFileDecisionTarget(execution, ctx.input);
+              if (execution.status === undefined) {
+                execution.status = create(AgentExecutionStatusSchema);
+              }
+
+              const decision = buildFileDecision(
+                ctx.input.changeSetId,
+                ctx.input.fileChangeId,
+                ctx.input.scope,
+                ctx.input.action,
+                ctx.input.expectedDigest,
+                reviewerId,
+                now,
+                ctx.input.reason,
+                ctx.input.acknowledgeUnreviewable,
+              );
+              recordFileDecisionEvent(execution.status, executionId, decision);
+
+              // Recompute file_change_sets from the authored ledger via
+              // the single projection seam, so the new decision reflects
+              // immediately and consistently with the source of truth.
+              execution.status.fileChangeSets = projectFileChangeSets(
+                execution.status.phase,
+                execution.status.fileReviewEventStream,
+              );
+            },
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            throw notFoundError("agent_execution", executionId);
+          }
+          // A precondition failure re-detected under the lock is already a
+          // status error (client fault); surface it verbatim rather than
+          // masking it as INTERNAL.
+          if (error instanceof ConnectError) {
+            throw error;
+          }
+          throw internalError(error, "failed to persist file decision");
+        }
+
+        deps.broker.broadcast(updated);
+        ctx.set(TARGET_RESOURCE_KEY, updated);
+      },
+    })
+    .addStep({
+      name: "SignalWorkflow",
+      async execute(ctx) {
+        if (ctx.get(FILE_DECISION_IDEMPOTENT_KEY) === true) {
+          deps.logger.debug(
+            "Skipping workflow signal for idempotent file decision",
+          );
+          return;
+        }
+        const engine = deps.engineState();
+        if (!engine.connected) {
+          deps.logger.warn(
+            "Workflow creator not available - skipping Temporal signal",
+          );
+          return;
+        }
+
+        const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+        const executionId = execution.metadata?.id ?? "";
+        const status = execution.status;
+
+        // Resume only when the WHOLE gate is clear: no change set awaiting
+        // review and no tool approval pending.
+        if (status === undefined || !gateResolved(status)) {
+          deps.logger.info(
+            "File decision recorded, HITL gate not yet resolved — waiting",
+            {
+              executionId,
+              changeSetId: ctx.input.changeSetId,
+              pendingApprovalsRemaining: status?.pendingApprovals.length ?? 0,
+              changeSetsAwaitingReview: countAwaitingReview(
+                status?.fileChangeSets ?? [],
+              ),
+            },
+          );
+          return;
+        }
+
+        deps.logger.info(
+          "HITL gate resolved by file decision — sending approvalGateResolved signal",
+          { executionId, changeSetId: ctx.input.changeSetId },
+        );
+
+        try {
+          await engine.engine.signalApprovalGateResolved(executionId);
+        } catch (error) {
+          if (error instanceof EngineWorkflowNotFoundError) {
+            deps.logger.warn(
+              "Workflow not found - reconciling stale execution status to FAILED",
+              { executionId },
+            );
+            await reconcileStaleFileReviewExecution(deps, execution);
+            throw failedPreconditionError(
+              `workflow not running for execution ${executionId} - the backing workflow has terminated unexpectedly and the execution has been marked as failed`,
+            );
+          }
+          throw unavailableError(
+            `failed to signal workflow: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        deps.logger.info(
+          "Successfully sent approvalGateResolved signal to workflow",
+          { executionId },
+        );
+      },
+    })
+    .addStep({
+      name: "BuildResponse",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+        deps.logger.info("AUDIT: File decision submitted", {
+          executionId: execution.metadata?.id ?? "",
+          org: execution.metadata?.org ?? "",
+          changeSetId: ctx.input.changeSetId,
+          fileChangeId: ctx.input.fileChangeId,
+          scope: enumToJson(FileDecisionScopeSchema, ctx.input.scope),
+          action: enumToJson(FileDecisionActionSchema, ctx.input.action),
+        });
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentExecution;
+}
+
+/**
+ * Enforces the preconditions against the current projection: non-terminal
+ * execution, change set (and file) existence, the FILE-scope
+ * file_change_id requirement, the APPROVE completeness gate, and the
+ * expected_digest enforcement gate. Shared by the pre-lock validate step
+ * and the under-lock re-check (Go validateFileDecisionTarget).
+ */
+function validateFileDecisionTarget(
+  execution: AgentExecution,
+  input: SubmitFileDecisionInput,
+): void {
+  const executionId = execution.metadata?.id ?? "";
+  const phase =
+    execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+
+  const changeSets = projectFileChangeSets(
+    phase,
+    execution.status?.fileReviewEventStream,
+  );
+  if (changeSets.length === 0) {
+    throw failedPreconditionError(
+      `execution ${executionId} has no actionable file change sets (phase ${enumToJson(ExecutionPhaseSchema, phase) as string})`,
+    );
+  }
+
+  const cs = findChangeSet(changeSets, input.changeSetId);
+  if (cs === undefined) {
+    throw failedPreconditionError(
+      `change set ${input.changeSetId} not found for execution ${executionId}`,
+    );
+  }
+
+  if (input.scope === FileDecisionScope.FILE) {
+    if (input.fileChangeId === "") {
+      throw invalidArgumentError("file_change_id is required for FILE scope");
+    }
+    if (findChange(cs, input.fileChangeId) === undefined) {
+      throw failedPreconditionError(
+        `file change ${input.fileChangeId} not found in change set ${input.changeSetId}`,
+      );
+    }
+  }
+
+  // Completeness precondition: a non-COMPLETE diff can never be approved
+  // as if complete. Gated before the digest check and only for APPROVE,
+  // so an unreviewable change stays discardable (REJECT) and the turn can
+  // still resume.
+  if (input.action === FileDecisionAction.APPROVE) {
+    const reason = approveBlockedReason(
+      cs,
+      input.scope,
+      input.fileChangeId,
+      input.acknowledgeUnreviewable,
+    );
+    if (reason !== "") {
+      throw failedPreconditionError(reason);
+    }
+  }
+
+  const target = targetDigest(cs, input.scope, input.fileChangeId);
+  if (input.expectedDigest !== target) {
+    throw invalidArgumentError(
+      `expected_digest mismatch for change set ${input.changeSetId}: the captured content changed since it was reviewed`,
+    );
+  }
+}
+
+function streamHasFileDecision(
+  stream: FileReviewEventStream | undefined,
+  input: SubmitFileDecisionInput,
+): boolean {
+  let scopeId = input.changeSetId;
+  if (input.scope === FileDecisionScope.FILE) {
+    scopeId = input.fileChangeId;
+  }
+  const id = fileReviewEventId(
+    input.changeSetId,
+    scopeId,
+    FileReviewEventType.FILE_DECIDED,
+  );
+  return (stream?.events ?? []).some((ev) => ev.eventId === id);
+}
+
+/**
+ * Marks an execution FAILED when its backing workflow is gone — the
+ * file-review twin of the approval path's reconcile; BOTH append-only
+ * ledgers are preserved verbatim for the audit trail, the projections
+ * left empty (terminal).
+ */
+async function reconcileStaleFileReviewExecution(
+  deps: SubmitFileDecisionDeps,
+  execution: AgentExecution,
+): Promise<void> {
+  const executionId = execution.metadata?.id ?? "";
+
+  const reconciled = create(AgentExecutionSchema, {
+    apiVersion: execution.apiVersion,
+    kind: execution.kind,
+    metadata: execution.metadata,
+    spec: execution.spec,
+    status: {
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      error:
+        "Workflow backing this execution is no longer running. Execution has been marked as failed.",
+      messages: execution.status?.messages ?? [],
+      audit: execution.status?.audit,
+      approvalEventStream: execution.status?.approvalEventStream,
+      fileReviewEventStream: execution.status?.fileReviewEventStream,
+    },
+  });
+  reconciled.status?.messages.push(
+    create(AgentMessageSchema, {
+      type: MessageType.MESSAGE_SYSTEM,
+      content:
+        "The workflow backing this execution is no longer running. This can happen due to infrastructure issues or manual termination. The execution has been marked as failed.",
+    }),
+  );
+
+  // Any in-flight tool call is still non-terminal; this write
+  // terminalizes the execution, so settle them (issue #207).
+  settleInterruptedToolCalls(
+    reconciled.status,
+    new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+  );
+
+  try {
+    await deps.store.saveResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+      reconciled,
+    );
+  } catch (error) {
+    deps.logger.error(
+      "Failed to reconcile stale execution status - execution will remain in WAITING_FOR_APPROVAL until next attempt",
+      {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+  deps.logger.info(
+    "RECONCILIATION: Updated stale file-review execution status to FAILED",
+    { executionId },
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/subscribe.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/subscribe.ts
@@ -47,24 +47,13 @@ import {
 } from "../../pipeline/errors.js";
 import type { Store } from "../../store/interface.js";
 
+import { isTranscriptTerminalPhase } from "./phases.js";
 import type { StreamBroker } from "./stream-broker.js";
 
 export interface SubscribeDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly broker: StreamBroker;
-}
-
-/**
- * Subscribe's OWN terminal set (subscribe.go isTerminalPhase) — narrower
- * than the merge engine's: TERMINATED is absent (the disclosed quirk).
- */
-function isSubscribeTerminalPhase(phase: ExecutionPhase): boolean {
-  return (
-    phase === ExecutionPhase.EXECUTION_COMPLETED ||
-    phase === ExecutionPhase.EXECUTION_FAILED ||
-    phase === ExecutionPhase.EXECUTION_CANCELLED
-  );
 }
 
 export async function* subscribeExecution(
@@ -139,9 +128,11 @@ export async function* subscribeExecution(
       yield updated;
       lastSent = updated;
 
+      // Subscribe's close set is the NARROW transcript-terminal set
+      // (phases.ts) — TERMINATED absent, the disclosed quirk.
       const phase =
         updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
-      if (isSubscribeTerminalPhase(phase)) {
+      if (isTranscriptTerminalPhase(phase)) {
         deps.logger.info(
           "Execution reached terminal state, ending subscription",
           { executionId: id, phase: ExecutionPhase[phase] },

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/subscribe.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/subscribe.ts
@@ -1,0 +1,156 @@
+/**
+ * Subscribe — ports controller/subscribe.go: the real-time execution
+ * stream (ADR 011 read path). The first DOMAIN server-streaming RPC on
+ * the TS server; the generator shape follows transport/health.ts watch,
+ * the transport's proven streaming idiom.
+ *
+ * Go drives the stream from inside a two-step pipeline by smuggling the
+ * gRPC stream object through the request context; ConnectRPC models
+ * server streams as async generators, which cannot yield from inside the
+ * pipeline executor — so the validate step collapses to the same guard
+ * inline and the StreamExecution step's body IS this generator. Every
+ * delivery rule ports verbatim:
+ *
+ *   - REGISTER-BEFORE-SNAPSHOT (the gap fix): the broker registration
+ *     happens before the snapshot read. Store writes serialize under the
+ *     per-resource write lock and UpdateStatus broadcasts only after its
+ *     persist commits, so any commit the snapshot missed broadcasts after
+ *     our registration — nothing lands in the old lossy window.
+ *   - The overlap frame (a commit the snapshot DID observe) arrives
+ *     value-equal to the snapshot; the consecutive-duplicate guard drops
+ *     it (Go sameFrame/proto.Equal) so clients never re-render an
+ *     identical state.
+ *   - The stream ends on a terminal BROADCAST frame; a terminal SNAPSHOT
+ *     leaves the stream open (Go sends the snapshot and parks in the
+ *     loop). Faithful port.
+ *   - Subscribe's terminal set is COMPLETED/FAILED/CANCELLED — it OMITS
+ *     TERMINATED, so a stream over a terminated execution never
+ *     self-closes. Known Go quirk, ported byte-faithfully; disclosed as a
+ *     both-editions issue candidate at the sub-project wrap-up.
+ *   - Registration and the loop share one owner so the unsubscribe fires
+ *     on every exit path (Go's defer → the generator's finally, which
+ *     ConnectRPC runs on client disconnect too).
+ */
+import { equals } from "@bufbuild/protobuf";
+import type { HandlerContext } from "@connectrpc/connect";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { AgentExecutionId } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { Store } from "../../store/interface.js";
+
+import type { StreamBroker } from "./stream-broker.js";
+
+export interface SubscribeDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+}
+
+/**
+ * Subscribe's OWN terminal set (subscribe.go isTerminalPhase) — narrower
+ * than the merge engine's: TERMINATED is absent (the disclosed quirk).
+ */
+function isSubscribeTerminalPhase(phase: ExecutionPhase): boolean {
+  return (
+    phase === ExecutionPhase.EXECUTION_COMPLETED ||
+    phase === ExecutionPhase.EXECUTION_FAILED ||
+    phase === ExecutionPhase.EXECUTION_CANCELLED
+  );
+}
+
+export async function* subscribeExecution(
+  deps: SubscribeDeps,
+  executionId: AgentExecutionId,
+  context: HandlerContext,
+): AsyncGenerator<AgentExecution> {
+  // Go ValidateSubscribeInputStep.
+  if (executionId.value === "") {
+    throw invalidArgumentError("execution id is required");
+  }
+  const id = executionId.value;
+  deps.logger.info("Starting execution subscription", { executionId: id });
+
+  // Register FIRST so no broadcast can slip through the window before the
+  // snapshot read (the happens-before argument in the module header).
+  const subscription = deps.broker.subscribe(id);
+  try {
+    let snapshot: AgentExecution;
+    try {
+      snapshot = await deps.store.getResource(
+        ApiResourceKind.agent_execution,
+        id,
+        AgentExecutionSchema,
+      );
+    } catch {
+      // Go converts every load failure here to the same NotFound.
+      throw notFoundError("AgentExecution", id);
+    }
+
+    yield snapshot;
+    deps.logger.debug("Sent initial execution state, streaming live updates", {
+      executionId: id,
+    });
+
+    // The consecutive-duplicate anchor (Go lastSent).
+    let lastSent = snapshot;
+
+    const abort = new Promise<void>((resolve) => {
+      context.signal.addEventListener("abort", () => resolve(), {
+        once: true,
+      });
+    });
+
+    while (!context.signal.aborted) {
+      if (subscription.closed) {
+        // Go's closed-channel arm: end quietly.
+        deps.logger.warn("Updates channel closed unexpectedly", {
+          executionId: id,
+        });
+        return;
+      }
+      if (subscription.queue.length === 0) {
+        await Promise.race([
+          abort,
+          new Promise<void>((resolve) => (subscription.notify = resolve)),
+        ]);
+        subscription.notify = undefined;
+        continue;
+      }
+
+      const updated = subscription.queue.shift();
+      if (updated === undefined) {
+        continue;
+      }
+      // Suppress the at-or-before-snapshot overlap frame (and any other
+      // exact repeat) so the client never re-renders an identical state.
+      if (equals(AgentExecutionSchema, updated, lastSent)) {
+        continue;
+      }
+
+      yield updated;
+      lastSent = updated;
+
+      const phase =
+        updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+      if (isSubscribeTerminalPhase(phase)) {
+        deps.logger.info(
+          "Execution reached terminal state, ending subscription",
+          { executionId: id, phase: ExecutionPhase[phase] },
+        );
+        return;
+      }
+    }
+    deps.logger.info("Subscription cancelled by client", { executionId: id });
+  } finally {
+    deps.broker.unsubscribe(id, subscription);
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/tool-call-settle.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/tool-call-settle.ts
@@ -1,0 +1,75 @@
+/**
+ * settleInterruptedToolCalls — ports controller/tool_call_settle.go:
+ * settles every non-terminal tool call — PENDING, RUNNING, or
+ * WAITING_APPROVAL — to TOOL_CALL_INTERRUPTED, across the top-level
+ * transcript and every sub-agent transcript, in place. Enforces the
+ * invariant that a terminal execution carries zero non-terminal tool
+ * calls (issue #207): a terminal execution's workflow is gone, so an
+ * in-flight call will never receive its terminal event and a gated call
+ * can never be decided.
+ *
+ * Called by every terminal writer: the updateStatus merge chokepoint (on
+ * a terminal merged phase), the Cancel/Terminate lifecycle transition,
+ * and the stale-workflow reconcilers. Idempotent — settled rows are
+ * terminal and re-running is a no-op.
+ *
+ * The settle is honest, not a hide: args, partial results, and approval
+ * provenance are preserved for the audit trail. Only the status, the
+ * completion timestamp (when empty, so a runner-recorded timestamp
+ * survives), and the streaming marker change — nothing streams on a dead
+ * execution, so a frozen streaming_source must not leave clients
+ * rendering a live stream.
+ *
+ * A gated (WAITING_APPROVAL) call settled here authors NO approval event:
+ * terminal-execution gate-exits are deliberately not modeled as per-call
+ * events (a terminal execution simply projects to zero pending approvals;
+ * RETRACTED is reserved for in-flight withdrawals).
+ */
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ToolCallStatus,
+  ToolCallStreamingSource,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+/** Returns the number of tool calls settled, for the callers' logs. */
+export function settleInterruptedToolCalls(
+  status: AgentExecutionStatus | undefined,
+  completedAt: string,
+): number {
+  if (status === undefined) {
+    return 0;
+  }
+  let settled = settleInMessages(status.messages, completedAt);
+  for (const sa of status.subAgentExecutions) {
+    settled += settleInMessages(sa.messages, completedAt);
+  }
+  return settled;
+}
+
+function settleInMessages(
+  messages: AgentMessage[],
+  completedAt: string,
+): number {
+  let settled = 0;
+  for (const m of messages) {
+    for (const tc of m.toolCalls) {
+      switch (tc.status) {
+        case ToolCallStatus.TOOL_CALL_PENDING:
+        case ToolCallStatus.TOOL_CALL_RUNNING:
+        case ToolCallStatus.TOOL_CALL_WAITING_APPROVAL: {
+          tc.status = ToolCallStatus.TOOL_CALL_INTERRUPTED;
+          if (tc.completedAt === "") {
+            tc.completedAt = completedAt;
+          }
+          tc.streamingSource = ToolCallStreamingSource.UNSPECIFIED;
+          settled++;
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  }
+  return settled;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/update-status.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/update-status.ts
@@ -1,0 +1,471 @@
+/**
+ * UpdateStatus — ports controller/update_status.go: the runner's
+ * progressive status-update RPC and the domain's single merge chokepoint.
+ *
+ * Chain per Go: ValidateUpdateStatusInput → MergeAndPersistExecution →
+ * BroadcastToStreams. The merge+persist is ONE atomic read-modify-write
+ * under the store's per-resource write lock (store.updateResource) — the
+ * same discipline SubmitApproval uses, load-bearing now that the
+ * append-only approval_event_stream is the source of truth for
+ * pending_approvals: a non-atomic load-then-save could drop an approval
+ * event a concurrent SubmitApproval appended in the window between the
+ * load and the save.
+ *
+ * applyUpdateStatusMerge is the merge body run inside the updateResource
+ * closure (and exercised directly by the guard tests), mirroring the Java
+ * BuildNewStateWithStatusStep strategy: most fields are replaced
+ * wholesale with the runner's latest complete state, while server-owned
+ * fields (approval decisions, the approval_event_stream, the file_review
+ * ledger) are preserved/authored here because the runner never sends
+ * them.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, PublishToRedis, and
+ * Publish steps (broadcast rides in-memory channels per ADR 011).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import {
+  ExecutionControlSignal,
+  ExecutionPhase,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  AgentExecutionUpdateStatusInput,
+  UpdateStatusResponse,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { UpdateStatusResponseSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+import { ensureApprovalRequests } from "./approval/author.js";
+import { preserveApprovalFields } from "./approval/preserve.js";
+import { projectPendingApprovals } from "./approval/project.js";
+import { appendRunnerEvents } from "./filereview/author.js";
+import { autoKeepApprovedCommandSets } from "./filereview/autokeep.js";
+import { projectFileChangeSets } from "./filereview/project.js";
+import { reconcileFileChangeProgress } from "./filereview/progress.js";
+import {
+  isTerminalExecutionPhase,
+  isTranscriptTerminalPhase,
+} from "./phases.js";
+import { settleInterruptedToolCalls } from "./tool-call-settle.js";
+import type { StreamBroker } from "./stream-broker.js";
+
+export interface UpdateStatusDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+}
+
+type UpdateStatusDesc =
+  typeof AgentExecutionCommandController.method.updateStatus.input;
+
+const EXECUTION_KEY = "execution";
+
+export async function updateStatus(
+  deps: UpdateStatusDeps,
+  input: AgentExecutionUpdateStatusInput,
+): Promise<UpdateStatusResponse> {
+  const reqCtx = new RequestContext(
+    AgentExecutionCommandController.method.updateStatus.input,
+    input,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<UpdateStatusDesc>(
+    "agentexecution-update-status",
+    deps.logger,
+  )
+    .addStep({
+      name: "ValidateUpdateStatusInput",
+      execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+        if (ctx.input.status === undefined) {
+          throw invalidArgumentError("status is required");
+        }
+      },
+    })
+    .addStep({
+      name: "MergeAndPersistExecution",
+      async execute(ctx) {
+        let updated: AgentExecution;
+        try {
+          updated = await deps.store.updateResource(
+            ApiResourceKind.agent_execution,
+            ctx.input.executionId,
+            AgentExecutionSchema,
+            (execution) => {
+              applyUpdateStatusMerge(execution, ctx.input, deps.logger);
+            },
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            throw notFoundError("AgentExecution", ctx.input.executionId);
+          }
+          throw internalError(error, "failed to update execution status");
+        }
+        // Hand the merged result to the broadcast step.
+        ctx.set(EXECUTION_KEY, updated);
+      },
+    })
+    .addStep({
+      name: "BroadcastToStreams",
+      execute(ctx) {
+        const execution = ctx.get(EXECUTION_KEY);
+        if (execution === undefined) {
+          throw internalError(
+            new Error("execution not found in context"),
+            "execution not found in context",
+          );
+        }
+        // Push to active subscribers AFTER the persist commits (ADR 011
+        // write path) — the ordering subscribe's register-before-snapshot
+        // guarantee builds on.
+        deps.broker.broadcast(execution as AgentExecution);
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return create(UpdateStatusResponseSchema, {
+    signal: ExecutionControlSignal.UNSPECIFIED,
+  });
+}
+
+/**
+ * Whether replacing existing with incoming would drop committed
+ * transcript history for a non-terminal execution, plus a short reason
+ * for the rejection log. Enforces the append-only-at-identity invariant:
+ * a non-terminal transcript may grow and reconcile entries in place, but
+ * it may neither shrink nor drop a previously committed tool-call id.
+ * Terminal executions (the TRANSCRIPT terminal set — TERMINATED stays
+ * protected) may be rewritten freely and so are never a regression here.
+ */
+export function nonTerminalTranscriptRegression(
+  phase: ExecutionPhase,
+  existing: AgentMessage[],
+  incoming: AgentMessage[],
+): { reject: boolean; reason: string } {
+  if (isTranscriptTerminalPhase(phase)) {
+    return { reject: false, reason: "" };
+  }
+  if (incoming.length < existing.length) {
+    return { reject: true, reason: "would shrink the message transcript" };
+  }
+
+  const incomingToolCallIds = new Set<string>();
+  for (const m of incoming) {
+    for (const tc of m.toolCalls) {
+      if (tc.id !== "") {
+        incomingToolCallIds.add(tc.id);
+      }
+    }
+  }
+  for (const m of existing) {
+    for (const tc of m.toolCalls) {
+      if (tc.id === "") {
+        continue;
+      }
+      if (!incomingToolCallIds.has(tc.id)) {
+        return {
+          reject: true,
+          reason: "would drop a previously-committed tool call",
+        };
+      }
+    }
+  }
+  return { reject: false, reason: "" };
+}
+
+/**
+ * Merges an incoming status update into the execution in place — the
+ * runner-owns-the-transcript merge rules, exactly update_status.go
+ * applyUpdateStatusMerge. Runs inside the updateResource closure
+ * (synchronous by store contract), so the merge, the approval event
+ * authoring, and the pending_approvals projection all see the same
+ * snapshot that will be persisted.
+ */
+export function applyUpdateStatusMerge(
+  execution: AgentExecution,
+  input: AgentExecutionUpdateStatusInput,
+  logger: Logger,
+): void {
+  if (execution.status === undefined) {
+    execution.status = create(AgentExecutionStatusSchema);
+  }
+  const status = execution.status;
+  const requestStatus = input.status;
+  if (requestStatus === undefined) {
+    // Unreachable through the RPC (the validate step refuses); the
+    // direct-call guard keeps the merge total.
+    return;
+  }
+
+  // Snapshot the pre-merge transcript before any replacement: the
+  // regression guard compares against the persisted messages, and
+  // preserveApprovalFields copies the SubmitApproval-owned decision
+  // fields from these existing messages onto the incoming ones.
+  // Reassigning status.messages below does not mutate these references.
+  const existingMessages = status.messages;
+  const existingSubAgents = status.subAgentExecutions;
+  const existingPhase = status.phase;
+
+  // Merge messages (replace with latest from request), guarding against
+  // any update that would drop committed transcript history for a
+  // non-terminal execution. The runner owns the transcript and only ever
+  // GROWS it in flight; two regressions are rejected at this single
+  // persistence chokepoint:
+  //  1. A strictly SHORTER transcript — the classic partial write.
+  //  2. A transcript that DROPS a committed tool-call id while appending
+  //     enough later turns to keep the count equal-or-greater
+  //     (front-truncation, invisible to a count-only check; tool-call
+  //     ids are the only stable identity in the transcript).
+  // Content is deliberately NOT compared: legitimate updates both grow
+  // it (streaming) and blank it in place (the Cursor runner's
+  // post-denial narration redaction), so a content check would reject
+  // valid writes.
+  if (requestStatus.messages.length > 0) {
+    const { reject, reason } = nonTerminalTranscriptRegression(
+      existingPhase,
+      existingMessages,
+      requestStatus.messages,
+    );
+    if (reject) {
+      logger.warn(
+        "Rejected status update that would drop committed transcript history for a non-terminal execution; keeping existing messages",
+        {
+          executionId: input.executionId,
+          existingMessages: existingMessages.length,
+          incomingMessages: requestStatus.messages.length,
+          reason,
+        },
+      );
+    } else {
+      status.messages = requestStatus.messages;
+    }
+  }
+
+  // Wholesale presence-guarded replacements (latest from request).
+  if (requestStatus.subAgentExecutions.length > 0) {
+    status.subAgentExecutions = requestStatus.subAgentExecutions;
+  }
+  // todos is a map field; Go's len() counts entries.
+  if (Object.keys(requestStatus.todos).length > 0) {
+    status.todos = requestStatus.todos;
+  }
+  // Artifacts are published by agents via publish_artifact during
+  // execution; the runner persists them through this RPC.
+  if (requestStatus.artifacts.length > 0) {
+    status.artifacts = requestStatus.artifacts;
+  }
+  // Write-backs are populated during post-execution processing when the
+  // platform detects git changes and creates PRs.
+  if (requestStatus.workspaceWriteBacks.length > 0) {
+    status.workspaceWriteBacks = requestStatus.workspaceWriteBacks;
+  }
+
+  // Preserve approval fields (approval_action, approval_decided_at,
+  // approved_by) atomically recorded by SubmitApproval — the runner
+  // always sends UNSPECIFIED, so the wholesale replacement above would
+  // otherwise erase user decisions.
+  preserveApprovalFields(
+    status.messages,
+    status.subAgentExecutions,
+    existingMessages,
+    existingSubAgents,
+  );
+
+  // Update phase (if provided) — latched once terminal. A terminal phase
+  // is final by contract, but a runner activity can outlive its
+  // workflow's termination, so a straggler streaming persist can arrive
+  // carrying IN_PROGRESS after Terminate already wrote TERMINATED.
+  // Without the latch that persist resurrects the phase — and the
+  // execution is stuck live forever, because the workflow that would
+  // re-terminalize it is gone. Recover is the one sanctioned
+  // un-terminalizer and runs through its own lifecycle step, never this
+  // merge.
+  if (requestStatus.phase !== ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) {
+    if (
+      isTerminalExecutionPhase(existingPhase) &&
+      requestStatus.phase !== existingPhase
+    ) {
+      logger.warn(
+        "Ignored phase change on a terminal execution; terminal phases are final (Recover is the sanctioned un-terminalizer)",
+        {
+          executionId: input.executionId,
+          storedPhase: ExecutionPhase[existingPhase],
+          ignoredPhase: ExecutionPhase[requestStatus.phase],
+        },
+      );
+    } else {
+      status.phase = requestStatus.phase;
+    }
+  }
+
+  if (requestStatus.error !== "") {
+    status.error = requestStatus.error;
+  }
+  if (requestStatus.startedAt !== "") {
+    status.startedAt = requestStatus.startedAt;
+  }
+  if (requestStatus.completedAt !== "") {
+    status.completedAt = requestStatus.completedAt;
+  }
+
+  // Defense-in-depth: completed_at must not be set for non-terminal
+  // phases. The runner clears completed_at on resume, but the
+  // empty-string merge above cannot propagate the clear — this guard
+  // prevents the contradictory state (completed_at set +
+  // phase=WAITING_FOR_APPROVAL) observed in production.
+  if (
+    status.phase === ExecutionPhase.EXECUTION_IN_PROGRESS ||
+    status.phase === ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL ||
+    status.phase === ExecutionPhase.EXECUTION_PENDING
+  ) {
+    status.completedAt = "";
+  }
+
+  // Terminal invariant (issue #207): a terminal execution carries zero
+  // non-terminal tool calls. Settling here — at the single merge
+  // chokepoint — covers every updateStatus writer without any of them
+  // having to remember it, and composes with the phase latch into a
+  // self-healing pair: a straggler persist that reintroduces RUNNING rows
+  // cannot move the terminal phase, so its rows are re-settled in the
+  // same merge. Runs before ensureApprovalRequests so a gated call on a
+  // dead execution never seeds a REQUESTED approval event.
+  if (isTerminalExecutionPhase(status.phase)) {
+    let settledAt = status.completedAt;
+    if (settledAt === "") {
+      settledAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    }
+    const settled = settleInterruptedToolCalls(status, settledAt);
+    if (settled > 0) {
+      logger.info(
+        "Settled in-flight tool calls to TOOL_CALL_INTERRUPTED on terminal execution",
+        {
+          executionId: input.executionId,
+          phase: ExecutionPhase[status.phase],
+          settledToolCalls: settled,
+        },
+      );
+    }
+  }
+
+  // Author REQUESTED events for any tool call now in the approval gate
+  // (seeding the persisted stream the first time it is touched). The
+  // runner never sends this server-only field; it is carried over from
+  // the loaded resource and mutated in place here. Decisions are authored
+  // separately by SubmitApproval. Because this runs inside the
+  // updateResource write lock on the freshly-loaded stream, the events it
+  // appends can never clobber a decision a concurrent SubmitApproval
+  // appended.
+  ensureApprovalRequests(status, input.executionId);
+
+  // Compute pending_approvals from the authored event stream, via the
+  // single projection seam (returns the event-stream projection and runs
+  // the scan parity cross-check).
+  status.pendingApprovals = projectPendingApprovals(
+    status.phase,
+    status.messages,
+    status.subAgentExecutions,
+    status.approvalEventStream,
+    logger,
+  );
+
+  // Fold the runner-authored capture/reconcile events (carried on the
+  // request payload) into the server-owned ledger: append-only,
+  // idempotent by event_id, FILE_DECIDED dropped (server-authored by
+  // SubmitFileDecision).
+  appendRunnerEvents(status, input.executionId, requestStatus);
+
+  // Approved-command auto-keep (DD-28): a candidate whose provenance
+  // verifies against the server-authored approval record is decided by
+  // policy IN THE SAME WRITE that folded it, so the gate never arms for a
+  // set the user already consented to via the command approval.
+  autoKeepApprovedCommandSets(
+    status,
+    input.executionId,
+    execution.spec?.autoApproveAll ?? false,
+    logger,
+  );
+
+  // Recompute file_change_sets from the append-only ledger via its single
+  // projection seam — always derived, never merged, so it cannot go
+  // stale.
+  status.fileChangeSets = projectFileChangeSets(
+    status.phase,
+    status.fileReviewEventStream,
+  );
+
+  // Mid-run live capture (DD-32): merge the runner-owned transient
+  // progress snapshot (presence-guarded replace, like streaming_usage
+  // below), then clear it unless its change set is still CAPTURING — run
+  // here so it sees the freshly-projected file_change_sets.
+  if (requestStatus.fileChangeProgress !== undefined) {
+    status.fileChangeProgress = requestStatus.fileChangeProgress;
+  }
+  status.fileChangeProgress = reconcileFileChangeProgress(
+    status.fileChangeSets,
+    status.fileChangeProgress,
+  );
+
+  // Merge streaming_usage (replace with latest from request): a
+  // display-only fallback when proxy-reported usage is unavailable.
+  if (requestStatus.streamingUsage !== undefined) {
+    status.streamingUsage = requestStatus.streamingUsage;
+  }
+
+  // Merge recalled_memories_report: runner-owned, written at most once
+  // per execution at prompt build (DD-008 D5). Later persists omit it, so
+  // this presence guard is what preserves the stored report across the
+  // execution's remaining status writes.
+  if (requestStatus.recalledMemoriesReport !== undefined) {
+    status.recalledMemoriesReport = requestStatus.recalledMemoriesReport;
+  }
+
+  if (requestStatus.contextInfo !== undefined) {
+    status.contextInfo = requestStatus.contextInfo;
+  }
+
+  if (requestStatus.setupProgress !== undefined) {
+    status.setupProgress = requestStatus.setupProgress;
+  }
+  // Clear setup_progress when phase leaves PENDING (defense-in-depth):
+  // the worker stops sending it once streaming begins, but an explicit
+  // clear prevents stale data if the phase transitions via a different
+  // code path.
+  if (status.phase !== ExecutionPhase.EXECUTION_PENDING) {
+    status.setupProgress = undefined;
+  }
+
+  // Merge structured_output: populated by the runner on COMPLETED when
+  // ExecutionConfig had structured_output_schema; immutable after first
+  // population.
+  if (requestStatus.structuredOutput !== undefined) {
+    status.structuredOutput = requestStatus.structuredOutput;
+  }
+
+  logger.debug("Merged status fields", {
+    executionId: input.executionId,
+    phase: ExecutionPhase[status.phase],
+    messagesCount: status.messages.length,
+    pendingApprovalsCount: status.pendingApprovals.length,
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/usage.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/usage.ts
@@ -1,0 +1,927 @@
+/**
+ * AgentExecution usage reports — ports usage_aggregation.go plus the four
+ * report pipelines (get_execution_usage_report.go,
+ * get_session_usage_report.go, get_agent_usage_report.go,
+ * get_org_usage_report.go) and the dashboard summary
+ * (get_execution_summary.go, a direct handler in Go too).
+ *
+ * The OSS zero-shapes contract (CW-7-pinned): runners record no
+ * per-message llm_metrics and there is no llm_call_usage_record
+ * collection (a cloud billing concern), so every aggregate is
+ * structurally valid and zero-valued, and the session/agent/org reports
+ * never error for "nothing to aggregate". The execution-scoped report is
+ * the ONE report that 404s (it verifies the execution exists).
+ *
+ * Faithful-port notes:
+ *   - The unknown-execution message is Go's mangled helper output,
+ *     byte-for-byte (constants.ts, sub-project DD-001).
+ *   - Org matching is case-insensitive (Go strings.EqualFold); slug-shaped
+ *     orgs make the exotic Unicode fold edges unreachable, so toLowerCase
+ *     comparison sits inside Go's envelope.
+ *   - Rank/summary tie order: Go iterates maps (nondeterministic) and
+ *     sorts unstably; TS Maps iterate insertion-ordered and Array.sort is
+ *     stable. Ties are not wire-assertable — the disclosed cross-edition
+ *     nuance from the agent-family sub-project applies here unchanged.
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+import type { Duration } from "@bufbuild/protobuf/wkt";
+import { DurationSchema } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type {
+  AgentExecutionSummary,
+  AgentFailureRank,
+  AgentUsageSummary,
+  DailyCostEntry,
+  ExecutionUsageSummary,
+  GetAgentExecutionSummaryRequest,
+  GetAgentUsageReportOutput,
+  GetExecutionUsageReportOutput,
+  GetOrgUsageReportOutput,
+  GetSessionUsageReportOutput,
+  SessionUsageSummary,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import {
+  AgentExecutionSummaryTimeWindow,
+  AgentExecutionSummarySchema,
+  AgentFailureRankSchema,
+  AgentUsageSummarySchema,
+  DailyCostEntrySchema,
+  ExecutionUsageSummarySchema,
+  GetAgentUsageReportOutputSchema,
+  GetExecutionUsageReportOutputSchema,
+  GetOrgUsageReportOutputSchema,
+  GetSessionUsageReportOutputSchema,
+  SessionUsageSummarySchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+import type { ModelUsage } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/usage_pb";
+import { UsageReportAggregateSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/usage_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import type { Store } from "../../store/interface.js";
+
+import { executionUsageReportNotFoundMessage } from "./constants.js";
+import { EXECUTION_LIST_KEY, loadAllAgentExecutions } from "./steps.js";
+
+export interface UsageReportDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+// Context keys for inter-step communication — Go's key strings, verbatim.
+const EXECUTION_USAGE_REPORT_KEY = "execution_usage_report";
+const EXECUTION_KEY = "execution";
+const SESSION_USAGE_REPORT_KEY = "session_usage_report";
+const AGENT_USAGE_REPORT_KEY = "agent_usage_report";
+const ORG_USAGE_REPORT_KEY = "org_usage_report";
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers (usage_aggregation.go) — the OSS zero-value posture.
+// ---------------------------------------------------------------------------
+
+/** Zero-valued UsageReportAggregate (Go aggregateUsageReport). */
+export function aggregateUsageReport(): ReturnType<
+  typeof create<typeof UsageReportAggregateSchema>
+> {
+  return create(UsageReportAggregateSchema);
+}
+
+/** Empty model breakdown (Go mergeModelBreakdowns returns nil). */
+export function mergeModelBreakdowns(): ModelUsage[] {
+  return [];
+}
+
+/**
+ * Projects a full AgentExecution into the lightweight per-execution
+ * summary (Go buildExecutionSummary). Token/cost fields stay zero.
+ */
+export function buildExecutionSummary(
+  exec: AgentExecution,
+): ExecutionUsageSummary {
+  return create(ExecutionUsageSummarySchema, {
+    executionId: exec.metadata?.id ?? "",
+    startedAt: exec.status?.startedAt ?? "",
+    completedAt: exec.status?.completedAt ?? "",
+    subAgentCount: exec.status?.subAgentExecutions.length ?? 0,
+    phase: exec.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+  });
+}
+
+/**
+ * Executions whose started_at falls within [from, to] (inclusive,
+ * ISO 8601 STRING comparison — Go filterByDateRange). Empty bounds
+ * disable that side; executions without started_at are excluded whenever
+ * any bound is set.
+ */
+export function filterByDateRange(
+  executions: AgentExecution[],
+  from: string,
+  to: string,
+): AgentExecution[] {
+  if (from === "" && to === "") {
+    return executions;
+  }
+  return executions.filter((exec) => {
+    const startedAt = exec.status?.startedAt ?? "";
+    if (startedAt === "") {
+      return false;
+    }
+    if (from !== "" && startedAt < from) {
+      return false;
+    }
+    if (to !== "" && startedAt > to) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/** Case-insensitive org filter (Go filterByOrg / strings.EqualFold). */
+export function filterByOrg(
+  executions: AgentExecution[],
+  orgId: string,
+): AgentExecution[] {
+  const target = orgId.toLowerCase();
+  return executions.filter(
+    (exec) => (exec.metadata?.org ?? "").toLowerCase() === target,
+  );
+}
+
+/** spec.agent_id equality filter (Go filterByAgentID). */
+export function filterByAgentId(
+  executions: AgentExecution[],
+  agentId: string,
+): AgentExecution[] {
+  return executions.filter((exec) => (exec.spec?.agentId ?? "") === agentId);
+}
+
+/** Groups by spec.session_id (Go groupBySessionID). */
+export function groupBySessionId(
+  executions: AgentExecution[],
+): Map<string, AgentExecution[]> {
+  const groups = new Map<string, AgentExecution[]>();
+  for (const exec of executions) {
+    const sid = exec.spec?.sessionId ?? "";
+    const group = groups.get(sid);
+    if (group === undefined) {
+      groups.set(sid, [exec]);
+    } else {
+      group.push(exec);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Groups by spec.agent_id; executions without one group under "" (Go
+ * groupByAgentID).
+ */
+export function groupByAgentId(
+  executions: AgentExecution[],
+): Map<string, AgentExecution[]> {
+  const groups = new Map<string, AgentExecution[]>();
+  for (const exec of executions) {
+    const aid = exec.spec?.agentId ?? "";
+    const group = groups.get(aid);
+    if (group === undefined) {
+      groups.set(aid, [exec]);
+    } else {
+      group.push(exec);
+    }
+  }
+  return groups;
+}
+
+/** The YYYY-MM-DD prefix of an ISO 8601 timestamp (Go extractDate). */
+export function extractDate(ts: string): string {
+  if (ts.length < 10) {
+    return "";
+  }
+  return ts.slice(0, 10);
+}
+
+/** Earliest non-empty started_at (Go earliestStartedAt). */
+export function earliestStartedAt(executions: AgentExecution[]): string {
+  let earliest = "";
+  for (const exec of executions) {
+    const sa = exec.status?.startedAt ?? "";
+    if (sa === "") {
+      continue;
+    }
+    if (earliest === "" || sa < earliest) {
+      earliest = sa;
+    }
+  }
+  return earliest;
+}
+
+/** Latest non-empty started_at (Go latestStartedAt). */
+export function latestStartedAt(executions: AgentExecution[]): string {
+  let latest = "";
+  for (const exec of executions) {
+    const sa = exec.status?.startedAt ?? "";
+    if (sa === "") {
+      continue;
+    }
+    if (latest === "" || sa > latest) {
+      latest = sa;
+    }
+  }
+  return latest;
+}
+
+/** Per-session zero-cost summary (Go buildSessionSummary). */
+export function buildSessionSummary(
+  sessionId: string,
+  executions: AgentExecution[],
+): SessionUsageSummary {
+  return create(SessionUsageSummarySchema, {
+    sessionId,
+    executionCount: executions.length,
+    firstExecutionAt: earliestStartedAt(executions),
+    lastExecutionAt: latestStartedAt(executions),
+  });
+}
+
+/** Per-agent zero-cost summary (Go buildAgentSummary). */
+export function buildAgentSummary(
+  agentId: string,
+  agentName: string,
+  executions: AgentExecution[],
+): AgentUsageSummary {
+  return create(AgentUsageSummarySchema, {
+    agentId,
+    agentName,
+    executionCount: executions.length,
+  });
+}
+
+/**
+ * Groups by the YYYY-MM-DD prefix of started_at; executions without one
+ * are dropped (Go groupByDate).
+ */
+export function groupByDate(
+  executions: AgentExecution[],
+): Map<string, AgentExecution[]> {
+  const groups = new Map<string, AgentExecution[]>();
+  for (const exec of executions) {
+    const date = extractDate(exec.status?.startedAt ?? "");
+    if (date === "") {
+      continue;
+    }
+    const group = groups.get(date);
+    if (group === undefined) {
+      groups.set(date, [exec]);
+    } else {
+      group.push(exec);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Chronologically sorted daily entries with zero cost (Go
+ * buildDailyCostEntries).
+ */
+export function buildDailyCostEntries(
+  executions: AgentExecution[],
+): DailyCostEntry[] {
+  const byDate = groupByDate(executions);
+  const entries: DailyCostEntry[] = [];
+  for (const [date, group] of byDate) {
+    entries.push(
+      create(DailyCostEntrySchema, {
+        date,
+        executionCount: group.length,
+      }),
+    );
+  }
+  entries.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+  return entries;
+}
+
+/** In-place chronological sort by started_at (Go sortExecutionsByStartedAt). */
+export function sortExecutionsByStartedAt(executions: AgentExecution[]): void {
+  executions.sort((a, b) => {
+    const sa = a.status?.startedAt ?? "";
+    const sb = b.status?.startedAt ?? "";
+    return sa < sb ? -1 : sa > sb ? 1 : 0;
+  });
+}
+
+/** Deduplicated, sorted non-empty agent ids (Go distinctAgentIDs). */
+export function distinctAgentIds(executions: AgentExecution[]): string[] {
+  const seen = new Set<string>();
+  for (const exec of executions) {
+    const aid = exec.spec?.agentId ?? "";
+    if (aid !== "") {
+      seen.add(aid);
+    }
+  }
+  return [...seen].sort();
+}
+
+/** Deduplicated, sorted non-empty session ids (Go distinctSessionIDs). */
+export function distinctSessionIds(executions: AgentExecution[]): string[] {
+  const seen = new Set<string>();
+  for (const exec of executions) {
+    const sid = exec.spec?.sessionId ?? "";
+    if (sid !== "") {
+      seen.add(sid);
+    }
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Top N agent summaries by billable cost descending (Go topAgentsByCost).
+ * All costs are zero in OSS, so this is order-preserving in practice.
+ */
+export function topAgentsByCost(
+  summaries: AgentUsageSummary[],
+  n: number,
+): AgentUsageSummary[] {
+  summaries.sort((a, b) =>
+    a.billableCostMicros < b.billableCostMicros
+      ? 1
+      : a.billableCostMicros > b.billableCostMicros
+        ? -1
+        : 0,
+  );
+  if (n > 0 && summaries.length > n) {
+    return summaries.slice(0, n);
+  }
+  return summaries;
+}
+
+/** Loads an agent's display name, falling back to the id (Go resolveAgentName). */
+async function resolveAgentNameFromStore(
+  deps: UsageReportDeps,
+  agentId: string,
+): Promise<string> {
+  let agent: Agent;
+  try {
+    agent = await deps.store.getResource(
+      ApiResourceKind.agent,
+      agentId,
+      AgentSchema,
+    );
+  } catch {
+    deps.logger.debug("Could not resolve agent name, using ID", { agentId });
+    return agentId;
+  }
+  const name = agent.metadata?.name ?? "";
+  return name !== "" ? name : agentId;
+}
+
+// ---------------------------------------------------------------------------
+// getExecutionUsageReport — the ONE report that 404s.
+// Chain per Go: ValidateExecutionUsageReport → LoadExecution →
+// BuildExecutionUsageReport.
+// ---------------------------------------------------------------------------
+
+type ExecutionReportDesc =
+  typeof AgentExecutionQueryController.method.getExecutionUsageReport.input;
+
+export async function getExecutionUsageReport(
+  deps: UsageReportDeps,
+  req: RequestContext<ExecutionReportDesc>["input"],
+): Promise<GetExecutionUsageReportOutput> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.getExecutionUsageReport.input,
+    req,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<ExecutionReportDesc>(
+    "get-execution-usage-report",
+    deps.logger,
+  )
+    .addStep({
+      name: "ValidateExecutionUsageReport",
+      execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+      },
+    })
+    .addStep(newLoadExecutionStep(deps.store))
+    .addStep({
+      name: "BuildExecutionUsageReport",
+      execute(ctx) {
+        ctx.set(
+          EXECUTION_USAGE_REPORT_KEY,
+          create(GetExecutionUsageReportOutputSchema, {
+            aggregate: aggregateUsageReport(),
+          }),
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return requireReport<GetExecutionUsageReportOutput>(
+    reqCtx.get(EXECUTION_USAGE_REPORT_KEY),
+    "execution usage report not found in context",
+  );
+}
+
+/**
+ * LoadExecution — verifies existence; any load failure answers the
+ * (mangled, DD-001) NotFound exactly as Go's step converts every
+ * GetResource error.
+ */
+function newLoadExecutionStep(
+  store: Store,
+): PipelineStep<ExecutionReportDesc> {
+  return {
+    name: "LoadExecution",
+    async execute(ctx) {
+      const executionId = ctx.input.executionId;
+      let execution: AgentExecution;
+      try {
+        execution = await store.getResource(
+          ApiResourceKind.agent_execution,
+          executionId,
+          AgentExecutionSchema,
+        );
+      } catch {
+        throw new ConnectError(
+          executionUsageReportNotFoundMessage(executionId),
+          Code.NotFound,
+        );
+      }
+      ctx.set(EXECUTION_KEY, execution);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getSessionUsageReport — zero shapes, no existence check.
+// Chain per Go: ValidateSessionUsageReport → LoadSessionExecutions →
+// BuildSessionUsageReport.
+// ---------------------------------------------------------------------------
+
+type SessionReportDesc =
+  typeof AgentExecutionQueryController.method.getSessionUsageReport.input;
+
+export async function getSessionUsageReport(
+  deps: UsageReportDeps,
+  req: RequestContext<SessionReportDesc>["input"],
+): Promise<GetSessionUsageReportOutput> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.getSessionUsageReport.input,
+    req,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<SessionReportDesc>("get-session-usage-report", deps.logger)
+    .addStep({
+      name: "ValidateSessionUsageReport",
+      execute(ctx) {
+        if (ctx.input.sessionId === "") {
+          throw invalidArgumentError("session_id is required");
+        }
+      },
+    })
+    .addStep({
+      name: "LoadSessionExecutions",
+      async execute(ctx) {
+        const all = await loadAllAgentExecutions(deps.store, deps.logger);
+        const executions = all.filter(
+          (exec) => (exec.spec?.sessionId ?? "") === ctx.input.sessionId,
+        );
+        deps.logger.debug("Loaded executions for session usage report", {
+          sessionId: ctx.input.sessionId,
+          count: executions.length,
+        });
+        ctx.set(EXECUTION_LIST_KEY, executions);
+      },
+    })
+    .addStep({
+      name: "BuildSessionUsageReport",
+      execute(ctx) {
+        const executions = requireExecutionList(ctx.get(EXECUTION_LIST_KEY));
+        sortExecutionsByStartedAt(executions);
+        ctx.set(
+          SESSION_USAGE_REPORT_KEY,
+          create(GetSessionUsageReportOutputSchema, {
+            sessionId: ctx.input.sessionId,
+            executionCount: executions.length,
+            totalUsage: aggregateUsageReport(),
+            executions: executions.map(buildExecutionSummary),
+            modelBreakdown: mergeModelBreakdowns(),
+            firstExecutionAt: earliestStartedAt(executions),
+            lastExecutionAt: latestStartedAt(executions),
+          }),
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return requireReport<GetSessionUsageReportOutput>(
+    reqCtx.get(SESSION_USAGE_REPORT_KEY),
+    "session usage report not found in context",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// getAgentUsageReport — org-scoped (oss#389), zero shapes.
+// Chain per Go: ValidateAgentUsageReport → LoadAgentExecutions →
+// BuildAgentUsageReport.
+// ---------------------------------------------------------------------------
+
+type AgentReportDesc =
+  typeof AgentExecutionQueryController.method.getAgentUsageReport.input;
+
+export async function getAgentUsageReport(
+  deps: UsageReportDeps,
+  req: RequestContext<AgentReportDesc>["input"],
+): Promise<GetAgentUsageReportOutput> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.getAgentUsageReport.input,
+    req,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<AgentReportDesc>("get-agent-usage-report", deps.logger)
+    .addStep({
+      name: "ValidateAgentUsageReport",
+      execute(ctx) {
+        if (ctx.input.agentId === "") {
+          throw invalidArgumentError("agent_id is required");
+        }
+        if (ctx.input.orgId === "") {
+          throw invalidArgumentError("org_id is required");
+        }
+      },
+    })
+    .addStep({
+      name: "LoadAgentExecutions",
+      async execute(ctx) {
+        const all = await loadAllAgentExecutions(deps.store, deps.logger);
+        let filtered = filterByOrg(all, ctx.input.orgId);
+        filtered = filterByAgentId(filtered, ctx.input.agentId);
+        filtered = filterByDateRange(
+          filtered,
+          ctx.input.fromDate,
+          ctx.input.toDate,
+        );
+        deps.logger.debug("Loaded executions for agent usage report", {
+          agentId: ctx.input.agentId,
+          orgId: ctx.input.orgId,
+          count: filtered.length,
+        });
+        ctx.set(EXECUTION_LIST_KEY, filtered);
+      },
+    })
+    .addStep({
+      name: "BuildAgentUsageReport",
+      async execute(ctx) {
+        const executions = requireExecutionList(ctx.get(EXECUTION_LIST_KEY));
+        const agentId = ctx.input.agentId;
+
+        // The name resolves only when the org has executions of the agent —
+        // contract parity with cloud, where this prevents the report from
+        // acting as an id-to-name oracle for agents the org never used.
+        let agentName = agentId;
+        if (executions.length > 0) {
+          agentName = await resolveAgentNameFromStore(deps, agentId);
+        }
+
+        sortExecutionsByStartedAt(executions);
+
+        const bySession = groupBySessionId(executions);
+        const sessionSummaries: SessionUsageSummary[] = [];
+        for (const [sid, group] of bySession) {
+          sessionSummaries.push(buildSessionSummary(sid, group));
+        }
+
+        ctx.set(
+          AGENT_USAGE_REPORT_KEY,
+          create(GetAgentUsageReportOutputSchema, {
+            agentId,
+            agentName,
+            totalUsage: aggregateUsageReport(),
+            modelBreakdown: mergeModelBreakdowns(),
+            sessions: sessionSummaries,
+            totalSessions: bySession.size,
+            totalExecutions: executions.length,
+          }),
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return requireReport<GetAgentUsageReportOutput>(
+    reqCtx.get(AGENT_USAGE_REPORT_KEY),
+    "agent usage report not found in context",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// getOrgUsageReport — required date range, zero shapes.
+// Chain per Go: ValidateOrgUsageReport → LoadOrgExecutions →
+// BuildOrgUsageReport.
+// ---------------------------------------------------------------------------
+
+/** Top-agents cap (Go topAgentsLimit). */
+const TOP_AGENTS_LIMIT = 10;
+
+type OrgReportDesc =
+  typeof AgentExecutionQueryController.method.getOrgUsageReport.input;
+
+export async function getOrgUsageReport(
+  deps: UsageReportDeps,
+  req: RequestContext<OrgReportDesc>["input"],
+): Promise<GetOrgUsageReportOutput> {
+  const reqCtx = new RequestContext(
+    AgentExecutionQueryController.method.getOrgUsageReport.input,
+    req,
+    ApiResourceKind.agent_execution,
+  );
+  await newPipeline<OrgReportDesc>("get-org-usage-report", deps.logger)
+    .addStep({
+      name: "ValidateOrgUsageReport",
+      execute(ctx) {
+        if (ctx.input.orgId === "") {
+          throw invalidArgumentError("org_id is required");
+        }
+        if (ctx.input.fromDate === "") {
+          throw invalidArgumentError("from_date is required");
+        }
+        if (ctx.input.toDate === "") {
+          throw invalidArgumentError("to_date is required");
+        }
+      },
+    })
+    .addStep({
+      name: "LoadOrgExecutions",
+      async execute(ctx) {
+        const all = await loadAllAgentExecutions(deps.store, deps.logger);
+        let filtered = filterByOrg(all, ctx.input.orgId);
+        filtered = filterByDateRange(
+          filtered,
+          ctx.input.fromDate,
+          ctx.input.toDate,
+        );
+        deps.logger.debug("Loaded executions for org usage report", {
+          orgId: ctx.input.orgId,
+          count: filtered.length,
+        });
+        ctx.set(EXECUTION_LIST_KEY, filtered);
+      },
+    })
+    .addStep({
+      name: "BuildOrgUsageReport",
+      async execute(ctx) {
+        const executions = requireExecutionList(ctx.get(EXECUTION_LIST_KEY));
+
+        const byAgent = groupByAgentId(executions);
+        const agentSummaries: AgentUsageSummary[] = [];
+        for (const [aid, group] of byAgent) {
+          const name =
+            aid === ""
+              ? "(unknown agent)"
+              : await resolveAgentNameFromStore(deps, aid);
+          agentSummaries.push(buildAgentSummary(aid, name, group));
+        }
+
+        ctx.set(
+          ORG_USAGE_REPORT_KEY,
+          create(GetOrgUsageReportOutputSchema, {
+            orgId: ctx.input.orgId,
+            totalAgents: distinctAgentIds(executions).length,
+            totalSessions: distinctSessionIds(executions).length,
+            totalExecutions: executions.length,
+            modelBreakdown: mergeModelBreakdowns(),
+            topAgentsByCost: topAgentsByCost(agentSummaries, TOP_AGENTS_LIMIT),
+            dailyCosts: buildDailyCostEntries(executions),
+          }),
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  return requireReport<GetOrgUsageReportOutput>(
+    reqCtx.get(ORG_USAGE_REPORT_KEY),
+    "org usage report not found in context",
+  );
+}
+
+function requireExecutionList(value: unknown): AgentExecution[] {
+  if (!Array.isArray(value)) {
+    throw internalError(
+      new Error("execution list not found in context"),
+      "execution list not found in context",
+    );
+  }
+  return value as AgentExecution[];
+}
+
+function requireReport<T>(value: unknown, message: string): T {
+  if (value === undefined) {
+    throw internalError(new Error(message), message);
+  }
+  return value as T;
+}
+
+// ---------------------------------------------------------------------------
+// getExecutionSummary — the dashboard aggregate (get_execution_summary.go,
+// a direct handler in Go as well — no pipeline). Cost is deliberately
+// absent from this shape (AD-DASH-005: the dashboard sources cost from
+// getOrgUsageReport to prevent double-counting).
+// ---------------------------------------------------------------------------
+
+export async function getExecutionSummary(
+  deps: UsageReportDeps,
+  req: GetAgentExecutionSummaryRequest,
+): Promise<AgentExecutionSummary> {
+  const executions = await loadAllAgentExecutions(deps.store, deps.logger);
+
+  const cutoffMs = resolveAgentTimeCutoffMs(req.timeWindow);
+
+  const phaseCounts: { [key: number]: number } = {};
+  let activeCount = 0;
+  const completedDurationsMs: number[] = [];
+  const failureCounts = new Map<string, number>();
+  const agentNames = new Map<string, string>();
+
+  for (const exec of executions) {
+    const createdAtMs = auditCreatedAtMs(exec);
+    if (
+      createdAtMs !== undefined &&
+      cutoffMs !== undefined &&
+      createdAtMs < cutoffMs
+    ) {
+      continue;
+    }
+
+    const phase =
+      exec.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+    phaseCounts[phase] = (phaseCounts[phase] ?? 0) + 1;
+
+    if (isAgentActivePhase(phase)) {
+      activeCount++;
+    }
+
+    const agentId = exec.spec?.agentId ?? "";
+
+    if (phase === ExecutionPhase.EXECUTION_COMPLETED) {
+      const d = completionDurationMs(exec);
+      if (d > 0) {
+        completedDurationsMs.push(d);
+      }
+    }
+
+    if (phase === ExecutionPhase.EXECUTION_FAILED && agentId !== "") {
+      failureCounts.set(agentId, (failureCounts.get(agentId) ?? 0) + 1);
+      const name = exec.metadata?.name ?? "";
+      if (name !== "") {
+        agentNames.set(agentId, name);
+      }
+    }
+  }
+
+  const summary = create(AgentExecutionSummarySchema, {
+    activeCount,
+    phaseCounts,
+  });
+
+  if (completedDurationsMs.length > 0) {
+    let totalMs = 0;
+    for (const d of completedDurationsMs) {
+      totalMs += d;
+    }
+    summary.avgDuration = durationFromMs(
+      totalMs / completedDurationsMs.length,
+    );
+  }
+
+  summary.topFailingAgents = buildAgentFailureRanks(
+    failureCounts,
+    agentNames,
+    10,
+  );
+
+  return summary;
+}
+
+/**
+ * The window cutoff in epoch ms; undefined = no cutoff (ALL_TIME's zero
+ * time). Default (UNSPECIFIED and unknown values) is LAST_7D — Go's
+ * switch default.
+ */
+function resolveAgentTimeCutoffMs(
+  tw: AgentExecutionSummaryTimeWindow,
+): number | undefined {
+  const now = Date.now();
+  switch (tw) {
+    case AgentExecutionSummaryTimeWindow.LAST_24H:
+      return now - 24 * 60 * 60 * 1000;
+    case AgentExecutionSummaryTimeWindow.LAST_7D:
+      return now - 7 * 24 * 60 * 60 * 1000;
+    case AgentExecutionSummaryTimeWindow.LAST_30D:
+      return now - 30 * 24 * 60 * 60 * 1000;
+    case AgentExecutionSummaryTimeWindow.ALL_TIME:
+      return undefined;
+    default:
+      return now - 7 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function isAgentActivePhase(p: ExecutionPhase): boolean {
+  return (
+    p === ExecutionPhase.EXECUTION_PENDING ||
+    p === ExecutionPhase.EXECUTION_IN_PROGRESS ||
+    p === ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL ||
+    p === ExecutionPhase.EXECUTION_PAUSED
+  );
+}
+
+/**
+ * status.audit.spec_audit.created_at in epoch ms; undefined when the
+ * timestamp is absent (Go's zero time, which disables the cutoff skip for
+ * that record).
+ */
+function auditCreatedAtMs(exec: AgentExecution): number | undefined {
+  const ts = exec.status?.audit?.specAudit?.createdAt;
+  if (ts === undefined) {
+    return undefined;
+  }
+  return Number(ts.seconds) * 1000 + Math.floor(ts.nanos / 1_000_000);
+}
+
+/**
+ * completed_at − started_at in ms; 0 when either side is missing or
+ * malformed (Go returns 0 on time.Parse error). Go parses strict RFC3339;
+ * Date.parse is more lenient, so a strictness guard keeps the reject set
+ * aligned for realistic inputs (both fields are machine-authored RFC3339;
+ * the exotic leniency edges are unreachable in practice).
+ */
+function completionDurationMs(exec: AgentExecution): number {
+  const started = parseRfc3339Ms(exec.status?.startedAt ?? "");
+  const completed = parseRfc3339Ms(exec.status?.completedAt ?? "");
+  if (started === undefined || completed === undefined) {
+    return 0;
+  }
+  return completed - started;
+}
+
+/** Full-timestamp RFC3339 shapes only (date-only strings are rejected). */
+const RFC3339_PATTERN =
+  /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/;
+
+function parseRfc3339Ms(value: string): number | undefined {
+  if (!RFC3339_PATTERN.test(value)) {
+    return undefined;
+  }
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/**
+ * Milliseconds → google.protobuf.Duration, truncating toward zero at
+ * nanosecond scale exactly like Go's integer division of a nanosecond
+ * total.
+ */
+function durationFromMs(ms: number): Duration {
+  const truncatedMs = Math.trunc(ms);
+  const seconds = Math.trunc(truncatedMs / 1000);
+  const nanos = Math.trunc((truncatedMs - seconds * 1000) * 1_000_000);
+  return create(DurationSchema, { seconds: BigInt(seconds), nanos });
+}
+
+/**
+ * Failure ranks sorted by count descending, capped (Go
+ * buildAgentFailureRanks — its manual insertion sort is stable, as is
+ * Array.sort; tie ORDER still differs cross-edition because Go feeds the
+ * sort from nondeterministic map iteration — not wire-assertable).
+ */
+function buildAgentFailureRanks(
+  counts: Map<string, number>,
+  names: Map<string, string>,
+  limit: number,
+): AgentFailureRank[] {
+  const entries = [...counts.entries()];
+  entries.sort((a, b) => b[1] - a[1]);
+  const capped = entries.length > limit ? entries.slice(0, limit) : entries;
+  return capped.map(([agentId, count]) =>
+    create(AgentFailureRankSchema, {
+      agentSlug: agentId,
+      agentName: names.get(agentId) ?? "",
+      failureCount: count,
+    }),
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/validate-service-tier.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/validate-service-tier.ts
@@ -1,0 +1,78 @@
+/**
+ * ValidateServiceTier — ports validate_service_tier.go: fail-closed
+ * validation of ExecutionConfig.service_tier against the model registry
+ * (stigmer/stigmer#357).
+ *
+ * The tier exists to make pricing deterministic, so it is validated where
+ * the price is decided — at create, against the current registry — never
+ * discovered as a silent no-op at run time. The rule is a pure function
+ * of (model_name, service_tier, registry):
+ *
+ *   - UNSPECIFIED / STANDARD: always valid — every model has a
+ *     base-priced configuration, and unset resolves to
+ *     explicitly-requested STANDARD in the runner (never the provider
+ *     account default).
+ *   - FAST: requires model_name to be set (Auto has no tier dimension)
+ *     and that model's registry entry to price a "fast" variant. A tier
+ *     the registry cannot price would trip billing's undercharge guard —
+ *     selection and billability are coupled by construction.
+ *
+ * Positioned directly after proto validation, before any side-effecting
+ * step. Mirrors the cloud Java ValidateServiceTierStep; all THREE
+ * editions must refuse the same request with the same message (pinned by
+ * the conformance tier suite, which runs against every target).
+ */
+import type { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ServiceTier } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import { invalidArgumentError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import {
+  FAST_VARIANT_KEY,
+  type ModelRegistryStore,
+} from "../workflow/registry/model-registry-store.js";
+
+export function newValidateServiceTierStep(
+  registry: ModelRegistryStore,
+): PipelineStep<typeof AgentExecutionSchema> {
+  return {
+    name: "ValidateServiceTier",
+    execute(ctx) {
+      const config = ctx.newState.spec?.executionConfig;
+      if (config?.serviceTier !== ServiceTier.FAST) {
+        // UNSPECIFIED and STANDARD are always valid; unknown enum numbers
+        // were already refused by proto field validation (defined_only).
+        return;
+      }
+
+      const modelName = (config.modelName ?? "").trim();
+      if (modelName === "") {
+        throw invalidArgumentError(
+          "service_tier 'fast' requires execution_config.model_name: the fast tier is a " +
+            "per-model price, and Auto (no pinned model) has no tier dimension. " +
+            `Pin a model that supports it${fastCapableSuffix(registry)}.`,
+        );
+      }
+
+      if (!registry.hasPricingVariant(modelName, FAST_VARIANT_KEY)) {
+        throw invalidArgumentError(
+          `service_tier 'fast' is not available for model '${modelName}': the model ` +
+            `registry prices no fast variant for it${fastCapableSuffix(registry)}.`,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * "; models with a fast tier: a, b, c" — actionable refusal detail,
+ * sorted (the store keeps the list sorted), empty when the registry
+ * prices none.
+ */
+function fastCapableSuffix(registry: ModelRegistryStore): string {
+  const capable = registry.canonicalModelsWithVariant(FAST_VARIANT_KEY);
+  if (capable.length === 0) {
+    return "";
+  }
+  return `; models with a fast tier: ${capable.join(", ")}`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/validate-thinking-mode.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/validate-thinking-mode.ts
@@ -1,0 +1,92 @@
+/**
+ * ValidateThinkingMode — ports validate_thinking_mode.go: fail-closed
+ * validation of ExecutionConfig.thinking_mode against the model registry
+ * (stigmer/stigmer#772) — the sibling of ValidateServiceTier for the
+ * second variant dimension.
+ *
+ * Unlike the fast tier, thinking is capability-gated, not pricing-gated:
+ * thinking variants bill at base per-token rates (ledger-verified), so
+ * the registry fact that makes ENABLED selectable is
+ * capabilities.thinking on the model's CURSOR-harness entry. The harness
+ * scoping is deliberate — native entries truthfully declare the same
+ * capability (Anthropic models support extended thinking natively) but no
+ * native wire mapping exists in v1, so validating them would accept a
+ * config the runner silently cannot honor (the exact silent-no-op class
+ * #357 exists to kill; mirrors the #361 FAST-on-native hold).
+ *
+ *   - UNSPECIFIED / DISABLED: always valid — every model has a base
+ *     variant, and unset resolves to explicitly-requested DISABLED in the
+ *     runner (never the provider account default).
+ *   - ENABLED: requires model_name to be set (Auto has no variant
+ *     dimensions) and that model's cursor-harness registry entry to
+ *     declare the thinking capability.
+ *
+ * Positioned beside ValidateServiceTier, before any side-effecting step.
+ * Mirrors the cloud Java ValidateThinkingModeStep; all three editions
+ * must refuse the same request with the same message.
+ */
+import type { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ThinkingMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import { invalidArgumentError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import {
+  THINKING_CAPABILITY_KEY,
+  type ModelRegistryStore,
+} from "../workflow/registry/model-registry-store.js";
+import { HARNESS_NAME_CURSOR } from "../workflow/registry/pin-validation.js";
+
+export function newValidateThinkingModeStep(
+  registry: ModelRegistryStore,
+): PipelineStep<typeof AgentExecutionSchema> {
+  return {
+    name: "ValidateThinkingMode",
+    execute(ctx) {
+      const config = ctx.newState.spec?.executionConfig;
+      if (config?.thinkingMode !== ThinkingMode.ENABLED) {
+        // UNSPECIFIED and DISABLED are always valid; unknown enum numbers
+        // were already refused by proto field validation (defined_only).
+        return;
+      }
+
+      const modelName = (config.modelName ?? "").trim();
+      if (modelName === "") {
+        throw invalidArgumentError(
+          "thinking_mode 'enabled' requires execution_config.model_name: thinking is a " +
+            "per-model capability, and Auto (no pinned model) has no variant dimensions. " +
+            `Pin a model that supports it${thinkingCapableSuffix(registry)}.`,
+        );
+      }
+
+      if (
+        !registry.hasCapabilityForHarness(
+          HARNESS_NAME_CURSOR,
+          modelName,
+          THINKING_CAPABILITY_KEY,
+        )
+      ) {
+        throw invalidArgumentError(
+          `thinking_mode 'enabled' is not available for model '${modelName}': the model ` +
+            "registry declares no thinking capability for it on the cursor " +
+            `harness${thinkingCapableSuffix(registry)}.`,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * "; models with a thinking mode: a, b, c" — actionable refusal detail,
+ * sorted (the store keeps the list sorted), empty when the registry
+ * declares none.
+ */
+function thinkingCapableSuffix(registry: ModelRegistryStore): string {
+  const capable = registry.canonicalModelsWithCapabilityForHarness(
+    HARNESS_NAME_CURSOR,
+    THINKING_CAPABILITY_KEY,
+  );
+  if (capable.length === 0) {
+    return "";
+  }
+  return `; models with a thinking mode: ${capable.join(", ")}`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/__tests__/agentinstance.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/__tests__/agentinstance.test.ts
@@ -77,6 +77,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/environment/__tests__/environment.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/__tests__/environment.test.ts
@@ -65,6 +65,9 @@ async function startServer(env: Record<string, string>): Promise<TestServer> {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/__tests__/executioncontext.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/__tests__/executioncontext.test.ts
@@ -89,6 +89,9 @@ async function startServer(env: Record<string, string>): Promise<TestServer> {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/token-refresh.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/token-refresh.test.ts
@@ -1,0 +1,345 @@
+/**
+ * OAuth token/refresh slice tests — ports the refresh-relevant halves of
+ * pkg/domain/mcpserver/oauth/token_test.go (the Slack authed_user
+ * "which token wins" resolution + the #410 client-secret placement pins,
+ * RefreshToken arm; ExchangeCode arrives with #19) and pins
+ * refreshTokenIfExpired's expiry-buffer / rotation contract that Go
+ * asserts through the connect pre-flight. The token endpoint is a fetch
+ * stub — deterministic, no sockets.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createLogger } from "../../../../boot/logger.js";
+import type { OAuthGrant } from "../../../../store/interface.js";
+
+import {
+  REFRESH_EXPIRY_BUFFER_SECONDS,
+  refreshTokenIfExpired,
+} from "../refresh.js";
+import {
+  TOKEN_AUTH_METHOD_BASIC,
+  TOKEN_AUTH_METHOD_POST,
+  refreshToken,
+} from "../token.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+/** A fetch stub answering the given JSON body with HTTP 200. */
+function tokenServer(body: string): typeof fetch {
+  return async () =>
+    new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+}
+
+/** A fetch stub that records the credential channels of each request. */
+interface CapturedTokenRequest {
+  basicUser: string;
+  basicPass: string;
+  hasBasic: boolean;
+  formSecret: string;
+  formClient: string;
+}
+
+function captureTokenServer(captured: CapturedTokenRequest): typeof fetch {
+  return async (_url, init) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const auth = headers["Authorization"] ?? "";
+    if (auth.startsWith("Basic ")) {
+      captured.hasBasic = true;
+      const decoded = Buffer.from(auth.slice(6), "base64").toString();
+      const colon = decoded.indexOf(":");
+      captured.basicUser = decoded.slice(0, colon);
+      captured.basicPass = decoded.slice(colon + 1);
+    }
+    const form = new URLSearchParams(String(init?.body ?? ""));
+    captured.formSecret = form.get("client_secret") ?? "";
+    captured.formClient = form.get("client_id") ?? "";
+    return new Response('{"access_token": "at-123", "token_type": "bearer"}', {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+// The Slack V2 authed_user resolution: which token wins (Go
+// TestResolveFromAuthedUser_*), driven through refreshToken since the TS
+// port inlines the resolution in the response parse.
+describe("authed_user token resolution", () => {
+  async function refreshAgainst(body: string) {
+    return refreshToken(
+      "https://vendor.example/token",
+      "rt-1",
+      "client-1",
+      "",
+      "",
+      tokenServer(body),
+    );
+  }
+
+  it("both tokens present: the nested user token wins", async () => {
+    const resp = await refreshAgainst(`{
+      "access_token": "xoxb-bot-token",
+      "token_type": "bearer",
+      "scope": "",
+      "authed_user": {
+        "access_token": "xoxp-user-token",
+        "token_type": "bearer",
+        "scope": "channels:read,chat:write"
+      }
+    }`);
+    expect(resp.accessToken).toBe("xoxp-user-token");
+    expect(resp.tokenType).toBe("bearer");
+    expect(resp.scope).toBe("channels:read,chat:write");
+  });
+
+  it("standard OAuth (no authed_user): top-level token untouched", async () => {
+    const resp = await refreshAgainst(`{
+      "access_token": "github-pat-123",
+      "token_type": "bearer",
+      "scope": "repo,user"
+    }`);
+    expect(resp.accessToken).toBe("github-pat-123");
+    expect(resp.scope).toBe("repo,user");
+  });
+
+  it("only authed_user carries a token", async () => {
+    const resp = await refreshAgainst(`{
+      "access_token": "",
+      "authed_user": {
+        "access_token": "xoxp-user-only",
+        "token_type": "bearer",
+        "scope": "search:read"
+      }
+    }`);
+    expect(resp.accessToken).toBe("xoxp-user-only");
+    expect(resp.tokenType).toBe("bearer");
+    expect(resp.scope).toBe("search:read");
+  });
+
+  it("blank authed_user token does not overwrite; non-blank fields still apply", async () => {
+    const resp = await refreshAgainst(`{
+      "access_token": "xoxb-bot-token",
+      "token_type": "bearer",
+      "authed_user": {
+        "access_token": "",
+        "scope": "channels:read"
+      }
+    }`);
+    expect(resp.accessToken).toBe("xoxb-bot-token");
+    expect(resp.scope).toBe("channels:read");
+  });
+
+  it("authed_user overwrites bot scope and token type", async () => {
+    const resp = await refreshAgainst(`{
+      "access_token": "xoxb-bot-token",
+      "token_type": "bot",
+      "scope": "bot:basic",
+      "authed_user": {
+        "access_token": "xoxp-user-token",
+        "token_type": "user",
+        "scope": "channels:read"
+      }
+    }`);
+    expect(resp.accessToken).toBe("xoxp-user-token");
+    expect(resp.tokenType).toBe("user");
+    expect(resp.scope).toBe("channels:read");
+  });
+
+  it("missing access_token everywhere throws", async () => {
+    await expect(refreshAgainst(`{"token_type": "bearer"}`)).rejects.toThrow(
+      "missing access_token",
+    );
+  });
+});
+
+// Client-secret placement (stigmer/stigmer#410): which channel carries
+// the secret per token_endpoint_auth_method, and never both (RFC 6749
+// §2.3). Go pins ExchangeCode and RefreshToken; only RefreshToken exists
+// in this slice.
+describe("refreshToken secret placement", () => {
+  const cases = [
+    {
+      name: "default empty method uses Basic (historical behavior)",
+      method: "",
+      secret: "s3cret",
+      wantBasic: true,
+      wantInForm: false,
+    },
+    {
+      name: "explicit client_secret_basic uses Basic",
+      method: TOKEN_AUTH_METHOD_BASIC,
+      secret: "s3cret",
+      wantBasic: true,
+      wantInForm: false,
+    },
+    {
+      name: "client_secret_post puts the secret in the form body only",
+      method: TOKEN_AUTH_METHOD_POST,
+      secret: "s3cret",
+      wantBasic: false,
+      wantInForm: true,
+    },
+    {
+      name: "public client (no secret) authenticates with neither channel",
+      method: "",
+      secret: "",
+      wantBasic: false,
+      wantInForm: false,
+    },
+    {
+      name: "post method without a secret is a no-op (public client)",
+      method: TOKEN_AUTH_METHOD_POST,
+      secret: "",
+      wantBasic: false,
+      wantInForm: false,
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, async () => {
+      const captured: CapturedTokenRequest = {
+        basicUser: "",
+        basicPass: "",
+        hasBasic: false,
+        formSecret: "",
+        formClient: "",
+      };
+      const resp = await refreshToken(
+        "https://vendor.example/token",
+        "rt-1",
+        "client-1",
+        tt.secret,
+        tt.method,
+        captureTokenServer(captured),
+      );
+      expect(resp.accessToken).toBe("at-123");
+
+      expect(captured.hasBasic).toBe(tt.wantBasic);
+      if (tt.wantBasic) {
+        expect(captured.basicUser).toBe("client-1");
+        expect(captured.basicPass).toBe(tt.secret);
+      }
+      expect(captured.formSecret).toBe(tt.wantInForm ? tt.secret : "");
+      // client_id always rides the form body regardless of method.
+      expect(captured.formClient).toBe("client-1");
+      // The invariant behind the per-mode expectations: the secret never
+      // travels both channels in one request.
+      expect(captured.hasBasic && captured.formSecret !== "").toBe(false);
+    });
+  }
+});
+
+// refreshTokenIfExpired's expiry-buffer / rotation contract.
+describe("refreshTokenIfExpired", () => {
+  function grant(accessTokenExpiresAt: number): OAuthGrant {
+    return {
+      identityAccountId: "",
+      resourceId: "mcps_1",
+      resourceKind: "mcp_server",
+      orgId: "acme",
+      accessTokenExpiresAt,
+      clientId: "client-1",
+      authMethod: "mcp_oauth",
+      tokenEndpoint: "https://vendor.example/token",
+      accessTokenEnvVar: "VENDOR_TOKEN",
+      refreshTokenEnvVar: "VENDOR_REFRESH_TOKEN",
+      environmentId: "env_managed",
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  }
+
+  const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+  it("no expiry (0) never refreshes — long-lived Notion/Slack-style tokens", async () => {
+    const result = await refreshTokenIfExpired(
+      grant(0),
+      "rt-1",
+      "",
+      "",
+      silentLogger,
+      () => {
+        throw new Error("token endpoint must not be reached");
+      },
+    );
+    expect(result.refreshed).toBe(false);
+  });
+
+  it("not yet within the 60s buffer: skip", async () => {
+    const result = await refreshTokenIfExpired(
+      grant(nowSeconds() + REFRESH_EXPIRY_BUFFER_SECONDS + 3600),
+      "rt-1",
+      "",
+      "",
+      silentLogger,
+      () => {
+        throw new Error("token endpoint must not be reached");
+      },
+    );
+    expect(result.refreshed).toBe(false);
+  });
+
+  it("expired with no refresh token: throws the re-auth error", async () => {
+    await expect(
+      refreshTokenIfExpired(grant(nowSeconds() - 10), "", "", "", silentLogger),
+    ).rejects.toThrow(
+      "access token for resource 'mcps_1' has expired and no refresh token is available. " +
+        "Please re-authenticate via OAuth Connect",
+    );
+  });
+
+  it("expired: refreshes, rotates the refresh token, computes newExpiresAt", async () => {
+    const before = nowSeconds();
+    const result = await refreshTokenIfExpired(
+      grant(before - 10),
+      "rt-old",
+      "",
+      "",
+      silentLogger,
+      tokenServer(
+        `{"access_token":"at-new","refresh_token":"rt-new","expires_in":3600}`,
+      ),
+    );
+    expect(result.refreshed).toBe(true);
+    expect(result.newAccessToken).toBe("at-new");
+    expect(result.newRefreshToken).toBe("rt-new");
+    expect(result.newExpiresAt).toBeGreaterThanOrEqual(before + 3600);
+    expect(result.newExpiresAt).toBeLessThanOrEqual(nowSeconds() + 3600);
+  });
+
+  it("expired: vendor omits refresh_token — the current one carries forward", async () => {
+    const result = await refreshTokenIfExpired(
+      grant(nowSeconds() - 10),
+      "rt-keep",
+      "",
+      "",
+      silentLogger,
+      tokenServer(`{"access_token":"at-new"}`),
+    );
+    expect(result.refreshed).toBe(true);
+    expect(result.newRefreshToken).toBe("rt-keep");
+    // No expires_in: the new token is treated as non-expiring.
+    expect(result.newExpiresAt).toBe(0);
+  });
+
+  it("refresh failure wraps with the re-auth guidance", async () => {
+    await expect(
+      refreshTokenIfExpired(
+        grant(nowSeconds() - 10),
+        "rt-1",
+        "",
+        "",
+        silentLogger,
+        async () => new Response("nope", { status: 401 }),
+      ),
+    ).rejects.toThrow(
+      /token refresh failed for resource 'mcps_1'.*Please re-authenticate via OAuth Connect/,
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/managed-env.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/managed-env.ts
@@ -1,0 +1,85 @@
+/**
+ * Managed-environment access — ports the slice of
+ * pkg/domain/mcpserver/oauth/managed_env.go the agentexecution EC builder
+ * consumes (#17): reading and rewriting OAuth token secrets through the
+ * environment domain's in-process client, so encryption, validation, and
+ * audit ride the environment pipeline automatically. The
+ * create/delete-managed-environment halves arrive with the connect/OAuth
+ * sub-project (#19), which owns the flows that mint managed environments.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { EnvironmentValue } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { UpdateEnvironmentVariablesRequest } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import {
+  EnvironmentSecretValueInputSchema,
+  UpdateEnvironmentVariablesRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+
+/** The label marking system-managed OAuth-token environments. */
+export const MANAGED_ENV_LABEL = "stigmer.ai/managed";
+
+/**
+ * The narrow in-process environment surface this service consumes —
+ * satisfied by the composition root's in-process clients (DD-002: full
+ * interceptor traversal on every internal call).
+ */
+export interface ManagedEnvironmentClient {
+  getSecretValue(
+    input: MessageInitShape<typeof EnvironmentSecretValueInputSchema>,
+  ): Promise<EnvironmentValue>;
+  updateVariables(
+    request: MessageInitShape<typeof UpdateEnvironmentVariablesRequestSchema>,
+  ): Promise<Environment>;
+}
+
+export class ManagedEnvironmentService {
+  constructor(private readonly client: ManagedEnvironmentClient) {}
+
+  /**
+   * Retrieves a single decrypted secret value from a managed environment
+   * (Go ReadSecretValue).
+   */
+  async readSecretValue(environmentId: string, key: string): Promise<string> {
+    let value: EnvironmentValue;
+    try {
+      value = await this.client.getSecretValue(
+        create(EnvironmentSecretValueInputSchema, {
+          environmentId,
+          key,
+        }),
+      );
+    } catch (error) {
+      throw new Error(
+        `failed to read secret ${JSON.stringify(key)} from managed environment ${environmentId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return value.value;
+  }
+
+  /**
+   * Writes secret variables into a managed environment (Go
+   * UpdateSecrets). Values must be plaintext (never enc:vN:-prefixed —
+   * the environment pipeline rejects ciphertext-shaped input, oss#395);
+   * the pipeline encrypts is_secret values at rest (oss#405).
+   */
+  async updateSecrets(
+    environmentId: string,
+    variables: { [key: string]: EnvironmentValue },
+  ): Promise<void> {
+    try {
+      await this.client.updateVariables(
+        create(UpdateEnvironmentVariablesRequestSchema, {
+          environmentId,
+          variables,
+        }),
+      );
+    } catch (error) {
+      throw new Error(
+        `failed to update secrets in managed environment ${environmentId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/refresh.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/refresh.ts
@@ -1,0 +1,118 @@
+/**
+ * Pre-flight token refresh — ports pkg/domain/mcpserver/oauth/refresh.go.
+ * Consumed by the agentexecution EC builder's OAuth injection (#17); the
+ * connect-lane refresh callers arrive with #19.
+ */
+import type { OAuthGrant } from "../../../store/interface.js";
+import type { Logger } from "../../../boot/logger.js";
+import { refreshToken } from "./token.js";
+
+/** The outcome of a refresh attempt (Go RefreshResult). */
+export interface RefreshResult {
+  refreshed: boolean;
+  newAccessToken: string;
+  newRefreshToken: string;
+  /** Unix seconds; 0 = does not expire. */
+  newExpiresAt: number;
+}
+
+/**
+ * Refresh slightly before expiry — Go's 60-second buffer, named per the
+ * guidelines' semantic-constant rule.
+ */
+export const REFRESH_EXPIRY_BUFFER_SECONDS = 60;
+
+/**
+ * Checks whether the grant's access token is expired and, if so, uses the
+ * refresh token to obtain a new one. The caller updates the managed
+ * environment and the grant record with the returned values.
+ *
+ * clientSecret is empty for DCR/public clients; tokenAuthMethod selects
+ * how a non-empty secret is presented (empty falls back to Basic).
+ * Returns refreshed=false when the token has no expiry (long-lived
+ * Notion/Slack-style tokens) or is not yet within the buffer; throws when
+ * the refresh is needed but impossible or fails (the caller surfaces a
+ * re-auth error).
+ */
+export async function refreshTokenIfExpired(
+  grant: OAuthGrant,
+  currentRefreshToken: string,
+  clientSecret: string,
+  tokenAuthMethod: string,
+  logger: Logger,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RefreshResult> {
+  if (grant.accessTokenExpiresAt === 0) {
+    // Token does not expire.
+    return notRefreshed();
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (now < grant.accessTokenExpiresAt - REFRESH_EXPIRY_BUFFER_SECONDS) {
+    return notRefreshed();
+  }
+
+  if (currentRefreshToken === "") {
+    throw new Error(
+      `access token for resource '${grant.resourceId}' has expired and no refresh token is available. ` +
+        "Please re-authenticate via OAuth Connect",
+    );
+  }
+
+  logger.info("Access token expired, refreshing via refresh_token grant", {
+    resourceId: grant.resourceId,
+    resourceKind: grant.resourceKind,
+    expiredAt: grant.accessTokenExpiresAt,
+    tokenEndpoint: grant.tokenEndpoint,
+  });
+
+  let tokenResponse;
+  try {
+    tokenResponse = await refreshToken(
+      grant.tokenEndpoint,
+      currentRefreshToken,
+      grant.clientId,
+      clientSecret,
+      tokenAuthMethod,
+      fetchImpl,
+    );
+  } catch (error) {
+    throw new Error(
+      `token refresh failed for resource '${grant.resourceId}': ${error instanceof Error ? error.message : String(error)}. ` +
+        "Please re-authenticate via OAuth Connect",
+    );
+  }
+
+  let newExpiresAt = 0;
+  if (tokenResponse.expiresIn > 0) {
+    newExpiresAt = Math.floor(Date.now() / 1000) + tokenResponse.expiresIn;
+  }
+
+  const newRefreshToken =
+    tokenResponse.refreshToken !== ""
+      ? tokenResponse.refreshToken
+      : currentRefreshToken;
+
+  logger.info("Token refresh successful", {
+    resourceId: grant.resourceId,
+    resourceKind: grant.resourceKind,
+    newExpiresAt,
+    refreshTokenRotated: tokenResponse.refreshToken !== "",
+  });
+
+  return {
+    refreshed: true,
+    newAccessToken: tokenResponse.accessToken,
+    newRefreshToken,
+    newExpiresAt,
+  };
+}
+
+function notRefreshed(): RefreshResult {
+  return {
+    refreshed: false,
+    newAccessToken: "",
+    newRefreshToken: "",
+    newExpiresAt: 0,
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/token.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/token.ts
@@ -1,0 +1,159 @@
+/**
+ * OAuth token-endpoint client — ports the refresh slice of
+ * pkg/domain/mcpserver/oauth/token.go (D4 #17 consumes the pre-flight
+ * refresh; ExchangeCode and the DCR/discovery/PKCE machinery arrive with
+ * the connect/OAuth sub-project, #19).
+ */
+
+/** Token-endpoint response (Go TokenResponse). */
+export interface TokenResponse {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  refreshToken: string;
+  scope: string;
+}
+
+/**
+ * Token-endpoint client authentication methods, in the RFC 8414
+ * token_endpoint_auth_methods_supported vocabulary. An empty or
+ * unrecognized method falls back to Basic — the RFC 6749 §2.3.1 baseline.
+ */
+export const TOKEN_AUTH_METHOD_BASIC = "client_secret_basic";
+export const TOKEN_AUTH_METHOD_POST = "client_secret_post";
+
+/** Go's tokenHTTPClient 15s timeout — a named constant per guidelines. */
+export const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Exchanges a refresh token for a new access token (refresh_token
+ * grant). For public clients (DCR), clientSecret is empty; for
+ * confidential clients (vendor OAuth) tokenAuthMethod selects how the
+ * secret is presented.
+ */
+export async function refreshToken(
+  tokenEndpoint: string,
+  currentRefreshToken: string,
+  clientId: string,
+  clientSecret: string,
+  tokenAuthMethod: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: currentRefreshToken,
+    client_id: clientId,
+  });
+  return doTokenRequest(
+    tokenEndpoint,
+    params,
+    clientId,
+    clientSecret,
+    tokenAuthMethod,
+    fetchImpl,
+  );
+}
+
+async function doTokenRequest(
+  tokenEndpoint: string,
+  params: URLSearchParams,
+  clientId: string,
+  clientSecret: string,
+  tokenAuthMethod: string,
+  fetchImpl: typeof fetch,
+): Promise<TokenResponse> {
+  // Exactly one credential channel per request — RFC 6749 §2.3 forbids
+  // presenting the secret through more than one method. Post mode rides
+  // the form body; anything else (including empty) is the Basic-header
+  // baseline.
+  const usePostSecret =
+    clientSecret !== "" && tokenAuthMethod === TOKEN_AUTH_METHOD_POST;
+  if (usePostSecret) {
+    params.set("client_secret", clientSecret);
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  };
+  if (clientSecret !== "" && !usePostSecret) {
+    headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(tokenEndpoint, {
+      method: "POST",
+      headers,
+      body: params.toString(),
+      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(
+      `token request to ${tokenEndpoint} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const body = await response.text();
+  if (response.status !== 200) {
+    throw new Error(
+      `token endpoint ${tokenEndpoint} returned HTTP ${response.status}: ${truncateBody(body)}`,
+    );
+  }
+
+  let raw: {
+    access_token?: string;
+    token_type?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    scope?: string;
+    authed_user?: {
+      access_token?: string;
+      token_type?: string;
+      scope?: string;
+    };
+  };
+  try {
+    raw = JSON.parse(body) as typeof raw;
+  } catch (error) {
+    throw new Error(
+      `failed to parse token response: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const tokenResponse: TokenResponse = {
+    accessToken: raw.access_token ?? "",
+    tokenType: raw.token_type ?? "",
+    expiresIn: raw.expires_in ?? 0,
+    refreshToken: raw.refresh_token ?? "",
+    scope: raw.scope ?? "",
+  };
+
+  // Slack V2 nests user tokens under authed_user when only user scopes
+  // are requested; its presence is the reliable signal to prefer the user
+  // token over the top-level bot token. Standard providers omit it.
+  if (raw.authed_user !== undefined) {
+    if ((raw.authed_user.access_token ?? "") !== "") {
+      tokenResponse.accessToken = raw.authed_user.access_token as string;
+    }
+    if ((raw.authed_user.token_type ?? "") !== "") {
+      tokenResponse.tokenType = raw.authed_user.token_type as string;
+    }
+    if ((raw.authed_user.scope ?? "") !== "") {
+      tokenResponse.scope = raw.authed_user.scope as string;
+    }
+  }
+
+  if (tokenResponse.accessToken === "") {
+    throw new Error(
+      `token response from ${tokenEndpoint} is missing access_token`,
+    );
+  }
+  return tokenResponse;
+}
+
+/** Bounded error detail (Go truncateBody's posture: never dump a page). */
+function truncateBody(body: string): string {
+  const MAX = 512;
+  return body.length <= MAX ? body : `${body.slice(0, MAX)}...`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/token.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/token.ts
@@ -152,8 +152,8 @@ async function doTokenRequest(
   return tokenResponse;
 }
 
-/** Bounded error detail (Go truncateBody's posture: never dump a page). */
+/** Bounded error detail — Go truncateBody's 256-byte cap, verbatim. */
 function truncateBody(body: string): string {
-  const MAX = 512;
+  const MAX = 256;
   return body.length <= MAX ? body : `${body.slice(0, MAX)}...`;
 }

--- a/backend/services/stigmer-server-ts/src/domain/memory/__tests__/memory.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/memory/__tests__/memory.test.ts
@@ -81,6 +81,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/organization/__tests__/organization.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/organization/__tests__/organization.test.ts
@@ -43,6 +43,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/session/__tests__/session.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/__tests__/session.test.ts
@@ -101,6 +101,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/domain/workflow/__tests__/workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflow/__tests__/workflow.test.ts
@@ -66,6 +66,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // Keep the artifact store inside the test dir — the default
+      // resolves to ~/.stigmer, which tests must never touch.
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
     }),
     logger: silentLogger,
     portOverride: 0,

--- a/backend/services/stigmer-server-ts/src/envmerge/__tests__/envmerge.test.ts
+++ b/backend/services/stigmer-server-ts/src/envmerge/__tests__/envmerge.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Ports backend/libs/go/envmerge/merge_test.go case-for-case: the merge
+ * priority chain, the least-privilege filter, and required-key
+ * validation. Go's nil-slice cases map to empty arrays/records; the
+ * same-map-reference test carries over because the TS filter has the
+ * same no-copy contract for empty declarations.
+ */
+import { describe, expect, it } from "vitest";
+
+import { create } from "@bufbuild/protobuf";
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type {
+  EnvVarDeclaration,
+  EnvironmentValue,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import {
+  EnvVarDeclarationSchema,
+  EnvironmentValueSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import { ExecutionValueSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+
+import {
+  filterByDeclaredKeys,
+  mergeEnvironmentLayers,
+  validateRequiredKeys,
+} from "../envmerge.js";
+
+function envVal(value: string, isSecret: boolean): EnvironmentValue {
+  return create(EnvironmentValueSchema, { value, isSecret });
+}
+
+function execVal(value: string, isSecret: boolean): ExecutionValue {
+  return create(ExecutionValueSchema, { value, isSecret });
+}
+
+function decl(isSecret: boolean, optional = false): EnvVarDeclaration {
+  return create(EnvVarDeclarationSchema, { isSecret, optional });
+}
+
+function makeEnv(data: { [key: string]: EnvironmentValue }): Environment {
+  return create(EnvironmentSchema, { spec: { data } });
+}
+
+describe("mergeEnvironmentLayers", () => {
+  const cases: Array<{
+    name: string;
+    environments: Environment[];
+    runtimeEnv: { [key: string]: ExecutionValue };
+    wantKeys: { [key: string]: ExecutionValue };
+  }> = [
+    {
+      name: "all empty inputs returns empty map",
+      environments: [],
+      runtimeEnv: {},
+      wantKeys: {},
+    },
+    {
+      name: "single environment",
+      environments: [
+        makeEnv({
+          API_KEY: envVal("key-123", true),
+          REGION: envVal("us-east-1", false),
+        }),
+      ],
+      runtimeEnv: {},
+      wantKeys: {
+        API_KEY: execVal("key-123", true),
+        REGION: execVal("us-east-1", false),
+      },
+    },
+    {
+      name: "multiple environments merge in order — later wins",
+      environments: [
+        makeEnv({
+          KEY1: envVal("env1-val", false),
+          SHARED: envVal("from-env1", false),
+        }),
+        makeEnv({
+          KEY2: envVal("env2-val", false),
+          SHARED: envVal("from-env2", false),
+        }),
+      ],
+      runtimeEnv: {},
+      wantKeys: {
+        KEY1: execVal("env1-val", false),
+        KEY2: execVal("env2-val", false),
+        SHARED: execVal("from-env2", false),
+      },
+    },
+    {
+      name: "environment entries with empty values are skipped",
+      environments: [
+        makeEnv({
+          FILLED: envVal("value", false),
+          EMPTY: envVal("", false),
+        }),
+      ],
+      runtimeEnv: {},
+      wantKeys: { FILLED: execVal("value", false) },
+    },
+    {
+      name: "runtime_env overrides environments",
+      environments: [makeEnv({ SHARED: envVal("env", false) })],
+      runtimeEnv: { SHARED: execVal("runtime", true) },
+      wantKeys: { SHARED: execVal("runtime", true) },
+    },
+    {
+      name: "full priority chain — env < runtime",
+      environments: [
+        makeEnv({
+          ENV_AND_RUNTIME: envVal("e-val", false),
+          ENV_ONLY: envVal("from-env", false),
+          BOTH: envVal("e-val", false),
+        }),
+      ],
+      runtimeEnv: {
+        BOTH: execVal("r-val", false),
+        RUNTIME_ONLY: execVal("from-runtime", false),
+      },
+      wantKeys: {
+        ENV_AND_RUNTIME: execVal("e-val", false),
+        BOTH: execVal("r-val", false),
+        ENV_ONLY: execVal("from-env", false),
+        RUNTIME_ONLY: execVal("from-runtime", false),
+      },
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, () => {
+      const got = mergeEnvironmentLayers(tt.environments, tt.runtimeEnv);
+      expect(got.size).toBe(Object.keys(tt.wantKeys).length);
+      for (const [key, wantVal] of Object.entries(tt.wantKeys)) {
+        const gotVal = got.get(key);
+        expect(gotVal, `missing key ${key}`).toBeDefined();
+        expect(gotVal?.value, `key ${key} value`).toBe(wantVal.value);
+        expect(gotVal?.isSecret, `key ${key} isSecret`).toBe(wantVal.isSecret);
+      }
+    });
+  }
+
+  it("explicitly-undefined runtime_env entries are skipped (Go nil entries)", () => {
+    const runtimeEnv = { GOOD: execVal("ok", false) } as {
+      [key: string]: ExecutionValue;
+    };
+    (runtimeEnv as Record<string, ExecutionValue | undefined>)["NIL"] =
+      undefined;
+    const got = mergeEnvironmentLayers([], runtimeEnv);
+    expect([...got.keys()]).toEqual(["GOOD"]);
+  });
+});
+
+describe("filterByDeclaredKeys", () => {
+  const cases: Array<{
+    name: string;
+    merged: Map<string, ExecutionValue>;
+    declarations: { [key: string]: EnvVarDeclaration };
+    wantFilteredKeys: string[];
+    wantExcluded: string[];
+  }> = [
+    {
+      name: "empty declarations passes all through",
+      merged: new Map([
+        ["A", execVal("a", false)],
+        ["B", execVal("b", false)],
+      ]),
+      declarations: {},
+      wantFilteredKeys: ["A", "B"],
+      wantExcluded: [],
+    },
+    {
+      name: "only declared vars pass through",
+      merged: new Map([
+        ["DECLARED", execVal("val", false)],
+        ["UNDECLARED", execVal("secret", true)],
+      ]),
+      declarations: { DECLARED: decl(false) },
+      wantFilteredKeys: ["DECLARED"],
+      wantExcluded: ["UNDECLARED"],
+    },
+    {
+      name: "secret declarations allow those keys",
+      merged: new Map([
+        ["GITHUB_TOKEN", execVal("ghp_abc123", true)],
+        ["EXTRA", execVal("not-needed", false)],
+      ]),
+      declarations: { GITHUB_TOKEN: decl(true) },
+      wantFilteredKeys: ["GITHUB_TOKEN"],
+      wantExcluded: ["EXTRA"],
+    },
+    {
+      name: "all merged keys in declarations — no exclusion",
+      merged: new Map([
+        ["A", execVal("a", false)],
+        ["B", execVal("b", false)],
+      ]),
+      declarations: { A: decl(false), B: decl(false), C: decl(false) },
+      wantFilteredKeys: ["A", "B"],
+      wantExcluded: [],
+    },
+    {
+      name: "excluded keys are sorted alphabetically",
+      merged: new Map([
+        ["ZEBRA", execVal("z", false)],
+        ["APPLE", execVal("a", false)],
+        ["MANGO", execVal("m", false)],
+        ["KEEP", execVal("k", false)],
+      ]),
+      declarations: { KEEP: decl(false) },
+      wantFilteredKeys: ["KEEP"],
+      wantExcluded: ["APPLE", "MANGO", "ZEBRA"],
+    },
+    {
+      name: "empty merged map returns empty",
+      merged: new Map(),
+      declarations: { A: decl(false) },
+      wantFilteredKeys: [],
+      wantExcluded: [],
+    },
+    {
+      name: "runtime overrides for undeclared vars are excluded",
+      merged: new Map([
+        ["DECLARED", execVal("from-runtime", false)],
+        ["RUNTIME_EXTRA", execVal("injected", true)],
+      ]),
+      declarations: { DECLARED: decl(false) },
+      wantFilteredKeys: ["DECLARED"],
+      wantExcluded: ["RUNTIME_EXTRA"],
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, () => {
+      const { filtered, excludedKeys } = filterByDeclaredKeys(
+        tt.merged,
+        tt.declarations,
+      );
+      expect([...filtered.keys()].sort()).toEqual(
+        [...tt.wantFilteredKeys].sort(),
+      );
+      expect(excludedKeys).toEqual(tt.wantExcluded);
+    });
+  }
+
+  it("returns the same map reference when declarations are empty", () => {
+    const original = new Map([["KEY", execVal("val", false)]]);
+    const { filtered, excludedKeys } = filterByDeclaredKeys(original, {});
+    expect(excludedKeys).toEqual([]);
+    original.set("NEW_KEY", execVal("new", false));
+    expect(filtered.has("NEW_KEY")).toBe(true);
+  });
+});
+
+describe("validateRequiredKeys", () => {
+  const cases: Array<{
+    name: string;
+    filtered: Map<string, ExecutionValue>;
+    declarations: { [key: string]: EnvVarDeclaration };
+    wantMissing: string[];
+  }> = [
+    {
+      name: "empty declarations — nothing required",
+      filtered: new Map(),
+      declarations: {},
+      wantMissing: [],
+    },
+    {
+      name: "all required keys present — valid",
+      filtered: new Map([["API_KEY", execVal("k", true)]]),
+      declarations: { API_KEY: decl(true, false) },
+      wantMissing: [],
+    },
+    {
+      name: "required key missing — reported",
+      filtered: new Map(),
+      declarations: { API_KEY: decl(true, false) },
+      wantMissing: ["API_KEY"],
+    },
+    {
+      name: "optional key missing — not reported",
+      filtered: new Map(),
+      declarations: { LOG_LEVEL: decl(false, true) },
+      wantMissing: [],
+    },
+    {
+      name: "mix of required present, required missing, optional missing",
+      filtered: new Map([["PRESENT", execVal("v", false)]]),
+      declarations: {
+        PRESENT: decl(false, false),
+        MISSING_REQUIRED: decl(true, false),
+        MISSING_OPTIONAL: decl(false, true),
+      },
+      wantMissing: ["MISSING_REQUIRED"],
+    },
+    {
+      name: "multiple missing required keys — sorted alphabetically",
+      filtered: new Map(),
+      declarations: {
+        ZEBRA_KEY: decl(false, false),
+        ALPHA_KEY: decl(true, false),
+        MIDDLE: decl(false, false),
+      },
+      wantMissing: ["ALPHA_KEY", "MIDDLE", "ZEBRA_KEY"],
+    },
+    {
+      name: "all optional — nothing required",
+      filtered: new Map(),
+      declarations: { OPT_A: decl(false, true), OPT_B: decl(true, true) },
+      wantMissing: [],
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, () => {
+      expect(validateRequiredKeys(tt.filtered, tt.declarations)).toEqual(
+        tt.wantMissing,
+      );
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/envmerge/__tests__/envmerge.test.ts
+++ b/backend/services/stigmer-server-ts/src/envmerge/__tests__/envmerge.test.ts
@@ -141,6 +141,16 @@ describe("mergeEnvironmentLayers", () => {
     });
   }
 
+  it("undefined environments in the array are skipped (Go nil elements)", () => {
+    const environments = [
+      undefined,
+      makeEnv({ KEY: envVal("val", false) }),
+    ] as unknown as Environment[];
+    const got = mergeEnvironmentLayers(environments, {});
+    expect([...got.keys()]).toEqual(["KEY"]);
+    expect(got.get("KEY")?.value).toBe("val");
+  });
+
   it("explicitly-undefined runtime_env entries are skipped (Go nil entries)", () => {
     const runtimeEnv = { GOOD: execVal("ok", false) } as {
       [key: string]: ExecutionValue;

--- a/backend/services/stigmer-server-ts/src/envmerge/__tests__/envmerge.test.ts
+++ b/backend/services/stigmer-server-ts/src/envmerge/__tests__/envmerge.test.ts
@@ -254,6 +254,24 @@ describe("filterByDeclaredKeys", () => {
     });
   }
 
+  it("prototype-chain names never slip the filter (own-key membership)", () => {
+    // `key in declarations` would answer true for inherited
+    // Object.prototype names — an undeclared secret named `constructor`
+    // (or toString/__proto__/…) would leak past the least-privilege
+    // filter. Go's map lookup is exact; the filter must be too.
+    const merged = new Map([
+      ["constructor", execVal("smuggled-1", true)],
+      ["toString", execVal("smuggled-2", true)],
+      ["__proto__", execVal("smuggled-3", true)],
+      ["DECLARED", execVal("ok", false)],
+    ]);
+    const { filtered, excludedKeys } = filterByDeclaredKeys(merged, {
+      DECLARED: decl(false),
+    });
+    expect([...filtered.keys()]).toEqual(["DECLARED"]);
+    expect(excludedKeys).toEqual(["__proto__", "constructor", "toString"]);
+  });
+
   it("returns the same map reference when declarations are empty", () => {
     const original = new Map([["KEY", execVal("val", false)]]);
     const { filtered, excludedKeys } = filterByDeclaredKeys(original, {});

--- a/backend/services/stigmer-server-ts/src/envmerge/envmerge.ts
+++ b/backend/services/stigmer-server-ts/src/envmerge/envmerge.ts
@@ -79,7 +79,11 @@ export function filterByDeclaredKeys(
   const filtered = new Map<string, ExecutionValue>();
   const excludedKeys: string[] = [];
   for (const [key, val] of merged) {
-    if (key in declarations) {
+    // Own-key membership only: `in` would answer true for inherited
+    // Object.prototype names (constructor, toString, __proto__, …),
+    // letting an undeclared secret with an exotic name slip the
+    // least-privilege filter. Go's map lookup is exact.
+    if (Object.hasOwn(declarations, key)) {
       filtered.set(key, val);
     } else {
       excludedKeys.push(key);

--- a/backend/services/stigmer-server-ts/src/envmerge/envmerge.ts
+++ b/backend/services/stigmer-server-ts/src/envmerge/envmerge.ts
@@ -1,0 +1,106 @@
+/**
+ * Environment layer merging — ports backend/libs/go/envmerge/merge.go.
+ * Consumed by the agentexecution execution-context builder (#17) and,
+ * with #20, the workflowexecution equivalent. Lives inside the server per
+ * the ratified shared-library posture (extraction to backend/libs/ts/
+ * only on a second SERVICE consumer — the temporal-codecs precedent).
+ */
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { EnvVarDeclaration } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import { ExecutionValueSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import { create } from "@bufbuild/protobuf";
+
+/**
+ * Merges two layers of environment configuration into a single map of
+ * ExecutionValue entries, suitable for persisting in an ExecutionContext.
+ *
+ * Merge priority (lowest to highest):
+ *  1. environments — resolved Environment resources from instance
+ *     environment_refs (in order; later overrides earlier; empty values
+ *     skipped)
+ *  2. runtimeEnv — execution-scoped runtime_env overrides
+ */
+export function mergeEnvironmentLayers(
+  environments: Environment[],
+  runtimeEnv: { [key: string]: ExecutionValue },
+): Map<string, ExecutionValue> {
+  const merged = new Map<string, ExecutionValue>();
+
+  for (const env of environments) {
+    for (const [key, ev] of Object.entries(env.spec?.data ?? {})) {
+      if (ev.value === "") {
+        continue;
+      }
+      merged.set(
+        key,
+        create(ExecutionValueSchema, {
+          value: ev.value,
+          isSecret: ev.isSecret,
+        }),
+      );
+    }
+  }
+
+  for (const [key, ev] of Object.entries(runtimeEnv)) {
+    // Go skips nil entries; the TS analogue is an explicitly-undefined
+    // value in the record.
+    if (ev === undefined) {
+      continue;
+    }
+    merged.set(key, ev);
+  }
+
+  return merged;
+}
+
+/**
+ * Restricts a merged environment map to only the keys declared in the
+ * blueprint's env field (least-privilege): a blueprint only receives the
+ * variables it explicitly declared, even if the linked environments carry
+ * additional secrets. Empty declarations return the merged map unchanged
+ * (backward compatibility for blueprints declaring no env vars). Returns
+ * the filtered map and a sorted list of excluded keys for observability.
+ */
+export function filterByDeclaredKeys(
+  merged: Map<string, ExecutionValue>,
+  declarations: { [key: string]: EnvVarDeclaration },
+): { filtered: Map<string, ExecutionValue>; excludedKeys: string[] } {
+  const declared = Object.keys(declarations);
+  if (declared.length === 0) {
+    return { filtered: merged, excludedKeys: [] };
+  }
+
+  const filtered = new Map<string, ExecutionValue>();
+  const excludedKeys: string[] = [];
+  for (const [key, val] of merged) {
+    if (key in declarations) {
+      filtered.set(key, val);
+    } else {
+      excludedKeys.push(key);
+    }
+  }
+  excludedKeys.sort();
+  return { filtered, excludedKeys };
+}
+
+/**
+ * Checks that every required (non-optional) declared key has an entry in
+ * the filtered map; returns the sorted missing keys (empty = passed).
+ */
+export function validateRequiredKeys(
+  filtered: Map<string, ExecutionValue>,
+  declarations: { [key: string]: EnvVarDeclaration },
+): string[] {
+  const missingRequired: string[] = [];
+  for (const [key, decl] of Object.entries(declarations)) {
+    if (decl.optional) {
+      continue;
+    }
+    if (!filtered.has(key)) {
+      missingRequired.push(key);
+    }
+  }
+  missingRequired.sort();
+  return missingRequired;
+}

--- a/backend/services/stigmer-server-ts/src/envmerge/envmerge.ts
+++ b/backend/services/stigmer-server-ts/src/envmerge/envmerge.ts
@@ -28,6 +28,11 @@ export function mergeEnvironmentLayers(
   const merged = new Map<string, ExecutionValue>();
 
   for (const env of environments) {
+    // Go skips nil slice elements; the defensive twin for a hole smuggled
+    // past the type system (Go merge_test.go pins this).
+    if (env === undefined) {
+      continue;
+    }
     for (const [key, ev] of Object.entries(env.spec?.data ?? {})) {
       if (ev.value === "") {
         continue;

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -24,6 +24,10 @@
 //     create-only secret-delivery domain. The suite is user-shaped by
 //     design — the runner-token decrypt lane is proven by the domain's
 //     own __tests__/executioncontext.test.ts).
+//   - agentexecution — sub-project #17 (sp.agentexecution-domain; the
+//     deepest domain: 23 RPCs incl. the subscribe stream, the HITL
+//     surfaces, and the engine-gate/lifecycle negatives that pin the
+//     no-Temporal posture until #18).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -39,6 +43,7 @@ export default defineConfig({
       "src/suites/workflow.conformance.test.ts",
       "src/suites/workflowinstance.conformance.test.ts",
       "src/suites/executioncontext.conformance.test.ts",
+      "src/suites/agentexecution.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the deepest domain — `agentexecution` — from the Go server to the TypeScript server (program 20260822.01, sub-project #17, D4 entry 17): all 23 RPCs including the `subscribe` server-stream, the updateStatus merge engine with the approval and file-review event ledgers, the 16-step create pipeline with the ExecutionContext builder (environment layering + MCP OAuth injection with inline pre-flight refresh), the five lifecycle RPCs, and the attachment/artifact surfaces. Adds the shared `envmerge` and `artifactstorage` modules and the OAuth refresh slice under `mcpserver/oauth/`.

## Context

The TS server rewrite proceeds domain-by-domain with byte-parity against Go as the prime directive. This entry is the critical-path head: #18 (orchestration) plugs Temporal into the engine seam this PR models, and #13 (artifact domain) builds on the storage module. Until #18, the engine is a permanently disconnected typed state — create refuses at the gate before any side effect, lifecycle RPCs refuse FailedPrecondition, and submitApproval records decisions while skipping the workflow signal, exactly the Go server's no-Temporal posture.

## Changes

- **Read/report surfaces**: get, list, listBySession, the four usage reports (OSS zero-value contract) and getExecutionSummary; update + delete pipelines; FTS search extractor.
- **Streaming**: StreamBroker (in-memory broadcast, ADR 011) + `subscribe` — snapshot-then-updates with the register-before-read ordering, duplicate-frame suppression, terminal-phase close.
- **Merge engine**: updateStatus as one atomic read-modify-write — transcript regression guard, wholesale-replace fields, approval-field preservation, terminal phase latch, tool-call settle (#207), approval-event authoring + pending projection, file-review fold (append-only ledger, DD-28 auto-keep, DD-32 progress reconcile).
- **HITL writers**: submitApproval (TOCTOU re-check, APPROVE_ALL lease-class bulk, stale-workflow reconcile) and submitFileDecision (digest + completeness gates), signaling through the engine seam.
- **Create pipeline**: default-agent resolution, one-call session bootstrap (#249), declared-preferences + recalled-memories snapshots, engine gate before the first side effect, ExecutionContext with schedule/workflow-task environment layering (DD-017/#358), least-privilege filtering, workspace-provisioning + personal-environment injection, OAuth token injection with fatal pre-flight refresh, StartWorkflow after persist.
- **Lifecycle**: cancel/terminate/pause/resume/recover over one shared step vocabulary; atomic phase persist; recover's terminate → EC-recreate → fresh-start chain.
- **Artifacts**: uploadAttachment (bare-filename traversal defense), getArtifactContent (CAS serve-time integrity, ZIP entry extraction via `fflate`, 512KB truncation), getArtifactDownloadUrl (prefix + spec.attachments ownership arms).
- **Shared modules**: `src/envmerge/` (merge/filter/validate), `src/artifactstorage/` (local backend, containment guard, disposition builder), `src/domain/mcpserver/oauth/` (token endpoint client, pre-flight refresh, managed-env service).
- **Boot**: artifact storage config + boot-fatal health probe; agentexecution in-process edges; one StreamBroker spanning both routers.

## Implementation notes — parity disclosures

- **Fail-closed divergence (owner-ratified)**: cross-execution artifact reads via `..`-carrying storage keys are rejected here; Go shares the bug and reconverges through stigmer/stigmer#858.
- **Faithful-ported bug (DD-001)**: getExecutionUsageReport's mangled NotFound message is reproduced byte-for-byte; the both-editions fix is stigmer/stigmer#859.
- **R2 artifact backend deferred to #13**: `ARTIFACT_STORAGE_TYPE=r2` boot-fails with an explicit message; local download URLs are correctly shaped for the port+1 file server that also lands with #13.
- **`canonicalize`/`fingerprint` excluded** (owner-ratified): contract-pin-only in Go with no production consumers; the TS source of truth lives in the runner.
- **OAuth**: only the refresh slice is ported; connect/DCR/PKCE flows arrive with #19.
- **MIME residue**: Go additionally consults the OS mime.types database beyond its builtin table; the TS stand-in carries Go's builtins verbatim (recorded gap for exotic extensions).
- Reviewed by a two-reviewer adversarial panel (parity/architecture + adversarial testing); all actionable findings fixed in-branch, including the `goWrappedStatusError` status-code propagation the domain initially skipped and an `Object.hasOwn` fix to the least-privilege filter.

## Test plan

- 764 unit/integration tests in the service (58 files), including: shared HITL corpus byte-parity suites (approval scenarios/sequences/lease-scope/policy-source, file-review projections + digest vectors), the 50-iteration pause-vs-approval race, updateStatus concurrency, composed-server wire tests, and case-for-case ports of every Go test file this domain owns.
- Conformance: the agentexecution suite is rostered on local-ts — full roster **245/245** against the TS server; the same suite passes **14/14** against the Go server (no Go changes in this PR).
- `tsc --noEmit` clean; production build boots, serves, and shuts down cleanly (`verify:dist`).

## Risks

- The engine seam's connected variant is interface-only until #18; any mismatch surfaces when the TemporalManager lands and is contained to that seam.
- Rollback: revert this PR; the domain registers only additive routes on the composed server.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible (additive; no Go server changes)
- [x] Parity divergences disclosed with issue links

Made with [Cursor](https://cursor.com)