### PR TITLE
test(test/conformance): add McpServer connect/OAuth conformance suites (CW-1)

### DIFF
--- a/test/conformance/src/harness/mcp-server.ts
+++ b/test/conformance/src/harness/mcp-server.ts
@@ -68,6 +68,7 @@ export interface CapturedMcpRequest {
 export class McpToolFixture {
   private server: Server | undefined;
   private captured: CapturedMcpRequest[] = [];
+  private hold: { promise: Promise<void>; release: () => void } | undefined;
 
   // Every JSON-RPC request observed since the last reset, oldest first.
   // Suites reset in afterEach (the mock-LLM convention) so captures never
@@ -78,6 +79,31 @@ export class McpToolFixture {
 
   resetCaptured(): void {
     this.captured = [];
+  }
+
+  // Hold every request open until releaseHolds() — the mock-llm `delayMs`
+  // analogue for this fixture. The lever for observing an IN-FLIGHT connect:
+  // discovery blocks on the held initialize, keeping connect_status in the
+  // `connecting` phase for a controllable window (the startConnect
+  // idempotent-attach contract needs exactly that window). Holds must stay
+  // comfortably inside the runner's 30s HTTP init budget
+  // (HTTP_INIT_TIMEOUT_MS in discover-mcp-server.ts), or the held connect
+  // classifies as a failure instead of staying in flight.
+  holdRequests(): void {
+    if (this.hold !== undefined) {
+      return;
+    }
+    let release!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.hold = { promise, release };
+  }
+
+  releaseHolds(): void {
+    const hold = this.hold;
+    this.hold = undefined;
+    hold?.release();
   }
 
   // Binds to an ephemeral loopback port; resolves once listening.
@@ -133,6 +159,12 @@ export class McpToolFixture {
     const body: unknown = JSON.parse(await readBody(req));
     for (const method of jsonRpcMethods(body)) {
       this.captured.push({ method, headers: { ...req.headers } });
+    }
+
+    // The capture above happens BEFORE the hold, so a test can already see
+    // that the in-flight request arrived while the response is still pending.
+    if (this.hold !== undefined) {
+      await this.hold.promise;
     }
 
     const mcp = buildEchoServer();

--- a/test/conformance/src/harness/oauth-authorization-server.ts
+++ b/test/conformance/src/harness/oauth-authorization-server.ts
@@ -1,0 +1,296 @@
+// A programmable mock OAuth 2.0 authorization server for the McpServer
+// connect/OAuth conformance suites (CW-1).
+// Domain: conformance harness.
+//
+// The Go server's OAuth Connect flow makes four kinds of server-side HTTP
+// calls, and this fixture is the counterparty for all of them:
+//   1. RFC 8414 metadata discovery — GET /.well-known/oauth-authorization-server
+//      at the ORIGIN of the McpServer's discovery/http URL (oauth/discovery.go).
+//   2. RFC 7591 Dynamic Client Registration — POST to the advertised
+//      registration_endpoint (oauth/dcr.go).
+//   3. The authorize pre-flight probe — a redirectless GET of the full
+//      authorization URL, where ONLY HTTP 400 counts as a rejection and
+//      everything else fails open (oauth/preflight.go, stigmer/stigmer#235).
+//   4. Token exchange and refresh — form-encoded POSTs to the token endpoint
+//      (oauth/token.go), where the client secret must arrive over exactly one
+//      channel: Basic header or form body, never both (RFC 6749 §2.3).
+//
+// Like the sibling fixtures (mock-llm.ts, mcp-server.ts) it is TS-pure,
+// long-lived within a suite file, programmable at runtime through public
+// levers, and request-capturing — the captures are the wire-level observation
+// point for what the Go server actually sent (PKCE verifier, DCR body shape,
+// secret channel). Suites call reset() in afterEach so levers and captures
+// never leak across tests.
+//
+// The fixture is suite-owned, not target-owned: the server under test reaches
+// it only through URLs carried in per-test resource specs (auth.discovery_url,
+// OAuthApp token_url), never through boot-time wiring — so no target class
+// needs to know it exists (sub-project DB-2).
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+// One token-endpoint request as the vendor saw it: the grant parameters plus
+// which channel (if any) carried the client secret. This is the assertable
+// record for the PKCE and single-secret-channel contracts.
+export interface CapturedTokenRequest {
+  grantType: string;
+  code?: string;
+  refreshToken?: string;
+  codeVerifier?: string;
+  clientId?: string;
+  redirectUri?: string;
+  // How the client secret arrived: "basic" (Authorization header), "post"
+  // (client_secret form field), or "none" (public client — the DCR contract).
+  secretChannel: "basic" | "post" | "none";
+  clientSecret?: string;
+}
+
+// One DCR registration request body, parsed. RFC 7591 field names preserved so
+// assertions read like the spec.
+export interface CapturedDcrRequest {
+  redirect_uris?: string[];
+  client_name?: string;
+  grant_types?: string[];
+  response_types?: string[];
+  token_endpoint_auth_method?: string;
+}
+
+// One authorize pre-flight probe: the query parameters of the authorization
+// URL the Go server built (response_type, client_id, code_challenge, ...).
+export interface CapturedAuthorizeProbe {
+  params: URLSearchParams;
+}
+
+export class MockOAuthAuthorizationServer {
+  // --- behavior levers (reset() restores every default) ---
+
+  // Drop registration_endpoint from the metadata document — the "provider
+  // does not support DCR" arm.
+  omitRegistrationEndpoint = false;
+  // HTTP status for the metadata document; non-200 exercises the discovery
+  // failure arm.
+  discoveryStatus = 200;
+  // Advertised scopes_supported — the fallback the Go server uses when the
+  // McpServer declares no scope_hints.
+  scopesSupported: string[] = [];
+  // HTTP status for the authorize endpoint. The pre-flight contract: 400 is a
+  // definite rejection, anything else (200 login page, 403 bot wall) fails open.
+  authorizeStatus = 200;
+  // Body served with a non-2xx authorize status. An RFC 6749-shaped JSON
+  // object yields a vendor detail in the rejection message; a plain string
+  // models an HTML error page (no extractable detail).
+  authorizeErrorBody: { error?: string; error_description?: string } | string | undefined;
+  // HTTP status for the token endpoint; non-200 exercises the exchange
+  // failure arm (Unavailable on the wire).
+  tokenStatus = 200;
+  // expires_in for issued tokens. undefined omits the field entirely — the
+  // "never expires" contract (grant health stays HEALTHY forever). Values at
+  // or below the server's 60s refresh buffer make a fresh grant immediately
+  // expired-but-refreshable.
+  tokenExpiresIn: number | undefined = 3600;
+  // Whether token responses include a refresh_token. Each issuance rotates the
+  // value, matching providers that rotate on every refresh.
+  issueRefreshToken = false;
+
+  private server: Server | undefined;
+  private tokenSerial = 0;
+  private clientSerial = 0;
+  private discoveryPaths: string[] = [];
+  private dcrRequests: CapturedDcrRequest[] = [];
+  private authorizeProbes: CapturedAuthorizeProbe[] = [];
+  private tokenRequests: CapturedTokenRequest[] = [];
+
+  // --- captures (oldest first; cleared by reset()) ---
+
+  capturedDiscoveryPaths(): readonly string[] {
+    return this.discoveryPaths;
+  }
+
+  capturedDcrRequests(): readonly CapturedDcrRequest[] {
+    return this.dcrRequests;
+  }
+
+  capturedAuthorizeProbes(): readonly CapturedAuthorizeProbe[] {
+    return this.authorizeProbes;
+  }
+
+  capturedTokenRequests(): readonly CapturedTokenRequest[] {
+    return this.tokenRequests;
+  }
+
+  // Restore every lever to its default and drop all captures. Suites call
+  // this in afterEach (the mock-llm.ts convention). The issuance serials
+  // reset too, so within any single test the first registered client is
+  // always "mock-dcr-client-1" and the first issued refresh token is always
+  // "mock-refresh-token-1" — assertions stay order-independent no matter how
+  // many earlier tests in the file ran handshakes.
+  reset(): void {
+    this.omitRegistrationEndpoint = false;
+    this.discoveryStatus = 200;
+    this.scopesSupported = [];
+    this.authorizeStatus = 200;
+    this.authorizeErrorBody = undefined;
+    this.tokenStatus = 200;
+    this.tokenExpiresIn = 3600;
+    this.issueRefreshToken = false;
+    this.tokenSerial = 0;
+    this.clientSerial = 0;
+    this.discoveryPaths = [];
+    this.dcrRequests = [];
+    this.authorizeProbes = [];
+    this.tokenRequests = [];
+  }
+
+  async start(): Promise<void> {
+    const server = createServer((req, res) => {
+      this.handle(req, res).catch(() => {
+        if (!res.headersSent) {
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "internal error" }));
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    this.server = server;
+  }
+
+  // The fixture's origin (scheme://host:port). RFC 8414 discovery always
+  // resolves against an origin, so this is what a McpServer's
+  // auth.discovery_url (or an OAuthApp's endpoint URLs, path-suffixed) points
+  // at.
+  origin(): string {
+    if (this.server === undefined) {
+      throw new Error("MockOAuthAuthorizationServer.start() must be called before origin()");
+    }
+    const { port } = this.server.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  tokenEndpoint(): string {
+    return `${this.origin()}/token`;
+  }
+
+  authorizationEndpoint(): string {
+    return `${this.origin()}/authorize`;
+  }
+
+  async close(): Promise<void> {
+    const server = this.server;
+    this.server = undefined;
+    if (server === undefined) {
+      return;
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const requestUrl = new URL(req.url ?? "/", this.origin());
+
+    if (req.method === "GET" && requestUrl.pathname === "/.well-known/oauth-authorization-server") {
+      this.discoveryPaths.push(requestUrl.pathname);
+      this.serveMetadata(res);
+      return;
+    }
+    if (req.method === "POST" && requestUrl.pathname === "/register") {
+      this.dcrRequests.push(JSON.parse(await readBody(req)) as CapturedDcrRequest);
+      this.clientSerial += 1;
+      respondJson(res, 201, { client_id: `mock-dcr-client-${this.clientSerial}` });
+      return;
+    }
+    if (req.method === "GET" && requestUrl.pathname === "/authorize") {
+      this.authorizeProbes.push({ params: requestUrl.searchParams });
+      this.serveAuthorize(res);
+      return;
+    }
+    if (req.method === "POST" && requestUrl.pathname === "/token") {
+      await this.serveToken(req, res);
+      return;
+    }
+
+    respondJson(res, 404, { error: "not found" });
+  }
+
+  private serveMetadata(res: ServerResponse): void {
+    if (this.discoveryStatus !== 200) {
+      respondJson(res, this.discoveryStatus, { error: "metadata unavailable" });
+      return;
+    }
+    respondJson(res, 200, {
+      issuer: this.origin(),
+      authorization_endpoint: this.authorizationEndpoint(),
+      token_endpoint: this.tokenEndpoint(),
+      ...(this.omitRegistrationEndpoint ? {} : { registration_endpoint: `${this.origin()}/register` }),
+      ...(this.scopesSupported.length > 0 ? { scopes_supported: this.scopesSupported } : {}),
+      code_challenge_methods_supported: ["S256"],
+    });
+  }
+
+  private serveAuthorize(res: ServerResponse): void {
+    if (this.authorizeStatus === 200) {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<html><body>Sign in to ConformanceVendor</body></html>");
+      return;
+    }
+    if (typeof this.authorizeErrorBody === "string") {
+      res.writeHead(this.authorizeStatus, { "content-type": "text/html" });
+      res.end(this.authorizeErrorBody);
+      return;
+    }
+    respondJson(res, this.authorizeStatus, this.authorizeErrorBody ?? { error: "access_denied" });
+  }
+
+  private async serveToken(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const form = new URLSearchParams(await readBody(req));
+
+    let secretChannel: CapturedTokenRequest["secretChannel"] = "none";
+    let clientSecret: string | undefined;
+    const authorization = req.headers.authorization;
+    if (authorization?.startsWith("Basic ") === true) {
+      secretChannel = "basic";
+      const decoded = Buffer.from(authorization.slice("Basic ".length), "base64").toString("utf8");
+      clientSecret = decoded.slice(decoded.indexOf(":") + 1);
+    } else if (form.has("client_secret")) {
+      secretChannel = "post";
+      clientSecret = form.get("client_secret") ?? undefined;
+    }
+
+    this.tokenRequests.push({
+      grantType: form.get("grant_type") ?? "",
+      code: form.get("code") ?? undefined,
+      refreshToken: form.get("refresh_token") ?? undefined,
+      codeVerifier: form.get("code_verifier") ?? undefined,
+      clientId: form.get("client_id") ?? undefined,
+      redirectUri: form.get("redirect_uri") ?? undefined,
+      secretChannel,
+      clientSecret,
+    });
+
+    if (this.tokenStatus !== 200) {
+      respondJson(res, this.tokenStatus, { error: "server_error" });
+      return;
+    }
+
+    this.tokenSerial += 1;
+    respondJson(res, 200, {
+      access_token: `mock-access-token-${this.tokenSerial}`,
+      token_type: "Bearer",
+      ...(this.tokenExpiresIn !== undefined ? { expires_in: this.tokenExpiresIn } : {}),
+      ...(this.issueRefreshToken ? { refresh_token: `mock-refresh-token-${this.tokenSerial}` } : {}),
+    });
+  }
+}
+
+function respondJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/test/conformance/src/harness/server-process.ts
+++ b/test/conformance/src/harness/server-process.ts
@@ -17,6 +17,12 @@ const TCP_READY_TIMEOUT_MS = 20_000;
 const TCP_READY_POLL_MS = 100;
 const LOG_TAIL_BYTES = 8_000;
 
+// The OAuth callback URL every conformance server boots with (see the env
+// block below). Exported so the OAuth suite can assert the redirect_uri the
+// server presents to an authorization server against the value the harness
+// configured — one source of truth, no copy drift.
+export const CONFORMANCE_OAUTH_REDIRECT_URI = "http://127.0.0.1:8234/auth/oauth/callback";
+
 export interface RunningServer {
   readonly baseUrl: string;
   readonly port: number;
@@ -87,6 +93,12 @@ export async function spawnServer(
       // the registry lane pass offline and flake online. Conformance servers
       // always serve the bundled snapshot.
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      // Enable the MCP OAuth Connect lanes (unset means initiateOAuthConnect
+      // refuses with FailedPrecondition). The value is a fixed dummy: the
+      // server never fetches this URL — it only forwards it to the
+      // authorization server as the redirect_uri parameter, and the OAuth
+      // conformance suite's mock authorization server never redirects.
+      STIGMER_OAUTH_REDIRECT_URI: CONFORMANCE_OAUTH_REDIRECT_URI,
       ...(opts.env ?? {}),
     },
   });

--- a/test/conformance/src/suites-execution/mcpserver-connect.conformance.test.ts
+++ b/test/conformance/src/suites-execution/mcpserver-connect.conformance.test.ts
@@ -1,0 +1,761 @@
+// Conformance suite for the McpServer connect lanes and the engine-backed
+// half of the OAuth handshake (CW-1, Class B).
+// Domain: agentic / mcpserver — the connect/OAuth facet, engine-backed half.
+//
+// Two facets share this file because they share one dependency: the Temporal
+// engine the execution target provisions.
+//
+// 1. connect / startConnect — tool discovery through the runner's connect
+//    workflow against the McpToolFixture, including the deterministic
+//    workflow-ID attach semantics (one discovery run shared by concurrent
+//    connects) and the refresh-on-connect OAuth pre-flight.
+// 2. completeOAuthConnect / getOAuthGrantStatus / disconnectOAuth happy paths
+//    — conceptually Temporal-free, but the Go server builds their managed
+//    environment service inside the Temporal-gated SetConnectDependencies, so
+//    on the Temporal-less local-go target complete refuses before validating
+//    input. The initiate lanes and Layer-1 guards (genuinely engine-free) live
+//    in suites/mcpserver-oauth.conformance.test.ts; everything that needs the
+//    managed-env service runs here. (The wiring gap is disclosed, not pinned:
+//    pinning it would force the TS port to reproduce a composition artifact.)
+//
+// Classification scripting note: the connect workflow's tool classifier
+// calls the LLM through the runner's proxy (the MockLlmProxy), using
+// LangChain's structured output — on the wire, a forced Anthropic tool call
+// named "extract" whose input is the classifier's { approvals: [...] }
+// schema. Every test that triggers a FIRST connect enqueues exactly one such
+// turn (scriptClassifierVerdict below), which makes classification instant
+// and lets the suite pin the persistence semantics both ways: a gated
+// verdict must surface in status.tool_approvals, and an ungated verdict must
+// be DROPPED (presence in the persisted list is what "gated" means).
+// Re-connects must not consume any turn at all — the content-addressed
+// carry-forward is asserted through the mock's own request log. The
+// classifier's LLM-outage fallback (fail closed) is runner-internal behavior
+// covered by the runner's unit tests, not re-proven here.
+import { Code } from "@connectrpc/connect";
+import { OAuthConnectionHealth } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { ConnectPhase } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { TokenEndpointAuthMethod } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+import { createHash } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { ECHO_TOOL_NAME, type McpToolFixture } from "../harness/mcp-server";
+import { anthropicToolUse, type MockLlmProxy } from "../harness/mock-llm";
+import { MockOAuthAuthorizationServer } from "../harness/oauth-authorization-server";
+import { CONFORMANCE_OAUTH_REDIRECT_URI } from "../harness/server-process";
+import { requireLlmProxy, requireMcpFixture } from "../support/agentexecutions";
+import {
+  makeHttpMcpServer,
+  makeOAuthMcpServer,
+  type OAuthMcpServerOptions,
+} from "../support/mcpservers";
+import { makeOAuthApp, type OAuthAppOptions } from "../support/oauthapps";
+import { uniqueName } from "../support/naming";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+let mockLlm: MockLlmProxy;
+let mcpTools: McpToolFixture;
+const fixtures = new FixtureTracker();
+const mockAs = new MockOAuthAuthorizationServer();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+  mockLlm = requireLlmProxy(target);
+  mcpTools = requireMcpFixture(target);
+  await mockAs.start();
+});
+
+afterEach(async () => {
+  mockAs.reset();
+  mockLlm.reset();
+  mcpTools.releaseHolds();
+  mcpTools.resetCaptured();
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await mockAs.close();
+  await target?.teardown();
+});
+
+// The env var the handshake fixtures declare as the token destination.
+const TARGET_ENV_VAR = "CONF_OAUTH_TOKEN";
+
+// How long to poll for an async connect to settle. Discovery against the
+// in-process fixture is fast; the budget covers the classifier's outage
+// fallback (client-side retries against the mock's 500) with headroom.
+const CONNECT_SETTLE_TIMEOUT_MS = 90_000;
+const CONNECT_SETTLE_POLL_MS = 500;
+
+async function createOAuthMcpServer(opts: Omit<OAuthMcpServerOptions, "targetEnvVar">) {
+  const created = await clients.mcpServerCommand.create(
+    makeOAuthMcpServer({ ...opts, targetEnvVar: TARGET_ENV_VAR }),
+  );
+  fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: created.metadata!.id }));
+  return created;
+}
+
+async function createVendorOAuthApp(org: string, name: string, opts: OAuthAppOptions = {}) {
+  const created = await clients.oauthAppCommand.create(
+    makeOAuthApp(org, name, { tokenUrl: mockAs.tokenEndpoint(), ...opts }),
+  );
+  fixtures.defer(() => clients.oauthAppCommand.delete({ resourceId: created.metadata!.id }));
+  return created;
+}
+
+// Runs the full DCR handshake (initiate → complete) against the mock
+// authorization server. `url` optionally makes the server a real (fixture)
+// HTTP MCP endpoint so a follow-up connect can discover tools.
+async function completeDcrHandshake(org: string, name: string, opts: { url?: string } = {}) {
+  const server = await createOAuthMcpServer({
+    org,
+    name,
+    discoveryUrl: mockAs.origin(),
+    ...(opts.url !== undefined ? { url: opts.url } : {}),
+  });
+  const initiated = await clients.mcpServerCommand.initiateOAuthConnect({
+    mcpServerId: server.metadata!.id,
+    org,
+  });
+  const completed = await clients.mcpServerCommand.completeOAuthConnect({
+    mcpServerId: server.metadata!.id,
+    state: initiated.state,
+    authorizationCode: "conformance-auth-code",
+  });
+  return { server, initiated, completed };
+}
+
+// Enqueues one classifier verdict for the next first connect (see the
+// header's classification scripting note). "extract" is LangChain's default
+// structured-output tool name on the Anthropic path.
+function scriptClassifierVerdict(requiresApproval: boolean) {
+  mockLlm.enqueue(
+    anthropicToolUse("toolu_classifier_verdict", "extract", {
+      approvals: [
+        { tool_name: ECHO_TOOL_NAME, requires_approval: requiresApproval, message: "Execute echo" },
+      ],
+    }),
+  );
+}
+
+// Polls the resource until its connect_status reaches the wanted phase —
+// the poll-don't-sleep core for the async connect lane.
+async function pollConnectPhase(mcpServerId: string, want: ConnectPhase) {
+  const deadline = Date.now() + CONNECT_SETTLE_TIMEOUT_MS;
+  let lastPhase: ConnectPhase | undefined;
+  while (Date.now() < deadline) {
+    const current = await clients.mcpServerQuery.get({ value: mcpServerId });
+    lastPhase = current.status?.connectStatus?.phase;
+    if (lastPhase === want) {
+      return current;
+    }
+    if (lastPhase === ConnectPhase.failed && want !== ConnectPhase.failed) {
+      throw new Error(
+        `connect settled FAILED while waiting for ${ConnectPhase[want]}: ` +
+          `${current.status?.connectStatus?.failureCode}: ${current.status?.connectStatus?.failureMessage}`,
+      );
+    }
+    await delay(CONNECT_SETTLE_POLL_MS);
+  }
+  throw new Error(
+    `connect did not reach phase ${ConnectPhase[want]} within ${CONNECT_SETTLE_TIMEOUT_MS}ms ` +
+      `(last observed: ${lastPhase === undefined ? "none" : ConnectPhase[lastPhase]})`,
+  );
+}
+
+describe("McpServer connect conformance — OAuth handshake completion", () => {
+  it("refuses an unknown state parameter (FailedPrecondition, pinned copy)", async () => {
+    const err = await expectGrpcCode(
+      () =>
+        clients.mcpServerCommand.completeOAuthConnect({
+          mcpServerId: "mcp_x",
+          state: "never-issued-state",
+          authorizationCode: "code",
+        }),
+      Code.FailedPrecondition,
+      "complete with unknown state",
+    );
+    expect(err.rawMessage).toBe(
+      "no pending OAuth state found for the given state parameter (expired or already used)",
+    );
+  });
+
+  it("consumes the state atomically: a second complete with the same state refuses", async () => {
+    const { org } = await target.provisionTenancy();
+    const { server, initiated } = await completeDcrHandshake(org, uniqueName("dcrdouble"));
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.mcpServerCommand.completeOAuthConnect({
+          mcpServerId: server.metadata!.id,
+          state: initiated.state,
+          authorizationCode: "conformance-auth-code",
+        }),
+      Code.FailedPrecondition,
+      "second complete with a consumed state",
+    );
+    expect(err.rawMessage).toBe(
+      "no pending OAuth state found for the given state parameter (expired or already used)",
+    );
+  });
+
+  it("refuses a state minted for a different server — and the mismatch consumes the state", async () => {
+    const { org } = await target.provisionTenancy();
+    const serverA = await createOAuthMcpServer({
+      org,
+      name: uniqueName("mismatchA"),
+      discoveryUrl: mockAs.origin(),
+    });
+    const serverB = await createOAuthMcpServer({
+      org,
+      name: uniqueName("mismatchB"),
+      discoveryUrl: mockAs.origin(),
+    });
+    const initiated = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: serverA.metadata!.id,
+      org,
+    });
+
+    const mismatch = await expectGrpcCode(
+      () =>
+        clients.mcpServerCommand.completeOAuthConnect({
+          mcpServerId: serverB.metadata!.id,
+          state: initiated.state,
+          authorizationCode: "code",
+        }),
+      Code.FailedPrecondition,
+      "complete against the wrong server",
+    );
+    expect(mismatch.rawMessage).toBe("state parameter does not match the requested mcp_server_id");
+
+    // GetAndDelete consumed the row before the mismatch check, so even the
+    // RIGHT server can no longer complete with this state — the price of the
+    // atomic single-use contract, pinned deliberately.
+    const consumed = await expectGrpcCode(
+      () =>
+        clients.mcpServerCommand.completeOAuthConnect({
+          mcpServerId: serverA.metadata!.id,
+          state: initiated.state,
+          authorizationCode: "code",
+        }),
+      Code.FailedPrecondition,
+      "complete after a mismatch consumed the state",
+    );
+    expect(consumed.rawMessage).toBe(
+      "no pending OAuth state found for the given state parameter (expired or already used)",
+    );
+  });
+
+  it("maps a token-endpoint failure to Unavailable", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("tokfail"),
+      discoveryUrl: mockAs.origin(),
+    });
+    const initiated = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+    mockAs.tokenStatus = 502;
+
+    const err = await expectGrpcCode(
+      () =>
+        clients.mcpServerCommand.completeOAuthConnect({
+          mcpServerId: server.metadata!.id,
+          state: initiated.state,
+          authorizationCode: "code",
+        }),
+      Code.Unavailable,
+      "complete with failing token endpoint",
+    );
+    expect(err.rawMessage).toContain("token exchange failed:");
+    expect(err.rawMessage).toContain("returned HTTP 502");
+  });
+
+  it("DCR happy path: exchanges with the sealed PKCE verifier as a public client and records the grant", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("dcrhappy");
+    const { server, initiated, completed } = await completeDcrHandshake(org, name);
+
+    expect(completed.connected).toBe(true);
+    expect(completed.targetEnvVar).toBe(TARGET_ENV_VAR);
+
+    // The exchange the vendor saw: authorization_code grant, the DCR client,
+    // no secret on any channel (public client), and a code_verifier whose
+    // S256 hash is EXACTLY the code_challenge initiate put in the auth URL —
+    // the full PKCE chain, proven end to end.
+    expect(mockAs.capturedTokenRequests()).toHaveLength(1);
+    const exchange = mockAs.capturedTokenRequests()[0]!;
+    expect(exchange.grantType).toBe("authorization_code");
+    expect(exchange.code).toBe("conformance-auth-code");
+    expect(exchange.clientId).toBe("mock-dcr-client-1");
+    expect(exchange.redirectUri).toBe(CONFORMANCE_OAUTH_REDIRECT_URI);
+    expect(exchange.secretChannel).toBe("none");
+    const challenge = new URL(initiated.authorizationUrl).searchParams.get("code_challenge");
+    expect(exchange.codeVerifier).toBeDefined();
+    expect(createHash("sha256").update(exchange.codeVerifier!).digest("base64url")).toBe(challenge);
+
+    // The grant is visible through the status read.
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+    expect(status.connected).toBe(true);
+    expect(status.targetEnvVar).toBe(TARGET_ENV_VAR);
+    expect(status.authMethod).toBe("mcp_oauth");
+    expect(status.connectionHealth).toBe(OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY);
+
+    // The tokens rest in a managed Environment named for the server.
+    const managed = await clients.environmentQuery.list({
+      org,
+      labels: { "stigmer.ai/managed": "true" },
+    });
+    expect(managed.items).toHaveLength(1);
+    expect(managed.items[0]!.metadata?.name).toBe(`OAuth: ${name}`);
+  });
+
+  it("vendor happy path: presents the client secret via Basic by default and via the form body on client_secret_post", async () => {
+    const { org } = await target.provisionTenancy();
+
+    const basicApp = await createVendorOAuthApp(org, uniqueName("vbasic"));
+    const basicServer = await createOAuthMcpServer({
+      org,
+      name: uniqueName("vbasicsrv"),
+      oauthAppSlug: basicApp.metadata!.slug,
+    });
+    const basicInit = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: basicServer.metadata!.id,
+      org,
+    });
+    const basicDone = await clients.mcpServerCommand.completeOAuthConnect({
+      mcpServerId: basicServer.metadata!.id,
+      state: basicInit.state,
+      authorizationCode: "vendor-code",
+    });
+    expect(basicDone.connected).toBe(true);
+
+    const postApp = await createVendorOAuthApp(org, uniqueName("vpost"), {
+      tokenEndpointAuthMethod: TokenEndpointAuthMethod.CLIENT_SECRET_POST,
+    });
+    const postServer = await createOAuthMcpServer({
+      org,
+      name: uniqueName("vpostsrv"),
+      oauthAppSlug: postApp.metadata!.slug,
+    });
+    const postInit = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: postServer.metadata!.id,
+      org,
+    });
+    await clients.mcpServerCommand.completeOAuthConnect({
+      mcpServerId: postServer.metadata!.id,
+      state: postInit.state,
+      authorizationCode: "vendor-code",
+    });
+
+    // RFC 6749 §2.3: exactly one credential channel per request.
+    expect(mockAs.capturedTokenRequests()).toHaveLength(2);
+    const basicExchange = mockAs.capturedTokenRequests()[0]!;
+    const postExchange = mockAs.capturedTokenRequests()[1]!;
+    expect(basicExchange.secretChannel).toBe("basic");
+    expect(basicExchange.clientSecret).toBe("conformance-client-secret");
+    expect(postExchange.secretChannel).toBe("post");
+    expect(postExchange.clientSecret).toBe("conformance-client-secret");
+
+    // The vendor grant records its auth method.
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: basicServer.metadata!.id,
+      org,
+    });
+    expect(status.authMethod).toBe("vendor_oauth");
+  });
+
+  it("re-connect reuses the existing managed environment instead of creating a second one", async () => {
+    const { org } = await target.provisionTenancy();
+    const { server } = await completeDcrHandshake(org, uniqueName("dcrreuse"));
+
+    const again = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+    await clients.mcpServerCommand.completeOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      state: again.state,
+      authorizationCode: "second-code",
+    });
+
+    const managed = await clients.environmentQuery.list({
+      org,
+      labels: { "stigmer.ai/managed": "true" },
+    });
+    expect(managed.items, "re-connect must reuse, not accumulate, managed environments").toHaveLength(1);
+  });
+});
+
+describe("McpServer connect conformance — grant health boundaries", () => {
+  it("reports HEALTHY for a token without an expiry (expires_in absent means never expires)", async () => {
+    const { org } = await target.provisionTenancy();
+    mockAs.tokenExpiresIn = undefined;
+    const { server } = await completeDcrHandshake(org, uniqueName("noexpiry"));
+
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.accessTokenExpiresAt).toBe(0n);
+    expect(status.connectionHealth).toBe(OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY);
+  });
+
+  it("reports TOKEN_EXPIRED_REFRESHABLE inside the 60s refresh buffer when a refresh token exists", async () => {
+    const { org } = await target.provisionTenancy();
+    // 30s < the 60s buffer: the grant is born already inside the refresh
+    // window — the boundary lever, no clock manipulation needed.
+    mockAs.tokenExpiresIn = 30;
+    mockAs.issueRefreshToken = true;
+    const { server } = await completeDcrHandshake(org, uniqueName("refreshable"));
+
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.connectionHealth).toBe(
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE,
+    );
+  });
+
+  it("reports TOKEN_EXPIRED_REFRESHABLE even without a refresh token (pinned current behavior)", async () => {
+    const { org } = await target.provisionTenancy();
+    mockAs.tokenExpiresIn = 30;
+    mockAs.issueRefreshToken = false;
+    const { server } = await completeDcrHandshake(org, uniqueName("norefresh"));
+
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+
+    // PINNED CURRENT BEHAVIOR, arguably a bug: completeOAuthConnect records
+    // the refresh-token ENV VAR NAME on the grant unconditionally (the
+    // `_REFRESH_TOKEN` naming convention), and evaluateHealth keys
+    // "refreshable" off that name being non-empty — so a grant whose vendor
+    // never issued a refresh token still reports TOKEN_EXPIRED_REFRESHABLE,
+    // and the TOKEN_EXPIRED health state is unreachable through this flow.
+    // Filed as stigmer/stigmer#863 — when fixed (both editions), flip this
+    // pin to TOKEN_EXPIRED.
+    expect(status.connected).toBe(true);
+    expect(status.connectionHealth).toBe(
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE,
+    );
+  });
+});
+
+describe("McpServer connect conformance — disconnect teardown", () => {
+  it("tears down the grant and its managed environment, then answers false on repeat", async () => {
+    const { org } = await target.provisionTenancy();
+    const { server } = await completeDcrHandshake(org, uniqueName("teardown"));
+
+    const first = await clients.mcpServerCommand.disconnectOAuth({
+      resourceId: server.metadata!.id,
+      org,
+    });
+    expect(first.disconnected).toBe(true);
+
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+    expect(status.connected).toBe(false);
+    expect(status.connectionHealth).toBe(OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT);
+
+    const managed = await clients.environmentQuery.list({
+      org,
+      labels: { "stigmer.ai/managed": "true" },
+    });
+    expect(managed.items, "the token-holding managed environment must be deleted").toHaveLength(0);
+
+    const second = await clients.mcpServerCommand.disconnectOAuth({
+      resourceId: server.metadata!.id,
+      org,
+    });
+    expect(second.disconnected).toBe(false);
+  });
+});
+
+describe("McpServer connect conformance — blocking connect", () => {
+  it("rejects missing inputs and unknown servers (InvalidArgument / NotFound)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.connect({ mcpServerId: "", org }),
+      Code.InvalidArgument,
+      "connect empty mcp_server_id",
+    );
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.connect({ mcpServerId: "mcp_x", org: "" }),
+      Code.InvalidArgument,
+      "connect empty org",
+    );
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.connect({ mcpServerId: "mcp_doesnotexist", org }),
+      Code.NotFound,
+      "connect unknown id",
+    );
+    expect(err.rawMessage).toBe("mcp_server not found: mcp_doesnotexist");
+  });
+
+  it("discovers the fixture's tools and persists SUCCEEDED with the classifier's gated verdict", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await clients.mcpServerCommand.create(
+      makeHttpMcpServer({ org, name: uniqueName("connect"), url: mcpTools.url() }),
+    );
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+    scriptClassifierVerdict(true);
+
+    const connected = await clients.mcpServerCommand.connect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(connected.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+    expect(connected.status?.connectStatus?.workflowId).toBe(
+      `stigmer/mcp-server/connect/${server.metadata!.id}`,
+    );
+    const tools = connected.status?.discoveredCapabilities?.tools ?? [];
+    expect(tools.map((t) => t.name)).toEqual([ECHO_TOOL_NAME]);
+
+    // The classifier gated echo, so it must surface in the persisted list.
+    // ToolApprovalPolicy carries no boolean — PRESENCE in the persisted list
+    // is what "gated" means (the conversion drops ungated entries; the
+    // ungated arm is pinned in the startConnect test below).
+    const approvals = connected.status?.toolApprovals ?? [];
+    expect(approvals.map((a) => a.toolName)).toEqual([ECHO_TOOL_NAME]);
+  });
+
+  it("re-connect keeps capabilities and the gated approval stable", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await clients.mcpServerCommand.create(
+      makeHttpMcpServer({ org, name: uniqueName("reconnect"), url: mcpTools.url() }),
+    );
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+    scriptClassifierVerdict(true);
+    // A second identical verdict for the re-connect. The runner's
+    // content-addressed carry-forward SHOULD make this turn unnecessary (an
+    // unchanged tool is not re-classified) — but today it re-classifies:
+    // the persisted input_schema round-trips through Go's structpb, whose
+    // JSON marshaling sorts object keys, while toolSignature() stringifies
+    // the live SDK object in insertion order, so byte-identical schemas
+    // never match. Discovered by this suite's first run (the re-connect
+    // consumed a full classification); filed as stigmer/stigmer#862.
+    // When fixed, tighten this test: drop the second verdict and
+    // assert the re-connect adds ZERO LLM traffic (mockLlm.requests()).
+    scriptClassifierVerdict(true);
+
+    await clients.mcpServerCommand.connect({ mcpServerId: server.metadata!.id, org });
+
+    const again = await clients.mcpServerCommand.connect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(again.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+    expect((again.status?.discoveredCapabilities?.tools ?? []).map((t) => t.name)).toEqual([
+      ECHO_TOOL_NAME,
+    ]);
+    const approvals = again.status?.toolApprovals ?? [];
+    expect(approvals.map((a) => a.toolName)).toEqual([ECHO_TOOL_NAME]);
+  });
+
+  it("classifies an unreachable http server as FailedPrecondition with the reachability guidance", async () => {
+    const { org } = await target.provisionTenancy();
+    // Port 9 (discard) on loopback: nothing listens there, so the runner's
+    // connection attempt fails fast and deterministically.
+    const server = await clients.mcpServerCommand.create(
+      makeHttpMcpServer({ org, name: uniqueName("unreachable"), url: "http://127.0.0.1:9/mcp" }),
+    );
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.connect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "connect to unreachable http server",
+    );
+    // The middle of the message is the runner's classified cause (transport
+    // text, not pinned); the frame around it is the Go server's http-arm
+    // guidance template, pinned. The template names the server by NAME, not
+    // id — it is user-facing copy.
+    expect(err.rawMessage).toContain(`connect failed for MCP server '${server.metadata!.name}':`);
+    expect(err.rawMessage).toContain(
+      "Check that the server URL is reachable and your credentials are valid.",
+    );
+  });
+
+  it("refuses connect when required credentials have no personal environment (pinned copy)", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await clients.mcpServerCommand.create(
+      makeHttpMcpServer({
+        org,
+        name: uniqueName("noenv"),
+        url: mcpTools.url(),
+        env: { CONF_REQUIRED_KEY: { description: "a required credential" } },
+      }),
+    );
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.connect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "connect with missing personal environment",
+    );
+    expect(err.rawMessage).toBe(
+      `personal environment not found for org '${org}'; save required credentials first: [CONF_REQUIRED_KEY]`,
+    );
+  });
+});
+
+describe("McpServer connect conformance — async startConnect", () => {
+  it("returns immediately with CONNECTING, attaches concurrent starts to one discovery run, and settles SUCCEEDED", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await clients.mcpServerCommand.create(
+      makeHttpMcpServer({ org, name: uniqueName("async"), url: mcpTools.url() }),
+    );
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+
+    // Hold the fixture so the discovery blocks and the CONNECTING window is
+    // observable instead of a race. The scripted verdict is UNGATED — the
+    // drop-ungated arm of the persistence contract (an auto-approved tool
+    // never appears in status.tool_approvals).
+    scriptClassifierVerdict(false);
+    mcpTools.holdRequests();
+
+    const started = await clients.mcpServerCommand.startConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+    expect(started.status?.connectStatus?.phase).toBe(ConnectPhase.connecting);
+    const workflowId = started.status?.connectStatus?.workflowId;
+    expect(workflowId).toBe(`stigmer/mcp-server/connect/${server.metadata!.id}`);
+
+    const attached = await clients.mcpServerCommand.startConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+    expect(attached.status?.connectStatus?.phase).toBe(ConnectPhase.connecting);
+    expect(attached.status?.connectStatus?.workflowId, "attach must join the in-flight run").toBe(
+      workflowId,
+    );
+
+    // The wire-level proof of attach: across two startConnect calls the
+    // fixture saw at most one in-flight discovery (a single held initialize),
+    // never two parallel runs.
+    expect(
+      mcpTools.capturedRequests().filter((r) => r.method === "initialize").length,
+    ).toBeLessThanOrEqual(1);
+
+    mcpTools.releaseHolds();
+
+    const settled = await pollConnectPhase(server.metadata!.id, ConnectPhase.succeeded);
+    expect((settled.status?.discoveredCapabilities?.tools ?? []).map((t) => t.name)).toEqual([
+      ECHO_TOOL_NAME,
+    ]);
+    expect(settled.status?.toolApprovals ?? [], "an ungated verdict must not persist").toEqual([]);
+  });
+});
+
+describe("McpServer connect conformance — refresh-on-connect pre-flight", () => {
+  it("refreshes an expired grant through the refresh_token grant before discovering", async () => {
+    const { org } = await target.provisionTenancy();
+    // Handshake leaves a grant already inside the 60s refresh window, with a
+    // refresh token to redeem.
+    mockAs.tokenExpiresIn = 30;
+    mockAs.issueRefreshToken = true;
+    const { server } = await completeDcrHandshake(org, uniqueName("refresh"), {
+      url: mcpTools.url(),
+    });
+    // The refreshed token should be born healthy.
+    mockAs.tokenExpiresIn = 3600;
+    scriptClassifierVerdict(true);
+
+    const connected = await clients.mcpServerCommand.connect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(connected.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+
+    // The vendor saw the refresh: a refresh_token grant redeeming the token
+    // the handshake issued, as the same public client.
+    const refresh = mockAs.capturedTokenRequests().at(-1)!;
+    expect(refresh.grantType).toBe("refresh_token");
+    expect(refresh.refreshToken).toBe("mock-refresh-token-1");
+    expect(refresh.clientId).toBe("mock-dcr-client-1");
+    expect(refresh.secretChannel).toBe("none");
+
+    // And the grant's recorded expiry advanced out of the refresh window.
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+    expect(status.connectionHealth).toBe(OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY);
+  });
+
+  it("surfaces a failing refresh as FailedPrecondition with the re-authenticate copy (pinned)", async () => {
+    const { org } = await target.provisionTenancy();
+    mockAs.tokenExpiresIn = 30;
+    mockAs.issueRefreshToken = true;
+    const { server } = await completeDcrHandshake(org, uniqueName("refreshfail"), {
+      url: mcpTools.url(),
+    });
+    mockAs.tokenStatus = 500;
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.connect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "connect with failing token refresh",
+    );
+    expect(err.rawMessage).toBe(
+      `token refresh failed for resource '${server.metadata!.id}': ` +
+        `token endpoint ${mockAs.tokenEndpoint()} returned HTTP 500: {"error":"server_error"}. ` +
+        "Please re-authenticate via OAuth Connect",
+    );
+  });
+
+  it("silently skips the refresh when the grant has no refresh token (pinned current behavior)", async () => {
+    const { org } = await target.provisionTenancy();
+    mockAs.tokenExpiresIn = 30;
+    mockAs.issueRefreshToken = false;
+    const { server } = await completeDcrHandshake(org, uniqueName("norefreshconnect"), {
+      url: mcpTools.url(),
+    });
+    const exchangesBeforeConnect = mockAs.capturedTokenRequests().length;
+    scriptClassifierVerdict(true);
+
+    const connected = await clients.mcpServerCommand.connect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    // PINNED CURRENT BEHAVIOR: with no refresh token stored, the pre-flight's
+    // managed-env read fails and the refresh is SKIPPED silently — connect
+    // proceeds with the expired token rather than refusing with the
+    // "no refresh token is available" re-authenticate error (that copy is
+    // unreachable through the wire: it fires only when the managed env
+    // returns an EMPTY refresh token, which completeOAuthConnect never
+    // writes). The stale token only fails later, at the target server —
+    // which the echo fixture, needing no auth, never does. Filed as
+    // stigmer/stigmer#863: the silent skip hides an expired, unrefreshable
+    // grant.
+    expect(connected.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+    expect(mockAs.capturedTokenRequests().length, "no refresh attempt must reach the vendor").toBe(
+      exchangesBeforeConnect,
+    );
+  });
+});

--- a/test/conformance/src/suites/mcpserver-oauth.conformance.test.ts
+++ b/test/conformance/src/suites/mcpserver-oauth.conformance.test.ts
@@ -1,0 +1,528 @@
+// Conformance suite for the McpServer OAuth initiate lanes (CW-1, Class A).
+// Domain: agentic / mcpserver — the connect/OAuth facet, engine-free half.
+//
+// Pins initiateOAuthConnect (both arms: DCR and vendor), the Layer-1 input
+// guards of the other handshake RPCs, the grant-free reads (NO_GRANT,
+// idempotent disconnect), and the three org-OAuth-app UNIMPLEMENTED refusals —
+// against a suite-owned mock OAuth authorization server
+// (harness/oauth-authorization-server.ts).
+//
+// Why exactly this slice is Class A: the Go server injects the OAuth stores
+// and redirect URI unconditionally, so initiate works with no Temporal behind
+// the server — but completeOAuthConnect ALSO requires the managed environment
+// service, which server.go builds only inside the Temporal-gated
+// SetConnectDependencies. On the Temporal-less local-go target, complete
+// refuses before validating input. The handshake-completion scenarios
+// (complete/grant-health/disconnect-teardown) therefore live in
+// suites-execution/mcpserver-connect.conformance.test.ts, where the engine is
+// provisioned — see that suite's header for the full flow.
+//
+// The refusal and guidance copy is byte-pinned: these strings are user-facing
+// (the SDK's getUserMessage passes initiate errors through verbatim) and they
+// are the porting contract for the TS server's mcpserver connect/OAuth slice.
+import { Code } from "@connectrpc/connect";
+import { OAuthConnectionHealth } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectGrpcCode } from "../contract/errors";
+import type { ConformanceClients } from "../harness/clients";
+import { FixtureTracker } from "../harness/fixtures";
+import { MockOAuthAuthorizationServer } from "../harness/oauth-authorization-server";
+import { CONFORMANCE_OAUTH_REDIRECT_URI } from "../harness/server-process";
+import { uniqueName } from "../support/naming";
+import {
+  MCPSERVER_API_VERSION,
+  MCPSERVER_KIND,
+  makeOAuthMcpServer,
+  type OAuthMcpServerOptions,
+} from "../support/mcpservers";
+import { makeOAuthApp, type OAuthAppOptions } from "../support/oauthapps";
+import { createTarget, type TargetProfile } from "../targets";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+const mockAs = new MockOAuthAuthorizationServer();
+
+// Collection-time capability read (construction is cheap and boots nothing —
+// the schedule-firing convention): decides whether the org-OAuth-app
+// UNIMPLEMENTED pins apply to this target.
+const orgOAuthAppConfigured = createTarget().capabilities.orgOAuthAppConfiguration;
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+  await mockAs.start();
+});
+
+afterEach(async () => {
+  mockAs.reset();
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await mockAs.close();
+  await target?.teardown();
+});
+
+// The env var the fixtures declare as the token destination.
+const TARGET_ENV_VAR = "CONF_OAUTH_TOKEN";
+
+// The host segment of the harness redirect URI, as the DCR pre-flight
+// rejection copy renders it (url.Parse(...).Host in Go).
+const REDIRECT_CALLBACK_HOST = new URL(CONFORMANCE_OAUTH_REDIRECT_URI).host;
+
+async function createOAuthMcpServer(opts: Omit<OAuthMcpServerOptions, "targetEnvVar">) {
+  const created = await clients.mcpServerCommand.create(
+    makeOAuthMcpServer({ ...opts, targetEnvVar: TARGET_ENV_VAR }),
+  );
+  fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: created.metadata!.id }));
+  return created;
+}
+
+async function createVendorOAuthApp(org: string, name: string, opts: OAuthAppOptions = {}) {
+  const created = await clients.oauthAppCommand.create(
+    makeOAuthApp(org, name, { tokenUrl: mockAs.tokenEndpoint(), ...opts }),
+  );
+  fixtures.defer(() => clients.oauthAppCommand.delete({ resourceId: created.metadata!.id }));
+  return created;
+}
+
+describe("McpServer OAuth conformance — initiateOAuthConnect guards", () => {
+  it("rejects an empty mcp_server_id (InvalidArgument)", async () => {
+    const { org } = await target.provisionTenancy();
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: "", org }),
+      Code.InvalidArgument,
+      "initiate empty mcp_server_id",
+    );
+  });
+
+  it("rejects an empty org (InvalidArgument)", () =>
+    expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: "mcp_x", org: "" }),
+      Code.InvalidArgument,
+      "initiate empty org",
+    ));
+
+  it("reports NotFound for an unknown mcp_server_id", async () => {
+    const { org } = await target.provisionTenancy();
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: "mcp_doesnotexist", org }),
+      Code.NotFound,
+      "initiate unknown id",
+    );
+    expect(err.rawMessage).toBe("mcp_server not found: mcp_doesnotexist");
+  });
+
+  it("refuses a server without an auth block (FailedPrecondition, pinned copy)", async () => {
+    const { org } = await target.provisionTenancy();
+    // No-auth shape written inline: the support builder represents validity
+    // for the OAuth facet, and "no auth block" is its deliberate negative.
+    const server = await clients.mcpServerCommand.create({
+      apiVersion: MCPSERVER_API_VERSION,
+      kind: MCPSERVER_KIND,
+      metadata: { name: uniqueName("noauth"), org },
+      spec: {
+        description: "no auth block",
+        serverType: { case: "stdio", value: { command: "conformance-oauth-noop" } },
+      },
+    });
+    fixtures.defer(() => clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }));
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate without auth block",
+    );
+    expect(err.rawMessage).toBe(
+      `MCP server '${server.metadata!.id}' does not have an auth block configured`,
+    );
+  });
+
+  it("refuses DCR with neither http.url nor discovery_url (FailedPrecondition, pinned copy)", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({ org, name: uniqueName("nodisc") });
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate without discoverable URL",
+    );
+    expect(err.rawMessage).toBe(
+      `DCR requires a discoverable URL. MCP server '${server.metadata!.id}' has no http.url and no auth.discovery_url. ` +
+        "Set auth.discovery_url for stdio servers, oauth_app_ref for vendor OAuth, or switch to HTTP transport",
+    );
+  });
+
+  it("surfaces a discovery failure (non-200 metadata) as FailedPrecondition", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("disc500"),
+      discoveryUrl: mockAs.origin(),
+    });
+    mockAs.discoveryStatus = 503;
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate with failing discovery",
+    );
+    expect(err.rawMessage).toBe(
+      `OAuth authorization server discovery failed for ${mockAs.origin()}: ` +
+        `authorization server discovery failed: ${mockAs.origin()}/.well-known/oauth-authorization-server ` +
+        "returned HTTP 503 (expected 200). This MCP server may not support the MCP Authorization specification",
+    );
+  });
+
+  it("refuses a provider that advertises no registration_endpoint (FailedPrecondition, pinned copy)", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("nodcr"),
+      discoveryUrl: mockAs.origin(),
+    });
+    mockAs.omitRegistrationEndpoint = true;
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate without registration endpoint",
+    );
+    expect(err.rawMessage).toBe(
+      `MCP server at ${mockAs.origin()} does not advertise a registration_endpoint for DCR`,
+    );
+  });
+});
+
+describe("McpServer OAuth conformance — initiate, DCR arm", () => {
+  it("discovers, registers via DCR, and returns a PKCE S256 authorization URL", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("dcr");
+    const server = await createOAuthMcpServer({
+      org,
+      name,
+      discoveryUrl: mockAs.origin(),
+      scopeHints: ["files:read", "files:write"],
+    });
+
+    const out = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(out.state, "state must be a generated handshake token").not.toBe("");
+    expect(out.providerName, "DCR arm names the provider after the server").toBe(name);
+    expect(out.scopes).toEqual(["files:read", "files:write"]);
+
+    // Discovery hit the RFC 8414 well-known path at the origin.
+    expect(mockAs.capturedDiscoveryPaths()).toEqual(["/.well-known/oauth-authorization-server"]);
+
+    // DCR registered a public client with the documented request shape.
+    expect(mockAs.capturedDcrRequests()).toHaveLength(1);
+    const dcr = mockAs.capturedDcrRequests()[0]!;
+    expect(dcr.client_name).toBe(`Stigmer (${name})`);
+    expect(dcr.token_endpoint_auth_method).toBe("none");
+    expect(dcr.grant_types).toEqual(["authorization_code"]);
+    expect(dcr.response_types).toEqual(["code"]);
+    expect(dcr.redirect_uris).toEqual([CONFORMANCE_OAUTH_REDIRECT_URI]);
+
+    // The authorization URL carries the full pinned parameter set.
+    const authUrl = new URL(out.authorizationUrl);
+    expect(`${authUrl.origin}${authUrl.pathname}`).toBe(mockAs.authorizationEndpoint());
+    expect(authUrl.searchParams.get("response_type")).toBe("code");
+    expect(authUrl.searchParams.get("client_id")).toBe("mock-dcr-client-1");
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(CONFORMANCE_OAUTH_REDIRECT_URI);
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authUrl.searchParams.get("code_challenge")).not.toBeNull();
+    expect(authUrl.searchParams.get("state")).toBe(out.state);
+    expect(authUrl.searchParams.get("scope")).toBe("files:read files:write");
+
+    // The pre-flight probe fetched exactly that URL server-side.
+    expect(mockAs.capturedAuthorizeProbes()).toHaveLength(1);
+    expect(mockAs.capturedAuthorizeProbes()[0]!.params.get("state")).toBe(out.state);
+  });
+
+  it("falls back to the provider's scopes_supported when the server declares no scope_hints", async () => {
+    const { org } = await target.provisionTenancy();
+    mockAs.scopesSupported = ["discovered:a", "discovered:b"];
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("dcrscopes"),
+      discoveryUrl: mockAs.origin(),
+    });
+
+    const out = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(out.scopes).toEqual(["discovered:a", "discovered:b"]);
+    const authUrl = new URL(out.authorizationUrl);
+    expect(authUrl.searchParams.get("scope")).toBe("discovered:a discovered:b");
+  });
+
+  it("blocks initiate when the authorize pre-flight answers 400, with the pinned rejection copy", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("dcrblocked");
+    const server = await createOAuthMcpServer({ org, name, discoveryUrl: mockAs.origin() });
+    mockAs.authorizeStatus = 400;
+    mockAs.authorizeErrorBody = { error: "invalid_request", error_description: "redirect host not allowed" };
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate with pre-flight 400",
+    );
+    expect(err.rawMessage).toBe(
+      `${name} rejected the sign-in request before showing a login page (HTTP 400). ` +
+        `The most common cause is a redirect-host allowlist: this deployment's OAuth callback host (${REDIRECT_CALLBACK_HOST}) ` +
+        "is not on the provider's approved list. Self-hosted deployments with a localhost callback are typically unaffected. " +
+        "Provider detail: redirect host not allowed",
+    );
+  });
+
+  it("omits the provider detail when the 400 body is an HTML error page", async () => {
+    const { org } = await target.provisionTenancy();
+    const name = uniqueName("dcrhtml");
+    const server = await createOAuthMcpServer({ org, name, discoveryUrl: mockAs.origin() });
+    mockAs.authorizeStatus = 400;
+    mockAs.authorizeErrorBody = "<html><body>vendor error page</body></html>";
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate with HTML pre-flight 400",
+    );
+    expect(err.rawMessage).toBe(
+      `${name} rejected the sign-in request before showing a login page (HTTP 400). ` +
+        `The most common cause is a redirect-host allowlist: this deployment's OAuth callback host (${REDIRECT_CALLBACK_HOST}) ` +
+        "is not on the provider's approved list. Self-hosted deployments with a localhost callback are typically unaffected.",
+    );
+  });
+
+  it("fails open when the authorize pre-flight answers a non-400 error (bot-wall contract)", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("dcrbotwall"),
+      discoveryUrl: mockAs.origin(),
+    });
+    // 403 is the bot-protection shape: server-side GETs blocked while real
+    // browsers pass. Only a definite 400 may block initiate.
+    mockAs.authorizeStatus = 403;
+    mockAs.authorizeErrorBody = { error: "forbidden" };
+
+    const out = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(out.state).not.toBe("");
+    expect(out.authorizationUrl).not.toBe("");
+  });
+});
+
+describe("McpServer OAuth conformance — initiate, vendor arm", () => {
+  it("reports NotFound for an unresolvable oauth_app_ref", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("vnoapp"),
+      oauthAppSlug: "does-not-exist",
+    });
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.NotFound,
+      "initiate with unknown oauth_app",
+    );
+    expect(err.rawMessage).toBe("oauth_app not found: does-not-exist");
+  });
+
+  it("refuses a vendor-PENDING app with the manual-token alternative (pinned copy)", async () => {
+    const { org } = await target.provisionTenancy();
+    const app = await createVendorOAuthApp(org, uniqueName("vpending"), {
+      vendorApprovalStatus: VendorApprovalStatus.PENDING,
+    });
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("vpendingsrv"),
+      oauthAppSlug: app.metadata!.slug,
+    });
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate with pending vendor approval",
+    );
+    expect(err.rawMessage).toBe(
+      "OAuth sign-in is unavailable: the platform's OAuth app for 'ConformanceVendor' is pending approval by the vendor. " +
+        "Please enter a token manually instead.",
+    );
+  });
+
+  it("refuses a vendor-REJECTED oauth_only server with the BYOA alternative (pinned copy)", async () => {
+    const { org } = await target.provisionTenancy();
+    const app = await createVendorOAuthApp(org, uniqueName("vrejected"), {
+      vendorApprovalStatus: VendorApprovalStatus.REJECTED,
+    });
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("vrejectedsrv"),
+      oauthAppSlug: app.metadata!.slug,
+      oauthOnly: true,
+    });
+
+    const err = await expectGrpcCode(
+      () => clients.mcpServerCommand.initiateOAuthConnect({ mcpServerId: server.metadata!.id, org }),
+      Code.FailedPrecondition,
+      "initiate with rejected vendor approval on oauth_only",
+    );
+    expect(err.rawMessage).toBe(
+      "OAuth sign-in is unavailable: the platform's OAuth app for 'ConformanceVendor' is rejected by the vendor. " +
+        "This server only accepts OAuth sign-in; an org admin can configure your own OAuth app instead.",
+    );
+  });
+
+  it("builds the authorization URL from the OAuthApp, honoring a custom scope parameter name", async () => {
+    const { org } = await target.provisionTenancy();
+    const app = await createVendorOAuthApp(org, uniqueName("vhappy"), {
+      scopeParameterName: "user_scope",
+    });
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("vhappysrv"),
+      oauthAppSlug: app.metadata!.slug,
+    });
+
+    const out = await clients.mcpServerCommand.initiateOAuthConnect({
+      mcpServerId: server.metadata!.id,
+      org,
+    });
+
+    expect(out.providerName, "vendor arm names the provider after the OAuthApp").toBe("ConformanceVendor");
+    expect(out.scopes).toEqual(["read", "write"]);
+    const authUrl = new URL(out.authorizationUrl);
+    expect(`${authUrl.origin}${authUrl.pathname}`).toBe("https://vendor.example.com/oauth/authorize");
+    expect(authUrl.searchParams.get("client_id")).toBe("conformance-client-id");
+    expect(authUrl.searchParams.get("user_scope")).toBe("read write");
+    expect(authUrl.searchParams.get("scope"), "the default parameter name must be replaced").toBeNull();
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    // Vendor initiate is network-free: no discovery, no DCR, no pre-flight.
+    expect(mockAs.capturedDiscoveryPaths()).toHaveLength(0);
+    expect(mockAs.capturedAuthorizeProbes()).toHaveLength(0);
+  });
+});
+
+describe("McpServer OAuth conformance — handshake input guards (Layer 1)", () => {
+  it("completeOAuthConnect rejects missing inputs (InvalidArgument each)", async () => {
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.completeOAuthConnect({ mcpServerId: "", state: "s", authorizationCode: "c" }),
+      Code.InvalidArgument,
+      "complete empty mcp_server_id",
+    );
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.completeOAuthConnect({ mcpServerId: "mcp_x", state: "", authorizationCode: "c" }),
+      Code.InvalidArgument,
+      "complete empty state",
+    );
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.completeOAuthConnect({ mcpServerId: "mcp_x", state: "s", authorizationCode: "" }),
+      Code.InvalidArgument,
+      "complete empty authorization_code",
+    );
+  });
+
+  it("getOAuthGrantStatus rejects missing resource_id and org (InvalidArgument each)", async () => {
+    await expectGrpcCode(
+      () => clients.mcpServerQuery.getOAuthGrantStatus({ resourceId: "", org: "acme" }),
+      Code.InvalidArgument,
+      "grant status empty resource_id",
+    );
+    await expectGrpcCode(
+      () => clients.mcpServerQuery.getOAuthGrantStatus({ resourceId: "mcp_x", org: "" }),
+      Code.InvalidArgument,
+      "grant status empty org",
+    );
+  });
+
+  it("disconnectOAuth rejects missing resource_id and org (InvalidArgument each)", async () => {
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.disconnectOAuth({ resourceId: "", org: "acme" }),
+      Code.InvalidArgument,
+      "disconnect empty resource_id",
+    );
+    await expectGrpcCode(
+      () => clients.mcpServerCommand.disconnectOAuth({ resourceId: "mcp_x", org: "" }),
+      Code.InvalidArgument,
+      "disconnect empty org",
+    );
+  });
+});
+
+describe("McpServer OAuth conformance — grant-free reads", () => {
+  it("getOAuthGrantStatus answers NO_GRANT for a server that never connected", async () => {
+    const { org } = await target.provisionTenancy();
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("nogrant"),
+      discoveryUrl: mockAs.origin(),
+    });
+
+    const status = await clients.mcpServerQuery.getOAuthGrantStatus({
+      resourceId: server.metadata!.id,
+      org,
+    });
+
+    expect(status.connected).toBe(false);
+    expect(status.connectionHealth).toBe(OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT);
+  });
+
+  it("disconnectOAuth is idempotent: no grant answers disconnected=false, not an error", async () => {
+    const { org } = await target.provisionTenancy();
+    const out = await clients.mcpServerCommand.disconnectOAuth({ resourceId: "mcp_nogrant", org });
+    expect(out.disconnected).toBe(false);
+  });
+});
+
+// The hosted BYOA lane: on OSS all three RPCs answer UNIMPLEMENTED by design,
+// as ONE capability — the SDK probes getOrgOAuthApp and gates its BYOA UI on
+// the answer (stigmer#558). Where the capability exists (cloud), these pins
+// gate off; the lane's real behavior needs a vendor OAuth app no hermetic
+// target can provision and stays with cloud's own integration tests.
+describe.skipIf(orgOAuthAppConfigured)(
+  "McpServer OAuth conformance — org OAuth app pins (OSS refusals)",
+  () => {
+    it("getOrgOAuthApp answers Unimplemented", async () => {
+      const { org } = await target.provisionTenancy();
+      await expectGrpcCode(
+        () => clients.mcpServerQuery.getOrgOAuthApp({ resourceId: "mcp_x", org }),
+        Code.Unimplemented,
+        "getOrgOAuthApp on OSS",
+      );
+    });
+
+    it("setOrgOAuthApp answers Unimplemented", async () => {
+      const { org } = await target.provisionTenancy();
+      await expectGrpcCode(
+        () =>
+          clients.mcpServerCommand.setOrgOAuthApp({
+            resourceId: "mcp_x",
+            org,
+            clientId: "byoa-client",
+            clientSecret: "byoa-secret",
+          }),
+        Code.Unimplemented,
+        "setOrgOAuthApp on OSS",
+      );
+    });
+
+    it("deleteOrgOAuthApp answers Unimplemented", async () => {
+      const { org } = await target.provisionTenancy();
+      await expectGrpcCode(
+        () => clients.mcpServerCommand.deleteOrgOAuthApp({ resourceId: "mcp_x", org }),
+        Code.Unimplemented,
+        "deleteOrgOAuthApp on OSS",
+      );
+    });
+  },
+);

--- a/test/conformance/src/support/mcpservers.ts
+++ b/test/conformance/src/support/mcpservers.ts
@@ -12,6 +12,7 @@
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { McpServerSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 export const MCPSERVER_API_VERSION = "agentic.stigmer.ai/v1";
 export const MCPSERVER_KIND = "McpServer";
@@ -74,6 +75,56 @@ export interface HttpMcpServerOptions {
   // declared `optional: true` — their values come from the runner at
   // execution time, not from an Environment (the docs guide's rule 2).
   env?: Record<string, { optional?: boolean; isSecret?: boolean; description?: string }>;
+}
+
+export interface OAuthMcpServerOptions {
+  org: string;
+  name: string;
+  // The env var the acquired access token is stored under (auth.target_env_var).
+  targetEnvVar: string;
+  // Base URL of an HTTP MCP server. When omitted the server is a stdio shape
+  // whose command never runs — the right isolation for handshake-only tests.
+  url?: string;
+  // auth.discovery_url — point at a mock authorization server's origin for
+  // the DCR arm (priority: discovery_url > http.url, so this also works on
+  // http servers whose URL serves no metadata).
+  discoveryUrl?: string;
+  // auth.oauth_app_ref slug — selects the vendor arm.
+  oauthAppSlug?: string;
+  // auth.oauth_only — flips the vendor refusal's alternative sentence.
+  oauthOnly?: boolean;
+  // auth.scope_hints — DCR scope selection (fallback: discovered metadata).
+  scopeHints?: string[];
+}
+
+// A complete, valid McpServer with an OAuth auth block — the fixture shape for
+// the connect/OAuth conformance suites (CW-1). Defaults to a stdio server with
+// a command that never executes: the OAuth handshake RPCs never touch the
+// server process itself, so a no-op command isolates them completely. Pass
+// `url` for the connect-time tests that need the runner to reach a real
+// (fixture) MCP endpoint after the handshake.
+export function makeOAuthMcpServer(opts: OAuthMcpServerOptions): MessageInitShape<typeof McpServerSchema> {
+  return {
+    apiVersion: MCPSERVER_API_VERSION,
+    kind: MCPSERVER_KIND,
+    metadata: { name: opts.name, org: opts.org },
+    spec: {
+      description: "OAuth conformance fixture",
+      serverType:
+        opts.url !== undefined
+          ? { case: "http", value: { url: opts.url } }
+          : { case: "stdio", value: { command: "conformance-oauth-noop" } },
+      auth: {
+        targetEnvVar: opts.targetEnvVar,
+        ...(opts.discoveryUrl !== undefined ? { discoveryUrl: opts.discoveryUrl } : {}),
+        ...(opts.oauthAppSlug !== undefined
+          ? { oauthAppRef: { kind: ApiResourceKind.oauth_app, org: opts.org, slug: opts.oauthAppSlug } }
+          : {}),
+        ...(opts.oauthOnly !== undefined ? { oauthOnly: opts.oauthOnly } : {}),
+        ...(opts.scopeHints !== undefined ? { scopeHints: opts.scopeHints } : {}),
+      },
+    },
+  };
 }
 
 // A complete, valid HTTP McpServer resource. Used by the execution suites to

--- a/test/conformance/src/support/oauthapps.ts
+++ b/test/conformance/src/support/oauthapps.ts
@@ -12,6 +12,10 @@
 // support/agents.ts convention: this module is validity by construction.
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import type {
+  TokenEndpointAuthMethod,
+  VendorApprovalStatus,
+} from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
 
 export const OAUTHAPP_API_VERSION = "iam.stigmer.ai/v1";
 export const OAUTHAPP_KIND = "OAuthApp";
@@ -33,6 +37,14 @@ export interface OAuthAppOptions {
   authorizationUrl?: string;
   tokenUrl?: string;
   scopes?: string[];
+  // Vendor marketplace approval state; PENDING/REJECTED gate the McpServer
+  // OAuth initiate flow with byte-pinned refusal copy.
+  vendorApprovalStatus?: VendorApprovalStatus;
+  // Non-standard scope query parameter name (e.g. Slack's user_scope).
+  scopeParameterName?: string;
+  // How the client secret is presented at the token endpoint; unset means
+  // HTTP Basic (the backwards-compatible baseline).
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
 }
 
 // A complete, valid OAuthApp resource ready to hand to create/apply/update.
@@ -52,6 +64,15 @@ export function makeOAuthApp(
       authorizationUrl: options.authorizationUrl ?? "https://vendor.example.com/oauth/authorize",
       tokenUrl: options.tokenUrl ?? "https://vendor.example.com/oauth/token",
       scopes: options.scopes ?? ["read", "write"],
+      ...(options.vendorApprovalStatus !== undefined
+        ? { vendorApprovalStatus: options.vendorApprovalStatus }
+        : {}),
+      ...(options.scopeParameterName !== undefined
+        ? { scopeParameterName: options.scopeParameterName }
+        : {}),
+      ...(options.tokenEndpointAuthMethod !== undefined
+        ? { tokenEndpointAuthMethod: options.tokenEndpointAuthMethod }
+        : {}),
     },
   };
 }

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -62,6 +62,10 @@ export class CloudTarget implements TargetProfile {
     // and proactive messaging for real — the OSS refusal pins are gated off
     // here (their full behavior needs live provider workspaces; see target.ts).
     channelMessaging: true,
+    // Cloud implements the org BYOA lane for real; the OSS UNIMPLEMENTED
+    // pins gate off here (full behavior needs a real vendor OAuth app — the
+    // channelMessaging coverage split).
+    orgOAuthAppConfiguration: true,
   };
 
   private grpcBaseUrl: string | undefined;

--- a/test/conformance/src/targets/local-go-execution.ts
+++ b/test/conformance/src/targets/local-go-execution.ts
@@ -56,6 +56,9 @@ export class LocalGoExecutionTarget implements TargetProfile {
     // provisions is the agent/workflow execution engine, not a channel
     // delivery runtime — the refusal posture is identical to local-go.
     channelMessaging: false,
+    // The org BYOA lane is UNIMPLEMENTED on OSS by design (stigmer#558) —
+    // the suite pins the three refusals here.
+    orgOAuthAppConfiguration: false,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local-go.ts
+++ b/test/conformance/src/targets/local-go.ts
@@ -30,6 +30,9 @@ export class LocalGoTarget implements TargetProfile {
     // No channel runtime in this edition (T02 §0-b) — the suite pins the
     // documented refusal copy on every runtime lane.
     channelMessaging: false,
+    // The org BYOA lane is UNIMPLEMENTED on OSS by design (stigmer#558) —
+    // the suite pins the three refusals here.
+    orgOAuthAppConfiguration: false,
   };
 
   private server: RunningServer | undefined;

--- a/test/conformance/src/targets/local-ts.ts
+++ b/test/conformance/src/targets/local-ts.ts
@@ -38,6 +38,9 @@ export class LocalTsTarget implements TargetProfile {
     // No channel runtime in this edition (T02 §0-b) — the suite pins the
     // documented refusal copy on every runtime lane.
     channelMessaging: false,
+    // The org BYOA lane is UNIMPLEMENTED on OSS by design (stigmer#558) —
+    // the TS port must reproduce the three refusals byte-for-byte.
+    orgOAuthAppConfiguration: false,
   };
 
   private server: RunningServer | undefined;

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -172,6 +172,24 @@ export interface CapabilityFlags {
   // this flag when the harness gains a platform-privileged caller
   // (stigmer#547) — until then the happy-path pin runs OSS-side only.
   clientPublicVisibilityWrites: boolean;
+  // The org-level OAuth-app configuration surface exists here: the McpServer
+  // service's setOrgOAuthApp / getOrgOAuthApp / deleteOrgOAuthApp RPCs (the
+  // hosted BYOA lane — an org admin registers their own vendor OAuth app for
+  // an MCP server).
+  //
+  // False for the local OSS targets — BY DOCUMENTED DESIGN, not a gap: the
+  // proto pins all three RPCs as "UNIMPLEMENTED on the OSS server by design"
+  // (one capability, probed via getOrgOAuthApp — stigmer/stigmer#558, the SDK
+  // gates its BYOA UI on exactly that answer). Where false, the suite pins
+  // the three UNIMPLEMENTED refusals — they are the OSS contract the TS port
+  // must reproduce, the same refusal-pin posture versionTagging and
+  // channelMessaging document above.
+  //
+  // True for cloud, whose Java service implements the lane for real. The
+  // pins are gated OFF there; the lane's full cloud behavior needs a real
+  // vendor OAuth app no hermetic target can provision, so it stays covered
+  // by cloud's own integration tests — the channelMessaging coverage split.
+  orgOAuthAppConfiguration: boolean;
 }
 
 // Tenancy scope a test operates within. Locally this is just a unique org slug

--- a/test/conformance/vitest.cloud-execution.config.ts
+++ b/test/conformance/vitest.cloud-execution.config.ts
@@ -23,6 +23,12 @@ export default defineConfig({
     exclude: [
       "src/suites-execution/schedule-firing.conformance.test.ts",
       "src/suites-execution/open-computer-use.conformance.test.ts",
+      // EXCLUDED for the same reason as mcpserver-oauth in
+      // vitest.cloud.config.ts: its OAuth handshake setup needs
+      // STIGMER_OAUTH_REDIRECT_URI on the service, which the hermetic
+      // launcher does not yet pass to the JAR. Cloud enablement is an
+      // owner-gated follow-up (CW-1 wrap-up, sub-project 20260824.05).
+      "src/suites-execution/mcpserver-connect.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-cloud-execution.ts"],
     env: {

--- a/test/conformance/vitest.cloud.config.ts
+++ b/test/conformance/vitest.cloud.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
       "src/suites/**/*.conformance.test.ts",
       "src/suites-execution/schedule-firing.conformance.test.ts",
     ],
+    // mcpserver-oauth is EXCLUDED (deliberately, the mcp.conformance
+    // convention): the OAuth initiate lanes need STIGMER_OAUTH_REDIRECT_URI
+    // on the service, which the hermetic launcher does not yet pass to the
+    // JAR — and the Java edition's refusal copy is already known to diverge
+    // (its unset-redirect message names the `stigmer.oauth.redirect-uri`
+    // property where the Go edition names the env var). Enabling this suite
+    // here is an owner-gated follow-up: wire the env var through the
+    // launcher, run hermetically, and two-arm the divergent copy from that
+    // evidence (CW-1 wrap-up, sub-project 20260824.05).
+    exclude: ["src/suites/mcpserver-oauth.conformance.test.ts"],
     globalSetup: ["./src/harness/global-setup-cloud.ts"],
     env: {
       CONFORMANCE_TARGET: "cloud",


### PR DESCRIPTION
## Summary

CW-1 (D4 entry #11 of the TS-server program): conformance coverage for the largest untested command surface in a covered domain — the McpServer connect/OAuth lanes — pinned against the Go server BEFORE entry #19 ports them to TS (coverage-before-port, DD-002). Suite-only: no production code is touched.

## Context

The McpServer domain suite covered only CRUD. connect/startConnect, the OAuth handshake (initiate/complete/disconnect/grant-status), and the org-OAuth-app refusals had no black-box coverage at all. Program record: stigmer-cloud sub-project `20260824.05.sp.conformance-mcp-oauth`.

## Changes

- **New harness fixture** `src/harness/oauth-authorization-server.ts`: a programmable mock OAuth 2.0 authorization server (RFC 8414 discovery, RFC 7591 DCR, the authorize pre-flight surface, token endpoint with authorization_code/refresh_token grants), request-capturing with per-test behavior levers, following the MockLlmProxy/McpToolFixture conventions.
- **Class A suite** `src/suites/mcpserver-oauth.conformance.test.ts` (24 tests): initiate guards and both arms (DCR: discovery → registration → PKCE S256 auth URL, scope fallback, pre-flight 400 rejection copy incl. provider detail, fails-open on non-400; vendor: approval-gate refusal copy for PENDING/REJECTED × oauth_only, custom scope parameter), Layer-1 input guards for the other handshake RPCs, grant-free reads, and the three org-OAuth-app UNIMPLEMENTED pins.
- **Class B suite** `src/suites-execution/mcpserver-connect.conformance.test.ts` (20 tests): the engine-backed handshake half (complete happy paths with the PKCE chain proven end-to-end — S256(code_verifier) == code_challenge — single-use state atomicity, secret-channel pins Basic vs POST, managed-environment lifecycle, grant-health boundaries via the mock's expires_in lever, disconnect teardown) plus connect/startConnect (fixture discovery, approval persistence both ways, deterministic-workflow-ID attach proven at the wire, refresh-on-connect pre-flight incl. the pinned failing-refresh re-authenticate copy).
- **Capability-matrix addendum** (owner-ratified at the plan gate): 12th flag `orgOAuthAppConfiguration` — false on all local targets (cutover gate unaffected), true on cloud, gating the UNIMPLEMENTED pins (the versionTagging/channelMessaging posture).
- **Harness deltas**: `STIGMER_OAUTH_REDIRECT_URI` (fixed dummy, exported constant) in the conformance server boot env — both editions read the same env var; a `holdRequests()`/`releaseHolds()` lever on McpToolFixture (the MockLlmProxy delayMs convention) making the startConnect CONNECTING window observable; `makeOAuthMcpServer` support builder and additive `makeOAuthApp` options.

## Implementation notes

- **Suite split (ratified DB-1, amended in execution)**: initiate lanes are genuinely Temporal-free and live in Class A; the handshake-COMPLETION lanes turned out to need the engine after all — `completeOAuthConnect` requires the managed environment service, which `server.go` builds only inside the Temporal-gated `SetConnectDependencies` (despite the "not gated by Temporal" comment). Those lanes run in Class B. The wiring artifact is disclosed, deliberately NOT pinned (recorded in the sub-project's wrong-assumptions).
- **Classifier scripting**: connect's tool classification calls the LLM through the proxy; the suite scripts one structured-output turn per first connect, pinning approval persistence both ways (gated verdict surfaces in `tool_approvals`; ungated verdict is dropped — presence means gated). The LLM-outage fail-closed fallback stays covered by runner unit tests.
- **Cloud posture (ratified)**: both suites are excluded from the nightly cloud configs with rationale comments — the hermetic launcher does not yet pass `STIGMER_OAUTH_REDIRECT_URI` to the JAR, and the Java edition's unset-redirect copy is already known to diverge (it names `stigmer.oauth.redirect-uri`). Zero new nightly reds; cloud enablement is an owner-gated follow-up.

## Bugs found by writing this suite

- stigmer/stigmer#862 — reconnect re-classifies unchanged tools: the content-addressed carry-forward signature is defeated by structpb JSON key ordering. The re-connect test pins the wire-stable contract and documents the tightening to apply when fixed.
- stigmer/stigmer#863 — grant health claims TOKEN_EXPIRED_REFRESHABLE without a refresh token (TOKEN_EXPIRED is unreachable through the real flow), and the connect pre-flight silently skips the impossible refresh instead of surfacing the re-authenticate error. Both pinned as current behavior with flip-when-fixed comments.

## Not wire-assertable (dispositioned at the plan gate)

Pending-state 10-minute TTL expiry (double-consume IS asserted; expiry stays in Go unit tests), the 420s sync DEADLINE_EXCEEDED lane, `failure_code` persistence for codes not cheaply provokable, and the runner's "requires OAuth" 401-classification passthrough (needs a 401 mode on McpToolFixture; disclosed follow-up).

## Test plan

- `make test-conformance`: 28 files, 492 passed (468 baseline + the 24 new), 1 pre-existing skip — regression-free.
- `make test-conformance-execution`: full roster; the 20 new tests green (13.5s); one pre-existing agentexecution test flaked under full-roster load and passes 38/38 in isolation.
- `tsc --noEmit`: no new errors (two pre-existing failures in memory/agentexecution suites verified identical on main).

## Risks

- Coordination with in-flight #18/#20: the new `CapabilityFlags` member must be added to the `local-ts-execution` target class whichever PR merges second; `server-process.ts`/`mcp-server.ts` are shared harness files with small additive changes here.
- The classifier scripting couples to LangChain's default structured-output tool name ("extract"); if that ever changes, affected tests degrade to the slow outage-fallback path and one assertion flags it loudly.

## Checklist

- [x] Tests added
- [x] Backward compatible (suite-only; no production code)
- [x] Cloud nightly unaffected (deliberate excludes with rationale)

Made with [Cursor](https://cursor.com)