### PR TITLE
feat(backend/stigmer-server-ts): port the workflowexecution domain (D4 #20)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -289,6 +289,21 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       // agentexecution seam above.
       engineState: () => WORKFLOW_EXECUTION_ENGINE_DISCONNECTED,
       broker: workflowExecutionStreamBroker,
+      workflowInstanceCreator: () =>
+        requireInProcess().workflowExecutionInstanceCreator,
+      approvalForwarder: () =>
+        requireInProcess().workflowExecutionApprovalForwarder,
+      fileDecisionForwarder: () =>
+        requireInProcess().workflowExecutionFileDecisionForwarder,
+      executionContextBuilder: {
+        store,
+        logger,
+        workflowInstanceLoader: () =>
+          requireInProcess().workflowExecutionInstanceLoader,
+        environmentResolution,
+        executionContextCreator: () =>
+          requireInProcess().workflowExecutionContextCreator,
+      },
     });
   };
   inProcess = createInProcessClients(routes, logger);

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -46,6 +46,8 @@ import {
 import { ModelRegistryStore } from "../domain/workflow/registry/model-registry-store.js";
 import { InProcessValidator } from "../domain/workflow/validation/validator.js";
 import { registerWorkflowInstanceServices } from "../domain/workflowinstance/controller.js";
+import { registerWorkflowExecutionServices } from "../domain/workflowexecution/controller.js";
+import { ENGINE_DISCONNECTED as WORKFLOW_EXECUTION_ENGINE_DISCONNECTED } from "../domain/workflowexecution/engine.js";
 import { HealthState, registerHealthService } from "../transport/health.js";
 import { createRegistryLanes } from "../transport/registry/lanes.js";
 import { createUnifiedPortServer } from "../transport/server.js";
@@ -266,6 +268,14 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       store,
       logger,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
+    });
+    registerWorkflowExecutionServices(router, {
+      store,
+      logger,
+      // Permanently disconnected until #21 lands the workflow-execution
+      // orchestrator on #18's worker infra; same provider shape as the
+      // agentexecution seam above.
+      engineState: () => WORKFLOW_EXECUTION_ENGINE_DISCONNECTED,
     });
   };
   inProcess = createInProcessClients(routes, logger);

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -48,6 +48,7 @@ import { InProcessValidator } from "../domain/workflow/validation/validator.js";
 import { registerWorkflowInstanceServices } from "../domain/workflowinstance/controller.js";
 import { registerWorkflowExecutionServices } from "../domain/workflowexecution/controller.js";
 import { ENGINE_DISCONNECTED as WORKFLOW_EXECUTION_ENGINE_DISCONNECTED } from "../domain/workflowexecution/engine.js";
+import { StreamBroker as WorkflowExecutionStreamBroker } from "../domain/workflowexecution/stream-broker.js";
 import { HealthState, registerHealthService } from "../transport/health.js";
 import { createRegistryLanes } from "../transport/registry/lanes.js";
 import { createUnifiedPortServer } from "../transport/server.js";
@@ -73,6 +74,12 @@ export interface ComposedServer {
    * UpdateStatus is the production writer.
    */
   agentExecutionStreamBroker: StreamBroker;
+  /**
+   * The workflowexecution broadcast fabric (exposed for tests and, with
+   * #21, its Temporal worker's broadcasts — Go's GetStreamBroker).
+   * UpdateStatus and the lifecycle RPCs are the production writers.
+   */
+  workflowExecutionStreamBroker: WorkflowExecutionStreamBroker;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
   start(): Promise<number>;
   /** NOT_SERVING first, stop background work, drain connections. */
@@ -158,6 +165,11 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // status through the in-process client, and those broadcasts must reach
   // externally-connected subscribe streams (Go's GetStreamBroker seam).
   const agentExecutionStreamBroker = new StreamBroker(logger);
+  // The workflowexecution twin (domain-local per that sub-project's
+  // DD-002); #21's activities broadcast through it the same way.
+  const workflowExecutionStreamBroker = new WorkflowExecutionStreamBroker(
+    logger,
+  );
   // The artifact blob store (Go server.go 349: shared by agentexecution
   // attachments now, the artifact domain + skill push later). Construction
   // boot-fails on ARTIFACT_STORAGE_TYPE=r2 (the ratified #13 deferral);
@@ -276,6 +288,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       // orchestrator on #18's worker infra; same provider shape as the
       // agentexecution seam above.
       engineState: () => WORKFLOW_EXECUTION_ENGINE_DISCONNECTED,
+      broker: workflowExecutionStreamBroker,
     });
   };
   inProcess = createInProcessClients(routes, logger);
@@ -293,6 +306,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     store,
     runnerAuthService,
     agentExecutionStreamBroker,
+    workflowExecutionStreamBroker,
 
     async start(): Promise<number> {
       // Artifact storage must be reachable and writable before the server

--- a/backend/services/stigmer-server-ts/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server-ts/src/boot/inprocess.ts
@@ -32,6 +32,9 @@ import { SessionIdSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/i
 import { WorkflowQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/query_pb";
 import { WorkflowIdSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/io_pb";
 import { WorkflowInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/command_pb";
+import { WorkflowInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/query_pb";
+import { WorkflowInstanceIdSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/io_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
 
 import type { AgentInstanceApplier } from "../domain/agent/steps.js";
 import type { ParentAgentLoader } from "../domain/agentinstance/steps.js";
@@ -49,6 +52,13 @@ import type {
 import type { ManagedEnvironmentClient } from "../domain/mcpserver/oauth/managed-env.js";
 import type { AgentInstanceCreator } from "../domain/session/steps.js";
 import type { WorkflowInstanceCreator } from "../domain/workflow/steps.js";
+import type { ExecutionWorkflowInstanceCreator } from "../domain/workflowexecution/create-steps.js";
+import type {
+  ExecutionWorkflowInstanceLoader,
+  WorkflowExecutionContextCreator,
+} from "../domain/workflowexecution/create-execution-context-step.js";
+import type { AgentExecutionApprovalForwarder } from "../domain/workflowexecution/submit-approval.js";
+import type { AgentExecutionFileDecisionForwarder } from "../domain/workflowexecution/submit-file-decision.js";
 import type { ParentWorkflowLoader } from "../domain/workflowinstance/steps.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import type { Logger } from "./logger.js";
@@ -76,6 +86,14 @@ export interface InProcessClients {
   readonly executionEnvironmentReader: EnvironmentReader &
     ManagedEnvironmentClient;
   readonly executionContextCreator: ExecutionContextCreator;
+  // The workflowexecution edges (server.go 636–642: the controller's
+  // workflowinstance/executioncontext clients and the two HITL forwarding
+  // interfaces satisfied by the agentexecution controller).
+  readonly workflowExecutionInstanceCreator: ExecutionWorkflowInstanceCreator;
+  readonly workflowExecutionInstanceLoader: ExecutionWorkflowInstanceLoader;
+  readonly workflowExecutionContextCreator: WorkflowExecutionContextCreator;
+  readonly workflowExecutionApprovalForwarder: AgentExecutionApprovalForwarder;
+  readonly workflowExecutionFileDecisionForwarder: AgentExecutionFileDecisionForwarder;
 }
 
 /**
@@ -115,7 +133,15 @@ export function createInProcessClients(
     WorkflowInstanceCommandController,
     transport,
   );
+  const workflowInstanceQuery = createClient(
+    WorkflowInstanceQueryController,
+    transport,
+  );
   const workflowQuery = createClient(WorkflowQueryController, transport);
+  const agentExecutionCommand = createClient(
+    AgentExecutionCommandController,
+    transport,
+  );
 
   return {
     // Go's ApplyAsSystem is the Apply RPC with no extra identity attached:
@@ -179,6 +205,32 @@ export function createInProcessClients(
     },
     executionContextCreator: {
       create: (ec) => executionContextCommand.create(ec),
+    },
+    // The workflowexecution edges. CreateAsSystem semantics per the
+    // workflow edge above: create under the process-global operator
+    // identity (default-instance self-heal must surface duplicate slugs
+    // as AlreadyExists).
+    workflowExecutionInstanceCreator: {
+      createAsSystem: (instance) => workflowInstanceCommand.create(instance),
+    },
+    workflowExecutionInstanceLoader: {
+      get: (instanceId) =>
+        workflowInstanceQuery.get(
+          create(WorkflowInstanceIdSchema, { value: instanceId }),
+        ),
+    },
+    workflowExecutionContextCreator: {
+      create: (ec) => executionContextCommand.create(ec),
+    },
+    // The two HITL forwarding edges — Go's method-segregated
+    // AgentExecutionApprovalClient / AgentExecutionFileDecisionClient,
+    // both satisfied by the in-process agentexecution controller.
+    workflowExecutionApprovalForwarder: {
+      submitApproval: (input) => agentExecutionCommand.submitApproval(input),
+    },
+    workflowExecutionFileDecisionForwarder: {
+      submitFileDecision: (input) =>
+        agentExecutionCommand.submitFileDecision(input),
     },
   };
 }

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/create-steps.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Pins the create-pipeline steps against Go case-for-case:
+ * pin_workflow_version_step_test.go (direct id, instance-only resolution,
+ * the graceful skips), normalize_workflow_ref_step_test.go (resolve from
+ * instance, no-op when set, graceful skips), the default-instance
+ * resolution paths of create.go (status id, slug self-heal + status
+ * backfill, create + backfill), and StartWorkflow's failure posture
+ * (execution marked FAILED with the error text and persisted —
+ * recoverable via Recover).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+
+import {
+  newCreateDefaultInstanceIfNeededStep,
+  newStartWorkflowStep,
+  newValidateWorkflowOrInstanceStep,
+} from "../create-steps.js";
+import { newNormalizeWorkflowRefStep } from "../normalize-workflow-ref-step.js";
+import { newPinWorkflowVersionStep } from "../pin-workflow-version-step.js";
+import { stubConnectedEngine } from "./engine-stub.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: SqliteStore;
+let counter = 0;
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "wfexec-create-steps-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function executionCtx(
+  init: MessageInitShape<typeof WorkflowExecutionSchema>,
+): RequestContext<typeof WorkflowExecutionSchema> {
+  return new RequestContext(
+    WorkflowExecutionSchema,
+    create(WorkflowExecutionSchema, init),
+    ApiResourceKind.workflow_execution,
+  );
+}
+
+async function seedWorkflow(overrides?: {
+  versionHash?: string;
+  defaultInstanceId?: string;
+  slug?: string;
+}): Promise<string> {
+  counter += 1;
+  const id = `wf_cs_${counter}`;
+  const slug = overrides?.slug ?? `flow-${counter}`;
+  await store.saveResource(
+    ApiResourceKind.workflow,
+    id,
+    WorkflowSchema,
+    create(WorkflowSchema, {
+      metadata: { id, name: slug, slug, org: "acme" },
+      status: {
+        versionHash: overrides?.versionHash ?? "",
+        defaultInstanceId: overrides?.defaultInstanceId ?? "",
+      },
+    }),
+  );
+  return id;
+}
+
+async function seedInstance(workflowId: string, slug: string): Promise<string> {
+  counter += 1;
+  const id = `wfi_cs_${counter}`;
+  await store.saveResource(
+    ApiResourceKind.workflow_instance,
+    id,
+    WorkflowInstanceSchema,
+    create(WorkflowInstanceSchema, {
+      metadata: { id, name: slug, slug, org: "acme" },
+      spec: { workflowId },
+    }),
+  );
+  return id;
+}
+
+describe("ValidateWorkflowOrInstance (the #196 InvalidArgument contrast)", () => {
+  it("refuses when neither reference is provided", () => {
+    const ctx = executionCtx({ metadata: { name: "x" }, spec: {} });
+    try {
+      newValidateWorkflowOrInstanceStep().execute(ctx);
+      expect.unreachable("expected InvalidArgument");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectError);
+      expect((error as ConnectError).code).toBe(Code.InvalidArgument);
+      expect((error as ConnectError).rawMessage).toBe(
+        "either workflow_id or workflow_instance_id must be provided",
+      );
+    }
+  });
+
+  it("passes with either reference", () => {
+    newValidateWorkflowOrInstanceStep().execute(
+      executionCtx({ spec: { workflowId: "wf_x" } }),
+    );
+    newValidateWorkflowOrInstanceStep().execute(
+      executionCtx({ spec: { workflowInstanceId: "wfi_x" } }),
+    );
+  });
+});
+
+describe("CreateDefaultInstanceIfNeeded (create.go resolution paths)", () => {
+  function stepDeps(created?: WorkflowInstance) {
+    const calls: WorkflowInstance[] = [];
+    return {
+      calls,
+      deps: {
+        store,
+        logger: silentLogger,
+        workflowInstanceCreator: () => ({
+          createAsSystem: async (instance: WorkflowInstance) => {
+            calls.push(instance);
+            return (
+              created ??
+              create(WorkflowInstanceSchema, {
+                metadata: { id: "wfi_created", name: "n", slug: "s" },
+              })
+            );
+          },
+        }),
+      },
+    };
+  }
+
+  it("skips when workflow_instance_id is provided", async () => {
+    const { deps, calls } = stepDeps();
+    const ctx = executionCtx({ spec: { workflowInstanceId: "wfi_given" } });
+    await newCreateDefaultInstanceIfNeededStep(deps).execute(ctx);
+    expect(calls).toHaveLength(0);
+    expect(ctx.newState.spec?.workflowInstanceId).toBe("wfi_given");
+  });
+
+  it("unknown workflow answers NotFound", async () => {
+    const { deps } = stepDeps();
+    const ctx = executionCtx({ spec: { workflowId: "wf_missing" } });
+    try {
+      await newCreateDefaultInstanceIfNeededStep(deps).execute(ctx);
+      expect.unreachable("expected NotFound");
+    } catch (error) {
+      expect((error as ConnectError).code).toBe(Code.NotFound);
+      expect((error as ConnectError).rawMessage).toBe(
+        "Workflow not found: wf_missing",
+      );
+    }
+  });
+
+  it("uses status.default_instance_id when set", async () => {
+    const workflowId = await seedWorkflow({ defaultInstanceId: "wfi_status" });
+    const { deps, calls } = stepDeps();
+    const ctx = executionCtx({ spec: { workflowId } });
+    await newCreateDefaultInstanceIfNeededStep(deps).execute(ctx);
+    expect(ctx.newState.spec?.workflowInstanceId).toBe("wfi_status");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("self-heals from the deterministic slug and backfills the workflow status", async () => {
+    const workflowId = await seedWorkflow({ slug: "healme" });
+    const instanceId = await seedInstance(workflowId, "healme-default");
+    const { deps, calls } = stepDeps();
+    const ctx = executionCtx({ spec: { workflowId } });
+    await newCreateDefaultInstanceIfNeededStep(deps).execute(ctx);
+    expect(ctx.newState.spec?.workflowInstanceId).toBe(instanceId);
+    expect(calls, "no create when the instance already exists").toHaveLength(0);
+
+    const workflow = await store.getResource(
+      ApiResourceKind.workflow,
+      workflowId,
+      WorkflowSchema,
+    );
+    expect(
+      workflow.status?.defaultInstanceId,
+      "the failed status write is healed",
+    ).toBe(instanceId);
+  });
+
+  it("creates the instance via the in-process edge and backfills", async () => {
+    const workflowId = await seedWorkflow({ slug: "fresh" });
+    const { deps, calls } = stepDeps();
+    const ctx = executionCtx({ spec: { workflowId } });
+    await newCreateDefaultInstanceIfNeededStep(deps).execute(ctx);
+    expect(calls).toHaveLength(1);
+    expect(ctx.newState.spec?.workflowInstanceId).toBe("wfi_created");
+    const workflow = await store.getResource(
+      ApiResourceKind.workflow,
+      workflowId,
+      WorkflowSchema,
+    );
+    expect(workflow.status?.defaultInstanceId).toBe("wfi_created");
+  });
+
+  it("a failing in-process create surfaces the inner code (goWrappedStatusError)", async () => {
+    const workflowId = await seedWorkflow({ slug: "collide" });
+    const deps = {
+      store,
+      logger: silentLogger,
+      workflowInstanceCreator: () => ({
+        createAsSystem: () =>
+          Promise.reject(
+            new ConnectError("slug already exists", Code.AlreadyExists),
+          ),
+      }),
+    };
+    const ctx = executionCtx({ spec: { workflowId } });
+    try {
+      await newCreateDefaultInstanceIfNeededStep(deps).execute(ctx);
+      expect.unreachable("expected AlreadyExists");
+    } catch (error) {
+      // The %w-wrapped inner code survives to the wire (oss#852 pattern).
+      expect((error as ConnectError).code).toBe(Code.AlreadyExists);
+      expect((error as ConnectError).rawMessage).toContain(
+        "failed to create default workflow instance",
+      );
+    }
+  });
+});
+
+describe("NormalizeWorkflowRef (normalize_workflow_ref_step_test.go)", () => {
+  it("resolves workflow_id from the instance", async () => {
+    const workflowId = await seedWorkflow();
+    const instanceId = await seedInstance(workflowId, `ref-${counter}`);
+    const ctx = executionCtx({ spec: { workflowInstanceId: instanceId } });
+    await newNormalizeWorkflowRefStep(store, silentLogger).execute(ctx);
+    expect(ctx.newState.spec?.workflowId).toBe(workflowId);
+  });
+
+  it("no-ops when workflow_id is already set", async () => {
+    const ctx = executionCtx({
+      spec: { workflowId: "wf_set", workflowInstanceId: "wfi_ignored" },
+    });
+    await newNormalizeWorkflowRefStep(store, silentLogger).execute(ctx);
+    expect(ctx.newState.spec?.workflowId).toBe("wf_set");
+  });
+
+  it("gracefully skips a missing instance id and a failed instance load", async () => {
+    const noInstance = executionCtx({ spec: {} });
+    await newNormalizeWorkflowRefStep(store, silentLogger).execute(noInstance);
+    expect(noInstance.newState.spec?.workflowId).toBe("");
+
+    const badInstance = executionCtx({
+      spec: { workflowInstanceId: "wfi_missing" },
+    });
+    await newNormalizeWorkflowRefStep(store, silentLogger).execute(badInstance);
+    expect(badInstance.newState.spec?.workflowId).toBe("");
+  });
+});
+
+describe("PinWorkflowVersion (pin_workflow_version_step_test.go)", () => {
+  it("pins from a direct workflow_id", async () => {
+    const workflowId = await seedWorkflow({ versionHash: "h".repeat(64) });
+    const ctx = executionCtx({ spec: { workflowId } });
+    await newPinWorkflowVersionStep(store, silentLogger).execute(ctx);
+    expect(ctx.newState.status?.workflowVersionHash).toBe("h".repeat(64));
+  });
+
+  it("resolves through the instance when only instance is set", async () => {
+    const workflowId = await seedWorkflow({ versionHash: "i".repeat(64) });
+    const instanceId = await seedInstance(workflowId, `pin-${counter}`);
+    const ctx = executionCtx({ spec: { workflowInstanceId: instanceId } });
+    await newPinWorkflowVersionStep(store, silentLogger).execute(ctx);
+    expect(ctx.newState.status?.workflowVersionHash).toBe("i".repeat(64));
+  });
+
+  it("skips when nothing is resolvable, on load failure, and on empty hash", async () => {
+    const noId = executionCtx({ spec: {} });
+    await newPinWorkflowVersionStep(store, silentLogger).execute(noId);
+    expect(noId.newState.status?.workflowVersionHash ?? "").toBe("");
+
+    const missing = executionCtx({ spec: { workflowId: "wf_missing" } });
+    await newPinWorkflowVersionStep(store, silentLogger).execute(missing);
+    expect(missing.newState.status?.workflowVersionHash ?? "").toBe("");
+
+    const noHash = executionCtx({
+      spec: { workflowId: await seedWorkflow({ versionHash: "" }) },
+    });
+    await newPinWorkflowVersionStep(store, silentLogger).execute(noHash);
+    expect(noHash.newState.status?.workflowVersionHash ?? "").toBe("");
+  });
+});
+
+describe("StartWorkflow failure posture (create.go startWorkflowStep)", () => {
+  it("marks the execution FAILED with the error text, persists, and answers Internal", async () => {
+    counter += 1;
+    const executionId = `wfx_start_${counter}`;
+    // The step runs post-persist: seed the record first, like the
+    // pipeline's Persist step just did.
+    const execution: WorkflowExecution = create(WorkflowExecutionSchema, {
+      metadata: { id: executionId, name: executionId, org: "acme" },
+      spec: { workflowId: "wf_x", workflowInstanceId: "wfi_x" },
+      status: { phase: ExecutionPhase.EXECUTION_PENDING },
+    });
+    await store.saveResource(
+      ApiResourceKind.workflow_execution,
+      executionId,
+      WorkflowExecutionSchema,
+      execution,
+    );
+
+    const engine = stubConnectedEngine();
+    engine.failures.startInvokeWorkflow = new Error("queue unreachable");
+    const ctx = new RequestContext(
+      WorkflowExecutionSchema,
+      execution,
+      ApiResourceKind.workflow_execution,
+    );
+    const step = newStartWorkflowStep({
+      store,
+      logger: silentLogger,
+      engineState: () => engine.state,
+    });
+    try {
+      await step.execute(ctx);
+      expect.unreachable("expected Internal");
+    } catch (error) {
+      expect((error as ConnectError).code).toBe(Code.Internal);
+      expect((error as ConnectError).rawMessage).toBe(
+        "failed to start workflow",
+      );
+    }
+    const stored = await store.getResource(
+      ApiResourceKind.workflow_execution,
+      executionId,
+      WorkflowExecutionSchema,
+    );
+    expect(stored.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
+    expect(stored.status?.error).toBe(
+      "Failed to start Temporal workflow: queue unreachable",
+    );
+  });
+
+  it("passes the slim input with recovery_mode false on success", async () => {
+    const engine = stubConnectedEngine();
+    const ctx = executionCtx({
+      metadata: { id: "wfx_ok", name: "wfx_ok", org: "acme" },
+      spec: { workflowId: "wf_x", workflowInstanceId: "wfi_x" },
+    });
+    await newStartWorkflowStep({
+      store,
+      logger: silentLogger,
+      engineState: () => engine.state,
+    }).execute(ctx);
+    expect(engine.calls).toHaveLength(1);
+    expect(engine.calls[0].args[0]).toMatchObject({
+      executionId: "wfx_ok",
+      workflowId: "wf_x",
+      workflowInstanceId: "wfi_x",
+      orgId: "acme",
+      recoveryMode: false,
+    });
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/engine-stub.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/engine-stub.ts
@@ -1,0 +1,64 @@
+/**
+ * A recording stub of the connected workflow-execution engine for unit
+ * tests — the #21 implementation's test double. Records every call and
+ * throws the configured error per operation (EngineWorkflowNotFoundError
+ * for the warn-and-proceed arms, plain errors for the Internal arms).
+ */
+import type { JsonValue } from "@bufbuild/protobuf";
+
+import type {
+  ConnectedWorkflowExecutionEngine,
+  StartWorkflowExecutionInput,
+  WorkflowExecutionEngineState,
+} from "../engine.js";
+
+export interface EngineCall {
+  readonly method: string;
+  readonly args: unknown[];
+}
+
+export interface EngineStub {
+  readonly engine: ConnectedWorkflowExecutionEngine;
+  readonly state: WorkflowExecutionEngineState;
+  readonly calls: EngineCall[];
+  failures: Partial<Record<keyof ConnectedWorkflowExecutionEngine, Error>>;
+}
+
+export function stubConnectedEngine(): EngineStub {
+  const calls: EngineCall[] = [];
+  const failures: EngineStub["failures"] = {};
+
+  async function record(method: keyof ConnectedWorkflowExecutionEngine, args: unknown[]): Promise<void> {
+    calls.push({ method, args });
+    const failure = failures[method];
+    if (failure !== undefined) {
+      throw failure;
+    }
+  }
+
+  const engine: ConnectedWorkflowExecutionEngine = {
+    startInvokeWorkflow: (input: StartWorkflowExecutionInput) =>
+      record("startInvokeWorkflow", [input]),
+    signalWithStart: (
+      input: StartWorkflowExecutionInput,
+      signalName: string,
+      payload: JsonValue,
+    ) => record("signalWithStart", [input, signalName, payload]),
+    signalWorkflow: (
+      workflowId: string,
+      signalName: string,
+      payload: JsonValue | undefined,
+    ) => record("signalWorkflow", [workflowId, signalName, payload]),
+    cancelWorkflow: (workflowId: string) =>
+      record("cancelWorkflow", [workflowId]),
+    terminateWorkflow: (workflowId: string, reason: string) =>
+      record("terminateWorkflow", [workflowId, reason]),
+  };
+
+  return {
+    engine,
+    state: { connected: true, engine },
+    calls,
+    failures,
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/execution-filter.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/execution-filter.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Pins the list filter/sort helpers against Go's execution_filter_test.go
+ * case-for-case (11 cases), plus TS-side edges Go covers implicitly
+ * through its type system: the strict RFC3339 gate (Go time.Parse rejects
+ * date-only strings; naive Date.parse would accept them), the legacy
+ * phase fallback, the descending comparator's tie stability, and the
+ * camelCase retry key.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { timestampFromMs } from "@bufbuild/protobuf/wkt";
+import { describe, expect, it } from "vitest";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowTaskSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import {
+  ExecutionPhase,
+  WorkflowTaskStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import {
+  ExecutionFilterCriteriaSchema,
+  ExecutionSortField,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+import {
+  applyFilterCriteria,
+  applyLegacyPhaseFilter,
+  applySortField,
+  executionDurationMs,
+  extractRetryCountFromMetadata,
+  parseRfc3339Ms,
+} from "../execution-filter.js";
+
+type TaskInit = MessageInitShape<typeof WorkflowTaskSchema>;
+
+function makeExec(
+  id: string,
+  phase: ExecutionPhase,
+  startedAt: string,
+  completedAt: string,
+  costMicros: bigint,
+  tasks: TaskInit[] = [],
+): WorkflowExecution {
+  return create(WorkflowExecutionSchema, {
+    metadata: { id },
+    status: {
+      phase,
+      startedAt,
+      completedAt,
+      totalCostMicros: costMicros,
+      tasks,
+    },
+  });
+}
+
+function ids(executions: WorkflowExecution[]): string[] {
+  return executions.map((execution) => execution.metadata?.id ?? "");
+}
+
+describe("applyFilterCriteria (execution_filter_test.go case-for-case)", () => {
+  it("nil filter passes everything through", () => {
+    const execs = [
+      makeExec("a", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n),
+    ];
+    expect(applyFilterCriteria(execs, undefined)).toHaveLength(1);
+  });
+
+  it("single phase filter", () => {
+    const execs = [
+      makeExec("completed", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n),
+      makeExec("failed", ExecutionPhase.EXECUTION_FAILED, "", "", 0n),
+      makeExec("running", ExecutionPhase.EXECUTION_IN_PROGRESS, "", "", 0n),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      phases: [ExecutionPhase.EXECUTION_FAILED],
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["failed"]);
+  });
+
+  it("multiple phases filter", () => {
+    const execs = [
+      makeExec("completed", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n),
+      makeExec("failed", ExecutionPhase.EXECUTION_FAILED, "", "", 0n),
+      makeExec("running", ExecutionPhase.EXECUTION_IN_PROGRESS, "", "", 0n),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      phases: [
+        ExecutionPhase.EXECUTION_COMPLETED,
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ],
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual([
+      "completed",
+      "running",
+    ]);
+  });
+
+  it("startedAfter excludes earlier starts and unparseable starts", () => {
+    const execs = [
+      makeExec(
+        "old",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-20T10:00:00Z",
+        "2026-05-20T10:01:00Z",
+        0n,
+      ),
+      makeExec(
+        "new",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:01:00Z",
+        0n,
+      ),
+      makeExec("no-start", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      startedAfter: timestampFromMs(Date.parse("2026-05-22T00:00:00Z")),
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["new"]);
+  });
+
+  it("duration range excludes over-max and incomplete executions", () => {
+    const execs = [
+      makeExec(
+        "fast",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:00:05Z",
+        0n,
+      ),
+      makeExec(
+        "slow",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:05:00Z",
+        0n,
+      ),
+      makeExec(
+        "running",
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        "2026-05-23T10:00:00Z",
+        "",
+        0n,
+      ),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      maxDuration: { seconds: 60n, nanos: 0 },
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["fast"]);
+  });
+
+  it("min cost excludes cheaper executions", () => {
+    const execs = [
+      makeExec("cheap", ExecutionPhase.EXECUTION_COMPLETED, "", "", 10_000n),
+      makeExec(
+        "expensive",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "",
+        "",
+        500_000n,
+      ),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      minCostMicros: 100_000n,
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["expensive"]);
+  });
+
+  it("failedTaskName matches only failed tasks with that exact name", () => {
+    const execs = [
+      makeExec("a", ExecutionPhase.EXECUTION_FAILED, "", "", 0n, [
+        {
+          taskName: "validate",
+          status: WorkflowTaskStatus.WORKFLOW_TASK_FAILED,
+        },
+      ]),
+      makeExec("b", ExecutionPhase.EXECUTION_FAILED, "", "", 0n, [
+        {
+          taskName: "send_email",
+          status: WorkflowTaskStatus.WORKFLOW_TASK_FAILED,
+        },
+      ]),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      failedTaskName: "validate",
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["a"]);
+  });
+
+  it("hasRetries keeps only executions with a retried task", () => {
+    const execs = [
+      makeExec("retried", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n, [
+        {
+          taskName: "flaky",
+          status: WorkflowTaskStatus.WORKFLOW_TASK_COMPLETED,
+          metadata: { retry_count: 3 },
+        },
+      ]),
+      makeExec("clean", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n, [
+        {
+          taskName: "stable",
+          status: WorkflowTaskStatus.WORKFLOW_TASK_COMPLETED,
+        },
+      ]),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, { hasRetries: true });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["retried"]);
+  });
+
+  it("combined filters apply AND logic", () => {
+    const failedValidate: TaskInit[] = [
+      { taskName: "validate", status: WorkflowTaskStatus.WORKFLOW_TASK_FAILED },
+    ];
+    const execs = [
+      makeExec(
+        "match",
+        ExecutionPhase.EXECUTION_FAILED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:01:00Z",
+        200_000n,
+        failedValidate,
+      ),
+      makeExec(
+        "wrong-phase",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:01:00Z",
+        200_000n,
+      ),
+      makeExec(
+        "wrong-cost",
+        ExecutionPhase.EXECUTION_FAILED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:01:00Z",
+        10n,
+        failedValidate,
+      ),
+    ];
+    const filter = create(ExecutionFilterCriteriaSchema, {
+      phases: [ExecutionPhase.EXECUTION_FAILED],
+      minCostMicros: 100_000n,
+      failedTaskName: "validate",
+    });
+    expect(ids(applyFilterCriteria(execs, filter))).toEqual(["match"]);
+  });
+});
+
+describe("applySortField (execution_filter_test.go case-for-case)", () => {
+  it("sorts by started_at both directions", () => {
+    const execs = [
+      makeExec("b", ExecutionPhase.EXECUTION_COMPLETED, "2026-05-23T12:00:00Z", "", 0n),
+      makeExec("a", ExecutionPhase.EXECUTION_COMPLETED, "2026-05-23T10:00:00Z", "", 0n),
+      makeExec("c", ExecutionPhase.EXECUTION_COMPLETED, "2026-05-23T14:00:00Z", "", 0n),
+    ];
+    applySortField(execs, ExecutionSortField.STARTED_AT, true);
+    expect(ids(execs)).toEqual(["a", "b", "c"]);
+    applySortField(execs, ExecutionSortField.STARTED_AT, false);
+    expect(ids(execs)).toEqual(["c", "b", "a"]);
+  });
+
+  it("sorts by cost ascending", () => {
+    const execs = [
+      makeExec("mid", ExecutionPhase.EXECUTION_COMPLETED, "", "", 200_000n),
+      makeExec("low", ExecutionPhase.EXECUTION_COMPLETED, "", "", 50_000n),
+      makeExec("high", ExecutionPhase.EXECUTION_COMPLETED, "", "", 500_000n),
+    ];
+    applySortField(execs, ExecutionSortField.COST, true);
+    expect(ids(execs)).toEqual(["low", "mid", "high"]);
+  });
+
+  it("sorts by duration with incomplete executions tied at -1 first", () => {
+    const execs = [
+      makeExec(
+        "long",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:10:00Z",
+        0n,
+      ),
+      makeExec("incomplete-1", ExecutionPhase.EXECUTION_IN_PROGRESS, "2026-05-23T10:00:00Z", "", 0n),
+      makeExec(
+        "short",
+        ExecutionPhase.EXECUTION_COMPLETED,
+        "2026-05-23T10:00:00Z",
+        "2026-05-23T10:00:01Z",
+        0n,
+      ),
+      makeExec("incomplete-2", ExecutionPhase.EXECUTION_IN_PROGRESS, "", "", 0n),
+    ];
+    applySortField(execs, ExecutionSortField.DURATION, true);
+    // -1 duration ties keep scan order (stable sort; Go SliceStable).
+    expect(ids(execs)).toEqual([
+      "incomplete-1",
+      "incomplete-2",
+      "short",
+      "long",
+    ]);
+  });
+
+  it("sorts by status (phase enum value) and keeps ties stable descending", () => {
+    const execs = [
+      makeExec("failed-1", ExecutionPhase.EXECUTION_FAILED, "", "", 0n),
+      makeExec("pending", ExecutionPhase.EXECUTION_PENDING, "", "", 0n),
+      makeExec("failed-2", ExecutionPhase.EXECUTION_FAILED, "", "", 0n),
+    ];
+    applySortField(execs, ExecutionSortField.STATUS, false);
+    // Descending is Go's strictly-greater-first: FAILED(4) > PENDING(1);
+    // the two FAILED entries tie and keep their scan order.
+    expect(ids(execs)).toEqual(["failed-1", "failed-2", "pending"]);
+  });
+
+  it("unparseable started_at sorts like Go's zero time (before real instants)", () => {
+    const execs = [
+      makeExec("real", ExecutionPhase.EXECUTION_COMPLETED, "2026-05-23T10:00:00Z", "", 0n),
+      makeExec("empty", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n),
+    ];
+    applySortField(execs, ExecutionSortField.STARTED_AT, true);
+    expect(ids(execs)).toEqual(["empty", "real"]);
+  });
+});
+
+describe("legacy phase filter and helpers", () => {
+  it("applyLegacyPhaseFilter is a no-op for UNSPECIFIED", () => {
+    const execs = [
+      makeExec("a", ExecutionPhase.EXECUTION_COMPLETED, "", "", 0n),
+      makeExec("b", ExecutionPhase.EXECUTION_FAILED, "", "", 0n),
+    ];
+    expect(
+      applyLegacyPhaseFilter(execs, ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED),
+    ).toHaveLength(2);
+    expect(
+      ids(applyLegacyPhaseFilter(execs, ExecutionPhase.EXECUTION_FAILED)),
+    ).toEqual(["b"]);
+  });
+
+  it("extractRetryCountFromMetadata reads both key spellings and rejects non-numbers", () => {
+    const snake = create(WorkflowExecutionSchema, {
+      status: { tasks: [{ metadata: { retry_count: 2 } }] },
+    });
+    const camel = create(WorkflowExecutionSchema, {
+      status: { tasks: [{ metadata: { retryCount: 1 } }] },
+    });
+    const stringValue = create(WorkflowExecutionSchema, {
+      status: { tasks: [{ metadata: { retry_count: "3" } }] },
+    });
+    expect(
+      extractRetryCountFromMetadata(snake.status!.tasks[0]),
+    ).toBe(2);
+    expect(extractRetryCountFromMetadata(camel.status!.tasks[0])).toBe(1);
+    // Go GetNumberValue answers 0 for non-number kinds.
+    expect(
+      extractRetryCountFromMetadata(stringValue.status!.tasks[0]),
+    ).toBe(0);
+  });
+
+  it("parseRfc3339Ms enforces Go time.Parse strictness", () => {
+    expect(parseRfc3339Ms("2026-05-23T10:00:00Z")).toBe(
+      Date.parse("2026-05-23T10:00:00Z"),
+    );
+    expect(parseRfc3339Ms("2026-05-23T10:00:00.123456789+05:30")).toBe(
+      Date.parse("2026-05-23T10:00:00.123456789+05:30"),
+    );
+    // Go rejects all of these (zero time); a bare Date.parse would accept
+    // the first two.
+    expect(parseRfc3339Ms("2026-05-23")).toBeNaN();
+    expect(parseRfc3339Ms("2026-05-23T10:00:00")).toBeNaN();
+    expect(parseRfc3339Ms("")).toBeNaN();
+    expect(parseRfc3339Ms("not a time")).toBeNaN();
+  });
+
+  it("executionDurationMs answers -1 without both timestamps", () => {
+    expect(
+      executionDurationMs(
+        makeExec("x", ExecutionPhase.EXECUTION_IN_PROGRESS, "2026-05-23T10:00:00Z", "", 0n),
+      ),
+    ).toBe(-1);
+    expect(
+      executionDurationMs(
+        makeExec(
+          "y",
+          ExecutionPhase.EXECUTION_COMPLETED,
+          "2026-05-23T10:00:00Z",
+          "2026-05-23T10:00:05Z",
+          0n,
+        ),
+      ),
+    ).toBe(5000);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/lifecycle.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Pins the five lifecycle RPCs against Go's lifecycle_test.go and
+ * terminate_existing_workflow_step_test.go case-for-case: the phase
+ * matrices with their byte-pinned FailedPrecondition copy, idempotent
+ * target-phase no-ops, the engineless postures, the connected-engine call
+ * shapes over the byte-pinned workflow IDs, the workflow-not-found
+ * warn-and-proceed arms, terminate's reason/error quirk, and recover's
+ * full choreography (terminate both tree members, EC recreate
+ * degrade-gracefully, fresh start with recovery_mode, error clear).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import {
+  CancelWorkflowExecutionInputSchema,
+  PauseWorkflowExecutionInputSchema,
+  RecoverWorkflowExecutionInputSchema,
+  ResumeWorkflowExecutionInputSchema,
+  TerminateWorkflowExecutionInputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+
+import {
+  childWorkflowId,
+  orchestratorWorkflowId,
+  TEMPORAL_UNAVAILABLE_CREATOR_MESSAGE,
+  TEMPORAL_UNAVAILABLE_MESSAGE,
+} from "../constants.js";
+import type { WorkflowExecutionContextBuilderDeps } from "../create-execution-context-step.js";
+import { ENGINE_DISCONNECTED, EngineWorkflowNotFoundError } from "../engine.js";
+import type { LifecycleDeps } from "../lifecycle.js";
+import {
+  applyLifecyclePhaseTransition,
+  cancelExecution,
+  pauseExecution,
+  recoverExecution,
+  resumeExecution,
+  terminateExecution,
+} from "../lifecycle.js";
+import { StreamBroker } from "../stream-broker.js";
+import { stubConnectedEngine } from "./engine-stub.js";
+import type { EngineStub } from "./engine-stub.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: SqliteStore;
+let broker: StreamBroker;
+let counter = 0;
+
+// Input builders — real proto messages (RequestContext clones through the
+// schema, so plain object literals are not acceptable).
+type IdReason = { id: string; reason?: string };
+const cancelInput = (init: IdReason) =>
+  create(CancelWorkflowExecutionInputSchema, init);
+const terminateInput = (init: IdReason) =>
+  create(TerminateWorkflowExecutionInputSchema, init);
+const pauseInput = (init: IdReason) =>
+  create(PauseWorkflowExecutionInputSchema, init);
+const resumeInput = (init: IdReason) =>
+  create(ResumeWorkflowExecutionInputSchema, init);
+const recoverInput = (init: IdReason) =>
+  create(RecoverWorkflowExecutionInputSchema, init);
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "wfexec-lifecycle-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+  broker = new StreamBroker(silentLogger);
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** The EC-builder deps recover consumes; the loaders throw NotFound-ish
+ * errors by default, exercising the degrade-gracefully arms. */
+function builderDeps(): WorkflowExecutionContextBuilderDeps {
+  return {
+    store,
+    logger: silentLogger,
+    workflowInstanceLoader: () => ({
+      get: () =>
+        Promise.reject(
+          new ConnectError("workflow_instance not found", Code.NotFound),
+        ),
+    }),
+    environmentResolution: {
+      resolveByReference: () =>
+        Promise.reject(new Error("no environments in this test")),
+    } as unknown as WorkflowExecutionContextBuilderDeps["environmentResolution"],
+    executionContextCreator: () => ({
+      create: () => Promise.reject(new Error("unused in this test")),
+    }),
+  };
+}
+
+function deps(engineStub?: EngineStub): LifecycleDeps {
+  return {
+    store,
+    logger: silentLogger,
+    broker,
+    engineState: () => engineStub?.state ?? ENGINE_DISCONNECTED,
+    executionContextBuilder: builderDeps(),
+  };
+}
+
+async function seed(
+  phase: ExecutionPhase,
+  overrides?: MessageInitShape<typeof WorkflowExecutionSchema>["status"],
+): Promise<string> {
+  counter += 1;
+  const id = `wfx_lc_${counter}`;
+  await store.saveResource(
+    ApiResourceKind.workflow_execution,
+    id,
+    WorkflowExecutionSchema,
+    create(WorkflowExecutionSchema, {
+      metadata: { id, name: id, org: "acme" },
+      spec: { workflowId: `wf_${counter}`, workflowInstanceId: `wfi_${counter}` },
+      status: { phase, ...overrides },
+    }),
+  );
+  return id;
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(code);
+    return error as ConnectError;
+  }
+  throw new Error(`expected ${Code[code]}, call succeeded`);
+}
+
+describe("shared load + validation arms (lifecycle_test.go)", () => {
+  it("empty id refuses InvalidArgument; unknown id NotFound", async () => {
+    const err = await expectCode(
+      () => cancelExecution(deps(), cancelInput({ id: "" })),
+      Code.InvalidArgument,
+    );
+    expect(err.rawMessage).toBe("execution id is required");
+    const missing = await expectCode(
+      () => cancelExecution(deps(), cancelInput({ id: "wfx_missing" })),
+      Code.NotFound,
+    );
+    expect(missing.rawMessage).toBe("workflow_execution not found: wfx_missing");
+  });
+
+  it("phase validators refuse with the pinned copy", async () => {
+    const completed = await seed(ExecutionPhase.EXECUTION_COMPLETED);
+    const cancelErr = await expectCode(
+      () => cancelExecution(deps(), cancelInput({ id: completed })),
+      Code.FailedPrecondition,
+    );
+    expect(cancelErr.rawMessage).toBe(
+      "cannot cancel execution in phase EXECUTION_COMPLETED; only PENDING, IN_PROGRESS, or PAUSED can be cancelled",
+    );
+
+    const terminateErr = await expectCode(
+      () => terminateExecution(deps(), terminateInput({ id: completed })),
+      Code.FailedPrecondition,
+    );
+    expect(terminateErr.rawMessage).toBe(
+      "cannot terminate execution in phase EXECUTION_COMPLETED; only PENDING, IN_PROGRESS, or PAUSED can be terminated",
+    );
+
+    const paused = await seed(ExecutionPhase.EXECUTION_PAUSED);
+    const pauseErr = await expectCode(
+      () => pauseExecution(deps(), pauseInput({ id: completed })),
+      Code.FailedPrecondition,
+    );
+    expect(pauseErr.rawMessage).toBe(
+      "cannot pause execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be paused",
+    );
+
+    const resumeErr = await expectCode(
+      () => resumeExecution(deps(), resumeInput({ id: completed })),
+      Code.FailedPrecondition,
+    );
+    expect(resumeErr.rawMessage).toBe(
+      "cannot resume execution in phase EXECUTION_COMPLETED; only PAUSED executions can be resumed",
+    );
+    // PAUSED is resumable — engineless it fails at the ENGINE, not the
+    // validator (proving validator pass-through).
+    const engineErr = await expectCode(
+      () => resumeExecution(deps(), resumeInput({ id: paused })),
+      Code.FailedPrecondition,
+    );
+    expect(engineErr.rawMessage).toBe(TEMPORAL_UNAVAILABLE_MESSAGE);
+
+    const recoverErr = await expectCode(
+      () => recoverExecution(deps(), recoverInput({ id: completed })),
+      Code.FailedPrecondition,
+    );
+    expect(recoverErr.rawMessage).toBe(
+      "cannot recover execution in phase EXECUTION_COMPLETED; only FAILED executions can be recovered",
+    );
+  });
+
+  it("target-phase idempotency succeeds without touching the engine", async () => {
+    const cancelled = await seed(ExecutionPhase.EXECUTION_CANCELLED);
+    const result = await cancelExecution(deps(), cancelInput({ id: cancelled }));
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+
+    const terminated = await seed(ExecutionPhase.EXECUTION_TERMINATED);
+    await terminateExecution(deps(), terminateInput({ id: terminated }));
+
+    const inProgress = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    await resumeExecution(deps(), resumeInput({ id: inProgress }));
+    await recoverExecution(deps(), recoverInput({ id: inProgress }));
+
+    const paused = await seed(ExecutionPhase.EXECUTION_PAUSED);
+    await pauseExecution(deps(), pauseInput({ id: paused }));
+  });
+
+  it("engineless postures: FailedPrecondition per pinned copy", async () => {
+    const running = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const englessOps = [
+      () => cancelExecution(deps(), cancelInput({ id: running })),
+      () => terminateExecution(deps(), terminateInput({ id: running })),
+      () => pauseExecution(deps(), pauseInput({ id: running })),
+    ];
+    for (const op of englessOps) {
+      const err = await expectCode(op, Code.FailedPrecondition);
+      expect(err.rawMessage).toBe(TEMPORAL_UNAVAILABLE_MESSAGE);
+    }
+    // Recover's first engine touch is the terminate-existing step.
+    const failed = await seed(ExecutionPhase.EXECUTION_FAILED);
+    const recoverErr = await expectCode(
+      () => recoverExecution(deps(), recoverInput({ id: failed })),
+      Code.FailedPrecondition,
+    );
+    expect(recoverErr.rawMessage).toBe(TEMPORAL_UNAVAILABLE_MESSAGE);
+  });
+});
+
+describe("connected-engine transitions", () => {
+  let engine: EngineStub;
+  beforeEach(() => {
+    engine = stubConnectedEngine();
+  });
+
+  it("cancel: CancelWorkflow on the orchestrator id, CANCELLED persisted with completed_at", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const result = await cancelExecution(deps(engine), cancelInput({ id }));
+
+    expect(engine.calls).toEqual([
+      { method: "cancelWorkflow", args: [orchestratorWorkflowId(id)] },
+    ]);
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+    expect(result.status?.completedAt).not.toBe("");
+    // Go time.RFC3339: seconds precision, no fractional part.
+    expect(result.status?.completedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+    );
+    // Cancel writes NO error (quiet terminal, #282).
+    expect(result.status?.error).toBe("");
+  });
+
+  it("workflow-not-found on the engine is warn-and-proceed (local state still transitions)", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    engine.failures.cancelWorkflow = new EngineWorkflowNotFoundError(
+      orchestratorWorkflowId(id),
+    );
+    const result = await cancelExecution(deps(engine), cancelInput({ id }));
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+  });
+
+  it("other engine failures answer Internal with the pinned message", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    engine.failures.cancelWorkflow = new Error("temporal exploded");
+    const err = await expectCode(
+      () => cancelExecution(deps(engine), cancelInput({ id })),
+      Code.Internal,
+    );
+    expect(err.rawMessage).toBe("failed to cancel Temporal workflow");
+  });
+
+  it("terminate: reason default + 'Terminated: {reason}' error copy", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const result = await terminateExecution(deps(engine), terminateInput({ id,
+      reason: "stuck", }));
+    expect(engine.calls).toEqual([
+      {
+        method: "terminateWorkflow",
+        args: [orchestratorWorkflowId(id), "stuck"],
+      },
+    ]);
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_TERMINATED);
+    expect(result.status?.error).toBe("Terminated: stuck");
+
+    const defaulted = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const result2 = await terminateExecution(deps(engine), terminateInput({ id: defaulted, }));
+    expect(result2.status?.error).toBe("Terminated: Terminated by user");
+  });
+
+  it("terminate quirk: workflow-gone termination falls back to 'Terminated by user'", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    engine.failures.terminateWorkflow = new EngineWorkflowNotFoundError(
+      orchestratorWorkflowId(id),
+    );
+    // Go's NotFound arm returns before ReasonKey is recorded — even an
+    // explicit reason is lost and the default copy applies.
+    const result = await terminateExecution(deps(engine), terminateInput({ id,
+      reason: "explicit reason", }));
+    expect(result.status?.error).toBe("Terminated by user");
+  });
+
+  it("pause/resume: the byte-pinned signal names with the reason payload", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const paused = await pauseExecution(deps(engine), pauseInput({ id }));
+    expect(paused.status?.phase).toBe(ExecutionPhase.EXECUTION_PAUSED);
+    // PAUSED is not terminal — completed_at stays empty.
+    expect(paused.status?.completedAt).toBe("");
+
+    const resumed = await resumeExecution(deps(engine), resumeInput({ id }));
+    expect(resumed.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+
+    expect(engine.calls).toEqual([
+      {
+        method: "signalWorkflow",
+        args: [orchestratorWorkflowId(id), "pause", "Paused by user"],
+      },
+      {
+        method: "signalWorkflow",
+        args: [orchestratorWorkflowId(id), "resume", undefined],
+      },
+    ]);
+  });
+
+  it("recover: terminates BOTH tree members, starts fresh with recovery_mode, clears error", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_FAILED, {
+      error: "boom",
+      completedAt: "2026-05-23T10:00:00Z",
+    });
+    const result = await recoverExecution(deps(engine), recoverInput({ id }));
+
+    expect(engine.calls[0]).toEqual({
+      method: "terminateWorkflow",
+      args: [
+        orchestratorWorkflowId(id),
+        "Recovery: terminating before fresh workflow start",
+      ],
+    });
+    expect(engine.calls[1]).toEqual({
+      method: "terminateWorkflow",
+      args: [
+        childWorkflowId(id),
+        "Recovery: terminating before fresh workflow start",
+      ],
+    });
+    expect(engine.calls[2]?.method).toBe("startInvokeWorkflow");
+    const startInput = engine.calls[2]?.args[0] as { recoveryMode: boolean };
+    expect(startInput.recoveryMode).toBe(true);
+
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(result.status?.error, "recover clears the error").toBe("");
+    expect(result.status?.completedAt, "back to IN_PROGRESS clears completed_at").toBe("");
+  });
+
+  it("recover: NOT_FOUND on either tree member is tolerated; orchestrator failure short-circuits the child", async () => {
+    const tolerated = await seed(ExecutionPhase.EXECUTION_FAILED);
+    engine.failures.terminateWorkflow = new EngineWorkflowNotFoundError("x");
+    const result = await recoverExecution(deps(engine), recoverInput({ id: tolerated, }));
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+
+    const failing = await seed(ExecutionPhase.EXECUTION_FAILED);
+    const hardFail = stubConnectedEngine();
+    hardFail.failures.terminateWorkflow = new Error("terminate exploded");
+    const err = await expectCode(
+      () => recoverExecution(deps(hardFail), recoverInput({ id: failing })),
+      Code.Internal,
+    );
+    expect(err.rawMessage).toBe(
+      "failed to terminate orchestrator workflow during recovery",
+    );
+    // The child terminate never ran (short-circuit).
+    expect(
+      hardFail.calls.filter((c) => c.method === "terminateWorkflow"),
+    ).toHaveLength(1);
+  });
+
+  it("recover: a fresh-start failure leaves the execution FAILED (user can retry)", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_FAILED, { error: "boom" });
+    engine.failures.startInvokeWorkflow = new Error("start exploded");
+    const err = await expectCode(
+      () => recoverExecution(deps(engine), recoverInput({ id })),
+      Code.Internal,
+    );
+    expect(err.rawMessage).toBe(
+      "failed to start fresh Temporal workflow for recovered execution",
+    );
+    const stored = await store.getResource(
+      ApiResourceKind.workflow_execution,
+      id,
+      WorkflowExecutionSchema,
+    );
+    expect(stored.status?.phase, "phase update never ran").toBe(
+      ExecutionPhase.EXECUTION_FAILED,
+    );
+    expect(stored.status?.error).toBe("boom");
+  });
+
+  it("lifecycle transitions broadcast the persisted state", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const subscription = broker.subscribe(id);
+    try {
+      await cancelExecution(deps(engine), cancelInput({ id }));
+      expect(subscription.queue).toHaveLength(1);
+      expect(subscription.queue[0].status?.phase).toBe(
+        ExecutionPhase.EXECUTION_CANCELLED,
+      );
+    } finally {
+      broker.unsubscribe(id, subscription);
+    }
+  });
+});
+
+describe("applyLifecyclePhaseTransition (the RMW body, exercised directly)", () => {
+  it("initializes a missing status and applies the terminal fields", () => {
+    const execution = create(WorkflowExecutionSchema, {
+      metadata: { id: "wfx_direct" },
+    });
+    applyLifecyclePhaseTransition(
+      execution,
+      ExecutionPhase.EXECUTION_TERMINATED,
+      true,
+      false,
+      "why",
+    );
+    expect(execution.status?.phase).toBe(ExecutionPhase.EXECUTION_TERMINATED);
+    expect(execution.status?.error).toBe("Terminated: why");
+    expect(execution.status?.completedAt).not.toBe("");
+  });
+});
+
+describe("recover engineless posture (fresh-start message)", () => {
+  it("start-fresh's creator-specific copy is distinct", async () => {
+    // Reach StartFreshWorkflow with a connected-then-broken engine is not
+    // possible through one provider — instead pin the constant here so a
+    // rename breaks loudly (the Class B suite asserts the wire arm once
+    // #21 wires a real engine).
+    expect(TEMPORAL_UNAVAILABLE_CREATOR_MESSAGE).toBe(
+      "Temporal is not available (workflow creator not set)",
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/send-signal.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/send-signal.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Pins sendSignal against Go's send_signal_test.go and
+ * send_signal_dedupe_test.go case-for-case: the validation and phase
+ * arms, the relay-envelope construction on the byte-pinned relaySignal
+ * channel, and the two-phase dedupe contract (oss#442) — ALREADY_EXISTS
+ * on a DELIVERED duplicate, ABORTED on a live in-flight claim,
+ * release-after-failure enabling an immediate retry, empty-key and
+ * store-error skips, and org-scoped key isolation.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { SendSignalInputSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type { SendSignalInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+
+import { WORKFLOW_CREATOR_UNAVAILABLE_MESSAGE } from "../constants.js";
+import { ENGINE_DISCONNECTED } from "../engine.js";
+import { sendSignal } from "../send-signal.js";
+import type { SendSignalDeps } from "../send-signal.js";
+import { stubConnectedEngine } from "./engine-stub.js";
+import type { EngineStub } from "./engine-stub.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let store: SqliteStore;
+let counter = 0;
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "wfexec-signal-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function deps(engineStub?: EngineStub): SendSignalDeps {
+  return {
+    store,
+    logger: silentLogger,
+    engineState: () => engineStub?.state ?? ENGINE_DISCONNECTED,
+  };
+}
+
+async function seed(phase: ExecutionPhase, org = "acme"): Promise<string> {
+  counter += 1;
+  const id = `wfx_sig_${counter}`;
+  await store.saveResource(
+    ApiResourceKind.workflow_execution,
+    id,
+    WorkflowExecutionSchema,
+    create(WorkflowExecutionSchema, {
+      metadata: { id, name: id, org },
+      spec: { workflowId: `wf_${counter}`, workflowInstanceId: `wfi_${counter}` },
+      status: { phase },
+    }),
+  );
+  return id;
+}
+
+function input(
+  executionId: string,
+  signalName = "user_event",
+  idempotencyKey = "",
+): SendSignalInput {
+  return create(SendSignalInputSchema, {
+    executionId,
+    signalName,
+    idempotencyKey,
+    payload: { hello: "world" },
+  });
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(code);
+    return error as ConnectError;
+  }
+  throw new Error(`expected ${Code[code]}, call succeeded`);
+}
+
+describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
+  it("requires execution_id and signal_name", async () => {
+    const missing = await expectCode(
+      () => sendSignal(deps(), input("", "sig")),
+      Code.InvalidArgument,
+    );
+    expect(missing.rawMessage).toBe("execution_id is required");
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const noName = await expectCode(
+      () => sendSignal(deps(), input(id, "")),
+      Code.InvalidArgument,
+    );
+    expect(noName.rawMessage).toBe("signal_name is required");
+  });
+
+  it("unknown execution answers NotFound", async () => {
+    const err = await expectCode(
+      () => sendSignal(deps(), input("wfx_missing")),
+      Code.NotFound,
+    );
+    expect(err.rawMessage).toBe("workflow_execution not found: wfx_missing");
+  });
+
+  it("terminal phases refuse FailedPrecondition with the pinned copy", async () => {
+    const completed = await seed(ExecutionPhase.EXECUTION_COMPLETED);
+    const err = await expectCode(
+      () => sendSignal(deps(), input(completed)),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(
+      "cannot send signal to execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS executions can receive signals",
+    );
+  });
+
+  it("engineless send refuses FailedPrecondition with the creator copy", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const err = await expectCode(
+      () => sendSignal(deps(), input(id)),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(WORKFLOW_CREATOR_UNAVAILABLE_MESSAGE);
+  });
+
+  it("delivers the relay envelope on the relaySignal channel (PENDING is signalable)", async () => {
+    const engine = stubConnectedEngine();
+    const id = await seed(ExecutionPhase.EXECUTION_PENDING);
+    const result = await sendSignal(deps(engine), input(id, "order_arrived"));
+    expect(result.metadata?.id).toBe(id);
+
+    expect(engine.calls).toHaveLength(1);
+    const [startInput, signalName, payload] = engine.calls[0].args as [
+      { executionId: string; recoveryMode: boolean },
+      string,
+      unknown,
+    ];
+    expect(startInput.executionId).toBe(id);
+    expect(signalName).toBe("relaySignal");
+    // The envelope's JSON shape is the runner's wire contract.
+    expect(payload).toEqual({
+      signalName: "order_arrived",
+      payload: { hello: "world" },
+    });
+  });
+
+  it("a nil payload rides as null in the envelope (Go interface{} nil)", async () => {
+    const engine = stubConnectedEngine();
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    await sendSignal(
+      deps(engine),
+      create(SendSignalInputSchema, { executionId: id, signalName: "ping" }),
+    );
+    const [, , payload] = engine.calls[0].args as [unknown, string, unknown];
+    expect(payload).toEqual({ signalName: "ping", payload: null });
+  });
+});
+
+describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
+  it("a DELIVERED duplicate answers AlreadyExists with the pinned shape", async () => {
+    const engine = stubConnectedEngine();
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    await sendSignal(deps(engine), input(id, "sig", "key-delivered"));
+
+    const err = await expectCode(
+      () => sendSignal(deps(engine), input(id, "sig", "key-delivered")),
+      Code.AlreadyExists,
+    );
+    expect(err.rawMessage).toBe(
+      "signal_with_idempotency_key already exists: key-delivered",
+    );
+    // The successful send delivered exactly once.
+    expect(
+      engine.calls.filter((call) => call.method === "signalWithStart"),
+    ).toHaveLength(1);
+  });
+
+  it("a live in-flight claim answers Aborted (retryable conflict)", async () => {
+    const engine = stubConnectedEngine();
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    // Claim the key directly (a concurrent request's live hold).
+    await store.signalDedupe.claim("acme", "key-inflight", id, "sig", 300_000);
+
+    const err = await expectCode(
+      () => sendSignal(deps(engine), input(id, "sig", "key-inflight")),
+      Code.Aborted,
+    );
+    expect(err.rawMessage).toBe(
+      'signal with idempotency_key "key-inflight" is currently being delivered; retry shortly',
+    );
+  });
+
+  it("a failed send releases the claim so the retry claims freshly", async () => {
+    const engine = stubConnectedEngine();
+    engine.failures.signalWithStart = new Error("temporal exploded");
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+
+    const err = await expectCode(
+      () => sendSignal(deps(engine), input(id, "sig", "key-retry")),
+      Code.Internal,
+    );
+    expect(err.rawMessage).toBe("failed to send signal to workflow");
+
+    // The retry with the same key must claim freshly and deliver.
+    const healthy = stubConnectedEngine();
+    await sendSignal(deps(healthy), input(id, "sig", "key-retry"));
+    expect(
+      healthy.calls.filter((call) => call.method === "signalWithStart"),
+    ).toHaveLength(1);
+  });
+
+  it("no idempotency key skips dedupe entirely (backward compatible)", async () => {
+    const engine = stubConnectedEngine();
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    await sendSignal(deps(engine), input(id, "sig", ""));
+    await sendSignal(deps(engine), input(id, "sig", ""));
+    expect(
+      engine.calls.filter((call) => call.method === "signalWithStart"),
+    ).toHaveLength(2);
+  });
+
+  it("distinct keys do not collide; keys are org-scoped", async () => {
+    const engine = stubConnectedEngine();
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    await sendSignal(deps(engine), input(id, "sig", "key-a"));
+    await sendSignal(deps(engine), input(id, "sig", "key-b"));
+
+    // The same key under ANOTHER org claims independently ({org}:{key}).
+    const otherOrg = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS, "beta");
+    await sendSignal(deps(engine), input(otherOrg, "sig", "key-a"));
+
+    expect(
+      engine.calls.filter((call) => call.method === "signalWithStart"),
+    ).toHaveLength(3);
+  });
+
+  it("engineless failure after a claim also releases it (the send step is the failure)", async () => {
+    const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    await expectCode(
+      () => sendSignal(deps(), input(id, "sig", "key-engineless")),
+      Code.FailedPrecondition,
+    );
+    // The claim was released: a healthy retry delivers instead of Aborted.
+    const healthy = stubConnectedEngine();
+    await sendSignal(deps(healthy), input(id, "sig", "key-engineless"));
+    expect(
+      healthy.calls.filter((call) => call.method === "signalWithStart"),
+    ).toHaveLength(1);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/stream-broker.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/stream-broker.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Pins the StreamBroker delivery semantics against Go stream_broker.go:
+ * per-execution fan-out, the non-blocking bounded buffer (drop at
+ * capacity, catch up on the next frame), idempotent unsubscribe with the
+ * closed flag + notify wake, and the missing-metadata no-op.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  StreamBroker,
+  SUBSCRIBER_BUFFER_CAPACITY,
+} from "../stream-broker.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+function frame(id: string, phase = ExecutionPhase.EXECUTION_IN_PROGRESS): WorkflowExecution {
+  return create(WorkflowExecutionSchema, {
+    metadata: { id, name: id },
+    status: { phase },
+  });
+}
+
+describe("StreamBroker (stream_broker.go semantics)", () => {
+  it("fans out to every subscriber of the execution, and only that execution", () => {
+    const broker = new StreamBroker(silentLogger);
+    const a1 = broker.subscribe("wfx_a");
+    const a2 = broker.subscribe("wfx_a");
+    const b = broker.subscribe("wfx_b");
+
+    broker.broadcast(frame("wfx_a"));
+
+    expect(a1.queue).toHaveLength(1);
+    expect(a2.queue).toHaveLength(1);
+    expect(b.queue).toHaveLength(0);
+    expect(broker.getSubscriberCount("wfx_a")).toBe(2);
+  });
+
+  it("notify fires once per push and is cleared after", () => {
+    const broker = new StreamBroker(silentLogger);
+    const subscription = broker.subscribe("wfx_notify");
+    let woken = 0;
+    subscription.notify = () => {
+      woken += 1;
+    };
+    broker.broadcast(frame("wfx_notify"));
+    expect(woken).toBe(1);
+    expect(subscription.notify, "notify is one-shot").toBeUndefined();
+  });
+
+  it("drops the frame for a subscriber at buffer capacity (non-blocking send)", () => {
+    const broker = new StreamBroker(silentLogger);
+    const full = broker.subscribe("wfx_full");
+    const healthy = broker.subscribe("wfx_full");
+    for (let i = 0; i < SUBSCRIBER_BUFFER_CAPACITY; i++) {
+      full.queue.push(frame("wfx_full"));
+    }
+
+    broker.broadcast(frame("wfx_full", ExecutionPhase.EXECUTION_COMPLETED));
+
+    expect(full.queue, "full buffer drops THIS frame").toHaveLength(
+      SUBSCRIBER_BUFFER_CAPACITY,
+    );
+    expect(healthy.queue, "healthy sibling still receives").toHaveLength(1);
+  });
+
+  it("unsubscribe closes, wakes a parked consumer, and is idempotent", () => {
+    const broker = new StreamBroker(silentLogger);
+    const subscription = broker.subscribe("wfx_close");
+    let woken = false;
+    subscription.notify = () => {
+      woken = true;
+    };
+
+    broker.unsubscribe("wfx_close", subscription);
+    expect(subscription.closed).toBe(true);
+    expect(woken, "a parked consumer observes the close").toBe(true);
+    expect(broker.getSubscriberCount("wfx_close")).toBe(0);
+
+    // Idempotent (Go's missing-channel early return).
+    broker.unsubscribe("wfx_close", subscription);
+    expect(broker.getSubscriberCount("wfx_close")).toBe(0);
+  });
+
+  it("a broadcast without metadata id is a no-op", () => {
+    const broker = new StreamBroker(silentLogger);
+    const subscription = broker.subscribe("");
+    broker.broadcast(create(WorkflowExecutionSchema, {}));
+    expect(subscription.queue).toHaveLength(0);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/subscribe.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/subscribe.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins the subscribe generator against Go subscribe_test.go case-for-case:
+ * the register-before-snapshot gap fix (a broadcast fired at the exact
+ * instant of the snapshot read must still be delivered) and the
+ * consecutive-duplicate suppression (the at-or-before-snapshot overlap
+ * frame is dropped; a distinct terminal frame still arrives). Plus the
+ * terminal-set quirk twins: a terminal BROADCAST closes the stream, a
+ * TERMINATED broadcast does not (the disclosed Go omission).
+ */
+import { clone, create } from "@bufbuild/protobuf";
+import type { HandlerContext } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { SubscribeWorkflowExecutionRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import type { Store } from "../../../store/interface.js";
+
+import { StreamBroker } from "../stream-broker.js";
+import { isWorkflowTerminalPhase, subscribeExecution } from "../subscribe.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+function execWithPhase(id: string, phase: ExecutionPhase): WorkflowExecution {
+  return create(WorkflowExecutionSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "WorkflowExecution",
+    metadata: { id, name: id },
+    status: { phase },
+  });
+}
+
+/**
+ * A store whose getResource answers the seeded snapshot and fires a
+ * one-shot hook at the START of the read — the seam that injects a
+ * broadcast "in the gap" (Go getHookStore). subscribeExecution consumes
+ * only getResource.
+ */
+function hookedSnapshotStore(
+  snapshot: WorkflowExecution,
+  onGet?: () => void,
+): Store {
+  let fired = false;
+  return {
+    async getResource() {
+      if (!fired && onGet !== undefined) {
+        fired = true;
+        onGet();
+      }
+      return clone(WorkflowExecutionSchema, snapshot);
+    },
+  } as unknown as Store;
+}
+
+function handlerContext(signal: AbortSignal): HandlerContext {
+  return { signal } as HandlerContext;
+}
+
+/**
+ * Runs the generator to completion under a watchdog (Go runSubscribe): if
+ * a regression reintroduces the gap, the post-gap terminal frame is
+ * dropped, the loop parks forever, and the watchdog aborts so the test
+ * fails fast instead of hanging.
+ */
+async function collectFrames(
+  generator: AsyncGenerator<WorkflowExecution>,
+  abortController: AbortController,
+): Promise<WorkflowExecution[]> {
+  const frames: WorkflowExecution[] = [];
+  const watchdog = setTimeout(() => abortController.abort(), 5000);
+  watchdog.unref();
+  try {
+    for await (const frame of generator) {
+      frames.push(frame);
+    }
+  } finally {
+    clearTimeout(watchdog);
+  }
+  if (abortController.signal.aborted) {
+    throw new Error(
+      "subscribe did not reach a terminal phase in time — the post-gap broadcast was likely dropped (register-before-snapshot regression)",
+    );
+  }
+  return frames;
+}
+
+describe("subscribe (subscribe_test.go case-for-case)", () => {
+  it("delivers an update broadcast during the snapshot read (the gap fix)", async () => {
+    const broker = new StreamBroker(silentLogger);
+    const id = "wfx-gap";
+    const older = execWithPhase(id, ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const newer = execWithPhase(id, ExecutionPhase.EXECUTION_COMPLETED);
+
+    // Fire the post-gap broadcast at the instant the snapshot is read.
+    const store = hookedSnapshotStore(older, () => broker.broadcast(newer));
+    const abortController = new AbortController();
+
+    const frames = await collectFrames(
+      subscribeExecution(
+        { store, logger: silentLogger, broker },
+        create(SubscribeWorkflowExecutionRequestSchema, { executionId: id }),
+        handlerContext(abortController.signal),
+      ),
+      abortController,
+    );
+
+    expect(frames).toHaveLength(2);
+    expect(frames[0].status?.phase, "first frame is the snapshot").toBe(
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+    );
+    expect(frames[1].status?.phase, "second frame is the post-gap update").toBe(
+      ExecutionPhase.EXECUTION_COMPLETED,
+    );
+  });
+
+  it("suppresses the overlap duplicate but delivers a distinct terminal frame", async () => {
+    const broker = new StreamBroker(silentLogger);
+    const id = "wfx-dup";
+    const snapshot = execWithPhase(id, ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const overlap = clone(WorkflowExecutionSchema, snapshot);
+    const terminal = execWithPhase(id, ExecutionPhase.EXECUTION_COMPLETED);
+
+    const store = hookedSnapshotStore(snapshot, () => {
+      broker.broadcast(overlap);
+      broker.broadcast(terminal);
+    });
+    const abortController = new AbortController();
+
+    const frames = await collectFrames(
+      subscribeExecution(
+        { store, logger: silentLogger, broker },
+        create(SubscribeWorkflowExecutionRequestSchema, { executionId: id }),
+        handlerContext(abortController.signal),
+      ),
+      abortController,
+    );
+
+    expect(
+      frames,
+      "the overlap duplicate is suppressed; snapshot + terminal remain",
+    ).toHaveLength(2);
+    expect(frames[1].status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+  });
+
+  it("unsubscribes from the broker on every exit path", async () => {
+    const broker = new StreamBroker(silentLogger);
+    const id = "wfx-cleanup";
+    const terminal = execWithPhase(id, ExecutionPhase.EXECUTION_IN_PROGRESS);
+    const store = hookedSnapshotStore(terminal, () =>
+      broker.broadcast(execWithPhase(id, ExecutionPhase.EXECUTION_CANCELLED)),
+    );
+    const abortController = new AbortController();
+    await collectFrames(
+      subscribeExecution(
+        { store, logger: silentLogger, broker },
+        create(SubscribeWorkflowExecutionRequestSchema, { executionId: id }),
+        handlerContext(abortController.signal),
+      ),
+      abortController,
+    );
+    expect(broker.getSubscriberCount(id), "the finally unsubscribed").toBe(0);
+  });
+});
+
+describe("the terminal set (isWorkflowTerminalPhase — the disclosed quirk)", () => {
+  it("closes on COMPLETED/FAILED/CANCELLED only; TERMINATED and PAUSED are absent", () => {
+    expect(isWorkflowTerminalPhase(ExecutionPhase.EXECUTION_COMPLETED)).toBe(true);
+    expect(isWorkflowTerminalPhase(ExecutionPhase.EXECUTION_FAILED)).toBe(true);
+    expect(isWorkflowTerminalPhase(ExecutionPhase.EXECUTION_CANCELLED)).toBe(true);
+    // The faithful-ported Go omission: a stream over a TERMINATED
+    // execution never self-closes (disclosed, both-editions candidate).
+    expect(isWorkflowTerminalPhase(ExecutionPhase.EXECUTION_TERMINATED)).toBe(false);
+    expect(isWorkflowTerminalPhase(ExecutionPhase.EXECUTION_PAUSED)).toBe(false);
+    expect(isWorkflowTerminalPhase(ExecutionPhase.EXECUTION_IN_PROGRESS)).toBe(false);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/update-status.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/update-status.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Pins the updateStatus merge engine against Go's update_status_test.go
+ * case-for-case: the flag-gated per-child pending_approvals /
+ * pending_file_reviews merge (the parallel-children no-clobber
+ * regression), mergePendingByChild's pure contract, and the
+ * phase-transition-only statusAudit bump (the recents-ordering contract
+ * shared with the cloud handler).
+ *
+ * Plus the DD-001 mechanism pins Go cannot have (its updateStatus is
+ * load-then-save): updateStatus persists through the store's atomic
+ * updateResource — proven by a counting store (a saveResource write here
+ * would be the lost-update regression) and by a concurrent
+ * different-children race through the REAL sqlite store, where
+ * load-then-save would drop one child's gate.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { clone, create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { timestampFromMs, timestampMs } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { WorkflowExecutionUpdateStatusInputSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type { WorkflowExecutionUpdateStatusInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+
+import { StreamBroker } from "../stream-broker.js";
+import {
+  applyUpdateStatusMerge,
+  mergePendingByChild,
+  updateStatus,
+} from "../update-status.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+function wfApproval(childId: string, toolCallId: string) {
+  return {
+    approval: { toolCallId, toolName: "deploy_code" },
+    childAgentExecutionId: childId,
+  };
+}
+
+function wfFileReview(childId: string, ...changeSetIds: string[]) {
+  return {
+    childAgentExecutionId: childId,
+    changeSetId: changeSetIds,
+  };
+}
+
+/**
+ * Applies the merge to a clone of the existing execution and returns the
+ * merged result (Go executeMerge, over the exported merge body).
+ */
+function executeMerge(
+  existing: WorkflowExecution,
+  inputInit: MessageInitShape<typeof WorkflowExecutionUpdateStatusInputSchema>,
+): WorkflowExecution {
+  const input: WorkflowExecutionUpdateStatusInput = create(
+    WorkflowExecutionUpdateStatusInputSchema,
+    inputInit,
+  );
+  const merged = clone(WorkflowExecutionSchema, existing);
+  applyUpdateStatusMerge(merged, input);
+  return merged;
+}
+
+function makeExecution(
+  statusInit: MessageInitShape<typeof WorkflowExecutionSchema>["status"],
+): WorkflowExecution {
+  return create(WorkflowExecutionSchema, {
+    metadata: { id: "wfx_test", name: "wfx_test" },
+    status: statusInit,
+  });
+}
+
+describe("pending_approvals per-child merge (update_status_test.go)", () => {
+  const makeExisting = () =>
+    makeExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      pendingApprovals: [wfApproval("aex_abc", "tc_123")],
+    });
+
+  it("flag false preserves existing approvals", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      updatePendingApprovals: false,
+    });
+    expect(result.status?.pendingApprovals).toHaveLength(1);
+    expect(result.status?.pendingApprovals[0].approval?.toolCallId).toBe(
+      "tc_123",
+    );
+  });
+
+  it("flag absent preserves existing approvals", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+    });
+    expect(result.status?.pendingApprovals).toHaveLength(1);
+  });
+
+  it("scoped write replaces only that child's approvals", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { pendingApprovals: [wfApproval("aex_abc", "tc_456")] },
+      updatePendingApprovals: true,
+      pendingUpdateChildAgentExecutionId: "aex_abc",
+    });
+    expect(result.status?.pendingApprovals).toHaveLength(1);
+    expect(result.status?.pendingApprovals[0].approval?.toolCallId).toBe(
+      "tc_456",
+    );
+  });
+
+  it("scoped empty list clears only that child", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { pendingApprovals: [] },
+      updatePendingApprovals: true,
+      pendingUpdateChildAgentExecutionId: "aex_abc",
+    });
+    expect(result.status?.pendingApprovals).toHaveLength(0);
+  });
+
+  // The core regression: two parallel children must not clobber each other.
+  it("parallel children not clobbered on set", () => {
+    const existing = makeExecution({
+      pendingApprovals: [wfApproval("aex_A", "tc_A"), wfApproval("aex_B", "tc_B")],
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: { pendingApprovals: [wfApproval("aex_B", "tc_B2")] },
+      updatePendingApprovals: true,
+      pendingUpdateChildAgentExecutionId: "aex_B",
+    });
+    expect(result.status?.pendingApprovals).toHaveLength(2);
+    const byChild = new Map(
+      result.status?.pendingApprovals.map((entry) => [
+        entry.childAgentExecutionId,
+        entry.approval?.toolCallId,
+      ]),
+    );
+    expect(byChild.get("aex_A"), "child A preserved").toBe("tc_A");
+    expect(byChild.get("aex_B"), "child B replaced").toBe("tc_B2");
+  });
+
+  it("scoped clear preserves siblings", () => {
+    const existing = makeExecution({
+      pendingApprovals: [wfApproval("aex_A", "tc_A"), wfApproval("aex_B", "tc_B")],
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: { pendingApprovals: [] },
+      updatePendingApprovals: true,
+      pendingUpdateChildAgentExecutionId: "aex_B",
+    });
+    expect(result.status?.pendingApprovals).toHaveLength(1);
+    expect(result.status?.pendingApprovals[0].childAgentExecutionId).toBe(
+      "aex_A",
+    );
+  });
+
+  it("concurrent event emission does not clobber approvals", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        tasks: [{ taskName: "some_task" }],
+      },
+    });
+    expect(
+      result.status?.pendingApprovals,
+      "event emission must not clear active approvals",
+    ).toHaveLength(1);
+    expect(result.status?.tasks).toHaveLength(1);
+    expect(result.status?.tasks[0].taskName).toBe("some_task");
+  });
+});
+
+describe("pending_file_reviews per-child merge (update_status_test.go)", () => {
+  const makeExisting = () =>
+    makeExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      pendingFileReviews: [wfFileReview("aex_abc", "fcs_1")],
+    });
+
+  it("flag false preserves existing file reviews", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+    });
+    expect(result.status?.pendingFileReviews).toHaveLength(1);
+  });
+
+  it("scoped write replaces only that child's file reviews", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: {
+        pendingFileReviews: [wfFileReview("aex_abc", "fcs_2", "fcs_3")],
+      },
+      updatePendingFileReviews: true,
+      pendingUpdateChildAgentExecutionId: "aex_abc",
+    });
+    expect(result.status?.pendingFileReviews).toHaveLength(1);
+    expect(result.status?.pendingFileReviews[0].changeSetId).toEqual([
+      "fcs_2",
+      "fcs_3",
+    ]);
+  });
+
+  it("parallel children not clobbered", () => {
+    const existing = makeExecution({
+      pendingFileReviews: [
+        wfFileReview("aex_A", "fcs_A"),
+        wfFileReview("aex_B", "fcs_B"),
+      ],
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: { pendingFileReviews: [wfFileReview("aex_B", "fcs_B2")] },
+      updatePendingFileReviews: true,
+      pendingUpdateChildAgentExecutionId: "aex_B",
+    });
+    expect(result.status?.pendingFileReviews).toHaveLength(2);
+  });
+
+  it("scoped empty list clears only that child", () => {
+    const existing = makeExecution({
+      pendingFileReviews: [
+        wfFileReview("aex_A", "fcs_A"),
+        wfFileReview("aex_B", "fcs_B"),
+      ],
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: { pendingFileReviews: [] },
+      updatePendingFileReviews: true,
+      pendingUpdateChildAgentExecutionId: "aex_A",
+    });
+    expect(result.status?.pendingFileReviews).toHaveLength(1);
+    expect(result.status?.pendingFileReviews[0].childAgentExecutionId).toBe(
+      "aex_B",
+    );
+  });
+
+  it("approvals and file reviews are independent", () => {
+    const existing = makeExecution({
+      pendingApprovals: [wfApproval("aex_abc", "tc_1")],
+      pendingFileReviews: [wfFileReview("aex_abc", "fcs_1")],
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: { pendingFileReviews: [] },
+      updatePendingFileReviews: true,
+      pendingUpdateChildAgentExecutionId: "aex_abc",
+    });
+    expect(
+      result.status?.pendingApprovals,
+      "approvals untouched by a file-review-only write",
+    ).toHaveLength(1);
+    expect(result.status?.pendingFileReviews).toHaveLength(0);
+  });
+});
+
+describe("mergePendingByChild (pure contract)", () => {
+  const childOf = (entry: string) => entry;
+
+  it("replaces scoped child, preserves siblings", () => {
+    expect(mergePendingByChild(["A", "B"], ["B"], childOf, "B")).toEqual([
+      "A",
+      "B",
+    ]);
+  });
+  it("empty incoming clears scoped child", () => {
+    expect(mergePendingByChild(["A", "B"], [], childOf, "B")).toEqual(["A"]);
+  });
+  it("adds new child", () => {
+    expect(mergePendingByChild(["A"], ["C"], childOf, "C")).toEqual([
+      "A",
+      "C",
+    ]);
+  });
+  it("empty existing", () => {
+    expect(mergePendingByChild([], ["A"], childOf, "A")).toEqual(["A"]);
+  });
+});
+
+describe("statusAudit bump only on phase transitions (recents-ordering contract)", () => {
+  const initialMs = Date.UTC(2026, 0, 2, 3, 4, 5);
+  const makeExisting = () =>
+    makeExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      audit: {
+        statusAudit: {
+          updatedAt: timestampFromMs(initialMs),
+          event: "created",
+        },
+      },
+    });
+
+  it("heartbeat with the same phase does not bump", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        tasks: [{ taskName: "step-1" }],
+      },
+    });
+    expect(timestampMs(result.status!.audit!.statusAudit!.updatedAt!)).toBe(
+      initialMs,
+    );
+    expect(result.status?.audit?.statusAudit?.event).toBe("created");
+  });
+
+  it("unspecified phase does not bump", () => {
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { tasks: [{ taskName: "step-1" }] },
+    });
+    expect(timestampMs(result.status!.audit!.statusAudit!.updatedAt!)).toBe(
+      initialMs,
+    );
+  });
+
+  it("phase transition bumps with the current time", () => {
+    const beforeMs = Date.now() - 1000;
+    const result = executeMerge(makeExisting(), {
+      executionId: "wfx_test",
+      status: { phase: ExecutionPhase.EXECUTION_COMPLETED },
+    });
+    const bumped = result.status?.audit?.statusAudit?.updatedAt;
+    expect(bumped).toBeDefined();
+    expect(timestampMs(bumped!)).toBeGreaterThan(beforeMs);
+    expect(result.status?.audit?.statusAudit?.event).toBe("updated");
+  });
+
+  it("phase transition initializes a missing audit chain", () => {
+    const existing = makeExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: { phase: ExecutionPhase.EXECUTION_FAILED },
+    });
+    expect(result.status?.audit?.statusAudit?.updatedAt).toBeDefined();
+  });
+});
+
+describe("presence-guarded field merges (BuildNewStateWithStatus)", () => {
+  it("merges only the provided fields; zero counters mean no update", () => {
+    const existing = makeExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      startedAt: "2026-05-23T10:00:00Z",
+      totalCostMicros: 500n,
+      totalInputTokens: 10n,
+      error: "prior error",
+    });
+    const result = executeMerge(existing, {
+      executionId: "wfx_test",
+      status: {
+        completedAt: "2026-05-23T10:05:00Z",
+        totalCostMicros: 900n,
+        // totalInputTokens omitted (0) — must NOT reset to 0.
+        temporalWorkflowId: "stigmer/workflow-execution/invoke/wfx_test",
+      },
+    });
+    const status = result.status!;
+    expect(status.phase, "unspecified phase preserved").toBe(
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+    );
+    expect(status.startedAt, "empty started_at preserved").toBe(
+      "2026-05-23T10:00:00Z",
+    );
+    expect(status.completedAt).toBe("2026-05-23T10:05:00Z");
+    expect(status.totalCostMicros).toBe(900n);
+    expect(status.totalInputTokens, "zero counter is not a reset").toBe(10n);
+    expect(status.error, "empty error preserved").toBe("prior error");
+    expect(status.temporalWorkflowId).toBe(
+      "stigmer/workflow-execution/invoke/wfx_test",
+    );
+  });
+});
+
+describe("updateStatus persistence mechanism (DD-001)", () => {
+  let dir: string;
+  let store: SqliteStore;
+  let broker: StreamBroker;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "wfexec-updatestatus-"));
+    store = SqliteStore.open(path.join(dir, "test.db"));
+    broker = new StreamBroker(silentLogger);
+  });
+
+  afterAll(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function seed(id: string): Promise<void> {
+    await store.saveResource(
+      ApiResourceKind.workflow_execution,
+      id,
+      WorkflowExecutionSchema,
+      create(WorkflowExecutionSchema, {
+        metadata: { id, name: id },
+        status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      }),
+    );
+  }
+
+  it("unknown execution answers NotFound (Go LoadExistingExecution)", async () => {
+    try {
+      await updateStatus(
+        { store, logger: silentLogger, broker },
+        create(WorkflowExecutionUpdateStatusInputSchema, {
+          executionId: "wfx_missing",
+          status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+        }),
+      );
+      expect.unreachable("expected NotFound");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectError);
+      expect((error as ConnectError).code).toBe(Code.NotFound);
+    }
+  });
+
+  it("uses the atomic updateResource, never a load-then-save (mechanism pin)", async () => {
+    const calls = { updateResource: 0, saveResource: 0 };
+    const countingStore = new Proxy(store, {
+      get(target, property, receiver) {
+        if (property === "updateResource") {
+          calls.updateResource += 1;
+        }
+        if (property === "saveResource") {
+          calls.saveResource += 1;
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Store;
+
+    await seed("wfx_mechanism");
+    await updateStatus(
+      { store: countingStore, logger: silentLogger, broker },
+      create(WorkflowExecutionUpdateStatusInputSchema, {
+        executionId: "wfx_mechanism",
+        status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      }),
+    );
+    expect(calls.updateResource, "the merge must run inside updateResource").toBe(1);
+    expect(
+      calls.saveResource,
+      "a saveResource write here would reintroduce the lost-update window",
+    ).toBe(0);
+  });
+
+  it("concurrent different-children updates both survive (the DD-001 race)", async () => {
+    const id = "wfx_race";
+    await seed(id);
+
+    // Two children write their gates concurrently, repeatedly. With
+    // load-then-save one write can clobber the other; the atomic RMW
+    // must preserve both every iteration.
+    for (let iteration = 0; iteration < 25; iteration++) {
+      const writeFor = (child: string, toolCallId: string) =>
+        updateStatus(
+          { store, logger: silentLogger, broker },
+          create(WorkflowExecutionUpdateStatusInputSchema, {
+            executionId: id,
+            status: { pendingApprovals: [wfApproval(child, toolCallId)] },
+            updatePendingApprovals: true,
+            pendingUpdateChildAgentExecutionId: child,
+          }),
+        );
+      await Promise.all([
+        writeFor("aex_A", `tc_A_${iteration}`),
+        writeFor("aex_B", `tc_B_${iteration}`),
+      ]);
+
+      const stored = await store.getResource(
+        ApiResourceKind.workflow_execution,
+        id,
+        WorkflowExecutionSchema,
+      );
+      const children = new Set(
+        stored.status?.pendingApprovals.map(
+          (entry) => entry.childAgentExecutionId,
+        ),
+      );
+      expect(
+        children,
+        `iteration ${iteration}: both children's gates must survive`,
+      ).toEqual(new Set(["aex_A", "aex_B"]));
+    }
+  });
+
+  it("broadcasts the merged execution AFTER persist", async () => {
+    const id = "wfx_broadcast";
+    await seed(id);
+    const subscription = broker.subscribe(id);
+    try {
+      await updateStatus(
+        { store, logger: silentLogger, broker },
+        create(WorkflowExecutionUpdateStatusInputSchema, {
+          executionId: id,
+          status: { phase: ExecutionPhase.EXECUTION_COMPLETED },
+        }),
+      );
+      expect(subscription.queue).toHaveLength(1);
+      expect(subscription.queue[0].status?.phase).toBe(
+        ExecutionPhase.EXECUTION_COMPLETED,
+      );
+      // The broadcast frame is the PERSISTED state.
+      const stored = await store.getResource(
+        ApiResourceKind.workflow_execution,
+        id,
+        WorkflowExecutionSchema,
+      );
+      expect(stored.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    } finally {
+      broker.unsubscribe(id, subscription);
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
@@ -1054,7 +1054,8 @@ describe("submitApproval over the wire (forwarding through the REAL in-process e
       },
     );
     // The forward goes through the REAL in-process agentexecution
-    // controller; the missing child's NotFound is flattened.
+    // controller; the missing child's NotFound is flattened to
+    // Unavailable, with Go's %v grpc-go wire text embedded byte-for-byte.
     const err = await expectCode(
       () =>
         command.submitApproval({
@@ -1064,8 +1065,8 @@ describe("submitApproval over the wire (forwarding through the REAL in-process e
         }),
       Code.Unavailable,
     );
-    expect(err.rawMessage).toContain(
-      "failed to forward approval to child agent:",
+    expect(err.rawMessage).toBe(
+      "failed to forward approval to child agent: rpc error: code = NotFound desc = agent_execution not found: aexec_child_missing",
     );
   });
 });

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
@@ -36,14 +36,29 @@ import type { Client, Transport } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ApprovalAction,
+  DiffCompleteness,
+  ExecutionPhase as AgentExecutionPhase,
+  FileChangeKind,
+  FileDecisionAction,
+  FileDecisionScope,
+  FileReviewEventType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { CapturedFileChangeSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import {
   WorkflowExecutionSchema,
+  WorkflowPendingApprovalSchema,
+  WorkflowPendingFileReviewSchema,
   WorkflowTaskSchema,
 } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
 import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
 import {
   ExecutionPhase,
   WorkflowTaskStatus,
+  WorkflowTaskType,
 } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
 import {
   WorkflowEventType,
@@ -60,6 +75,10 @@ import { loadConfig } from "../../../boot/config.js";
 import { composeServer } from "../../../boot/compose.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
+import {
+  aggregateDigest,
+  fileDigest,
+} from "../../agentexecution/filereview/digest.js";
 import type { WorkflowExecutionEventRecord } from "../../../store/interface.js";
 
 const silentLogger = createLogger({
@@ -190,7 +209,7 @@ async function expectCode(
   } catch (error) {
     expect(error).toBeInstanceOf(ConnectError);
     const connectError = error as ConnectError;
-    expect(connectError.code).toBe(code);
+    expect(connectError.code, connectError.rawMessage).toBe(code);
     return connectError;
   }
   throw new Error(`expected code ${Code[code]}, call succeeded`);
@@ -800,6 +819,529 @@ describe("subscribeEvents over the wire (the first server-side poll loop)", () =
       types.push(event.eventType);
     }
     expect(types).toEqual([WorkflowEventType.task_started]);
+  });
+});
+
+describe("create over the wire (the engine gate, F7 regression)", () => {
+  async function seedWorkflow(slug: string): Promise<string> {
+    const id = `wf_${slug.replaceAll("-", "_")}`;
+    await server.store.saveResource(
+      ApiResourceKind.workflow,
+      id,
+      WorkflowSchema,
+      create(WorkflowSchema, {
+        apiVersion: API_VERSION,
+        kind: "Workflow",
+        metadata: { id, name: slug, slug, org: ORG },
+      }),
+    );
+    return id;
+  }
+
+  it("valid create refuses Unavailable at the gate, BEFORE any side effect", async () => {
+    // A real workflow, so the refusal is provably the gate and not an
+    // earlier miss.
+    const workflowId = await seedWorkflow("gate-flow");
+    const before = (
+      await server.store.listResources(ApiResourceKind.workflow_execution)
+    ).length;
+
+    const err = await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "Gate Execution", org: ORG },
+          spec: { workflowId },
+        }),
+      Code.Unavailable,
+    );
+    expect(err.rawMessage).toBe(
+      "The execution engine is temporarily unavailable. Please try again shortly.",
+    );
+
+    // Zero trace: no execution record, no ExecutionContext.
+    const after = (
+      await server.store.listResources(ApiResourceKind.workflow_execution)
+    ).length;
+    expect(after, "nothing persisted behind the gate").toBe(before);
+  });
+
+  it("the gate takes precedence over the workflow lookup", async () => {
+    // A nonexistent workflow_id would answer NotFound if resolution ran
+    // first; the gate fires before any lookup (Go's precedence pin).
+    const err = await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "Gate Precedence", org: ORG },
+          spec: { workflowId: "wf_does_not_exist" },
+        }),
+      Code.Unavailable,
+    );
+    expect(err.rawMessage).toBe(
+      "The execution engine is temporarily unavailable. Please try again shortly.",
+    );
+  });
+
+  it("neither reference refuses InvalidArgument BEFORE the gate (#196)", async () => {
+    const err = await expectCode(
+      () =>
+        command.create({
+          apiVersion: API_VERSION,
+          kind: KIND,
+          metadata: { name: "No Refs", org: ORG },
+          spec: {},
+        }),
+      Code.InvalidArgument,
+    );
+    expect(err.rawMessage).toBe(
+      "either workflow_id or workflow_instance_id must be provided",
+    );
+  });
+});
+
+describe("lifecycle over the wire (engineless postures)", () => {
+  it("cancel: unknown NotFound; live FailedPrecondition; terminal-target idempotent", async () => {
+    await expectCode(
+      () => command.cancel({ id: "wfexec_missing" }),
+      Code.NotFound,
+    );
+
+    const running = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    const engineless = await expectCode(
+      () => command.cancel({ id: running }),
+      Code.FailedPrecondition,
+    );
+    expect(engineless.rawMessage).toBe("Temporal is not available");
+
+    const cancelled = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_CANCELLED }),
+    );
+    const result = await command.cancel({ id: cancelled });
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+  });
+
+  it("pause refuses terminal phases with the pinned copy", async () => {
+    const completed = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    const err = await expectCode(
+      () => command.pause({ id: completed }),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(
+      "cannot pause execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be paused",
+    );
+  });
+
+  it("recover refuses non-FAILED phases", async () => {
+    const completed = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    const err = await expectCode(
+      () => command.recover({ id: completed }),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(
+      "cannot recover execution in phase EXECUTION_COMPLETED; only FAILED executions can be recovered",
+    );
+  });
+});
+
+describe("sendSignal over the wire (engineless)", () => {
+  it("unknown NotFound; live execution refuses at the creator seam", async () => {
+    await expectCode(
+      () =>
+        command.sendSignal({
+          executionId: "wfexec_missing",
+          signalName: "sig",
+        }),
+      Code.NotFound,
+    );
+    const running = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    const err = await expectCode(
+      () => command.sendSignal({ executionId: running, signalName: "sig" }),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe("workflow creator is not available");
+  });
+});
+
+describe("submitApproval over the wire (forwarding through the REAL in-process edge)", () => {
+  it("no pending approvals refuses FailedPrecondition", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    const err = await expectCode(
+      () =>
+        command.submitApproval({
+          executionId: id,
+          toolCallId: "tc_x",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(
+      `workflow execution ${id} has no pending approvals`,
+    );
+  });
+
+  it("tool_call_id mismatch refuses InvalidArgument; empty child FailedPrecondition", async () => {
+    const withGate = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    await server.store.updateResource(
+      ApiResourceKind.workflow_execution,
+      withGate,
+      WorkflowExecutionSchema,
+      (execution) => {
+        execution.status!.pendingApprovals = [
+          create(WorkflowPendingApprovalSchema, {
+            approval: { toolCallId: "tc_real", toolName: "deploy" },
+            childAgentExecutionId: "",
+          }),
+        ];
+      },
+    );
+    const mismatch = await expectCode(
+      () =>
+        command.submitApproval({
+          executionId: withGate,
+          toolCallId: "tc_wrong",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.InvalidArgument,
+    );
+    expect(mismatch.rawMessage).toBe(
+      `tool_call_id tc_wrong not found in pending_approvals for workflow execution ${withGate}`,
+    );
+
+    const noChild = await expectCode(
+      () =>
+        command.submitApproval({
+          executionId: withGate,
+          toolCallId: "tc_real",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.FailedPrecondition,
+    );
+    expect(noChild.rawMessage).toBe(
+      `workflow execution ${withGate} has no child agent execution ID for tool_call tc_real - approval must be submitted directly to the agent`,
+    );
+  });
+
+  it("forwarding failures FLATTEN to Unavailable (the approval asymmetry)", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    await server.store.updateResource(
+      ApiResourceKind.workflow_execution,
+      id,
+      WorkflowExecutionSchema,
+      (execution) => {
+        execution.status!.pendingApprovals = [
+          create(WorkflowPendingApprovalSchema, {
+            approval: { toolCallId: "tc_fwd", toolName: "deploy" },
+            childAgentExecutionId: "aexec_child_missing",
+          }),
+        ];
+      },
+    );
+    // The forward goes through the REAL in-process agentexecution
+    // controller; the missing child's NotFound is flattened.
+    const err = await expectCode(
+      () =>
+        command.submitApproval({
+          executionId: id,
+          toolCallId: "tc_fwd",
+          action: ApprovalAction.APPROVE,
+        }),
+      Code.Unavailable,
+    );
+    expect(err.rawMessage).toContain(
+      "failed to forward approval to child agent:",
+    );
+  });
+});
+
+describe("submitFileDecision over the wire (propagation through the REAL in-process edge)", () => {
+  function buildChange() {
+    const change = create(CapturedFileChangeSchema, {
+      id: "fc-1",
+      pathBefore: "src/a.ts",
+      pathAfter: "src/a.ts",
+      kind: FileChangeKind.MODIFY,
+      beforeSha256: "a".repeat(64),
+      afterSha256: "b".repeat(64),
+      diffComplete: true,
+    });
+    change.fileDigest = fileDigest(change);
+    return change;
+  }
+
+  async function seedChildWithLedger(): Promise<{
+    childId: string;
+    changeSetId: string;
+    aggregate: string;
+  }> {
+    counter += 1;
+    const childId = `aexec_wf_child_${counter}`;
+    const changeSetId = `cs_wf_${counter}`;
+    const change = buildChange();
+    const aggregate = aggregateDigest([change]);
+    await server.store.saveResource(
+      ApiResourceKind.agent_execution,
+      childId,
+      AgentExecutionSchema,
+      create(AgentExecutionSchema, {
+        apiVersion: API_VERSION,
+        kind: "AgentExecution",
+        metadata: {
+          id: childId,
+          name: childId.replaceAll("_", "-"),
+          slug: childId.replaceAll("_", "-"),
+          org: ORG,
+        },
+        spec: { message: "Say hello." },
+        status: {
+          phase: AgentExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+          fileReviewEventStream: {
+            executionId: childId,
+            events: [
+              {
+                eventId: `${changeSetId}:${changeSetId}:BASELINE`,
+                changeSetId,
+                eventType: FileReviewEventType.BASELINE_CAPTURED,
+                actor: "runner",
+                payload: {
+                  case: "baselineCaptured",
+                  value: { turnId: "turn-1", harnessId: "harness-1" },
+                },
+              },
+              {
+                eventId: `${changeSetId}:${changeSetId}:CANDIDATE`,
+                changeSetId,
+                eventType: FileReviewEventType.CANDIDATE_CAPTURED,
+                actor: "runner",
+                payload: {
+                  case: "candidateCaptured",
+                  value: {
+                    changes: [change],
+                    aggregateDigest: aggregate,
+                    diffCompleteness: DiffCompleteness.COMPLETE,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+    return { childId, changeSetId, aggregate };
+  }
+
+  async function seedParentSurfacing(
+    childId: string,
+    changeSetId: string,
+  ): Promise<string> {
+    const parentId = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    await server.store.updateResource(
+      ApiResourceKind.workflow_execution,
+      parentId,
+      WorkflowExecutionSchema,
+      (execution) => {
+        execution.status!.pendingFileReviews = [
+          create(WorkflowPendingFileReviewSchema, {
+            childAgentExecutionId: childId,
+            changeSetId: [changeSetId],
+          }),
+        ];
+      },
+    );
+    return parentId;
+  }
+
+  it("refuses an unsurfaced (child, change_set) pair", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    const noReviews = await expectCode(
+      () =>
+        command.submitFileDecision({
+          executionId: id,
+          childAgentExecutionId: "aexec_x",
+          changeSetId: "cs_x",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+          expectedDigest: "0".repeat(64),
+        }),
+      Code.FailedPrecondition,
+    );
+    expect(noReviews.rawMessage).toBe(
+      `workflow execution ${id} has no pending file reviews`,
+    );
+
+    const { childId, changeSetId } = await seedChildWithLedger();
+    const parentId = await seedParentSurfacing(childId, changeSetId);
+    const wrongPair = await expectCode(
+      () =>
+        command.submitFileDecision({
+          executionId: parentId,
+          childAgentExecutionId: childId,
+          changeSetId: "cs_unsurfaced",
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+          expectedDigest: "0".repeat(64),
+        }),
+      Code.FailedPrecondition,
+    );
+    expect(wrongPair.rawMessage).toBe(
+      `workflow execution ${parentId} has no pending file review for child ${childId} change set cs_unsurfaced`,
+    );
+  });
+
+  it("forwards to the real child: the decision lands on the child's ledger", async () => {
+    const { childId, changeSetId, aggregate } = await seedChildWithLedger();
+    const parentId = await seedParentSurfacing(childId, changeSetId);
+
+    const result = await command.submitFileDecision({
+      executionId: parentId,
+      childAgentExecutionId: childId,
+      changeSetId,
+      scope: FileDecisionScope.CHANGE_SET,
+      action: FileDecisionAction.APPROVE,
+      expectedDigest: aggregate,
+    });
+    // The parent state returns unchanged (the gate clears later through
+    // call-agent-status).
+    expect(result.metadata?.id).toBe(parentId);
+
+    const child = await server.store.getResource(
+      ApiResourceKind.agent_execution,
+      childId,
+      AgentExecutionSchema,
+    );
+    const changeSet = child.status?.fileChangeSets.find(
+      (cs) => cs.id === changeSetId,
+    );
+    expect(changeSet?.decisions, "the child recorded the decision").toHaveLength(1);
+  });
+
+  it("the child's actionable rejection PROPAGATES unchanged (the file-decision asymmetry)", async () => {
+    const { childId, changeSetId } = await seedChildWithLedger();
+    const parentId = await seedParentSurfacing(childId, changeSetId);
+
+    const err = await expectCode(
+      () =>
+        command.submitFileDecision({
+          executionId: parentId,
+          childAgentExecutionId: childId,
+          changeSetId,
+          scope: FileDecisionScope.CHANGE_SET,
+          action: FileDecisionAction.APPROVE,
+          expectedDigest: "0".repeat(64),
+        }),
+      Code.InvalidArgument,
+    );
+    expect(err.rawMessage).toBe(
+      `expected_digest mismatch for change set ${changeSetId}: the captured content changed since it was reviewed`,
+    );
+  });
+});
+
+describe("submitWorkflowTaskApproval over the wire", () => {
+  it("validates the task and its type with the pinned copy", async () => {
+    const id = await seed(
+      seedInput({
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        tasks: [
+          {
+            taskName: "not-a-gate",
+            taskType: WorkflowTaskType.WORKFLOW_TASK_AGENT_INVOCATION,
+            status: WorkflowTaskStatus.WORKFLOW_TASK_IN_PROGRESS,
+          },
+        ],
+      }),
+    );
+
+    const missing = await expectCode(
+      () =>
+        command.submitWorkflowTaskApproval({
+          executionId: id,
+          taskName: "no-such-task",
+          outcome: "approved",
+        }),
+      Code.InvalidArgument,
+    );
+    expect(missing.rawMessage).toBe(
+      "task 'no-such-task' not found in execution status",
+    );
+
+    const wrongType = await expectCode(
+      () =>
+        command.submitWorkflowTaskApproval({
+          executionId: id,
+          taskName: "not-a-gate",
+          outcome: "approved",
+        }),
+      Code.InvalidArgument,
+    );
+    expect(wrongType.rawMessage).toBe(
+      "task 'not-a-gate' is not a human_input task (type: WORKFLOW_TASK_AGENT_INVOCATION)",
+    );
+  });
+
+  it("a valid human_input task refuses Unavailable at the creator seam (engineless)", async () => {
+    const id = await seed(
+      seedInput({
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        tasks: [
+          {
+            taskName: "gate",
+            taskType: WorkflowTaskType.WORKFLOW_TASK_APPROVAL,
+            status: WorkflowTaskStatus.WORKFLOW_TASK_WAITING_APPROVAL,
+          },
+        ],
+      }),
+    );
+    const err = await expectCode(
+      () =>
+        command.submitWorkflowTaskApproval({
+          executionId: id,
+          taskName: "gate",
+          outcome: "approved",
+        }),
+      Code.Unavailable,
+    );
+    expect(err.rawMessage).toBe(
+      "workflow creator not configured for task 'gate'",
+    );
+  });
+
+  it("refuses non-signalable phases with the pinned copy", async () => {
+    const completed = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    const err = await expectCode(
+      () =>
+        command.submitWorkflowTaskApproval({
+          executionId: completed,
+          taskName: "gate",
+          outcome: "approved",
+        }),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe(
+      "cannot submit task approval: execution is in EXECUTION_COMPLETED phase",
+    );
   });
 });
 

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Pins the workflowexecution Phase-1 surfaces against Go's controller —
+ * through the REAL stack: a composed server on an ephemeral port, a
+ * native gRPC client, the full interceptor chain. Executions cannot be
+ * created through the RPC surface here (the engine gate refuses without
+ * Temporal — exactly the production posture until #21), so records are
+ * seeded directly through the store, the same way Go's controller tests
+ * seed with SaveResource.
+ *
+ * Load-bearing pins the zero-record conformance arm cannot cover:
+ *   - list's legacy-phase fallback vs filter.phases precedence, the T13
+ *     structured filter over seeded rows, the started_at-descending sort
+ *     default, and the total_pages placeholder;
+ *   - listByWorkflow matching EITHER spec.workflow_id or
+ *     spec.workflow_instance_id;
+ *   - getEventLog cursor pagination over REAL persisted events: has_more
+ *     from the +1 fetch, latest_sequence, the 500 cap, the multi-type
+ *     in-memory filter, and the malformed-record skip;
+ *   - the populated getExecutionSummary arm (phase counts, active count,
+ *     avg duration, failure ranks, cost breakdown, workflow scoping,
+ *     time-window cutoff);
+ *   - listPendingApprovals projection (task_name not task_id; requester
+ *     from spec audit) and its pre-truncation total_count;
+ *   - update's status-clearing standard build and delete's audit-trail
+ *     return, over the wire.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create, toBinary } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { timestampFromMs } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  WorkflowExecutionSchema,
+  WorkflowTaskSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import {
+  ExecutionPhase,
+  WorkflowTaskStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import {
+  WorkflowEventType,
+  WorkflowExecutionEventSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import {
+  ExecutionSortField,
+  SummaryTimeWindow,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { WorkflowExecutionEventRecord } from "../../../store/interface.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "WorkflowExecution";
+const ORG = "acme";
+
+type CommandClient = Client<typeof WorkflowExecutionCommandController>;
+type QueryClient = Client<typeof WorkflowExecutionQueryController>;
+
+let server: ComposedServer;
+let dir: string;
+let command: CommandClient;
+let query: QueryClient;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "wfexec-domain-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
+  vi.stubEnv(
+    "STIGMER_RUNNER_TOKEN_KEY",
+    Buffer.alloc(32, 8).toString("base64"),
+  );
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(WorkflowExecutionCommandController, transport);
+  query = createClient(WorkflowExecutionQueryController, transport);
+});
+
+afterAll(async () => {
+  try {
+    await server?.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
+let counter = 0;
+function seedInput(overrides?: {
+  id?: string;
+  org?: string;
+  workflowId?: string;
+  workflowInstanceId?: string;
+  phase?: ExecutionPhase;
+  startedAt?: string;
+  completedAt?: string;
+  totalCostMicros?: bigint;
+  createdAtMs?: number;
+  slug?: string;
+  name?: string;
+  tasks?: MessageInitShape<typeof WorkflowTaskSchema>[];
+}): MessageInitShape<typeof WorkflowExecutionSchema> & {
+  metadata: { id: string };
+} {
+  counter += 1;
+  const id = overrides?.id ?? `wfexec_test_${counter}`;
+  const slug = overrides?.slug ?? `exec-${id.replaceAll("_", "-")}`;
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      id,
+      name: overrides?.name ?? slug,
+      slug,
+      org: overrides?.org ?? ORG,
+    },
+    spec: {
+      workflowId: overrides?.workflowId ?? `wf_test_${counter}`,
+      workflowInstanceId:
+        overrides?.workflowInstanceId ?? `wfi_test_${counter}`,
+    },
+    status: {
+      phase: overrides?.phase ?? ExecutionPhase.EXECUTION_COMPLETED,
+      startedAt: overrides?.startedAt ?? "",
+      completedAt: overrides?.completedAt ?? "",
+      totalCostMicros: overrides?.totalCostMicros ?? 0n,
+      tasks: overrides?.tasks ?? [],
+      audit:
+        overrides?.createdAtMs === undefined
+          ? undefined
+          : {
+              specAudit: {
+                createdAt: timestampFromMs(overrides.createdAtMs),
+                createdBy: { id: "usr_seeder" },
+              },
+            },
+    },
+  };
+}
+
+async function seed(
+  init: MessageInitShape<typeof WorkflowExecutionSchema> & {
+    metadata: { id: string };
+  },
+): Promise<string> {
+  await server.store.saveResource(
+    ApiResourceKind.workflow_execution,
+    init.metadata.id,
+    WorkflowExecutionSchema,
+    create(WorkflowExecutionSchema, init),
+  );
+  return init.metadata.id;
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    const connectError = error as ConnectError;
+    expect(connectError.code).toBe(code);
+    return connectError;
+  }
+  throw new Error(`expected code ${Code[code]}, call succeeded`);
+}
+
+function eventRecord(
+  executionId: string,
+  sequenceNumber: number,
+  eventType: WorkflowEventType,
+  taskName = "",
+): WorkflowExecutionEventRecord {
+  return {
+    executionId,
+    sequenceNumber,
+    eventType: WorkflowEventType[eventType] ?? "",
+    taskName,
+    data: toBinary(
+      WorkflowExecutionEventSchema,
+      create(WorkflowExecutionEventSchema, {
+        eventId: `evt_${executionId}_${sequenceNumber}`,
+        eventType,
+        sequenceNumber: BigInt(sequenceNumber),
+        occurredAt: "2026-05-23T10:00:00Z",
+        taskName,
+      }),
+    ),
+    createdAt: "2026-05-23T10:00:00Z",
+  };
+}
+
+describe("get / list / listByWorkflow over the wire", () => {
+  it("get answers NotFound for an unknown id", async () => {
+    await expectCode(() => query.get({ value: "wfexec_missing" }), Code.NotFound);
+  });
+
+  it("get round-trips a seeded execution", async () => {
+    const id = await seed(seedInput());
+    const got = await query.get({ value: id });
+    expect(got.metadata?.id).toBe(id);
+  });
+
+  it("list applies the legacy phase filter only when filter.phases is absent", async () => {
+    const failed = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_FAILED }),
+    );
+    await seed(seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }));
+
+    const legacy = await query.list({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+    });
+    expect(
+      legacy.entries.every(
+        (entry) => entry.status?.phase === ExecutionPhase.EXECUTION_FAILED,
+      ),
+    ).toBe(true);
+    expect(legacy.entries.map((entry) => entry.metadata?.id)).toContain(
+      failed,
+    );
+    expect(legacy.totalPages).toBe(1);
+
+    // filter.phases supersedes the legacy field: a COMPLETED filter with a
+    // FAILED legacy phase answers COMPLETED rows.
+    const structured = await query.list({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      filter: { phases: [ExecutionPhase.EXECUTION_COMPLETED] },
+    });
+    expect(structured.entries.length).toBeGreaterThan(0);
+    expect(
+      structured.entries.every(
+        (entry) => entry.status?.phase === ExecutionPhase.EXECUTION_COMPLETED,
+      ),
+    ).toBe(true);
+  });
+
+  it("list defaults to started_at descending", async () => {
+    const early = await seed(
+      seedInput({ startedAt: "2026-05-23T10:00:00Z" }),
+    );
+    const late = await seed(seedInput({ startedAt: "2026-05-23T14:00:00Z" }));
+
+    const result = await query.list({});
+    const positions = new Map(
+      result.entries.map((entry, index) => [entry.metadata?.id, index]),
+    );
+    expect(positions.get(late)).toBeLessThan(positions.get(early)!);
+  });
+
+  it("listByWorkflow requires workflow_id and matches either spec reference", async () => {
+    await expectCode(
+      () => query.listByWorkflow({ workflowId: "" }),
+      Code.InvalidArgument,
+    );
+
+    const byWorkflow = await seed(seedInput({ workflowId: "wf_shared_ref" }));
+    const byInstance = await seed(
+      seedInput({ workflowInstanceId: "wf_shared_ref" }),
+    );
+    await seed(seedInput());
+
+    const result = await query.listByWorkflow({
+      workflowId: "wf_shared_ref",
+      sortField: ExecutionSortField.STARTED_AT,
+      sortAscending: true,
+    });
+    const resultIds = result.entries.map((entry) => entry.metadata?.id);
+    expect(resultIds).toContain(byWorkflow);
+    expect(resultIds).toContain(byInstance);
+    expect(resultIds).toHaveLength(2);
+    expect(result.totalPages).toBe(1);
+  });
+});
+
+describe("getEventLog over the wire (CW-7 pagination contract)", () => {
+  it("empty id refuses InvalidArgument; unknown id answers an empty page", async () => {
+    await expectCode(
+      () => query.getEventLog({ executionId: "" }),
+      Code.InvalidArgument,
+    );
+    const empty = await query.getEventLog({ executionId: "wfexec_missing" });
+    expect(empty.events).toHaveLength(0);
+    expect(empty.hasMore).toBe(false);
+    expect(empty.latestSequence).toBe(0n);
+  });
+
+  it("paginates with has_more from the +1 fetch and latest_sequence as cursor", async () => {
+    const id = await seed(seedInput());
+    const records: WorkflowExecutionEventRecord[] = [];
+    for (let sequence = 1; sequence <= 5; sequence++) {
+      records.push(
+        eventRecord(id, sequence, WorkflowEventType.task_started, `t${sequence}`),
+      );
+    }
+    expect(
+      await server.store.appendWorkflowExecutionEvents(id, records),
+    ).toBe(5);
+
+    const page1 = await query.getEventLog({ executionId: id, pageSize: 2 });
+    expect(page1.events).toHaveLength(2);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.latestSequence).toBe(2n);
+
+    const page2 = await query.getEventLog({
+      executionId: id,
+      pageSize: 2,
+      afterSequence: page1.latestSequence,
+    });
+    expect(page2.events.map((event) => event.sequenceNumber)).toEqual([
+      3n,
+      4n,
+    ]);
+    expect(page2.hasMore).toBe(true);
+
+    const page3 = await query.getEventLog({
+      executionId: id,
+      pageSize: 2,
+      afterSequence: page2.latestSequence,
+    });
+    expect(page3.events).toHaveLength(1);
+    expect(page3.hasMore).toBe(false);
+    expect(page3.latestSequence).toBe(5n);
+  });
+
+  it("filters by a single event type in the store and multiple types in memory", async () => {
+    const id = await seed(seedInput());
+    await server.store.appendWorkflowExecutionEvents(id, [
+      eventRecord(id, 1, WorkflowEventType.execution_started),
+      eventRecord(id, 2, WorkflowEventType.task_started, "a"),
+      eventRecord(id, 3, WorkflowEventType.task_completed, "a"),
+      eventRecord(id, 4, WorkflowEventType.execution_completed),
+    ]);
+
+    const single = await query.getEventLog({
+      executionId: id,
+      eventTypes: [WorkflowEventType.task_started],
+    });
+    expect(single.events).toHaveLength(1);
+    expect(single.events[0].eventType).toBe(WorkflowEventType.task_started);
+
+    const multi = await query.getEventLog({
+      executionId: id,
+      eventTypes: [
+        WorkflowEventType.execution_started,
+        WorkflowEventType.execution_completed,
+      ],
+    });
+    expect(multi.events.map((event) => event.eventType)).toEqual([
+      WorkflowEventType.execution_started,
+      WorkflowEventType.execution_completed,
+    ]);
+  });
+
+  it("skips malformed event records without failing the page", async () => {
+    const id = await seed(seedInput());
+    const good = eventRecord(id, 1, WorkflowEventType.execution_started);
+    const malformed: WorkflowExecutionEventRecord = {
+      executionId: id,
+      sequenceNumber: 2,
+      eventType: "execution_started",
+      taskName: "",
+      data: new Uint8Array([0xff, 0xff, 0xff, 0x01, 0x02]),
+      createdAt: "2026-05-23T10:00:00Z",
+    };
+    const alsoGood = eventRecord(id, 3, WorkflowEventType.execution_completed);
+    await server.store.appendWorkflowExecutionEvents(id, [
+      good,
+      malformed,
+      alsoGood,
+    ]);
+
+    const page = await query.getEventLog({ executionId: id });
+    expect(page.events.map((event) => event.sequenceNumber)).toEqual([1n, 3n]);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("caps page_size at 500 and defaults to 100", async () => {
+    const id = await seed(seedInput());
+    const records: WorkflowExecutionEventRecord[] = [];
+    for (let sequence = 1; sequence <= 120; sequence++) {
+      records.push(eventRecord(id, sequence, WorkflowEventType.task_started));
+    }
+    await server.store.appendWorkflowExecutionEvents(id, records);
+
+    const defaulted = await query.getEventLog({ executionId: id });
+    expect(defaulted.events).toHaveLength(100);
+    expect(defaulted.hasMore).toBe(true);
+
+    const capped = await query.getEventLog({
+      executionId: id,
+      pageSize: 100_000,
+    });
+    // 120 < the 500 cap, so everything arrives; the cap is proven by the
+    // request not erroring and the page staying bounded.
+    expect(capped.events).toHaveLength(120);
+    expect(capped.hasMore).toBe(false);
+  });
+});
+
+describe("getExecutionSummary over the wire", () => {
+  // The composed store is shared across this file's tests, so summary
+  // assertions scope through workflow_id filters seeded uniquely here.
+  it("aggregates phase counts, cost, avg duration, ranks — scoped by workflow", async () => {
+    const wf = "wf_summary_scope";
+    const nowMs = Date.now();
+    await seed(
+      seedInput({
+        workflowId: wf,
+        slug: "summary-flow",
+        name: "Summary Flow",
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        startedAt: "2026-05-23T10:00:00Z",
+        completedAt: "2026-05-23T10:00:10Z",
+        totalCostMicros: 2_000_000n,
+        createdAtMs: nowMs,
+      }),
+    );
+    await seed(
+      seedInput({
+        workflowId: wf,
+        slug: "summary-flow",
+        name: "Summary Flow",
+        phase: ExecutionPhase.EXECUTION_FAILED,
+        totalCostMicros: 1_000_000n,
+        createdAtMs: nowMs,
+      }),
+    );
+    await seed(
+      seedInput({
+        workflowId: wf,
+        slug: "summary-flow",
+        name: "Summary Flow",
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        createdAtMs: nowMs,
+      }),
+    );
+
+    const summary = await query.getExecutionSummary({
+      org: ORG,
+      timeWindow: SummaryTimeWindow.ALL_TIME,
+      workflowId: wf,
+    });
+    expect(summary.totalCount).toBe(3);
+    expect(summary.activeCount).toBe(1);
+    expect(summary.phaseCounts[ExecutionPhase.EXECUTION_COMPLETED]).toBe(1);
+    expect(summary.phaseCounts[ExecutionPhase.EXECUTION_FAILED]).toBe(1);
+    expect(summary.phaseCounts[ExecutionPhase.EXECUTION_IN_PROGRESS]).toBe(1);
+    // 1 completed / 2 terminal.
+    expect(summary.successRate).toBeCloseTo(0.5);
+    expect(summary.totalCost?.totalCostUsd).toBeCloseTo(3.0);
+    // One completed 10s run.
+    expect(summary.avgDuration?.seconds).toBe(10n);
+    expect(summary.topFailingWorkflows).toHaveLength(1);
+    expect(summary.topFailingWorkflows[0].workflowSlug).toBe("summary-flow");
+    expect(summary.topFailingWorkflows[0].failureCount).toBe(1);
+    expect(summary.costByWorkflow).toHaveLength(1);
+    expect(summary.costByWorkflow[0].executionCount).toBe(3);
+  });
+
+  it("time window excludes older executions; success_rate keeps the -1 sentinel", async () => {
+    const wf = "wf_summary_window";
+    const thirtyOneDaysAgoMs = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    await seed(
+      seedInput({
+        workflowId: wf,
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        createdAtMs: thirtyOneDaysAgoMs,
+      }),
+    );
+
+    const windowed = await query.getExecutionSummary({
+      org: ORG,
+      timeWindow: SummaryTimeWindow.LAST_24H,
+      workflowId: wf,
+    });
+    expect(windowed.totalCount).toBe(0);
+    expect(windowed.successRate).toBe(-1);
+    expect(windowed.totalCost, "zero cost summary is ALWAYS present").toBeDefined();
+    expect(windowed.avgDuration, "no completed runs → absent").toBeUndefined();
+
+    const allTime = await query.getExecutionSummary({
+      org: ORG,
+      timeWindow: SummaryTimeWindow.ALL_TIME,
+      workflowId: wf,
+    });
+    expect(allTime.totalCount).toBe(1);
+  });
+});
+
+describe("listPendingApprovals over the wire", () => {
+  it("projects WAITING_APPROVAL tasks of IN_PROGRESS executions (task_name, not task_id)", async () => {
+    const id = await seed(
+      seedInput({
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        name: "Approval Flow",
+        createdAtMs: Date.now(),
+        tasks: [
+          {
+            taskId: "gate:2",
+            taskName: "gate",
+            status: WorkflowTaskStatus.WORKFLOW_TASK_WAITING_APPROVAL,
+            startedAt: "2026-05-23T10:00:00Z",
+            uiHint: "approval-form",
+          },
+          {
+            taskId: "done:1",
+            taskName: "done",
+            status: WorkflowTaskStatus.WORKFLOW_TASK_COMPLETED,
+          },
+        ],
+      }),
+    );
+    // A WAITING_APPROVAL task on a non-IN_PROGRESS execution is excluded.
+    await seed(
+      seedInput({
+        phase: ExecutionPhase.EXECUTION_PAUSED,
+        tasks: [
+          {
+            taskName: "paused-gate",
+            status: WorkflowTaskStatus.WORKFLOW_TASK_WAITING_APPROVAL,
+          },
+        ],
+      }),
+    );
+
+    const result = await query.listPendingApprovals({ org: ORG });
+    const entry = result.entries.find((item) => item.executionId === id);
+    expect(entry).toBeDefined();
+    expect(entry?.taskName).toBe("gate");
+    expect(entry?.workflowName).toBe("Approval Flow");
+    expect(entry?.requester).toBe("usr_seeder");
+    expect(entry?.uiHint).toBe("approval-form");
+    expect(
+      result.entries.some((item) => item.taskName === "paused-gate"),
+    ).toBe(false);
+  });
+
+  it("total_count is the pre-truncation total", async () => {
+    const tasks = Array.from({ length: 3 }, (_, index) => ({
+      taskName: `bulk-gate-${index}`,
+      status: WorkflowTaskStatus.WORKFLOW_TASK_WAITING_APPROVAL,
+    }));
+    await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS, tasks }),
+    );
+
+    const page = await query.listPendingApprovals({ org: ORG, pageSize: 1 });
+    expect(page.entries).toHaveLength(1);
+    expect(page.totalCount).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("update / delete over the wire", () => {
+  it("update rewrites the spec through the standard build", async () => {
+    const init = seedInput({ phase: ExecutionPhase.EXECUTION_FAILED });
+    const id = await seed(init);
+
+    const updated = await command.update({
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: init.metadata,
+      spec: {
+        workflowId: init.spec?.workflowId,
+        workflowInstanceId: init.spec?.workflowInstanceId,
+        triggerMessage: "updated trigger",
+      },
+    });
+    expect(updated.metadata?.id).toBe(id);
+    expect(updated.spec?.triggerMessage).toBe("updated trigger");
+
+    const got = await query.get({ value: id });
+    expect(got.spec?.triggerMessage).toBe("updated trigger");
+  });
+
+  it("delete returns the deleted record (audit-trail convention) and removes it", async () => {
+    const id = await seed(seedInput());
+    const deleted = await command.delete({ value: id });
+    expect(deleted.metadata?.id).toBe(id);
+    await expectCode(() => query.get({ value: id }), Code.NotFound);
+  });
+
+  it("delete answers NotFound for an unknown id", async () => {
+    await expectCode(
+      () => command.delete({ value: "wfexec_missing" }),
+      Code.NotFound,
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
@@ -581,6 +581,228 @@ describe("listPendingApprovals over the wire", () => {
   });
 });
 
+describe("updateStatus over the wire", () => {
+  it("merges status, persists events, and broadcasts to subscribers", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+
+    const subscription = server.workflowExecutionStreamBroker.subscribe(id);
+    try {
+      const merged = await command.updateStatus({
+        executionId: id,
+        status: {
+          phase: ExecutionPhase.EXECUTION_COMPLETED,
+          completedAt: "2026-05-23T10:05:00Z",
+          totalCostMicros: 1234n,
+        },
+        events: [
+          {
+            eventId: "evt_1",
+            eventType: WorkflowEventType.execution_completed,
+            sequenceNumber: 1n,
+            occurredAt: "2026-05-23T10:05:00Z",
+          },
+        ],
+      });
+      expect(merged.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+      expect(merged.status?.totalCostMicros).toBe(1234n);
+
+      // The event batch persisted through the insert-or-skip lane.
+      const log = await query.getEventLog({ executionId: id });
+      expect(log.events).toHaveLength(1);
+      expect(log.latestSequence).toBe(1n);
+
+      // The broadcast carries the merged state (ADR 011 write path).
+      expect(subscription.queue).toHaveLength(1);
+      expect(subscription.queue[0].status?.phase).toBe(
+        ExecutionPhase.EXECUTION_COMPLETED,
+      );
+    } finally {
+      server.workflowExecutionStreamBroker.unsubscribe(id, subscription);
+    }
+  });
+
+  it("retried event batches are idempotent (insert-or-skip)", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    const events = [
+      {
+        eventId: "evt_r1",
+        eventType: WorkflowEventType.task_started,
+        sequenceNumber: 1n,
+        occurredAt: "2026-05-23T10:00:00Z",
+        taskName: "t1",
+      },
+    ];
+    await command.updateStatus({
+      executionId: id,
+      status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      events,
+    });
+    // The runner's retried batch: same sequence, first-writer-wins.
+    await command.updateStatus({
+      executionId: id,
+      status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      events,
+    });
+    const log = await query.getEventLog({ executionId: id });
+    expect(log.events).toHaveLength(1);
+  });
+
+  it("unknown execution answers NotFound; missing status InvalidArgument", async () => {
+    await expectCode(
+      () =>
+        command.updateStatus({
+          executionId: "wfexec_missing",
+          status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+        }),
+      Code.NotFound,
+    );
+    await expectCode(
+      () => command.updateStatus({ executionId: "wfexec_missing" }),
+      Code.InvalidArgument,
+    );
+  });
+});
+
+describe("subscribe over the wire (streaming smoke through the real transport)", () => {
+  it("refuses empty id InvalidArgument and unknown id NotFound", async () => {
+    await expectCode(async () => {
+      for await (const _ of query.subscribe({ executionId: "" })) {
+        break;
+      }
+    }, Code.InvalidArgument);
+    await expectCode(async () => {
+      for await (const _ of query.subscribe({ executionId: "wfexec_missing" })) {
+        break;
+      }
+    }, Code.NotFound);
+  });
+
+  it("streams the snapshot, then live updates, closing on a terminal frame", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+
+    const frames: ExecutionPhase[] = [];
+    const stream = (async () => {
+      for await (const frame of query.subscribe({ executionId: id })) {
+        frames.push(
+          frame.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+        );
+        if (frames.length === 1) {
+          // Snapshot received — drive a terminal transition through the
+          // REAL write path (updateStatus persists then broadcasts).
+          await command.updateStatus({
+            executionId: id,
+            status: { phase: ExecutionPhase.EXECUTION_COMPLETED },
+          });
+        }
+      }
+    })();
+
+    await stream;
+    expect(frames).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    ]);
+  });
+});
+
+describe("subscribeEvents over the wire (the first server-side poll loop)", () => {
+  it("refuses empty id InvalidArgument and unknown id NotFound", async () => {
+    await expectCode(async () => {
+      for await (const _ of query.subscribeEvents({ executionId: "" })) {
+        break;
+      }
+    }, Code.InvalidArgument);
+    await expectCode(async () => {
+      for await (const _ of query.subscribeEvents({
+        executionId: "wfexec_missing",
+      })) {
+        break;
+      }
+    }, Code.NotFound);
+  });
+
+  it("replays persisted events and closes after the terminal drain", async () => {
+    // Terminal execution with three persisted events: the stream replays
+    // everything after the cursor, hits the terminal check, drains, and
+    // closes — fully deterministic, no timing dependence.
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    await server.store.appendWorkflowExecutionEvents(id, [
+      eventRecord(id, 1, WorkflowEventType.execution_started),
+      eventRecord(id, 2, WorkflowEventType.task_started, "t1"),
+      eventRecord(id, 3, WorkflowEventType.execution_completed),
+    ]);
+
+    const sequences: bigint[] = [];
+    for await (const event of query.subscribeEvents({
+      executionId: id,
+      afterSequence: 1n,
+    })) {
+      sequences.push(event.sequenceNumber);
+    }
+    expect(sequences, "replay strictly after the cursor").toEqual([2n, 3n]);
+  });
+
+  it("live-tails new events until the execution turns terminal", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_IN_PROGRESS }),
+    );
+    await server.store.appendWorkflowExecutionEvents(id, [
+      eventRecord(id, 1, WorkflowEventType.execution_started),
+    ]);
+
+    const sequences: bigint[] = [];
+    for await (const event of query.subscribeEvents({ executionId: id })) {
+      sequences.push(event.sequenceNumber);
+      if (event.sequenceNumber === 1n) {
+        // First frame received — append the tail AND flip terminal
+        // through the real write path; the poll loop must deliver the
+        // tail event and then close on the terminal drain.
+        await command.updateStatus({
+          executionId: id,
+          status: { phase: ExecutionPhase.EXECUTION_COMPLETED },
+          events: [
+            {
+              eventId: "evt_tail",
+              eventType: WorkflowEventType.execution_completed,
+              sequenceNumber: 2n,
+              occurredAt: "2026-05-23T10:05:00Z",
+            },
+          ],
+        });
+      }
+    }
+    expect(sequences).toEqual([1n, 2n]);
+  });
+
+  it("filters the stream by event type", async () => {
+    const id = await seed(
+      seedInput({ phase: ExecutionPhase.EXECUTION_COMPLETED }),
+    );
+    await server.store.appendWorkflowExecutionEvents(id, [
+      eventRecord(id, 1, WorkflowEventType.execution_started),
+      eventRecord(id, 2, WorkflowEventType.task_started, "t1"),
+      eventRecord(id, 3, WorkflowEventType.execution_completed),
+    ]);
+
+    const types: WorkflowEventType[] = [];
+    for await (const event of query.subscribeEvents({
+      executionId: id,
+      eventTypes: [WorkflowEventType.task_started],
+    })) {
+      types.push(event.eventType);
+    }
+    expect(types).toEqual([WorkflowEventType.task_started]);
+  });
+});
+
 describe("update / delete over the wire", () => {
   it("update rewrites the spec through the standard build", async () => {
     const init = seedInput({ phase: ExecutionPhase.EXECUTION_FAILED });

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/__tests__/workflowexecution.test.ts
@@ -422,6 +422,25 @@ describe("getEventLog over the wire (CW-7 pagination contract)", () => {
     const page = await query.getEventLog({ executionId: id });
     expect(page.events.map((event) => event.sequenceNumber)).toEqual([1n, 3n]);
     expect(page.hasMore).toBe(false);
+
+    // A malformed record must NOT advance latest_sequence (Go updates it
+    // only after a successful unmarshal): with the malformed row as the
+    // HIGHEST sequence, latest stays at the last parsed one.
+    const tail = await seed(seedInput());
+    await server.store.appendWorkflowExecutionEvents(tail, [
+      eventRecord(tail, 1, WorkflowEventType.execution_started),
+      {
+        executionId: tail,
+        sequenceNumber: 2,
+        eventType: "execution_started",
+        taskName: "",
+        data: new Uint8Array([0xff, 0xff, 0xff, 0x01, 0x02]),
+        createdAt: "2026-05-23T10:00:00Z",
+      },
+    ]);
+    const tailPage = await query.getEventLog({ executionId: tail });
+    expect(tailPage.events.map((event) => event.sequenceNumber)).toEqual([1n]);
+    expect(tailPage.latestSequence, "malformed rows never advance the cursor").toBe(1n);
   });
 
   it("caps page_size at 500 and defaults to 100", async () => {

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/constants.ts
@@ -1,0 +1,102 @@
+/**
+ * WorkflowExecution byte-pinned wire copy and identifiers — every string a
+ * client or the Temporal wire can observe from this domain, copied
+ * character-for-character from the Go controller
+ * (pkg/domain/workflowexecution/controller). Coexistence rule: the Go
+ * server is the behavioral reference; do not "improve" copy here
+ * (guidelines §2).
+ */
+
+/**
+ * create's engine-gate refusal (create.go engineUnavailableMessage) —
+ * deliberately identical across AgentExecution and WorkflowExecution so
+ * both domains present one symmetric create-boundary contract. Pinned by
+ * the Class A conformance engine-gate test.
+ */
+export const ENGINE_UNAVAILABLE_MESSAGE =
+  "The execution engine is temporarily unavailable. Please try again shortly.";
+
+/**
+ * The lifecycle steps' engineless refusal (lifecycle_steps.go, five
+ * sites: pause/resume/cancel/terminate signal steps and recover's
+ * terminate-existing). FailedPrecondition, not Unavailable — the ratified
+ * Go asymmetry between the create gate and the lifecycle surface.
+ */
+export const TEMPORAL_UNAVAILABLE_MESSAGE = "Temporal is not available";
+
+/**
+ * Recover's fresh-start refusal (lifecycle_steps.go
+ * StartFreshWorkflowStep) — the creator-specific variant of the message
+ * above, also FailedPrecondition.
+ */
+export const TEMPORAL_UNAVAILABLE_CREATOR_MESSAGE =
+  "Temporal is not available (workflow creator not set)";
+
+/**
+ * sendSignal's engineless refusal (send_signal.go SendSignalToWorkflowStep)
+ * — FailedPrecondition with its own copy, distinct from both messages
+ * above.
+ */
+export const WORKFLOW_CREATOR_UNAVAILABLE_MESSAGE =
+  "workflow creator is not available";
+
+/**
+ * The Go orchestrator workflow name (temporal/workflows
+ * InvokeWorkflowExecutionWorkflowName) — a cross-edition Temporal wire
+ * constant; the orchestrator's workflow ID is `{name}/{executionId}`.
+ */
+export const INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME =
+  "stigmer/workflow-execution/invoke";
+
+/** The orchestrator workflow ID for an execution (lifecycle_steps.go). */
+export function orchestratorWorkflowId(executionId: string): string {
+  return `${INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME}/${executionId}`;
+}
+
+/**
+ * The TS runner child workflow ID (lifecycle_steps.go
+ * TerminateExistingWorkflowStep: "workflow-exec-" + executionID). The
+ * child has ParentClosePolicy=REQUEST_CANCEL, so recover terminates it
+ * explicitly for a hard ID-reuse guarantee.
+ */
+export function childWorkflowId(executionId: string): string {
+  return `workflow-exec-${executionId}`;
+}
+
+/**
+ * Signal channel names on the orchestrator (temporal/workflows). pause and
+ * resume are handled by Go's single selector goroutine; every other signal
+ * rides the generic relaySignal envelope (June DD-013).
+ */
+export const PAUSE_SIGNAL_NAME = "pause";
+export const RESUME_SIGNAL_NAME = "resume";
+export const RELAY_SIGNAL_CHANNEL_NAME = "relaySignal";
+
+/**
+ * submitWorkflowTaskApproval's signal-name prefix
+ * (submit_workflow_task_approval.go humanInputSignalPrefix): the runner
+ * listens on `human_input_{taskName}`.
+ */
+export const HUMAN_INPUT_SIGNAL_PREFIX = "human_input_";
+
+/**
+ * getEventLog pagination bounds (get_event_log.go): requests default to
+ * 100 events and are capped at 500 — the pinned CW-7 pagination contract.
+ */
+export const DEFAULT_EVENT_PAGE_SIZE = 100;
+export const MAX_EVENT_PAGE_SIZE = 500;
+
+/**
+ * listPendingApprovals pagination bounds (list_pending_approvals.go):
+ * default 20, cap 100.
+ */
+export const DEFAULT_PENDING_APPROVALS_PAGE_SIZE = 20;
+export const MAX_PENDING_APPROVALS_PAGE_SIZE = 100;
+
+/**
+ * subscribeEvents' live-tail poll interval (subscribe_events.go
+ * eventPollInterval = 500ms): the latency floor Go chose for event
+ * delivery after replay; faster polling buys little (the runner batches
+ * updates through updateStatus) and multiplies read load per subscriber.
+ */
+export const EVENT_POLL_INTERVAL_MS = 500;

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/controller.ts
@@ -75,6 +75,10 @@ import { getExecutionSummary } from "./get-execution-summary.js";
 import { listPendingApprovals } from "./list-pending-approvals.js";
 import { loadAllWorkflowExecutions } from "./queries.js";
 import { workflowExecutionSearchExtractor } from "./search-extractor.js";
+import type { StreamBroker } from "./stream-broker.js";
+import { subscribeExecution } from "./subscribe.js";
+import { subscribeEvents } from "./subscribe-events.js";
+import { updateStatus } from "./update-status.js";
 
 export interface WorkflowExecutionControllerDeps {
   readonly store: Store;
@@ -86,6 +90,13 @@ export interface WorkflowExecutionControllerDeps {
    * submitWorkflowTaskApproval.
    */
   readonly engineState: WorkflowExecutionEngineStateProvider;
+  /**
+   * The shared broadcast fabric for subscribe streams. ONE instance spans
+   * both routers (serving + in-process) — see stream-broker.ts; the
+   * composition root owns it (Go: NewStreamBroker in the controller
+   * constructor + GetStreamBroker for #21's Temporal activities).
+   */
+  readonly broker: StreamBroker;
 }
 
 /** Registers both workflowexecution services on the router (routes stage). */
@@ -95,13 +106,16 @@ export function registerWorkflowExecutionServices(
 ): void {
   router.service(WorkflowExecutionCommandController, {
     update: (execution, ctx) => update(deps, execution, ctx),
+    updateStatus: (input) => updateStatus(deps, input),
     delete: (id, ctx) => deleteExecution(deps, id, ctx),
   });
   router.service(WorkflowExecutionQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
     list: (req) => list(deps, req),
     listByWorkflow: (req) => listByWorkflow(deps, req),
+    subscribe: (req, ctx) => subscribeExecution(deps, req, ctx),
     getEventLog: (req) => getEventLog(deps, req),
+    subscribeEvents: (req, ctx) => subscribeEvents(deps, req, ctx),
     getExecutionSummary: (req) => getExecutionSummary(deps, req),
     listPendingApprovals: (req) => listPendingApprovals(deps, req),
   });

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/controller.ts
@@ -41,6 +41,9 @@ import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
 import {
   newDeleteResourceStep,
   newExtractResourceIdStep,
@@ -64,12 +67,41 @@ import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
+import type {
+  AgentExecutionApprovalForwarderProvider,
+} from "./submit-approval.js";
+import { submitApproval } from "./submit-approval.js";
+import type {
+  AgentExecutionFileDecisionForwarderProvider,
+} from "./submit-file-decision.js";
+import { submitFileDecision } from "./submit-file-decision.js";
+import { submitWorkflowTaskApproval } from "./submit-workflow-task-approval.js";
+import type { ExecutionWorkflowInstanceCreatorProvider } from "./create-steps.js";
+import {
+  newCreateDefaultInstanceIfNeededStep,
+  newSetInitialPhaseStep,
+  newStartWorkflowStep,
+  newValidateWorkflowOrInstanceStep,
+} from "./create-steps.js";
+import type { WorkflowExecutionContextBuilderDeps } from "./create-execution-context-step.js";
+import { newCreateExecutionContextStep } from "./create-execution-context-step.js";
 import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
+import { newEnsureEngineAvailableStep } from "./engine.js";
 import {
   applyFilterCriteria,
   applyLegacyPhaseFilter,
   applySortField,
 } from "./execution-filter.js";
+import {
+  cancelExecution,
+  pauseExecution,
+  recoverExecution,
+  resumeExecution,
+  terminateExecution,
+} from "./lifecycle.js";
+import { newNormalizeWorkflowRefStep } from "./normalize-workflow-ref-step.js";
+import { newPinWorkflowVersionStep } from "./pin-workflow-version-step.js";
+import { sendSignal } from "./send-signal.js";
 import { getEventLog } from "./get-event-log.js";
 import { getExecutionSummary } from "./get-execution-summary.js";
 import { listPendingApprovals } from "./list-pending-approvals.js";
@@ -97,6 +129,17 @@ export interface WorkflowExecutionControllerDeps {
    * constructor + GetStreamBroker for #21's Temporal activities).
    */
   readonly broker: StreamBroker;
+  /**
+   * The in-process edges (lazy providers — the routes↔clients cycle
+   * resolves at request time): the default-instance creator, the two
+   * HITL forwarding edges into the agentexecution controller, and the
+   * EC-builder loaders.
+   */
+  readonly workflowInstanceCreator: ExecutionWorkflowInstanceCreatorProvider;
+  readonly approvalForwarder: AgentExecutionApprovalForwarderProvider;
+  readonly fileDecisionForwarder: AgentExecutionFileDecisionForwarderProvider;
+  /** The shared EC-builder deps (create's step 12 + recover's recreate). */
+  readonly executionContextBuilder: WorkflowExecutionContextBuilderDeps;
 }
 
 /** Registers both workflowexecution services on the router (routes stage). */
@@ -104,10 +147,28 @@ export function registerWorkflowExecutionServices(
   router: ConnectRouter,
   deps: WorkflowExecutionControllerDeps,
 ): void {
+  const lifecycleDeps = {
+    store: deps.store,
+    logger: deps.logger,
+    broker: deps.broker,
+    engineState: deps.engineState,
+    executionContextBuilder: deps.executionContextBuilder,
+  };
   router.service(WorkflowExecutionCommandController, {
+    create: (execution, ctx) => createExecution(deps, execution, ctx),
     update: (execution, ctx) => update(deps, execution, ctx),
     updateStatus: (input) => updateStatus(deps, input),
+    submitApproval: (input) => submitApproval(deps, input),
+    submitFileDecision: (input) => submitFileDecision(deps, input),
+    submitWorkflowTaskApproval: (input) =>
+      submitWorkflowTaskApproval(deps, input),
     delete: (id, ctx) => deleteExecution(deps, id, ctx),
+    sendSignal: (input) => sendSignal(deps, input),
+    cancel: (input) => cancelExecution(lifecycleDeps, input),
+    terminate: (input) => terminateExecution(lifecycleDeps, input),
+    recover: (input) => recoverExecution(lifecycleDeps, input),
+    pause: (input) => pauseExecution(lifecycleDeps, input),
+    resume: (input) => resumeExecution(lifecycleDeps, input),
   });
   router.service(WorkflowExecutionQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
@@ -119,6 +180,71 @@ export function registerWorkflowExecutionServices(
     getExecutionSummary: (req) => getExecutionSummary(deps, req),
     listPendingApprovals: (req) => listPendingApprovals(deps, req),
   });
+}
+
+/**
+ * Create — create.go buildCreatePipeline, step-for-step (the numbered
+ * 15-step chain): validation (proto → visibility → slug →
+ * workflow-or-instance presence, the #196 InvalidArgument contrast) →
+ * the ENGINE GATE at its pinned position (before every side effect — a
+ * down engine orphans nothing; Go's unit test pins that it precedes even
+ * the workflow lookup) → default-instance resolution → the standard
+ * build → PENDING phase → workflow-ref denormalization → version pin →
+ * the ExecutionContext with merged env (runtime_env consumed and
+ * cleared) → Persist → IndexSearch → StartWorkflow (after persist; a
+ * start failure marks the execution FAILED, recoverable via Recover).
+ */
+async function createExecution(
+  deps: WorkflowExecutionControllerDeps,
+  execution: WorkflowExecution,
+  ctx: HandlerContext,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionSchema,
+    execution,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof WorkflowExecutionSchema>(
+    "workflowexecution-create",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newValidateWorkflowOrInstanceStep())
+    .addStep(newEnsureEngineAvailableStep(deps.engineState))
+    .addStep(
+      newCreateDefaultInstanceIfNeededStep({
+        store: deps.store,
+        logger: deps.logger,
+        workflowInstanceCreator: deps.workflowInstanceCreator,
+      }),
+    )
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newSetInitialPhaseStep())
+    .addStep(newNormalizeWorkflowRefStep(deps.store, deps.logger))
+    .addStep(newPinWorkflowVersionStep(deps.store, deps.logger))
+    .addStep(newCreateExecutionContextStep(deps.executionContextBuilder))
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        workflowExecutionSearchExtractor,
+        deps.logger,
+      ),
+    )
+    .addStep(
+      newStartWorkflowStep({
+        store: deps.store,
+        logger: deps.logger,
+        engineState: deps.engineState,
+      }),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
 }
 
 function kindOf(ctx: HandlerContext): ApiResourceKind {

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/controller.ts
@@ -1,0 +1,286 @@
+/**
+ * WorkflowExecution controller — ports pkg/domain/workflowexecution/
+ * controller (command + query sides): the workflow-run record surface.
+ * One Go controller implements both services; this module mirrors that
+ * with one deps object and one registration function.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character;
+ * the list/summary/pending-approval reads are direct handlers, exactly as
+ * Go writes them (no pipeline in list.go / list_by_workflow.go /
+ * get_execution_summary.go / list_pending_approvals.go).
+ *
+ * Proven by workflowexecution.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and __tests__/.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, Publish,
+ * PublishToRedis, and TransformResponse steps (no multi-tenant auth,
+ * event publishing, or Redis here — subscribe streams ride in-memory
+ * channels per ADR 011).
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import { ExecutionSortField } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { WorkflowExecutionListSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type {
+  ListWorkflowExecutionsByWorkflowRequest,
+  ListWorkflowExecutionsRequest,
+  WorkflowExecutionId,
+  WorkflowExecutionList,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
+import type { ApiResourceId } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { create } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import type { Store } from "../../store/interface.js";
+
+import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
+import {
+  applyFilterCriteria,
+  applyLegacyPhaseFilter,
+  applySortField,
+} from "./execution-filter.js";
+import { getEventLog } from "./get-event-log.js";
+import { getExecutionSummary } from "./get-execution-summary.js";
+import { listPendingApprovals } from "./list-pending-approvals.js";
+import { loadAllWorkflowExecutions } from "./queries.js";
+import { workflowExecutionSearchExtractor } from "./search-extractor.js";
+
+export interface WorkflowExecutionControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  /**
+   * The workflow-execution engine seam (engine.ts): permanently
+   * disconnected until #21's TemporalManager flips it. Consumed by the
+   * create gate, the lifecycle RPCs, sendSignal, and
+   * submitWorkflowTaskApproval.
+   */
+  readonly engineState: WorkflowExecutionEngineStateProvider;
+}
+
+/** Registers both workflowexecution services on the router (routes stage). */
+export function registerWorkflowExecutionServices(
+  router: ConnectRouter,
+  deps: WorkflowExecutionControllerDeps,
+): void {
+  router.service(WorkflowExecutionCommandController, {
+    update: (execution, ctx) => update(deps, execution, ctx),
+    delete: (id, ctx) => deleteExecution(deps, id, ctx),
+  });
+  router.service(WorkflowExecutionQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    list: (req) => list(deps, req),
+    listByWorkflow: (req) => listByWorkflow(deps, req),
+    getEventLog: (req) => getEventLog(deps, req),
+    getExecutionSummary: (req) => getExecutionSummary(deps, req),
+    listPendingApprovals: (req) => listPendingApprovals(deps, req),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Update — update.go buildUpdatePipeline: USER-initiated spec updates
+ * (status updates from the runner use UpdateStatus instead). Standard
+ * chain; BuildUpdateState clears status per the shared pattern.
+ */
+async function update(
+  deps: WorkflowExecutionControllerDeps,
+  execution: WorkflowExecution,
+  ctx: HandlerContext,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionSchema,
+    execution,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof WorkflowExecutionSchema>(
+    "workflowexecution-update",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        workflowExecutionSearchExtractor,
+        deps.logger,
+      ),
+    )
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Delete — delete.go buildDeletePipeline; returns the deleted execution
+ * for the audit trail (gRPC convention). Executions and audit rows of the
+ * parent workflow are untouched — only this record and its search-index
+ * row go.
+ */
+async function deleteExecution(
+  deps: WorkflowExecutionControllerDeps,
+  id: ApiResourceId,
+  ctx: HandlerContext,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionCommandController.method.delete.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof WorkflowExecutionCommandController.method.delete.input
+  >("workflowexecution-delete", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(
+      newLoadExistingForDeleteStep(deps.store, WorkflowExecutionSchema),
+    )
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted workflow execution not found in context"),
+      "deleted workflow execution not found in context",
+    );
+  }
+  return deleted as WorkflowExecution;
+}
+
+/** Get — get.go buildGetPipeline: ValidateProto → LoadTarget. */
+async function get(
+  deps: WorkflowExecutionControllerDeps,
+  id: WorkflowExecutionId,
+  ctx: HandlerContext,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof WorkflowExecutionQueryController.method.get.input>(
+    "workflowexecution-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, WorkflowExecutionSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as WorkflowExecution;
+}
+
+/**
+ * List — list.go: full scan, the legacy top-level phase filter (only when
+ * filter.phases is absent), structured filter criteria (T13), and the
+ * sort default started_at descending. No pagination (total_pages
+ * placeholder 1); the request `org` field is a deliberate no-op on this
+ * single-tenant edition.
+ */
+async function list(
+  deps: WorkflowExecutionControllerDeps,
+  req: ListWorkflowExecutionsRequest,
+): Promise<WorkflowExecutionList> {
+  let executions = await loadAllWorkflowExecutions(
+    deps.store,
+    deps.logger,
+    "failed to list workflow executions",
+  );
+
+  if (req.filter === undefined || req.filter.phases.length === 0) {
+    executions = applyLegacyPhaseFilter(executions, req.phase);
+  }
+  executions = applyFilterCriteria(executions, req.filter);
+
+  let sortField = req.sortField;
+  let ascending = req.sortAscending;
+  if (sortField === ExecutionSortField.UNSPECIFIED) {
+    sortField = ExecutionSortField.STARTED_AT;
+    ascending = false;
+  }
+  applySortField(executions, sortField, ascending);
+
+  return create(WorkflowExecutionListSchema, {
+    entries: executions,
+    totalPages: 1,
+  });
+}
+
+/**
+ * ListByWorkflow — list_by_workflow.go: the request field accepts either
+ * a Workflow ID or a WorkflowInstance ID, so both spec fields are
+ * matched. Same filter/sort tail as list; no pagination.
+ */
+async function listByWorkflow(
+  deps: WorkflowExecutionControllerDeps,
+  req: ListWorkflowExecutionsByWorkflowRequest,
+): Promise<WorkflowExecutionList> {
+  if (req.workflowId === "") {
+    throw invalidArgumentError("workflow_id is required");
+  }
+
+  const all = await loadAllWorkflowExecutions(
+    deps.store,
+    deps.logger,
+    "failed to list workflow executions",
+  );
+  let executions = all.filter(
+    (execution) =>
+      execution.spec?.workflowInstanceId === req.workflowId ||
+      execution.spec?.workflowId === req.workflowId,
+  );
+
+  executions = applyFilterCriteria(executions, req.filter);
+
+  let sortField = req.sortField;
+  let ascending = req.sortAscending;
+  if (sortField === ExecutionSortField.UNSPECIFIED) {
+    sortField = ExecutionSortField.STARTED_AT;
+    ascending = false;
+  }
+  applySortField(executions, sortField, ascending);
+
+  return create(WorkflowExecutionListSchema, {
+    entries: executions,
+    totalPages: 1,
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/create-execution-context-step.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/create-execution-context-step.ts
@@ -1,0 +1,233 @@
+/**
+ * CreateExecutionContext — ports create_execution_context_step.go: builds
+ * and persists the ExecutionContext carrying the fully-merged environment
+ * for the run, then strips spec.runtime_env so secrets never reach the
+ * persisted execution or Temporal history.
+ *
+ * Resolution chain: execution.spec.workflow_instance_id (always set by
+ * CreateDefaultInstanceIfNeeded) → instance.environment_refs resolved
+ * through the environment RuntimeResolutionService (decrypted — the RPC
+ * surface redacts, oss#405) → envmerge with spec.runtime_env as the top
+ * layer → least-privilege filter against the workflow's env declarations
+ * (undeclared keys warn + drop; empty declarations pass everything for
+ * backward compatibility) → required-key validation (warn-only) →
+ * ExecutionContext create through the in-process client.
+ *
+ * Go skips the whole step when its late-injected deps are nil; the TS
+ * composition root wires them unconditionally, so that arm is
+ * structurally unreachable here and deliberately not modeled (the
+ * loud-boot doctrine: a missing dependency is a wiring bug, not a mode).
+ *
+ * The recover pipeline's RecreateExecutionContext twin lives in
+ * lifecycle.ts — its failure posture differs (degrade gracefully).
+ */
+import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+
+import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { RuntimeResolutionService } from "../../domain/environment/resolution/resolution.js";
+import {
+  filterByDeclaredKeys,
+  mergeEnvironmentLayers,
+  validateRequiredKeys,
+} from "../../envmerge/envmerge.js";
+import {
+  goWrappedStatusError,
+  internalError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * The narrow workflowinstance READ edge (Go workflowInstanceClient.Get)
+ * — consumer-defined, satisfied by the in-process query client.
+ */
+export interface ExecutionWorkflowInstanceLoader {
+  get(instanceId: string): Promise<WorkflowInstance>;
+}
+export type ExecutionWorkflowInstanceLoaderProvider =
+  () => ExecutionWorkflowInstanceLoader;
+
+/** The narrow executioncontext CREATE edge (Go executionCtxClient.Create). */
+export interface WorkflowExecutionContextCreator {
+  create(executionContext: ExecutionContext): Promise<ExecutionContext>;
+}
+export type WorkflowExecutionContextCreatorProvider =
+  () => WorkflowExecutionContextCreator;
+
+export interface WorkflowExecutionContextBuilderDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly workflowInstanceLoader: ExecutionWorkflowInstanceLoaderProvider;
+  /** The decrypt-for-execution path (oss#405); a direct service, no RPC. */
+  readonly environmentResolution: RuntimeResolutionService;
+  readonly executionContextCreator: WorkflowExecutionContextCreatorProvider;
+}
+
+export function newCreateExecutionContextStep(
+  deps: WorkflowExecutionContextBuilderDeps,
+): PipelineStep<typeof WorkflowExecutionSchema> {
+  return {
+    name: "CreateExecutionContext",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      const executionId = execution.metadata?.id ?? "";
+      const executionOrg = execution.metadata?.org ?? "";
+
+      // CreateDefaultInstanceIfNeeded always stamps this, user-provided
+      // or auto-resolved.
+      const workflowInstanceId = execution.spec?.workflowInstanceId ?? "";
+      if (workflowInstanceId === "") {
+        throw internalError(
+          new Error(
+            "workflow_instance_id not resolved from context or execution spec",
+          ),
+          "workflow_instance_id not resolved from context or execution spec",
+        );
+      }
+
+      let instance: WorkflowInstance;
+      try {
+        instance = await deps.workflowInstanceLoader().get(workflowInstanceId);
+      } catch (error) {
+        if (error instanceof ConnectError) {
+          throw goWrappedStatusError(
+            `load workflow instance ${workflowInstanceId}`,
+            error,
+          );
+        }
+        throw internalError(
+          error,
+          `load workflow instance ${workflowInstanceId}`,
+        );
+      }
+
+      const workflowId = instance.spec?.workflowId ?? "";
+      let workflow: Workflow;
+      try {
+        workflow = await deps.store.getResource(
+          ApiResourceKind.workflow,
+          workflowId,
+          WorkflowSchema,
+        );
+      } catch (error) {
+        throw internalError(error, `load workflow ${workflowId}`);
+      }
+
+      const environments = await resolveEnvironments(
+        deps,
+        instance.spec?.environmentRefs ?? [],
+      );
+
+      const merged = mergeEnvironmentLayers(
+        environments,
+        execution.spec?.runtimeEnv ?? {},
+      );
+
+      // Least-privilege whitelist: workflows only receive declared vars.
+      const workflowEnvDecls = workflow.spec?.env ?? {};
+      const { filtered, excludedKeys } = filterByDeclaredKeys(
+        merged,
+        workflowEnvDecls,
+      );
+      if (excludedKeys.length > 0) {
+        deps.logger.warn("Filtered env vars not declared in workflow env", {
+          executionId,
+          workflowId,
+          excludedKeys,
+        });
+      }
+
+      const missingRequired = validateRequiredKeys(filtered, workflowEnvDecls);
+      if (missingRequired.length > 0) {
+        deps.logger.warn(
+          "Required env vars missing after environment merge — execution may fail",
+          { executionId, workflowId, missingRequired },
+        );
+      }
+
+      const executionContext = create(ExecutionContextSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "ExecutionContext",
+        metadata: {
+          name: `exec-ctx-${executionId}`,
+          org: executionOrg,
+        },
+        spec: {
+          executionId,
+          data: Object.fromEntries(filtered),
+        },
+      });
+
+      try {
+        const created = await deps
+          .executionContextCreator()
+          .create(executionContext);
+        deps.logger.info("Successfully created execution context", {
+          executionContextId: created.metadata?.id ?? "",
+          executionId,
+          dataEntries: filtered.size,
+        });
+      } catch (error) {
+        if (error instanceof ConnectError) {
+          throw goWrappedStatusError(
+            `create execution context for ${executionId}`,
+            error,
+          );
+        }
+        throw internalError(
+          error,
+          `create execution context for ${executionId}`,
+        );
+      }
+
+      // runtime_env is a transient creation-time input, now materialized
+      // in the ExecutionContext; clearing it keeps secrets out of the
+      // persisted execution and Temporal history.
+      if (
+        execution.spec !== undefined &&
+        Object.keys(execution.spec.runtimeEnv).length > 0
+      ) {
+        execution.spec.runtimeEnv = {};
+      }
+    },
+  };
+}
+
+/**
+ * Fetches each referenced Environment in order through the runtime
+ * resolution service (decrypted values; the RPC surface redacts,
+ * oss#405). A failed ref fails the create — Go wraps with the ref
+ * coordinates.
+ */
+async function resolveEnvironments(
+  deps: WorkflowExecutionContextBuilderDeps,
+  refs: ApiResourceReference[],
+): Promise<Environment[]> {
+  if (refs.length === 0) {
+    return [];
+  }
+  const environments: Environment[] = [];
+  for (const ref of refs) {
+    try {
+      environments.push(await deps.environmentResolution.resolveByReference(ref));
+    } catch (error) {
+      const prefix = `resolve environment ref (org=${ref.org}, slug=${ref.slug})`;
+      if (error instanceof ConnectError) {
+        throw goWrappedStatusError(prefix, error);
+      }
+      throw internalError(error, prefix);
+    }
+  }
+  return environments;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/create-steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/create-steps.ts
@@ -1,0 +1,368 @@
+/**
+ * Create-pipeline steps — ports create.go's inline steps: the
+ * workflow-or-instance presence validation (the #196 InvalidArgument
+ * contrast to agentexecution's Internal invariant), the self-healing
+ * default-instance resolution, the initial PENDING phase, and the
+ * post-persist Temporal start whose failure marks the execution FAILED
+ * (recoverable via Recover).
+ *
+ * The engine gate itself lives in engine.ts (shared shape with the
+ * sibling domain); its pinned position is step 4 of the create chain.
+ */
+import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { WorkflowInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/status_pb";
+import {
+  WorkflowExecutionSchema,
+  WorkflowExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  goWrappedStatusError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { Store } from "../../store/interface.js";
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { defaultWorkflowInstanceSlug } from "../workflowinstance/defaultinstance.js";
+import { buildDefaultWorkflowInstanceRequest } from "../workflowinstance/defaultinstance.js";
+
+import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
+
+type ExecutionDesc = typeof WorkflowExecutionSchema;
+
+/**
+ * The narrow workflowinstance CREATE edge (Go
+ * workflowInstanceClient.CreateAsSystem) — consumer-defined so the
+ * dependency reads at the domain boundary; satisfied by the in-process
+ * workflowinstance command client under the process-global operator
+ * identity.
+ */
+export interface ExecutionWorkflowInstanceCreator {
+  createAsSystem(instance: WorkflowInstance): Promise<WorkflowInstance>;
+}
+export type ExecutionWorkflowInstanceCreatorProvider =
+  () => ExecutionWorkflowInstanceCreator;
+
+/**
+ * ValidateWorkflowOrInstance — at least one of workflow_id /
+ * workflow_instance_id must be provided. Matches the cloud
+ * WorkflowExecutionCreateHandler. AgentExecution differs: it has a
+ * ResolveDefaultAgent step, so its guard is an unreachable invariant
+ * (Internal), not reachable InvalidArgument validation (issue #196).
+ */
+export function newValidateWorkflowOrInstanceStep(): PipelineStep<ExecutionDesc> {
+  return {
+    name: "ValidateWorkflowOrInstance",
+    execute(ctx) {
+      const spec = ctx.input.spec;
+      if (
+        (spec?.workflowInstanceId ?? "") === "" &&
+        (spec?.workflowId ?? "") === ""
+      ) {
+        throw invalidArgumentError(
+          "either workflow_id or workflow_instance_id must be provided",
+        );
+      }
+    },
+  };
+}
+
+export interface CreateDefaultInstanceDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly workflowInstanceCreator: ExecutionWorkflowInstanceCreatorProvider;
+}
+
+/**
+ * CreateDefaultInstanceIfNeeded — create.go: when only workflow_id is
+ * provided, resolve (or provision) the workflow's default instance:
+ *
+ *   1. load the workflow (NotFound if missing);
+ *   2. use status.default_instance_id when set;
+ *   3. else look the instance up by its deterministic slug — the
+ *      self-heal for a past run where the instance was created but the
+ *      workflow status write failed (prevents duplicate-slug errors);
+ *   4. else create it via the in-process client (CreateAsSystem) and
+ *      write default_instance_id back onto the workflow.
+ *
+ * Every path stamps the resolved id onto execution.spec.
+ * workflow_instance_id, which downstream steps (EC creation, workflow
+ * start) read.
+ */
+export function newCreateDefaultInstanceIfNeededStep(
+  deps: CreateDefaultInstanceDeps,
+): PipelineStep<ExecutionDesc> {
+  return {
+    name: "CreateDefaultInstanceIfNeeded",
+    async execute(ctx) {
+      const input = ctx.input;
+      if ((input.spec?.workflowInstanceId ?? "") !== "") {
+        return;
+      }
+      const workflowId = input.spec?.workflowId ?? "";
+      const execution = ctx.newState;
+
+      let workflow: Workflow;
+      try {
+        workflow = await deps.store.getResource(
+          ApiResourceKind.workflow,
+          workflowId,
+          WorkflowSchema,
+        );
+      } catch {
+        throw notFoundError("Workflow", workflowId);
+      }
+
+      const defaultInstanceId = workflow.status?.defaultInstanceId ?? "";
+      if (defaultInstanceId !== "") {
+        setInstanceId(execution, defaultInstanceId);
+        return;
+      }
+
+      // Self-heal: the instance may exist even though the workflow status
+      // write failed on a previous run.
+      const slug = defaultWorkflowInstanceSlug(workflow.metadata?.slug ?? "");
+      let existingInstance: WorkflowInstance | undefined;
+      try {
+        existingInstance = await findInstanceBySlug(deps, slug);
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to look up existing default instance",
+        );
+      }
+
+      if (existingInstance !== undefined) {
+        const existingId = existingInstance.metadata?.id ?? "";
+        deps.logger.info(
+          "Found existing default instance, updating workflow status",
+          { instanceId: existingId, workflowId },
+        );
+        await backfillDefaultInstanceId(
+          deps,
+          workflow,
+          workflowId,
+          existingId,
+          "failed to update workflow with existing default instance",
+        );
+        setInstanceId(execution, existingId);
+        return;
+      }
+
+      deps.logger.info("Default instance not found, creating new one", {
+        workflowId,
+      });
+      const instanceRequest = buildDefaultWorkflowInstanceRequest(
+        workflow.metadata!,
+      );
+      let createdInstance: WorkflowInstance;
+      try {
+        createdInstance = await deps
+          .workflowInstanceCreator()
+          .createAsSystem(instanceRequest);
+      } catch (error) {
+        if (error instanceof ConnectError) {
+          // Go wraps the client error with %w — the inner gRPC code
+          // survives to the wire (oss#852 convention).
+          throw goWrappedStatusError(
+            "failed to create default workflow instance",
+            error,
+          );
+        }
+        throw internalError(error, "failed to create default workflow instance");
+      }
+
+      const createdId = createdInstance.metadata?.id ?? "";
+      await backfillDefaultInstanceId(
+        deps,
+        workflow,
+        workflowId,
+        createdId,
+        "failed to update workflow with default instance",
+      );
+      setInstanceId(execution, createdId);
+      deps.logger.info("Successfully created and registered default instance", {
+        instanceId: createdId,
+        workflowId,
+      });
+    },
+  };
+}
+
+function setInstanceId(
+  execution: { spec?: { workflowInstanceId: string } },
+  instanceId: string,
+): void {
+  if (execution.spec !== undefined) {
+    execution.spec.workflowInstanceId = instanceId;
+  }
+}
+
+async function backfillDefaultInstanceId(
+  deps: CreateDefaultInstanceDeps,
+  workflow: Workflow,
+  workflowId: string,
+  instanceId: string,
+  failureMessage: string,
+): Promise<void> {
+  const status = workflow.status ?? create(WorkflowStatusSchema);
+  workflow.status = status;
+  status.defaultInstanceId = instanceId;
+  try {
+    await deps.store.saveResource(
+      ApiResourceKind.workflow,
+      workflowId,
+      WorkflowSchema,
+      workflow,
+    );
+  } catch (error) {
+    throw internalError(error, failureMessage);
+  }
+}
+
+/**
+ * Go findInstanceBySlug: a full workflow_instance scan matched on
+ * metadata.slug; malformed rows are skipped.
+ */
+async function findInstanceBySlug(
+  deps: CreateDefaultInstanceDeps,
+  slug: string,
+): Promise<WorkflowInstance | undefined> {
+  const rows = await deps.store.listResources(
+    ApiResourceKind.workflow_instance,
+  );
+  for (const data of rows) {
+    let instance: WorkflowInstance;
+    try {
+      instance = fromBinary(WorkflowInstanceSchema, data);
+    } catch {
+      deps.logger.warn(
+        "Failed to unmarshal workflow instance during slug lookup",
+      );
+      continue;
+    }
+    if (instance.metadata?.slug === slug) {
+      return instance;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * SetInitialPhase — PENDING before the Temporal workflow starts, so the
+ * frontend shows a thinking indicator immediately.
+ */
+export function newSetInitialPhaseStep(): PipelineStep<ExecutionDesc> {
+  return {
+    name: "SetInitialPhase",
+    execute(ctx) {
+      const execution = ctx.newState;
+      if (execution.status === undefined) {
+        execution.status = create(WorkflowExecutionStatusSchema);
+      }
+      execution.status.phase = ExecutionPhase.EXECUTION_PENDING;
+    },
+  };
+}
+
+export interface StartWorkflowDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly engineState: WorkflowExecutionEngineStateProvider;
+}
+
+/**
+ * StartWorkflow — create.go startWorkflowStep: runs AFTER persist. Engine
+ * availability was guaranteed by the step-4 gate, so a failure here is a
+ * live/transient Temporal error: the execution is marked FAILED with the
+ * error text and persisted (recoverable via Recover), then the RPC
+ * answers Internal. Dispatch-queue resolution lives inside the engine
+ * (#21), fed by spec.execution_target.
+ */
+export function newStartWorkflowStep(
+  deps: StartWorkflowDeps,
+): PipelineStep<ExecutionDesc> {
+  return {
+    name: "StartWorkflow",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      const executionId = execution.metadata?.id ?? "";
+
+      const engineState = deps.engineState();
+      // Unreachable while the gate holds (the engine cannot flip between
+      // step 4 and here pre-#21); modeled the same way Go's non-nil
+      // assumption is — a loud failure, not a silent skip.
+      let startError: Error | undefined;
+      if (!engineState.connected) {
+        startError = new Error(
+          "workflow engine disconnected after the create gate",
+        );
+      } else {
+        try {
+          await engineState.engine.startInvokeWorkflow({
+            executionId,
+            workflowInstanceId: execution.spec?.workflowInstanceId ?? "",
+            workflowId: execution.spec?.workflowId ?? "",
+            orgId: execution.metadata?.org ?? "",
+            recoveryMode: false,
+            executionTarget: execution.spec?.executionTarget ?? 0,
+          });
+        } catch (error) {
+          startError =
+            error instanceof Error ? error : new Error(String(error));
+        }
+      }
+
+      if (startError === undefined) {
+        deps.logger.info("Temporal workflow started successfully", {
+          executionId,
+        });
+        return;
+      }
+
+      deps.logger.error(
+        "Failed to start Temporal workflow - marking execution as FAILED",
+        { executionId, error: startError.message },
+      );
+      if (execution.status === undefined) {
+        execution.status = create(WorkflowExecutionStatusSchema);
+      }
+      execution.status.phase = ExecutionPhase.EXECUTION_FAILED;
+      execution.status.error = `Failed to start Temporal workflow: ${goErrorText(startError)}`;
+      try {
+        await deps.store.saveResource(
+          ApiResourceKind.workflow_execution,
+          executionId,
+          WorkflowExecutionSchema,
+          execution,
+        );
+      } catch (persistError) {
+        throw internalError(
+          persistError,
+          "failed to start workflow and failed to update status",
+        );
+      }
+      throw internalError(startError, "failed to start workflow");
+    },
+  };
+}
+
+/**
+ * The %v rendering Go embeds in status.error: a ConnectError renders as
+ * grpc-go wire text via its message; plain errors as their message.
+ */
+function goErrorText(error: Error): string {
+  return error.message;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/engine.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/engine.ts
@@ -1,0 +1,170 @@
+/**
+ * The workflow-execution engine seam — the ONE place this controller
+ * touches Temporal-shaped behavior before sub-project #21 lands the
+ * workflow-execution orchestrator on #18's shared worker infrastructure.
+ *
+ * Go models engine availability as two separately-injected nilable fields
+ * on the controller (workflowCreator for create/sendSignal/taskApproval/
+ * recover-start, temporalClient for the lifecycle signal/cancel/terminate
+ * steps), re-injected by TemporalManager on every reconnect. The TS
+ * guidelines forbid nullable modeling of optional infrastructure, so
+ * availability is an explicit two-variant state instead (the shape the
+ * sibling agentexecution domain ratified); #21's TemporalManager flips the
+ * provider between the variants exactly where Go calls
+ * SetWorkflowCreator/SetTemporalClient.
+ *
+ * Until #21, the composition root wires ENGINE_DISCONNECTED permanently —
+ * byte-identical behavior to the Go server running without Temporal, with
+ * each call site's own pinned posture (constants.ts): create refuses
+ * Unavailable at the gate; the four lifecycle signal steps and recover's
+ * terminate-existing refuse FailedPrecondition "Temporal is not
+ * available"; sendSignal's send step refuses FailedPrecondition "workflow
+ * creator is not available"; submitWorkflowTaskApproval refuses
+ * Unavailable "workflow creator not configured for task '%s'"; recover's
+ * fresh-start refuses FailedPrecondition with the creator-specific copy.
+ *
+ * The connected variant's surface carries exactly the operations THIS
+ * controller consumes. Workflow IDs are built by the DOMAIN (Go builds
+ * them in the controller steps — they are ported byte-pinned constants,
+ * see constants.ts); dispatch-queue resolution (Go
+ * wftemporal.ResolveWorkflowTaskQueue over spec.execution_target) is
+ * temporal-slice code and lands inside #21's implementations, the same
+ * absorption the agentexecution seam ratified.
+ */
+import type { JsonValue } from "@bufbuild/protobuf";
+import type { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import type { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+
+import { unavailableError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+
+import { ENGINE_UNAVAILABLE_MESSAGE } from "./constants.js";
+
+/**
+ * The slim workflow-start input (Go wfactivities.
+ * InvokeWorkflowExecutionWorkflowInput): only orchestration coordinates —
+ * the slim-input doctrine keeps secrets out of Temporal history (they were
+ * already consumed into the ExecutionContext). executionTarget feeds
+ * #21's dispatch resolution ("global" → stigmer_runner, "execution" →
+ * wfexec:{id}); the cloud-only CallbackToken/InvokerIdentityAccountID
+ * fields have no OSS producer and are not modeled.
+ */
+export interface StartWorkflowExecutionInput {
+  readonly executionId: string;
+  readonly workflowInstanceId: string;
+  readonly workflowId: string;
+  readonly orgId: string;
+  readonly recoveryMode: boolean;
+  /** spec.execution_target — consumed by dispatch resolution, not Temporal. */
+  readonly executionTarget: ExecutionTarget;
+}
+
+/**
+ * The engine operations this controller consumes once Temporal is wired.
+ * Implemented by #21; empty by design until then — see the module header.
+ */
+export interface ConnectedWorkflowExecutionEngine {
+  /**
+   * Starts the orchestrator workflow (Go workflowCreator.Create after
+   * ResolveWorkflowTaskQueue). Used by create's StartWorkflow step and
+   * recover's StartFreshWorkflow step.
+   */
+  startInvokeWorkflow(input: StartWorkflowExecutionInput): Promise<void>;
+
+  /**
+   * SignalWithStart against the orchestrator (Go
+   * workflowCreator.SignalWithStart) — race-proof for PENDING executions
+   * whose orchestrator has not started yet. Used by sendSignal and
+   * submitWorkflowTaskApproval, always on the relaySignal channel.
+   */
+  signalWithStart(
+    input: StartWorkflowExecutionInput,
+    signalName: string,
+    payload: JsonValue,
+  ): Promise<void>;
+
+  /**
+   * Raw signal to a workflow ID (Go temporalClient.SignalWorkflow with
+   * empty run ID = latest run). Used by the pause/resume lifecycle steps
+   * against the orchestrator ID. Throws EngineWorkflowNotFoundError when
+   * the workflow no longer exists — the steps treat that as
+   * warn-and-proceed (the local state update still applies).
+   */
+  signalWorkflow(
+    workflowId: string,
+    signalName: string,
+    payload: JsonValue | undefined,
+  ): Promise<void>;
+
+  /**
+   * Cancels a workflow by ID (Go temporalClient.CancelWorkflow, empty run
+   * ID). EngineWorkflowNotFoundError → warn-and-proceed.
+   */
+  cancelWorkflow(workflowId: string): Promise<void>;
+
+  /**
+   * Terminates a workflow by ID (Go temporalClient.TerminateWorkflow,
+   * empty run ID). EngineWorkflowNotFoundError → warn-and-proceed (the
+   * recover path treats NOT_FOUND on either tree member as success).
+   */
+  terminateWorkflow(workflowId: string, reason: string): Promise<void>;
+}
+
+/**
+ * The engine's "workflow not found" sentinel (Go *serviceerror.NotFound
+ * from the Temporal client). #21's implementation maps Temporal's
+ * not-found onto it; tests construct it directly.
+ */
+export class EngineWorkflowNotFoundError extends Error {
+  constructor(workflowId: string) {
+    super(`workflow not found: ${workflowId}`);
+    this.name = "EngineWorkflowNotFoundError";
+  }
+}
+
+/** Engine availability as an explicit modeled state (guidelines §4). */
+export type WorkflowExecutionEngineState =
+  | {
+      readonly connected: true;
+      readonly engine: ConnectedWorkflowExecutionEngine;
+    }
+  | { readonly connected: false };
+
+/**
+ * The permanent pre-#21 state: no Temporal behind this server. A frozen
+ * singleton so identity comparisons in tests stay meaningful.
+ */
+export const ENGINE_DISCONNECTED: WorkflowExecutionEngineState =
+  Object.freeze({ connected: false });
+
+/**
+ * A provider rather than a value: #21's TemporalManager re-injects on
+ * every reconnect (Go's SetWorkflowCreator/SetTemporalClient), so
+ * consumers must observe the CURRENT state at request time, never a
+ * boot-time snapshot.
+ */
+export type WorkflowExecutionEngineStateProvider =
+  () => WorkflowExecutionEngineState;
+
+/**
+ * EnsureEngineAvailable — create.go ensureEngineAvailableStep: rejects the
+ * create fast — before any persistence or side effect — when the engine is
+ * not connected. Pinned position: step 4, after ValidateWorkflowOrInstance
+ * (a malformed request still answers InvalidArgument first) and before
+ * CreateDefaultInstanceIfNeeded (a down engine orphans nothing — no
+ * default instance, no ExecutionContext, no execution record). Go's unit
+ * test pins the precedence: engine-unavailable beats workflow lookup.
+ */
+export function newEnsureEngineAvailableStep(
+  engineState: WorkflowExecutionEngineStateProvider,
+): PipelineStep<typeof WorkflowExecutionSchema> {
+  return {
+    name: "EnsureEngineAvailable",
+    execute(_ctx: RequestContext<typeof WorkflowExecutionSchema>): void {
+      if (!engineState().connected) {
+        throw unavailableError(ENGINE_UNAVAILABLE_MESSAGE);
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/execution-filter.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/execution-filter.ts
@@ -1,0 +1,255 @@
+/**
+ * Execution list filtering and sorting — ports execution_filter.go
+ * (T13 Execution History): the structured ExecutionFilterCriteria
+ * matcher, the sort-field comparator, and the legacy top-level phase
+ * filter. Proven by __tests__/execution-filter.test.ts (Go's 11-case
+ * execution_filter_test.go ported case-for-case).
+ *
+ * Time parsing: Go accepts RFC3339Nano/RFC3339 and treats unparseable
+ * strings as the zero time (which sorts before every real instant and
+ * fails IsZero-guarded filters). This port parses to epoch milliseconds
+ * with the same strictness (date+time+zone required) and mirrors zero
+ * time as NaN. Precision note: Go compares at nanosecond precision, JS
+ * Date at millisecond — sub-millisecond duration-filter boundaries are
+ * the only divergence, below anything the system writes or the suites
+ * assert.
+ */
+import type { Duration } from "@bufbuild/protobuf/wkt";
+import { timestampMs } from "@bufbuild/protobuf/wkt";
+
+import type {
+  WorkflowExecution,
+  WorkflowTask,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import {
+  ExecutionPhase,
+  WorkflowTaskStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ExecutionSortField } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type { ExecutionFilterCriteria } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+/**
+ * Strict RFC3339 shape gate: Go time.Parse(RFC3339Nano/RFC3339) requires
+ * the T separator and an explicit zone; JS Date.parse is looser (it
+ * accepts date-only strings, for one), so unguarded parsing would accept
+ * strings Go maps to the zero time.
+ */
+const RFC3339_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Go's parseTime: RFC3339(Nano) → instant; anything else → the zero time,
+ * mirrored here as NaN (callers guard with Number.isNaN exactly where Go
+ * guards with IsZero).
+ */
+export function parseRfc3339Ms(iso: string): number {
+  if (iso === "" || !RFC3339_PATTERN.test(iso)) {
+    return Number.NaN;
+  }
+  return Date.parse(iso);
+}
+
+/**
+ * applyFilterCriteria — returns only entries matching every specified
+ * condition (AND logic); a nil filter passes everything through.
+ */
+export function applyFilterCriteria(
+  executions: WorkflowExecution[],
+  filter: ExecutionFilterCriteria | undefined,
+): WorkflowExecution[] {
+  if (filter === undefined) {
+    return executions;
+  }
+  return executions.filter((execution) => matchesFilter(execution, filter));
+}
+
+function matchesFilter(
+  execution: WorkflowExecution,
+  f: ExecutionFilterCriteria,
+): boolean {
+  const status = execution.status;
+
+  if (f.phases.length > 0) {
+    const phase = status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+    if (!f.phases.includes(phase)) {
+      return false;
+    }
+  }
+
+  if (f.startedAfter !== undefined) {
+    const started = parseRfc3339Ms(status?.startedAt ?? "");
+    if (Number.isNaN(started) || started < timestampMs(f.startedAfter)) {
+      return false;
+    }
+  }
+
+  if (f.startedBefore !== undefined) {
+    const started = parseRfc3339Ms(status?.startedAt ?? "");
+    if (Number.isNaN(started) || started > timestampMs(f.startedBefore)) {
+      return false;
+    }
+  }
+
+  if (f.minDuration !== undefined || f.maxDuration !== undefined) {
+    const started = parseRfc3339Ms(status?.startedAt ?? "");
+    const completed = parseRfc3339Ms(status?.completedAt ?? "");
+    if (Number.isNaN(started) || Number.isNaN(completed)) {
+      return false;
+    }
+    const durationMs = completed - started;
+    if (
+      f.minDuration !== undefined &&
+      durationMs < durationToMs(f.minDuration)
+    ) {
+      return false;
+    }
+    if (
+      f.maxDuration !== undefined &&
+      durationMs > durationToMs(f.maxDuration)
+    ) {
+      return false;
+    }
+  }
+
+  const costMicros = status?.totalCostMicros ?? 0n;
+  if (f.minCostMicros > 0n && costMicros < f.minCostMicros) {
+    return false;
+  }
+  if (f.maxCostMicros > 0n && costMicros > f.maxCostMicros) {
+    return false;
+  }
+
+  if (f.failedTaskName !== "") {
+    const found = (status?.tasks ?? []).some(
+      (task) =>
+        task.status === WorkflowTaskStatus.WORKFLOW_TASK_FAILED &&
+        task.taskName === f.failedTaskName,
+    );
+    if (!found) {
+      return false;
+    }
+  }
+
+  if (f.hasRetries) {
+    const hasRetry = (status?.tasks ?? []).some(
+      (task) => extractRetryCountFromMetadata(task) > 0,
+    );
+    if (!hasRetry) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * A task counts as retried when its metadata carries retry_count > 0
+ * (either snake_case or camelCase key — Go checks both).
+ */
+export function extractRetryCountFromMetadata(task: WorkflowTask): number {
+  const fields = task.metadata;
+  if (fields === undefined) {
+    return 0;
+  }
+  const retryField = fields["retry_count"] ?? fields["retryCount"];
+  if (typeof retryField !== "number" || retryField <= 0) {
+    return 0;
+  }
+  return Math.trunc(retryField);
+}
+
+function durationToMs(duration: Duration): number {
+  return Number(duration.seconds) * 1000 + duration.nanos / 1e6;
+}
+
+/**
+ * applySortField — stable in-place sort by the requested field (Go
+ * sort.SliceStable; Array.prototype.sort is spec-stable). Descending is
+ * Go's `!less(a,b) && less(b,a)` — strictly-greater-first, ties keeping
+ * scan order.
+ */
+export function applySortField(
+  executions: WorkflowExecution[],
+  sortField: ExecutionSortField,
+  ascending: boolean,
+): void {
+  if (executions.length <= 1) {
+    return;
+  }
+  executions.sort((a, b) => {
+    if (lessBySortField(a, b, sortField)) {
+      return ascending ? -1 : 1;
+    }
+    if (lessBySortField(b, a, sortField)) {
+      return ascending ? 1 : -1;
+    }
+    return 0;
+  });
+}
+
+function lessBySortField(
+  a: WorkflowExecution,
+  b: WorkflowExecution,
+  field: ExecutionSortField,
+): boolean {
+  switch (field) {
+    case ExecutionSortField.DURATION:
+      return executionDurationMs(a) < executionDurationMs(b);
+    case ExecutionSortField.COST:
+      return (
+        (a.status?.totalCostMicros ?? 0n) < (b.status?.totalCostMicros ?? 0n)
+      );
+    case ExecutionSortField.STATUS:
+      return (
+        (a.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) <
+        (b.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED)
+      );
+    case ExecutionSortField.UNSPECIFIED:
+    case ExecutionSortField.STARTED_AT: {
+      // Go's zero time (unparseable/empty started_at) sorts before every
+      // real instant; NaN maps to -Infinity to preserve that ordering.
+      const ta = orNegativeInfinity(parseRfc3339Ms(a.status?.startedAt ?? ""));
+      const tb = orNegativeInfinity(parseRfc3339Ms(b.status?.startedAt ?? ""));
+      return ta < tb;
+    }
+    default: {
+      const exhaustive: never = field;
+      throw new Error(`unhandled sort field: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Go's executionDurationMs: -1 when either timestamp is missing, so all
+ * incomplete executions tie below every real duration.
+ */
+export function executionDurationMs(execution: WorkflowExecution): number {
+  const started = parseRfc3339Ms(execution.status?.startedAt ?? "");
+  const completed = parseRfc3339Ms(execution.status?.completedAt ?? "");
+  if (Number.isNaN(started) || Number.isNaN(completed)) {
+    return -1;
+  }
+  return completed - started;
+}
+
+function orNegativeInfinity(value: number): number {
+  return Number.isNaN(value) ? Number.NEGATIVE_INFINITY : value;
+}
+
+/**
+ * applyLegacyPhaseFilter — the deprecated top-level `phase` request field,
+ * applied only when filter.phases is absent (list.go's fallback).
+ */
+export function applyLegacyPhaseFilter(
+  executions: WorkflowExecution[],
+  phase: ExecutionPhase,
+): WorkflowExecution[] {
+  if (phase === ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) {
+    return executions;
+  }
+  return executions.filter(
+    (execution) =>
+      (execution.status?.phase ??
+        ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) === phase,
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/get-event-log.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/get-event-log.ts
@@ -1,0 +1,121 @@
+/**
+ * GetEventLog — ports get_event_log.go: cursor-paginated reads over the
+ * workflow_execution_events side table (sequence_number ascending,
+ * strictly after the cursor). The asymmetry the Class A suite pins: an
+ * empty execution_id refuses InvalidArgument, but an UNKNOWN id answers
+ * an empty page — there is deliberately no existence check (the opposite
+ * of the subscribe lanes).
+ *
+ * The store filters by at most one event type; multi-type requests fetch
+ * unfiltered and filter in memory — which can under-fill a page (Go
+ * accepts this: has_more is computed from the pre-filter fetch).
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { WorkflowExecutionEventSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import type { WorkflowExecutionEvent } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import { WorkflowEventType } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import { GetEventLogResponseSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type {
+  GetEventLogRequest,
+  GetEventLogResponse,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import type { Store, WorkflowExecutionEventRecord } from "../../store/interface.js";
+
+import { DEFAULT_EVENT_PAGE_SIZE, MAX_EVENT_PAGE_SIZE } from "./constants.js";
+
+export interface EventLogDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+/** The proto enum's value NAME — exactly Go's WorkflowEventType.String(). */
+export function eventTypeName(eventType: WorkflowEventType): string {
+  return WorkflowEventType[eventType] ?? "";
+}
+
+export async function getEventLog(
+  deps: EventLogDeps,
+  req: GetEventLogRequest,
+): Promise<GetEventLogResponse> {
+  if (req.executionId === "") {
+    throw invalidArgumentError("execution_id is required");
+  }
+
+  let pageSize = req.pageSize;
+  if (pageSize <= 0) {
+    pageSize = DEFAULT_EVENT_PAGE_SIZE;
+  }
+  if (pageSize > MAX_EVENT_PAGE_SIZE) {
+    pageSize = MAX_EVENT_PAGE_SIZE;
+  }
+
+  // The store filters by one event type; multiple requested types fall
+  // back to in-memory filtering after an unfiltered fetch.
+  let eventTypeFilter = "";
+  if (req.eventTypes.length === 1) {
+    eventTypeFilter = eventTypeName(req.eventTypes[0]);
+  }
+
+  // Fetch one extra record to compute has_more.
+  let records: WorkflowExecutionEventRecord[];
+  try {
+    records = await deps.store.getWorkflowExecutionEvents(
+      req.executionId,
+      Number(req.afterSequence),
+      eventTypeFilter,
+      req.taskName,
+      pageSize + 1,
+    );
+  } catch (error) {
+    deps.logger.error("Failed to query execution events", {
+      executionId: req.executionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to query execution events");
+  }
+
+  const hasMore = records.length > pageSize;
+  if (hasMore) {
+    records = records.slice(0, pageSize);
+  }
+
+  let typeFilter: Set<string> | undefined;
+  if (req.eventTypes.length > 1) {
+    typeFilter = new Set(req.eventTypes.map(eventTypeName));
+  }
+
+  const events: WorkflowExecutionEvent[] = [];
+  let latestSequence = 0n;
+
+  for (const record of records) {
+    if (typeFilter !== undefined && !typeFilter.has(record.eventType)) {
+      continue;
+    }
+
+    let event: WorkflowExecutionEvent;
+    try {
+      event = fromBinary(WorkflowExecutionEventSchema, record.data);
+    } catch {
+      deps.logger.warn("Skipping malformed event record", {
+        executionId: req.executionId,
+        sequenceNumber: record.sequenceNumber,
+      });
+      continue;
+    }
+
+    events.push(event);
+    if (BigInt(record.sequenceNumber) > latestSequence) {
+      latestSequence = BigInt(record.sequenceNumber);
+    }
+  }
+
+  return create(GetEventLogResponseSchema, {
+    events,
+    hasMore,
+    latestSequence,
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/get-execution-summary.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/get-execution-summary.ts
@@ -1,0 +1,283 @@
+/**
+ * GetExecutionSummary — ports get_execution_summary.go (T14 dashboard,
+ * T12 overview): a full scan aggregated into phase counts, cost totals,
+ * average completed duration, top failure ranks, and per-workflow cost
+ * breakdown, optionally scoped by time window and workflow.
+ *
+ * Zero-shape pins (Class A suite): success_rate is the -1 sentinel when
+ * no terminal executions exist (distinguishable from a real 0%); the
+ * zero-valued total_cost summary is ALWAYS present; avg_duration is
+ * deliberately absent when nothing completed (an average over nothing is
+ * not 0).
+ *
+ * Tie order in the two ranked lists is not wire-stable in Go (map
+ * iteration feeds a stable sort), so ties here — deterministic first-seen
+ * order — are not a wire divergence (the #6 sort-stability precedent).
+ */
+import { create } from "@bufbuild/protobuf";
+import { DurationSchema } from "@bufbuild/protobuf/wkt";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+import { timestampMs } from "@bufbuild/protobuf/wkt";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import {
+  ExecutionSummarySchema,
+  SummaryTimeWindow,
+  WorkflowCostBreakdownSchema,
+  WorkflowCostSummarySchema,
+  WorkflowFailureRankSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type {
+  ExecutionSummary,
+  GetExecutionSummaryRequest,
+  WorkflowCostBreakdown,
+  WorkflowFailureRank,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { Store } from "../../store/interface.js";
+
+import { parseRfc3339Ms } from "./execution-filter.js";
+import { loadAllWorkflowExecutions } from "./queries.js";
+
+const RANK_LIMIT = 10;
+
+export interface SummaryDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+export async function getExecutionSummary(
+  deps: SummaryDeps,
+  req: GetExecutionSummaryRequest,
+): Promise<ExecutionSummary> {
+  const executions = await loadAllWorkflowExecutions(
+    deps.store,
+    deps.logger,
+    "failed to list workflow executions for summary",
+  );
+
+  const cutoffMs = resolveTimeCutoffMs(req.timeWindow);
+  const workflowFilter = req.workflowId;
+
+  const phaseCounts: Record<number, number> = {};
+  let activeCount = 0;
+  let totalCount = 0;
+  let completedCount = 0;
+  let failedCount = 0;
+  const completedDurationsMs: number[] = [];
+  const failureCounts = new Map<string, number>();
+  const workflowNames = new Map<string, string>();
+  const execByWorkflow = new Map<string, number>();
+  const costByWorkflow = new Map<string, number>();
+
+  let totalCostMicros = 0n;
+  let totalInputTokens = 0n;
+  let totalOutputTokens = 0n;
+
+  for (const execution of executions) {
+    const createdAtMs = auditCreatedAtMs(
+      execution.status?.audit?.specAudit?.createdAt,
+    );
+    if (
+      createdAtMs !== undefined &&
+      cutoffMs !== undefined &&
+      createdAtMs < cutoffMs
+    ) {
+      continue;
+    }
+
+    if (
+      workflowFilter !== "" &&
+      execution.spec?.workflowId !== workflowFilter &&
+      execution.spec?.workflowInstanceId !== workflowFilter
+    ) {
+      continue;
+    }
+
+    const phase =
+      execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+    phaseCounts[phase] = (phaseCounts[phase] ?? 0) + 1;
+    totalCount++;
+
+    if (isActivePhase(phase)) {
+      activeCount++;
+    }
+    if (phase === ExecutionPhase.EXECUTION_COMPLETED) {
+      completedCount++;
+    }
+    if (phase === ExecutionPhase.EXECUTION_FAILED) {
+      failedCount++;
+    }
+
+    // Go's extractWorkflowSlug reads the EXECUTION's metadata.slug (the
+    // per-workflow grouping key the dashboard renders).
+    const slug = execution.metadata?.slug ?? "";
+    if (slug !== "") {
+      execByWorkflow.set(slug, (execByWorkflow.get(slug) ?? 0) + 1);
+      const name = execution.metadata?.name ?? "";
+      if (name !== "") {
+        workflowNames.set(slug, name);
+      }
+    }
+
+    const execCostMicros = execution.status?.totalCostMicros ?? 0n;
+    totalCostMicros += execCostMicros;
+    totalInputTokens += execution.status?.totalInputTokens ?? 0n;
+    totalOutputTokens += execution.status?.totalOutputTokens ?? 0n;
+    if (slug !== "" && execCostMicros > 0n) {
+      costByWorkflow.set(
+        slug,
+        (costByWorkflow.get(slug) ?? 0) + Number(execCostMicros) / 1_000_000,
+      );
+    }
+
+    if (phase === ExecutionPhase.EXECUTION_COMPLETED) {
+      const durationMs = completionDurationMs(execution);
+      if (durationMs > 0) {
+        completedDurationsMs.push(durationMs);
+      }
+    }
+
+    if (phase === ExecutionPhase.EXECUTION_FAILED && slug !== "") {
+      failureCounts.set(slug, (failureCounts.get(slug) ?? 0) + 1);
+    }
+  }
+
+  let successRate = -1;
+  const terminal = completedCount + failedCount;
+  if (terminal > 0) {
+    successRate = completedCount / terminal;
+  }
+
+  const summary = create(ExecutionSummarySchema, {
+    activeCount,
+    phaseCounts,
+    totalCost: create(WorkflowCostSummarySchema, {
+      totalCostUsd: Number(totalCostMicros) / 1_000_000,
+      totalInputTokens,
+      totalOutputTokens,
+    }),
+    totalCount,
+    successRate,
+  });
+
+  if (completedDurationsMs.length > 0) {
+    let totalMs = 0;
+    for (const durationMs of completedDurationsMs) {
+      totalMs += durationMs;
+    }
+    summary.avgDuration = durationFromMs(
+      totalMs / completedDurationsMs.length,
+    );
+  }
+
+  summary.topFailingWorkflows = buildFailureRanks(
+    failureCounts,
+    workflowNames,
+    RANK_LIMIT,
+  );
+  summary.costByWorkflow = buildCostBreakdown(
+    costByWorkflow,
+    execByWorkflow,
+    workflowNames,
+    RANK_LIMIT,
+  );
+
+  return summary;
+}
+
+/**
+ * resolveTimeCutoff — LAST_7D is the default for unspecified/unknown
+ * windows; ALL_TIME is the "no cutoff" sentinel (Go's zero time,
+ * undefined here).
+ */
+export function resolveTimeCutoffMs(
+  timeWindow: SummaryTimeWindow,
+): number | undefined {
+  const nowMs = Date.now();
+  switch (timeWindow) {
+    case SummaryTimeWindow.LAST_24H:
+      return nowMs - 24 * 60 * 60 * 1000;
+    case SummaryTimeWindow.LAST_7D:
+      return nowMs - 7 * 24 * 60 * 60 * 1000;
+    case SummaryTimeWindow.LAST_30D:
+      return nowMs - 30 * 24 * 60 * 60 * 1000;
+    case SummaryTimeWindow.ALL_TIME:
+      return undefined;
+    default:
+      return nowMs - 7 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function isActivePhase(phase: ExecutionPhase): boolean {
+  return (
+    phase === ExecutionPhase.EXECUTION_PENDING ||
+    phase === ExecutionPhase.EXECUTION_IN_PROGRESS ||
+    phase === ExecutionPhase.EXECUTION_PAUSED
+  );
+}
+
+/** Go auditCreatedAt: nil timestamp → zero time (undefined here). */
+function auditCreatedAtMs(createdAt: Timestamp | undefined): number | undefined {
+  if (createdAt === undefined) {
+    return undefined;
+  }
+  return timestampMs(createdAt);
+}
+
+/**
+ * Go completionDuration: 0 when either timestamp is missing or
+ * unparseable — those executions are excluded from the average (the
+ * `> 0` guard at the call site).
+ */
+function completionDurationMs(execution: WorkflowExecution): number {
+  const started = parseRfc3339Ms(execution.status?.startedAt ?? "");
+  const completed = parseRfc3339Ms(execution.status?.completedAt ?? "");
+  if (Number.isNaN(started) || Number.isNaN(completed)) {
+    return 0;
+  }
+  return completed - started;
+}
+
+function durationFromMs(ms: number) {
+  const truncatedMs = Math.trunc(ms);
+  const seconds = Math.trunc(truncatedMs / 1000);
+  const nanos = Math.trunc((truncatedMs - seconds * 1000) * 1_000_000);
+  return create(DurationSchema, { seconds: BigInt(seconds), nanos });
+}
+
+/** Failure ranks by count descending, capped (stable; ties first-seen). */
+function buildFailureRanks(
+  counts: Map<string, number>,
+  names: Map<string, string>,
+  limit: number,
+): WorkflowFailureRank[] {
+  const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  return entries.slice(0, limit).map(([slug, count]) =>
+    create(WorkflowFailureRankSchema, {
+      workflowSlug: slug,
+      workflowName: names.get(slug) ?? "",
+      failureCount: count,
+    }),
+  );
+}
+
+/** Cost breakdown by total cost descending, capped (ties first-seen). */
+function buildCostBreakdown(
+  costs: Map<string, number>,
+  execCounts: Map<string, number>,
+  names: Map<string, string>,
+  limit: number,
+): WorkflowCostBreakdown[] {
+  const entries = [...costs.entries()].sort((a, b) => b[1] - a[1]);
+  return entries.slice(0, limit).map(([slug, cost]) =>
+    create(WorkflowCostBreakdownSchema, {
+      workflowSlug: slug,
+      workflowName: names.get(slug) ?? "",
+      totalCostUsd: cost,
+      executionCount: execCounts.get(slug) ?? 0,
+    }),
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/lifecycle.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/lifecycle.ts
@@ -1,0 +1,858 @@
+/**
+ * The lifecycle RPCs — ports cancel.go, terminate.go, pause.go,
+ * resume.go, recover.go, lifecycle_steps.go, and
+ * recreate_execution_context_step.go: the five phase-transition commands
+ * over one shared step vocabulary.
+ *
+ * Every Temporal touchpoint rides the engine seam. With the engine
+ * disconnected (pre-#21) the signal/cancel/terminate steps refuse
+ * FailedPrecondition("Temporal is not available") and recover's
+ * fresh-start refuses the creator-specific variant — Go's nil-client
+ * arms, asserted by the Class B conformance suites once #21 wires the
+ * engine. With a connected engine, workflow-not-found is warn-and-proceed
+ * (the local state update still applies; the workflow may simply have
+ * completed).
+ *
+ * The phase transition + persist is ONE atomic read-modify-write under
+ * the store's per-resource write lock — the lifecycle counterpart of the
+ * DD-001 updateStatus decision and the shape the sibling agentexecution
+ * domain ratified: Go's separate load → mutate → SaveResource can clobber
+ * a runner updateStatus merge that lands between them. Wire-identical in
+ * sequential flows; disclosed with DD-001.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import {
+  WorkflowExecutionSchema,
+  WorkflowExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import type {
+  CancelWorkflowExecutionInput,
+  PauseWorkflowExecutionInput,
+  RecoverWorkflowExecutionInput,
+  ResumeWorkflowExecutionInput,
+  TerminateWorkflowExecutionInput,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  filterByDeclaredKeys,
+  mergeEnvironmentLayers,
+} from "../../envmerge/envmerge.js";
+import {
+  failedPreconditionError,
+  goWrappedStatusError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+
+import {
+  TEMPORAL_UNAVAILABLE_CREATOR_MESSAGE,
+  TEMPORAL_UNAVAILABLE_MESSAGE,
+  PAUSE_SIGNAL_NAME,
+  RESUME_SIGNAL_NAME,
+  childWorkflowId,
+  orchestratorWorkflowId,
+} from "./constants.js";
+import type { WorkflowExecutionContextBuilderDeps } from "./create-execution-context-step.js";
+import { EngineWorkflowNotFoundError } from "./engine.js";
+import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
+import type { StreamBroker } from "./stream-broker.js";
+
+// Context keys (Go lifecycle_steps.go constants).
+const LOADED_EXECUTION_KEY = "loadedExecution";
+const REASON_KEY = "reason";
+const ALREADY_IN_TARGET_STATE_KEY = "alreadyInTargetState";
+
+export interface LifecycleDeps {
+  readonly store: WorkflowExecutionContextBuilderDeps["store"];
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+  readonly engineState: WorkflowExecutionEngineStateProvider;
+  /** Recover's RecreateExecutionContext consumes the same builder deps. */
+  readonly executionContextBuilder: WorkflowExecutionContextBuilderDeps;
+}
+
+// ---------------------------------------------------------------------------
+// Shared steps (lifecycle_steps.go).
+// ---------------------------------------------------------------------------
+
+interface LifecycleInputShape {
+  readonly id: string;
+}
+
+function loadedExecution<Desc extends DescMessage>(
+  ctx: RequestContext<Desc>,
+): WorkflowExecution {
+  return ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+}
+
+/** LoadExecutionById — empty-id InvalidArgument, then NotFound on miss. */
+function newLoadExecutionByIdStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "LoadExecutionById",
+    async execute(ctx) {
+      const executionId = (ctx.input as unknown as LifecycleInputShape).id;
+      if (executionId === "") {
+        throw invalidArgumentError("execution id is required");
+      }
+      let execution: WorkflowExecution;
+      try {
+        execution = await deps.store.getResource(
+          ApiResourceKind.workflow_execution,
+          executionId,
+          WorkflowExecutionSchema,
+        );
+      } catch {
+        throw notFoundError("workflow_execution", executionId);
+      }
+      ctx.set(LOADED_EXECUTION_KEY, execution);
+    },
+  };
+}
+
+/**
+ * One validator per operation (Go's five ValidateXxxable steps): the
+ * target phase is idempotent success (the Temporal + persist steps skip),
+ * the allowed set passes, everything else refuses FailedPrecondition with
+ * the pinned copy.
+ */
+function newValidatePhaseStep<Desc extends DescMessage>(
+  name: string,
+  idempotentPhase: ExecutionPhase,
+  allowedPhases: readonly ExecutionPhase[],
+  refusalMessage: (phaseName: string) => string,
+): PipelineStep<Desc> {
+  return {
+    name,
+    execute(ctx) {
+      const phase =
+        loadedExecution(ctx).status?.phase ??
+        ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+      if (phase === idempotentPhase) {
+        ctx.set(ALREADY_IN_TARGET_STATE_KEY, true);
+        return;
+      }
+      if (!allowedPhases.includes(phase)) {
+        throw failedPreconditionError(refusalMessage(ExecutionPhase[phase]));
+      }
+    },
+  };
+}
+
+/**
+ * The engine touchpoints for pause/resume/cancel/terminate: target the
+ * orchestrator's byte-pinned workflow ID; disconnected →
+ * FailedPrecondition; workflow-not-found → warn-and-proceed; any other
+ * engine failure → Internal with the operation's pinned message.
+ */
+function newEngineLifecycleStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+  name: string,
+  failureMessage: string,
+  operation: (
+    engine: NonNullable<
+      Extract<
+        ReturnType<WorkflowExecutionEngineStateProvider>,
+        { connected: true }
+      >
+    >["engine"],
+    execution: WorkflowExecution,
+    ctx: RequestContext<Desc>,
+  ) => Promise<void>,
+): PipelineStep<Desc> {
+  return {
+    name,
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const engineState = deps.engineState();
+      if (!engineState.connected) {
+        throw failedPreconditionError(TEMPORAL_UNAVAILABLE_MESSAGE);
+      }
+      const execution = loadedExecution(ctx);
+      try {
+        await operation(engineState.engine, execution, ctx);
+      } catch (error) {
+        if (error instanceof EngineWorkflowNotFoundError) {
+          // The workflow may have already completed — continue and update
+          // local state anyway (Go's *serviceerror.NotFound arm).
+          deps.logger.warn(
+            "Temporal workflow not found, may have already completed",
+            { executionId: execution.metadata?.id ?? "" },
+          );
+          return;
+        }
+        throw internalError(error, failureMessage);
+      }
+    },
+  };
+}
+
+/**
+ * Applies a lifecycle phase transition in place (Go
+ * UpdateExecutionPhaseStep's mutation): target phase, completed_at for
+ * the terminal CANCELLED/TERMINATED (RFC3339 seconds precision — Go
+ * time.RFC3339; PAUSED is NOT terminal and keeps completed_at as-is),
+ * completed_at cleared on the way back to IN_PROGRESS (recover/resume),
+ * and the terminate error copy / recover error clear. Exercised directly
+ * by the lifecycle unit tests.
+ */
+export function applyLifecyclePhaseTransition(
+  execution: WorkflowExecution,
+  targetPhase: ExecutionPhase,
+  setError: boolean,
+  clearError: boolean,
+  reason: string,
+): void {
+  execution.status ??= create(WorkflowExecutionStatusSchema);
+  const status = execution.status;
+  status.phase = targetPhase;
+
+  if (
+    targetPhase === ExecutionPhase.EXECUTION_CANCELLED ||
+    targetPhase === ExecutionPhase.EXECUTION_TERMINATED
+  ) {
+    status.completedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  }
+  if (targetPhase === ExecutionPhase.EXECUTION_IN_PROGRESS) {
+    status.completedAt = "";
+  }
+
+  if (setError) {
+    // Go reads the ReasonKey the terminate signal step recorded; when the
+    // signal step short-circuited (workflow already gone) no reason was
+    // recorded and the default copy applies — quirk ported faithfully.
+    status.error =
+      reason !== "" ? `Terminated: ${reason}` : "Terminated by user";
+  }
+  if (clearError) {
+    status.error = "";
+  }
+}
+
+/**
+ * The atomic phase-transition persist: one read-modify-write under the
+ * per-resource write lock (see the module header for the DD-001-adjacent
+ * rationale). updateResource requires existence: a lifecycle op racing a
+ * delete answers NotFound rather than resurrecting the row.
+ */
+function newUpdateExecutionPhaseAndPersistStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+  targetPhase: ExecutionPhase,
+  setError: boolean,
+  clearError: boolean,
+): PipelineStep<Desc> {
+  return {
+    name: "UpdateExecutionPhaseAndPersist",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const executionId = loadedExecution(ctx).metadata?.id ?? "";
+      const reasonValue = ctx.get(REASON_KEY);
+      const reason = typeof reasonValue === "string" ? reasonValue : "";
+
+      let updated: WorkflowExecution;
+      try {
+        updated = await deps.store.updateResource(
+          ApiResourceKind.workflow_execution,
+          executionId,
+          WorkflowExecutionSchema,
+          (loaded) => {
+            applyLifecyclePhaseTransition(
+              loaded,
+              targetPhase,
+              setError,
+              clearError,
+              reason,
+            );
+          },
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError("workflow_execution", executionId);
+        }
+        throw internalError(error, "failed to persist execution");
+      }
+      ctx.set(LOADED_EXECUTION_KEY, updated);
+    },
+  };
+}
+
+/** Publishes the transition to live subscribers (Go LifecycleBroadcastStep). */
+function newLifecycleBroadcastStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "LifecycleBroadcast",
+    execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      deps.broker.broadcast(loadedExecution(ctx));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recover-only steps.
+// ---------------------------------------------------------------------------
+
+/**
+ * TerminateExistingWorkflow — recover terminates BOTH tree members before
+ * the fresh start: the orchestrator and the TS child
+ * (ParentClosePolicy=REQUEST_CANCEL only soft-cancels the child; explicit
+ * termination hard-guarantees the child workflow ID is reusable).
+ * NOT_FOUND on either is success (already completed/purged).
+ */
+function newTerminateExistingWorkflowStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "TerminateExistingWorkflow",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const engineState = deps.engineState();
+      if (!engineState.connected) {
+        throw failedPreconditionError(TEMPORAL_UNAVAILABLE_MESSAGE);
+      }
+      const executionId = loadedExecution(ctx).metadata?.id ?? "";
+      const targets: Array<[string, string]> = [
+        [orchestratorWorkflowId(executionId), "orchestrator workflow"],
+        [childWorkflowId(executionId), "child TS workflow"],
+      ];
+      for (const [workflowId, description] of targets) {
+        try {
+          await engineState.engine.terminateWorkflow(
+            workflowId,
+            "Recovery: terminating before fresh workflow start",
+          );
+          deps.logger.info(`Successfully terminated ${description}`, {
+            executionId,
+            workflowId,
+          });
+        } catch (error) {
+          if (error instanceof EngineWorkflowNotFoundError) {
+            deps.logger.info(
+              `${description} already completed/terminated (NOT_FOUND). Proceeding.`,
+              { executionId, workflowId },
+            );
+            continue;
+          }
+          throw internalError(
+            error,
+            `failed to terminate ${description} during recovery`,
+          );
+        }
+      }
+    },
+  };
+}
+
+/**
+ * RecreateExecutionContext — recreate_execution_context_step.go: the
+ * previous run's orchestrator deleted the EC on exit; a recovered
+ * workflow hydrating with an empty environment would fail every task
+ * needing secrets. Env is re-resolved from the CURRENT instance refs and
+ * workflow declarations ("fix the config, then recover" works by
+ * design); the original runtime_env overrides were stripped at create
+ * and are not preserved (documented limitation).
+ *
+ * Failure posture: DEGRADE GRACEFULLY (the opposite of the create step) —
+ * missing instance/workflow/env refs warn and proceed without an EC; only
+ * the EC create call itself fails the recover.
+ */
+function newRecreateExecutionContextStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "RecreateExecutionContext",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const builder = deps.executionContextBuilder;
+      const execution = loadedExecution(ctx);
+      const executionId = execution.metadata?.id ?? "";
+      const executionOrg = execution.metadata?.org ?? "";
+      const workflowInstanceId = execution.spec?.workflowInstanceId ?? "";
+
+      // Delete a stale EC if the TTL has not reclaimed it (best-effort).
+      await deleteStaleExecutionContext(deps, executionId);
+
+      let instance: WorkflowInstance;
+      try {
+        instance = await builder.workflowInstanceLoader().get(workflowInstanceId);
+      } catch (error) {
+        deps.logger.warn(
+          "WorkflowInstance not found during recovery EC recreation. Proceeding without environment — workflow tasks may fail if they need env vars.",
+          {
+            executionId,
+            workflowInstanceId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      const workflowId = instance.spec?.workflowId ?? "";
+      let workflow: Workflow;
+      try {
+        workflow = await builder.store.getResource(
+          ApiResourceKind.workflow,
+          workflowId,
+          WorkflowSchema,
+        );
+      } catch (error) {
+        deps.logger.warn(
+          "Workflow not found during recovery EC recreation. Proceeding without environment.",
+          {
+            executionId,
+            workflowId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      const environments = [];
+      for (const ref of instance.spec?.environmentRefs ?? []) {
+        try {
+          environments.push(
+            await builder.environmentResolution.resolveByReference(ref),
+          );
+        } catch (error) {
+          deps.logger.warn(
+            "Failed to resolve environments during recovery. Proceeding without environment.",
+            {
+              executionId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return;
+        }
+      }
+
+      // No runtime_env layer — it was stripped at create time.
+      const merged = mergeEnvironmentLayers(environments, {});
+      const { filtered } = filterByDeclaredKeys(
+        merged,
+        workflow.spec?.env ?? {},
+      );
+      if (filtered.size === 0) {
+        deps.logger.info(
+          "No environment variables to recreate for recovered execution",
+          { executionId },
+        );
+        return;
+      }
+
+      const executionContext = create(ExecutionContextSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "ExecutionContext",
+        metadata: { name: `exec-ctx-${executionId}`, org: executionOrg },
+        spec: { executionId, data: Object.fromEntries(filtered) },
+      });
+
+      try {
+        const created = await builder
+          .executionContextCreator()
+          .create(executionContext);
+        deps.logger.info("Recreated ExecutionContext for recovered execution", {
+          executionContextId: created.metadata?.id ?? "",
+          executionId,
+          dataEntries: filtered.size,
+        });
+      } catch (error) {
+        const prefix = `recreate execution context for recovered execution ${executionId}`;
+        if (error instanceof ConnectError) {
+          throw goWrappedStatusError(prefix, error);
+        }
+        throw internalError(error, prefix);
+      }
+    },
+  };
+}
+
+/** Best-effort stale-EC removal (Go deleteStaleEC — every miss is a no-op). */
+async function deleteStaleExecutionContext(
+  deps: LifecycleDeps,
+  executionId: string,
+): Promise<void> {
+  let staleId = "";
+  try {
+    const existing = await deps.executionContextBuilder.store.findByField(
+      ApiResourceKind.execution_context,
+      "spec.executionId",
+      executionId,
+      ExecutionContextSchema,
+    );
+    staleId = existing.metadata?.id ?? "";
+  } catch {
+    return;
+  }
+  if (staleId === "") {
+    return;
+  }
+  deps.logger.info("Deleting stale ExecutionContext before recreation", {
+    executionContextId: staleId,
+    executionId,
+  });
+  try {
+    await deps.executionContextBuilder.store.deleteResource(
+      ApiResourceKind.execution_context,
+      staleId,
+    );
+  } catch (error) {
+    deps.logger.warn(
+      "Failed to delete stale ExecutionContext (proceeding anyway)",
+      {
+        executionContextId: staleId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+/**
+ * StartFreshWorkflow — starts a brand-new orchestrator for the recovered
+ * execution with recovery_mode=true (the engine reads completed task
+ * outputs from status.tasks and resumes from the first incomplete one).
+ * Temporal allows workflow-ID reuse after termination (ALLOW_DUPLICATE).
+ */
+function newStartFreshWorkflowStep<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "StartFreshWorkflow",
+    async execute(ctx) {
+      if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+        return;
+      }
+      const engineState = deps.engineState();
+      if (!engineState.connected) {
+        throw failedPreconditionError(TEMPORAL_UNAVAILABLE_CREATOR_MESSAGE);
+      }
+      const execution = loadedExecution(ctx);
+      const executionId = execution.metadata?.id ?? "";
+      try {
+        await engineState.engine.startInvokeWorkflow({
+          executionId,
+          workflowInstanceId: execution.spec?.workflowInstanceId ?? "",
+          workflowId: execution.spec?.workflowId ?? "",
+          orgId: execution.metadata?.org ?? "",
+          recoveryMode: true,
+          executionTarget: execution.spec?.executionTarget ?? 0,
+        });
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to start fresh Temporal workflow for recovered execution",
+        );
+      }
+      deps.logger.info(
+        "Started fresh Temporal workflow for recovered execution (recovery_mode=true)",
+        { executionId },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The five RPCs.
+// ---------------------------------------------------------------------------
+
+async function runLifecyclePipeline<Desc extends DescMessage>(
+  deps: LifecycleDeps,
+  pipelineName: string,
+  schema: Desc,
+  input: MessageShape<Desc>,
+  steps: PipelineStep<Desc>[],
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    schema,
+    input,
+    ApiResourceKind.workflow_execution,
+  );
+  const builder = newPipeline<Desc>(pipelineName, deps.logger);
+  for (const step of steps) {
+    builder.addStep(step);
+  }
+  await builder.build().execute(reqCtx);
+
+  const execution = reqCtx.get(LOADED_EXECUTION_KEY);
+  if (execution === undefined) {
+    throw internalError(
+      new Error(`execution not found in context after ${pipelineName}`),
+      `execution not found in context after ${pipelineName.replace("workflowexecution-", "")} pipeline`,
+    );
+  }
+  return execution as WorkflowExecution;
+}
+
+/**
+ * Cancel — graceful stop via Temporal's CancelWorkflow: the workflow can
+ * run compensation before CANCELLED. Idempotent on already-CANCELLED.
+ */
+export async function cancelExecution(
+  deps: LifecycleDeps,
+  input: CancelWorkflowExecutionInput,
+): Promise<WorkflowExecution> {
+  type Desc = typeof WorkflowExecutionCommandController.method.cancel.input;
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "workflowexecution-cancel",
+    WorkflowExecutionCommandController.method.cancel.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep(
+        "ValidateCancellable",
+        ExecutionPhase.EXECUTION_CANCELLED,
+        [
+          ExecutionPhase.EXECUTION_PENDING,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+          ExecutionPhase.EXECUTION_PAUSED,
+        ],
+        (phase) =>
+          `cannot cancel execution in phase ${phase}; only PENDING, IN_PROGRESS, or PAUSED can be cancelled`,
+      ),
+      newEngineLifecycleStep<Desc>(
+        deps,
+        "CancelTemporalWorkflow",
+        "failed to cancel Temporal workflow",
+        (engine, execution) =>
+          engine.cancelWorkflow(
+            orchestratorWorkflowId(execution.metadata?.id ?? ""),
+          ),
+      ),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_CANCELLED,
+        false,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/**
+ * Terminate — force-kill via Temporal's TerminateWorkflow (no cleanup),
+ * for stuck workflows that ignore cancellation. Sets the error copy from
+ * the reason. Idempotent on already-TERMINATED.
+ */
+export async function terminateExecution(
+  deps: LifecycleDeps,
+  input: TerminateWorkflowExecutionInput,
+): Promise<WorkflowExecution> {
+  type Desc = typeof WorkflowExecutionCommandController.method.terminate.input;
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "workflowexecution-terminate",
+    WorkflowExecutionCommandController.method.terminate.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep(
+        "ValidateTerminable",
+        ExecutionPhase.EXECUTION_TERMINATED,
+        [
+          ExecutionPhase.EXECUTION_PENDING,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+          ExecutionPhase.EXECUTION_PAUSED,
+        ],
+        (phase) =>
+          `cannot terminate execution in phase ${phase}; only PENDING, IN_PROGRESS, or PAUSED can be terminated`,
+      ),
+      newEngineLifecycleStep<Desc>(
+        deps,
+        "TerminateTemporalWorkflow",
+        "failed to terminate Temporal workflow",
+        async (engine, execution, ctx) => {
+          // The reason default and its ReasonKey record happen HERE, on
+          // the successful-send path only (Go's quirk: a workflow-gone
+          // terminate falls back to "Terminated by user").
+          const inputReason =
+            (ctx.input as unknown as { reason: string }).reason;
+          const reason = inputReason !== "" ? inputReason : "Terminated by user";
+          await engine.terminateWorkflow(
+            orchestratorWorkflowId(execution.metadata?.id ?? ""),
+            reason,
+          );
+          ctx.set(REASON_KEY, reason);
+        },
+      ),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_TERMINATED,
+        true,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/**
+ * Pause — the pause signal; the workflow checkpoints at the next task
+ * boundary and waits for resume. NOT terminal (no completed_at).
+ * Idempotent on already-PAUSED.
+ */
+export async function pauseExecution(
+  deps: LifecycleDeps,
+  input: PauseWorkflowExecutionInput,
+): Promise<WorkflowExecution> {
+  type Desc = typeof WorkflowExecutionCommandController.method.pause.input;
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "workflowexecution-pause",
+    WorkflowExecutionCommandController.method.pause.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep(
+        "ValidatePausable",
+        ExecutionPhase.EXECUTION_PAUSED,
+        [
+          ExecutionPhase.EXECUTION_PENDING,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+        ],
+        (phase) =>
+          `cannot pause execution in phase ${phase}; only PENDING or IN_PROGRESS can be paused`,
+      ),
+      newEngineLifecycleStep<Desc>(
+        deps,
+        "SignalPauseToTemporal",
+        "failed to send pause signal to Temporal workflow",
+        async (engine, execution, ctx) => {
+          const inputReason =
+            (ctx.input as unknown as { reason: string }).reason;
+          const reason = inputReason !== "" ? inputReason : "Paused by user";
+          await engine.signalWorkflow(
+            orchestratorWorkflowId(execution.metadata?.id ?? ""),
+            PAUSE_SIGNAL_NAME,
+            reason,
+          );
+          ctx.set(REASON_KEY, reason);
+        },
+      ),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_PAUSED,
+        false,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/**
+ * Resume — the resume signal (empty payload); the orchestrator forwards
+ * to the TS child, unblocking the engine's condition(). Idempotent on
+ * already-IN_PROGRESS.
+ */
+export async function resumeExecution(
+  deps: LifecycleDeps,
+  input: ResumeWorkflowExecutionInput,
+): Promise<WorkflowExecution> {
+  type Desc = typeof WorkflowExecutionCommandController.method.resume.input;
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "workflowexecution-resume",
+    WorkflowExecutionCommandController.method.resume.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep(
+        "ValidateResumable",
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        [ExecutionPhase.EXECUTION_PAUSED],
+        (phase) =>
+          `cannot resume execution in phase ${phase}; only PAUSED executions can be resumed`,
+      ),
+      newEngineLifecycleStep<Desc>(
+        deps,
+        "SignalResumeToTemporal",
+        "failed to send resume signal to Temporal workflow",
+        (engine, execution) =>
+          engine.signalWorkflow(
+            orchestratorWorkflowId(execution.metadata?.id ?? ""),
+            RESUME_SIGNAL_NAME,
+            undefined,
+          ),
+      ),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        false,
+        false,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}
+
+/**
+ * Recover — FAILED → IN_PROGRESS via a fresh orchestrator: terminate the
+ * old tree, recreate the EC (degrade-gracefully), start fresh with
+ * recovery_mode, clear the error. Step order rationale (recover.go):
+ * terminate BEFORE EC recreation (the old workflow's cleanup must not
+ * delete the new EC); EC BEFORE the start (hydration needs env); start
+ * BEFORE the phase update (a failed start leaves the execution FAILED —
+ * the user can retry). Idempotent on already-IN_PROGRESS.
+ */
+export async function recoverExecution(
+  deps: LifecycleDeps,
+  input: RecoverWorkflowExecutionInput,
+): Promise<WorkflowExecution> {
+  type Desc = typeof WorkflowExecutionCommandController.method.recover.input;
+  return runLifecyclePipeline<Desc>(
+    deps,
+    "workflowexecution-recover",
+    WorkflowExecutionCommandController.method.recover.input,
+    input,
+    [
+      newLoadExecutionByIdStep(deps),
+      newValidatePhaseStep(
+        "ValidateRecoverable",
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        [ExecutionPhase.EXECUTION_FAILED],
+        (phase) =>
+          `cannot recover execution in phase ${phase}; only FAILED executions can be recovered`,
+      ),
+      newTerminateExistingWorkflowStep(deps),
+      newRecreateExecutionContextStep(deps),
+      newStartFreshWorkflowStep(deps),
+      newUpdateExecutionPhaseAndPersistStep(
+        deps,
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        false,
+        true,
+      ),
+      newLifecycleBroadcastStep(deps),
+    ],
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/list-pending-approvals.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/list-pending-approvals.ts
@@ -1,0 +1,102 @@
+/**
+ * ListPendingApprovals — ports list_pending_approvals.go (T14 dashboard):
+ * scans IN_PROGRESS executions for tasks in WORKFLOW_TASK_WAITING_APPROVAL
+ * and projects them into PendingApproval entries. total_count is the
+ * pre-truncation total; only the entries list is trimmed to the page.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+import { timestampFromMs } from "@bufbuild/protobuf/wkt";
+
+import { ExecutionPhase, WorkflowTaskStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import {
+  PendingApprovalSchema,
+  PendingApprovalsListSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import type {
+  ListPendingApprovalsRequest,
+  PendingApproval,
+  PendingApprovalsList,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { Store } from "../../store/interface.js";
+
+import {
+  DEFAULT_PENDING_APPROVALS_PAGE_SIZE,
+  MAX_PENDING_APPROVALS_PAGE_SIZE,
+} from "./constants.js";
+import { parseRfc3339Ms } from "./execution-filter.js";
+import { loadAllWorkflowExecutions } from "./queries.js";
+
+export interface PendingApprovalsDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+export async function listPendingApprovals(
+  deps: PendingApprovalsDeps,
+  req: ListPendingApprovalsRequest,
+): Promise<PendingApprovalsList> {
+  const executions = await loadAllWorkflowExecutions(
+    deps.store,
+    deps.logger,
+    "failed to list workflow executions for pending approvals",
+  );
+
+  let pageSize = req.pageSize;
+  if (pageSize <= 0) {
+    pageSize = DEFAULT_PENDING_APPROVALS_PAGE_SIZE;
+  }
+  if (pageSize > MAX_PENDING_APPROVALS_PAGE_SIZE) {
+    pageSize = MAX_PENDING_APPROVALS_PAGE_SIZE;
+  }
+
+  let approvals: PendingApproval[] = [];
+  for (const execution of executions) {
+    const phase =
+      execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+    if (phase !== ExecutionPhase.EXECUTION_IN_PROGRESS) {
+      continue;
+    }
+
+    for (const task of execution.status?.tasks ?? []) {
+      if (task.status !== WorkflowTaskStatus.WORKFLOW_TASK_WAITING_APPROVAL) {
+        continue;
+      }
+      approvals.push(
+        create(PendingApprovalSchema, {
+          executionId: execution.metadata?.id ?? "",
+          workflowName: execution.metadata?.name ?? "",
+          // task_name, not task_id: the composite task_id ("gate:2")
+          // would break submitWorkflowTaskApproval, whose runner-side
+          // signal is keyed by the plain task name.
+          taskName: task.taskName,
+          requester:
+            execution.status?.audit?.specAudit?.createdBy?.id ?? "",
+          requestedAt: parseTimestampString(task.startedAt),
+          uiHint: task.uiHint,
+        }),
+      );
+    }
+  }
+
+  const totalCount = approvals.length;
+  if (approvals.length > pageSize) {
+    approvals = approvals.slice(0, pageSize);
+  }
+
+  return create(PendingApprovalsListSchema, {
+    entries: approvals,
+    totalCount,
+  });
+}
+
+/** Go parseTimestampString: RFC3339 or nothing (nil on parse failure). */
+function parseTimestampString(value: string): Timestamp | undefined {
+  const ms = parseRfc3339Ms(value);
+  if (Number.isNaN(ms)) {
+    return undefined;
+  }
+  return timestampFromMs(ms);
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/normalize-workflow-ref-step.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/normalize-workflow-ref-step.ts
@@ -1,0 +1,79 @@
+/**
+ * NormalizeWorkflowRef — ports normalize_workflow_ref_step.go: guarantees
+ * spec.workflow_id is populated by denormalizing it from the execution's
+ * workflow instance. Without it, an instance-only create detaches the
+ * execution from its parent Workflow in every workflow-scoped query
+ * (ListByWorkflow and GetExecutionSummary match on either spec field). An
+ * instance's parent Workflow is immutable, so the denormalization cannot
+ * drift.
+ *
+ * Pipeline position: after CreateDefaultInstanceIfNeeded (which
+ * guarantees spec.workflow_instance_id) and before PinWorkflowVersion.
+ * Resolution is best-effort: load failures and missing ids warn and
+ * continue rather than failing the create.
+ */
+import { WorkflowInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { Store } from "../../store/interface.js";
+
+export function newNormalizeWorkflowRefStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof WorkflowExecutionSchema> {
+  return {
+    name: "NormalizeWorkflowRef",
+    async execute(ctx) {
+      const execution = ctx.newState;
+      const executionId = execution.metadata?.id ?? "";
+
+      if ((execution.spec?.workflowId ?? "") !== "") {
+        return;
+      }
+      const instanceId = execution.spec?.workflowInstanceId ?? "";
+      if (instanceId === "") {
+        logger.warn(
+          "Cannot resolve spec.workflow_id: workflow_instance_id is empty",
+          { executionId },
+        );
+        return;
+      }
+
+      let instance: WorkflowInstance;
+      try {
+        instance = await store.getResource(
+          ApiResourceKind.workflow_instance,
+          instanceId,
+          WorkflowInstanceSchema,
+        );
+      } catch (error) {
+        logger.warn(
+          "Cannot resolve spec.workflow_id: failed to load workflow instance",
+          {
+            executionId,
+            workflowInstanceId: instanceId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      const workflowId = instance.spec?.workflowId ?? "";
+      if (workflowId === "") {
+        logger.warn(
+          "Cannot resolve spec.workflow_id: instance has no workflow_id",
+          { executionId, workflowInstanceId: instanceId },
+        );
+        return;
+      }
+
+      if (execution.spec !== undefined) {
+        execution.spec.workflowId = workflowId;
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/pin-workflow-version-step.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/pin-workflow-version-step.ts
@@ -1,0 +1,114 @@
+/**
+ * PinWorkflowVersion — ports pin_workflow_version_step.go: stamps the
+ * workflow's current status.version_hash onto
+ * execution.status.workflow_version_hash, permanently tying the run to
+ * the definition active at creation time (the runner executes the pinned
+ * version even if the workflow is updated before hydration; the viewer
+ * renders the correct historical graph).
+ *
+ * Every miss is a graceful skip: no resolvable workflow_id, a failed
+ * workflow load, or an empty hash (pre-versioning workflows) leaves the
+ * field empty and the runner falls back to the live workflow.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { WorkflowInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import {
+  WorkflowExecutionSchema,
+  WorkflowExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import type { Store } from "../../store/interface.js";
+
+type ExecutionDesc = typeof WorkflowExecutionSchema;
+
+export function newPinWorkflowVersionStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<ExecutionDesc> {
+  return {
+    name: "PinWorkflowVersion",
+    async execute(ctx) {
+      const execution = ctx.newState;
+
+      // Priority: spec.workflow_id > input.spec.workflow_id > resolve
+      // from the instance (mirrors the runner's resolveWorkflowId).
+      let workflowId = execution.spec?.workflowId ?? "";
+      if (workflowId === "") {
+        workflowId = ctx.input.spec?.workflowId ?? "";
+      }
+      if (workflowId === "") {
+        workflowId = await resolveWorkflowIdFromInstance(store, logger, ctx);
+      }
+      if (workflowId === "") {
+        return;
+      }
+
+      let workflow: Workflow;
+      try {
+        workflow = await store.getResource(
+          ApiResourceKind.workflow,
+          workflowId,
+          WorkflowSchema,
+        );
+      } catch (error) {
+        logger.warn(
+          "Failed to load workflow for version pinning — execution will use live workflow at hydration",
+          {
+            workflowId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      const versionHash = workflow.status?.versionHash ?? "";
+      if (versionHash === "") {
+        return;
+      }
+
+      if (execution.status === undefined) {
+        execution.status = create(WorkflowExecutionStatusSchema);
+      }
+      execution.status.workflowVersionHash = versionHash;
+      logger.info("Pinned workflow version on execution", {
+        workflowId,
+        versionHash: `${versionHash.slice(0, 12)}...`,
+      });
+    },
+  };
+}
+
+async function resolveWorkflowIdFromInstance(
+  store: Store,
+  logger: Logger,
+  ctx: RequestContext<ExecutionDesc>,
+): Promise<string> {
+  let instanceId = ctx.newState.spec?.workflowInstanceId ?? "";
+  if (instanceId === "") {
+    instanceId = ctx.input.spec?.workflowInstanceId ?? "";
+  }
+  if (instanceId === "") {
+    return "";
+  }
+  try {
+    const instance = await store.getResource(
+      ApiResourceKind.workflow_instance,
+      instanceId,
+      WorkflowInstanceSchema,
+    );
+    return instance.spec?.workflowId ?? "";
+  } catch (error) {
+    logger.debug("Could not load workflow instance for version pin resolution", {
+      workflowInstanceId: instanceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return "";
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/queries.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/queries.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared full-scan load for the workflowexecution read surfaces (list,
+ * listByWorkflow, getExecutionSummary, listPendingApprovals) — Go's
+ * store.ListResources + proto.Unmarshal-continue loop, where malformed
+ * rows are skipped rather than failing the read.
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError } from "../../pipeline/errors.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * Loads every workflow execution. The Internal message varies by caller in
+ * Go (each handler wraps the same store error with its own text), so the
+ * caller supplies it.
+ */
+export async function loadAllWorkflowExecutions(
+  store: Store,
+  logger: Logger,
+  internalMessage: string,
+): Promise<WorkflowExecution[]> {
+  let rows: Uint8Array[];
+  try {
+    rows = await store.listResources(ApiResourceKind.workflow_execution);
+  } catch (error) {
+    throw internalError(error, internalMessage);
+  }
+
+  const executions: WorkflowExecution[] = [];
+  for (const data of rows) {
+    let execution: WorkflowExecution;
+    try {
+      execution = fromBinary(WorkflowExecutionSchema, data);
+    } catch (error) {
+      logger.warn("Failed to unmarshal workflow execution, skipping", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    executions.push(execution);
+  }
+  return executions;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/search-extractor.ts
@@ -1,0 +1,38 @@
+/**
+ * WorkflowExecution search extractor — ports the GetSearchIndexEntry side
+ * of pkg/query/search/extractor/workflow_execution_extractor.go. Workflow
+ * executions are invocation records; they have no description field, so
+ * the FTS description stays empty. The query side of the extractor
+ * contract arrives with the search service sub-project (#14).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import type { SearchIndexEntry } from "../../store/interface.js";
+
+export const workflowExecutionSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const execution = resource as unknown as WorkflowExecution;
+    const metadata = execution.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      // No description field on executions (Go leaves entry.Description
+      // at its zero value).
+      description: "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        execution.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/send-signal.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/send-signal.ts
@@ -1,0 +1,293 @@
+/**
+ * SendSignal — ports send_signal.go: signal delivery to a LISTEN task via
+ * SignalWithStart (race-proof for PENDING executions), with the two-phase
+ * idempotency-key dedupe (oss#442, shared contract with the cloud
+ * edition).
+ *
+ * The signal channels for signal-receiving tasks live in the TS child
+ * workflow, not the orchestrator; the orchestrator exposes one generic
+ * relaySignal handler, so the user's signal is wrapped in the relay
+ * envelope and sent on the relaySignal channel (mirroring
+ * SubmitWorkflowTaskApproval, the other relay-based sender).
+ *
+ * Codes (pinned): InvalidArgument (missing fields), NotFound (unknown
+ * execution), FailedPrecondition (terminal phase, or no engine),
+ * AlreadyExists (DELIVERED duplicate — stop retrying), Aborted (live
+ * in-flight claim — retry shortly). Dedupe-store errors degrade to
+ * no-dedupe rather than failing the send; a failed send RELEASES the
+ * claim (status-guarded) so the retry claims freshly instead of waiting
+ * out the in-flight hold.
+ */
+import type { JsonValue } from "@bufbuild/protobuf";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import type { SendSignalInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  abortedError,
+  alreadyExistsError,
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { IN_FLIGHT_CLAIM_TTL_MS } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+import {
+  RELAY_SIGNAL_CHANNEL_NAME,
+  WORKFLOW_CREATOR_UNAVAILABLE_MESSAGE,
+} from "./constants.js";
+import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
+
+export interface SendSignalDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly engineState: WorkflowExecutionEngineStateProvider;
+}
+
+type SendSignalDesc =
+  typeof WorkflowExecutionCommandController.method.sendSignal.input;
+
+// Context keys (send_signal.go).
+const LOADED_EXECUTION_KEY = "loadedExecution";
+const DEDUPE_CLAIMED_KEY = "dedupe_claimed";
+const DEDUPE_SKIPPED_KEY = "dedupe_skipped";
+
+export async function sendSignal(
+  deps: SendSignalDeps,
+  input: SendSignalInput,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionCommandController.method.sendSignal.input,
+    input,
+    ApiResourceKind.workflow_execution,
+  );
+
+  const pipeline = newPipeline<SendSignalDesc>(
+    "workflowexecution-send-signal",
+    deps.logger,
+  )
+    .addStep({
+      name: "ValidateSignalInput",
+      execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+        if (ctx.input.signalName === "") {
+          throw invalidArgumentError("signal_name is required");
+        }
+      },
+    })
+    .addStep({
+      name: "LoadExecutionByExecutionId",
+      async execute(ctx) {
+        let execution: WorkflowExecution;
+        try {
+          execution = await deps.store.getResource(
+            ApiResourceKind.workflow_execution,
+            ctx.input.executionId,
+            WorkflowExecutionSchema,
+          );
+        } catch {
+          throw notFoundError("workflow_execution", ctx.input.executionId);
+        }
+        ctx.set(LOADED_EXECUTION_KEY, execution);
+      },
+    })
+    .addStep({
+      name: "ValidateSignalable",
+      execute(ctx) {
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const phase =
+          execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+        // PENDING is signalable — SignalWithStart starts the workflow
+        // first when it has not begun yet.
+        if (
+          phase !== ExecutionPhase.EXECUTION_PENDING &&
+          phase !== ExecutionPhase.EXECUTION_IN_PROGRESS
+        ) {
+          throw failedPreconditionError(
+            `cannot send signal to execution in phase ${ExecutionPhase[phase]}; only PENDING or IN_PROGRESS executions can receive signals`,
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "DedupeClaimStep",
+      async execute(ctx) {
+        const idempotencyKey = ctx.input.idempotencyKey;
+        // No key → no dedupe (backward compatible).
+        if (idempotencyKey === "") {
+          ctx.set(DEDUPE_SKIPPED_KEY, true);
+          return;
+        }
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const org = execution.metadata?.org ?? "";
+        const executionId = execution.metadata?.id ?? "";
+
+        let result;
+        try {
+          result = await deps.store.signalDedupe.claim(
+            org,
+            idempotencyKey,
+            executionId,
+            ctx.input.signalName,
+            IN_FLIGHT_CLAIM_TTL_MS,
+          );
+        } catch (error) {
+          // A claim-store error degrades to no-dedupe rather than failing
+          // the request (Go's graceful-degradation arm).
+          deps.logger.error("Failed to claim idempotency key", {
+            executionId,
+            idempotencyKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          ctx.set(DEDUPE_SKIPPED_KEY, true);
+          return;
+        }
+
+        if (result.status === "DUPLICATE") {
+          if (result.record?.status === "DELIVERED") {
+            // True duplicate: the signal already landed — stop retrying.
+            throw alreadyExistsError(
+              "signal_with_idempotency_key",
+              idempotencyKey,
+            );
+          }
+          // Live in-flight claim: retryable conflict; it resolves when
+          // that delivery settles or its short hold lapses.
+          throw abortedError(
+            `signal with idempotency_key "${idempotencyKey}" is currently being delivered; retry shortly`,
+          );
+        }
+        ctx.set(DEDUPE_CLAIMED_KEY, true);
+      },
+    })
+    .addStep({
+      name: "SendSignalToWorkflow",
+      async execute(ctx) {
+        const engineState = deps.engineState();
+        if (!engineState.connected) {
+          throw failedPreconditionError(WORKFLOW_CREATOR_UNAVAILABLE_MESSAGE);
+        }
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const executionId = execution.metadata?.id ?? "";
+
+        // The relay envelope (Go workflows.RelaySignalPayload JSON shape).
+        const relayPayload: JsonValue = {
+          signalName: ctx.input.signalName,
+          payload: (ctx.input.payload as JsonValue | undefined) ?? null,
+        };
+
+        try {
+          await engineState.engine.signalWithStart(
+            {
+              executionId,
+              workflowInstanceId: execution.spec?.workflowInstanceId ?? "",
+              workflowId: execution.spec?.workflowId ?? "",
+              orgId: execution.metadata?.org ?? "",
+              recoveryMode: false,
+              executionTarget: execution.spec?.executionTarget ?? 0,
+            },
+            RELAY_SIGNAL_CHANNEL_NAME,
+            relayPayload,
+          );
+        } catch (error) {
+          throw internalError(error, "failed to send signal to workflow");
+        }
+      },
+    })
+    .addStep({
+      name: "DedupeMarkDeliveredStep",
+      async execute(ctx) {
+        if (ctx.get(DEDUPE_SKIPPED_KEY) === true) {
+          return;
+        }
+        if (ctx.get(DEDUPE_CLAIMED_KEY) !== true) {
+          return;
+        }
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const org = execution.metadata?.org ?? "";
+        try {
+          // Delivery earns the 24h window (oss#442).
+          await deps.store.signalDedupe.markDelivered(
+            org,
+            ctx.input.idempotencyKey,
+          );
+        } catch (error) {
+          // The signal already landed — never fail the request here.
+          deps.logger.warn(
+            "Failed to mark idempotency key as delivered (signal was sent)",
+            {
+              executionId: execution.metadata?.id ?? "",
+              idempotencyKey: ctx.input.idempotencyKey,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      },
+    })
+    .build();
+
+  try {
+    await pipeline.execute(reqCtx);
+  } catch (error) {
+    // The only step that can fail after the claim landed is the send
+    // itself — release the claim so the caller's retry with the same key
+    // claims freshly instead of being rejected (oss#442). Best-effort: a
+    // release failure is logged and swallowed; the stranded claim
+    // self-heals when its in-flight hold lapses.
+    await releaseDedupeClaimAfterFailure(deps, reqCtx, input);
+    throw error;
+  }
+
+  const execution = reqCtx.get(LOADED_EXECUTION_KEY);
+  if (execution === undefined) {
+    throw internalError(
+      new Error("execution not found in context after send signal pipeline"),
+      "execution not found in context after send signal pipeline",
+    );
+  }
+  return execution as WorkflowExecution;
+}
+
+async function releaseDedupeClaimAfterFailure(
+  deps: SendSignalDeps,
+  reqCtx: RequestContext<SendSignalDesc>,
+  input: SendSignalInput,
+): Promise<void> {
+  if (reqCtx.get(DEDUPE_CLAIMED_KEY) !== true) {
+    return;
+  }
+  const execution = reqCtx.get(LOADED_EXECUTION_KEY) as
+    | WorkflowExecution
+    | undefined;
+  if (execution === undefined) {
+    // The claim step runs after the load step, so a claimed key implies a
+    // loaded execution; unreachable in practice.
+    return;
+  }
+  try {
+    await deps.store.signalDedupe.release(
+      execution.metadata?.org ?? "",
+      input.idempotencyKey,
+    );
+  } catch (error) {
+    deps.logger.warn(
+      "Failed to release idempotency key after failed delivery (claim self-heals when its hold lapses)",
+      {
+        executionId: input.executionId,
+        idempotencyKey: input.idempotencyKey,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/stream-broker.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/stream-broker.ts
@@ -1,0 +1,133 @@
+/**
+ * StreamBroker — ports controller/stream_broker.go: the in-memory
+ * broadcast fabric for real-time workflow-execution updates (ADR 011's
+ * "Stream Broker" responsibility; the OSS stand-in for cloud's Redis
+ * streams).
+ *
+ * Go's shape is a map of executionID → buffered channels (capacity 100)
+ * under an RWMutex: Broadcast is non-blocking — a full buffer drops the
+ * frame for that subscriber (they catch up on the next one) — and
+ * Unsubscribe closes the channel. The TS port keeps the exact delivery
+ * semantics on the queue-plus-notify idiom the transport proved for
+ * streams: each subscription owns a bounded FIFO queue the subscribe
+ * generator drains, and a notify hook wakes the drain loop. Node's
+ * single-threaded event loop replaces the mutex; the bounded queue
+ * replaces the channel buffer.
+ *
+ * Deliberately a domain-local twin of agentexecution/stream-broker.ts
+ * rather than a shared generic (sub-project DD-002): Go duplicates the
+ * broker per execution domain, and #18 is concurrently building on the
+ * agentexecution instance. The `StreamBroker<T>` consolidation is a
+ * recorded post-#18/#21 cleanup candidate.
+ *
+ * ONE instance serves both routers (serving + in-process): #21's Temporal
+ * activities will update status through the in-process client, and those
+ * broadcasts must reach externally-connected subscribers — the same
+ * reason Go exposes GetStreamBroker. The composition root owns the
+ * instance.
+ */
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+
+import type { Logger } from "../../boot/logger.js";
+
+/**
+ * Go's channel buffer size: bursts up to this many undelivered frames per
+ * subscriber are absorbed; beyond it, broadcasts drop for that subscriber
+ * (stream_broker.go's `make(chan ..., 100)` + non-blocking send).
+ */
+export const SUBSCRIBER_BUFFER_CAPACITY = 100;
+
+/**
+ * One subscriber's delivery state. The subscribe stream loop drains
+ * `queue` and parks on `notify`; the broker pushes and wakes. `closed`
+ * flips on unsubscribe (Go's close(ch)) so a parked or late consumer
+ * observes the end instead of waiting forever.
+ */
+export interface BrokerSubscription {
+  readonly queue: WorkflowExecution[];
+  notify: (() => void) | undefined;
+  closed: boolean;
+}
+
+export class StreamBroker {
+  private readonly subscribers = new Map<string, Set<BrokerSubscription>>();
+
+  constructor(private readonly logger: Logger) {}
+
+  /**
+   * Registers a new subscriber for the execution. The caller MUST
+   * unsubscribe when done (the subscribe generator's `finally`) — Go's
+   * "caller MUST call Unsubscribe" contract, enforced there by defer.
+   */
+  subscribe(executionId: string): BrokerSubscription {
+    const subscription: BrokerSubscription = {
+      queue: [],
+      notify: undefined,
+      closed: false,
+    };
+    const set = this.subscribers.get(executionId) ?? new Set();
+    set.add(subscription);
+    this.subscribers.set(executionId, set);
+    this.logger.debug("New subscriber registered", {
+      executionId,
+      totalSubscribers: set.size,
+    });
+    return subscription;
+  }
+
+  /** Removes and closes a subscription; idempotent (Go Unsubscribe). */
+  unsubscribe(executionId: string, subscription: BrokerSubscription): void {
+    const set = this.subscribers.get(executionId);
+    if (set === undefined || !set.has(subscription)) {
+      return;
+    }
+    set.delete(subscription);
+    subscription.closed = true;
+    subscription.notify?.();
+    subscription.notify = undefined;
+    this.logger.debug("Subscriber unregistered", {
+      executionId,
+      remainingSubscribers: set.size,
+    });
+    if (set.size === 0) {
+      this.subscribers.delete(executionId);
+    }
+  }
+
+  /**
+   * Delivers an execution update to every active subscriber of its id.
+   * Non-blocking by construction: a subscriber at buffer capacity drops
+   * THIS frame (it catches up on the next broadcast) — Go's select/default
+   * arm, warn included.
+   */
+  broadcast(execution: WorkflowExecution): void {
+    const executionId = execution.metadata?.id ?? "";
+    if (executionId === "") {
+      return;
+    }
+    const set = this.subscribers.get(executionId);
+    if (set === undefined || set.size === 0) {
+      return;
+    }
+    this.logger.debug("Broadcasting execution update", {
+      executionId,
+      subscribers: set.size,
+    });
+    for (const subscription of set) {
+      if (subscription.queue.length >= SUBSCRIBER_BUFFER_CAPACITY) {
+        this.logger.warn("Subscriber channel full, dropping update", {
+          executionId,
+        });
+        continue;
+      }
+      subscription.queue.push(execution);
+      subscription.notify?.();
+      subscription.notify = undefined;
+    }
+  }
+
+  /** Active subscriber count for an execution (Go GetSubscriberCount). */
+  getSubscriberCount(executionId: string): number {
+    return this.subscribers.get(executionId)?.size ?? 0;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-approval.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-approval.ts
@@ -21,9 +21,12 @@ import type { SubmitWorkflowApprovalInput } from "@stigmer/protos/ai/stigmer/age
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { create } from "@bufbuild/protobuf";
 
+import { ConnectError } from "@connectrpc/connect";
+
 import type { Logger } from "../../boot/logger.js";
 import {
   failedPreconditionError,
+  goGrpcErrorText,
   internalError,
   invalidArgumentError,
   notFoundError,
@@ -141,9 +144,17 @@ export async function submitApproval(
             }),
           );
         } catch (error) {
-          // Flattened to Unavailable — Go's %v embeds the child error text.
+          // Flattened to Unavailable; Go's %v embeds the child's grpc-go
+          // wire text ("rpc error: code = ... desc = ..."), byte-matched
+          // here via goGrpcErrorText.
+          const embedded =
+            error instanceof ConnectError
+              ? goGrpcErrorText(error)
+              : error instanceof Error
+                ? error.message
+                : String(error);
           throw unavailableError(
-            `failed to forward approval to child agent: ${error instanceof Error ? error.message : String(error)}`,
+            `failed to forward approval to child agent: ${embedded}`,
           );
         }
       },

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-approval.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-approval.ts
@@ -1,0 +1,177 @@
+/**
+ * SubmitApproval — ports submit_approval.go: forwards a tool-call
+ * approval decision to the child AgentExecution holding the gate (HITL
+ * Phase 5.3). The child is identified by the child_agent_execution_id on
+ * the pending_approvals entry matched by tool_call_id; the parent's own
+ * state is returned unchanged (the gate clears later through the runner's
+ * call-agent-status updateStatus).
+ *
+ * Forwarding failures FLATTEN to Unavailable — the deliberate asymmetry
+ * with SubmitFileDecision, which propagates the child's status unchanged
+ * (its digest/completeness rejections are actionable; a failed approval
+ * forward is treated as transient).
+ */
+import type { SubmitApprovalInput as AgentSubmitApprovalInput } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { SubmitApprovalInputSchema as AgentSubmitApprovalInputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import type { SubmitWorkflowApprovalInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { create } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * The narrow agentexecution forwarding edge (Go
+ * AgentExecutionApprovalClient) — method-segregated from the
+ * file-decision edge so each handler depends only on the RPC it uses;
+ * the in-process agentexecution controller satisfies both.
+ */
+export interface AgentExecutionApprovalForwarder {
+  submitApproval(input: AgentSubmitApprovalInput): Promise<AgentExecution>;
+}
+export type AgentExecutionApprovalForwarderProvider =
+  () => AgentExecutionApprovalForwarder;
+
+export interface SubmitApprovalDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly approvalForwarder: AgentExecutionApprovalForwarderProvider;
+}
+
+type SubmitApprovalDesc =
+  typeof WorkflowExecutionCommandController.method.submitApproval.input;
+
+const TARGET_EXECUTION_KEY = "targetResource";
+const CHILD_EXECUTION_ID_KEY = "childAgentExecutionId";
+
+export async function submitApproval(
+  deps: SubmitApprovalDeps,
+  input: SubmitWorkflowApprovalInput,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionCommandController.method.submitApproval.input,
+    input,
+    ApiResourceKind.workflow_execution,
+  );
+  await newPipeline<SubmitApprovalDesc>(
+    "workflow-execution-submit-approval",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep({
+      name: "LoadExisting",
+      async execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+        let execution: WorkflowExecution;
+        try {
+          execution = await deps.store.getResource(
+            ApiResourceKind.workflow_execution,
+            ctx.input.executionId,
+            WorkflowExecutionSchema,
+          );
+        } catch {
+          throw notFoundError("workflow_execution", ctx.input.executionId);
+        }
+        ctx.set(TARGET_EXECUTION_KEY, execution);
+      },
+    })
+    .addStep({
+      name: "ValidateApproval",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_EXECUTION_KEY) as WorkflowExecution;
+        const executionId = execution.metadata?.id ?? "";
+        const requestedToolCallId = ctx.input.toolCallId;
+        const pendingApprovals = execution.status?.pendingApprovals ?? [];
+
+        if (pendingApprovals.length === 0) {
+          throw failedPreconditionError(
+            `workflow execution ${executionId} has no pending approvals`,
+          );
+        }
+
+        const matched = pendingApprovals.find(
+          (entry) => entry.approval?.toolCallId === requestedToolCallId,
+        );
+        if (matched === undefined) {
+          throw invalidArgumentError(
+            `tool_call_id ${requestedToolCallId} not found in pending_approvals for workflow execution ${executionId}`,
+          );
+        }
+
+        const childExecutionId = matched.childAgentExecutionId;
+        if (childExecutionId === "") {
+          throw failedPreconditionError(
+            `workflow execution ${executionId} has no child agent execution ID for tool_call ${requestedToolCallId} - approval must be submitted directly to the agent`,
+          );
+        }
+        ctx.set(CHILD_EXECUTION_ID_KEY, childExecutionId);
+      },
+    })
+    .addStep({
+      name: "ForwardToChild",
+      async execute(ctx) {
+        const childExecutionId = ctx.get(CHILD_EXECUTION_ID_KEY) as string;
+        deps.logger.info("Forwarding approval to child AgentExecution", {
+          childExecutionId,
+          toolCallId: ctx.input.toolCallId,
+        });
+        try {
+          await deps.approvalForwarder().submitApproval(
+            create(AgentSubmitApprovalInputSchema, {
+              agentExecutionId: childExecutionId,
+              toolCallId: ctx.input.toolCallId,
+              action: ctx.input.action,
+              comment: ctx.input.comment,
+            }),
+          );
+        } catch (error) {
+          // Flattened to Unavailable — Go's %v embeds the child error text.
+          throw unavailableError(
+            `failed to forward approval to child agent: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "BuildResponse",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_EXECUTION_KEY) as WorkflowExecution;
+        deps.logger.info(
+          "AUDIT: Workflow approval decision submitted and forwarded to child agent",
+          {
+            workflowExecutionId: execution.metadata?.id ?? "",
+            org: execution.metadata?.org ?? "",
+            toolCallId: ctx.input.toolCallId,
+            childExecutionId: ctx.get(CHILD_EXECUTION_ID_KEY) as string,
+          },
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  const execution = reqCtx.get(TARGET_EXECUTION_KEY);
+  if (execution === undefined) {
+    throw internalError(
+      new Error("execution not found in context"),
+      "execution not found in context",
+    );
+  }
+  return execution as WorkflowExecution;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-file-decision.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-file-decision.ts
@@ -1,0 +1,181 @@
+/**
+ * SubmitFileDecision — ports submit_file_decision.go: forwards a
+ * file-review keep/discard decision to the child AgentExecution whose
+ * gate is surfaced on this workflow via status.pending_file_reviews. The
+ * (child, change_set_id) pair must be surfaced on the parent — a caller
+ * can never decide on a gate the workflow has not surfaced.
+ *
+ * The child's gRPC status PROPAGATES UNCHANGED on forwarding failure —
+ * the deliberate asymmetry with SubmitApproval: a digest mismatch or
+ * incomplete diff is a real, actionable rejection
+ * (FailedPrecondition/InvalidArgument), not a transient transport failure
+ * to flatten.
+ */
+import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { SubmitFileDecisionInput as AgentSubmitFileDecisionInput } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { SubmitFileDecisionInputSchema as AgentSubmitFileDecisionInputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import type { SubmitWorkflowFileDecisionInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * The narrow agentexecution file-decision edge (Go
+ * AgentExecutionFileDecisionClient) — method-segregated from the approval
+ * edge; the in-process agentexecution controller satisfies both.
+ */
+export interface AgentExecutionFileDecisionForwarder {
+  submitFileDecision(
+    input: AgentSubmitFileDecisionInput,
+  ): Promise<AgentExecution>;
+}
+export type AgentExecutionFileDecisionForwarderProvider =
+  () => AgentExecutionFileDecisionForwarder;
+
+export interface SubmitFileDecisionDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly fileDecisionForwarder: AgentExecutionFileDecisionForwarderProvider;
+}
+
+type SubmitFileDecisionDesc =
+  typeof WorkflowExecutionCommandController.method.submitFileDecision.input;
+
+const TARGET_EXECUTION_KEY = "targetResource";
+
+export async function submitFileDecision(
+  deps: SubmitFileDecisionDeps,
+  input: SubmitWorkflowFileDecisionInput,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionCommandController.method.submitFileDecision.input,
+    input,
+    ApiResourceKind.workflow_execution,
+  );
+  await newPipeline<SubmitFileDecisionDesc>(
+    "workflow-execution-submit-file-decision",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep({
+      name: "LoadExisting",
+      async execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+        let execution: WorkflowExecution;
+        try {
+          execution = await deps.store.getResource(
+            ApiResourceKind.workflow_execution,
+            ctx.input.executionId,
+            WorkflowExecutionSchema,
+          );
+        } catch {
+          throw notFoundError("workflow_execution", ctx.input.executionId);
+        }
+        ctx.set(TARGET_EXECUTION_KEY, execution);
+      },
+    })
+    .addStep({
+      name: "ValidateFileDecision",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_EXECUTION_KEY) as WorkflowExecution;
+        const executionId = execution.metadata?.id ?? "";
+        const childId = ctx.input.childAgentExecutionId;
+        const changeSetId = ctx.input.changeSetId;
+        const pendingFileReviews = execution.status?.pendingFileReviews ?? [];
+
+        if (pendingFileReviews.length === 0) {
+          throw failedPreconditionError(
+            `workflow execution ${executionId} has no pending file reviews`,
+          );
+        }
+        const surfaced = pendingFileReviews.some(
+          (review) =>
+            review.childAgentExecutionId === childId &&
+            review.changeSetId.includes(changeSetId),
+        );
+        if (!surfaced) {
+          throw failedPreconditionError(
+            `workflow execution ${executionId} has no pending file review for child ${childId} change set ${changeSetId}`,
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "ForwardToChild",
+      async execute(ctx) {
+        deps.logger.info("Forwarding file decision to child AgentExecution", {
+          childExecutionId: ctx.input.childAgentExecutionId,
+          changeSetId: ctx.input.changeSetId,
+        });
+        try {
+          await deps.fileDecisionForwarder().submitFileDecision(
+            create(AgentSubmitFileDecisionInputSchema, {
+              agentExecutionId: ctx.input.childAgentExecutionId,
+              changeSetId: ctx.input.changeSetId,
+              scope: ctx.input.scope,
+              fileChangeId: ctx.input.fileChangeId,
+              action: ctx.input.action,
+              expectedDigest: ctx.input.expectedDigest,
+              reason: ctx.input.reason,
+              acknowledgeUnreviewable: ctx.input.acknowledgeUnreviewable,
+            }),
+          );
+        } catch (error) {
+          // Propagate the child's STATUS unchanged (code + message) — its
+          // completeness and digest gates return actionable rejections the
+          // caller must see. Re-minted rather than rethrown: the client-side
+          // ConnectError carries the in-process response's metadata, and
+          // echoing that envelope through the serving response corrupts the
+          // HTTP/2 trailers.
+          if (error instanceof ConnectError) {
+            throw new ConnectError(error.rawMessage, error.code);
+          }
+          throw error;
+        }
+      },
+    })
+    .addStep({
+      name: "BuildResponse",
+      execute(ctx) {
+        const execution = ctx.get(TARGET_EXECUTION_KEY) as WorkflowExecution;
+        deps.logger.info(
+          "AUDIT: Workflow file decision submitted and forwarded to child agent",
+          {
+            workflowExecutionId: execution.metadata?.id ?? "",
+            org: execution.metadata?.org ?? "",
+            childExecutionId: ctx.input.childAgentExecutionId,
+            changeSetId: ctx.input.changeSetId,
+          },
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  const execution = reqCtx.get(TARGET_EXECUTION_KEY);
+  if (execution === undefined) {
+    throw internalError(
+      new Error("execution not found in context"),
+      "execution not found in context",
+    );
+  }
+  return execution as WorkflowExecution;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-workflow-task-approval.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/submit-workflow-task-approval.ts
@@ -1,0 +1,206 @@
+/**
+ * SubmitWorkflowTaskApproval — ports submit_workflow_task_approval.go
+ * (T13c): a human reviewer's decision for a workflow-level human_input
+ * task. Constructs the runner's HumanInputResult signal payload, wraps it
+ * in the relaySignal envelope on the `human_input_{task}` channel, and
+ * delivers via SignalWithStart (the orchestrator forwards to the TS child
+ * where the task is blocking).
+ *
+ * Quirk ported faithfully: the SignalWithStart input's workflowId field
+ * carries status.temporal_workflow_id (NOT spec.workflow_id — every other
+ * sender passes the spec reference).
+ *
+ * Reviewer attribution: OSS is single-user; an explicit client-supplied
+ * reviewer is honored, otherwise it stays empty ("Empty when not
+ * attributed"). Cloud attributes server-side from the authenticated
+ * caller.
+ */
+import type { JsonValue } from "@bufbuild/protobuf";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import {
+  ExecutionPhase,
+  WorkflowTaskType,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import type { SubmitWorkflowTaskApprovalInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import type { Store } from "../../store/interface.js";
+
+import {
+  HUMAN_INPUT_SIGNAL_PREFIX,
+  RELAY_SIGNAL_CHANNEL_NAME,
+} from "./constants.js";
+import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
+
+export interface SubmitWorkflowTaskApprovalDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly engineState: WorkflowExecutionEngineStateProvider;
+}
+
+type TaskApprovalDesc =
+  typeof WorkflowExecutionCommandController.method.submitWorkflowTaskApproval.input;
+
+const LOADED_EXECUTION_KEY = "loadedExecution";
+
+export async function submitWorkflowTaskApproval(
+  deps: SubmitWorkflowTaskApprovalDeps,
+  input: SubmitWorkflowTaskApprovalInput,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionCommandController.method.submitWorkflowTaskApproval.input,
+    input,
+    ApiResourceKind.workflow_execution,
+  );
+  await newPipeline<TaskApprovalDesc>(
+    "workflowexecution-submit-task-approval",
+    deps.logger,
+  )
+    .addStep({
+      name: "ValidateTaskApprovalInput",
+      execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+        if (ctx.input.taskName === "") {
+          throw invalidArgumentError("task_name is required");
+        }
+        if (ctx.input.outcome === "") {
+          throw invalidArgumentError("outcome is required");
+        }
+      },
+    })
+    .addStep({
+      name: "LoadExecutionForApproval",
+      async execute(ctx) {
+        let execution: WorkflowExecution;
+        try {
+          execution = await deps.store.getResource(
+            ApiResourceKind.workflow_execution,
+            ctx.input.executionId,
+            WorkflowExecutionSchema,
+          );
+        } catch {
+          throw notFoundError("WorkflowExecution", ctx.input.executionId);
+        }
+        ctx.set(LOADED_EXECUTION_KEY, execution);
+      },
+    })
+    .addStep({
+      name: "ValidateApprovalSignalable",
+      execute(ctx) {
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const phase =
+          execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+        if (
+          phase !== ExecutionPhase.EXECUTION_PENDING &&
+          phase !== ExecutionPhase.EXECUTION_IN_PROGRESS
+        ) {
+          throw failedPreconditionError(
+            `cannot submit task approval: execution is in ${ExecutionPhase[phase]} phase`,
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "ValidateHumanInputTask",
+      execute(ctx) {
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const taskName = ctx.input.taskName;
+        const task = (execution.status?.tasks ?? []).find(
+          (candidate) => candidate.taskName === taskName,
+        );
+        if (task === undefined) {
+          throw invalidArgumentError(
+            `task '${taskName}' not found in execution status`,
+          );
+        }
+        if (task.taskType !== WorkflowTaskType.WORKFLOW_TASK_APPROVAL) {
+          throw invalidArgumentError(
+            `task '${taskName}' is not a human_input task (type: ${WorkflowTaskType[task.taskType]})`,
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "SendTaskApprovalSignal",
+      async execute(ctx) {
+        const execution = ctx.get(LOADED_EXECUTION_KEY) as WorkflowExecution;
+        const executionId = ctx.input.executionId;
+        const humanInputSignalName =
+          HUMAN_INPUT_SIGNAL_PREFIX + ctx.input.taskName;
+
+        const signalPayload: Record<string, JsonValue> = {
+          outcome: ctx.input.outcome,
+          reviewer: ctx.input.reviewer,
+          // Go time.Now().UTC().Format(time.RFC3339): seconds precision.
+          responded_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+        };
+        if (ctx.input.formData !== undefined) {
+          signalPayload["form_data"] = ctx.input.formData as JsonValue;
+        }
+        if (ctx.input.comment !== "") {
+          signalPayload["comment"] = ctx.input.comment;
+        }
+
+        const engineState = deps.engineState();
+        if (!engineState.connected) {
+          throw unavailableError(
+            `workflow creator not configured for task '${ctx.input.taskName}'`,
+          );
+        }
+        try {
+          await engineState.engine.signalWithStart(
+            {
+              executionId,
+              workflowInstanceId: execution.spec?.workflowInstanceId ?? "",
+              // Go's quirk: the temporal workflow id, not spec.workflow_id.
+              workflowId: execution.status?.temporalWorkflowId ?? "",
+              orgId: execution.metadata?.org ?? "",
+              recoveryMode: false,
+              executionTarget: execution.spec?.executionTarget ?? 0,
+            },
+            RELAY_SIGNAL_CHANNEL_NAME,
+            { signalName: humanInputSignalName, payload: signalPayload },
+          );
+        } catch (error) {
+          throw unavailableError(
+            `failed to send approval signal for task '${ctx.input.taskName}': ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        deps.logger.info(
+          "AUDIT: Workflow task approval submitted via relaySignal",
+          {
+            executionId,
+            taskName: ctx.input.taskName,
+            outcome: ctx.input.outcome,
+            signalName: humanInputSignalName,
+          },
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  const execution = reqCtx.get(LOADED_EXECUTION_KEY);
+  if (execution === undefined) {
+    throw internalError(
+      new Error("execution not found in context after pipeline"),
+      "execution not found in context after pipeline",
+    );
+  }
+  return execution as WorkflowExecution;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/subscribe-events.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/subscribe-events.ts
@@ -1,0 +1,203 @@
+/**
+ * SubscribeEvents — ports controller/subscribe_events.go: the incremental
+ * event stream for the execution viewer timeline (replay + live tail).
+ * Unlike Subscribe (full snapshots via the broker), this reads the
+ * persisted event log directly:
+ *
+ *   - Replays events with sequence_number > after_sequence, then polls
+ *     the store every EVENT_POLL_INTERVAL_MS for new ones — the first
+ *     server-side poll loop in this codebase, ported from Go's own
+ *     ticker design (all other TS streams are notify-based; the event
+ *     WRITER is the store, not the broker, so polling is the mechanism
+ *     here in both editions).
+ *   - The existence check runs BEFORE streaming: unknown id → NotFound
+ *     (the deliberate opposite of getEventLog's no-existence-check
+ *     empty-page contract; the Class A suite pins both arms).
+ *   - The cursor advances past type-filtered and malformed records too,
+ *     so a poisoned row cannot wedge the stream.
+ *   - Terminal check every iteration: on COMPLETED/FAILED/CANCELLED the
+ *     remaining events after the cursor are drained (one page, same
+ *     filter, malformed skipped) and the stream closes. TERMINATED is
+ *     absent from that set — the disclosed Go quirk shared with
+ *     subscribe.ts.
+ *   - Client disconnect surfaces as the abort signal; Go's stream.Send
+ *     error arm returns nil the same way.
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+import type { HandlerContext } from "@connectrpc/connect";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { WorkflowExecutionEventSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import type { WorkflowExecutionEvent } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import type { SubscribeEventsRequest } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type {
+  Store,
+  WorkflowExecutionEventRecord,
+} from "../../store/interface.js";
+
+import {
+  DEFAULT_EVENT_PAGE_SIZE,
+  EVENT_POLL_INTERVAL_MS,
+} from "./constants.js";
+import { eventTypeName } from "./get-event-log.js";
+import { isWorkflowTerminalPhase } from "./subscribe.js";
+
+export interface SubscribeEventsDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+export async function* subscribeEvents(
+  deps: SubscribeEventsDeps,
+  request: SubscribeEventsRequest,
+  context: HandlerContext,
+): AsyncGenerator<WorkflowExecutionEvent> {
+  if (request.executionId === "") {
+    throw invalidArgumentError("execution_id is required");
+  }
+  const executionId = request.executionId;
+
+  // Verify the execution exists (the opposite of getEventLog's contract).
+  try {
+    await deps.store.getResource(
+      ApiResourceKind.workflow_execution,
+      executionId,
+      WorkflowExecutionSchema,
+    );
+  } catch {
+    throw notFoundError("WorkflowExecution", executionId);
+  }
+
+  let typeFilter: Set<string> | undefined;
+  if (request.eventTypes.length > 0) {
+    typeFilter = new Set(request.eventTypes.map(eventTypeName));
+  }
+
+  let cursor = Number(request.afterSequence);
+  deps.logger.info("Starting event subscription", {
+    executionId,
+    afterSequence: cursor,
+  });
+
+  const abort = new Promise<void>((resolve) => {
+    context.signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+
+  while (!context.signal.aborted) {
+    // Poll for new events.
+    let records: WorkflowExecutionEventRecord[];
+    try {
+      records = await deps.store.getWorkflowExecutionEvents(
+        executionId,
+        cursor,
+        "",
+        "",
+        DEFAULT_EVENT_PAGE_SIZE,
+      );
+    } catch (error) {
+      deps.logger.error("Failed to poll execution events", {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw internalError(error, "failed to poll execution events");
+    }
+
+    for (const record of records) {
+      // The cursor advances past filtered and malformed records too, so a
+      // poisoned row cannot wedge the stream.
+      if (typeFilter !== undefined && !typeFilter.has(record.eventType)) {
+        cursor = record.sequenceNumber;
+        continue;
+      }
+      let event: WorkflowExecutionEvent;
+      try {
+        event = fromBinary(WorkflowExecutionEventSchema, record.data);
+      } catch {
+        deps.logger.warn("Skipping malformed event record", {
+          executionId,
+          sequenceNumber: record.sequenceNumber,
+        });
+        cursor = record.sequenceNumber;
+        continue;
+      }
+      if (context.signal.aborted) {
+        // Go's stream.Send error arm: the client is gone, end quietly.
+        return;
+      }
+      yield event;
+      cursor = record.sequenceNumber;
+    }
+
+    // Terminal check: Go tolerates a failed re-read (skips the check and
+    // keeps polling), so load errors here are deliberately swallowed.
+    try {
+      const execution = await deps.store.getResource(
+        ApiResourceKind.workflow_execution,
+        executionId,
+        WorkflowExecutionSchema,
+      );
+      const phase =
+        execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+      if (isWorkflowTerminalPhase(phase)) {
+        // Drain any remaining events after terminal state (one page, Go's
+        // best-effort drain — its read error is ignored the same way).
+        let remaining: WorkflowExecutionEventRecord[] = [];
+        try {
+          remaining = await deps.store.getWorkflowExecutionEvents(
+            executionId,
+            cursor,
+            "",
+            "",
+            DEFAULT_EVENT_PAGE_SIZE,
+          );
+        } catch {
+          remaining = [];
+        }
+        for (const record of remaining) {
+          if (typeFilter !== undefined && !typeFilter.has(record.eventType)) {
+            continue;
+          }
+          let event: WorkflowExecutionEvent;
+          try {
+            event = fromBinary(WorkflowExecutionEventSchema, record.data);
+          } catch {
+            continue;
+          }
+          if (context.signal.aborted) {
+            return;
+          }
+          yield event;
+        }
+        deps.logger.info(
+          "Execution reached terminal state, closing event stream",
+          { executionId, phase: ExecutionPhase[phase] },
+        );
+        return;
+      }
+    } catch {
+      // Execution re-read failed — keep polling (Go's `if err == nil`).
+    }
+
+    // Wait for the next poll tick or client cancellation.
+    await Promise.race([abort, sleep(EVENT_POLL_INTERVAL_MS)]);
+  }
+  deps.logger.info("Event subscription cancelled by client", { executionId });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // A parked poll timer must never hold the process open (Go tickers
+    // live in goroutines; Node timers pin the event loop unless unref'd).
+    timer.unref();
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/subscribe.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/subscribe.ts
@@ -1,0 +1,155 @@
+/**
+ * Subscribe — ports controller/subscribe.go: the real-time
+ * workflow-execution stream (ADR 011 read path), streaming full
+ * WorkflowExecution snapshots. The generator shape follows the sibling
+ * agentexecution subscribe (itself derived from transport/health.ts
+ * watch); every delivery rule ports verbatim:
+ *
+ *   - REGISTER-BEFORE-SNAPSHOT (the gap fix): the broker registration
+ *     happens before the snapshot read. Store writes serialize under the
+ *     per-resource write lock and UpdateStatus/lifecycle broadcast only
+ *     after their persist commits, so any commit the snapshot missed
+ *     broadcasts after our registration — nothing lands in the old lossy
+ *     window (Go keeps registration and the loop in ONE step for the same
+ *     reason; here the generator's finally owns the unsubscribe).
+ *   - The overlap frame (a commit the snapshot DID observe) arrives
+ *     value-equal to the snapshot; the consecutive-duplicate guard drops
+ *     it (Go sameFrame/proto.Equal) so clients never re-render an
+ *     identical state.
+ *   - The stream ends on a terminal BROADCAST frame; a terminal SNAPSHOT
+ *     leaves the stream open (Go sends the snapshot and parks in the
+ *     loop). Faithful port.
+ *   - The terminal set is COMPLETED/FAILED/CANCELLED — it OMITS
+ *     TERMINATED, so a stream over a terminated execution never
+ *     self-closes. Known Go quirk (isWorkflowTerminalPhase,
+ *     subscribe.go:216), ported byte-faithfully; disclosed as a
+ *     both-editions issue candidate, the same finding #17 made on
+ *     agentexecution.
+ */
+import { equals } from "@bufbuild/protobuf";
+import type { HandlerContext } from "@connectrpc/connect";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import type { SubscribeWorkflowExecutionRequest } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { invalidArgumentError, notFoundError } from "../../pipeline/errors.js";
+import type { Store } from "../../store/interface.js";
+
+import type { StreamBroker } from "./stream-broker.js";
+
+export interface SubscribeDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+}
+
+/**
+ * Go isWorkflowTerminalPhase (subscribe.go): the stream-closing set.
+ * Deliberately narrower than "the execution can never run again" —
+ * TERMINATED and PAUSED are absent (TERMINATED being the disclosed
+ * quirk).
+ */
+export function isWorkflowTerminalPhase(phase: ExecutionPhase): boolean {
+  return (
+    phase === ExecutionPhase.EXECUTION_COMPLETED ||
+    phase === ExecutionPhase.EXECUTION_FAILED ||
+    phase === ExecutionPhase.EXECUTION_CANCELLED
+  );
+}
+
+export async function* subscribeExecution(
+  deps: SubscribeDeps,
+  request: SubscribeWorkflowExecutionRequest,
+  context: HandlerContext,
+): AsyncGenerator<WorkflowExecution> {
+  // Go ValidateSubscribeInputStep.
+  if (request.executionId === "") {
+    throw invalidArgumentError("execution_id is required");
+  }
+  const id = request.executionId;
+  deps.logger.info("Starting workflow execution subscription", {
+    executionId: id,
+  });
+
+  // Register FIRST so no broadcast can slip through the window before the
+  // snapshot read (the happens-before argument in the module header).
+  const subscription = deps.broker.subscribe(id);
+  try {
+    let snapshot: WorkflowExecution;
+    try {
+      snapshot = await deps.store.getResource(
+        ApiResourceKind.workflow_execution,
+        id,
+        WorkflowExecutionSchema,
+      );
+    } catch {
+      // Go converts every load failure here to the same NotFound.
+      throw notFoundError("WorkflowExecution", id);
+    }
+
+    yield snapshot;
+    deps.logger.debug(
+      "Sent initial workflow execution state, streaming live updates",
+      { executionId: id },
+    );
+
+    // The consecutive-duplicate anchor (Go lastSent).
+    let lastSent = snapshot;
+
+    const abort = new Promise<void>((resolve) => {
+      context.signal.addEventListener("abort", () => resolve(), {
+        once: true,
+      });
+    });
+
+    while (!context.signal.aborted) {
+      if (subscription.closed) {
+        // Go's closed-channel arm: end quietly.
+        deps.logger.warn("Updates channel closed unexpectedly", {
+          executionId: id,
+        });
+        return;
+      }
+      if (subscription.queue.length === 0) {
+        await Promise.race([
+          abort,
+          new Promise<void>((resolve) => (subscription.notify = resolve)),
+        ]);
+        subscription.notify = undefined;
+        continue;
+      }
+
+      const updated = subscription.queue.shift();
+      if (updated === undefined) {
+        continue;
+      }
+      // Suppress the at-or-before-snapshot overlap frame (and any other
+      // exact repeat) so the client never re-renders an identical state.
+      if (equals(WorkflowExecutionSchema, updated, lastSent)) {
+        continue;
+      }
+
+      yield updated;
+      lastSent = updated;
+
+      const phase =
+        updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+      if (isWorkflowTerminalPhase(phase)) {
+        deps.logger.info(
+          "Workflow execution reached terminal state, ending subscription",
+          { executionId: id, phase: ExecutionPhase[phase] },
+        );
+        return;
+      }
+    }
+    deps.logger.info("Workflow execution subscription cancelled by client", {
+      executionId: id,
+    });
+  } finally {
+    deps.broker.unsubscribe(id, subscription);
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/update-status.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/update-status.ts
@@ -1,0 +1,367 @@
+/**
+ * UpdateStatus — ports controller/update_status.go: the runner's
+ * progressive status-update RPC (merge + persist + event append + stream
+ * broadcast — the OSS replacement for cloud's Redis write path).
+ *
+ * Chain per Go: ValidateUpdateStatusInput → merge+persist → PersistEvents
+ * → BroadcastToStreams. Go still does the merge as a separate
+ * LoadExisting step followed by a plain SaveResource — a lost-update
+ * window under concurrent updates. This port runs the SAME merge body
+ * inside the store's atomic `updateResource` instead (sub-project DD-001,
+ * owner-ratified): Go's own agentexecution domain already calls that
+ * discipline load-bearing, and this domain's per-child pending-gate merge
+ * is exactly the concurrent-children write that the window can corrupt.
+ * Wire-identical in sequential flows; strictly safer under concurrency;
+ * the Go-side race is filed as an OSS issue.
+ *
+ * applyUpdateStatusMerge is the merge body run inside the updateResource
+ * closure (and exercised directly by the guard tests), mirroring the
+ * cloud handler's strategy: presence-guarded field merges (tasks replaced
+ * wholesale, counters only when > 0), the flag-gated per-child
+ * pending_approvals / pending_file_reviews merge, and the
+ * phase-transition-only statusAudit bump (heartbeats must not perpetually
+ * re-sort long-running executions above new ones in the recents sidebar).
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, PublishToRedis, and
+ * Publish steps (broadcast rides in-memory channels per ADR 011).
+ */
+import { create, toBinary } from "@bufbuild/protobuf";
+import { timestampNow } from "@bufbuild/protobuf/wkt";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import {
+  WorkflowExecutionSchema,
+  WorkflowExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { WorkflowEventType } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import { WorkflowExecutionEventSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
+import type { WorkflowExecutionUpdateStatusInput } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import {
+  ApiResourceAuditInfoSchema,
+  ApiResourceAuditSchema,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type {
+  Store,
+  WorkflowExecutionEventRecord,
+} from "../../store/interface.js";
+
+import type { StreamBroker } from "./stream-broker.js";
+
+export interface UpdateStatusDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+}
+
+type UpdateStatusDesc =
+  typeof WorkflowExecutionCommandController.method.updateStatus.input;
+
+const EXECUTION_KEY = "execution";
+
+export async function updateStatus(
+  deps: UpdateStatusDeps,
+  input: WorkflowExecutionUpdateStatusInput,
+): Promise<WorkflowExecution> {
+  const reqCtx = new RequestContext(
+    WorkflowExecutionCommandController.method.updateStatus.input,
+    input,
+    ApiResourceKind.workflow_execution,
+  );
+  await newPipeline<UpdateStatusDesc>(
+    "workflowexecution-update-status",
+    deps.logger,
+  )
+    .addStep({
+      name: "ValidateUpdateStatusInput",
+      execute(ctx) {
+        if (ctx.input.executionId === "") {
+          throw invalidArgumentError("execution_id is required");
+        }
+        if (ctx.input.status === undefined) {
+          throw invalidArgumentError("status is required");
+        }
+      },
+    })
+    .addStep({
+      name: "MergeAndPersistExecution",
+      async execute(ctx) {
+        let updated: WorkflowExecution;
+        try {
+          updated = await deps.store.updateResource(
+            ApiResourceKind.workflow_execution,
+            ctx.input.executionId,
+            WorkflowExecutionSchema,
+            (execution) => {
+              applyUpdateStatusMerge(execution, ctx.input);
+            },
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            // Go's LoadExistingExecution answers this exact NotFound.
+            throw notFoundError("WorkflowExecution", ctx.input.executionId);
+          }
+          throw internalError(error, "failed to update execution status");
+        }
+        ctx.set(EXECUTION_KEY, updated);
+        deps.logger.info("Successfully updated execution status", {
+          executionId: ctx.input.executionId,
+          phase:
+            ExecutionPhase[
+              updated.status?.phase ??
+                ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED
+            ],
+        });
+      },
+    })
+    .addStep({
+      name: "PersistEvents",
+      async execute(ctx) {
+        await persistEvents(deps, ctx.input);
+      },
+    })
+    .addStep({
+      name: "BroadcastToStreams",
+      execute(ctx) {
+        const execution = ctx.get(EXECUTION_KEY);
+        if (execution === undefined) {
+          throw internalError(
+            new Error("execution not found in context"),
+            "execution not found in context",
+          );
+        }
+        // Push to active subscribers AFTER the persist commits (ADR 011
+        // write path) — the ordering subscribe's register-before-snapshot
+        // guarantee builds on.
+        deps.broker.broadcast(execution as WorkflowExecution);
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  const merged = reqCtx.get(EXECUTION_KEY);
+  if (merged === undefined) {
+    throw internalError(
+      new Error("execution not found in context after pipeline"),
+      "execution not found in context after pipeline",
+    );
+  }
+  return merged as WorkflowExecution;
+}
+
+/**
+ * mergePendingByChild — a per-child upsert of a workflow status list
+ * (pending_approvals or pending_file_reviews): drops the existing entries
+ * that belong to scopeChildId and appends the incoming entries (which
+ * must all belong to scopeChildId). Every other child's entries are
+ * preserved untouched, so parallel child agents surfacing/clearing their
+ * own gates never clobber each other. An empty incoming list therefore
+ * clears just scopeChildId's entries.
+ *
+ * childOf extracts an entry's owning child_agent_execution_id. Kept
+ * generic so the approval and file-review lists share exactly one merge
+ * semantic (Go's mergePendingByChild).
+ */
+export function mergePendingByChild<T>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  childOf: (entry: T) => string,
+  scopeChildId: string,
+): T[] {
+  const merged: T[] = [];
+  for (const entry of existing) {
+    if (childOf(entry) !== scopeChildId) {
+      merged.push(entry);
+    }
+  }
+  merged.push(...incoming);
+  return merged;
+}
+
+/**
+ * The merge body run inside the updateResource closure — Go
+ * BuildNewStateWithStatusStep field-for-field. Mutates `execution` in
+ * place over the freshly-loaded, write-locked state. Synchronous by
+ * contract (the store's modify callback), which is also what makes it
+ * directly unit-testable.
+ */
+export function applyUpdateStatusMerge(
+  execution: WorkflowExecution,
+  input: WorkflowExecutionUpdateStatusInput,
+): void {
+  if (execution.status === undefined) {
+    execution.status = create(WorkflowExecutionStatusSchema);
+  }
+  const status = execution.status;
+  const requestStatus = input.status;
+  if (requestStatus === undefined) {
+    return;
+  }
+
+  // The phase-transition check compares against the phase BEFORE this
+  // merge writes it (Go compares to `existing`, its pre-clone snapshot).
+  const previousPhase = status.phase;
+
+  // Tasks: replaced wholesale with the runner's latest complete set.
+  if (requestStatus.tasks.length > 0) {
+    status.tasks = requestStatus.tasks;
+  }
+
+  if (requestStatus.phase !== ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) {
+    status.phase = requestStatus.phase;
+  }
+  if (requestStatus.output !== undefined) {
+    status.output = requestStatus.output;
+  }
+  if (requestStatus.error !== "") {
+    status.error = requestStatus.error;
+  }
+  if (requestStatus.startedAt !== "") {
+    status.startedAt = requestStatus.startedAt;
+  }
+  if (requestStatus.completedAt !== "") {
+    status.completedAt = requestStatus.completedAt;
+  }
+  if (requestStatus.temporalWorkflowId !== "") {
+    status.temporalWorkflowId = requestStatus.temporalWorkflowId;
+  }
+
+  // Cost/token totals: the runner sends accumulated totals; zero means
+  // "no update", never "reset".
+  if (requestStatus.totalCostMicros > 0n) {
+    status.totalCostMicros = requestStatus.totalCostMicros;
+  }
+  if (requestStatus.totalInputTokens > 0n) {
+    status.totalInputTokens = requestStatus.totalInputTokens;
+  }
+  if (requestStatus.totalOutputTokens > 0n) {
+    status.totalOutputTokens = requestStatus.totalOutputTokens;
+  }
+
+  // Guarded, per-child merge: only touch pending_approvals /
+  // pending_file_reviews when explicitly requested, and even then replace
+  // only the scoped child's entries. This both prevents event emissions
+  // (which don't include these lists) from clobbering active gates set by
+  // call-agent-status, and prevents parallel child agents from clobbering
+  // each other's gates.
+  const scopeChildId = input.pendingUpdateChildAgentExecutionId;
+  if (input.updatePendingApprovals) {
+    status.pendingApprovals = mergePendingByChild(
+      status.pendingApprovals,
+      requestStatus.pendingApprovals,
+      (entry) => entry.childAgentExecutionId,
+      scopeChildId,
+    );
+  }
+  if (input.updatePendingFileReviews) {
+    status.pendingFileReviews = mergePendingByChild(
+      status.pendingFileReviews,
+      requestStatus.pendingFileReviews,
+      (entry) => entry.childAgentExecutionId,
+      scopeChildId,
+    );
+  }
+
+  // Only bump statusAudit.updatedAt on phase transitions — not on every
+  // task-progress heartbeat from the runner. This prevents long-running
+  // executions from perpetually sorting above freshly created ones in the
+  // recents sidebar (ActivityQueryController orders by this field).
+  // Mirrors the cloud's WorkflowExecutionUpdateStatusHandler exactly.
+  const isPhaseTransition =
+    requestStatus.phase !== ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED &&
+    requestStatus.phase !== previousPhase;
+  if (isPhaseTransition) {
+    const audit = status.audit ?? create(ApiResourceAuditSchema);
+    status.audit = audit;
+    const statusAudit =
+      audit.statusAudit ?? create(ApiResourceAuditInfoSchema);
+    audit.statusAudit = statusAudit;
+    statusAudit.updatedAt = timestampNow();
+    statusAudit.event = "updated";
+  }
+}
+
+/**
+ * PersistEvents — appends the input's events to the event log. Events are
+ * supplementary: a failure here does NOT fail the pipeline because status
+ * persistence already succeeded. A real append failure means timeline
+ * data loss, so it logs at error level; skipped duplicates are the
+ * expected result of the runner's idempotent batch retries and only log
+ * at debug (the store's INSERT OR IGNORE first-writer-wins, oss#308).
+ */
+async function persistEvents(
+  deps: UpdateStatusDeps,
+  input: WorkflowExecutionUpdateStatusInput,
+): Promise<void> {
+  if (input.events.length === 0) {
+    return;
+  }
+  const executionId = input.executionId;
+
+  const records: WorkflowExecutionEventRecord[] = [];
+  for (const event of input.events) {
+    let data: Uint8Array;
+    try {
+      data = toBinary(WorkflowExecutionEventSchema, event);
+    } catch (error) {
+      deps.logger.error(
+        "Failed to marshal event — dropping batch (non-fatal, timeline data lost)",
+        {
+          executionId,
+          sequenceNumber: event.sequenceNumber,
+          eventCount: input.events.length,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return;
+    }
+    records.push({
+      executionId,
+      sequenceNumber: Number(event.sequenceNumber),
+      eventType: WorkflowEventType[event.eventType] ?? "",
+      taskName: event.taskName,
+      data,
+      createdAt: "",
+    });
+  }
+
+  let appended: number;
+  try {
+    appended = await deps.store.appendWorkflowExecutionEvents(
+      executionId,
+      records,
+    );
+  } catch (error) {
+    deps.logger.error(
+      "Failed to persist execution events (non-fatal, timeline data lost)",
+      {
+        executionId,
+        submitted: records.length,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+
+  const skipped = records.length - appended;
+  if (skipped > 0) {
+    deps.logger.debug(
+      "Persisted execution events (idempotent retry skipped already-persisted sequences)",
+      { executionId, appended, skippedDuplicates: skipped },
+    );
+  } else {
+    deps.logger.debug("Persisted execution events", { executionId, appended });
+  }
+}

--- a/backend/services/stigmer-server-ts/src/pipeline/errors.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/errors.ts
@@ -100,7 +100,19 @@ export function goWrappedStatusError(
   error: ConnectError,
 ): ConnectError {
   return new ConnectError(
-    `${prefix}: rpc error: code = ${GRPC_CODE_NAMES[error.code]} desc = ${error.rawMessage}`,
+    `${prefix}: ${goGrpcErrorText(error)}`,
     error.code,
   );
+}
+
+/**
+ * The `%v` rendering of a grpc-go status error — `rpc error: code = <Name>
+ * desc = <message>` — for sites that embed a downstream error's text under
+ * a DIFFERENT outer code (e.g. workflowexecution's approval forwarding
+ * flattens the child's status to Unavailable but Go's %v still prints the
+ * inner wire text). goWrappedStatusError above is the %w twin that also
+ * keeps the inner code.
+ */
+export function goGrpcErrorText(error: ConnectError): string {
+  return `rpc error: code = ${GRPC_CODE_NAMES[error.code]} desc = ${error.rawMessage}`;
 }

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -28,6 +28,11 @@
 //     deepest domain: 23 RPCs incl. the subscribe stream, the HITL
 //     surfaces, and the engine-gate/lifecycle negatives that pin the
 //     no-Temporal posture until #18).
+//   - workflowexecution — sub-project #20 (sp.workflowexecution-domain;
+//     the Class A engineless surface: the create gate, the CW-7
+//     zero-record reads, the subscribe/subscribeEvents error arms, and
+//     the submitFileDecision negatives. The Class B suites in
+//     suites-execution/ roster with #21's orchestrator).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -44,6 +49,7 @@ export default defineConfig({
       "src/suites/workflowinstance.conformance.test.ts",
       "src/suites/executioncontext.conformance.test.ts",
       "src/suites/agentexecution.conformance.test.ts",
+      "src/suites/workflowexecution.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the WorkflowExecution controller slice — 21 RPCs across the command/query services, the signal-dedupe choreography, and the event-log machinery — from `backend/services/stigmer-server/pkg/domain/workflowexecution/` (controller/ + dedupe/) to `backend/services/stigmer-server-ts/src/domain/workflowexecution/`, at byte parity. The `temporal/` orchestrator slice is #21's (sp.workflowexecution-orchestration); until then the engine seam is a modeled disconnected state with Go's per-site postures pinned.

Program: stigmer-cloud `20260822.01.oss-ts-server-and-self-hosting`, D4 entry #20 (sub-project `20260824.04.sp.workflowexecution-domain`).

## Changes

- **Read surfaces**: `get`, `list`/`listByWorkflow` with the T13 structured filter + sort module (Go's stable-sort/zero-time semantics reproduced, incl. the strict RFC3339 gate), `getEventLog` (cursor pagination, 100/500 bounds, multi-type in-memory filter, malformed-record skip that never advances `latest_sequence`), `getExecutionSummary` (zero-shape pins: `-1` success-rate sentinel, always-present zero cost summary, absent avg_duration), `listPendingApprovals` (task_name projection, pre-truncation total).
- **The merge engine**: `updateStatus` — presence-guarded field merges, the flag-gated per-child `mergePendingByChild` for pending approvals/file reviews, statusAudit bumped only on phase transitions, insert-or-skip event persistence (non-fatal), post-persist broadcast.
- **Streams**: domain-local StreamBroker (DD-002); `subscribe` with the register-before-snapshot gap fix and consecutive-duplicate suppression; `subscribeEvents` — replay + 500ms live-tail poll (the first server-side poll loop in this codebase, faithful to Go's ticker design) with terminal drain-then-close.
- **Create**: the 15-step pipeline — the #196 InvalidArgument contrast, the engine gate at its pinned position (before every side effect; precedence over the workflow lookup asserted), default-instance self-heal via the in-process `createAsSystem` edge, workflow-ref denormalization, version pinning, ExecutionContext creation with env resolution + envmerge + `runtime_env` clearing, StartWorkflow-failure → persisted EXECUTION_FAILED (recoverable).
- **Lifecycle**: cancel/terminate/pause/resume/recover with byte-pinned phase matrices, idempotent target-phase no-ops, terminate's reason/error quirk (workflow-gone → "Terminated by user"), and recover's full choreography (terminate both tree members incl. the `workflow-exec-{id}` child, EC recreate degrade-gracefully, `recovery_mode` fresh start, error clear).
- **Signals + HITL forwarding**: `sendSignal` with the oss#442 two-phase dedupe over the store's `signalDedupe` sub-store (AlreadyExists/Aborted contract, release-after-failure); `submitApproval`/`submitFileDecision` forwarding to the child AgentExecution through the real in-process edge with the pinned asymmetry (approval flattens to Unavailable with Go's `%v` wire text; file-decision propagates the child's status unchanged); `submitWorkflowTaskApproval` (the `human_input_{task}` relaySignal envelope, incl. the `status.temporal_workflow_id` workflow-input quirk).
- **Conformance**: the `local-ts` roster grows 11 → 12 suites (`workflowexecution.conformance.test.ts`). The five Class B suites in `suites-execution/` roster with #21.
- **Shared**: `goGrpcErrorText` added beside `goWrappedStatusError` in `pipeline/errors.ts` (the `%v` twin of the `%w` shim).

## Implementation notes

- **DD-001 (owner-ratified)**: `updateStatus` and the lifecycle phase persists run their merge inside the store's atomic `updateResource` instead of Go's load-then-save. Go's own agentexecution domain calls this discipline "load-bearing"; workflowexecution predates it, and its per-child gate merge is exactly the interleaving the race corrupts. Wire-identical sequentially, strictly safer concurrently; a 25-iteration concurrency test pins the mechanism. The Go-side race is tracked by #865.
- **DD-002 (owner-ratified)**: the StreamBroker is a domain-local twin of agentexecution's (Go duplicates it per domain; #18 is concurrently building on the agentexecution instance). `StreamBroker<T>` consolidation is a recorded post-#18/#21 cleanup candidate.
- Dispatch-queue resolution (Go `wftemporal.ResolveWorkflowTaskQueue`) is absorbed into the engine seam (#21 implements it), same as the agentexecution seam ratified; the engine input carries `spec.execution_target`.

## Parity nuances disclosed (for the register)

1. **DD-001 atomicity** (above) — safe-direction divergence; Go race filed as #865.
2. **Terminal-set quirk ported faithfully**: `subscribe`/`subscribeEvents` close on COMPLETED/FAILED/CANCELLED only — TERMINATED is absent, so a stream over a terminated execution never self-closes. Both-editions issue candidate (the same finding #17 disclosed for agentexecution).
3. **File-decision propagation re-mints the child's status** (code + message byte-identical) instead of rethrowing the client-side ConnectError — echoing the in-process response envelope corrupts the serving HTTP/2 trailers. Error *details* (google.rpc) would not propagate; none exist on these arms today.
4. **Millisecond time precision** in duration filters and avg_duration (Go compares nanoseconds; JS Date is ms) — sub-millisecond boundaries only, below anything the system writes.
5. **Ranked-list tie order** in getExecutionSummary is deterministic first-seen (Go feeds a stable sort from nondeterministic map iteration) — not wire-assertable, the #6 sort-stability precedent.
6. **updateStatus load-error mapping**: Go maps ANY load failure to NotFound; the TS port maps only missing-row to NotFound and other store failures to Internal (the sibling domain's ratified convention).
7. **list.go's silent malformed-row skip** logs a warning here (log-only; list_by_workflow.go already warns in Go).

## Test plan

- 902 unit/composed-server tests green (66 files; 160 new for this domain), incl.: Go's `execution_filter_test.go` (11 cases), `update_status_test.go` (per-child merge + statusAudit bump), `subscribe_test.go` (gap fix + duplicate suppression), `send_signal_test.go` + `send_signal_dedupe_test.go` (full dedupe contract), `lifecycle_test.go` + `terminate_existing_workflow_step_test.go`, `pin_workflow_version_step_test.go`, `normalize_workflow_ref_step_test.go` ported case-for-case, plus the DD-001 mechanism pin (counting store: updateResource, never saveResource) and the 25-iteration concurrency race.
- Composed-server wire coverage through the real transport: engine gate (zero-trace + precedence), lifecycle postures, updateStatus merge + event idempotency + broadcast, subscribe snapshot→live→terminal-close, subscribeEvents replay/live-tail/type-filter/terminal-drain, HITL forwarding through the REAL in-process agentexecution controller (a real file-review ledger: decision lands on the child; digest mismatch propagates; approval flatten byte-matched).
- **Conformance: `local-ts` 12 suites / 252 passed** (first rostered run green); **`local-go` 468 passed, regression-free**.
- Two-reviewer adversarial panel: 1 blocking parity fix (the approval-flatten `%v` wire text) and 1 test gap (latest_sequence vs malformed-highest) found and fixed in-branch; mutation testing verified the load-bearing tests fail under 6 seeded regressions (load-then-save, register-after-snapshot, suppression removal, cursor-advance-on-malformed, scope-filter inversion, release-after-failure removal).

## Risks

- Additive: the Go server is untouched; the TS server is not yet user-facing (cutover is #24). Rollback is reverting this PR.
- Runs in parallel with #18 (sp.agentexecution-orchestration): both touch `boot/compose.ts` and domain-adjacent files — whichever merges second rebases (mechanical).

## Checklist

- [x] Tests added/updated
- [x] Conformance roster grown in the same PR (11 → 12)
- [x] Backward compatible (additive port)
- [x] Parity divergences disclosed above; Go-side race filed (#865)

Made with [Cursor](https://cursor.com)