### PR TITLE
feat(backend/stigmer-server-ts): port the small domains — oauthapp, platform, github, artifact (D4 #13)

### DIFF
--- a/backend/services/stigmer-server-ts/package-lock.json
+++ b/backend/services/stigmer-server-ts/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "3.1116.0",
+        "@aws-sdk/s3-request-presigner": "3.1116.0",
         "@bufbuild/protobuf": "2.12.0",
         "@bufbuild/protovalidate": "^1.1.1",
         "@connectrpc/connect": "^2.0.0",
@@ -43,6 +45,331 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.29.tgz",
+      "integrity": "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1116.0.tgz",
+      "integrity": "sha512-UKRl9qSVW0rZpvSOauQNpYAy8+ONBAVYnpfKVtCyOF+FZVT1tl6MunYuHvuarCrroD2/YJs+tHTALYNgAlec3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.29",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.75",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.75.tgz",
+      "integrity": "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1116.0.tgz",
+      "integrity": "sha512-WwaaVpvrZyML5L8SNY7sUGsYlMeCHzQ/8A/ms7dz/7sfYRvPn+qf0OasUWk+zuT8qGwjsYhILD0WVtlqUU08pQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@bufbuild/cel": {
@@ -933,6 +1260,87 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@stigmer/protos": {
       "resolved": "../../../apis/stubs/ts",
       "link": true
@@ -1109,6 +1517,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1577,6 +1991,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.23.12",

--- a/backend/services/stigmer-server-ts/package.json
+++ b/backend/services/stigmer-server-ts/package.json
@@ -25,6 +25,8 @@
     "directory": "backend/services/stigmer-server-ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.1116.0",
+    "@aws-sdk/s3-request-presigner": "3.1116.0",
     "@bufbuild/protobuf": "2.12.0",
     "@bufbuild/protovalidate": "^1.1.1",
     "@connectrpc/connect": "^2.0.0",

--- a/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
+++ b/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
@@ -55,6 +55,16 @@ await build({
   format: "esm",
   target: "node22",
   define: versionDefine,
+  // The AWS SDK (the R2 driver, D4 #13) is CommonJS; bundled into ESM its
+  // internal require() calls hit esbuild's throwing __require stub unless a
+  // real require exists at top level. The banner installs one via
+  // createRequire — the canonical esbuild recipe for CJS deps in an ESM
+  // bundle (verified by `npm run verify:slim`, which caught the failure).
+  banner: {
+    js:
+      'import { createRequire as __stigmerCreateRequire } from "node:module";' +
+      "const require = __stigmerCreateRequire(import.meta.url);",
+  },
   // Identifiers stay readable in stack traces; the external sourcemap
   // recovers file/line (runner precedent).
   minifyWhitespace: true,

--- a/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
+++ b/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
@@ -27,6 +27,16 @@ const outDir = join(serverRoot, "dist-slim");
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 
+// The ldflags equivalent (platform domain, D4 #13): release lanes export
+// STIGMER_SERVER_VERSION and the define stamps it into
+// src/domain/platform/version.ts's fallback chain. Unset keeps the "dev"
+// default — exactly Go's unstamped build.
+const versionDefine =
+  process.env.STIGMER_SERVER_VERSION !== undefined &&
+  process.env.STIGMER_SERVER_VERSION !== ""
+    ? { __STIGMER_SERVER_VERSION__: JSON.stringify(process.env.STIGMER_SERVER_VERSION) }
+    : { __STIGMER_SERVER_VERSION__: "undefined" };
+
 await build({
   entryPoints: [join(distDir, "main.js")],
   outfile: join(outDir, "main.js"),
@@ -34,6 +44,7 @@ await build({
   platform: "node",
   format: "esm",
   target: "node22",
+  define: versionDefine,
   // Identifiers stay readable in stack traces; the external sourcemap
   // recovers file/line (runner precedent).
   minifyWhitespace: true,

--- a/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
+++ b/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
@@ -27,15 +27,25 @@ const outDir = join(serverRoot, "dist-slim");
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 
-// The ldflags equivalent (platform domain, D4 #13): release lanes export
-// STIGMER_SERVER_VERSION and the define stamps it into
-// src/domain/platform/version.ts's fallback chain. Unset keeps the "dev"
-// default — exactly Go's unstamped build.
-const versionDefine =
-  process.env.STIGMER_SERVER_VERSION !== undefined &&
-  process.env.STIGMER_SERVER_VERSION !== ""
-    ? { __STIGMER_SERVER_VERSION__: JSON.stringify(process.env.STIGMER_SERVER_VERSION) }
-    : { __STIGMER_SERVER_VERSION__: "undefined" };
+// The ldflags equivalent (D4 #13): release lanes export these env vars and
+// the defines stamp them into their fallback chains
+// (src/domain/platform/version.ts, boot/config.ts's bundled GitHub OAuth
+// defaults). Unset keeps each source default — exactly Go's unstamped
+// build.
+const defineFromEnv = (identifier, envName) => ({
+  [identifier]:
+    process.env[envName] !== undefined && process.env[envName] !== ""
+      ? JSON.stringify(process.env[envName])
+      : "undefined",
+});
+const versionDefine = {
+  ...defineFromEnv("__STIGMER_SERVER_VERSION__", "STIGMER_SERVER_VERSION"),
+  ...defineFromEnv("__STIGMER_GITHUB_CLIENT_ID__", "STIGMER_GITHUB_CLIENT_ID"),
+  ...defineFromEnv(
+    "__STIGMER_GITHUB_CLIENT_SECRET__",
+    "STIGMER_GITHUB_CLIENT_SECRET",
+  ),
+};
 
 await build({
   entryPoints: [join(distDir, "main.js")],

--- a/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/artifact-storage.test.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/artifact-storage.test.ts
@@ -156,6 +156,14 @@ describe("LocalArtifactStorage", () => {
   });
 });
 
+const NO_R2 = {
+  r2Bucket: "",
+  r2Endpoint: "",
+  r2AccessKeyId: "",
+  r2SecretAccessKey: "",
+  r2Region: "",
+} as const;
+
 describe("newArtifactStorage factory", () => {
   it("empty type defaults to local", () => {
     const parent = mkdtempSync(path.join(tmpdir(), "artifact-factory-"));
@@ -164,6 +172,7 @@ describe("newArtifactStorage factory", () => {
         type: "",
         localBasePath: path.join(parent, "store"),
         localServeUrl: "http://localhost:7235",
+        ...NO_R2,
       });
       expect(s).toBeInstanceOf(LocalArtifactStorage);
     } finally {
@@ -171,15 +180,17 @@ describe("newArtifactStorage factory", () => {
     }
   });
 
-  it("r2 refuses with the deferral message", () => {
+  it("r2 constructs the R2 backend (validation pins live in r2-storage tests)", () => {
+    // The former boot-fail deferral test: the r2 arm now constructs, and
+    // an incomplete config fails with Go NewR2Storage's copy.
     expect(() =>
-      newArtifactStorage({ type: "r2", localBasePath: "", localServeUrl: "" }),
-    ).toThrow("ARTIFACT_STORAGE_TYPE=r2 is not yet supported by the TS server");
+      newArtifactStorage({ type: "r2", localBasePath: "", localServeUrl: "", ...NO_R2 }),
+    ).toThrow("R2 bucket name is required");
   });
 
   it("unknown type refuses", () => {
     expect(() =>
-      newArtifactStorage({ type: "s3", localBasePath: "", localServeUrl: "" }),
+      newArtifactStorage({ type: "s3", localBasePath: "", localServeUrl: "", ...NO_R2 }),
     ).toThrow("unknown storage type: s3 (must be 'local' or 'r2')");
   });
 });

--- a/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/r2-storage.test.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/__tests__/r2-storage.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Pins the R2 driver's logic-bearing pieces — hermetically (presigning is
+ * pure local SigV4 computation; no call leaves the host). The Go tree
+ * ships r2_storage.go untested; these pins are what the port adds:
+ * required-config copy, the 7-day presign clamp, the signed
+ * Content-Disposition, and the not-found mapping.
+ */
+import { describe, expect, it } from "vitest";
+
+import { R2ArtifactStorage, R2_MAX_EXPIRATION_MS, isNotFoundError } from "../r2-storage.js";
+
+const VALID = {
+  bucket: "stigmer-artifacts",
+  endpoint: "https://accountid.r2.cloudflarestorage.com",
+  accessKeyId: "test-access-key",
+  secretAccessKey: "test-secret-key",
+  region: "auto",
+};
+
+describe("R2ArtifactStorage config validation (Go NewR2Storage copy)", () => {
+  it.each([
+    [{ ...VALID, bucket: "" }, "R2 bucket name is required"],
+    [{ ...VALID, endpoint: "" }, "R2 endpoint is required"],
+    [{ ...VALID, accessKeyId: "" }, "R2 access key ID is required"],
+    [{ ...VALID, secretAccessKey: "" }, "R2 secret access key is required"],
+  ])("refuses incomplete config", (config, message) => {
+    expect(() => new R2ArtifactStorage(config)).toThrow(message);
+  });
+});
+
+describe("R2ArtifactStorage presigned URLs", () => {
+  const storage = new R2ArtifactStorage(VALID);
+
+  it("presigns a path-style GET under the endpoint and bucket", async () => {
+    const url = await storage.getSignedUrl("abc123hash", 3_600_000, "");
+    expect(url.startsWith(`${VALID.endpoint}/${VALID.bucket}/abc123hash?`)).toBe(true);
+    expect(url).toContain("X-Amz-Expires=3600");
+    expect(url).not.toContain("response-content-disposition");
+  });
+
+  it("clamps expiry to the R2 maximum of 7 days", async () => {
+    const url = await storage.getSignedUrl(
+      "abc123hash",
+      R2_MAX_EXPIRATION_MS * 3,
+      "",
+    );
+    expect(url).toContain("X-Amz-Expires=604800");
+  });
+
+  it("signs the attachment disposition into the URL when a filename is given", async () => {
+    const url = await storage.getSignedUrl("abc123hash", 3_600_000, "report.txt");
+    // Signed as a response-content-disposition override, mirroring Go.
+    expect(url).toContain("response-content-disposition=");
+    expect(decodeURIComponent(url)).toContain('attachment; filename="report.txt"');
+  });
+});
+
+describe("isNotFoundError", () => {
+  it("maps the SDK's structured not-found shapes", () => {
+    expect(isNotFoundError(Object.assign(new Error("x"), { name: "NotFound" }))).toBe(true);
+    expect(isNotFoundError(Object.assign(new Error("x"), { name: "NoSuchKey" }))).toBe(true);
+    expect(
+      isNotFoundError(
+        Object.assign(new Error("x"), { $metadata: { httpStatusCode: 404 } }),
+      ),
+    ).toBe(true);
+    expect(isNotFoundError(new Error("status 404 from upstream"))).toBe(true);
+    expect(isNotFoundError(new Error("object not found"))).toBe(true);
+  });
+
+  it("does not swallow real failures", () => {
+    expect(isNotFoundError(new Error("connection refused"))).toBe(false);
+    expect(
+      isNotFoundError(
+        Object.assign(new Error("x"), { $metadata: { httpStatusCode: 500 } }),
+      ),
+    ).toBe(false);
+    expect(isNotFoundError(undefined)).toBe(false);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
@@ -11,12 +11,9 @@
  * segment, so the server and the runner (LOCAL_ARTIFACT_PATH) share one
  * store by construction (#285).
  *
- * The R2 backend (S3-compatible, AWS SDK) is DEFERRED to #13 per the
- * owner-ratified plan decision: it would drag the AWS SDK into this
- * package's dependency surface and its presigned-URL semantics are
- * asserted on #13's RPC surface. Until then ARTIFACT_STORAGE_TYPE=r2
- * boot-fails with an explicit message — a disclosed, temporary
- * coexistence divergence (the Go server serves r2 today).
+ * The R2 backend (S3-compatible, AWS SDK) lives in r2-storage.ts — it
+ * arrived with the artifact domain (#13) per the ratified deferral, closing
+ * the temporary ARTIFACT_STORAGE_TYPE=r2 boot-fail divergence #17 shipped.
  */
 import { mkdirSync } from "node:fs";
 import {
@@ -30,6 +27,7 @@ import {
 import path from "node:path";
 
 import { goQueryEscape } from "../gocompat/query-escape.js";
+import { R2ArtifactStorage } from "./r2-storage.js";
 
 /** Query key carrying the desired download filename on local URLs; the
  * artifact file server (#13) reads it to set Content-Disposition. */
@@ -63,9 +61,15 @@ export interface ArtifactStorageConfig {
   readonly type: string;
   readonly localBasePath: string;
   readonly localServeUrl: string;
+  /** Cloudflare R2 (S3-compatible) settings — required when type is "r2". */
+  readonly r2Bucket: string;
+  readonly r2Endpoint: string;
+  readonly r2AccessKeyId: string;
+  readonly r2SecretAccessKey: string;
+  readonly r2Region: string;
 }
 
-/** Factory mirroring Go NewArtifactStorage; r2 is the deferred arm. */
+/** Factory mirroring Go NewArtifactStorage. */
 export function newArtifactStorage(
   config: ArtifactStorageConfig,
 ): ArtifactStorage {
@@ -77,13 +81,13 @@ export function newArtifactStorage(
         config.localServeUrl,
       );
     case "r2":
-      // Deferred to #13 (owner-ratified): fail loud at boot rather than
-      // serving a silently different artifact store than configured.
-      throw new Error(
-        "ARTIFACT_STORAGE_TYPE=r2 is not yet supported by the TS server; " +
-          "the R2 backend arrives with the artifact domain sub-project (D4 #13). " +
-          "Use the Go server for r2-backed deployments during coexistence.",
-      );
+      return new R2ArtifactStorage({
+        bucket: config.r2Bucket,
+        endpoint: config.r2Endpoint,
+        accessKeyId: config.r2AccessKeyId,
+        secretAccessKey: config.r2SecretAccessKey,
+        region: config.r2Region,
+      });
     default:
       throw new Error(
         `unknown storage type: ${storageType} (must be 'local' or 'r2')`,

--- a/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/artifact-storage.ts
@@ -29,6 +29,8 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 
+import { goQueryEscape } from "../gocompat/query-escape.js";
+
 /** Query key carrying the desired download filename on local URLs; the
  * artifact file server (#13) reads it to set Content-Disposition. */
 export const LOCAL_DOWNLOAD_QUERY_PARAM = "download";
@@ -223,26 +225,9 @@ export class LocalArtifactStorage implements ArtifactStorage {
   }
 }
 
-/**
- * Go url.QueryEscape, byte-exact: unreserved [A-Za-z0-9-_.~] pass, space
- * becomes '+', everything else percent-encodes. URLSearchParams differs
- * on two characters ('~' escaped, '*' bare), so the stdlib encoder would
- * break URL byte parity for filenames carrying them.
- */
-function goQueryEscape(s: string): string {
-  let out = "";
-  for (const byte of Buffer.from(s, "utf-8")) {
-    const c = String.fromCharCode(byte);
-    if (/[A-Za-z0-9\-_.~]/.test(c)) {
-      out += c;
-    } else if (c === " ") {
-      out += "+";
-    } else {
-      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
-    }
-  }
-  return out;
-}
+// goQueryEscape moved to src/gocompat/query-escape.ts when the github
+// broker became its second consumer (#13) — the shared-steps promotion
+// rule. Behavior unchanged; the URL parity tests below still pin it.
 
 /**
  * Whether `p` is `root` itself or a descendant — cleaned-path comparison

--- a/backend/services/stigmer-server-ts/src/artifactstorage/r2-storage.ts
+++ b/backend/services/stigmer-server-ts/src/artifactstorage/r2-storage.ts
@@ -1,0 +1,205 @@
+/**
+ * R2 artifact storage — ports pkg/domain/artifact/storage/r2_storage.go:
+ * the Cloudflare R2 (S3-compatible) backend, filling the factory arm #17
+ * deferred to this sub-project (owner-ratified, approved at the #13 plan
+ * gate together with the @aws-sdk dependency).
+ *
+ * Not conformance-assertable on the local targets (same as Go — the Go
+ * tree carries no R2 tests at all); the port adds unit pins for the pieces
+ * that have logic: config validation copy, the 7-day presign clamp, the
+ * signed Content-Disposition, and the not-found mapping.
+ */
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadBucketCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl as presignGetObject } from "@aws-sdk/s3-request-presigner";
+
+import type { ArtifactStorage } from "./artifact-storage.js";
+import { contentDispositionAttachment } from "./artifact-storage.js";
+
+/** Go: "R2 has a maximum expiration of 7 days" — presigns clamp here. */
+export const R2_MAX_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Go get_content/get_download_url wrap their storage calls in a 30s
+ * context timeout. The TS ArtifactStorage interface carries no signal, so
+ * the same bound lives one layer down, on the driver's network reads —
+ * identical ceiling, applied at the only backend where it can fire.
+ */
+const R2_CALL_TIMEOUT_MS = 30_000;
+
+export interface R2StorageConfig {
+  readonly bucket: string;
+  readonly endpoint: string;
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  /** Usually "auto" for R2 (Go default). */
+  readonly region: string;
+}
+
+/** Test seam: the two AWS clients, injectable for hermetic unit tests. */
+export interface R2Clients {
+  readonly client: S3Client;
+  readonly presign: typeof presignGetObject;
+}
+
+export class R2ArtifactStorage implements ArtifactStorage {
+  private readonly client: S3Client;
+  private readonly presign: typeof presignGetObject;
+  private readonly bucket: string;
+
+  constructor(config: R2StorageConfig, clients?: R2Clients) {
+    // Go NewR2Storage's required-config errors, byte-mirrored.
+    if (config.bucket === "") {
+      throw new Error("R2 bucket name is required");
+    }
+    if (config.endpoint === "") {
+      throw new Error("R2 endpoint is required");
+    }
+    if (config.accessKeyId === "") {
+      throw new Error("R2 access key ID is required");
+    }
+    if (config.secretAccessKey === "") {
+      throw new Error("R2 secret access key is required");
+    }
+
+    this.bucket = config.bucket;
+    if (clients !== undefined) {
+      this.client = clients.client;
+      this.presign = clients.presign;
+      return;
+    }
+    this.client = new S3Client({
+      region: config.region === "" ? "auto" : config.region,
+      endpoint: config.endpoint,
+      // R2 uses path-style addressing (Go o.UsePathStyle = true).
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+    });
+    this.presign = presignGetObject;
+  }
+
+  async upload(key: string, data: Uint8Array, contentType: string): Promise<void> {
+    try {
+      await this.client.send(
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+          Body: data,
+          ...(contentType !== "" ? { ContentType: contentType } : {}),
+        }),
+      );
+    } catch (error) {
+      throw new Error(`r2 upload failed: ${errorText(error)}`, { cause: error });
+    }
+  }
+
+  async download(key: string): Promise<Uint8Array> {
+    let body: Uint8Array;
+    try {
+      const result = await this.client.send(
+        new GetObjectCommand({ Bucket: this.bucket, Key: key }),
+        { abortSignal: AbortSignal.timeout(R2_CALL_TIMEOUT_MS) },
+      );
+      if (result.Body === undefined) {
+        throw new Error("empty response body");
+      }
+      body = await result.Body.transformToByteArray();
+    } catch (error) {
+      throw new Error(`r2 download failed: ${errorText(error)}`, { cause: error });
+    }
+    return body;
+  }
+
+  async getSignedUrl(
+    key: string,
+    expiresInMs: number,
+    downloadFilename: string,
+  ): Promise<string> {
+    const clampedMs = Math.min(expiresInMs, R2_MAX_EXPIRATION_MS);
+    const command = new GetObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      // Go signs Content-Disposition into the presigned URL — the browser
+      // saves the object under the given name instead of rendering inline.
+      ...(downloadFilename !== ""
+        ? { ResponseContentDisposition: contentDispositionAttachment(downloadFilename) }
+        : {}),
+    });
+    try {
+      return await this.presign(this.client, command, {
+        expiresIn: Math.floor(clampedMs / 1000),
+      });
+    } catch (error) {
+      throw new Error(`r2 presign failed: ${errorText(error)}`, { cause: error });
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+    } catch (error) {
+      throw new Error(`r2 delete failed: ${errorText(error)}`, { cause: error });
+    }
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+      return true;
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return false;
+      }
+      throw new Error(`r2 head failed: ${errorText(error)}`, { cause: error });
+    }
+  }
+
+  async health(): Promise<void> {
+    try {
+      await this.client.send(new HeadBucketCommand({ Bucket: this.bucket }));
+    } catch (error) {
+      throw new Error(`r2 health check failed: ${errorText(error)}`, {
+        cause: error,
+      });
+    }
+  }
+}
+
+/**
+ * Whether the error means "no such object" (Go isNotFoundError, adapted to
+ * the SDK's structured errors instead of Go's string matching): the S3
+ * NotFound/NoSuchKey names, an HTTP 404, or the legacy text forms.
+ */
+export function isNotFoundError(error: unknown): boolean {
+  if (error === null || error === undefined) {
+    return false;
+  }
+  const name = (error as { name?: string }).name ?? "";
+  if (name === "NotFound" || name === "NoSuchKey") {
+    return true;
+  }
+  const statusCode = (error as { $metadata?: { httpStatusCode?: number } })
+    .$metadata?.httpStatusCode;
+  if (statusCode === 404) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("404") || message.includes("not found");
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -33,6 +33,7 @@ import { registerExecutionContextServices } from "../domain/executioncontext/con
 import { registerMemoryServices } from "../domain/memory/controller.js";
 import { registerOAuthAppServices } from "../domain/oauthapp/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
+import { registerPlatformServices } from "../domain/platform/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
 import { SecretService } from "../encryption/encryption.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
@@ -270,6 +271,13 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       store,
       logger,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
+    });
+    // Platform registers LAST of all controllers (Go server.go 530–535).
+    registerPlatformServices(router, {
+      temporalHostPort: config.temporalHostPort,
+      temporalNamespace: config.temporalNamespace,
+      runnerAuthService,
+      logger,
     });
   };
   inProcess = createInProcessClients(routes, logger);

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -28,6 +28,11 @@ import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
 import { RuntimeResolutionService } from "../domain/environment/resolution/resolution.js";
 import { ManagedEnvironmentService } from "../domain/mcpserver/oauth/managed-env.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
+import { registerArtifactServices } from "../domain/artifact/controller.js";
+import {
+  createArtifactFileServer,
+  warnOnLegacyArtifactLayout,
+} from "../domain/artifact/file-server.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
 import { registerGitHubServices } from "../domain/github/controller.js";
@@ -160,14 +165,30 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // externally-connected subscribe streams (Go's GetStreamBroker seam).
   const agentExecutionStreamBroker = new StreamBroker(logger);
   // The artifact blob store (Go server.go 349: shared by agentexecution
-  // attachments now, the artifact domain + skill push later). Construction
-  // boot-fails on ARTIFACT_STORAGE_TYPE=r2 (the ratified #13 deferral);
-  // the health probe runs in start(), matching Go's boot check.
+  // attachments, the artifact domain (#13), and skill push (#8)). The r2
+  // arm landed with #13; the health probe runs in start(), matching Go's
+  // boot check.
   const artifactStorage = newArtifactStorage({
     type: config.artifactStorageType,
     localBasePath: config.artifactLocalBasePath,
     localServeUrl: config.artifactLocalServeUrl,
+    r2Bucket: config.r2Bucket,
+    r2Endpoint: config.r2Endpoint,
+    r2AccessKeyId: config.r2AccessKeyId,
+    r2SecretAccessKey: config.r2SecretAccessKey,
+    r2Region: config.r2Region,
   });
+  // The artifact download lane: a SECOND loopback listener on
+  // ARTIFACT_HTTP_PORT, local storage only (Go server.go 849–870) —
+  // deliberately not a unified-port lane. Lifecycle rides start()/
+  // shutdown().
+  const artifactFileServer =
+    config.artifactStorageType === "local"
+      ? createArtifactFileServer({
+          basePath: config.artifactLocalBasePath,
+          logger,
+        })
+      : undefined;
   // The environment runtime-resolution service (#5) — the decrypt-for-
   // execution path the EC builder uses to resolve environment_refs (the
   // RPC surface redacts secret values, oss#405).
@@ -273,6 +294,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       logger,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
     });
+    // Artifact CRUD shares the ONE blob store with agentexecution's
+    // attachment lanes (Go server.go 347–374).
+    registerArtifactServices(router, { store, artifactStorage, logger });
     // GitHub broker: config-only, no store (Go server.go 524–528).
     registerGitHubServices(router, {
       clientId: config.gitHubOAuthClientId,
@@ -317,12 +341,26 @@ export function composeServer(options: ComposeOptions): ComposedServer {
         options.host,
       );
       logger.info("stigmer-server-ts listening", { port });
+      // The artifact file server binds AFTER the main server, exactly Go's
+      // boot order; a bind failure is logged but NOT fatal (Go's
+      // ListenAndServe goroutine logs and dies while the server runs on).
+      if (artifactFileServer !== undefined) {
+        await warnOnLegacyArtifactLayout(config.artifactLocalBasePath, logger);
+        try {
+          await artifactFileServer.listen(config.artifactHttpPort);
+        } catch (error) {
+          logger.error("Artifact HTTP file server failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
       return port;
     },
 
     async shutdown(): Promise<void> {
       healthState.setOverall(ServingStatus.NOT_SERVING);
       modelRegistryStore.stopRefresh();
+      await artifactFileServer?.shutdown();
       await server.shutdown();
       // The store closes LAST: in-flight handlers drained above may still
       // be mid-write (Go closes the store after grpcServer.Stop too).

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -31,6 +31,7 @@ import { registerAgentInstanceServices } from "../domain/agentinstance/controlle
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
 import { registerMemoryServices } from "../domain/memory/controller.js";
+import { registerOAuthAppServices } from "../domain/oauthapp/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
 import { SecretService } from "../encryption/encryption.js";
@@ -204,6 +205,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     registerHealthService(router, healthState);
     registerOrganizationServices(router, { store, logger });
     registerEnvironmentServices(router, { store, logger, secretService });
+    // OAuthApp reuses the environment's SecretService instance — Go wires
+    // ONE encryption service for both (server.go 302–307).
+    registerOAuthAppServices(router, { store, secretService, logger });
     registerExecutionContextServices(router, {
       store,
       logger,

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -30,6 +30,7 @@ import { ManagedEnvironmentService } from "../domain/mcpserver/oauth/managed-env
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
+import { registerGitHubServices } from "../domain/github/controller.js";
 import { registerMemoryServices } from "../domain/memory/controller.js";
 import { registerOAuthAppServices } from "../domain/oauthapp/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
@@ -271,6 +272,13 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       store,
       logger,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
+    });
+    // GitHub broker: config-only, no store (Go server.go 524–528).
+    registerGitHubServices(router, {
+      clientId: config.gitHubOAuthClientId,
+      clientSecret: config.gitHubOAuthClientSecret,
+      logger,
+      fetchImpl: options.fetchImpl,
     });
     // Platform registers LAST of all controllers (Go server.go 530–535).
     registerPlatformServices(router, {

--- a/backend/services/stigmer-server-ts/src/boot/config.ts
+++ b/backend/services/stigmer-server-ts/src/boot/config.ts
@@ -64,7 +64,36 @@ export interface ServerConfig {
    * full path).
    */
   readonly artifactLocalServeUrl: string;
+  /**
+   * GitHub OAuth credentials for workspace repo selection (the github
+   * broker domain). Override via STIGMER_GITHUB_CLIENT_ID /
+   * STIGMER_GITHUB_CLIENT_SECRET — an empty value is treated as unset
+   * (Go getEnvString), so no configuration can blank the bundled
+   * defaults on OSS.
+   */
+  readonly gitHubOAuthClientId: string;
+  readonly gitHubOAuthClientSecret: string;
 }
+
+// The bundled "Stigmer Local" OAuth App credentials (callback:
+// localhost:3000), hardcoded in source following the GitHub CLI (gh)
+// pattern: a localhost-only OAuth App's client_secret has negligible
+// security value. Byte-mirrored from Go pkg/config/config.go. Release
+// bundles may stamp the Cloud OAuth App via the esbuild defines in
+// scripts/bundle-slim.mjs — the ldflags equivalent.
+declare const __STIGMER_GITHUB_CLIENT_ID__: string | undefined;
+declare const __STIGMER_GITHUB_CLIENT_SECRET__: string | undefined;
+
+const DEFAULT_GITHUB_OAUTH_CLIENT_ID: string =
+  typeof __STIGMER_GITHUB_CLIENT_ID__ === "string" &&
+  __STIGMER_GITHUB_CLIENT_ID__ !== ""
+    ? __STIGMER_GITHUB_CLIENT_ID__
+    : "Ov23li4q5kgj90QMr226";
+const DEFAULT_GITHUB_OAUTH_CLIENT_SECRET: string =
+  typeof __STIGMER_GITHUB_CLIENT_SECRET__ === "string" &&
+  __STIGMER_GITHUB_CLIENT_SECRET__ !== ""
+    ? __STIGMER_GITHUB_CLIENT_SECRET__
+    : "edc089d10b6cc0dcee898f9680d62d1504e2c89a";
 
 /** Default unified port; the CLI's env contract pins the same value. */
 export const DEFAULT_GRPC_PORT = 7234;
@@ -106,6 +135,16 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     dbPath: envString(env, "DB_PATH", defaultDbPath()),
     operatorEmail,
     operatorName,
+    gitHubOAuthClientId: envString(
+      env,
+      "STIGMER_GITHUB_CLIENT_ID",
+      DEFAULT_GITHUB_OAUTH_CLIENT_ID,
+    ),
+    gitHubOAuthClientSecret: envString(
+      env,
+      "STIGMER_GITHUB_CLIENT_SECRET",
+      DEFAULT_GITHUB_OAUTH_CLIENT_SECRET,
+    ),
   };
 }
 

--- a/backend/services/stigmer-server-ts/src/boot/config.ts
+++ b/backend/services/stigmer-server-ts/src/boot/config.ts
@@ -42,6 +42,15 @@ export interface ServerConfig {
   readonly operatorEmail: string;
   readonly operatorName: string;
   /**
+   * Temporal coordinates this server runs against (Go TemporalHostPort/
+   * TemporalNamespace). Published to embedded runners via the platform
+   * domain's getRunnerBootstrapConfig — in OSS the server and its runners
+   * are co-located, so the address the server dials is the one runners
+   * dial too. The Temporal workers (#18) read the same fields.
+   */
+  readonly temporalHostPort: string;
+  readonly temporalNamespace: string;
+  /**
    * Artifact blob storage (attachments + execution outputs; Go
    * config.ArtifactStorage). "local" is the OSS default; "r2" boot-fails
    * on this server until #13 (the owner-ratified deferral).
@@ -70,6 +79,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   const artifactHttpPort = envInt(env, "ARTIFACT_HTTP_PORT", grpcPort + 1);
   return {
     grpcPort,
+    temporalHostPort: envString(env, "TEMPORAL_HOST_PORT", "localhost:7233"),
+    temporalNamespace: envString(env, "TEMPORAL_NAMESPACE", "default"),
     artifactStorageType: envString(env, "ARTIFACT_STORAGE_TYPE", "local"),
     artifactLocalBasePath: envString(
       env,

--- a/backend/services/stigmer-server-ts/src/boot/config.ts
+++ b/backend/services/stigmer-server-ts/src/boot/config.ts
@@ -65,6 +65,17 @@ export interface ServerConfig {
    */
   readonly artifactLocalServeUrl: string;
   /**
+   * The artifact file server's own port (ARTIFACT_HTTP_PORT, default
+   * grpcPort+1). Only bound when artifact storage is local.
+   */
+  readonly artifactHttpPort: number;
+  /** Cloudflare R2 settings (S3-compatible; validated when type is "r2"). */
+  readonly r2Bucket: string;
+  readonly r2Endpoint: string;
+  readonly r2AccessKeyId: string;
+  readonly r2SecretAccessKey: string;
+  readonly r2Region: string;
+  /**
    * GitHub OAuth credentials for workspace repo selection (the github
    * broker domain). Override via STIGMER_GITHUB_CLIENT_ID /
    * STIGMER_GITHUB_CLIENT_SECRET — an empty value is treated as unset
@@ -106,11 +117,27 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   const grpcPort = envInt(env, "GRPC_PORT", DEFAULT_GRPC_PORT);
   // Go: ARTIFACT_HTTP_PORT defaults to the gRPC port + 1.
   const artifactHttpPort = envInt(env, "ARTIFACT_HTTP_PORT", grpcPort + 1);
+  const artifactStorageType = envString(env, "ARTIFACT_STORAGE_TYPE", "local");
+  const r2 = {
+    r2Bucket: envString(env, "R2_BUCKET", ""),
+    r2Endpoint: envString(env, "R2_ENDPOINT", ""),
+    r2AccessKeyId: envString(env, "R2_ACCESS_KEY_ID", ""),
+    r2SecretAccessKey: envString(env, "R2_SECRET_ACCESS_KEY", ""),
+    r2Region: envString(env, "R2_REGION", "auto"),
+  };
+  // Go validateR2Config: boot-fatal on incomplete r2 configuration — a
+  // second deliberate exception to the lenient-loader posture (a server
+  // that silently ignored half an R2 config would write blobs nowhere).
+  if (artifactStorageType === "r2") {
+    validateR2Config(r2);
+  }
   return {
     grpcPort,
+    artifactHttpPort,
+    ...r2,
     temporalHostPort: envString(env, "TEMPORAL_HOST_PORT", "localhost:7233"),
     temporalNamespace: envString(env, "TEMPORAL_NAMESPACE", "default"),
-    artifactStorageType: envString(env, "ARTIFACT_STORAGE_TYPE", "local"),
+    artifactStorageType,
     artifactLocalBasePath: envString(
       env,
       "ARTIFACT_LOCAL_BASE_PATH",
@@ -146,6 +173,28 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
       DEFAULT_GITHUB_OAUTH_CLIENT_SECRET,
     ),
   };
+}
+
+/** Go validateR2Config — the four required fields, error copy mirrored. */
+function validateR2Config(r2: {
+  r2Bucket: string;
+  r2Endpoint: string;
+  r2AccessKeyId: string;
+  r2SecretAccessKey: string;
+}): void {
+  const requirements: Array<[string, string]> = [
+    [r2.r2Bucket, "R2_BUCKET"],
+    [r2.r2Endpoint, "R2_ENDPOINT"],
+    [r2.r2AccessKeyId, "R2_ACCESS_KEY_ID"],
+    [r2.r2SecretAccessKey, "R2_SECRET_ACCESS_KEY"],
+  ];
+  for (const [value, name] of requirements) {
+    if (value === "") {
+      throw new Error(
+        `invalid R2 configuration: ${name} is required when ARTIFACT_STORAGE_TYPE=r2`,
+      );
+    }
+  }
 }
 
 /** Go defaultDBPath: ~/.stigmer/stigmer.db, ./stigmer.db without a home. */

--- a/backend/services/stigmer-server-ts/src/domain/agent/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/search-extractor.ts
@@ -5,7 +5,7 @@
  * prompt) — the common pattern where older agents may not have a dedicated
  * description field, but all agents have instructions. The query side of
  * the extractor contract arrives with the search service sub-project
- * (#13), exactly as the organization extractor's header records.
+ * (#14), exactly as the organization extractor's header records.
  */
 import type { Message } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/search-extractor.ts
@@ -3,7 +3,7 @@
  * pkg/query/search/extractor/agent_instance_extractor.go. Agent instances
  * are configured incarnations of an agent blueprint; the summary is
  * spec.description. The query side of the extractor contract arrives with
- * the search service sub-project (#13).
+ * the search service sub-project (#14).
  */
 import type { Message } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server-ts/src/domain/artifact/__tests__/artifact.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/artifact/__tests__/artifact.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Pins the artifact domain against Go's artifact_controller_test.go —
+ * through the real stack (composed server, native gRPC client, the port+1
+ * file server on a pre-picked free port).
+ *
+ * The load-bearing pins the conformance suite CANNOT cover:
+ *   - the 50MB domain cap → ResourceExhausted with Go's copy (sits behind
+ *     the transport's 10MB message cap on the wire — the wave-2 S1
+ *     amendment names this port as the carrier; proven here through an
+ *     in-process router, which has no transport cap);
+ *   - the org-derivation proxy trick reading metadata.org out of a REAL
+ *     stored execution row (the suite can only pin the fabricated-id
+ *     fallback);
+ *   - expires_at renders RFC3339 WITHOUT fractional seconds (Go
+ *     time.RFC3339 byte shape);
+ *   - the file server's traversal guard (a crafted key must never escape
+ *     the artifact root — the SQLite db file lives right next to it).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient, createRouterTransport } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ArtifactSchema } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
+import { ArtifactCommandController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/command_pb";
+import { ArtifactStorageState } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/enum_pb";
+import { ArtifactQueryController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { LocalArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import { MAX_CONTENT_BYTES, artifactNotFoundMessage } from "../constants.js";
+import { registerArtifactServices } from "../controller.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+type CommandClient = Client<typeof ArtifactCommandController>;
+type QueryClient = Client<typeof ArtifactQueryController>;
+
+/** A free loopback port, picked ahead so the file server can pin it. */
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      const port = address !== null && typeof address === "object" ? address.port : 0;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+let server: ComposedServer;
+let command: CommandClient;
+let query: QueryClient;
+let dir: string;
+let artifactPort: number;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "artifact-domain-test-"));
+  artifactPort = await freePort();
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 3).toString("base64"));
+  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 4).toString("base64"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      ARTIFACT_HTTP_PORT: String(artifactPort),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(ArtifactCommandController, transport);
+  query = createClient(ArtifactQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+let counter = 0;
+function artifactInput(overrides?: {
+  content?: Uint8Array;
+  ttlDays?: number;
+  agentExecutionId?: string;
+  workflowExecutionId?: string;
+}) {
+  counter += 1;
+  const source =
+    overrides?.agentExecutionId !== undefined ||
+    overrides?.workflowExecutionId !== undefined
+      ? {
+          agentExecutionId: overrides.agentExecutionId ?? "",
+          workflowExecutionId: overrides.workflowExecutionId ?? "",
+        }
+      : { agentExecutionId: `aexec_01test${counter}` };
+  return {
+    spec: {
+      displayName: `artifact-${counter}.txt`,
+      contentType: "text/plain",
+      source,
+      ...(overrides?.ttlDays !== undefined
+        ? { retention: { ttlDays: overrides.ttlDays } }
+        : {}),
+    },
+    content: overrides?.content ?? new TextEncoder().encode(`content ${counter}\n`),
+  };
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+describe("artifact domain — create & content addressing", () => {
+  it("assigns an art_ id and stamps the content-addressed status", async () => {
+    const input = artifactInput();
+    const created = await command.create(input);
+
+    expect(created.metadata?.id).toMatch(/^art_/);
+    expect(created.metadata?.name).toBe(input.spec.displayName);
+    expect(created.status?.contentHash).toBe(
+      createHash("sha256").update(input.content).digest("hex"),
+    );
+    expect(created.status?.sizeBytes).toBe(BigInt(input.content.byteLength));
+    expect(created.status?.storageState).toBe(ArtifactStorageState.storage_state_stored);
+  });
+
+  it("expires_at is RFC3339 WITHOUT fractional seconds, ~30 days out by default", async () => {
+    const created = await command.create(artifactInput());
+    const expiresAt = created.status?.expiresAt ?? "";
+    // Go time.RFC3339: no millis (toISOString would emit .000Z).
+    expect(expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    const delta = Date.parse(expiresAt) - Date.now();
+    expect(delta).toBeGreaterThan(29.9 * 24 * 3600 * 1000);
+    expect(delta).toBeLessThan(30.1 * 24 * 3600 * 1000);
+  });
+
+  it("ttl_days -1 is permanent; other non-positive values fall back to 30", async () => {
+    const permanent = await command.create(artifactInput({ ttlDays: -1 }));
+    expect(permanent.status?.expiresAt).toBe("");
+
+    const fallback = await command.create(artifactInput({ ttlDays: -7 }));
+    expect(fallback.status?.expiresAt).not.toBe("");
+  });
+
+  it("derives the org from a REAL stored source execution (the proxy trick)", async () => {
+    // Seed a workflow_execution row carrying an org. The row is written
+    // through the Artifact schema — the SAME wire-layout proxy the reader
+    // uses (all resources share metadata at field 3).
+    const executionId = "wexec_01orgproxy";
+    await server.store.saveResource(
+      ApiResourceKind.workflow_execution,
+      executionId,
+      ArtifactSchema,
+      create(ArtifactSchema, {
+        metadata: { id: executionId, name: "seed", org: "proxy-org" },
+      }),
+    );
+
+    const created = await command.create(
+      artifactInput({ workflowExecutionId: executionId }),
+    );
+    expect(created.metadata?.org).toBe("proxy-org");
+  });
+
+  it("falls back to the empty org for a fabricated execution id (OSS posture)", async () => {
+    const created = await command.create(
+      artifactInput({ agentExecutionId: "aexec_01neverexisted" }),
+    );
+    expect(created.metadata?.org).toBe("");
+  });
+
+  it("rejects content over the 50MB domain cap with ResourceExhausted (unit-level arm)", async () => {
+    // Through an in-process router — the wire path hits the transport's
+    // 10MB cap first (the S1 amendment), so the domain arm is provable
+    // only here.
+    const storeDir = mkdtempSync(path.join(tmpdir(), "artifact-cap-test-"));
+    const store = SqliteStore.open(path.join(storeDir, "cap.db"), silentLogger);
+    try {
+      const transport = createRouterTransport((router) => {
+        registerArtifactServices(router, {
+          store,
+          artifactStorage: new LocalArtifactStorage(
+            path.join(storeDir, "artifacts"),
+            "http://localhost:1",
+          ),
+          logger: silentLogger,
+        });
+      });
+      const local = createClient(ArtifactCommandController, transport);
+      const err = await grpcError(() =>
+        local.create(
+          artifactInput({ content: new Uint8Array(MAX_CONTENT_BYTES + 1) }),
+        ),
+      );
+      expect(err.code).toBe(Code.ResourceExhausted);
+      expect(err.rawMessage).toBe(
+        `content exceeds maximum size of ${MAX_CONTENT_BYTES} bytes`,
+      );
+    } finally {
+      await store.close();
+      rmSync(storeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("artifact domain — read surfaces", () => {
+  it("get resolves by id; listByExecution filters on the matching source arm", async () => {
+    const executionId = `wexec_01list${++counter}`;
+    const created = await command.create(
+      artifactInput({ workflowExecutionId: executionId }),
+    );
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.status?.contentHash).toBe(created.status?.contentHash);
+
+    const listed = await query.listByExecution({ workflowExecutionId: executionId });
+    expect(listed.totalPages).toBe(1);
+    expect(listed.entries).toHaveLength(1);
+
+    // The OTHER source arm must not match the same id.
+    const other = await query.listByExecution({ agentExecutionId: executionId });
+    expect(other.entries).toHaveLength(0);
+  });
+
+  it("listByExecution without any filter answers InvalidArgument", async () => {
+    const err = await grpcError(() => query.listByExecution({}));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(
+      "workflow_execution_id or agent_execution_id is required",
+    );
+  });
+
+  it("getContent truncates to max_bytes and reports the FULL size", async () => {
+    const content = new TextEncoder().encode("0123456789".repeat(100)); // 1000 bytes
+    const created = await command.create(artifactInput({ content }));
+
+    const full = await query.getContent({ artifactId: created.metadata!.id });
+    expect(full.truncated).toBe(false);
+    expect(full.totalSizeBytes).toBe(1000n);
+    expect(new Uint8Array(full.content)).toEqual(content);
+
+    const truncated = await query.getContent({
+      artifactId: created.metadata!.id,
+      maxBytes: 100n,
+    });
+    expect(truncated.truncated).toBe(true);
+    expect(truncated.totalSizeBytes).toBe(1000n);
+    expect(truncated.content).toHaveLength(100);
+  });
+
+  it("getDownloadUrl reports the unconditional 604800 ttl and blob facts", async () => {
+    const created = await command.create(artifactInput());
+    const download = await query.getDownloadUrl({ value: created.metadata!.id });
+    expect(download.url).toContain(created.status!.contentHash);
+    expect(download.ttlSeconds).toBe(604800);
+    expect(download.sizeBytes).toBe(created.status?.sizeBytes);
+    expect(download.contentType).toBe("text/plain");
+  });
+
+  it("unknown ids answer NotFound with the pinned copy on all read surfaces", async () => {
+    const missing = "art_01domainmissing";
+    for (const call of [
+      () => query.get({ value: missing }),
+      () => query.getDownloadUrl({ value: missing }),
+      () => query.getContent({ artifactId: missing }),
+    ]) {
+      const err = await grpcError(call);
+      expect(err.code).toBe(Code.NotFound);
+      expect(err.rawMessage).toBe(artifactNotFoundMessage(missing));
+    }
+  });
+});
+
+describe("artifact domain — soft delete", () => {
+  it("flips storage_state, keeps the metadata row, fails blob reads closed", async () => {
+    const created = await command.create(artifactInput());
+
+    const deleted = await command.delete({ value: created.metadata!.id });
+    expect(deleted.status?.storageState).toBe(ArtifactStorageState.storage_state_deleted);
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.status?.storageState).toBe(ArtifactStorageState.storage_state_deleted);
+
+    const download = await grpcError(() =>
+      query.getDownloadUrl({ value: created.metadata!.id }),
+    );
+    expect(download.code).toBe(Code.FailedPrecondition);
+    expect(download.rawMessage).toBe(
+      `artifact blob has been deleted: ${created.metadata!.id}`,
+    );
+    const content = await grpcError(() =>
+      query.getContent({ artifactId: created.metadata!.id }),
+    );
+    expect(content.code).toBe(Code.FailedPrecondition);
+  });
+
+  it("deleting a missing artifact answers NotFound", async () => {
+    const err = await grpcError(() => command.delete({ value: "art_01nothere" }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+});
+
+describe("artifact domain — the local file-server lane", () => {
+  it("serves the blob inline; ?download= adds the attachment disposition", async () => {
+    const content = new TextEncoder().encode("file-server domain test body\n");
+    const created = await command.create(artifactInput({ content }));
+    const download = await query.getDownloadUrl({ value: created.metadata!.id });
+
+    const inline = await fetch(download.url);
+    expect(inline.status).toBe(200);
+    expect(inline.headers.get("content-disposition")).toBeNull();
+    expect(new Uint8Array(await inline.arrayBuffer())).toEqual(content);
+
+    const attachment = await fetch(`${download.url}?download=report.txt`);
+    expect(attachment.status).toBe(200);
+    expect(attachment.headers.get("content-disposition")).toBe(
+      'attachment; filename="report.txt"',
+    );
+  });
+
+  it("answers 404 for missing keys and refuses path traversal out of the root", async () => {
+    const missing = await fetch(`http://127.0.0.1:${artifactPort}/nope`);
+    expect(missing.status).toBe(404);
+
+    // The SQLite db sits one level above the artifact root — a traversal
+    // escape would serve it.
+    const traversal = await fetch(
+      `http://127.0.0.1:${artifactPort}/..%2Fstigmer.db`,
+    );
+    expect(traversal.status).toBe(404);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/artifact/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/artifact/constants.ts
@@ -1,0 +1,47 @@
+/**
+ * Artifact domain constants — byte-pinned values and wire copy from
+ * pkg/domain/artifact. The error formats are asserted by the conformance
+ * suite (get NotFound copy, deleted-blob copy) and shown verbatim by
+ * clients — never reword.
+ */
+
+/** Go kind string on the built resource. */
+export const ARTIFACT_KIND = "Artifact";
+
+/**
+ * Go maxContentBytes (50 MB): the domain-level content cap →
+ * ResourceExhausted. Sits BEHIND the transport's 10MB message cap, so it
+ * is not wire-assertable from the reference client — the arm stays
+ * unit-level in both editions (the wave-2 S1 amendment).
+ */
+export const MAX_CONTENT_BYTES = 50 * 1024 * 1024;
+
+/** Go defaultTTLDays: expires_at defaults ~30 days out. */
+export const DEFAULT_TTL_DAYS = 30;
+
+/** Go permanentTTLMarker: retention.ttl_days = -1 means never expires. */
+export const PERMANENT_TTL_MARKER = -1;
+
+/**
+ * Go DefaultMaxContentBytes (512 KB): getContent's default/implicit cap,
+ * matching AgentExecutionController.GetArtifactContent so the two
+ * content-read endpoints behave identically from a client's perspective.
+ */
+export const DEFAULT_MAX_CONTENT_BYTES = 512n * 1024n;
+
+/**
+ * Go downloadURLExpiration (7 days — the R2 maximum). Reported as
+ * ttl_seconds UNCONDITIONALLY, even by the local backend whose URLs never
+ * expire — the ratified P3 wire pin.
+ */
+export const DOWNLOAD_URL_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Go: status.Errorf(codes.NotFound, "Artifact not found: %s", id). */
+export function artifactNotFoundMessage(artifactId: string): string {
+  return `Artifact not found: ${artifactId}`;
+}
+
+/** Go: "artifact blob has been deleted: %s" (FailedPrecondition). */
+export function artifactBlobDeletedMessage(artifactId: string): string {
+  return `artifact blob has been deleted: ${artifactId}`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/artifact/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/artifact/controller.ts
@@ -1,0 +1,589 @@
+/**
+ * Artifact controller — ports pkg/domain/artifact (command + query sides).
+ * Artifact is the execution-output store (T07): a metadata resource in the
+ * generic resources table plus a blob in ArtifactStorage, keyed by the
+ * content's SHA-256 (content-addressable).
+ *
+ * Direct handlers, matching Go: create takes CreateArtifactInput (spec +
+ * content bytes — not a HasMetadata resource), delete is a soft
+ * storage_state transition rather than the hard-delete pipeline; only
+ * get/listByExecution ride pipelines. Proven by
+ * artifact.conformance.test.ts (CONFORMANCE_TARGET=local-ts, incl. the
+ * file-server lane) and __tests__/artifact.test.ts.
+ *
+ * Go tolerates a nil ArtifactStorage (two-phase wiring) and answers
+ * Internal "artifact storage not configured"; the TS composition root
+ * cannot produce that state — the dependency is required, and a missing
+ * one is a compile error (the modeled-not-nullable idiom). The nil-guard
+ * arms are therefore not ported.
+ *
+ * Versus Stigmer Cloud, OSS derives the artifact's org from its source
+ * execution BEST-EFFORT (fabricated ids fall back to an empty org — what
+ * makes the domain standalone-testable), where the multi-tenant edition
+ * requires a real org-carrying source (the wave-2 disclosed edition split).
+ */
+import { createHash } from "node:crypto";
+
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import {
+  ArtifactSchema,
+  ArtifactStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
+import type { Artifact } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
+import { ArtifactCommandController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/command_pb";
+import { ArtifactStorageState } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/enum_pb";
+import {
+  ArtifactDownloadUrlSchema,
+  ArtifactListSchema,
+  GetArtifactContentResponseSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/io_pb";
+import type {
+  ArtifactDownloadUrl,
+  ArtifactId,
+  ArtifactList,
+  CreateArtifactInput,
+  GetArtifactContentRequest,
+  GetArtifactContentResponse,
+  ListArtifactsByExecutionRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/io_pb";
+import { ArtifactQueryController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/query_pb";
+import type { ArtifactSource } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { ApiResourceId } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+
+import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import type { Logger } from "../../boot/logger.js";
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import {
+  generateId,
+  setAuditFieldsForCreate,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import type { Store } from "../../store/interface.js";
+import {
+  ARTIFACT_KIND,
+  DEFAULT_MAX_CONTENT_BYTES,
+  DEFAULT_TTL_DAYS,
+  DOWNLOAD_URL_EXPIRATION_MS,
+  MAX_CONTENT_BYTES,
+  PERMANENT_TTL_MARKER,
+  artifactBlobDeletedMessage,
+  artifactNotFoundMessage,
+} from "./constants.js";
+
+export interface ArtifactControllerDeps {
+  readonly store: Store;
+  readonly artifactStorage: ArtifactStorage;
+  readonly logger: Logger;
+}
+
+/** Registers both artifact services on the router (routes stage). */
+export function registerArtifactServices(
+  router: ConnectRouter,
+  deps: ArtifactControllerDeps,
+): void {
+  router.service(ArtifactCommandController, {
+    create: (input) => createArtifact(deps, input),
+    delete: (id) => deleteArtifact(deps, id),
+  });
+  router.service(ArtifactQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    listByExecution: (req, ctx) => listByExecution(deps, req, ctx),
+    getDownloadUrl: (id) => getDownloadUrl(deps, id),
+    getContent: (req) => getContent(deps, req),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — Go's direct handler, step for step: validate spec/content/
+ * source, SHA-256 the content (the hex hash IS the blob key), upload,
+ * derive org best-effort, build the resource with an art_ id and the
+ * content-addressed status, persist. The audit-field failure is LOG-ONLY
+ * (Go behavior); the empty-content arm is normally answered by
+ * protovalidate before this code runs, and the 50MB cap sits behind the
+ * transport's 10MB message cap — both arms stay unit-level (the wave-2 S1
+ * amendment names this port as their carrier).
+ */
+async function createArtifact(
+  deps: ArtifactControllerDeps,
+  input: CreateArtifactInput,
+): Promise<Artifact> {
+  const spec = input.spec;
+  if (spec === undefined) {
+    throw invalidArgumentError("spec is required");
+  }
+  const content = input.content;
+  if (content.length === 0) {
+    throw invalidArgumentError("content is required");
+  }
+  if (content.length > MAX_CONTENT_BYTES) {
+    throw new ConnectError(
+      `content exceeds maximum size of ${MAX_CONTENT_BYTES} bytes`,
+      Code.ResourceExhausted,
+    );
+  }
+  const source = spec.source;
+  if (
+    source === undefined ||
+    (source.workflowExecutionId === "" && source.agentExecutionId === "")
+  ) {
+    throw invalidArgumentError(
+      "spec.source must include workflow_execution_id or agent_execution_id",
+    );
+  }
+
+  const contentHash = createHash("sha256").update(content).digest("hex");
+
+  deps.logger.info("creating artifact", {
+    contentHash,
+    contentSize: content.length,
+    contentType: spec.contentType,
+    displayName: spec.displayName,
+  });
+
+  try {
+    await deps.artifactStorage.upload(contentHash, content, spec.contentType);
+  } catch (error) {
+    deps.logger.error("failed to upload artifact blob", {
+      contentHash,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to upload artifact content");
+  }
+
+  const org = await deriveOrgFromSource(deps, source);
+
+  const artifactId = generateId("art");
+  const artifact = create(ArtifactSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: ARTIFACT_KIND,
+    metadata: {
+      id: artifactId,
+      name: spec.displayName,
+      org,
+    },
+    spec,
+    status: {
+      contentHash,
+      sizeBytes: BigInt(content.length),
+      storageState: ArtifactStorageState.storage_state_stored,
+      expiresAt: computeExpiresAt(spec.retention?.ttlDays),
+    },
+  });
+
+  // Go: SetAuditFieldsForCreate failure is LOG-ONLY — an artifact write
+  // must not fail over audit stamping.
+  try {
+    setAuditFieldsForCreate(ArtifactSchema, artifact);
+  } catch (error) {
+    deps.logger.error("failed to set audit fields on artifact", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    await deps.store.saveResource(
+      ApiResourceKind.artifact,
+      artifactId,
+      ArtifactSchema,
+      artifact,
+    );
+  } catch (error) {
+    deps.logger.error("failed to persist artifact metadata", {
+      artifactId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to persist artifact");
+  }
+
+  deps.logger.info("artifact created successfully", {
+    artifactId,
+    contentHash,
+    sizeBytes: content.length,
+  });
+
+  return artifact;
+}
+
+/**
+ * Go deriveOrgFromSource — the wire-layout proxy trick: every Stigmer
+ * resource shares the metadata wire position (field 3 =
+ * ApiResourceMetadata), so the Artifact schema reads metadata.org from any
+ * execution kind without importing execution-specific protos. Best-effort
+ * by design: unknown/fabricated executions fall back to the empty org (the
+ * OSS single-user posture, pinned by the suite).
+ */
+async function deriveOrgFromSource(
+  deps: ArtifactControllerDeps,
+  source: ArtifactSource,
+): Promise<string> {
+  const lookups: Array<{ id: string; kind: ApiResourceKind }> = [
+    { id: source.workflowExecutionId, kind: ApiResourceKind.workflow_execution },
+    { id: source.agentExecutionId, kind: ApiResourceKind.agent_execution },
+  ];
+  for (const lookup of lookups) {
+    if (lookup.id === "") {
+      continue;
+    }
+    try {
+      const proxy = await deps.store.getResource(
+        lookup.kind,
+        lookup.id,
+        ArtifactSchema,
+      );
+      const org = proxy.metadata?.org ?? "";
+      if (org !== "") {
+        return org;
+      }
+    } catch {
+      // Best-effort: a missing or unreadable source is not an error.
+    }
+  }
+  return "";
+}
+
+/** Go computeExpiresAt: 30-day default; -1 permanent; <=0 falls back. */
+function computeExpiresAt(ttlDaysInput: number | undefined): string {
+  let ttlDays = ttlDaysInput ?? DEFAULT_TTL_DAYS;
+  if (ttlDays === PERMANENT_TTL_MARKER) {
+    return ""; // never expires
+  }
+  if (ttlDays <= 0) {
+    ttlDays = DEFAULT_TTL_DAYS;
+  }
+  const expires = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
+  // RFC3339 without fractional seconds — Go time.Format(time.RFC3339)
+  // (the store/lifecycle modules use the same idiom).
+  return expires.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Delete — Go's soft delete: a storage_state transition + save, never a
+ * row removal (the metadata row is the audit trail of what an execution
+ * produced; the blob is left for GC). Stamps status_audit only — a status
+ * transition, not a spec change (#540). The response is the STORED
+ * resource, exactly as Go returns it.
+ */
+async function deleteArtifact(
+  deps: ArtifactControllerDeps,
+  id: ApiResourceId,
+): Promise<Artifact> {
+  const resourceId = id.value;
+  if (resourceId === "") {
+    throw invalidArgumentError("artifact id is required");
+  }
+
+  const artifact = await loadArtifactOrNotFound(deps, resourceId);
+
+  deps.logger.info("soft-deleting artifact", {
+    artifactId: resourceId,
+    previousState: ArtifactStorageState[artifact.status?.storageState ?? 0],
+  });
+
+  if (artifact.status === undefined) {
+    artifact.status = create(ArtifactStatusSchema);
+  }
+  artifact.status.storageState = ArtifactStorageState.storage_state_deleted;
+
+  // Soft-delete is a status transition: stamp status_audit only — cloud
+  // currently stamps neither slot; OSS stays honest rather than copying
+  // that omission (stigmer/stigmer#540). Failure is LOG-ONLY, as in Go.
+  try {
+    setAuditFieldsForUpdate(ArtifactSchema, artifact, "status_audit");
+  } catch (error) {
+    deps.logger.error("failed to set audit fields on artifact delete", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    await deps.store.saveResource(
+      ApiResourceKind.artifact,
+      resourceId,
+      ArtifactSchema,
+      artifact,
+    );
+  } catch (error) {
+    deps.logger.error("failed to persist artifact deletion", {
+      artifactId: resourceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to persist artifact deletion");
+  }
+
+  deps.logger.info("artifact soft-deleted successfully", {
+    artifactId: resourceId,
+  });
+
+  return artifact;
+}
+
+/** Get — Go's two-step pipeline (ValidateProto → LoadTarget). */
+async function get(
+  deps: ArtifactControllerDeps,
+  id: ArtifactId,
+  ctx: HandlerContext,
+): Promise<Artifact> {
+  const reqCtx = new RequestContext(
+    ArtifactQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ArtifactQueryController.method.get.input>(
+    "artifact-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, ArtifactSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Artifact;
+}
+
+const ARTIFACT_LIST_KEY = "artifactList";
+
+/**
+ * ListByExecution — Go's custom pipeline: an at-least-one-filter check,
+ * then a FULL ListResources scan with an in-memory source filter (the Go
+ * doc comment claims FindAllByField; the CODE full-scans — the port
+ * mirrors the code, the mismatch is disclosed in the PR), unmarshal
+ * failures skipped, TotalPages hardcoded to 1.
+ */
+async function listByExecution(
+  deps: ArtifactControllerDeps,
+  req: ListArtifactsByExecutionRequest,
+  ctx: HandlerContext,
+): Promise<ArtifactList> {
+  const reqCtx = new RequestContext(
+    ArtifactQueryController.method.listByExecution.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ArtifactQueryController.method.listByExecution.input>(
+    "artifact-list-by-execution",
+    deps.logger,
+  )
+    .addStep({
+      name: "ValidateListByExecutionRequest",
+      execute(stepCtx): void {
+        const input = stepCtx.input;
+        if (input.workflowExecutionId === "" && input.agentExecutionId === "") {
+          throw invalidArgumentError(
+            "workflow_execution_id or agent_execution_id is required",
+          );
+        }
+      },
+    })
+    .addStep({
+      name: "QueryArtifactsByExecution",
+      async execute(stepCtx): Promise<void> {
+        const input = stepCtx.input;
+        let data: Uint8Array[];
+        try {
+          data = await deps.store.listResources(ApiResourceKind.artifact);
+        } catch (error) {
+          throw internalError(error, "failed to list artifacts");
+        }
+
+        const artifacts: Artifact[] = [];
+        for (const bytes of data) {
+          let artifact: Artifact;
+          try {
+            artifact = fromBinary(ArtifactSchema, bytes);
+          } catch (error) {
+            deps.logger.warn("failed to unmarshal artifact, skipping", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            continue;
+          }
+          const source = artifact.spec?.source;
+          if (
+            input.workflowExecutionId !== "" &&
+            source?.workflowExecutionId === input.workflowExecutionId
+          ) {
+            artifacts.push(artifact);
+          } else if (
+            input.agentExecutionId !== "" &&
+            source?.agentExecutionId === input.agentExecutionId
+          ) {
+            artifacts.push(artifact);
+          }
+        }
+
+        stepCtx.set(
+          ARTIFACT_LIST_KEY,
+          create(ArtifactListSchema, { totalPages: 1, entries: artifacts }),
+        );
+      },
+    })
+    .build()
+    .execute(reqCtx);
+
+  const list = reqCtx.get(ARTIFACT_LIST_KEY);
+  if (list === undefined) {
+    throw internalError(
+      new Error("artifact list missing from pipeline context"),
+      "artifact list not found in pipeline context",
+    );
+  }
+  return list as ArtifactList;
+}
+
+/**
+ * GetDownloadUrl — Go's direct handler: load, refuse deleted blobs, mint
+ * the storage URL. ttl_seconds reports the 7-day constant UNCONDITIONALLY
+ * (ratified P3): local URLs never actually expire — pinned as the wire
+ * contract, the semantic mismatch disclosed in the wave-2 PR. The empty
+ * download filename keeps the URL inline; attachment disposition is
+ * opt-in only on the AgentExecution artifact download path.
+ */
+async function getDownloadUrl(
+  deps: ArtifactControllerDeps,
+  id: ArtifactId,
+): Promise<ArtifactDownloadUrl> {
+  const resourceId = id.value;
+  if (resourceId === "") {
+    throw invalidArgumentError("artifact id is required");
+  }
+
+  const artifact = await loadArtifactOrNotFound(deps, resourceId);
+  const contentHash = requireLiveBlob(artifact, resourceId);
+
+  deps.logger.info("generating download URL for artifact", {
+    artifactId: resourceId,
+    contentHash,
+  });
+
+  let downloadUrl: string;
+  try {
+    downloadUrl = await deps.artifactStorage.getSignedUrl(
+      contentHash,
+      DOWNLOAD_URL_EXPIRATION_MS,
+      "",
+    );
+  } catch (error) {
+    deps.logger.error("failed to generate download URL for artifact", {
+      artifactId: resourceId,
+      contentHash,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to generate download URL");
+  }
+
+  return create(ArtifactDownloadUrlSchema, {
+    url: downloadUrl,
+    ttlSeconds: Math.floor(DOWNLOAD_URL_EXPIRATION_MS / 1000),
+    sizeBytes: artifact.status?.sizeBytes ?? 0n,
+    contentType: artifact.spec?.contentType ?? "",
+  });
+}
+
+/**
+ * GetContent — Go's direct handler: the artifact bytes in the response
+ * (no CORS concerns for SDK consumers), truncated to max_bytes with the
+ * FULL blob size reported. Default/implicit cap 512KB, matching
+ * AgentExecution.GetArtifactContent so the two content-read endpoints
+ * behave identically.
+ */
+async function getContent(
+  deps: ArtifactControllerDeps,
+  req: GetArtifactContentRequest,
+): Promise<GetArtifactContentResponse> {
+  const artifactId = req.artifactId;
+  if (artifactId === "") {
+    throw invalidArgumentError("artifact_id is required");
+  }
+
+  const artifact = await loadArtifactOrNotFound(deps, artifactId);
+  const contentHash = requireLiveBlob(artifact, artifactId);
+
+  let maxBytes = req.maxBytes;
+  if (maxBytes <= 0n) {
+    maxBytes = DEFAULT_MAX_CONTENT_BYTES;
+  }
+
+  let data: Uint8Array;
+  try {
+    data = await deps.artifactStorage.download(contentHash);
+  } catch (error) {
+    deps.logger.error("failed to download artifact content", {
+      artifactId,
+      contentHash,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to read artifact content");
+  }
+
+  const totalSize = BigInt(data.length);
+  let truncated = false;
+  if (totalSize > maxBytes) {
+    data = data.subarray(0, Number(maxBytes));
+    truncated = true;
+  }
+
+  deps.logger.info("read artifact content", {
+    artifactId,
+    totalSizeBytes: data.length,
+    truncated,
+  });
+
+  return create(GetArtifactContentResponseSchema, {
+    content: data,
+    contentType: artifact.spec?.contentType ?? "",
+    totalSizeBytes: totalSize,
+    truncated,
+  });
+}
+
+/** Load by id with the byte-pinned Go NotFound copy. */
+async function loadArtifactOrNotFound(
+  deps: ArtifactControllerDeps,
+  artifactId: string,
+): Promise<Artifact> {
+  try {
+    return await deps.store.getResource(
+      ApiResourceKind.artifact,
+      artifactId,
+      ArtifactSchema,
+    );
+  } catch {
+    // Go answers NotFound for ANY store failure here (status.Errorf on
+    // err != nil), not only missing rows — mirrored.
+    throw new ConnectError(artifactNotFoundMessage(artifactId), Code.NotFound);
+  }
+}
+
+/**
+ * The shared deleted-blob and missing-hash guards of the two blob-read
+ * surfaces (Go repeats them inline in both handlers).
+ */
+function requireLiveBlob(artifact: Artifact, artifactId: string): string {
+  if (
+    artifact.status?.storageState === ArtifactStorageState.storage_state_deleted
+  ) {
+    throw new ConnectError(
+      artifactBlobDeletedMessage(artifactId),
+      Code.FailedPrecondition,
+    );
+  }
+  const contentHash = artifact.status?.contentHash ?? "";
+  if (contentHash === "") {
+    throw internalError(
+      new Error(`artifact has no content hash: ${artifactId}`),
+      `artifact has no content hash: ${artifactId}`,
+    );
+  }
+  return contentHash;
+}

--- a/backend/services/stigmer-server-ts/src/domain/artifact/file-server.ts
+++ b/backend/services/stigmer-server-ts/src/domain/artifact/file-server.ts
@@ -1,0 +1,194 @@
+/**
+ * The artifact HTTP file server — ports the local-download lane from Go
+ * pkg/server/server.go (artifactDownloadHandler + the boot block, lines
+ * 849–926): a second listener on 127.0.0.1:ARTIFACT_HTTP_PORT (default
+ * grpcPort+1), started only when artifact storage is LOCAL, serving
+ * GET /<key> as the exact bytes LocalArtifactStorage wrote. The lane
+ * dissolved into its owning domain per the ratified D4 decision — it is
+ * NOT a unified-port lane (Go runs it as a separate listener, and so does
+ * this port).
+ *
+ * Disposition contract (proven by the artifact suite's file-server block):
+ * a request carrying ?download=<name> (set by getSignedUrl) is served as a
+ * browser download named by that parameter — mirroring the R2 backend,
+ * which signs Content-Disposition into the presigned URL. Requests without
+ * the parameter are served INLINE with no disposition header.
+ *
+ * Two disclosed nuances versus Go's http.FileServer (neither pinned by the
+ * suite, both recorded in the PR):
+ *   - No Content-Type header: Go sniffs one (net/http DetectContentType);
+ *     porting the whole sniffing algorithm for an unpinned header is not
+ *     parity the register demands, and an absent header lets clients apply
+ *     the same sniffing themselves.
+ *   - No Range support: range requests are answered with the full body
+ *     (200), which HTTP permits; Go's ServeContent honors them.
+ */
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+
+import { contentDispositionAttachment, LOCAL_DOWNLOAD_QUERY_PARAM } from "../../artifactstorage/artifact-storage.js";
+import type { Logger } from "../../boot/logger.js";
+
+export interface ArtifactFileServerOptions {
+  /** The artifact root — the base path IS the root (#285). */
+  readonly basePath: string;
+  readonly logger: Logger;
+}
+
+export interface ArtifactFileServer {
+  /** Binds 127.0.0.1:<port> (an explicit port 0 picks ephemeral for tests). */
+  listen(port: number): Promise<number>;
+  shutdown(): Promise<void>;
+}
+
+export function createArtifactFileServer(
+  options: ArtifactFileServerOptions,
+): ArtifactFileServer {
+  const { basePath, logger } = options;
+
+  const server = http.createServer((req, res) => {
+    void serveArtifact(basePath, req, res, logger);
+  });
+
+  return {
+    listen(port: number): Promise<number> {
+      return new Promise((resolve, reject) => {
+        server.once("error", reject);
+        // Loopback-only, as Go binds "127.0.0.1:<port>": download URLs are
+        // minted for the local machine, never a network interface.
+        server.listen(port, "127.0.0.1", () => {
+          server.removeListener("error", reject);
+          const address = server.address();
+          const boundPort =
+            address !== null && typeof address === "object" ? address.port : port;
+          logger.info("artifact HTTP file server listening", {
+            port: boundPort,
+            dir: basePath,
+          });
+          resolve(boundPort);
+        });
+      });
+    },
+    shutdown(): Promise<void> {
+      return new Promise((resolve) => {
+        server.close(() => resolve());
+        // In-flight downloads do not hold shutdown open (Go's file server
+        // is simply abandoned on exit; close() at least stops the listener).
+        server.closeAllConnections();
+      });
+    },
+  };
+}
+
+async function serveArtifact(
+  basePath: string,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  logger: Logger,
+): Promise<void> {
+  try {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      res.writeHead(405, { Allow: "GET, HEAD" });
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const key = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+
+    // The same containment guard LocalArtifactStorage applies on writes: a
+    // crafted path must never escape the artifact root.
+    const root = path.resolve(basePath);
+    const filePath = path.resolve(root, key);
+    if (filePath !== root && !filePath.startsWith(root + path.sep)) {
+      res.writeHead(404);
+      res.end("404 page not found\n");
+      return;
+    }
+
+    let info;
+    try {
+      info = await stat(filePath);
+    } catch {
+      res.writeHead(404);
+      res.end("404 page not found\n");
+      return;
+    }
+    if (!info.isFile()) {
+      res.writeHead(404);
+      res.end("404 page not found\n");
+      return;
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Length": String(info.size),
+    };
+    // The download query parameter (set by getSignedUrl) rides the URL
+    // because the local lane has no presigning; applied here exactly as
+    // Go's artifactDownloadHandler does. Absent → inline, no header.
+    const downloadName = url.searchParams.get(LOCAL_DOWNLOAD_QUERY_PARAM) ?? "";
+    if (downloadName !== "") {
+      headers["Content-Disposition"] = contentDispositionAttachment(downloadName);
+    }
+
+    res.writeHead(200, headers);
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+    const stream = createReadStream(filePath);
+    stream.on("error", (error) => {
+      logger.error("artifact file stream failed", {
+        key,
+        error: error.message,
+      });
+      res.destroy();
+    });
+    stream.pipe(res);
+  } catch (error) {
+    logger.error("artifact file server request failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    if (!res.headersSent) {
+      res.writeHead(500);
+    }
+    res.end();
+  }
+}
+
+/**
+ * Go warnOnLegacyArtifactLayout: a one-line migration hint when a
+ * pre-#285 store layout is detected (base was a PARENT; artifacts lived at
+ * <base>/artifacts/<key>). Keys off the two subpaths only the OLD layout
+ * produces — <base>/artifacts/attachments and the doubled
+ * <base>/artifacts/artifacts — so it cannot false-positive on a healthy
+ * new-layout install.
+ */
+export async function warnOnLegacyArtifactLayout(
+  basePath: string,
+  logger: Logger,
+): Promise<void> {
+  for (const sub of ["attachments", "artifacts"]) {
+    const legacy = path.join(basePath, "artifacts", sub);
+    try {
+      const info = await stat(legacy);
+      if (info.isDirectory()) {
+        logger.warn(
+          "Detected artifacts under a pre-#285 layout at <base>/artifacts/*. " +
+            "The artifact root is now <base> itself. Move <base>/artifacts/* up into " +
+            "<base> (or set ARTIFACT_LOCAL_BASE_PATH to the old <base>/artifacts) so " +
+            "existing artifacts remain reachable.",
+          {
+            legacyDir: path.join(basePath, "artifacts"),
+            artifactRoot: basePath,
+          },
+        );
+        return;
+      }
+    } catch {
+      // Absent legacy path: the healthy case.
+    }
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/artifact/file-server.ts
+++ b/backend/services/stigmer-server-ts/src/domain/artifact/file-server.ts
@@ -96,7 +96,16 @@ async function serveArtifact(
     }
 
     const url = new URL(req.url ?? "/", "http://localhost");
-    const key = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+    let key: string;
+    try {
+      key = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+    } catch {
+      // Malformed percent-escapes are a client error, not a server fault
+      // (Go's net/http rejects them before the file server runs).
+      res.writeHead(404);
+      res.end("404 page not found\n");
+      return;
+    }
 
     // The same containment guard LocalArtifactStorage applies on writes: a
     // crafted path must never escape the artifact root.

--- a/backend/services/stigmer-server-ts/src/domain/environment/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/search-extractor.ts
@@ -4,7 +4,7 @@
  * is spec.description). Secret DATA is deliberately never indexed — only
  * name, description, tags, org, and visibility reach FTS5. The query side
  * of the extractor contract arrives with the search service sub-project
- * (#13), exactly as the organization extractor's header records.
+ * (#14), exactly as the organization extractor's header records.
  */
 import type { Message } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server-ts/src/domain/github/__tests__/github.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/github/__tests__/github.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Pins the github broker against Go's controller behavior — the arms the
+ * conformance suite deliberately cannot assert (they dial github.com for
+ * real on a configured broker, and the OSS broker is ALWAYS configured):
+ * authorize-URL byte parity, the exchange request's exact wire shape, and
+ * the error-mapping contract (GitHub error → InvalidArgument, network →
+ * Unavailable, unparseable → Internal, config-missing →
+ * FailedPrecondition). Go keeps no in-package tests for these; this file
+ * is the reference-pinning the port adds.
+ *
+ * All arms run against an in-process router with an injected fetch — a
+ * test must never leave the host.
+ */
+import { createClient, createRouterTransport, Code, ConnectError } from "@connectrpc/connect";
+
+import { describe, expect, it } from "vitest";
+
+import { GitHubService } from "@stigmer/protos/ai/stigmer/platform/github/v1/service_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { registerGitHubServices } from "../controller.js";
+import type { GitHubControllerDeps } from "../controller.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const REDIRECT = "https://app.example.com/oauth/callback";
+
+function makeClient(overrides: Partial<GitHubControllerDeps> = {}) {
+  const transport = createRouterTransport((router) => {
+    registerGitHubServices(router, {
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      logger: silentLogger,
+      ...overrides,
+    });
+  });
+  return createClient(GitHubService, transport);
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+/** A fetch stub returning the given body (or failing), recording the request. */
+function fetchStub(result: { body?: string; reject?: Error }): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; init: RequestInit }>;
+} {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchImpl = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    if (result.reject !== undefined) {
+      throw result.reject;
+    }
+    return new Response(result.body ?? "", { status: 200 });
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("github broker — getOAuthAuthorizeUrl", () => {
+  it("builds the authorize URL with Go url.Values.Encode byte parity", async () => {
+    const client = makeClient();
+    const out = await client.getOAuthAuthorizeUrl({ redirectUri: REDIRECT });
+
+    // 16 random bytes, hex-encoded (Go generateState).
+    expect(out.state).toMatch(/^[0-9a-f]{32}$/);
+
+    // Keys sorted (client_id, redirect_uri, scope, state), values
+    // QueryEscape'd: ':' → %3A, ',' → %2C, '/' → %2F — the exact bytes Go
+    // produces.
+    expect(out.authorizeUrl).toBe(
+      "https://github.com/login/oauth/authorize" +
+        "?client_id=test-client-id" +
+        "&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth%2Fcallback" +
+        "&scope=repo%2Cread%3Auser" +
+        `&state=${out.state}`,
+    );
+  });
+
+  it("generates a fresh state per call", async () => {
+    const client = makeClient();
+    const first = await client.getOAuthAuthorizeUrl({ redirectUri: REDIRECT });
+    const second = await client.getOAuthAuthorizeUrl({ redirectUri: REDIRECT });
+    expect(first.state).not.toBe(second.state);
+  });
+
+  it("answers FailedPrecondition without a client id (the cloud-live guard)", async () => {
+    const client = makeClient({ clientId: "" });
+    const err = await grpcError(() =>
+      client.getOAuthAuthorizeUrl({ redirectUri: REDIRECT }),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(
+      "GitHub OAuth is not configured (STIGMER_GITHUB_CLIENT_ID not set)",
+    );
+  });
+});
+
+describe("github broker — exchangeOAuthCode", () => {
+  it("POSTs the Go-encoded form and relays the token response", async () => {
+    const { fetchImpl, calls } = fetchStub({
+      body: JSON.stringify({
+        access_token: "gho_testtoken",
+        token_type: "bearer",
+        scope: "repo,read:user",
+      }),
+    });
+    const client = makeClient({ fetchImpl });
+
+    const out = await client.exchangeOAuthCode({
+      code: "authcode123",
+      state: "st",
+      redirectUri: REDIRECT,
+    });
+
+    expect(out.accessToken).toBe("gho_testtoken");
+    expect(out.tokenType).toBe("bearer");
+    expect(out.scope).toBe("repo,read:user");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://github.com/login/oauth/access_token");
+    expect(calls[0]?.init.method).toBe("POST");
+    const headers = calls[0]?.init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    expect(headers["Accept"]).toBe("application/json");
+    // Sorted keys, QueryEscape'd values — Go url.Values.Encode bytes.
+    expect(calls[0]?.init.body).toBe(
+      "client_id=test-client-id" +
+        "&client_secret=test-client-secret" +
+        "&code=authcode123" +
+        "&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth%2Fcallback",
+    );
+  });
+
+  it("maps GitHub's OAuth error to InvalidArgument with the description", async () => {
+    const { fetchImpl } = fetchStub({
+      body: JSON.stringify({
+        error: "bad_verification_code",
+        error_description: "The code passed is incorrect or expired.",
+      }),
+    });
+    const client = makeClient({ fetchImpl });
+
+    const err = await grpcError(() =>
+      client.exchangeOAuthCode({ code: "bad", state: "st", redirectUri: REDIRECT }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(
+      "GitHub OAuth error: The code passed is incorrect or expired.",
+    );
+  });
+
+  it("maps a network failure to Unavailable", async () => {
+    const { fetchImpl } = fetchStub({ reject: new Error("connect ECONNREFUSED") });
+    const client = makeClient({ fetchImpl });
+
+    const err = await grpcError(() =>
+      client.exchangeOAuthCode({ code: "c", state: "st", redirectUri: REDIRECT }),
+    );
+    expect(err.code).toBe(Code.Unavailable);
+    expect(err.rawMessage).toBe("failed to reach GitHub for token exchange");
+  });
+
+  it("maps an unparseable response to Internal", async () => {
+    const { fetchImpl } = fetchStub({ body: "<html>not json</html>" });
+    const client = makeClient({ fetchImpl });
+
+    const err = await grpcError(() =>
+      client.exchangeOAuthCode({ code: "c", state: "st", redirectUri: REDIRECT }),
+    );
+    expect(err.code).toBe(Code.Internal);
+    expect(err.rawMessage).toBe("failed to parse GitHub response");
+  });
+
+  it("answers FailedPrecondition when either credential is missing", async () => {
+    for (const overrides of [{ clientId: "" }, { clientSecret: "" }]) {
+      const client = makeClient(overrides);
+      const err = await grpcError(() =>
+        client.exchangeOAuthCode({ code: "c", state: "st", redirectUri: REDIRECT }),
+      );
+      expect(err.code).toBe(Code.FailedPrecondition);
+      expect(err.rawMessage).toBe("GitHub OAuth is not configured");
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/github/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/github/controller.ts
@@ -1,0 +1,203 @@
+/**
+ * GitHub broker controller — ports pkg/domain/github: the stateless OAuth
+ * utility service for workspace repo selection (NOT a resource domain — no
+ * store, no persistence of state or tokens; the frontend never holds the
+ * client credentials).
+ *
+ * Proven by github.conformance.test.ts (the Layer-1 protovalidate arms —
+ * the only hermetic, cross-edition-true surface; see that suite's header
+ * for why the other arms are deliberately absent) and
+ * __tests__/github.test.ts (the broker mechanics against an injected
+ * fetch, mirroring where Go keeps these pins).
+ *
+ * The config-missing FailedPrecondition arms are STRUCTURALLY UNREACHABLE
+ * on OSS — the bundled "Stigmer Local" defaults (boot/config.ts) cannot be
+ * blanked — but they are ported and unit-tested: the guard is live on the
+ * cloud edition, and the error copy is cross-edition contract.
+ */
+import { randomBytes } from "node:crypto";
+
+import type { ConnectRouter } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  ExchangeOAuthCodeResponseSchema,
+  GetOAuthAuthorizeUrlResponseSchema,
+  GitHubService,
+} from "@stigmer/protos/ai/stigmer/platform/github/v1/service_pb";
+import type {
+  ExchangeOAuthCodeRequest,
+  ExchangeOAuthCodeResponse,
+  GetOAuthAuthorizeUrlRequest,
+  GetOAuthAuthorizeUrlResponse,
+} from "@stigmer/protos/ai/stigmer/platform/github/v1/service_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { goUrlValuesEncode } from "../../gocompat/query-escape.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+
+/** Go githubAuthorizeURL. */
+const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+
+/** Go githubTokenURL. */
+const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+/** Go oauthScopes — repo access + user identity, the workspace needs. */
+const OAUTH_SCOPES = "repo,read:user";
+
+/**
+ * Go httpTimeout (10s): the exchange is a single interactive round-trip to
+ * github.com; anything slower should fail the RPC rather than hold the
+ * caller's OAuth callback open.
+ */
+const HTTP_TIMEOUT_MS = 10_000;
+
+export interface GitHubControllerDeps {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly logger: Logger;
+  /** Test seam for the token exchange; defaults to global fetch. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** Registers the GitHub broker service on the router (routes stage). */
+export function registerGitHubServices(
+  router: ConnectRouter,
+  deps: GitHubControllerDeps,
+): void {
+  router.service(GitHubService, {
+    getOAuthAuthorizeUrl: (req) => getOAuthAuthorizeUrl(deps, req),
+    exchangeOAuthCode: (req) => exchangeOAuthCode(deps, req),
+  });
+}
+
+/**
+ * Go GetOAuthAuthorizeUrl: pure URL construction — client_id, the caller's
+ * redirect_uri, the pinned scopes, and a random 16-byte hex state, encoded
+ * with Go url.Values.Encode semantics (sorted keys, QueryEscape) so the
+ * URL is byte-identical across editions.
+ */
+function getOAuthAuthorizeUrl(
+  deps: GitHubControllerDeps,
+  req: GetOAuthAuthorizeUrlRequest,
+): GetOAuthAuthorizeUrlResponse {
+  if (deps.clientId === "") {
+    throw failedPreconditionError(
+      "GitHub OAuth is not configured (STIGMER_GITHUB_CLIENT_ID not set)",
+    );
+  }
+
+  let state: string;
+  try {
+    state = randomBytes(16).toString("hex");
+  } catch (error) {
+    deps.logger.error("failed to generate OAuth state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to generate OAuth state");
+  }
+
+  const authorizeUrl =
+    GITHUB_AUTHORIZE_URL +
+    "?" +
+    goUrlValuesEncode({
+      client_id: deps.clientId,
+      redirect_uri: req.redirectUri,
+      scope: OAUTH_SCOPES,
+      state,
+    });
+
+  return create(GetOAuthAuthorizeUrlResponseSchema, { authorizeUrl, state });
+}
+
+/** The JSON shape of GitHub's token endpoint response (Go githubTokenResponse). */
+interface GitHubTokenResponse {
+  readonly access_token?: string;
+  readonly token_type?: string;
+  readonly scope?: string;
+  readonly error?: string;
+  readonly error_description?: string;
+}
+
+/**
+ * Go ExchangeOAuthCode: POSTs the code to github.com and relays the token
+ * to the caller — nothing stored. Error mapping is contract: GitHub's own
+ * OAuth error → InvalidArgument (the caller sent a bad/expired code);
+ * network failure → Unavailable; unreadable/unparseable response →
+ * Internal.
+ */
+async function exchangeOAuthCode(
+  deps: GitHubControllerDeps,
+  req: ExchangeOAuthCodeRequest,
+): Promise<ExchangeOAuthCodeResponse> {
+  if (deps.clientId === "" || deps.clientSecret === "") {
+    throw failedPreconditionError("GitHub OAuth is not configured");
+  }
+
+  const body = goUrlValuesEncode({
+    client_id: deps.clientId,
+    client_secret: deps.clientSecret,
+    code: req.code,
+    redirect_uri: req.redirectUri,
+  });
+
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  let response: Response;
+  try {
+    response = await fetchImpl(GITHUB_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body,
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+  } catch (error) {
+    deps.logger.error("GitHub token exchange failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw unavailableError("failed to reach GitHub for token exchange");
+  }
+
+  let raw: string;
+  try {
+    raw = await response.text();
+  } catch (error) {
+    deps.logger.error("failed to read GitHub token response", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to read GitHub response");
+  }
+
+  let tokenResponse: GitHubTokenResponse;
+  try {
+    tokenResponse = JSON.parse(raw) as GitHubTokenResponse;
+  } catch (error) {
+    deps.logger.error("failed to parse GitHub token response", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to parse GitHub response");
+  }
+
+  if (tokenResponse.error !== undefined && tokenResponse.error !== "") {
+    deps.logger.warn("GitHub OAuth error", {
+      error: tokenResponse.error,
+      description: tokenResponse.error_description ?? "",
+    });
+    throw invalidArgumentError(
+      `GitHub OAuth error: ${tokenResponse.error_description ?? ""}`,
+    );
+  }
+
+  return create(ExchangeOAuthCodeResponseSchema, {
+    accessToken: tokenResponse.access_token ?? "",
+    tokenType: tokenResponse.token_type ?? "",
+    scope: tokenResponse.scope ?? "",
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/__tests__/oauthapp.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/__tests__/oauthapp.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Pins the oauthapp domain against Go's oauthapp_secrets_test.go +
+ * delete_referential_integrity_test.go + refresolution_test.go — through
+ * the REAL stack: a composed server on an ephemeral port, a native gRPC
+ * client, the full interceptor chain.
+ *
+ * The load-bearing pins the conformance suite CANNOT cover (black box; these
+ * need direct store access or key control):
+ *   - client_secret rests as enc:v1: CIPHERTEXT in the store, never
+ *     plaintext, and the marker round-trip re-persists the IDENTICAL
+ *     ciphertext (no double encryption);
+ *   - the keyless WARN-degrade path stores plaintext yet still redacts on
+ *     read, and the enc:v<N>: shape rejection stays UNCONDITIONAL (oss#395);
+ *   - the delete RPC returns the STORED secret unredacted — Go behavior
+ *     ported byte-faithfully (delete is absent from RedactOAuthApp's
+ *     response list) and disclosed in the PR;
+ *   - the referential delete guard's resolution semantics (stigmer#584),
+ *     proven by seeding McpServer rows directly through the store — the
+ *     McpServer RPC surface belongs to #9 and is not required here.
+ *
+ * Keys are injected via env (vi.stubEnv) so the ladder short-circuits
+ * before its file steps — the real ~/.stigmer is never touched.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import { OAuthAppCommandController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/command_pb";
+import { OAuthAppQueryController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/query_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { ENCRYPTED_PREFIX } from "../../../encryption/encryption.js";
+import type { Store } from "../../../store/interface.js";
+import {
+  CIPHERTEXT_SHAPED_SECRET_MESSAGE,
+  MARKER_ON_CREATE_MESSAGE,
+  REDACTED_MARKER,
+  deleteBlockedByMcpServerMessage,
+} from "../constants.js";
+import { resolveOAuthAppRef } from "../refresolution/refresolution.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const TEST_KEY_B64 = Buffer.alloc(32, 9).toString("base64");
+const API_VERSION = "iam.stigmer.ai/v1";
+const KIND = "OAuthApp";
+const ORG = "acme";
+
+type CommandClient = Client<typeof OAuthAppCommandController>;
+type QueryClient = Client<typeof OAuthAppQueryController>;
+
+interface TestServer {
+  server: ComposedServer;
+  command: CommandClient;
+  query: QueryClient;
+  dir: string;
+}
+
+async function startServer(env: Record<string, string>): Promise<TestServer> {
+  const dir = mkdtempSync(path.join(tmpdir(), "oauthapp-domain-test-"));
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+  const server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  return {
+    server,
+    command: createClient(OAuthAppCommandController, transport),
+    query: createClient(OAuthAppQueryController, transport),
+    dir,
+  };
+}
+
+async function stopServer(ts: TestServer): Promise<void> {
+  await ts.server.shutdown();
+  rmSync(ts.dir, { recursive: true, force: true });
+}
+
+let counter = 0;
+function appInput(overrides?: {
+  name?: string;
+  org?: string;
+  clientId?: string;
+  clientSecret?: string;
+}) {
+  counter += 1;
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      name: overrides?.name ?? `Vendor App ${counter}`,
+      org: overrides?.org ?? ORG,
+    },
+    spec: {
+      provider: "TestVendor",
+      clientId: overrides?.clientId ?? "test-client-id",
+      clientSecret: overrides?.clientSecret ?? "test-client-secret",
+      authorizationUrl: "https://vendor.example.com/oauth/authorize",
+      tokenUrl: "https://vendor.example.com/oauth/token",
+      scopes: ["read"],
+    },
+  };
+}
+
+/** The stored (unredacted) row, read directly from the store. */
+async function storedApp(store: Store, id: string) {
+  return store.getResource(ApiResourceKind.oauth_app, id, OAuthAppSchema);
+}
+
+/** Seeds an McpServer row whose auth references the given (org, slug). */
+async function seedReferencingMcpServer(
+  store: Store,
+  id: string,
+  name: string,
+  refOrg: string,
+  refSlug: string,
+): Promise<void> {
+  const mcp = create(McpServerSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "McpServer",
+    metadata: { id, name, org: ORG, slug: name },
+    spec: {
+      description: "references an OAuthApp for the delete-block pins",
+      serverType: { case: "stdio", value: { command: "npx", args: ["-y", "x"] } },
+      auth: {
+        oauthAppRef: { org: refOrg, slug: refSlug, kind: ApiResourceKind.oauth_app },
+        targetEnvVar: "VENDOR_TOKEN",
+      },
+    },
+  });
+  await store.saveResource(ApiResourceKind.mcp_server, id, McpServerSchema, mcp);
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Encryption-enabled server (the production shape).
+// ---------------------------------------------------------------------------
+
+describe("oauthapp domain (encryption enabled)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({ STIGMER_ENCRYPTION_KEY: TEST_KEY_B64 });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+    vi.unstubAllEnvs();
+  });
+
+  it("create encrypts at rest, redacts the response, and assigns an oapp_ id", async () => {
+    const created = await ts.command.create(appInput());
+
+    expect(created.metadata?.id).toMatch(/^oapp_/);
+    expect(created.spec?.clientSecret).toBe(REDACTED_MARKER);
+
+    const stored = await storedApp(ts.server.store, created.metadata!.id);
+    expect(
+      stored.spec?.clientSecret.startsWith(ENCRYPTED_PREFIX),
+      "the stored secret must be enc:v1: ciphertext, never plaintext",
+    ).toBe(true);
+    expect(stored.spec?.clientSecret).not.toContain("test-client-secret");
+  });
+
+  it("the marker round-trip on update preserves the IDENTICAL ciphertext (no double encryption)", async () => {
+    const created = await ts.command.create(appInput());
+    const before = (await storedApp(ts.server.store, created.metadata!.id)).spec!.clientSecret;
+
+    const fetched = await ts.query.get({ value: created.metadata!.id });
+    expect(fetched.spec?.clientSecret).toBe(REDACTED_MARKER);
+    const updated = await ts.command.update(fetched);
+    expect(updated.spec?.clientSecret).toBe(REDACTED_MARKER);
+
+    const after = (await storedApp(ts.server.store, created.metadata!.id)).spec!.clientSecret;
+    expect(after, "marker echo restores the stored ciphertext byte-for-byte").toBe(before);
+  });
+
+  it("update with a new plaintext secret re-encrypts to a different ciphertext", async () => {
+    const created = await ts.command.create(appInput());
+    const before = (await storedApp(ts.server.store, created.metadata!.id)).spec!.clientSecret;
+
+    const fetched = await ts.query.get({ value: created.metadata!.id });
+    fetched.spec!.clientSecret = "rotated-secret";
+    await ts.command.update(fetched);
+
+    const after = (await storedApp(ts.server.store, created.metadata!.id)).spec!.clientSecret;
+    expect(after.startsWith(ENCRYPTED_PREFIX)).toBe(true);
+    expect(after).not.toBe(before);
+  });
+
+  it("rejects the redaction marker on create with the pinned copy", async () => {
+    const err = await grpcError(() =>
+      ts.command.create(appInput({ clientSecret: REDACTED_MARKER })),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(MARKER_ON_CREATE_MESSAGE);
+  });
+
+  it("rejects ciphertext-shaped secrets on create and update (oss#395)", async () => {
+    for (const smuggled of ["enc:v1:Zm9yZ2Vk", "enc:v2:ZnV0dXJl"]) {
+      const err = await grpcError(() =>
+        ts.command.create(appInput({ clientSecret: smuggled })),
+      );
+      expect(err.code).toBe(Code.InvalidArgument);
+      expect(err.rawMessage).toBe(CIPHERTEXT_SHAPED_SECRET_MESSAGE);
+    }
+
+    const created = await ts.command.create(appInput());
+    const fetched = await ts.query.get({ value: created.metadata!.id });
+    fetched.spec!.clientSecret = "enc:v1:Zm9yZ2Vk";
+    const err = await grpcError(() => ts.command.update(fetched));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(CIPHERTEXT_SHAPED_SECRET_MESSAGE);
+  });
+
+  it("get, getByReference, and listByOrg all redact", async () => {
+    const created = await ts.command.create(appInput());
+
+    const got = await ts.query.get({ value: created.metadata!.id });
+    expect(got.spec?.clientSecret).toBe(REDACTED_MARKER);
+
+    const byRef = await ts.query.getByReference({
+      org: ORG,
+      slug: created.metadata!.slug,
+    });
+    expect(byRef.metadata?.id).toBe(created.metadata?.id);
+    expect(byRef.spec?.clientSecret).toBe(REDACTED_MARKER);
+
+    const listed = await ts.query.listByOrg({ org: ORG });
+    expect(listed.entries.length).toBeGreaterThan(0);
+    for (const entry of listed.entries) {
+      expect(entry.spec?.clientSecret).toBe(REDACTED_MARKER);
+    }
+  });
+
+  it("listByOrg filters by org and sorts created_at descending", async () => {
+    const otherOrg = "other-org";
+    const first = await ts.command.create(appInput({ org: otherOrg }));
+    const second = await ts.command.create(appInput({ org: otherOrg }));
+
+    const listed = await ts.query.listByOrg({ org: otherOrg });
+    expect(listed.entries).toHaveLength(2);
+    // Newest first (Go's created_at-descending comparator).
+    expect(listed.entries[0]?.metadata?.id).toBe(second.metadata?.id);
+    expect(listed.entries[1]?.metadata?.id).toBe(first.metadata?.id);
+  });
+
+  it("delete returns the STORED resource unredacted — the ported Go behavior (disclosed)", async () => {
+    const created = await ts.command.create(appInput());
+    const deleted = await ts.command.delete({ resourceId: created.metadata!.id });
+
+    // Go's delete path never calls RedactOAuthApp: the response carries the
+    // stored ciphertext (plaintext on a keyless server). Pinned so the
+    // faithful port cannot silently "fix" the divergence candidate.
+    expect(deleted.spec?.clientSecret.startsWith(ENCRYPTED_PREFIX)).toBe(true);
+
+    const err = await grpcError(() => ts.query.get({ value: created.metadata!.id }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  describe("referential delete guard (stigmer#584 resolution semantics)", () => {
+    afterEach(async () => {
+      // Each test seeds its own McpServer rows; sweep them so arms stay
+      // independent (no shared state across tests).
+      await ts.server.store.deleteResourcesByKind(ApiResourceKind.mcp_server);
+    });
+
+    it("blocks deletion while an exact (org, slug) ref resolves to the app, then frees it", async () => {
+      const app = await ts.command.create(appInput());
+      await seedReferencingMcpServer(
+        ts.server.store,
+        "mcps_01refexact",
+        "ref-exact",
+        ORG,
+        app.metadata!.slug,
+      );
+
+      const err = await grpcError(() =>
+        ts.command.delete({ resourceId: app.metadata!.id }),
+      );
+      expect(err.code).toBe(Code.FailedPrecondition);
+      expect(err.rawMessage).toBe(
+        deleteBlockedByMcpServerMessage(ORG, app.metadata!.slug, "ref-exact"),
+      );
+
+      await ts.server.store.deleteResource(ApiResourceKind.mcp_server, "mcps_01refexact");
+      const deleted = await ts.command.delete({ resourceId: app.metadata!.id });
+      expect(deleted.metadata?.id).toBe(app.metadata?.id);
+    });
+
+    it("blocks through the unique-slug fallback (ref pinned to a foreign org)", async () => {
+      const app = await ts.command.create(appInput());
+      // The seedpack posture: ref pinned to `org: stigmer`, app applied in
+      // the user's own org — resolution reaches it via unique slug (#584).
+      await seedReferencingMcpServer(
+        ts.server.store,
+        "mcps_01reffallback",
+        "ref-fallback",
+        "stigmer",
+        app.metadata!.slug,
+      );
+
+      const err = await grpcError(() =>
+        ts.command.delete({ resourceId: app.metadata!.id }),
+      );
+      expect(err.code).toBe(Code.FailedPrecondition);
+
+      await ts.server.store.deleteResource(ApiResourceKind.mcp_server, "mcps_01reffallback");
+      await ts.command.delete({ resourceId: app.metadata!.id });
+    });
+
+    it("does not block when the ref resolves to a DIFFERENT app (literal-match is not the rule)", async () => {
+      const name = `Shared Slug ${++counter}`;
+      const target = await ts.command.create(appInput({ name, org: "org-a" }));
+      const other = await ts.command.create(appInput({ name, org: "org-b" }));
+
+      // The ref names org-b explicitly: it resolves to org-b's app, so
+      // deleting org-a's app (same slug) must NOT be blocked.
+      await seedReferencingMcpServer(
+        ts.server.store,
+        "mcps_01refother",
+        "ref-other",
+        "org-b",
+        other.metadata!.slug,
+      );
+
+      const deleted = await ts.command.delete({ resourceId: target.metadata!.id });
+      expect(deleted.metadata?.id).toBe(target.metadata?.id);
+
+      // org-b's app IS still referenced — blocked.
+      const err = await grpcError(() =>
+        ts.command.delete({ resourceId: other.metadata!.id }),
+      );
+      expect(err.code).toBe(Code.FailedPrecondition);
+
+      await ts.server.store.deleteResource(ApiResourceKind.mcp_server, "mcps_01refother");
+      await ts.command.delete({ resourceId: other.metadata!.id });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyless server (the WARN-degrade posture).
+// ---------------------------------------------------------------------------
+
+describe("oauthapp domain (encryption disabled)", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    // An unusable explicit key → SecretService.fromEnv throws → compose
+    // degrades to the keyless pass-through service (WARN, not fatal).
+    ts = await startServer({ STIGMER_ENCRYPTION_KEY: "not-valid-base64!!!" });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+    vi.unstubAllEnvs();
+  });
+
+  it("stores plaintext, still redacts on read", async () => {
+    const created = await ts.command.create(appInput());
+    expect(created.spec?.clientSecret).toBe(REDACTED_MARKER);
+
+    const stored = await storedApp(ts.server.store, created.metadata!.id);
+    expect(stored.spec?.clientSecret).toBe("test-client-secret");
+  });
+
+  it("still rejects ciphertext-shaped secrets — the oss#395 boundary is not gated on key state", async () => {
+    const err = await grpcError(() =>
+      ts.command.create(appInput({ clientSecret: "enc:v1:c211Z2dsZWQ=" })),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(CIPHERTEXT_SHAPED_SECRET_MESSAGE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refresolution — Go refresolution_test.go, direct against a store.
+// ---------------------------------------------------------------------------
+
+describe("resolveOAuthAppRef", () => {
+  let ts: TestServer;
+
+  beforeAll(async () => {
+    ts = await startServer({ STIGMER_ENCRYPTION_KEY: TEST_KEY_B64 });
+  });
+
+  afterAll(async () => {
+    await stopServer(ts);
+    vi.unstubAllEnvs();
+  });
+
+  it("an empty slug resolves to nothing (the DCR/manual-token arm)", async () => {
+    const resolved = await resolveOAuthAppRef(
+      ts.server.store,
+      create(ApiResourceReferenceSchema, { org: ORG, slug: "" }),
+      silentLogger,
+    );
+    expect(resolved).toBeUndefined();
+  });
+
+  it("an exact (org, slug) match wins over other slug matches", async () => {
+    const name = `Resolve Exact ${++counter}`;
+    await ts.command.create(appInput({ name, org: "res-org-a" }));
+    const exact = await ts.command.create(appInput({ name, org: "res-org-b" }));
+
+    const resolved = await resolveOAuthAppRef(
+      ts.server.store,
+      create(ApiResourceReferenceSchema, { org: "res-org-b", slug: exact.metadata!.slug }),
+      silentLogger,
+    );
+    expect(resolved?.metadata?.id).toBe(exact.metadata?.id);
+  });
+
+  it("a UNIQUE slug-only match is honored when the ref's org does not exist here", async () => {
+    const app = await ts.command.create(appInput({ org: "res-org-c" }));
+
+    const resolved = await resolveOAuthAppRef(
+      ts.server.store,
+      create(ApiResourceReferenceSchema, { org: "stigmer", slug: app.metadata!.slug }),
+      silentLogger,
+    );
+    expect(resolved?.metadata?.id).toBe(app.metadata?.id);
+  });
+
+  it("two or more slug matches with no exact hit resolve to NOTHING (ambiguity refused)", async () => {
+    const name = `Resolve Ambiguous ${++counter}`;
+    const a = await ts.command.create(appInput({ name, org: "res-org-d" }));
+    await ts.command.create(appInput({ name, org: "res-org-e" }));
+
+    const resolved = await resolveOAuthAppRef(
+      ts.server.store,
+      create(ApiResourceReferenceSchema, { org: "res-org-none", slug: a.metadata!.slug }),
+      silentLogger,
+    );
+    expect(resolved).toBeUndefined();
+  });
+
+  it("an unknown slug resolves to nothing", async () => {
+    const resolved = await resolveOAuthAppRef(
+      ts.server.store,
+      create(ApiResourceReferenceSchema, { org: ORG, slug: "never-created" }),
+      silentLogger,
+    );
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/constants.ts
@@ -1,0 +1,46 @@
+/**
+ * OAuthApp domain constants — byte-pinned wire copy, ported from
+ * pkg/domain/oauthapp/controller/steps (RedactedMarker and the secret
+ * contract's error messages). These strings are cross-edition API surface:
+ * the CLI, console, and SDK show them verbatim, and the conformance suite
+ * asserts codes against them — never reword.
+ */
+
+/**
+ * The sentinel the response path substitutes for client_secret before it
+ * leaves the server (Go RedactedMarker). A client sending this value back
+ * on update/apply means "keep the existing secret" — not "store the
+ * literal marker". Deliberately domain-local (Go defines it per package):
+ * environment's redaction marker is a separate constant with the same
+ * text, and collapsing them would couple two domains' wire contracts.
+ */
+export const REDACTED_MARKER = "***REDACTED***";
+
+/** Go: redaction marker on create has no existing secret to preserve. */
+export const MARKER_ON_CREATE_MESSAGE =
+  "cannot use the redaction marker as client_secret on create";
+
+/** Go: marker sent on update but the stored resource has no secret. */
+export const PRESERVE_NO_EXISTING_SECRET_MESSAGE =
+  "cannot preserve client_secret: no existing secret value found";
+
+/**
+ * Go: a client-supplied enc:v<N>:-shaped value is refused on every write
+ * door (oss#395) — the prefix is server-reserved, so a prefixed request
+ * value is either forged ciphertext or an attempt to pin stale ciphertext.
+ */
+export const CIPHERTEXT_SHAPED_SECRET_MESSAGE =
+  "client_secret must be plaintext — values carrying the 'enc:' " +
+  "encryption prefix are not accepted from clients";
+
+/**
+ * Go FailedPreconditionError format for the referential delete-block:
+ * "cannot delete OAuthApp '%s/%s': referenced by MCP server '%s'".
+ */
+export function deleteBlockedByMcpServerMessage(
+  org: string,
+  slug: string,
+  mcpServerName: string,
+): string {
+  return `cannot delete OAuthApp '${org}/${slug}': referenced by MCP server '${mcpServerName}'`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/controller.ts
@@ -1,0 +1,364 @@
+/**
+ * OAuthApp controller — ports pkg/domain/oauthapp (command + query sides).
+ * OAuthApp is the outbound-auth registration with an external vendor:
+ * client credentials plus the vendor's OAuth endpoints, referenced by
+ * McpServer resources via McpServerAuth.oauth_app_ref. The outbound
+ * counterpart to IdentityProvider (inbound auth).
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by oauthapp.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/oauthapp.test.ts.
+ *
+ * The secret contract: client_secret is AES-256-GCM encrypted at rest via
+ * the SAME SecretService instance the Environment controller uses (Go
+ * wires one service for both), and redacted to ***REDACTED*** on every
+ * read surface; the marker round-trips on update/apply as "keep the stored
+ * secret"; client-supplied enc:v<N>:-shaped values are refused on every
+ * write door (oss#395). Deletion is blocked while an McpServer's
+ * oauth_app_ref resolves to the app (stigmer/stigmer#584).
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies, and
+ * Publish steps (no multi-tenant auth, IAM/FGA, or event publishing), and
+ * OAuthApp is deliberately not search-indexed (a configuration resource;
+ * `not_search_indexed` in the kind registry).
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type {
+  ApiResourceDeleteInput,
+  ApiResourceId,
+  ApiResourceReference,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import { OAuthAppCommandController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/command_pb";
+import { OAuthAppsSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/io_pb";
+import type {
+  ListOAuthAppsByOrgInput,
+  OAuthApps,
+} from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/io_pb";
+import { OAuthAppQueryController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/query_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { internalError } from "../../pipeline/errors.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import {
+  RESOURCE_ID_KEY,
+  newDeleteResourceStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import {
+  newCheckNoReferencingMcpServersStep,
+  newEncryptClientSecretForCreateStep,
+  newEncryptClientSecretForUpdateStep,
+  redactOAuthApp,
+} from "./steps.js";
+
+export interface OAuthAppControllerDeps {
+  readonly store: Store;
+  readonly secretService: SecretService;
+  readonly logger: Logger;
+}
+
+/** Registers both OAuthApp services on the router (routes stage). */
+export function registerOAuthAppServices(
+  router: ConnectRouter,
+  deps: OAuthAppControllerDeps,
+): void {
+  router.service(OAuthAppCommandController, {
+    apply: (app, ctx) => apply(deps, app, ctx),
+    create: (app, ctx) => createOAuthApp(deps, app, ctx),
+    update: (app, ctx) => update(deps, app, ctx),
+    delete: (input, ctx) => deleteOAuthApp(deps, input, ctx),
+  });
+  router.service(OAuthAppQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    listByOrg: (req, ctx) => listByOrg(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. ResolveSlug runs before
+ * ValidateProto so clients can omit the slug; EncryptClientSecret runs
+ * BEFORE BuildNewState because BuildNewState clones the current state —
+ * the encrypted value must be in place before the clone. The response is
+ * redacted after the pipeline (the persisted row keeps the ciphertext).
+ */
+async function createOAuthApp(
+  deps: OAuthAppControllerDeps,
+  app: OAuthApp,
+  ctx: HandlerContext,
+): Promise<OAuthApp> {
+  const reqCtx = new RequestContext(OAuthAppSchema, app, kindOf(ctx));
+  await newPipeline<typeof OAuthAppSchema>("oauthapp-create", deps.logger)
+    .addStep(newResolveSlugStep())
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newEncryptClientSecretForCreateStep(deps.secretService, deps.logger))
+    .addStep(newBuildNewStateStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  const result = reqCtx.newState;
+  redactOAuthApp(result);
+  return result;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline. EncryptClientSecret runs
+ * AFTER BuildUpdateState (which replaces newState with a fresh clone of
+ * the input): it then either encrypts a new plaintext secret or restores
+ * the stored ciphertext when the redaction marker is echoed back.
+ */
+async function update(
+  deps: OAuthAppControllerDeps,
+  app: OAuthApp,
+  ctx: HandlerContext,
+): Promise<OAuthApp> {
+  const reqCtx = new RequestContext(OAuthAppSchema, app, kindOf(ctx));
+  await newPipeline<typeof OAuthAppSchema>("oauthapp-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newEncryptClientSecretForUpdateStep(deps.secretService, deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  const result = reqCtx.newState;
+  redactOAuthApp(result);
+  return result;
+}
+
+/**
+ * Apply — kubectl-style idempotent create-or-update: a minimal pipeline
+ * decides existence, then delegates to Create or Update with the ORIGINAL
+ * request message (Go delegates `app`, not the pipeline's mutated clone).
+ */
+async function apply(
+  deps: OAuthAppControllerDeps,
+  app: OAuthApp,
+  ctx: HandlerContext,
+): Promise<OAuthApp> {
+  const reqCtx = new RequestContext(OAuthAppSchema, app, kindOf(ctx));
+  await newPipeline<typeof OAuthAppSchema>("oauthapp-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate
+    ? createOAuthApp(deps, app, ctx)
+    : update(deps, app, ctx);
+}
+
+/**
+ * Delete — chain per Go buildDeletePipeline: the referential guard runs
+ * between load and delete. The RESOURCE_ID_KEY is set manually because
+ * ApiResourceDeleteInput carries resourceId, not the value field
+ * ExtractResourceId expects (the environment-domain pattern). Returns the
+ * deleted resource for the audit trail — unredacted, exactly as Go does
+ * (see redactOAuthApp's header for the disclosure).
+ */
+async function deleteOAuthApp(
+  deps: OAuthAppControllerDeps,
+  input: ApiResourceDeleteInput,
+  ctx: HandlerContext,
+): Promise<OAuthApp> {
+  const reqCtx = new RequestContext(
+    OAuthAppCommandController.method.delete.input,
+    input,
+    kindOf(ctx),
+  );
+  reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
+  await newPipeline<typeof OAuthAppCommandController.method.delete.input>(
+    "oauthapp-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, OAuthAppSchema))
+    .addStep(newCheckNoReferencingMcpServersStep(deps.store, deps.logger))
+    .addStep(newDeleteResourceStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted OAuthApp not found in context"),
+      "deleted OAuthApp not found in context",
+    );
+  }
+  return deleted as OAuthApp;
+}
+
+/** Get — LoadTarget by id, then redact (Go buildGetPipeline). */
+async function get(
+  deps: OAuthAppControllerDeps,
+  id: ApiResourceId,
+  ctx: HandlerContext,
+): Promise<OAuthApp> {
+  const reqCtx = new RequestContext(
+    OAuthAppQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof OAuthAppQueryController.method.get.input>(
+    "oauthapp-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, OAuthAppSchema))
+    .build()
+    .execute(reqCtx);
+  const app = reqCtx.get(TARGET_RESOURCE_KEY) as OAuthApp;
+  redactOAuthApp(app);
+  return app;
+}
+
+/** GetByReference — LoadByReference (org/slug), then redact. */
+async function getByReference(
+  deps: OAuthAppControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<OAuthApp> {
+  const reqCtx = new RequestContext(
+    OAuthAppQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof OAuthAppQueryController.method.getByReference.input>(
+    "oauthapp-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, OAuthAppSchema))
+    .build()
+    .execute(reqCtx);
+  const app = reqCtx.get(TARGET_RESOURCE_KEY) as OAuthApp;
+  redactOAuthApp(app);
+  return app;
+}
+
+const LIST_RESULT_KEY = "listResult";
+
+/**
+ * ListByOrg — all OAuthApps whose metadata.org matches, each redacted,
+ * sorted created_at descending (Go listByOrgStep). No pagination:
+ * typically 1–5 per org. No authorization filtering in OSS.
+ */
+async function listByOrg(
+  deps: OAuthAppControllerDeps,
+  req: ListOAuthAppsByOrgInput,
+  ctx: HandlerContext,
+): Promise<OAuthApps> {
+  const reqCtx = new RequestContext(
+    OAuthAppQueryController.method.listByOrg.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof OAuthAppQueryController.method.listByOrg.input>(
+    "oauthapp-list-by-org",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const list = reqCtx.get(LIST_RESULT_KEY);
+  if (list === undefined) {
+    throw internalError(
+      new Error("list result missing from pipeline context"),
+      "OAuthApp list not found in context",
+    );
+  }
+  return list as OAuthApps;
+}
+
+/** The domain-local list step: load all, filter by org, redact, sort. */
+function newListByOrgStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof OAuthAppQueryController.method.listByOrg.input> {
+  return {
+    name: "ListByOrg",
+    async execute(
+      ctx: RequestContext<typeof OAuthAppQueryController.method.listByOrg.input>,
+    ): Promise<void> {
+      const org = ctx.input.org;
+
+      let resources: Uint8Array[];
+      try {
+        resources = await store.listResources(ApiResourceKind.oauth_app);
+      } catch (error) {
+        throw internalError(error, "failed to list OAuthApps");
+      }
+
+      const apps: OAuthApp[] = [];
+      for (const data of resources) {
+        let app: OAuthApp;
+        try {
+          app = fromBinary(OAuthAppSchema, data);
+        } catch (error) {
+          logger.warn("failed to unmarshal OAuthApp, skipping", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+        if ((app.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        redactOAuthApp(app);
+        apps.push(app);
+      }
+
+      apps.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      logger.info("listed OAuthApps by organization", {
+        org,
+        matchCount: apps.length,
+      });
+
+      ctx.set(LIST_RESULT_KEY, create(OAuthAppsSchema, { entries: apps }));
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/refresolution/refresolution.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/refresolution/refresolution.ts
@@ -1,0 +1,94 @@
+/**
+ * OAuthApp ref resolution — ports pkg/domain/oauthapp/refresolution: the
+ * ONE answer to "which OAuthApp does this `oauth_app_ref` mean?" (the
+ * defaultinstance pattern — one small module holds a cross-domain semantic
+ * so its consumers cannot drift apart, stigmer/stigmer#584).
+ *
+ * Consumers: the OAuthApp delete guard (this domain, #13); the OAuth
+ * initiate path, the read-path oauth_status enricher, and the token-refresh
+ * path arrive with the mcpserver connect/OAuth sub-project (#19) and MUST
+ * route through this function — three hand-rolled divergent answers are
+ * exactly what #584 removed.
+ *
+ * Resolution semantics (OSS has a flat OAuthApp store — no org-override
+ * chain like the cloud's OAuthAppResolutionService, so the ref is the whole
+ * resolution): matching is by slug, with the ref's org as a preference
+ * rather than a gate:
+ *
+ *  1. An exact (org, slug) match wins — unique by the create pipeline's
+ *     duplicate check.
+ *  2. Otherwise a slug-only match is honored when it is UNIQUE. This lets
+ *     a self-hosted deployment satisfy seedpack refs pinned to
+ *     `org: stigmer` with an OAuthApp applied in the user's own org (#584).
+ *  3. Two or more slug matches with no exact hit resolve to nothing, with
+ *     a WARN naming the candidate orgs: ambiguity is never silently
+ *     collapsed into a credential pick.
+ *
+ * Returns undefined when nothing resolves; callers own the severity of that
+ * outcome (the delete guard treats it as unreferenced; initiate will refuse
+ * NOT_FOUND, refresh will error — #19).
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import type { Store } from "../../../store/interface.js";
+
+/**
+ * Resolves the OAuthApp the ref means (Go refresolution.Resolve). A ref
+ * without a slug resolves to nothing — an McpServerAuth with no (or an
+ * empty) oauth_app_ref is the DCR/manual-token arm, not a lookup. Store
+ * errors propagate to the caller (Go returns them).
+ */
+export async function resolveOAuthAppRef(
+  store: Store,
+  ref: ApiResourceReference,
+  logger: Logger,
+): Promise<OAuthApp | undefined> {
+  if (ref.slug === "") {
+    return undefined;
+  }
+
+  const rows = await store.listResources(ApiResourceKind.oauth_app);
+
+  // Collect-then-decide: a single pass gathers every slug match so the
+  // outcome depends only on the store's contents, never on its iteration
+  // order (Go's earlier first-match-wins scan was nondeterministic when a
+  // slug existed in several orgs).
+  const slugMatches: OAuthApp[] = [];
+  for (const data of rows) {
+    let app: OAuthApp;
+    try {
+      app = fromBinary(OAuthAppSchema, data);
+    } catch {
+      continue; // skip malformed rows, as Go does
+    }
+    if ((app.metadata?.slug ?? "") !== ref.slug) {
+      continue;
+    }
+    if (ref.org !== "" && app.metadata?.org === ref.org) {
+      return app; // exact match: unique by the create duplicate check
+    }
+    slugMatches.push(app);
+  }
+
+  if (slugMatches.length === 0) {
+    return undefined;
+  }
+  if (slugMatches.length === 1) {
+    return slugMatches[0];
+  }
+  logger.warn(
+    "oauth_app_ref is ambiguous (slug exists in several orgs, none matching the ref); refusing to pick — pin the ref's org to resolve",
+    {
+      oauthAppSlug: ref.slug,
+      refOrg: ref.org,
+      candidateOrgs: slugMatches.map((app) => app.metadata?.org ?? ""),
+    },
+  );
+  return undefined;
+}

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/steps.ts
@@ -1,0 +1,241 @@
+/**
+ * OAuthApp domain-local pipeline steps — port
+ * pkg/domain/oauthapp/controller/steps: the client-secret encrypt/preserve
+ * step, the referential delete guard, and the response redaction helper.
+ * Proven by oauthapp.conformance.test.ts and __tests__/oauthapp.test.ts.
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { isCiphertextShaped } from "../../encryption/encryption.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+import {
+  CIPHERTEXT_SHAPED_SECRET_MESSAGE,
+  MARKER_ON_CREATE_MESSAGE,
+  PRESERVE_NO_EXISTING_SECRET_MESSAGE,
+  REDACTED_MARKER,
+  deleteBlockedByMcpServerMessage,
+} from "./constants.js";
+import { resolveOAuthAppRef } from "./refresolution/refresolution.js";
+
+/**
+ * Replaces client_secret with the redaction marker (Go RedactOAuthApp).
+ *
+ * A function rather than a pipeline step because redaction applies at
+ * different points per operation: create/update after persist on newState;
+ * get/getByReference after load on the target; listByOrg per entry. Go's
+ * response list deliberately excludes DELETE — the delete RPC returns the
+ * STORED resource with its encrypted secret intact, ported byte-faithfully
+ * and disclosed in the PR (a cross-edition follow-up candidate: with
+ * encryption disabled the stored value is plaintext).
+ */
+export function redactOAuthApp(app: OAuthApp): void {
+  if (app.spec !== undefined && app.spec.clientSecret !== "") {
+    app.spec.clientSecret = REDACTED_MARKER;
+  }
+}
+
+/**
+ * EncryptClientSecret for the create pipeline (Go
+ * NewEncryptClientSecretForCreateStep): encrypts the plaintext secret;
+ * rejects the redaction marker — there is no existing secret to preserve.
+ */
+export function newEncryptClientSecretForCreateStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof OAuthAppSchema> {
+  return newEncryptClientSecretStep(secretService, logger, true);
+}
+
+/**
+ * EncryptClientSecret for the update pipeline (Go
+ * NewEncryptClientSecretForUpdateStep): the redaction marker restores the
+ * stored encrypted value from ExistingResource; a new plaintext value is
+ * encrypted.
+ */
+export function newEncryptClientSecretForUpdateStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof OAuthAppSchema> {
+  return newEncryptClientSecretStep(secretService, logger, false);
+}
+
+/**
+ * The shared encrypt/preserve mechanics. On both arms a ciphertext-shaped
+ * (enc:v<N>:) client value is rejected UNCONDITIONALLY — not gated on
+ * isEnabled: the prefix is server-reserved regardless of key state, and a
+ * keyless deployment that later gains a key must not wake up holding
+ * smuggled "ciphertext" (oss#395). The marker arm stays FIRST — it
+ * restores stored ciphertext, which is legitimate and returns before the
+ * shape check.
+ */
+function newEncryptClientSecretStep(
+  secretService: SecretService,
+  logger: Logger,
+  isCreate: boolean,
+): PipelineStep<typeof OAuthAppSchema> {
+  return {
+    name: "EncryptClientSecret",
+    execute(ctx: RequestContext<typeof OAuthAppSchema>): void {
+      const app = ctx.newState;
+      if (app.spec === undefined) {
+        return;
+      }
+      const clientSecret = app.spec.clientSecret;
+      if (clientSecret === "") {
+        return;
+      }
+
+      if (clientSecret === REDACTED_MARKER) {
+        preserveExistingSecret(ctx, app, isCreate, logger);
+        return;
+      }
+
+      if (isCiphertextShaped(clientSecret)) {
+        throw invalidArgumentError(CIPHERTEXT_SHAPED_SECRET_MESSAGE);
+      }
+
+      if (!secretService.isEnabled()) {
+        logger.warn(
+          "encryption disabled: client_secret will be stored in plaintext",
+        );
+        return;
+      }
+
+      try {
+        app.spec.clientSecret = secretService.encrypt(clientSecret);
+      } catch (error) {
+        throw internalError(error, "failed to encrypt client_secret");
+      }
+    },
+  };
+}
+
+/** Go preserveExistingSecret: copy the stored ciphertext on marker echo. */
+function preserveExistingSecret(
+  ctx: RequestContext<typeof OAuthAppSchema>,
+  app: OAuthApp,
+  isCreate: boolean,
+  logger: Logger,
+): void {
+  if (isCreate) {
+    throw invalidArgumentError(MARKER_ON_CREATE_MESSAGE);
+  }
+
+  const existing = ctx.get(EXISTING_RESOURCE_KEY) as OAuthApp | undefined;
+  if (existing === undefined) {
+    throw internalError(
+      new Error("existing resource not loaded"),
+      "cannot preserve client_secret: existing resource not loaded",
+    );
+  }
+
+  const existingSecret = existing.spec?.clientSecret ?? "";
+  if (existingSecret === "") {
+    throw invalidArgumentError(PRESERVE_NO_EXISTING_SECRET_MESSAGE);
+  }
+
+  if (app.spec !== undefined) {
+    app.spec.clientSecret = existingSecret;
+  }
+
+  logger.debug("preserved existing encrypted client_secret", {
+    oauthAppId: app.metadata?.id ?? "",
+  });
+}
+
+/**
+ * CheckNoReferencingMcpServers (Go newCheckNoReferencingMcpServersStep):
+ * blocks deletion while any McpServer's spec.auth.oauth_app_ref RESOLVES
+ * to the app being deleted — resolution semantics through the shared
+ * refresolution, not literal field match (stigmer/stigmer#584). A ref
+ * pinned to another org can reach this app through the unique-slug
+ * fallback (deleting would sever a live vendor-OAuth connection), while a
+ * literal match whose resolution lands elsewhere must not block.
+ *
+ * Requires LoadExistingForDelete to have run first (the OAuthApp being
+ * deleted is read from ExistingResource). Generic over the delete input
+ * Desc, like the shared delete steps.
+ */
+export function newCheckNoReferencingMcpServersStep<
+  Desc extends DescMessage,
+>(store: Store, logger: Logger): PipelineStep<Desc> {
+  return {
+    name: "CheckNoReferencingMcpServers",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as OAuthApp | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing OAuthApp missing from pipeline context"),
+          "existing OAuthApp not loaded in delete pipeline",
+        );
+      }
+
+      let resources: Uint8Array[];
+      try {
+        resources = await store.listResources(ApiResourceKind.mcp_server);
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to list MCP servers for referential integrity check",
+        );
+      }
+
+      for (const data of resources) {
+        let mcp: McpServer;
+        try {
+          mcp = fromBinary(McpServerSchema, data);
+        } catch (error) {
+          logger.warn(
+            "failed to unmarshal MCP server during referential integrity check, skipping",
+            { error: error instanceof Error ? error.message : String(error) },
+          );
+          continue;
+        }
+
+        const ref = mcp.spec?.auth?.oauthAppRef;
+        if (ref === undefined) {
+          continue;
+        }
+
+        let resolved: OAuthApp | undefined;
+        try {
+          resolved = await resolveOAuthAppRef(store, ref, logger);
+        } catch (error) {
+          throw internalError(
+            error,
+            "failed to resolve oauth_app_ref during referential integrity check",
+          );
+        }
+        if (
+          resolved !== undefined &&
+          (resolved.metadata?.id ?? "") === (existing.metadata?.id ?? "")
+        ) {
+          throw failedPreconditionError(
+            deleteBlockedByMcpServerMessage(
+              existing.metadata?.org ?? "",
+              existing.metadata?.slug ?? "",
+              mcp.metadata?.name ?? "",
+            ),
+          );
+        }
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/organization/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/organization/search-extractor.ts
@@ -3,7 +3,7 @@
  * pkg/query/search/extractor/organization_extractor.go (the search summary
  * is spec.description). Indexed domains carry their extractors (D4); the
  * QUERY side of the extractor contract (ToSearchResult, the registry
- * validation) arrives with the search service sub-project (#13) — only the
+ * validation) arrives with the search service sub-project (#14) — only the
  * write-path extraction the IndexSearch step needs lives here.
  */
 import type { Message } from "@bufbuild/protobuf";

--- a/backend/services/stigmer-server-ts/src/domain/platform/__tests__/platform.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/platform/__tests__/platform.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins the platform domain against Go's platform_controller_test.go +
+ * get_runner_scoped_token_test.go — through the real stack (composed
+ * server, native gRPC client, full interceptor chain; the #15 pattern),
+ * plus a keyless-service arm on an in-process router.
+ *
+ * The load-bearing pins the conformance suite deliberately does NOT cover
+ * (its platform file excludes getRunnerScopedToken — the arms are gated on
+ * runner-class flows):
+ *   - the oss#535 FAIL-SOFT matrix: execution-id arms mint; pool_claim/
+ *     renewal/unset/empty-id/keyless all answer the presence-based
+ *     "not minted" EMPTY output, never a gRPC error;
+ *   - a minted token actually verifies against the SAME key the
+ *     executioncontext decrypt lane uses, bound to exactly the named
+ *     execution id;
+ *   - getRunnerBootstrapConfig echoes the configured Temporal coordinates
+ *     with the token fields empty (minting a proxy token is cloud-only).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Code, ConnectError, createClient, createRouterTransport } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import {
+  GetRunnerScopedTokenInputSchema,
+  PlatformQueryController,
+  ServerEdition,
+} from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { RunnerAuthService } from "../../../runnerauth/runnerauth.js";
+import { registerPlatformServices } from "../controller.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const RUNNER_KEY = Buffer.alloc(32, 5);
+const ENC_KEY = Buffer.alloc(32, 6);
+
+type PlatformClient = Client<typeof PlatformQueryController>;
+
+describe("platform domain (composed server)", () => {
+  let server: ComposedServer;
+  let client: PlatformClient;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "platform-domain-test-"));
+    vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", RUNNER_KEY.toString("base64"));
+    vi.stubEnv("STIGMER_ENCRYPTION_KEY", ENC_KEY.toString("base64"));
+    server = composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+        TEMPORAL_HOST_PORT: "127.0.0.1:7777",
+        TEMPORAL_NAMESPACE: "conformance-ns",
+      }),
+      logger: silentLogger,
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    const port = await server.start();
+    const transport: Transport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+    client = createClient(PlatformQueryController, transport);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("getServerInfo names the oss edition and the dev version, stable across calls", async () => {
+    const first = await client.getServerInfo({});
+    expect(first.edition).toBe(ServerEdition.oss);
+    // Unbundled runs report Go's unstamped default; release bundles stamp
+    // the esbuild define (scripts/bundle-slim.mjs).
+    expect(first.version).toBe("dev");
+
+    const second = await client.getServerInfo({});
+    expect(second.edition).toBe(first.edition);
+    expect(second.version).toBe(first.version);
+  });
+
+  it("getRunnerBootstrapConfig echoes the configured Temporal coordinates, token fields empty", async () => {
+    const config = await client.getRunnerBootstrapConfig({});
+    expect(config.temporalAddress).toBe("127.0.0.1:7777");
+    expect(config.temporalNamespace).toBe("conformance-ns");
+
+    // Presence-based contract: no token means no companion fields — OSS
+    // never mints the proxy token (cloud-only capability).
+    expect(config.runnerAccessToken).toBe("");
+    expect(config.tokenType).toBe("");
+    expect(config.runnerAccessTokenExpiresInSeconds).toBe(0);
+    expect(config.payloadEncryptionKeyId).toBe("");
+    expect(config.payloadEncryptionKey).toBe("");
+  });
+
+  it("mints for the agent_execution_id arm, bound to exactly that execution", async () => {
+    const out = await client.getRunnerScopedToken({
+      scope: { case: "agentExecutionId", value: "aexec_01platformtest" },
+    });
+
+    expect(out.runnerScopedToken).not.toBe("");
+    expect(out.tokenType).toBe("Bearer");
+    expect(out.expiresInSeconds).toBe(3600);
+
+    // The minted token verifies against the SAME key the EC decrypt lane
+    // uses, and its binding is the named execution id.
+    expect(server.runnerAuthService.verify(out.runnerScopedToken)).toBe(
+      "aexec_01platformtest",
+    );
+  });
+
+  it("mints for the workflow_execution_id arm", async () => {
+    const out = await client.getRunnerScopedToken({
+      scope: { case: "workflowExecutionId", value: "wexec_01platformtest" },
+    });
+    expect(out.tokenType).toBe("Bearer");
+    expect(server.runnerAuthService.verify(out.runnerScopedToken)).toBe(
+      "wexec_01platformtest",
+    );
+  });
+
+  it("answers the not-minted shape for empty ids, pool_claim, and renewal", async () => {
+    const arms: MessageInitShape<typeof GetRunnerScopedTokenInputSchema>[] = [
+      { scope: { case: "agentExecutionId", value: "" } },
+      { scope: { case: "workflowExecutionId", value: "" } },
+      { scope: { case: "poolClaim", value: { sessionId: "ses_x" } } },
+      { scope: { case: "renewal", value: {} } },
+    ];
+    for (const input of arms) {
+      const out = await client.getRunnerScopedToken(input);
+      expect(out.runnerScopedToken, JSON.stringify(input)).toBe("");
+      expect(out.tokenType, JSON.stringify(input)).toBe("");
+      expect(out.expiresInSeconds, JSON.stringify(input)).toBe(0);
+    }
+  });
+
+  it("an unset scope is rejected by protovalidate BEFORE the handler (both editions)", async () => {
+    // The proto pins `scope` as a required oneof, so the wire can never
+    // reach the handler's defensive undefined arm — the same InvalidArgument
+    // protovalidate answers on the Go server.
+    try {
+      await client.getRunnerScopedToken({});
+      throw new Error("expected the call to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectError);
+      expect((error as ConnectError).code).toBe(Code.InvalidArgument);
+    }
+  });
+});
+
+describe("platform domain (keyless runner-token service)", () => {
+  it("a keyless service answers not-minted — fail-soft, never an error", async () => {
+    const transport = createRouterTransport((router) => {
+      registerPlatformServices(router, {
+        temporalHostPort: "localhost:7233",
+        temporalNamespace: "default",
+        runnerAuthService: RunnerAuthService.create(undefined),
+        logger: silentLogger,
+      });
+    });
+    const client = createClient(PlatformQueryController, transport);
+
+    const out = await client.getRunnerScopedToken({
+      scope: { case: "agentExecutionId", value: "aexec_01keyless" },
+    });
+    expect(out.runnerScopedToken).toBe("");
+    expect(out.tokenType).toBe("");
+    expect(out.expiresInSeconds).toBe(0);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/platform/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/platform/controller.ts
@@ -1,0 +1,165 @@
+/**
+ * Platform controller — ports pkg/domain/platform: the server's
+ * self-description surface (NOT a resource domain — no store, no
+ * pipelines; three direct handlers on PlatformQueryController).
+ *
+ * Proven by platform.conformance.test.ts (getServerInfo +
+ * getRunnerBootstrapConfig shapes; getRunnerScopedToken is deliberately
+ * excluded there — its arms are exercised mid-execution) and
+ * __tests__/platform.test.ts (the fail-soft mint matrix, the #15
+ * composed-server pattern).
+ *
+ * getRunnerScopedToken is the mint side of the runner-token lane
+ * (oss#535) — the seam src/runnerauth/ reserved for this sub-project. OSS
+ * has no caller identity, so unlike the cloud exchange there is no
+ * credential to verify: any caller naming an execution receives a token
+ * for it. On a single-user server the token is the LANE DISCRIMINATOR that
+ * lets the EC read RPCs redact by default without breaking the runner, not
+ * a trust boundary (DD-004).
+ */
+import type { ConnectRouter } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  GetRunnerBootstrapConfigOutputSchema,
+  GetRunnerScopedTokenOutputSchema,
+  GetServerInfoOutputSchema,
+  PlatformQueryController,
+  ServerEdition,
+} from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import type {
+  GetRunnerBootstrapConfigOutput,
+  GetRunnerScopedTokenInput,
+  GetRunnerScopedTokenOutput,
+  GetServerInfoOutput,
+} from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import { SERVER_VERSION } from "./version.js";
+
+export interface PlatformControllerDeps {
+  /**
+   * Temporal coordinates this server runs against, published to embedded
+   * runners. In OSS the server and its runners are co-located, so the
+   * address the server itself dials is the one runners should dial too —
+   * no internal/external split (unlike Stigmer Cloud).
+   */
+  readonly temporalHostPort: string;
+  readonly temporalNamespace: string;
+  /**
+   * Mints the execution-scoped tokens getRunnerScopedToken hands to
+   * runners for the ExecutionContext decrypt lane (oss#535). Keyless
+   * yields the presence-based "not minted" response. (Go also tolerates a
+   * nil service in tests; the composition root here always wires one — a
+   * keyless instance is the modeled disabled state.)
+   */
+  readonly runnerAuthService: RunnerAuthService;
+  readonly logger: Logger;
+}
+
+/** Registers the platform query service on the router (routes stage). */
+export function registerPlatformServices(
+  router: ConnectRouter,
+  deps: PlatformControllerDeps,
+): void {
+  router.service(PlatformQueryController, {
+    getServerInfo: () => getServerInfo(),
+    getRunnerBootstrapConfig: () => getRunnerBootstrapConfig(deps),
+    getRunnerScopedToken: (input) => getRunnerScopedToken(deps, input),
+  });
+}
+
+/** Go GetServerInfo: the server edition and build version. */
+function getServerInfo(): GetServerInfoOutput {
+  return create(GetServerInfoOutputSchema, {
+    edition: ServerEdition.oss,
+    version: SERVER_VERSION,
+  });
+}
+
+/**
+ * Go GetRunnerBootstrapConfig: the Temporal coordinates an embedded runner
+ * should connect to so it can self-bootstrap from a token alone. The
+ * RunnerAccessToken / TokenType / RunnerAccessTokenExpiresInSeconds fields
+ * are intentionally left empty: minting an iss=stigmer proxy token is a
+ * cloud-only capability (OSS has no Cursor BiDi proxy to authenticate
+ * against), so OSS runners keep using the token they already hold. The
+ * suite pins the presence-based all-or-nothing coupling of those fields.
+ */
+function getRunnerBootstrapConfig(
+  deps: PlatformControllerDeps,
+): GetRunnerBootstrapConfigOutput {
+  return create(GetRunnerBootstrapConfigOutputSchema, {
+    temporalAddress: deps.temporalHostPort,
+    temporalNamespace: deps.temporalNamespace,
+  });
+}
+
+/**
+ * Go GetRunnerScopedToken (oss#535): mints a token scoped to one unit of
+ * dispatched work, accepted by the ExecutionContext getByExecutionId
+ * decrypt lane.
+ *
+ * Arms:
+ *   - agent_execution_id / workflow_execution_id: minted. Both ids ARE the
+ *     ExecutionContext's spec.execution_id, so the token binds directly to
+ *     the one EC it may decrypt. (Cloud scopes agent tokens to the parent
+ *     session for warm-pool multi-turn reuse; OSS runners exchange
+ *     immediately before each read, so the tighter per-execution binding
+ *     costs nothing.)
+ *   - pool_claim / renewal / unset scope: the presence-based "not minted"
+ *     shape — OSS has no warm pool, and per-read minting makes renewal
+ *     moot.
+ *
+ * FAIL-SOFT is the contract: empty id, keyless service, or a mint error
+ * all answer the empty output rather than a gRPC error — the runner's
+ * no-credential path treats absence as "proceed tokenless", which degrades
+ * to redacted values (a clear downstream signal), while an error here
+ * would abort the activity.
+ */
+function getRunnerScopedToken(
+  deps: PlatformControllerDeps,
+  input: GetRunnerScopedTokenInput,
+): GetRunnerScopedTokenOutput {
+  let executionId: string;
+  switch (input.scope.case) {
+    case "agentExecutionId":
+      executionId = input.scope.value;
+      break;
+    case "workflowExecutionId":
+      executionId = input.scope.value;
+      break;
+    case "poolClaim":
+    case "renewal":
+    case undefined:
+      // pool_claim, renewal, or an unset scope: nothing OSS mints for.
+      return create(GetRunnerScopedTokenOutputSchema);
+    default: {
+      const exhaustive: never = input.scope;
+      throw new Error(`unhandled scope arm: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+
+  if (executionId === "" || !deps.runnerAuthService.isEnabled()) {
+    return create(GetRunnerScopedTokenOutputSchema);
+  }
+
+  try {
+    const minted = deps.runnerAuthService.mint(executionId, 0);
+    return create(GetRunnerScopedTokenOutputSchema, {
+      runnerScopedToken: minted.token,
+      tokenType: "Bearer",
+      expiresInSeconds: minted.ttlSeconds,
+    });
+  } catch (error) {
+    deps.logger.warn(
+      "failed to mint runner scoped token — answering not-minted",
+      {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return create(GetRunnerScopedTokenOutputSchema);
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/platform/version.ts
+++ b/backend/services/stigmer-server-ts/src/domain/platform/version.ts
@@ -1,0 +1,21 @@
+/**
+ * Server build version — ports the Go platform package's
+ * `var Version = "dev"` (set at build time via -ldflags).
+ *
+ * The TS equivalent of ldflags is an esbuild `define`: release builds
+ * replace the __STIGMER_SERVER_VERSION__ identifier in scripts/
+ * bundle-slim.mjs (owner-ratified at this sub-project's plan gate), so the
+ * bundle carries its version as a compile-time constant — hermetic, no
+ * package.json read at boot. Unbundled runs (tsx dev mode, vitest) leave
+ * the identifier undefined and fall back to "dev", exactly Go's unstamped
+ * default.
+ */
+
+declare const __STIGMER_SERVER_VERSION__: string | undefined;
+
+/** The version getServerInfo reports (Go platform.Version). */
+export const SERVER_VERSION: string =
+  typeof __STIGMER_SERVER_VERSION__ === "string" &&
+  __STIGMER_SERVER_VERSION__ !== ""
+    ? __STIGMER_SERVER_VERSION__
+    : "dev";

--- a/backend/services/stigmer-server-ts/src/domain/session/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/search-extractor.ts
@@ -3,7 +3,7 @@
  * pkg/query/search/extractor/session_extractor.go. Sessions are
  * conversation threads between a user and an agent instance; the summary
  * is spec.subject (the conversation topic). The query side of the
- * extractor contract arrives with the search service sub-project (#13).
+ * extractor contract arrives with the search service sub-project (#14).
  */
 import type { Message } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server-ts/src/domain/workflow/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflow/search-extractor.ts
@@ -3,7 +3,7 @@
  * pkg/query/search/extractor/workflow_extractor.go. The search summary is
  * spec.description (workflows are serverless workflow definitions; the
  * spec-level description is the authored summary). The query side of the
- * extractor contract arrives with the search service sub-project (#13),
+ * extractor contract arrives with the search service sub-project (#14),
  * exactly as the organization extractor's header records.
  */
 import type { Message } from "@bufbuild/protobuf";

--- a/backend/services/stigmer-server-ts/src/domain/workflowinstance/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowinstance/search-extractor.ts
@@ -3,7 +3,7 @@
  * pkg/query/search/extractor/workflow_instance_extractor.go. The search
  * summary is spec.description (for the default instance that is the
  * factory's canonical copy). The query side of the extractor contract
- * arrives with the search service sub-project (#13).
+ * arrives with the search service sub-project (#14).
  */
 import type { Message } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server-ts/src/gocompat/__tests__/query-escape.test.ts
+++ b/backend/services/stigmer-server-ts/src/gocompat/__tests__/query-escape.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Pins the Go net/url encoding ports on the exact characters where
+ * URLSearchParams would diverge — the reason these helpers exist. The
+ * artifact storage's signed-URL tests exercise goQueryEscape end-to-end;
+ * this file pins the primitive and the Values.Encode composition directly.
+ */
+import { describe, expect, it } from "vitest";
+
+import { goQueryEscape, goUrlValuesEncode } from "../query-escape.js";
+
+describe("goQueryEscape", () => {
+  it("matches Go url.QueryEscape on the divergent characters", () => {
+    expect(goQueryEscape("a b")).toBe("a+b"); // space → '+'
+    expect(goQueryEscape("~tilde")).toBe("~tilde"); // '~' unescaped (URLSearchParams escapes it)
+    expect(goQueryEscape("star*")).toBe("star%2A"); // '*' escaped (URLSearchParams leaves it bare)
+    expect(goQueryEscape("repo,read:user")).toBe("repo%2Cread%3Auser");
+    expect(goQueryEscape("https://x.example/cb")).toBe("https%3A%2F%2Fx.example%2Fcb");
+  });
+
+  it("percent-encodes multi-byte UTF-8 per byte, uppercase hex", () => {
+    expect(goQueryEscape("é")).toBe("%C3%A9");
+  });
+});
+
+describe("goUrlValuesEncode", () => {
+  it("sorts keys and escapes keys and values (Go url.Values.Encode)", () => {
+    expect(
+      goUrlValuesEncode({ b: "2 2", a: "1", "c:key": "v" }),
+    ).toBe("a=1&b=2+2&c%3Akey=v");
+  });
+
+  it("keeps empty values as key=", () => {
+    expect(goUrlValuesEncode({ a: "" })).toBe("a=");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/gocompat/query-escape.ts
+++ b/backend/services/stigmer-server-ts/src/gocompat/query-escape.ts
@@ -1,0 +1,41 @@
+/**
+ * Byte-exact ports of Go's net/url query encoding — shared by the artifact
+ * storage's signed URLs (#17) and the github broker's authorize-URL/token
+ * exchange (#13). Promoted out of src/artifactstorage/ on its second
+ * consumer per the shared-steps guideline.
+ *
+ * WHY not URLSearchParams: it differs from Go's url.QueryEscape on two
+ * characters ('~' escaped, '*' bare), which would break URL byte parity
+ * for values carrying them. The Go server is the behavioral reference for
+ * every URL a client sees during coexistence.
+ */
+
+/**
+ * Go url.QueryEscape, byte-exact: unreserved [A-Za-z0-9-_.~] pass, space
+ * becomes '+', everything else percent-encodes.
+ */
+export function goQueryEscape(s: string): string {
+  let out = "";
+  for (const byte of Buffer.from(s, "utf-8")) {
+    const c = String.fromCharCode(byte);
+    if (/[A-Za-z0-9\-_.~]/.test(c)) {
+      out += c;
+    } else if (c === " ") {
+      out += "+";
+    } else {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+/**
+ * Go url.Values.Encode for single-valued params: keys sorted
+ * lexicographically, keys and values QueryEscape'd, joined with '&'.
+ */
+export function goUrlValuesEncode(values: Record<string, string>): string {
+  return Object.keys(values)
+    .sort()
+    .map((key) => `${goQueryEscape(key)}=${goQueryEscape(values[key] ?? "")}`)
+    .join("&");
+}

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -28,6 +28,13 @@
 //     deepest domain: 23 RPCs incl. the subscribe stream, the HITL
 //     surfaces, and the engine-gate/lifecycle negatives that pin the
 //     no-Temporal posture until #18).
+//   - oauthapp + platform + github + artifact — sub-project #13
+//     (sp.small-domains; the four small remaining Class A domains, incl.
+//     the client-secret contract, the runner-bootstrap shapes, the broker
+//     Layer-1 arms, and the artifact file-server disposition lane). The
+//     oauthapp suite's delete-block test drives McpServer create/delete —
+//     it goes green here the moment #9 (McpServer CRUD) merges, the
+//     recorded merge-order dependency of this entry.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -44,6 +51,10 @@ export default defineConfig({
       "src/suites/workflowinstance.conformance.test.ts",
       "src/suites/executioncontext.conformance.test.ts",
       "src/suites/agentexecution.conformance.test.ts",
+      "src/suites/oauthapp.conformance.test.ts",
+      "src/suites/platform.conformance.test.ts",
+      "src/suites/github.conformance.test.ts",
+      "src/suites/artifact.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the four small remaining Class A domains from the Go `stigmer-server` to `backend/services/stigmer-server-ts`, closing the long tail before the execution cluster: **oauthapp**, **platform**, **github**, and **artifact** (with its port+1 file server and the R2 storage driver). The `local-ts` conformance roster grows 11 suites → 15. This is D4 entry #13 of the OSS TS-server rewrite (stigmer-cloud program `20260822.01`).

Additive only — the Go server is untouched.

## What ships

- **oauthapp** (`src/domain/oauthapp/`): 7 RPCs on the pipeline framework; AES-256-GCM client-secret encryption reusing the environment's `SecretService`; `***REDACTED***` on every read surface; the redaction-marker round-trip (preserve stored ciphertext) with the marker arm ordered before the `enc:v<N>:` shape rejection (oss#395); the referential delete-block that resolves each McpServer's `oauth_app_ref` through the ported `refresolution` (resolution semantics, stigmer#584).
- **platform** (`src/domain/platform/`): `getServerInfo` (edition `oss` + build-stamped version), `getRunnerBootstrapConfig` (Temporal coordinates, presence-based token fields), and `getRunnerScopedToken` — the runner-token mint side (oss#535) over the existing `RunnerAuthService.mint`, fail-soft on every non-minting arm.
- **github** (`src/domain/github/`): the stateless OAuth broker with the bundled "Stigmer Local" defaults; authorize-URL and token-exchange byte parity with Go `url.Values.Encode` via the promoted `src/gocompat/query-escape.ts`.
- **artifact** (`src/domain/artifact/`): content-addressed create, TTL arms, `getContent` truncation, soft-delete, the wire-layout org-derivation proxy; the port+1 HTTP file server (loopback, local-storage-only, `?download=` attachment disposition); and the **R2 driver** (`@aws-sdk/client-s3` + presigner, pinned) that closes the `ARTIFACT_STORAGE_TYPE=r2` boot-fail #17 shipped.
- Version/GitHub-credential release stamping via esbuild `define` in `scripts/bundle-slim.mjs` (the ldflags equivalent), plus a `createRequire` banner so the ESM slim bundle loads the CJS AWS SDK.

## Parity nuances (disclosed)

- `oauthapp` delete returns the STORED secret unredacted — faithful to Go's `delete.go` (no `RedactOAuthApp` call); with encryption disabled that is plaintext. Both-editions follow-up candidate.
- `artifact.listByExecution`'s Go doc-comment says `FindAllByField`, but the code full-scans `ListResources` with an in-memory source filter — the port mirrors the code.
- The artifact 50MB cap and empty-content arm are unit-level only (they sit behind the transport's 10MB message cap / protovalidate; the wave-2 S1 amendment).
- `getDownloadUrl` reports `ttl_seconds` 604800 unconditionally even though local URLs never expire (ratified P3).
- The file server sets no Content-Type (Go sniffs) and no Range support (Go `ServeContent` honors) — neither is wire-pinned.

## Merge order

**Hold this PR until #9 `sp.mcpserver-crud` merges.** The oauthapp conformance suite's delete-block test drives McpServer `create`/`delete` RPCs that #9 owns; it goes green on `local-ts` after the rebase on #9. All other suites (platform, github, artifact) are green now. This is the recorded merge-order dependency — the suite is not skip-gated.

## Test plan

- [x] `tsc --noEmit` clean; Vitest 825/825 (64 files).
- [x] `make test-conformance-ts` — platform, github, artifact green; oauthapp green post-#9 (276/277 today, the one red is the McpServer-dependent delete-block arm).
- [x] `make test-conformance` (local-go) regression-free: 468 passed, 1 skipped (baseline).
- [x] `npm run verify:slim` — the stamped ESM bundle boots, serves, and shuts down cleanly.
- [ ] After #9 merges: rebase, confirm `local-ts` 15/15 suites, then merge.
