### PR TITLE
feat(backend/stigmer-server-ts): port the skill domain with the artifact transfer lane (D4 #8)

### DIFF
--- a/.github/workflows/ci.ts-libs.yaml
+++ b/.github/workflows/ci.ts-libs.yaml
@@ -75,3 +75,12 @@ jobs:
 
       - name: Test @stigmer/temporal-codecs
         run: npm run test -w @stigmer/temporal-codecs
+
+      - name: Build @stigmer/zip-structure
+        run: npm run build -w @stigmer/zip-structure
+
+      - name: Typecheck @stigmer/zip-structure (incl. tests)
+        run: npm run typecheck -w @stigmer/zip-structure
+
+      - name: Test @stigmer/zip-structure
+        run: npm run test -w @stigmer/zip-structure

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -150,8 +150,9 @@ jobs:
             pkg.version = process.env.VERSION;
             pkg.dependencies['@stigmer/protos'] = process.env.VERSION;
             pkg.dependencies['@stigmer/temporal-codecs'] = process.env.VERSION;
+            pkg.dependencies['@stigmer/zip-structure'] = process.env.VERSION;
             fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-            console.log('stamped @stigmer/runner@' + pkg.version + ' (protos: ' + pkg.dependencies['@stigmer/protos'] + ', temporal-codecs: ' + pkg.dependencies['@stigmer/temporal-codecs'] + ')');
+            console.log('stamped @stigmer/runner@' + pkg.version + ' (protos: ' + pkg.dependencies['@stigmer/protos'] + ', temporal-codecs: ' + pkg.dependencies['@stigmer/temporal-codecs'] + ', zip-structure: ' + pkg.dependencies['@stigmer/zip-structure'] + ')');
           "
 
       - name: Verify published file list
@@ -164,7 +165,7 @@ jobs:
         env:
           VERSION: ${{ needs.determine-version.outputs.version }}
         run: |
-          for pkg in @stigmer/protos @stigmer/temporal-codecs; do
+          for pkg in @stigmer/protos @stigmer/temporal-codecs @stigmer/zip-structure; do
             echo "Confirming $pkg@$VERSION is queryable on npm..."
             found=""
             for i in $(seq 1 30); do

--- a/backend/libs/ts/zip-structure/package.json
+++ b/backend/libs/ts/zip-structure/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stigmer/zip-structure",
+  "version": "0.0.0-dev",
+  "description": "Policy-free structural ZIP parsing shared by Stigmer's TypeScript processes — central-directory-based entry enumeration (never local-header walks) plus the byte-level archive builder its consumers' tests craft fixtures with",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js",
+      "default": "./dist/testing.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": "^22.13.0 || >=23.4.0"
+  },
+  "keywords": [
+    "stigmer",
+    "zip",
+    "central-directory",
+    "structural-parsing"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing.d.ts",
+        "import": "./dist/testing.js",
+        "default": "./dist/testing.js"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stigmer/stigmer.git",
+    "directory": "backend/libs/ts/zip-structure"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.1",
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/backend/libs/ts/zip-structure/src/__tests__/zip-structure.test.ts
+++ b/backend/libs/ts/zip-structure/src/__tests__/zip-structure.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The structural layer's own suite. Until the lib extraction this module
+ * was tested only through its consumers (the runner's zip-extract and
+ * attachment-injector suites); per ci.ts-libs' contract a lib change must
+ * fail attributably here even when no consumer file moved.
+ */
+import { inflateRawSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import { buildZip } from "../testing.js";
+import { parseZipStructure } from "../zip-structure.js";
+
+function text(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+describe("parseZipStructure", () => {
+  it("enumerates stored entries with names, sizes, and payload views", () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: "# Skill" },
+      { name: "references/schema.md", content: "tables" },
+    ]);
+
+    const entries = parseZipStructure(zip);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.name).toBe("SKILL.md");
+    expect(entries[0]!.compressionMethod).toBe(0);
+    expect(entries[0]!.uncompressedSize).toBe("# Skill".length);
+    expect(entries[0]!.compressedSize).toBe("# Skill".length);
+    expect(text(entries[0]!.compressedData)).toBe("# Skill");
+    expect(entries[1]!.name).toBe("references/schema.md");
+  });
+
+  it("inflates a deflated entry's payload back to the original bytes", () => {
+    const content = "compressed with deflate, long enough to actually shrink ".repeat(8);
+    const zip = buildZip([{ name: "notes.txt", content, method: "deflated" }]);
+
+    const [entry] = parseZipStructure(zip);
+    expect(entry!.compressionMethod).toBe(8);
+    expect(text(new Uint8Array(inflateRawSync(entry!.compressedData)))).toBe(content);
+  });
+
+  it("reads sizes from the central directory for streaming entries (zeroed local headers, #450)", () => {
+    const content = "streamed by Go's archive/zip writer";
+    const zip = buildZip([{ name: "streamed.md", content, streaming: true }]);
+
+    const [entry] = parseZipStructure(zip);
+    expect(entry!.uncompressedSize).toBe(content.length);
+    expect(text(entry!.compressedData)).toBe(content);
+  });
+
+  it("marks directory entries", () => {
+    const zip = buildZip([
+      { name: "references/", content: "" },
+      { name: "references/data.md", content: "data" },
+    ]);
+
+    const entries = parseZipStructure(zip);
+    expect(entries[0]!.isDirectory).toBe(true);
+    expect(entries[1]!.isDirectory).toBe(false);
+  });
+
+  it("locates the EOCD behind a trailing archive comment", () => {
+    const zip = buildZip([{ name: "a.md", content: "a" }], { comment: "trailing comment" });
+    expect(parseZipStructure(zip)).toHaveLength(1);
+  });
+
+  it("is not fooled by EOCD signature bytes inside the comment", () => {
+    // The four signature bytes ("PK\x05\x06") occur INSIDE the comment; a
+    // signature-only scan would lock onto them and misparse. The parser
+    // requires the candidate record to point at a real central directory.
+    const zip = buildZip([{ name: "a.md", content: "a" }], {
+      comment: "x PK\x05\x06 y padding padding padding",
+    });
+    const entries = parseZipStructure(zip);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.name).toBe("a.md");
+  });
+
+  it("parses a genuinely empty archive to zero entries", () => {
+    const zip = buildZip([]);
+    expect(parseZipStructure(zip)).toEqual([]);
+  });
+
+  it("throws when the central directory and EOCD are missing (truncated download)", () => {
+    const zip = buildZip([{ name: "a.md", content: "a" }], { omitCentralDirectory: true });
+    expect(() => parseZipStructure(zip)).toThrow("no end-of-central-directory record found");
+  });
+
+  it("throws on a corrupted central directory record", () => {
+    const zip = buildZip([{ name: "a.md", content: "a" }]);
+    // The EOCD's central-directory-offset field (u32 at EOCD+16) locates the
+    // record; corrupt the record's signature byte behind it. The EOCD scan
+    // then rejects the record (directoryLooksReal fails) and no other valid
+    // EOCD exists.
+    const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+    const eocdPos = zip.length - 22; // no comment in this fixture
+    const cdOffset = view.getUint32(eocdPos + 16, true);
+    zip[cdOffset] = 0x00;
+    expect(() => parseZipStructure(zip)).toThrow("no end-of-central-directory record found");
+  });
+
+  it("exposes versionMadeBy and externalAttributes verbatim for policy layers", () => {
+    // A Unix-creator entry carrying a POSIX mode in the attribute high bits
+    // (0o120777 = a symlink) — the raw facts the server's safearchive-parity
+    // pre-filter decodes. The structural layer must not interpret them.
+    const symlinkMode = (0o120777 << 16) >>> 0;
+    const zip = buildZip([
+      {
+        name: "link",
+        content: "target",
+        versionMadeBy: 0x0314, // high byte 3 = Unix, low byte 20
+        externalAttributes: symlinkMode,
+      },
+      { name: "plain.md", content: "plain" },
+    ]);
+
+    const entries = parseZipStructure(zip);
+    expect(entries[0]!.versionMadeBy).toBe(0x0314);
+    expect(entries[0]!.externalAttributes).toBe(symlinkMode);
+    expect(entries[1]!.versionMadeBy).toBe(20);
+    expect(entries[1]!.externalAttributes).toBe(0);
+  });
+});

--- a/backend/libs/ts/zip-structure/src/index.ts
+++ b/backend/libs/ts/zip-structure/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  EOCD_MIN_SIZE,
+  crc32,
+  parseZipStructure,
+  type ZipStructuralEntry,
+} from "./zip-structure.js";

--- a/backend/libs/ts/zip-structure/src/testing.ts
+++ b/backend/libs/ts/zip-structure/src/testing.ts
@@ -1,24 +1,27 @@
 /**
- * Shared ZIP fixture builder for runner unit tests.
+ * Byte-level ZIP fixture builder for the structural parser's consumers'
+ * tests (exported as `@stigmer/zip-structure/testing`). Moved here from the
+ * runner's src/__test-utils__/zip-fixtures.ts when the lib was extracted —
+ * the lib's own tests, the runner's, and the TS server's skill-gate tests
+ * all craft archives with it, and one builder keeps their fixture shapes
+ * from drifting apart.
  *
  * Emits complete, real-shaped archives — local file headers (optionally
  * streaming-style, the Go stdlib writer's default), payloads, central
  * directory, and EOCD — because that is the only shape that can reach the
  * runner: both editions' skill push gates validate artifacts with
- * central-directory-based readers (see zip-extract.ts's module doc and
- * design record 017). Earlier fixtures emitted local headers only, a
- * shape no real ZIP writer produces, and were coupled to the old parser's
- * front-to-back walk.
+ * central-directory-based readers (see zip-structure.ts's module doc).
+ * Earlier fixtures emitted local headers only, a shape no real ZIP writer
+ * produces, and were coupled to the old parser's front-to-back walk.
  *
  * Mirrors the conformance suite's `zipFilesStreaming()`
  * (test/conformance/src/support/skills.ts) so unit fixtures and
  * cross-edition fixtures share one shape.
- *
- * Lives in src/__test-utils__/ so `tsc --noEmit` covers it while
- * tsconfig.build.json keeps it out of dist/.
  */
 
 import { deflateRawSync } from "node:zlib";
+
+import { crc32 } from "./zip-structure.js";
 
 export interface ZipFixtureFile {
   name: string;
@@ -40,6 +43,17 @@ export interface ZipFixtureFile {
    * exists to reject (issue #567).
    */
   declaredUncompressedSize?: number;
+  /**
+   * The central directory's "version made by" field. Defaults to 20
+   * (MS-DOS creator, the historical fixture value). Set the high byte to
+   * 3 (`0x0300 | 20`) to model a Unix creator, which makes readers
+   * interpret `externalAttributes`' high 16 bits as a POSIX mode — how
+   * symlink and device entries are represented (the server's
+   * safearchive-parity pre-filter fixtures need this).
+   */
+  versionMadeBy?: number;
+  /** The central directory's external file attributes field. Defaults to 0. */
+  externalAttributes?: number;
 }
 
 export interface ZipFixtureOptions {
@@ -64,6 +78,8 @@ export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): 
     crc: number;
     flags: number;
     method: number;
+    versionMadeBy: number;
+    externalAttributes: number;
     localHeaderOffset: number;
   }
   const written: WrittenEntry[] = [];
@@ -80,6 +96,8 @@ export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): 
       crc: crc32(contentBytes),
       flags: file.streaming ? 0x0008 : 0,
       method: deflated ? 8 : 0,
+      versionMadeBy: file.versionMadeBy ?? 20,
+      externalAttributes: file.externalAttributes ?? 0,
       localHeaderOffset: out.length,
     };
     written.push(entry);
@@ -113,7 +131,7 @@ export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): 
   const centralDirectoryOffset = out.length;
   for (const entry of written) {
     out.u32(0x02014b50); // central directory record signature
-    out.u16(20); // version made by
+    out.u16(entry.versionMadeBy);
     out.u16(20); // version needed to extract
     out.u16(entry.flags);
     out.u16(entry.method);
@@ -127,7 +145,7 @@ export function buildZip(files: ZipFixtureFile[], options?: ZipFixtureOptions): 
     out.u16(0); // comment length
     out.u16(0); // disk number start
     out.u16(0); // internal attributes
-    out.u32(0); // external attributes
+    out.u32(entry.externalAttributes);
     out.u32(entry.localHeaderOffset);
     out.raw(entry.nameBytes);
   }
@@ -182,25 +200,6 @@ class ByteWriter {
   }
 }
 
-// Standard CRC-32 (IEEE 802.3, the ZIP checksum), table-driven so fixtures
-// at the injector's 100 MB limit stay cheap to build. Semantically identical
-// to the conformance suite's inline bit-loop helper.
-const CRC_TABLE = (() => {
-  const table = new Uint32Array(256);
-  for (let n = 0; n < 256; n++) {
-    let c = n;
-    for (let bit = 0; bit < 8; bit++) {
-      c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
-    }
-    table[n] = c;
-  }
-  return table;
-})();
-
-function crc32(data: Uint8Array): number {
-  let crc = 0xffffffff;
-  for (let i = 0; i < data.length; i++) {
-    crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ data[i]!) & 0xff]!;
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
+// CRC-32 comes from the structural module (one implementation for the
+// parser's consumers and this builder; semantically identical to the
+// conformance suite's inline bit-loop helper).

--- a/backend/libs/ts/zip-structure/src/zip-structure.ts
+++ b/backend/libs/ts/zip-structure/src/zip-structure.ts
@@ -2,6 +2,11 @@
  * Policy-free structural ZIP parsing: end-of-central-directory (EOCD)
  * location plus central-directory walk, producing one record per entry.
  *
+ * Lived in the runner (src/shared/zip-structure.ts) until the TS server's
+ * skill push gate became its second consumer; extracted to backend/libs/ts/
+ * per the program's shared-library rule (a library moves here when a second
+ * consumer exists — @stigmer/temporal-codecs is the precedent).
+ *
  * Parsing is *central-directory-based* — never a front-to-back walk of
  * local file headers. This is a correctness decision, not a style choice
  * (issues #450 and #567): local headers of streaming entries
@@ -17,15 +22,18 @@
  * a structural failure means, which entries are acceptable, how payloads
  * are decoded — belongs to the consumers, and they differ on purpose:
  *
- *   - shared/zip-extract.ts (skill artifacts): structural failure is
- *     NON-FATAL — both editions' push gates validated every artifact
+ *   - runner shared/zip-extract.ts (skill artifacts): structural failure
+ *     is NON-FATAL — both editions' push gates validated every artifact
  *     with a central-directory-based reader before storage, so a defect
  *     here can only be a truncated or corrupted download.
- *   - execute-deep-agent/attachment-injector.ts (user attachments):
- *     structural failure is FAIL-HARD — the input is an untrusted
- *     upload and nothing upstream vouched for it.
+ *   - runner execute-deep-agent/attachment-injector.ts (user
+ *     attachments): structural failure is FAIL-HARD — the input is an
+ *     untrusted upload and nothing upstream vouched for it.
+ *   - stigmer-server-ts src/domain/skill/storage/ (the push gate):
+ *     FAIL-HARD, plus a safearchive-parity entry pre-filter decoded from
+ *     the raw creator/attribute fields exposed below.
  *
- * ZIP64 is deliberately unsupported: both consumers cap input far below
+ * ZIP64 is deliberately unsupported: every consumer caps input far below
  * every ZIP64 threshold (skill push gates: 100MB / 10,000 files;
  * attachment uploads: 10MB).
  *
@@ -49,6 +57,29 @@ export interface ZipStructuralEntry {
    * against the actual decompressed output.
    */
   readonly uncompressedSize: number;
+  /** The central directory's declared compressed size (the payload length). */
+  readonly compressedSize: number;
+  /**
+   * The central directory's CRC-32 of the uncompressed content, verbatim.
+   * Raw fact for consumers that verify payload integrity after
+   * decompression (Go's archive/zip checks it on every read); consumers
+   * that trust their input ignore it.
+   */
+  readonly crc32: number;
+  /**
+   * The central directory's "version made by" field, verbatim. The high
+   * byte identifies the creator OS (0 = MS-DOS/FAT, 3 = Unix, 19 = macOS),
+   * which decides how `externalAttributes` is interpreted. Raw facts for
+   * policy layers that decode entry file modes; most consumers ignore it.
+   */
+  readonly versionMadeBy: number;
+  /**
+   * The central directory's external file attributes field, verbatim.
+   * Unix creators store the POSIX mode in the high 16 bits; MS-DOS
+   * creators store FAT attribute bits in the low byte. Interpretation is
+   * policy — see the server's safearchive-parity pre-filter.
+   */
+  readonly externalAttributes: number;
   /** The entry's raw payload slice (a view, not a copy) of the archive buffer. */
   readonly compressedData: Uint8Array;
 }
@@ -88,12 +119,15 @@ export function parseZipStructure(data: Uint8Array): ZipStructuralEntry[] {
       throw new Error(`invalid central directory record at offset ${offset}`);
     }
 
+    const versionMadeBy = view.getUint16(offset + 4, true);
     const compressionMethod = view.getUint16(offset + 10, true);
+    const crc32 = view.getUint32(offset + 16, true);
     const compressedSize = view.getUint32(offset + 20, true);
     const uncompressedSize = view.getUint32(offset + 24, true);
     const fileNameLength = view.getUint16(offset + 28, true);
     const extraFieldLength = view.getUint16(offset + 30, true);
     const commentLength = view.getUint16(offset + 32, true);
+    const externalAttributes = view.getUint32(offset + 38, true);
     const localHeaderOffset = view.getUint32(offset + 42, true);
 
     const fileName = new TextDecoder().decode(
@@ -114,6 +148,10 @@ export function parseZipStructure(data: Uint8Array): ZipStructuralEntry[] {
       isDirectory: fileName.endsWith("/"),
       compressionMethod,
       uncompressedSize,
+      compressedSize,
+      crc32,
+      versionMadeBy,
+      externalAttributes,
       compressedData: data.subarray(dataStart, dataStart + compressedSize),
     });
 
@@ -159,6 +197,35 @@ function findEndOfCentralDirectory(data: Uint8Array, view: DataView): EndOfCentr
   }
 
   throw new Error("no end-of-central-directory record found");
+}
+
+// ─── CRC-32 ──────────────────────────────────────────────────────────────
+
+// Standard CRC-32 (IEEE 802.3, the ZIP checksum), table-driven so callers
+// hashing payloads at the consumers' 100 MB caps stay cheap.
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let bit = 0; bit < 8; bit++) {
+      c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
+    }
+    table[n] = c;
+  }
+  return table;
+})();
+
+/**
+ * CRC-32 of `data` — the ZIP checksum. Exported for consumers that verify
+ * decompressed payloads against an entry's declared `crc32` (Go's
+ * archive/zip does this on every read) and for the fixture builder.
+ */
+export function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ data[i]!) & 0xff]!;
+  }
+  return (crc ^ 0xffffffff) >>> 0;
 }
 
 /** Resolve where an entry's payload begins, from its local file header. */

--- a/backend/libs/ts/zip-structure/tsconfig.build.json
+++ b/backend/libs/ts/zip-structure/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__"]
+}

--- a/backend/libs/ts/zip-structure/tsconfig.json
+++ b/backend/libs/ts/zip-structure/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/backend/libs/ts/zip-structure/vitest.config.ts
+++ b/backend/libs/ts/zip-structure/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    alias: [
+      // Source imports carry NodeNext-style `.js` extensions; strip them so
+      // vitest resolves the sibling `.ts` sources directly (same alias the
+      // runner's and temporal-codecs' vitest configs use).
+      {
+        find: /^(\..*)\.js$/,
+        replacement: "$1",
+      },
+    ],
+  },
+});

--- a/backend/services/runner/package-lock.json
+++ b/backend/services/runner/package-lock.json
@@ -32,6 +32,7 @@
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
         "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
+        "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
         "@temporalio/activity": "1.16.2",
         "@temporalio/common": "1.16.2",
         "@temporalio/interceptors-opentelemetry": "1.16.2",
@@ -88,6 +89,19 @@
         "@temporalio/common": "1.16.2",
         "@temporalio/proto": "1.16.2"
       },
+      "devDependencies": {
+        "@types/node": "^22.13.1",
+        "typescript": "^5.7.0",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=23.4.0"
+      }
+    },
+    "../../libs/ts/zip-structure": {
+      "name": "@stigmer/zip-structure",
+      "version": "0.0.0-dev",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.13.1",
         "typescript": "^5.7.0",
@@ -3801,6 +3815,10 @@
     },
     "node_modules/@stigmer/temporal-codecs": {
       "resolved": "../../libs/ts/temporal-codecs",
+      "link": true
+    },
+    "node_modules/@stigmer/zip-structure": {
+      "resolved": "../../libs/ts/zip-structure",
       "link": true
     },
     "node_modules/@swc/core": {

--- a/backend/services/runner/package.json
+++ b/backend/services/runner/package.json
@@ -96,6 +96,7 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@stigmer/protos": "file:../../../apis/stubs/ts",
     "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
+    "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
     "@temporalio/activity": "1.16.2",
     "@temporalio/common": "1.16.2",
     "@temporalio/interceptors-opentelemetry": "1.16.2",

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/skill-resolver.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ConnectError, Code } from "@connectrpc/connect";
 import { resolveSkills } from "../skill-resolver.js";
-import { buildZip } from "../../../__test-utils__/zip-fixtures.js";
+import { buildZip } from "@stigmer/zip-structure/testing";
 
 /** A server that predates the transfer lane (#675) answers the mint RPC
  * with UNIMPLEMENTED — the default posture for these tests, which keeps

--- a/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/__tests__/attachment-injector.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../attachment-injector.js";
 import { mockWorkspaceBackend } from "../../../__test-utils__/mock-workspace.js";
 import { makeInMemoryArtifactStorage } from "../../../__test-utils__/fake-artifact-storage.js";
-import { buildZip, type ZipFixtureFile } from "../../../__test-utils__/zip-fixtures.js";
+import { buildZip, type ZipFixtureFile } from "@stigmer/zip-structure/testing";
 import {
   DEEP_AGENT_VISION_PROFILE,
   VisionBudget,
@@ -22,7 +22,8 @@ import {
 
 // ── ZIP Construction Helpers ─────────────────────────────────────────
 //
-// All archives come from the shared real-shape builder (zip-fixtures.ts):
+// All archives come from the shared real-shape builder
+// (@stigmer/zip-structure/testing):
 // local headers, payloads, central directory, EOCD — the only shape real
 // ZIP writers produce and the shape central-directory parsing requires.
 // The record-form helpers below keep ordinary call sites terse; tests that

--- a/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
+++ b/backend/services/runner/src/activities/execute-deep-agent/attachment-injector.ts
@@ -7,7 +7,7 @@
  *
  * Security model: attachments are untrusted user uploads. ZIP archives are
  * parsed from the central directory — the format's authoritative index —
- * via the shared structural layer (shared/zip-structure.ts; issue #567,
+ * via the shared structural layer (@stigmer/zip-structure; issue #567,
  * which killed this module's local-header walk: it silently truncated
  * stored streaming entries and rejected Go-default archives outright).
  * Every entry is validated for path traversal, zip bombs, and format
@@ -48,7 +48,7 @@ import {
   EOCD_MIN_SIZE,
   parseZipStructure,
   type ZipStructuralEntry,
-} from "../../shared/zip-structure.js";
+} from "@stigmer/zip-structure";
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/backend/services/runner/src/shared/__tests__/skill-mount.test.ts
+++ b/backend/services/runner/src/shared/__tests__/skill-mount.test.ts
@@ -9,7 +9,7 @@ import {
   downloadArtifact,
   writeSkillMount,
 } from "../skill-mount.js";
-import { buildZip } from "../../__test-utils__/zip-fixtures.js";
+import { buildZip } from "@stigmer/zip-structure/testing";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 

--- a/backend/services/runner/src/shared/__tests__/skill-writer.test.ts
+++ b/backend/services/runner/src/shared/__tests__/skill-writer.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../skill-writer.js";
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
 import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
-import { buildZip } from "../../__test-utils__/zip-fixtures.js";
+import { buildZip } from "@stigmer/zip-structure/testing";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 

--- a/backend/services/runner/src/shared/__tests__/zip-extract.test.ts
+++ b/backend/services/runner/src/shared/__tests__/zip-extract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { extractZipFileEntries, type ZipFileEntry } from "../zip-extract.js";
-import { buildZip } from "../../__test-utils__/zip-fixtures.js";
+import { buildZip } from "@stigmer/zip-structure/testing";
 
 /**
  * Decode entries for text-content assertions. The production contract is

--- a/backend/services/runner/src/shared/zip-extract.ts
+++ b/backend/services/runner/src/shared/zip-extract.ts
@@ -33,7 +33,7 @@
  */
 
 import { createInflateRaw } from "node:zlib";
-import { EOCD_MIN_SIZE, parseZipStructure, type ZipStructuralEntry } from "./zip-structure.js";
+import { EOCD_MIN_SIZE, parseZipStructure, type ZipStructuralEntry } from "@stigmer/zip-structure";
 
 // ─── Public API ──────────────────────────────────────────────────────────
 

--- a/backend/services/stigmer-server-ts/package-lock.json
+++ b/backend/services/stigmer-server-ts/package-lock.json
@@ -14,6 +14,7 @@
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
+        "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
         "fflate": "^0.8.3",
         "js-yaml": "^4.3.1",
         "ulidx": "2.4.1"
@@ -43,6 +44,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "../../libs/ts/zip-structure": {
+      "name": "@stigmer/zip-structure",
+      "version": "0.0.0-dev",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.13.1",
+        "typescript": "^5.7.0",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=23.4.0"
       }
     },
     "node_modules/@bufbuild/cel": {
@@ -935,6 +949,10 @@
     },
     "node_modules/@stigmer/protos": {
       "resolved": "../../../apis/stubs/ts",
+      "link": true
+    },
+    "node_modules/@stigmer/zip-structure": {
+      "resolved": "../../libs/ts/zip-structure",
       "link": true
     },
     "node_modules/@types/chai": {

--- a/backend/services/stigmer-server-ts/package.json
+++ b/backend/services/stigmer-server-ts/package.json
@@ -30,6 +30,7 @@
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
     "@stigmer/protos": "file:../../../apis/stubs/ts",
+    "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
     "fflate": "^0.8.3",
     "js-yaml": "^4.3.1",
     "ulidx": "2.4.1"

--- a/backend/services/stigmer-server-ts/scripts/verify-boot.mjs
+++ b/backend/services/stigmer-server-ts/scripts/verify-boot.mjs
@@ -28,15 +28,22 @@ if (entry === undefined) {
 const serverRoot = fileURLToPath(new URL("..", import.meta.url));
 const BOOT_TIMEOUT_MS = 15_000;
 
+// Every filesystem-touching stage gets a throwaway root: the boot check
+// must never write the operator's ~/.stigmer. STORAGE_PATH matters beyond
+// hygiene — the skill domain WIPES {STORAGE_PATH}/skills-staging at boot
+// (crash recovery, #8), which against the real default would clear a
+// running server's in-flight uploads.
+const scratch = mkdtempSync(join(tmpdir(), "verify-boot-"));
+
 const child = spawn(process.execPath, [join(serverRoot, entry)], {
   env: {
     ...process.env,
     GRPC_PORT: "0",
     LOG_LEVEL: "info",
     ENV: "ci",
-    // The storage stage opens DB_PATH for real — point it at a throwaway
-    // file so the boot check never writes the operator's ~/.stigmer.
-    DB_PATH: join(mkdtempSync(join(tmpdir(), "verify-boot-")), "stigmer.db"),
+    DB_PATH: join(scratch, "stigmer.db"),
+    STORAGE_PATH: join(scratch, "storage"),
+    ARTIFACT_LOCAL_BASE_PATH: join(scratch, "artifacts"),
   },
   stdio: ["ignore", "inherit", "pipe"],
 });

--- a/backend/services/stigmer-server-ts/src/boot/__tests__/compose.test.ts
+++ b/backend/services/stigmer-server-ts/src/boot/__tests__/compose.test.ts
@@ -41,6 +41,9 @@ function compose() {
     DB_PATH: path.join(testDir, "stigmer.db"),
     // Keep the artifact store inside the test dir (never ~/.stigmer).
     ARTIFACT_LOCAL_BASE_PATH: path.join(testDir, "artifacts"),
+    // Same for the skill artifact store — its boot-time staging wipe (#8)
+    // must never run against the real ~/.stigmer/storage.
+    STORAGE_PATH: path.join(testDir, "storage"),
   });
   return composeServer({
     config,

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -15,6 +15,8 @@
  * that — the CLI's serverGate TCP probe treats port-bind as readiness.
  * Shutdown is the reverse (grpc lib Stop): NOT_SERVING first, then drain.
  */
+import path from "node:path";
+
 import type { ConnectRouter } from "@connectrpc/connect";
 
 import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
@@ -33,6 +35,11 @@ import { registerExecutionContextServices } from "../domain/executioncontext/con
 import { registerMemoryServices } from "../domain/memory/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
+import { registerSkillServices } from "../domain/skill/controller.js";
+import { DEFAULT_SLOT_TTL_MS, MAX_ZIP_SIZE } from "../domain/skill/constants.js";
+import { LocalFileStorage as SkillLocalFileStorage } from "../domain/skill/storage/artifact-storage.js";
+import { newSkillTransferLane } from "../domain/skill/transfer/handler.js";
+import { UploadSlots } from "../domain/skill/transfer/slots.js";
 import { SecretService } from "../encryption/encryption.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
@@ -165,6 +172,24 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     localBasePath: config.artifactLocalBasePath,
     localServeUrl: config.artifactLocalServeUrl,
   });
+  // The skill artifact store + transfer lane (Go server.go:318-340). The
+  // store is content-addressed and never-GC at {storagePath}/skills/;
+  // the slots registry wipes {storagePath}/skills-staging at boot (orphans
+  // from a dead process are useless — the registry died with it). On OSS
+  // the lane is ALWAYS configured (Go wires it unconditionally too): the
+  // FailedPrecondition lane-absent arms exist for construction-order
+  // safety, and the capability matrix pins skillArtifactTransferLane=true.
+  const skillArtifactStorage = new SkillLocalFileStorage(config.storagePath);
+  const skillUploadSlots = new UploadSlots(
+    path.join(config.storagePath, "skills-staging"),
+    DEFAULT_SLOT_TTL_MS,
+    MAX_ZIP_SIZE,
+  );
+  const skillTransferLane = newSkillTransferLane(
+    skillUploadSlots,
+    skillArtifactStorage,
+    logger,
+  );
   // The environment runtime-resolution service (#5) — the decrypt-for-
   // execution path the EC builder uses to resolve environment_refs (the
   // RPC surface redacts secret values, oss#405).
@@ -267,6 +292,18 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       logger,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
     });
+    registerSkillServices(router, {
+      store,
+      logger,
+      artifactStorage: skillArtifactStorage,
+      // The agentexecution blob store (server.go:362-363) — read side of
+      // pushFromExecutionArtifact.
+      executionArtifactStorage: artifactStorage,
+      transferLane: {
+        slots: skillUploadSlots,
+        baseUrl: config.skillTransferBaseUrl,
+      },
+    });
   };
   inProcess = createInProcessClients(routes, logger);
 
@@ -276,6 +313,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     interceptors: buildInterceptorChain(logger),
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
     modelRegistryLane: registryLanes.modelRegistryLane,
+    skillTransferLane,
   });
 
   return {

--- a/backend/services/stigmer-server-ts/src/boot/config.ts
+++ b/backend/services/stigmer-server-ts/src/boot/config.ts
@@ -55,6 +55,21 @@ export interface ServerConfig {
    * full path).
    */
   readonly artifactLocalServeUrl: string;
+  /**
+   * Skill artifact storage root (STORAGE_PATH; Go defaultStoragePath
+   * ~/.stigmer/storage). Artifacts live at {storagePath}/skills/,
+   * upload staging at {storagePath}/skills-staging/ — byte-identical to
+   * Go's layout, so a Go-written directory is served in place at cutover.
+   */
+  readonly storagePath: string;
+  /**
+   * Externally-reachable base of the skill artifact transfer lane's
+   * capability URLs (#675). Defaults to the server's own port on
+   * localhost; SKILL_TRANSFER_BASE_URL overrides when the server is
+   * reached through a tunnel or reverse proxy (the ARTIFACT_LOCAL_SERVE_URL
+   * idiom, Go config.go:52-58).
+   */
+  readonly skillTransferBaseUrl: string;
 }
 
 /** Default unified port; the CLI's env contract pins the same value. */
@@ -93,9 +108,24 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     modelRegistryRefreshEnabled:
       env["STIGMER_MODEL_REGISTRY_REFRESH"] !== "off",
     dbPath: envString(env, "DB_PATH", defaultDbPath()),
+    storagePath: envString(env, "STORAGE_PATH", defaultStoragePath()),
+    skillTransferBaseUrl: envString(
+      env,
+      "SKILL_TRANSFER_BASE_URL",
+      `http://localhost:${grpcPort}`,
+    ),
     operatorEmail,
     operatorName,
   };
+}
+
+/** Go defaultStoragePath: ~/.stigmer/storage, ./storage without a home. */
+function defaultStoragePath(): string {
+  try {
+    return path.join(os.homedir(), ".stigmer", "storage");
+  } catch {
+    return "./storage";
+  }
 }
 
 /** Go defaultDBPath: ~/.stigmer/stigmer.db, ./stigmer.db without a home. */

--- a/backend/services/stigmer-server-ts/src/domain/agent/__tests__/agent.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/__tests__/agent.test.ts
@@ -74,6 +74,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -95,6 +95,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/__tests__/agentinstance.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/__tests__/agentinstance.test.ts
@@ -77,6 +77,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/environment/__tests__/environment.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/__tests__/environment.test.ts
@@ -65,6 +65,9 @@ async function startServer(env: Record<string, string>): Promise<TestServer> {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/__tests__/executioncontext.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/__tests__/executioncontext.test.ts
@@ -89,6 +89,9 @@ async function startServer(env: Record<string, string>): Promise<TestServer> {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/memory/__tests__/memory.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/memory/__tests__/memory.test.ts
@@ -81,6 +81,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/organization/__tests__/organization.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/organization/__tests__/organization.test.ts
@@ -43,6 +43,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/session/__tests__/session.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/__tests__/session.test.ts
@@ -101,6 +101,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/artifact-storage.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/artifact-storage.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pins the skill artifact store against Go's artifact_storage_test.go:
+ * path layout ({root}/skills/{hash}.zip — cutover inherits Go-written
+ * directories), permissions, traversal-guarded reads, and the dedupe
+ * surface (exists/getStorageKey).
+ */
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ArtifactNotFoundError, LocalFileStorage } from "../storage/artifact-storage.js";
+
+const HASH = "a".repeat(64);
+const DATA = new TextEncoder().encode("zip bytes");
+
+let dir: string;
+let storage: LocalFileStorage;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "skill-artifact-test-"));
+  storage = new LocalFileStorage(dir);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("LocalFileStorage", () => {
+  it("stores under skills/{hash}.zip — a LITERAL forward-slash key on every platform — and round-trips the bytes", async () => {
+    const key = await storage.store(HASH, DATA);
+    expect(key).toBe(`skills/${HASH}.zip`);
+    expect(await storage.get(key)).toEqual(Buffer.from(DATA));
+  });
+
+  it("writes artifacts owner-only (0600) under a 0755 directory", async () => {
+    const key = await storage.store(HASH, DATA);
+    const mode = statSync(path.join(dir, key)).mode & 0o777;
+    expect(mode).toBe(0o600);
+    const dirMode = statSync(path.join(dir, "skills")).mode & 0o777;
+    expect(dirMode).toBe(0o755);
+  });
+
+  it("reports existence by hash for dedupe", async () => {
+    expect(await storage.exists(HASH)).toBe(false);
+    await storage.store(HASH, DATA);
+    expect(await storage.exists(HASH)).toBe(true);
+  });
+
+  it("stats size without loading", async () => {
+    const key = await storage.store(HASH, DATA);
+    expect(await storage.size(key)).toBe(DATA.length);
+  });
+
+  it("answers not-found for a missing key", async () => {
+    await expect(storage.get("skills/missing.zip")).rejects.toThrow(
+      new ArtifactNotFoundError("skills/missing.zip").message,
+    );
+    await expect(storage.size("skills/missing.zip")).rejects.toThrow(
+      "artifact not found: skills/missing.zip",
+    );
+  });
+
+  it("treats traversal keys as missing artifacts, never reading escaped paths", async () => {
+    for (const key of ["../../etc/passwd", "skills/../../secret", "/etc/passwd"]) {
+      await expect(storage.get(key)).rejects.toThrow(`artifact not found: ${key}`);
+      await expect(storage.size(key)).rejects.toThrow(`artifact not found: ${key}`);
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/frontmatter.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/frontmatter.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Pins frontmatter parsing against Go's frontmatter_test.go table: the
+ * delimiter rules, required-name enforcement, and the kebab-case /
+ * dot-scoped name pattern. Error copy is wire-visible teaching text — the
+ * assertions check the load-bearing first lines.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseFrontmatter } from "../storage/frontmatter.js";
+
+function skillMd(frontmatter: string, body = "# Title"): string {
+  return `---\n${frontmatter}\n---\n${body}`;
+}
+
+describe("parseFrontmatter", () => {
+  it("parses name, description, and version", () => {
+    const fm = parseFrontmatter(
+      skillMd("name: web-scraper\ndescription: Scrapes pages\nversion: 1.0.0"),
+    );
+    expect(fm).toEqual({
+      name: "web-scraper",
+      description: "Scrapes pages",
+      version: "1.0.0",
+    });
+  });
+
+  it("accepts dot-scoped namespace names", () => {
+    expect(
+      parseFrontmatter(skillMd("name: platform.planton-architecture")).name,
+    ).toBe("platform.planton-architecture");
+  });
+
+  it("defaults description and version to empty", () => {
+    const fm = parseFrontmatter(skillMd("name: calculator"));
+    expect(fm.description).toBe("");
+    expect(fm.version).toBe("");
+  });
+
+  it("rejects empty content", () => {
+    expect(() => parseFrontmatter("")).toThrow("SKILL.md is empty");
+  });
+
+  it("rejects content that does not start with ---", () => {
+    expect(() => parseFrontmatter("# No frontmatter")).toThrow(
+      "SKILL.md must start with YAML frontmatter (---)",
+    );
+  });
+
+  it("rejects unclosed frontmatter", () => {
+    expect(() => parseFrontmatter("---\nname: x")).toThrow(
+      "SKILL.md frontmatter is not closed (missing closing ---)",
+    );
+  });
+
+  it("rejects empty frontmatter", () => {
+    expect(() => parseFrontmatter("---\n---\n# Body")).toThrow(
+      "SKILL.md has empty frontmatter",
+    );
+  });
+
+  it("rejects a missing name field", () => {
+    expect(() => parseFrontmatter(skillMd("description: no name here"))).toThrow(
+      "SKILL.md is missing required 'name' field in YAML frontmatter",
+    );
+  });
+
+  it("rejects malformed YAML", () => {
+    expect(() => parseFrontmatter(skillMd("name: [unclosed"))).toThrow(
+      "failed to parse YAML frontmatter",
+    );
+  });
+
+  it("rejects duplicated mapping keys (yaml.v3 and js-yaml both refuse)", () => {
+    expect(() => parseFrontmatter(skillMd("name: a\nname: b"))).toThrow(
+      "failed to parse YAML frontmatter",
+    );
+  });
+
+  it("rejects a BOM'd first line — Go's TrimSpace does not strip U+FEFF (#8 parity review)", () => {
+    expect(() => parseFrontmatter(`\uFEFF${skillMd("name: bom-skill")}`)).toThrow(
+      "SKILL.md must start with YAML frontmatter (---)",
+    );
+  });
+
+  it("accepts Unicode-whitespace-padded delimiters — Go trims the full White_Space set", () => {
+    // U+2000 (en quad) is White_Space: Go's TrimSpace reduces the line to
+    // "---" and accepts the file; the port must agree.
+    const fm = parseFrontmatter(`\u2000---\u2000\nname: padded-skill\n\u3000---\n# Body`);
+    expect(fm.name).toBe("padded-skill");
+  });
+
+  it("reports a first line over the 64KB scanner cap as empty — Go's !Scan() arm, bug-for-bug", () => {
+    const longFirstLine = "x".repeat(64 * 1024 + 1);
+    expect(() => parseFrontmatter(`${longFirstLine}\n---\nname: a\n---`)).toThrow(
+      "SKILL.md is empty",
+    );
+  });
+
+  it("reports an over-cap line INSIDE the frontmatter as the scanner error, beating 'not closed'", () => {
+    const longLine = `description: ${"y".repeat(64 * 1024)}`;
+    expect(() => parseFrontmatter(`---\nname: a\n${longLine}\n---`)).toThrow(
+      "error reading SKILL.md content: bufio.Scanner: token too long",
+    );
+  });
+
+  const badNames = [
+    "Web-Scraper", // uppercase
+    "web scraper", // space
+    "-leading", // leading separator
+    "trailing-", // trailing separator
+    "double--hyphen", // consecutive separators
+    "dot..dot", // consecutive dots
+    ".leading-dot",
+    "trailing-dot.",
+    "under_score",
+  ];
+  for (const name of badNames) {
+    it(`rejects the invalid name ${JSON.stringify(name)}`, () => {
+      expect(() => parseFrontmatter(skillMd(`name: ${JSON.stringify(name)}`))).toThrow(
+        `invalid skill name '${name}' in SKILL.md`,
+      );
+    });
+  }
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/prefilter.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/prefilter.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Pins the safearchive-parity pre-filter (DD-001) against the behaviors
+ * read from safearchive's source at the go.mod-pinned version: sanitizer
+ * tests (sanitizer_nix_test.go), applyMagic's skip/shadow order, and the
+ * archive/zip mode-decode rules. Fixtures are byte-crafted with the shared
+ * builder so entry attributes are exactly what a real archive carries.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseZipStructure } from "@stigmer/zip-structure";
+import { buildZip } from "@stigmer/zip-structure/testing";
+
+import {
+  applyEntryPrefilter,
+  entryTypeBits,
+  hasWindowsShortFilenames,
+  sanitizePath,
+} from "../storage/prefilter.js";
+
+// versionMadeBy high byte 3 = Unix creator; POSIX mode rides the attribute
+// high 16 bits (how zip writers encode symlinks and special files).
+const UNIX_CREATOR = 0x0314;
+const symlinkAttrs = (0o120777 << 16) >>> 0;
+const charDeviceAttrs = (0o020644 << 16) >>> 0;
+const fifoAttrs = (0o010644 << 16) >>> 0;
+const regularAttrs = (0o100644 << 16) >>> 0;
+
+describe("sanitizePath (safearchive sanitizer.SanitizePath)", () => {
+  // Table from sanitizer_nix_test.go plus the arms the gate leans on.
+  const cases: Array<[string, string]> = [
+    ["some/thing", "some/thing"],
+    ["../../some/thing", "some/thing"],
+    ["..\\..\\some\\thing", "some/thing"],
+    ["/rooted/path", "rooted/path"],
+    ["../SKILL.md", "SKILL.md"],
+    ["a/../b", "b"],
+    ["a//b", "a/b"],
+    ["a/./b", "a/b"],
+    ["..", ""],
+    ["/", ""],
+    ["", ""],
+  ];
+  for (const [input, expected] of cases) {
+    it(`sanitizes ${JSON.stringify(input)} to ${JSON.stringify(expected)}`, () => {
+      expect(sanitizePath(input)).toBe(expected);
+    });
+  }
+
+  it("preserves a trailing separator when the result is non-empty", () => {
+    expect(sanitizePath("dir/")).toBe("dir/");
+    expect(sanitizePath("..\\dir\\")).toBe("dir/");
+    expect(sanitizePath("/")).toBe("");
+  });
+});
+
+describe("hasWindowsShortFilenames", () => {
+  it("detects 8.3-style markers in any path component", () => {
+    expect(hasWindowsShortFilenames("DOWNLO~1/file.txt")).toBe(true);
+    expect(hasWindowsShortFilenames("dir/FOOOOO~1.JPG")).toBe(true);
+    expect(hasWindowsShortFilenames("dir\\1(3)~1.PNG")).toBe(true);
+  });
+
+  it("passes ordinary names, including tildes without digits", () => {
+    expect(hasWindowsShortFilenames("references/schema.md")).toBe(false);
+    expect(hasWindowsShortFilenames("notes~draft.md")).toBe(false);
+  });
+});
+
+describe("entryTypeBits (archive/zip FileHeader.Mode decode)", () => {
+  function entryWith(versionMadeBy: number, externalAttributes: number) {
+    const zip = buildZip([
+      { name: "x", content: "x", versionMadeBy, externalAttributes },
+    ]);
+    return parseZipStructure(zip)[0]!;
+  }
+
+  it("decodes Unix symlink and special-file types", () => {
+    expect(entryTypeBits(entryWith(UNIX_CREATOR, symlinkAttrs))).toEqual({
+      isSymlink: true,
+      isSpecial: false,
+    });
+    expect(entryTypeBits(entryWith(UNIX_CREATOR, charDeviceAttrs))).toEqual({
+      isSymlink: false,
+      isSpecial: true,
+    });
+    expect(entryTypeBits(entryWith(UNIX_CREATOR, fifoAttrs))).toEqual({
+      isSymlink: false,
+      isSpecial: true,
+    });
+    expect(entryTypeBits(entryWith(UNIX_CREATOR, regularAttrs))).toEqual({
+      isSymlink: false,
+      isSpecial: false,
+    });
+  });
+
+  it("never decodes symlink/special for FAT creators — MSDOS attrs cannot express them", () => {
+    // The same attribute BITS under a FAT creator (versionMadeBy 20) are
+    // FAT attributes, not a POSIX mode.
+    expect(entryTypeBits(entryWith(20, symlinkAttrs))).toEqual({
+      isSymlink: false,
+      isSpecial: false,
+    });
+  });
+});
+
+describe("applyEntryPrefilter (safearchive applyMagic)", () => {
+  it("sanitizes names — a traversal-shaped SKILL.md becomes root SKILL.md", () => {
+    const zip = buildZip([{ name: "../SKILL.md", content: "# via traversal" }]);
+    const filtered = applyEntryPrefilter(parseZipStructure(zip));
+    expect(filtered.map((f) => f.name)).toEqual(["SKILL.md"]);
+  });
+
+  it("drops entries with Windows 8.3-style components", () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: "# ok" },
+      { name: "DOWNLO~1/asset.png", content: "x" },
+    ]);
+    const filtered = applyEntryPrefilter(parseZipStructure(zip));
+    expect(filtered.map((f) => f.name)).toEqual(["SKILL.md"]);
+  });
+
+  it("drops entries shadowed by an earlier symlink, case-insensitively; the symlink entry itself stays", () => {
+    const zip = buildZip([
+      {
+        name: "Link",
+        content: "target",
+        versionMadeBy: UNIX_CREATOR,
+        externalAttributes: symlinkAttrs,
+      },
+      { name: "link/inside.txt", content: "smuggled" },
+      { name: "safe/file.txt", content: "ok" },
+    ]);
+    const filtered = applyEntryPrefilter(parseZipStructure(zip));
+    expect(filtered.map((f) => f.name)).toEqual(["Link", "safe/file.txt"]);
+  });
+
+  it("drops special-file entries (devices, pipes)", () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: "# ok" },
+      {
+        name: "dev-node",
+        content: "",
+        versionMadeBy: UNIX_CREATOR,
+        externalAttributes: charDeviceAttrs,
+      },
+    ]);
+    const filtered = applyEntryPrefilter(parseZipStructure(zip));
+    expect(filtered.map((f) => f.name)).toEqual(["SKILL.md"]);
+  });
+
+  it("keeps regular Unix-creator entries untouched", () => {
+    const zip = buildZip([
+      {
+        name: "SKILL.md",
+        content: "# ok",
+        versionMadeBy: UNIX_CREATOR,
+        externalAttributes: regularAttrs,
+      },
+    ]);
+    const filtered = applyEntryPrefilter(parseZipStructure(zip));
+    expect(filtered.map((f) => f.name)).toEqual(["SKILL.md"]);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/push-degradation.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/push-degradation.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Pins ArchiveCurrentSkill's safe-degradation arms (Go push_test.go's
+ * failing-store cases) at step level — the composed suite cannot make the
+ * real store fail selectively:
+ *
+ *   - archive (saveAudit) failure clears status.version_hash AND
+ *     metadata.version.id — the persisted head never references an
+ *     unresolvable audit entry; the push itself still succeeds;
+ *   - tag assignment (setAuditTag) failure clears the live spec.tag — the
+ *     head never advertises a tag the audit column cannot resolve;
+ *   - an UNEXPECTED repoint-lookup failure degrades to archiving anyway (a
+ *     possible duplicate row beats a failed push);
+ *   - already-archived content repoints: saveAudit is never called, the
+ *     tag assignment still runs (re-pushing under a new tag is skills'
+ *     only retag path).
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { PushSkillRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { AuditNotFoundError } from "../../../store/interface.js";
+import type { Store } from "../../../store/interface.js";
+import { SKILL_KEY, newArchiveCurrentSkillStep } from "../push.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const HASH = "b".repeat(64);
+
+interface FakeAuditStore {
+  getAuditByHashError: Error | undefined;
+  saveAuditError: Error | undefined;
+  setAuditTagError: Error | undefined;
+  saveAuditCalls: number;
+  setAuditTagCalls: Array<{ versionHash: string; tag: string }>;
+}
+
+/** A store exposing ONLY the members the step touches; the cast is the seam. */
+function fakeStore(overrides?: Partial<FakeAuditStore>): { store: Store; state: FakeAuditStore } {
+  const state: FakeAuditStore = {
+    getAuditByHashError: new AuditNotFoundError("not archived"),
+    saveAuditError: undefined,
+    setAuditTagError: undefined,
+    saveAuditCalls: 0,
+    setAuditTagCalls: [],
+    ...overrides,
+  };
+  const store = {
+    async getAuditByHash(): Promise<never> {
+      if (state.getAuditByHashError !== undefined) {
+        throw state.getAuditByHashError;
+      }
+      return undefined as never; // "found" — repoint path
+    },
+    async saveAudit(): Promise<void> {
+      state.saveAuditCalls += 1;
+      if (state.saveAuditError !== undefined) {
+        throw state.saveAuditError;
+      }
+    },
+    async setAuditTag(_k: unknown, _r: unknown, versionHash: string, tag: string): Promise<void> {
+      state.setAuditTagCalls.push({ versionHash, tag });
+      if (state.setAuditTagError !== undefined) {
+        throw state.setAuditTagError;
+      }
+    },
+  } as unknown as Store;
+  return { store, state };
+}
+
+function contextWithSkill(tag: string) {
+  const ctx = new RequestContext(
+    PushSkillRequestSchema,
+    create(PushSkillRequestSchema, {}),
+    ApiResourceKind.skill,
+  );
+  const skill = create(SkillSchema, {
+    metadata: { id: "skl_test", org: "acme", version: { id: HASH } },
+    spec: { tag },
+    status: { versionHash: HASH },
+  });
+  ctx.set(SKILL_KEY, skill);
+  return { ctx, skill };
+}
+
+describe("ArchiveCurrentSkill — safe degradation", () => {
+  it("archive failure clears the version hash and version id; the step does not throw", async () => {
+    const { store } = fakeStore({ saveAuditError: new Error("disk full") });
+    const { ctx, skill } = contextWithSkill("stable");
+
+    await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
+
+    expect(skill.status?.versionHash).toBe("");
+    expect(skill.metadata?.version?.id).toBe("");
+    // The tag assignment never ran — there is no archived row to hold it.
+    expect(skill.spec?.tag).toBe("stable");
+  });
+
+  it("tag-assignment failure clears the live spec.tag; the archived row stands", async () => {
+    const { store, state } = fakeStore({ setAuditTagError: new Error("tag column locked") });
+    const { ctx, skill } = contextWithSkill("stable");
+
+    await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
+
+    expect(state.saveAuditCalls).toBe(1);
+    expect(skill.spec?.tag).toBe("");
+    expect(skill.status?.versionHash).toBe(HASH);
+  });
+
+  it("an unexpected repoint-lookup failure degrades to archiving anyway", async () => {
+    const { store, state } = fakeStore({
+      getAuditByHashError: new Error("io error, not AuditNotFound"),
+    });
+    const { ctx, skill } = contextWithSkill("");
+
+    await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
+
+    expect(state.saveAuditCalls).toBe(1);
+    expect(skill.status?.versionHash).toBe(HASH);
+  });
+
+  it("already-archived content repoints without a new row; the tag still moves", async () => {
+    const { store, state } = fakeStore({ getAuditByHashError: undefined });
+    const { ctx } = contextWithSkill("stable");
+
+    await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
+
+    expect(state.saveAuditCalls).toBe(0);
+    expect(state.setAuditTagCalls).toEqual([{ versionHash: HASH, tag: "stable" }]);
+  });
+
+  it("a skill with no version hash is a no-op (nothing to archive)", async () => {
+    const { store, state } = fakeStore();
+    const ctx = new RequestContext(
+      PushSkillRequestSchema,
+      create(PushSkillRequestSchema, {}),
+      ApiResourceKind.skill,
+    );
+    ctx.set(
+      SKILL_KEY,
+      create(SkillSchema, { metadata: { id: "skl_x" }, spec: {}, status: {} }),
+    );
+
+    await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
+    expect(state.saveAuditCalls).toBe(0);
+    expect(state.setAuditTagCalls).toEqual([]);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/skill.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/skill.test.ts
@@ -1,0 +1,596 @@
+/**
+ * Pins the skill domain against Go's skill_controller_test.go +
+ * push_test.go + versioning_repoint_test.go + transfer_lane_test.go +
+ * get_artifact_test.go — through the REAL stack: a composed server on an
+ * ephemeral port, a native gRPC client, the full interceptor chain, and
+ * plain fetch against the HTTP transfer lane.
+ *
+ * The load-bearing pins the conformance suite CANNOT cover (needs direct
+ * store access): repoint-never-duplicate row counts, the single-holder tag
+ * column, audit-slot preservation across pushes (#540), and delete's
+ * archive cleanup.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import http2 from "node:http2";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { buildZip } from "@stigmer/zip-structure/testing";
+import { SkillCommandController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/command_pb";
+import { SkillQueryController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/query_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const ORG = "acme";
+
+type CommandClient = Client<typeof SkillCommandController>;
+type QueryClient = Client<typeof SkillQueryController>;
+
+let server: ComposedServer;
+let command: CommandClient;
+let query: QueryClient;
+let baseUrl: string;
+let dir: string;
+
+/**
+ * Reserves a free port the way the CLI/conformance harness does: the
+ * transfer lane mints capability URLs from CONFIG (base defaults to
+ * http://localhost:{grpcPort}), so the server must boot with GRPC_PORT set
+ * to its real port — a portOverride would leave minted URLs pointing at
+ * the config default.
+ */
+async function reserveFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address() as net.AddressInfo;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "skill-domain-test-"));
+  const grpcPort = await reserveFreePort();
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      GRPC_PORT: String(grpcPort),
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      STORAGE_PATH: path.join(dir, "storage"),
+    }),
+    logger: silentLogger,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  baseUrl = `http://127.0.0.1:${port}`;
+  const transport: Transport = createGrpcTransport({ baseUrl });
+  command = createClient(SkillCommandController, transport);
+  query = createClient(SkillQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let nameCounter = 0;
+function uniqueName(): string {
+  nameCounter += 1;
+  return `test-skill-${nameCounter}`;
+}
+
+function makeArtifact(name: string, extra?: { body?: string; file?: string }): Uint8Array {
+  return buildZip([
+    {
+      name: "SKILL.md",
+      content: `---\nname: ${name}\ndescription: composed-server test skill\n---\n${extra?.body ?? "# Skill body"}`,
+    },
+    { name: extra?.file ?? "references/data.md", content: "supporting file" },
+  ]);
+}
+
+/** PUT over cleartext HTTP/2 (h2c with prior knowledge — the demux's h2 lane). */
+function h2Put(url: string, body: Buffer): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const session = http2.connect(target.origin);
+    session.on("error", reject);
+    const stream = session.request({
+      ":method": "PUT",
+      ":path": target.pathname,
+      "content-type": "application/zip",
+    });
+    stream.on("error", reject);
+    stream.on("response", (headers) => {
+      const status = Number(headers[":status"]);
+      stream.resume();
+      stream.on("end", () => {
+        session.close();
+        resolve(status);
+      });
+    });
+    stream.end(body);
+  });
+}
+
+async function expectCode(promise: Promise<unknown>, code: Code, arm: string): Promise<ConnectError> {
+  try {
+    await promise;
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(connectError.code, `${arm}: expected ${Code[code]}, got ${Code[connectError.code]} (${connectError.rawMessage})`).toBe(code);
+    return connectError;
+  }
+  throw new Error(`${arm}: expected a ${Code[code]} error, got success`);
+}
+
+describe("push — identity and versioning", () => {
+  it("creates a skill with frontmatter-derived identity and content-addressed status", async () => {
+    const name = uniqueName();
+    const skill = await command.push({ org: ORG, artifact: makeArtifact(name) });
+
+    expect(skill.metadata?.id).toMatch(/^skl_[0-9a-z]{26}$/);
+    expect(skill.metadata?.name).toBe(name);
+    expect(skill.metadata?.slug).toBe(name);
+    expect(skill.metadata?.org).toBe(ORG);
+    // Skill is a blueprint kind: default visibility is org (proto config).
+    expect(skill.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+    expect(skill.spec?.name).toBe(name);
+    expect(skill.spec?.description).toBe("composed-server test skill");
+    expect(skill.spec?.skillMd).toContain(`name: ${name}`);
+    expect(skill.status?.versionHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(skill.status?.artifactStorageKey).toBe(`skills/${skill.status?.versionHash}.zip`);
+    expect(skill.metadata?.version?.id).toBe(skill.status?.versionHash);
+    expect(skill.metadata?.version?.previousVersionId).toBe("");
+  });
+
+  it("re-push with the same slug updates in place: same id, chained versions, spec_audit-only stamp (#540)", async () => {
+    const name = uniqueName();
+    const first = await command.push({ org: ORG, artifact: makeArtifact(name) });
+    const second = await command.push({
+      org: ORG,
+      artifact: makeArtifact(name, { body: "# Changed body" }),
+      message: "second push",
+    });
+
+    expect(second.metadata?.id).toBe(first.metadata?.id);
+    expect(second.status?.versionHash).not.toBe(first.status?.versionHash);
+    expect(second.metadata?.version?.previousVersionId).toBe(first.status?.versionHash);
+    expect(second.metadata?.version?.message).toBe("second push");
+    // #540: a push is a definition change — spec_audit re-stamped with the
+    // original creation preserved; status_audit untouched.
+    expect(second.status?.audit?.specAudit?.createdAt).toEqual(
+      first.status?.audit?.specAudit?.createdAt,
+    );
+    expect(second.status?.audit?.statusAudit).toEqual(first.status?.audit?.statusAudit);
+  });
+
+  it("re-pushing identical bytes repoints without a new history row (A→B→A, #475)", async () => {
+    const name = uniqueName();
+    const artifactA = makeArtifact(name, { body: "# A" });
+    const artifactB = makeArtifact(name, { body: "# B" });
+
+    const pushA = await command.push({ org: ORG, artifact: artifactA });
+    await command.push({ org: ORG, artifact: artifactB });
+    const repushA = await command.push({ org: ORG, artifact: artifactA });
+
+    expect(repushA.status?.versionHash).toBe(pushA.status?.versionHash);
+
+    // Exactly TWO history rows — the A re-push repointed, never duplicated.
+    const history = await query.listVersions({ org: ORG, slug: name });
+    expect(history.totalCount).toBe(2);
+    const current = history.versions.filter((v) => v.isCurrent);
+    expect(current).toHaveLength(1);
+    expect(current[0]?.versionHash).toBe(pushA.status?.versionHash);
+    // Direct store proof: two audit rows, not three.
+    expect(
+      await server.store.countAuditEntries(ApiResourceKind.skill, repushA.metadata!.id),
+    ).toBe(2);
+  });
+
+  it("a tag is a single-holder: re-tagging content moves the tag off its prior holder", async () => {
+    const name = uniqueName();
+    await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# A" }), tag: "stable" });
+    await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# B" }), tag: "stable" });
+
+    const history = await query.listVersions({ org: ORG, slug: name });
+    const tagged = history.versions.filter((v) => v.tag === "stable");
+    expect(tagged).toHaveLength(1);
+    expect(tagged[0]?.isCurrent).toBe(true);
+  });
+
+  it("push into a different org creates an independent skill under the same slug", async () => {
+    const name = uniqueName();
+    const inAcme = await command.push({ org: ORG, artifact: makeArtifact(name) });
+    const inOther = await command.push({ org: "other-org", artifact: makeArtifact(name) });
+    expect(inOther.metadata?.id).not.toBe(inAcme.metadata?.id);
+    expect(inOther.metadata?.org).toBe("other-org");
+  });
+});
+
+describe("get / getByReference — the version ladder", () => {
+  it("gets by id and answers NotFound for unknown ids", async () => {
+    const pushed = await command.push({ org: ORG, artifact: makeArtifact(uniqueName()) });
+    const got = await query.get({ value: pushed.metadata!.id });
+    expect(got.metadata?.id).toBe(pushed.metadata?.id);
+    await expectCode(query.get({ value: "skl_missing" }), Code.NotFound, "get unknown id");
+  });
+
+  it("resolves empty and 'latest' to the live head", async () => {
+    const name = uniqueName();
+    await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# v1" }) });
+    const head = await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# v2" }) });
+
+    for (const version of ["", "latest"]) {
+      const got = await query.getByReference({ org: ORG, slug: name, version });
+      expect(got.status?.versionHash).toBe(head.status?.versionHash);
+    }
+  });
+
+  it("resolves an archived version by its 64-hex hash", async () => {
+    const name = uniqueName();
+    const v1 = await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# v1" }) });
+    await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# v2" }) });
+
+    const got = await query.getByReference({
+      org: ORG,
+      slug: name,
+      version: v1.status!.versionHash,
+    });
+    expect(got.status?.versionHash).toBe(v1.status?.versionHash);
+    expect(got.spec?.skillMd).toContain("# v1");
+  });
+
+  it("resolves a tag on the live head and on archived versions", async () => {
+    const name = uniqueName();
+    const v1 = await command.push({
+      org: ORG,
+      artifact: makeArtifact(name, { body: "# v1" }),
+      tag: "v1",
+    });
+    const v2 = await command.push({
+      org: ORG,
+      artifact: makeArtifact(name, { body: "# v2" }),
+      tag: "v2",
+    });
+
+    const byLiveTag = await query.getByReference({ org: ORG, slug: name, version: "v2" });
+    expect(byLiveTag.status?.versionHash).toBe(v2.status?.versionHash);
+    const byArchivedTag = await query.getByReference({ org: ORG, slug: name, version: "v1" });
+    expect(byArchivedTag.status?.versionHash).toBe(v1.status?.versionHash);
+  });
+
+  it("answers NotFound for an unknown version and an unknown slug", async () => {
+    const name = uniqueName();
+    await command.push({ org: ORG, artifact: makeArtifact(name) });
+    const versionError = await expectCode(
+      query.getByReference({ org: ORG, slug: name, version: "no-such-tag" }),
+      Code.NotFound,
+      "unknown version",
+    );
+    expect(versionError.rawMessage).toBe(`skill version not found: ${name}:no-such-tag`);
+    await expectCode(
+      query.getByReference({ org: ORG, slug: "no-such-skill" }),
+      Code.NotFound,
+      "unknown slug",
+    );
+  });
+
+  it("rejects an org-less reference (org-scoped kind) and a kind mismatch", async () => {
+    const orgError = await expectCode(
+      query.getByReference({ slug: "anything" }),
+      Code.InvalidArgument,
+      "org-less reference",
+    );
+    // The kind's proto meta name ("Skill"), exactly Go's meta.GetName().
+    expect(orgError.rawMessage).toBe("org is required for Skill lookup");
+    const kindError = await expectCode(
+      query.getByReference({ org: ORG, slug: "anything", kind: ApiResourceKind.agent }),
+      Code.InvalidArgument,
+      "kind mismatch",
+    );
+    expect(kindError.rawMessage).toBe("kind mismatch: expected skill, got agent");
+  });
+});
+
+describe("listVersions — pagination", () => {
+  it("pages newest-first with base64 cursors and a stable total", async () => {
+    const name = uniqueName();
+    for (const body of ["# 1", "# 2", "# 3"]) {
+      await command.push({ org: ORG, artifact: makeArtifact(name, { body }) });
+    }
+
+    const page1 = await query.listVersions({ org: ORG, slug: name, pageSize: 2 });
+    expect(page1.totalCount).toBe(3);
+    expect(page1.versions).toHaveLength(2);
+    expect(page1.nextPageToken).not.toBe("");
+
+    const page2 = await query.listVersions({
+      org: ORG,
+      slug: name,
+      pageSize: 2,
+      pageToken: page1.nextPageToken,
+    });
+    expect(page2.versions).toHaveLength(1);
+    expect(page2.nextPageToken).toBe("");
+
+    const hashes = [...page1.versions, ...page2.versions].map((v) => v.versionHash);
+    expect(new Set(hashes).size).toBe(3);
+  });
+
+  it("rejects malformed page tokens", async () => {
+    const name = uniqueName();
+    await command.push({ org: ORG, artifact: makeArtifact(name) });
+    for (const pageToken of ["!!!not-base64!!!", Buffer.from("garbage").toString("base64")]) {
+      const err = await expectCode(
+        query.listVersions({ org: ORG, slug: name, pageToken }),
+        Code.InvalidArgument,
+        `page token ${pageToken}`,
+      );
+      expect(err.rawMessage).toBe("invalid page_token");
+    }
+  });
+
+  it("answers NotFound for an unknown slug, naming the org", async () => {
+    const err = await expectCode(
+      query.listVersions({ org: ORG, slug: "never-pushed" }),
+      Code.NotFound,
+      "listVersions unknown slug",
+    );
+    expect(err.rawMessage).toBe(`skill not found: never-pushed (org: ${ORG})`);
+  });
+});
+
+describe("getArtifact — capability-key reads", () => {
+  it("returns the pushed ZIP verbatim", async () => {
+    const artifact = makeArtifact(uniqueName());
+    const pushed = await command.push({ org: ORG, artifact });
+    const got = await query.getArtifact({
+      artifactStorageKey: pushed.status!.artifactStorageKey,
+    });
+    expect(Buffer.from(got.artifact).equals(Buffer.from(artifact))).toBe(true);
+  });
+
+  it("answers NotFound for unknown and traversal-shaped keys", async () => {
+    const missing = await expectCode(
+      query.getArtifact({ artifactStorageKey: "skills/deadbeef.zip" }),
+      Code.NotFound,
+      "unknown key",
+    );
+    expect(missing.rawMessage).toBe("skill artifact not found: skills/deadbeef.zip");
+    await expectCode(
+      query.getArtifact({ artifactStorageKey: "../../etc/passwd" }),
+      Code.NotFound,
+      "traversal key",
+    );
+  });
+});
+
+describe("transfer lane (#675) — mint → PUT → push-by-ref → download", () => {
+  it("round-trips bytes and identity exactly like an inline push", async () => {
+    const name = uniqueName();
+    const artifact = makeArtifact(name);
+
+    const minted = await command.createArtifactUploadUrl({
+      org: ORG,
+      sizeBytes: BigInt(artifact.length),
+    });
+    expect(minted.url).toMatch(/^http:\/\//);
+    expect(minted.artifactUploadRef).toMatch(/^sau_/);
+    expect(minted.ttlSeconds).toBe(900);
+
+    const put = await fetch(minted.url, {
+      method: "PUT",
+      body: Buffer.from(artifact),
+      headers: { "content-type": "application/zip" },
+    });
+    expect(put.status).toBe(204);
+
+    const pushed = await command.push({ org: ORG, artifactUploadRef: minted.artifactUploadRef });
+    expect(pushed.metadata?.name).toBe(name);
+
+    const stored = await query.getArtifact({
+      artifactStorageKey: pushed.status!.artifactStorageKey,
+    });
+    expect(Buffer.from(stored.artifact).equals(Buffer.from(artifact))).toBe(true);
+  });
+
+  it("rejects a replayed upload ref (single-use) with the re-mint hint", async () => {
+    const artifact = makeArtifact(uniqueName());
+    const minted = await command.createArtifactUploadUrl({
+      org: ORG,
+      sizeBytes: BigInt(artifact.length),
+    });
+    await fetch(minted.url, { method: "PUT", body: Buffer.from(artifact) });
+    await command.push({ org: ORG, artifactUploadRef: minted.artifactUploadRef });
+
+    const err = await expectCode(
+      command.push({ org: ORG, artifactUploadRef: minted.artifactUploadRef }),
+      Code.InvalidArgument,
+      "replayed ref",
+    );
+    expect(err.rawMessage).toBe(
+      "artifact_upload_ref not usable: upload reference unknown or expired — request a new upload URL via createArtifactUploadUrl",
+    );
+  });
+
+  it("a ref whose slot was minted but never uploaded is rejected at push", async () => {
+    const minted = await command.createArtifactUploadUrl({ org: ORG, sizeBytes: 1024n });
+    const err = await expectCode(
+      command.push({ org: ORG, artifactUploadRef: minted.artifactUploadRef }),
+      Code.InvalidArgument,
+      "empty slot",
+    );
+    expect(err.rawMessage).toBe(
+      "artifact_upload_ref not usable: upload reference has no uploaded bytes — request a new upload URL via createArtifactUploadUrl",
+    );
+  });
+
+  it("mint refuses an over-limit declaration BEFORE any bytes move, naming the limit", async () => {
+    const err = await expectCode(
+      command.createArtifactUploadUrl({ org: ORG, sizeBytes: BigInt(101 * 1024 * 1024) }),
+      Code.InvalidArgument,
+      "over-limit mint",
+    );
+    expect(err.rawMessage).toBe(
+      "skill artifact size 105906176 bytes exceeds the 104857600-byte (100MB) skill limit",
+    );
+  });
+
+  it("HTTP lane arms: unknown ref 404, size mismatch 400, replay 409, wrong methods 405", async () => {
+    expect((await fetch(`${baseUrl}/v1/skill-artifacts/uploads/sau_unknown`, { method: "PUT", body: "x" })).status).toBe(404);
+
+    const minted = await command.createArtifactUploadUrl({ org: ORG, sizeBytes: 10n });
+    const short = await fetch(minted.url, { method: "PUT", body: "short" });
+    expect(short.status).toBe(400);
+    expect(await short.text()).toContain("upload size mismatch: received 5 bytes, declared 10");
+
+    const artifact = makeArtifact(uniqueName());
+    const minted2 = await command.createArtifactUploadUrl({ org: ORG, sizeBytes: BigInt(artifact.length) });
+    await fetch(minted2.url, { method: "PUT", body: Buffer.from(artifact) });
+    expect((await fetch(minted2.url, { method: "PUT", body: Buffer.from(artifact) })).status).toBe(409);
+
+    expect((await fetch(minted2.url, { method: "GET" })).status).toBe(405);
+    expect((await fetch(`${baseUrl}/v1/skill-artifacts/skills/x.zip`, { method: "PUT", body: "x" })).status).toBe(405);
+  });
+
+  it("the lane serves BOTH protocol stacks: a PUT and a size-mismatch arm over h2c behave exactly as over HTTP/1.1", async () => {
+    // fetch speaks HTTP/1.1; the demux hands cleartext-HTTP/2 connections
+    // to the http2 server, which runs the SAME lane router — this pins the
+    // Http2ServerRequest/Response half of the LaneHandler contract.
+    const name = uniqueName();
+    const artifact = makeArtifact(name);
+    const minted = await command.createArtifactUploadUrl({
+      org: ORG,
+      sizeBytes: BigInt(artifact.length),
+    });
+    expect(await h2Put(minted.url, Buffer.from(artifact))).toBe(204);
+    const pushed = await command.push({ org: ORG, artifactUploadRef: minted.artifactUploadRef });
+    expect(pushed.metadata?.name).toBe(name);
+
+    const mismatch = await command.createArtifactUploadUrl({ org: ORG, sizeBytes: 10n });
+    expect(await h2Put(mismatch.url, Buffer.from("short"))).toBe(400);
+  });
+
+  it("getArtifactDownloadUrl serves the exact stored bytes over HTTP; download space is skills/-only", async () => {
+    const artifact = makeArtifact(uniqueName());
+    const pushed = await command.push({ org: ORG, artifact });
+
+    const minted = await query.getArtifactDownloadUrl({
+      artifactStorageKey: pushed.status!.artifactStorageKey,
+    });
+    expect(minted.ttlSeconds).toBe(0);
+    expect(minted.sizeBytes).toBe(BigInt(artifact.length));
+
+    const resp = await fetch(minted.url);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toBe("application/zip");
+    expect(new Uint8Array(await resp.arrayBuffer())).toEqual(artifact);
+
+    // Keys outside skills/ never reach the artifact store from this lane.
+    expect((await fetch(`${baseUrl}/v1/skill-artifacts/etc/passwd`)).status).toBe(404);
+
+    await expectCode(
+      query.getArtifactDownloadUrl({ artifactStorageKey: "skills/deadbeef.zip" }),
+      Code.NotFound,
+      "download-url unknown key",
+    );
+  });
+});
+
+describe("updateVisibility", () => {
+  it("flips only metadata.visibility and stamps status_audit", async () => {
+    const pushed = await command.push({ org: ORG, artifact: makeArtifact(uniqueName()) });
+    const updated = await command.updateVisibility({
+      resourceId: pushed.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_private,
+    });
+    expect(updated.metadata?.visibility).toBe(ApiResourceVisibility.visibility_private);
+    expect(updated.spec?.skillMd).toBe(pushed.spec?.skillMd);
+    expect(updated.status?.versionHash).toBe(pushed.status?.versionHash);
+  });
+
+  it("NOT_FOUND wins over level validation (load-before-validate, the cloud-parity ordering)", async () => {
+    // Unknown id + an unsupported level: the load must fail first.
+    await expectCode(
+      command.updateVisibility({
+        resourceId: "skl_missing",
+        visibility: ApiResourceVisibility.visibility_public,
+      }),
+      Code.NotFound,
+      "unknown id with bad level",
+    );
+  });
+});
+
+describe("delete", () => {
+  it("returns the deleted skill and cleans up its version history", async () => {
+    const name = uniqueName();
+    await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# v1" }) });
+    const head = await command.push({ org: ORG, artifact: makeArtifact(name, { body: "# v2" }) });
+    const skillId = head.metadata!.id;
+    expect(await server.store.countAuditEntries(ApiResourceKind.skill, skillId)).toBe(2);
+
+    const deleted = await command.delete({ value: skillId });
+    expect(deleted.metadata?.id).toBe(skillId);
+
+    await expectCode(query.get({ value: skillId }), Code.NotFound, "get after delete");
+    expect(await server.store.countAuditEntries(ApiResourceKind.skill, skillId)).toBe(0);
+  });
+});
+
+describe("pushFromExecutionArtifact — validation surface (happy path is integration-layer per D1)", () => {
+  it("rejects missing required fields — the protovalidate interceptor answers on the wire (both editions run it before the handler's manual arms)", async () => {
+    const cases: Array<[Record<string, string>, string]> = [
+      [
+        { storageKey: "artifacts/aex_x/skill.zip", org: ORG },
+        "execution_id: must be at least 1 characters [string.min_len]",
+      ],
+      [
+        { executionId: "aex_x", org: ORG },
+        "storage_key: must be at least 1 characters [string.min_len]",
+      ],
+      [
+        { executionId: "aex_x", storageKey: "artifacts/aex_x/skill.zip" },
+        "org: value is required [required]",
+      ],
+    ];
+    for (const [request, message] of cases) {
+      const err = await expectCode(
+        command.pushFromExecutionArtifact(request),
+        Code.InvalidArgument,
+        message,
+      );
+      expect(err.rawMessage).toBe(message);
+    }
+  });
+
+  it("rejects a storage key outside the execution's namespace (traversal guard)", async () => {
+    const err = await expectCode(
+      command.pushFromExecutionArtifact({
+        org: ORG,
+        executionId: "aex_example",
+        storageKey: "artifacts/aex_other/skill.zip",
+      }),
+      Code.InvalidArgument,
+      "prefix guard",
+    );
+    expect(err.rawMessage).toBe("storage_key does not belong to this execution");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/slots.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/slots.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Pins the upload-slot registry against Go's slots_test.go: mint bounds,
+ * ref shape, TTL expiry (injected clock), exact-declared-size enforcement
+ * (short AND long bodies), strict single-use consume, staged-file cleanup,
+ * expiry sweep on mint, and the boot-time staging wipe.
+ */
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SizeMismatchError,
+  SlotConsumedError,
+  SlotEmptyError,
+  SlotUnknownError,
+  UploadSlots,
+} from "../transfer/slots.js";
+
+const TTL_MS = 15 * 60 * 1000;
+const MAX_SIZE = 100 * 1024 * 1024;
+
+let dir: string;
+let stagingDir: string;
+let nowMs: number;
+let slots: UploadSlots;
+
+function body(text: string): Readable {
+  return Readable.from([Buffer.from(text)]);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "skill-slots-test-"));
+  stagingDir = path.join(dir, "skills-staging");
+  nowMs = 1_000_000;
+  slots = new UploadSlots(stagingDir, TTL_MS, MAX_SIZE, () => nowMs);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("UploadSlots", () => {
+  it("mints sau_-prefixed 128-bit hex refs with the registry TTL", () => {
+    const { ref, ttlMs } = slots.mint(1024);
+    expect(ref).toMatch(/^sau_[0-9a-f]{32}$/);
+    expect(ttlMs).toBe(TTL_MS);
+  });
+
+  it("rejects out-of-bounds declarations at mint", () => {
+    expect(() => slots.mint(0)).toThrow("declared size 0 outside (0, 104857600]");
+    expect(() => slots.mint(-1)).toThrow(`declared size -1 outside (0, ${MAX_SIZE}]`);
+    expect(() => slots.mint(MAX_SIZE + 1)).toThrow(
+      `declared size ${MAX_SIZE + 1} outside (0, ${MAX_SIZE}]`,
+    );
+  });
+
+  it("round-trips: mint → receive → consume returns the exact bytes and retires the slot", async () => {
+    const { ref } = slots.mint(5);
+    await slots.receive(ref, body("hello"));
+    const data = await slots.consume(ref);
+    expect(Buffer.from(data).toString()).toBe("hello");
+    // Strictly single-use: the slot AND its staged file are gone.
+    await expect(slots.consume(ref)).rejects.toThrow(SlotUnknownError);
+    expect(readdirSync(stagingDir)).toEqual([]);
+  });
+
+  it("rejects receive on an unknown ref", async () => {
+    await expect(slots.receive("sau_nope", body("x"))).rejects.toThrow(SlotUnknownError);
+  });
+
+  it("rejects receive on an expired ref", async () => {
+    const { ref } = slots.mint(1);
+    nowMs += TTL_MS + 1;
+    await expect(slots.receive(ref, body("x"))).rejects.toThrow(SlotUnknownError);
+  });
+
+  it("rejects a second upload to the same ref", async () => {
+    const { ref } = slots.mint(1);
+    await slots.receive(ref, body("x"));
+    await expect(slots.receive(ref, body("x"))).rejects.toThrow(SlotConsumedError);
+  });
+
+  it("rejects a short body, naming both sizes, and stages nothing", async () => {
+    const { ref } = slots.mint(10);
+    await expect(slots.receive(ref, body("short"))).rejects.toThrow(
+      "upload size mismatch: received 5 bytes, declared 10",
+    );
+    await expect(slots.receive(ref, body("short"))).rejects.toBeInstanceOf(SizeMismatchError);
+    expect(readdirSync(stagingDir)).toEqual([]);
+  });
+
+  it("rejects an over-declaration body without buffering it whole (declared+1 proof)", async () => {
+    const { ref } = slots.mint(3);
+    await expect(slots.receive(ref, body("longer than three"))).rejects.toThrow(
+      "upload size mismatch: received 4 bytes, declared 3",
+    );
+  });
+
+  it("rejects consume on a minted-but-never-uploaded ref", async () => {
+    const { ref } = slots.mint(1);
+    await expect(slots.consume(ref)).rejects.toThrow(SlotEmptyError);
+  });
+
+  it("rejects consume on an expired ref", async () => {
+    const { ref } = slots.mint(1);
+    await slots.receive(ref, body("x"));
+    nowMs += TTL_MS + 1;
+    await expect(slots.consume(ref)).rejects.toThrow(SlotUnknownError);
+  });
+
+  it("sweeps expired slots and their staged files on mint", async () => {
+    const { ref } = slots.mint(1);
+    await slots.receive(ref, body("x"));
+    expect(readdirSync(stagingDir)).toHaveLength(1);
+    nowMs += TTL_MS + 1;
+    slots.mint(1);
+    expect(readdirSync(stagingDir)).toEqual([]);
+  });
+
+  it("wipes the staging directory at construction (orphans are unreachable)", () => {
+    const orphanDir = path.join(dir, "staging-with-orphans");
+    mkdirSync(orphanDir, { recursive: true });
+    const orphan = path.join(orphanDir, "sau_orphan.zip");
+    writeFileSync(orphan, "stale bytes");
+    new UploadSlots(orphanDir, TTL_MS, MAX_SIZE);
+    expect(existsSync(orphan)).toBe(false);
+    expect(readdirSync(orphanDir)).toEqual([]);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/__tests__/zip-gate.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/__tests__/zip-gate.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Pins the ZIP gate against Go's zip_extractor_test.go arms plus the
+ * DD-001 pre-filter integration: every rejection message byte-for-byte
+ * where the text is static, prefix-matched where it embeds sizes.
+ */
+import { deflateRawSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import { buildZip } from "@stigmer/zip-structure/testing";
+
+import { MAX_SKILL_MD_SIZE, MAX_ZIP_SIZE } from "../constants.js";
+import { calculateHash, extractSkillMd } from "../storage/zip-gate.js";
+
+const VALID_SKILL_MD = "---\nname: test-skill\ndescription: A test\n---\n# Test";
+
+function validZip(): Uint8Array {
+  return buildZip([
+    { name: "SKILL.md", content: VALID_SKILL_MD },
+    { name: "references/schema.md", content: "tables" },
+  ]);
+}
+
+describe("extractSkillMd — happy path", () => {
+  it("extracts content, identity, and the content-addressed hash", () => {
+    const zip = validZip();
+    const result = extractSkillMd(zip);
+    expect(result.content).toBe(VALID_SKILL_MD);
+    expect(result.name).toBe("test-skill");
+    expect(result.description).toBe("A test");
+    expect(result.hash).toBe(calculateHash(zip));
+    expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("reads a deflated SKILL.md", () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: VALID_SKILL_MD, method: "deflated" },
+    ]);
+    expect(extractSkillMd(zip).name).toBe("test-skill");
+  });
+
+  it("reads a streaming-style archive (Go zip writer default)", () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: VALID_SKILL_MD, streaming: true },
+    ]);
+    expect(extractSkillMd(zip).name).toBe("test-skill");
+  });
+
+  it("accepts a traversal-named SKILL.md — safearchive sanitizes it to root (DD-001)", () => {
+    const zip = buildZip([{ name: "../SKILL.md", content: VALID_SKILL_MD }]);
+    expect(extractSkillMd(zip).name).toBe("test-skill");
+  });
+});
+
+describe("extractSkillMd — rejection arms (Go validateZipContent order)", () => {
+  it("rejects an over-limit archive before parsing", () => {
+    // A sparse Uint8Array is enough — the size check runs first.
+    const oversized = new Uint8Array(MAX_ZIP_SIZE + 1);
+    expect(() => extractSkillMd(oversized)).toThrow(
+      `ZIP file too large: ${MAX_ZIP_SIZE + 1} bytes (max: ${MAX_ZIP_SIZE})`,
+    );
+  });
+
+  it("rejects non-ZIP bytes with Go's stdlib text", () => {
+    expect(() => extractSkillMd(new TextEncoder().encode("not a zip"))).toThrow(
+      "invalid ZIP file: zip: not a valid zip file",
+    );
+  });
+
+  it("rejects an empty archive", () => {
+    expect(() => extractSkillMd(buildZip([]))).toThrow("ZIP file is empty");
+  });
+
+  it("rejects an archive whose only entries the pre-filter dropped as empty", () => {
+    const zip = buildZip([{ name: "DOWNLO~1/only.txt", content: "x" }]);
+    expect(() => extractSkillMd(zip)).toThrow("ZIP file is empty");
+  });
+
+  it("rejects control characters in entry names", () => {
+    const zip = buildZip([
+      { name: "SKILL.md", content: VALID_SKILL_MD },
+      { name: "bad\u0001name.txt", content: "x" },
+    ]);
+    expect(() => extractSkillMd(zip)).toThrow("invalid character in filename: bad\u0001name.txt");
+  });
+
+  it("rejects a suspicious per-file compression ratio", () => {
+    // Highly compressible: 200KB of zeros deflates far below 2KB.
+    const bomb = new Uint8Array(200 * 1024);
+    const zip = buildZip([
+      { name: "SKILL.md", content: VALID_SKILL_MD },
+      { name: "bomb.bin", content: bomb, method: "deflated" },
+    ]);
+    expect(() => extractSkillMd(zip)).toThrow(/^suspicious compression ratio in bomb\.bin: \d+:1 \(max: 100:1\)$/);
+  });
+
+  it("rejects an over-budget declared-uncompressed total (fail-fast on the crossing entry)", () => {
+    // Two stored entries declaring 300MB each over 3MB payloads: ratio is
+    // exactly 100 (not > 100, passes), and the running total crosses the
+    // 500MB budget on the second entry — the arm under test.
+    const payload = new Uint8Array(3 * 1024 * 1024);
+    const declared = 300 * 1024 * 1024;
+    const zip = buildZip([
+      { name: "SKILL.md", content: VALID_SKILL_MD },
+      { name: "a.bin", content: payload, declaredUncompressedSize: declared },
+      { name: "b.bin", content: payload, declaredUncompressedSize: declared },
+    ]);
+    expect(() => extractSkillMd(zip)).toThrow(
+      /^total uncompressed size too large: \d+ bytes \(max: 524288000\)$/,
+    );
+  });
+
+  it("rejects a missing SKILL.md", () => {
+    const zip = buildZip([{ name: "README.md", content: "no skill here" }]);
+    expect(() => extractSkillMd(zip)).toThrow("SKILL.md not found in ZIP archive");
+  });
+
+  it("rejects a nested-only SKILL.md with the #452 hint", () => {
+    const zip = buildZip([{ name: "my-skill/SKILL.md", content: VALID_SKILL_MD }]);
+    expect(() => extractSkillMd(zip)).toThrow(
+      "SKILL.md must be at the archive root — zip the skill folder's contents, not the folder itself",
+    );
+  });
+
+  it("rejects an empty SKILL.md", () => {
+    const zip = buildZip([{ name: "SKILL.md", content: "" }]);
+    expect(() => extractSkillMd(zip)).toThrow("SKILL.md is empty");
+  });
+
+  it("rejects an over-cap stored SKILL.md", () => {
+    // Stored (no compression) so the ratio check cannot fire first; the
+    // declared total stays under the 500MB budget.
+    const huge = new Uint8Array(MAX_SKILL_MD_SIZE + 1).fill(0x61);
+    const zip = buildZip([{ name: "SKILL.md", content: huge }]);
+    expect(() => extractSkillMd(zip)).toThrow(
+      `SKILL.md too large (max: ${MAX_SKILL_MD_SIZE} bytes)`,
+    );
+  });
+
+  it("rejects a SKILL.md whose ACTUAL inflation exceeds the cap while its declaration lies small", () => {
+    // The declaration-based checks (total budget, ratio) see a small lie;
+    // only bounding the actual inflated output catches it. Incompressible
+    // (seeded-PRNG) content keeps the declared ratio honest-looking.
+    const big = new Uint8Array(2 * 1024 * 1024);
+    let seed = 0x2f6e2b1;
+    for (let i = 0; i < big.length; i++) {
+      seed = (seed * 1103515245 + 12345) >>> 0;
+      big[i] = seed & 0xff;
+    }
+    const zip = buildZip([
+      {
+        name: "SKILL.md",
+        content: big,
+        method: "deflated",
+        declaredUncompressedSize: 20_000,
+      },
+    ]);
+    expect(() => extractSkillMd(zip)).toThrow(
+      `SKILL.md too large (max: ${MAX_SKILL_MD_SIZE} bytes)`,
+    );
+  });
+
+  it("rejects a checksum mismatch with Go's stdlib text", () => {
+    // Corrupt one payload byte after building; the CD's CRC then disagrees
+    // with the stored content.
+    const zip = buildZip([{ name: "SKILL.md", content: VALID_SKILL_MD }]);
+    // Local header (30) + name (8) = payload start for the first entry.
+    const payloadStart = 30 + "SKILL.md".length;
+    zip[payloadStart] = zip[payloadStart]! ^ 0xff;
+    expect(() => extractSkillMd(zip)).toThrow(
+      "failed to read SKILL.md: zip: checksum error",
+    );
+  });
+
+  it("rejects an unsupported compression method with Go's stdlib text", () => {
+    const zip = buildZip([{ name: "SKILL.md", content: VALID_SKILL_MD }]);
+    // Rewrite the method field (bzip2 = 12) in BOTH the local header and
+    // the central directory record.
+    const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+    view.setUint16(8, 12, true); // local header method @ offset 8
+    const eocdPos = zip.length - 22;
+    const cdOffset = view.getUint32(eocdPos + 16, true);
+    view.setUint16(cdOffset + 10, 12, true); // CD method @ +10
+    expect(() => extractSkillMd(zip)).toThrow(
+      "failed to open SKILL.md: zip: unsupported compression algorithm",
+    );
+  });
+
+  it("wraps frontmatter failures with Go's prefix", () => {
+    const zip = buildZip([{ name: "SKILL.md", content: "# no frontmatter" }]);
+    expect(() => extractSkillMd(zip)).toThrow(
+      /^invalid SKILL\.md frontmatter: SKILL\.md must start with YAML frontmatter/,
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/skill/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/constants.ts
@@ -1,0 +1,77 @@
+/**
+ * Skill domain constants — every byte-pinned limit and wire-visible string
+ * in one place (guidelines: errors are API surface; the CLI, console, and
+ * SDK show these verbatim). Values and copy are character-for-character
+ * from pkg/domain/skill/storage/zip_extractor.go, frontmatter.go, and
+ * transfer/slots.go; the #452 hint is additionally byte-identical to the
+ * cloud edition's.
+ */
+
+/**
+ * The compressed-artifact ceiling. Exported because it is the platform's
+ * skill size limit, not just an extraction guard: the transfer lane
+ * (createArtifactUploadUrl) enforces it before any bytes move, and clients
+ * quote it in fail-loud size errors (#675). Go: storage.MaxZipSize.
+ */
+export const MAX_ZIP_SIZE = 100 * 1024 * 1024;
+
+/** Total declared-uncompressed budget across all entries (ZIP-bomb guard). */
+export const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024;
+
+/** Per-file declared compression ratio ceiling (ZIP-bomb guard). */
+export const MAX_COMPRESSION_RATIO = 100;
+
+/** Entry-count ceiling. */
+export const MAX_FILES = 10_000;
+
+/** SKILL.md in-memory extraction cap (memory-exhaustion guard). */
+export const MAX_SKILL_MD_SIZE = 1 * 1024 * 1024;
+
+/**
+ * Upload-slot lifetime — generous enough for a 100MB upload on a slow
+ * link, short enough that abandoned slots don't accumulate. Go:
+ * transfer.DefaultSlotTTL (15 minutes).
+ */
+export const DEFAULT_SLOT_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Random capability-token size: 16 bytes = 128 bits of entropy, matching
+ * the unguessability of the content-hash download keys. Go: refByteLen.
+ */
+export const REF_BYTE_LEN = 16;
+
+/**
+ * Upload-reference prefix — recognizable in logs, never confusable with
+ * artifact storage keys. Go: refPrefix.
+ */
+export const REF_PREFIX = "sau_";
+
+/**
+ * Lane URL space (Go transfer/handler.go): PUT {prefix}/uploads/{ref}
+ * stages bytes; GET {prefix}/{storage_key} serves them. The path prefix
+ * itself lives in transport/constants.ts (SKILL_ARTIFACTS_PATH_PREFIX) —
+ * the lane router owns it.
+ */
+export const UPLOADS_SEGMENT = "/uploads/";
+
+/**
+ * Downloads are restricted to the skill artifact store's own keys
+ * ("skills/<hash>.zip"); everything else under the storage root — should
+ * the two ever share one — stays unreachable from this lane.
+ */
+export const DOWNLOAD_KEY_PREFIX = "skills/";
+
+/**
+ * The #452 nested-only-SKILL.md hint — the "zipped the folder instead of
+ * its contents" mistake. Byte-identical to the cloud edition's copy.
+ */
+export const NESTED_SKILL_MD_HINT =
+  "SKILL.md must be at the archive root — zip the skill folder's contents, not the folder itself";
+
+/**
+ * FailedPrecondition copy for the three lane-dependent surfaces when the
+ * transfer lane was not configured (Go: identical string at all three
+ * sites).
+ */
+export const TRANSFER_LANE_NOT_CONFIGURED =
+  "skill artifact transfer lane is not configured on this server";

--- a/backend/services/stigmer-server-ts/src/domain/skill/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/controller.ts
@@ -1,0 +1,701 @@
+/**
+ * Skill controller — ports pkg/domain/skill/controller (command + query
+ * sides): push-only content-addressed artifacts with the HTTP transfer
+ * lane (#675). Skills are knowledge documents (SKILL.md + supporting
+ * files) pushed as ZIP artifacts; identity derives from the frontmatter,
+ * versions are content-addressed SHA-256 hashes with single-holder tags,
+ * artifacts are write-once and never garbage-collected.
+ *
+ * Wiring mirrors Go's: the store and skill artifact storage are required;
+ * execution artifact storage (pushFromExecutionArtifact) and the transfer
+ * lane (createArtifactUploadUrl / getArtifactDownloadUrl / push-by-ref)
+ * are OPTIONAL modeled states — Go injects them via setters, here they are
+ * optional deps; every absent-surface answer is a deliberate arm, not an
+ * accident.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize/TransformResponse/
+ * SendResponse steps (no multi-tenant auth or response transformation) and
+ * serves artifact bytes itself instead of R2 pre-signed URLs — same
+ * capability-URL trust model, same client semantics.
+ *
+ * Proven by skill.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * the co-located __tests__/ suites.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { SkillCommandController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/command_pb";
+import { SkillQueryController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/query_pb";
+import {
+  GetArtifactResponseSchema,
+  PushSkillRequestSchema,
+  SkillArtifactDownloadUrlSchema,
+  SkillArtifactUploadUrlSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import type {
+  CreateSkillArtifactUploadUrlRequest,
+  GetArtifactRequest,
+  GetArtifactResponse,
+  ListSkillVersionsInput,
+  ListSkillVersionsResponse,
+  PushSkillFromExecutionArtifactRequest,
+  PushSkillRequest,
+  SkillArtifactDownloadUrl,
+  SkillArtifactUploadUrl,
+  SkillId,
+} from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import type {
+  ApiResourceReference,
+  UpdateVisibilityInput,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import {
+  RESOURCE_ID_KEY,
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { newDeleteSearchIndexStep } from "../../pipeline/steps/index-search.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityUpdateStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import { MAX_ZIP_SIZE, TRANSFER_LANE_NOT_CONFIGURED } from "./constants.js";
+import {
+  SKILL_KEY,
+  newArchiveCurrentSkillStep,
+  newBuildInitialSkillStep,
+  newCheckAndStoreArtifactStep,
+  newExtractAndHashArtifactStep,
+  newFindExistingBySlugStep,
+  newGenerateIdIfNeededStep,
+  newIndexSkillSearchStep,
+  newPopulateSkillFieldsStep,
+  newResolveArtifactSourceStep,
+  newResolveSlugForPushStep,
+  newStoreSkillStep,
+} from "./push.js";
+import { skillSearchExtractor } from "./search-extractor.js";
+import { ArtifactNotFoundError } from "./storage/artifact-storage.js";
+import type { SkillArtifactStorage } from "./storage/artifact-storage.js";
+import { downloadUrl, uploadUrl } from "./transfer/handler.js";
+import type { UploadSlots } from "./transfer/slots.js";
+import {
+  LIST_VERSIONS_RESPONSE_KEY,
+  newLoadAndMapVersionsStep,
+  newLoadSkillByReferenceStep,
+  newResolveSkillBySlugStep,
+} from "./version-resolution.js";
+
+/**
+ * Go's PushFromExecutionArtifact download deadline: bounds the artifact
+ * fetch, sized for the cloud edition's remote storage; the OSS local read
+ * finishes far inside it.
+ */
+const EXECUTION_ARTIFACT_DOWNLOAD_TIMEOUT_MS = 60_000;
+
+/** The transfer lane's controller-side pair (Go SetTransferLane). */
+export interface SkillTransferLaneDeps {
+  readonly slots: UploadSlots;
+  /** Externally-reachable base minted into upload and download URLs. */
+  readonly baseUrl: string;
+}
+
+export interface SkillControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly artifactStorage: SkillArtifactStorage;
+  /**
+   * Execution artifact storage for pushFromExecutionArtifact (Go
+   * SetExecutionArtifactStorage). Optional — absent answers Internal
+   * "execution artifact storage not configured".
+   */
+  readonly executionArtifactStorage?: ArtifactStorage;
+  /**
+   * The HTTP transfer lane (Go SetTransferLane). Optional — absent,
+   * createArtifactUploadUrl and getArtifactDownloadUrl answer
+   * FailedPrecondition and push accepts inline bytes only.
+   */
+  readonly transferLane?: SkillTransferLaneDeps;
+}
+
+/** Registers both skill services on the router (routes stage). */
+export function registerSkillServices(
+  router: ConnectRouter,
+  deps: SkillControllerDeps,
+): void {
+  router.service(SkillCommandController, {
+    push: (req, ctx) => push(deps, req, ctx),
+    createArtifactUploadUrl: (req, ctx) => createArtifactUploadUrl(deps, req, ctx),
+    pushFromExecutionArtifact: (req, ctx) => pushFromExecutionArtifact(deps, req, ctx),
+    updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
+    delete: (id, ctx) => deleteSkill(deps, id, ctx),
+  });
+  router.service(SkillQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getArtifact: (req, ctx) => getArtifact(deps, req, ctx),
+    getArtifactDownloadUrl: (req, ctx) => getArtifactDownloadUrl(deps, req, ctx),
+    listVersions: (req, ctx) => listVersions(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Push — the 12-step upsert-by-slug pipeline (push.ts holds the steps and
+ * the versioning discipline). Returns the built skill from context: the
+ * pipeline's message type is the request, so the resource rides SKILL_KEY.
+ */
+async function push(
+  deps: SkillControllerDeps,
+  req: PushSkillRequest,
+  ctx: HandlerContext,
+): Promise<Skill> {
+  const reqCtx = new RequestContext(PushSkillRequestSchema, req, kindOf(ctx));
+  await newPipeline<typeof PushSkillRequestSchema>("skill-push", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveArtifactSourceStep(deps.transferLane?.slots))
+    .addStep(newBuildInitialSkillStep())
+    .addStep(newExtractAndHashArtifactStep())
+    .addStep(newResolveSlugForPushStep())
+    .addStep(newFindExistingBySlugStep(deps.store))
+    .addStep(newGenerateIdIfNeededStep())
+    .addStep(newCheckAndStoreArtifactStep(deps.artifactStorage))
+    .addStep(newPopulateSkillFieldsStep())
+    .addStep(newArchiveCurrentSkillStep(deps.store, deps.logger))
+    .addStep(newStoreSkillStep(deps.store))
+    .addStep(newIndexSkillSearchStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(SKILL_KEY) as Skill;
+}
+
+/**
+ * CreateArtifactUploadUrl — mints a short-lived, single-use HTTP upload
+ * URL for an artifact exceeding the gRPC message cap (#675). The size gate
+ * is the fail-loud half of the contract: an over-limit artifact is refused
+ * with the actual limit in the message BEFORE any bytes move, instead of
+ * surfacing as a transport error mid-upload.
+ */
+async function createArtifactUploadUrl(
+  deps: SkillControllerDeps,
+  req: CreateSkillArtifactUploadUrlRequest,
+  ctx: HandlerContext,
+): Promise<SkillArtifactUploadUrl> {
+  const lane = deps.transferLane;
+  if (lane === undefined) {
+    throw failedPreconditionError(TRANSFER_LANE_NOT_CONFIGURED);
+  }
+
+  const reqCtx = new RequestContext(
+    SkillCommandController.method.createArtifactUploadUrl.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillCommandController.method.createArtifactUploadUrl.input>(
+    "skill-create-artifact-upload-url",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .build()
+    .execute(reqCtx);
+
+  if (req.sizeBytes > BigInt(MAX_ZIP_SIZE)) {
+    throw invalidArgumentError(
+      `skill artifact size ${req.sizeBytes} bytes exceeds the ${MAX_ZIP_SIZE}-byte (100MB) skill limit`,
+    );
+  }
+
+  let minted: { ref: string; ttlMs: number };
+  try {
+    minted = lane.slots.mint(Number(req.sizeBytes));
+  } catch (error) {
+    throw internalError(error, "failed to mint upload reference");
+  }
+
+  return create(SkillArtifactUploadUrlSchema, {
+    url: uploadUrl(lane.baseUrl, minted.ref),
+    artifactUploadRef: minted.ref,
+    ttlSeconds: Math.trunc(minted.ttlMs / 1000),
+  });
+}
+
+/**
+ * PushFromExecutionArtifact — the server-side push: reads a directory
+ * artifact an agent execution produced and delegates to the standard push
+ * pipeline. The storage_key prefix convention is the ownership check: a
+ * key outside artifacts/{execution_id}/ is a traversal attempt.
+ */
+async function pushFromExecutionArtifact(
+  deps: SkillControllerDeps,
+  req: PushSkillFromExecutionArtifactRequest,
+  ctx: HandlerContext,
+): Promise<Skill> {
+  if (deps.executionArtifactStorage === undefined) {
+    deps.logger.error(
+      "Execution artifact storage not configured - cannot push from execution artifact",
+    );
+    throw internalError(
+      new Error("execution artifact storage not configured"),
+      "execution artifact storage not configured",
+    );
+  }
+
+  if (req.executionId === "") {
+    throw invalidArgumentError("execution_id is required");
+  }
+  if (req.storageKey === "") {
+    throw invalidArgumentError("storage_key is required");
+  }
+  if (req.org === "") {
+    throw invalidArgumentError("org is required");
+  }
+
+  const expectedPrefix = `artifacts/${req.executionId}/`;
+  if (!req.storageKey.startsWith(expectedPrefix)) {
+    deps.logger.warn(
+      "Storage key does not belong to execution - potential path traversal attempt",
+      {
+        executionId: req.executionId,
+        storageKey: req.storageKey,
+        expectedPrefix,
+      },
+    );
+    throw invalidArgumentError("storage_key does not belong to this execution");
+  }
+
+  deps.logger.info("Pushing skill from execution artifact", {
+    executionId: req.executionId,
+    storageKey: req.storageKey,
+    org: req.org,
+    tag: req.tag,
+  });
+
+  let data: Uint8Array;
+  try {
+    data = await withTimeout(
+      deps.executionArtifactStorage.download(req.storageKey),
+      EXECUTION_ARTIFACT_DOWNLOAD_TIMEOUT_MS,
+    );
+  } catch (error) {
+    deps.logger.error("Failed to download execution artifact", {
+      executionId: req.executionId,
+      storageKey: req.storageKey,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to download execution artifact");
+  }
+
+  const skill = await push(
+    deps,
+    create(PushSkillRequestSchema, {
+      org: req.org,
+      artifact: data,
+      tag: req.tag,
+    }),
+    ctx,
+  );
+
+  deps.logger.info("Successfully pushed skill from execution artifact", {
+    executionId: req.executionId,
+    storageKey: req.storageKey,
+    skillId: skill.metadata?.id ?? "",
+    skillName: skill.metadata?.name ?? "",
+  });
+
+  return skill;
+}
+
+// ─── updateVisibility ────────────────────────────────────────────────────
+// Go update_visibility.go: a targeted metadata update — only
+// metadata.visibility changes; spec, status, and other metadata fields are
+// untouched. Load runs before level validation so NOT_FOUND wins, as in
+// Cloud.
+// ─────────────────────────────────────────────────────────────────────────
+
+const UPDATE_VISIBILITY_SKILL_KEY = "updateVisibilitySkill";
+
+type UpdateVisibilityDesc =
+  typeof SkillCommandController.method.updateVisibility.input;
+
+async function updateVisibility(
+  deps: SkillControllerDeps,
+  input: UpdateVisibilityInput,
+  ctx: HandlerContext,
+): Promise<Skill> {
+  const reqCtx = new RequestContext(
+    SkillCommandController.method.updateVisibility.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<UpdateVisibilityDesc>("skill-update-visibility", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadSkillForVisibilityUpdateStep(deps.store))
+    .addStep(newValidateVisibilityUpdateStep())
+    .addStep(newSetVisibilityStep())
+    .addStep(newPersistSkillForVisibilityUpdateStep(deps.store))
+    .addStep(newIndexSkillAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(UPDATE_VISIBILITY_SKILL_KEY) as Skill;
+}
+
+/** Loads the skill by resource_id; ANY load failure → NotFound. */
+function newLoadSkillForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "LoadSkillForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const input = ctx.input;
+      let skill: Skill;
+      try {
+        skill = await store.getResource(
+          ctx.apiResourceKind,
+          input.resourceId,
+          SkillSchema,
+        );
+      } catch {
+        throw notFoundError("skill", input.resourceId);
+      }
+      ctx.set(UPDATE_VISIBILITY_SKILL_KEY, skill);
+    },
+  };
+}
+
+/** Sets metadata.visibility and stamps the StatusAudit slot (#540). */
+function newSetVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "SetVisibility",
+    execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
+      const skill = ctx.get(UPDATE_VISIBILITY_SKILL_KEY) as Skill;
+      if (skill.metadata !== undefined) {
+        skill.metadata.visibility = ctx.input.visibility;
+      }
+      setAuditFieldsForUpdate(SkillSchema, skill, "status_audit");
+    },
+  };
+}
+
+/** Persists the visibility change. */
+function newPersistSkillForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "PersistSkillForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const skill = ctx.get(UPDATE_VISIBILITY_SKILL_KEY) as Skill;
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          skill.metadata?.id ?? "",
+          SkillSchema,
+          skill,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to save skill");
+      }
+    },
+  };
+}
+
+/** Re-indexes after the change (visibility is indexed); best-effort. */
+function newIndexSkillAfterVisibilityUpdateStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "IndexSkillAfterVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const skill = ctx.get(UPDATE_VISIBILITY_SKILL_KEY) as Skill;
+      const entry = skillSearchExtractor.getSearchIndexEntry(skill);
+      if (entry === undefined) {
+        logger.warn("IndexSkillAfterVisibilityUpdate: extractor returned nil, skipping", {
+          id: skill.metadata?.id ?? "",
+        });
+        return;
+      }
+      try {
+        await store.upsertSearchIndex(ctx.apiResourceKind, skill.metadata?.id ?? "", entry);
+      } catch (error) {
+        logger.warn("IndexSkillAfterVisibilityUpdate: failed (best-effort)", {
+          id: skill.metadata?.id ?? "",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}
+
+/**
+ * Delete — the 6-step chain; version-history archives are cleaned up
+ * best-effort BEFORE the resource row (no FK cascade in the schema, by
+ * design). Returns the deleted skill for the audit-trail convention.
+ */
+async function deleteSkill(
+  deps: SkillControllerDeps,
+  id: SkillId,
+  ctx: HandlerContext,
+): Promise<Skill> {
+  const reqCtx = new RequestContext(
+    SkillCommandController.method.delete.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillCommandController.method.delete.input>(
+    "skill-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, SkillSchema))
+    .addStep(newDeleteSkillArchivesStep(deps.store, deps.logger))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted skill not found in context"),
+      "deleted skill not found in context",
+    );
+  }
+  return deleted as Skill;
+}
+
+/**
+ * DeleteSkillArchives — best-effort audit cleanup (Go
+ * DeleteSkillArchivesStep): failures log and never block the delete.
+ */
+function newDeleteSkillArchivesStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof SkillCommandController.method.delete.input> {
+  return {
+    name: "DeleteSkillArchives",
+    async execute(
+      ctx: RequestContext<typeof SkillCommandController.method.delete.input>,
+    ): Promise<void> {
+      const resourceId = ctx.get(RESOURCE_ID_KEY);
+      if (typeof resourceId !== "string") {
+        throw new Error(
+          "resource id not found in context (ExtractResourceIdStep must run first)",
+        );
+      }
+      try {
+        const deletedCount = await store.deleteAuditByResourceId(
+          ctx.apiResourceKind,
+          resourceId,
+        );
+        if (deletedCount > 0) {
+          logger.info("Deleted archive records for skill", {
+            skillId: resourceId,
+            count: deletedCount,
+          });
+        }
+      } catch (error) {
+        logger.warn("failed to delete skill archives (best-effort)", {
+          skillId: resourceId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}
+
+/** Get — the standard LoadTarget-by-id pipeline. */
+async function get(
+  deps: SkillControllerDeps,
+  id: SkillId,
+  ctx: HandlerContext,
+): Promise<Skill> {
+  const reqCtx = new RequestContext(
+    SkillQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillQueryController.method.get.input>(
+    "skill-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, SkillSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Skill;
+}
+
+/** GetByReference — slug + org with the version-resolution ladder. */
+async function getByReference(
+  deps: SkillControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<Skill> {
+  const reqCtx = new RequestContext(
+    SkillQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillQueryController.method.getByReference.input>(
+    "skill-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadSkillByReferenceStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Skill;
+}
+
+/**
+ * GetArtifact — raw ZIP bytes by storage key over gRPC (≤10MB messages;
+ * larger artifacts ride the download-URL lane). Authorization is skipped
+ * by proto config: the content-hash storage key is the capability token.
+ */
+async function getArtifact(
+  deps: SkillControllerDeps,
+  req: GetArtifactRequest,
+  ctx: HandlerContext,
+): Promise<GetArtifactResponse> {
+  const reqCtx = new RequestContext(
+    SkillQueryController.method.getArtifact.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillQueryController.method.getArtifact.input>(
+    "skill-get-artifact",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .build()
+    .execute(reqCtx);
+
+  let artifact: Uint8Array;
+  try {
+    artifact = await deps.artifactStorage.get(req.artifactStorageKey);
+  } catch (error) {
+    if (error instanceof ArtifactNotFoundError) {
+      // Go: status.Errorf(codes.NotFound, "skill artifact not found: %s").
+      throw new ConnectError(
+        `skill artifact not found: ${req.artifactStorageKey}`,
+        Code.NotFound,
+      );
+    }
+    throw internalError(error, "failed to load skill artifact");
+  }
+
+  return create(GetArtifactResponseSchema, { artifact });
+}
+
+/**
+ * GetArtifactDownloadUrl — the transfer-lane twin of GetArtifact (#675):
+ * stats (never loads) the artifact and mints its capability URL. The URL
+ * does not expire on OSS (ttl_seconds = 0) — it embeds the same
+ * content-hash capability a stored storage key would.
+ */
+async function getArtifactDownloadUrl(
+  deps: SkillControllerDeps,
+  req: GetArtifactRequest,
+  ctx: HandlerContext,
+): Promise<SkillArtifactDownloadUrl> {
+  const lane = deps.transferLane;
+  if (lane === undefined) {
+    throw failedPreconditionError(TRANSFER_LANE_NOT_CONFIGURED);
+  }
+
+  const reqCtx = new RequestContext(
+    SkillQueryController.method.getArtifactDownloadUrl.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillQueryController.method.getArtifactDownloadUrl.input>(
+    "skill-get-artifact-download-url",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .build()
+    .execute(reqCtx);
+
+  let size: number;
+  try {
+    size = await deps.artifactStorage.size(req.artifactStorageKey);
+  } catch (error) {
+    if (error instanceof ArtifactNotFoundError) {
+      throw new ConnectError(
+        `skill artifact not found: ${req.artifactStorageKey}`,
+        Code.NotFound,
+      );
+    }
+    throw internalError(error, "failed to stat skill artifact");
+  }
+
+  return create(SkillArtifactDownloadUrlSchema, {
+    url: downloadUrl(lane.baseUrl, req.artifactStorageKey),
+    ttlSeconds: 0,
+    sizeBytes: BigInt(size),
+  });
+}
+
+/** ListVersions — resolve by slug, map audit records, paginate. */
+async function listVersions(
+  deps: SkillControllerDeps,
+  req: ListSkillVersionsInput,
+  ctx: HandlerContext,
+): Promise<ListSkillVersionsResponse> {
+  const reqCtx = new RequestContext(
+    SkillQueryController.method.listVersions.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof SkillQueryController.method.listVersions.input>(
+    "skill-list-versions",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSkillBySlugStep(deps.store))
+    .addStep(newLoadAndMapVersionsStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(LIST_VERSIONS_RESPONSE_KEY) as ListSkillVersionsResponse;
+}
+
+/** Bounds a promise by the named deadline (Go's context.WithTimeout arm). */
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("context deadline exceeded")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/push.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/push.ts
@@ -1,0 +1,492 @@
+/**
+ * Skill push pipeline — ports pkg/domain/skill/controller/push.go: the
+ * 12-step chain converting PushSkillRequest → Skill under the
+ * content-addressed versioning model shared with workflows (#341, adopted
+ * for skills in #475).
+ *
+ *   ValidateProto → ResolveArtifactSource → BuildInitialSkill →
+ *   ExtractAndHashArtifact → ResolveSlugForPush → FindExistingBySlug →
+ *   GenerateIDIfNeeded → CheckAndStoreArtifact → PopulateSkillFields →
+ *   ArchiveCurrentSkill → StoreSkill → IndexSkillSearch
+ *
+ * Step names and context keys are Go's, verbatim. The load-bearing
+ * semantics, all preserved:
+ *   - exactly one artifact source (inline bytes XOR upload ref — proto
+ *     CEL); a staged ref is consumed (retired) whatever happens downstream;
+ *   - content addressing: same bytes = same SHA-256 = one stored copy;
+ *   - repoint-never-duplicate: re-pushing EVER-archived content repoints
+ *     the head to the existing audit row (an A→B→A re-push must not
+ *     duplicate A's row);
+ *   - snapshots archive TAGLESS; the audit tag COLUMN is the tag's only
+ *     home, assigned through the single-holder setAuditTag primitive —
+ *     assigned even when the content was already archived, because
+ *     re-pushing under a new tag is skills' only retag path;
+ *   - safe degradation: archive failure clears the version hash from the
+ *     head (the persisted head never references an unresolvable audit
+ *     entry); tag-assignment failure clears the live spec.tag.
+ *
+ * Proven by __tests__/skill.test.ts (composed-server round-trips),
+ * __tests__/push-degradation.test.ts (the failing-store arms), and the
+ * skill conformance suite.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import type { PushSkillRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { SkillSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/spec_pb";
+import { SkillState, SkillStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/status_pb";
+import {
+  ApiResourceMetadataSchema,
+  ApiResourceMetadataVersionSchema,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+import { ApiResourceAuditSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/status_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { defaultVisibilityFor, getIdPrefix } from "../../pipeline/apiresource-meta.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import {
+  generateId,
+  setAuditFieldsForCreate,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import { generateSlug } from "../../pipeline/steps/slug.js";
+import { AuditNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import { TRANSFER_LANE_NOT_CONFIGURED } from "./constants.js";
+import { skillSearchExtractor } from "./search-extractor.js";
+import { extractSkillMd } from "./storage/zip-gate.js";
+import type { ExtractSkillMdResult } from "./storage/zip-gate.js";
+import type { SkillArtifactStorage } from "./storage/artifact-storage.js";
+import type { UploadSlots } from "./transfer/slots.js";
+
+type PushDesc = typeof PushSkillRequestSchema;
+
+// Context keys for the push operation (Go push.go, verbatim).
+export const SKILL_KEY = "skill";
+export const ARTIFACT_BYTES_KEY = "pushArtifactBytes";
+export const EXTRACT_RESULT_KEY = "extractResult";
+export const ARTIFACT_STORAGE_KEY_KEY = "artifactStorageKey";
+export const EXISTING_SKILL_KEY = "existingSkill";
+export const SHOULD_CREATE_SKILL_KEY = "shouldCreateSkill";
+
+/**
+ * ResolveArtifactSource — materializes the artifact ZIP bytes from
+ * whichever source the request carries (proto validation has already
+ * guaranteed exactly one): inline bytes pass through; an upload ref is
+ * consumed HERE, which retires the single-use reference regardless of how
+ * the rest of the pipeline fares. Downstream steps read ARTIFACT_BYTES_KEY
+ * and never touch the request's artifact field, so the two sources are
+ * indistinguishable past this point.
+ */
+export function newResolveArtifactSourceStep(
+  slots: UploadSlots | undefined,
+): PipelineStep<PushDesc> {
+  return {
+    name: "ResolveArtifactSource",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      const req = ctx.input;
+      if (req.artifactUploadRef === "") {
+        ctx.set(ARTIFACT_BYTES_KEY, req.artifact);
+        return;
+      }
+      if (slots === undefined) {
+        throw failedPreconditionError(TRANSFER_LANE_NOT_CONFIGURED);
+      }
+      let data: Uint8Array;
+      try {
+        data = await slots.consume(req.artifactUploadRef);
+      } catch (error) {
+        // The reference is client-supplied state, not server fault:
+        // unknown, expired, already consumed, or minted-but-never-uploaded
+        // all mean the client must re-mint and re-upload.
+        throw invalidArgumentError(
+          `artifact_upload_ref not usable: ${error instanceof Error ? error.message : String(error)} — request a new upload URL via createArtifactUploadUrl`,
+        );
+      }
+      ctx.set(ARTIFACT_BYTES_KEY, data);
+    },
+  };
+}
+
+/**
+ * BuildInitialSkill — the Skill scaffold from the request. Name, ID, and
+ * slug are NOT set here; they come from the SKILL.md frontmatter via the
+ * later steps.
+ */
+export function newBuildInitialSkillStep(): PipelineStep<PushDesc> {
+  return {
+    name: "BuildInitialSkill",
+    execute(ctx: RequestContext<PushDesc>): void {
+      const req = ctx.input;
+      const skill = create(SkillSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Skill",
+        metadata: create(ApiResourceMetadataSchema, { org: req.org }),
+        spec: create(SkillSpecSchema, { tag: req.tag }),
+        status: create(SkillStatusSchema, { state: SkillState.READY }),
+      });
+      ctx.set(SKILL_KEY, skill);
+    },
+  };
+}
+
+/**
+ * ExtractAndHashArtifact — the ZIP gate: bomb/limit validation, in-memory
+ * SKILL.md extraction, frontmatter parse, SHA-256 content hash. Every gate
+ * failure is the InvalidArgument "failed to extract SKILL.md: ..." arm.
+ */
+export function newExtractAndHashArtifactStep(): PipelineStep<PushDesc> {
+  return {
+    name: "ExtractAndHashArtifact",
+    execute(ctx: RequestContext<PushDesc>): void {
+      const artifactBytes = ctx.get(ARTIFACT_BYTES_KEY) as Uint8Array;
+      let extractResult: ExtractSkillMdResult;
+      try {
+        extractResult = extractSkillMd(artifactBytes);
+      } catch (error) {
+        throw invalidArgumentError(
+          `failed to extract SKILL.md: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      ctx.set(EXTRACT_RESULT_KEY, extractResult);
+    },
+  };
+}
+
+/**
+ * ResolveSlugForPush — the frontmatter name becomes metadata.name and,
+ * slugified, metadata.slug. The frontmatter pattern already constrains the
+ * name, so an empty slug is a defensive arm, not a reachable one.
+ */
+export function newResolveSlugForPushStep(): PipelineStep<PushDesc> {
+  return {
+    name: "ResolveSlugForPush",
+    execute(ctx: RequestContext<PushDesc>): void {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      const extractResult = ctx.get(EXTRACT_RESULT_KEY) as ExtractSkillMdResult;
+      skill.metadata!.name = extractResult.name;
+      const slug = generateSlug(extractResult.name);
+      if (slug === "") {
+        throw invalidArgumentError(`invalid skill name: ${extractResult.name}`);
+      }
+      skill.metadata!.slug = slug;
+    },
+  };
+}
+
+/**
+ * FindExistingBySlug — push is upsert-by-slug: an existing skill's ID is
+ * adopted (update), otherwise the create flag is raised.
+ */
+export function newFindExistingBySlugStep(store: Store): PipelineStep<PushDesc> {
+  return {
+    name: "FindExistingBySlug",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      let existing: Skill | undefined;
+      try {
+        existing = await findResourceBySlug(
+          store,
+          ctx.apiResourceKind,
+          SkillSchema,
+          skill.metadata!.slug,
+          skill.metadata!.org,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to search for existing skill");
+      }
+      if (existing !== undefined) {
+        skill.metadata!.id = existing.metadata!.id;
+        ctx.set(EXISTING_SKILL_KEY, existing);
+        ctx.set(SHOULD_CREATE_SKILL_KEY, false);
+      } else {
+        ctx.set(EXISTING_SKILL_KEY, undefined);
+        ctx.set(SHOULD_CREATE_SKILL_KEY, true);
+      }
+    },
+  };
+}
+
+/** GenerateIDIfNeeded — skl_{ulid} for new skills; updates keep theirs. */
+export function newGenerateIdIfNeededStep(): PipelineStep<PushDesc> {
+  return {
+    name: "GenerateIDIfNeeded",
+    execute(ctx: RequestContext<PushDesc>): void {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      const shouldCreate = ctx.get(SHOULD_CREATE_SKILL_KEY) as boolean;
+      if (shouldCreate) {
+        skill.metadata!.id = generateId(getIdPrefix(ctx.apiResourceKind));
+      }
+    },
+  };
+}
+
+/**
+ * CheckAndStoreArtifact — content-addressed dedupe: same hash reuses the
+ * stored copy; new content is written 0600.
+ */
+export function newCheckAndStoreArtifactStep(
+  artifactStorage: SkillArtifactStorage,
+): PipelineStep<PushDesc> {
+  return {
+    name: "CheckAndStoreArtifact",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      const artifactBytes = ctx.get(ARTIFACT_BYTES_KEY) as Uint8Array;
+      const extractResult = ctx.get(EXTRACT_RESULT_KEY) as ExtractSkillMdResult;
+
+      let exists: boolean;
+      try {
+        exists = await artifactStorage.exists(extractResult.hash);
+      } catch (error) {
+        throw internalError(error, "failed to check artifact existence");
+      }
+
+      let storageKey: string;
+      if (exists) {
+        storageKey = artifactStorage.getStorageKey(extractResult.hash);
+      } else {
+        try {
+          storageKey = await artifactStorage.store(extractResult.hash, artifactBytes);
+        } catch (error) {
+          throw internalError(error, "failed to store artifact");
+        }
+      }
+      ctx.set(ARTIFACT_STORAGE_KEY_KEY, storageKey);
+    },
+  };
+}
+
+/**
+ * PopulateSkillFields — spec content + frontmatter identity, default
+ * visibility from the kind's proto config (skill is a blueprint →
+ * visibility_org, so OSS and Cloud agree by construction), git provenance
+ * passthrough, status artifact fields, the metadata.version chain, and
+ * the audit stamping discipline: creates stamp both slots; updates copy
+ * the loaded skill's slot pointers onto a fresh wrapper and stamp
+ * spec_audit ONLY (a push is a definition change; status_audit stays on
+ * the shared pointer, untouched — #540: the helper sets a newly allocated
+ * spec_audit message, never mutating the copied pointer in place).
+ */
+export function newPopulateSkillFieldsStep(): PipelineStep<PushDesc> {
+  return {
+    name: "PopulateSkillFields",
+    execute(ctx: RequestContext<PushDesc>): void {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      const extractResult = ctx.get(EXTRACT_RESULT_KEY) as ExtractSkillMdResult;
+      const storageKey = ctx.get(ARTIFACT_STORAGE_KEY_KEY) as string;
+      const shouldCreate = ctx.get(SHOULD_CREATE_SKILL_KEY) as boolean;
+      const req = ctx.input;
+
+      skill.spec!.skillMd = extractResult.content;
+      skill.spec!.name = extractResult.name;
+      skill.spec!.description = extractResult.description;
+
+      if (
+        skill.metadata!.visibility ===
+        ApiResourceVisibility.api_resource_visibility_unspecified
+      ) {
+        skill.metadata!.visibility = defaultVisibilityFor(ctx.apiResourceKind);
+      }
+
+      if (req.gitProvenance !== undefined) {
+        skill.status!.gitProvenance = req.gitProvenance;
+      }
+
+      skill.status!.versionHash = extractResult.hash;
+      skill.status!.artifactStorageKey = storageKey;
+      skill.status!.state = SkillState.READY;
+
+      let previousVersionHash = "";
+      if (!shouldCreate) {
+        const existing = ctx.get(EXISTING_SKILL_KEY) as Skill | undefined;
+        previousVersionHash = existing?.status?.versionHash ?? "";
+      }
+      skill.metadata!.version = create(ApiResourceMetadataVersionSchema, {
+        id: extractResult.hash,
+        message: req.message,
+        previousVersionId: previousVersionHash,
+      });
+
+      if (shouldCreate) {
+        setAuditFieldsForCreate(SkillSchema, skill);
+      } else {
+        const existing = ctx.get(EXISTING_SKILL_KEY) as Skill;
+        if (existing.status?.audit !== undefined) {
+          const status = skill.status!;
+          status.audit ??= create(ApiResourceAuditSchema, {});
+          // Copy slot pointers from the loaded skill; the helper below
+          // SETS a newly allocated spec_audit, so the copied pointers are
+          // never mutated in place (#540).
+          status.audit.specAudit = existing.status.audit.specAudit;
+          status.audit.statusAudit = existing.status.audit.statusAudit;
+        }
+        setAuditFieldsForUpdate(SkillSchema, skill, "spec_audit");
+      }
+    },
+  };
+}
+
+/**
+ * ArchiveCurrentSkill — the versioning heart (#341/#475): repoint or
+ * archive, then the single-holder tag assignment, each with its safe
+ * degradation (see the module doc). Runs AFTER PopulateSkillFields so the
+ * archived snapshot is the fully-populated head.
+ */
+export function newArchiveCurrentSkillStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<PushDesc> {
+  return {
+    name: "ArchiveCurrentSkill",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      const versionHash = skill.status?.versionHash ?? "";
+      if (versionHash === "") {
+        return;
+      }
+      const tag = skill.spec?.tag ?? "";
+      const skillId = skill.metadata!.id;
+
+      // Repoint, never duplicate: if this content was ever archived, the
+      // head simply repoints to the existing row and only the tag
+      // assignment below still runs. An unexpected lookup failure degrades
+      // to archiving anyway — a possible duplicate row beats a failed push
+      // (readers resolve duplicates newest-wins).
+      let alreadyArchived = false;
+      try {
+        await store.getAuditByHash(ctx.apiResourceKind, skillId, versionHash, SkillSchema);
+        alreadyArchived = true;
+      } catch (error) {
+        if (!(error instanceof AuditNotFoundError)) {
+          logger.warn(
+            "Could not check for an existing archived skill version — archiving anyway",
+            {
+              skillId,
+              versionHash,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      }
+
+      if (!alreadyArchived) {
+        // Archive the snapshot tagless: the tag lives only in the audit
+        // tag column (the source of truth), assigned below through the
+        // single-holder primitive — a later tag move never rewrites this
+        // immutable content.
+        try {
+          await store.saveAudit(ctx.apiResourceKind, skillId, SkillSchema, skill, versionHash, "");
+        } catch (error) {
+          logger.error(
+            "Failed to archive skill version — reverting the version hash to maintain the audit-resolvability invariant",
+            {
+              skillId,
+              versionHash,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          // Revert: the persisted head must never reference an audit entry
+          // that does not exist. The push still succeeds, but without
+          // version tracking for this apply.
+          skill.status!.versionHash = "";
+          if (skill.metadata?.version !== undefined) {
+            skill.metadata.version.id = "";
+          }
+          return;
+        }
+      }
+
+      // Assign the requested tag through setAuditTag — the single-holder
+      // primitive — so the head version (freshly archived or repointed-to)
+      // becomes the tag's sole holder; any prior holder is cleared.
+      if (tag !== "") {
+        try {
+          await store.setAuditTag(ctx.apiResourceKind, skillId, versionHash, tag);
+        } catch (error) {
+          logger.error(
+            "Archived skill version but failed to assign its tag — clearing the live tag to stay consistent with the audit column",
+            {
+              skillId,
+              versionHash,
+              tag,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          // The audit head is now untagged; keep the live head consistent
+          // so get / getByReference never advertise a tag the store cannot
+          // resolve.
+          skill.spec!.tag = "";
+        }
+      }
+
+      if (alreadyArchived) {
+        logger.info(
+          "Skill version content already archived — repointed head without a new history row",
+          { skillId, versionHash, tag },
+        );
+      } else {
+        logger.info("Archived skill version to audit history", {
+          skillId,
+          versionHash,
+          tag,
+        });
+      }
+    },
+  };
+}
+
+/** StoreSkill — persists the fully populated head. */
+export function newStoreSkillStep(store: Store): PipelineStep<PushDesc> {
+  return {
+    name: "StoreSkill",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      try {
+        await store.saveResource(ctx.apiResourceKind, skill.metadata!.id, SkillSchema, skill);
+      } catch (error) {
+        throw internalError(error, "failed to save skill");
+      }
+    },
+  };
+}
+
+/**
+ * IndexSkillSearch — FTS5 upsert, best-effort by contract. Domain-local
+ * (not the shared IndexSearch step) because the push pipeline's message is
+ * PushSkillRequest: the skill rides SKILL_KEY, not newState.
+ */
+export function newIndexSkillSearchStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<PushDesc> {
+  return {
+    name: "IndexSkillSearch",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      const entry = skillSearchExtractor.getSearchIndexEntry(skill);
+      if (entry === undefined) {
+        logger.warn("IndexSkillSearch: extractor returned nil entry, skipping", {
+          id: skill.metadata?.id ?? "",
+        });
+        return;
+      }
+      try {
+        await store.upsertSearchIndex(ctx.apiResourceKind, skill.metadata!.id, entry);
+      } catch (error) {
+        logger.warn("IndexSkillSearch: failed to update search index (best-effort)", {
+          id: skill.metadata?.id ?? "",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/search-extractor.ts
@@ -1,0 +1,36 @@
+/**
+ * Skill search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/skill_extractor.go. Skills are knowledge
+ * documents (SKILL.md files); the search summary is spec.description,
+ * extracted from the SKILL.md YAML frontmatter at push time. The query
+ * side of the extractor contract arrives with the search service
+ * sub-project (#14).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const skillSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const skill = resource as unknown as Skill;
+    const metadata = skill.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      // Go SkillExtractor.GetSearchSummary: spec.description.
+      description: skill.spec?.description ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(skill.status?.audit?.specAudit?.createdAt?.seconds ?? 0n),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/skill/storage/artifact-storage.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/storage/artifact-storage.ts
@@ -1,0 +1,153 @@
+/**
+ * Skill artifact store — ports pkg/domain/skill/storage/artifact_storage.go.
+ * Content-addressed, write-once, never garbage-collected (OD-5): artifacts
+ * live at {storagePath}/skills/{sha256}.zip, byte-identical to Go's paths —
+ * at cutover the TS server inherits a Go-written storage directory and must
+ * serve its artifacts in place. There is deliberately NO delete method on
+ * the interface: historical versions stay downloadable through the storage
+ * keys listVersions exposes.
+ *
+ * Proven by __tests__/artifact-storage.test.ts and the skill conformance
+ * suite's getArtifact/round-trip tests.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Storage abstraction for skill artifacts (Go ArtifactStorage). The
+ * interface exists for the same reason as Go's: cloud uses R2 behind the
+ * identical surface, and the controller must not know which one it holds.
+ */
+export interface SkillArtifactStorage {
+  /** Saves an artifact under its content hash; returns the storage key. */
+  store(hash: string, data: Uint8Array): Promise<string>;
+  /** Loads an artifact by storage key; throws ArtifactNotFoundError if absent. */
+  get(storageKey: string): Promise<Uint8Array>;
+  /** Whether an artifact with this content hash already exists (dedupe). */
+  exists(hash: string): Promise<boolean>;
+  /** The storage key for a hash, without storing ("skills/<hash>.zip"). */
+  getStorageKey(hash: string): string;
+  /** The stored artifact's byte size via stat — never loads content. */
+  size(storageKey: string): Promise<number>;
+}
+
+/**
+ * A storage key that addresses nothing inside the store — missing file OR
+ * a traversal-shaped key (both render as Go's "artifact not found: %s";
+ * distinguishing them would tell a probing caller which escapes exist).
+ */
+export class ArtifactNotFoundError extends Error {
+  constructor(storageKey: string) {
+    super(`artifact not found: ${storageKey}`);
+    this.name = "ArtifactNotFoundError";
+  }
+}
+
+/** Filesystem implementation (Go LocalFileStorage). */
+export class LocalFileStorage implements SkillArtifactStorage {
+  private readonly storagePath: string;
+
+  /** Creates the backend and ensures {storagePath}/skills exists (0755). */
+  constructor(storagePath: string) {
+    this.storagePath = storagePath;
+    fs.mkdirSync(path.join(storagePath, "skills"), {
+      recursive: true,
+      mode: 0o755,
+    });
+  }
+
+  /** Writes with 0600 (owner-only) — artifacts are not world-readable. */
+  async store(hash: string, data: Uint8Array): Promise<string> {
+    const storageKey = this.getStorageKey(hash);
+    const filePath = path.join(this.storagePath, storageKey);
+    await fs.promises.mkdir(path.dirname(filePath), {
+      recursive: true,
+      mode: 0o755,
+    });
+    await fs.promises.writeFile(filePath, data, { mode: 0o600 });
+    return storageKey;
+  }
+
+  async get(storageKey: string): Promise<Uint8Array> {
+    const filePath = this.resolveWithinRoot(storageKey);
+    if (filePath === undefined) {
+      throw new ArtifactNotFoundError(storageKey);
+    }
+    try {
+      return await fs.promises.readFile(filePath);
+    } catch (error) {
+      if (isNotFound(error)) {
+        throw new ArtifactNotFoundError(storageKey);
+      }
+      throw new Error(
+        `failed to read artifact: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  async exists(hash: string): Promise<boolean> {
+    const filePath = path.join(this.storagePath, this.getStorageKey(hash));
+    try {
+      await fs.promises.stat(filePath);
+      return true;
+    } catch (error) {
+      if (isNotFound(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * "skills/<hash>.zip" — the relative key format shared with cloud R2.
+   * Deliberately a LITERAL forward-slash join, not path.join: the key is
+   * a wire-visible identifier (status.artifact_storage_key, download
+   * URLs, the lane's "skills/" prefix check), and Windows support arrives
+   * only through this server (#24) — path.join would mint backslash keys
+   * there that the download lane could never serve. Filesystem access
+   * re-joins the key per-OS (store/get/size).
+   */
+  getStorageKey(hash: string): string {
+    return `skills/${hash}.zip`;
+  }
+
+  async size(storageKey: string): Promise<number> {
+    const filePath = this.resolveWithinRoot(storageKey);
+    if (filePath === undefined) {
+      throw new ArtifactNotFoundError(storageKey);
+    }
+    try {
+      const info = await fs.promises.stat(filePath);
+      return info.size;
+    } catch (error) {
+      if (isNotFound(error)) {
+        throw new ArtifactNotFoundError(storageKey);
+      }
+      throw new Error(
+        `failed to stat artifact: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Joins a client-supplied storage key to the root and confirms the
+   * resolved path stays inside it (Go resolveWithinRoot) — traversal keys
+   * ("../../etc/passwd") address nothing inside the store.
+   */
+  private resolveWithinRoot(storageKey: string): string | undefined {
+    const root = path.resolve(this.storagePath);
+    const filePath = path.resolve(root, storageKey);
+    if (filePath !== root && !filePath.startsWith(root + path.sep)) {
+      return undefined;
+    }
+    return filePath;
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/storage/frontmatter.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/storage/frontmatter.ts
@@ -1,0 +1,192 @@
+/**
+ * SKILL.md frontmatter parsing — ports pkg/domain/skill/storage/
+ * frontmatter.go. The backend is the single source of truth for parsing
+ * SKILL.md: name (required, kebab-case with optional dot-scoped
+ * namespaces) and description come from the YAML frontmatter between ---
+ * markers at the start of the file. Every error string is wire-visible
+ * teaching copy, byte-pinned from Go (multi-line "expected format" blocks
+ * included).
+ *
+ * Proven by __tests__/frontmatter.test.ts and the skill conformance
+ * suite's push-validation negatives.
+ */
+import yaml from "js-yaml";
+
+/** Parsed SKILL.md frontmatter (Go SkillFrontmatter). */
+export interface SkillFrontmatter {
+  /** Canonical skill identifier (required; kebab-case, optionally dot-scoped). */
+  readonly name: string;
+  /** Human-readable summary (optional but recommended). */
+  readonly description: string;
+  /** Informational only — hash-based versioning is used instead. */
+  readonly version: string;
+}
+
+/**
+ * Kebab-case skill names, optionally scoped with dot-separated namespaces:
+ * lowercase letters, numbers, hyphens (words), and dots (namespace
+ * segments). Every segment between separators must be alphanumeric, so a
+ * name cannot start or end with a separator, nor contain consecutive
+ * separators. The derived slug renders dots as hyphens (generateSlug).
+ */
+const SKILL_NAME_PATTERN = /^[a-z0-9]+([.-][a-z0-9]+)*$/;
+
+/**
+ * Go strings.TrimSpace trims by unicode.IsSpace — the Unicode White_Space
+ * property (ASCII spaces, U+0085, U+00A0, U+1680, U+2000–U+200A, U+2028,
+ * U+2029, U+202F, U+205F, U+3000) — which EXCLUDES U+FEFF. JS
+ * String.trim's set is White_Space PLUS U+FEFF, so a BOM'd "---" first
+ * line would pass a .trim() delimiter check while Go rejects the file.
+ * The delimiter comparisons must trim exactly Go's set or the two
+ * editions disagree on BOM'd SKILL.md files (found by the #8 parity
+ * review panel).
+ */
+const GO_TRIM_PATTERN =
+  /^[\t\n\v\f\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+|[\t\n\v\f\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+$/g;
+
+function goTrimSpace(value: string): string {
+  return value.replace(GO_TRIM_PATTERN, "");
+}
+
+/**
+ * bufio.Scanner's default token cap (Go bufio.MaxScanTokenSize): lines
+ * longer than this fail Go's scan loop, so the port enforces the same
+ * ceiling — measured in BYTES, as the scanner buffers bytes. Two distinct
+ * arms, faithful to Go's checking order: a too-long FIRST line makes the
+ * initial Scan() return false before Err() is consulted (reported as
+ * "SKILL.md is empty"), while a too-long line inside the frontmatter
+ * surfaces the scanner error.
+ */
+const MAX_SCAN_TOKEN_SIZE = 64 * 1024;
+
+function lineTooLong(line: string): boolean {
+  return Buffer.byteLength(line, "utf8") > MAX_SCAN_TOKEN_SIZE;
+}
+
+/**
+ * Extracts and parses YAML frontmatter from SKILL.md content (Go
+ * ParseFrontmatter). Throws plain Errors — the push pipeline wraps them
+ * into the InvalidArgument "failed to extract SKILL.md: ..." arm.
+ */
+export function parseFrontmatter(content: string): SkillFrontmatter {
+  const frontmatterYaml = extractFrontmatterYaml(content);
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(frontmatterYaml);
+  } catch (error) {
+    throw new Error(
+      `failed to parse YAML frontmatter: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const record =
+    typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  const frontmatter: SkillFrontmatter = {
+    name: typeof record["name"] === "string" ? record["name"] : "",
+    description:
+      typeof record["description"] === "string" ? record["description"] : "",
+    version: typeof record["version"] === "string" ? record["version"] : "",
+  };
+
+  validateFrontmatter(frontmatter);
+  return frontmatter;
+}
+
+/**
+ * Extracts the raw YAML between --- delimiters: the frontmatter must
+ * start on the FIRST line with --- and end with --- on its own line
+ * (whitespace-trimmed comparison on both, as Go's scanner loop does).
+ */
+function extractFrontmatterYaml(content: string): string {
+  if (content === "") {
+    throw new Error("SKILL.md is empty");
+  }
+
+  const lines = content.split(/\r?\n/);
+  // Go's initial Scan() returns false for a first line over the scanner
+  // cap — and its !Scan() arm reports "SKILL.md is empty" without ever
+  // consulting Err(). Bug-for-bug: the misleading copy IS the contract.
+  if (lineTooLong(lines[0]!)) {
+    throw new Error("SKILL.md is empty");
+  }
+  const firstLine = goTrimSpace(lines[0]!);
+  if (firstLine !== "---") {
+    throw new Error(
+      "SKILL.md must start with YAML frontmatter (---)\n\n" +
+        "Expected format:\n" +
+        "---\n" +
+        "name: my-skill-name\n" +
+        "description: A brief description of what this skill does\n" +
+        "---\n" +
+        "# Skill Title\n" +
+        "...",
+    );
+  }
+
+  const frontmatterLines: string[] = [];
+  let foundClosing = false;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (lineTooLong(line)) {
+      // Go: the scan loop stops, and Err() is checked BEFORE the
+      // closing-delimiter check — so an over-cap line inside the
+      // frontmatter wins over "not closed". Message text is the %w-chain
+      // rendering of bufio.ErrTooLong.
+      throw new Error(
+        "error reading SKILL.md content: bufio.Scanner: token too long",
+      );
+    }
+    if (goTrimSpace(line) === "---") {
+      foundClosing = true;
+      break;
+    }
+    frontmatterLines.push(line);
+  }
+
+  if (!foundClosing) {
+    throw new Error("SKILL.md frontmatter is not closed (missing closing ---)");
+  }
+
+  if (frontmatterLines.length === 0) {
+    throw new Error(
+      "SKILL.md has empty frontmatter\n\n" +
+        "The frontmatter must contain at least a 'name' field:\n" +
+        "---\n" +
+        "name: my-skill-name\n" +
+        "---",
+    );
+  }
+
+  return frontmatterLines.join("\n");
+}
+
+/** Required-field and format validation (Go validateFrontmatter). */
+function validateFrontmatter(frontmatter: SkillFrontmatter): void {
+  if (frontmatter.name === "") {
+    throw new Error(
+      "SKILL.md is missing required 'name' field in YAML frontmatter\n\n" +
+        "Expected format:\n" +
+        "---\n" +
+        "name: my-skill-name\n" +
+        "---\n\n" +
+        "The name must be kebab-case (lowercase letters, numbers, and hyphens), " +
+        "optionally scoped with dots (e.g. 'platform.my-skill')",
+    );
+  }
+
+  if (!SKILL_NAME_PATTERN.test(frontmatter.name)) {
+    throw new Error(
+      `invalid skill name '${frontmatter.name}' in SKILL.md\n\n` +
+        "Skill names must be kebab-case, optionally scoped with dot-separated namespaces:\n" +
+        "- Lowercase letters (a-z)\n" +
+        "- Numbers (0-9)\n" +
+        "- Hyphens (-) to separate words\n" +
+        "- Dots (.) to separate namespace segments\n\n" +
+        "Every segment must be alphanumeric: no leading, trailing, or consecutive separators.\n\n" +
+        "Examples: 'calculator', 'web-scraper', 'math-utils', 'platform.planton-architecture'",
+    );
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/storage/prefilter.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/storage/prefilter.ts
@@ -1,0 +1,200 @@
+/**
+ * safearchive-parity entry pre-filter — ports the OBSERVABLE half of
+ * github.com/google/safearchive's zip.MaximumSecurityMode (applyMagic,
+ * zip.go:158, at the go.mod-pinned v0.0.0-20241025131057) plus its
+ * sanitizer package. Go's push gate opens ZIPs through safearchive, which
+ * rewrites the entry list BEFORE zip_extractor.go's validation loop sees
+ * it — so the gate's accept/reject behavior includes this filter, and
+ * local-ts parity requires reproducing it (sub-project DD-001, Option A,
+ * owner-ratified 2026-08-24). The cloud edition applies none of this; the
+ * parity target is the Go server.
+ *
+ * The four observable behaviors, in safearchive's exact order per entry:
+ *   1. SanitizeFilenames — names become unrooted, ..-free, /-separated.
+ *      Consequence: "../SKILL.md" IS a root SKILL.md to the gate.
+ *   2. SkipWindowsShortFilenames — entries with an 8.3-style path
+ *      component (`~N`) are dropped.
+ *   3. PreventSymlinkTraversal (+ case-insensitive) — entries whose path
+ *      passes through an earlier symlink entry are dropped; symlink
+ *      entries themselves stay (and register as shadows).
+ *   4. SkipSpecialFiles — device/pipe/socket/char-device entries are
+ *      dropped.
+ * (safearchive's fifth measure, SanitizeFileMode, strips permission bits
+ * the gate never exposes — not observable, not ported.)
+ *
+ * Entry file types are decoded from the central directory's raw
+ * creator/attribute fields exactly as Go archive/zip's FileHeader.Mode()
+ * does: Unix/macOS creators carry a POSIX mode in the attribute high 16
+ * bits; FAT/NTFS/VFAT creators carry MSDOS bits that can never encode a
+ * symlink or special file; unknown creators decode to a regular file.
+ *
+ * Proven by __tests__/prefilter.test.ts (byte-crafted fixtures per DD-001).
+ */
+import type { ZipStructuralEntry } from "@stigmer/zip-structure";
+
+// ─── sanitizer.SanitizePath ──────────────────────────────────────────────
+
+/**
+ * safearchive sanitizer.SanitizePath (nix variant): backslashes normalize
+ * to slashes, then TrimPrefix(Clean("/"+path), "/") — always unrooted with
+ * no ".." elements; a trailing separator on the input is preserved when
+ * the sanitized result is non-empty.
+ *
+ * The nix variant is deliberate: Go compiles the _win variant only on
+ * Windows hosts, where sanitized names carry backslashes. The TS gate
+ * normalizes to slashes everywhere — a Windows-host-only cosmetic
+ * divergence in ERROR TEXT for pathological names, disclosed in the PR.
+ */
+export function sanitizePath(input: string): string {
+  const sanitized = sanitizeCore(input);
+  if (
+    input.length > 0 &&
+    (input.endsWith("/") || input.endsWith("\\")) &&
+    sanitized.length > 0
+  ) {
+    return `${sanitized}/`;
+  }
+  return sanitized;
+}
+
+function sanitizeCore(input: string): string {
+  const normalizedSeparators = input.replaceAll("\\", "/");
+  // Go filepath.Clean("/"+in): resolve "." and ".." lexically against a
+  // rooted path (leading ".." cannot climb above the root), collapse
+  // duplicate separators, and drop any trailing separator.
+  const segments = `/${normalizedSeparators}`.split("/");
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(segment);
+  }
+  return resolved.join("/");
+}
+
+// ─── sanitizer.HasWindowsShortFilenames ──────────────────────────────────
+
+/** Matches a Windows 8.3 short-name marker (`~1`, `~23.`) in a component. */
+const WINDOWS_SHORT_FILENAME_PATTERN = /~\d+\.?/;
+
+/** safearchive sanitizer.HasWindowsShortFilenames, verbatim semantics. */
+export function hasWindowsShortFilenames(input: string): boolean {
+  return input
+    .replaceAll("\\", "/")
+    .split("/")
+    .some((part) => WINDOWS_SHORT_FILENAME_PATTERN.test(part));
+}
+
+// ─── archive/zip FileHeader.Mode() — the type bits the filter tests ──────
+
+// CreatorVersion high bytes (Go archive/zip creator* constants).
+const CREATOR_UNIX = 3;
+const CREATOR_MACOSX = 19;
+
+// POSIX file-type field masks (syscall.S_IF*).
+const S_IFMT = 0o170000;
+const S_IFBLK = 0o060000;
+const S_IFCHR = 0o020000;
+const S_IFIFO = 0o010000;
+const S_IFLNK = 0o120000;
+const S_IFSOCK = 0o140000;
+
+interface EntryTypeBits {
+  readonly isSymlink: boolean;
+  /** Device, char device, named pipe, or socket (safearchive isSpecialFile). */
+  readonly isSpecial: boolean;
+}
+
+/**
+ * Decodes the entry's file-type bits the way Go's zip.FileHeader.Mode()
+ * does. Only Unix/macOS creators can express symlinks or special files;
+ * every other creator (FAT, NTFS, VFAT, unknown) decodes to a regular
+ * file for the two bits this filter tests.
+ */
+export function entryTypeBits(entry: ZipStructuralEntry): EntryTypeBits {
+  const creator = entry.versionMadeBy >> 8;
+  if (creator !== CREATOR_UNIX && creator !== CREATOR_MACOSX) {
+    return { isSymlink: false, isSpecial: false };
+  }
+  const unixMode = (entry.externalAttributes >>> 16) & 0xffff;
+  const fileType = unixMode & S_IFMT;
+  return {
+    isSymlink: fileType === S_IFLNK,
+    isSpecial:
+      fileType === S_IFBLK ||
+      fileType === S_IFCHR ||
+      fileType === S_IFIFO ||
+      fileType === S_IFSOCK,
+  };
+}
+
+// ─── applyMagic ──────────────────────────────────────────────────────────
+
+/**
+ * A structural entry after the pre-filter: same record, sanitized name.
+ * The original entry rides along for payload access.
+ */
+export interface PrefilteredEntry {
+  /** The sanitized name — what every downstream check sees (Go f.Name). */
+  readonly name: string;
+  readonly entry: ZipStructuralEntry;
+}
+
+/**
+ * safearchive applyMagic under MaximumSecurityMode, step-for-step in its
+ * per-entry order: sanitize the name; drop 8.3-named entries; drop entries
+ * shadowed by an earlier symlink (case-insensitive path-prefix match,
+ * registering symlink entries as shadows); drop special files.
+ */
+export function applyEntryPrefilter(
+  entries: readonly ZipStructuralEntry[],
+): PrefilteredEntry[] {
+  const symlinks = new Set<string>();
+  const result: PrefilteredEntry[] = [];
+
+  for (const entry of entries) {
+    const name = sanitizePath(entry.name);
+
+    if (hasWindowsShortFilenames(name)) {
+      continue;
+    }
+
+    // PreventSymlinkTraversal + PreventCaseInsensitiveSymlinkTraversal:
+    // re-sanitize (idempotent — safearchive does the same), strip the
+    // trailing separator, lowercase, and test every path prefix against
+    // the symlinks seen so far.
+    const shadowKey = trimTrailingSlash(sanitizePath(name)).toLowerCase();
+    const parts = shadowKey.split("/");
+    let traversal = false;
+    for (let i = 1; i <= parts.length; i++) {
+      if (symlinks.has(parts.slice(0, i).join("/"))) {
+        traversal = true;
+        break;
+      }
+    }
+    if (traversal) {
+      continue;
+    }
+
+    const typeBits = entryTypeBits(entry);
+    if (typeBits.isSymlink) {
+      symlinks.add(shadowKey);
+    }
+    if (typeBits.isSpecial) {
+      continue;
+    }
+
+    result.push({ name, entry });
+  }
+
+  return result;
+}
+
+function trimTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path.slice(0, -1) : path;
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/storage/zip-gate.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/storage/zip-gate.ts
@@ -1,0 +1,244 @@
+/**
+ * Skill artifact ZIP gate — ports pkg/domain/skill/storage/zip_extractor.go
+ * arm-for-arm. Validates an uploaded artifact (size caps, ZIP-bomb
+ * budgets, entry-count and filename rules, root-SKILL.md presence with the
+ * #452 hint), extracts SKILL.md IN MEMORY ONLY (never to disk), and parses
+ * its frontmatter. Structural parsing rides @stigmer/zip-structure
+ * (central-directory-based, issues #450/#567); the safearchive-parity
+ * entry pre-filter runs first (prefilter.ts, sub-project DD-001) exactly
+ * as Go's reader rewrites its entry list before validation.
+ *
+ * Error strings are wire-visible contract (the push pipeline wraps them
+ * into the InvalidArgument "failed to extract SKILL.md: ..." arm), pinned
+ * from Go including the stdlib texts Go's %w wrapping surfaces
+ * ("zip: not a valid zip file", "zip: unsupported compression algorithm",
+ * "zip: checksum error"). Two disclosed nuances versus Go, both stricter
+ * only on pathological archives: a corrupt payload SLICE on any entry
+ * fails structural parsing here while Go only fails when it opens that
+ * entry, and deflate-corruption error text carries zlib's message rather
+ * than Go flate's.
+ *
+ * Proven by __tests__/zip-gate.test.ts and the skill conformance suite's
+ * push-validation negatives (CONFORMANCE_TARGET=local-ts).
+ */
+import { createHash } from "node:crypto";
+import { inflateRawSync } from "node:zlib";
+
+import { crc32, parseZipStructure } from "@stigmer/zip-structure";
+import type { ZipStructuralEntry } from "@stigmer/zip-structure";
+
+import {
+  MAX_COMPRESSION_RATIO,
+  MAX_FILES,
+  MAX_SKILL_MD_SIZE,
+  MAX_UNCOMPRESSED_SIZE,
+  MAX_ZIP_SIZE,
+  NESTED_SKILL_MD_HINT,
+} from "../constants.js";
+import { applyEntryPrefilter } from "./prefilter.js";
+import type { PrefilteredEntry } from "./prefilter.js";
+import { parseFrontmatter } from "./frontmatter.js";
+
+/** Result of a successful gate pass (Go ExtractSkillMdResult). */
+export interface ExtractSkillMdResult {
+  /** Full SKILL.md content, frontmatter included. */
+  readonly content: string;
+  /** SHA-256 of the ZIP bytes — the content-addressed version identity. */
+  readonly hash: string;
+  /** Skill identifier from the frontmatter (kebab-case). */
+  readonly name: string;
+  /** Human-readable summary from the frontmatter. */
+  readonly description: string;
+}
+
+/** ZIP compression methods the gate can open (Go registers the same two). */
+const METHOD_STORED = 0;
+const METHOD_DEFLATED = 8;
+
+/**
+ * Validates the artifact and extracts SKILL.md + frontmatter (Go
+ * ExtractSkillMd). Throws plain Errors with byte-pinned messages; the
+ * push pipeline owns the gRPC code.
+ */
+export function extractSkillMd(zipData: Uint8Array): ExtractSkillMdResult {
+  if (zipData.length > MAX_ZIP_SIZE) {
+    throw new Error(
+      `ZIP file too large: ${zipData.length} bytes (max: ${MAX_ZIP_SIZE})`,
+    );
+  }
+
+  const hash = calculateHash(zipData);
+
+  let entries: readonly ZipStructuralEntry[];
+  try {
+    entries = parseZipStructure(zipData);
+  } catch {
+    // Go's zip.NewReader surfaces stdlib ErrFormat here; its text is what
+    // clients see via the %w chain, so it is pinned verbatim.
+    throw new Error("invalid ZIP file: zip: not a valid zip file");
+  }
+
+  // safearchive MaximumSecurityMode rewrites the entry list before any
+  // validation sees it (DD-001) — sanitized names, shadowed/special/8.3
+  // entries dropped.
+  const filtered = applyEntryPrefilter(entries);
+
+  validateZipContent(filtered);
+
+  const content = extractSkillMdContent(filtered);
+
+  let frontmatter;
+  try {
+    frontmatter = parseFrontmatter(content);
+  } catch (error) {
+    throw new Error(
+      `invalid SKILL.md frontmatter: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return {
+    content,
+    hash,
+    name: frontmatter.name,
+    description: frontmatter.description,
+  };
+}
+
+/**
+ * Security validation over the (pre-filtered) entry list — Go
+ * validateZipContent, checks in its exact order: empty archive, file-count
+ * cap, then per entry SKILL.md placement tracking, filename
+ * control-character rejection, the running declared-uncompressed budget
+ * (fail-fast), and the per-file compression-ratio cap; finally the
+ * root-SKILL.md presence rule with the #452 nested-only hint.
+ */
+function validateZipContent(entries: readonly PrefilteredEntry[]): void {
+  if (entries.length === 0) {
+    throw new Error("ZIP file is empty");
+  }
+
+  if (entries.length > MAX_FILES) {
+    throw new Error(`too many files in ZIP: ${entries.length} (max: ${MAX_FILES})`);
+  }
+
+  let totalUncompressedSize = 0;
+  let hasSkillMd = false;
+  let hasNestedSkillMd = false;
+
+  for (const { name, entry } of entries) {
+    // SKILL.md must be at the archive root. Nested occurrences are tracked
+    // only to make the rejection actionable (below).
+    if (name === "SKILL.md") {
+      hasSkillMd = true;
+    } else if (name.endsWith("/SKILL.md")) {
+      hasNestedSkillMd = true;
+    }
+
+    // Reject null bytes and control characters in entry names (code
+    // points, not UTF-16 units — Go ranges over runes).
+    for (const ch of name) {
+      const codePoint = ch.codePointAt(0)!;
+      if (codePoint < 32 || codePoint === 127) {
+        throw new Error(`invalid character in filename: ${name}`);
+      }
+    }
+
+    // Track the declared uncompressed total (fail fast once exceeded).
+    totalUncompressedSize += entry.uncompressedSize;
+    if (totalUncompressedSize > MAX_UNCOMPRESSED_SIZE) {
+      throw new Error(
+        `total uncompressed size too large: ${totalUncompressedSize} bytes (max: ${MAX_UNCOMPRESSED_SIZE})`,
+      );
+    }
+
+    // Per-file compression ratio (ZIP-bomb guard); integer division as Go.
+    if (entry.compressedSize > 0) {
+      const ratio = Math.floor(entry.uncompressedSize / entry.compressedSize);
+      if (ratio > MAX_COMPRESSION_RATIO) {
+        throw new Error(
+          `suspicious compression ratio in ${name}: ${ratio}:1 (max: ${MAX_COMPRESSION_RATIO}:1)`,
+        );
+      }
+    }
+  }
+
+  if (!hasSkillMd) {
+    if (hasNestedSkillMd) {
+      throw new Error(NESTED_SKILL_MD_HINT);
+    }
+    throw new Error("SKILL.md not found in ZIP archive");
+  }
+}
+
+/**
+ * Extracts SKILL.md's content in memory (Go extractSkillMdContent): the
+ * first root-named entry, decompressed under the 1MB cap, CRC-verified
+ * (Go's reader checks the checksum on every read), UTF-8 decoded.
+ */
+function extractSkillMdContent(entries: readonly PrefilteredEntry[]): string {
+  for (const { name, entry } of entries) {
+    if (name !== "SKILL.md") {
+      continue;
+    }
+
+    let contentBytes: Uint8Array;
+    switch (entry.compressionMethod) {
+      case METHOD_STORED:
+        contentBytes = entry.compressedData;
+        break;
+      case METHOD_DEFLATED:
+        try {
+          // The cap bounds the ACTUAL inflated output — declared sizes are
+          // client claims (the ratio check upstream only sees declarations).
+          contentBytes = new Uint8Array(
+            inflateRawSync(entry.compressedData, {
+              maxOutputLength: MAX_SKILL_MD_SIZE + 1,
+            }),
+          );
+        } catch (error) {
+          if (isOutputLengthError(error)) {
+            throw new Error(`SKILL.md too large (max: ${MAX_SKILL_MD_SIZE} bytes)`);
+          }
+          throw new Error(
+            `failed to read SKILL.md: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        break;
+      default:
+        // Go: File.Open returns ErrAlgorithm for methods without a
+        // registered decompressor; the text is pinned via the %w chain.
+        throw new Error("failed to open SKILL.md: zip: unsupported compression algorithm");
+    }
+
+    if (contentBytes.length > MAX_SKILL_MD_SIZE) {
+      throw new Error(`SKILL.md too large (max: ${MAX_SKILL_MD_SIZE} bytes)`);
+    }
+
+    if (crc32(contentBytes) !== entry.crc32) {
+      // Go's checksumReader: stdlib ErrChecksum via the read-error arm.
+      throw new Error("failed to read SKILL.md: zip: checksum error");
+    }
+
+    if (contentBytes.length === 0) {
+      throw new Error("SKILL.md is empty");
+    }
+
+    return new TextDecoder().decode(contentBytes);
+  }
+
+  throw new Error("SKILL.md not found in ZIP archive");
+}
+
+/** node:zlib's maxOutputLength violation (the output-cap arm). */
+function isOutputLengthError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (("code" in error && (error as { code?: string }).code === "ERR_BUFFER_TOO_LARGE") ||
+      error.message.includes("maxOutputLength"))
+  );
+}
+
+/** SHA-256 hex of the artifact bytes (Go CalculateHash). */
+export function calculateHash(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/transfer/handler.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/transfer/handler.ts
@@ -1,0 +1,185 @@
+/**
+ * Skill artifact transfer lane — ports pkg/domain/skill/transfer/handler.go:
+ * the HTTP upload/download surface that carries skill artifact bytes
+ * OUTSIDE the gRPC control plane (#675). The gRPC server caps messages at
+ * 10MB while the skill layer permits 100MB artifacts, so inline bytes
+ * physically cannot carry every valid skill.
+ *
+ *   PUT {prefix}/uploads/{ref}  — stage artifact bytes (capability: ref)
+ *   GET {prefix}/{storage_key}  — serve artifact bytes (capability: key)
+ *
+ * Neither route carries bearer auth by design: the URL is the credential,
+ * mirroring cloud's pre-signed R2 URLs. Minting an upload URL requires the
+ * same gRPC authorization as push; download keys are unguessable content
+ * hashes handed out by authorized skill reads.
+ *
+ * The lane slots into the transport's existing skillTransferLane seam
+ * (transport/server.ts lane 3); URL renderers live next to the route
+ * dispatch so the URL shape and its handler cannot drift apart (Go's
+ * stated invariant). Proven by __tests__/skill.test.ts's transfer-lane
+ * block (both protocol stacks) and the conformance suite's transfer-lane
+ * tests.
+ */
+import type { Logger } from "../../../boot/logger.js";
+import { SKILL_ARTIFACTS_PATH_PREFIX } from "../../../transport/constants.js";
+import type { LaneHandler, LaneRequest, LaneResponse } from "../../../transport/lanes.js";
+import { DOWNLOAD_KEY_PREFIX, UPLOADS_SEGMENT } from "../constants.js";
+import { ArtifactNotFoundError } from "../storage/artifact-storage.js";
+import type { SkillArtifactStorage } from "../storage/artifact-storage.js";
+import {
+  SizeMismatchError,
+  SlotConsumedError,
+  SlotUnknownError,
+} from "./slots.js";
+import type { UploadSlots } from "./slots.js";
+
+/**
+ * Renders the capability URL for a minted reference against the lane's
+ * externally-reachable base URL.
+ */
+export function uploadUrl(baseUrl: string, ref: string): string {
+  return `${trimTrailingSlash(baseUrl)}${SKILL_ARTIFACTS_PATH_PREFIX}${UPLOADS_SEGMENT}${ref}`;
+}
+
+/** Renders the download URL for an artifact storage key. */
+export function downloadUrl(baseUrl: string, storageKey: string): string {
+  return `${trimTrailingSlash(baseUrl)}${SKILL_ARTIFACTS_PATH_PREFIX}/${storageKey}`;
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/** Builds the lane handler (Go NewHandler). */
+export function newSkillTransferLane(
+  slots: UploadSlots,
+  artifacts: SkillArtifactStorage,
+  logger: Logger,
+): LaneHandler {
+  return (request: LaneRequest, response: LaneResponse): void => {
+    const url = request.url ?? "";
+    const pathOnly = url.split("?")[0] ?? "";
+    if (!pathOnly.startsWith(SKILL_ARTIFACTS_PATH_PREFIX)) {
+      // Unreachable through the lane router (it dispatches by this exact
+      // prefix); kept as the honest Go http.NotFound arm for direct use.
+      writeText(response, 404, "404 page not found");
+      return;
+    }
+    const rest = pathOnly.slice(SKILL_ARTIFACTS_PATH_PREFIX.length);
+
+    // The lane router is synchronous; the async handlers run detached. The
+    // terminal catch is load-bearing: a response-write failure on a
+    // vanished client would otherwise escape as an unhandled rejection —
+    // process-fatal under Node's default policy.
+    const logDetachedFailure = (arm: string) => (error: unknown) => {
+      logger.error(`skill transfer lane ${arm} handler failed`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    };
+
+    if (rest.startsWith(UPLOADS_SEGMENT)) {
+      const ref = rest.slice(UPLOADS_SEGMENT.length);
+      handleUpload(request, response, slots, ref, logger).catch(
+        logDetachedFailure("upload"),
+      );
+      return;
+    }
+
+    handleDownload(
+      request,
+      response,
+      artifacts,
+      rest.replace(/^\//, ""),
+      logger,
+    ).catch(logDetachedFailure("download"));
+  };
+}
+
+async function handleUpload(
+  request: LaneRequest,
+  response: LaneResponse,
+  slots: UploadSlots,
+  ref: string,
+  logger: Logger,
+): Promise<void> {
+  if (request.method !== "PUT") {
+    response.setHeader("Allow", "PUT");
+    writeText(response, 405, "method not allowed");
+    return;
+  }
+
+  try {
+    await slots.receive(ref, request);
+    response.statusCode = 204;
+    response.end();
+  } catch (error) {
+    if (error instanceof SlotUnknownError) {
+      // Deliberately the same shape for "never existed" and "expired":
+      // distinguishing them would let an unauthorized caller probe which
+      // tokens were once valid.
+      writeText(response, 404, "upload reference unknown or expired — request a new upload URL");
+    } else if (error instanceof SlotConsumedError) {
+      writeText(response, 409, "upload reference already used — request a new upload URL");
+    } else if (error instanceof SizeMismatchError) {
+      writeText(
+        response,
+        400,
+        `${error.message} — the upload must match the size declared to createArtifactUploadUrl`,
+      );
+    } else {
+      logger.error("skill artifact upload failed", {
+        ref,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      writeText(response, 500, "failed to stage upload");
+    }
+  }
+}
+
+async function handleDownload(
+  request: LaneRequest,
+  response: LaneResponse,
+  artifacts: SkillArtifactStorage,
+  key: string,
+  logger: Logger,
+): Promise<void> {
+  if (request.method !== "GET") {
+    response.setHeader("Allow", "GET");
+    writeText(response, 405, "method not allowed");
+    return;
+  }
+  if (!key.startsWith(DOWNLOAD_KEY_PREFIX)) {
+    writeText(response, 404, "404 page not found");
+    return;
+  }
+
+  let data: Uint8Array;
+  try {
+    // Full in-memory read matches the store's own interface (get returns
+    // bytes) and the ≤100MB validation ceiling bounds the allocation.
+    data = await artifacts.get(key);
+  } catch (error) {
+    if (error instanceof ArtifactNotFoundError) {
+      writeText(response, 404, "404 page not found");
+      return;
+    }
+    logger.error("skill artifact download failed", {
+      storageKey: key,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    writeText(response, 500, "failed to load artifact");
+    return;
+  }
+
+  response.setHeader("Content-Type", "application/zip");
+  response.setHeader("Content-Length", String(data.length));
+  response.statusCode = 200;
+  response.end(Buffer.from(data));
+}
+
+/** Go http.Error's shape: text/plain body with a trailing newline. */
+function writeText(response: LaneResponse, status: number, body: string): void {
+  response.statusCode = status;
+  response.setHeader("Content-Type", "text/plain; charset=utf-8");
+  response.end(`${body}\n`);
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/transfer/slots.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/transfer/slots.ts
@@ -1,0 +1,242 @@
+/**
+ * Skill artifact upload slots — ports pkg/domain/skill/transfer/slots.go.
+ * The in-memory registry of single-use upload capabilities plus the
+ * staging directory their bytes land in (#675).
+ *
+ * In-memory is deliberate: the OSS server is single-instance (the same
+ * assumption the in-process router transport and SQLite store already
+ * make), and a slot is worthless across restarts anyway — its bytes live
+ * in the staging directory, which is swept on boot.
+ *
+ * Sentinel error classes replace Go's sentinel error values so the HTTP
+ * handler maps registry failures onto honest status codes without string
+ * matching; their message texts are Go's, verbatim (they ride wire-visible
+ * copy: push's "artifact_upload_ref not usable: %v" and the handler's 400
+ * body).
+ *
+ * Proven by __tests__/slots.test.ts (injected clock for expiry) and the
+ * conformance suite's transfer-lane tests.
+ */
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import type { Readable } from "node:stream";
+
+import { REF_BYTE_LEN, REF_PREFIX } from "../constants.js";
+
+/** Go errSlotUnknown — never existed, expired, or swept. */
+export class SlotUnknownError extends Error {
+  constructor() {
+    super("upload reference unknown or expired");
+    this.name = "SlotUnknownError";
+  }
+}
+
+/** Go errSlotConsumed — the slot already carries an upload. */
+export class SlotConsumedError extends Error {
+  constructor() {
+    super("upload reference already carries an upload");
+    this.name = "SlotConsumedError";
+  }
+}
+
+/** Go errSlotEmpty — minted but never (successfully) uploaded to. */
+export class SlotEmptyError extends Error {
+  constructor() {
+    super("upload reference has no uploaded bytes");
+    this.name = "SlotEmptyError";
+  }
+}
+
+/** Go errSizeMismatch — the body disagreed with the minted declaration. */
+export class SizeMismatchError extends Error {
+  constructor(received: number, declared: number) {
+    super(`upload size mismatch: received ${received} bytes, declared ${declared}`);
+    this.name = "SizeMismatchError";
+  }
+}
+
+interface Slot {
+  readonly declaredSize: number;
+  readonly expiresAtMs: number;
+  uploaded: boolean;
+}
+
+export class UploadSlots {
+  private readonly slots = new Map<string, Slot>();
+  private readonly stagingDir: string;
+  private readonly ttlMs: number;
+  private readonly maxSize: number;
+  /** Injectable for expiry tests, mirroring Go's `now` field. */
+  private readonly now: () => number;
+
+  /**
+   * Creates the registry and prepares the staging directory. Any file
+   * already present is an orphan from a previous process (the registry
+   * that knew about it died with that process), so the directory is
+   * emptied — this is also the crash-recovery story for uploads that
+   * never reached their push.
+   */
+  constructor(
+    stagingDir: string,
+    ttlMs: number,
+    maxSize: number,
+    now: () => number = Date.now,
+  ) {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+    fs.mkdirSync(stagingDir, { recursive: true, mode: 0o700 });
+    this.stagingDir = stagingDir;
+    this.ttlMs = ttlMs;
+    this.maxSize = maxSize;
+    this.now = now;
+  }
+
+  /**
+   * Reserves an upload slot for an artifact of declaredSize bytes and
+   * returns its single-use reference + TTL. The caller has already
+   * authorized the request and validated declaredSize against the skill
+   * size limit; this guard is the registry's own invariant.
+   */
+  mint(declaredSize: number): { ref: string; ttlMs: number } {
+    if (declaredSize <= 0 || declaredSize > this.maxSize) {
+      throw new Error(`declared size ${declaredSize} outside (0, ${this.maxSize}]`);
+    }
+    const ref = REF_PREFIX + randomBytes(REF_BYTE_LEN).toString("hex");
+    this.sweep();
+    this.slots.set(ref, {
+      declaredSize,
+      expiresAtMs: this.now() + this.ttlMs,
+      uploaded: false,
+    });
+    return { ref, ttlMs: this.ttlMs };
+  }
+
+  /**
+   * Streams an upload's body into the slot's staging file. The body must
+   * match the size declared at mint time exactly: a shorter body means a
+   * truncated transfer, a longer one means the client lied — both reject
+   * rather than staging bytes that would fail (or worse, surprise)
+   * validation later. The staged file only becomes consumable once this
+   * resolves.
+   */
+  async receive(ref: string, body: Readable): Promise<void> {
+    const slot = this.slots.get(ref);
+    if (slot === undefined || this.now() > slot.expiresAtMs) {
+      throw new SlotUnknownError();
+    }
+    if (slot.uploaded) {
+      throw new SlotConsumedError();
+    }
+    const declared = slot.declaredSize;
+
+    const filePath = this.stagePath(ref);
+    let written = 0;
+    try {
+      // Consume at most declared+1 bytes: seeing the extra byte proves the
+      // body exceeds the declaration without buffering an unbounded stream
+      // (Go's io.LimitReader(declared+1) + written != declared check).
+      await pipeline(
+        body,
+        limitBytes(declared + 1, (n) => {
+          written += n;
+        }),
+        fs.createWriteStream(filePath, { flags: "w", mode: 0o600 }),
+      );
+    } catch (error) {
+      await fs.promises.rm(filePath, { force: true });
+      throw new Error(
+        `failed to receive upload: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (written !== declared) {
+      await fs.promises.rm(filePath, { force: true });
+      throw new SizeMismatchError(written, declared);
+    }
+
+    // Re-check after the write: the slot may have expired mid-upload
+    // (Go re-checks under the lock for the same reason).
+    const current = this.slots.get(ref);
+    if (current === undefined || this.now() > current.expiresAtMs) {
+      await fs.promises.rm(filePath, { force: true });
+      throw new SlotUnknownError();
+    }
+    current.uploaded = true;
+  }
+
+  /**
+   * Returns the staged bytes for ref and retires the slot — an upload
+   * reference is strictly single-use. Push calls this when it sees
+   * artifact_upload_ref; whatever happens downstream (validation failure
+   * included), the slot is gone and the client must re-mint to retry.
+   */
+  async consume(ref: string): Promise<Uint8Array> {
+    const slot = this.slots.get(ref);
+    if (slot === undefined || this.now() > slot.expiresAtMs) {
+      throw new SlotUnknownError();
+    }
+    if (!slot.uploaded) {
+      throw new SlotEmptyError();
+    }
+    this.slots.delete(ref);
+
+    const filePath = this.stagePath(ref);
+    try {
+      const data = await fs.promises.readFile(filePath);
+      return data;
+    } catch (error) {
+      throw new Error(
+        `failed to read staged artifact: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      await fs.promises.rm(filePath, { force: true });
+    }
+  }
+
+  /**
+   * Drops expired slots and their staged files. Called from mint, which
+   * bounds the registry: it can hold at most the slots minted within one
+   * TTL window.
+   */
+  private sweep(): void {
+    const nowMs = this.now();
+    for (const [ref, slot] of this.slots) {
+      if (nowMs > slot.expiresAtMs) {
+        this.slots.delete(ref);
+        fs.rmSync(this.stagePath(ref), { force: true });
+      }
+    }
+  }
+
+  /**
+   * Maps a reference to its staging file. refs are server-generated hex
+   * (never client-supplied paths), so simple joining is safe.
+   */
+  private stagePath(ref: string): string {
+    return path.join(this.stagingDir, `${ref}.zip`);
+  }
+}
+
+/**
+ * A byte-capped pass-through: forwards up to `limit` bytes (counting via
+ * onBytes) and then stops consuming — the TS analogue of piping through
+ * io.LimitReader.
+ */
+function limitBytes(
+  limit: number,
+  onBytes: (count: number) => void,
+): (source: AsyncIterable<Buffer>) => AsyncIterable<Buffer> {
+  return async function* (source: AsyncIterable<Buffer>): AsyncIterable<Buffer> {
+    let remaining = limit;
+    for await (const chunk of source) {
+      if (remaining <= 0) {
+        return;
+      }
+      const slice = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+      remaining -= slice.length;
+      onBytes(slice.length);
+      yield slice;
+    }
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/skill/version-resolution.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/version-resolution.ts
@@ -1,0 +1,336 @@
+/**
+ * Skill version resolution — ports pkg/domain/skill/controller/
+ * load_skill_by_reference.go and list_versions.go: the getByReference
+ * version ladder and the paginated version history.
+ *
+ * The ladder (Go LoadSkillByReferenceStep): resolve the live head by
+ * slug+org; empty/"latest" returns it; a 64-hex version matches the head's
+ * hash or falls to the indexed audit-by-hash lookup; anything else is a
+ * tag, matching the head's live spec.tag first (honest under the
+ * single-holder model: push reconciles the live tag with the audit tag
+ * column, clearing spec.tag when assignment fails) and then the indexed
+ * audit-by-tag lookup.
+ *
+ * listVersions marks is_current by HEAD-HASH match, not recency: under
+ * repoint semantics (#475) re-pushing archived content re-activates its
+ * existing row, so the current version need not be the newest-archived
+ * one. Tags come from the audit COLUMN (the single-holder source of
+ * truth), never from the snapshot — snapshots archive tagless and a legacy
+ * snapshot's embedded tag may have moved since it was written.
+ *
+ * Proven by __tests__/skill.test.ts's ladder and pagination blocks and
+ * the conformance suite's getByReference/listVersions blocks.
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { SkillQueryController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/query_pb";
+import {
+  ListSkillVersionsResponseSchema,
+  SkillVersionEntrySchema,
+} from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import type { SkillVersionEntry } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { findResourceBySlug, requireOrgForReference } from "../../pipeline/steps/helpers.js";
+import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import { AuditNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+/** A 64-character lowercase-hex string (a SHA-256 content hash). */
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+function isHash(version: string): boolean {
+  return HASH_PATTERN.test(version);
+}
+
+type GetByReferenceDesc =
+  typeof SkillQueryController.method.getByReference.input;
+
+/** Go LoadSkillByReferenceStep — the reference + version ladder. */
+export function newLoadSkillByReferenceStep(
+  store: Store,
+): PipelineStep<GetByReferenceDesc> {
+  return {
+    name: "LoadSkillByReference",
+    async execute(ctx: RequestContext<GetByReferenceDesc>): Promise<void> {
+      const ref = ctx.input;
+
+      if (ref.slug === "") {
+        throw invalidArgumentError("slug is required in reference");
+      }
+
+      // Skill is org-scoped: its slug is unique only within an org, so an
+      // empty-org reference is under-specified.
+      requireOrgForReference(ctx.apiResourceKind, ref.org);
+
+      if (
+        ref.kind !== ApiResourceKind.api_resource_kind_unknown &&
+        ref.kind !== ApiResourceKind.skill
+      ) {
+        throw invalidArgumentError(
+          `kind mismatch: expected ${ApiResourceKind[ApiResourceKind.skill]}, got ${ApiResourceKind[ref.kind]}`,
+        );
+      }
+
+      let mainSkill: Skill | undefined;
+      try {
+        mainSkill = await findResourceBySlug(
+          store,
+          ctx.apiResourceKind,
+          SkillSchema,
+          ref.slug,
+          ref.org,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to list skills");
+      }
+      if (mainSkill === undefined) {
+        throw notFoundError("skill", ref.slug);
+      }
+
+      const version = ref.version.trim();
+      if (version === "" || version === "latest") {
+        ctx.set(TARGET_RESOURCE_KEY, mainSkill);
+        return;
+      }
+
+      if (skillMatchesVersion(mainSkill, version)) {
+        ctx.set(TARGET_RESOURCE_KEY, mainSkill);
+        return;
+      }
+
+      const auditSkill = await findAuditSkillByVersion(
+        store,
+        ctx.apiResourceKind,
+        mainSkill.metadata!.id,
+        version,
+      );
+      if (auditSkill === undefined) {
+        throw notFoundError("skill version", `${ref.slug}:${version}`);
+      }
+      ctx.set(TARGET_RESOURCE_KEY, auditSkill);
+    },
+  };
+}
+
+/**
+ * Whether the live head IS the requested version — by hash, or by its
+ * live spec.tag (honest under the single-holder tag model, see module doc).
+ */
+function skillMatchesVersion(skill: Skill, version: string): boolean {
+  if (skill.status === undefined) {
+    return false;
+  }
+  if (isHash(version)) {
+    return skill.status.versionHash === version;
+  }
+  return skill.spec !== undefined && skill.spec.tag === version;
+}
+
+/**
+ * Indexed audit lookup by hash or tag (Go findAuditSkillByVersion) —
+ * not-found is a normal outcome (undefined), storage failures are
+ * Internal.
+ */
+async function findAuditSkillByVersion(
+  store: Store,
+  kind: ApiResourceKind,
+  skillId: string,
+  version: string,
+): Promise<Skill | undefined> {
+  if (isHash(version)) {
+    try {
+      return await store.getAuditByHash(kind, skillId, version, SkillSchema);
+    } catch (error) {
+      if (error instanceof AuditNotFoundError) {
+        return undefined;
+      }
+      throw internalError(error, "failed to query audit by hash");
+    }
+  }
+  try {
+    return await store.getAuditByTag(kind, skillId, version, SkillSchema);
+  } catch (error) {
+    if (error instanceof AuditNotFoundError) {
+      return undefined;
+    }
+    throw internalError(error, "failed to query audit by tag");
+  }
+}
+
+// ─── listVersions ────────────────────────────────────────────────────────
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 100;
+
+export const LIST_VERSIONS_SKILL_ID_KEY = "listVersionsSkillId";
+export const LIST_VERSIONS_HEAD_HASH_KEY = "listVersionsHeadHash";
+export const LIST_VERSIONS_RESPONSE_KEY = "listVersionsResponse";
+
+type ListVersionsDesc = typeof SkillQueryController.method.listVersions.input;
+
+/** Go ResolveSkillBySlugStep — resolves the skill and captures the head hash. */
+export function newResolveSkillBySlugStep(
+  store: Store,
+): PipelineStep<ListVersionsDesc> {
+  return {
+    name: "ResolveSkillBySlug",
+    async execute(ctx: RequestContext<ListVersionsDesc>): Promise<void> {
+      const req = ctx.input;
+      let skill: Skill | undefined;
+      try {
+        skill = await findResourceBySlug(
+          store,
+          ctx.apiResourceKind,
+          SkillSchema,
+          req.slug,
+          req.org,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to search for skill");
+      }
+      if (skill === undefined) {
+        throw notFoundError("skill", `${req.slug} (org: ${req.org})`);
+      }
+      ctx.set(LIST_VERSIONS_SKILL_ID_KEY, skill.metadata!.id);
+      // The live head's hash decides is_current downstream. Under repoint
+      // semantics the current version need not be the newest-archived row,
+      // so recency cannot stand in for currency.
+      ctx.set(LIST_VERSIONS_HEAD_HASH_KEY, skill.status?.versionHash ?? "");
+    },
+  };
+}
+
+/** Go LoadAndMapVersionsStep — audit records → entries → one page. */
+export function newLoadAndMapVersionsStep(
+  store: Store,
+): PipelineStep<ListVersionsDesc> {
+  return {
+    name: "LoadAndMapVersions",
+    async execute(ctx: RequestContext<ListVersionsDesc>): Promise<void> {
+      const req = ctx.input;
+      const skillId = ctx.get(LIST_VERSIONS_SKILL_ID_KEY) as string;
+
+      let records;
+      try {
+        records = await store.listAuditRecords(ctx.apiResourceKind, skillId);
+      } catch (error) {
+        throw internalError(error, "failed to load version history");
+      }
+
+      // is_current = the entry whose hash matches the live head, not the
+      // newest row. Legacy data may hold duplicate-hash rows (predating
+      // repoint semantics); marking only the first match keeps
+      // exactly-one-current true for them too.
+      const headHash = ctx.get(LIST_VERSIONS_HEAD_HASH_KEY) as string;
+      let currentMarked = false;
+      const entries: SkillVersionEntry[] = [];
+      for (const record of records) {
+        let skill: Skill;
+        try {
+          skill = fromBinary(SkillSchema, record.data);
+        } catch {
+          continue;
+        }
+        const isCurrent: boolean =
+          !currentMarked &&
+          headHash !== "" &&
+          (skill.status?.versionHash ?? "") === headHash;
+        currentMarked = currentMarked || isCurrent;
+        // Tag comes from the audit column (source of truth), not the snapshot.
+        entries.push(mapSkillToVersionEntry(skill, isCurrent, record.tag));
+      }
+
+      let pageSize = req.pageSize;
+      if (pageSize <= 0) {
+        pageSize = DEFAULT_PAGE_SIZE;
+      }
+      if (pageSize > MAX_PAGE_SIZE) {
+        pageSize = MAX_PAGE_SIZE;
+      }
+
+      let startIndex = 0;
+      if (req.pageToken !== "") {
+        startIndex = decodePageToken(req.pageToken);
+      }
+
+      let pageEntries: SkillVersionEntry[] = [];
+      let nextPageToken = "";
+      if (startIndex < entries.length) {
+        const end = Math.min(startIndex + pageSize, entries.length);
+        pageEntries = entries.slice(startIndex, end);
+        if (end < entries.length) {
+          nextPageToken = Buffer.from(String(end)).toString("base64");
+        }
+      }
+
+      ctx.set(
+        LIST_VERSIONS_RESPONSE_KEY,
+        create(ListSkillVersionsResponseSchema, {
+          versions: pageEntries,
+          nextPageToken,
+          totalCount: entries.length,
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * Decodes the base64 cursor with Go's strictness: base64.StdEncoding
+ * rejects malformed input and strconv.Atoi rejects trailing garbage —
+ * Buffer.from is lenient on both, so validity is checked explicitly.
+ */
+function decodePageToken(token: string): number {
+  const decoded = Buffer.from(token, "base64");
+  if (decoded.toString("base64") !== token) {
+    throw invalidArgumentError("invalid page_token");
+  }
+  const text = decoded.toString("utf8");
+  const index = Number.parseInt(text, 10);
+  if (!Number.isSafeInteger(index) || String(index) !== text || index < 0) {
+    throw invalidArgumentError("invalid page_token");
+  }
+  return index;
+}
+
+/**
+ * Maps an archived Skill snapshot to a version entry (Go
+ * mapSkillToVersionEntry). pushed_at/pushed_by prefer the spec-audit
+ * updated stamps and fall back to created (first pushes only carry
+ * created).
+ */
+function mapSkillToVersionEntry(
+  skill: Skill,
+  isCurrent: boolean,
+  tag: string,
+): SkillVersionEntry {
+  const entry = create(SkillVersionEntrySchema, { isCurrent, tag });
+
+  if (skill.status !== undefined) {
+    entry.versionHash = skill.status.versionHash;
+    entry.artifactStorageKey = skill.status.artifactStorageKey;
+    entry.gitProvenance = skill.status.gitProvenance;
+
+    const specAudit = skill.status.audit?.specAudit;
+    if (specAudit !== undefined) {
+      entry.pushedAt = specAudit.updatedAt ?? specAudit.createdAt;
+      entry.pushedBy = specAudit.updatedBy ?? specAudit.createdBy;
+    }
+  }
+
+  if (skill.metadata?.version !== undefined) {
+    entry.message = skill.metadata.version.message;
+  }
+
+  return entry;
+}

--- a/backend/services/stigmer-server-ts/src/domain/workflow/__tests__/workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflow/__tests__/workflow.test.ts
@@ -66,6 +66,9 @@ beforeAll(async () => {
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
       DB_PATH: path.join(dir, "stigmer.db"),
+      // The skill artifact store + staging wipe (#8) must stay inside the
+      // test dir — the default resolves to ~/.stigmer/storage.
+      STORAGE_PATH: path.join(dir, "storage"),
       // Keep the artifact store inside the test dir — the default
       // resolves to ~/.stigmer, which tests must never touch.
       ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),

--- a/backend/services/stigmer-server-ts/src/transport/registry/__tests__/lanes.test.ts
+++ b/backend/services/stigmer-server-ts/src/transport/registry/__tests__/lanes.test.ts
@@ -10,6 +10,10 @@
  * the data now — src/domain/workflow/registry/__tests__/bundled.test.ts
  * (the registry moved home to the domain, workflow-family DD-A).
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { loadConfig } from "../../../boot/config.js";
@@ -25,10 +29,23 @@ const silentLogger = createLogger({
 let server: ComposedServer;
 let baseUrl: string;
 
+let testDir: string;
+
 beforeAll(async () => {
   // Refresh pinned off, as the conformance harness pins it — the served
   // model registry IS the embedded snapshot, deterministic offline.
-  const config = loadConfig({ STIGMER_MODEL_REGISTRY_REFRESH: "off" });
+  // Every filesystem-touching stage is pinned into a throwaway dir: this
+  // test previously composed against the DEFAULT paths, which meant
+  // opening the developer's real ~/.stigmer/stigmer.db — and with the
+  // skill domain's boot-time staging wipe (#8) it would now also clear
+  // ~/.stigmer/storage/skills-staging. Tests never touch the home dir.
+  testDir = mkdtempSync(path.join(tmpdir(), "registry-lanes-test-"));
+  const config = loadConfig({
+    STIGMER_MODEL_REGISTRY_REFRESH: "off",
+    DB_PATH: path.join(testDir, "stigmer.db"),
+    ARTIFACT_LOCAL_BASE_PATH: path.join(testDir, "artifacts"),
+    STORAGE_PATH: path.join(testDir, "storage"),
+  });
   server = composeServer({
     config,
     logger: silentLogger,
@@ -41,6 +58,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await server.shutdown();
+  rmSync(testDir, { recursive: true, force: true });
 });
 
 const routes = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "workspaces": [
         "apis/stubs/ts",
         "backend/libs/ts/temporal-codecs",
+        "backend/libs/ts/zip-structure",
         "sdk/typescript",
         "sdk/theme",
         "sdk/react",
@@ -64,6 +65,29 @@
       }
     },
     "backend/libs/ts/temporal-codecs/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "backend/libs/ts/zip-structure": {
+      "name": "@stigmer/zip-structure",
+      "version": "0.0.0-dev",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.13.1",
+        "typescript": "^5.7.0",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=23.4.0"
+      }
+    },
+    "backend/libs/ts/zip-structure/node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
@@ -2947,6 +2971,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3786,6 +3811,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3808,6 +3834,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3830,6 +3857,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3846,6 +3874,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3862,6 +3891,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3878,6 +3908,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3894,6 +3925,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3910,6 +3942,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3926,6 +3959,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3942,6 +3976,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3958,6 +3993,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3974,6 +4010,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3990,6 +4027,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4012,6 +4050,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4034,6 +4073,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4056,6 +4096,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4078,6 +4119,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4100,6 +4142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4122,6 +4165,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4144,6 +4188,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4166,6 +4211,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4185,6 +4231,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4204,6 +4251,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4223,6 +4271,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5845,6 +5894,10 @@
     },
     "node_modules/@stigmer/theme": {
       "resolved": "sdk/theme",
+      "link": true
+    },
+    "node_modules/@stigmer/zip-structure": {
+      "resolved": "backend/libs/ts/zip-structure",
       "link": true
     },
     "node_modules/@swc/helpers": {
@@ -17048,12 +17101,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": [
     "apis/stubs/ts",
     "backend/libs/ts/temporal-codecs",
+    "backend/libs/ts/zip-structure",
     "sdk/typescript",
     "sdk/theme",
     "sdk/react",
@@ -22,10 +23,10 @@
   ],
   "scripts": {
     "prepare": "husky || true",
-    "build:runner-deps": "npm run build -w @stigmer/protos && npm run build -w @stigmer/temporal-codecs",
-    "build:libs": "npm run build -w @stigmer/protos && npm run build -w @stigmer/temporal-codecs && npm run build -w @stigmer/sdk && npm run build -w @stigmer/theme && npm run build -w @stigmer/react && npm run build -w @stigmer/embed && npm run build -w @stigmer/ink && npm run build -w @stigmer/mcp-server && npm run build -w @stigmer/seedpack && npm run build -w @stigmer/cli",
-    "clean:libs": "npm run clean -w @stigmer/protos && npm run clean -w @stigmer/temporal-codecs && npm run clean -w @stigmer/sdk && npm run clean -w @stigmer/theme && npm run clean -w @stigmer/react && npm run clean -w @stigmer/embed && npm run clean -w @stigmer/ink && npm run clean -w @stigmer/mcp-server && npm run clean -w @stigmer/seedpack && npm run clean -w @stigmer/cli",
-    "test": "node --test scripts/*.test.mjs && npm run test -w @stigmer/temporal-codecs && npm run test -w @stigmer/sdk && npm run test -w @stigmer/react && npm run test -w @stigmer/theme && npm run test -w @stigmer/embed && npm run test -w @stigmer/ink && npm run test -w @stigmer/mcp-server && npm run test -w @stigmer/seedpack && npm run test -w @stigmer/cli"
+    "build:runner-deps": "npm run build -w @stigmer/protos && npm run build -w @stigmer/temporal-codecs && npm run build -w @stigmer/zip-structure",
+    "build:libs": "npm run build -w @stigmer/protos && npm run build -w @stigmer/temporal-codecs && npm run build -w @stigmer/zip-structure && npm run build -w @stigmer/sdk && npm run build -w @stigmer/theme && npm run build -w @stigmer/react && npm run build -w @stigmer/embed && npm run build -w @stigmer/ink && npm run build -w @stigmer/mcp-server && npm run build -w @stigmer/seedpack && npm run build -w @stigmer/cli",
+    "clean:libs": "npm run clean -w @stigmer/protos && npm run clean -w @stigmer/temporal-codecs && npm run clean -w @stigmer/zip-structure && npm run clean -w @stigmer/sdk && npm run clean -w @stigmer/theme && npm run clean -w @stigmer/react && npm run clean -w @stigmer/embed && npm run clean -w @stigmer/ink && npm run clean -w @stigmer/mcp-server && npm run clean -w @stigmer/seedpack && npm run clean -w @stigmer/cli",
+    "test": "node --test scripts/*.test.mjs && npm run test -w @stigmer/temporal-codecs && npm run test -w @stigmer/zip-structure && npm run test -w @stigmer/sdk && npm run test -w @stigmer/react && npm run test -w @stigmer/theme && npm run test -w @stigmer/embed && npm run test -w @stigmer/ink && npm run test -w @stigmer/mcp-server && npm run test -w @stigmer/seedpack && npm run test -w @stigmer/cli"
   },
   "lint-staged": {
     "docs/**/*.{md,mdx}": [

--- a/scripts/publish-libs.mjs
+++ b/scripts/publish-libs.mjs
@@ -47,6 +47,10 @@ export const PACKAGES = [
   // release workflows) depends on it, pinned to the exact release version
   // at stamp time — exactly like @stigmer/protos.
   "backend/libs/ts/temporal-codecs",
+  // @stigmer/zip-structure has no deps at all, so its position is order-free.
+  // It MUST publish for the same reason as temporal-codecs: the runner links
+  // it and pins the exact release version at stamp time.
+  "backend/libs/ts/zip-structure",
   "sdk/typescript",
   "sdk/theme",
   "sdk/react",

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -28,6 +28,10 @@
 //     deepest domain: 23 RPCs incl. the subscribe stream, the HITL
 //     surfaces, and the engine-gate/lifecycle negatives that pin the
 //     no-Temporal posture until #18).
+//   - skill — sub-project #8 (sp.skill; push-only content-addressed
+//     artifacts, the version-resolution ladder, and the #675 HTTP transfer
+//     lane — skillArtifactTransferLane is honest on this target from this
+//     entry on).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -44,6 +48,7 @@ export default defineConfig({
       "src/suites/workflowinstance.conformance.test.ts",
       "src/suites/executioncontext.conformance.test.ts",
       "src/suites/agentexecution.conformance.test.ts",
+      "src/suites/skill.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

D4 entry #8 (`sp.skill`, program 20260822.01): the Skill domain ported whole to the TS server — push-only content-addressed artifacts with the version-resolution ladder and the #675 HTTP transfer lane on the unified port — plus the extraction of the runner's structural ZIP parser to `backend/libs/ts/zip-structure` (the program's second-consumer rule; `@stigmer/temporal-codecs` packaging precedent).

## Context

The D4 sequence continues Stage 2: skill needed only #4 (merged) and the transport seam #3 reserved (`skillTransferLane`). The `local-ts` capability matrix has declared `skillArtifactTransferLane: true` since #4 — this PR makes that flag honest.

## Changes

- **`backend/libs/ts/zip-structure`** (new lib): the runner's policy-free central-directory ZIP parser, moved with additive raw CD fields (`versionMadeBy`, `externalAttributes`, `crc32`, `compressedSize`) and the byte-level fixture builder as a `./testing` subpath export; its first dedicated test suite (10 tests). Runner consumes via `file:` dep — imports updated, behavior-neutral under its full suite (277 files / 4732 tests green). Wired into `ci.ts-libs`, `release.npm-libs` (publish loop + runner stamping + wait), `publish-libs.mjs`, and the root `build:runner-deps`/`build:libs`/`clean:libs`/`test` scripts.
- **`src/domain/skill/`**: all 10 RPCs. The 12-step push pipeline name-for-name (repoint-never-duplicate #475, tagless snapshots + single-holder `setAuditTag`, the two safe-degradation arms, #540 audit-slot discipline); the getByReference version ladder (empty/latest → head, 64-hex → hash, else tag; live-head-first); listVersions with head-hash `is_current` and strict base64 cursors; updateVisibility (load-before-validate); delete with best-effort archive cleanup; pushFromExecutionArtifact with the `artifacts/{execution_id}/` ownership guard; FTS search extractor.
- **`storage/`**: the ZIP gate mirroring Go's `zip_extractor.go` arm-for-arm INCLUDING safearchive's `MaximumSecurityMode` entry pre-filter (sub-project DD-001, owner-ratified: name sanitization, 8.3-name skip, symlink-shadow skip, special-file skip, with the `archive/zip` mode decode); frontmatter parsing with Go's exact delimiter/scanner semantics (incl. the `bufio.Scanner` 64KB line cap and Go's `TrimSpace` White_Space set — U+FEFF excluded); the content-addressed filesystem store at Go's exact paths (`{STORAGE_PATH}/skills/{sha256}.zip`, never-GC, traversal-guarded).
- **`transfer/`**: `UploadSlots` (in-memory single-use capabilities, `sau_` refs, 15-min TTL, exact-declared-size streaming enforcement, boot-time staging wipe) and the lane handler on the transport's existing seam, serving both protocol stacks.
- **Config**: `STORAGE_PATH` (default `~/.stigmer/storage`) and `SKILL_TRANSFER_BASE_URL` (default `http://localhost:{GRPC_PORT}`), mirroring Go's `pkg/config`.
- **Test hygiene**: all composed-server tests and `verify-boot.mjs` now pin `STORAGE_PATH` (and the previously-missing isolation in `lanes.test.ts`) into temp dirs — the staging wipe must never touch a developer's real `~/.stigmer`.
- **Roster**: `skill.conformance.test.ts` rosters on `local-ts` (12th suite).

## Implementation notes

- **DD-001 (safearchive pre-filter, full port)**: Go's reader rewrites the entry list before validation — `../SKILL.md` sanitizes to a root `SKILL.md` and is ACCEPTED; symlink-shadowed/special/8.3 entries silently drop. Reproduced byte-for-byte from safearchive source at the pinned version, with crafted-fixture tests per arm. The cloud edition applies none of this; the parity bar is the Go server.
- **Two-reviewer adversarial panel ran; all findings applied.** Parity findings fixed in-branch: BOM'd SKILL.md acceptance (JS `trim()` strips U+FEFF, Go doesn't), the missing 64KB scanner-line arms (including Go's bug-for-bug "SKILL.md is empty" for an over-cap FIRST line), platform-independent storage keys (literal `skills/` join — Windows arrives only via this server, #24), and a detached-rejection catch on the lane handlers. Quality panel: no blocking findings; h2c lane coverage added as a permanent test.
- **Disclosed parity nuances** (for the register; all code-level InvalidArgument parity holds):
  1. A corrupt payload SLICE on any non-SKILL.md entry fails the TS structural parse ("invalid ZIP file") where Go accepts the archive (it never opens that entry). TS is stricter on corrupt archives only.
  2. Deflate-corruption error text carries zlib's message where Go carries flate's; js-yaml's duplicate-key/YAML-error texts differ from yaml.v3's (both editions reject with the same code).
  3. A frontmatter `name:` with a non-string YAML value reports the missing-name arm here vs yaml.v3's unmarshal-error text in Go.
  4. Page tokens: Go's lenient base64 accepts non-canonical trailing bits; the TS round-trip check rejects them (InvalidArgument either way for garbage).
  5. Go's sanitizer compiles a Windows variant on Windows hosts; the TS gate uses the nix variant everywhere (forward-slash names) — cosmetic-only, and Go never shipped on Windows.
  6. Concurrent `receive()` calls replaying ONE upload ref can interleave into the staging file — faithful to Go's identical lock window; single-use capability semantics bound the blast radius to a corrupt-ZIP InvalidArgument at push.

## Test plan

- Unit: 878 server tests green (65 files; +115 for skill incl. crafted safearchive fixtures, degradation arms via failing-store fakes, and an h2c lane test); 10 lib tests; runner 4732 green on the lib move.
- Conformance: `local-ts` 12 suites / 299 passed (skill's 55 green on the FIRST rostered run; the 1 skip is the lane-absent inverse arm, skipped on lane-bearing targets by design). `local-go` 468 passed, regression-free.
- Builds: `tsc --noEmit` clean everywhere; dist + slim bundles boot-verified (plain node, #399 class).

## Risks

- Additive until #24; the Go server is untouched. Rollback is reverting the merge — the lib move is contained in the same commit, so a revert restores the runner's in-tree parser atomically.
- The next release publishes `@stigmer/zip-structure` for the runner's pinned dep (wired in `release.npm-libs`; the pre-publish ESM gate covers its dists).

## Checklist

- [x] Tests added/updated
- [x] Backward compatible (additive; no Go changes)
- [x] CI wiring for the new lib (`ci.ts-libs`, release lanes)

Made with [Cursor](https://cursor.com)