### PR TITLE
feat(backend/stigmer-server-ts): port the sharing/channel family — agentshare, agentchannel, channelapp (D4 #12)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -28,6 +28,11 @@ import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
 import { RuntimeResolutionService } from "../domain/environment/resolution/resolution.js";
 import { ManagedEnvironmentService } from "../domain/mcpserver/oauth/managed-env.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
+import { registerAgentChannelServices } from "../domain/agentchannel/controller.js";
+import { registerChannelConversationServices } from "../domain/agentchannel/conversation.js";
+import { registerChannelMessageServices } from "../domain/agentchannel/message.js";
+import { registerAgentShareServices } from "../domain/agentshare/controller.js";
+import { registerChannelAppServices } from "../domain/channelapp/controller.js";
 import { registerEnvironmentServices } from "../domain/environment/controller.js";
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
 import { registerMemoryServices } from "../domain/memory/controller.js";
@@ -226,6 +231,23 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       temporalConfig,
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
     });
+    // The sharing/channel family registers after the agent family, as in
+    // Go server.go (agent 378 → agentshare 384 → agentchannel 391 →
+    // channelmessage 399 → channelconversation 408 → channelapp 416).
+    // ChannelApp shares the ONE SecretService instance with Environment —
+    // one key, one enc:v1: format (Go wires the same pointer).
+    registerAgentShareServices(router, { store, logger });
+    registerAgentChannelServices(router, {
+      store,
+      logger,
+      // The SAME domain-owned registry instance the workflow validator
+      // and the registry lanes read — the channel model-pin rule
+      // (stigmer/stigmer#774) can never drift from the served pickers.
+      modelRegistry: modelRegistryStore,
+    });
+    registerChannelMessageServices(router);
+    registerChannelConversationServices(router);
+    registerChannelAppServices(router, { store, logger, secretService });
     registerMemoryServices(router, { store, logger });
     registerAgentExecutionServices(router, {
       store,

--- a/backend/services/stigmer-server-ts/src/domain/agentchannel/__tests__/agentchannel.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentchannel/__tests__/agentchannel.test.ts
@@ -1,0 +1,1021 @@
+/**
+ * Pins the agentchannel domain against Go's agentchannel_test.go,
+ * case-for-case — through the REAL stack: a composed server on an
+ * ephemeral port, native gRPC clients for all four registration blocks
+ * (channel command/query, message, conversation), the full interceptor
+ * chain.
+ *
+ * One deliberate adaptation from the Go file, a strengthening: Go pins
+ * provider-arm immutability at the STEP level with a no-arm stand-in
+ * (the test predates the WhatsApp arm); here a real slack→whatsapp flip
+ * runs through the wire and pins the copy. Go's TestProviderFieldName
+ * ports as a seam-level pin below — the TS derivation resolves the PROTO
+ * field name through the schema descriptor, because the oneof `case` is
+ * the camelCased localName and would silently diverge from Go's pinned
+ * error copy on a future snake_case arm.
+ *
+ * Go tests run one store per test function; this file shares ONE server,
+ * so count-sensitive assertions use dedicated orgs and every agent /
+ * channel name is unique per test.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { AgentChannelSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/spec_pb";
+import { AgentChannelCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/command_pb";
+import { AgentChannelQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/query_pb";
+import { ChannelMessageCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_command_pb";
+import { ChannelMessageQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_query_pb";
+import { ChannelConversationCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_command_pb";
+import { ChannelConversationQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_query_pb";
+import { AgentChannelInstallState } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { providerFieldName } from "../steps.js";
+import {
+  APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE,
+  APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE,
+  APP_REF_SAME_ORG_MESSAGE,
+  CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+  INSTALL_UNAVAILABLE_MESSAGE,
+  NO_DOWNLOADABLE_MEDIA_MESSAGE,
+  PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE,
+  agentRefImmutableMessage,
+  providerImmutableMessage,
+  sameOrgInvariantMessage,
+} from "../constants.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "channel-test-org";
+
+let server: ComposedServer;
+let channels: Client<typeof AgentChannelCommandController>;
+let query: Client<typeof AgentChannelQueryController>;
+let agents: Client<typeof AgentCommandController>;
+let messageCommand: Client<typeof ChannelMessageCommandController>;
+let messageQuery: Client<typeof ChannelMessageQueryController>;
+let conversationCommand: Client<typeof ChannelConversationCommandController>;
+let conversationQuery: Client<typeof ChannelConversationQueryController>;
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "agentchannel-domain-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
+  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  channels = createClient(AgentChannelCommandController, transport);
+  query = createClient(AgentChannelQueryController, transport);
+  agents = createClient(AgentCommandController, transport);
+  messageCommand = createClient(ChannelMessageCommandController, transport);
+  messageQuery = createClient(ChannelMessageQueryController, transport);
+  conversationCommand = createClient(ChannelConversationCommandController, transport);
+  conversationQuery = createClient(ChannelConversationQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+let counter = 0;
+function uniqueName(base: string): string {
+  counter += 1;
+  return `${base} ${counter}`;
+}
+
+async function createTestAgent(name: string, org: string = ORG): Promise<Agent> {
+  return agents.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org },
+    spec: {
+      description: "Agent for channel tests",
+      instructions: "You are a helpful agent for channel verification.",
+    },
+  });
+}
+
+/**
+ * A named Slack channel for an agent. Unlike shares, channels have no
+ * canonical-slug default (P7: N-per-agent), so tests always provide a
+ * name for the generic derive-from-name slug.
+ */
+function channelFor(agent: Agent, name: string, enabled: boolean) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "AgentChannel",
+    metadata: { name, org: agent.metadata!.org },
+    spec: {
+      agentRef: { kind: ApiResourceKind.agent, slug: agent.metadata!.slug },
+      enabled,
+      providerConfig: { case: "slack" as const, value: {} },
+    },
+  };
+}
+
+/** The whatsapp variant — no app_ref by default (DD-WA-2 arms test it). */
+function whatsAppChannelFor(agent: Agent, name: string) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "AgentChannel",
+    metadata: { name, org: agent.metadata!.org },
+    spec: {
+      agentRef: { kind: ApiResourceKind.agent, slug: agent.metadata!.slug },
+      enabled: true,
+      providerConfig: {
+        case: "whatsapp" as const,
+        value: { phoneNumberId: "106540352242922" },
+      },
+    },
+  };
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model-pin existence (Go TestAgentChannelController_ModelPinExistence,
+// stigmer/stigmer#774) — validated against the bundled registry.
+// ---------------------------------------------------------------------------
+
+describe("model-pin existence (oss#774)", () => {
+  it("create refuses a pin unknown to every harness, with a did-you-mean", async () => {
+    const agent = await createTestAgent(uniqueName("pin-agent"));
+    const ch = channelFor(agent, uniqueName("typod-pin"), true);
+    (ch.spec as Record<string, unknown>).runConfig = { modelName: "composr-2.5" };
+
+    const err = await grpcError(() => channels.create(ch));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("not in the model registry (any harness)");
+    expect(err.rawMessage).toContain("'composer-2.5'");
+  });
+
+  it("create accepts a pin valid under some harness", async () => {
+    const agent = await createTestAgent(uniqueName("pin-agent"));
+    const ch = channelFor(agent, uniqueName("valid-pin"), true);
+    (ch.spec as Record<string, unknown>).runConfig = { modelName: "composer-2.5" };
+    await channels.create(ch);
+  });
+
+  it("update refuses the same typo", async () => {
+    const agent = await createTestAgent(uniqueName("pin-agent"));
+    const created = await channels.create(channelFor(agent, uniqueName("update-pin-target"), true));
+
+    const update = channelFor(agent, created.metadata!.name, true);
+    (update.metadata as Record<string, string>).id = created.metadata!.id;
+    (update.metadata as Record<string, string>).slug = created.metadata!.slug;
+    (update.spec as Record<string, unknown>).runConfig = { modelName: "composr-2.5" };
+
+    const err = await grpcError(() => channels.update(update));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("not in the model registry (any harness)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create (Go TestAgentChannelController_Create).
+// ---------------------------------------------------------------------------
+
+describe("agentchannel create", () => {
+  it("creates with ach_ prefix, normalized ref, pending_install", async () => {
+    const agent = await createTestAgent(uniqueName("Create Basics Agent"));
+    const channel = await channels.create(channelFor(agent, uniqueName("Slack Workspace"), true));
+
+    expect(channel.metadata?.id).toMatch(/^ach_/);
+    expect(channel.spec?.agentRef?.org).toBe(agent.metadata!.org);
+    expect(channel.status?.installState).toBe(AgentChannelInstallState.pending_install);
+  });
+
+  it("no slug default from the agent — name derives the slug (P7)", async () => {
+    const agent = await createTestAgent(uniqueName("Slug Discipline Agent"));
+    const name = uniqueName("Team Slack");
+    const channel = await channels.create(channelFor(agent, name, true));
+
+    expect(channel.metadata?.slug).toBe(name.toLowerCase().replace(/\s+/g, "-"));
+    expect(channel.metadata?.slug).not.toBe(agent.metadata!.slug);
+  });
+
+  it("nameless and slugless channel is INVALID_ARGUMENT, never agent-slug fallback", async () => {
+    const agent = await createTestAgent(uniqueName("No Name Agent"));
+    const err = await grpcError(() => channels.create(channelFor(agent, "", true)));
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("client-provided status is discarded, never trusted", async () => {
+    const agent = await createTestAgent(uniqueName("Status Forgery Agent"));
+    const created = await channels.create({
+      ...channelFor(agent, uniqueName("Forged Status Slack"), true),
+      status: { installState: AgentChannelInstallState.installed },
+    });
+    expect(created.status?.installState).toBe(AgentChannelInstallState.pending_install);
+  });
+
+  it("missing org is INVALID_ARGUMENT with the shared copy", async () => {
+    const agent = await createTestAgent(uniqueName("Orgless Channel Agent"));
+    const ch = channelFor(agent, uniqueName("Orgless Slack"), true);
+    ch.metadata.org = "";
+
+    const err = await grpcError(() => channels.create(ch));
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("missing agent_ref slug is INVALID_ARGUMENT naming the field", async () => {
+    const err = await grpcError(() =>
+      channels.create({
+        apiVersion: API_VERSION,
+        kind: "AgentChannel",
+        metadata: { name: uniqueName("Refless Channel"), org: ORG },
+        spec: {
+          agentRef: { kind: ApiResourceKind.agent },
+          enabled: true,
+          providerConfig: { case: "slack" as const, value: {} },
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toContain("spec.agent_ref.slug");
+  });
+
+  it("nonexistent agent is NOT_FOUND with the direct-lookup copy", async () => {
+    const err = await grpcError(() =>
+      channels.create({
+        apiVersion: API_VERSION,
+        kind: "AgentChannel",
+        metadata: { name: uniqueName("Ghost Channel"), org: ORG },
+        spec: {
+          agentRef: { kind: ApiResourceKind.agent, slug: "no-such-agent" },
+          enabled: true,
+          providerConfig: { case: "slack" as const, value: {} },
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toBe("Agent not found: no-such-agent");
+  });
+
+  it("cross-org agent_ref is FAILED_PRECONDITION with the shared copy", async () => {
+    const agent = await createTestAgent(uniqueName("Foreign Agent"), "channel-other-org");
+    const ch = channelFor(agent, uniqueName("Cross Org Channel"), true);
+    ch.metadata.org = ORG;
+    ch.spec.agentRef = { ...ch.spec.agentRef, org: "channel-other-org" } as never;
+
+    const err = await grpcError(() => channels.create(ch));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(sameOrgInvariantMessage("channel-other-org"));
+  });
+
+  it("cross-org refusal precedes the agent load — no slug probing", async () => {
+    // The referenced slug does NOT exist in the foreign org; the refusal
+    // must still be FAILED_PRECONDITION, never NOT_FOUND — this path must
+    // not disclose whether a foreign org's slug exists.
+    const err = await grpcError(() =>
+      channels.create({
+        apiVersion: API_VERSION,
+        kind: "AgentChannel",
+        metadata: { name: uniqueName("Probe Channel"), org: ORG },
+        spec: {
+          agentRef: {
+            kind: ApiResourceKind.agent,
+            org: "some-foreign-org",
+            slug: "possibly-private-slug",
+          },
+          enabled: true,
+          providerConfig: { case: "slack" as const, value: {} },
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+  });
+
+  it("duplicate org+slug is ALREADY_EXISTS", async () => {
+    const agent = await createTestAgent(uniqueName("Duplicate Channel Agent"));
+    const name = uniqueName("Duplicate Slack");
+    await channels.create(channelFor(agent, name, true));
+
+    const err = await grpcError(() => channels.create(channelFor(agent, name, true)));
+    expect(err.code).toBe(Code.AlreadyExists);
+  });
+
+  it("missing provider arm is INVALID_ARGUMENT (required oneof)", async () => {
+    const agent = await createTestAgent(uniqueName("Providerless Agent"));
+    const err = await grpcError(() =>
+      channels.create({
+        apiVersion: API_VERSION,
+        kind: "AgentChannel",
+        metadata: { name: uniqueName("Providerless Channel"), org: ORG },
+        spec: {
+          agentRef: { kind: ApiResourceKind.agent, slug: agent.metadata!.slug },
+          enabled: true,
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("two channels for one agent coexist under distinct slugs", async () => {
+    const agent = await createTestAgent(uniqueName("Multi Channel Agent"));
+    const first = await channels.create(channelFor(agent, uniqueName("Sales Slack"), true));
+    const second = await channels.create(channelFor(agent, uniqueName("Support Slack"), true));
+    expect(first.metadata?.slug).not.toBe(second.metadata?.slug);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Update (Go TestAgentChannelController_Update + provider immutability).
+// ---------------------------------------------------------------------------
+
+describe("agentchannel update", () => {
+  it("disable is a config-preserving pause; status survives a status-less manifest", async () => {
+    const agent = await createTestAgent(uniqueName("Pause Agent"));
+    const created = await channels.create(channelFor(agent, uniqueName("Pausable Slack"), true));
+
+    created.spec!.enabled = false;
+    created.status = undefined; // a manifest apply sends no status
+    const updated = await channels.update(created);
+    expect(updated.spec?.enabled).toBe(false);
+    expect(updated.status?.installState).toBe(AgentChannelInstallState.pending_install);
+  });
+
+  it("agent_ref is immutable with the shared copy", async () => {
+    const agentA = await createTestAgent(uniqueName("Immutable Ref Agent A"));
+    const agentB = await createTestAgent(uniqueName("Immutable Ref Agent B"));
+    const created = await channels.create(channelFor(agentA, uniqueName("Repoint Slack"), true));
+
+    const repointed = channelFor(agentB, "ignored", true);
+    (repointed.metadata as Record<string, string>).id = created.metadata!.id;
+    (repointed.metadata as Record<string, string>).slug = created.metadata!.slug;
+    (repointed.metadata as Record<string, string>).name = created.metadata!.name;
+    repointed.spec.agentRef = {
+      kind: ApiResourceKind.agent,
+      org: agentB.metadata!.org,
+      slug: agentB.metadata!.slug,
+    } as never;
+
+    const err = await grpcError(() => channels.update(repointed));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(
+      agentRefImmutableMessage(agentA.metadata!.org, agentA.metadata!.slug),
+    );
+  });
+
+  it("relative agent_ref org normalizes before the immutability compare", async () => {
+    const agent = await createTestAgent(uniqueName("Relative Ref Agent"));
+    const created = await channels.create(
+      channelFor(agent, uniqueName("Relative Ref Slack"), true),
+    );
+
+    // Same slug, empty org — means "the channel's own org"; must pass.
+    const relative = channelFor(agent, created.metadata!.name, true);
+    (relative.metadata as Record<string, string>).id = created.metadata!.id;
+    (relative.metadata as Record<string, string>).slug = created.metadata!.slug;
+    await channels.update(relative);
+  });
+
+  it("providerFieldName derives the PROTO field name (Go TestProviderFieldName)", () => {
+    // The error copy interpolates this; a camelCase/snake_case mismatch
+    // with Go would be a silent cross-edition wire divergence.
+    const slack = create(AgentChannelSpecSchema, {
+      providerConfig: { case: "slack", value: {} },
+    });
+    expect(providerFieldName(slack)).toBe("slack");
+    expect(providerFieldName(create(AgentChannelSpecSchema))).toBe("");
+    expect(providerFieldName(undefined)).toBe("");
+  });
+
+  it("provider arm is immutable — a real slack→whatsapp flip refuses with the shared copy", async () => {
+    const agent = await createTestAgent(uniqueName("Provider Flip Agent"));
+    const created = await channels.create(channelFor(agent, uniqueName("Prov Slack"), true));
+
+    const flipped = whatsAppChannelFor(agent, created.metadata!.name);
+    (flipped.metadata as Record<string, string>).id = created.metadata!.id;
+    (flipped.metadata as Record<string, string>).slug = created.metadata!.slug;
+    (flipped.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "acme-meta-app",
+    };
+
+    const err = await grpcError(() => channels.update(flipped));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(providerImmutableMessage("slack"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Apply (Go TestAgentChannelController_Apply) — dedicated org: the final
+// List asserts an exact count.
+// ---------------------------------------------------------------------------
+
+describe("apply semantics", () => {
+  it("apply creates (pending_install), re-apply updates in place preserving status", async () => {
+    const org = "channel-apply-org";
+    const agent = await createTestAgent(uniqueName("Apply Semantics Agent"), org);
+    const name = uniqueName("Apply Slack");
+
+    const created = await channels.apply(channelFor(agent, name, true));
+    expect(created.metadata?.id).not.toBe("");
+    expect(created.status?.installState).toBe(AgentChannelInstallState.pending_install);
+
+    const updated = await channels.apply(channelFor(agent, name, false));
+    expect(updated.metadata?.id).toBe(created.metadata!.id);
+    expect(updated.spec?.enabled).toBe(false);
+    expect(updated.status?.installState).toBe(AgentChannelInstallState.pending_install);
+
+    const list = await query.list({ org });
+    expect(list.totalCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// environment_refs (Go TestAgentChannelController_EnvironmentRefs, T04).
+// ---------------------------------------------------------------------------
+
+describe("environment_refs (channel-bound credentials)", () => {
+  it("persist in order, empty org normalizes; apply replaces and unbinds; CEL kind check", async () => {
+    const agent = await createTestAgent(uniqueName("Env Refs Agent"));
+    const name = uniqueName("Env Refs Slack");
+
+    const withRefs = channelFor(agent, name, true);
+    (withRefs.spec as Record<string, unknown>).environmentRefs = [
+      { kind: ApiResourceKind.environment, slug: "github-credentials" },
+      { kind: ApiResourceKind.environment, org: ORG, slug: "search-credentials" },
+    ];
+    const created = await channels.create(withRefs);
+    expect(created.spec?.environmentRefs).toHaveLength(2);
+    expect(created.spec?.environmentRefs[0]?.org).toBe(ORG);
+    expect(created.spec?.environmentRefs[0]?.slug).toBe("github-credentials");
+    expect(created.spec?.environmentRefs[1]?.slug).toBe("search-credentials");
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.spec?.environmentRefs).toHaveLength(2);
+
+    // Apply replaces the refs wholesale — credentials are mutable.
+    const rebound = channelFor(agent, name, true);
+    (rebound.spec as Record<string, unknown>).environmentRefs = [
+      { kind: ApiResourceKind.environment, org: ORG, slug: "rotated-credentials" },
+    ];
+    const updated = await channels.apply(rebound);
+    expect(updated.spec?.environmentRefs).toHaveLength(1);
+    expect(updated.spec?.environmentRefs[0]?.slug).toBe("rotated-credentials");
+
+    // Apply omitting the refs unbinds them (declarative semantics).
+    const unbound = await channels.apply(channelFor(agent, name, true));
+    expect(unbound.spec?.environmentRefs).toHaveLength(0);
+
+    // A non-environment ref kind is INVALID_ARGUMENT (proto CEL).
+    const wrongKind = channelFor(agent, uniqueName("Wrong Kind Slack"), true);
+    (wrongKind.spec as Record<string, unknown>).environmentRefs = [
+      { kind: ApiResourceKind.agent, org: ORG, slug: "not-an-environment" },
+    ];
+    const err = await grpcError(() => channels.create(wrongKind));
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// app_ref (Go TestAgentChannelController_AppRef, T04 item 2).
+// ---------------------------------------------------------------------------
+
+describe("app_ref (BYO channel-app binding)", () => {
+  it("an empty app_ref org normalizes to the channel's org and persists", async () => {
+    const agent = await createTestAgent(uniqueName("App Ref Agent"));
+    const ch = channelFor(agent, uniqueName("BYO Slack"), true);
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "acme-support-app",
+    };
+
+    const created = await channels.create(ch);
+    expect(created.spec?.appRef?.org).toBe(agent.metadata!.org);
+    expect(created.spec?.appRef?.slug).toBe("acme-support-app");
+  });
+
+  it("a cross-org app_ref is FAILED_PRECONDITION with the shared copy", async () => {
+    const agent = await createTestAgent(uniqueName("Cross Org App Agent"));
+    const ch = channelFor(agent, uniqueName("Cross Org App Slack"), true);
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      org: "channel-other-org",
+      slug: "their-app",
+    };
+
+    const err = await grpcError(() => channels.create(ch));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(APP_REF_SAME_ORG_MESSAGE);
+  });
+
+  it("a non-channel_app ref kind is INVALID_ARGUMENT (proto CEL)", async () => {
+    const agent = await createTestAgent(uniqueName("Wrong Kind App Agent"));
+    const ch = channelFor(agent, uniqueName("Wrong Kind App Slack"), true);
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.agent,
+      org: agent.metadata!.org,
+      slug: "not-a-channel-app",
+    };
+
+    const err = await grpcError(() => channels.create(ch));
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("a pending channel may rebind freely — rebind-before-install is the intended flow", async () => {
+    const agent = await createTestAgent(uniqueName("Pending Rebind Agent"));
+    const ch = channelFor(agent, uniqueName("Pending Rebind Slack"), true);
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "first-app",
+    };
+    const created = await channels.create(ch);
+
+    const rebound = channelFor(agent, created.metadata!.name, true);
+    (rebound.metadata as Record<string, string>).id = created.metadata!.id;
+    (rebound.metadata as Record<string, string>).slug = created.metadata!.slug;
+    (rebound.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "second-app",
+    };
+    const updated = await channels.update(rebound);
+    expect(updated.spec?.appRef?.slug).toBe("second-app");
+  });
+
+  it("app_ref is frozen while installed, with the shared copy", async () => {
+    const agent = await createTestAgent(uniqueName("Installed Freeze Agent"));
+    const name = uniqueName("Installed Freeze Slack");
+    const ch = channelFor(agent, name, true);
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "granted-app",
+    };
+    const created = await channels.create(ch);
+
+    // Flip the stored row to installed directly — OSS has no install
+    // flow, and the freeze keys on stored status, not on how it got there.
+    const stored = await server.store.getResource(
+      ApiResourceKind.agent_channel,
+      created.metadata!.id,
+      AgentChannelSchema,
+    );
+    stored.status!.installState = AgentChannelInstallState.installed;
+    await server.store.saveResource(
+      ApiResourceKind.agent_channel,
+      created.metadata!.id,
+      AgentChannelSchema,
+      stored,
+    );
+
+    const rebindBase = () => {
+      const c = channelFor(agent, name, true);
+      (c.metadata as Record<string, string>).id = created.metadata!.id;
+      (c.metadata as Record<string, string>).slug = created.metadata!.slug;
+      return c;
+    };
+
+    const rebound = rebindBase();
+    (rebound.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "different-app",
+    };
+    const err = await grpcError(() => channels.update(rebound));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE);
+
+    // Unbinding while installed is equally a change.
+    const unbindErr = await grpcError(() => channels.update(rebindBase()));
+    expect(unbindErr.code).toBe(Code.FailedPrecondition);
+
+    // An unchanged binding must pass — the disable toggle keeps it.
+    const unchanged = rebindBase();
+    unchanged.spec.enabled = false;
+    (unchanged.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      org: agent.metadata!.org,
+      slug: "granted-app",
+    };
+    await channels.update(unchanged);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WhatsApp app_ref (Go TestAgentChannelController_WhatsAppAppRef, DD-WA-2).
+// ---------------------------------------------------------------------------
+
+describe("whatsapp app_ref (BYO-only, DD-WA-2)", () => {
+  it("create without app_ref is INVALID_ARGUMENT with the shared copy", async () => {
+    const agent = await createTestAgent(uniqueName("WA No App Agent"));
+    const err = await grpcError(() =>
+      channels.create(whatsAppChannelFor(agent, uniqueName("WA No App"))),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE);
+  });
+
+  it("apply without app_ref is refused on the same path", async () => {
+    const agent = await createTestAgent(uniqueName("WA Apply Agent"));
+    const err = await grpcError(() =>
+      channels.apply(whatsAppChannelFor(agent, uniqueName("WA Apply"))),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("create with app_ref passes; empty org normalizes", async () => {
+    const agent = await createTestAgent(uniqueName("WA Bound Agent"));
+    const ch = whatsAppChannelFor(agent, uniqueName("WA Bound"));
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "acme-meta-app",
+    };
+
+    const created = await channels.create(ch);
+    expect(created.spec?.appRef?.slug).toBe("acme-meta-app");
+    expect(created.spec?.appRef?.org).toBe(agent.metadata!.org);
+  });
+
+  it("update clearing app_ref is INVALID_ARGUMENT — the binding may change, never disappear", async () => {
+    const agent = await createTestAgent(uniqueName("WA Unbind Agent"));
+    const name = uniqueName("WA Unbind");
+    const ch = whatsAppChannelFor(agent, name);
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "acme-meta-app",
+    };
+    const created = await channels.create(ch);
+
+    const unbound = whatsAppChannelFor(agent, name);
+    (unbound.metadata as Record<string, string>).id = created.metadata!.id;
+    (unbound.metadata as Record<string, string>).slug = created.metadata!.slug;
+
+    const err = await grpcError(() => channels.update(unbound));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE);
+  });
+
+  it("update keeping the binding passes (uninstalled rebind stays legitimate)", async () => {
+    const agent = await createTestAgent(uniqueName("WA Rebind Agent"));
+    const ch = whatsAppChannelFor(agent, uniqueName("WA Rebind"));
+    (ch.spec as Record<string, unknown>).appRef = {
+      kind: ApiResourceKind.channel_app,
+      slug: "first-meta-app",
+    };
+    const created = await channels.create(ch);
+
+    (created.spec!.appRef as Record<string, unknown>).slug = "second-meta-app";
+    const updated = await channels.update(created);
+    expect(updated.spec?.appRef?.slug).toBe("second-meta-app");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete + queries (Go TestAgentChannelController_Delete / _Queries /
+// _GetByAgent) — list counts use a dedicated org.
+// ---------------------------------------------------------------------------
+
+describe("delete and queries", () => {
+  it("delete returns the deleted channel; get after delete is NOT_FOUND", async () => {
+    const agent = await createTestAgent(uniqueName("Delete Agent"));
+    const created = await channels.create(channelFor(agent, uniqueName("Doomed Slack"), true));
+
+    const deleted = await channels.delete({ value: created.metadata!.id });
+    expect(deleted.metadata?.id).toBe(created.metadata!.id);
+
+    const err = await grpcError(() => query.get({ value: created.metadata!.id }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("nonexistent channel delete is NOT_FOUND", async () => {
+    const err = await grpcError(() => channels.delete({ value: "ach_does_not_exist" }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("get by id and by reference round-trip", async () => {
+    const agent = await createTestAgent(uniqueName("Query Agent"));
+    const created = await channels.create(channelFor(agent, uniqueName("Query Slack"), true));
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.metadata?.slug).toBe(created.metadata!.slug);
+
+    const byRef = await query.getByReference({
+      kind: ApiResourceKind.agent_channel,
+      org: created.metadata!.org,
+      slug: created.metadata!.slug,
+    });
+    expect(byRef.metadata?.id).toBe(created.metadata!.id);
+  });
+
+  it("list scopes to the requested org and filters labels", async () => {
+    const org = "channel-list-org";
+    const agent = await createTestAgent(uniqueName("List Agent"), org);
+    await channels.create(channelFor(agent, uniqueName("Plain Slack"), true));
+
+    const labeled = channelFor(agent, uniqueName("Labeled Slack"), true);
+    (labeled.metadata as Record<string, unknown>).labels = { team: "sales" };
+    await channels.create(labeled);
+
+    const all = await query.list({ org });
+    expect(all.totalCount).toBe(2);
+
+    const filtered = await query.list({ org, labels: { team: "sales" } });
+    expect(filtered.totalCount).toBe(1);
+
+    const foreign = await query.list({ org: "channel-bystander-org" });
+    expect(foreign.totalCount).toBe(0);
+  });
+
+  it("getByAgent finds every channel regardless of slug; org scope filters", async () => {
+    const agent = await createTestAgent(uniqueName("Get By Agent Agent"));
+    const first = await channels.create(channelFor(agent, uniqueName("Primary Slack"), true));
+    const second = await channels.create(channelFor(agent, uniqueName("Secondary Slack"), false));
+
+    const list = await query.getByAgent({ agentId: agent.metadata!.id });
+    expect(list.totalCount).toBe(2);
+    const slugs = list.items.map((c) => c.metadata?.slug);
+    expect(slugs).toContain(first.metadata!.slug);
+    expect(slugs).toContain(second.metadata!.slug);
+
+    const matching = await query.getByAgent({ agentId: agent.metadata!.id, org: ORG });
+    expect(matching.totalCount).toBe(2);
+
+    const foreign = await query.getByAgent({
+      agentId: agent.metadata!.id,
+      org: "channel-bystander-org",
+    });
+    expect(foreign.totalCount).toBe(0);
+  });
+
+  it("nonexistent agent yields an empty list", async () => {
+    const list = await query.getByAgent({ agentId: "agt-does-not-exist" });
+    expect(list.totalCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Install posture (Go TestAgentChannelController_InstallPosture, §0-b).
+// ---------------------------------------------------------------------------
+
+describe("install posture (§0-b)", () => {
+  it("the full contract: NOT_FOUND with the cloud copy, refusal on existing, nothing persisted", async () => {
+    const agent = await createTestAgent(uniqueName("Install Posture Agent"));
+    const created = await channels.create(channelFor(agent, uniqueName("Installable Slack"), true));
+
+    const missErr = await grpcError(() =>
+      channels.initiateInstall({ resourceId: "ach_does_not_exist" }),
+    );
+    expect(missErr.code).toBe(Code.NotFound);
+    expect(missErr.rawMessage).toBe("AgentChannel not found: ach_does_not_exist");
+
+    const refuseErr = await grpcError(() =>
+      channels.initiateInstall({ resourceId: created.metadata!.id }),
+    );
+    expect(refuseErr.code).toBe(Code.FailedPrecondition);
+    expect(refuseErr.rawMessage).toBe(INSTALL_UNAVAILABLE_MESSAGE);
+
+    // completeInstall mirrors the same contract.
+    const completeMiss = await grpcError(() =>
+      channels.completeInstall({
+        resourceId: "ach_does_not_exist",
+        state: "some-state",
+        code: "some-code",
+      }),
+    );
+    expect(completeMiss.code).toBe(Code.NotFound);
+
+    const completeRefuse = await grpcError(() =>
+      channels.completeInstall({
+        resourceId: created.metadata!.id,
+        state: "some-state",
+        code: "some-code",
+      }),
+    );
+    expect(completeRefuse.code).toBe(Code.FailedPrecondition);
+
+    // Missing input fields are INVALID_ARGUMENT before any load (Layer-1).
+    const emptyInitiate = await grpcError(() => channels.initiateInstall({}));
+    expect(emptyInitiate.code).toBe(Code.InvalidArgument);
+    const partialComplete = await grpcError(() =>
+      channels.completeInstall({ resourceId: created.metadata!.id }),
+    );
+    expect(partialComplete.code).toBe(Code.InvalidArgument);
+
+    // The refused install persists nothing.
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.status?.installState).toBe(AgentChannelInstallState.pending_install);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Messaging posture (Go TestChannelMessageController_CloudOnlyPosture).
+// ---------------------------------------------------------------------------
+
+describe("channel messaging posture (cloud-only runtime)", () => {
+  const textPayload = (body: string) => ({
+    kind: { case: "text" as const, value: { body } },
+  });
+
+  it("sendMessage refuses with FAILED_PRECONDITION and the documented copy", async () => {
+    const err = await grpcError(() =>
+      messageCommand.sendMessage({
+        recipient: "15551234567",
+        payload: textPayload("your fee is due"),
+      }),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
+  });
+
+  it("sendMessage refusal is independent of channel existence (no probe)", async () => {
+    const err = await grpcError(() =>
+      messageCommand.sendMessage({
+        channel: "no-such-channel",
+        org: "no-such-org",
+        recipient: "15551234567",
+        payload: textPayload("hello"),
+      }),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+  });
+
+  it("sendMessage contract violations are INVALID_ARGUMENT before the refusal", async () => {
+    const cases: Array<[string, Parameters<typeof messageCommand.sendMessage>[0]]> = [
+      ["empty recipient", { payload: textPayload("hello") }],
+      ["missing payload", { recipient: "15551234567" }],
+      ["unset payload arm", { recipient: "15551234567", payload: {} }],
+      ["empty text body", { recipient: "15551234567", payload: textPayload("") }],
+      [
+        "oversized text body",
+        { recipient: "15551234567", payload: textPayload("x".repeat(4097)) },
+      ],
+      [
+        "empty template name",
+        {
+          recipient: "15551234567",
+          payload: { kind: { case: "template" as const, value: {} } },
+        },
+      ],
+    ];
+    for (const [name, input] of cases) {
+      const err = await grpcError(() => messageCommand.sendMessage(input));
+      expect(err.code, name).toBe(Code.InvalidArgument);
+    }
+  });
+
+  it("listTemplates refuses with FAILED_PRECONDITION and the documented copy", async () => {
+    const err = await grpcError(() =>
+      messageQuery.listTemplates({ channel: "some-channel", approvedOnly: true }),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
+  });
+
+  it("listMessagingChannels answers with an empty list, never a refusal (DD-006 D3)", async () => {
+    const res = await messageQuery.listMessagingChannels({});
+    expect(res.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation posture (Go TestChannelConversationController_CloudOnlyPosture).
+// ---------------------------------------------------------------------------
+
+describe("channel conversation posture (cloud-only runtime)", () => {
+  const controlInput = { agentChannelId: "ach-123", conversationKey: "15551234567" };
+
+  it("discovery reads answer truthful emptiness", async () => {
+    const list = await conversationQuery.listConversations({ org: "acme" });
+    expect(list.items).toHaveLength(0);
+
+    const timeline = await conversationQuery.getTimeline({
+      agentChannelId: "ach-123",
+      conversationKey: "15551234567",
+    });
+    expect(timeline.items).toHaveLength(0);
+    expect(timeline.nextPageToken).toBe("");
+  });
+
+  it("single-row reads answer the uniform miss", async () => {
+    const getErr = await grpcError(() =>
+      conversationQuery.getConversation({
+        agentChannelId: "ach-123",
+        conversationKey: "15551234567",
+      }),
+    );
+    expect(getErr.code).toBe(Code.NotFound);
+
+    const mediaErr = await grpcError(() =>
+      conversationQuery.getMediaDownloadUrl({
+        agentChannelId: "ach-123",
+        conversationKey: "15551234567",
+        itemId: "wa:wamid.abc123",
+      }),
+    );
+    expect(mediaErr.code).toBe(Code.NotFound);
+    expect(mediaErr.rawMessage).toBe(NO_DOWNLOADABLE_MEDIA_MESSAGE);
+  });
+
+  it("every command refuses with FAILED_PRECONDITION and the documented copy", async () => {
+    const commands: Array<[string, () => Promise<unknown>]> = [
+      [
+        "reply",
+        () =>
+          conversationCommand.reply({
+            agentChannelId: "ach-123",
+            conversationKey: "15551234567",
+            payload: { kind: { case: "text" as const, value: { body: "on my way" } } },
+          }),
+      ],
+      ["takeOver", () => conversationCommand.takeOver(controlInput)],
+      ["handBack", () => conversationCommand.handBack(controlInput)],
+      ["clearAttention", () => conversationCommand.clearAttention(controlInput)],
+      [
+        "escalate",
+        () =>
+          conversationCommand.escalate({
+            reason: "the member is asking about a refund I cannot process",
+          }),
+      ],
+    ];
+    for (const [name, call] of commands) {
+      const err = await grpcError(call);
+      expect(err.code, name).toBe(Code.FailedPrecondition);
+      expect(err.rawMessage, name).toBe(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
+    }
+  });
+
+  it("contract violations are INVALID_ARGUMENT before the refusal", async () => {
+    const cases: Array<[string, () => Promise<unknown>]> = [
+      ["listConversations without org", () => conversationQuery.listConversations({})],
+      [
+        "getTimeline without conversation key",
+        () => conversationQuery.getTimeline({ agentChannelId: "ach-123" }),
+      ],
+      [
+        "getConversation without conversation key",
+        () => conversationQuery.getConversation({ agentChannelId: "ach-123" }),
+      ],
+      [
+        "getMediaDownloadUrl without item id",
+        () =>
+          conversationQuery.getMediaDownloadUrl({
+            agentChannelId: "ach-123",
+            conversationKey: "15551234567",
+          }),
+      ],
+      [
+        "takeOver without channel id",
+        () => conversationCommand.takeOver({ conversationKey: "15551234567" }),
+      ],
+      [
+        "reply without payload",
+        () =>
+          conversationCommand.reply({
+            agentChannelId: "ach-123",
+            conversationKey: "15551234567",
+          }),
+      ],
+      ["escalate without reason", () => conversationCommand.escalate({})],
+      [
+        "escalate with an over-budget reason",
+        () => conversationCommand.escalate({ reason: "x".repeat(1025) }),
+      ],
+    ];
+    for (const [name, call] of cases) {
+      const err = await grpcError(call);
+      expect(err.code, name).toBe(Code.InvalidArgument);
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentchannel/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentchannel/constants.ts
@@ -1,0 +1,112 @@
+/**
+ * AgentChannel domain constants — the byte-pinned wire copy shared with
+ * the Go server and the cloud edition. The three cloud-only refusal
+ * strings ARE the OSS contract (engineered refusals, not gaps — asserted
+ * by the conformance suite where channelMessaging is false); none is
+ * editable without an owner-ratified wire change.
+ */
+
+/**
+ * FailedPrecondition copy for the install lane (T02 §0-b, the documented
+ * OSS posture) — Go install.go installUnavailableMessage: this edition
+ * has no webhook receiver and no delivery runtime, so an installed
+ * channel could never serve traffic; an honest refusal beats a
+ * half-connected install.
+ */
+export const INSTALL_UNAVAILABLE_MESSAGE = "channel installs require Stigmer Cloud";
+
+/**
+ * FailedPrecondition copy for the messaging surface (proactive-messaging
+ * DD-002/DD-003) — Go message.go proactiveMessagingUnavailableMessage.
+ */
+export const PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE =
+  "proactive channel messaging requires Stigmer Cloud";
+
+/**
+ * FailedPrecondition copy for the conversation participation surface
+ * (channel-conversations DD-003 D-f) — Go conversation.go
+ * conversationParticipationUnavailableMessage.
+ */
+export const CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE =
+  "conversation participation requires Stigmer Cloud";
+
+/**
+ * NotFound copy for getMediaDownloadUrl — Go conversation.go, raw status
+ * text because the "%s not found: %s" helper shape cannot say it.
+ * Byte-identical with the cloud handler's uniform miss (which covers
+ * every cause the same way so a prober cannot learn which items exist).
+ */
+export const NO_DOWNLOADABLE_MEDIA_MESSAGE = "no downloadable media at this timeline item";
+
+/** InvalidArgument copy when metadata.org is absent — Go, byte-pinned. */
+export const ORG_REQUIRED_MESSAGE = "metadata.org is required for an agent channel";
+
+/** InvalidArgument copy when spec.agent_ref.slug is absent — Go, pinned. */
+export const AGENT_REF_SLUG_REQUIRED_MESSAGE = "spec.agent_ref.slug is required";
+
+/**
+ * FailedPrecondition copy for the same-org invariant — Go
+ * resolveChannelDefaultsStep, byte-pinned. Unlike shares (decision 013),
+ * channels have NO cross-org arm: the channel's org is the billing org
+ * and the credentials org, and both must be the agent's (decision 004).
+ */
+export function sameOrgInvariantMessage(refOrg: string): string {
+  return (
+    "spec.agent_ref.org must match metadata.org — an agent channel must " +
+    `live in the referenced agent's organization (${refOrg})`
+  );
+}
+
+/**
+ * InvalidArgument copy for a WhatsApp channel without an app binding
+ * (DD-WA-2: WhatsApp is BYO-only) — Go, byte-pinned; enforced in the
+ * defaults resolver, not a field-level CEL, because the rule conditions
+ * on the oneof case.
+ */
+export const APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE =
+  "spec.app_ref is required for WhatsApp channels — register your Meta app " +
+  "as a channel app and reference it";
+
+/**
+ * FailedPrecondition copy for a cross-org app_ref (secrets never cross
+ * orgs — the T06 invariant applied to app credentials) — Go, byte-pinned.
+ */
+export const APP_REF_SAME_ORG_MESSAGE =
+  "spec.app_ref.org must match metadata.org — a channel can only install " +
+  "through its own organization's channel app";
+
+/**
+ * FailedPrecondition copy for rebinding an INSTALLED channel's app — Go
+ * validateAppRefUpdate, byte-pinned. Pending and revoked channels rebind
+ * freely; the installed freeze exists because the workspace granted THAT
+ * app and the stored bot token belongs to it.
+ */
+export const APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE =
+  "spec.app_ref cannot change while the channel is installed — the " +
+  "workspace authorized the current app; uninstall or disconnect first, " +
+  "then rebind and re-install";
+
+/**
+ * FailedPrecondition copy for an agent_ref change on update — Go
+ * validateChannelUpdateStep, byte-pinned.
+ */
+export function agentRefImmutableMessage(org: string, slug: string): string {
+  return (
+    `spec.agent_ref is immutable (channel connects ${org}/${slug}) — ` +
+    "create a new channel to connect a different agent"
+  );
+}
+
+/**
+ * FailedPrecondition copy for a provider-arm change on update — Go
+ * validateChannelUpdateStep, byte-pinned. Deliberately a DIFFERENT code
+ * than channelapp's provider rule (FailedPrecondition here vs
+ * InvalidArgument there) — a pinned cross-domain inconsistency both
+ * editions share; harmonization is a post-cutover wire change.
+ */
+export function providerImmutableMessage(existingProvider: string): string {
+  return (
+    `spec provider is immutable (channel provider is ${existingProvider}) — ` +
+    "create a new channel for a different provider"
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentchannel/controller.ts
@@ -1,0 +1,520 @@
+/**
+ * AgentChannel controller — ports pkg/domain/agentchannel/controller
+ * (AgentChannelCommandController + AgentChannelQueryController): the
+ * connection binding an agent to an external messaging-platform workspace
+ * (Slack/WhatsApp). Workspace identity and credentials are produced by
+ * the provider install flow and live in STATUS — a declarative apply can
+ * never clobber them. Unlike shares (decision 013), channels have NO
+ * cross-org arm: the channel's org is the billing org and the credentials
+ * org, and both must be the referenced agent's (decision 004).
+ *
+ * Install posture (OSS, T02 §0-b — a deliberate, developer-approved
+ * divergence): initiateInstall and completeInstall validate, LOAD the
+ * channel (byte-identical NOT_FOUND with cloud's LoadChannel step), then
+ * refuse FailedPrecondition — this edition has no webhook receiver and no
+ * delivery runtime, so an installed channel could never serve traffic.
+ * Nothing is persisted on that path. The messaging/conversation runtime
+ * surfaces live in message.ts / conversation.ts (Go's file seams).
+ *
+ * NOT search-indexed by design; channels are NOT swept on agent delete
+ * (only same-org shares are) — a dangling channel is tolerated because
+ * OSS has no serving runtime and cloud fails closed elsewhere.
+ *
+ * Proven by agentchannel.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentchannel.test.ts.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { AgentChannelCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/command_pb";
+import { AgentChannelQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/query_pb";
+import { AgentChannelListSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/io_pb";
+import type {
+  AgentChannelId,
+  AgentChannelList,
+  CompleteChannelInstallInput,
+  GetAgentChannelsByAgentRequest,
+  InitiateChannelInstallInput,
+  InitiateChannelInstallOutput,
+  ListAgentChannelsRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/io_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import {
+  failedPreconditionError,
+  internalError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { compareCreatedAtDesc, matchesAllLabels } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import { INSTALL_UNAVAILABLE_MESSAGE } from "./constants.js";
+import {
+  newInitInstallStateStep,
+  newResolveChannelDefaultsStep,
+  newValidateChannelUpdateStep,
+} from "./steps.js";
+
+export interface AgentChannelControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly modelRegistry: ModelRegistryStore;
+}
+
+/** Registers both agentchannel resource services on the router. */
+export function registerAgentChannelServices(
+  router: ConnectRouter,
+  deps: AgentChannelControllerDeps,
+): void {
+  router.service(AgentChannelCommandController, {
+    apply: (channel, ctx) => apply(deps, channel, ctx),
+    create: (channel, ctx) => createChannel(deps, channel, ctx),
+    update: (channel, ctx) => update(deps, channel, ctx),
+    initiateInstall: (input, ctx) => initiateInstall(deps, input, ctx),
+    completeInstall: (input, ctx) => completeInstall(deps, input, ctx),
+    delete: (channelId, ctx) => deleteChannel(deps, channelId, ctx),
+  });
+  router.service(AgentChannelQueryController, {
+    get: (channelId, ctx) => get(deps, channelId, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getByAgent: (req, ctx) => getByAgent(deps, req, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. InitInstallState runs AFTER
+ * BuildNewState so the status wipe cannot erase pending_install; no
+ * agent-slug default (channels are N-per-agent — see ResolveChannelDefaults).
+ */
+async function createChannel(
+  deps: AgentChannelControllerDeps,
+  channel: AgentChannel,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  const reqCtx = new RequestContext(AgentChannelSchema, channel, kindOf(ctx));
+  await newPipeline<typeof AgentChannelSchema>("agent-channel-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveChannelDefaultsStep(deps.store, deps.modelRegistry))
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newInitInstallStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline. The spec is replaced
+ * wholesale; status is preserved verbatim, which keeps the install facts
+ * and credentials reference immune to declarative clobber (the install
+ * flow is their sole writer — decision 004).
+ */
+async function update(
+  deps: AgentChannelControllerDeps,
+  channel: AgentChannel,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  const reqCtx = new RequestContext(AgentChannelSchema, channel, kindOf(ctx));
+  await newPipeline<typeof AgentChannelSchema>("agent-channel-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateChannelUpdateStep(deps.modelRegistry))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update. Delegates with the pipeline's
+ * CLONED state (Go delegates reqCtx.NewState(), like agentshare and
+ * unlike channelapp): the normalized agent_ref (from
+ * ResolveChannelDefaults) and the populated id (from LoadForApply) live
+ * only on the clone. Defaults resolution runs BEFORE routing so the
+ * existence check sees the normalized ref and the same-org invariant
+ * fails loudly first (matching the cloud edition's resolver-before-
+ * routing order); the create pipeline re-running it is harmless
+ * (resolution is idempotent).
+ */
+async function apply(
+  deps: AgentChannelControllerDeps,
+  channel: AgentChannel,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  const reqCtx = new RequestContext(AgentChannelSchema, channel, kindOf(ctx));
+  await newPipeline<typeof AgentChannelSchema>("agent-channel-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveChannelDefaultsStep(deps.store, deps.modelRegistry))
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  const resolved = reqCtx.newState;
+  return shouldCreate
+    ? createChannel(deps, resolved, ctx)
+    : update(deps, resolved, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Install lane — Go install.go. Input validation is Layer-1 (the transport
+// interceptor chain validates every request, matching Go's explicit
+// SharedValidator call); the channel is loaded FIRST so the NOT_FOUND
+// contract is identical to cloud's LoadChannel step, and only the final
+// step diverges — the documented one. Nothing is persisted.
+// ---------------------------------------------------------------------------
+
+async function initiateInstall(
+  deps: AgentChannelControllerDeps,
+  input: InitiateChannelInstallInput,
+  ctx: HandlerContext,
+): Promise<InitiateChannelInstallOutput> {
+  await loadChannelForInstall(deps, ctx, input.resourceId);
+  throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
+}
+
+/**
+ * CompleteInstall — same load-then-refuse contract; a completion can only
+ * be reached with a state token from a successful initiate, which this
+ * edition never issues.
+ */
+async function completeInstall(
+  deps: AgentChannelControllerDeps,
+  input: CompleteChannelInstallInput,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  await loadChannelForInstall(deps, ctx, input.resourceId);
+  throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
+}
+
+/** Verifies the target exists — cloud's LoadChannel NOT_FOUND, verbatim. */
+async function loadChannelForInstall(
+  deps: AgentChannelControllerDeps,
+  ctx: HandlerContext,
+  resourceId: string,
+): Promise<void> {
+  try {
+    await deps.store.getResource(kindOf(ctx), resourceId, AgentChannelSchema);
+  } catch {
+    throw notFoundError("AgentChannel", resourceId);
+  }
+}
+
+/**
+ * Delete — the connection's full teardown; disabling (update with
+ * enabled=false) is the config-preserving pause. Versus cloud, OSS
+ * excludes the teardown cascade (managed credentials environment, OAuth
+ * grant, pending-delivery abandonment) — none of that state can exist
+ * here because the install flow never runs (§0-b).
+ */
+async function deleteChannel(
+  deps: AgentChannelControllerDeps,
+  channelId: AgentChannelId,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  const reqCtx = new RequestContext(
+    AgentChannelCommandController.method.delete.input,
+    channelId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelCommandController.method.delete.input>(
+    "agent-channel-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, AgentChannelSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted agent channel not found in context"),
+      "deleted agent channel not found in context",
+    );
+  }
+  return deleted as AgentChannel;
+}
+
+/** Get — LoadTarget by id-wrapper input (AgentChannelId). */
+async function get(
+  deps: AgentChannelControllerDeps,
+  channelId: AgentChannelId,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  const reqCtx = new RequestContext(
+    AgentChannelQueryController.method.get.input,
+    channelId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelQueryController.method.get.input>(
+    "agent-channel-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, AgentChannelSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentChannel;
+}
+
+/** GetByReference — org/slug lookup. */
+async function getByReference(
+  deps: AgentChannelControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<AgentChannel> {
+  const reqCtx = new RequestContext(
+    AgentChannelQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelQueryController.method.getByReference.input>(
+    "agent-channel-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, AgentChannelSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentChannel;
+}
+
+const CHANNEL_LIST_KEY = "agentChannelList";
+
+/**
+ * GetByAgent — all channels of one agent, optionally org-scoped. This is
+ * how the agent's integrations surface and CLI resolve an agent's
+ * channels regardless of slug (channels are N-per-agent across
+ * providers). A nonexistent agent yields an EMPTY list, not an error.
+ * The org filter is contract parity, not authorization (channels are
+ * same-org by invariant, so it only excludes rows when the requested org
+ * differs from the agent's — kept for parity with the sibling RPCs).
+ */
+async function getByAgent(
+  deps: AgentChannelControllerDeps,
+  req: GetAgentChannelsByAgentRequest,
+  ctx: HandlerContext,
+): Promise<AgentChannelList> {
+  const reqCtx = new RequestContext(
+    AgentChannelQueryController.method.getByAgent.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelQueryController.method.getByAgent.input>(
+    "agent-channel-get-by-agent",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadChannelsByAgentStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(CHANNEL_LIST_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("agent channel list not found in context"),
+      "agent channel list not found in context",
+    );
+  }
+  return result as AgentChannelList;
+}
+
+/** LoadChannelsByAgent — Go loadChannelsByAgentStep. */
+function newLoadChannelsByAgentStep(
+  store: Store,
+): PipelineStep<typeof AgentChannelQueryController.method.getByAgent.input> {
+  return {
+    name: "LoadChannelsByAgent",
+    async execute(
+      ctx: RequestContext<typeof AgentChannelQueryController.method.getByAgent.input>,
+    ): Promise<void> {
+      const req = ctx.input;
+      const emptyList = create(AgentChannelListSchema, { totalCount: 0, items: [] });
+
+      let agentOrg: string;
+      let agentSlug: string;
+      try {
+        const agent = await store.getResource(
+          ApiResourceKind.agent,
+          req.agentId,
+          AgentSchema,
+        );
+        agentOrg = agent.metadata?.org ?? "";
+        agentSlug = agent.metadata?.slug ?? "";
+      } catch {
+        ctx.set(CHANNEL_LIST_KEY, emptyList);
+        return;
+      }
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_channel);
+      } catch (error) {
+        throw internalError(error, "failed to list agent channels");
+      }
+
+      const channels: AgentChannel[] = [];
+      for (const bytes of rows) {
+        let channel: AgentChannel;
+        try {
+          channel = fromBinary(AgentChannelSchema, bytes);
+        } catch {
+          continue;
+        }
+        const ref = channel.spec?.agentRef;
+        if ((ref?.org ?? "") !== agentOrg || (ref?.slug ?? "") !== agentSlug) {
+          continue;
+        }
+        if (req.org !== "" && (channel.metadata?.org ?? "") !== req.org) {
+          continue;
+        }
+        channels.push(channel);
+      }
+
+      ctx.set(
+        CHANNEL_LIST_KEY,
+        create(AgentChannelListSchema, {
+          totalCount: channels.length,
+          items: channels,
+        }),
+      );
+    },
+  };
+}
+
+const LIST_RESULT_KEY = "listResult";
+
+/** List — org + labels filter (AND semantics), newest first (Go list.go). */
+async function list(
+  deps: AgentChannelControllerDeps,
+  req: ListAgentChannelsRequest,
+  ctx: HandlerContext,
+): Promise<AgentChannelList> {
+  const reqCtx = new RequestContext(
+    AgentChannelQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelQueryController.method.list.input>(
+    "agent-channel-list",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgAndLabelsStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("agent channel list not found in context"),
+      "agent channel list not found in context",
+    );
+  }
+  return result as AgentChannelList;
+}
+
+/**
+ * ListByOrgAndLabels — Go listByOrgAndLabelsStep. Malformed rows are
+ * skipped SILENTLY (Go's list routes through unmarshalChannel, which does
+ * not log — unlike agentshare's list, which warns; the asymmetry is Go's).
+ */
+function newListByOrgAndLabelsStep(
+  store: Store,
+): PipelineStep<typeof AgentChannelQueryController.method.list.input> {
+  return {
+    name: "ListByOrgAndLabels",
+    async execute(
+      ctx: RequestContext<typeof AgentChannelQueryController.method.list.input>,
+    ): Promise<void> {
+      const { org, labels: filterLabels } = ctx.input;
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ctx.apiResourceKind);
+      } catch (error) {
+        throw internalError(error, "failed to list agent channels");
+      }
+
+      const channels: AgentChannel[] = [];
+      for (const bytes of rows) {
+        let channel: AgentChannel;
+        try {
+          channel = fromBinary(AgentChannelSchema, bytes);
+        } catch {
+          continue;
+        }
+        if ((channel.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        if (!matchesAllLabels(channel.metadata?.labels ?? {}, filterLabels)) {
+          continue;
+        }
+        channels.push(channel);
+      }
+
+      channels.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(AgentChannelListSchema, {
+          totalCount: channels.length,
+          items: channels,
+        }),
+      );
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentchannel/conversation.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentchannel/conversation.ts
@@ -1,0 +1,88 @@
+/**
+ * ChannelConversation controllers — ports pkg/domain/agentchannel/
+ * controller/conversation.go: the conversation surface beside the channel
+ * messaging controllers, on the same runtime side of the resource/runtime
+ * split. Stateless — no store.
+ *
+ * Queries answer EMPTY and commands refuse FailedPrecondition, the two
+ * established postures side by side (channel-conversations DD-003 D-f): a
+ * conversation list is a discovery-shaped read whose truthful OSS answer
+ * is "none" (conversations are created by the cloud channel runtime,
+ * which does not run here), while every command asks to DO a cloud-only
+ * thing. The single-row reads cannot answer "empty" — getConversation
+ * answers NotFound unconditionally, and getMediaDownloadUrl answers the
+ * byte-pinned uniform miss (raw copy — the "%s not found: %s" helper
+ * shape cannot say it). As in message.ts, there is deliberately NO
+ * load-then-NOT_FOUND: probing local stores for conversations this
+ * edition never materializes would create an edition divergence, not
+ * prevent one.
+ *
+ * Input validation is Layer-1: the transport interceptor chain validates
+ * every request (matching Go's explicit SharedValidator calls), so the
+ * INVALID_ARGUMENT contract holds before every refusal.
+ *
+ * Proven by agentchannel.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentchannel.test.ts.
+ */
+import type { ConnectRouter } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import { ChannelConversationCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_command_pb";
+import { ChannelConversationQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_query_pb";
+import {
+  ChannelConversationListSchema,
+  ConversationTimelineSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+import type {
+  ChannelConversationList,
+  ConversationTimeline,
+  GetChannelConversationInput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+
+import { failedPreconditionError, notFoundError } from "../../pipeline/errors.js";
+import {
+  CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+  NO_DOWNLOADABLE_MEDIA_MESSAGE,
+} from "./constants.js";
+
+/** Registers both channel-conversation services on the router. */
+export function registerChannelConversationServices(router: ConnectRouter): void {
+  router.service(ChannelConversationQueryController, {
+    // Discovery-shaped reads answer truthful emptiness.
+    listConversations: (): ChannelConversationList =>
+      create(ChannelConversationListSchema),
+    getTimeline: (): ConversationTimeline => create(ConversationTimelineSchema),
+    // Single-row reads answer the uniform miss, with no local probing.
+    getConversation: (input: GetChannelConversationInput) => {
+      throw notFoundError("channel conversation", input.conversationKey);
+    },
+    getMediaDownloadUrl: () => {
+      // Byte-identical with the cloud handler's uniform miss (which
+      // covers every cause the same way so a prober cannot learn which
+      // items exist) — a raw ConnectError because notFoundError's
+      // "%s not found: %s" shape cannot express this copy.
+      throw new ConnectError(NO_DOWNLOADABLE_MEDIA_MESSAGE, Code.NotFound);
+    },
+  });
+  router.service(ChannelConversationCommandController, {
+    // Every command asks to DO a cloud-only thing: staff replies ride the
+    // outbound delivery lane; take-over/hand-back/attention are the
+    // participation state machine; escalation is ingest — all cloud-only.
+    reply: () => {
+      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
+    },
+    takeOver: () => {
+      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
+    },
+    handBack: () => {
+      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
+    },
+    clearAttention: () => {
+      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
+    },
+    escalate: () => {
+      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
+    },
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentchannel/message.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentchannel/message.ts
@@ -1,0 +1,56 @@
+/**
+ * ChannelMessage controllers — ports pkg/domain/agentchannel/controller/
+ * message.go: the runtime messaging surface beside the AgentChannel
+ * resource controllers, kept off the resource CRUD surface. Stateless —
+ * no store.
+ *
+ * Both command-shaped RPCs are cloud-only runtime and refuse with
+ * FailedPrecondition. Unlike the install refusal (controller.ts), there
+ * is deliberately NO load-then-NOT_FOUND here: the cloud send handler
+ * fails closed with PERMISSION_DENIED for an unknown channel (DD-002 D4's
+ * error table, no existence leak), so probing the store first would
+ * CREATE an edition divergence rather than prevent one.
+ *
+ * listMessagingChannels answers an EMPTY list — a deliberate divergence
+ * from its refusing siblings (proactive-messaging DD-006 D3): it is a
+ * capability-DISCOVERY read the runner issues on every agent execution to
+ * decide whether to attach the send_channel_message tool. The truthful
+ * OSS answer is "none", and an expected-error path in that hot loop would
+ * be noise; the empty list produces the identical, honest outcome.
+ *
+ * Input validation is Layer-1: the transport interceptor chain validates
+ * every request (matching Go's explicit SharedValidator calls), so the
+ * INVALID_ARGUMENT contract holds before every refusal.
+ *
+ * Proven by agentchannel.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentchannel.test.ts.
+ */
+import type { ConnectRouter } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { ChannelMessageCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_command_pb";
+import { ChannelMessageQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_query_pb";
+import { MessagingChannelsSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+import type { MessagingChannels } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+
+import { failedPreconditionError } from "../../pipeline/errors.js";
+import { PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE } from "./constants.js";
+
+/** Registers both channel-message services on the router (routes stage). */
+export function registerChannelMessageServices(router: ConnectRouter): void {
+  router.service(ChannelMessageCommandController, {
+    // Business-initiated channel messaging is cloud-only runtime.
+    sendMessage: () => {
+      throw failedPreconditionError(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
+    },
+  });
+  router.service(ChannelMessageQueryController, {
+    // Provider registry reads are cloud-only runtime; consumers degrade
+    // to honest absence (no template section, typed console error state).
+    listTemplates: () => {
+      throw failedPreconditionError(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
+    },
+    listMessagingChannels: (): MessagingChannels =>
+      create(MessagingChannelsSchema),
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentchannel/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentchannel/steps.ts
@@ -1,0 +1,304 @@
+/**
+ * AgentChannel domain steps — ports pkg/domain/agentchannel/controller/
+ * steps.go: channel defaults with the anti-probing ordering (same-org
+ * invariant BEFORE the agent load), the write-time model-pin existence
+ * rule (stigmer/stigmer#774), the WhatsApp BYO app_ref rules (DD-WA-2 /
+ * T04 item 2), the install-state stamp, and the update immutability
+ * rules.
+ *
+ * Proven by agentchannel.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentchannel.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { AgentChannelSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/spec_pb";
+import type { AgentChannelSpec } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/spec_pb";
+import {
+  AgentChannelInstallState,
+  AgentChannelStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/status_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+import { unknownModelPinRefusal } from "../workflow/registry/pin-validation.js";
+import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import {
+  AGENT_REF_SLUG_REQUIRED_MESSAGE,
+  APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE,
+  APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE,
+  APP_REF_SAME_ORG_MESSAGE,
+  ORG_REQUIRED_MESSAGE,
+  agentRefImmutableMessage,
+  providerImmutableMessage,
+  sameOrgInvariantMessage,
+} from "./constants.js";
+
+type AgentChannelDesc = typeof AgentChannelSchema;
+
+/**
+ * The write-time model-pin EXISTENCE rule (stigmer/stigmer#774) on a
+ * channel's run_config — Go validateChannelModelPin: a typo'd pin used to
+ * ride through opaquely and silently run (and bill) as Auto wherever the
+ * channel serves. Validated against EVERY registry harness section (the
+ * "" harness mode) because this edition stores channel specs without a
+ * serving runtime (the DD-015 divergence posture). Go reads a
+ * package-level registry; the TS registry is the domain-owned
+ * ModelRegistryStore (workflow-family DD-A), passed explicitly. Shared by
+ * create (ResolveChannelDefaults) and update (ValidateChannelUpdate).
+ */
+function validateChannelModelPin(
+  registry: ModelRegistryStore,
+  spec: AgentChannelSpec | undefined,
+): void {
+  const reason = unknownModelPinRefusal(
+    registry,
+    "spec.run_config.model_name",
+    "",
+    spec?.runConfig?.modelName ?? "",
+  );
+  if (reason !== "") {
+    throw invalidArgumentError(reason);
+  }
+}
+
+/**
+ * ResolveChannelDefaults — Go resolveChannelDefaultsStep, the cloud
+ * AgentChannelDefaultsResolver mirror whose error contracts this step
+ * replicates byte-identically:
+ *   1. Requires metadata.org (billing + credentials org, never inferred).
+ *   2. Requires spec.agent_ref.slug; normalizes agent_ref.org (empty
+ *      means same-org).
+ *   3. Enforces the same-org invariant BEFORE the agent load, so a
+ *      cross-org request cannot probe another org's slugs through this
+ *      path.
+ *   4. Validates the model pin and the WhatsApp BYO app_ref rules.
+ *   5. Loads the referenced agent — a nonexistent agent is refused with
+ *      the same NOT_FOUND a direct agent lookup would produce (T09).
+ *
+ * Deliberately NO slug default from the agent (unlike the share's
+ * canonical-slug rule): channels are N-per-agent across providers, so no
+ * single channel is "the" canonical one. Resolution is idempotent, so the
+ * apply pipeline running it before the create pipeline re-runs it is
+ * harmless.
+ */
+export function newResolveChannelDefaultsStep(
+  store: Store,
+  registry: ModelRegistryStore,
+): PipelineStep<AgentChannelDesc> {
+  return {
+    name: "ResolveChannelDefaults",
+    async execute(ctx: RequestContext<AgentChannelDesc>): Promise<void> {
+      const channel = ctx.newState;
+      const metadata = channel.metadata;
+
+      if ((metadata?.org ?? "") === "") {
+        throw invalidArgumentError(ORG_REQUIRED_MESSAGE);
+      }
+
+      const agentRef = channel.spec?.agentRef;
+      if ((agentRef?.slug ?? "") === "") {
+        throw invalidArgumentError(AGENT_REF_SLUG_REQUIRED_MESSAGE);
+      }
+
+      const refOrg = agentRef!.org !== "" ? agentRef!.org : metadata!.org;
+
+      if (refOrg !== metadata!.org) {
+        throw failedPreconditionError(sameOrgInvariantMessage(refOrg));
+      }
+
+      validateChannelModelPin(registry, channel.spec);
+
+      const appRef = channel.spec?.appRef;
+      const isWhatsApp = channel.spec?.providerConfig.case === "whatsapp";
+      if (isWhatsApp && (appRef?.slug ?? "") === "") {
+        throw invalidArgumentError(APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE);
+      }
+
+      // The BYO app must be the channel's own org's; normalized and
+      // checked before the agent load for the same no-probing reason.
+      // Deliberately NO existence or provider-match check: like
+      // environment_refs, enforcement lives at resolution time (the cloud
+      // install flow fails closed; OSS has no install flow).
+      if ((appRef?.slug ?? "") !== "") {
+        const appRefOrg = appRef!.org !== "" ? appRef!.org : metadata!.org;
+        if (appRefOrg !== metadata!.org) {
+          throw failedPreconditionError(APP_REF_SAME_ORG_MESSAGE);
+        }
+        appRef!.org = appRefOrg;
+      }
+
+      let agent;
+      try {
+        agent = await findResourceBySlug(
+          store,
+          ApiResourceKind.agent,
+          AgentSchema,
+          agentRef!.slug,
+          refOrg,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to list agent resources");
+      }
+      if (agent === undefined) {
+        // Byte-identical with the direct agent lookup's refusal (T09).
+        throw notFoundError("Agent", agentRef!.slug);
+      }
+
+      agentRef!.org = refOrg;
+    },
+  };
+}
+
+/**
+ * InitInstallState — Go initInstallStateStep: writes
+ * status.install_state = pending_install; the channel exists but serves
+ * no traffic until the provider install completes — which in this edition
+ * never happens (the §0-b refusal is the only install surface).
+ *
+ * Runs AFTER BuildNewState, which clears client-provided status — the
+ * install state is system-managed and must survive that wipe, exactly
+ * like the audit fields (the agentshare StampAgentPin positioning).
+ */
+export function newInitInstallStateStep(): PipelineStep<AgentChannelDesc> {
+  return {
+    name: "InitInstallState",
+    execute(ctx: RequestContext<AgentChannelDesc>): void {
+      const channel = ctx.newState;
+      const status = channel.status ?? create(AgentChannelStatusSchema);
+      status.installState = AgentChannelInstallState.pending_install;
+      channel.status = status;
+    },
+  };
+}
+
+/**
+ * The manifest vocabulary for the channel's provider arm — Go
+ * providerFieldName resolves the populated oneof member's PROTO field
+ * name through reflection (what users declared in YAML), and that name is
+ * interpolated into byte-pinned error copy. protobuf-es surfaces the
+ * arm's camelCased localName as the oneof `case`, which coincides with
+ * the proto name for `slack`/`whatsapp` but would diverge for a future
+ * snake_case arm (e.g. `ms_teams` → case "msTeams") — so the proto name
+ * is resolved through the schema descriptor, not read off the case.
+ * Exported for the unit pin (Go TestProviderFieldName).
+ */
+export function providerFieldName(spec: AgentChannelSpec | undefined): string {
+  const arm = spec?.providerConfig.case;
+  if (arm === undefined) {
+    return "";
+  }
+  const oneof = AgentChannelSpecSchema.oneofs.find(
+    (o) => o.name === "provider_config",
+  );
+  return oneof?.fields.find((f) => f.localName === arm)?.name ?? arm;
+}
+
+/**
+ * ValidateChannelUpdate — Go validateChannelUpdateStep: spec.agent_ref
+ * must keep referencing the same agent; the provider arm must not change
+ * (install state, credentials, and delivery records are all
+ * provider-shaped); the model pin is re-validated; then the app_ref rules
+ * (validateAppRefUpdate). Runs after LoadExisting. metadata.slug/org and
+ * status (install facts, credentials reference) need no step — the
+ * generic BuildUpdateState preserves them wholesale.
+ */
+export function newValidateChannelUpdateStep(
+  registry: ModelRegistryStore,
+): PipelineStep<AgentChannelDesc> {
+  return {
+    name: "ValidateChannelUpdate",
+    execute(ctx: RequestContext<AgentChannelDesc>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as AgentChannel | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing agent channel not found in context"),
+          "existing agent channel not found in context",
+        );
+      }
+
+      const inputRef = ctx.input.spec?.agentRef;
+      const existingRef = existing.spec?.agentRef;
+
+      // Normalize the input ref's org the same way create does (empty
+      // means the channel's own org) before comparing.
+      const inputOrg =
+        (inputRef?.org ?? "") !== "" ? inputRef!.org : (existing.metadata?.org ?? "");
+
+      if (
+        (inputRef?.slug ?? "") !== (existingRef?.slug ?? "") ||
+        inputOrg !== (existingRef?.org ?? "")
+      ) {
+        throw failedPreconditionError(
+          agentRefImmutableMessage(existingRef?.org ?? "", existingRef?.slug ?? ""),
+        );
+      }
+
+      const inputProvider = providerFieldName(ctx.input.spec);
+      const existingProvider = providerFieldName(existing.spec);
+      if (inputProvider !== existingProvider) {
+        throw failedPreconditionError(providerImmutableMessage(existingProvider));
+      }
+
+      validateChannelModelPin(registry, ctx.input.spec);
+
+      validateAppRefUpdate(ctx, existing);
+    },
+  };
+}
+
+/**
+ * The app_ref rules on update (T04 item 2) — Go validateAppRefUpdate,
+ * byte-identical with the cloud edition's ValidateChannelUpdate:
+ *   - required for whatsapp (repeated here because update does not run
+ *     the defaults resolver; provider immutability above guarantees the
+ *     existing channel is also whatsapp);
+ *   - same-org always;
+ *   - frozen while installed — pending and revoked channels rebind
+ *     freely (on OSS only the rebind-while-pending half is reachable:
+ *     install_state never reaches `installed` here).
+ */
+function validateAppRefUpdate(
+  ctx: RequestContext<AgentChannelDesc>,
+  existing: AgentChannel,
+): void {
+  const inputAppRef = ctx.input.spec?.appRef;
+  const existingAppRef = existing.spec?.appRef;
+
+  const isWhatsApp = ctx.input.spec?.providerConfig.case === "whatsapp";
+  if (isWhatsApp && (inputAppRef?.slug ?? "") === "") {
+    throw invalidArgumentError(APP_REF_REQUIRED_FOR_WHATSAPP_MESSAGE);
+  }
+
+  let inputAppOrg = "";
+  if ((inputAppRef?.slug ?? "") !== "") {
+    inputAppOrg =
+      inputAppRef!.org !== "" ? inputAppRef!.org : (existing.metadata?.org ?? "");
+  }
+
+  if (inputAppOrg !== "" && inputAppOrg !== (existing.metadata?.org ?? "")) {
+    throw failedPreconditionError(APP_REF_SAME_ORG_MESSAGE);
+  }
+
+  const installed =
+    existing.status?.installState === AgentChannelInstallState.installed;
+  const changed =
+    (inputAppRef?.slug ?? "") !== (existingAppRef?.slug ?? "") ||
+    ((inputAppRef?.slug ?? "") !== "" && inputAppOrg !== (existingAppRef?.org ?? ""));
+
+  if (installed && changed) {
+    throw failedPreconditionError(APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE);
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentshare/__tests__/agentshare.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentshare/__tests__/agentshare.test.ts
@@ -1,0 +1,865 @@
+/**
+ * Pins the agentshare domain against Go's agentshare_test.go, case-for-case
+ * — through the REAL stack: a composed server on an ephemeral port, native
+ * gRPC clients (share + agent — the cross-org arms flip real visibility
+ * through the agent pipeline), the full interceptor chain.
+ *
+ * The load-bearing pins beyond the conformance suite's black-box view:
+ *   - the client-provided agent-id pin is discarded and re-stamped;
+ *   - the T09 indistinguishability contract compared ERROR-TO-ERROR (a
+ *     private cross-org agent vs a genuinely missing one; disabled vs
+ *     deleted vs locked-link vs no-share);
+ *   - the pin keeps a recreated same-slug agent from reviving a dangling
+ *     share (decision 013's rebind guard);
+ *   - the #478 store-failure sanitization, pinned at the seam
+ *     (findShareByOrgAndSlug) with an injected failing store — the
+ *     composed server cannot fault-inject storage.
+ *
+ * Go tests run one store per test function; this file shares ONE server,
+ * so count-sensitive assertions use dedicated orgs and every agent name is
+ * unique (slugs derive from names).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentShareCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/command_pb";
+import { AgentShareQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/query_pb";
+import type { AgentShare } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import { AgentShareAudience } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/spec_pb";
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { Store } from "../../../store/interface.js";
+import {
+  ORG_REQUIRED_FOR_LOOKUP_MESSAGE,
+  crossOrgAudienceMessage,
+} from "../constants.js";
+import { findShareByOrgAndSlug, sharingLinkTokenAllowed } from "../steps.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+
+type ShareCommand = Client<typeof AgentShareCommandController>;
+type ShareQuery = Client<typeof AgentShareQueryController>;
+type AgentCommand = Client<typeof AgentCommandController>;
+
+let server: ComposedServer;
+let shares: ShareCommand;
+let query: ShareQuery;
+let agents: AgentCommand;
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "agentshare-domain-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
+  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  shares = createClient(AgentShareCommandController, transport);
+  query = createClient(AgentShareQueryController, transport);
+  agents = createClient(AgentCommandController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+let counter = 0;
+function uniqueName(base: string): string {
+  counter += 1;
+  return `${base} ${counter}`;
+}
+
+async function createTestAgent(name: string, org: string): Promise<Agent> {
+  return agents.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org },
+    spec: {
+      description: "Agent for sharing tests",
+      instructions: "You are a helpful agent for sharing verification.",
+      iconUrl: "https://example.com/icon.svg",
+    },
+  });
+}
+
+/** Flips the agent marketplace-public through the real pipeline (D1). */
+async function makeAgentPublic(agent: Agent): Promise<void> {
+  await agents.updateVisibility({
+    resourceId: agent.metadata!.id,
+    visibility: ApiResourceVisibility.visibility_public,
+  });
+}
+
+/**
+ * Writes a skill fixture directly to the store — the established
+ * cross-domain fixture pattern (the skill domain is not ported yet, and
+ * Go's test does the same because the skill controller needs artifact
+ * storage the sharing tests don't).
+ */
+async function saveSkill(
+  id: string,
+  org: string,
+  slug: string,
+  visibility: ApiResourceVisibility,
+): Promise<void> {
+  const skill = create(SkillSchema, {
+    apiVersion: API_VERSION,
+    kind: "Skill",
+    metadata: { id, name: slug, slug, org, visibility },
+  });
+  await server.store.saveResource(ApiResourceKind.skill, id, SkillSchema, skill);
+}
+
+/** Minimal canonical share: no slug, no name — both default from the agent. */
+function shareFor(agent: Agent, enabled: boolean) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "AgentShare",
+    metadata: { org: agent.metadata!.org },
+    spec: {
+      agentRef: { kind: ApiResourceKind.agent, slug: agent.metadata!.slug },
+      enabled,
+    },
+  };
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Create (Go TestAgentShareController_Create).
+// ---------------------------------------------------------------------------
+
+describe("agentshare create", () => {
+  const ORG = "create-test-org";
+
+  it("canonical share defaults slug and name from the agent; ash_ id; ref normalized", async () => {
+    const agent = await createTestAgent(uniqueName("Canonical Default Agent"), ORG);
+    const share = await shares.create(shareFor(agent, true));
+
+    expect(share.metadata?.slug).toBe(agent.metadata!.slug);
+    expect(share.metadata?.id).toMatch(/^ash_/);
+    expect(share.spec?.agentRef?.org).toBe(agent.metadata!.org);
+  });
+
+  it("nonexistent agent is NOT_FOUND", async () => {
+    const err = await grpcError(() =>
+      shares.create({
+        apiVersion: API_VERSION,
+        kind: "AgentShare",
+        metadata: { org: ORG },
+        spec: {
+          agentRef: { kind: ApiResourceKind.agent, slug: "no-such-agent" },
+          enabled: true,
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toBe("Agent not found: no-such-agent");
+  });
+
+  it("cross-org ref to a nonexistent agent is NOT_FOUND — no cross-org fallback", async () => {
+    const agent = await createTestAgent(uniqueName("Cross Org Ghost Agent"), ORG);
+    const share = shareFor(agent, true);
+    share.spec.agentRef = { ...share.spec.agentRef, org: "some-other-org" } as never;
+
+    const err = await grpcError(() => shares.create(share));
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("stamps the agent-id pin on the created share", async () => {
+    const agent = await createTestAgent(uniqueName("Pin Stamp Agent"), ORG);
+    const share = await shares.create(shareFor(agent, true));
+    expect(share.status?.agentId).toBe(agent.metadata!.id);
+  });
+
+  it("a client-provided pin is discarded, never trusted", async () => {
+    const agent = await createTestAgent(uniqueName("Pin Forgery Agent"), ORG);
+    const created = await shares.create({
+      ...shareFor(agent, true),
+      status: { agentId: "agt_forged" },
+    });
+    expect(created.status?.agentId).toBe(agent.metadata!.id);
+  });
+
+  it("missing org is INVALID_ARGUMENT with the pinned copy", async () => {
+    const agent = await createTestAgent(uniqueName("Orgless Share Agent"), ORG);
+    const share = shareFor(agent, true);
+    share.metadata.org = "";
+
+    const err = await grpcError(() => shares.create(share));
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("second canonical share for the same agent is ALREADY_EXISTS", async () => {
+    const agent = await createTestAgent(uniqueName("Duplicate Share Agent"), ORG);
+    await shares.create(shareFor(agent, true));
+
+    const err = await grpcError(() => shares.create(shareFor(agent, true)));
+    expect(err.code).toBe(Code.AlreadyExists);
+  });
+
+  it("a named share coexists under its own slug", async () => {
+    const agent = await createTestAgent(uniqueName("Multi Channel Agent"), ORG);
+    await shares.create(shareFor(agent, true));
+
+    const named = shareFor(agent, true);
+    (named.metadata as Record<string, string>).name = uniqueName("Docs Site Channel");
+    const second = await shares.create(named);
+    expect(second.metadata?.slug).not.toBe(agent.metadata!.slug);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Launch-gate config (Go TestAgentShareController_LaunchGateConfig) — the
+// validation arms are protovalidate CEL rules in the proto, enforced by
+// the shared ValidateProto step; asserted here, not reimplemented.
+// ---------------------------------------------------------------------------
+
+describe("launch-gate config", () => {
+  const ORG = "launchgate-test-org";
+
+  it("allowed_origins and messages persist and round-trip", async () => {
+    const agent = await createTestAgent(uniqueName("Launch Gate Config Agent"), ORG);
+    const created = await shares.create({
+      ...shareFor(agent, true),
+      spec: {
+        ...shareFor(agent, true).spec,
+        allowedOrigins: ["https://docs.example.com", "http://localhost:3000"],
+        messages: {
+          rateLimited: "Custom rate copy",
+          unavailable: "Custom unavailable copy",
+          conversationEnded: "Custom ended copy",
+        },
+      },
+    });
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.spec?.allowedOrigins).toEqual([
+      "https://docs.example.com",
+      "http://localhost:3000",
+    ]);
+    expect(fetched.spec?.messages?.rateLimited).toBe("Custom rate copy");
+    expect(fetched.spec?.messages?.unavailable).toBe("Custom unavailable copy");
+    expect(fetched.spec?.messages?.conversationEnded).toBe("Custom ended copy");
+  });
+
+  it("malformed origins are INVALID_ARGUMENT", async () => {
+    const agent = await createTestAgent(uniqueName("Origin Validation Agent"), ORG);
+    for (const origin of [
+      "docs.example.com", // missing scheme
+      "https://example.com/path", // path not allowed
+      "https://example.com/", // trailing slash not allowed
+      "ftp://example.com", // wrong scheme
+      "https://example.com?q=1", // query not allowed
+    ]) {
+      const err = await grpcError(() =>
+        shares.create({
+          ...shareFor(agent, true),
+          spec: { ...shareFor(agent, true).spec, allowedOrigins: [origin] },
+        }),
+      );
+      expect(err.code, `origin ${origin}`).toBe(Code.InvalidArgument);
+    }
+  });
+
+  it("overlong custom message is INVALID_ARGUMENT", async () => {
+    const agent = await createTestAgent(uniqueName("Message Length Agent"), ORG);
+    const err = await grpcError(() =>
+      shares.create({
+        ...shareFor(agent, true),
+        spec: {
+          ...shareFor(agent, true).spec,
+          messages: { rateLimited: "x".repeat(301) },
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("environment_refs on an org-audience share is INVALID_ARGUMENT; public persists", async () => {
+    const agent = await createTestAgent(uniqueName("Env Refs Audience Agent"), ORG);
+    const envRef = {
+      kind: ApiResourceKind.environment,
+      org: ORG,
+      slug: "shared-credentials",
+    };
+
+    const err = await grpcError(() =>
+      shares.create({
+        ...shareFor(agent, true),
+        spec: {
+          ...shareFor(agent, true).spec,
+          audience: AgentShareAudience.org,
+          environmentRefs: [envRef],
+        },
+      }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+
+    const created = await shares.create({
+      ...shareFor(agent, true),
+      spec: {
+        ...shareFor(agent, true).spec,
+        audience: AgentShareAudience.public,
+        environmentRefs: [envRef],
+      },
+    });
+    expect(created.spec?.environmentRefs).toHaveLength(1);
+    expect(created.spec?.environmentRefs[0]?.slug).toBe("shared-credentials");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Update (Go TestAgentShareController_Update).
+// ---------------------------------------------------------------------------
+
+describe("agentshare update", () => {
+  const ORG = "update-test-org";
+
+  it("disable is a config-preserving pause", async () => {
+    const agent = await createTestAgent(uniqueName("Pause Agent"), ORG);
+    const created = await shares.create({
+      ...shareFor(agent, true),
+      spec: {
+        ...shareFor(agent, true).spec,
+        allowedOrigins: ["https://docs.example.com"],
+      },
+    });
+
+    created.spec!.enabled = false;
+    const updated = await shares.update(created);
+    expect(updated.spec?.enabled).toBe(false);
+    expect(updated.spec?.allowedOrigins).toHaveLength(1);
+  });
+
+  it("agent_ref is immutable — FAILED_PRECONDITION with the pinned copy", async () => {
+    const agentA = await createTestAgent(uniqueName("Immutable Ref Agent A"), ORG);
+    const agentB = await createTestAgent(uniqueName("Immutable Ref Agent B"), ORG);
+    const created = await shares.create(shareFor(agentA, true));
+
+    created.spec!.agentRef = create(ApiResourceReferenceSchema, {
+      kind: ApiResourceKind.agent,
+      org: agentB.metadata!.org,
+      slug: agentB.metadata!.slug,
+    });
+    const err = await grpcError(() => shares.update(created));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toContain("spec.agent_ref is immutable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-org contract (Go TestAgentShareController_CrossOrg, decision 013).
+// ---------------------------------------------------------------------------
+
+describe("cross-org shares (decision 013)", () => {
+  const PROVIDER = "provider-org";
+  const CONSUMER = "consumer-org";
+
+  function crossOrgShare(agent: Agent, enabled: boolean) {
+    const share = shareFor(agent, enabled);
+    share.metadata.org = CONSUMER;
+    share.spec.agentRef = { ...share.spec.agentRef, org: agent.metadata!.org } as never;
+    return share;
+  }
+
+  it("public agent is shareable cross-org: pin stamped, slug defaulted, profile resolves", async () => {
+    const agent = await createTestAgent(uniqueName("Public Provider Agent"), PROVIDER);
+    await makeAgentPublic(agent);
+
+    const created = await shares.create(crossOrgShare(agent, true));
+    expect(created.metadata?.org).toBe(CONSUMER);
+    expect(created.spec?.agentRef?.org).toBe(PROVIDER);
+    expect(created.metadata?.slug).toBe(agent.metadata!.slug);
+    expect(created.status?.agentId).toBe(agent.metadata!.id);
+
+    const profile = await query.getSharedProfile({
+      org: CONSUMER,
+      slug: created.metadata!.slug,
+    });
+    expect(profile.org).toBe(CONSUMER);
+    expect(profile.name).toBe(agent.metadata!.name);
+  });
+
+  it("non-public agent is NOT_FOUND, indistinguishable from absence", async () => {
+    const agent = await createTestAgent(uniqueName("Private Provider Agent"), PROVIDER);
+
+    const err = await grpcError(() => shares.create(crossOrgShare(agent, true)));
+    expect(err.code).toBe(Code.NotFound);
+
+    // The refusal must match a genuinely missing agent — no existence
+    // probe for private slugs (the T09 indistinguishability contract).
+    const ghost = crossOrgShare(agent, true);
+    ghost.spec.agentRef = { ...ghost.spec.agentRef, org: "empty-provider-org" } as never;
+    const ghostErr = await grpcError(() => shares.create(ghost));
+    expect(err.rawMessage).toBe(ghostErr.rawMessage);
+  });
+
+  it("org audience is refused cross-org, on create and on update", async () => {
+    const agent = await createTestAgent(uniqueName("Audience Rule Agent"), PROVIDER);
+    await makeAgentPublic(agent);
+
+    const orgAudience = crossOrgShare(agent, true);
+    (orgAudience.spec as Record<string, unknown>).audience = AgentShareAudience.org;
+    const createErr = await grpcError(() => shares.create(orgAudience));
+    expect(createErr.code).toBe(Code.FailedPrecondition);
+    expect(createErr.rawMessage).toBe(crossOrgAudienceMessage(PROVIDER));
+
+    const created = await shares.create(crossOrgShare(agent, true));
+    created.spec!.audience = AgentShareAudience.org;
+    const updateErr = await grpcError(() => shares.update(created));
+    expect(updateErr.code).toBe(Code.FailedPrecondition);
+    expect(updateErr.rawMessage).toBe(crossOrgAudienceMessage(PROVIDER));
+  });
+
+  it("non-public dependencies block creation, naming every blocker sorted", async () => {
+    await saveSkill(
+      "skl_private_dep",
+      PROVIDER,
+      "private-skill",
+      ApiResourceVisibility.visibility_private,
+    );
+    await saveSkill(
+      "skl_public_dep",
+      PROVIDER,
+      "public-skill",
+      ApiResourceVisibility.visibility_public,
+    );
+
+    const agent = await agents.create({
+      apiVersion: API_VERSION,
+      kind: "Agent",
+      metadata: { name: uniqueName("Tooling Agent"), org: PROVIDER },
+      spec: {
+        instructions: "You are a tool-using cross-org test agent.",
+        skillRefs: [
+          { kind: ApiResourceKind.skill, slug: "private-skill" },
+          { kind: ApiResourceKind.skill, slug: "public-skill" },
+        ],
+      },
+    });
+    await makeAgentPublic(agent);
+
+    const err = await grpcError(() => shares.create(crossOrgShare(agent, true)));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toContain("provider-org/private-skill");
+    expect(err.rawMessage).not.toContain("public-skill");
+
+    // Same-org sharing of the same agent stays unaffected — the sweep is
+    // a cross-org rule only.
+    await shares.create(shareFor(agent, true));
+  });
+
+  it("visibility flip fails the profile closed", async () => {
+    const agent = await createTestAgent(uniqueName("Revocable Agent"), PROVIDER);
+    await makeAgentPublic(agent);
+    const created = await shares.create(crossOrgShare(agent, true));
+
+    const ref = { org: CONSUMER, slug: created.metadata!.slug };
+    await query.getSharedProfile(ref);
+
+    await agents.updateVisibility({
+      resourceId: agent.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_private,
+    });
+
+    const err = await grpcError(() => query.getSharedProfile(ref));
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("agent delete leaves the cross-org share failing closed; recreate never rebinds", async () => {
+    const name = uniqueName("Ephemeral Provider Agent");
+    const agent = await createTestAgent(name, PROVIDER);
+    await makeAgentPublic(agent);
+    const created = await shares.create(crossOrgShare(agent, true));
+    const ref = { org: CONSUMER, slug: created.metadata!.slug };
+
+    await agents.delete({ value: agent.metadata!.id });
+
+    // The consumer org's share survives the provider's delete (cross-org
+    // shares are NOT cascaded — not the provider's resource to destroy)
+    // but fails closed.
+    const survived = await query.get({ value: created.metadata!.id });
+    expect(survived.status?.agentId).toBe(agent.metadata!.id);
+    const danglingErr = await grpcError(() => query.getSharedProfile(ref));
+    expect(danglingErr.code).toBe(Code.NotFound);
+
+    // A DIFFERENT public agent later claims the same org/slug: the pin
+    // must keep the old share dark.
+    const recreated = await createTestAgent(name, PROVIDER);
+    await makeAgentPublic(recreated);
+    expect(recreated.metadata!.slug).toBe(agent.metadata!.slug);
+
+    const rebindErr = await grpcError(() => query.getSharedProfile(ref));
+    expect(rebindErr.code).toBe(Code.NotFound);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anonymous profile lane (Go TestAgentShareController_GetSharedProfile).
+// ---------------------------------------------------------------------------
+
+describe("getSharedProfile (anonymous lane)", () => {
+  const ORG = "profile-test-org";
+
+  it("uniform NotFound across no-share / disabled / deleted; enabled resolves trimmed", async () => {
+    const agent = await createTestAgent(uniqueName("Shared Profile Agent"), ORG);
+    const ref = { org: ORG, slug: agent.metadata!.slug };
+
+    // No share yet.
+    const noShareErr = await grpcError(() => query.getSharedProfile(ref));
+    expect(noShareErr.code).toBe(Code.NotFound);
+    expect(noShareErr.rawMessage).toBe(`Agent not found: ${agent.metadata!.slug}`);
+
+    // Enabled share resolves to the trimmed profile — display fields from
+    // the AGENT, URL identity from the SHARE, never the full Agent.
+    const share = await shares.create(shareFor(agent, true));
+    const profile = await query.getSharedProfile(ref);
+    expect(profile.org).toBe(share.metadata!.org);
+    expect(profile.slug).toBe(share.metadata!.slug);
+    expect(profile.name).toBe(agent.metadata!.name);
+    expect(profile.description).toBe(agent.spec!.description);
+    expect(profile.iconUrl).toBe(agent.spec!.iconUrl);
+    expect(profile.defaultInstanceId).not.toBe("");
+
+    // Disabled: byte-identical to no-share.
+    share.spec!.enabled = false;
+    await shares.update(share);
+    const disabledErr = await grpcError(() => query.getSharedProfile(ref));
+    expect(disabledErr.code).toBe(Code.NotFound);
+    expect(disabledErr.rawMessage).toBe(noShareErr.rawMessage);
+
+    // Deleted: indistinguishable too.
+    await shares.delete({ value: share.metadata!.id });
+    const deletedErr = await grpcError(() => query.getSharedProfile(ref));
+    expect(deletedErr.code).toBe(Code.NotFound);
+    expect(deletedErr.rawMessage).toBe(noShareErr.rawMessage);
+  });
+
+  it("dangling agent_ref fails closed with the same error", async () => {
+    const agent = await createTestAgent(uniqueName("Soon Deleted Agent"), ORG);
+    await shares.create(shareFor(agent, true));
+    await agents.delete({ value: agent.metadata!.id });
+
+    const err = await grpcError(() =>
+      query.getSharedProfile({ org: ORG, slug: agent.metadata!.slug }),
+    );
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("empty org is INVALID_ARGUMENT (anti-enumeration)", async () => {
+    const err = await grpcError(() =>
+      query.getSharedProfile({ org: "", slug: "any-slug" }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(ORG_REQUIRED_FOR_LOOKUP_MESSAGE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audience + member lane (Go TestAgentShareController_Audience).
+// ---------------------------------------------------------------------------
+
+describe("audience and the member resolution lane", () => {
+  const ORG = "audience-test-org";
+
+  it("audience persists and round-trips", async () => {
+    const agent = await createTestAgent(uniqueName("Audience Round Trip Agent"), ORG);
+    const created = await shares.create({
+      ...shareFor(agent, true),
+      spec: { ...shareFor(agent, true).spec, audience: AgentShareAudience.org },
+    });
+    expect(created.spec?.audience).toBe(AgentShareAudience.org);
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    expect(fetched.spec?.audience).toBe(AgentShareAudience.org);
+  });
+
+  it("member path resolves shares in either audience (OSS: membership always holds)", async () => {
+    const agent = await createTestAgent(uniqueName("Member Resolution Agent"), ORG);
+    const ref = { org: ORG, slug: agent.metadata!.slug };
+
+    const noShareErr = await grpcError(() => query.getSharedProfileForMember(ref));
+    expect(noShareErr.code).toBe(Code.NotFound);
+
+    await shares.create({
+      ...shareFor(agent, true),
+      spec: { ...shareFor(agent, true).spec, audience: AgentShareAudience.org },
+    });
+
+    const profile = await query.getSharedProfileForMember(ref);
+    expect(profile.slug).toBe(agent.metadata!.slug);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent-apply isolation (Go TestAgentShareController_AgentApplyNeverTouchesShare).
+// ---------------------------------------------------------------------------
+
+describe("agent apply never touches the share (decision 011)", () => {
+  it("a full agent update leaves the share resolving, with fresh display fields", async () => {
+    const agent = await createTestAgent(
+      uniqueName("Apply Isolation Agent"),
+      "apply-isolation-org",
+    );
+    await shares.create(shareFor(agent, true));
+
+    agent.spec!.description = "Updated description";
+    await agents.update(agent);
+
+    const profile = await query.getSharedProfile({
+      org: "apply-isolation-org",
+      slug: agent.metadata!.slug,
+    });
+    expect(profile.description).toBe("Updated description");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateShareLink (Go TestAgentShareController_RotateShareLink + org-audience
+// member-path twin).
+// ---------------------------------------------------------------------------
+
+describe("rotateShareLink", () => {
+  const ORG = "rotate-test-org";
+
+  it("the full rotation lifecycle: lock, resolve-with-token, re-rotate, preserve across update", async () => {
+    const agent = await createTestAgent(uniqueName("Rotate Link Agent"), ORG);
+    const request = (token: string) => ({
+      org: ORG,
+      slug: agent.metadata!.slug,
+      linkToken: token,
+    });
+
+    // Capture the no-share NOT_FOUND before creating — the locked-link
+    // refusal must be byte-identical to it.
+    const noShareErr = await grpcError(() => query.getSharedProfile(request("")));
+
+    const share = await shares.create(shareFor(agent, true));
+
+    // A stray ?k= on an unlocked link is harmless.
+    await query.getSharedProfile(request("stray-token"));
+
+    // Rotation locks the link: 27 url-safe chars, status-resident.
+    const rotated = await shares.rotateShareLink({ resourceId: share.metadata!.id });
+    const firstToken = rotated.status?.shareLinkToken ?? "";
+    expect(firstToken).toHaveLength(27);
+    expect(firstToken).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const lockedErr = await grpcError(() => query.getSharedProfile(request("")));
+    expect(lockedErr.code).toBe(Code.NotFound);
+    expect(lockedErr.rawMessage).toBe(noShareErr.rawMessage);
+
+    await query.getSharedProfile(request(firstToken));
+
+    // Re-rotation kills the previous token.
+    const reRotated = await shares.rotateShareLink({ resourceId: share.metadata!.id });
+    const secondToken = reRotated.status?.shareLinkToken ?? "";
+    expect(secondToken).not.toBe(firstToken);
+
+    const deadErr = await grpcError(() => query.getSharedProfile(request(firstToken)));
+    expect(deadErr.code).toBe(Code.NotFound);
+    await query.getSharedProfile(request(secondToken));
+
+    // The tokenless member path must not reveal a token-locked PUBLIC share.
+    const memberErr = await grpcError(() =>
+      query.getSharedProfileForMember({ org: ORG, slug: agent.metadata!.slug }),
+    );
+    expect(memberErr.code).toBe(Code.NotFound);
+
+    // A manifest-shaped update (no status) preserves the token — status
+    // survives every update verbatim, the design's core guarantee.
+    const current = await query.get({ value: share.metadata!.id });
+    current.status = undefined;
+    const updated = await shares.update(current);
+    expect(updated.status?.shareLinkToken).toBe(secondToken);
+  });
+
+  it("nonexistent share is NOT_FOUND", async () => {
+    const err = await grpcError(() =>
+      shares.rotateShareLink({ resourceId: "ash-does-not-exist" }),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toBe("AgentShare not found: ash-does-not-exist");
+  });
+
+  it("member path stays open for org-audience shares even when a token exists", async () => {
+    const agent = await createTestAgent(uniqueName("Org Audience Rotate Agent"), ORG);
+    const created = await shares.create({
+      ...shareFor(agent, true),
+      spec: { ...shareFor(agent, true).spec, audience: AgentShareAudience.org },
+    });
+    await shares.rotateShareLink({ resourceId: created.metadata!.id });
+
+    const profile = await query.getSharedProfileForMember({
+      org: ORG,
+      slug: agent.metadata!.slug,
+    });
+    expect(profile.slug).toBe(agent.metadata!.slug);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getByAgent (Go TestAgentShareController_GetByAgent).
+// ---------------------------------------------------------------------------
+
+describe("getByAgent", () => {
+  it("finds the canonical share and a renamed share", async () => {
+    const agent = await createTestAgent(uniqueName("Get By Agent Agent"), "gba-org");
+    const canonical = await shares.create(shareFor(agent, true));
+
+    const renamed = shareFor(agent, true);
+    (renamed.metadata as Record<string, string>).name = uniqueName("Renamed Channel");
+    const second = await shares.create(renamed);
+
+    const list = await query.getByAgent({ agentId: agent.metadata!.id });
+    expect(list.totalCount).toBe(2);
+    const slugs = list.items.map((s: AgentShare) => s.metadata?.slug);
+    expect(slugs).toContain(canonical.metadata!.slug);
+    expect(slugs).toContain(second.metadata!.slug);
+  });
+
+  it("nonexistent agent yields an empty list, not an error", async () => {
+    const list = await query.getByAgent({ agentId: "agt-does-not-exist" });
+    expect(list.totalCount).toBe(0);
+  });
+
+  it("org scopes the list to one org's shares", async () => {
+    const agent = await createTestAgent(
+      uniqueName("Org Scoped List Agent"),
+      "gba-provider-org",
+    );
+    await makeAgentPublic(agent);
+    await shares.create(shareFor(agent, true));
+
+    const crossOrg = shareFor(agent, true);
+    crossOrg.metadata.org = "gba-consumer-org";
+    crossOrg.spec.agentRef = {
+      ...crossOrg.spec.agentRef,
+      org: agent.metadata!.org,
+    } as never;
+    await shares.create(crossOrg);
+
+    const cases: Array<{ org: string; want: number; wantOrg: string }> = [
+      { org: "", want: 2, wantOrg: "" },
+      { org: "gba-provider-org", want: 1, wantOrg: "gba-provider-org" },
+      { org: "gba-consumer-org", want: 1, wantOrg: "gba-consumer-org" },
+      { org: "gba-bystander-org", want: 0, wantOrg: "" },
+    ];
+    for (const tt of cases) {
+      const list = await query.getByAgent({ agentId: agent.metadata!.id, org: tt.org });
+      expect(list.totalCount, `org ${tt.org}`).toBe(tt.want);
+      for (const item of list.items) {
+        if (tt.wantOrg !== "") {
+          expect(item.metadata?.org).toBe(tt.wantOrg);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Apply semantics (Go TestAgentShareController_Apply) — delegates the
+// CLONED state, so a canonical manifest (no name/slug) applies twice into
+// ONE share.
+// ---------------------------------------------------------------------------
+
+describe("apply semantics", () => {
+  it("apply creates, re-apply updates in place — never duplicates", async () => {
+    const agent = await createTestAgent(
+      uniqueName("Apply Semantics Agent"),
+      "apply-sem-org",
+    );
+
+    const created = await shares.apply(shareFor(agent, true));
+    expect(created.metadata?.id).not.toBe("");
+
+    const again = shareFor(agent, true);
+    (again.spec as Record<string, unknown>).allowedOrigins = ["https://docs.example.com"];
+    const updated = await shares.apply(again);
+    expect(updated.metadata?.id).toBe(created.metadata!.id);
+    expect(updated.spec?.allowedOrigins).toHaveLength(1);
+
+    const list = await query.list({ org: "apply-sem-org" });
+    expect(list.totalCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seam-level pins that the composed server cannot reach.
+// ---------------------------------------------------------------------------
+
+describe("seam-level pins", () => {
+  it("store failure leaks no internals (stigmer/stigmer#478)", async () => {
+    // Go injects a failing store into the controller; here the pin sits on
+    // the exact seam that formats the wire error — the share lookup used
+    // by the ONLY anonymous RPC. The wire carries the static message; the
+    // cause stays server-side on ConnectError.cause.
+    const cause = new Error("bbolt: /var/lib/stigmer/store.db corrupted");
+    const failing = {
+      listResources: async () => {
+        throw cause;
+      },
+    } as unknown as Store;
+
+    const err = await grpcError(() => findShareByOrgAndSlug(failing, "o", "s"));
+    expect(err.code).toBe(Code.Internal);
+    expect(err.rawMessage).toBe("failed to list agent share resources");
+    expect(err.rawMessage).not.toContain("bbolt");
+    expect(err.cause).toBe(cause);
+  });
+
+  it("sharingLinkTokenAllowed: constant-time compare with Go's length semantics", () => {
+    // Unlocked link: anything presented is ignored.
+    expect(sharingLinkTokenAllowed("", "")).toBe(true);
+    expect(sharingLinkTokenAllowed("stray", "")).toBe(true);
+    // Locked link: exact match only; empty and length-mismatched presented
+    // tokens refuse (Go's ConstantTimeCompare returns 0 on length
+    // mismatch; Node's timingSafeEqual would THROW without the guard).
+    expect(sharingLinkTokenAllowed("", "live-token")).toBe(false);
+    expect(sharingLinkTokenAllowed("live-token", "live-token")).toBe(true);
+    expect(sharingLinkTokenAllowed("live-tok", "live-token")).toBe(false);
+    expect(sharingLinkTokenAllowed("live-tokeX", "live-token")).toBe(false);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/agentshare/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentshare/constants.ts
@@ -1,0 +1,72 @@
+/**
+ * AgentShare domain constants — the byte-pinned wire copy shared with the
+ * Go server and the cloud edition. Every string here is asserted by the
+ * conformance suite or the cross-edition error contract; none is editable
+ * without an owner-ratified wire change.
+ */
+
+/**
+ * Entropy behind a rotated link: 20 bytes → 27 url-safe base64 characters
+ * — Go shareLinkTokenBytes. Comfortably beyond guessability for a
+ * rate-limited public endpoint while keeping the share URL short.
+ */
+export const SHARE_LINK_TOKEN_BYTES = 20;
+
+/**
+ * InvalidArgument copy when metadata.org is absent — Go
+ * resolveShareDefaultsStep, byte-pinned. The share's org appears in the
+ * hosted chat URL and is the billing org, so it can never be inferred.
+ */
+export const ORG_REQUIRED_MESSAGE = "metadata.org is required for an agent share";
+
+/** InvalidArgument copy when spec.agent_ref.slug is absent — Go, pinned. */
+export const AGENT_REF_SLUG_REQUIRED_MESSAGE = "spec.agent_ref.slug is required";
+
+/**
+ * InvalidArgument copy for BOTH profile lanes when org is absent — Go
+ * loadShareForProfileStep / loadShareForMemberProfileStep, byte-pinned.
+ * Anti-enumeration: an empty org would mean "match slug across all orgs"
+ * on a public endpoint.
+ */
+export const ORG_REQUIRED_FOR_LOOKUP_MESSAGE = "org is required for shared agent lookup";
+
+/**
+ * FailedPrecondition copy for an org-audience cross-org share (decision
+ * 013 D3) — Go validateCrossOrgShare AND validateShareUpdateStep (update
+ * replaces the spec wholesale and must not open a side door), byte-pinned.
+ */
+export function crossOrgAudienceMessage(agentOrg: string): string {
+  return (
+    "a cross-org share must have a public audience — org-audience shares " +
+    `are limited to the agent's own organization (${agentOrg})`
+  );
+}
+
+/**
+ * FailedPrecondition copy naming every non-public dependency blocking a
+ * cross-org share (decision 013 D5) — Go validateCrossOrgShare,
+ * byte-pinned. Blockers are deduped, formatted "<kind> <org>/<slug>", and
+ * sorted, so the refusal is deterministic.
+ */
+export function crossOrgBlockersMessage(
+  agentOrg: string,
+  agentSlug: string,
+  blockers: readonly string[],
+): string {
+  return (
+    `cannot share ${agentOrg}/${agentSlug} across organizations: ` +
+    `it references resources that are not public: ${blockers.join(", ")}`
+  );
+}
+
+/**
+ * FailedPrecondition copy for an agent_ref change on update — Go
+ * validateShareUpdateStep, byte-pinned. A share is a channel FOR one
+ * agent; re-pointing it would silently move guest traffic (and billing).
+ */
+export function agentRefImmutableMessage(org: string, slug: string): string {
+  return (
+    `spec.agent_ref is immutable (share references ${org}/${slug}) — ` +
+    "create a new share to distribute a different agent"
+  );
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentshare/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentshare/controller.ts
@@ -1,0 +1,729 @@
+/**
+ * AgentShare controller — ports pkg/domain/agentshare/controller (command +
+ * query sides): the first-class sharing channel promoted out of
+ * Agent.spec.sharing (decision 011). A share carries everything a hosted
+ * chat link needs — audience, embed origins, visitor-facing messages,
+ * guest tool credentials (environment_refs), and the rotatable link token.
+ * Share operations never modify the referenced agent.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character. NOT
+ * search-indexed by design (the kind declares not_search_indexed — a share
+ * is channel configuration reached through its agent, not a library
+ * artifact), so no index steps appear in any chain. The agent-delete
+ * cascade of same-org shares lives in the AGENT domain (ported with #6);
+ * share delete itself cascades nothing.
+ *
+ * Authorization posture (OSS): single-user and local, so handlers perform
+ * no authorization — a documented no-op, not a silent divergence. The
+ * cloud edition enforces the same contracts via FGA plus app-level gates
+ * for the anonymous resolution paths.
+ *
+ * Proven by agentshare.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentshare.test.ts.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentShareSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import type { AgentShare } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import { AgentShareStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/status_pb";
+import { AgentShareCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/command_pb";
+import { AgentShareQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/query_pb";
+import { AgentShareListSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/io_pb";
+import type {
+  AgentShareId,
+  AgentShareList,
+  GetAgentSharesByAgentRequest,
+  GetSharedProfileRequest,
+  ListAgentSharesRequest,
+  RotateShareLinkInput,
+  SharedAgentProfile,
+} from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/io_pb";
+import { AgentShareAudience } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/spec_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { compareCreatedAtDesc, matchesAllLabels } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import { ORG_REQUIRED_FOR_LOOKUP_MESSAGE } from "./constants.js";
+import {
+  buildSharedAgentProfile,
+  findShareByOrgAndSlug,
+  generateShareLinkToken,
+  newResolveShareDefaultsStep,
+  newStampAgentPinStep,
+  newValidateShareUpdateStep,
+  sharedNotFound,
+  sharingLinkTokenAllowed,
+} from "./steps.js";
+
+export interface AgentShareControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+/** Registers both agentshare services on the router (routes stage). */
+export function registerAgentShareServices(
+  router: ConnectRouter,
+  deps: AgentShareControllerDeps,
+): void {
+  router.service(AgentShareCommandController, {
+    apply: (share, ctx) => apply(deps, share, ctx),
+    create: (share, ctx) => createShare(deps, share, ctx),
+    update: (share, ctx) => update(deps, share, ctx),
+    rotateShareLink: (input, ctx) => rotateShareLink(deps, input, ctx),
+    delete: (shareId, ctx) => deleteShare(deps, shareId, ctx),
+  });
+  router.service(AgentShareQueryController, {
+    get: (shareId, ctx) => get(deps, shareId, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getByAgent: (req, ctx) => getByAgent(deps, req, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+    getSharedProfile: (req, ctx) => getSharedProfile(deps, req, ctx),
+    getSharedProfileForMember: (ref, ctx) => getSharedProfileForMember(deps, ref, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. StampAgentPin runs AFTER
+ * BuildNewState so the wipe of client-provided status cannot erase the
+ * rebind pin; with the agent-slug default, CheckDuplicate structurally
+ * caps shares at one canonical link per agent per org.
+ */
+async function createShare(
+  deps: AgentShareControllerDeps,
+  share: AgentShare,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(AgentShareSchema, share, kindOf(ctx));
+  await newPipeline<typeof AgentShareSchema>("agent-share-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveShareDefaultsStep(deps.store))
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newStampAgentPinStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline. The spec is replaced
+ * wholesale (declarative semantics); status is preserved verbatim from the
+ * existing share, which is the guarantee that keeps
+ * status.share_link_token immune to declarative clobber (rotateShareLink
+ * is its sole writer).
+ */
+async function update(
+  deps: AgentShareControllerDeps,
+  share: AgentShare,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(AgentShareSchema, share, kindOf(ctx));
+  await newPipeline<typeof AgentShareSchema>("agent-share-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateShareUpdateStep())
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update. Delegates with the pipeline's
+ * CLONED state (Go delegates reqCtx.NewState(), NOT the original input —
+ * unlike channelapp/session): the canonical-share manifest legitimately
+ * omits both name and slug, and the defaulted slug/name (from
+ * ResolveShareDefaults) and the populated id (from LoadForApply) live only
+ * on the clone.
+ */
+async function apply(
+  deps: AgentShareControllerDeps,
+  share: AgentShare,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(AgentShareSchema, share, kindOf(ctx));
+  await newPipeline<typeof AgentShareSchema>("agent-share-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveShareDefaultsStep(deps.store))
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  const resolved = reqCtx.newState;
+  return shouldCreate
+    ? createShare(deps, resolved, ctx)
+    : update(deps, resolved, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// rotateShareLink — Go rotate_share_link.go: this handler is the token's
+// SOLE writer; clients never supply it. The token lives in STATUS — not
+// spec — so manifest applies can never wipe it and silently fail open to
+// the plain guessable URL.
+// ---------------------------------------------------------------------------
+
+const ROTATE_SHARE_KEY = "rotateShareLinkShare";
+
+type RotateDesc = typeof AgentShareCommandController.method.rotateShareLink.input;
+
+async function rotateShareLink(
+  deps: AgentShareControllerDeps,
+  input: RotateShareLinkInput,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(
+    AgentShareCommandController.method.rotateShareLink.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<RotateDesc>("agent-share-rotate-share-link", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadShareForLinkRotationStep(deps.store))
+    .addStep(newRotateShareLinkTokenStep())
+    .addStep(newPersistShareForLinkRotationStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(ROTATE_SHARE_KEY) as AgentShare;
+}
+
+/** Loads the share by resource_id; ANY load failure → NotFound (Go). */
+function newLoadShareForLinkRotationStep(store: Store): PipelineStep<RotateDesc> {
+  return {
+    name: "LoadShareForLinkRotation",
+    async execute(ctx: RequestContext<RotateDesc>): Promise<void> {
+      let share: AgentShare;
+      try {
+        share = await store.getResource(
+          ctx.apiResourceKind,
+          ctx.input.resourceId,
+          AgentShareSchema,
+        );
+      } catch {
+        throw notFoundError("AgentShare", ctx.input.resourceId);
+      }
+      ctx.set(ROTATE_SHARE_KEY, share);
+    },
+  };
+}
+
+/**
+ * Sets status.share_link_token to fresh entropy, preserving the rest of
+ * status and stamping the StatusAudit slot — the same status-preserving
+ * discipline as the update pipeline. Go wraps a stamping failure as a
+ * PLAIN error (not grpclib) — the wire then carries the sanitized
+ * "internal server error", exactly what the pipeline's non-Connect
+ * fallback produces here.
+ */
+function newRotateShareLinkTokenStep(): PipelineStep<RotateDesc> {
+  return {
+    name: "RotateShareLinkToken",
+    execute(ctx: RequestContext<RotateDesc>): void {
+      const share = ctx.get(ROTATE_SHARE_KEY) as AgentShare;
+      // Go wraps an entropy failure as Internal "failed to rotate share
+      // link" (practically unreachable, but the arm's copy is contract).
+      let token: string;
+      try {
+        token = generateShareLinkToken();
+      } catch (error) {
+        throw internalError(error, "failed to rotate share link");
+      }
+      const status = share.status ?? create(AgentShareStatusSchema);
+      status.shareLinkToken = token;
+      share.status = status;
+      setAuditFieldsForUpdate(AgentShareSchema, share, "status_audit");
+    },
+  };
+}
+
+/** Saves the rotated share. */
+function newPersistShareForLinkRotationStep(store: Store): PipelineStep<RotateDesc> {
+  return {
+    name: "PersistShareForLinkRotation",
+    async execute(ctx: RequestContext<RotateDesc>): Promise<void> {
+      const share = ctx.get(ROTATE_SHARE_KEY) as AgentShare;
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          share.metadata?.id ?? "",
+          AgentShareSchema,
+          share,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to save agent share");
+      }
+    },
+  };
+}
+
+/**
+ * Delete — the channel's full teardown: the hosted link stops resolving
+ * and the share's configuration is gone (disable via update is the
+ * config-preserving pause). The referenced agent is untouched; share
+ * delete cascades nothing.
+ */
+async function deleteShare(
+  deps: AgentShareControllerDeps,
+  shareId: AgentShareId,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(
+    AgentShareCommandController.method.delete.input,
+    shareId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentShareCommandController.method.delete.input>(
+    "agent-share-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, AgentShareSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted agent share not found in context"),
+      "deleted agent share not found in context",
+    );
+  }
+  return deleted as AgentShare;
+}
+
+/** Get — LoadTarget by id-wrapper input (AgentShareId). */
+async function get(
+  deps: AgentShareControllerDeps,
+  shareId: AgentShareId,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(
+    AgentShareQueryController.method.get.input,
+    shareId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentShareQueryController.method.get.input>(
+    "agent-share-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, AgentShareSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentShare;
+}
+
+/** GetByReference — org/slug lookup. */
+async function getByReference(
+  deps: AgentShareControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<AgentShare> {
+  const reqCtx = new RequestContext(
+    AgentShareQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentShareQueryController.method.getByReference.input>(
+    "agent-share-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, AgentShareSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as AgentShare;
+}
+
+const SHARE_LIST_KEY = "agentShareList";
+
+/**
+ * GetByAgent — all shares of one agent, optionally org-scoped. This is how
+ * the Share dialog and CLI resolve an agent's existing share regardless of
+ * its slug (rename-by-recreate, decision 011 D2). A nonexistent agent
+ * yields an EMPTY list, not an error — "no shares" is the useful answer
+ * either way. The org filter is contract parity, not authorization: a
+ * multi-org caller asking for one org's channels must not see another
+ * org's cross-org shares of the same agent.
+ */
+async function getByAgent(
+  deps: AgentShareControllerDeps,
+  req: GetAgentSharesByAgentRequest,
+  ctx: HandlerContext,
+): Promise<AgentShareList> {
+  const reqCtx = new RequestContext(
+    AgentShareQueryController.method.getByAgent.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentShareQueryController.method.getByAgent.input>(
+    "agent-share-get-by-agent",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadSharesByAgentStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(SHARE_LIST_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("agent share list not found in context"),
+      "agent share list not found in context",
+    );
+  }
+  return result as AgentShareList;
+}
+
+/**
+ * LoadSharesByAgent — Go loadSharesByAgentStep: resolves the agent by ID
+ * to its org+slug identity (shares reference agents by org+slug while
+ * this RPC is keyed on the stable agent ID), then filters shares whose
+ * spec.agent_ref matches.
+ */
+function newLoadSharesByAgentStep(
+  store: Store,
+): PipelineStep<typeof AgentShareQueryController.method.getByAgent.input> {
+  return {
+    name: "LoadSharesByAgent",
+    async execute(
+      ctx: RequestContext<typeof AgentShareQueryController.method.getByAgent.input>,
+    ): Promise<void> {
+      const req = ctx.input;
+      const emptyList = create(AgentShareListSchema, { totalCount: 0, items: [] });
+
+      let agentOrg: string;
+      let agentSlug: string;
+      try {
+        const agent = await store.getResource(
+          ApiResourceKind.agent,
+          req.agentId,
+          AgentSchema,
+        );
+        agentOrg = agent.metadata?.org ?? "";
+        agentSlug = agent.metadata?.slug ?? "";
+      } catch {
+        ctx.set(SHARE_LIST_KEY, emptyList);
+        return;
+      }
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_share);
+      } catch (error) {
+        throw internalError(error, "failed to list agent shares");
+      }
+
+      const shares: AgentShare[] = [];
+      for (const bytes of rows) {
+        let share: AgentShare;
+        try {
+          share = fromBinary(AgentShareSchema, bytes);
+        } catch {
+          continue;
+        }
+        const ref = share.spec?.agentRef;
+        if ((ref?.org ?? "") !== agentOrg || (ref?.slug ?? "") !== agentSlug) {
+          continue;
+        }
+        if (req.org !== "" && (share.metadata?.org ?? "") !== req.org) {
+          continue;
+        }
+        shares.push(share);
+      }
+
+      ctx.set(
+        SHARE_LIST_KEY,
+        create(AgentShareListSchema, { totalCount: shares.length, items: shares }),
+      );
+    },
+  };
+}
+
+const LIST_RESULT_KEY = "listResult";
+
+/**
+ * List — org + labels filter (AND semantics), newest first. Versus Cloud,
+ * OSS excludes authorization filtering AND pagination, exactly as Go's
+ * list.go records.
+ */
+async function list(
+  deps: AgentShareControllerDeps,
+  req: ListAgentSharesRequest,
+  ctx: HandlerContext,
+): Promise<AgentShareList> {
+  const reqCtx = new RequestContext(
+    AgentShareQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentShareQueryController.method.list.input>(
+    "agent-share-list",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgAndLabelsStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("agent share list not found in context"),
+      "agent share list not found in context",
+    );
+  }
+  return result as AgentShareList;
+}
+
+/** ListByOrgAndLabels — Go listByOrgAndLabelsStep, warn-and-skip rows. */
+function newListByOrgAndLabelsStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof AgentShareQueryController.method.list.input> {
+  return {
+    name: "ListByOrgAndLabels",
+    async execute(
+      ctx: RequestContext<typeof AgentShareQueryController.method.list.input>,
+    ): Promise<void> {
+      const { org, labels: filterLabels } = ctx.input;
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ctx.apiResourceKind);
+      } catch (error) {
+        throw internalError(error, "failed to list agent shares");
+      }
+
+      const shares: AgentShare[] = [];
+      for (const bytes of rows) {
+        let share: AgentShare;
+        try {
+          share = fromBinary(AgentShareSchema, bytes);
+        } catch {
+          logger.warn("Failed to unmarshal agent share, skipping");
+          continue;
+        }
+        if ((share.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        if (!matchesAllLabels(share.metadata?.labels ?? {}, filterLabels)) {
+          continue;
+        }
+        shares.push(share);
+      }
+
+      shares.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      ctx.set(
+        LIST_RESULT_KEY,
+        create(AgentShareListSchema, { totalCount: shares.length, items: shares }),
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The profile lanes — Go get_shared_profile.go. GetSharedProfile is the
+// ANONYMOUS resolution path for the hosted chat page; visitors resolve a
+// shared link to the trimmed SharedAgentProfile — never the full Agent,
+// whose spec carries the system prompt. GetSharedProfileForMember is the
+// tokenless authenticated twin: in OSS the one principal IS the
+// organization, so membership always holds and it resolves any enabled
+// share — with ONE exception mirrored from cloud (see below).
+// ---------------------------------------------------------------------------
+
+const RESOLVED_SHARE_KEY = "resolvedAgentShare";
+const SHARED_PROFILE_KEY = "sharedAgentProfile";
+
+type ProfileDesc = typeof AgentShareQueryController.method.getSharedProfile.input;
+type MemberProfileDesc =
+  typeof AgentShareQueryController.method.getSharedProfileForMember.input;
+
+async function getSharedProfile(
+  deps: AgentShareControllerDeps,
+  req: GetSharedProfileRequest,
+  ctx: HandlerContext,
+): Promise<SharedAgentProfile> {
+  const reqCtx = new RequestContext(
+    AgentShareQueryController.method.getSharedProfile.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<ProfileDesc>("agent-share-get-shared-profile", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadShareForProfileStep(deps.store))
+    .addStep(newProjectSharedProfileStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(SHARED_PROFILE_KEY) as SharedAgentProfile;
+}
+
+async function getSharedProfileForMember(
+  deps: AgentShareControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<SharedAgentProfile> {
+  const reqCtx = new RequestContext(
+    AgentShareQueryController.method.getSharedProfileForMember.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<MemberProfileDesc>(
+    "agent-share-get-shared-profile-for-member",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadShareForMemberProfileStep(deps.store))
+    .addStep(newProjectMemberSharedProfileStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(SHARED_PROFILE_KEY) as SharedAgentProfile;
+}
+
+/**
+ * Loads the share by org+slug for the anonymous path. Org is required —
+ * an empty org would mean "match slug across all orgs", an enumeration
+ * hazard on this public endpoint.
+ */
+function newLoadShareForProfileStep(store: Store): PipelineStep<ProfileDesc> {
+  return {
+    name: "LoadShareForProfile",
+    async execute(ctx: RequestContext<ProfileDesc>): Promise<void> {
+      const req = ctx.input;
+      if (req.org === "") {
+        throw invalidArgumentError(ORG_REQUIRED_FOR_LOOKUP_MESSAGE);
+      }
+      const share = await findShareByOrgAndSlug(store, req.org, req.slug);
+      if (share === undefined) {
+        throw sharedNotFound(req.slug);
+      }
+      ctx.set(RESOLVED_SHARE_KEY, share);
+    },
+  };
+}
+
+/** The member path's loader — same org-required contract, same refusal. */
+function newLoadShareForMemberProfileStep(store: Store): PipelineStep<MemberProfileDesc> {
+  return {
+    name: "LoadShareForMemberProfile",
+    async execute(ctx: RequestContext<MemberProfileDesc>): Promise<void> {
+      const ref = ctx.input;
+      if (ref.org === "") {
+        throw invalidArgumentError(ORG_REQUIRED_FOR_LOOKUP_MESSAGE);
+      }
+      const share = await findShareByOrgAndSlug(store, ref.org, ref.slug);
+      if (share === undefined) {
+        throw sharedNotFound(ref.slug);
+      }
+      ctx.set(RESOLVED_SHARE_KEY, share);
+    },
+  };
+}
+
+/**
+ * Gates on spec.enabled plus the live link token, then projects the
+ * trimmed public profile. A disabled share and a locked link with a wrong
+ * or absent token are both indistinguishable from a nonexistent share —
+ * a rotated (killed) link must look exactly like one that never existed.
+ */
+function newProjectSharedProfileStep(store: Store): PipelineStep<ProfileDesc> {
+  return {
+    name: "ProjectSharedProfile",
+    async execute(ctx: RequestContext<ProfileDesc>): Promise<void> {
+      const share = ctx.get(RESOLVED_SHARE_KEY) as AgentShare;
+      const req = ctx.input;
+
+      if (share.spec?.enabled !== true) {
+        throw sharedNotFound(req.slug);
+      }
+      if (!sharingLinkTokenAllowed(req.linkToken, share.status?.shareLinkToken ?? "")) {
+        throw sharedNotFound(req.slug);
+      }
+
+      ctx.set(SHARED_PROFILE_KEY, await buildSharedAgentProfile(store, share));
+    },
+  };
+}
+
+/**
+ * The member path's projection: gates on spec.enabled and refuses
+ * token-locked PUBLIC-audience shares — this tokenless path must not
+ * reveal a killed (rotated) link's profile; such shares resolve only
+ * through GetSharedProfile with the matching token. Org-audience shares
+ * are unaffected — their gate is membership, not the link token.
+ */
+function newProjectMemberSharedProfileStep(store: Store): PipelineStep<MemberProfileDesc> {
+  return {
+    name: "ProjectMemberSharedProfile",
+    async execute(ctx: RequestContext<MemberProfileDesc>): Promise<void> {
+      const share = ctx.get(RESOLVED_SHARE_KEY) as AgentShare;
+
+      if (share.spec?.enabled !== true) {
+        throw sharedNotFound(ctx.input.slug);
+      }
+
+      const isOrgAudience = share.spec.audience === AgentShareAudience.org;
+      if (!isOrgAudience && (share.status?.shareLinkToken ?? "") !== "") {
+        throw sharedNotFound(ctx.input.slug);
+      }
+
+      ctx.set(SHARED_PROFILE_KEY, await buildSharedAgentProfile(store, share));
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/agentshare/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentshare/steps.ts
@@ -1,0 +1,459 @@
+/**
+ * AgentShare domain steps — ports pkg/domain/agentshare/controller/steps.go
+ * and the get_shared_profile.go helpers: share defaults + the cross-org
+ * public-dependency contract (decision 013), the agent-id rebind pin, the
+ * update immutability rules, the uniform-NotFound profile resolution
+ * helpers, and the constant-time link-token predicate.
+ *
+ * OD-1 (deliberate exclusion): Go's boot migration
+ * (pkg/domain/agentshare/migration/bootstrap_shares.go — protowire
+ * decoding of the REMOVED Agent.spec.sharing fields into AgentShare rows)
+ * is NOT ported. It exists only for self-hosters upgrading a SQLite file
+ * across the decision-011 promotion; a TS server adopting such a database
+ * arrives at cutover (D4 #24), by which time the Go binary has already
+ * run the backfill on every upgraded installation. Ratified in the D4
+ * breakdown (entry #12) and disclosed in the PR.
+ *
+ * Proven by agentshare.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/agentshare.test.ts.
+ */
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+import { create, fromBinary } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentShareSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import type { AgentShare } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/api_pb";
+import { AgentShareStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/status_pb";
+import { SharedAgentProfileSchema } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/io_pb";
+import type { SharedAgentProfile } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/io_pb";
+import { AgentShareAudience } from "@stigmer/protos/ai/stigmer/agentic/agentshare/v1/spec_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+import {
+  AGENT_REF_SLUG_REQUIRED_MESSAGE,
+  ORG_REQUIRED_MESSAGE,
+  SHARE_LINK_TOKEN_BYTES,
+  agentRefImmutableMessage,
+  crossOrgAudienceMessage,
+  crossOrgBlockersMessage,
+} from "./constants.js";
+
+type AgentShareDesc = typeof AgentShareSchema;
+
+/**
+ * Context key for the agent resolved from spec.agent_ref during
+ * create/apply, so later steps never re-load it — Go referencedAgentKey.
+ * Module-private: only ResolveShareDefaults writes it and StampAgentPin
+ * reads it, both in this file.
+ */
+const REFERENCED_AGENT_KEY = "agentShareReferencedAgent";
+
+/**
+ * The single refusal for every anonymous/member resolution miss: share
+ * missing, share disabled, dangling agent_ref, stale pin, wrong or absent
+ * link token — Go sharedNotFound. The message deliberately says "Agent":
+ * the visitor asked for an agent's chat page, and the share resource is an
+ * internal modeling detail a public error must not teach. One constructor
+ * guarantees the byte-identical-errors contract by construction.
+ */
+export function sharedNotFound(slug: string): ConnectError {
+  return notFoundError("Agent", slug);
+}
+
+/**
+ * The link-token predicate — Go sharingLinkTokenAllowed, the mirror of the
+ * cloud edition's SharingLinkTokenPolicy:
+ *   - No live token: allowed (a stale ?k= on an unlocked link is harmless).
+ *   - Live token set: the presented token must match exactly; a missing or
+ *     rotated-away token refuses (surfacing as the uniform NotFound).
+ *
+ * Comparison is constant-time. Node's timingSafeEqual THROWS on unequal
+ * lengths where Go's subtle.ConstantTimeCompare returns 0, so the length
+ * guard restores Go's semantics; the length of a token is not secret (all
+ * server-minted tokens are 27 chars).
+ */
+export function sharingLinkTokenAllowed(presented: string, live: string): boolean {
+  if (live === "") {
+    return true;
+  }
+  if (presented === "") {
+    return false;
+  }
+  const presentedBytes = Buffer.from(presented);
+  const liveBytes = Buffer.from(live);
+  if (presentedBytes.length !== liveBytes.length) {
+    return false;
+  }
+  return timingSafeEqual(presentedBytes, liveBytes);
+}
+
+/**
+ * Fresh server-side entropy for status.share_link_token — Go
+ * generateShareLinkToken: 20 crypto-random bytes, unpadded url-safe base64
+ * (Node's "base64url" = Go's base64.RawURLEncoding), 27 characters.
+ */
+export function generateShareLinkToken(): string {
+  return randomBytes(SHARE_LINK_TOKEN_BYTES).toString("base64url");
+}
+
+/**
+ * Scans agents for an org+slug match — Go findAgentByOrgAndSlug. Full-scan
+ * lookup matches the store's local/OSS posture; malformed rows are
+ * skipped, as Go does. Module-private: consumed by the defaults resolver
+ * and the profile projection, both in this file.
+ */
+async function findAgentByOrgAndSlug(
+  store: Store,
+  org: string,
+  slug: string,
+): Promise<Agent | undefined> {
+  let rows: Uint8Array[];
+  try {
+    rows = await store.listResources(ApiResourceKind.agent);
+  } catch (error) {
+    throw internalError(error, "failed to list agent resources");
+  }
+  for (const data of rows) {
+    let agent: Agent;
+    try {
+      agent = fromBinary(AgentSchema, data);
+    } catch {
+      continue;
+    }
+    if (agent.metadata?.slug === slug && agent.metadata.org === org) {
+      return agent;
+    }
+  }
+  return undefined;
+}
+
+/** Scans shares for an org+slug match — Go findShareByOrgAndSlug. */
+export async function findShareByOrgAndSlug(
+  store: Store,
+  org: string,
+  slug: string,
+): Promise<AgentShare | undefined> {
+  let rows: Uint8Array[];
+  try {
+    rows = await store.listResources(ApiResourceKind.agent_share);
+  } catch (error) {
+    throw internalError(error, "failed to list agent share resources");
+  }
+  for (const data of rows) {
+    let share: AgentShare;
+    try {
+      share = fromBinary(AgentShareSchema, data);
+    } catch {
+      continue;
+    }
+    if (share.metadata?.slug === slug && share.metadata.org === org) {
+      return share;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * ResolveShareDefaults — Go resolveShareDefaultsStep:
+ *   1. Requires metadata.org (URL + billing identity, never inferred).
+ *   2. Normalizes spec.agent_ref.org (empty means same-org) and loads the
+ *      referenced agent — a nonexistent agent is refused with the same
+ *      NOT_FOUND a direct agent lookup would produce.
+ *   3. For a CROSS-ORG share, enforces the decision-013 contract.
+ *   4. Defaults metadata.slug (and name) from the agent when the caller
+ *      provided neither — the canonical share keeps the agent's hosted URL.
+ *      Runs before ResolveSlug, which skips already-set slugs.
+ */
+export function newResolveShareDefaultsStep(store: Store): PipelineStep<AgentShareDesc> {
+  return {
+    name: "ResolveShareDefaults",
+    async execute(ctx: RequestContext<AgentShareDesc>): Promise<void> {
+      const share = ctx.newState;
+      const metadata = share.metadata;
+
+      if ((metadata?.org ?? "") === "") {
+        throw invalidArgumentError(ORG_REQUIRED_MESSAGE);
+      }
+
+      const agentRef = share.spec?.agentRef;
+      if ((agentRef?.slug ?? "") === "") {
+        throw invalidArgumentError(AGENT_REF_SLUG_REQUIRED_MESSAGE);
+      }
+
+      // Empty ref org means same-org (the platform-wide relative-reference
+      // convention); make it absolute before anything compares orgs.
+      if (agentRef!.org === "") {
+        agentRef!.org = metadata!.org;
+      }
+
+      const agent = await findAgentByOrgAndSlug(store, agentRef!.org, agentRef!.slug);
+      if (agent === undefined) {
+        throw notFoundError("Agent", agentRef!.slug);
+      }
+
+      if (agentRef!.org !== metadata!.org) {
+        await validateCrossOrgShare(store, share, agent);
+      }
+
+      ctx.set(REFERENCED_AGENT_KEY, agent);
+
+      // Canonical-share default: no slug and no name means "share this
+      // agent under its own slug". A caller-provided name still flows
+      // through ResolveSlug for a deliberately distinct link.
+      if (metadata!.slug === "" && metadata!.name === "") {
+        metadata!.slug = agent.metadata?.slug ?? "";
+        metadata!.name = agent.metadata?.name ?? "";
+      }
+    },
+  };
+}
+
+/**
+ * The cross-org share contract (decision 013) — Go validateCrossOrgShare:
+ *   - The agent must be marketplace-public; a non-public agent is refused
+ *     with the same NOT_FOUND as a missing one (no existence probe for
+ *     private slugs).
+ *   - The audience must be public — org-audience semantics don't carry
+ *     across the org boundary.
+ *   - Every declared dependency must itself be public; the refusal names
+ *     every blocker (sorted) so the sharing org knows exactly what to ask
+ *     the agent's org to publish.
+ * Runtime re-enforcement is cloud-side; this create-time sweep is the
+ * fail-loud half, mirrored in both editions.
+ */
+async function validateCrossOrgShare(
+  store: Store,
+  share: AgentShare,
+  agent: Agent,
+): Promise<void> {
+  const agentMeta = agent.metadata;
+
+  if (agentMeta?.visibility !== ApiResourceVisibility.visibility_public) {
+    throw notFoundError("Agent", agentMeta?.slug ?? "");
+  }
+
+  // protobuf-es strips the shared enum prefix: proto
+  // agent_share_audience_org generates as AgentShareAudience.org.
+  if (share.spec?.audience === AgentShareAudience.org) {
+    throw failedPreconditionError(crossOrgAudienceMessage(agentMeta.org));
+  }
+
+  const blockers = await findNonPublicDependencies(store, agent);
+  if (blockers.length > 0) {
+    throw failedPreconditionError(
+      crossOrgBlockersMessage(agentMeta.org, agentMeta.slug, blockers),
+    );
+  }
+}
+
+/**
+ * Sweeps the agent's declared blueprint dependencies — skill_refs
+ * (including every sub-agent's) and mcp_server_usages — and returns a
+ * deterministic "kind org/slug" entry for each that is missing or not
+ * visibility_public — Go findNonPublicDependencies. A reference with an
+ * empty org is relative to the AGENT's org (defensive parity with the
+ * cloud edition's referenceMatches; agent writes normalize refs to
+ * absolute form).
+ */
+async function findNonPublicDependencies(
+  store: Store,
+  agent: Agent,
+): Promise<string[]> {
+  const spec = agent.spec;
+  const agentOrg = agent.metadata?.org ?? "";
+
+  interface DepRef {
+    kind: ApiResourceKind;
+    org: string;
+    slug: string;
+  }
+
+  const seen = new Set<string>();
+  const deps: DepRef[] = [];
+  const add = (kind: ApiResourceKind, ref: ApiResourceReference | undefined): void => {
+    if (ref === undefined || ref.slug === "") {
+      return;
+    }
+    const org = ref.org !== "" ? ref.org : agentOrg;
+    const key = `${kind}|${org}|${ref.slug}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deps.push({ kind, org, slug: ref.slug });
+    }
+  };
+
+  for (const ref of spec?.skillRefs ?? []) {
+    add(ApiResourceKind.skill, ref);
+  }
+  for (const sub of spec?.subAgents ?? []) {
+    for (const ref of sub.skillRefs) {
+      add(ApiResourceKind.skill, ref);
+    }
+  }
+  for (const usage of spec?.mcpServerUsages ?? []) {
+    add(ApiResourceKind.mcp_server, usage.mcpServerRef);
+  }
+
+  const blockers: string[] = [];
+  for (const dep of deps) {
+    let visibility: ApiResourceVisibility | undefined;
+    try {
+      // Per-kind resolution, exactly Go's switch — skill and mcp_server
+      // are the only dependency kinds an agent blueprint declares.
+      const resolved =
+        dep.kind === ApiResourceKind.skill
+          ? await findResourceBySlug(store, dep.kind, SkillSchema, dep.slug, dep.org)
+          : await findResourceBySlug(store, dep.kind, McpServerSchema, dep.slug, dep.org);
+      visibility = resolved?.metadata?.visibility;
+    } catch (error) {
+      throw internalError(
+        error,
+        `failed to resolve ${ApiResourceKind[dep.kind]} ${dep.org}/${dep.slug} while validating cross-org share`,
+      );
+    }
+    if (visibility !== ApiResourceVisibility.visibility_public) {
+      blockers.push(`${ApiResourceKind[dep.kind]} ${dep.org}/${dep.slug}`);
+    }
+  }
+
+  blockers.sort();
+  return blockers;
+}
+
+/**
+ * StampAgentPin — Go stampAgentPinStep: writes status.agent_id, the
+ * server-owned rebind pin (decision 013). agent_ref is org+slug and slugs
+ * are reusable after delete, so without the pin a stale share would
+ * silently attach its audience, link token, and bound credentials to
+ * whatever agent later claims the slug.
+ *
+ * Runs AFTER BuildNewState, which clears client-provided status — the pin
+ * is system-managed and must survive that wipe, exactly like the audit
+ * fields. Reads the agent ResolveShareDefaults already loaded.
+ */
+export function newStampAgentPinStep(): PipelineStep<AgentShareDesc> {
+  return {
+    name: "StampAgentPin",
+    execute(ctx: RequestContext<AgentShareDesc>): void {
+      const agent = ctx.get(REFERENCED_AGENT_KEY) as Agent | undefined;
+      if (agent === undefined) {
+        throw internalError(
+          new Error("referenced agent not found in context"),
+          "referenced agent not found in context (ResolveShareDefaults must run first)",
+        );
+      }
+
+      const share = ctx.newState;
+      const status = share.status ?? create(AgentShareStatusSchema);
+      status.agentId = agent.metadata?.id ?? "";
+      share.status = status;
+    },
+  };
+}
+
+/**
+ * ValidateShareUpdate — Go validateShareUpdateStep: spec.agent_ref must
+ * keep referencing the same agent, and the cross-org public-audience rule
+ * must hold on update too (update replaces the spec wholesale and must not
+ * open a side door to an org-audience cross-org share). Runs after
+ * LoadExisting. metadata.slug/org immutability needs no step — the generic
+ * BuildUpdateState preserves both, and status (including the pin and link
+ * token) wholesale.
+ */
+export function newValidateShareUpdateStep(): PipelineStep<AgentShareDesc> {
+  return {
+    name: "ValidateShareUpdate",
+    execute(ctx: RequestContext<AgentShareDesc>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as AgentShare | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing agent share not found in context"),
+          "existing agent share not found in context",
+        );
+      }
+
+      const inputRef = ctx.input.spec?.agentRef;
+      const existingRef = existing.spec?.agentRef;
+
+      // Normalize the input ref's org the same way create does (empty
+      // means the share's own org) before comparing.
+      const inputOrg =
+        (inputRef?.org ?? "") !== "" ? inputRef!.org : (existing.metadata?.org ?? "");
+
+      if (
+        (inputRef?.slug ?? "") !== (existingRef?.slug ?? "") ||
+        inputOrg !== (existingRef?.org ?? "")
+      ) {
+        throw failedPreconditionError(
+          agentRefImmutableMessage(existingRef?.org ?? "", existingRef?.slug ?? ""),
+        );
+      }
+
+      const isCrossOrg = (existingRef?.org ?? "") !== (existing.metadata?.org ?? "");
+      if (isCrossOrg && ctx.input.spec?.audience === AgentShareAudience.org) {
+        throw failedPreconditionError(crossOrgAudienceMessage(existingRef?.org ?? ""));
+      }
+    },
+  };
+}
+
+/**
+ * Projects a share and its referenced agent to the trimmed public profile
+ * — Go buildSharedAgentProfile, the single projection shared by the
+ * anonymous and member paths. URL identity (org, slug) comes from the
+ * SHARE; display fields and default_instance_id from the AGENT. Three
+ * misses all fail closed with the uniform refusal, indistinguishable from
+ * absence: a dangling agent_ref, a stale agent-id pin (the rebind guard),
+ * and a cross-org agent no longer visibility_public (withdrawing public
+ * visibility must kill every external channel).
+ */
+export async function buildSharedAgentProfile(
+  store: Store,
+  share: AgentShare,
+): Promise<SharedAgentProfile> {
+  const ref = share.spec?.agentRef;
+  const agent = await findAgentByOrgAndSlug(store, ref?.org ?? "", ref?.slug ?? "");
+  if (agent === undefined) {
+    throw sharedNotFound(share.metadata?.slug ?? "");
+  }
+
+  const pin = share.status?.agentId ?? "";
+  if (pin !== "" && pin !== (agent.metadata?.id ?? "")) {
+    throw sharedNotFound(share.metadata?.slug ?? "");
+  }
+
+  const isCrossOrg = (share.metadata?.org ?? "") !== (agent.metadata?.org ?? "");
+  if (
+    isCrossOrg &&
+    agent.metadata?.visibility !== ApiResourceVisibility.visibility_public
+  ) {
+    throw sharedNotFound(share.metadata?.slug ?? "");
+  }
+
+  return create(SharedAgentProfileSchema, {
+    org: share.metadata?.org ?? "",
+    slug: share.metadata?.slug ?? "",
+    name: agent.metadata?.name ?? "",
+    description: agent.spec?.description ?? "",
+    iconUrl: agent.spec?.iconUrl ?? "",
+    defaultInstanceId: agent.status?.defaultInstanceId ?? "",
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/channelapp/__tests__/channelapp.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/channelapp/__tests__/channelapp.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Pins the channelapp domain against Go's channelapp_test.go, case-for-case
+ * — through the REAL stack: a composed server on an ephemeral port, a
+ * native gRPC client, the full interceptor chain.
+ *
+ * The load-bearing pins the conformance suite CANNOT cover (it is a black
+ * box; these need direct store access or key control):
+ *   - secrets rest as enc:v1: CIPHERTEXT in the store and decrypt to the
+ *     original plaintext — per provider arm, via the oneof-reflection
+ *     tripwire (Go TestRedactAndEncryptCoverEveryProviderArm, the #324
+ *     regression guard: a new provider arm fails this test until it gets
+ *     redaction, encryption, and a case entry);
+ *   - the marker round-trip preserves the stored ciphertext PER FIELD (one
+ *     request rotates one secret while keeping the others);
+ *   - the delete block fires for normalized AND pre-normalization
+ *     (empty-org) app_refs, reading seeded store rows directly.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { ChannelAppSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import { ChannelAppCommandController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/command_pb";
+import { ChannelAppQueryController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/query_pb";
+import { ChannelAppSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { SecretService, isCiphertextShaped } from "../../../encryption/encryption.js";
+import {
+  PROVIDER_IMMUTABLE_MESSAGE,
+  REDACTED_MARKER,
+  deleteBlockedByChannelMessage,
+  markerOnCreateMessage,
+  noExistingSecretMessage,
+  plaintextRequiredMessage,
+} from "../constants.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+// A real 32-byte key so encrypt/redact round-trips are exercised for real
+// (the Go harness posture); the same key decrypts stored values below.
+const TEST_KEY = Buffer.alloc(32, 7);
+const TEST_KEY_B64 = TEST_KEY.toString("base64");
+const secrets = SecretService.create(TEST_KEY);
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "ChannelApp";
+const ORG = "acme";
+
+type CommandClient = Client<typeof ChannelAppCommandController>;
+type QueryClient = Client<typeof ChannelAppQueryController>;
+
+let server: ComposedServer;
+let command: CommandClient;
+let query: QueryClient;
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "channelapp-domain-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", TEST_KEY_B64);
+  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(ChannelAppCommandController, transport);
+  query = createClient(ChannelAppQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+let counter = 0;
+function uniqueName(base: string): string {
+  counter += 1;
+  return `${base} ${counter}`;
+}
+
+function newSlackApp(name: string, org: string = ORG) {
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: { name, org },
+    spec: {
+      providerConfig: {
+        case: "slack" as const,
+        value: {
+          clientId: "1234.5678",
+          clientSecret: "shh-client-secret",
+          signingSecret: "shh-signing-secret",
+        },
+      },
+    },
+  };
+}
+
+function newWhatsAppApp(name: string, org: string = ORG) {
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: { name, org },
+    spec: {
+      providerConfig: {
+        case: "whatsapp" as const,
+        value: {
+          appId: "108954",
+          appSecret: "shh-app-secret",
+          accessToken: "shh-access-token",
+          verifyToken: "shh-verify-token",
+        },
+      },
+    },
+  };
+}
+
+async function readStored(id: string): Promise<ChannelApp> {
+  return server.store.getResource(ApiResourceKind.channel_app, id, ChannelAppSchema);
+}
+
+async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The provider-arm tripwire (Go TestRedactAndEncryptCoverEveryProviderArm).
+// ---------------------------------------------------------------------------
+
+describe("provider-arm redact/encrypt tripwire (#324 regression guard)", () => {
+  // Per arm: an app builder whose secrets hold known plaintexts, and a
+  // getter for every secret field so the assertions stay field-by-field.
+  const cases: Record<
+    string,
+    {
+      newApp: (name: string) => Parameters<CommandClient["create"]>[0];
+      secretsOf: (app: ChannelApp) => Record<string, string>;
+    }
+  > = {
+    slack: {
+      newApp: (name) => newSlackApp(name),
+      secretsOf: (app) => {
+        const slack = app.spec?.providerConfig.case === "slack" ? app.spec.providerConfig.value : undefined;
+        return {
+          client_secret: slack?.clientSecret ?? "",
+          signing_secret: slack?.signingSecret ?? "",
+        };
+      },
+    },
+    whatsapp: {
+      newApp: (name) => newWhatsAppApp(name),
+      secretsOf: (app) => {
+        const wa = app.spec?.providerConfig.case === "whatsapp" ? app.spec.providerConfig.value : undefined;
+        return {
+          app_secret: wa?.appSecret ?? "",
+          access_token: wa?.accessToken ?? "",
+          verify_token: wa?.verifyToken ?? "",
+        };
+      },
+    },
+  };
+
+  it("covers every oneof arm in the case table", () => {
+    // The tripwire proper: the case table must cover every provider_config
+    // arm. Adding a provider arm to the proto fails here until the arm has
+    // redaction, encryption, and a case entry (the Go tripwire's posture).
+    const oneof = ChannelAppSpecSchema.oneofs.find((o) => o.name === "provider_config");
+    expect(oneof).toBeDefined();
+    const armNames = oneof!.fields.map((f) => f.name);
+    for (const arm of armNames) {
+      expect(cases, `provider arm "${arm}" has no redaction/encryption coverage`).toHaveProperty(arm);
+    }
+    expect(Object.keys(cases).length, "remove stale case entries").toBe(armNames.length);
+  });
+
+  for (const [arm, tc] of Object.entries(cases)) {
+    it(`${arm}: response redacted, stored ciphertext decrypts to the original`, async () => {
+      const name = uniqueName(`Acme ${arm} App`);
+      const plaintexts = tc.secretsOf(
+        create(ChannelAppSchema, tc.newApp(name)),
+      );
+
+      const created = await command.create(tc.newApp(name));
+      for (const [field, value] of Object.entries(tc.secretsOf(created))) {
+        expect(value, `${field} must be redacted in the create response`).toBe(REDACTED_MARKER);
+      }
+
+      const stored = await readStored(created.metadata!.id);
+      for (const [field, value] of Object.entries(tc.secretsOf(stored))) {
+        expect(isCiphertextShaped(value), `stored ${field} must be encrypted`).toBe(true);
+        expect(secrets.decrypt(value), `stored ${field} must decrypt to the original`).toBe(
+          plaintexts[field],
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Create (Go TestChannelAppController_CreateEncryptsAndRedacts + marker).
+// ---------------------------------------------------------------------------
+
+describe("channelapp create", () => {
+  it("encrypts at rest, redacts the response, stamps the chapp id", async () => {
+    const created = await command.create(newSlackApp(uniqueName("Acme Support App")));
+
+    expect(created.metadata?.id).toMatch(/^chapp/);
+    expect(created.spec?.providerConfig.case).toBe("slack");
+    const slack = created.spec!.providerConfig.case === "slack" ? created.spec!.providerConfig.value : undefined;
+    expect(slack?.clientSecret).toBe(REDACTED_MARKER);
+    expect(slack?.signingSecret).toBe(REDACTED_MARKER);
+
+    const stored = await readStored(created.metadata!.id);
+    const storedSlack =
+      stored.spec?.providerConfig.case === "slack" ? stored.spec.providerConfig.value : undefined;
+    expect(isCiphertextShaped(storedSlack?.clientSecret ?? "")).toBe(true);
+    expect(isCiphertextShaped(storedSlack?.signingSecret ?? "")).toBe(true);
+    expect(secrets.decrypt(storedSlack!.clientSecret)).toBe("shh-client-secret");
+  });
+
+  it("refuses the redaction marker on create", async () => {
+    const app = newSlackApp(uniqueName("Acme Support App"));
+    app.spec.providerConfig.value.clientSecret = REDACTED_MARKER;
+
+    const err = await grpcError(() => command.create(app));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(markerOnCreateMessage("client_secret"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ciphertext-shaped input (Go TestChannelAppController_RefusesCiphertextShapedSecrets).
+// ---------------------------------------------------------------------------
+
+describe("ciphertext-shaped secrets are refused (oss#395)", () => {
+  it("slack create", async () => {
+    const app = newSlackApp(uniqueName("Acme Slack App"));
+    app.spec.providerConfig.value.clientSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
+
+    const err = await grpcError(() => command.create(app));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(plaintextRequiredMessage("client_secret"));
+  });
+
+  it("whatsapp create refuses a FUTURE-version prefix too", async () => {
+    const app = newWhatsAppApp(uniqueName("Acme WhatsApp App"));
+    app.spec.providerConfig.value.accessToken = "enc:v2:ZnV0dXJlLXZlcnNpb24=";
+
+    const err = await grpcError(() => command.create(app));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(plaintextRequiredMessage("access_token"));
+  });
+
+  it("slack update (marker for one field, forged ciphertext for the other)", async () => {
+    const name = uniqueName("Acme Update App");
+    const created = await command.create(newSlackApp(name));
+
+    const update = newSlackApp(name);
+    (update.metadata as Record<string, string>).id = created.metadata!.id;
+    (update.metadata as Record<string, string>).slug = created.metadata!.slug;
+    update.spec.providerConfig.value.clientSecret = REDACTED_MARKER;
+    update.spec.providerConfig.value.signingSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
+
+    const err = await grpcError(() => command.update(update));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(plaintextRequiredMessage("signing_secret"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-field marker preservation (Go UpdateMarkerPreservesPerField, both arms).
+// ---------------------------------------------------------------------------
+
+describe("update marker preserves per field", () => {
+  it("slack: rotates the signing secret, keeps the client secret", async () => {
+    const name = uniqueName("Acme Support App");
+    const created = await command.create(newSlackApp(name));
+
+    const update = newSlackApp(name);
+    (update.metadata as Record<string, string>).id = created.metadata!.id;
+    (update.metadata as Record<string, string>).slug = created.metadata!.slug;
+    update.spec.providerConfig.value.clientSecret = REDACTED_MARKER;
+    update.spec.providerConfig.value.signingSecret = "rotated-signing-secret";
+    await command.update(update);
+
+    const stored = await readStored(created.metadata!.id);
+    const slack = stored.spec?.providerConfig.case === "slack" ? stored.spec.providerConfig.value : undefined;
+    expect(secrets.decrypt(slack!.clientSecret), "marker must preserve the ORIGINAL client_secret").toBe(
+      "shh-client-secret",
+    );
+    expect(secrets.decrypt(slack!.signingSecret), "plaintext must rotate to the new value").toBe(
+      "rotated-signing-secret",
+    );
+  });
+
+  it("whatsapp: rotates the access token, keeps app_secret and verify_token", async () => {
+    const name = uniqueName("Clinic Meta App");
+    const created = await command.create(newWhatsAppApp(name));
+
+    const update = newWhatsAppApp(name);
+    (update.metadata as Record<string, string>).id = created.metadata!.id;
+    (update.metadata as Record<string, string>).slug = created.metadata!.slug;
+    update.spec.providerConfig.value.appSecret = REDACTED_MARKER;
+    update.spec.providerConfig.value.accessToken = "rotated-access-token";
+    update.spec.providerConfig.value.verifyToken = REDACTED_MARKER;
+    await command.update(update);
+
+    const stored = await readStored(created.metadata!.id);
+    const wa = stored.spec?.providerConfig.case === "whatsapp" ? stored.spec.providerConfig.value : undefined;
+    expect(secrets.decrypt(wa!.appSecret)).toBe("shh-app-secret");
+    expect(secrets.decrypt(wa!.accessToken)).toBe("rotated-access-token");
+    expect(secrets.decrypt(wa!.verifyToken)).toBe("shh-verify-token");
+  });
+
+  it("marker with no stored value is InvalidArgument (adversarial arm)", async () => {
+    // A stored row with one empty secret can only exist via direct store
+    // writes (the proto requires min_len=1 on the wire) — seeded here to
+    // prove preserveExistingSecret fails closed instead of storing the
+    // marker literal.
+    const seeded = create(ChannelAppSchema, {
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: {
+        id: "chapp_seeded_empty",
+        name: "Seeded Empty Secret",
+        org: ORG,
+        slug: "seeded-empty-secret",
+      },
+      spec: {
+        providerConfig: {
+          case: "slack",
+          value: { clientId: "1.2", clientSecret: secrets.encrypt("x"), signingSecret: "" },
+        },
+      },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.channel_app,
+      seeded.metadata!.id,
+      ChannelAppSchema,
+      seeded,
+    );
+
+    const update = newSlackApp("Seeded Empty Secret");
+    (update.metadata as Record<string, string>).id = seeded.metadata!.id;
+    (update.metadata as Record<string, string>).slug = seeded.metadata!.slug;
+    update.spec.providerConfig.value.clientSecret = REDACTED_MARKER;
+    update.spec.providerConfig.value.signingSecret = REDACTED_MARKER;
+
+    const err = await grpcError(() => command.update(update));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(noExistingSecretMessage("signing_secret"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Apply round-trip (Go TestChannelAppController_ApplyRoundTripsWithMarkers).
+// ---------------------------------------------------------------------------
+
+describe("apply round-trips with markers", () => {
+  it("get → apply back verbatim preserves both stored secrets", async () => {
+    const created = await command.apply(newSlackApp(uniqueName("Acme Support App")));
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    await command.apply(fetched);
+
+    const stored = await readStored(created.metadata!.id);
+    const slack = stored.spec?.providerConfig.case === "slack" ? stored.spec.providerConfig.value : undefined;
+    expect(secrets.decrypt(slack!.clientSecret)).toBe("shh-client-secret");
+    expect(secrets.decrypt(slack!.signingSecret)).toBe("shh-signing-secret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query redaction (Go QueriesRedactSecrets + WhatsAppQueriesRedactSecrets).
+// ---------------------------------------------------------------------------
+
+describe("queries redact secrets", () => {
+  it("slack: get, getByReference, and listByOrg redact; org filter holds", async () => {
+    const org = "acme-slack-queries";
+    const created = await command.create(newSlackApp(uniqueName("Acme Support App"), org));
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    const fetchedSlack =
+      fetched.spec?.providerConfig.case === "slack" ? fetched.spec.providerConfig.value : undefined;
+    expect(fetchedSlack?.clientSecret).toBe(REDACTED_MARKER);
+    expect(fetchedSlack?.signingSecret).toBe(REDACTED_MARKER);
+
+    const byRef = await query.getByReference({
+      org,
+      kind: ApiResourceKind.channel_app,
+      slug: created.metadata!.slug,
+    });
+    const byRefSlack =
+      byRef.spec?.providerConfig.case === "slack" ? byRef.spec.providerConfig.value : undefined;
+    expect(byRefSlack?.clientSecret).toBe(REDACTED_MARKER);
+
+    const list = await query.listByOrg({ org });
+    expect(list.entries).toHaveLength(1);
+    const listSlack =
+      list.entries[0]!.spec?.providerConfig.case === "slack"
+        ? list.entries[0]!.spec!.providerConfig.value
+        : undefined;
+    expect(listSlack?.signingSecret).toBe(REDACTED_MARKER);
+
+    const other = await query.listByOrg({ org: "some-other-org" });
+    expect(other.entries).toHaveLength(0);
+  });
+
+  it("whatsapp: all three secrets redact; app_id is public and stays", async () => {
+    const org = "acme-wa-queries";
+    const created = await command.create(newWhatsAppApp(uniqueName("Clinic Meta App"), org));
+
+    const fetched = await query.get({ value: created.metadata!.id });
+    const wa = fetched.spec?.providerConfig.case === "whatsapp" ? fetched.spec.providerConfig.value : undefined;
+    expect(wa?.appSecret).toBe(REDACTED_MARKER);
+    expect(wa?.accessToken).toBe(REDACTED_MARKER);
+    expect(wa?.verifyToken).toBe(REDACTED_MARKER);
+    expect(wa?.appId, "app_id is public and must NOT be redacted").toBe("108954");
+
+    const byRef = await query.getByReference({
+      org,
+      kind: ApiResourceKind.channel_app,
+      slug: created.metadata!.slug,
+    });
+    const byRefWa = byRef.spec?.providerConfig.case === "whatsapp" ? byRef.spec.providerConfig.value : undefined;
+    expect(byRefWa?.appSecret).toBe(REDACTED_MARKER);
+
+    const list = await query.listByOrg({ org });
+    expect(list.entries).toHaveLength(1);
+    const listWa =
+      list.entries[0]!.spec?.providerConfig.case === "whatsapp"
+        ? list.entries[0]!.spec!.providerConfig.value
+        : undefined;
+    expect(listWa?.accessToken).toBe(REDACTED_MARKER);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider immutability (Go TestValidateProviderImmutableStep, on the wire).
+// ---------------------------------------------------------------------------
+
+describe("provider arm is immutable on update", () => {
+  it("a slack app cannot become a whatsapp app — InvalidArgument by pinned contract", async () => {
+    const name = uniqueName("Acme Support App");
+    const created = await command.create(newSlackApp(name));
+
+    const flip = newWhatsAppApp(name);
+    (flip.metadata as Record<string, string>).id = created.metadata!.id;
+    (flip.metadata as Record<string, string>).slug = created.metadata!.slug;
+
+    const err = await grpcError(() => command.update(flip));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(PROVIDER_IMMUTABLE_MESSAGE);
+  });
+
+  it("an unchanged provider arm passes", async () => {
+    const name = uniqueName("Acme Support App");
+    const created = await command.create(newSlackApp(name));
+
+    const update = newSlackApp(name);
+    (update.metadata as Record<string, string>).id = created.metadata!.id;
+    (update.metadata as Record<string, string>).slug = created.metadata!.slug;
+    const updated = await command.update(update);
+    expect(updated.metadata?.id).toBe(created.metadata!.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Referential delete block (Go DeleteBlockedByReferencingChannel + RelativeRef).
+// ---------------------------------------------------------------------------
+
+describe("delete is blocked while referenced", () => {
+  it("names a referencing channel; deletion succeeds after unreferencing, redacted", async () => {
+    const created = await command.create(newSlackApp(uniqueName("Acme Support App")));
+
+    // Seed a referencing channel directly — the referential check reads
+    // stored state, not the channel pipeline (the Go test's posture).
+    const channel = create(AgentChannelSchema, {
+      metadata: {
+        id: "ach_01ref",
+        name: "support-bot-slack",
+        org: ORG,
+        slug: "support-bot-slack",
+      },
+      spec: {
+        appRef: {
+          org: ORG,
+          kind: ApiResourceKind.channel_app,
+          slug: created.metadata!.slug,
+        },
+      },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_channel,
+      channel.metadata!.id,
+      AgentChannelSchema,
+      channel,
+    );
+
+    const err = await grpcError(() => command.delete({ resourceId: created.metadata!.id }));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(
+      deleteBlockedByChannelMessage(ORG, created.metadata!.slug, "support-bot-slack"),
+    );
+
+    await server.store.deleteResource(ApiResourceKind.agent_channel, channel.metadata!.id);
+    const deleted = await command.delete({ resourceId: created.metadata!.id });
+    const slack =
+      deleted.spec?.providerConfig.case === "slack" ? deleted.spec.providerConfig.value : undefined;
+    expect(slack?.clientSecret, "the delete response must be redacted").toBe(REDACTED_MARKER);
+  });
+
+  it("a pre-normalization app_ref with no org still guards its app", async () => {
+    const created = await command.create(newSlackApp(uniqueName("Acme Support App")));
+
+    const channel = create(AgentChannelSchema, {
+      metadata: {
+        id: "ach_02rel",
+        name: "relative-ref-channel",
+        org: ORG,
+        slug: "relative-ref-channel",
+      },
+      spec: {
+        appRef: {
+          kind: ApiResourceKind.channel_app,
+          slug: created.metadata!.slug,
+        },
+      },
+    });
+    await server.store.saveResource(
+      ApiResourceKind.agent_channel,
+      channel.metadata!.id,
+      AgentChannelSchema,
+      channel,
+    );
+
+    const err = await grpcError(() => command.delete({ resourceId: created.metadata!.id }));
+    expect(err.code).toBe(Code.FailedPrecondition);
+
+    await server.store.deleteResource(ApiResourceKind.agent_channel, channel.metadata!.id);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/channelapp/constants.ts
+++ b/backend/services/stigmer-server-ts/src/domain/channelapp/constants.ts
@@ -1,0 +1,66 @@
+/**
+ * ChannelApp domain constants — the byte-pinned wire copy shared with the
+ * Go server and the cloud edition. Every string here is asserted by the
+ * conformance suite or the cross-edition error contract; none is editable
+ * without an owner-ratified wire change.
+ */
+
+/**
+ * The sentinel the response path substitutes for secret values before they
+ * leave the server — Go channelapp RedactedMarker, equal to the
+ * platform-wide marker (environment/oauthapp here, the cloud edition's
+ * SecretEncryptionService.REDACTED_MARKER). A client sending it back on
+ * update means "keep the stored secret".
+ */
+export const REDACTED_MARKER = "***REDACTED***";
+
+/**
+ * InvalidArgument copy for client-supplied enc:v<N>: input (oss#395) — Go
+ * steps.go resolveSecret, byte-pinned. Unconditional: the prefix is
+ * server-reserved regardless of key state.
+ */
+export function plaintextRequiredMessage(fieldName: string): string {
+  return (
+    `${fieldName} must be plaintext — values carrying the 'enc:' ` +
+    "encryption prefix are not accepted from clients"
+  );
+}
+
+/**
+ * InvalidArgument copy for the redaction marker on create (nothing to
+ * preserve) — Go steps.go preserveExistingSecret, byte-pinned.
+ */
+export function markerOnCreateMessage(fieldName: string): string {
+  return `cannot use the redaction marker as ${fieldName} on create`;
+}
+
+/**
+ * InvalidArgument copy for the marker on an update whose stored field is
+ * empty — Go steps.go preserveExistingSecret, byte-pinned.
+ */
+export function noExistingSecretMessage(fieldName: string): string {
+  return `cannot preserve ${fieldName}: no existing secret value found`;
+}
+
+/**
+ * InvalidArgument copy for a provider-arm change on update — Go steps.go
+ * validateProviderImmutableStep, byte-pinned. Deliberately a DIFFERENT
+ * code than agentchannel's provider rule (InvalidArgument here vs
+ * FailedPrecondition there) — a pinned cross-domain inconsistency both
+ * editions share; harmonization is a post-cutover wire change.
+ */
+export const PROVIDER_IMMUTABLE_MESSAGE =
+  "the provider of a channel app cannot be changed";
+
+/**
+ * FailedPrecondition copy for deleting a ChannelApp still referenced by an
+ * AgentChannel — Go steps.go checkNoReferencingChannelsStep, byte-pinned.
+ * Names the referencing channel by metadata.name (not slug), as Go does.
+ */
+export function deleteBlockedByChannelMessage(
+  org: string,
+  slug: string,
+  channelName: string,
+): string {
+  return `cannot delete ChannelApp '${org}/${slug}': referenced by agent channel '${channelName}'`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/channelapp/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/channelapp/controller.ts
@@ -1,0 +1,368 @@
+/**
+ * ChannelApp controller — ports pkg/domain/channelapp/controller (command +
+ * query sides): the org-scoped holder of customer messaging-app credentials
+ * (Slack OAuth client + signing secret; WhatsApp app_secret / access_token /
+ * verify_token), referenced by AgentChannel spec.app_ref. The channel-domain
+ * sibling of OAuthApp: inline encrypted secrets (AES-256-GCM via the shared
+ * SecretService — the same instance Environment uses), ***REDACTED*** on
+ * every response surface, delete blocked while referenced.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character —
+ * notably create's ResolveSlug-before-ValidateProto order and the encrypt
+ * step's placement (before BuildNewState on create, after BuildUpdateState
+ * on update; see steps.ts). NOT search-indexed by design (the kind declares
+ * not_search_indexed — configuration reached through its parent surface,
+ * not a library artifact), so no index steps appear in any chain.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies, and
+ * Publish steps (single-user local posture); validation, secret handling,
+ * and the referential delete block are byte-compatible.
+ *
+ * Proven by channelapp.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/channelapp.test.ts.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { ChannelAppSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import { ChannelAppCommandController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/command_pb";
+import { ChannelAppQueryController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/query_pb";
+import { ChannelAppsSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/io_pb";
+import type {
+  ChannelApps,
+  ListChannelAppsByOrgInput,
+} from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/io_pb";
+import type {
+  ApiResourceDeleteInput,
+  ApiResourceId,
+  ApiResourceReference,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  RESOURCE_ID_KEY,
+  newDeleteResourceStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import {
+  newCheckNoReferencingChannelsStep,
+  newEncryptChannelAppSecretsForCreateStep,
+  newEncryptChannelAppSecretsForUpdateStep,
+  newValidateProviderImmutableStep,
+  redactChannelApp,
+} from "./steps.js";
+
+export interface ChannelAppControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly secretService: SecretService;
+}
+
+/** Registers both channelapp services on the router (routes stage). */
+export function registerChannelAppServices(
+  router: ConnectRouter,
+  deps: ChannelAppControllerDeps,
+): void {
+  router.service(ChannelAppCommandController, {
+    apply: (app, ctx) => apply(deps, app, ctx),
+    create: (app, ctx) => createChannelApp(deps, app, ctx),
+    update: (app, ctx) => update(deps, app, ctx),
+    delete: (input, ctx) => deleteChannelApp(deps, input, ctx),
+  });
+  router.service(ChannelAppQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    listByOrg: (req, ctx) => listByOrg(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline. ResolveSlug runs BEFORE
+ * ValidateProto (unique among the sharing/channel domains — Go's order,
+ * preserved); EncryptChannelAppSecrets runs before BuildNewState because
+ * BuildNewState clones state (the oauthapp ordering). The response is
+ * redacted; the store keeps ciphertext.
+ */
+async function createChannelApp(
+  deps: ChannelAppControllerDeps,
+  app: ChannelApp,
+  ctx: HandlerContext,
+): Promise<ChannelApp> {
+  const reqCtx = new RequestContext(ChannelAppSchema, app, kindOf(ctx));
+  await newPipeline<typeof ChannelAppSchema>("channelapp-create", deps.logger)
+    .addStep(newResolveSlugStep())
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newEncryptChannelAppSecretsForCreateStep(deps.secretService, deps.logger))
+    .addStep(newBuildNewStateStep())
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  redactChannelApp(reqCtx.newState);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline; EncryptChannelAppSecrets runs
+ * AFTER BuildUpdateState because BuildUpdateState replaces newState with
+ * the merged clone (the oauthapp ordering). The marker preserves the
+ * stored value PER FIELD — one request may rotate one secret while
+ * keeping the other.
+ */
+async function update(
+  deps: ChannelAppControllerDeps,
+  app: ChannelApp,
+  ctx: HandlerContext,
+): Promise<ChannelApp> {
+  const reqCtx = new RequestContext(ChannelAppSchema, app, kindOf(ctx));
+  await newPipeline<typeof ChannelAppSchema>("channelapp-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateProviderImmutableStep())
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newEncryptChannelAppSecretsForUpdateStep(deps.secretService, deps.logger))
+    .addStep(newPersistStep(deps.store))
+    .build()
+    .execute(reqCtx);
+  redactChannelApp(reqCtx.newState);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update (the OAuthApp apply shape): a
+ * minimal probe pipeline decides existence, then delegates to Create or
+ * Update with the ORIGINAL request message (Go delegates `app`, not the
+ * pipeline's clone — unlike agentshare/agentchannel, whose defaults live
+ * on the clone; channelapp's Update re-resolves the slug itself). Sending
+ * the marker for a secret field on an apply that resolves to update
+ * preserves the stored value; on an apply that resolves to create it is
+ * refused — there is nothing to preserve.
+ */
+async function apply(
+  deps: ChannelAppControllerDeps,
+  app: ChannelApp,
+  ctx: HandlerContext,
+): Promise<ChannelApp> {
+  const reqCtx = new RequestContext(ChannelAppSchema, app, kindOf(ctx));
+  await newPipeline<typeof ChannelAppSchema>("channelapp-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate
+    ? createChannelApp(deps, app, ctx)
+    : update(deps, app, ctx);
+}
+
+/**
+ * Delete — blocked with FAILED_PRECONDITION while any AgentChannel
+ * references this app via spec.app_ref. The deleted ChannelApp is returned
+ * for audit purposes, redacted like every other response. The id is seeded
+ * manually because ApiResourceDeleteInput carries resource_id, not the
+ * `value` field ExtractResourceId expects (the oauthapp delete shape).
+ */
+async function deleteChannelApp(
+  deps: ChannelAppControllerDeps,
+  input: ApiResourceDeleteInput,
+  ctx: HandlerContext,
+): Promise<ChannelApp> {
+  const reqCtx = new RequestContext(
+    ChannelAppCommandController.method.delete.input,
+    input,
+    kindOf(ctx),
+  );
+  reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
+  await newPipeline<typeof ChannelAppCommandController.method.delete.input>(
+    "channelapp-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, ChannelAppSchema))
+    .addStep(newCheckNoReferencingChannelsStep(deps.store, deps.logger))
+    .addStep(newDeleteResourceStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted ChannelApp not found in context"),
+      "deleted ChannelApp not found in context",
+    );
+  }
+  const app = deleted as ChannelApp;
+  redactChannelApp(app);
+  return app;
+}
+
+/** Get — LoadTarget by id; the response is redacted. */
+async function get(
+  deps: ChannelAppControllerDeps,
+  id: ApiResourceId,
+  ctx: HandlerContext,
+): Promise<ChannelApp> {
+  const reqCtx = new RequestContext(
+    ChannelAppQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ChannelAppQueryController.method.get.input>(
+    "channelapp-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, ChannelAppSchema))
+    .build()
+    .execute(reqCtx);
+  const app = reqCtx.get(TARGET_RESOURCE_KEY) as ChannelApp;
+  redactChannelApp(app);
+  return app;
+}
+
+/** GetByReference — org/slug lookup; the response is redacted. */
+async function getByReference(
+  deps: ChannelAppControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<ChannelApp> {
+  const reqCtx = new RequestContext(
+    ChannelAppQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ChannelAppQueryController.method.getByReference.input>(
+    "channelapp-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, ChannelAppSchema))
+    .build()
+    .execute(reqCtx);
+  const app = reqCtx.get(TARGET_RESOURCE_KEY) as ChannelApp;
+  redactChannelApp(app);
+  return app;
+}
+
+const LIST_RESULT_KEY = "listResult";
+
+/**
+ * ListByOrg — all ChannelApps of an organization, newest-first, every
+ * entry redacted. No pagination — the set is small by nature (typically
+ * one app per provider per org), the OAuthApp listByOrg posture.
+ */
+async function listByOrg(
+  deps: ChannelAppControllerDeps,
+  req: ListChannelAppsByOrgInput,
+  ctx: HandlerContext,
+): Promise<ChannelApps> {
+  const reqCtx = new RequestContext(
+    ChannelAppQueryController.method.listByOrg.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ChannelAppQueryController.method.listByOrg.input>(
+    "channelapp-list-by-org",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("ChannelApp list not found in context"),
+      "ChannelApp list not found in context",
+    );
+  }
+  return result as ChannelApps;
+}
+
+/**
+ * ListByOrg — Go list_by_org.go's domain step: full scan, malformed rows
+ * skipped with a warning, org equality filter, per-item redaction, sorted
+ * by spec-audit created_at descending (seconds then nanos; timestamped
+ * entries before untimestamped ones).
+ */
+function newListByOrgStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<typeof ChannelAppQueryController.method.listByOrg.input> {
+  return {
+    name: "ListByOrg",
+    async execute(
+      ctx: RequestContext<typeof ChannelAppQueryController.method.listByOrg.input>,
+    ): Promise<void> {
+      const org = ctx.input.org;
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.channel_app);
+      } catch (error) {
+        throw internalError(error, "failed to list ChannelApps");
+      }
+
+      const apps: ChannelApp[] = [];
+      for (const bytes of rows) {
+        let app: ChannelApp;
+        try {
+          app = fromBinary(ChannelAppSchema, bytes);
+        } catch {
+          logger.warn("Failed to unmarshal ChannelApp, skipping");
+          continue;
+        }
+        if ((app.metadata?.org ?? "") !== org) {
+          continue;
+        }
+        redactChannelApp(app);
+        apps.push(app);
+      }
+
+      apps.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      ctx.set(LIST_RESULT_KEY, create(ChannelAppsSchema, { entries: apps }));
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/channelapp/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/channelapp/steps.ts
@@ -1,0 +1,369 @@
+/**
+ * ChannelApp domain steps — ports pkg/domain/channelapp/controller/steps.go:
+ * per-field secret encryption/preservation over the provider oneof, the
+ * response-side redaction, provider-arm immutability, and the referential
+ * delete block against AgentChannels.
+ *
+ * The marker/ciphertext-guard logic is DELIBERATELY domain-local (not
+ * shared with environment or oauthapp): Go keeps each domain's steps in its
+ * own package, and the three shapes genuinely differ (environment: a
+ * variable map; here: provider-oneof fields; oauthapp: one field). The
+ * ratified promotion rule requires an identical second consumer — recorded
+ * in the sub-project plan so review does not re-litigate.
+ *
+ * Proven by channelapp.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/channelapp.test.ts.
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { ChannelAppSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import type { ChannelApp } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import type { ChannelAppCommandController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/command_pb";
+import type {
+  SlackChannelAppConfig,
+  WhatsAppChannelAppConfig,
+} from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { isCiphertextShaped } from "../../encryption/encryption.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+import {
+  PROVIDER_IMMUTABLE_MESSAGE,
+  REDACTED_MARKER,
+  deleteBlockedByChannelMessage,
+  markerOnCreateMessage,
+  noExistingSecretMessage,
+  plaintextRequiredMessage,
+} from "./constants.js";
+
+type ChannelAppDesc = typeof ChannelAppSchema;
+type DeleteInputDesc = typeof ChannelAppCommandController.method.delete.input;
+
+/**
+ * Replaces every non-empty secret field with the marker on the given app —
+ * used in ALL API responses (get, getByReference, create, update, delete,
+ * listByOrg), Go RedactChannelApp.
+ *
+ * Every provider arm must be handled here. The provider-arm tripwire test
+ * (__tests__/channelapp.test.ts) fails if an arm is added to the spec
+ * oneof without redaction coverage.
+ */
+export function redactChannelApp(app: ChannelApp): void {
+  const provider = app.spec?.providerConfig;
+  switch (provider?.case) {
+    case "slack":
+      redactSlack(provider.value);
+      return;
+    case "whatsapp":
+      redactWhatsApp(provider.value);
+      return;
+    case undefined:
+      return;
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`unhandled provider arm: ${String(exhaustive)}`);
+    }
+  }
+}
+
+function redactSlack(slack: SlackChannelAppConfig): void {
+  if (slack.clientSecret !== "") {
+    slack.clientSecret = REDACTED_MARKER;
+  }
+  if (slack.signingSecret !== "") {
+    slack.signingSecret = REDACTED_MARKER;
+  }
+}
+
+/** app_id is public and stays — only the three secret fields redact. */
+function redactWhatsApp(whatsapp: WhatsAppChannelAppConfig): void {
+  if (whatsapp.appSecret !== "") {
+    whatsapp.appSecret = REDACTED_MARKER;
+  }
+  if (whatsapp.accessToken !== "") {
+    whatsapp.accessToken = REDACTED_MARKER;
+  }
+  if (whatsapp.verifyToken !== "") {
+    whatsapp.verifyToken = REDACTED_MARKER;
+  }
+}
+
+/**
+ * EncryptChannelAppSecrets — Go encryptChannelAppSecretsStep: the oauthapp
+ * encryptClientSecretStep generalized to a provider oneof carrying
+ * multiple secrets (Slack: client_secret and signing_secret; WhatsApp:
+ * app_secret, access_token and verify_token).
+ *
+ * Each field is handled independently, per field:
+ *   - Create: encrypts the plaintext value; the redaction marker is
+ *     refused (nothing to preserve).
+ *   - Update with a new value: encrypts the new plaintext.
+ *   - Update with the marker: preserves the existing encrypted value from
+ *     the loaded resource. Independence matters: one request may rotate
+ *     one secret while keeping the other.
+ *   - A ciphertext-shaped (enc:v<N>:) value is refused on both create and
+ *     update (oss#395).
+ *
+ * Ordering is load-bearing (Go's pipeline comments): on CREATE this runs
+ * BEFORE BuildNewState (which clones state — the encrypted values must be
+ * in place before the clone); on UPDATE it runs AFTER BuildUpdateState
+ * (which replaces newState with the merged clone).
+ */
+export function newEncryptChannelAppSecretsForCreateStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<ChannelAppDesc> {
+  return newEncryptChannelAppSecretsStep(secretService, logger, true);
+}
+
+export function newEncryptChannelAppSecretsForUpdateStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<ChannelAppDesc> {
+  return newEncryptChannelAppSecretsStep(secretService, logger, false);
+}
+
+function newEncryptChannelAppSecretsStep(
+  secretService: SecretService,
+  logger: Logger,
+  isCreate: boolean,
+): PipelineStep<ChannelAppDesc> {
+  /**
+   * Computes the storage-ready value for one secret field.
+   *
+   * Arm order is load-bearing: the marker arm restores STORED ciphertext
+   * and returns before the ciphertext-shape rejection, which therefore
+   * only ever sees raw client input (oss#395).
+   */
+  function resolveSecret(
+    ctx: RequestContext<ChannelAppDesc>,
+    fieldName: string,
+    requestValue: string,
+    readExisting: (existing: ChannelApp) => string,
+  ): string {
+    if (requestValue === "") {
+      return requestValue;
+    }
+
+    if (requestValue === REDACTED_MARKER) {
+      return preserveExistingSecret(ctx, fieldName, readExisting);
+    }
+
+    // Unconditional (not gated on isEnabled): the enc:v<N>: prefix is
+    // server-reserved regardless of key state.
+    if (isCiphertextShaped(requestValue)) {
+      throw invalidArgumentError(plaintextRequiredMessage(fieldName));
+    }
+
+    if (!secretService.isEnabled()) {
+      logger.warn(`Encryption disabled: ${fieldName} will be stored in plaintext`);
+      return requestValue;
+    }
+
+    try {
+      return secretService.encrypt(requestValue);
+    } catch (error) {
+      throw internalError(error, `failed to encrypt ${fieldName}`);
+    }
+  }
+
+  /** Copies the stored encrypted value when the client sends the marker. */
+  function preserveExistingSecret(
+    ctx: RequestContext<ChannelAppDesc>,
+    fieldName: string,
+    readExisting: (existing: ChannelApp) => string,
+  ): string {
+    if (isCreate) {
+      throw invalidArgumentError(markerOnCreateMessage(fieldName));
+    }
+
+    const existing = ctx.get(EXISTING_RESOURCE_KEY) as ChannelApp | undefined;
+    if (existing === undefined) {
+      throw internalError(
+        new Error("existing resource not loaded"),
+        `cannot preserve ${fieldName}: existing resource not loaded`,
+      );
+    }
+
+    const existingSecret = readExisting(existing);
+    if (existingSecret === "") {
+      throw invalidArgumentError(noExistingSecretMessage(fieldName));
+    }
+    return existingSecret;
+  }
+
+  return {
+    name: "EncryptChannelAppSecrets",
+    execute(ctx: RequestContext<ChannelAppDesc>): void {
+      const provider = ctx.newState.spec?.providerConfig;
+      switch (provider?.case) {
+        case "slack": {
+          const slack = provider.value;
+          slack.clientSecret = resolveSecret(
+            ctx,
+            "client_secret",
+            slack.clientSecret,
+            (existing) =>
+              existing.spec?.providerConfig.case === "slack"
+                ? existing.spec.providerConfig.value.clientSecret
+                : "",
+          );
+          slack.signingSecret = resolveSecret(
+            ctx,
+            "signing_secret",
+            slack.signingSecret,
+            (existing) =>
+              existing.spec?.providerConfig.case === "slack"
+                ? existing.spec.providerConfig.value.signingSecret
+                : "",
+          );
+          return;
+        }
+        case "whatsapp": {
+          const whatsapp = provider.value;
+          whatsapp.appSecret = resolveSecret(
+            ctx,
+            "app_secret",
+            whatsapp.appSecret,
+            (existing) =>
+              existing.spec?.providerConfig.case === "whatsapp"
+                ? existing.spec.providerConfig.value.appSecret
+                : "",
+          );
+          whatsapp.accessToken = resolveSecret(
+            ctx,
+            "access_token",
+            whatsapp.accessToken,
+            (existing) =>
+              existing.spec?.providerConfig.case === "whatsapp"
+                ? existing.spec.providerConfig.value.accessToken
+                : "",
+          );
+          whatsapp.verifyToken = resolveSecret(
+            ctx,
+            "verify_token",
+            whatsapp.verifyToken,
+            (existing) =>
+              existing.spec?.providerConfig.case === "whatsapp"
+                ? existing.spec.providerConfig.value.verifyToken
+                : "",
+          );
+          return;
+        }
+        case undefined:
+          return;
+        default: {
+          const exhaustive: never = provider;
+          throw new Error(`unhandled provider arm: ${String(exhaustive)}`);
+        }
+      }
+    },
+  };
+}
+
+/**
+ * ValidateProviderImmutable — Go validateProviderImmutableStep: a slack
+ * app cannot become a whatsapp app — every referencing channel's install
+ * state and the webhook verification path are provider-shaped. Compares
+ * the INPUT's oneof arm against the loaded resource's (Go WhichOneof over
+ * provider_config); runs after LoadExisting. InvalidArgument by pinned
+ * contract (see constants.ts on the cross-domain inconsistency).
+ */
+export function newValidateProviderImmutableStep(): PipelineStep<ChannelAppDesc> {
+  return {
+    name: "ValidateProviderImmutable",
+    execute(ctx: RequestContext<ChannelAppDesc>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as ChannelApp | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing channel app not found in context"),
+          "existing channel app not found in context",
+        );
+      }
+
+      const existingCase = existing.spec?.providerConfig.case;
+      const inputCase = ctx.input.spec?.providerConfig.case;
+      if (existingCase !== inputCase) {
+        throw invalidArgumentError(PROVIDER_IMMUTABLE_MESSAGE);
+      }
+    },
+  };
+}
+
+/**
+ * CheckNoReferencingChannels — Go checkNoReferencingChannelsStep: prevents
+ * deletion of a ChannelApp still referenced by any AgentChannel via
+ * spec.app_ref — a deleted app would break the referencing channels'
+ * webhook verification and any future re-install (the oauthapp
+ * checkNoReferencingMcpServers precedent). Full scan through the store
+ * (the OSS lookup posture); malformed rows are skipped with a warning.
+ *
+ * Requires LoadExistingForDelete to have run first.
+ */
+export function newCheckNoReferencingChannelsStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<DeleteInputDesc> {
+  return {
+    name: "CheckNoReferencingChannels",
+    async execute(ctx: RequestContext<DeleteInputDesc>): Promise<void> {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as ChannelApp | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing ChannelApp not loaded in delete pipeline"),
+          "existing ChannelApp not loaded in delete pipeline",
+        );
+      }
+
+      const org = existing.metadata?.org ?? "";
+      const slug = existing.metadata?.slug ?? "";
+
+      let rows: Uint8Array[];
+      try {
+        rows = await store.listResources(ApiResourceKind.agent_channel);
+      } catch (error) {
+        throw internalError(
+          error,
+          "failed to list agent channels for referential integrity check",
+        );
+      }
+
+      for (const bytes of rows) {
+        let channel;
+        try {
+          channel = fromBinary(AgentChannelSchema, bytes);
+        } catch {
+          logger.warn(
+            "Failed to unmarshal agent channel during referential integrity check, skipping",
+          );
+          continue;
+        }
+
+        const ref = channel.spec?.appRef;
+        if (ref === undefined || ref.slug === "") {
+          continue;
+        }
+        // An empty ref org means same-org; normalize before comparing so a
+        // pre-normalization row still guards its app.
+        const refOrg = ref.org !== "" ? ref.org : (channel.metadata?.org ?? "");
+
+        if (refOrg === org && ref.slug === slug) {
+          throw failedPreconditionError(
+            deleteBlockedByChannelMessage(org, slug, channel.metadata?.name ?? ""),
+          );
+        }
+      }
+    },
+  };
+}

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -28,6 +28,13 @@
 //     deepest domain: 23 RPCs incl. the subscribe stream, the HITL
 //     surfaces, and the engine-gate/lifecycle negatives that pin the
 //     no-Temporal posture until #18).
+//   - agentshare + agentchannel + channelapp — sub-project #12
+//     (sp.sharing-and-channels; the sharing/channel family: the anonymous
+//     getSharedProfile lane + cross-org contract, the four channel
+//     registration blocks with the three cloud-only refusal postures, and
+//     the per-field secret rotation. The agentshare suite's cross-org
+//     blocker test creates a McpServer, so this roster entry lands after
+//     entry #9 (McpServer CRUD) merges).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -44,6 +51,9 @@ export default defineConfig({
       "src/suites/workflowinstance.conformance.test.ts",
       "src/suites/executioncontext.conformance.test.ts",
       "src/suites/agentexecution.conformance.test.ts",
+      "src/suites/agentshare.conformance.test.ts",
+      "src/suites/agentchannel.conformance.test.ts",
+      "src/suites/channelapp.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the three sharing/channel domains from the Go server to `backend/services/stigmer-server-ts` at strict parity (program 20260822.01, D4 entry #12): **agentshare** (11 RPCs), **agentchannel** (22 RPCs across 4 registration blocks), and **channelapp** (7 RPCs). The `local-ts` conformance roster grows by the three matching suites.

> **MERGE HOLD LIFTED (2026-08-24)** — #9 merged as PR #871; this branch is synced with main (merge commits `72fbaeab8`, `ce46f7742`). Post-sync proof: `local-ts` roster 18 suites, **382 passed / 1 skipped — fully green incl. the formerly-held agentshare blocker test**; `local-go` 492 regression-free; 1,141/1,141 unit tests; typecheck clean. Merge-ready.

## Changes

- **agentshare**: create with the canonical-share slug default and the server-owned `status.agent_id` rebind pin; the cross-org public-dependency contract (decision 013 — public agent, public audience, every declared dependency public, blockers named sorted); `rotateShareLink` (20-byte crypto-random → 27-char base64url token, status-resident, sole writer); the anonymous `getSharedProfile` lane with ONE uniform `"Agent not found: <slug>"` for every miss (absent / disabled / dangling ref / stale pin / withdrawn visibility / wrong token) and constant-time token comparison; `getSharedProfileForMember` incl. the token-locked public-audience exception.
- **agentchannel**: CRUD with the anti-probing ordering (same-org invariant BEFORE the agent load), the write-time model-pin existence rule (#774) against the domain-owned ModelRegistryStore, WhatsApp BYO `app_ref` rules (required / same-org / frozen-while-installed), `pending_install` stamping; the three cloud-only postures byte-pinned — commands refuse FailedPrecondition, discovery reads answer truthful-empty, single-row reads answer the uniform NotFound; install is load-then-refuse with cloud's exact NotFound copy.
- **channelapp**: per-field secret rotation over the provider oneof (marker preserves stored ciphertext per field; `enc:v<N>:` input refused unconditionally, oss#395), AES-256-GCM at rest via the shared SecretService, `***REDACTED***` on every response surface incl. delete and per-list-entry, referential delete-block while any AgentChannel references the app, and the provider-arm redact/encrypt tripwire test (#324 regression guard).
- **compose.ts**: five registrations in Go `server.go` order; channelapp shares the ONE SecretService instance with Environment; no `inprocess.ts` changes (none of the three domains has a client edge).

## Implementation notes

- **Apply-delegation asymmetry preserved per domain**: agentshare/agentchannel delegate the pipeline's CLONED state (the canonical-share defaults and normalized refs live on the clone); channelapp delegates the ORIGINAL input (its update loads by slug) — each matches its own Go handler, documented in the handler comments.
- **OD-1 exclusion (ratified)**: Go's boot migration (`agentshare/migration/bootstrap_shares.go`, protowire decoding of removed proto fields) is deliberately NOT ported — a fresh TS server has no pre-promotion SQLite data; stated in the domain lineage header.
- `providerFieldName` resolves the PROTO field name through the schema descriptor (not the camelCased oneof `case`), so a future snake_case provider arm cannot silently diverge from Go's byte-pinned error copy; unit-pinned.
- Node's `timingSafeEqual` throws on length mismatch where Go's `ConstantTimeCompare` returns 0 — the wrapper length-guards first (token length is not secret; all server-minted tokens are 27 chars).
- Pinned cross-domain inconsistency ported as-is: provider-arm immutability is InvalidArgument on ChannelApp vs FailedPrecondition on AgentChannel (both editions share it; harmonization is a post-cutover wire change).
- The secret marker/ciphertext-guard logic stays domain-local (no shared module with environment/oauthapp): Go keeps each domain's steps in its own package, the three shapes differ (variable map vs oneof fields vs single field), and the ratified promotion rule requires an identical second consumer.

## Parity nuances disclosed (for the register)

1. **Inherited shared-step store-failure mapping** (pre-existing since #4, all domains): Go's generic loaders map ANY store error to NotFound; the TS twins map only `ResourceNotFoundError` and surface other store failures as Internal. Wire-visible only under storage corruption/I/O failure.
2. **Log-only asymmetries mirrored faithfully**: agentchannel list skips malformed rows silently (Go's `unmarshalChannel`), agentshare list and channelapp listByOrg warn — Go's own asymmetry, preserved.
3. Go's Apply/ListByOrg info logs are not emitted (log-only, no wire impact).
4. Blocker-list sorting uses JS default sort (UTF-16 code units) vs Go `sort.Strings` (bytes) — identical for the slug/org alphabet validation enforces.

## Test plan

- `tsc --noEmit` clean; **865/865** package tests (100 new domain tests ported case-for-case from the Go catalogs, incl. the adversarial arms: client-provided pin discarded, store-failure leaks no internals (#478), re-rotation kills the previous token, recreate-never-rebinds, apply-with-markers round-trip, the provider-arm tripwire).
- `make test-conformance-ts`: **301/302** — agentchannel 25/25, channelapp 13/13, agentshare 18/19; the single failure is the documented #9-held blocker test. All 11 previously rostered suites regression-free.
- `make test-conformance` (local-go): **468 passed, 1 skipped** — baseline exactly, regression-free.
- Two-reviewer adversarial panel (Go byte-fidelity + TS quality): no blocking findings; all minors fixed in-branch (rotate-lane entropy-failure copy, log-level parity, schema-derived provider naming + unit pin, import hygiene, dead exports) or disclosed above.

Made with [Cursor](https://cursor.com)
