### PR TITLE
feat(backend/stigmer-server-ts): port the mcpserver CRUD slice (D4 #9)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -32,6 +32,7 @@ import { registerEnvironmentServices } from "../domain/environment/controller.js
 import { registerExecutionContextServices } from "../domain/executioncontext/controller.js";
 import { registerMemoryServices } from "../domain/memory/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
+import { registerMcpServerServices } from "../domain/mcpserver/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
 import { SecretService } from "../encryption/encryption.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
@@ -305,6 +306,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
           requireInProcess().workflowExecutionContextCreator,
       },
     });
+    // CRUD slice only (D4 #9) — Go's constructor takes exactly the store
+    // for this slice; the connect/OAuth deps arrive with #19.
+    registerMcpServerServices(router, { store, logger });
   };
   inProcess = createInProcessClients(routes, logger);
 

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/mcpserver.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/mcpserver.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Pins the McpServer CRUD slice against Go's mcpserver_controller_test.go
+ * + validate_default_enabled_tools_test.go + enrich_oauth_status_test.go +
+ * org_oauth_app_unimplemented_test.go — through the REAL stack: a composed
+ * server on an ephemeral port, a native gRPC client, the full interceptor
+ * chain.
+ *
+ * The load-bearing pins the conformance suite CANNOT cover (needs direct
+ * store access or surfaces it doesn't roster): the #402 enabledtools arms
+ * (capabilities only exist post-connect, which needs store seeding here),
+ * the #523 oauth_status enrichment matrix (needs seeded OAuthApps), the
+ * updateVisibility ordering (no conformance coverage for this domain —
+ * the D4-disclosed gap), and the #558 UNIMPLEMENTED guard (unit-level in
+ * Go too).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import {
+  DiscoveredCapabilitiesSchema,
+  McpServerStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const KIND = "McpServer";
+const ORG = "acme";
+
+type CommandClient = Client<typeof McpServerCommandController>;
+type QueryClient = Client<typeof McpServerQueryController>;
+
+let server: ComposedServer;
+let command: CommandClient;
+let query: QueryClient;
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "mcpserver-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      STORAGE_PATH: path.join(dir, "storage"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(McpServerCommandController, transport);
+  query = createClient(McpServerQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let counter = 0;
+function serverInput(overrides?: {
+  name?: string;
+  org?: string;
+  defaultEnabledTools?: string[];
+  oauthAppSlug?: string;
+  /** An auth block WITHOUT an oauth_app_ref — the DCR/manual-token arm. */
+  dcrAuth?: boolean;
+}) {
+  counter += 1;
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      name: overrides?.name ?? `Test Server ${counter}`,
+      org: overrides?.org ?? ORG,
+    },
+    spec: {
+      description: "created by the domain test",
+      serverType: {
+        case: "stdio" as const,
+        value: { command: "npx", args: ["-y", "@example/mcp"] },
+      },
+      defaultEnabledTools: overrides?.defaultEnabledTools ?? [],
+      ...(overrides?.oauthAppSlug !== undefined
+        ? {
+            auth: {
+              oauthAppRef: {
+                org: ORG,
+                slug: overrides.oauthAppSlug,
+                kind: ApiResourceKind.oauth_app,
+              },
+              targetEnvVar: "EXAMPLE_TOKEN",
+            },
+          }
+        : {}),
+      ...(overrides?.dcrAuth === true
+        ? { auth: { targetEnvVar: "EXAMPLE_TOKEN" } }
+        : {}),
+    },
+  };
+}
+
+async function expectCode(promise: Promise<unknown>, code: Code, arm: string): Promise<ConnectError> {
+  try {
+    await promise;
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(
+      connectError.code,
+      `${arm}: expected ${Code[code]}, got ${Code[connectError.code]} (${connectError.rawMessage})`,
+    ).toBe(code);
+    return connectError;
+  }
+  throw new Error(`${arm}: expected a ${Code[code]} error, got success`);
+}
+
+/**
+ * Grafts discovered capabilities onto a stored server, modeling the state
+ * a connect leaves behind — the only way to reach the #402 arms before
+ * #19 ports the connect slice.
+ */
+async function seedCapabilities(
+  serverId: string,
+  tools: string[],
+  resourceTemplates: string[],
+): Promise<void> {
+  const stored = await server.store.getResource(
+    ApiResourceKind.mcp_server,
+    serverId,
+    McpServerSchema,
+  );
+  const patched = fromBinary(McpServerSchema, toBinary(McpServerSchema, stored));
+  patched.status ??= create(McpServerStatusSchema, {});
+  patched.status.discoveredCapabilities = create(DiscoveredCapabilitiesSchema, {
+    tools: tools.map((name) => ({ name })),
+    resourceTemplates: resourceTemplates.map((name) => ({ name })),
+  });
+  await server.store.saveResource(
+    ApiResourceKind.mcp_server,
+    serverId,
+    McpServerSchema,
+    patched,
+  );
+}
+
+describe("CRUD", () => {
+  it("create derives identity and defaults org visibility (blueprint kind)", async () => {
+    const created = await command.create(serverInput({ name: "GitHub Tools" }));
+    expect(created.metadata?.id).toMatch(/^mcp_[0-9a-z]{26}$/);
+    expect(created.metadata?.slug).toBe("github-tools");
+    expect(created.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+  });
+
+  it("rejects a duplicate create by slug within the org; a different org reuses the slug", async () => {
+    const name = `Dup Target ${++counter}`;
+    await command.create(serverInput({ name }));
+    await expectCode(command.create(serverInput({ name })), Code.AlreadyExists, "duplicate create");
+    const other = await command.create(serverInput({ name, org: "other-org" }));
+    expect(other.metadata?.org).toBe("other-org");
+  });
+
+  it("apply branches to create then update, keeping the id stable", async () => {
+    const input = serverInput();
+    const created = await command.apply(input);
+    const updated = await command.apply({
+      ...input,
+      spec: { ...input.spec, description: "changed by apply" },
+    });
+    expect(updated.metadata?.id).toBe(created.metadata?.id);
+    expect(updated.spec?.description).toBe("changed by apply");
+  });
+
+  it("get and getByReference resolve the same resource; unknowns answer NotFound", async () => {
+    const created = await command.create(serverInput());
+    const byId = await query.get({ value: created.metadata!.id });
+    const byRef = await query.getByReference({ org: ORG, slug: created.metadata!.slug });
+    expect(byId.metadata?.id).toBe(created.metadata?.id);
+    expect(byRef.metadata?.id).toBe(created.metadata?.id);
+    await expectCode(query.get({ value: "mcps_missing" }), Code.NotFound, "get unknown");
+    await expectCode(
+      query.getByReference({ org: ORG, slug: "never-created" }),
+      Code.NotFound,
+      "getByReference unknown",
+    );
+  });
+
+  it("delete returns the deleted server; reads answer NotFound after", async () => {
+    const created = await command.create(serverInput());
+    const deleted = await command.delete({ resourceId: created.metadata!.id });
+    expect(deleted.metadata?.id).toBe(created.metadata?.id);
+    await expectCode(query.get({ value: created.metadata!.id }), Code.NotFound, "get after delete");
+  });
+
+  it("update of a non-existent server and delete of a non-existent server answer NotFound; delete with an empty id is InvalidArgument", async () => {
+    const ghost = create(McpServerSchema, {
+      metadata: { id: "mcp_missing", name: "Ghost Server", org: ORG },
+    });
+    await expectCode(
+      command.update(updateInput(ghost, [])),
+      Code.NotFound,
+      "update non-existent",
+    );
+    await expectCode(
+      command.delete({ resourceId: "mcp_missing" }),
+      Code.NotFound,
+      "delete non-existent",
+    );
+    await expectCode(command.delete({}), Code.InvalidArgument, "delete empty id");
+  });
+});
+
+describe("updateVisibility (no conformance coverage for this domain — the D4-disclosed gap)", () => {
+  it("flips only metadata.visibility, stamps status_audit, and leaves spec_audit alone (#540)", async () => {
+    const created = await command.create(serverInput());
+    const updated = await command.updateVisibility({
+      resourceId: created.metadata!.id,
+      visibility: ApiResourceVisibility.visibility_private,
+    });
+    expect(updated.metadata?.visibility).toBe(ApiResourceVisibility.visibility_private);
+    expect(updated.spec?.description).toBe(created.spec?.description);
+    // A visibility change is a STATUS mutation: status_audit re-stamped
+    // (updated event, fresh timestamp bounds are creation-or-later),
+    // spec_audit byte-untouched.
+    expect(updated.status?.audit?.statusAudit?.event).toBe("updated");
+    expect(updated.status?.audit?.specAudit).toEqual(created.status?.audit?.specAudit);
+  });
+
+  it("answers NotFound for an unknown id", async () => {
+    // NOTE: the load-before-validate ORDERING (NOT_FOUND beats level
+    // validation, the cloud-parity rule) is untestable through this
+    // domain — mcp_server's kind config supports EVERY visibility level,
+    // so ValidateVisibilityUpdate can never fire here (same in Go). This
+    // is a plain NotFound pin; the ordering is pinned by the environment
+    // domain, whose kind DOES reject levels.
+    await expectCode(
+      command.updateVisibility({
+        resourceId: "mcps_missing",
+        visibility: ApiResourceVisibility.visibility_public,
+      }),
+      Code.NotFound,
+      "unknown id",
+    );
+  });
+});
+
+/** A fully-typed update request for an existing server (no casts — N5). */
+function updateInput(created: McpServer, defaultEnabledTools: string[]) {
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      id: created.metadata!.id,
+      name: created.metadata!.name,
+      org: created.metadata!.org,
+    },
+    spec: {
+      description: "updated by the domain test",
+      serverType: {
+        case: "stdio" as const,
+        value: { command: "npx", args: ["-y", "@example/mcp"] },
+      },
+      defaultEnabledTools,
+    },
+  };
+}
+
+describe("ValidateDefaultEnabledTools (#402)", () => {
+  it("accepts names the server exposes; skips when the list is empty or the server never connected", async () => {
+    // Never connected: any names pass (no authoritative toolset yet).
+    const fresh = await command.create(serverInput());
+    const freshUpdate = await command.update(updateInput(fresh, ["anything-goes"]));
+    expect(freshUpdate.spec?.defaultEnabledTools).toEqual(["anything-goes"]);
+
+    // Connected: valid names pass.
+    const connected = await command.create(serverInput());
+    await seedCapabilities(connected.metadata!.id, ["search", "fetch"], []);
+    const ok = await command.update(updateInput(connected, ["search"]));
+    expect(ok.spec?.defaultEnabledTools).toEqual(["search"]);
+  });
+
+  it("rejects unknown tools and resource templates with the byte-pinned teaching copy", async () => {
+    const created = await command.create(serverInput());
+    await seedCapabilities(created.metadata!.id, ["search", "fetch"], ["files"]);
+
+    const err = await expectCode(
+      command.update(updateInput(created, ["serch", "files"])),
+      Code.InvalidArgument,
+      "unknown + template",
+    );
+    expect(err.rawMessage).toBe(
+      `MCP server '${created.metadata!.slug}': default_enabled_tools names tool(s) this server does not expose: 'serch'; default_enabled_tools names resource template(s): 'files' — resource templates are read-only data endpoints, not callable tools, and must not appear in default_enabled_tools. Discovered tools: 'search', 'fetch'. If the server's toolset changed, run 'stigmer connect' on it to refresh discovered capabilities.`,
+    );
+  });
+});
+
+describe("EnrichOAuthStatus (#523) — response-only oauth_status", () => {
+  async function seedOAuthApp(
+    slug: string,
+    approval: VendorApprovalStatus,
+    docsUrl: string,
+  ): Promise<void> {
+    const id = `oaa_${slug.replaceAll("-", "")}`;
+    await server.store.saveResource(
+      ApiResourceKind.oauth_app,
+      id,
+      OAuthAppSchema,
+      create(OAuthAppSchema, {
+        metadata: { id, org: ORG, slug, name: slug },
+        spec: { vendorApprovalStatus: approval, vendorApprovalDocsUrl: docsUrl },
+      }),
+    );
+  }
+
+  it("servers without an oauth_app_ref are untouched", async () => {
+    const created = await command.create(serverInput());
+    const got = await query.get({ value: created.metadata!.id });
+    expect(got.status?.oauthStatus).toBeUndefined();
+  });
+
+  it("a missing OAuthApp skips enrichment (the initiate path owns refusing)", async () => {
+    const created = await command.create(serverInput({ oauthAppSlug: "never-applied" }));
+    const got = await query.get({ value: created.metadata!.id });
+    expect(got.status?.oauthStatus).toBeUndefined();
+  });
+
+  it("nothing-to-report means ABSENT — presence itself is the SDK's signal", async () => {
+    await seedOAuthApp("plain-app", VendorApprovalStatus.UNSPECIFIED, "");
+    const created = await command.create(serverInput({ oauthAppSlug: "plain-app" }));
+    const got = await query.get({ value: created.metadata!.id });
+    expect(got.status?.oauthStatus).toBeUndefined();
+  });
+
+  // The two boundary arms below are the mutation killers for the presence
+  // rule (UNSPECIFIED && docs==""): EITHER a gating status OR a docs URL
+  // alone must enrich (Go enrich_oauth_status_test.go's docs-only and
+  // status-only arms — the executable spec of the #523 shared contract).
+  it("a docs URL ALONE enriches, even with an UNSPECIFIED approval status", async () => {
+    await seedOAuthApp("docs-only-app", VendorApprovalStatus.UNSPECIFIED, "https://vendor.example/setup");
+    const created = await command.create(serverInput({ oauthAppSlug: "docs-only-app" }));
+    const got = await query.get({ value: created.metadata!.id });
+    expect(got.status?.oauthStatus?.vendorApprovalStatus).toBe(VendorApprovalStatus.UNSPECIFIED);
+    expect(got.status?.oauthStatus?.vendorApprovalDocsUrl).toBe("https://vendor.example/setup");
+  });
+
+  it("a non-default approval status ALONE enriches — REJECTED and even APPROVED are reported", async () => {
+    await seedOAuthApp("rejected-app", VendorApprovalStatus.REJECTED, "");
+    const rejected = await command.create(serverInput({ oauthAppSlug: "rejected-app" }));
+    const gotRejected = await query.get({ value: rejected.metadata!.id });
+    expect(gotRejected.status?.oauthStatus?.vendorApprovalStatus).toBe(VendorApprovalStatus.REJECTED);
+    expect(gotRejected.status?.oauthStatus?.vendorApprovalDocsUrl).toBe("");
+
+    await seedOAuthApp("approved-app", VendorApprovalStatus.APPROVED, "");
+    const approved = await command.create(serverInput({ oauthAppSlug: "approved-app" }));
+    const gotApproved = await query.get({ value: approved.metadata!.id });
+    expect(gotApproved.status?.oauthStatus?.vendorApprovalStatus).toBe(VendorApprovalStatus.APPROVED);
+  });
+
+  it("an auth block WITHOUT an oauth_app_ref (the DCR arm) is untouched", async () => {
+    const created = await command.create(serverInput({ dcrAuth: true }));
+    const got = await query.get({ value: created.metadata!.id });
+    expect(got.spec?.auth?.targetEnvVar).toBe("EXAMPLE_TOKEN");
+    expect(got.status?.oauthStatus).toBeUndefined();
+  });
+
+  it("a gating approval status or docs URL enriches BOTH read paths, response-only", async () => {
+    await seedOAuthApp("gated-app", VendorApprovalStatus.PENDING, "https://vendor.example/approval");
+    const created = await command.create(serverInput({ oauthAppSlug: "gated-app" }));
+
+    for (const loaded of [
+      await query.get({ value: created.metadata!.id }),
+      await query.getByReference({ org: ORG, slug: created.metadata!.slug }),
+    ]) {
+      expect(loaded.status?.oauthStatus?.vendorApprovalStatus).toBe(
+        VendorApprovalStatus.PENDING,
+      );
+      expect(loaded.status?.oauthStatus?.vendorApprovalDocsUrl).toBe(
+        "https://vendor.example/approval",
+      );
+    }
+
+    // Response-only: the stored row never carries the enrichment.
+    const stored = await server.store.getResource(
+      ApiResourceKind.mcp_server,
+      created.metadata!.id,
+      McpServerSchema,
+    );
+    expect(stored.status?.oauthStatus).toBeUndefined();
+  });
+});
+
+describe("org-OAuth-app surface — UNIMPLEMENTED by design (#558, DD-019)", () => {
+  // The three RPCs are ONE capability; the SDK probes getOrgOAuthApp and
+  // hides every BYOA affordance on UNIMPLEMENTED. Codes AND grpc-go's
+  // generated texts are pinned — implementing any one RPC without the
+  // other two + the SDK gate would resurrect dead affordances on OSS.
+  it("getOrgOAuthApp / setOrgOAuthApp / deleteOrgOAuthApp answer Unimplemented with Go's text", async () => {
+    const getErr = await expectCode(
+      query.getOrgOAuthApp({ resourceId: "mcps_test", org: ORG }),
+      Code.Unimplemented,
+      "getOrgOAuthApp",
+    );
+    expect(getErr.rawMessage).toBe("method GetOrgOAuthApp not implemented");
+
+    const setErr = await expectCode(
+      command.setOrgOAuthApp({ resourceId: "mcps_test", org: ORG, clientId: "x", clientSecret: "y" }),
+      Code.Unimplemented,
+      "setOrgOAuthApp",
+    );
+    expect(setErr.rawMessage).toBe("method SetOrgOAuthApp not implemented");
+
+    const deleteErr = await expectCode(
+      command.deleteOrgOAuthApp({ resourceId: "mcps_test", org: ORG }),
+      Code.Unimplemented,
+      "deleteOrgOAuthApp",
+    );
+    expect(deleteErr.rawMessage).toBe("method DeleteOrgOAuthApp not implemented");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/controller.ts
@@ -1,0 +1,435 @@
+/**
+ * McpServer controller — ports pkg/domain/mcpserver/controller's CRUD
+ * slice (D4 entry #9): the declarative MCP server surface. Registered
+ * methods: apply/create/update/delete/updateVisibility on the command
+ * side; get/getByReference on the query side; plus the three org-OAuth
+ * RPCs as PERMANENT UNIMPLEMENTED stubs (below).
+ *
+ * The connect/OAuth slice (connect, startConnect, initiateOAuthConnect,
+ * completeOAuthConnect, disconnectOAuth, getOAuthGrantStatus) arrives
+ * with #19 — those methods stay unregistered here; connect-es answers
+ * them Unimplemented with its own generated text. Go's constructor takes
+ * only the store for exactly this slice; its connect/OAuth deps are
+ * optional setters. The interim gap is DISCLOSED, not uniform
+ * "unported" lag: Go wires the OAuth deps unconditionally (server.go:718),
+ * so getOAuthGrantStatus, completeOAuthConnect, and disconnectOAuth give
+ * real answers on Go today (grant-status even answers NO_GRANT with a nil
+ * store), and connect/startConnect answer FailedPrecondition on a
+ * Temporal-less Go rather than Unimplemented. Clients treating
+ * Unimplemented as capability-absent (the SDK's posture) degrade
+ * gracefully; the surfaces themselves return with #19.
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies,
+ * and Publish steps (no multi-tenant auth, IAM/FGA, or event publishing).
+ *
+ * Proven by mcpserver.conformance.test.ts +
+ * agent-mcpserver-references.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and __tests__/mcpserver.test.ts.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import type {
+  ApiResourceDeleteInput,
+  ApiResourceId,
+  ApiResourceReference,
+  UpdateVisibilityInput,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError, notFoundError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { setAuditFieldsForUpdate, newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  RESOURCE_ID_KEY,
+  newDeleteResourceStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import {
+  newValidateVisibilityStep,
+  newValidateVisibilityUpdateStep,
+} from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import { mcpServerSearchExtractor } from "./search-extractor.js";
+import {
+  newEnrichOAuthStatusStep,
+  newValidateDefaultEnabledToolsStep,
+} from "./steps.js";
+
+export interface McpServerControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+}
+
+/** Registers both mcpserver services on the router (routes stage). */
+export function registerMcpServerServices(
+  router: ConnectRouter,
+  deps: McpServerControllerDeps,
+): void {
+  router.service(McpServerCommandController, {
+    apply: (server, ctx) => apply(deps, server, ctx),
+    create: (server, ctx) => createMcpServer(deps, server, ctx),
+    update: (server, ctx) => update(deps, server, ctx),
+    updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
+    delete: (input, ctx) => deleteMcpServer(deps, input, ctx),
+    setOrgOAuthApp: () => {
+      throw orgOAuthAppUnimplemented("SetOrgOAuthApp");
+    },
+    deleteOrgOAuthApp: () => {
+      throw orgOAuthAppUnimplemented("DeleteOrgOAuthApp");
+    },
+  });
+  router.service(McpServerQueryController, {
+    get: (id, ctx) => get(deps, id, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getOrgOAuthApp: () => {
+      throw orgOAuthAppUnimplemented("GetOrgOAuthApp");
+    },
+  });
+}
+
+/**
+ * The org-OAuth-app (BYOA override) surface answers UNIMPLEMENTED on OSS —
+ * deliberately, not as coexistence lag (stigmer/stigmer#558, DD-019 in the
+ * triage project). An OAuthAppOverride binds an org's own OAuthApp OVER a
+ * platform-managed default; OSS has no platform operator distinct from the
+ * user — the flat oauthapp domain gives the user full CRUD over the very
+ * apps a hosted org could only override — and the OSS OAuth resolution
+ * (refresolution) has no override level to consult: the ref IS the whole
+ * resolution.
+ *
+ * The three RPCs are ONE capability. The shared SDK probes it via
+ * getOrgOAuthApp and hides every BYOA affordance when the probe answers
+ * UNIMPLEMENTED (useOrgOAuthApp.isSupported). Implementing any one RPC
+ * without the other two — e.g. a "truthful" read returning
+ * has_override=false — would break the probe and resurrect dead
+ * affordances on OSS. If this surface is ever brought to OSS, all three
+ * RPCs, the OSS resolution chain, and the SDK gate must move together.
+ *
+ * Explicit stubs (never unregistered methods): connect-es DOES answer an
+ * unregistered method of a registered service with Code.Unimplemented —
+ * but with ITS generated text ("<service>.<method> is not implemented"),
+ * not grpc-go's. Go answers through its embedded
+ * Unimplemented*ControllerServer, whose text is the pinned contract; the
+ * stubs exist to carry that text byte-for-byte and this doc block.
+ */
+function orgOAuthAppUnimplemented(method: string): ConnectError {
+  return new ConnectError(`method ${method} not implemented`, Code.Unimplemented);
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/** Create — chain per Go buildCreatePipeline. */
+async function createMcpServer(
+  deps: McpServerControllerDeps,
+  server: McpServer,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(McpServerSchema, server, kindOf(ctx));
+  await newPipeline<typeof McpServerSchema>("mcpserver-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline. ValidateDefaultEnabledTools
+ * (#402) runs AFTER BuildUpdateState: the check is self-referential
+ * against the OWN status the merge just carried over.
+ */
+async function update(
+  deps: McpServerControllerDeps,
+  server: McpServer,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(McpServerSchema, server, kindOf(ctx));
+  await newPipeline<typeof McpServerSchema>("mcpserver-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newValidateDefaultEnabledToolsStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — kubectl-style create-or-update: a minimal probe pipeline
+ * decides existence, then delegates with the ORIGINAL request message.
+ *
+ * Go's tail fires `go StartBestEffortConnect(result)` here — auto
+ * discovery through the runner's Temporal workflow. That call is a SILENT
+ * no-op when connect dependencies are absent (connect.go:1046: nil
+ * temporalClient returns immediately), which is this server's exact state
+ * until #19 wires the connect slice — so its absence here IS byte-parity,
+ * not an approximation. #19 adds the seam.
+ */
+async function apply(
+  deps: McpServerControllerDeps,
+  server: McpServer,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(McpServerSchema, server, kindOf(ctx));
+  await newPipeline<typeof McpServerSchema>("mcpserver-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  return shouldCreate
+    ? createMcpServer(deps, server, ctx)
+    : update(deps, server, ctx);
+}
+
+/**
+ * Delete — returns the deleted server (the audit-trail convention). The
+ * id is seeded into context manually because ApiResourceDeleteInput
+ * carries resource_id, not the `value` field ExtractResourceId expects
+ * (Go does the same manual seed).
+ */
+async function deleteMcpServer(
+  deps: McpServerControllerDeps,
+  input: ApiResourceDeleteInput,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(
+    McpServerCommandController.method.delete.input,
+    input,
+    kindOf(ctx),
+  );
+  reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
+  await newPipeline<typeof McpServerCommandController.method.delete.input>(
+    "mcpserver-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, McpServerSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted mcp server not found in context"),
+      "deleted mcp server not found in context",
+    );
+  }
+  return deleted as McpServer;
+}
+
+// ---------------------------------------------------------------------------
+// updateVisibility — Go update_visibility.go: a targeted metadata update
+// (only metadata.visibility changes). Load runs before level validation so
+// NOT_FOUND wins, as in Cloud.
+// ---------------------------------------------------------------------------
+
+const UPDATE_VISIBILITY_MCP_SERVER_KEY = "updateVisibilityMcpServer";
+
+type UpdateVisibilityDesc =
+  typeof McpServerCommandController.method.updateVisibility.input;
+
+async function updateVisibility(
+  deps: McpServerControllerDeps,
+  input: UpdateVisibilityInput,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(
+    McpServerCommandController.method.updateVisibility.input,
+    input,
+    kindOf(ctx),
+  );
+  await newPipeline<UpdateVisibilityDesc>("mcpserver-update-visibility", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadMcpServerForVisibilityUpdateStep(deps.store))
+    .addStep(newValidateVisibilityUpdateStep())
+    .addStep(newSetMcpServerVisibilityStep())
+    .addStep(newPersistMcpServerForVisibilityUpdateStep(deps.store))
+    .addStep(newIndexMcpServerAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(UPDATE_VISIBILITY_MCP_SERVER_KEY) as McpServer;
+}
+
+/** Loads the server by resource_id; ANY load failure → NotFound. */
+function newLoadMcpServerForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "LoadMcpServerForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const input = ctx.input;
+      let mcpServer: McpServer;
+      try {
+        mcpServer = await store.getResource(
+          ctx.apiResourceKind,
+          input.resourceId,
+          McpServerSchema,
+        );
+      } catch {
+        throw notFoundError("mcp_server", input.resourceId);
+      }
+      ctx.set(UPDATE_VISIBILITY_MCP_SERVER_KEY, mcpServer);
+    },
+  };
+}
+
+/** Sets metadata.visibility and stamps the StatusAudit slot (#540). */
+function newSetMcpServerVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "SetMcpServerVisibility",
+    execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
+      const mcpServer = ctx.get(UPDATE_VISIBILITY_MCP_SERVER_KEY) as McpServer;
+      if (mcpServer.metadata !== undefined) {
+        mcpServer.metadata.visibility = ctx.input.visibility;
+      }
+      setAuditFieldsForUpdate(McpServerSchema, mcpServer, "status_audit");
+    },
+  };
+}
+
+/** Persists the visibility change. */
+function newPersistMcpServerForVisibilityUpdateStep(
+  store: Store,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "PersistMcpServerForVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const mcpServer = ctx.get(UPDATE_VISIBILITY_MCP_SERVER_KEY) as McpServer;
+      try {
+        await store.saveResource(
+          ctx.apiResourceKind,
+          mcpServer.metadata?.id ?? "",
+          McpServerSchema,
+          mcpServer,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to save mcp server");
+      }
+    },
+  };
+}
+
+/** Re-indexes after the change (visibility is indexed); best-effort. */
+function newIndexMcpServerAfterVisibilityUpdateStep(
+  store: Store,
+  logger: Logger,
+): PipelineStep<UpdateVisibilityDesc> {
+  return {
+    name: "IndexMcpServerAfterVisibilityUpdate",
+    async execute(ctx: RequestContext<UpdateVisibilityDesc>): Promise<void> {
+      const mcpServer = ctx.get(UPDATE_VISIBILITY_MCP_SERVER_KEY) as McpServer;
+      const entry = mcpServerSearchExtractor.getSearchIndexEntry(mcpServer);
+      if (entry === undefined) {
+        logger.warn(
+          "IndexMcpServerAfterVisibilityUpdate: extractor returned nil, skipping",
+          { id: mcpServer.metadata?.id ?? "" },
+        );
+        return;
+      }
+      try {
+        await store.upsertSearchIndex(
+          ctx.apiResourceKind,
+          mcpServer.metadata?.id ?? "",
+          entry,
+        );
+      } catch (error) {
+        logger.warn("IndexMcpServerAfterVisibilityUpdate: failed (best-effort)", {
+          id: mcpServer.metadata?.id ?? "",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}
+
+/** Get — LoadTarget by id, then the response-only oauth_status enrich. */
+async function get(
+  deps: McpServerControllerDeps,
+  id: ApiResourceId,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(
+    McpServerQueryController.method.get.input,
+    id,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof McpServerQueryController.method.get.input>(
+    "mcpserver-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, McpServerSchema))
+    .addStep(newEnrichOAuthStatusStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as McpServer;
+}
+
+/** GetByReference — slug+org lookup, then the oauth_status enrich. */
+async function getByReference(
+  deps: McpServerControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<McpServer> {
+  const reqCtx = new RequestContext(
+    McpServerQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof McpServerQueryController.method.getByReference.input>(
+    "mcpserver-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, McpServerSchema))
+    .addStep(newEnrichOAuthStatusStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as McpServer;
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/search-extractor.ts
@@ -1,0 +1,36 @@
+/**
+ * McpServer search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/mcpserver_extractor.go. The search summary is
+ * spec.description. The query side of the extractor contract arrives with
+ * the search service sub-project (#14).
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+export const mcpServerSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const mcpServer = resource as unknown as McpServer;
+    const metadata = mcpServer.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      // Go McpServerExtractor.GetSearchSummary: spec.description.
+      description: mcpServer.spec?.description ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        mcpServer.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/steps.ts
@@ -1,0 +1,185 @@
+/**
+ * McpServer domain-local pipeline steps — port
+ * pkg/domain/mcpserver/controller/validate_default_enabled_tools.go and
+ * enrich_oauth_status.go. Shared vocabulary step names; error copy
+ * byte-pinned from Go.
+ *
+ * Proven by __tests__/mcpserver.test.ts and mcpserver.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts).
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import type { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import {
+  McpServerStatusSchema,
+  OAuthStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { VendorApprovalStatus } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { invalidArgumentError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import type { Store } from "../../store/interface.js";
+import { resolveOAuthAppRef } from "../oauthapp/refresolution.js";
+import {
+  classify,
+  isValidClassification,
+  quoteJoin,
+  toolNames,
+} from "./enabledtools/enabledtools.js";
+
+/**
+ * ValidateDefaultEnabledTools — rejects updates whose
+ * spec.default_enabled_tools name tools this server does not expose
+ * (issue #402, the mcpserver twin of the agent controller's
+ * ValidateEnabledTools step).
+ *
+ * The check is self-referential — spec against the resource's OWN stored
+ * discovered capabilities — so it needs no store fetch: BuildUpdateState
+ * has already copied the existing status (including capabilities) onto
+ * the merged state this step reads.
+ *
+ * Wired into the UPDATE pipeline only. On create the resource cannot have
+ * a status yet (the first discovery is the post-apply best-effort
+ * connect), so a create-side check would be a no-op by construction;
+ * leaving it unwired keeps the create pipeline honest about what it
+ * enforces.
+ *
+ * Deliberate skips: an empty default_enabled_tools means "all tools
+ * enabled" — nothing to check; absent discovered capabilities mean the
+ * server was never connected, so there is no authoritative toolset to
+ * validate against (the runner's warn-and-intersect, issue #350, remains
+ * the safety net for that window).
+ */
+export function newValidateDefaultEnabledToolsStep(): PipelineStep<
+  typeof McpServerSchema
+> {
+  return {
+    name: "ValidateDefaultEnabledTools",
+    execute(ctx: RequestContext<typeof McpServerSchema>): void {
+      const mcpServer = ctx.newState;
+
+      const requested = mcpServer.spec?.defaultEnabledTools ?? [];
+      if (requested.length === 0) {
+        return;
+      }
+
+      const caps = mcpServer.status?.discoveredCapabilities;
+      if (caps === undefined) {
+        return;
+      }
+
+      const classification = classify(caps, requested);
+      if (isValidClassification(classification)) {
+        return;
+      }
+
+      const problems: string[] = [];
+      if (classification.unknown.length > 0) {
+        problems.push(
+          `default_enabled_tools names tool(s) this server does not expose: ${quoteJoin(classification.unknown)}`,
+        );
+      }
+      if (classification.resourceTemplates.length > 0) {
+        problems.push(
+          `default_enabled_tools names resource template(s): ${quoteJoin(classification.resourceTemplates)} — resource templates are read-only data endpoints, not callable tools, and must not appear in default_enabled_tools`,
+        );
+      }
+
+      throw invalidArgumentError(
+        `MCP server '${mcpServer.metadata?.slug ?? ""}': ${problems.join("; ")}. Discovered tools: ${quoteJoin(toolNames(caps))}. If the server's toolset changed, run 'stigmer connect' on it to refresh discovered capabilities.`,
+      );
+    },
+  };
+}
+
+/**
+ * EnrichOAuthStatus — populates response-only status.oauth_status on a
+ * loaded McpServer from the OAuthApp its spec.auth.oauth_app_ref points
+ * to, mirroring the cloud's McpServerVendorApprovalEnricher so the shared
+ * SDK's vendor-approval-blocked UI renders identically on both editions
+ * (stigmer/stigmer#523). Without it, an OSS user's first hint that OAuth
+ * sign-in is vendor-blocked is the initiate RPC's refusal — after they
+ * click.
+ *
+ * Semantics shared with the cloud enricher:
+ *   - Servers without an oauth_app_ref (DCR or manual-token) are
+ *     untouched.
+ *   - A missing OAuthApp skips enrichment (the initiate path owns
+ *     refusing).
+ *   - oauth_status is set only when there is something to gate on: a
+ *     non-default vendor_approval_status or a docs URL. Its very presence
+ *     is the signal the SDK keys on, so "nothing to report" means absent.
+ *   - The fields are response-only, per the OAuthStatus proto contract.
+ *     Nothing here persists: get pipelines don't save, and the write
+ *     pipelines clear client-sent status, so a round-tripped enriched
+ *     read cannot leak into the store.
+ *
+ * One deliberate divergence from cloud (Go's, preserved): a store failure
+ * during the lookup degrades to an unenriched response (WARN) instead of
+ * failing the read. Enrichment is advisory — the initiate RPC's vendor
+ * refusal remains the enforcement boundary — and an advisory lookup must
+ * not take down the primary read path.
+ *
+ * Generic over the pipeline input (get takes an ApiResourceId,
+ * getByReference an ApiResourceReference); it only touches the
+ * already-loaded target resource.
+ */
+export function newEnrichOAuthStatusStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "EnrichOAuthStatus",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const mcpServer = ctx.get(TARGET_RESOURCE_KEY) as McpServer | undefined;
+      if (mcpServer === undefined) {
+        return;
+      }
+
+      const ref = mcpServer.spec?.auth?.oauthAppRef;
+      if ((ref?.slug ?? "") === "") {
+        return;
+      }
+
+      let oauthApp;
+      try {
+        oauthApp = await resolveOAuthAppRef(store, ref, logger);
+      } catch (error) {
+        logger.warn(
+          "OAuthApp lookup failed; returning MCP server without oauth_status enrichment",
+          {
+            mcpServerId: mcpServer.metadata?.id ?? "",
+            oauthAppSlug: ref?.slug ?? "",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+      if (oauthApp === undefined) {
+        logger.debug("OAuthApp not found for ref; skipping oauth_status enrichment", {
+          mcpServerId: mcpServer.metadata?.id ?? "",
+          oauthAppSlug: ref?.slug ?? "",
+        });
+        return;
+      }
+
+      const approvalStatus =
+        oauthApp.spec?.vendorApprovalStatus ?? VendorApprovalStatus.UNSPECIFIED;
+      const docsUrl = oauthApp.spec?.vendorApprovalDocsUrl ?? "";
+      if (approvalStatus === VendorApprovalStatus.UNSPECIFIED && docsUrl === "") {
+        return;
+      }
+
+      mcpServer.status ??= create(McpServerStatusSchema, {});
+      mcpServer.status.oauthStatus = create(OAuthStatusSchema, {
+        vendorApprovalStatus: approvalStatus,
+        vendorApprovalDocsUrl: docsUrl,
+      });
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/__tests__/refresolution.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/__tests__/refresolution.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins the OAuthApp ref-resolution ladder against Go's
+ * refresolution_test.go table: exact (org, slug) wins; a UNIQUE slug-only
+ * match is honored across orgs (the seedpack `org: stigmer` case, #584);
+ * ambiguity resolves to nothing; an empty slug is the DCR/manual-token
+ * arm, not a lookup.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+import { resolveOAuthAppRef } from "../refresolution.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+let dir: string;
+let store: Store;
+
+async function seedApp(id: string, org: string, slug: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.oauth_app,
+    id,
+    OAuthAppSchema,
+    create(OAuthAppSchema, { metadata: { id, org, slug, name: slug } }),
+  );
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "refresolution-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"), silentLogger);
+  await seedApp("oaa_github_acme", "acme", "github");
+  await seedApp("oaa_github_beta", "beta-corp", "github");
+  await seedApp("oaa_slack_stigmer", "stigmer", "slack");
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function ref(org: string, slug: string) {
+  return create(ApiResourceReferenceSchema, { org, slug });
+}
+
+describe("resolveOAuthAppRef", () => {
+  it("resolves an exact (org, slug) match even when the slug exists elsewhere", async () => {
+    const app = await resolveOAuthAppRef(store, ref("beta-corp", "github"), silentLogger);
+    expect(app?.metadata?.id).toBe("oaa_github_beta");
+  });
+
+  it("honors a UNIQUE slug-only match when the ref's org has no app (the seedpack case, #584)", async () => {
+    // Two orgs hold 'github' and neither is 'stigmer': ambiguous → nothing.
+    expect(await resolveOAuthAppRef(store, ref("stigmer", "github"), silentLogger)).toBeUndefined();
+
+    const unique = await resolveOAuthAppRef(store, ref("some-user-org", "slack"), silentLogger);
+    expect(unique?.metadata?.id).toBe("oaa_slack_stigmer");
+  });
+
+  it("refuses to pick among ambiguous slug-only matches", async () => {
+    expect(await resolveOAuthAppRef(store, ref("", "github"), silentLogger)).toBeUndefined();
+  });
+
+  it("an org-less ref resolves through a UNIQUE slug match (Go's org-less arm)", async () => {
+    const app = await resolveOAuthAppRef(store, ref("", "slack"), silentLogger);
+    expect(app?.metadata?.id).toBe("oaa_slack_stigmer");
+  });
+
+  it("resolves nothing for an unknown slug", async () => {
+    expect(await resolveOAuthAppRef(store, ref("acme", "never-applied"), silentLogger)).toBeUndefined();
+  });
+
+  it("treats an absent or empty-slug ref as the DCR/manual-token arm", async () => {
+    expect(await resolveOAuthAppRef(store, undefined, silentLogger)).toBeUndefined();
+    expect(await resolveOAuthAppRef(store, ref("acme", ""), silentLogger)).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/oauthapp/refresolution.ts
+++ b/backend/services/stigmer-server-ts/src/domain/oauthapp/refresolution.ts
@@ -1,0 +1,98 @@
+/**
+ * OAuthApp reference resolution — ports pkg/domain/oauthapp/refresolution:
+ * the OSS semantics of resolving an `oauth_app_ref` (an
+ * ApiResourceReference on McpServerAuth) to a stored OAuthApp. One small
+ * module holds a cross-domain semantic so its consumers cannot drift
+ * apart (stigmer/stigmer#584, which found three divergent hand-rolled
+ * answers): the read-path oauth_status enricher (mcpserver, #9), the
+ * OAuth initiate and token-refresh paths (#19 — refresh MUST use the app
+ * initiate selected or it runs against the wrong vendor credentials), and
+ * the OAuthApp delete guard (#13). This file seeds src/domain/oauthapp/;
+ * the domain's controllers arrive with #13.
+ *
+ * Resolution semantics: OSS has a flat OAuthApp store — no org-override
+ * chain like the cloud's OAuthAppResolutionService, so the ref is the
+ * whole resolution (#558 DD-019). Matching is by slug, with the ref's org
+ * as a preference rather than a gate:
+ *
+ *  1. An exact (org, slug) match wins. Uniqueness is guaranteed by the
+ *     create pipeline's duplicate check.
+ *  2. Otherwise a slug-only match is honored when it is UNIQUE — what
+ *     lets a self-hosted deployment satisfy seedpack refs pinned to
+ *     `org: stigmer` with an OAuthApp applied in the user's own org.
+ *  3. Two or more slug matches with no exact hit resolve to nothing, with
+ *     a WARN naming the candidate orgs: ambiguity is never silently
+ *     collapsed into a credential pick.
+ *
+ * Returns undefined when nothing resolves; callers own the severity of
+ * that outcome (the enricher skips, initiate refuses NOT_FOUND, token
+ * refresh errors, the delete guard treats it as unreferenced).
+ *
+ * Proven by __tests__/refresolution.test.ts (Go's table ported).
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * Resolves the OAuthApp the ref means (Go refresolution.Resolve). A ref
+ * without a slug resolves to nothing — an McpServerAuth with no (or an
+ * empty) oauth_app_ref is the DCR/manual-token arm, not a lookup.
+ * Storage failures propagate; callers own their severity.
+ */
+export async function resolveOAuthAppRef(
+  store: Store,
+  ref: ApiResourceReference | undefined,
+  logger: Logger,
+): Promise<OAuthApp | undefined> {
+  const slug = ref?.slug ?? "";
+  if (slug === "") {
+    return undefined;
+  }
+
+  const rows = await store.listResources(ApiResourceKind.oauth_app);
+
+  // Collect-then-decide: a single pass gathers every slug match so the
+  // outcome depends only on the store's contents, never on its iteration
+  // order (Go's previous first-match-wins scan was nondeterministic when
+  // a slug existed in several orgs).
+  const slugMatches: OAuthApp[] = [];
+  for (const data of rows) {
+    let app: OAuthApp;
+    try {
+      app = fromBinary(OAuthAppSchema, data);
+    } catch {
+      continue; // skip malformed rows, as Go does
+    }
+    if ((app.metadata?.slug ?? "") !== slug) {
+      continue;
+    }
+    const refOrg = ref?.org ?? "";
+    if (refOrg !== "" && app.metadata?.org === refOrg) {
+      return app; // exact match: unique by the create duplicate check
+    }
+    slugMatches.push(app);
+  }
+
+  if (slugMatches.length === 0) {
+    return undefined;
+  }
+  if (slugMatches.length === 1) {
+    return slugMatches[0];
+  }
+  logger.warn(
+    "oauth_app_ref is ambiguous (slug exists in several orgs, none matching the ref); refusing to pick — pin the ref's org to resolve",
+    {
+      oauthAppSlug: slug,
+      refOrg: ref?.org ?? "",
+      candidateOrgs: slugMatches.map((app) => app.metadata?.org ?? ""),
+    },
+  );
+  return undefined;
+}

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -28,6 +28,12 @@
 //     deepest domain: 23 RPCs incl. the subscribe stream, the HITL
 //     surfaces, and the engine-gate/lifecycle negatives that pin the
 //     no-Temporal posture until #18).
+//   - mcpserver + agent-mcpserver-references — sub-project #9
+//     (sp.mcpserver-crud; the declarative CRUD slice with the #402
+//     enabledtools validation and the #558 org-OAuth UNIMPLEMENTED pins;
+//     the agent-references suite was split out by sp.agent-family DD-001
+//     and held for this entry, whose McpServer service its accept-path
+//     fixture needs. The connect/OAuth slice arrives with #19).
 //   - workflowexecution — sub-project #20 (sp.workflowexecution-domain;
 //     the Class A engineless surface: the create gate, the CW-7
 //     zero-record reads, the subscribe/subscribeEvents error arms, and
@@ -50,6 +56,8 @@ export default defineConfig({
       "src/suites/executioncontext.conformance.test.ts",
       "src/suites/agentexecution.conformance.test.ts",
       "src/suites/workflowexecution.conformance.test.ts",
+      "src/suites/mcpserver.conformance.test.ts",
+      "src/suites/agent-mcpserver-references.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

D4 entry #9 (`sp.mcpserver-crud`, program 20260822.01): the declarative McpServer surface ported to the TS server — CRUD + the #402 enabled-tools validation + the #523 oauth_status enrichment + the three org-OAuth RPCs as permanent byte-pinned UNIMPLEMENTED stubs (#558). The connect/OAuth slice stays with #19, per the D4 split.

## Context

Stage 2 continues: #9 needed #5 and #6 (both merged), and its groundwork was already in place — `enabledtools/` was ported with the agent family (its module doc announces this entry), the `oauth_grant`/`pending_oauth_state` sub-stores landed with migration v7 (untouched here, they are #19's), and the conformance suites were written in waves. `agent-mcpserver-references` was explicitly held for this entry, whose McpServer service its accept-path fixture needs.

## Changes

- **`src/domain/mcpserver/`**: `controller.ts` with the seven CRUD RPCs from shared pipeline steps at Go's exact chains (create's ValidateVisibility-before-ResolveSlug, update's LoadExisting → BuildUpdateState → ValidateDefaultEnabledTools, apply's probe-then-delegate, delete's manual resource-id seed, updateVisibility's load-before-validate); `steps.ts` with the #402 step (self-referential against the resource's OWN discovered capabilities, update-only by construction, byte-pinned teaching copy incl. the "run 'stigmer connect'" hint) and the #523 enrich step (advisory-degrade, presence-is-the-signal); the FTS `search-extractor.ts`.
- **`src/domain/oauthapp/refresolution.ts`** (new folder, seeded for #13): the #584 one-home resolution ladder — exact (org, slug) wins, unique slug-only honored (the seedpack `org: stigmer` case), ambiguity refuses with a WARN naming candidate orgs. #19's initiate/refresh and #13's delete guard consume this same module.
- **The #558 stubs**: `getOrgOAuthApp`/`setOrgOAuthApp`/`deleteOrgOAuthApp` throw `Unimplemented` with grpc-go's generated text byte-for-byte, carrying the full DD-019 doctrine (the three RPCs are ONE capability; the SDK probe gates on getOrgOAuthApp; never move one without the other two + the SDK gate).
- **Composition**: `registerMcpServerServices(router, { store, logger })` — matching Go's store-only CRUD constructor (server.go:472).
- **Roster**: + `mcpserver.conformance.test.ts` (17) + `agent-mcpserver-references.conformance.test.ts` (2).

## Implementation notes

- **Apply's Go tail** (`go StartBestEffortConnect`) is a verified silent no-op when Temporal connect deps are absent (connect.go:1046) — its omission here is byte-parity with a Temporal-less Go server, not an approximation; #19 wires the real seam.
- **Adversarial review panel ran; all findings applied.** The blocking finding: the enrich test matrix was missing the boundary arms that make the #523 presence rule (`UNSPECIFIED && docs==""` → absent) mutation-proof — docs-URL-only, status-only (REJECTED and APPROVED), and the DCR arm are now pinned, so flipping the `&&` fails the suite. Also applied: the stub-rationale comment corrected (connect-es answers unregistered methods Unimplemented with ITS text — the stubs exist for grpc-go text parity, verified by the reviewer's live probe), precise non-generic typing on the #402 step, the vacuous "ordering" test renamed to the plain NotFound pin it is (mcp_server supports every visibility level, so level validation can never fire — same in Go; the ordering is pinned by the environment domain), the #540 status_audit stamp now asserted, update/delete-non-existent and delete-empty-id arms added, the org-less unique-slug refresolution arm added, and the `as never` test-input casts replaced with typed builders.
- **Disclosed coexistence gap (for the register)**: Go wires its OAuth deps unconditionally, so `getOAuthGrantStatus` (and complete/disconnect) give real answers on Go TODAY — grant-status answers `NO_GRANT` even with no grant — while this server answers Unimplemented until #19; `connect`/`startConnect` answer FailedPrecondition on a Temporal-less Go vs Unimplemented here. Clients treating Unimplemented as capability-absent (the SDK's posture) degrade gracefully. Documented in the controller header.
- Two smaller disclosures: `updateVisibility` has no conformance coverage for this domain (the D4-disclosed gap — parity rests on the unit suite, incl. the audit-slot assertions), and connect-es's unimplemented text for the UNREGISTERED #19 methods differs from any Go answer (interim, dissolves at #19).

## Test plan

- Unit: 926 server tests green (68 files; +48 for this slice: 18 composed-server mcpserver + 6 refresolution + the enrich boundary matrix); `tsc --noEmit` clean; dist + slim bundles boot-verified.
- Conformance: `local-ts` 14 suites / 271 passed — mcpserver (17) and agent-mcpserver-references (2) green on the FIRST rostered run. `local-go` 492 passed, regression-free (baseline grew with #864's CW-1 suites).

## Risks

- Additive; the Go server is untouched. Rollback is reverting the merge.
- Expected trivial conflict with #868 (sp.skill) on the roster file and compose.ts — whichever merges second rebases mechanically.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible (additive; no Go changes)

Made with [Cursor](https://cursor.com)