### PR TITLE
feat(backend/stigmer-server-ts): port the Project domain — CRUD + membership reconciliation (D4 #16)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -51,6 +51,7 @@ import { registerOAuthAppServices } from "../domain/oauthapp/controller.js";
 import { registerOrganizationServices } from "../domain/organization/controller.js";
 import { registerMcpServerServices } from "../domain/mcpserver/controller.js";
 import { registerPlatformServices } from "../domain/platform/controller.js";
+import { registerProjectServices } from "../domain/project/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
 import { registerSkillServices } from "../domain/skill/controller.js";
 import { DEFAULT_SLOT_TTL_MS, MAX_ZIP_SIZE } from "../domain/skill/constants.js";
@@ -437,6 +438,16 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     // Artifact CRUD shares the ONE blob store with agentexecution's
     // attachment lanes (Go server.go 347–374).
     registerArtifactServices(router, { store, artifactStorage, logger });
+    // Project registers after all four reconciled kinds (agent, workflow,
+    // mcpserver, skill) — the last Class A domain. The lazy deleter
+    // provider replaces Go's SetReconciliationService late-bind
+    // (server.go 478 registration + 635–648 injection): orphan deletes
+    // route through the in-process command clients' FULL pipelines.
+    registerProjectServices(router, {
+      store,
+      logger,
+      orphanDeleter: () => requireInProcess().projectOrphanDeleter,
+    });
     // GitHub broker: config-only, no store (Go server.go 524–528).
     registerGitHubServices(router, {
       clientId: config.gitHubOAuthClientId,

--- a/backend/services/stigmer-server-ts/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server-ts/src/boot/inprocess.ts
@@ -18,8 +18,14 @@ import { createClient, createRouterTransport } from "@connectrpc/connect";
 import type { ConnectRouter } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
 import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
 import { AgentIdSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import { ApiResourceDeleteInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { SkillCommandController } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/command_pb";
+import { SkillIdSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
+import { WorkflowCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/command_pb";
 import { AgentInstanceCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/command_pb";
 import { AgentInstanceQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/query_pb";
 import { AgentInstanceIdSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/io_pb";
@@ -60,6 +66,8 @@ import type {
 import type { AgentExecutionApprovalForwarder } from "../domain/workflowexecution/submit-approval.js";
 import type { AgentExecutionFileDecisionForwarder } from "../domain/workflowexecution/submit-file-decision.js";
 import type { ParentWorkflowLoader } from "../domain/workflowinstance/steps.js";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { OrphanDeleter } from "../domain/project/reconcile.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import type { Logger } from "./logger.js";
 
@@ -94,6 +102,15 @@ export interface InProcessClients {
   readonly workflowExecutionContextCreator: WorkflowExecutionContextCreator;
   readonly workflowExecutionApprovalForwarder: AgentExecutionApprovalForwarder;
   readonly workflowExecutionFileDecisionForwarder: AgentExecutionFileDecisionForwarder;
+  /**
+   * The project reconciler's orphan-delete edge (server.go 635-648: Go's
+   * DownstreamClients + ResourceDeleterAdapter). Go retains the four full
+   * CRUD client interfaces; the reconciler uses ONLY Delete, so this
+   * surface exposes only the delete routing — every orphan delete runs the
+   * owning domain's FULL pipeline (referential blocks included) through
+   * the same interceptor chain as an external delete.
+   */
+  readonly projectOrphanDeleter: OrphanDeleter;
 }
 
 /**
@@ -142,6 +159,10 @@ export function createInProcessClients(
     AgentExecutionCommandController,
     transport,
   );
+  const agentCommand = createClient(AgentCommandController, transport);
+  const workflowCommand = createClient(WorkflowCommandController, transport);
+  const mcpServerCommand = createClient(McpServerCommandController, transport);
+  const skillCommand = createClient(SkillCommandController, transport);
 
   return {
     // Go's ApplyAsSystem is the Apply RPC with no extra identity attached:
@@ -231,6 +252,44 @@ export function createInProcessClients(
     workflowExecutionFileDecisionForwarder: {
       submitFileDecision: (input) =>
         agentExecutionCommand.submitFileDecision(input),
+    },
+    // The project reconciler's delete routing — Go's
+    // ResourceDeleterAdapter.Delete switch (execution_engine.go:75-92).
+    // The unsupported-kind default is defense-in-depth kept for Go parity:
+    // the reconciler's slug resolver rejects unsupported kinds before any
+    // delete is attempted, in both editions. Log-only surface: reconcile
+    // failures never reach the wire.
+    projectOrphanDeleter: {
+      async delete(kind, resourceId) {
+        switch (kind) {
+          case ApiResourceKind.agent:
+            await agentCommand.delete(
+              create(AgentIdSchema, { value: resourceId }),
+            );
+            return;
+          case ApiResourceKind.workflow:
+            await workflowCommand.delete(
+              create(WorkflowIdSchema, { value: resourceId }),
+            );
+            return;
+          case ApiResourceKind.mcp_server:
+            // McpServer's delete input is the commons ApiResourceDeleteInput
+            // (not an id wrapper) — Go's client builds the same message.
+            await mcpServerCommand.delete(
+              create(ApiResourceDeleteInputSchema, { resourceId }),
+            );
+            return;
+          case ApiResourceKind.skill:
+            await skillCommand.delete(
+              create(SkillIdSchema, { value: resourceId }),
+            );
+            return;
+          default:
+            throw new Error(
+              `unsupported resource kind for delete: ${ApiResourceKind[kind] ?? String(kind)}`,
+            );
+        }
+      },
     },
   };
 }

--- a/backend/services/stigmer-server-ts/src/domain/project/__tests__/project.composed.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/project/__tests__/project.composed.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Pins the project domain against Go's controller tests — through the REAL
+ * stack: a composed server on an ephemeral port, a native gRPC client, the
+ * full interceptor chain, and REAL orphan deletes through the in-process
+ * command clients' full pipelines.
+ *
+ * The load-bearing pins the conformance suite does NOT cover (it never
+ * touches spec.members or last_reconciliation):
+ *   - every successful apply response carries status.last_reconciliation,
+ *     even as a present-but-EMPTY message — and it is NEVER persisted;
+ *   - apply→prune end to end: a dropped member is actually deleted through
+ *     its owning domain's pipeline; an unresolvable member is silently
+ *     absent from `deleted` while apply still succeeds;
+ *   - members referencing nonexistent resources persist silently (no
+ *     ValidateReferences in any project chain);
+ *   - the create/update pipeline ASYMMETRY: ValidateVisibility and
+ *     NormalizeReferences run on create only;
+ *   - project delete never cascades to members.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ProjectCommandController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/command_pb";
+import { ProjectQueryController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/query_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+let dir: string;
+let server: ComposedServer;
+let transport: Transport;
+let command: Client<typeof ProjectCommandController>;
+let query: Client<typeof ProjectQueryController>;
+let agentQuery: Client<typeof AgentQueryController>;
+let mcpServerQuery: Client<typeof McpServerQueryController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "project-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      // No engine behind composed tests: 127.0.0.1:1 is deterministically
+      // closed, so boots fail the non-fatal connect fast and can never touch
+      // a live local Temporal (the conformance CRUD harness does the same).
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      // Everything filesystem-backed stays inside the test dir — the
+      // defaults resolve into ~/.stigmer, which tests must never touch.
+      STORAGE_PATH: path.join(dir, "storage"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  command = createClient(ProjectCommandController, transport);
+  query = createClient(ProjectQueryController, transport);
+  agentQuery = createClient(AgentQueryController, transport);
+  mcpServerQuery = createClient(McpServerQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const API_VERSION = "tenancy.stigmer.ai/v1";
+const KIND = "Project";
+const ORG = "local";
+
+let seq = 0;
+function uniqueName(prefix: string): string {
+  seq += 1;
+  return `${prefix} ${seq}`;
+}
+
+interface MemberInit {
+  kind: ApiResourceKind;
+  slug: string;
+  org?: string;
+}
+
+function projectInput(
+  name: string,
+  extras?: { members?: MemberInit[]; visibility?: ApiResourceVisibility },
+) {
+  return {
+    apiVersion: API_VERSION,
+    kind: KIND,
+    metadata: {
+      name,
+      org: ORG,
+      ...(extras?.visibility !== undefined ? { visibility: extras.visibility } : {}),
+    },
+    spec: {
+      description: "created by the domain test",
+      members: (extras?.members ?? []).map((m) => ({
+        kind: m.kind,
+        slug: m.slug,
+        org: m.org ?? ORG,
+      })),
+    },
+  };
+}
+
+async function seedAgent(id: string, slug: string): Promise<void> {
+  await server.store.saveResource(
+    ApiResourceKind.agent,
+    id,
+    AgentSchema,
+    create(AgentSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Agent",
+      metadata: { id, name: slug, slug, org: ORG },
+    }),
+  );
+}
+
+async function seedMcpServer(id: string, slug: string): Promise<void> {
+  await server.store.saveResource(
+    ApiResourceKind.mcp_server,
+    id,
+    McpServerSchema,
+    create(McpServerSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "McpServer",
+      metadata: { id, name: slug, slug, org: ORG },
+    }),
+  );
+}
+
+async function grpcCode(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+    throw new Error("expected the call to fail");
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+describe("apply reconciliation summary (Go apply_test.go)", () => {
+  it("first apply reports all members as created and the prj_ id shape", async () => {
+    const applied = await command.apply(
+      projectInput(uniqueName("Members Project"), {
+        members: [
+          { kind: ApiResourceKind.agent, slug: "member-a" },
+          { kind: ApiResourceKind.workflow, slug: "member-b" },
+        ],
+      }),
+    );
+
+    expect(applied.metadata?.id).toMatch(/^prj_[0-9a-z]{26}$/);
+    expect(applied.status?.audit?.specAudit?.event).toBe("created");
+    expect(applied.status?.lastReconciliation).toBeDefined();
+    expect(
+      applied.status?.lastReconciliation?.created.map((r) => r.slug),
+    ).toEqual(["member-a", "member-b"]);
+    expect(applied.status?.lastReconciliation?.updated).toEqual([]);
+    expect(applied.status?.lastReconciliation?.deleted).toEqual([]);
+  });
+
+  it("a no-change apply still carries a PRESENT (empty) summary — and it is never persisted", async () => {
+    const name = uniqueName("Summary Presence");
+    const first = await command.apply(projectInput(name));
+    // No members at all: the summary message must still be present.
+    expect(first.status?.lastReconciliation).toBeDefined();
+    expect(first.status?.lastReconciliation?.created).toEqual([]);
+    expect(first.status?.lastReconciliation?.deleted).toEqual([]);
+
+    // Response-only: the persisted resource has NO last_reconciliation.
+    const fetched = await query.get({ value: first.metadata!.id });
+    expect(fetched.status?.lastReconciliation).toBeUndefined();
+
+    // And the second apply's summary is computed fresh from the delta.
+    const second = await command.apply(projectInput(name));
+    expect(second.metadata?.id).toBe(first.metadata?.id);
+    expect(second.status?.audit?.specAudit?.event).toBe("updated");
+    expect(second.status?.lastReconciliation).toBeDefined();
+    expect(second.status?.lastReconciliation?.created).toEqual([]);
+  });
+
+  it("prunes a dropped member FOR REAL through its domain's delete pipeline", async () => {
+    await seedAgent("agt_prune_keep", "prune-keep-agent");
+    await seedMcpServer("mcps_prune_drop", "prune-drop-mcps");
+    const name = uniqueName("Orphan Prune");
+
+    await command.apply(
+      projectInput(name, {
+        members: [
+          { kind: ApiResourceKind.agent, slug: "prune-keep-agent" },
+          { kind: ApiResourceKind.mcp_server, slug: "prune-drop-mcps" },
+        ],
+      }),
+    );
+
+    // The second apply both DROPS the mcpserver and INTRODUCES a new
+    // member, so one wire summary carries created and deleted together.
+    const second = await command.apply(
+      projectInput(name, {
+        members: [
+          { kind: ApiResourceKind.agent, slug: "prune-keep-agent" },
+          { kind: ApiResourceKind.workflow, slug: "prune-new-member" },
+        ],
+      }),
+    );
+
+    expect(
+      second.status?.lastReconciliation?.deleted.map((r) => r.slug),
+    ).toEqual(["prune-drop-mcps"]);
+    expect(
+      second.status?.lastReconciliation?.created.map((r) => r.slug),
+    ).toEqual(["prune-new-member"]);
+
+    // The orphan is GONE (deleted through mcpserver's own pipeline)…
+    const gone = await grpcCode(() =>
+      mcpServerQuery.get({ value: "mcps_prune_drop" }),
+    );
+    expect(gone.code).toBe(Code.NotFound);
+    // …and the retained member is untouched.
+    const kept = await agentQuery.get({ value: "agt_prune_keep" });
+    expect(kept.metadata?.slug).toBe("prune-keep-agent");
+  });
+
+  it("an id-carrying apply captures previous members and prunes on the update path", async () => {
+    await seedAgent("agt_idpath", "idpath-agent");
+    const name = uniqueName("Id Carrying Apply");
+
+    const first = await command.apply(
+      projectInput(name, {
+        members: [{ kind: ApiResourceKind.agent, slug: "idpath-agent" }],
+      }),
+    );
+
+    // Second apply addresses the project by its ID (the CLI's steady-state
+    // shape) with the member dropped — previousMembers must still be
+    // captured from the loaded existing resource.
+    const second = await command.apply({
+      ...projectInput(name),
+      metadata: { id: first.metadata!.id, name, org: ORG },
+    });
+
+    expect(second.metadata?.id).toBe(first.metadata?.id);
+    expect(
+      second.status?.lastReconciliation?.deleted.map((r) => r.slug),
+    ).toEqual(["idpath-agent"]);
+    const gone = await grpcCode(() => agentQuery.get({ value: "agt_idpath" }));
+    expect(gone.code).toBe(Code.NotFound);
+  });
+
+  it("a member dropped via plain UPDATE is stranded — the next apply prunes nothing", async () => {
+    // Update runs NO reconciliation, and apply diffs against the STORED
+    // members: dropping a member through update shrinks the stored list
+    // first, so the later apply computes no orphan and the resource
+    // survives. User-visible Go behavior (update strands, apply prunes).
+    await seedAgent("agt_stranded", "stranded-agent");
+    const name = uniqueName("Update Strands");
+
+    await command.apply(
+      projectInput(name, {
+        members: [{ kind: ApiResourceKind.agent, slug: "stranded-agent" }],
+      }),
+    );
+    await command.update(projectInput(name));
+
+    const applied = await command.apply(projectInput(name));
+    expect(applied.status?.lastReconciliation?.deleted).toEqual([]);
+    const survivor = await agentQuery.get({ value: "agt_stranded" });
+    expect(survivor.metadata?.slug).toBe("stranded-agent");
+  });
+
+  it("an unresolvable orphan is silently absent from deleted; apply still succeeds", async () => {
+    const name = uniqueName("Ghost Member");
+    // No ValidateReferences in any project chain: a member that points at
+    // nothing persists silently (pinned Go behavior).
+    const first = await command.apply(
+      projectInput(name, {
+        members: [{ kind: ApiResourceKind.agent, slug: "ghost-agent" }],
+      }),
+    );
+    expect(first.spec?.members.map((m) => m.slug)).toEqual(["ghost-agent"]);
+
+    const second = await command.apply(projectInput(name));
+    // Resolution failed (nothing to delete) → collected log-only, absent
+    // from the wire's deleted list, and apply SUCCEEDS.
+    expect(second.status?.lastReconciliation).toBeDefined();
+    expect(second.status?.lastReconciliation?.deleted).toEqual([]);
+  });
+});
+
+describe("create/update pipeline asymmetry (create.go vs update.go)", () => {
+  it("create rejects an unsupported visibility level; update IGNORES the carried level", async () => {
+    // Project's kind_meta has no VisibilityConfig → private-only.
+    const rejected = await grpcCode(() =>
+      command.create(
+        projectInput(uniqueName("Visibility Reject"), {
+          visibility: ApiResourceVisibility.visibility_org,
+        }),
+      ),
+    );
+    expect(rejected.code).toBe(Code.InvalidArgument);
+
+    // Update has NO ValidateVisibility step; the carried level is ignored
+    // (visibility is update-immutable, oss#573) — never rejected.
+    const name = uniqueName("Visibility Ignore");
+    const created = await command.create(projectInput(name));
+    const updated = await command.update(
+      projectInput(name, { visibility: ApiResourceVisibility.visibility_org }),
+    );
+    expect(updated.metadata?.id).toBe(created.metadata?.id);
+    expect(updated.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_private,
+    );
+  });
+
+  it("create normalizes empty member orgs; update persists them EMPTY", async () => {
+    const name = uniqueName("Normalize Asymmetry");
+    const created = await command.create(
+      projectInput(name, {
+        members: [{ kind: ApiResourceKind.agent, slug: "norm-a", org: "" }],
+      }),
+    );
+    // NormalizeReferences filled the empty org from metadata.org.
+    expect(created.spec?.members[0]?.org).toBe(ORG);
+
+    const updated = await command.update(
+      projectInput(name, {
+        members: [{ kind: ApiResourceKind.agent, slug: "norm-b", org: "" }],
+      }),
+    );
+    // Update runs NO NormalizeReferences: the empty org persists as-is.
+    expect(updated.spec?.members[0]?.slug).toBe("norm-b");
+    expect(updated.spec?.members[0]?.org).toBe("");
+  });
+});
+
+describe("delete has no member cascade (delete.go)", () => {
+  it("returns the pre-delete resource and leaves members untouched", async () => {
+    await seedAgent("agt_cascade_safe", "cascade-safe-agent");
+    const created = await command.create(
+      projectInput(uniqueName("No Cascade"), {
+        members: [{ kind: ApiResourceKind.agent, slug: "cascade-safe-agent" }],
+      }),
+    );
+
+    const deleted = await command.delete({ value: created.metadata!.id });
+    expect(deleted.metadata?.id).toBe(created.metadata?.id);
+    expect(deleted.spec?.members.map((m) => m.slug)).toEqual([
+      "cascade-safe-agent",
+    ]);
+
+    const notFound = await grpcCode(() =>
+      query.get({ value: created.metadata!.id }),
+    );
+    expect(notFound.code).toBe(Code.NotFound);
+    // The member survives: delete removes ONLY the project entity.
+    const survivor = await agentQuery.get({ value: "agt_cascade_safe" });
+    expect(survivor.metadata?.slug).toBe("cascade-safe-agent");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/project/__tests__/reconcile.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/project/__tests__/reconcile.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Pins the project reconciler against Go's reconcile/service_test.go
+ * case-for-case (set difference, dry-run, prune-off, orphan resolution and
+ * deletion with continue-on-failure) over a REAL sqlite store, plus the
+ * toProtoSummary mapping (updated ALWAYS empty; an all-empty result is
+ * still a present message) and the search extractor's field mapping.
+ *
+ * Go's nil-deleter stub arm and nil-options arm are deliberately absent —
+ * both unreachable here (plan-gate decisions 2/3, tasks/T01_0_plan.md).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceReferenceSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import {
+  DEFAULT_RECONCILIATION_OPTIONS,
+  newReconciliationService,
+  referenceKey,
+  toProtoSummary,
+} from "../reconcile.js";
+import type { OrphanDeleter, ReconciliationService } from "../reconcile.js";
+import { projectSearchExtractor } from "../search-extractor.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+/** Records delete calls; throws for kinds listed in failKinds (Go's fake clients). */
+class RecordingDeleter implements OrphanDeleter {
+  readonly calls: Array<{ kind: ApiResourceKind; resourceId: string }> = [];
+  constructor(private readonly failKinds: ReadonlySet<ApiResourceKind> = new Set()) {}
+
+  async delete(kind: ApiResourceKind, resourceId: string): Promise<void> {
+    this.calls.push({ kind, resourceId });
+    if (this.failKinds.has(kind)) {
+      throw new Error("permission denied");
+    }
+  }
+}
+
+let dir: string;
+let store: SqliteStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "project-reconcile-test-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterEach(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function service(deleter: OrphanDeleter): ReconciliationService {
+  return newReconciliationService({
+    store,
+    orphanDeleter: () => deleter,
+    logger: silentLogger,
+  });
+}
+
+function ref(kind: ApiResourceKind, slug: string): ApiResourceReference {
+  return create(ApiResourceReferenceSchema, { org: "local", kind, slug });
+}
+
+async function seedAgent(id: string, slug: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.agent,
+    id,
+    AgentSchema,
+    create(AgentSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Agent",
+      metadata: { id, name: slug, slug, org: "local" },
+    }),
+  );
+}
+
+async function seedWorkflow(id: string, slug: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.workflow,
+    id,
+    WorkflowSchema,
+    create(WorkflowSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Workflow",
+      metadata: { id, name: slug, slug, org: "local" },
+    }),
+  );
+}
+
+async function seedMcpServer(id: string, slug: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.mcp_server,
+    id,
+    McpServerSchema,
+    create(McpServerSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "McpServer",
+      metadata: { id, name: slug, slug, org: "local" },
+    }),
+  );
+}
+
+async function seedSkill(id: string, slug: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.skill,
+    id,
+    SkillSchema,
+    create(SkillSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Skill",
+      metadata: { id, name: slug, slug, org: "local" },
+    }),
+  );
+}
+
+describe("reconcile set difference (Go service_test.go)", () => {
+  it("returns the empty result when both lists are empty", async () => {
+    const deleter = new RecordingDeleter();
+    const result = await service(deleter).reconcile([], [], DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result).toEqual({ added: [], removed: [], errors: [] });
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("returns the empty result when previous == current", async () => {
+    const deleter = new RecordingDeleter();
+    const members = [ref(ApiResourceKind.agent, "my-agent")];
+    const result = await service(deleter).reconcile(members, members, DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result).toEqual({ added: [], removed: [], errors: [] });
+  });
+
+  it("first apply: all current members are added, none removed", async () => {
+    const deleter = new RecordingDeleter();
+    const current = [
+      ref(ApiResourceKind.agent, "agent-1"),
+      ref(ApiResourceKind.workflow, "wf-1"),
+    ];
+    const result = await service(deleter).reconcile([], current, DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result.added).toHaveLength(2);
+    expect(result.removed).toHaveLength(0);
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("prune disabled: orphans are neither reported nor deleted", async () => {
+    const deleter = new RecordingDeleter();
+    const previous = [ref(ApiResourceKind.agent, "old-agent")];
+    const result = await service(deleter).reconcile(previous, [], {
+      pruneEnabled: false,
+      dryRun: false,
+    });
+    expect(result.removed).toHaveLength(0);
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("dry run: orphans are reported in removed WITHOUT deleting", async () => {
+    const deleter = new RecordingDeleter();
+    const previous = [ref(ApiResourceKind.agent, "orphan-agent")];
+    const result = await service(deleter).reconcile(previous, [], {
+      pruneEnabled: true,
+      dryRun: true,
+    });
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0]?.slug).toBe("orphan-agent");
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("dry run WINS over prune-disabled: orphans still reported (Go branch order)", async () => {
+    // Go checks dryRun BEFORE pruneEnabled (service.go:61-67), so this
+    // combination reports the orphan plan; prune-first ordering would
+    // return an empty removed list — the one combination that pins the
+    // branch precedence.
+    const deleter = new RecordingDeleter();
+    const previous = [ref(ApiResourceKind.agent, "orphan-agent")];
+    const result = await service(deleter).reconcile(previous, [], {
+      pruneEnabled: false,
+      dryRun: true,
+    });
+    expect(result.removed.map((r) => r.slug)).toEqual(["orphan-agent"]);
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("mixed change reports exactly the delta (Go MixedAddedAndRemoved)", async () => {
+    await seedAgent("agent-id-old", "agent-old");
+    const deleter = new RecordingDeleter();
+    const previous = [
+      ref(ApiResourceKind.agent, "agent-old"),
+      ref(ApiResourceKind.agent, "agent-keep"),
+    ];
+    const current = [
+      ref(ApiResourceKind.agent, "agent-keep"),
+      ref(ApiResourceKind.workflow, "wf-new"),
+    ];
+    const result = await service(deleter).reconcile(previous, current, DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result.added.map((r) => r.slug)).toEqual(["wf-new"]);
+    expect(result.removed.map((r) => r.slug)).toEqual(["agent-old"]);
+  });
+});
+
+describe("orphan deletion (Go service_test.go)", () => {
+  it("resolves each of the four member kinds by slug and routes its delete", async () => {
+    await seedAgent("agent-id-1", "orphan-agent");
+    await seedWorkflow("wf-id-1", "orphan-wf");
+    await seedMcpServer("mcps-id-1", "orphan-mcps");
+    await seedSkill("skill-id-1", "orphan-skill");
+
+    const deleter = new RecordingDeleter();
+    const previous = [
+      ref(ApiResourceKind.agent, "orphan-agent"),
+      ref(ApiResourceKind.workflow, "orphan-wf"),
+      ref(ApiResourceKind.mcp_server, "orphan-mcps"),
+      ref(ApiResourceKind.skill, "orphan-skill"),
+    ];
+    const result = await service(deleter).reconcile(previous, [], DEFAULT_RECONCILIATION_OPTIONS);
+
+    expect(result.removed).toHaveLength(4);
+    expect(result.errors).toHaveLength(0);
+    expect(deleter.calls).toEqual([
+      { kind: ApiResourceKind.agent, resourceId: "agent-id-1" },
+      { kind: ApiResourceKind.workflow, resourceId: "wf-id-1" },
+      { kind: ApiResourceKind.mcp_server, resourceId: "mcps-id-1" },
+      { kind: ApiResourceKind.skill, resourceId: "skill-id-1" },
+    ]);
+  });
+
+  it("orphan lookup is slug-only, matching across orgs (pinned Go behavior)", async () => {
+    // Seeded under org "local"; the orphan reference carries a DIFFERENT
+    // org — resolution still matches, because Go's resolveResourceID
+    // filters by slug alone (reconcile/service.go:126).
+    await seedAgent("agent-id-x", "cross-org-agent");
+    const deleter = new RecordingDeleter();
+    const previous = [
+      create(ApiResourceReferenceSchema, {
+        org: "another-org",
+        kind: ApiResourceKind.agent,
+        slug: "cross-org-agent",
+      }),
+    ];
+    const result = await service(deleter).reconcile(previous, [], DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result.removed).toHaveLength(1);
+    expect(deleter.calls).toEqual([
+      { kind: ApiResourceKind.agent, resourceId: "agent-id-x" },
+    ]);
+  });
+
+  it("unresolvable slug: collected as an error, nothing deleted", async () => {
+    const deleter = new RecordingDeleter();
+    const previous = [ref(ApiResourceKind.agent, "ghost-agent")];
+    const result = await service(deleter).reconcile(previous, [], DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result.removed).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.resourceKey).toBe("agent:ghost-agent");
+    expect(result.errors[0]?.message).toBe("failed to resolve resource for deletion");
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("unsupported member kind: an unsupported-kind resolution error", async () => {
+    const deleter = new RecordingDeleter();
+    const previous = [ref(ApiResourceKind.project, "nested-project")];
+    const result = await service(deleter).reconcile(previous, [], DEFAULT_RECONCILIATION_OPTIONS);
+    expect(result.removed).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.resourceKey).toBe("project:nested-project");
+    expect((result.errors[0]?.cause as Error).message).toBe(
+      "unsupported resource kind: project",
+    );
+    expect(deleter.calls).toHaveLength(0);
+  });
+
+  it("continues on failure: one failed delete never blocks the rest (Go PartialFailure)", async () => {
+    await seedAgent("agent-ok", "good-agent");
+    await seedWorkflow("wf-fail", "bad-workflow");
+    await seedSkill("skill-ok", "good-skill");
+
+    // Ordering matters: the failing workflow sits BETWEEN two successes,
+    // proving the loop continues past a failure in both directions.
+    const deleter = new RecordingDeleter(new Set([ApiResourceKind.workflow]));
+    const previous = [
+      ref(ApiResourceKind.agent, "good-agent"),
+      ref(ApiResourceKind.workflow, "bad-workflow"),
+      ref(ApiResourceKind.skill, "good-skill"),
+    ];
+    const result = await service(deleter).reconcile(previous, [], DEFAULT_RECONCILIATION_OPTIONS);
+
+    expect(result.removed.map((r) => r.slug)).toEqual(["good-agent", "good-skill"]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.resourceKey).toBe("workflow:bad-workflow");
+    expect(result.errors[0]?.message).toBe("failed to delete orphaned resource");
+    expect(deleter.calls).toHaveLength(3);
+  });
+
+  it("a seeded resource without an id is a resolution error, not a delete", async () => {
+    // saveResource keys the row by the passed id, but the reconciler reads
+    // metadata.id off the unmarshaled message — absent means unresolvable
+    // (Go: "resource %s/%s has no ID").
+    await store.saveResource(
+      ApiResourceKind.agent,
+      "row-key-only",
+      AgentSchema,
+      create(AgentSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Agent",
+        metadata: { name: "no-id", slug: "no-id", org: "local" },
+      }),
+    );
+    const deleter = new RecordingDeleter();
+    const result = await service(deleter).reconcile(
+      [ref(ApiResourceKind.agent, "no-id")],
+      [],
+      DEFAULT_RECONCILIATION_OPTIONS,
+    );
+    expect(result.errors).toHaveLength(1);
+    expect((result.errors[0]?.cause as Error).message).toBe(
+      "resource agent/no-id has no ID",
+    );
+    expect(deleter.calls).toHaveLength(0);
+  });
+});
+
+describe("referenceKey (Go TestReferenceKey)", () => {
+  it("renders the kind's enum NAME, exactly Go's %s", () => {
+    expect(referenceKey(ref(ApiResourceKind.agent, "my-agent"))).toBe("agent:my-agent");
+    expect(referenceKey(ref(ApiResourceKind.mcp_server, "tools"))).toBe("mcp_server:tools");
+  });
+});
+
+describe("toProtoSummary (Go ToProtoSummary)", () => {
+  it("maps added → created and removed → deleted; updated is ALWAYS empty", () => {
+    const added = [ref(ApiResourceKind.agent, "a1")];
+    const removed = [ref(ApiResourceKind.workflow, "w1")];
+    const summary = toProtoSummary({ added, removed, errors: [] });
+    expect(summary.created.map((r) => r.slug)).toEqual(["a1"]);
+    expect(summary.updated).toEqual([]);
+    expect(summary.deleted.map((r) => r.slug)).toEqual(["w1"]);
+  });
+
+  it("an all-empty result still yields a message (wire-visible presence)", () => {
+    const summary = toProtoSummary({ added: [], removed: [], errors: [] });
+    expect(summary.created).toEqual([]);
+    expect(summary.deleted).toEqual([]);
+  });
+
+  it("a failed orphan is simply absent from deleted (errors never map)", () => {
+    const summary = toProtoSummary({
+      added: [],
+      removed: [ref(ApiResourceKind.agent, "deleted-ok")],
+      errors: [
+        { resourceKey: "workflow:failed", message: "failed to delete orphaned resource", cause: new Error("x") },
+      ],
+    });
+    expect(summary.deleted.map((r) => r.slug)).toEqual(["deleted-ok"]);
+  });
+});
+
+describe("project search extractor (Go project_extractor.go)", () => {
+  it("extracts name/description/tags/org/visibility-name/createdAt-seconds", () => {
+    const createdAt = timestampFromDate(new Date(1_700_000_000_000));
+    const project = create(ProjectSchema, {
+      metadata: {
+        id: "prj_x",
+        name: "Data Platform",
+        slug: "data-platform",
+        org: "acme",
+        tags: ["infra", "data"],
+        visibility: ApiResourceVisibility.visibility_private,
+      },
+      spec: { description: "the data platform project" },
+      status: { audit: { specAudit: { createdAt } } },
+    });
+    expect(projectSearchExtractor.getSearchIndexEntry(project)).toEqual({
+      name: "Data Platform",
+      description: "the data platform project",
+      tags: "infra data",
+      org: "acme",
+      visibility: "visibility_private",
+      createdAt: 1_700_000_000,
+    });
+  });
+
+  it("summary is empty without a spec; extraction skips without metadata (Go nil arms)", () => {
+    const noSpec = create(ProjectSchema, { metadata: { name: "n", org: "o" } });
+    expect(projectSearchExtractor.getSearchIndexEntry(noSpec)?.description).toBe("");
+    expect(
+      projectSearchExtractor.getSearchIndexEntry(create(ProjectSchema)),
+    ).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/project/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/project/controller.ts
@@ -1,0 +1,316 @@
+/**
+ * Project controller — ports pkg/domain/project/controller (command + query
+ * sides). Project is the aggregate root grouping related resources: its spec
+ * carries lightweight ApiResourceReference members the CLI derives from
+ * individual apply responses (never user-authored); apply reconciles the
+ * membership and prunes orphans through the four downstream domains'
+ * in-process clients — the widest client fan-out of any CRUD domain, which
+ * is why it ported last of Class A (D4 #16).
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character; the
+ * create/update ASYMMETRY is contract: create runs ValidateVisibility and
+ * NormalizeReferences, update runs neither (an updated members list persists
+ * without reference normalization — Go update.go). No chain runs
+ * ValidateReferences: members referencing nonexistent resources persist
+ * silently. Delete removes ONLY the project — members are never cascaded.
+ *
+ * Proven by project.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/{reconcile,project.composed}.test.ts (the conformance suite
+ * never touches spec.members or last_reconciliation; the composed tests own
+ * those pins).
+ *
+ * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies,
+ * Publish, and TransformResponse steps (no multi-tenant auth, IAM/FGA, or
+ * event publishing here).
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+import type { Project } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+import { ProjectCommandController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/command_pb";
+import type { ProjectId } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/io_pb";
+import { ProjectQueryController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/query_pb";
+import { ProjectStatusSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/status_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError } from "../../pipeline/errors.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteSearchIndexStep,
+  newIndexSearchStep,
+} from "../../pipeline/steps/index-search.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import type { Store } from "../../store/interface.js";
+import {
+  DEFAULT_RECONCILIATION_OPTIONS,
+  newReconciliationService,
+  toProtoSummary,
+} from "./reconcile.js";
+import type { OrphanDeleter, ReconciliationService } from "./reconcile.js";
+import { projectSearchExtractor } from "./search-extractor.js";
+
+export interface ProjectControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  /**
+   * The four downstream delete edges (agent/workflow/mcp_server/skill),
+   * lazy per the compose root's boot-ordering idiom — the TS replacement
+   * for Go's SetReconciliationService late-bind (server.go:635-648).
+   */
+  readonly orphanDeleter: () => OrphanDeleter;
+}
+
+/** Registers both project services on the router (routes stage). */
+export function registerProjectServices(
+  router: ConnectRouter,
+  deps: ProjectControllerDeps,
+): void {
+  const reconciliation = newReconciliationService({
+    store: deps.store,
+    orphanDeleter: deps.orphanDeleter,
+    logger: deps.logger,
+  });
+  router.service(ProjectCommandController, {
+    apply: (project, ctx) => apply(deps, reconciliation, project, ctx),
+    create: (project, ctx) => createProject(deps, project, ctx),
+    update: (project, ctx) => update(deps, project, ctx),
+    delete: (projectId, ctx) => deleteProject(deps, projectId, ctx),
+  });
+  router.service(ProjectQueryController, {
+    get: (projectId, ctx) => get(deps, projectId, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/** Create — chain per Go buildCreatePipeline (create.go:54-63). */
+async function createProject(
+  deps: ProjectControllerDeps,
+  project: Project,
+  ctx: HandlerContext,
+): Promise<Project> {
+  const reqCtx = new RequestContext(ProjectSchema, project, kindOf(ctx));
+  await newPipeline<typeof ProjectSchema>("project-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Update — chain per Go buildUpdatePipeline (update.go:55-62). Deliberately
+ * narrower than create (no ValidateVisibility, no NormalizeReferences —
+ * the asymmetry is contract; see the module header).
+ */
+async function update(
+  deps: ProjectControllerDeps,
+  project: Project,
+  ctx: HandlerContext,
+): Promise<Project> {
+  const reqCtx = new RequestContext(ProjectSchema, project, kindOf(ctx));
+  await newPipeline<typeof ProjectSchema>("project-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — declarative create-or-update PLUS membership reconciliation
+ * (apply.go:29-85): a minimal pipeline decides existence, the previous
+ * members are captured BEFORE delegation overwrites them, the full Create
+ * or Update handler runs, then the reconciler diffs previous vs persisted
+ * members and prunes orphans.
+ *
+ * Two ported postures:
+ *   - A reconcile failure is logged and SWALLOWED — apply still succeeds,
+ *     returning the persisted project without a summary (apply.go:77-82;
+ *     defensive in both editions — the reconciler never throws).
+ *   - On success the summary is set UNCONDITIONALLY, so every successful
+ *     apply response carries status.last_reconciliation, even as an empty
+ *     message. Response-only — never persisted.
+ */
+async function apply(
+  deps: ProjectControllerDeps,
+  reconciliation: ReconciliationService,
+  project: Project,
+  ctx: HandlerContext,
+): Promise<Project> {
+  const reqCtx = new RequestContext(ProjectSchema, project, kindOf(ctx));
+  await newPipeline<typeof ProjectSchema>("project-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+
+  // Captured before Create/Update runs; on first apply (create) there are
+  // no previous members (Go apply.go:45-50).
+  const previousMembers: ReadonlyArray<ApiResourceReference> = shouldCreate
+    ? []
+    : ((reqCtx.get(EXISTING_RESOURCE_KEY) as Project | undefined)?.spec
+        ?.members ?? []);
+
+  const persisted = shouldCreate
+    ? await createProject(deps, project, ctx)
+    : await update(deps, project, ctx);
+
+  const currentMembers = persisted.spec?.members ?? [];
+
+  try {
+    const result = await reconciliation.reconcile(
+      previousMembers,
+      currentMembers,
+      DEFAULT_RECONCILIATION_OPTIONS,
+    );
+    persisted.status ??= create(ProjectStatusSchema);
+    persisted.status.lastReconciliation = toProtoSummary(result);
+  } catch (error) {
+    deps.logger.error("Reconciliation failed", {
+      projectId: persisted.metadata?.id ?? "",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return persisted;
+}
+
+/**
+ * Delete — returns the pre-delete resource (delete.go). Deletes ONLY the
+ * project entity: member resources are never cascaded.
+ */
+async function deleteProject(
+  deps: ProjectControllerDeps,
+  projectId: ProjectId,
+  ctx: HandlerContext,
+): Promise<Project> {
+  const reqCtx = new RequestContext(
+    ProjectCommandController.method.delete.input,
+    projectId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ProjectCommandController.method.delete.input>(
+    "project-delete",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, ProjectSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    // Go puts this text ON THE WIRE (delete.go:43, InternalError(nil, …));
+    // the arm is unreachable in practice but the copy is byte-pinned.
+    throw internalError(
+      new Error("delete pipeline completed without a loaded resource"),
+      "deleted project not found in context",
+    );
+  }
+  return deleted as Project;
+}
+
+/** Get — LoadTarget by id; NotFound when absent (get.go). */
+async function get(
+  deps: ProjectControllerDeps,
+  projectId: ProjectId,
+  ctx: HandlerContext,
+): Promise<Project> {
+  const reqCtx = new RequestContext(
+    ProjectQueryController.method.get.input,
+    projectId,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ProjectQueryController.method.get.input>(
+    "project-get",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, ProjectSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Project;
+}
+
+/**
+ * GetByReference — slug lookup within an org (get_by_reference.go). Project
+ * is org-scoped, so an empty-org reference is rejected InvalidArgument by
+ * the shared step's kind_meta scope check — a bare slug is under-specified,
+ * never a global search (the conformance suite pins this; Go's file-level
+ * doc comment claiming a platform-scoped fallback is stale).
+ */
+async function getByReference(
+  deps: ProjectControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<Project> {
+  const reqCtx = new RequestContext(
+    ProjectQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<typeof ProjectQueryController.method.getByReference.input>(
+    "project-get-by-reference",
+    deps.logger,
+  )
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, ProjectSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Project;
+}

--- a/backend/services/stigmer-server-ts/src/domain/project/reconcile.ts
+++ b/backend/services/stigmer-server-ts/src/domain/project/reconcile.ts
@@ -1,0 +1,291 @@
+/**
+ * Project membership reconciliation — ports pkg/domain/project/reconcile/
+ * (service.go, execution_engine.go, reconciliation_{result,options,error}.go).
+ * Proven by __tests__/reconcile.test.ts and the apply→prune composed arms in
+ * __tests__/project.composed.test.ts.
+ *
+ * Apply compares the previous project's spec.members with the newly persisted
+ * spec.members, both keyed "{kind}:{slug}" (the kind's enum NAME — Go's %s).
+ * Members only in the current list are ADDED; members only in the previous
+ * list are ORPHANS and, with pruning enabled, are deleted through the four
+ * downstream domains' in-process clients — their FULL delete pipelines, so a
+ * referentially-blocked orphan fails exactly as an external delete would.
+ *
+ * Error posture (Go, verified): reconcile NEVER throws. Per-orphan failures
+ * are collected on the result and are log-only — ToProtoSummary carries only
+ * created/deleted, so a failed orphan is simply absent from `deleted`. The
+ * wire surface of this whole module is those two lists.
+ *
+ * Deliberately not ported (plan-gate decisions, tasks/T01_0_plan.md):
+ *   - Go's nil-deleter stub arm (service.go:95-98) and the
+ *     SetReconciliationService late-bind — both exist only for Go's
+ *     registration-before-clients boot window; the compose root's lazy
+ *     provider closes that window, so here a deleter always exists.
+ *   - ResultBuilder and the DryRun/NoPrune option factories — zero non-test
+ *     uses in Go; the sole production call is
+ *     reconcile(previous, current, DEFAULT_RECONCILIATION_OPTIONS).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ReconciliationSummarySchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/status_pb";
+import type { ReconciliationSummary } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/status_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { metadataOf } from "../../pipeline/steps/shapes.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * Deletes one orphaned resource by kind and id — Go's ResourceDeleter, the
+ * only execution capability the reference model needs (resources are
+ * created/updated individually by the CLI; the server only deletes orphans).
+ * Implemented over the four in-process command clients (boot/inprocess.ts).
+ */
+export interface OrphanDeleter {
+  delete(kind: ApiResourceKind, resourceId: string): Promise<void>;
+}
+
+/**
+ * Go ReconciliationOptions, reduced to the two flags the algorithm reads.
+ * Production always passes DEFAULT_RECONCILIATION_OPTIONS; the other
+ * combinations remain reachable for tests because the branches are part of
+ * the ported algorithm.
+ */
+export interface ReconciliationOptions {
+  /** When true, orphaned resources are deleted (Go default). */
+  readonly pruneEnabled: boolean;
+  /** When true, the plan is computed but nothing is deleted. */
+  readonly dryRun: boolean;
+}
+
+export const DEFAULT_RECONCILIATION_OPTIONS: ReconciliationOptions = {
+  pruneEnabled: true,
+  dryRun: false,
+};
+
+/** One per-orphan failure — log-only, never wire-visible (Go, verified). */
+export interface ReconciliationError {
+  /** "{kind}:{slug}" of the orphan that failed. */
+  readonly resourceKey: string;
+  readonly message: string;
+  readonly cause: unknown;
+}
+
+/** Go ReconciliationResult, as a plain immutable value. */
+export interface ReconciliationResult {
+  /** References in current but not previous — newly associated members. */
+  readonly added: ReadonlyArray<ApiResourceReference>;
+  /**
+   * Orphans successfully deleted (or, on a dry run, the orphans that WOULD
+   * be deleted — Go reports them in the same slot without deleting).
+   */
+  readonly removed: ReadonlyArray<ApiResourceReference>;
+  readonly errors: ReadonlyArray<ReconciliationError>;
+}
+
+export interface ReconciliationService {
+  /**
+   * Compares memberships and prunes orphans per the options. NEVER throws —
+   * Go's implementation always returns a nil error; failures ride
+   * result.errors (and the apply handler's error-swallow arm upstream is
+   * therefore defensive dead code in both editions, ported anyway).
+   */
+  reconcile(
+    previousMembers: ReadonlyArray<ApiResourceReference>,
+    currentMembers: ReadonlyArray<ApiResourceReference>,
+    options: ReconciliationOptions,
+  ): Promise<ReconciliationResult>;
+}
+
+export interface ReconciliationServiceDeps {
+  readonly store: Store;
+  /**
+   * Lazy per the compose root's boot-ordering idiom: the in-process clients
+   * behind the deleter exist only after routes registration completes.
+   */
+  readonly orphanDeleter: () => OrphanDeleter;
+  readonly logger: Logger;
+}
+
+export function newReconciliationService(
+  deps: ReconciliationServiceDeps,
+): ReconciliationService {
+  return {
+    async reconcile(previousMembers, currentMembers, options) {
+      const previousSet = buildReferenceSet(previousMembers);
+      const currentSet = buildReferenceSet(currentMembers);
+
+      const added = currentMembers.filter(
+        (ref) => !previousSet.has(referenceKey(ref)),
+      );
+      const orphans = previousMembers.filter(
+        (ref) => !currentSet.has(referenceKey(ref)),
+      );
+
+      if (added.length === 0 && orphans.length === 0) {
+        return { added: [], removed: [], errors: [] };
+      }
+
+      // Dry run reports the orphans in `removed` WITHOUT deleting (Go
+      // service.go:61-63 passes them straight through).
+      if (options.dryRun) {
+        return { added, removed: orphans, errors: [] };
+      }
+
+      if (!options.pruneEnabled || orphans.length === 0) {
+        return { added, removed: [], errors: [] };
+      }
+
+      const { removed, errors } = await deleteOrphans(deps, orphans);
+      return { added, removed, errors };
+    },
+  };
+}
+
+/**
+ * Deletes each orphan, continuing on failure (Go deleteOrphans). Failures
+ * are warned here — Go collects them onto a result nothing in production
+ * reads, which leaves operators blind; the log is edition-local and the
+ * wire behavior is identical.
+ */
+async function deleteOrphans(
+  deps: ReconciliationServiceDeps,
+  orphans: ReadonlyArray<ApiResourceReference>,
+): Promise<{
+  removed: ApiResourceReference[];
+  errors: ReconciliationError[];
+}> {
+  const removed: ApiResourceReference[] = [];
+  const errors: ReconciliationError[] = [];
+
+  for (const ref of orphans) {
+    const refKey = referenceKey(ref);
+
+    let resourceId: string;
+    try {
+      resourceId = await resolveResourceId(deps.store, ref);
+    } catch (cause) {
+      errors.push({
+        resourceKey: refKey,
+        message: "failed to resolve resource for deletion",
+        cause,
+      });
+      deps.logger.warn("reconciliation: failed to resolve orphan for deletion", {
+        resource: refKey,
+        error: cause instanceof Error ? cause.message : String(cause),
+      });
+      continue;
+    }
+
+    try {
+      await deps.orphanDeleter().delete(ref.kind, resourceId);
+    } catch (cause) {
+      errors.push({
+        resourceKey: refKey,
+        message: "failed to delete orphaned resource",
+        cause,
+      });
+      deps.logger.warn("reconciliation: failed to delete orphaned resource", {
+        resource: refKey,
+        resourceId,
+        error: cause instanceof Error ? cause.message : String(cause),
+      });
+      continue;
+    }
+
+    removed.push(ref);
+  }
+
+  return { removed, errors };
+}
+
+/**
+ * Resolves an orphan reference to its resource id — Go resolveResourceID:
+ * FindByField on metadata.slug, SLUG ONLY, no org filter (the pinned
+ * behavior: first match of that kind+slug across all orgs; tolerable in
+ * single-tenant OSS).
+ */
+async function resolveResourceId(
+  store: Store,
+  ref: ApiResourceReference,
+): Promise<string> {
+  const schema = schemaForKind(ref.kind);
+  let resource;
+  try {
+    resource = await store.findByField(
+      ref.kind,
+      "metadata.slug",
+      ref.slug,
+      schema,
+    );
+  } catch (cause) {
+    throw new Error(
+      `resource ${kindName(ref.kind)}/${ref.slug} not found: ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause },
+    );
+  }
+
+  const id = metadataOf(resource)?.id ?? "";
+  if (id === "") {
+    throw new Error(`resource ${kindName(ref.kind)}/${ref.slug} has no ID`);
+  }
+  return id;
+}
+
+/**
+ * The four member kinds the reconciler supports (Go newProtoForKind);
+ * anything else is an unsupported-kind resolution error.
+ */
+function schemaForKind(kind: ApiResourceKind) {
+  switch (kind) {
+    case ApiResourceKind.agent:
+      return AgentSchema;
+    case ApiResourceKind.workflow:
+      return WorkflowSchema;
+    case ApiResourceKind.mcp_server:
+      return McpServerSchema;
+    case ApiResourceKind.skill:
+      return SkillSchema;
+    default:
+      throw new Error(`unsupported resource kind: ${kindName(kind)}`);
+  }
+}
+
+/**
+ * "{kind}:{slug}" with the kind's enum NAME — Go fmt %s of the enum (e.g.
+ * "agent:my-agent", "mcp_server:tools"). The numeric form would diverge
+ * from Go's log/error copy.
+ */
+export function referenceKey(ref: ApiResourceReference): string {
+  return `${kindName(ref.kind)}:${ref.slug}`;
+}
+
+function kindName(kind: ApiResourceKind): string {
+  return ApiResourceKind[kind] ?? String(kind);
+}
+
+function buildReferenceSet(
+  refs: ReadonlyArray<ApiResourceReference>,
+): Set<string> {
+  return new Set(refs.map(referenceKey));
+}
+
+/**
+ * Go ToProtoSummary: added → created, updated ALWAYS empty (not applicable
+ * in the reference model), removed → deleted. Every successful apply sets
+ * the summary — even an all-empty one is a PRESENT message on the wire.
+ */
+export function toProtoSummary(
+  result: ReconciliationResult,
+): ReconciliationSummary {
+  return create(ReconciliationSummarySchema, {
+    created: [...result.added],
+    updated: [],
+    deleted: [...result.removed],
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/project/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/project/search-extractor.ts
@@ -1,0 +1,38 @@
+/**
+ * Project search extractor — ports the GetSearchIndexEntry side of
+ * pkg/query/search/extractor/project_extractor.go (the search summary is
+ * spec.description, empty without a spec). Indexed domains carry their
+ * extractors (D4); the QUERY side of the extractor contract (ToSearchResult,
+ * the registry validation) arrives with the search service sub-project
+ * (#14) — only the write-path extraction the IndexSearch step needs lives
+ * here.
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { Project } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import type { SearchIndexEntry } from "../../store/interface.js";
+
+export const projectSearchExtractor: SearchIndexExtractor = {
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const project = resource as unknown as Project;
+    const metadata = project.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      description: project.spec?.description ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        project.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -56,6 +56,12 @@
 //     Layer-1 arms, and the artifact file-server disposition lane). The
 //     oauthapp suite's delete-block test drives McpServer create/delete,
 //     so it rosters here only after #9 (McpServer CRUD) merged.
+//   - project — sub-project #16 (sp.project; the LAST Class A domain: the
+//     aggregate root with apply-time membership reconciliation. The suite
+//     is CRUD/apply-branching/reference-contract only — the reconciler's
+//     orphan-prune lanes are proven by the domain's own
+//     __tests__/{reconcile,project.composed}.test.ts, which drive real
+//     deletes through the four in-process command clients).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -83,6 +89,7 @@ export default defineConfig({
       "src/suites/platform.conformance.test.ts",
       "src/suites/github.conformance.test.ts",
       "src/suites/artifact.conformance.test.ts",
+      "src/suites/project.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

D4 entry **#16 `sp.project`** — the **last Class A domain** of the TS server rewrite (program `20260822.01`, stigmer-cloud). Ports the Go `project` domain whole:

- **All 6 RPCs** at Go's exact step chains: `apply`, `create`, `update`, `delete`, `get`, `getByReference` (no list RPC exists). The create/update pipeline **asymmetry is preserved as contract**: create runs `ValidateVisibility` + `NormalizeReferences`, update runs neither; no chain runs `ValidateReferences` (members referencing nonexistent resources persist silently); delete removes only the project — members are never cascaded.
- **The membership reconciler** (`src/domain/project/reconcile.ts`): apply diffs previous vs current `spec.members` keyed `{kind-enum-name}:{slug}`, prunes orphans with continue-on-failure through the four downstream domains' **full delete pipelines** via new in-process command-client edges (agent/workflow/mcp_server/skill), and returns `status.last_reconciliation` (added→created, updated always empty, removed→deleted) — **response-only, never persisted, present even when empty**.
- **New in-process orphan-deleter surface** (`src/boot/inprocess.ts`): the TS twin of Go's `DownstreamClients` + `ResourceDeleterAdapter` (server.go 635–648), exposed as one narrow delete-only surface consumed through a lazy provider — Go's `SetReconciliationService` late-bind is replaced by the compose root's established boot-ordering idiom (ratified at the sub-project plan gate).
- **The project search extractor** (write-path FTS entry; the query side arrives with #14) and the **`local-ts` roster entry: 22 → 23 suites**.

Ratified at the plan gate (owner-approved): the nil-deleter stub arm (`service.go:95-98`, unreachable in a booted Go server) and the test-only `ResultBuilder`/options factories (zero non-test uses in Go) are deliberately not ported; the algorithm's dry-run/prune branches ARE ported and test-pinned.

## Verification

- **`local-ts` conformance: 23 suites, 429 passed / 1 skipped** — the project suite (15 tests) green on its **first rostered run**.
- **`local-go` conformance: 492 passed / 1 skipped — regression-free** (exact baseline).
- **1303 unit tests** (28 new: the reconciler case-for-case against Go's `service_test.go` + composed-server apply→prune flows driving REAL deletes through the in-process pipelines).
- Both `dist` and `dist-slim` bundles boot-verified; typecheck clean.
- **Two-reviewer adversarial panel** (parity + quality): quality found 1 blocking test gap (the dry-run-over-prune-disabled branch precedence was a survivable mutation) + 4 minors — all fixed in-branch; parity found **zero blocking** divergences and confirmed every pin (chains, error copy, summary presence, slug-only orphan resolution, reference-key rendering, extractor fields, in-process request shapes).

## Disclosed parity nuances (for the program register)

1. **Cancellation mid-reconcile**: Go threads the RPC ctx into orphan deletes (a client cancel aborts remaining deletes); the TS in-process edges do not forward the handler's abort signal, so a started prune runs to completion. Only observable under mid-flight cancellation; the "orphans left undeleted" state is one Go produces routinely via continue-on-failure. Same class as all existing TS in-process edges (HITL forwarders etc.).
2. **Inherited shared-step store-failure mapping** (program-wide, disclosed since #12): Go maps ANY store error on the load steps to NotFound; TS maps only genuine not-found, else Internal. Reachable only under storage I/O failure; program-level disposition pending.
3. **GetByReference store-failure text**: Go renders `failed to list Project resources`; TS's shared helper reaches the pipeline's `internal server error` fallback. Same Internal code; reachable only when `ListResources` fails.
4. **FTS visibility rendering of an out-of-range enum**: Go writes the decimal string, TS writes `""`. Unreachable through validated pipelines; the FTS index is rebuildable; same pattern as all existing TS extractors.
5. **Stale Go doc comment** (`get_by_reference.go:29`): claims an empty-org reference falls back to platform-scoped lookup; the shared step and the conformance suite both pin InvalidArgument. Docs-only, noted for a Go-side sweep.

Sub-project record: `stigmer-cloud/_projects/2026-08/20260825.01.sp.project/` (plan, gate, checkpoint).

## Test plan

- [x] `make test-conformance-ts` — 23 suites green (project 15/15 first run)
- [x] `make test-conformance` — local-go 492/1 regression-free
- [x] `npm run typecheck && npm test` — 1303 passed
- [x] `npm run verify:dist` / `verify:slim` — both bundles boot

Made with [Cursor](https://cursor.com)