### PR TITLE
fix(ci): close the @stigmer/zip-structure file-link gaps from D4 #8

### DIFF
--- a/backend/services/runner/scripts/verify-consumer-install.mjs
+++ b/backend/services/runner/scripts/verify-consumer-install.mjs
@@ -67,6 +67,7 @@ const bootCheck = join(runnerDir, "scripts", "verify-dist-boot.mjs");
 const LOCAL_LIBS = [
   { name: "@stigmer/protos", dir: join(runnerDir, "..", "..", "..", "apis", "stubs", "ts") },
   { name: "@stigmer/temporal-codecs", dir: join(runnerDir, "..", "..", "libs", "ts", "temporal-codecs") },
+  { name: "@stigmer/zip-structure", dir: join(runnerDir, "..", "..", "libs", "ts", "zip-structure") },
 ];
 
 function fail(message) {

--- a/test/conformance/src/harness/ts-build.ts
+++ b/test/conformance/src/harness/ts-build.ts
@@ -6,9 +6,9 @@
 // tsc is deterministic and the dist path is stable, so workers locate the
 // entry without env-var plumbing, exactly like the Go binary's temp path.
 // Dependencies install only when node_modules is missing (a fresh checkout
-// or CI); the file-linked @stigmer/protos dist must exist first — the
-// make target's build-ts-stubs dependency guarantees it, and the fallback
-// here keeps single-file editor runs working.
+// or CI); the file-linked workspace-lib dists must exist first — built
+// below through the canonical root script, which also keeps single-file
+// editor runs working from a fresh checkout.
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -27,11 +27,15 @@ export function tsServerEntryPath(): string {
 }
 
 export async function buildTsServer(): Promise<string> {
-  // The server file-links @stigmer/temporal-codecs (its decode-only payload
-  // codec wraps the lib since D4 #18), so the lib's dist must exist before
-  // the server compiles — built through the root workspace, same as
-  // @stigmer/protos. Idempotent tsc; always fresh so the suite tests HEAD.
-  await execFileAsync("npm", ["run", "build", "-w", "@stigmer/temporal-codecs"], {
+  // The server file-links the workspace libs (@stigmer/protos,
+  // @stigmer/temporal-codecs since D4 #18, @stigmer/zip-structure since
+  // D4 #8), so their dists must exist before the server compiles. The root
+  // build:runner-deps script is the one canonical list of those libs —
+  // building through it (rather than naming libs here) means a future
+  // file-linked lib cannot silently break this harness the way
+  // zip-structure did when only temporal-codecs was built. Idempotent tsc;
+  // always fresh so the suite tests HEAD.
+  await execFileAsync("npm", ["run", "build:runner-deps"], {
     cwd: REPO_ROOT,
     maxBuffer: 64 * 1024 * 1024,
   });

--- a/test/conformance/src/targets/local-ts-execution.ts
+++ b/test/conformance/src/targets/local-ts-execution.ts
@@ -50,6 +50,9 @@ export class LocalTsExecutionTarget implements TargetProfile {
     // provisions is the agent/workflow execution engine, not a channel
     // delivery runtime — the refusal posture is identical to local-ts.
     channelMessaging: false,
+    // The org BYOA lane is UNIMPLEMENTED on OSS by design (stigmer#558) —
+    // the TS port must reproduce the three refusals byte-for-byte.
+    orgOAuthAppConfiguration: false,
   };
 
   private temporal: RunningTemporal | undefined;


### PR DESCRIPTION
## Summary
Heals the two CI lanes red on `main` since `283b0b1d7` (#868, the `@stigmer/zip-structure` extraction): the local-ts conformance roster and the runner's consumer-install smoke. Also lands the capability flag the #864/#873 merge-coordination note assigned to whichever PR merged second.

## Context
The D4 #8 skill port extracted the runner's structural ZIP parser into `backend/libs/ts/zip-structure`, consumed via `file:` links by both the runner and the TS server. Two consumers of the file-link convention were not updated, so every push to `main` (and every open sub-project PR) fails these lanes:

- `ci.conformance` / Conformance (local-ts): the harness builds `@stigmer/temporal-codecs` before compiling the server but not zip-structure — the server build dies with TS2307 (`Cannot find module '@stigmer/zip-structure'`).
- `ci.runner` / Consumer-install smoke check: `verify-consumer-install.mjs` packs stand-in tarballs for the dev `file:` links but its `LOCAL_LIBS` list was missing zip-structure — the staged runner crashes `ERR_MODULE_NOT_FOUND` at boot.

## Changes
- `test/conformance/src/harness/ts-build.ts`: build the server's file-linked lib dists via the canonical root `build:runner-deps` script (protos + temporal-codecs + zip-structure) instead of naming individual libs in the harness — a future file-linked lib gets added in one place and cannot silently break this path again.
- `backend/services/runner/scripts/verify-consumer-install.mjs`: one `LOCAL_LIBS` entry for `@stigmer/zip-structure` (the array's own comment marks it as the extension point for new runner-linked libs).
- `test/conformance/src/targets/local-ts-execution.ts`: add `orgOAuthAppConfiguration: false` with the same refusal-pin comment the other local targets carry. This was the #864↔#873 merge-order coordination line that fell through; the `CapabilityFlags` interface requires the member, so the file failed `tsc --noEmit` (runtime behavior was accidentally correct — `undefined` is falsy).

## Test plan
- Server build through the fixed harness path: `build:runner-deps` then `stigmer-server-ts` `npm ci && npm run build` — green (previously TS2307).
- Full harness end-to-end on Node 22.22.1 (the CI version): `vitest run -c vitest.local-ts.config.ts src/suites/organization.conformance.test.ts` — 11/11 passed, server boots through the fixed build.
- `node scripts/verify-consumer-install.mjs` — PASS: zip-structure packed, single `@temporalio/proto` copy, staged dist boots (previously ERR_MODULE_NOT_FOUND).
- `tsc --noEmit` in `test/conformance`: the `local-ts-execution.ts` TS2741 is gone (error count 20 → 19; the remaining 19 are pre-existing debt in `mcp-server`/`sdk/typescript` sources the conformance tsconfig pulls in — out of scope here, reported to the program).

## Risks
- Minimal: the harness change swaps one npm invocation for the canonical script that CI already uses elsewhere (`ci.integration-offline` calls the same script); the other two changes are single-line additive. Rollback is a revert.

## Notes for the register
- `ci.integration-offline` and `ci.e2e-interactive` are ALSO red on `main` but predate the TS-server program entirely (offline red since at least 2026-08-22) — deliberately not touched here; they need separate triage.

Made with [Cursor](https://cursor.com)