### PR TITLE
feat(backend/stigmer-server-ts): port the search and activity query services (D4 #14)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -58,6 +58,12 @@ import { LocalFileStorage as SkillLocalFileStorage } from "../domain/skill/stora
 import { newSkillTransferLane } from "../domain/skill/transfer/handler.js";
 import { UploadSlots } from "../domain/skill/transfer/slots.js";
 import { SecretService } from "../encryption/encryption.js";
+import { registerActivityServices } from "../query/activity/controller.js";
+import { ActivityHandler } from "../query/activity/handler.js";
+import { registerSearchServices } from "../query/search/controller.js";
+import { SearchHandler } from "../query/search/handler.js";
+import { SqliteSearchQueryStore } from "../query/search/query-store.js";
+import { newSearchableResourceRegistry } from "../query/search/registry.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
 import { SqliteStore } from "../store/sqlite/store.js";
@@ -276,6 +282,21 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     skillArtifactStorage,
     logger,
   );
+  // The search read side (#14): the 13-kind extractor registry, the query
+  // store over the driver's FTS5 read (OD-3 — no DB() escape hatch), and
+  // the CQRS handler. Registry validation is warn-only, Go server.go:509's
+  // posture — run ONCE here rather than inside routes(), which executes
+  // twice (serving router + in-process router).
+  const searchRegistry = newSearchableResourceRegistry();
+  searchRegistry.validateExpectedKinds(logger);
+  const searchQueryStore = new SqliteSearchQueryStore(
+    store,
+    searchRegistry,
+    logger,
+  );
+  const searchHandler = new SearchHandler(searchQueryStore, logger);
+  // The activity recents feed (#14) — pure reads over listResources.
+  const activityHandler = new ActivityHandler(store, logger);
   // The environment runtime-resolution service (#5) — the decrypt-for-
   // execution path the EC builder uses to resolve environment_refs (the
   // RPC surface redacts secret values, oss#405).
@@ -437,6 +458,12 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     // Artifact CRUD shares the ONE blob store with agentexecution's
     // attachment lanes (Go server.go 347–374).
     registerArtifactServices(router, { store, artifactStorage, logger });
+    // The two CQRS query services register between the domains and the
+    // github/platform tail, mirroring Go's registration order
+    // (server.go: organization 487 → search 493 → activity 513 →
+    // github 524 → platform 530).
+    registerSearchServices(router, { handler: searchHandler, logger });
+    registerActivityServices(router, { handler: activityHandler, logger });
     // GitHub broker: config-only, no store (Go server.go 524–528).
     registerGitHubServices(router, {
       clientId: config.gitHubOAuthClientId,
@@ -485,6 +512,20 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       // Artifact storage must be reachable and writable before the server
       // answers (Go server.go boots-fatal on the same probe).
       await artifactStorage.health();
+      // Rebuild the FTS5 search index before the port binds (Go
+      // server.go:617): the index is separate from the resources table,
+      // and rebuilding here makes every resource — including seedpack
+      // rows bootstrapped into an earlier database — discoverable the
+      // moment the server accepts connections. Warn-only: a partial
+      // rebuild degrades search, never boot.
+      try {
+        const indexed = await searchQueryStore.rebuildIndex();
+        logger.info("Search index rebuilt at startup", { indexed });
+      } catch (error) {
+        logger.warn("Failed to rebuild search index at startup", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       // Wiring complete → SERVING → background refresh → bind. The port
       // must be the LAST observable effect (serverGate contract).
       healthState.setOverall(ServingStatus.SERVING);

--- a/backend/services/stigmer-server-ts/src/domain/agent/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agent/search-extractor.ts
@@ -1,21 +1,45 @@
 /**
- * Agent search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/agent_extractor.go. The search summary uses
- * spec.description if available, falling back to instructions (the system
- * prompt) — the common pattern where older agents may not have a dedicated
- * description field, but all agents have instructions. The query side of
- * the extractor contract arrives with the search service sub-project
- * (#14), exactly as the organization extractor's header records.
+ * Agent search extractor — ports pkg/query/search/extractor/
+ * agent_extractor.go (both sides: the #4 index side, the #14 query side).
+ * The search summary uses spec.description if available, falling back to
+ * instructions (the system prompt) — the common pattern where older agents
+ * may not have a dedicated description field, but all agents have
+ * instructions. Agents are one of the two kinds carrying an icon_url on
+ * the search projection.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const agentSearchExtractor: SearchIndexExtractor = {
+export const agentSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.agent,
+  schema: AgentSchema,
+
+  getSearchSummary(resource: Message): string {
+    return agentSearchSummary(resource as unknown as Agent);
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const agent = resource as unknown as Agent;
+    return buildSearchResult({
+      kind: ApiResourceKind.agent,
+      metadata: agent.metadata,
+      summary: agentSearchSummary(agent),
+      score,
+      createdAt: agent.status?.audit?.specAudit?.createdAt,
+      updatedAt: agent.status?.audit?.specAudit?.updatedAt,
+      iconUrl: agent.spec?.iconUrl ?? "",
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const agent = resource as unknown as Agent;
     const metadata = agent.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/agentexecution/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentexecution/search-extractor.ts
@@ -1,20 +1,50 @@
 /**
- * AgentExecution search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/agent_execution_extractor.go. Agent
- * executions are individual invocation records; they have no description
- * field, so the FTS description stays empty and the name is the summary.
- * The query side of the extractor contract arrives with the search
- * service sub-project (#14).
+ * AgentExecution search extractor — ports pkg/query/search/extractor/
+ * agent_execution_extractor.go (both sides: the #4 index side, the #14
+ * query side). Agent executions are individual invocation records with no
+ * description field. Go's GetSearchSummary returns metadata.name, but BOTH
+ * projections deliberately ignore it: ToSearchResult pins Description ""
+ * (extractor line 59) and GetSearchIndexEntry leaves the FTS description
+ * at its zero value — the name is already the top-weighted indexed column.
+ * That asymmetry is Go's, ported as-is.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const agentExecutionSearchExtractor: SearchIndexExtractor = {
+export const agentExecutionSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.agent_execution,
+  schema: AgentExecutionSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go AgentExecutionExtractor.GetSearchSummary: metadata.name. Neither
+    // projection consumes it (see the header) — the interface contract is
+    // still served for any caller that does.
+    const execution = resource as unknown as AgentExecution;
+    return execution.metadata?.name ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const execution = resource as unknown as AgentExecution;
+    return buildSearchResult({
+      kind: ApiResourceKind.agent_execution,
+      metadata: execution.metadata,
+      // Go pins Description "" here — NOT GetSearchSummary.
+      summary: "",
+      score,
+      createdAt: execution.status?.audit?.specAudit?.createdAt,
+      updatedAt: execution.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const execution = resource as unknown as AgentExecution;
     const metadata = execution.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/agentinstance/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/agentinstance/search-extractor.ts
@@ -1,19 +1,43 @@
 /**
- * AgentInstance search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/agent_instance_extractor.go. Agent instances
- * are configured incarnations of an agent blueprint; the summary is
- * spec.description. The query side of the extractor contract arrives with
- * the search service sub-project (#14).
+ * AgentInstance search extractor — ports pkg/query/search/extractor/
+ * agent_instance_extractor.go (both sides: the #4 index side, the #14
+ * query side). Agent instances are configured incarnations of an agent
+ * blueprint; the summary is spec.description.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
 import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const agentInstanceSearchExtractor: SearchIndexExtractor = {
+export const agentInstanceSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.agent_instance,
+  schema: AgentInstanceSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go AgentInstanceExtractor.GetSearchSummary: spec.description.
+    const instance = resource as unknown as AgentInstance;
+    return instance.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const instance = resource as unknown as AgentInstance;
+    return buildSearchResult({
+      kind: ApiResourceKind.agent_instance,
+      metadata: instance.metadata,
+      summary: instance.spec?.description ?? "",
+      score,
+      createdAt: instance.status?.audit?.specAudit?.createdAt,
+      updatedAt: instance.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const instance = resource as unknown as AgentInstance;
     const metadata = instance.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/environment/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/environment/search-extractor.ts
@@ -1,20 +1,45 @@
 /**
- * Environment search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/environment_extractor.go (the search summary
- * is spec.description). Secret DATA is deliberately never indexed — only
- * name, description, tags, org, and visibility reach FTS5. The query side
- * of the extractor contract arrives with the search service sub-project
- * (#14), exactly as the organization extractor's header records.
+ * Environment search extractor — ports pkg/query/search/extractor/
+ * environment_extractor.go (both sides: the #4 index side, the #14 query
+ * side; the search summary is spec.description). Secret DATA is
+ * deliberately never indexed — only name, description, tags, org, and
+ * visibility reach FTS5, and the query projection carries the same
+ * non-secret fields.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
 import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const environmentSearchExtractor: SearchIndexExtractor = {
+export const environmentSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.environment,
+  schema: EnvironmentSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go EnvironmentExtractor.GetSearchSummary: spec.description.
+    const env = resource as unknown as Environment;
+    return env.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const env = resource as unknown as Environment;
+    return buildSearchResult({
+      kind: ApiResourceKind.environment,
+      metadata: env.metadata,
+      summary: env.spec?.description ?? "",
+      score,
+      createdAt: env.status?.audit?.specAudit?.createdAt,
+      updatedAt: env.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const env = resource as unknown as Environment;
     const metadata = env.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/executioncontext/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/executioncontext/search-extractor.ts
@@ -1,21 +1,44 @@
 /**
- * ExecutionContext search extractor — ports the GetSearchIndexEntry side
- * of pkg/query/search/extractor/execution_context_extractor.go. Execution
- * contexts have no description field, so the summary is empty — and
- * secret DATA is deliberately never indexed: only name, tags, org, and
- * visibility reach FTS5. The query side of the extractor contract
- * (ToSearchResult) arrives with the search service sub-project (#14
- * sp.search-and-activity).
+ * ExecutionContext search extractor — ports pkg/query/search/extractor/
+ * execution_context_extractor.go (both sides: the #4 index side, the #14
+ * query side). Execution contexts have no description field, so the
+ * summary is empty everywhere — and secret DATA is deliberately never
+ * indexed nor projected: only name, tags, org, and visibility reach FTS5
+ * and the SearchResult.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
 import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const executionContextSearchExtractor: SearchIndexExtractor = {
+export const executionContextSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.execution_context,
+  schema: ExecutionContextSchema,
+
+  getSearchSummary(): string {
+    // Go ExecutionContextExtractor.GetSearchSummary: always "".
+    return "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const ec = resource as unknown as ExecutionContext;
+    return buildSearchResult({
+      kind: ApiResourceKind.execution_context,
+      metadata: ec.metadata,
+      summary: "",
+      score,
+      createdAt: ec.status?.audit?.specAudit?.createdAt,
+      updatedAt: ec.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const ec = resource as unknown as ExecutionContext;
     const metadata = ec.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/search-extractor.ts
@@ -1,18 +1,44 @@
 /**
- * McpServer search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/mcpserver_extractor.go. The search summary is
- * spec.description. The query side of the extractor contract arrives with
- * the search service sub-project (#14).
+ * McpServer search extractor — ports pkg/query/search/extractor/
+ * mcpserver_extractor.go (both sides: the #4 index side, the #14 query
+ * side). The search summary is spec.description; MCP servers are one of
+ * the two kinds carrying an icon_url on the search projection.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const mcpServerSearchExtractor: SearchIndexExtractor = {
+export const mcpServerSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.mcp_server,
+  schema: McpServerSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go McpServerExtractor.GetSearchSummary: spec.description.
+    const mcpServer = resource as unknown as McpServer;
+    return mcpServer.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const mcpServer = resource as unknown as McpServer;
+    return buildSearchResult({
+      kind: ApiResourceKind.mcp_server,
+      metadata: mcpServer.metadata,
+      summary: mcpServer.spec?.description ?? "",
+      score,
+      createdAt: mcpServer.status?.audit?.specAudit?.createdAt,
+      updatedAt: mcpServer.status?.audit?.specAudit?.updatedAt,
+      iconUrl: mcpServer.spec?.iconUrl ?? "",
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const mcpServer = resource as unknown as McpServer;
     const metadata = mcpServer.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/organization/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/organization/search-extractor.ts
@@ -1,20 +1,43 @@
 /**
- * Organization search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/organization_extractor.go (the search summary
- * is spec.description). Indexed domains carry their extractors (D4); the
- * QUERY side of the extractor contract (ToSearchResult, the registry
- * validation) arrives with the search service sub-project (#14) — only the
- * write-path extraction the IndexSearch step needs lives here.
+ * Organization search extractor — ports pkg/query/search/extractor/
+ * organization_extractor.go (both sides: the #4 index side, the #14 query
+ * side; the search summary is spec.description). Organizations are the
+ * top-level container for all Stigmer resources.
  */
 import type { Message } from "@bufbuild/protobuf";
 
-import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const organizationSearchExtractor: SearchIndexExtractor = {
+export const organizationSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.organization,
+  schema: OrganizationSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go OrganizationExtractor.GetSearchSummary: spec.description.
+    const org = resource as unknown as Organization;
+    return org.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const org = resource as unknown as Organization;
+    return buildSearchResult({
+      kind: ApiResourceKind.organization,
+      metadata: org.metadata,
+      summary: org.spec?.description ?? "",
+      score,
+      createdAt: org.status?.audit?.specAudit?.createdAt,
+      updatedAt: org.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const org = resource as unknown as Organization;
     const metadata = org.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/project/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/project/search-extractor.ts
@@ -1,0 +1,70 @@
+/**
+ * Project search extractor — ports pkg/query/search/extractor/
+ * project_extractor.go (both sides; the search summary is
+ * spec.description).
+ *
+ * Shipped by #14 (sp.search-and-activity) AHEAD of the project domain
+ * port (#16, in flight): boot RebuildIndex re-indexes every registered
+ * kind from the resources table, and an adopted Go database may already
+ * hold projects — without this extractor those rows would silently vanish
+ * from search (D4 #14 DD-D, owner-ratified). The extractor depends only
+ * on the generated Project proto; #16 wires it into the domain's write
+ * pipelines (IndexSearch/DeleteSearchIndex steps) when the domain lands.
+ * Coordination note on both PRs: #16's branch creates this same file
+ * (index side only) — second-to-merge reconciles to this full-contract
+ * version.
+ */
+import type { Message } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+import type { Project } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+
+import type { SearchIndexEntry } from "../../store/interface.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
+
+export const projectSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.project,
+  schema: ProjectSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go ProjectExtractor.GetSearchSummary: spec.description.
+    const project = resource as unknown as Project;
+    return project.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const project = resource as unknown as Project;
+    return buildSearchResult({
+      kind: ApiResourceKind.project,
+      metadata: project.metadata,
+      summary: project.spec?.description ?? "",
+      score,
+      createdAt: project.status?.audit?.specAudit?.createdAt,
+      updatedAt: project.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
+  getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
+    const project = resource as unknown as Project;
+    const metadata = project.metadata;
+    if (metadata === undefined) {
+      return undefined;
+    }
+    return {
+      name: metadata.name,
+      description: project.spec?.description ?? "",
+      // Tags join space-separated for FTS5 (Go extractor.JoinTags).
+      tags: metadata.tags.join(" "),
+      org: metadata.org,
+      // The enum NAME string, exactly Go's visibility.String().
+      visibility: ApiResourceVisibility[metadata.visibility] ?? "",
+      createdAt: Number(
+        project.status?.audit?.specAudit?.createdAt?.seconds ?? 0n,
+      ),
+    };
+  },
+};

--- a/backend/services/stigmer-server-ts/src/domain/session/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/session/search-extractor.ts
@@ -1,19 +1,43 @@
 /**
- * Session search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/session_extractor.go. Sessions are
- * conversation threads between a user and an agent instance; the summary
- * is spec.subject (the conversation topic). The query side of the
- * extractor contract arrives with the search service sub-project (#14).
+ * Session search extractor — ports pkg/query/search/extractor/
+ * session_extractor.go (both sides: the #4 index side, the #14 query
+ * side). Sessions are conversation threads between a user and an agent
+ * instance; the summary is spec.subject (the conversation topic).
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const sessionSearchExtractor: SearchIndexExtractor = {
+export const sessionSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.session,
+  schema: SessionSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go SessionExtractor.GetSearchSummary: spec.subject.
+    const session = resource as unknown as Session;
+    return session.spec?.subject ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const session = resource as unknown as Session;
+    return buildSearchResult({
+      kind: ApiResourceKind.session,
+      metadata: session.metadata,
+      summary: session.spec?.subject ?? "",
+      score,
+      createdAt: session.status?.audit?.specAudit?.createdAt,
+      updatedAt: session.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const session = resource as unknown as Session;
     const metadata = session.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/skill/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/search-extractor.ts
@@ -1,20 +1,44 @@
 /**
- * Skill search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/skill_extractor.go. Skills are knowledge
- * documents (SKILL.md files); the search summary is spec.description,
- * extracted from the SKILL.md YAML frontmatter at push time. The query
- * side of the extractor contract arrives with the search service
- * sub-project (#14).
+ * Skill search extractor — ports pkg/query/search/extractor/
+ * skill_extractor.go (both sides: the #4 index side, the #14 query side).
+ * Skills are knowledge documents (SKILL.md files); the search summary is
+ * spec.description, extracted from the SKILL.md YAML frontmatter at push
+ * time.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const skillSearchExtractor: SearchIndexExtractor = {
+export const skillSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.skill,
+  schema: SkillSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go SkillExtractor.GetSearchSummary: spec.description.
+    const skill = resource as unknown as Skill;
+    return skill.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const skill = resource as unknown as Skill;
+    return buildSearchResult({
+      kind: ApiResourceKind.skill,
+      metadata: skill.metadata,
+      summary: skill.spec?.description ?? "",
+      score,
+      createdAt: skill.status?.audit?.specAudit?.createdAt,
+      updatedAt: skill.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const skill = resource as unknown as Skill;
     const metadata = skill.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/skill/storage/frontmatter.ts
+++ b/backend/services/stigmer-server-ts/src/domain/skill/storage/frontmatter.ts
@@ -12,6 +12,12 @@
  */
 import yaml from "js-yaml";
 
+// goTrimSpace: Go's exact TrimSpace set — a .trim()-based delimiter check
+// would accept BOM'd "---" lines Go rejects (found by the #8 parity review
+// panel; promoted to gocompat when search criteria became the second
+// consumer, #14).
+import { goTrimSpace } from "../../../gocompat/trim.js";
+
 /** Parsed SKILL.md frontmatter (Go SkillFrontmatter). */
 export interface SkillFrontmatter {
   /** Canonical skill identifier (required; kebab-case, optionally dot-scoped). */
@@ -30,23 +36,6 @@ export interface SkillFrontmatter {
  * separators. The derived slug renders dots as hyphens (generateSlug).
  */
 const SKILL_NAME_PATTERN = /^[a-z0-9]+([.-][a-z0-9]+)*$/;
-
-/**
- * Go strings.TrimSpace trims by unicode.IsSpace — the Unicode White_Space
- * property (ASCII spaces, U+0085, U+00A0, U+1680, U+2000–U+200A, U+2028,
- * U+2029, U+202F, U+205F, U+3000) — which EXCLUDES U+FEFF. JS
- * String.trim's set is White_Space PLUS U+FEFF, so a BOM'd "---" first
- * line would pass a .trim() delimiter check while Go rejects the file.
- * The delimiter comparisons must trim exactly Go's set or the two
- * editions disagree on BOM'd SKILL.md files (found by the #8 parity
- * review panel).
- */
-const GO_TRIM_PATTERN =
-  /^[\t\n\v\f\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+|[\t\n\v\f\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+$/g;
-
-function goTrimSpace(value: string): string {
-  return value.replace(GO_TRIM_PATTERN, "");
-}
 
 /**
  * bufio.Scanner's default token cap (Go bufio.MaxScanTokenSize): lines

--- a/backend/services/stigmer-server-ts/src/domain/workflow/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflow/search-extractor.ts
@@ -1,20 +1,44 @@
 /**
- * Workflow search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/workflow_extractor.go. The search summary is
- * spec.description (workflows are serverless workflow definitions; the
- * spec-level description is the authored summary). The query side of the
- * extractor contract arrives with the search service sub-project (#14),
- * exactly as the organization extractor's header records.
+ * Workflow search extractor — ports pkg/query/search/extractor/
+ * workflow_extractor.go (both sides: the #4 index side, the #14 query
+ * side). The search summary is spec.description (workflows are serverless
+ * workflow definitions; the spec-level description is the authored
+ * summary).
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { WorkflowSchema } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
 import type { Workflow } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const workflowSearchExtractor: SearchIndexExtractor = {
+export const workflowSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.workflow,
+  schema: WorkflowSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go WorkflowExtractor.GetSearchSummary: spec.description.
+    const workflow = resource as unknown as Workflow;
+    return workflow.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const workflow = resource as unknown as Workflow;
+    return buildSearchResult({
+      kind: ApiResourceKind.workflow,
+      metadata: workflow.metadata,
+      summary: workflow.spec?.description ?? "",
+      score,
+      createdAt: workflow.status?.audit?.specAudit?.createdAt,
+      updatedAt: workflow.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const workflow = resource as unknown as Workflow;
     const metadata = workflow.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/search-extractor.ts
@@ -1,19 +1,43 @@
 /**
- * WorkflowExecution search extractor — ports the GetSearchIndexEntry side
- * of pkg/query/search/extractor/workflow_execution_extractor.go. Workflow
- * executions are invocation records; they have no description field, so
- * the FTS description stays empty. The query side of the extractor
- * contract arrives with the search service sub-project (#14).
+ * WorkflowExecution search extractor — ports pkg/query/search/extractor/
+ * workflow_execution_extractor.go (both sides: the #4 index side, the #14
+ * query side). Workflow executions are invocation records with no
+ * description field: Go's GetSearchSummary returns "" and BOTH
+ * projections leave the description at its zero value.
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
 import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
 import type { SearchIndexEntry } from "../../store/interface.js";
 
-export const workflowExecutionSearchExtractor: SearchIndexExtractor = {
+export const workflowExecutionSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.workflow_execution,
+  schema: WorkflowExecutionSchema,
+
+  getSearchSummary(): string {
+    // Go WorkflowExecutionExtractor.GetSearchSummary: always "".
+    return "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const execution = resource as unknown as WorkflowExecution;
+    return buildSearchResult({
+      kind: ApiResourceKind.workflow_execution,
+      metadata: execution.metadata,
+      summary: "",
+      score,
+      createdAt: execution.status?.audit?.specAudit?.createdAt,
+      updatedAt: execution.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const execution = resource as unknown as WorkflowExecution;
     const metadata = execution.metadata;

--- a/backend/services/stigmer-server-ts/src/domain/workflowinstance/search-extractor.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowinstance/search-extractor.ts
@@ -1,19 +1,43 @@
 /**
- * WorkflowInstance search extractor — ports the GetSearchIndexEntry side of
- * pkg/query/search/extractor/workflow_instance_extractor.go. The search
- * summary is spec.description (for the default instance that is the
- * factory's canonical copy). The query side of the extractor contract
- * arrives with the search service sub-project (#14).
+ * WorkflowInstance search extractor — ports pkg/query/search/extractor/
+ * workflow_instance_extractor.go (both sides: the #4 index side, the #14
+ * query side). The search summary is spec.description (for the default
+ * instance that is the factory's canonical copy).
  */
 import type { Message } from "@bufbuild/protobuf";
 
+import { WorkflowInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
 import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { SearchIndexEntry } from "../../store/interface.js";
-import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+import { buildSearchResult } from "../../query/search/extractor.js";
+import type { SearchableExtractor } from "../../query/search/extractor.js";
 
-export const workflowInstanceSearchExtractor: SearchIndexExtractor = {
+export const workflowInstanceSearchExtractor: SearchableExtractor = {
+  kind: ApiResourceKind.workflow_instance,
+  schema: WorkflowInstanceSchema,
+
+  getSearchSummary(resource: Message): string {
+    // Go WorkflowInstanceExtractor.GetSearchSummary: spec.description.
+    const instance = resource as unknown as WorkflowInstance;
+    return instance.spec?.description ?? "";
+  },
+
+  toSearchResult(resource: Message, score: number): SearchResult | undefined {
+    const instance = resource as unknown as WorkflowInstance;
+    return buildSearchResult({
+      kind: ApiResourceKind.workflow_instance,
+      metadata: instance.metadata,
+      summary: instance.spec?.description ?? "",
+      score,
+      createdAt: instance.status?.audit?.specAudit?.createdAt,
+      updatedAt: instance.status?.audit?.specAudit?.updatedAt,
+    });
+  },
+
   getSearchIndexEntry(resource: Message): SearchIndexEntry | undefined {
     const instance = resource as unknown as WorkflowInstance;
     const metadata = instance.metadata;

--- a/backend/services/stigmer-server-ts/src/gocompat/__tests__/trim.test.ts
+++ b/backend/services/stigmer-server-ts/src/gocompat/__tests__/trim.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Pins goTrimSpace/goFields against Go's strings.TrimSpace/Fields on
+ * exactly the characters where JS's .trim()/\s+ disagree: U+FEFF (JS
+ * trims/splits, Go does NOT) and U+0085 (Go trims/splits, JS does NOT).
+ * A regression here flips search-mode selection and FTS5 tokenization on
+ * BOM'd or NEL-padded queries (the #8 BOM divergence class).
+ */
+import { describe, expect, it } from "vitest";
+
+import { goFields, goTrimSpace } from "../trim.js";
+
+describe("goTrimSpace", () => {
+  it("trims Go's White_Space set including U+0085 and U+00A0", () => {
+    expect(goTrimSpace("  foo  ")).toBe("foo");
+    expect(goTrimSpace("\t\nfoo\r\n")).toBe("foo");
+    expect(goTrimSpace("\u0085foo\u0085")).toBe("foo");
+    expect(goTrimSpace("\u00A0foo\u3000")).toBe("foo");
+  });
+
+  it("does NOT trim U+FEFF — Go keeps the BOM", () => {
+    expect(goTrimSpace("\uFEFFfoo")).toBe("\uFEFFfoo");
+    expect(goTrimSpace("\uFEFF")).toBe("\uFEFF");
+  });
+
+  it("reduces all-space input to empty", () => {
+    expect(goTrimSpace("")).toBe("");
+    expect(goTrimSpace(" \t\u0085\u2003 ")).toBe("");
+  });
+});
+
+describe("goFields", () => {
+  it("splits around runs of Go's space set, no empty fields", () => {
+    expect(goFields("foo bar")).toEqual(["foo", "bar"]);
+    expect(goFields("  foo \t bar  ")).toEqual(["foo", "bar"]);
+    expect(goFields("foo\u0085bar")).toEqual(["foo", "bar"]);
+  });
+
+  it("does NOT split on U+FEFF — one Go token", () => {
+    expect(goFields("foo\uFEFFbar")).toEqual(["foo\uFEFFbar"]);
+  });
+
+  it("yields [] for empty and all-space input", () => {
+    expect(goFields("")).toEqual([]);
+    expect(goFields(" \n\u0085 ")).toEqual([]);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/gocompat/trim.ts
+++ b/backend/services/stigmer-server-ts/src/gocompat/trim.ts
@@ -1,0 +1,38 @@
+/**
+ * Go strings.TrimSpace — trims by unicode.IsSpace, the Unicode White_Space
+ * property (ASCII spaces, U+0085, U+00A0, U+1680, U+2000–U+200A, U+2028,
+ * U+2029, U+202F, U+205F, U+3000) — which EXCLUDES U+FEFF. JS String.trim's
+ * set is White_Space PLUS U+FEFF and MINUS U+0085, so the two disagree on
+ * BOM'd and NEL-padded input: a .trim()-based port flips Go's verdict on
+ * both (first found by the #8 skill parity panel on BOM'd SKILL.md files;
+ * promoted here when search criteria became the second consumer — a
+ * .trim()'d search query of exactly "\uFEFF" reads as LIST MODE where Go
+ * runs an empty-match SEARCH, and "\u0085" the mirror image).
+ *
+ * Proven by src/gocompat/__tests__/trim.test.ts and both consumers' suites.
+ */
+const GO_SPACE_CLASS =
+  "\\t\\n\\v\\f\\r \\u0085\\u00A0\\u1680\\u2000-\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000";
+
+const GO_TRIM_PATTERN = new RegExp(
+  `^[${GO_SPACE_CLASS}]+|[${GO_SPACE_CLASS}]+$`,
+  "g",
+);
+
+const GO_FIELDS_PATTERN = new RegExp(`[${GO_SPACE_CLASS}]+`);
+
+export function goTrimSpace(value: string): string {
+  return value.replace(GO_TRIM_PATTERN, "");
+}
+
+/**
+ * Go strings.Fields — splits around runs of unicode.IsSpace. The JS twin
+ * hazard mirrors trim's: `\s` splits on U+FEFF (Go does not) and misses
+ * U+0085 (Go splits) — a `\s+`-based split changes which FTS5 tokens a
+ * query produces on exactly those inputs. Returns no empty fields; an
+ * all-space (or empty) input yields [].
+ */
+export function goFields(value: string): string[] {
+  const trimmed = goTrimSpace(value);
+  return trimmed === "" ? [] : trimmed.split(GO_FIELDS_PATTERN);
+}

--- a/backend/services/stigmer-server-ts/src/query/README.md
+++ b/backend/services/stigmer-server-ts/src/query/README.md
@@ -1,5 +1,16 @@
-# query/ — reserved seam
+# query/ — the CQRS read-side services
 
-The search and activity query services land here with their D4 sub-projects
-(FTS5-backed search rides the storage driver; see D2 §5's layout and the domain
-inventory's query rows). Nothing in the scaffold may import from this directory.
+The two cross-aggregate query services (D4 #14; Go `pkg/query/`):
+
+- `search/` — the FTS5-backed SearchService: criteria value object, the
+  searchable-extractor registry (13 kinds, `kind_meta`-derived set), the
+  query store over `Store.querySearchIndex`, and boot-time RebuildIndex.
+- `activity/` — the ActivityQueryController recents feed: sessions +
+  workflow executions merged newest-first (stigmer#461).
+
+Neither is a domain: no `api_resource_kind` service option, no pipeline
+lifecycle — plain CQRS handlers over the store, registered in
+`boot/compose.ts` between artifact and github (Go server.go:493–522's
+order). Domain `search-extractor.ts` files implement `search/extractor.ts`'s
+`SearchableExtractor` contract; growing the searchable surface is one
+registry entry plus the domain's extractor file.

--- a/backend/services/stigmer-server-ts/src/query/__tests__/query-services.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/__tests__/query-services.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Composed-server tests for the two query services (D4 #14): the arms
+ * conformance cannot cover on local-ts plus the wiring proofs —
+ * search/activity ANSWER on the composed server (stigmer#461: OSS
+ * historically returned UNIMPLEMENTED for activity), synchronous
+ * index-on-write feeds search over the wire, the protovalidate
+ * interceptor answers the two InvalidArgument arms, and BOOT-TIME
+ * RebuildIndex makes pre-existing rows — including a project row on an
+ * adopted database, whose domain is not yet ported (#16) — searchable
+ * with zero pipeline writes (DD-D/DD-F).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { ActivityQueryController } from "@stigmer/protos/ai/stigmer/activity/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { SearchService } from "@stigmer/protos/ai/stigmer/search/v1/query_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
+import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+
+import { loadConfig } from "../../boot/config.js";
+import { composeServer } from "../../boot/compose.js";
+import type { ComposedServer } from "../../boot/compose.js";
+import { createLogger } from "../../boot/logger.js";
+import { SqliteStore } from "../../store/sqlite/store.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => undefined,
+});
+
+function bootServer(dir: string): ComposedServer {
+  return composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      // No engine behind composed tests: 127.0.0.1:1 is deterministically
+      // closed, so boots fail the non-fatal connect fast and can never
+      // touch a live local Temporal.
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      STORAGE_PATH: path.join(dir, "storage"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+}
+
+async function grpcError(promise: Promise<unknown>): Promise<ConnectError> {
+  try {
+    await promise;
+  } catch (error) {
+    return ConnectError.from(error);
+  }
+  throw new Error("expected the call to reject");
+}
+
+describe("query services on the composed server", () => {
+  let dir: string;
+  let server: ComposedServer;
+  let search: Client<typeof SearchService>;
+  let activity: Client<typeof ActivityQueryController>;
+  let organizations: Client<typeof OrganizationCommandController>;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "query-services-test-"));
+    server = bootServer(dir);
+    const port = await server.start();
+    const transport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+    search = createClient(SearchService, transport);
+    activity = createClient(ActivityQueryController, transport);
+    organizations = createClient(OrganizationCommandController, transport);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("serves synchronous index-on-write through list and query modes", async () => {
+    await organizations.create(
+      create(OrganizationSchema, {
+        apiVersion: "tenancy.stigmer.ai/v1",
+        kind: "Organization",
+        metadata: { id: "searchwired", name: "Search Wired", slug: "searchwired" },
+        spec: { description: "a uniquely zebrawire description" },
+      }),
+    );
+
+    // List mode: created_at ordering, score pinned 1.0, counts by kind.
+    const listed = await search.search({
+      kinds: [ApiResourceKind.organization],
+    });
+    const listedIds = listed.entries.map((entry) => entry.id);
+    expect(listedIds).toContain("searchwired");
+    expect(listed.countsByKind.organization).toBeGreaterThanOrEqual(1);
+    for (const entry of listed.entries) {
+      expect(entry.score).toBe(1);
+    }
+
+    // Query mode: the unique description token matches with a positive
+    // relevance score (membership only — never pinned BM25 values).
+    const queried = await search.search({
+      kinds: [ApiResourceKind.organization],
+      query: "zebrawire",
+    });
+    expect(queried.entries.map((entry) => entry.id)).toEqual(["searchwired"]);
+    expect(queried.entries[0]?.score).toBeGreaterThan(0);
+  });
+
+  it("answers the two validation arms via the protovalidate interceptor (codes only, P2)", async () => {
+    const overLength = await grpcError(
+      search.search({ query: "x".repeat(501) }),
+    );
+    expect(overLength.code).toBe(Code.InvalidArgument);
+
+    const badOrg = await grpcError(search.search({ org: "NotASlug" }));
+    expect(badOrg.code).toBe(Code.InvalidArgument);
+  });
+
+  it("activity ANSWERS on OSS (stigmer#461 — never UNIMPLEMENTED) with an empty page on an empty store", async () => {
+    const response = await activity.listRecentActivity({ pageSize: 10 });
+    expect(response.entries).toEqual([]);
+  });
+});
+
+describe("boot-time RebuildIndex (DD-D/DD-F)", () => {
+  let dir: string;
+  let server: ComposedServer;
+  let port: number;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "query-rebuild-test-"));
+    // Pre-seed the database DIRECTLY — resource rows only, no index
+    // writes — the adopted-database shape: rows exist, the FTS index
+    // knows nothing about them. The project row's domain is not even
+    // ported yet (#16 in flight); only the boot rebuild through the
+    // 13-kind registry can make it searchable.
+    const dbPath = path.join(dir, "stigmer.db");
+    const seedStore = SqliteStore.open(dbPath);
+    await seedStore.saveResource(
+      ApiResourceKind.organization,
+      "preboot",
+      OrganizationSchema,
+      create(OrganizationSchema, {
+        apiVersion: "tenancy.stigmer.ai/v1",
+        kind: "Organization",
+        metadata: { id: "preboot", name: "Preboot Org", slug: "preboot" },
+        spec: { description: "seeded before boot" },
+      }),
+    );
+    await seedStore.saveResource(
+      ApiResourceKind.project,
+      "prj_adopted",
+      ProjectSchema,
+      create(ProjectSchema, {
+        metadata: {
+          id: "prj_adopted",
+          name: "adopted-project",
+          slug: "adopted-project",
+          org: "preboot",
+        },
+        spec: { description: "a project from the Go era" },
+        status: {
+          audit: { specAudit: { createdAt: { seconds: 1_700_000_000n } } },
+        },
+      }),
+    );
+    await seedStore.close();
+
+    server = bootServer(dir);
+    port = await server.start();
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("makes pre-existing rows searchable the moment the port answers", async () => {
+    const transport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+    const search = createClient(SearchService, transport);
+
+    const orgs = await search.search({
+      kinds: [ApiResourceKind.organization],
+    });
+    expect(orgs.entries.map((entry) => entry.id)).toContain("preboot");
+
+    const projects = await search.search({
+      kinds: [ApiResourceKind.project],
+      org: "preboot",
+    });
+    expect(projects.entries.map((entry) => entry.id)).toEqual(["prj_adopted"]);
+    expect(projects.entries[0]?.description).toBe("a project from the Go era");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/activity/__tests__/handler.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/activity/__tests__/handler.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Pins the activity handler against Go's
+ * pkg/query/activity/handler/handler_test.go, case-for-case: the two-kind
+ * newest-first merge, the projection fields, the subject sentinels, the
+ * runtime-origin exclusions, the page-size table (default 30 / cap 100 —
+ * the constants conformance deliberately does not drive over the wire),
+ * the timestamp fallback + tie ordering (sessions before executions), the
+ * empty store, and the resolvePhase / timestampAfter tables.
+ */
+import { create } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ListRecentActivityRequestSchema } from "@stigmer/protos/ai/stigmer/activity/v1/io_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  tempStore,
+  type TempStore,
+} from "../../../store/sqlite/__tests__/support.js";
+import {
+  ActivityHandler,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  normalizePageSize,
+  resolvePhase,
+  resolveSubject,
+  timestampAfter,
+} from "../handler.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => undefined,
+});
+
+function request(pageSize: number) {
+  return create(ListRecentActivityRequestSchema, { pageSize, org: "" });
+}
+
+let temp: TempStore;
+let handler: ActivityHandler;
+
+beforeEach(() => {
+  temp = tempStore();
+  handler = new ActivityHandler(temp.store, silentLogger);
+});
+
+afterEach(async () => {
+  await temp.cleanup();
+});
+
+async function seedSession(
+  id: string,
+  opts?: {
+    subject?: string;
+    labels?: Record<string, string>;
+    statusUpdatedAtSeconds?: number;
+    statusUpdatedAtNanos?: number;
+    specCreatedAtSeconds?: number;
+  },
+): Promise<void> {
+  const statusAudit =
+    opts?.statusUpdatedAtSeconds === undefined
+      ? undefined
+      : {
+          updatedAt: {
+            seconds: BigInt(opts.statusUpdatedAtSeconds),
+            nanos: opts.statusUpdatedAtNanos ?? 0,
+          },
+        };
+  const specAudit =
+    opts?.specCreatedAtSeconds === undefined
+      ? undefined
+      : { createdAt: { seconds: BigInt(opts.specCreatedAtSeconds) } };
+  const session = create(SessionSchema, {
+    metadata: { id, name: id, org: "acme", labels: opts?.labels ?? {} },
+    spec: { subject: opts?.subject ?? "", agentInstanceId: "agi_test" },
+    status: { audit: { statusAudit, specAudit } },
+  });
+  await temp.store.saveResource(
+    ApiResourceKind.session,
+    id,
+    SessionSchema,
+    session,
+  );
+}
+
+async function seedExecution(
+  id: string,
+  opts?: {
+    name?: string;
+    phase?: ExecutionPhase;
+    statusUpdatedAtSeconds?: number;
+  },
+): Promise<void> {
+  const execution = create(WorkflowExecutionSchema, {
+    metadata: { id, name: opts?.name ?? id, org: "acme" },
+    status: {
+      phase: opts?.phase ?? ExecutionPhase.EXECUTION_COMPLETED,
+      audit:
+        opts?.statusUpdatedAtSeconds === undefined
+          ? undefined
+          : {
+              statusAudit: {
+                updatedAt: { seconds: BigInt(opts.statusUpdatedAtSeconds) },
+              },
+            },
+    },
+  });
+  await temp.store.saveResource(
+    ApiResourceKind.workflow_execution,
+    id,
+    WorkflowExecutionSchema,
+    execution,
+  );
+}
+
+describe("listRecentActivity (Go handler_test.go)", () => {
+  it("merges both kinds newest-first", async () => {
+    await seedSession("ses_old", {
+      subject: "oldest",
+      statusUpdatedAtSeconds: 100,
+    });
+    await seedExecution("wfe_mid", { statusUpdatedAtSeconds: 200 });
+    await seedSession("ses_new", {
+      subject: "newest",
+      statusUpdatedAtSeconds: 300,
+    });
+
+    const response = await handler.listRecentActivity(request(100));
+
+    expect(response.entries.map((entry) => entry.id)).toEqual([
+      "ses_new",
+      "wfe_mid",
+      "ses_old",
+    ]);
+  });
+
+  it("projects the sidebar fields per kind", async () => {
+    await seedSession("ses_1", {
+      subject: "Plan the migration",
+      statusUpdatedAtSeconds: 100,
+    });
+    await seedExecution("wfe_1", {
+      name: "nightly-sync",
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+      statusUpdatedAtSeconds: 200,
+    });
+
+    const response = await handler.listRecentActivity(request(100));
+
+    const session = response.entries.find((entry) => entry.id === "ses_1");
+    expect(session?.type).toBe("session");
+    expect(session?.subject).toBe("Plan the migration");
+    expect(session?.status).toBe("");
+    expect(session?.updatedAt).toBeDefined();
+
+    const execution = response.entries.find((entry) => entry.id === "wfe_1");
+    expect(execution?.type).toBe("workflow_execution");
+    expect(execution?.subject).toBe("nightly-sync");
+    expect(execution?.status).toBe("running");
+  });
+
+  it("maps the subject sentinels to display placeholders", async () => {
+    await seedSession("ses_auto", {
+      subject: "Auto-created session",
+      statusUpdatedAtSeconds: 100,
+    });
+    await seedSession("ses_empty", {
+      subject: "",
+      statusUpdatedAtSeconds: 200,
+    });
+    await seedExecution("wfe_unnamed", {
+      name: "",
+      statusUpdatedAtSeconds: 300,
+    });
+
+    const response = await handler.listRecentActivity(request(100));
+    const byId = new Map(response.entries.map((entry) => [entry.id, entry]));
+
+    expect(byId.get("ses_auto")?.subject).toBe("Untitled session");
+    expect(byId.get("ses_empty")?.subject).toBe("Untitled session");
+    expect(byId.get("wfe_unnamed")?.subject).toBe("Untitled execution");
+  });
+
+  it("excludes runtime-origin sessions for every label key", async () => {
+    await seedSession("ses_console", {
+      subject: "personal",
+      statusUpdatedAtSeconds: 100,
+    });
+    const labeled: Array<[id: string, key: string]> = [
+      ["ses_channel", "stigmer.ai/channel-id"],
+      ["ses_share", "stigmer.ai/share-id"],
+      ["ses_guest", "stigmer.ai/guest-cookie-id"],
+      ["ses_schedule", "stigmer.ai/schedule-id"],
+    ];
+    for (const [id, key] of labeled) {
+      await seedSession(id, {
+        subject: "runtime",
+        labels: { [key]: "x" },
+        statusUpdatedAtSeconds: 200,
+      });
+    }
+
+    const response = await handler.listRecentActivity(request(100));
+    const ids = response.entries.map((entry) => entry.id);
+
+    expect(ids).toContain("ses_console");
+    for (const [id] of labeled) {
+      expect(ids, `${id} must be excluded`).not.toContain(id);
+    }
+  });
+
+  it("trims to page_size keeping the newest; zero and negatives mean the default page", async () => {
+    for (let i = 0; i < 3; i++) {
+      await seedSession(`ses_${i}`, {
+        subject: `s${i}`,
+        statusUpdatedAtSeconds: 100 + i,
+      });
+    }
+
+    const trimmed = await handler.listRecentActivity(request(1));
+    expect(trimmed.entries.map((entry) => entry.id)).toEqual(["ses_2"]);
+
+    for (const pageSize of [0, -5]) {
+      const response = await handler.listRecentActivity(request(pageSize));
+      expect(response.entries).toHaveLength(3);
+    }
+
+    const oversize = await handler.listRecentActivity(request(100_000));
+    expect(oversize.entries).toHaveLength(3);
+  });
+
+  it("falls back to specAudit.createdAt when the status audit is unstamped", async () => {
+    await seedSession("ses_stamped", {
+      subject: "stamped",
+      statusUpdatedAtSeconds: 100,
+    });
+    await seedSession("ses_fallback", {
+      subject: "fallback",
+      specCreatedAtSeconds: 200,
+    });
+
+    const response = await handler.listRecentActivity(request(100));
+
+    expect(response.entries.map((entry) => entry.id)).toEqual([
+      "ses_fallback",
+      "ses_stamped",
+    ]);
+  });
+
+  it("keeps sessions before executions on equal timestamps (stable sort)", async () => {
+    await seedExecution("wfe_tie", { statusUpdatedAtSeconds: 100 });
+    await seedSession("ses_tie", {
+      subject: "tie",
+      statusUpdatedAtSeconds: 100,
+    });
+
+    const response = await handler.listRecentActivity(request(100));
+
+    // Sessions load first (Go's append order), and the stable sort keeps
+    // insertion order on ties.
+    expect(response.entries.map((entry) => entry.id)).toEqual([
+      "ses_tie",
+      "wfe_tie",
+    ]);
+  });
+
+  it("answers an empty store with an empty page", async () => {
+    const response = await handler.listRecentActivity(request(10));
+    expect(response.entries).toEqual([]);
+  });
+});
+
+describe("normalizePageSize (Go's table)", () => {
+  it("folds out-of-range values into range", () => {
+    expect(normalizePageSize(0)).toBe(DEFAULT_PAGE_SIZE);
+    expect(normalizePageSize(-1)).toBe(DEFAULT_PAGE_SIZE);
+    expect(normalizePageSize(1)).toBe(1);
+    expect(normalizePageSize(30)).toBe(30);
+    expect(normalizePageSize(100)).toBe(MAX_PAGE_SIZE);
+    expect(normalizePageSize(101)).toBe(MAX_PAGE_SIZE);
+    expect(normalizePageSize(100_000)).toBe(MAX_PAGE_SIZE);
+  });
+});
+
+describe("resolveSubject", () => {
+  it("maps the sentinel and emptiness to the placeholder, passes real titles", () => {
+    expect(resolveSubject("")).toBe("Untitled session");
+    expect(resolveSubject("Auto-created session")).toBe("Untitled session");
+    expect(resolveSubject("Real title")).toBe("Real title");
+  });
+});
+
+describe("resolvePhase (Go's table)", () => {
+  it("maps every phase to its badge token, unknowns to 'unknown'", () => {
+    expect(resolvePhase(ExecutionPhase.EXECUTION_PENDING)).toBe("pending");
+    expect(resolvePhase(ExecutionPhase.EXECUTION_IN_PROGRESS)).toBe("running");
+    expect(resolvePhase(ExecutionPhase.EXECUTION_COMPLETED)).toBe("completed");
+    expect(resolvePhase(ExecutionPhase.EXECUTION_FAILED)).toBe("failed");
+    expect(resolvePhase(ExecutionPhase.EXECUTION_CANCELLED)).toBe("cancelled");
+    expect(resolvePhase(ExecutionPhase.EXECUTION_TERMINATED)).toBe(
+      "terminated",
+    );
+    expect(resolvePhase(ExecutionPhase.EXECUTION_PAUSED)).toBe("paused");
+    expect(resolvePhase(ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED)).toBe(
+      "unknown",
+    );
+    expect(resolvePhase(999 as ExecutionPhase)).toBe("unknown");
+  });
+});
+
+describe("timestampAfter (Go's table)", () => {
+  const ts = (seconds: number, nanos = 0) =>
+    create(TimestampSchema, { seconds: BigInt(seconds), nanos });
+
+  it("compares seconds first, then nanos, strictly", () => {
+    expect(timestampAfter(ts(2), ts(1))).toBe(true);
+    expect(timestampAfter(ts(1), ts(2))).toBe(false);
+    expect(timestampAfter(ts(1, 5), ts(1, 3))).toBe(true);
+    expect(timestampAfter(ts(1, 3), ts(1, 5))).toBe(false);
+    // Strictly after: equality is false on both sides (the stable-sort
+    // tie contract depends on it).
+    expect(timestampAfter(ts(1, 1), ts(1, 1))).toBe(false);
+    expect(timestampAfter(undefined, undefined)).toBe(false);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/activity/controller.ts
+++ b/backend/services/stigmer-server-ts/src/query/activity/controller.ts
@@ -1,0 +1,49 @@
+/**
+ * Activity controller — ports
+ * pkg/query/activity/controller/activity_controller.go: the thin adapter
+ * between ConnectRPC and the activity handler, following the search
+ * controller's pattern.
+ *
+ * The handler's only failure mode is a storage read error — server
+ * internals that must stay off the wire (stigmer/stigmer#478); the full
+ * error is logged here at the boundary and the wire carries the sanitized
+ * Internal.
+ *
+ * ActivityQueryController carries no api_resource_kind option and
+ * is_skip_authorization (cross-aggregate CQRS read; single-tenant OSS has
+ * no authorization set to enumerate — stigmer#461).
+ *
+ * Proven by activity.conformance.test.ts (CONFORMANCE_TARGET=local-ts)
+ * and __tests__/handler.test.ts.
+ */
+import type { ConnectRouter } from "@connectrpc/connect";
+
+import { ActivityQueryController } from "@stigmer/protos/ai/stigmer/activity/v1/query_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError } from "../../pipeline/errors.js";
+import type { ActivityHandler } from "./handler.js";
+
+export interface ActivityControllerDeps {
+  readonly handler: ActivityHandler;
+  readonly logger: Logger;
+}
+
+/** Registers the ActivityQueryController on the router (routes stage). */
+export function registerActivityServices(
+  router: ConnectRouter,
+  deps: ActivityControllerDeps,
+): void {
+  router.service(ActivityQueryController, {
+    listRecentActivity: async (request) => {
+      try {
+        return await deps.handler.listRecentActivity(request);
+      } catch (error) {
+        deps.logger.error("ListRecentActivity failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw internalError(error, "failed to list recent activity");
+      }
+    },
+  });
+}

--- a/backend/services/stigmer-server-ts/src/query/activity/handler.ts
+++ b/backend/services/stigmer-server-ts/src/query/activity/handler.ts
@@ -1,0 +1,282 @@
+/**
+ * Recent-activity handler — ports pkg/query/activity/handler/handler.go:
+ * sessions and workflow executions merged into one time-sorted list for
+ * the console's Recents sidebar.
+ *
+ * This is the OSS twin of the cloud's ListRecentActivityHandler; the
+ * merge, ordering, projection, and filtering semantics are deliberately
+ * identical (stigmer#461). What differs is only what single-tenancy
+ * removes: no FGA id enumeration (the candidate set is every stored row),
+ * the request's org is a no-op (single-tenant; a recents filter stricter
+ * than the per-kind lists it summarizes would hide locally-owned rows),
+ * and load-all-then-sort-in-memory instead of per-kind SQL LIMIT windows
+ * (each kind's newest page_size rows are a superset of its contribution
+ * to the merged page — the identical final list; the full scan is this
+ * store's contract, the same pattern every OSS list handler uses).
+ *
+ * Proven by __tests__/handler.test.ts (Go's handler_test.go arms) and
+ * activity.conformance.test.ts on local-ts.
+ */
+import { create, fromBinary } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+
+import {
+  ListRecentActivityResponseSchema,
+  RecentActivityEntrySchema,
+} from "@stigmer/protos/ai/stigmer/activity/v1/io_pb";
+import type {
+  ListRecentActivityRequest,
+  ListRecentActivityResponse,
+  RecentActivityEntry,
+} from "@stigmer/protos/ai/stigmer/activity/v1/io_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { ApiResourceAudit } from "@stigmer/protos/ai/stigmer/commons/apiresource/status_pb";
+import type { ApiResourceMetadata } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * defaultPageSize / maxPageSize mirror the cloud handler's
+ * DEFAULT_PAGE_SIZE / MAX_PAGE_SIZE — the page contract is part of the
+ * cross-edition behavior, not an implementation detail.
+ */
+export const DEFAULT_PAGE_SIZE = 30;
+export const MAX_PAGE_SIZE = 100;
+
+/**
+ * The platform-wide sentinel subject stamped on sessions created without
+ * a user-provided title (the SDK's PENDING_SUBJECT, the CLI's resume
+ * flow, the runner's call-agent, and this server's agent-execution create
+ * all use the same literal). The sidebar shows the friendlier placeholder
+ * until subject generation replaces the sentinel.
+ */
+export const AUTO_CREATED_SESSION_SUBJECT = "Auto-created session";
+
+export const UNTITLED_SESSION_SUBJECT = "Untitled session";
+export const UNTITLED_EXECUTION_SUBJECT = "Untitled execution";
+
+/**
+ * Marks a session as runtime-originated. Recents shows personal sessions
+ * only (cloud design decision 012): channel conversations, guest/share
+ * sessions, and schedule-triggered sessions are excluded for every caller
+ * — each runtime surface owns its own list. Keys match the cloud's
+ * RUNTIME_ORIGIN_LABELS exactly; share/guest are cloud-only today but
+ * excluded identically so a future OSS share surface cannot silently
+ * regress the recents policy.
+ */
+export const RUNTIME_ORIGIN_LABELS: readonly string[] = [
+  "stigmer.ai/channel-id",
+  "stigmer.ai/share-id",
+  "stigmer.ai/guest-cookie-id",
+  "stigmer.ai/schedule-id",
+];
+
+/** Answers ActivityQueryController.listRecentActivity against the store. */
+export class ActivityHandler {
+  constructor(
+    private readonly store: Store,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Go ListRecentActivity: load both kinds, project to sidebar entries,
+   * merge-sort newest-first, trim to the page.
+   */
+  async listRecentActivity(
+    request: ListRecentActivityRequest,
+  ): Promise<ListRecentActivityResponse> {
+    const pageSize = normalizePageSize(request.pageSize);
+
+    const sessions = await this.loadSessions();
+    const executions = await this.loadExecutions();
+
+    // Sessions before executions, then a stable sort: entries with equal
+    // timestamps keep this insertion order — the same tie-break the
+    // cloud gets from java.util.List.sort's stability over the same load
+    // order (JS Array.prototype.sort is stable, matching Go's
+    // sort.SliceStable).
+    let entries = [...sessions, ...executions].sort((a, b) => {
+      if (timestampAfter(a.updatedAt, b.updatedAt)) {
+        return -1;
+      }
+      if (timestampAfter(b.updatedAt, a.updatedAt)) {
+        return 1;
+      }
+      return 0;
+    });
+
+    if (entries.length > pageSize) {
+      entries = entries.slice(0, pageSize);
+    }
+
+    this.logger.debug("Recent activity merged", {
+      entries: entries.length,
+      page_size: pageSize,
+    });
+
+    return create(ListRecentActivityResponseSchema, { entries });
+  }
+
+  /**
+   * Go loadSessions: every stored personal session projected to a recents
+   * entry; runtime-originated sessions excluded.
+   */
+  private async loadSessions(): Promise<RecentActivityEntry[]> {
+    const rows = await this.store.listResources(ApiResourceKind.session);
+    const entries: RecentActivityEntry[] = [];
+    for (const row of rows) {
+      let session;
+      try {
+        session = fromBinary(SessionSchema, row);
+      } catch {
+        this.logger.warn("Skipping undecodable session row in recent activity");
+        continue;
+      }
+      if (hasRuntimeOriginLabel(session.metadata)) {
+        continue;
+      }
+      entries.push(
+        create(RecentActivityEntrySchema, {
+          id: session.metadata?.id ?? "",
+          type: "session",
+          subject: resolveSubject(session.spec?.subject ?? ""),
+          updatedAt: extractUpdatedAt(session.status?.audit),
+        }),
+      );
+    }
+    return entries;
+  }
+
+  /** Go loadExecutions: every stored workflow execution projected. */
+  private async loadExecutions(): Promise<RecentActivityEntry[]> {
+    const rows = await this.store.listResources(
+      ApiResourceKind.workflow_execution,
+    );
+    const entries: RecentActivityEntry[] = [];
+    for (const row of rows) {
+      let execution;
+      try {
+        execution = fromBinary(WorkflowExecutionSchema, row);
+      } catch {
+        this.logger.warn(
+          "Skipping undecodable workflow execution row in recent activity",
+        );
+        continue;
+      }
+      const name = execution.metadata?.name ?? "";
+      entries.push(
+        create(RecentActivityEntrySchema, {
+          id: execution.metadata?.id ?? "",
+          type: "workflow_execution",
+          subject: name === "" ? UNTITLED_EXECUTION_SUBJECT : name,
+          updatedAt: extractUpdatedAt(execution.status?.audit),
+          status: resolvePhase(
+            execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+          ),
+        }),
+      );
+    }
+    return entries;
+  }
+}
+
+/** Go normalizePageSize: ≤0 → default 30; >100 → cap 100. */
+export function normalizePageSize(requested: number): number {
+  if (requested <= 0) {
+    return DEFAULT_PAGE_SIZE;
+  }
+  if (requested > MAX_PAGE_SIZE) {
+    return MAX_PAGE_SIZE;
+  }
+  return requested;
+}
+
+function hasRuntimeOriginLabel(
+  metadata: ApiResourceMetadata | undefined,
+): boolean {
+  const labels = metadata?.labels;
+  if (labels === undefined) {
+    return false;
+  }
+  return RUNTIME_ORIGIN_LABELS.some((key) => key in labels);
+}
+
+/**
+ * Go resolveSubject: missing subjects AND the auto-created sentinel map
+ * to the display placeholder — a just-created session shows "Untitled
+ * session" until subject generation writes a real title.
+ */
+export function resolveSubject(subject: string): string {
+  if (subject === "" || subject === AUTO_CREATED_SESSION_SUBJECT) {
+    return UNTITLED_SESSION_SUBJECT;
+  }
+  return subject;
+}
+
+/**
+ * Go resolvePhase: the lifecycle phase → the display token the console's
+ * status badge renders. Unspecified (and any future value this build
+ * does not know) reads as "unknown" — no badge.
+ */
+export function resolvePhase(phase: ExecutionPhase): string {
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_PENDING:
+      return "pending";
+    case ExecutionPhase.EXECUTION_IN_PROGRESS:
+      return "running";
+    case ExecutionPhase.EXECUTION_COMPLETED:
+      return "completed";
+    case ExecutionPhase.EXECUTION_FAILED:
+      return "failed";
+    case ExecutionPhase.EXECUTION_CANCELLED:
+      return "cancelled";
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      return "terminated";
+    case ExecutionPhase.EXECUTION_PAUSED:
+      return "paused";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Go extractUpdatedAt — the entry's sort key: statusAudit.updatedAt
+ * (bumped on meaningful status changes; heartbeats deliberately do NOT
+ * bump it) falling back to specAudit.createdAt for rows whose status
+ * audit was never stamped (older builds or external tooling; OSS creates
+ * always stamp both slots).
+ */
+export function extractUpdatedAt(
+  audit: ApiResourceAudit | undefined,
+): Timestamp {
+  const updatedAt = audit?.statusAudit?.updatedAt;
+  if (updatedAt !== undefined) {
+    return updatedAt;
+  }
+  const createdAt = audit?.specAudit?.createdAt;
+  if (createdAt !== undefined) {
+    return createdAt;
+  }
+  return create(TimestampSchema);
+}
+
+/**
+ * Go timestampAfter: a sorts strictly after b (newer first), comparing
+ * (seconds, nanos) exactly like the cloud's comparator.
+ */
+export function timestampAfter(
+  a: Timestamp | undefined,
+  b: Timestamp | undefined,
+): boolean {
+  const aSeconds = a?.seconds ?? 0n;
+  const bSeconds = b?.seconds ?? 0n;
+  if (aSeconds !== bSeconds) {
+    return aSeconds > bSeconds;
+  }
+  return (a?.nanos ?? 0) > (b?.nanos ?? 0);
+}

--- a/backend/services/stigmer-server-ts/src/query/activity/handler.ts
+++ b/backend/services/stigmer-server-ts/src/query/activity/handler.ts
@@ -203,7 +203,9 @@ function hasRuntimeOriginLabel(
   if (labels === undefined) {
     return false;
   }
-  return RUNTIME_ORIGIN_LABELS.some((key) => key in labels);
+  // Object.hasOwn, not `in`: own keys only, matching Go's map lookup
+  // (the #17 least-privilege-filter precedent).
+  return RUNTIME_ORIGIN_LABELS.some((key) => Object.hasOwn(labels, key));
 }
 
 /**

--- a/backend/services/stigmer-server-ts/src/query/search/__tests__/controller.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/__tests__/controller.test.ts
@@ -103,23 +103,26 @@ describe("activity error mapping", () => {
     // A CLOSED store's reads throw — the handler's only failure mode,
     // reached without stubbing the wide Store interface.
     const temp: TempStore = tempStore();
-    await temp.store.close();
+    try {
+      await temp.store.close();
 
-    const transport = createRouterTransport((router) => {
-      registerActivityServices(router, {
-        handler: new ActivityHandler(temp.store, silentLogger),
-        logger: silentLogger,
+      const transport = createRouterTransport((router) => {
+        registerActivityServices(router, {
+          handler: new ActivityHandler(temp.store, silentLogger),
+          logger: silentLogger,
+        });
       });
-    });
-    const client = createClient(ActivityQueryController, transport);
+      const client = createClient(ActivityQueryController, transport);
 
-    const error = await grpcError(
-      client.listRecentActivity(
-        create(ListRecentActivityRequestSchema, { pageSize: 10 }),
-      ),
-    );
-    expect(error.code).toBe(Code.Internal);
-    expect(error.rawMessage).toBe("failed to list recent activity");
-    await temp.cleanup();
+      const error = await grpcError(
+        client.listRecentActivity(
+          create(ListRecentActivityRequestSchema, { pageSize: 10 }),
+        ),
+      );
+      expect(error.code).toBe(Code.Internal);
+      expect(error.rawMessage).toBe("failed to list recent activity");
+    } finally {
+      await temp.cleanup();
+    }
   });
 });

--- a/backend/services/stigmer-server-ts/src/query/search/__tests__/controller.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/__tests__/controller.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Pins the controllers' error mapping (Go search_controller.go
+ * toGRPCError + activity_controller.go): the string-contains
+ * InvalidArgument arms CARRY the wrapped handler text, everything else
+ * sanitizes to the static Internal copy (#478) — including the
+ * deliberately-quirky Go arm where a store error containing "invalid"
+ * answers InvalidArgument with its raw text. Driven through
+ * createRouterTransport so the mapping is proven at the ConnectRPC
+ * boundary, not by calling private functions.
+ */
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import { createRouterTransport } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import { ListRecentActivityRequestSchema } from "@stigmer/protos/ai/stigmer/activity/v1/io_pb";
+import { ActivityQueryController } from "@stigmer/protos/ai/stigmer/activity/v1/query_pb";
+import { SearchRequestSchema } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+import { SearchService } from "@stigmer/protos/ai/stigmer/search/v1/query_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  tempStore,
+  type TempStore,
+} from "../../../store/sqlite/__tests__/support.js";
+import { ActivityHandler } from "../../activity/handler.js";
+import { registerActivityServices } from "../../activity/controller.js";
+import { registerSearchServices } from "../controller.js";
+import { SearchHandler } from "../handler.js";
+import type { SearchQueryStore } from "../query-store.js";
+import { emptyResult } from "../paged-result.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => undefined,
+});
+
+function searchClientOver(store: SearchQueryStore) {
+  const transport = createRouterTransport((router) => {
+    registerSearchServices(router, {
+      handler: new SearchHandler(store, silentLogger),
+      logger: silentLogger,
+    });
+  });
+  return createClient(SearchService, transport);
+}
+
+async function grpcError(promise: Promise<unknown>): Promise<ConnectError> {
+  try {
+    await promise;
+  } catch (error) {
+    return ConnectError.from(error);
+  }
+  throw new Error("expected the call to reject");
+}
+
+describe("search error mapping (Go toGRPCError)", () => {
+  it("sanitizes an unmatched store failure to Internal 'search failed' (#478)", async () => {
+    const client = searchClientOver({
+      search: () => Promise.reject(new Error("disk exploded at /var/lib")),
+      rebuildIndex: () => Promise.resolve(0),
+    });
+    const error = await grpcError(
+      client.search(create(SearchRequestSchema, { query: "x" })),
+    );
+    expect(error.code).toBe(Code.Internal);
+    // The raw text stays off the wire — only the static copy crosses.
+    expect(error.rawMessage).toBe("search failed");
+  });
+
+  it("maps a store error containing 'invalid' to InvalidArgument WITH the wrapped text (Go's string-contains quirk)", async () => {
+    const client = searchClientOver({
+      search: () => Promise.reject(new Error("invalid cursor state")),
+      rebuildIndex: () => Promise.resolve(0),
+    });
+    const error = await grpcError(
+      client.search(create(SearchRequestSchema, { query: "x" })),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+    expect(error.rawMessage).toBe("search failed: invalid cursor state");
+  });
+
+  it("answers the handler's defensive protovalidate arm as InvalidArgument", async () => {
+    // No interceptor chain rides createRouterTransport here, so the
+    // HANDLER's own validate — Go's step 1, wire-unreachable behind the
+    // real chain — answers. The wrapped "validation failed: ..." text
+    // string-matches to InvalidArgument.
+    const client = searchClientOver({
+      search: () => Promise.resolve(emptyResult()),
+      rebuildIndex: () => Promise.resolve(0),
+    });
+    const error = await grpcError(
+      client.search(create(SearchRequestSchema, { query: "x".repeat(501) })),
+    );
+    expect(error.code).toBe(Code.InvalidArgument);
+    expect(error.rawMessage).toContain("validation failed");
+  });
+});
+
+describe("activity error mapping", () => {
+  it("sanitizes a storage failure to Internal 'failed to list recent activity' (#478)", async () => {
+    // A CLOSED store's reads throw — the handler's only failure mode,
+    // reached without stubbing the wide Store interface.
+    const temp: TempStore = tempStore();
+    await temp.store.close();
+
+    const transport = createRouterTransport((router) => {
+      registerActivityServices(router, {
+        handler: new ActivityHandler(temp.store, silentLogger),
+        logger: silentLogger,
+      });
+    });
+    const client = createClient(ActivityQueryController, transport);
+
+    const error = await grpcError(
+      client.listRecentActivity(
+        create(ListRecentActivityRequestSchema, { pageSize: 10 }),
+      ),
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe("failed to list recent activity");
+    await temp.cleanup();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/search/__tests__/criteria.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/__tests__/criteria.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Pins SearchCriteria against Go's search_criteria_test.go tables:
+ * normalization (trimming, clamps), the 500-char boundary, the three-mode
+ * contract, and the #440 arm — named-but-unsearchable kinds yield an EMPTY
+ * effective set, never a discover fallback. The kind_meta derivation is
+ * pinned here too: 13 searchable kinds, project included (DD-D).
+ */
+import { describe, expect, it } from "vitest";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MAX_QUERY_LENGTH,
+  SearchCriteria,
+  searchIndexedKinds,
+} from "../criteria.js";
+
+function criteria(overrides?: {
+  kinds?: ApiResourceKind[];
+  query?: string;
+  org?: string;
+  excludePublic?: boolean;
+  crossOrgPublic?: boolean;
+  pageNumber?: number;
+  pageSize?: number;
+}): SearchCriteria {
+  return SearchCriteria.create(
+    overrides?.kinds ?? [],
+    overrides?.query ?? "",
+    overrides?.org ?? "",
+    overrides?.excludePublic ?? false,
+    overrides?.crossOrgPublic ?? false,
+    overrides?.pageNumber ?? 1,
+    overrides?.pageSize ?? 20,
+  );
+}
+
+describe("searchIndexedKinds derivation (kind_meta)", () => {
+  it("derives exactly the 13 searchable kinds, project included", () => {
+    // Go's SearchableKinds map, pinned by its invariant test against the
+    // same kind_meta derivation. project rides #14 (DD-D) although its
+    // domain ports with #16 — RebuildIndex on an adopted Go database
+    // must be able to re-index existing project rows.
+    expect([...searchIndexedKinds()].sort((a, b) => a - b)).toEqual(
+      [
+        ApiResourceKind.agent,
+        ApiResourceKind.skill,
+        ApiResourceKind.mcp_server,
+        ApiResourceKind.workflow,
+        ApiResourceKind.project,
+        ApiResourceKind.environment,
+        ApiResourceKind.session,
+        ApiResourceKind.agent_execution,
+        ApiResourceKind.agent_instance,
+        ApiResourceKind.execution_context,
+        ApiResourceKind.organization,
+        ApiResourceKind.workflow_execution,
+        ApiResourceKind.workflow_instance,
+      ].sort((a, b) => a - b),
+    );
+  });
+
+  it("excludes not_search_indexed kinds (agent_channel, memory)", () => {
+    const kinds = searchIndexedKinds();
+    expect(kinds).not.toContain(ApiResourceKind.agent_channel);
+    expect(kinds).not.toContain(ApiResourceKind.channel_app);
+    expect(kinds).not.toContain(ApiResourceKind.memory);
+  });
+});
+
+describe("SearchCriteria normalization (Go NewSearchCriteria)", () => {
+  it("keeps valid input verbatim", () => {
+    const c = criteria({
+      kinds: [ApiResourceKind.agent, ApiResourceKind.skill],
+      query: "kubernetes",
+      org: "acme",
+      pageNumber: 2,
+      pageSize: 50,
+    });
+    expect(c.kinds()).toEqual([ApiResourceKind.agent, ApiResourceKind.skill]);
+    expect(c.query()).toBe("kubernetes");
+    expect(c.orgFilter()).toBe("acme");
+    expect(c.pageNumber()).toBe(2);
+    expect(c.pageSize()).toBe(50);
+  });
+
+  it("trims the query and the org filter", () => {
+    const c = criteria({ query: "  hello  ", org: "  acme  " });
+    expect(c.query()).toBe("hello");
+    expect(c.orgFilter()).toBe("acme");
+  });
+
+  it("rejects a query over the cap with Go's exact message", () => {
+    expect(() =>
+      criteria({ query: "x".repeat(MAX_QUERY_LENGTH + 1) }),
+    ).toThrowError(
+      "search query exceeds maximum length of 500 characters",
+    );
+  });
+
+  it("accepts a query at exactly the cap", () => {
+    const c = criteria({ query: "x".repeat(MAX_QUERY_LENGTH) });
+    expect(c.query().length).toBe(MAX_QUERY_LENGTH);
+  });
+
+  it("clamps the page number: 0 and negatives normalize to 1", () => {
+    expect(criteria({ pageNumber: 0 }).pageNumber()).toBe(1);
+    expect(criteria({ pageNumber: -5 }).pageNumber()).toBe(1);
+    expect(criteria({ pageNumber: 3 }).pageNumber()).toBe(3);
+  });
+
+  it("clamps the page size: <1 → default, >100 → max", () => {
+    expect(criteria({ pageSize: 0 }).pageSize()).toBe(DEFAULT_PAGE_SIZE);
+    expect(criteria({ pageSize: -1 }).pageSize()).toBe(DEFAULT_PAGE_SIZE);
+    expect(criteria({ pageSize: 1000 }).pageSize()).toBe(MAX_PAGE_SIZE);
+    expect(criteria({ pageSize: MAX_PAGE_SIZE }).pageSize()).toBe(
+      MAX_PAGE_SIZE,
+    );
+  });
+});
+
+describe("mode selection", () => {
+  it("empty kinds is discover mode; requested kinds is not", () => {
+    expect(criteria({ kinds: [] }).isDiscoverMode()).toBe(true);
+    expect(
+      criteria({ kinds: [ApiResourceKind.agent] }).isDiscoverMode(),
+    ).toBe(false);
+  });
+
+  it("hasQuery: empty and whitespace-only queries mean list mode", () => {
+    expect(criteria({ query: "" }).hasQuery()).toBe(false);
+    expect(criteria({ query: "   " }).hasQuery()).toBe(false);
+    expect(criteria({ query: "x" }).hasQuery()).toBe(true);
+  });
+
+  it("hasOrgFilter follows the trimmed org", () => {
+    expect(criteria({ org: "" }).hasOrgFilter()).toBe(false);
+    expect(criteria({ org: "acme" }).hasOrgFilter()).toBe(true);
+  });
+});
+
+describe("effectiveKinds (the #440 contract)", () => {
+  it("discover mode returns every searchable kind", () => {
+    expect(criteria({ kinds: [] }).effectiveKinds()).toEqual(
+      searchIndexedKinds(),
+    );
+  });
+
+  it("specific kinds pass through when searchable", () => {
+    expect(
+      criteria({
+        kinds: [ApiResourceKind.agent, ApiResourceKind.workflow],
+      }).effectiveKinds(),
+    ).toEqual([ApiResourceKind.agent, ApiResourceKind.workflow]);
+  });
+
+  it("non-searchable kinds are silently dropped from a mixed request", () => {
+    expect(
+      criteria({
+        kinds: [ApiResourceKind.agent, ApiResourceKind.agent_channel],
+      }).effectiveKinds(),
+    ).toEqual([ApiResourceKind.agent]);
+  });
+
+  it("ONLY non-searchable kinds yields the empty set — never discover (#440)", () => {
+    const c = criteria({ kinds: [ApiResourceKind.agent_channel] });
+    expect(c.effectiveKinds()).toEqual([]);
+    expect(c.isDiscoverMode()).toBe(false);
+  });
+
+  it("kinds() returns the request verbatim, including unsearchable ones", () => {
+    const c = criteria({ kinds: [ApiResourceKind.agent_channel] });
+    expect(c.kinds()).toEqual([ApiResourceKind.agent_channel]);
+  });
+});
+
+describe("offset", () => {
+  it("computes the zero-indexed row offset (Go Offset)", () => {
+    expect(criteria({ pageNumber: 1, pageSize: 20 }).offset()).toBe(0);
+    expect(criteria({ pageNumber: 2, pageSize: 20 }).offset()).toBe(20);
+    expect(criteria({ pageNumber: 3, pageSize: 50 }).offset()).toBe(100);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/search/__tests__/paged-result.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/__tests__/paged-result.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the paged-result math against Go's search_paged_result_test.go:
+ * the totalPages ceiling table, the zero-pageSize arm, the negative-input
+ * rejections, and the EmptyResult shape.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { SearchResultSchema } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+
+import { emptyResult, newSearchPagedResult } from "../paged-result.js";
+
+describe("newSearchPagedResult", () => {
+  it("carries results, counts, and totals through", () => {
+    const results = [create(SearchResultSchema, { id: "agt_1" })];
+    const paged = newSearchPagedResult(results, { agent: 5 }, 5, 20);
+    expect(paged.results).toHaveLength(1);
+    expect(paged.countsByKind).toEqual({ agent: 5 });
+    expect(paged.totalCount).toBe(5);
+    expect(paged.totalPages).toBe(1);
+  });
+
+  it("computes totalPages = ceil(totalCount / pageSize) (Go's table)", () => {
+    const cases: Array<[total: number, size: number, pages: number]> = [
+      [0, 20, 0],
+      [1, 20, 1],
+      [20, 20, 1],
+      [21, 20, 2],
+      [100, 20, 5],
+      [101, 20, 6],
+      [5, 2, 3],
+    ];
+    for (const [total, size, pages] of cases) {
+      expect(newSearchPagedResult([], {}, total, size).totalPages).toBe(pages);
+    }
+  });
+
+  it("pageSize 0 yields totalPages 0 (no division)", () => {
+    expect(newSearchPagedResult([], {}, 10, 0).totalPages).toBe(0);
+  });
+
+  it("rejects negative totals and page sizes with Go's messages", () => {
+    expect(() => newSearchPagedResult([], {}, -1, 20)).toThrowError(
+      "totalCount cannot be negative: -1",
+    );
+    expect(() => newSearchPagedResult([], {}, 0, -2)).toThrowError(
+      "pageSize cannot be negative: -2",
+    );
+  });
+});
+
+describe("emptyResult", () => {
+  it("is the all-zero shape", () => {
+    const empty = emptyResult();
+    expect(empty.results).toEqual([]);
+    expect(empty.countsByKind).toEqual({});
+    expect(empty.totalCount).toBe(0);
+    expect(empty.totalPages).toBe(0);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/search/__tests__/query-store.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/__tests__/query-store.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Pins the search query store against Go's
+ * sqlite_search_query_store_test.go (the escaping / kind-parsing /
+ * score-normalization tables) and
+ * sqlite_search_query_store_query_test.go (the end-to-end
+ * write→index→query pins: session list mode, the #440 emptiness arm, the
+ * #439 newly-searchable-kind arm), plus the scope-filter matrix
+ * (org strict / crossOrgPublic / excludePublic) and RebuildIndex —
+ * including the DD-D proof: rebuilding over an ADOPTED Go-created
+ * database re-indexes its project rows.
+ */
+import { create, toBinary } from "@bufbuild/protobuf";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ProjectSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/api_pb";
+
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import {
+  materializeGoFixture,
+  tempStore,
+  type TempStore,
+} from "../../../store/sqlite/__tests__/support.js";
+import { SearchCriteria } from "../criteria.js";
+import {
+  SqliteSearchQueryStore,
+  escapeFTS5Query,
+  normalizeScore,
+  parseKind,
+} from "../query-store.js";
+import { newSearchableResourceRegistry } from "../registry.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => undefined,
+});
+const registry = newSearchableResourceRegistry();
+
+let temp: TempStore;
+let queryStore: SqliteSearchQueryStore;
+
+beforeEach(() => {
+  temp = tempStore();
+  queryStore = new SqliteSearchQueryStore(temp.store, registry, silentLogger);
+});
+
+afterEach(async () => {
+  await temp.cleanup();
+});
+
+/**
+ * Writes through the same seams production writes use: saveResource for
+ * the document, the kind's extractor + upsertSearchIndex for the FTS
+ * entry (Go's newSeededSQLiteStore).
+ */
+async function seed<Desc extends DescMessage>(
+  kind: ApiResourceKind,
+  id: string,
+  schema: Desc,
+  msg: MessageShape<Desc>,
+): Promise<void> {
+  await temp.store.saveResource(kind, id, schema, msg);
+  const extractor = registry.getExtractor(kind);
+  if (extractor === undefined) {
+    throw new Error(`no extractor for kind ${ApiResourceKind[kind]}`);
+  }
+  const entry = extractor.getSearchIndexEntry(msg);
+  if (entry === undefined) {
+    throw new Error(`extractor for ${ApiResourceKind[kind]} returned no entry`);
+  }
+  await temp.store.upsertSearchIndex(kind, id, entry);
+}
+
+function newSession(
+  id: string,
+  org: string,
+  subject: string,
+  opts?: { visibility?: ApiResourceVisibility; createdAtSeconds?: number },
+) {
+  return create(SessionSchema, {
+    metadata: {
+      id,
+      name: id,
+      slug: id,
+      org,
+      visibility: opts?.visibility ?? ApiResourceVisibility.visibility_private,
+    },
+    spec: { subject, agentInstanceId: "agi_test" },
+    status: {
+      audit: {
+        specAudit: {
+          createdAt: { seconds: BigInt(opts?.createdAtSeconds ?? 1_700_000_000) },
+        },
+      },
+    },
+  });
+}
+
+function newAgent(id: string, org: string, description: string) {
+  return create(AgentSchema, {
+    metadata: { id, name: id, slug: id, org },
+    spec: { description, instructions: "do things" },
+    status: {
+      audit: { specAudit: { createdAt: { seconds: 1_700_000_000n } } },
+    },
+  });
+}
+
+function criteria(overrides: {
+  kinds?: ApiResourceKind[];
+  query?: string;
+  org?: string;
+  excludePublic?: boolean;
+  crossOrgPublic?: boolean;
+  pageNumber?: number;
+  pageSize?: number;
+}): SearchCriteria {
+  return SearchCriteria.create(
+    overrides.kinds ?? [],
+    overrides.query ?? "",
+    overrides.org ?? "",
+    overrides.excludePublic ?? false,
+    overrides.crossOrgPublic ?? false,
+    overrides.pageNumber ?? 1,
+    overrides.pageSize ?? 20,
+  );
+}
+
+describe("escapeFTS5Query (Go's table, case-for-case)", () => {
+  const cases: Array<[name: string, input: string, expected: string]> = [
+    ["empty query", "", ""],
+    ["single word", "kubernetes", `"kubernetes"*`],
+    ["multiple words", "kubernetes deployment", `"kubernetes" "deployment"`],
+    ["whitespace trimmed", "  hello  ", `"hello"*`],
+    ["AND treated as literal", "foo AND bar", `"foo" "AND" "bar"`],
+    ["OR treated as literal", "foo OR bar", `"foo" "OR" "bar"`],
+    ["NOT treated as literal", "foo NOT bar", `"foo" "NOT" "bar"`],
+    ["NEAR treated as literal", "foo NEAR bar", `"foo" "NEAR" "bar"`],
+    ["colon in single token", "server:skill-creator", `"server:skill-creator"*`],
+    ["colon with simple term", "name:kubernetes", `"name:kubernetes"*`],
+    [
+      "colon in multi-word query",
+      "find server:something here",
+      `"find" "server:something" "here"`,
+    ],
+    ["dash in token", "mcp-server", `"mcp-server"*`],
+    ["leading dash", "-excluded", `"-excluded"*`],
+    ["dash in multi-word", "mcp-server deployment", `"mcp-server" "deployment"`],
+    ["asterisk in token", "kube*", `"kube*"*`],
+    ["parentheses", "NEAR(a b)", `"NEAR(a" "b)"`],
+    ["brackets", "test[0]", `"test[0]"*`],
+    ["caret", "^boost", `"^boost"*`],
+    ["embedded quotes stripped", `foo"bar`, `"foobar"*`],
+    ["only quotes", `"""`, ""],
+    [
+      "mixed specials multi-word",
+      `server:x mcp-server kube*`,
+      `"server:x" "mcp-server" "kube*"`,
+    ],
+  ];
+  for (const [name, input, expected] of cases) {
+    it(name, () => {
+      expect(escapeFTS5Query(input)).toBe(expected);
+    });
+  }
+});
+
+describe("parseKind (Go's table)", () => {
+  it("parses known kind names and rejects unknown ones", () => {
+    expect(parseKind("agent")).toBe(ApiResourceKind.agent);
+    expect(parseKind("skill")).toBe(ApiResourceKind.skill);
+    expect(parseKind("mcp_server")).toBe(ApiResourceKind.mcp_server);
+    expect(parseKind("workflow")).toBe(ApiResourceKind.workflow);
+    expect(parseKind("invalid_kind")).toBeUndefined();
+    expect(parseKind("")).toBeUndefined();
+  });
+});
+
+describe("normalizeScore (Go's table)", () => {
+  const cases: Array<[bm25: number, min: number, max: number]> = [
+    [0, 1.0, 1.0],
+    [1.0, 1.0, 1.0],
+    [-1.0, 0.8, 1.0],
+    [-5.0, 0.4, 0.6],
+    [-15.0, 0, 0.1],
+  ];
+  for (const [bm25, min, max] of cases) {
+    it(`bm25 ${bm25} → [${min}, ${max}]`, () => {
+      const score = normalizeScore(bm25);
+      expect(score).toBeGreaterThanOrEqual(min);
+      expect(score).toBeLessThanOrEqual(max);
+    });
+  }
+});
+
+describe("write→index→query pins (Go's query_test.go)", () => {
+  it("session list mode returns the indexed session with the subject as description (#310 class)", async () => {
+    await seed(
+      ApiResourceKind.session,
+      "ses-acme-1",
+      SessionSchema,
+      newSession("ses-acme-1", "acme", "Fix the deploy pipeline"),
+    );
+    await seed(
+      ApiResourceKind.session,
+      "ses-other-1",
+      SessionSchema,
+      newSession("ses-other-1", "otherorg", "Unrelated thread"),
+    );
+    await seed(
+      ApiResourceKind.agent,
+      "agt-acme-1",
+      AgentSchema,
+      newAgent("agt-acme-1", "acme", "An agent in the same org"),
+    );
+
+    const result = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session], org: "acme" }),
+    );
+
+    expect(result.totalCount).toBe(1);
+    expect(result.results[0]?.kind).toBe(ApiResourceKind.session);
+    expect(result.results[0]?.id).toBe("ses-acme-1");
+    expect(result.results[0]?.description).toBe("Fix the deploy pipeline");
+    // List mode pins the score to exactly 1.0.
+    expect(result.results[0]?.score).toBe(1);
+  });
+
+  it("ONLY non-searchable kinds answers emptiness in both modes (#440)", async () => {
+    await seed(
+      ApiResourceKind.session,
+      "ses-acme-1",
+      SessionSchema,
+      newSession("ses-acme-1", "acme", "Fix the deploy pipeline"),
+    );
+    await seed(
+      ApiResourceKind.agent,
+      "agt-acme-1",
+      AgentSchema,
+      newAgent("agt-acme-1", "acme", "An agent in the same org"),
+    );
+
+    for (const query of ["", "acme"]) {
+      const result = await queryStore.search(
+        criteria({
+          kinds: [ApiResourceKind.agent_channel],
+          query,
+          org: "acme",
+        }),
+      );
+      expect(result.totalCount).toBe(0);
+      expect(result.results).toEqual([]);
+    }
+  });
+
+  it("a newly-searchable kind serves list AND query mode (#439)", async () => {
+    const newExecution = (id: string, org: string) =>
+      create(AgentExecutionSchema, {
+        metadata: { id, name: id, slug: id, org },
+        status: {
+          audit: { specAudit: { createdAt: { seconds: 1_700_000_000n } } },
+        },
+      });
+    await seed(
+      ApiResourceKind.agent_execution,
+      "exe-acme-1",
+      AgentExecutionSchema,
+      newExecution("exe-acme-1", "acme"),
+    );
+    await seed(
+      ApiResourceKind.agent_execution,
+      "exe-other-1",
+      AgentExecutionSchema,
+      newExecution("exe-other-1", "otherorg"),
+    );
+    await seed(
+      ApiResourceKind.session,
+      "ses-acme-1",
+      SessionSchema,
+      newSession("ses-acme-1", "acme", "Fix the deploy pipeline"),
+    );
+
+    // Executions index their name (no description field), so the
+    // query-mode term matches the seeded name.
+    for (const query of ["", "exe-acme-1"]) {
+      const result = await queryStore.search(
+        criteria({
+          kinds: [ApiResourceKind.agent_execution],
+          query,
+          org: "acme",
+        }),
+      );
+      expect(result.totalCount).toBe(1);
+      expect(result.results[0]?.kind).toBe(ApiResourceKind.agent_execution);
+      expect(result.results[0]?.id).toBe("exe-acme-1");
+    }
+  });
+});
+
+describe("scope-filter matrix (Go buildScopeFilter)", () => {
+  beforeEach(async () => {
+    await seed(
+      ApiResourceKind.session,
+      "ses-a-private",
+      SessionSchema,
+      newSession("ses-a-private", "org-a", "a private", {
+        createdAtSeconds: 1_700_000_003,
+      }),
+    );
+    await seed(
+      ApiResourceKind.session,
+      "ses-b-private",
+      SessionSchema,
+      newSession("ses-b-private", "org-b", "b private", {
+        createdAtSeconds: 1_700_000_002,
+      }),
+    );
+    await seed(
+      ApiResourceKind.session,
+      "ses-b-public",
+      SessionSchema,
+      newSession("ses-b-public", "org-b", "b public", {
+        visibility: ApiResourceVisibility.visibility_public,
+        createdAtSeconds: 1_700_000_001,
+      }),
+    );
+  });
+
+  const ids = (result: { results: readonly { id: string }[] }) =>
+    result.results.map((entry) => entry.id);
+
+  it("a strict org filter returns only that org's rows", async () => {
+    const result = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session], org: "org-a" }),
+    );
+    expect(ids(result)).toEqual(["ses-a-private"]);
+  });
+
+  it("crossOrgPublic widens to OTHER orgs' public rows only", async () => {
+    const result = await queryStore.search(
+      criteria({
+        kinds: [ApiResourceKind.session],
+        org: "org-a",
+        crossOrgPublic: true,
+      }),
+    );
+    expect(new Set(ids(result))).toEqual(
+      new Set(["ses-a-private", "ses-b-public"]),
+    );
+  });
+
+  it("excludePublic subtracts public rows from any scope", async () => {
+    const unscoped = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session], excludePublic: true }),
+    );
+    expect(new Set(ids(unscoped))).toEqual(
+      new Set(["ses-a-private", "ses-b-private"]),
+    );
+
+    const widened = await queryStore.search(
+      criteria({
+        kinds: [ApiResourceKind.session],
+        org: "org-a",
+        crossOrgPublic: true,
+        excludePublic: true,
+      }),
+    );
+    expect(ids(widened)).toEqual(["ses-a-private"]);
+  });
+
+  it("no org filter returns every row, newest first (list mode ordering)", async () => {
+    const result = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session] }),
+    );
+    expect(ids(result)).toEqual([
+      "ses-a-private",
+      "ses-b-private",
+      "ses-b-public",
+    ]);
+  });
+});
+
+describe("pagination through the store", () => {
+  it("pages partition the result set with full counts on every page", async () => {
+    for (let i = 0; i < 3; i++) {
+      await seed(
+        ApiResourceKind.session,
+        `ses-${i}`,
+        SessionSchema,
+        newSession(`ses-${i}`, "acme", `subject ${i}`, {
+          createdAtSeconds: 1_700_000_000 + i,
+        }),
+      );
+    }
+
+    const first = await queryStore.search(
+      criteria({
+        kinds: [ApiResourceKind.session],
+        org: "acme",
+        pageNumber: 1,
+        pageSize: 2,
+      }),
+    );
+    const second = await queryStore.search(
+      criteria({
+        kinds: [ApiResourceKind.session],
+        org: "acme",
+        pageNumber: 2,
+        pageSize: 2,
+      }),
+    );
+
+    expect(first.totalCount).toBe(3);
+    expect(first.totalPages).toBe(2);
+    expect(first.results).toHaveLength(2);
+    expect(second.results).toHaveLength(1);
+    const seen = new Set(
+      [...first.results, ...second.results].map((entry) => entry.id),
+    );
+    expect(seen.size).toBe(3);
+  });
+});
+
+describe("stale-index resilience", () => {
+  it("skips a hit whose resource was deleted (warn, never fail)", async () => {
+    await seed(
+      ApiResourceKind.session,
+      "ses-1",
+      SessionSchema,
+      newSession("ses-1", "acme", "kept"),
+    );
+    await seed(
+      ApiResourceKind.session,
+      "ses-2",
+      SessionSchema,
+      newSession("ses-2", "acme", "stale"),
+    );
+    // Delete the resource but leave its index row — the stale-row state.
+    await temp.store.deleteResource(ApiResourceKind.session, "ses-2");
+
+    const result = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session], org: "acme" }),
+    );
+
+    // Counts come from the index (still 2 — Go's shape); the page skips
+    // the unloadable row.
+    expect(result.totalCount).toBe(2);
+    expect(result.results.map((entry) => entry.id)).toEqual(["ses-1"]);
+  });
+});
+
+describe("rebuildIndex", () => {
+  it("repopulates a wiped index from the resources table", async () => {
+    await seed(
+      ApiResourceKind.session,
+      "ses-1",
+      SessionSchema,
+      newSession("ses-1", "acme", "rebuild me"),
+    );
+    await temp.store.clearSearchIndex();
+
+    const before = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session], org: "acme" }),
+    );
+    expect(before.totalCount).toBe(0);
+
+    const indexed = await queryStore.rebuildIndex();
+    expect(indexed).toBe(1);
+
+    const after = await queryStore.search(
+      criteria({ kinds: [ApiResourceKind.session], org: "acme" }),
+    );
+    expect(after.totalCount).toBe(1);
+    expect(after.results[0]?.id).toBe("ses-1");
+  });
+
+  it("re-indexes project rows on an ADOPTED Go-created database (DD-D)", async () => {
+    // The committed Go-v6 fixture, opened through the driver (migrates
+    // v6→v7 — real adoption), then given a project row the way a Go
+    // server would have written one: raw resource bytes.
+    const fixture = materializeGoFixture();
+    const adopted = SqliteStore.open(fixture.dbPath);
+    try {
+      const project = create(ProjectSchema, {
+        metadata: { id: "prj_1", name: "billing", slug: "billing", org: "acme" },
+        spec: { description: "the billing project" },
+        status: {
+          audit: { specAudit: { createdAt: { seconds: 1_700_000_000n } } },
+        },
+      });
+      await adopted.saveResource(
+        ApiResourceKind.project,
+        "prj_1",
+        ProjectSchema,
+        project,
+      );
+      // Boot state: the TS server wipes and rebuilds — a 12-kind registry
+      // would erase this row from search forever.
+      const adoptedQueryStore = new SqliteSearchQueryStore(
+        adopted,
+        registry,
+        silentLogger,
+      );
+      await adoptedQueryStore.rebuildIndex();
+
+      const result = await adoptedQueryStore.search(
+        criteria({ kinds: [ApiResourceKind.project], org: "acme" }),
+      );
+      expect(result.totalCount).toBe(1);
+      expect(result.results[0]?.id).toBe("prj_1");
+      expect(result.results[0]?.description).toBe("the billing project");
+
+      // toBinary sanity: the row loaded back is byte-equal to what a Go
+      // server holds (protobuf wire format is shared).
+      const raw = await adopted.getResource(
+        ApiResourceKind.project,
+        "prj_1",
+        ProjectSchema,
+      );
+      expect(toBinary(ProjectSchema, raw)).toEqual(
+        toBinary(ProjectSchema, project),
+      );
+    } finally {
+      await adopted.close();
+      fixture.cleanup();
+    }
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/search/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/__tests__/registry.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pins the extractor registry against Go's registry_test.go — duplicate
+ * rejection, lookup, name-sorted supportedKinds, both validateExpectedKinds
+ * arms — plus THE invariant test (Go's
+ * TestSearchableKinds_CoverSearchIndexedProtoKinds, #439): the production
+ * registry serves exactly the kind_meta-derived searchable set. A kind may
+ * join or leave search only by flipping its proto annotation AND its
+ * registry entry together; this test fails until both move.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import { agentSearchExtractor } from "../../../domain/agent/search-extractor.js";
+import { searchIndexedKinds } from "../criteria.js";
+import {
+  SearchableResourceRegistry,
+  newSearchableResourceRegistry,
+} from "../registry.js";
+
+interface CapturingLogger extends Logger {
+  readonly warns: Array<Record<string, unknown> | undefined>;
+  readonly infos: Array<Record<string, unknown> | undefined>;
+}
+
+function testLogger(): CapturingLogger {
+  const warns: Array<Record<string, unknown> | undefined> = [];
+  const infos: Array<Record<string, unknown> | undefined> = [];
+  return {
+    debug: () => undefined,
+    info: (_message, fields) => {
+      infos.push(fields);
+    },
+    warn: (_message, fields) => {
+      warns.push(fields);
+    },
+    error: () => undefined,
+    warns,
+    infos,
+  };
+}
+
+describe("the #439 invariant", () => {
+  it("registers an extractor for EXACTLY the kind_meta-derived searchable set", () => {
+    const registry = newSearchableResourceRegistry();
+    const registered = [...registry.supportedKinds()].sort((a, b) => a - b);
+    const derived = [...searchIndexedKinds()].sort((a, b) => a - b);
+    expect(registered).toEqual(derived);
+  });
+
+  it("every extractor's kind field matches its registry slot", () => {
+    const registry = newSearchableResourceRegistry();
+    for (const kind of registry.supportedKinds()) {
+      expect(registry.getExtractor(kind)?.kind).toBe(kind);
+    }
+  });
+});
+
+describe("SearchableResourceRegistry (Go registry_test.go)", () => {
+  it("rejects duplicate registration at construction (Go's init panic)", () => {
+    expect(
+      () =>
+        new SearchableResourceRegistry([
+          agentSearchExtractor,
+          agentSearchExtractor,
+        ]),
+    ).toThrowError("duplicate SearchableExtractor for kind agent");
+  });
+
+  it("returns the extractor for a registered kind, undefined otherwise", () => {
+    const registry = new SearchableResourceRegistry([agentSearchExtractor]);
+    expect(registry.getExtractor(ApiResourceKind.agent)).toBe(
+      agentSearchExtractor,
+    );
+    expect(registry.getExtractor(ApiResourceKind.skill)).toBeUndefined();
+  });
+
+  it("supportedKinds sorts by the kind NAME string (Go's kind.String() sort)", () => {
+    const registry = newSearchableResourceRegistry();
+    const names = registry.supportedKinds().map((kind) => ApiResourceKind[kind]);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("validateExpectedKinds warns with the missing kinds (never throws)", () => {
+    const logger = testLogger();
+    new SearchableResourceRegistry([agentSearchExtractor]).validateExpectedKinds(
+      logger,
+    );
+    expect(logger.warns).toHaveLength(1);
+    const missing = logger.warns[0]?.missing_kinds as string[];
+    expect(missing).toContain("skill");
+    expect(missing).not.toContain("agent");
+  });
+
+  it("validateExpectedKinds logs the healthy roster when complete", () => {
+    const logger = testLogger();
+    newSearchableResourceRegistry().validateExpectedKinds(logger);
+    expect(logger.warns).toHaveLength(0);
+    expect(logger.infos).toHaveLength(1);
+    expect(logger.infos[0]?.count).toBe(searchIndexedKinds().length);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/query/search/controller.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/controller.ts
@@ -1,0 +1,90 @@
+/**
+ * Search controller — ports
+ * pkg/query/search/controller/search_controller.go: the thin adapter
+ * between ConnectRPC and the SearchHandler, owning the error-to-status
+ * mapping.
+ *
+ * The mapping is Go's string-contains heuristic ported byte-for-byte
+ * (toGRPCError): handler texts containing "validation failed", "invalid",
+ * or "exceeds maximum" answer InvalidArgument CARRYING the wrapped text;
+ * everything else is sanitized to Internal "search failed"
+ * (stigmer/stigmer#478 — the raw error is server internals, logged here
+ * at the boundary, never on the wire). The conformance suite pins the
+ * codes only (ratified guard P2); the texts ride the parity register's
+ * protovalidate-es watch item.
+ *
+ * SearchService carries no api_resource_kind option and
+ * is_skip_authorization (cross-aggregate CQRS read) — the apiresource
+ * interceptor injects nothing and the auth slot is a pass-through, both
+ * verified; no interceptor changes ride this port.
+ *
+ * Proven by search.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/handler.test.ts's mapping arms.
+ */
+import type { ConnectRouter } from "@connectrpc/connect";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { SearchService } from "@stigmer/protos/ai/stigmer/search/v1/query_pb";
+import type {
+  SearchRequest,
+  SearchResponse,
+} from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import type { ConnectError } from "@connectrpc/connect";
+import type { SearchHandler } from "./handler.js";
+
+export interface SearchControllerDeps {
+  readonly handler: SearchHandler;
+  readonly logger: Logger;
+}
+
+/** Registers the SearchService on the router (routes stage). */
+export function registerSearchServices(
+  router: ConnectRouter,
+  deps: SearchControllerDeps,
+): void {
+  router.service(SearchService, {
+    search: (request) => search(deps, request),
+  });
+}
+
+async function search(
+  deps: SearchControllerDeps,
+  request: SearchRequest,
+): Promise<SearchResponse> {
+  deps.logger.debug("SearchService.Search called", {
+    kinds: request.kinds.map((kind) => ApiResourceKind[kind] ?? String(kind)),
+    query: request.query,
+    org: request.org,
+    exclude_public: request.excludePublic,
+  });
+
+  try {
+    return await deps.handler.handle(request);
+  } catch (error) {
+    deps.logger.error("Search failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw toGrpcError(error);
+  }
+}
+
+/**
+ * Go toGRPCError: substring-match validation texts to InvalidArgument
+ * (carrying the wrapped text), default everything else to the sanitized
+ * Internal (#478) — the call site above has already logged the full
+ * error.
+ */
+function toGrpcError(error: unknown): ConnectError {
+  const text = error instanceof Error ? error.message : String(error);
+  if (
+    text.includes("validation failed") ||
+    text.includes("invalid") ||
+    text.includes("exceeds maximum")
+  ) {
+    return invalidArgumentError(text);
+  }
+  return internalError(error, "search failed");
+}

--- a/backend/services/stigmer-server-ts/src/query/search/criteria.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/criteria.ts
@@ -1,0 +1,197 @@
+/**
+ * Search criteria value object — ports
+ * pkg/query/search/valueobject/search_criteria.go: validated, normalized,
+ * immutable search parameters and the three-mode contract (list / search /
+ * discover).
+ *
+ * The searchable-kind set is DERIVED from the proto kind_meta extension
+ * (not_search_indexed: false, tier != cloud_only) — Go's
+ * SearchIndexedKinds() posture since stigmer/stigmer#439, where hand-copied
+ * kind lists drifted from the proto and from each other. Go still carries a
+ * hand map (SearchableKinds) pinned to the derivation by an invariant test;
+ * here the derivation IS the set — parity by construction, one source. The
+ * registry unit test pins the registered extractors against this same
+ * derivation (the #439 invariant's TS home).
+ *
+ * kinds are kept VERBATIM from the request; filtering to the searchable set
+ * happens in effectiveKinds(). Keeping the raw request is what
+ * distinguishes "no kinds requested" (discover mode) from "kinds requested
+ * but none searchable" (empty result) — collapsing the two at construction
+ * made kind-targeted requests for non-searchable kinds silently degrade to
+ * discover mode and return every other kind's resources
+ * (stigmer/stigmer#440).
+ *
+ * Proven by __tests__/criteria.test.ts (Go's tables case-for-case) and
+ * search.conformance.test.ts on local-ts.
+ */
+import {
+  ApiResourceKind,
+  ApiResourceKindSchema,
+  ResourceTier,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { getKindMeta } from "../../pipeline/apiresource-meta.js";
+
+/** Go DefaultPageSize. */
+export const DEFAULT_PAGE_SIZE = 20;
+/** Go MaxPageSize. */
+export const MAX_PAGE_SIZE = 100;
+/** Go MaxQueryLength (the proto's max_len twin; see newSearchCriteria). */
+export const MAX_QUERY_LENGTH = 500;
+
+let searchIndexedKindsCache: readonly ApiResourceKind[] | undefined;
+let searchableKindSetCache: ReadonlySet<ApiResourceKind> | undefined;
+
+/**
+ * Go SearchIndexedKinds(): every kind this edition's search read side
+ * serves — kind_meta declares it search-indexed and servable outside the
+ * cloud. Sorted ascending by enum value, exactly Go's sort. Kinds whose
+ * kind_meta cannot be read are skipped (Go's contract; the registry unit
+ * test separately fails on such a defect).
+ */
+export function searchIndexedKinds(): readonly ApiResourceKind[] {
+  if (searchIndexedKindsCache === undefined) {
+    const kinds: ApiResourceKind[] = [];
+    for (const value of ApiResourceKindSchema.values) {
+      const kind = value.number as ApiResourceKind;
+      if (kind === ApiResourceKind.api_resource_kind_unknown) {
+        continue;
+      }
+      let meta;
+      try {
+        meta = getKindMeta(kind);
+      } catch {
+        continue;
+      }
+      if (meta.notSearchIndexed || meta.tier === ResourceTier.cloud_only) {
+        continue;
+      }
+      kinds.push(kind);
+    }
+    kinds.sort((a, b) => a - b);
+    searchIndexedKindsCache = kinds;
+  }
+  return searchIndexedKindsCache;
+}
+
+/** The derivation as a Set — effectiveKinds' filter (Go SearchableKinds). */
+function searchableKindSet(): ReadonlySet<ApiResourceKind> {
+  if (searchableKindSetCache === undefined) {
+    searchableKindSetCache = new Set(searchIndexedKinds());
+  }
+  return searchableKindSetCache;
+}
+
+/**
+ * Immutable, validated search parameters. Construct via newSearchCriteria.
+ */
+export class SearchCriteria {
+  private constructor(
+    private readonly requestedKinds: readonly ApiResourceKind[],
+    private readonly queryText: string,
+    private readonly orgFilterValue: string,
+    private readonly excludePublicFlag: boolean,
+    private readonly crossOrgPublicFlag: boolean,
+    private readonly pageNumberValue: number,
+    private readonly pageSizeValue: number,
+  ) {}
+
+  /**
+   * Go NewSearchCriteria: trims query and org, clamps pagination
+   * (num < 1 → 1; size < 1 → default 20; size > 100 → 100), keeps kinds
+   * verbatim. Throws on an over-length query — defensive twin of the
+   * proto's max_len 500, which the protovalidate interceptor answers
+   * first on the wire (Go carries the same unreachable guard).
+   */
+  static create(
+    kinds: readonly ApiResourceKind[],
+    query: string,
+    orgFilter: string,
+    excludePublic: boolean,
+    crossOrgPublic: boolean,
+    pageNumber: number,
+    pageSize: number,
+  ): SearchCriteria {
+    const normalizedQuery = query.trim();
+    if (normalizedQuery.length > MAX_QUERY_LENGTH) {
+      throw new Error(
+        `search query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`,
+      );
+    }
+    return new SearchCriteria(
+      [...kinds],
+      normalizedQuery,
+      orgFilter.trim(),
+      excludePublic,
+      crossOrgPublic,
+      pageNumber < 1 ? 1 : pageNumber,
+      pageSize < 1 ? DEFAULT_PAGE_SIZE : Math.min(pageSize, MAX_PAGE_SIZE),
+    );
+  }
+
+  /** The requested kinds VERBATIM — including non-searchable ones. */
+  kinds(): readonly ApiResourceKind[] {
+    return [...this.requestedKinds];
+  }
+
+  query(): string {
+    return this.queryText;
+  }
+
+  orgFilter(): string {
+    return this.orgFilterValue;
+  }
+
+  excludePublic(): boolean {
+    return this.excludePublicFlag;
+  }
+
+  crossOrgPublic(): boolean {
+    return this.crossOrgPublicFlag;
+  }
+
+  pageNumber(): number {
+    return this.pageNumberValue;
+  }
+
+  pageSize(): number {
+    return this.pageSizeValue;
+  }
+
+  /**
+   * Discover mode = NO kinds requested. A request naming only
+   * non-searchable kinds is NOT discover mode — it searches nothing.
+   */
+  isDiscoverMode(): boolean {
+    return this.requestedKinds.length === 0;
+  }
+
+  /** False = list mode (created_at ordering, score pinned 1.0). */
+  hasQuery(): boolean {
+    return this.queryText !== "";
+  }
+
+  hasOrgFilter(): boolean {
+    return this.orgFilterValue !== "";
+  }
+
+  /**
+   * Go EffectiveKinds: discover mode → all searchable kinds; otherwise
+   * the requested kinds filtered to the searchable set — silently
+   * dropping non-searchable ones (the forward-compatibility contract on
+   * SearchRequest.kinds). The result may be EMPTY: the caller answers
+   * emptiness, never a discover fallback (stigmer/stigmer#440).
+   */
+  effectiveKinds(): readonly ApiResourceKind[] {
+    if (this.requestedKinds.length === 0) {
+      return searchIndexedKinds();
+    }
+    const searchable = searchableKindSet();
+    return this.requestedKinds.filter((kind) => searchable.has(kind));
+  }
+
+  /** Zero-indexed row offset for the page (Go Offset). */
+  offset(): number {
+    return (this.pageNumberValue - 1) * this.pageSizeValue;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/query/search/criteria.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/criteria.ts
@@ -30,6 +30,7 @@ import {
   ResourceTier,
 } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
+import { goTrimSpace } from "../../gocompat/trim.js";
 import { getKindMeta } from "../../pipeline/apiresource-meta.js";
 
 /** Go DefaultPageSize. */
@@ -102,6 +103,12 @@ export class SearchCriteria {
    * verbatim. Throws on an over-length query — defensive twin of the
    * proto's max_len 500, which the protovalidate interceptor answers
    * first on the wire (Go carries the same unreachable guard).
+   *
+   * Trimming is goTrimSpace, NOT String.trim: hasQuery() decides
+   * list-vs-search mode from the trimmed query, and the two trim sets
+   * disagree on U+FEFF/U+0085 — a BOM-only query would read as list mode
+   * (return everything) where Go runs an empty-match search (the #8 BOM
+   * divergence class, caught again by this sub-project's parity panel).
    */
   static create(
     kinds: readonly ApiResourceKind[],
@@ -112,7 +119,7 @@ export class SearchCriteria {
     pageNumber: number,
     pageSize: number,
   ): SearchCriteria {
-    const normalizedQuery = query.trim();
+    const normalizedQuery = goTrimSpace(query);
     if (normalizedQuery.length > MAX_QUERY_LENGTH) {
       throw new Error(
         `search query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`,
@@ -121,7 +128,7 @@ export class SearchCriteria {
     return new SearchCriteria(
       [...kinds],
       normalizedQuery,
-      orgFilter.trim(),
+      goTrimSpace(orgFilter),
       excludePublic,
       crossOrgPublic,
       pageNumber < 1 ? 1 : pageNumber,

--- a/backend/services/stigmer-server-ts/src/query/search/extractor.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/extractor.ts
@@ -1,0 +1,93 @@
+/**
+ * Searchable-extractor contract — ports the query side of
+ * pkg/query/search/extractor/extractor.go (the index side,
+ * SearchIndexExtractor, shipped with #4 in pipeline/steps/index-search.ts;
+ * this module extends it, mirroring Go's single interface).
+ *
+ * Go duplicates the ToSearchResult body 13× (protobuf structs cannot share
+ * methods); the OUTPUT is formulaic — metadata identity, spec-audit
+ * timestamps with zero-Timestamp defaults, per-kind summary — so it ports
+ * ONCE as buildSearchResult, parameterized by what actually varies (kind,
+ * summary, icon). Byte-visible output is identical; the per-kind summary
+ * sources are pinned in each domain's search-extractor.ts and in the
+ * conformance suite (D4 #14 DD-C, owner-ratified).
+ *
+ * Proven by search.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * the registry/extractor unit tests.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage, Message } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
+
+import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { ApiResourceMetadata } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+import { SearchResultSchema } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+
+import type { SearchIndexExtractor } from "../../pipeline/steps/index-search.js";
+
+/**
+ * The full extractor contract (Go SearchableExtractor): the #4 index side
+ * plus the query side this sub-project adds. One extractor per searchable
+ * kind, registered in registry.ts.
+ */
+export interface SearchableExtractor extends SearchIndexExtractor {
+  /** Go Kind(): the kind this extractor serves. */
+  readonly kind: ApiResourceKind;
+  /** Go NewEmptyProto(): the schema RebuildIndex unmarshals rows with. */
+  readonly schema: DescMessage;
+  /**
+   * Go GetSearchSummary(): the display description for search results.
+   * The source field varies by kind (see each domain's extractor header);
+   * truncation is a presentation concern — return the full text.
+   */
+  getSearchSummary(resource: Message): string;
+  /**
+   * Go ToSearchResult(): the wire projection for one hit. Returns
+   * undefined when the resource carries no metadata (Go returns nil) —
+   * the caller skips the row.
+   */
+  toSearchResult(resource: Message, score: number): SearchResult | undefined;
+}
+
+/**
+ * The formulaic SearchResult assembly every Go extractor repeats:
+ * metadata identity + qualified slug, spec-audit timestamps defaulting to
+ * the ZERO Timestamp when unstamped (Go sets &timestamppb.Timestamp{}),
+ * and the caller's summary/icon/score.
+ */
+export function buildSearchResult(params: {
+  readonly kind: ApiResourceKind;
+  readonly metadata: ApiResourceMetadata | undefined;
+  readonly summary: string;
+  readonly score: number;
+  readonly createdAt: Timestamp | undefined;
+  readonly updatedAt: Timestamp | undefined;
+  readonly iconUrl?: string;
+}): SearchResult | undefined {
+  const metadata = params.metadata;
+  if (metadata === undefined) {
+    return undefined;
+  }
+  return create(SearchResultSchema, {
+    kind: params.kind,
+    id: metadata.id,
+    name: metadata.name,
+    slug: metadata.slug,
+    org: metadata.org,
+    qualifiedSlug: buildQualifiedSlug(metadata.org, metadata.slug),
+    description: params.summary,
+    visibility: metadata.visibility,
+    tags: metadata.tags,
+    score: params.score,
+    iconUrl: params.iconUrl ?? "",
+    createdAt: params.createdAt ?? create(TimestampSchema),
+    updatedAt: params.updatedAt ?? create(TimestampSchema),
+  });
+}
+
+/** Go buildQualifiedSlug: "org/slug", or the bare slug when org is empty. */
+function buildQualifiedSlug(org: string, slug: string): string {
+  return org === "" ? slug : `${org}/${slug}`;
+}

--- a/backend/services/stigmer-server-ts/src/query/search/handler.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/handler.ts
@@ -29,6 +29,7 @@ import type {
 
 import type { Logger } from "../../boot/logger.js";
 import { SearchCriteria } from "./criteria.js";
+import type { SearchPagedResult } from "./paged-result.js";
 import type { SearchQueryStore } from "./query-store.js";
 
 export class SearchHandler {
@@ -70,7 +71,7 @@ export class SearchHandler {
       );
     }
 
-    let result;
+    let result: SearchPagedResult;
     try {
       result = await this.store.search(criteria);
     } catch (error) {

--- a/backend/services/stigmer-server-ts/src/query/search/handler.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/handler.ts
@@ -1,0 +1,98 @@
+/**
+ * Search handler — ports pkg/query/search/handler/search_handler.go: the
+ * plain 4-step CQRS pipeline (validate → criteria → store → response).
+ * Deliberately NOT the domain pipeline library — Go's query side doesn't
+ * use its pipeline either; queries have no persist/audit lifecycle.
+ *
+ * Step 1's protovalidate run is Go's defensive twin: the interceptor
+ * chain has already validated the request on every wire and in-process
+ * path (chain position 3; Go server.go:246 "protovalidate runs first"),
+ * so this arm is unreachable from the wire — ported because Go carries
+ * it, and because the handler contract ("Handle validates") must not
+ * silently depend on the caller's chain.
+ *
+ * Proven by __tests__/handler.test.ts and search.conformance.test.ts on
+ * local-ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import { createValidator } from "@bufbuild/protovalidate";
+import type { Validator } from "@bufbuild/protovalidate";
+
+import {
+  SearchRequestSchema,
+  SearchResponseSchema,
+} from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+import type {
+  SearchRequest,
+  SearchResponse,
+} from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { SearchCriteria } from "./criteria.js";
+import type { SearchQueryStore } from "./query-store.js";
+
+export class SearchHandler {
+  private readonly validator: Validator;
+
+  constructor(
+    private readonly store: SearchQueryStore,
+    private readonly logger: Logger,
+  ) {
+    this.validator = createValidator();
+  }
+
+  /**
+   * Go Handle: validate → build criteria → execute → build response.
+   * Errors carry Go's exact wrap prefixes — the controller's error
+   * mapping string-matches them (#478 sanitization contract).
+   */
+  async handle(request: SearchRequest): Promise<SearchResponse> {
+    const validation = this.validator.validate(SearchRequestSchema, request);
+    if (validation.kind !== "valid") {
+      throw new Error(`validation failed: ${validation.error.message}`);
+    }
+
+    let criteria: SearchCriteria;
+    try {
+      criteria = SearchCriteria.create(
+        request.kinds,
+        request.query,
+        request.org,
+        request.excludePublic,
+        request.crossOrgPublic,
+        request.page?.num ?? 0,
+        request.page?.size ?? 0,
+      );
+    } catch (error) {
+      throw new Error(
+        `build criteria failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+
+    let result;
+    try {
+      result = await this.store.search(criteria);
+    } catch (error) {
+      throw new Error(
+        `search failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+
+    const response = create(SearchResponseSchema, {
+      entries: [...result.results],
+      countsByKind: { ...result.countsByKind },
+      totalCount: result.totalCount,
+      totalPages: result.totalPages,
+    });
+
+    this.logger.debug("Search completed", {
+      results: response.entries.length,
+      total: response.totalCount,
+      has_query: criteria.hasQuery(),
+    });
+
+    return response;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/query/search/paged-result.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/paged-result.ts
@@ -1,0 +1,54 @@
+/**
+ * Paged search result — ports
+ * pkg/query/search/valueobject/search_paged_result.go: the page of
+ * SearchResult projections plus the counts the response carries.
+ * totalPages = ceil(totalCount / pageSize), 0 when pageSize is 0 (the
+ * EmptyResult shape). Negative totals/page sizes are internal-contract
+ * violations and throw, as Go's constructor errors.
+ *
+ * Go defensively copies on construction AND on every accessor; here the
+ * readonly types carry the same do-not-mutate contract without the
+ * per-call copies (TS's compile-time twin of Go's runtime discipline).
+ */
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+
+export interface SearchPagedResult {
+  readonly results: readonly SearchResult[];
+  /** Total matches per kind NAME string — totals, not page counts. */
+  readonly countsByKind: Readonly<Record<string, number>>;
+  readonly totalCount: number;
+  readonly totalPages: number;
+}
+
+const EMPTY_RESULT: SearchPagedResult = {
+  results: [],
+  countsByKind: {},
+  totalCount: 0,
+  totalPages: 0,
+};
+
+/** Go EmptyResult(): the shared empty page. */
+export function emptyResult(): SearchPagedResult {
+  return EMPTY_RESULT;
+}
+
+/** Go NewSearchPagedResult. */
+export function newSearchPagedResult(
+  results: readonly SearchResult[],
+  countsByKind: Readonly<Record<string, number>>,
+  totalCount: number,
+  pageSize: number,
+): SearchPagedResult {
+  if (totalCount < 0) {
+    throw new Error(`totalCount cannot be negative: ${totalCount}`);
+  }
+  if (pageSize < 0) {
+    throw new Error(`pageSize cannot be negative: ${pageSize}`);
+  }
+  return {
+    results,
+    countsByKind,
+    totalCount,
+    totalPages: pageSize > 0 ? Math.ceil(totalCount / pageSize) : 0,
+  };
+}

--- a/backend/services/stigmer-server-ts/src/query/search/query-store.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/query-store.ts
@@ -23,6 +23,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import { goFields, goTrimSpace } from "../../gocompat/trim.js";
 import { apiResourceKindName } from "../../store/sqlite/proto-fields.js";
 import type { Store } from "../../store/interface.js";
 import type { SearchCriteria } from "./criteria.js";
@@ -235,15 +236,20 @@ export class SqliteSearchQueryStore implements SearchQueryStore {
  * trailing `*` for prefix matching (valid on quoted terms); multi-token
  * queries use FTS5's implicit AND. The porter unicode61 tokenizer still
  * stems inside quotes.
+ *
+ * Trim and split are the gocompat twins of Go's strings.TrimSpace and
+ * strings.Fields — JS .trim()/\s+ disagree with Go on U+FEFF/U+0085,
+ * which changes the produced tokens on exactly those inputs (the #8 BOM
+ * divergence class).
  */
 export function escapeFTS5Query(query: string): string {
-  const trimmed = query.trim();
+  const trimmed = goTrimSpace(query);
   if (trimmed === "") {
     return trimmed;
   }
 
   const quoted: string[] = [];
-  for (const word of trimmed.split(/\s+/)) {
+  for (const word of goFields(trimmed)) {
     const clean = word.replaceAll('"', "");
     if (clean === "") {
       continue;

--- a/backend/services/stigmer-server-ts/src/query/search/query-store.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/query-store.ts
@@ -1,0 +1,289 @@
+/**
+ * Search query store — ports
+ * pkg/query/search/store/sqlite_search_query_store.go: the CQRS read path
+ * over the FTS5 index. The SQL itself lives in the storage driver
+ * (Store.querySearchIndex / clearSearchIndex — OD-3: no DB() escape
+ * hatch); this module owns what Go's store layer owned around the SQL —
+ * MATCH-expression escaping, BM25 score normalization, per-hit
+ * load-and-convert through the extractor registry, and RebuildIndex.
+ *
+ * Per-hit loading is Go's shape ported faithfully: each page row loads
+ * its resource individually and converts through the kind's extractor;
+ * a row that fails to parse, load, or convert logs a warning and is
+ * SKIPPED — the request never fails over one bad row. (The N+1 read is
+ * disclosed in the PR — parity over optimization, laptop-scale by
+ * design.)
+ *
+ * Proven by __tests__/query-store.test.ts (Go's store test tables +
+ * the scope-filter matrix) and search.conformance.test.ts on local-ts.
+ */
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { SearchResult } from "@stigmer/protos/ai/stigmer/search/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindName } from "../../store/sqlite/proto-fields.js";
+import type { Store } from "../../store/interface.js";
+import type { SearchCriteria } from "./criteria.js";
+import { emptyResult, newSearchPagedResult } from "./paged-result.js";
+import type { SearchPagedResult } from "./paged-result.js";
+import type { SearchableResourceRegistry } from "./registry.js";
+
+/** Go SearchQueryStore, the handler's read seam. */
+export interface SearchQueryStore {
+  search(criteria: SearchCriteria): Promise<SearchPagedResult>;
+  /**
+   * Wipes and repopulates the FTS5 index from the resources table.
+   * Returns the indexed-row count; throws AFTER indexing what it could
+   * when one or more kinds failed (the caller warns and boots on —
+   * Go server.go:617's posture).
+   */
+  rebuildIndex(): Promise<number>;
+}
+
+export class SqliteSearchQueryStore implements SearchQueryStore {
+  constructor(
+    private readonly store: Store,
+    private readonly registry: SearchableResourceRegistry,
+    private readonly logger: Logger,
+  ) {}
+
+  async search(criteria: SearchCriteria): Promise<SearchPagedResult> {
+    const effectiveKinds = criteria.effectiveKinds();
+    // A request naming only non-searchable kinds answers emptiness —
+    // never a discover fallback (stigmer/stigmer#440).
+    if (effectiveKinds.length === 0) {
+      return emptyResult();
+    }
+
+    const { countsByKind, totalCount, hits } =
+      await this.store.querySearchIndex({
+        kinds: effectiveKinds.map((kind) => apiResourceKindName(kind)),
+        matchExpression: criteria.hasQuery()
+          ? escapeFTS5Query(criteria.query())
+          : undefined,
+        orgFilter: criteria.orgFilter(),
+        crossOrgPublic: criteria.crossOrgPublic(),
+        excludePublic: criteria.excludePublic(),
+        limit: criteria.pageSize(),
+        offset: criteria.offset(),
+      });
+
+    if (totalCount === 0) {
+      return emptyResult();
+    }
+
+    const results: SearchResult[] = [];
+    for (const hit of hits) {
+      const kind = parseKind(hit.kind);
+      if (kind === undefined) {
+        this.logger.warn("Unknown resource kind in search index", {
+          kind: hit.kind,
+        });
+        continue;
+      }
+      const result = await this.loadAndConvertResource(
+        kind,
+        hit.resourceId,
+        normalizeScore(hit.rank),
+      );
+      if (result !== undefined) {
+        results.push(result);
+      }
+    }
+
+    return newSearchPagedResult(
+      results,
+      countsByKind,
+      totalCount,
+      criteria.pageSize(),
+    );
+  }
+
+  /** Go loadAndConvertResource: load the hit, convert via its extractor. */
+  private async loadAndConvertResource(
+    kind: ApiResourceKind,
+    resourceId: string,
+    score: number,
+  ): Promise<SearchResult | undefined> {
+    const extractor = this.registry.getExtractor(kind);
+    if (extractor === undefined) {
+      this.logger.warn("Failed to load resource", {
+        kind: ApiResourceKind[kind],
+        id: resourceId,
+        error: "no SearchableExtractor registered",
+      });
+      return undefined;
+    }
+    try {
+      const resource = await this.store.getResource(
+        kind,
+        resourceId,
+        extractor.schema,
+      );
+      return extractor.toSearchResult(resource, score);
+    } catch (error) {
+      // A stale index row (resource deleted between the page query and
+      // this load) or a corrupt row: warn and skip, exactly Go.
+      this.logger.warn("Failed to load resource", {
+        kind: ApiResourceKind[kind],
+        id: resourceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  async rebuildIndex(): Promise<number> {
+    this.logger.info("Rebuilding search index...");
+    await this.store.clearSearchIndex();
+
+    let totalIndexed = 0;
+    const indexErrors: string[] = [];
+
+    for (const kind of this.registry.supportedKinds()) {
+      try {
+        const count = await this.indexKind(kind);
+        totalIndexed += count;
+        this.logger.info("Indexed resources", {
+          kind: ApiResourceKind[kind],
+          count,
+        });
+      } catch (error) {
+        this.logger.warn(
+          "Failed to index kind (continuing with remaining kinds)",
+          {
+            kind: ApiResourceKind[kind],
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        indexErrors.push(
+          `${ApiResourceKind[kind]}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    if (indexErrors.length > 0) {
+      this.logger.warn("Search index rebuild completed with errors", {
+        total: totalIndexed,
+        failed_kinds: indexErrors.length,
+      });
+      throw new Error(
+        `failed to index ${indexErrors.length} kind(s): ${indexErrors.join("; ")}`,
+      );
+    }
+
+    this.logger.info("Search index rebuild complete", { total: totalIndexed });
+    return totalIndexed;
+  }
+
+  /** Go indexKind: every row of the kind through its extractor. */
+  private async indexKind(kind: ApiResourceKind): Promise<number> {
+    const extractor = this.registry.getExtractor(kind);
+    if (extractor === undefined) {
+      // supportedKinds() only yields registered kinds; this arm guards
+      // the same impossible state Go's GetExtractor error return does.
+      throw new Error("no SearchableExtractor registered");
+    }
+
+    const rows = await this.store.listResources(kind);
+    let count = 0;
+    for (const data of rows) {
+      let resource;
+      try {
+        resource = fromBinary(extractor.schema, data);
+      } catch (error) {
+        this.logger.warn("Failed to unmarshal resource", {
+          kind: ApiResourceKind[kind],
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+
+      const entry = extractor.getSearchIndexEntry(resource);
+      if (entry === undefined) {
+        continue;
+      }
+      // The resource ID rides the SearchResult projection (it has the
+      // metadata access) — Go's exact two-step.
+      const result = extractor.toSearchResult(resource, 1.0);
+      if (result === undefined) {
+        continue;
+      }
+
+      try {
+        await this.store.upsertSearchIndex(kind, result.id, entry);
+      } catch (error) {
+        this.logger.warn("Failed to index resource", {
+          kind: ApiResourceKind[kind],
+          id: result.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+      count += 1;
+    }
+    return count;
+  }
+}
+
+/**
+ * Go escapeFTS5Query: every whitespace-delimited token individually
+ * double-quoted (operator syntax — NOT/NEAR, column filters — becomes
+ * literal text); embedded double quotes stripped; a single token gets a
+ * trailing `*` for prefix matching (valid on quoted terms); multi-token
+ * queries use FTS5's implicit AND. The porter unicode61 tokenizer still
+ * stems inside quotes.
+ */
+export function escapeFTS5Query(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed === "") {
+    return trimmed;
+  }
+
+  const quoted: string[] = [];
+  for (const word of trimmed.split(/\s+/)) {
+    const clean = word.replaceAll('"', "");
+    if (clean === "") {
+      continue;
+    }
+    quoted.push(`"${clean}"`);
+  }
+
+  if (quoted.length === 0) {
+    return "";
+  }
+  if (quoted.length === 1) {
+    return `${quoted[0]}*`;
+  }
+  return quoted.join(" ");
+}
+
+/**
+ * Go normalizeScore: FTS5 bm25() is negative (lower = better); map to the
+ * wire's 0–1 (higher = better). Non-negative input (list mode's pinned
+ * 1.0) → exactly 1.0; else 1 + bm25/10, clamped to [0, 1] — the linear
+ * mapping for bm25's typical −5..0 range.
+ */
+export function normalizeScore(bm25Score: number): number {
+  if (bm25Score >= 0) {
+    return 1.0;
+  }
+  const score = 1.0 + bm25Score / 10.0;
+  if (score < 0) {
+    return 0;
+  }
+  if (score > 1) {
+    return 1;
+  }
+  return score;
+}
+
+/** Go parseKind: the enum-name string back to the enum value. */
+export function parseKind(kindName: string): ApiResourceKind | undefined {
+  const value = (ApiResourceKind as unknown as Record<string, unknown>)[
+    kindName
+  ];
+  return typeof value === "number" ? (value as ApiResourceKind) : undefined;
+}

--- a/backend/services/stigmer-server-ts/src/query/search/registry.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/registry.ts
@@ -1,0 +1,116 @@
+/**
+ * Searchable-resource registry — ports
+ * pkg/query/search/extractor/registry.go with the composition-root idiom
+ * in place of Go's init() self-registration (house rule: no import side
+ * effects). The ENTIRE searchable surface is this one explicit list; a
+ * kind is searchable exactly when its extractor appears here AND kind_meta
+ * declares it search-indexed — the registry unit test pins the two sets
+ * equal (Go's #439 invariant, TS home).
+ *
+ * Duplicate registration throws at construction (Go panics at init).
+ * validateExpectedKinds is WARN-only at boot, exactly Go's posture
+ * (registry.go ValidateExpectedKinds; server.go:509): a missing extractor
+ * degrades that kind to unsearchable, never refuses boot.
+ *
+ * The project extractor is registered here by THIS sub-project (#14)
+ * although the project DOMAIN ports with #16 — boot RebuildIndex re-indexes
+ * every registered kind from the resources table, and an adopted Go
+ * database may already hold projects; without the extractor those rows
+ * would silently vanish from search (D4 #14 DD-D, owner-ratified).
+ */
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { agentSearchExtractor } from "../../domain/agent/search-extractor.js";
+import { agentExecutionSearchExtractor } from "../../domain/agentexecution/search-extractor.js";
+import { agentInstanceSearchExtractor } from "../../domain/agentinstance/search-extractor.js";
+import { environmentSearchExtractor } from "../../domain/environment/search-extractor.js";
+import { executionContextSearchExtractor } from "../../domain/executioncontext/search-extractor.js";
+import { mcpServerSearchExtractor } from "../../domain/mcpserver/search-extractor.js";
+import { organizationSearchExtractor } from "../../domain/organization/search-extractor.js";
+import { projectSearchExtractor } from "../../domain/project/search-extractor.js";
+import { sessionSearchExtractor } from "../../domain/session/search-extractor.js";
+import { skillSearchExtractor } from "../../domain/skill/search-extractor.js";
+import { workflowSearchExtractor } from "../../domain/workflow/search-extractor.js";
+import { workflowExecutionSearchExtractor } from "../../domain/workflowexecution/search-extractor.js";
+import { workflowInstanceSearchExtractor } from "../../domain/workflowinstance/search-extractor.js";
+import type { Logger } from "../../boot/logger.js";
+import { searchIndexedKinds } from "./criteria.js";
+import type { SearchableExtractor } from "./extractor.js";
+
+/** Go SearchableResourceRegistry — kind → extractor, read-only after build. */
+export class SearchableResourceRegistry {
+  private readonly extractors: ReadonlyMap<ApiResourceKind, SearchableExtractor>;
+
+  constructor(extractors: readonly SearchableExtractor[]) {
+    const map = new Map<ApiResourceKind, SearchableExtractor>();
+    for (const extractor of extractors) {
+      if (map.has(extractor.kind)) {
+        throw new Error(
+          `duplicate SearchableExtractor for kind ${ApiResourceKind[extractor.kind]}`,
+        );
+      }
+      map.set(extractor.kind, extractor);
+    }
+    this.extractors = map;
+  }
+
+  /** Go GetExtractorOrNil — undefined when the kind is not registered. */
+  getExtractor(kind: ApiResourceKind): SearchableExtractor | undefined {
+    return this.extractors.get(kind);
+  }
+
+  /**
+   * Go SupportedKinds: registered kinds sorted by their NAME strings
+   * (Go sorts on kind.String()) — RebuildIndex's deterministic order.
+   */
+  supportedKinds(): readonly ApiResourceKind[] {
+    return [...this.extractors.keys()].sort((a, b) =>
+      (ApiResourceKind[a] ?? "").localeCompare(ApiResourceKind[b] ?? ""),
+    );
+  }
+
+  /**
+   * Go ValidateExpectedKinds (server.go:509): warn about searchable kinds
+   * with no extractor — those kinds are silently unsearchable — or log
+   * the healthy roster. Never throws: boot proceeds either way.
+   */
+  validateExpectedKinds(logger: Logger): void {
+    const missing = searchIndexedKinds()
+      .filter((kind) => !this.extractors.has(kind))
+      .map((kind) => ApiResourceKind[kind] ?? String(kind));
+    if (missing.length > 0) {
+      logger.warn(
+        "SearchableResourceRegistry is missing extractors. These kinds will not be searchable.",
+        { missing_kinds: missing },
+      );
+      return;
+    }
+    logger.info("SearchableResourceRegistry initialized successfully", {
+      count: this.extractors.size,
+      kinds: this.supportedKinds().map((kind) => ApiResourceKind[kind]),
+    });
+  }
+}
+
+/**
+ * The production registry — every searchable kind's extractor, in one
+ * place. Growing the searchable surface = one entry here + the domain's
+ * extractor file (the registry test fails until both exist).
+ */
+export function newSearchableResourceRegistry(): SearchableResourceRegistry {
+  return new SearchableResourceRegistry([
+    agentSearchExtractor,
+    agentExecutionSearchExtractor,
+    agentInstanceSearchExtractor,
+    environmentSearchExtractor,
+    executionContextSearchExtractor,
+    mcpServerSearchExtractor,
+    organizationSearchExtractor,
+    projectSearchExtractor,
+    sessionSearchExtractor,
+    skillSearchExtractor,
+    workflowSearchExtractor,
+    workflowExecutionSearchExtractor,
+    workflowInstanceSearchExtractor,
+  ]);
+}

--- a/backend/services/stigmer-server-ts/src/query/search/registry.ts
+++ b/backend/services/stigmer-server-ts/src/query/search/registry.ts
@@ -60,13 +60,18 @@ export class SearchableResourceRegistry {
   }
 
   /**
-   * Go SupportedKinds: registered kinds sorted by their NAME strings
-   * (Go sorts on kind.String()) — RebuildIndex's deterministic order.
+   * Go SupportedKinds: registered kinds sorted by their NAME strings —
+   * RebuildIndex's deterministic order. Code-unit `<`, not localeCompare:
+   * Go's sort is byte-wise on kind.String(), and locale collation could
+   * reorder names around `_` (not wire-visible, but log/error order is
+   * part of the operator-facing contract).
    */
   supportedKinds(): readonly ApiResourceKind[] {
-    return [...this.extractors.keys()].sort((a, b) =>
-      (ApiResourceKind[a] ?? "").localeCompare(ApiResourceKind[b] ?? ""),
-    );
+    return [...this.extractors.keys()].sort((a, b) => {
+      const nameA = ApiResourceKind[a] ?? "";
+      const nameB = ApiResourceKind[b] ?? "";
+      return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+    });
   }
 
   /**

--- a/backend/services/stigmer-server-ts/src/store/interface.ts
+++ b/backend/services/stigmer-server-ts/src/store/interface.ts
@@ -143,6 +143,55 @@ export interface SearchIndexEntry {
   readonly createdAt: number;
 }
 
+/**
+ * Parameters for one FTS5 read (Go SQLiteSearchQueryStore.Search's two
+ * statements, D4 #14 / OD-3: the SQL lives in the driver, the search
+ * service composes criteria). The caller guarantees `kinds` is non-empty —
+ * the empty effective-kind set short-circuits ABOVE the store
+ * (stigmer/stigmer#440), never as an `IN ()` syntax accident here.
+ */
+export interface SearchIndexQuery {
+  /** Kind NAME strings (the search_index.kind column values). */
+  readonly kinds: readonly string[];
+  /**
+   * Pre-escaped FTS5 MATCH expression (search mode), or undefined for
+   * list mode (created_at ordering, rank pinned 1.0). Escaping is search
+   * semantics and stays in the search service (escapeFTS5Query).
+   */
+  readonly matchExpression: string | undefined;
+  /** Org scope; "" = no org filter. */
+  readonly orgFilter: string;
+  /** With orgFilter: also admit visibility_public rows from ANY org. */
+  readonly crossOrgPublic: boolean;
+  /** Independent subtraction: drop visibility_public rows from any scope. */
+  readonly excludePublic: boolean;
+  readonly limit: number;
+  readonly offset: number;
+}
+
+/** One page row of a search-index read, in result order. */
+export interface SearchIndexHit {
+  /** Kind NAME string as stored (parsed back to the enum by the caller). */
+  readonly kind: string;
+  readonly resourceId: string;
+  /**
+   * bm25() rank (negative, lower = better) in search mode; the pinned
+   * 1.0 in list mode. Normalization to the wire's 0–1 score happens in
+   * the search service (normalizeScore).
+   */
+  readonly rank: number;
+}
+
+/** A search-index read: full counts plus the requested page. */
+export interface SearchIndexQueryResult {
+  /** Total matches per kind NAME (GROUP BY kind — zero-count kinds absent). */
+  readonly countsByKind: Record<string, number>;
+  /** Sum of countsByKind values. */
+  readonly totalCount: number;
+  /** The requested page, empty when totalCount is 0 (count short-circuit). */
+  readonly hits: readonly SearchIndexHit[];
+}
+
 // =============================================================================
 // Bootstrap state (Go: concrete-type methods, sqlite/store.go:1480-1611)
 // =============================================================================
@@ -668,6 +717,21 @@ export interface Store {
 
   /** Removes a resource's search-index row (post-delete). */
   deleteSearchIndex(kind: ApiResourceKind, resourceId: string): Promise<void>;
+
+  /**
+   * One FTS5 read: the count statement (GROUP BY kind), short-circuiting
+   * to an empty page at zero matches, then the ranked page statement —
+   * Go SQLiteSearchQueryStore's searchWithQuery/listWithoutQuery pair,
+   * SQL byte-identical (D4 #14, OD-3: no DB() escape hatch; the driver
+   * owns the SQL, the search service owns criteria and conversion).
+   */
+  querySearchIndex(query: SearchIndexQuery): Promise<SearchIndexQueryResult>;
+
+  /**
+   * Empties the search index (RebuildIndex's wipe before re-indexing from
+   * the resources table — Go's `DELETE FROM search_index`).
+   */
+  clearSearchIndex(): Promise<void>;
 
   // ---------------------------------------------------------------------------
   // Consolidated sub-stores (D2 §3 — inside the boundary, no DB() hatch)

--- a/backend/services/stigmer-server-ts/src/store/sqlite/store.ts
+++ b/backend/services/stigmer-server-ts/src/store/sqlite/store.ts
@@ -51,6 +51,9 @@ import type {
   PendingOAuthStateStore,
   ScheduleRunRecord,
   SearchIndexEntry,
+  SearchIndexHit,
+  SearchIndexQuery,
+  SearchIndexQueryResult,
   SignalDedupeRecord,
   SignalDedupeStatus,
   SignalDedupeStore,
@@ -770,6 +773,104 @@ export class SqliteStore implements Store {
     db.prepare(
       `DELETE FROM search_index WHERE kind = ? AND resource_id = ?`,
     ).run(apiResourceKindName(kind), resourceId);
+  }
+
+  async querySearchIndex(
+    query: SearchIndexQuery,
+  ): Promise<SearchIndexQueryResult> {
+    const db = this.open();
+
+    const kindPlaceholders = query.kinds.map(() => "?").join(",");
+    const kindArgs = [...query.kinds];
+
+    // The scope-filter fragments, byte-identical to Go's buildScopeFilter:
+    // org (strict or public-widened) and the independent public subtraction.
+    const scopeClauses: string[] = [];
+    const scopeArgs: string[] = [];
+    if (query.orgFilter !== "") {
+      scopeClauses.push(
+        query.crossOrgPublic
+          ? `AND (org = ? OR visibility = 'visibility_public')`
+          : `AND org = ?`,
+      );
+      scopeArgs.push(query.orgFilter);
+    }
+    if (query.excludePublic) {
+      scopeClauses.push(`AND visibility != 'visibility_public'`);
+    }
+    const scopeSql = scopeClauses.join("\n        ");
+
+    const searchMode = query.matchExpression !== undefined;
+    const matchClause = searchMode ? `search_index MATCH ? AND ` : "";
+    const matchArgs = searchMode ? [query.matchExpression as string] : [];
+
+    // Statement 1 — full counts per kind (Go's count query; zero-count
+    // kinds never appear: the counts come from GROUP BY over matches).
+    const countRows = db
+      .prepare(
+        `SELECT kind, COUNT(*) as cnt
+         FROM search_index
+         WHERE ${matchClause}kind IN (${kindPlaceholders})
+         ${scopeSql}
+         GROUP BY kind`,
+      )
+      .all(...matchArgs, ...kindArgs, ...scopeArgs) as Array<{
+      kind: string;
+      cnt: number;
+    }>;
+
+    const countsByKind: Record<string, number> = {};
+    let totalCount = 0;
+    for (const row of countRows) {
+      countsByKind[row.kind] = row.cnt;
+      totalCount += row.cnt;
+    }
+
+    // Go short-circuits to EmptyResult before the page statement.
+    if (totalCount === 0) {
+      return { countsByKind: {}, totalCount: 0, hits: [] };
+    }
+
+    // Statement 2 — the ranked page. Search mode: bm25 with the pinned
+    // weight vector (kind=1, resource_id=0, name=10, description=5,
+    // tags=5), ascending rank (bm25 is negative, lower = better). List
+    // mode: rank pinned 1.0, newest first.
+    const pageSql = searchMode
+      ? `SELECT kind, resource_id, bm25(search_index, 1.0, 0, 10.0, 5.0, 5.0) as rank
+         FROM search_index
+         WHERE search_index MATCH ? AND kind IN (${kindPlaceholders})
+         ${scopeSql}
+         ORDER BY rank
+         LIMIT ? OFFSET ?`
+      : `SELECT kind, resource_id, 1.0 as rank
+         FROM search_index
+         WHERE kind IN (${kindPlaceholders})
+         ${scopeSql}
+         ORDER BY created_at DESC
+         LIMIT ? OFFSET ?`;
+
+    const pageRows = db
+      .prepare(pageSql)
+      .all(
+        ...matchArgs,
+        ...kindArgs,
+        ...scopeArgs,
+        query.limit,
+        query.offset,
+      ) as Array<{ kind: string; resource_id: string; rank: number }>;
+
+    const hits: SearchIndexHit[] = pageRows.map((row) => ({
+      kind: row.kind,
+      resourceId: row.resource_id,
+      rank: row.rank,
+    }));
+
+    return { countsByKind, totalCount, hits };
+  }
+
+  async clearSearchIndex(): Promise<void> {
+    const db = this.open();
+    db.exec("DELETE FROM search_index");
   }
 
   // ---------------------------------------------------------------------------

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -56,6 +56,11 @@
 //     Layer-1 arms, and the artifact file-server disposition lane). The
 //     oauthapp suite's delete-block test drives McpServer create/delete,
 //     so it rosters here only after #9 (McpServer CRUD) merged.
+//   - search + activity — sub-project #14 (sp.search-and-activity; the
+//     two CQRS query services: the FTS5 SearchService with the 13-kind
+//     extractor registry — project's extractor rides this entry per DD-D,
+//     ahead of #16's domain — boot-time RebuildIndex, and the
+//     ActivityQueryController recents feed, stigmer#461).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -83,6 +88,8 @@ export default defineConfig({
       "src/suites/platform.conformance.test.ts",
       "src/suites/github.conformance.test.ts",
       "src/suites/artifact.conformance.test.ts",
+      "src/suites/search.conformance.test.ts",
+      "src/suites/activity.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the two CQRS read-side services to the TS server (D4 entry #14, program 20260822.01): the FTS5-backed `SearchService` (unified list/search/discover) and the `ActivityQueryController` recents feed. The `local-ts` conformance roster grows 22 → 24 suites (search 9 tests + activity 7), both first-run green.

## Context

The TS write side (FTS5 table, index-on-save, 12 domain extractors) has existed since #4; `src/query/` was the reserved seam. This entry fills it: the read path, the extractor query side, boot-time index rebuild, and the roster gate. Prerequisites #4 (FTS5/SP-C) and #10 (CW-5) are merged.

## Changes

- **Store surface (OD-3)**: `querySearchIndex` (Go's count + ranked-page statements, clause-identical SQL, zero-match short-circuit, `buildScopeFilter` fragments byte-for-byte) and `clearSearchIndex` on the `Store` interface; sqlite driver implementation.
- **`src/query/search/`**: criteria value object (searchable set DERIVED from proto `kind_meta` — Go #439's derivation is the single source here; #440 verbatim-kinds semantics; Go's clamps/error text), paged result, the `SearchableExtractor` contract + shared `buildSearchResult`, the explicit 13-entry registry (throw-on-duplicate, warn-only boot validation), the query store (Go's `escapeFTS5Query`, bm25 weights `(1.0, 0, 10.0, 5.0, 5.0)`, `normalizeScore`, per-hit load-and-convert with skip-on-failure, resilient `RebuildIndex`), the 4-step CQRS handler, and the controller with the #478 string-contains error mapping.
- **`src/query/activity/`**: two-kind newest-first stable merge (sessions-before-executions tie order), runtime-origin label exclusions, `"Auto-created session"` → `"Untitled session"` sentinel, phase→badge map, page normalize 30/100 (stigmer#461).
- **Extractors**: the 12 domain `search-extractor.ts` files gain the query side; `src/domain/project/search-extractor.ts` is NEW — see implementation notes.
- **`src/gocompat/trim.ts`**: `goTrimSpace`/`goFields` (promoted from skill's frontmatter under the second-consumer rule) — criteria trimming and FTS5 tokenization match Go's `strings.TrimSpace`/`Fields` on U+FEFF/U+0085, where JS `.trim()`/`\s+` flip mode selection and token boundaries.
- **Boot**: registry construction + warn-only validation at the controllers stage; registration between artifact and github (Go server.go:493–522 order); `RebuildIndex` in `start()` before the port binds, warn-only (Go server.go:617).
- **Conformance**: `search` + `activity` join `vitest.local-ts.config.ts` (22 → 24) with the roster-history entry.

## Implementation notes

- **The `project` extractor ships HERE, ahead of #16's domain port (ratified DD-D)**: boot `RebuildIndex` wipes and re-indexes every REGISTERED kind — on an adopted Go database holding projects, a 12-kind registry would silently erase them from search. The extractor depends only on the generated proto. **Coordination**: #16's in-flight branch creates the same file (index side only); whichever merges second reconciles to this full-contract version.
- Go's `init()`-side-effect registry singleton becomes an explicitly-constructed list (house rule: no import side effects); a unit test pins registry keys == the `kind_meta` derivation (Go's #439 invariant, drift-proof by construction).
- Go duplicates the formulaic `ToSearchResult` body 13×; it ports once as `buildSearchResult`. Byte-visible output identical, pinned by tests — including Go's three deliberate divergences where the projection description is NOT `GetSearchSummary` (agent_execution pins `""`; workflow_execution and execution_context omit it).
- Two-reviewer panel note: both reviewer subagents died to model limits (the #13/#20 precedent); the panel ran directly in-session. Findings fixed in-branch: the U+FEFF/U+0085 trim/split divergence (wire-visible on BOM-only queries), `Object.hasOwn` for label lookups (the #17 precedent), code-unit sort for `supportedKinds` (Go's byte-wise order), a test temp-dir leak, a typed binding.

## Disclosed parity nuances (for the register)

- **Per-hit N+1 loading ported faithfully**: each page row loads its resource individually; stale index rows are counted in totals but skipped on the page (Go's exact shape). A both-editions optimization candidate, post-cutover.
- **`normalizeScore` formula** ported exactly (`>= 0 → 1.0`, else `1 + bm25/10` clamped); scores are float32 on the wire with a single rounding at the same serialization point in both editions. Conformance never pins score values (D1).
- **protovalidate-es violation text**: the two InvalidArgument arms (query > 500, malformed org slug) are answered by the interceptor in both editions; codes are suite-pinned (P2), text remains the standing watch item.
- **The controller's Go string-contains mapping is ported quirks-and-all**: a store error whose text contains "invalid" answers InvalidArgument carrying the raw text (pinned by a unit test).
- **Criteria's length check counts UTF-16 code units where Go counts bytes** — both are wire-unreachable defensive twins behind the proto's `max_len` (code-point semantics in both editions).
- **Discovered, pre-existing, NOT changed here**: Node 23.4.0 — admitted by the package's engines range `^22.13.0 || >=23.4.0` — has no FTS5 in `node:sqlite` (the store suite fails on it; reproduced locally). A self-hosting user on exactly 23.4.x gets a loud boot failure at migration v3. Recommend an OSS issue to narrow the engines floor; owner-gated.

## Breaking changes

- None. Additive: two new services, two new store methods, no Go-side changes.

## Test plan

- `tsc --noEmit` clean; unit suite **1368/1368** (99 files; 93 new tests: criteria/paged-result/registry/query-store tables ported case-for-case from Go's `*_test.go`, the activity handler arms, controller error-mapping via router transport, gocompat trim pins, and composed-server tests incl. boot-rebuild over a pre-seeded DB with an adopted project row).
- Conformance `local-ts`: **24 suites, 430 passed / 1 skipped** — search and activity first-run green.
- Conformance `local-go`: **492 passed / 1 skipped** — the tracker baseline exactly, regression-free (no Go or suite changes).
- `npm run build` + `verify:dist`: bundle boots, serves, shuts down cleanly.
- All runs on Node 22.23.2 (see the engines disclosure above).

## Risks

- Low: additive services behind their own conformance suites. Rollback = revert (no schema changes; migration v3's FTS5 table pre-exists).
- The one-file overlap with #16 (`src/domain/project/search-extractor.ts`) is a known, documented merge-order reconciliation.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Conformance roster updated (the reviewable statement of what this PR ports)

Made with [Cursor](https://cursor.com)