### PR TITLE
feat(backend/stigmer-server-ts): port workflow-execution Temporal orchestration (D4 #21)

### DIFF
--- a/backend/services/stigmer-server-ts/scripts/capture-wfexec-replay-histories.ts
+++ b/backend/services/stigmer-server-ts/scripts/capture-wfexec-replay-histories.ts
@@ -1,0 +1,134 @@
+/**
+ * Captures workflow-execution orchestrator histories for the replay
+ * determinism gate — the twin of capture-replay-histories.ts (see its
+ * header for the discipline and the proto-JSON round-trip rationale).
+ *
+ * Runs the core orchestration scenarios against a local Temporal test
+ * server with the scriptable stub child (test-workflows.ts) and no-op
+ * recorder activities (mock data only — safe to commit), writing each
+ * history's proto-JSON to
+ * src/temporal/workflowexecution/__tests__/replay-histories/.
+ *
+ * Usage: npx tsx scripts/capture-wfexec-replay-histories.ts
+ * (requires the `temporal` CLI on PATH — same as the workflow tests)
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import proto from "@temporalio/proto";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+
+const TASK_QUEUE = "wfexec-replay-capture";
+const WORKFLOWS_PATH = fileURLToPath(
+  new URL(
+    "../src/temporal/workflowexecution/__tests__/test-workflows.ts",
+    import.meta.url,
+  ),
+);
+const OUT_DIR = fileURLToPath(
+  new URL(
+    "../src/temporal/workflowexecution/__tests__/replay-histories",
+    import.meta.url,
+  ),
+);
+
+const childEvents: string[] = [];
+
+const activities = {
+  UpdateWorkflowExecutionStatus: async () => {},
+  DeleteExecutionContext: async () => {},
+  TestRecordChildEvent: async (event: string) => {
+    childEvents.push(event);
+  },
+};
+
+async function waitForChildEvent(event: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (childEvents.includes(event)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`capture timed out waiting for child event ${event}`);
+}
+
+async function main(): Promise<void> {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const env = await TestWorkflowEnvironment.createLocal();
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowsPath: WORKFLOWS_PATH,
+    activities,
+  });
+  const runPromise = worker.run();
+
+  async function capture(
+    name: string,
+    executionId: string,
+    drive: (
+      handle: import("@temporalio/client").WorkflowHandle,
+    ) => Promise<void>,
+  ): Promise<void> {
+    childEvents.length = 0;
+    const handle = await env.client.workflow.start(
+      "stigmer/workflow-execution/invoke",
+      {
+        taskQueue: TASK_QUEUE,
+        workflowId: `wfexec-replay-${name}`,
+        args: [
+          {
+            execution_id: executionId,
+            workflow_instance_id: "wfi-replay",
+            workflow_id: "wf-replay",
+            org_id: "org-replay",
+          },
+        ],
+        memo: { runnerTaskQueue: TASK_QUEUE },
+      },
+    );
+    await drive(handle);
+    const history = await handle.fetchHistory();
+    const json = proto.temporal.api.history.v1.History.fromObject(
+      history,
+    ).toJSON();
+    writeFileSync(
+      `${OUT_DIR}/${name}.json`,
+      JSON.stringify(json, null, 2) + "\n",
+    );
+    console.log(`captured ${name}.json`);
+  }
+
+  // 1. Happy path: child completes → EC cleanup, no persists.
+  await capture("happy-completed", "wfe-ok", async (handle) => {
+    await handle.result();
+  });
+
+  // 2. Pause/resume: serialized PAUSED/IN_PROGRESS persists + relays,
+  //    release THROUGH the relay lane (the orchestrator has no
+  //    test-release handler of its own — the envelope is how any
+  //    task-specific signal reaches the child), completion.
+  await capture("pause-resume", "wfe-hold-pr", async (handle) => {
+    await waitForChildEvent("started");
+    await handle.signal("pause", "replay capture");
+    await waitForChildEvent("pause:replay capture");
+    await handle.signal("resume");
+    await waitForChildEvent("resume");
+    await handle.signal("relaySignal", {
+      signalName: "test-release",
+      payload: null,
+    });
+    await handle.result();
+  });
+
+  // 3. Failure path: FAILED persist + EC cleanup + ApplicationFailure.
+  await capture("child-failed", "wfe-fail", async (handle) => {
+    await handle.result().catch(() => {});
+  });
+
+  worker.shutdown();
+  await runPromise.catch(() => {});
+  await env.teardown();
+}
+
+await main();
+process.exit(0);

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -71,8 +71,10 @@ import { ModelRegistryStore } from "../domain/workflow/registry/model-registry-s
 import { InProcessValidator } from "../domain/workflow/validation/validator.js";
 import { registerWorkflowInstanceServices } from "../domain/workflowinstance/controller.js";
 import { registerWorkflowExecutionServices } from "../domain/workflowexecution/controller.js";
-import { ENGINE_DISCONNECTED as WORKFLOW_EXECUTION_ENGINE_DISCONNECTED } from "../domain/workflowexecution/engine.js";
 import { StreamBroker as WorkflowExecutionStreamBroker } from "../domain/workflowexecution/stream-broker.js";
+import { newWorkflowExecutionConfigFromEnv } from "../domain/workflowexecution/temporal/config.js";
+import { newWorkflowExecutionEngineStateProvider } from "../temporal/workflowexecution/engine-client.js";
+import { newWorkflowExecutionWorkerFactory } from "../temporal/workflowexecution/worker.js";
 import { HealthState, registerHealthService } from "../transport/health.js";
 import { createRegistryLanes } from "../transport/registry/lanes.js";
 import { createUnifiedPortServer } from "../transport/server.js";
@@ -106,9 +108,10 @@ export interface ComposedServer {
    */
   agentExecutionStreamBroker: StreamBroker;
   /**
-   * The workflowexecution broadcast fabric (exposed for tests and, with
-   * #21, its Temporal worker's broadcasts — Go's GetStreamBroker).
-   * UpdateStatus and the lifecycle RPCs are the production writers.
+   * The workflowexecution broadcast fabric (exposed for tests and for the
+   * Temporal worker's persist broadcasts, #21 — Go's GetStreamBroker).
+   * UpdateStatus, the lifecycle RPCs, and the worker's activities are the
+   * production writers.
    */
   workflowExecutionStreamBroker: WorkflowExecutionStreamBroker;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
@@ -177,6 +180,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   // dispatch uses — one definition, so policy and dispatch can never
   // disagree (oss#397).
   const temporalConfig = newConfigFromEnv();
+  // The workflow-execution twin (#21) — its config has no policy
+  // consumer, so it lives here with the temporal stage.
+  const workflowExecutionTemporalConfig = newWorkflowExecutionConfigFromEnv();
   const healthState = new HealthState();
   // The model-registry store is DOMAIN-owned (workflow-family DD-A,
   // restoring Go's ownership): workflow validation and the transport's
@@ -207,9 +213,9 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   const workflowExecutionStreamBroker = new WorkflowExecutionStreamBroker(
     logger,
   );
-  // The manager owns the connection lifecycle; the agent-execution worker
-  // is the first factory (workflow-execution and the schedule clock
-  // append theirs in #21/#22 — Go createWorkers' list).
+  // The manager owns the connection lifecycle; one factory per domain
+  // worker (Go createWorkers' list) — agent-execution (#18),
+  // workflow-execution (#21); the schedule clock appends its own in #22.
   const temporalManager = new TemporalManager({
     hostPort: config.temporalHostPort,
     namespace: config.temporalNamespace,
@@ -222,6 +228,12 @@ export function composeServer(options: ComposeOptions): ComposedServer {
         broker: agentExecutionStreamBroker,
         temporalConfig,
       }),
+      newWorkflowExecutionWorkerFactory({
+        store,
+        logger,
+        broker: workflowExecutionStreamBroker,
+        temporalConfig: workflowExecutionTemporalConfig,
+      }),
     ],
   });
   // The provider IS the injection mechanism (no Go-style creator
@@ -233,6 +245,15 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     store,
     logger,
   });
+  // The workflow-execution twin: the same provider-is-the-injection
+  // mechanism, filling the seam #20 left disconnected.
+  const workflowExecutionEngineState = newWorkflowExecutionEngineStateProvider(
+    {
+      manager: temporalManager,
+      config: workflowExecutionTemporalConfig,
+      logger,
+    },
+  );
   // The artifact blob store (Go server.go 349: shared by agentexecution
   // attachments, the artifact domain (#13), and skill push (#8)). The r2
   // arm landed with #13; the health probe runs in start(), matching Go's
@@ -398,10 +419,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     registerWorkflowExecutionServices(router, {
       store,
       logger,
-      // Permanently disconnected until #21 lands the workflow-execution
-      // orchestrator on #18's worker infra; same provider shape as the
-      // agentexecution seam above.
-      engineState: () => WORKFLOW_EXECUTION_ENGINE_DISCONNECTED,
+      engineState: workflowExecutionEngineState,
       broker: workflowExecutionStreamBroker,
       workflowInstanceCreator: () =>
         requireInProcess().workflowExecutionInstanceCreator,

--- a/backend/services/stigmer-server-ts/src/domain/workflowexecution/temporal/config.ts
+++ b/backend/services/stigmer-server-ts/src/domain/workflowexecution/temporal/config.ts
@@ -1,0 +1,129 @@
+/**
+ * Workflow-execution Temporal config — ports
+ * pkg/domain/workflowexecution/temporal/config.go: the queue names,
+ * routing mode, and default execution target for workflow-execution
+ * dispatch.
+ *
+ * The tree corresponds to Go's (config lives with the domain, like
+ * src/domain/agentexecution/temporal/config.ts); the Temporal-importing
+ * slice (worker, workflow, engine client) lives in
+ * src/temporal/workflowexecution/.
+ *
+ * resolveWorkflowExecutionTarget is the single definition of the
+ * UNSPECIFIED-resolution rule for WORKFLOW executions (Go
+ * resolveWorkflowExecutionTarget) — dispatch resolution (#21's engine)
+ * is its one consumer today; a future policy consumer must use it rather
+ * than re-derive the default, the same one-definition discipline the
+ * agentexecution config records (oss#397).
+ */
+import { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+
+/**
+ * Routes all child workflows to the shared global runner queue
+ * (runnerQueue, default stigmer_runner) — the default for OSS local
+ * development where a single runner polls one queue (Go RoutingGlobal).
+ */
+export const WORKFLOW_ROUTING_GLOBAL = "global";
+
+/**
+ * Derives a per-execution task queue (wfexec:{execution_id}) for each
+ * workflow execution — for deployments where each execution gets a
+ * dedicated runner (cloud sandboxes, or the desktop runner-manager's
+ * per-execution workers; Go RoutingExecution).
+ */
+export const WORKFLOW_ROUTING_EXECUTION = "execution";
+
+/**
+ * Resolves UNSPECIFIED to LOCAL — OSS/self-hosted deployments (Go
+ * DefaultExecutionTargetLocal).
+ */
+export const WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL = "local";
+
+/**
+ * Resolves UNSPECIFIED to CLOUD — the managed cloud service (Go
+ * DefaultExecutionTargetCloud).
+ */
+export const WORKFLOW_DEFAULT_EXECUTION_TARGET_CLOUD = "cloud";
+
+/**
+ * Configuration for workflow-execution Temporal workers (Go
+ * temporal.Config).
+ *
+ * Queue architecture (worker_config.go's contract):
+ *   - stigmerQueue: this server's orchestrator workflows on
+ *     workflow_execution_stigmer
+ *   - runnerQueue: the TS unified runner's child workflows on
+ *     stigmer_runner (global) or wfexec:{id} (per-execution)
+ */
+export class WorkflowExecutionTemporalConfig {
+  constructor(
+    /**
+     * Task queue for the orchestrator workflows this server registers.
+     * Default: workflow_execution_stigmer.
+     */
+    readonly stigmerQueue: string,
+    /**
+     * Default task queue for the runner's child workflows
+     * (stigmer_runner). In global routing mode all children route here;
+     * in execution routing mode it is unused (every execution derives
+     * wfexec:{id}) but kept as the memo fallback Go keeps.
+     */
+    readonly runnerQueue: string,
+    /** WORKFLOW_ROUTING_GLOBAL or WORKFLOW_ROUTING_EXECUTION. */
+    readonly workflowActivityRouting: string,
+    /**
+     * Resolves EXECUTION_TARGET_UNSPECIFIED on workflow executions:
+     * LOCAL (the operator's runner polls the queue) or CLOUD (the server
+     * provisions a per-execution sandbox).
+     */
+    readonly defaultExecutionTarget: string,
+  ) {}
+
+  /**
+   * Resolves a workflow execution's execution_target to its effective
+   * target: UNSPECIFIED becomes the configured default; explicit values
+   * pass through unchanged (Go resolveWorkflowExecutionTarget).
+   */
+  resolveWorkflowExecutionTarget(target: ExecutionTarget): ExecutionTarget {
+    if (target !== ExecutionTarget.UNSPECIFIED) {
+      return target;
+    }
+    if (
+      this.defaultExecutionTarget === WORKFLOW_DEFAULT_EXECUTION_TARGET_CLOUD
+    ) {
+      return ExecutionTarget.CLOUD;
+    }
+    return ExecutionTarget.LOCAL;
+  }
+}
+
+/**
+ * Builds the config from environment variables with Go LoadConfig's
+ * defaults. Env-derived strings only — no Temporal connection is made
+ * here (the manager owns connections).
+ */
+export function newWorkflowExecutionConfigFromEnv(): WorkflowExecutionTemporalConfig {
+  return new WorkflowExecutionTemporalConfig(
+    valueOrDefault(
+      process.env.TEMPORAL_WORKFLOW_EXECUTION_STIGMER_TASK_QUEUE,
+      "workflow_execution_stigmer",
+    ),
+    valueOrDefault(
+      process.env.TEMPORAL_WORKFLOW_EXECUTION_RUNNER_TASK_QUEUE,
+      "stigmer_runner",
+    ),
+    valueOrDefault(
+      process.env.STIGMER_WORKFLOW_ACTIVITY_ROUTING,
+      WORKFLOW_ROUTING_GLOBAL,
+    ),
+    valueOrDefault(
+      process.env.STIGMER_WORKFLOW_DEFAULT_EXECUTION_TARGET,
+      WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL,
+    ),
+  );
+}
+
+/** Go's `if v == "" { v = default }` idiom for env reads. */
+function valueOrDefault(value: string | undefined, fallback: string): string {
+  return value === undefined || value === "" ? fallback : value;
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/activities.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/activities.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Pins the worker's UpdateWorkflowExecutionStatus activity against Go's
+ * update_status_impl.go — the ACTIVITY merge, deliberately distinct from
+ * the RPC's applyUpdateStatusMerge (sub-project DD-001 brief):
+ *
+ *   - the statusAudit bump is UNCONDITIONAL (the RPC bumps only on phase
+ *     transitions) — the pin that would catch a "consolidate the merges"
+ *     refactor changing wire-visible audit timestamps;
+ *   - no events are written (getEventLog must not grow from orchestrator
+ *     persists);
+ *   - a missing execution is a wrapped ordinary error with Go's
+ *     "workflow execution not found:" text, not a NotFound RPC error;
+ *   - the persist rides the atomic updateResource and broadcasts through
+ *     the domain broker after commit.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create, toJson } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { timestampMs } from "@bufbuild/protobuf/wkt";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import {
+  WorkflowExecutionSchema,
+  WorkflowExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { StreamBroker } from "../../../domain/workflowexecution/stream-broker.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import type { Store } from "../../../store/interface.js";
+import {
+  applyActivityStatusMerge,
+  createWorkflowExecutionActivities,
+} from "../activities.js";
+import { UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME } from "../names.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+describe("applyActivityStatusMerge (the activity's own merge, not the RPC's)", () => {
+  function merged(
+    existingStatus: MessageInitShape<typeof WorkflowExecutionStatusSchema>,
+    updates: WorkflowExecutionStatus,
+  ): WorkflowExecution {
+    const execution = create(WorkflowExecutionSchema, {
+      metadata: { id: "wfe-1" },
+      status: existingStatus,
+    });
+    applyActivityStatusMerge(execution, updates);
+    return execution;
+  }
+
+  it("applies a phase-only update and preserves tasks, error, and totals", () => {
+    const result = merged(
+      {
+        phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+        tasks: [{ taskName: "t1" }],
+        error: "prior",
+        totalCostMicros: 5n,
+      },
+      create(WorkflowExecutionStatusSchema, {
+        phase: ExecutionPhase.EXECUTION_PAUSED,
+      }),
+    );
+    expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_PAUSED);
+    expect(result.status?.tasks.map((task) => task.taskName)).toEqual(["t1"]);
+    expect(result.status?.error).toBe("prior");
+    expect(result.status?.totalCostMicros).toBe(5n);
+  });
+
+  it("bumps statusAudit.updatedAt UNCONDITIONALLY — even without a phase transition", () => {
+    // The RPC merge would NOT bump here (same phase re-asserted); the
+    // activity always does (update_status_impl.go's unconditional bump).
+    const before = Date.now() - 1;
+    const result = merged(
+      { phase: ExecutionPhase.EXECUTION_PAUSED },
+      create(WorkflowExecutionStatusSchema, {
+        phase: ExecutionPhase.EXECUTION_PAUSED,
+      }),
+    );
+    const updatedAt = result.status?.audit?.statusAudit?.updatedAt;
+    expect(updatedAt).toBeDefined();
+    expect(timestampMs(updatedAt!)).toBeGreaterThanOrEqual(before);
+    expect(result.status?.audit?.statusAudit?.event).toBe("updated");
+  });
+
+  it("replaces tasks only when the update carries a non-empty set", () => {
+    const withEmpty = merged(
+      { tasks: [{ taskName: "keep" }] },
+      create(WorkflowExecutionStatusSchema, {
+        phase: ExecutionPhase.EXECUTION_FAILED,
+      }),
+    );
+    expect(withEmpty.status?.tasks.map((task) => task.taskName)).toEqual([
+      "keep",
+    ]);
+
+    const withTasks = merged(
+      { tasks: [{ taskName: "old" }] },
+      create(WorkflowExecutionStatusSchema, {
+        tasks: [{ taskName: "new-1" }, { taskName: "new-2" }],
+      }),
+    );
+    expect(withTasks.status?.tasks.map((task) => task.taskName)).toEqual([
+      "new-1",
+      "new-2",
+    ]);
+  });
+
+  it("treats zero totals as no-update, never reset", () => {
+    const result = merged(
+      { totalCostMicros: 7n, totalInputTokens: 3n, totalOutputTokens: 2n },
+      create(WorkflowExecutionStatusSchema, {
+        phase: ExecutionPhase.EXECUTION_FAILED,
+        error: "boom",
+      }),
+    );
+    expect(result.status?.totalCostMicros).toBe(7n);
+    expect(result.status?.totalInputTokens).toBe(3n);
+    expect(result.status?.totalOutputTokens).toBe(2n);
+    expect(result.status?.error).toBe("boom");
+  });
+
+  it("sets timestamps only when provided", () => {
+    const result = merged(
+      { startedAt: "2026-01-01T00:00:00Z" },
+      create(WorkflowExecutionStatusSchema, {
+        completedAt: "2026-01-02T00:00:00Z",
+      }),
+    );
+    expect(result.status?.startedAt).toBe("2026-01-01T00:00:00Z");
+    expect(result.status?.completedAt).toBe("2026-01-02T00:00:00Z");
+  });
+});
+
+describe("UpdateWorkflowExecutionStatus activity (real store)", () => {
+  let dir: string;
+  let store: Store;
+  let broker: StreamBroker;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "wfexec-activity-"));
+    store = SqliteStore.open(path.join(dir, "test.db"));
+    broker = new StreamBroker(silentLogger);
+  });
+
+  afterAll(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function activity() {
+    const activities = createWorkflowExecutionActivities({
+      store,
+      logger: silentLogger,
+      broker,
+    });
+    return activities[UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME] as (
+      executionId: string,
+      statusJson: unknown,
+    ) => Promise<void>;
+  }
+
+  it("persists the merge atomically and broadcasts the updated execution", async () => {
+    const id = "wfe-activity-1";
+    await store.saveResource(
+      ApiResourceKind.workflow_execution,
+      id,
+      WorkflowExecutionSchema,
+      create(WorkflowExecutionSchema, {
+        metadata: { id, name: id },
+        status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      }),
+    );
+
+    const subscription = broker.subscribe(id);
+    try {
+      await activity()(
+        id,
+        toJson(
+          WorkflowExecutionStatusSchema,
+          create(WorkflowExecutionStatusSchema, {
+            phase: ExecutionPhase.EXECUTION_CANCELLED,
+          }),
+        ),
+      );
+
+      const stored = await store.getResource(
+        ApiResourceKind.workflow_execution,
+        id,
+        WorkflowExecutionSchema,
+      );
+      expect(stored.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+      // CANCELLED carries NO error (stigmer#282's quiet-terminal contract).
+      expect(stored.status?.error).toBe("");
+      // The unconditional audit bump reached the stored state.
+      expect(stored.status?.audit?.statusAudit?.updatedAt).toBeDefined();
+
+      // The broadcast landed on the registered subscriber AFTER the
+      // persist committed (ADR 011 write path).
+      const frames: WorkflowExecution[] = subscription.queue;
+      expect(frames).toHaveLength(1);
+      expect(frames[0]!.status?.phase).toBe(
+        ExecutionPhase.EXECUTION_CANCELLED,
+      );
+    } finally {
+      broker.unsubscribe(id, subscription);
+    }
+  });
+
+  it("writes NO workflow_execution_events (the activity never touches the event log)", async () => {
+    const id = "wfe-activity-2";
+    await store.saveResource(
+      ApiResourceKind.workflow_execution,
+      id,
+      WorkflowExecutionSchema,
+      create(WorkflowExecutionSchema, {
+        metadata: { id, name: id },
+        status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      }),
+    );
+
+    await activity()(
+      id,
+      toJson(
+        WorkflowExecutionStatusSchema,
+        create(WorkflowExecutionStatusSchema, {
+          phase: ExecutionPhase.EXECUTION_FAILED,
+          error: "Workflow execution failed: child boom",
+        }),
+      ),
+    );
+
+    const events = await store.getWorkflowExecutionEvents(id, 0, "", "", 10);
+    expect(events).toHaveLength(0);
+  });
+
+  it("wraps a missing execution with Go's 'workflow execution not found:' text", async () => {
+    await expect(
+      activity()(
+        "wfe-missing",
+        toJson(
+          WorkflowExecutionStatusSchema,
+          create(WorkflowExecutionStatusSchema, {
+            phase: ExecutionPhase.EXECUTION_FAILED,
+          }),
+        ),
+      ),
+    ).rejects.toThrowError(/^workflow execution not found: /);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/dispatch.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/dispatch.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Pins resolveWorkflowTaskQueue against Go's dispatch_test.go: the two
+ * routing modes, the wfexec:{id} format, and the UNSPECIFIED-target
+ * resolution through the config's single rule.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  WORKFLOW_DEFAULT_EXECUTION_TARGET_CLOUD,
+  WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL,
+  WORKFLOW_ROUTING_EXECUTION,
+  WORKFLOW_ROUTING_GLOBAL,
+  WorkflowExecutionTemporalConfig,
+} from "../../../domain/workflowexecution/temporal/config.js";
+import { resolveWorkflowTaskQueue } from "../dispatch.js";
+import { formatWfExecTaskQueue } from "../names.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+function config(
+  routing: string,
+  defaultTarget = WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL,
+): WorkflowExecutionTemporalConfig {
+  return new WorkflowExecutionTemporalConfig(
+    "workflow_execution_stigmer",
+    "stigmer_runner",
+    routing,
+    defaultTarget,
+  );
+}
+
+describe("resolveWorkflowTaskQueue", () => {
+  it("routes to the global runner queue in global mode", () => {
+    const result = resolveWorkflowTaskQueue(
+      "wfe-1",
+      ExecutionTarget.LOCAL,
+      config(WORKFLOW_ROUTING_GLOBAL),
+      silentLogger,
+    );
+    expect(result.taskQueue).toBe("stigmer_runner");
+    expect(result.executionTarget).toBe(ExecutionTarget.LOCAL);
+  });
+
+  it("derives wfexec:{id} in execution mode regardless of target", () => {
+    for (const target of [
+      ExecutionTarget.LOCAL,
+      ExecutionTarget.CLOUD,
+      ExecutionTarget.UNSPECIFIED,
+    ]) {
+      const result = resolveWorkflowTaskQueue(
+        "wfe-42",
+        target,
+        config(WORKFLOW_ROUTING_EXECUTION),
+        silentLogger,
+      );
+      expect(result.taskQueue).toBe("wfexec:wfe-42");
+    }
+  });
+
+  it("resolves UNSPECIFIED to the configured default target", () => {
+    const local = resolveWorkflowTaskQueue(
+      "wfe-1",
+      ExecutionTarget.UNSPECIFIED,
+      config(WORKFLOW_ROUTING_GLOBAL, WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL),
+      silentLogger,
+    );
+    expect(local.executionTarget).toBe(ExecutionTarget.LOCAL);
+
+    const cloud = resolveWorkflowTaskQueue(
+      "wfe-1",
+      ExecutionTarget.UNSPECIFIED,
+      config(WORKFLOW_ROUTING_GLOBAL, WORKFLOW_DEFAULT_EXECUTION_TARGET_CLOUD),
+      silentLogger,
+    );
+    expect(cloud.executionTarget).toBe(ExecutionTarget.CLOUD);
+  });
+
+  it("passes explicit targets through unchanged", () => {
+    const result = resolveWorkflowTaskQueue(
+      "wfe-1",
+      ExecutionTarget.CLOUD,
+      config(WORKFLOW_ROUTING_GLOBAL, WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL),
+      silentLogger,
+    );
+    expect(result.executionTarget).toBe(ExecutionTarget.CLOUD);
+  });
+
+  it("formatWfExecTaskQueue matches Go's format", () => {
+    expect(formatWfExecTaskQueue("abc")).toBe("wfexec:abc");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/engine-client.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/engine-client.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Pins the ConnectedWorkflowExecutionEngine implementation against
+ * workflow_creator.go and the lifecycle steps' temporalClient contract:
+ * the workflow name/ID, the runnerTaskQueue memo, the slim input's
+ * omitempty JSON shape, the SignalWithStart lane, the one-null-argument
+ * raw-signal convention, the WorkflowNotFoundError → seam-sentinel
+ * mapping, and the provider's memoization/disconnected semantics.
+ *
+ * The Temporal Client is a recording double — the real dial path is
+ * proven by local-ts-execution.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { Client } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/common";
+
+import { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  ENGINE_DISCONNECTED,
+  EngineWorkflowNotFoundError,
+  type StartWorkflowExecutionInput,
+} from "../../../domain/workflowexecution/engine.js";
+import {
+  WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL,
+  WORKFLOW_ROUTING_GLOBAL,
+  WorkflowExecutionTemporalConfig,
+} from "../../../domain/workflowexecution/temporal/config.js";
+import type { TemporalManager } from "../../manager.js";
+import {
+  newWorkflowExecutionEngineStateProvider,
+  TemporalWorkflowExecutionEngine,
+} from "../engine-client.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const config = new WorkflowExecutionTemporalConfig(
+  "workflow_execution_stigmer",
+  "stigmer_runner",
+  WORKFLOW_ROUTING_GLOBAL,
+  WORKFLOW_DEFAULT_EXECUTION_TARGET_LOCAL,
+);
+
+interface RecordedStart {
+  readonly workflowType: string;
+  readonly options: Record<string, unknown>;
+}
+
+interface RecordedHandleCall {
+  readonly workflowId: string;
+  readonly method: string;
+  readonly args: unknown[];
+}
+
+function newClientDouble(handleError?: Error) {
+  const starts: RecordedStart[] = [];
+  const signalWithStarts: RecordedStart[] = [];
+  const handleCalls: RecordedHandleCall[] = [];
+
+  const client = {
+    workflow: {
+      start: async (workflowType: string, options: Record<string, unknown>) => {
+        starts.push({ workflowType, options });
+      },
+      signalWithStart: async (
+        workflowType: string,
+        options: Record<string, unknown>,
+      ) => {
+        signalWithStarts.push({ workflowType, options });
+      },
+      getHandle: (workflowId: string) => ({
+        signal: async (...args: unknown[]) => {
+          if (handleError) throw handleError;
+          handleCalls.push({ workflowId, method: "signal", args });
+        },
+        cancel: async () => {
+          if (handleError) throw handleError;
+          handleCalls.push({ workflowId, method: "cancel", args: [] });
+        },
+        terminate: async (reason: string) => {
+          if (handleError) throw handleError;
+          handleCalls.push({ workflowId, method: "terminate", args: [reason] });
+        },
+      }),
+    },
+  } as unknown as Client;
+
+  return { client, starts, signalWithStarts, handleCalls };
+}
+
+function startInput(
+  overrides: Partial<StartWorkflowExecutionInput> = {},
+): StartWorkflowExecutionInput {
+  return {
+    executionId: "wfe-1",
+    workflowInstanceId: "wfi-1",
+    workflowId: "wf-1",
+    orgId: "org-1",
+    recoveryMode: false,
+    executionTarget: ExecutionTarget.LOCAL,
+    ...overrides,
+  };
+}
+
+describe("TemporalWorkflowExecutionEngine", () => {
+  it("starts the orchestrator with the pinned ID, queue, memo, and omitempty input", async () => {
+    const double = newClientDouble();
+    const engine = new TemporalWorkflowExecutionEngine({
+      client: double.client,
+      config,
+      logger: silentLogger,
+    });
+
+    await engine.startInvokeWorkflow(startInput());
+
+    expect(double.starts).toHaveLength(1);
+    const start = double.starts[0]!;
+    expect(start.workflowType).toBe("stigmer/workflow-execution/invoke");
+    expect(start.options["workflowId"]).toBe(
+      "stigmer/workflow-execution/invoke/wfe-1",
+    );
+    expect(start.options["taskQueue"]).toBe("workflow_execution_stigmer");
+    expect(start.options["memo"]).toEqual({ runnerTaskQueue: "stigmer_runner" });
+    // Go's omitempty shape: recovery_mode false is OMITTED, not false.
+    expect(start.options["args"]).toEqual([
+      {
+        execution_id: "wfe-1",
+        workflow_instance_id: "wfi-1",
+        workflow_id: "wf-1",
+        org_id: "org-1",
+      },
+    ]);
+    // No workflowRunTimeout — durable execution (module header).
+    expect(start.options["workflowRunTimeout"]).toBeUndefined();
+  });
+
+  it("omits every zero-valued optional field and carries recovery_mode when set", async () => {
+    const double = newClientDouble();
+    const engine = new TemporalWorkflowExecutionEngine({
+      client: double.client,
+      config,
+      logger: silentLogger,
+    });
+
+    await engine.startInvokeWorkflow(
+      startInput({
+        workflowInstanceId: "",
+        workflowId: "",
+        orgId: "",
+        recoveryMode: true,
+      }),
+    );
+
+    expect(double.starts[0]!.options["args"]).toEqual([
+      { execution_id: "wfe-1", recovery_mode: true },
+    ]);
+  });
+
+  it("signalWithStart carries the signal, its payload, and the same start options", async () => {
+    const double = newClientDouble();
+    const engine = new TemporalWorkflowExecutionEngine({
+      client: double.client,
+      config,
+      logger: silentLogger,
+    });
+
+    await engine.signalWithStart(startInput(), "relaySignal", {
+      signalName: "human_input_step1",
+      payload: { answer: 42 },
+    });
+
+    expect(double.signalWithStarts).toHaveLength(1);
+    const call = double.signalWithStarts[0]!;
+    expect(call.workflowType).toBe("stigmer/workflow-execution/invoke");
+    expect(call.options["workflowId"]).toBe(
+      "stigmer/workflow-execution/invoke/wfe-1",
+    );
+    expect(call.options["signal"]).toBe("relaySignal");
+    expect(call.options["signalArgs"]).toEqual([
+      { signalName: "human_input_step1", payload: { answer: 42 } },
+    ]);
+    expect(call.options["memo"]).toEqual({ runnerTaskQueue: "stigmer_runner" });
+  });
+
+  it("raw signal sends exactly one argument, null when the payload is absent", async () => {
+    const double = newClientDouble();
+    const engine = new TemporalWorkflowExecutionEngine({
+      client: double.client,
+      config,
+      logger: silentLogger,
+    });
+
+    await engine.signalWorkflow("wf-id-1", "pause", "user requested");
+    await engine.signalWorkflow("wf-id-1", "resume", undefined);
+
+    expect(double.handleCalls).toEqual([
+      { workflowId: "wf-id-1", method: "signal", args: ["pause", "user requested"] },
+      // Go SignalWorkflow(nil) — one nil argument, not zero arguments.
+      { workflowId: "wf-id-1", method: "signal", args: ["resume", null] },
+    ]);
+  });
+
+  it("maps WorkflowNotFoundError onto the seam's sentinel for signal/cancel/terminate", async () => {
+    const notFound = new WorkflowNotFoundError("gone", "wf-id-x", undefined);
+    const double = newClientDouble(notFound);
+    const engine = new TemporalWorkflowExecutionEngine({
+      client: double.client,
+      config,
+      logger: silentLogger,
+    });
+
+    await expect(
+      engine.signalWorkflow("wf-id-x", "pause", "r"),
+    ).rejects.toBeInstanceOf(EngineWorkflowNotFoundError);
+    await expect(engine.cancelWorkflow("wf-id-x")).rejects.toBeInstanceOf(
+      EngineWorkflowNotFoundError,
+    );
+    await expect(
+      engine.terminateWorkflow("wf-id-x", "reason"),
+    ).rejects.toBeInstanceOf(EngineWorkflowNotFoundError);
+  });
+
+  it("passes non-not-found errors through unchanged", async () => {
+    const boom = new Error("connection refused");
+    const double = newClientDouble(boom);
+    const engine = new TemporalWorkflowExecutionEngine({
+      client: double.client,
+      config,
+      logger: silentLogger,
+    });
+
+    await expect(engine.cancelWorkflow("wf-id-x")).rejects.toBe(boom);
+  });
+});
+
+describe("newWorkflowExecutionEngineStateProvider", () => {
+  it("is disconnected until the first client and memoizes per client instance", () => {
+    let client: Client | undefined;
+    const manager = {
+      getClient: () => client,
+    } as unknown as TemporalManager;
+
+    const provider = newWorkflowExecutionEngineStateProvider({
+      manager,
+      config,
+      logger: silentLogger,
+    });
+
+    expect(provider()).toBe(ENGINE_DISCONNECTED);
+
+    client = newClientDouble().client;
+    const first = provider();
+    expect(first.connected).toBe(true);
+    // Same client → the SAME memoized state object.
+    expect(provider()).toBe(first);
+
+    // A reconnect swaps the client → a fresh engine wrapping it.
+    client = newClientDouble().client;
+    const second = provider();
+    expect(second.connected).toBe(true);
+    expect(second).not.toBe(first);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/invoke-workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/invoke-workflow.test.ts
@@ -103,6 +103,7 @@ let workflowSeq = 0;
 
 async function startOrchestrator(
   executionId: string,
+  overrides: Partial<InvokeWorkflowExecutionWorkflowInput> = {},
 ): Promise<import("@temporalio/client").WorkflowHandle> {
   if (!env) throw new Error("TestWorkflowEnvironment not initialized");
   workflowSeq++;
@@ -111,6 +112,7 @@ async function startOrchestrator(
     workflow_instance_id: "wfi-1",
     workflow_id: "wf-1",
     org_id: "org-1",
+    ...overrides,
   };
   return env.client.workflow.start(INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME, {
     taskQueue: TASK_QUEUE,
@@ -239,17 +241,13 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     const handle = await startOrchestrator("wfe-hold-pr");
     await waitFor(() => childEvents.includes("started"), "child start");
 
+    // Back-to-back, no intermediate wait — Go's resume test's shape: the
+    // two signals typically land buffered in one workflow task, so this
+    // also exercises the serialized loop's pause-first tie rule, not just
+    // sequential arrival order.
     await handle.signal(PAUSE_SIGNAL_NAME, "take a break");
-    await waitFor(
-      () => persistedPhases().includes(ExecutionPhase.EXECUTION_PAUSED),
-      "PAUSED persist",
-    );
-    await waitFor(
-      () => childEvents.includes("pause:take a break"),
-      "pause relay at the child",
-    );
-
     await handle.signal(RESUME_SIGNAL_NAME);
+
     await waitFor(
       () => persistedPhases().includes(ExecutionPhase.EXECUTION_IN_PROGRESS),
       "IN_PROGRESS persist",
@@ -296,6 +294,22 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     expect(childEvents).toContain('custom:{"answer":42}');
     // No status persist rides the relay lane (Go relays without one).
     expect(persistedStatuses).toEqual([]);
+  }, 30_000);
+
+  it("forwards the input to the child UNCHANGED — recovery_mode included", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-hold-recovery", {
+      recovery_mode: true,
+    });
+    await waitFor(
+      () => childEvents.includes("recovery-mode"),
+      "recovery flag at the child",
+    );
+    await releaseChild(handle);
+    await handle.result();
+
+    expect(childEvents).toContain("recovery-mode");
+    expect(deletedExecutionContexts).toEqual(["wfe-hold-recovery"]);
   }, 30_000);
 
   it("ignores a malformed relay envelope without failing the workflow", async (testCtx) => {

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/invoke-workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/invoke-workflow.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Invoke-workflow-execution orchestration tests — ports the scenario
+ * matrix of invoke_workflow_impl_test.go against a real
+ * TestWorkflowEnvironment with the scriptable stub child
+ * (test-workflows.ts) and recorder activities.
+ *
+ * What these pin (the orchestration contracts):
+ *   - the happy path: child completes → orchestrator completes, EC
+ *     cleaned up, ZERO orchestrator-side status persists;
+ *   - child failure: FAILED persist with the "Workflow execution
+ *     failed:" copy, EC cleanup, ApplicationFailure to the caller;
+ *   - external cancellation: CANCELLED persisted QUIETLY (no
+ *     status.error — stigmer#282) on the non-cancellable cleanup scope,
+ *     EC cleaned up;
+ *   - pause/resume: PAUSED/IN_PROGRESS persists in order, relays reach
+ *     the child in arrival order (the serialized-loop FIFO guarantee);
+ *   - relaySignal: the generic envelope reaches the child's
+ *     task-specific channel with its payload; a malformed envelope is
+ *     ignored without burning a relay.
+ *
+ * Follows #18's discipline: TestWorkflowEnvironment.createLocal (needs
+ * the `temporal` CLI); every test skips VISIBLY when the local test
+ * server cannot start — never a vacuous green (panel finding B3).
+ */
+import { fromJson } from "@bufbuild/protobuf";
+import type { JsonValue } from "@bufbuild/protobuf";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { WorkflowExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+
+import {
+  INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME,
+  MEMO_RUNNER_TASK_QUEUE,
+  PAUSE_SIGNAL_NAME,
+  RELAY_SIGNAL_CHANNEL_NAME,
+  RESUME_SIGNAL_NAME,
+  UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME,
+} from "../names.js";
+import type { InvokeWorkflowExecutionWorkflowInput } from "../workflow-input.js";
+import {
+  TEST_CUSTOM_SIGNAL,
+  TEST_RECORD_CHILD_EVENT_ACTIVITY,
+  TEST_RELEASE_SIGNAL,
+} from "./test-workflows.js";
+import { DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME } from "../../../domain/executioncontext/temporal/delete-execution-context.js";
+
+const TASK_QUEUE = "invoke-wfexec-test";
+const WORKFLOWS_PATH = new URL("./test-workflows.ts", import.meta.url).pathname;
+
+type TestWorkflowEnvironment =
+  import("@temporalio/testing").TestWorkflowEnvironment;
+type Worker = import("@temporalio/worker").Worker;
+
+let env: TestWorkflowEnvironment | null = null;
+let worker: Worker | null = null;
+let workerRunPromise: Promise<void> | null = null;
+let envReady = false;
+
+// ─── Recorders (reset per test; order-independent tests) ────────────────
+
+interface RecordedStatus {
+  readonly executionId: string;
+  readonly status: WorkflowExecutionStatus;
+}
+
+let persistedStatuses: RecordedStatus[] = [];
+let deletedExecutionContexts: string[] = [];
+let childEvents: string[] = [];
+
+function resetRecorders(): void {
+  persistedStatuses = [];
+  deletedExecutionContexts = [];
+  childEvents = [];
+}
+
+function recorderActivities(): Record<string, (...args: never[]) => Promise<unknown>> {
+  return {
+    [UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME]: async (
+      executionId: string,
+      statusJson: JsonValue,
+    ): Promise<void> => {
+      persistedStatuses.push({
+        executionId,
+        status: fromJson(WorkflowExecutionStatusSchema, statusJson),
+      });
+    },
+    [DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME]: async (
+      executionId: string,
+    ): Promise<void> => {
+      deletedExecutionContexts.push(executionId);
+    },
+    [TEST_RECORD_CHILD_EVENT_ACTIVITY]: async (event: string): Promise<void> => {
+      childEvents.push(event);
+    },
+  };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+let workflowSeq = 0;
+
+async function startOrchestrator(
+  executionId: string,
+): Promise<import("@temporalio/client").WorkflowHandle> {
+  if (!env) throw new Error("TestWorkflowEnvironment not initialized");
+  workflowSeq++;
+  const input: InvokeWorkflowExecutionWorkflowInput = {
+    execution_id: executionId,
+    workflow_instance_id: "wfi-1",
+    workflow_id: "wf-1",
+    org_id: "org-1",
+  };
+  return env.client.workflow.start(INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME, {
+    taskQueue: TASK_QUEUE,
+    workflowId: `wfexec-test-${workflowSeq}-${Date.now()}`,
+    args: [input],
+    memo: { [MEMO_RUNNER_TASK_QUEUE]: TASK_QUEUE },
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `timed out waiting for ${label}; ` +
+      `persisted=[${persistedStatuses.map((entry) => ExecutionPhase[entry.status.phase]).join(", ")}] ` +
+      `childEvents=[${childEvents.join(", ")}]`,
+  );
+}
+
+function persistedPhases(): ExecutionPhase[] {
+  return persistedStatuses.map((entry) => entry.status.phase);
+}
+
+/**
+ * Releases a holding stub child THROUGH the orchestrator's relay lane —
+ * the orchestrator has no test-release handler of its own; the envelope
+ * is exactly how any task-specific signal reaches the child in
+ * production (June DD-013).
+ */
+async function releaseChild(
+  handle: import("@temporalio/client").WorkflowHandle,
+): Promise<void> {
+  await handle.signal(RELAY_SIGNAL_CHANNEL_NAME, {
+    signalName: TEST_RELEASE_SIGNAL,
+    payload: null,
+  });
+}
+
+describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
+  beforeAll(async () => {
+    try {
+      const { TestWorkflowEnvironment: TWE } = await import(
+        "@temporalio/testing"
+      );
+      const { Worker: W } = await import("@temporalio/worker");
+      env = await TWE.createLocal();
+      worker = await W.create({
+        connection: env.nativeConnection,
+        taskQueue: TASK_QUEUE,
+        workflowsPath: WORKFLOWS_PATH,
+        activities: recorderActivities(),
+      });
+      workerRunPromise = worker.run();
+      envReady = true;
+    } catch (error) {
+      console.warn(
+        `Temporal test server unavailable (tests will be skipped): ${error instanceof Error ? error.message : String(error)}`,
+      );
+      envReady = false;
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (worker) {
+      worker.shutdown();
+      await workerRunPromise?.catch(() => {});
+    }
+    if (env) await env.teardown();
+  }, 30_000);
+
+  afterEach(() => {
+    resetRecorders();
+  });
+
+  it("completes the happy path with EC cleanup and ZERO orchestrator persists", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-ok");
+    await handle.result();
+
+    expect(deletedExecutionContexts).toEqual(["wfe-ok"]);
+    // The runner streams real statuses via gRPC; the orchestrator's own
+    // persists exist only for the failure/cancel/pause lanes.
+    expect(persistedStatuses).toEqual([]);
+  }, 30_000);
+
+  it("persists FAILED with Go's copy, cleans up the EC, and fails with ApplicationFailure", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-fail");
+    await expect(handle.result()).rejects.toThrowError(
+      /Workflow execution failed/,
+    );
+
+    expect(persistedPhases()).toEqual([ExecutionPhase.EXECUTION_FAILED]);
+    const failed = persistedStatuses[0]!;
+    expect(failed.executionId).toBe("wfe-fail");
+    // Go: "Workflow execution failed: %s" over the child's error text.
+    expect(failed.status.error).toMatch(/^Workflow execution failed: /);
+    expect(failed.status.error).toContain("child engine boom");
+    expect(deletedExecutionContexts).toEqual(["wfe-fail"]);
+  }, 30_000);
+
+  it("cancellation persists a QUIET CANCELLED (no error) and cleans up the EC", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-hold-cancel");
+    await waitFor(() => childEvents.includes("started"), "child start");
+
+    await handle.cancel();
+    await expect(handle.result()).rejects.toThrowError();
+
+    expect(persistedPhases()).toEqual([ExecutionPhase.EXECUTION_CANCELLED]);
+    // stigmer#282: a user cancel is a quiet terminal state — display
+    // layers key error styling on status.error.
+    expect(persistedStatuses[0]!.status.error).toBe("");
+    expect(deletedExecutionContexts).toEqual(["wfe-hold-cancel"]);
+  }, 30_000);
+
+  it("pause then resume: persists PAUSED/IN_PROGRESS in order and relays reach the child in arrival order", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-hold-pr");
+    await waitFor(() => childEvents.includes("started"), "child start");
+
+    await handle.signal(PAUSE_SIGNAL_NAME, "take a break");
+    await waitFor(
+      () => persistedPhases().includes(ExecutionPhase.EXECUTION_PAUSED),
+      "PAUSED persist",
+    );
+    await waitFor(
+      () => childEvents.includes("pause:take a break"),
+      "pause relay at the child",
+    );
+
+    await handle.signal(RESUME_SIGNAL_NAME);
+    await waitFor(
+      () => persistedPhases().includes(ExecutionPhase.EXECUTION_IN_PROGRESS),
+      "IN_PROGRESS persist",
+    );
+    await waitFor(
+      () => childEvents.includes("resume"),
+      "resume relay at the child",
+    );
+
+    await releaseChild(handle);
+    await handle.result();
+
+    // Persist order is the loop's serialization; child order is the FIFO
+    // relay guarantee (a resume overtaking its pause would wedge the
+    // production child).
+    expect(persistedPhases()).toEqual([
+      ExecutionPhase.EXECUTION_PAUSED,
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+    ]);
+    expect(childEvents.filter((event) => event !== "started")).toEqual([
+      "pause:take a break",
+      "resume",
+    ]);
+    expect(deletedExecutionContexts).toEqual(["wfe-hold-pr"]);
+  }, 30_000);
+
+  it("forwards relaySignal envelopes to the child's task-specific channel with the payload", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-hold-relay");
+    await waitFor(() => childEvents.includes("started"), "child start");
+
+    await handle.signal(RELAY_SIGNAL_CHANNEL_NAME, {
+      signalName: TEST_CUSTOM_SIGNAL,
+      payload: { answer: 42 },
+    });
+    await waitFor(
+      () => childEvents.some((event) => event.startsWith("custom:")),
+      "relayed custom signal at the child",
+    );
+
+    await releaseChild(handle);
+    await handle.result();
+
+    expect(childEvents).toContain('custom:{"answer":42}');
+    // No status persist rides the relay lane (Go relays without one).
+    expect(persistedStatuses).toEqual([]);
+  }, 30_000);
+
+  it("ignores a malformed relay envelope without failing the workflow", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    const handle = await startOrchestrator("wfe-hold-badrelay");
+    await waitFor(() => childEvents.includes("started"), "child start");
+
+    // No envelope at all — Go zero-values it and fails the relay
+    // harmlessly; this port refuses it before burning the relay command.
+    await handle.signal(RELAY_SIGNAL_CHANNEL_NAME);
+
+    await releaseChild(handle);
+    await handle.result();
+
+    expect(childEvents.filter((event) => event !== "started")).toEqual([]);
+    expect(deletedExecutionContexts).toEqual(["wfe-hold-badrelay"]);
+  }, 30_000);
+});

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay-histories/child-failed.json
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay-histories/child-failed.json
@@ -1,0 +1,678 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 621083000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048895",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "stigmer/workflow-execution/invoke"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJ3ZmUtZmFpbCIsIndvcmtmbG93X2luc3RhbmNlX2lkIjoid2ZpLXJlcGxheSIsIndvcmtmbG93X2lkIjoid2YtcmVwbGF5Iiwib3JnX2lkIjoib3JnLXJlcGxheSJ9"
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a03845-5b6d-7144-8490-7d7e9495e805",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03845-5b6d-7144-8490-7d7e9495e805",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "memo": {
+          "fields": {
+            "runnerTaskQueue": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZXhlYy1yZXBsYXktY2FwdHVyZSI="
+            }
+          }
+        },
+        "header": {},
+        "workflowId": "wfexec-replay-child-failed"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 621127000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048896",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 647943000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048901",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "110862b7-25a8-44a2-8fe0-aa02eaa05a9a",
+        "historySizeBytes": "518",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 654319000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048905",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            1,
+            2,
+            3
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 654603000
+      },
+      "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048906",
+      "startChildWorkflowExecutionInitiatedEventAttributes": {
+        "namespace": "default",
+        "workflowId": "workflow-exec-wfe-fail",
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJ3ZmUtZmFpbCIsIndvcmtmbG93X2luc3RhbmNlX2lkIjoid2ZpLXJlcGxheSIsIndvcmtmbG93X2lkIjoid2YtcmVwbGF5Iiwib3JnX2lkIjoib3JnLXJlcGxheSJ9"
+            }
+          ]
+        },
+        "workflowRunTimeout": {},
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "parentClosePolicy": "PARENT_CLOSE_POLICY_REQUEST_CANCEL",
+        "workflowTaskCompletedEventId": "4",
+        "workflowIdReusePolicy": "WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "1"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "100"
+          },
+          "maximumAttempts": 1
+        },
+        "header": {},
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda",
+        "inheritBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 698450000
+      },
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048914",
+      "childWorkflowExecutionStartedEventAttributes": {
+        "namespace": "default",
+        "initiatedEventId": "5",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-fail",
+          "runId": "01a03845-5bb9-7aa6-815a-11b07309d6a5"
+        },
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "header": {},
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 698456000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048915",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 747910000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048923",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "bf9ed284-7421-477f-84b5-cc503acce3b3",
+        "historySizeBytes": "1574",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 755076000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048931",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 795780000
+      },
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED",
+      "taskId": "1048939",
+      "childWorkflowExecutionFailedEventAttributes": {
+        "failure": {
+          "message": "child engine boom",
+          "source": "TypeScriptSDK",
+          "stackTrace": "ApplicationFailure: child engine boom\n    at Function.create (/Users/suresh/scm/github.com/stigmer/.worktrees/stigmer/feat-20260825.04.sp.workflowexecution-orchestration/backend/services/stigmer-server-ts/node_modules/@temporalio/common/src/failure.ts:227:11)\n    at create (/Users/suresh/scm/github.com/stigmer/.worktrees/stigmer/feat-20260825.04.sp.workflowexecution-orchestration/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/test-workflows.ts:57:29)",
+          "applicationFailureInfo": {}
+        },
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-fail",
+          "runId": "01a03845-5bb9-7aa6-815a-11b07309d6a5"
+        },
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "initiatedEventId": "5",
+        "startedEventId": "6",
+        "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED",
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 795788000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048940",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 847899000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048944",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "59aecb09-5664-44be-9eee-3cc55c0a7778",
+        "historySizeBytes": "2771",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 854380000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048948",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 854411000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048949",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "UpdateWorkflowExecutionStatus"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZS1mYWlsIg=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJwaGFzZSI6IkVYRUNVVElPTl9GQUlMRUQiLCJlcnJvciI6IldvcmtmbG93IGV4ZWN1dGlvbiBmYWlsZWQ6IENoaWxkIFdvcmtmbG93IGV4ZWN1dGlvbiBmYWlsZWQ6IGNoaWxkIGVuZ2luZSBib29tIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {
+          "seconds": "30"
+        },
+        "scheduleToStartTimeout": {
+          "seconds": "30"
+        },
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "13",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "2"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "200"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 898219000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048955",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "823dd4cb-a8f5-4d92-858d-9f47f0678c0e",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 900845000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048956",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "80921@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 900853000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048957",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 948155000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048961",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "ee3b1ddf-b6f2-436e-9a0a-be867ca8df62",
+        "historySizeBytes": "3862",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 953747000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048965",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 953793000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048966",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "DeleteExecutionContext"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZS1mYWlsIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {
+          "seconds": "30"
+        },
+        "scheduleToStartTimeout": {
+          "seconds": "30"
+        },
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "19",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "2"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "200"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 998406000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048972",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "18c9b7b9-6a23-49c3-9d9b-7d8ff6917a01",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": {
+        "seconds": "1787650465",
+        "nanos": 2775000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048973",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "scheduledEventId": "20",
+        "startedEventId": "21",
+        "identity": "80921@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": {
+        "seconds": "1787650465",
+        "nanos": 2788000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048974",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": {
+        "seconds": "1787650465",
+        "nanos": 47314000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048978",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "23",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "4d704bcd-0e55-4b3b-b849-861678bdea6d",
+        "historySizeBytes": "4798",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": {
+        "seconds": "1787650465",
+        "nanos": 55050000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048982",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "23",
+        "startedEventId": "24",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": {
+        "seconds": "1787650465",
+        "nanos": 55115000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_FAILED",
+      "taskId": "1048983",
+      "workflowExecutionFailedEventAttributes": {
+        "failure": {
+          "message": "Workflow execution failed",
+          "source": "TypeScriptSDK",
+          "stackTrace": "ApplicationFailure: Workflow execution failed\n    at Function.create (/Users/suresh/scm/github.com/stigmer/.worktrees/stigmer/feat-20260825.04.sp.workflowexecution-orchestration/backend/services/stigmer-server-ts/node_modules/@temporalio/common/src/failure.ts:227:11)\n    at create (/Users/suresh/scm/github.com/stigmer/.worktrees/stigmer/feat-20260825.04.sp.workflowexecution-orchestration/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflows/invoke-workflow-execution.ts:205:29)",
+          "cause": {
+            "message": "Child Workflow execution failed",
+            "cause": {
+              "message": "child engine boom",
+              "source": "TypeScriptSDK",
+              "stackTrace": "ApplicationFailure: child engine boom\n    at Function.create (/Users/suresh/scm/github.com/stigmer/.worktrees/stigmer/feat-20260825.04.sp.workflowexecution-orchestration/backend/services/stigmer-server-ts/node_modules/@temporalio/common/src/failure.ts:227:11)\n    at create (/Users/suresh/scm/github.com/stigmer/.worktrees/stigmer/feat-20260825.04.sp.workflowexecution-orchestration/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/test-workflows.ts:57:29)",
+              "applicationFailureInfo": {}
+            },
+            "childWorkflowExecutionFailureInfo": {
+              "namespace": "default",
+              "workflowExecution": {
+                "workflowId": "workflow-exec-wfe-fail",
+                "runId": "01a03845-5bb9-7aa6-815a-11b07309d6a5"
+              },
+              "workflowType": {
+                "name": "stigmer/workflow/execute-from-execution"
+              },
+              "initiatedEventId": "5",
+              "startedEventId": "6",
+              "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+            }
+          },
+          "applicationFailureInfo": {}
+        },
+        "retryState": "RETRY_STATE_RETRY_POLICY_NOT_SET",
+        "workflowTaskCompletedEventId": "25"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay-histories/happy-completed.json
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay-histories/happy-completed.json
@@ -1,0 +1,504 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787650463",
+        "nanos": 979599000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048587",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "stigmer/workflow-execution/invoke"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJ3ZmUtb2siLCJ3b3JrZmxvd19pbnN0YW5jZV9pZCI6IndmaS1yZXBsYXkiLCJ3b3JrZmxvd19pZCI6IndmLXJlcGxheSIsIm9yZ19pZCI6Im9yZy1yZXBsYXkifQ=="
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a03845-58eb-791f-8b51-644a38a640e6",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03845-58eb-791f-8b51-644a38a640e6",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "memo": {
+          "fields": {
+            "runnerTaskQueue": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZXhlYy1yZXBsYXktY2FwdHVyZSI="
+            }
+          }
+        },
+        "header": {},
+        "workflowId": "wfexec-replay-happy-completed"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787650463",
+        "nanos": 979656000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048588",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787650463",
+        "nanos": 982201000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048593",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "45f9f98e-1371-4957-99aa-abacd2782eb5",
+        "historySizeBytes": "519",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 43879000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048597",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            1,
+            3,
+            2
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 44264000
+      },
+      "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048598",
+      "startChildWorkflowExecutionInitiatedEventAttributes": {
+        "namespace": "default",
+        "workflowId": "workflow-exec-wfe-ok",
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJ3ZmUtb2siLCJ3b3JrZmxvd19pbnN0YW5jZV9pZCI6IndmaS1yZXBsYXkiLCJ3b3JrZmxvd19pZCI6IndmLXJlcGxheSIsIm9yZ19pZCI6Im9yZy1yZXBsYXkifQ=="
+            }
+          ]
+        },
+        "workflowRunTimeout": {},
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "parentClosePolicy": "PARENT_CLOSE_POLICY_REQUEST_CANCEL",
+        "workflowTaskCompletedEventId": "4",
+        "workflowIdReusePolicy": "WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "1"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "100"
+          },
+          "maximumAttempts": 1
+        },
+        "header": {},
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda",
+        "inheritBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 46682000
+      },
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048606",
+      "childWorkflowExecutionStartedEventAttributes": {
+        "namespace": "default",
+        "initiatedEventId": "5",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-ok",
+          "runId": "01a03845-592e-716f-ac32-61f181bab9bf"
+        },
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "header": {},
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 46686000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048607",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 47823000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048615",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "73faeb9e-b834-4e95-b595-176b725be88a",
+        "historySizeBytes": "1565",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 54915000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048623",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 56355000
+      },
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048631",
+      "childWorkflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-ok",
+          "runId": "01a03845-592e-716f-ac32-61f181bab9bf"
+        },
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "initiatedEventId": "5",
+        "startedEventId": "6",
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 56359000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048632",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 57784000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048636",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "8834b788-17b9-46d7-93b0-6ccc77c2a50c",
+        "historySizeBytes": "2258",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 65407000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048640",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 65461000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048641",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "DeleteExecutionContext"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZS1vayI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {
+          "seconds": "30"
+        },
+        "scheduleToStartTimeout": {
+          "seconds": "30"
+        },
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "13",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "2"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "200"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 66834000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048647",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "4b7353c3-77d5-4ef1-8385-ed43f4132138",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 71608000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048648",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "80921@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 71616000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048649",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 72464000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048653",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "7899e393-e09f-4397-aeba-a2c6c5f8f1ed",
+        "historySizeBytes": "3188",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 76289000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048657",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 76308000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048658",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "19"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay-histories/pause-resume.json
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay-histories/pause-resume.json
@@ -1,0 +1,1116 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 92081000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048663",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "stigmer/workflow-execution/invoke"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJ3ZmUtaG9sZC1wciIsIndvcmtmbG93X2luc3RhbmNlX2lkIjoid2ZpLXJlcGxheSIsIndvcmtmbG93X2lkIjoid2YtcmVwbGF5Iiwib3JnX2lkIjoib3JnLXJlcGxheSJ9"
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a03845-595c-713c-a11c-647e4e7dc6ac",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03845-595c-713c-a11c-647e4e7dc6ac",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "memo": {
+          "fields": {
+            "runnerTaskQueue": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZXhlYy1yZXBsYXktY2FwdHVyZSI="
+            }
+          }
+        },
+        "header": {},
+        "workflowId": "wfexec-replay-pause-resume"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 92129000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048664",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 93548000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048669",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "7888ff1d-d172-46bf-80e4-526a7f271612",
+        "historySizeBytes": "519",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 99121000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048673",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            2,
+            3,
+            1
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 99360000
+      },
+      "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048674",
+      "startChildWorkflowExecutionInitiatedEventAttributes": {
+        "namespace": "default",
+        "workflowId": "workflow-exec-wfe-hold-pr",
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJ3ZmUtaG9sZC1wciIsIndvcmtmbG93X2luc3RhbmNlX2lkIjoid2ZpLXJlcGxheSIsIndvcmtmbG93X2lkIjoid2YtcmVwbGF5Iiwib3JnX2lkIjoib3JnLXJlcGxheSJ9"
+            }
+          ]
+        },
+        "workflowRunTimeout": {},
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "parentClosePolicy": "PARENT_CLOSE_POLICY_REQUEST_CANCEL",
+        "workflowTaskCompletedEventId": "4",
+        "workflowIdReusePolicy": "WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "1"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "100"
+          },
+          "maximumAttempts": 1
+        },
+        "header": {},
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda",
+        "inheritBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 101057000
+      },
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048682",
+      "childWorkflowExecutionStartedEventAttributes": {
+        "namespace": "default",
+        "initiatedEventId": "5",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr",
+          "runId": "01a03845-5964-7265-8d20-a23f7204e915"
+        },
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "header": {},
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 101061000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048683",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 101833000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048691",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "e48e7ab6-31f0-4ce5-93a1-82a3dde91266",
+        "historySizeBytes": "1579",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 104845000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048699",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 147745000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048720",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "pause",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheSBjYXB0dXJlIg=="
+            }
+          ]
+        },
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 147747000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048721",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 148753000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048725",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "f2b3610f-3f06-43fb-8054-6ee190ab35c1",
+        "historySizeBytes": "2172",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 157035000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048729",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            2
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 157105000
+      },
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048730",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_local_activity",
+        "details": {
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          },
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjEsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiMSIsImFjdGl2aXR5X3R5cGUiOiJVcGRhdGVXb3JrZmxvd0V4ZWN1dGlvblN0YXR1cyIsImNvbXBsZXRlX3RpbWUiOnsic2Vjb25kcyI6MTc4NzY1MDQ2NCwibmFub3MiOjE0OTQxNzA0Mn0sImJhY2tvZmYiOm51bGwsIm9yaWdpbmFsX3NjaGVkdWxlX3RpbWUiOnsic2Vjb25kcyI6MTc4NzY1MDQ2NCwibmFub3MiOjE1NDE0NTAwMH19"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "13"
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 157136000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048731",
+      "signalExternalWorkflowExecutionInitiatedEventAttributes": {
+        "workflowTaskCompletedEventId": "13",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr"
+        },
+        "signalName": "pause",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheSBjYXB0dXJlIg=="
+            }
+          ]
+        },
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 158460000
+      },
+      "eventType": "EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048739",
+      "externalWorkflowExecutionSignaledEventAttributes": {
+        "initiatedEventId": "15",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr"
+        },
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 158462000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048740",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 159111000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048747",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "8dfcd0b8-41b8-497b-bb44-f4b8c170faa1",
+        "historySizeBytes": "3275",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 163276000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048755",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 201288000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048772",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "resume",
+        "input": {},
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 201290000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048773",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 202161000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048777",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "21",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "53a5905e-bfaf-498b-b2b7-4714a2b39731",
+        "historySizeBytes": "3825",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 207682000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048781",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "21",
+        "startedEventId": "22",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 207710000
+      },
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048782",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_local_activity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjIsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiMiIsImFjdGl2aXR5X3R5cGUiOiJVcGRhdGVXb3JrZmxvd0V4ZWN1dGlvblN0YXR1cyIsImNvbXBsZXRlX3RpbWUiOnsic2Vjb25kcyI6MTc4NzY1MDQ2NCwibmFub3MiOjIwMjc1NDEyNX0sImJhY2tvZmYiOm51bGwsIm9yaWdpbmFsX3NjaGVkdWxlX3RpbWUiOnsic2Vjb25kcyI6MTc4NzY1MDQ2NCwibmFub3MiOjIwNTIwNzAwMH19"
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "23"
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 207725000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048783",
+      "signalExternalWorkflowExecutionInitiatedEventAttributes": {
+        "workflowTaskCompletedEventId": "23",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr"
+        },
+        "signalName": "resume",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "bnVsbA=="
+            }
+          ]
+        },
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 208973000
+      },
+      "eventType": "EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048791",
+      "externalWorkflowExecutionSignaledEventAttributes": {
+        "initiatedEventId": "25",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr"
+        },
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 208975000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048792",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 247894000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048804",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "27",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "b9938f97-2258-4e20-88aa-f9daff77a96b",
+        "historySizeBytes": "4913",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 251054000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048816",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "27",
+        "startedEventId": "28",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 254028000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048818",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "relaySignal",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzaWduYWxOYW1lIjoidGVzdC1yZWxlYXNlIiwicGF5bG9hZCI6bnVsbH0="
+            }
+          ]
+        },
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 254030000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048819",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 297187000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048823",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "31",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "3d6e9271-2d72-44bb-babb-0060fbb59ede",
+        "historySizeBytes": "5541",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 302063000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048833",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "31",
+        "startedEventId": "32",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 302093000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048834",
+      "signalExternalWorkflowExecutionInitiatedEventAttributes": {
+        "workflowTaskCompletedEventId": "33",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr"
+        },
+        "signalName": "test-release",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "bnVsbA=="
+            }
+          ]
+        },
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 348575000
+      },
+      "eventType": "EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048842",
+      "externalWorkflowExecutionSignaledEventAttributes": {
+        "initiatedEventId": "34",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr"
+        },
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 348578000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048843",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 397975000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048847",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "36",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "345bc77a-c426-4f5e-9c6b-3e45a395fa22",
+        "historySizeBytes": "6283",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 403071000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048855",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "36",
+        "startedEventId": "37",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "39",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 447313000
+      },
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048863",
+      "childWorkflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "workflow-exec-wfe-hold-pr",
+          "runId": "01a03845-5964-7265-8d20-a23f7204e915"
+        },
+        "workflowType": {
+          "name": "stigmer/workflow/execute-from-execution"
+        },
+        "initiatedEventId": "5",
+        "startedEventId": "6",
+        "namespaceId": "01a03845-5416-75df-ad79-7de07a12fcda"
+      }
+    },
+    {
+      "eventId": "40",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 447321000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048864",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "41",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 497994000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048868",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "40",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "a539b4d4-b058-4f9b-a7a7-31bf286f56e4",
+        "historySizeBytes": "6985",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "42",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 503922000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048872",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "40",
+        "startedEventId": "41",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "43",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 503968000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048873",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "DeleteExecutionContext"
+        },
+        "taskQueue": {
+          "name": "wfexec-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndmZS1ob2xkLXByIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {
+          "seconds": "30"
+        },
+        "scheduleToStartTimeout": {
+          "seconds": "30"
+        },
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "42",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "2"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "200"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "44",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 548076000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048879",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "43",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "8bd9fb6c-6203-4487-ae5b-bd431c4e736d",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "45",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 551013000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048880",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "scheduledEventId": "43",
+        "startedEventId": "44",
+        "identity": "80921@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "46",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 551025000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048881",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "80921@Sureshs-Mac-Studio.local-670b029174644213afa4c6027a2dfb67",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "wfexec-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "47",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 598864000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048885",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "46",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "requestId": "239ec688-3bb8-4731-8de5-c42f561f6430",
+        "historySizeBytes": "7926",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        }
+      }
+    },
+    {
+      "eventId": "48",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 605554000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048889",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "46",
+        "startedEventId": "47",
+        "identity": "80921@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+753e8d315e3846ed5defc17568737bd526b236d45bf233da4d013573ddbefcb2"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "49",
+      "eventTime": {
+        "seconds": "1787650464",
+        "nanos": 605631000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048890",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "48"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/replay.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Replay determinism gate for the workflow-execution orchestrator — the
+ * twin of the agentexecution gate (see its header for the OD-6
+ * discipline): committed histories from released workflow code must
+ * replay green on the CURRENT code; a red run means a change is not
+ * replay-safe for in-flight executions and needs patched(), never a
+ * history regeneration.
+ *
+ * Fully local (no Temporal server needed). Histories are captured by
+ * scripts/capture-wfexec-replay-histories.ts (mock payloads only).
+ * The replay worker loads test-workflows.ts because the captured
+ * histories' child-workflow references resolve against the same barrel
+ * that produced them; the orchestrator under replay is the REAL one.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import proto from "@temporalio/proto";
+import { Worker } from "@temporalio/worker";
+import { describe, expect, it } from "vitest";
+
+const HISTORY_DIR = fileURLToPath(
+  new URL("./replay-histories", import.meta.url),
+);
+const WORKFLOWS_PATH = fileURLToPath(
+  new URL("./test-workflows.ts", import.meta.url),
+);
+
+const historyFiles = readdirSync(HISTORY_DIR).filter((name) =>
+  name.endsWith(".json"),
+);
+
+describe("invoke-workflow-execution replay determinism", () => {
+  it("has committed histories to replay (the gate cannot be empty)", () => {
+    expect(historyFiles.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("replays every committed history deterministically", async () => {
+    // ONE runReplayHistories call for all files (the agentexecution
+    // gate's native-runtime-handle rationale).
+    const histories = historyFiles.map((file) => ({
+      workflowId: file,
+      history: proto.temporal.api.history.v1.History.fromObject(
+        JSON.parse(readFileSync(`${HISTORY_DIR}/${file}`, "utf8")),
+      ),
+    }));
+    const results = await Worker.runReplayHistories(
+      { workflowsPath: WORKFLOWS_PATH },
+      histories,
+    );
+    for await (const result of results) {
+      expect(
+        result.error,
+        `history ${result.workflowId} must replay without nondeterminism`,
+      ).toBeUndefined();
+    }
+  }, 120_000);
+});

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/test-workflows.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/test-workflows.ts
@@ -78,6 +78,12 @@ async function stubChild(
   });
 
   await recorder[TEST_RECORD_CHILD_EVENT_ACTIVITY]("started");
+  if (input.recovery_mode === true) {
+    // Pins that the orchestrator forwards the input UNCHANGED to the
+    // child (Go TestChildWorkflow_RecoveryModeAccepted) — the recover
+    // lane depends on this flag arriving.
+    await recorder[TEST_RECORD_CHILD_EVENT_ACTIVITY]("recovery-mode");
+  }
   await condition(() => released);
 }
 

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/test-workflows.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/__tests__/test-workflows.ts
@@ -1,0 +1,84 @@
+/**
+ * Test-only workflow barrel for the orchestrator tests and the replay
+ * capture script: the REAL orchestrator under its byte-pinned name plus a
+ * scriptable stub child registered under the runner's child workflow type
+ * (in production the runner registers it; tests point the child memo at
+ * the test worker's own queue).
+ *
+ * The stub child cannot see host state (the workflow sandbox), so it is
+ * scripted BY ID and observed THROUGH AN ACTIVITY: behavior branches on
+ * the execution_id the orchestrator forwards, and every observation
+ * (started, received signals) is reported immediately via the
+ * TestRecordChildEvent activity the test worker registers as a recorder.
+ *
+ * Behavior by execution_id:
+ *   - contains "fail" → throws ApplicationFailure("child engine boom");
+ *   - contains "hold" → records "started", records every received
+ *     pause/resume/test-custom signal, and completes only on the
+ *     "test-release" signal;
+ *   - anything else → completes immediately, silently.
+ *
+ * WORKFLOW-BUNDLE IMPORT DISCIPLINE applies (sandbox module).
+ */
+import { ApplicationFailure } from "@temporalio/common";
+import {
+  condition,
+  defineSignal,
+  proxyActivities,
+  setHandler,
+} from "@temporalio/workflow";
+
+import type { InvokeWorkflowExecutionWorkflowInput } from "../workflow-input.js";
+
+export { invokeWorkflowExecution as "stigmer/workflow-execution/invoke" } from "../workflows/invoke-workflow-execution.js";
+
+export const TEST_RECORD_CHILD_EVENT_ACTIVITY = "TestRecordChildEvent";
+export const TEST_RELEASE_SIGNAL = "test-release";
+export const TEST_CUSTOM_SIGNAL = "test-custom";
+
+const pauseSignal = defineSignal<[string?]>("pause");
+const resumeSignal = defineSignal<[string?]>("resume");
+const customSignal = defineSignal<[unknown]>(TEST_CUSTOM_SIGNAL);
+const releaseSignal = defineSignal(TEST_RELEASE_SIGNAL);
+
+const recorder = proxyActivities<{
+  [TEST_RECORD_CHILD_EVENT_ACTIVITY]: (event: string) => Promise<void>;
+}>({
+  startToCloseTimeout: "10s",
+  retry: { maximumAttempts: 1 },
+});
+
+async function stubChild(
+  input: InvokeWorkflowExecutionWorkflowInput,
+): Promise<void> {
+  const executionId = input.execution_id;
+
+  if (executionId.includes("fail")) {
+    throw ApplicationFailure.create({ message: "child engine boom" });
+  }
+
+  if (!executionId.includes("hold")) {
+    return;
+  }
+
+  let released = false;
+  setHandler(pauseSignal, (reason?: string) => {
+    void recorder[TEST_RECORD_CHILD_EVENT_ACTIVITY](`pause:${reason ?? ""}`);
+  });
+  setHandler(resumeSignal, () => {
+    void recorder[TEST_RECORD_CHILD_EVENT_ACTIVITY]("resume");
+  });
+  setHandler(customSignal, (payload: unknown) => {
+    void recorder[TEST_RECORD_CHILD_EVENT_ACTIVITY](
+      `custom:${JSON.stringify(payload ?? null)}`,
+    );
+  });
+  setHandler(releaseSignal, () => {
+    released = true;
+  });
+
+  await recorder[TEST_RECORD_CHILD_EVENT_ACTIVITY]("started");
+  await condition(() => released);
+}
+
+export { stubChild as "stigmer/workflow/execute-from-execution" };

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/activities.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/activities.ts
@@ -1,0 +1,188 @@
+/**
+ * Server-side activity implementations for the workflow-execution worker —
+ * ports pkg/domain/workflowexecution/temporal/activities
+ * (update_status_impl.go) and registers #15's DeleteExecutionContext seam.
+ *
+ * UpdateWorkflowExecutionStatus deliberately does NOT reuse the domain's
+ * updateStatus RPC merge (the choice agentexecution's port made): in Go
+ * the two merges are DIFFERENT code with different semantics, and the
+ * differences are wire-visible for exactly the payloads this workflow
+ * sends (sub-project DD-001 brief, owner-ratified):
+ *
+ *   - The activity bumps statusAudit.updatedAt on EVERY call; the RPC
+ *     bumps only on phase TRANSITIONS (the recents-sidebar rule). A
+ *     defense re-assert of an unchanged phase must keep bumping.
+ *   - The activity never touches events, output, temporal_workflow_id,
+ *     or the pending gate lists.
+ *   - A missing execution is an ordinary wrapped activity error
+ *     ("workflow execution not found: …"), not the RPC's NotFound.
+ *
+ * What IS adopted from the domain: the atomic `updateResource` persist
+ * (the #20 DD-001 posture — Go's activity is a load-then-save with the
+ * same lost-update window its RPC has; not ported) and the post-persist
+ * broadcast through the domain's StreamBroker (Go wires the same broker
+ * into both).
+ *
+ * Payload boundary (sub-project 20260824.03 design rule): statuses cross
+ * as proto-JSON — the TS default payload converter cannot serialize the
+ * bigint int64 fields of typed messages. Server-internal payloads; only
+ * the activity NAMES are byte-pinned.
+ */
+import { create, fromJson } from "@bufbuild/protobuf";
+import type { JsonValue } from "@bufbuild/protobuf";
+import { timestampNow } from "@bufbuild/protobuf/wkt";
+
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import {
+  WorkflowExecutionSchema,
+  WorkflowExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import {
+  ApiResourceAuditInfoSchema,
+  ApiResourceAuditSchema,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { StreamBroker } from "../../domain/workflowexecution/stream-broker.js";
+import {
+  DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME,
+  deleteExecutionContextForExecution,
+} from "../../domain/executioncontext/temporal/delete-execution-context.js";
+import type { Store } from "../../store/interface.js";
+import { UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME } from "./names.js";
+
+export interface WorkflowExecutionActivityDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+}
+
+/**
+ * Builds the activity record the worker registers. Keys are the
+ * byte-pinned activity names; the runner-owned child workflow is
+ * deliberately NOT here — a worker registering the other side's names
+ * would break queue-based routing (worker_config.go's contract).
+ */
+export function createWorkflowExecutionActivities(
+  deps: WorkflowExecutionActivityDeps,
+): Record<string, (...args: never[]) => Promise<unknown>> {
+  const { store, logger, broker } = deps;
+
+  return {
+    /**
+     * The orchestrator's status persist, invoked as a LOCAL activity
+     * (pause/resume handlers) AND a REGULAR activity (failure/
+     * cancellation paths) — one implementation serves both modes,
+     * exactly one named registration (see names.ts's DD-002 note on why
+     * the NAME is load-bearing).
+     */
+    [UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME]: async (
+      executionId: string,
+      statusJson: JsonValue,
+    ): Promise<void> => {
+      const statusUpdates = fromJson(WorkflowExecutionStatusSchema, statusJson);
+
+      let updated: WorkflowExecution;
+      try {
+        updated = await store.updateResource(
+          ApiResourceKind.workflow_execution,
+          executionId,
+          WorkflowExecutionSchema,
+          (execution) => {
+            applyActivityStatusMerge(execution, statusUpdates);
+          },
+        );
+      } catch (error) {
+        // Go wraps EVERY load/save failure with this one text ("workflow
+        // execution not found: %w" — update_status_impl.go names the
+        // load; the atomic persist folds both arms into it).
+        throw new Error(
+          `workflow execution not found: ${errorText(error)}`,
+          { cause: error },
+        );
+      }
+
+      logger.info("Activity updated workflow execution status", {
+        execution_id: executionId,
+        phase:
+          ExecutionPhase[
+            updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED
+          ],
+        tasks: updated.status?.tasks.length ?? 0,
+      });
+
+      // Broadcast to active subscribers AFTER the persist commits
+      // (ADR 011 write path) — failure recovery updates must be
+      // immediately visible to externally-connected subscribe streams.
+      broker.broadcast(updated);
+    },
+
+    /** #15's seam, shared with the agent-execution worker exactly as in Go. */
+    [DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME]: async (
+      executionId: string,
+    ): Promise<void> => {
+      await deleteExecutionContextForExecution(store, logger, executionId);
+    },
+  };
+}
+
+/**
+ * The ACTIVITY's merge body (update_status_impl.go UpdateExecutionStatus,
+ * field-for-field), run inside the store's atomic updateResource closure.
+ * Deliberately NOT applyUpdateStatusMerge from the domain's RPC path —
+ * see the module header for the wire-visible differences. Exported for
+ * the co-located unit tests.
+ */
+export function applyActivityStatusMerge(
+  execution: WorkflowExecution,
+  statusUpdates: WorkflowExecutionStatus,
+): void {
+  if (execution.status === undefined) {
+    execution.status = create(WorkflowExecutionStatusSchema);
+  }
+  const status = execution.status;
+
+  // Tasks: replaced wholesale with the worker's latest complete set.
+  if (statusUpdates.tasks.length > 0) {
+    status.tasks = statusUpdates.tasks;
+  }
+  if (statusUpdates.phase !== ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) {
+    status.phase = statusUpdates.phase;
+  }
+  if (statusUpdates.error !== "") {
+    status.error = statusUpdates.error;
+  }
+  if (statusUpdates.startedAt !== "") {
+    status.startedAt = statusUpdates.startedAt;
+  }
+  if (statusUpdates.completedAt !== "") {
+    status.completedAt = statusUpdates.completedAt;
+  }
+  // Cost/token aggregates: monotonically increasing, always take the
+  // latest value; zero means "no update", never "reset".
+  if (statusUpdates.totalCostMicros > 0n) {
+    status.totalCostMicros = statusUpdates.totalCostMicros;
+  }
+  if (statusUpdates.totalInputTokens > 0n) {
+    status.totalInputTokens = statusUpdates.totalInputTokens;
+  }
+  if (statusUpdates.totalOutputTokens > 0n) {
+    status.totalOutputTokens = statusUpdates.totalOutputTokens;
+  }
+
+  // UNCONDITIONAL statusAudit bump — the activity's semantic, distinct
+  // from the RPC merge's phase-transition-only rule (module header).
+  const audit = status.audit ?? create(ApiResourceAuditSchema);
+  status.audit = audit;
+  const statusAudit = audit.statusAudit ?? create(ApiResourceAuditInfoSchema);
+  audit.statusAudit = statusAudit;
+  statusAudit.updatedAt = timestampNow();
+  statusAudit.event = "updated";
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/dispatch.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/dispatch.ts
@@ -1,0 +1,70 @@
+/**
+ * Workflow dispatch-queue resolution — ports
+ * pkg/domain/workflowexecution/temporal/dispatch.go
+ * (ResolveWorkflowTaskQueue): which Temporal task queue a workflow
+ * execution's CHILD workflow starts on.
+ *
+ * Unlike agentexecution's dispatch (which loads the session to read its
+ * harness and target), this resolution is PURE — the execution target
+ * rides in on the create pipeline's spec read (the seam's
+ * StartWorkflowExecutionInput.executionTarget), so there is no store
+ * read and no failure lane: Go's Create has no dispatch error boundary
+ * and neither does this port.
+ *
+ * Routing modes (config.workflowActivityRouting):
+ *   - "global": always the configured runner queue (stigmer_runner) —
+ *     all workflow executions share the global runner pool.
+ *   - "execution": wfexec:{execution_id} regardless of execution target.
+ *     For CLOUD a dedicated sandbox is provisioned for that queue; for
+ *     LOCAL the desktop runner-manager creates a worker on it.
+ */
+import type { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  WORKFLOW_ROUTING_EXECUTION,
+  type WorkflowExecutionTemporalConfig,
+} from "../../domain/workflowexecution/temporal/config.js";
+import { formatWfExecTaskQueue } from "./names.js";
+
+/**
+ * The resolved Temporal task queue and effective execution target for a
+ * workflow execution's child dispatch (Go WorkflowDispatchResult).
+ */
+export interface WorkflowDispatchResult {
+  readonly taskQueue: string;
+  readonly executionTarget: ExecutionTarget;
+}
+
+/**
+ * Go ResolveWorkflowTaskQueue: resolves the child's task queue from the
+ * routing mode, and UNSPECIFIED targets through the config's single
+ * resolution rule.
+ */
+export function resolveWorkflowTaskQueue(
+  executionId: string,
+  executionTarget: ExecutionTarget,
+  config: WorkflowExecutionTemporalConfig,
+  logger: Logger,
+): WorkflowDispatchResult {
+  const resolved = config.resolveWorkflowExecutionTarget(executionTarget);
+
+  if (config.workflowActivityRouting === WORKFLOW_ROUTING_EXECUTION) {
+    const taskQueue = formatWfExecTaskQueue(executionId);
+    logger.info("Workflow dispatch resolved per-execution queue", {
+      execution_id: executionId,
+      task_queue: taskQueue,
+      routing_mode: config.workflowActivityRouting,
+      execution_target: resolved,
+    });
+    return { taskQueue, executionTarget: resolved };
+  }
+
+  logger.info("Workflow dispatch resolved global queue", {
+    execution_id: executionId,
+    task_queue: config.runnerQueue,
+    routing_mode: config.workflowActivityRouting,
+    execution_target: resolved,
+  });
+  return { taskQueue: config.runnerQueue, executionTarget: resolved };
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/engine-client.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/engine-client.ts
@@ -1,0 +1,242 @@
+/**
+ * The ConnectedWorkflowExecutionEngine implementation — ports
+ * pkg/domain/workflowexecution/temporal/workflows/workflow_creator.go
+ * (Create, SignalWithStart) plus the controller-side temporalClient
+ * operations the lifecycle steps consume (lifecycle_steps.go: raw
+ * signal, cancel, terminate).
+ *
+ * #20 modeled the engine as the ConnectedWorkflowExecutionEngine seam
+ * (src/domain/workflowexecution/engine.ts); this module fills it.
+ * Dispatch-queue resolution lives INSIDE startInvokeWorkflow/
+ * signalWithStart (the seam's ratified boundary — Go's controller calls
+ * ResolveWorkflowTaskQueue immediately before Create/SignalWithStart).
+ * Unlike agentexecution's dispatch it is PURE (no store read), so there
+ * is no EngineDispatchError lane — Go's Create has no dispatch failure
+ * boundary and neither does this port.
+ *
+ * The engine-state provider is the injection mechanism (no Go-style
+ * SetWorkflowCreator/SetTemporalClient re-injection): it reads the
+ * manager's CURRENT client at request time, so reconnects propagate
+ * automatically. It memoizes the engine per client instance — a new
+ * engine object per RPC would be garbage for no behavior.
+ *
+ * Workflow IDs: the ORCHESTRATOR id is built here from the execution id
+ * (workflow_creator.go); the lifecycle steps pass fully-built IDs
+ * (orchestrator or child — they terminate both), so the raw
+ * signal/cancel/terminate operations take a workflowId verbatim. That
+ * asymmetry is the seam's documented contract.
+ *
+ * Proven by the workflowexecution suites on local-ts-execution.
+ */
+import type { JsonValue } from "@bufbuild/protobuf";
+import type { Client } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/common";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  EngineWorkflowNotFoundError,
+  ENGINE_DISCONNECTED,
+  type ConnectedWorkflowExecutionEngine,
+  type StartWorkflowExecutionInput,
+  type WorkflowExecutionEngineState,
+  type WorkflowExecutionEngineStateProvider,
+} from "../../domain/workflowexecution/engine.js";
+import type { WorkflowExecutionTemporalConfig } from "../../domain/workflowexecution/temporal/config.js";
+import type { TemporalManager } from "../manager.js";
+import { resolveWorkflowTaskQueue } from "./dispatch.js";
+import {
+  INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME,
+  MEMO_RUNNER_TASK_QUEUE,
+  orchestratorWorkflowId,
+} from "./names.js";
+import type { InvokeWorkflowExecutionWorkflowInput } from "./workflow-input.js";
+
+export interface TemporalWorkflowExecutionEngineDeps {
+  readonly client: Client;
+  readonly config: WorkflowExecutionTemporalConfig;
+  readonly logger: Logger;
+}
+
+export class TemporalWorkflowExecutionEngine
+  implements ConnectedWorkflowExecutionEngine
+{
+  constructor(private readonly deps: TemporalWorkflowExecutionEngineDeps) {}
+
+  async startInvokeWorkflow(
+    input: StartWorkflowExecutionInput,
+  ): Promise<void> {
+    const { client, config, logger } = this.deps;
+    const dispatch = resolveWorkflowTaskQueue(
+      input.executionId,
+      input.executionTarget,
+      config,
+      logger,
+    );
+    const workflowId = orchestratorWorkflowId(input.executionId);
+
+    // NOTE deliberately NO workflowRunTimeout: a workflow with LISTEN or
+    // human_input tasks can legitimately wait for days — a finite
+    // timeout would contradict the durable-execution promise
+    // (workflow_creator.go configures none either).
+    await client.workflow.start(INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME, {
+      workflowId,
+      taskQueue: config.stigmerQueue,
+      memo: { [MEMO_RUNNER_TASK_QUEUE]: dispatch.taskQueue },
+      args: [buildWorkflowInput(input)],
+    });
+
+    logger.info("Started InvokeWorkflowExecutionWorkflow", {
+      workflow_id: workflowId,
+      execution_id: input.executionId,
+      stigmer_queue: config.stigmerQueue,
+      runner_queue: dispatch.taskQueue,
+    });
+  }
+
+  async signalWithStart(
+    input: StartWorkflowExecutionInput,
+    signalName: string,
+    payload: JsonValue,
+  ): Promise<void> {
+    const { client, config, logger } = this.deps;
+    const dispatch = resolveWorkflowTaskQueue(
+      input.executionId,
+      input.executionTarget,
+      config,
+      logger,
+    );
+    const workflowId = orchestratorWorkflowId(input.executionId);
+
+    // Temporal's SignalWithStart is atomic: workflow exists → signal
+    // delivered; not started yet → started, then signalled. Race-proof
+    // for signals racing the create pipeline's async start
+    // (workflow_creator.go SignalWithStart).
+    await client.workflow.signalWithStart(
+      INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME,
+      {
+        workflowId,
+        taskQueue: config.stigmerQueue,
+        memo: { [MEMO_RUNNER_TASK_QUEUE]: dispatch.taskQueue },
+        args: [buildWorkflowInput(input)],
+        signal: signalName,
+        signalArgs: [payload],
+      },
+    );
+
+    logger.info("SignalWithStart completed successfully", {
+      workflow_id: workflowId,
+      execution_id: input.executionId,
+      signal_name: signalName,
+      stigmer_queue: config.stigmerQueue,
+    });
+  }
+
+  async signalWorkflow(
+    workflowId: string,
+    signalName: string,
+    payload: JsonValue | undefined,
+  ): Promise<void> {
+    const handle = this.deps.client.workflow.getHandle(workflowId);
+    try {
+      // Go SignalWorkflow always passes one payload argument (nil when
+      // the signal carries nothing); one argument is what the
+      // orchestrator's handlers read.
+      await handle.signal(signalName, payload ?? null);
+    } catch (error) {
+      throw mapNotFound(error, workflowId);
+    }
+  }
+
+  async cancelWorkflow(workflowId: string): Promise<void> {
+    const handle = this.deps.client.workflow.getHandle(workflowId);
+    try {
+      await handle.cancel();
+    } catch (error) {
+      throw mapNotFound(error, workflowId);
+    }
+  }
+
+  async terminateWorkflow(workflowId: string, reason: string): Promise<void> {
+    const handle = this.deps.client.workflow.getHandle(workflowId);
+    try {
+      await handle.terminate(reason);
+    } catch (error) {
+      throw mapNotFound(error, workflowId);
+    }
+  }
+}
+
+/**
+ * The slim input with Go's omitempty shape (workflow-input.ts): zero
+ * values are omitted so TS-authored histories carry the same keys a
+ * Go-authored one would. The cloud-only fields are unmodeled (the seam's
+ * ratified boundary).
+ */
+function buildWorkflowInput(
+  input: StartWorkflowExecutionInput,
+): InvokeWorkflowExecutionWorkflowInput {
+  return {
+    execution_id: input.executionId,
+    ...(input.workflowInstanceId !== ""
+      ? { workflow_instance_id: input.workflowInstanceId }
+      : {}),
+    ...(input.workflowId !== "" ? { workflow_id: input.workflowId } : {}),
+    ...(input.orgId !== "" ? { org_id: input.orgId } : {}),
+    ...(input.recoveryMode ? { recovery_mode: true } : {}),
+  };
+}
+
+/**
+ * Maps the TS SDK's workflow-not-found onto the seam's sentinel (Go
+ * *serviceerror.NotFound → the steps' warn-and-proceed contract).
+ */
+function mapNotFound(error: unknown, workflowId: string): unknown {
+  if (error instanceof WorkflowNotFoundError) {
+    return new EngineWorkflowNotFoundError(workflowId);
+  }
+  return error;
+}
+
+export interface WorkflowExecutionEngineStateProviderDeps {
+  readonly manager: TemporalManager;
+  readonly config: WorkflowExecutionTemporalConfig;
+  readonly logger: Logger;
+}
+
+/**
+ * Builds the provider compose hands the workflowexecution registration —
+ * replacing the pre-#21 `() => WORKFLOW_EXECUTION_ENGINE_DISCONNECTED`
+ * lambda.
+ *
+ * Availability parity with Go (manager.ts module header): disconnected
+ * ONLY until the first successful connect; afterwards the engine wraps
+ * the manager's CURRENT client, stale-during-outage included — operations
+ * then fail exactly as Go's stale-client operations do.
+ */
+export function newWorkflowExecutionEngineStateProvider(
+  deps: WorkflowExecutionEngineStateProviderDeps,
+): WorkflowExecutionEngineStateProvider {
+  let memo:
+    | { client: Client; state: WorkflowExecutionEngineState }
+    | undefined;
+  return () => {
+    const client = deps.manager.getClient();
+    if (client === undefined) {
+      return ENGINE_DISCONNECTED;
+    }
+    if (memo === undefined || memo.client !== client) {
+      memo = {
+        client,
+        state: {
+          connected: true,
+          engine: new TemporalWorkflowExecutionEngine({
+            client,
+            config: deps.config,
+            logger: deps.logger,
+          }),
+        },
+      };
+    }
+    return memo.state;
+  };
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/names.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/names.ts
@@ -1,0 +1,84 @@
+/**
+ * Workflow-execution Temporal wire identifiers — ports the constants of
+ * pkg/domain/workflowexecution/temporal (workflow_types.go,
+ * workflows/invoke_workflow.go, workflows/workflow_creator.go,
+ * activities/update_status.go, dispatch.go).
+ *
+ * Every value here is a byte-pinned cross-edition wire constant (D2 §4).
+ * The orchestrator workflow NAME, its ID format, the child workflow ID,
+ * and the pause/resume/relaySignal channel names are canonically owned by
+ * the DOMAIN's constants module (src/domain/workflowexecution/
+ * constants.ts — #20 shipped them for the lifecycle steps) and re-exported
+ * here so the temporal slice has one import surface and the program has
+ * one definition.
+ *
+ * This module is imported by BOTH the workflow bundle and host code, so it
+ * must stay free of node built-ins and framework imports (the Temporal
+ * workflow sandbox bundler hard-fails on node imports — sub-project
+ * 20260824.03 workflow-bundle import discipline; the domain constants
+ * module it re-exports from is import-free).
+ */
+export {
+  INVOKE_WORKFLOW_EXECUTION_WORKFLOW_NAME,
+  orchestratorWorkflowId,
+  childWorkflowId,
+  PAUSE_SIGNAL_NAME,
+  RESUME_SIGNAL_NAME,
+  RELAY_SIGNAL_CHANNEL_NAME,
+} from "../../domain/workflowexecution/constants.js";
+
+/**
+ * The TS unified runner's child workflow type
+ * (invoke_workflow_impl.go executeChildWorkflow; registered by the runner
+ * in backend/services/runner/src/workflows/index.ts). This server never
+ * registers it — starting it as a child on the memo-resolved runner queue
+ * is the whole orchestration.
+ */
+export const CHILD_WORKFLOW_TYPE = "stigmer/workflow/execute-from-execution";
+
+/**
+ * The ONLY memo key this domain writes (workflow_creator.go); the
+ * workflow reads it back to place the child. Go also falls back to the
+ * legacy "activityTaskQueue" key for pre-migration in-flight histories —
+ * NOT ported: no Go-era history can replay on this server (OD-6
+ * start-clean), so the legacy read would be dead code.
+ */
+export const MEMO_RUNNER_TASK_QUEUE = "runnerTaskQueue";
+
+/**
+ * Fallback when the memo is somehow absent ("should never happen" — Go
+ * getRunnerTaskQueue) and the dispatch default (config.go RunnerQueue).
+ */
+export const DEFAULT_RUNNER_TASK_QUEUE = "stigmer_runner";
+
+/**
+ * The status-persist activity, registered by THIS worker and invoked in
+ * both modes: as a LOCAL activity from the pause/resume signal handlers
+ * and as a REGULAR activity from the failure/cancellation paths (the same
+ * local/regular split as agentexecution — remote on terminal paths dodges
+ * the Go-SDK RECORD_MARKER replay bug; the history shape is contract).
+ *
+ * The name is Go's UpdateWorkflowExecutionStatusActivityName constant.
+ * NOTE (sub-project DD-002): Go's production worker registers this
+ * activity WITHOUT an explicit name, deriving "UpdateExecutionStatus"
+ * from the method — so Go's own orchestrator persists never resolve the
+ * activity and fail silently behind their best-effort call sites. This
+ * server registers AND invokes under the one constant name, making the
+ * lane work (the #18 DD-001 broken-Go-lane precedent; Go issue filed).
+ */
+export const UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME =
+  "UpdateWorkflowExecutionStatus";
+
+/**
+ * The prefix for per-execution task queue names (dispatch.go
+ * WfExecQueuePrefix). Format: "wfexec:{workflow_execution_id}".
+ */
+export const WFEXEC_QUEUE_PREFIX = "wfexec:";
+
+/**
+ * Derives the canonical per-execution Temporal task queue name
+ * (dispatch.go FormatWfExecTaskQueue).
+ */
+export function formatWfExecTaskQueue(executionId: string): string {
+  return `${WFEXEC_QUEUE_PREFIX}${executionId}`;
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/worker.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/worker.ts
@@ -1,0 +1,87 @@
+/**
+ * The workflow-execution worker factory — ports the registration half of
+ * pkg/domain/workflowexecution/temporal/worker_config.go.
+ *
+ * Queue architecture (worker_config.go's contract):
+ *   - This worker polls ONLY the stigmer queue
+ *     (workflow_execution_stigmer): the orchestrator workflow + the
+ *     server-side activities (UpdateWorkflowExecutionStatus,
+ *     DeleteExecutionContext).
+ *   - The TS unified runner polls the runner queue and owns the child
+ *     workflow "stigmer/workflow/execute-from-execution". Each worker
+ *     registers ONLY what it implements — registering the other side's
+ *     names would break queue-based routing.
+ *
+ * The workflow type registers under its byte-pinned slash name via the
+ *
+ * barrel's arbitrary export name (workflows/index.ts); the SDK derives
+ * workflow types from export names, so no explicit registration option
+ * exists or is needed.
+ *
+ * Workflow source: runtime bundling from the compiled entry (ratified
+ * brief #7 of sub-project 20260824.03 — the operative mode until #24
+ * ships prebuilt bundles; the prebuilt sibling is the hook it fills).
+ */
+import { Worker } from "@temporalio/worker";
+
+import type { Logger } from "../../boot/logger.js";
+import type { WorkflowExecutionTemporalConfig } from "../../domain/workflowexecution/temporal/config.js";
+import type { StreamBroker } from "../../domain/workflowexecution/stream-broker.js";
+import type { Store } from "../../store/interface.js";
+import type { WorkerFactory } from "../manager.js";
+import { resolveWorkflowSource } from "../workflow-source.js";
+import { createWorkflowExecutionActivities } from "./activities.js";
+
+export interface WorkflowExecutionWorkerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly broker: StreamBroker;
+  readonly temporalConfig: WorkflowExecutionTemporalConfig;
+}
+
+export function newWorkflowExecutionWorkerFactory(
+  deps: WorkflowExecutionWorkerDeps,
+): WorkerFactory {
+  return async ({ nativeConnection, namespace, payloadCodecs }) => {
+    const activities = createWorkflowExecutionActivities({
+      store: deps.store,
+      logger: deps.logger,
+      broker: deps.broker,
+    });
+
+    const workflowSource = resolveWorkflowSource({
+      workflowsEntryCandidates: [
+        // Compiled dist (how conformance and the CLI boot the server).
+        new URL("./workflows/index.js", import.meta.url),
+        // The tsx dev loop runs from src/ — the SDK bundler compiles TS.
+        new URL("./workflows/index.ts", import.meta.url),
+      ],
+      prebuiltSibling: new URL(
+        "./workflow-bundle-workflow-execution.js",
+        import.meta.url,
+      ),
+    });
+
+    deps.logger.info("Creating workflow-execution Temporal worker", {
+      stigmer_queue: deps.temporalConfig.stigmerQueue,
+      runner_queue: deps.temporalConfig.runnerQueue,
+      workflow_source: workflowSource.kind,
+    });
+
+    return Worker.create({
+      connection: nativeConnection,
+      namespace,
+      taskQueue: deps.temporalConfig.stigmerQueue,
+      activities,
+      ...(workflowSource.kind === "prebuilt"
+        ? { workflowBundle: { codePath: workflowSource.codePath } }
+        : { workflowsPath: workflowSource.workflowsPath }),
+      // The decode-only codec chain: workflow tasks replay history
+      // containing runner-encrypted payloads (manager.ts's choke-point
+      // note).
+      ...(payloadCodecs.length > 0
+        ? { dataConverter: { payloadCodecs } }
+        : {}),
+    });
+  };
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflow-input.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflow-input.ts
@@ -1,0 +1,42 @@
+/**
+ * The slim orchestration input for stigmer/workflow-execution/invoke —
+ * ports activities.InvokeWorkflowExecutionWorkflowInput
+ * (execute_workflow.go): orchestration coordinates only, snake_case keys
+ * with Go's omitempty shape so TS-authored histories carry the same keys
+ * a Go-authored history would.
+ *
+ * The slim-input doctrine keeps secrets out of Temporal's durable
+ * history: the child workflow hydrates the full context
+ * (WorkflowInstance, Workflow, ExecutionContext) via gRPC from these IDs.
+ * The SAME object is passed to the child, so the key set is a
+ * cross-component contract with the runner's execute-from-execution.
+ *
+ * Go's callback_token / invoker_identity_account_id fields have no OSS
+ * producer (cloud-only lanes) and are not modeled — the seam's ratified
+ * boundary (src/domain/workflowexecution/engine.ts).
+ *
+ * Sandbox-shared module: type-only, no imports.
+ */
+export interface InvokeWorkflowExecutionWorkflowInput {
+  readonly execution_id: string;
+  readonly workflow_instance_id?: string;
+  readonly workflow_id?: string;
+  readonly org_id?: string;
+  /**
+   * Signals the runner's workflow engine to skip completed tasks and
+   * resume from the first incomplete/failed task. Set only by the
+   * recover pipeline; normal executions omit it (Go omitempty).
+   */
+  readonly recovery_mode?: boolean;
+}
+
+/**
+ * The relaySignal envelope (invoke_workflow_impl.go RelaySignalPayload,
+ * June DD-013): an arbitrary signal to forward to the child, sent by the
+ * controller's sendSignal / submitWorkflowTaskApproval through
+ * SignalWithStart. JSON keys are the Go struct tags.
+ */
+export interface RelaySignalPayload {
+  readonly signalName: string;
+  readonly payload: unknown;
+}

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflows/index.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflows/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Workflow barrel — the entry point for Temporal's workflow bundler
+ * (the agentexecution barrel's twin; runner precedent).
+ *
+ * The Temporal TS SDK derives the workflow TYPE from the export name of
+ * the module passed to workflowsPath; the ES2022 arbitrary module export
+ * name maps the TypeScript function to the slash-delimited, byte-pinned
+ * workflow type the engine client starts
+ * ("stigmer/workflow-execution/invoke", names.ts).
+ *
+ * WORKFLOW-BUNDLE IMPORT DISCIPLINE: everything reachable from this
+ * module runs in the deterministic sandbox — no node built-ins, no
+ * store/transport imports (see invoke-workflow-execution.ts's header).
+ */
+export { invokeWorkflowExecution as "stigmer/workflow-execution/invoke" } from "./invoke-workflow-execution.js";

--- a/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflows/invoke-workflow-execution.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/workflowexecution/workflows/invoke-workflow-execution.ts
@@ -1,0 +1,568 @@
+/**
+ * The workflow-execution orchestrator workflow — ports
+ * pkg/domain/workflowexecution/temporal/workflows/invoke_workflow_impl.go
+ * (registered as "stigmer/workflow-execution/invoke"; proven by the
+ * workflowexecution execution suites on local-ts-execution and the
+ * co-located TestWorkflowEnvironment tests).
+ *
+ * Orchestration only — the TS unified runner owns the actual CNCF
+ * Serverless Workflow engine as the child workflow
+ * "stigmer/workflow/execute-from-execution" on the memo-pinned runner
+ * queue; the runner reports progressive status via gRPC. This workflow:
+ *
+ *   1. Installs the signal forwarders (pause, resume, relaySignal).
+ *   2. Starts the child (ID "workflow-exec-{executionId}",
+ *      ParentClosePolicy REQUEST_CANCEL, MaximumAttempts 1) and awaits it.
+ *   3. On failure: FAILED persist (worker-shutdown shapes mapped to the
+ *      honest platform-failure copy, #776), EC delete, ApplicationFailure.
+ *      On cancellation: CANCELLED persist + EC delete on a
+ *      non-cancellable scope (Go's disconnected context). On success:
+ *      EC delete.
+ *
+ * Pause/resume ordering guarantee (D2 §4, Go startSignalHandlers): both
+ * signals are processed by ONE serialized loop so their relays to the
+ * child can never be reordered — both mutate the same `paused` flag in
+ * the child, and a resume overtaking its preceding pause would leave the
+ * child blocked forever. Each signal's status persist and relay complete
+ * before the next signal is read; pause wins ties when both are buffered
+ * in the same workflow task (Go registers pause first on its Selector).
+ *
+ * v1 semantics only (OD-6): Go's "child-workflow-migration" and
+ * "remote-cleanup-stubs" version gates and the legacy ExecuteWorkflow
+ * activity path are NOT ported — no Go-era history can replay here. The
+ * surviving arms are the child-workflow path and the REGULAR-activity
+ * cleanup persists (Go v1 uses remote activities on the failure/cancel
+ * paths to dodge a Go-SDK RECORD_MARKER replay bug; the history shape is
+ * preserved as contract, the same ruling as agentexecution's port).
+ *
+ * Status persists are best-effort defense-in-depth: the RPC lifecycle
+ * steps persist the same phases synchronously, and the runner streams
+ * real statuses via gRPC. NOTE (sub-project DD-002): in Go these persists
+ * are silently DEAD — the production worker registers the activity under
+ * a derived name the workflow's constant never matches. This port
+ * registers and invokes under the one constant name, so the lane works
+ * here (disclosed divergence in the safe direction; Go issue filed).
+ *
+ * WORKFLOW-BUNDLE IMPORT DISCIPLINE: this file runs in Temporal's
+ * deterministic sandbox. Only @temporalio/workflow, @temporalio/common,
+ * @bufbuild/protobuf, generated protos, and verified-pure modules may be
+ * imported (sub-project 20260824.03 discipline).
+ */
+import { create, toJson } from "@bufbuild/protobuf";
+import type { JsonValue } from "@bufbuild/protobuf";
+import { ApplicationFailure, CancelledFailure } from "@temporalio/common";
+import {
+  CancellationScope,
+  condition,
+  defineSignal,
+  executeChild,
+  getExternalWorkflowHandle,
+  log,
+  ParentClosePolicy,
+  proxyActivities,
+  proxyLocalActivities,
+  setHandler,
+  workflowInfo,
+} from "@temporalio/workflow";
+
+import { WorkflowExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import type { WorkflowExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+
+import { DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME } from "../../../domain/executioncontext/temporal/delete-execution-context.js";
+import {
+  isWorkerShutdown,
+  WORKER_SHUTDOWN_STATUS_ERROR,
+} from "../../runner-failure.js";
+import {
+  CHILD_WORKFLOW_TYPE,
+  childWorkflowId,
+  DEFAULT_RUNNER_TASK_QUEUE,
+  MEMO_RUNNER_TASK_QUEUE,
+  PAUSE_SIGNAL_NAME,
+  RELAY_SIGNAL_CHANNEL_NAME,
+  RESUME_SIGNAL_NAME,
+  UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME,
+} from "../names.js";
+import type {
+  InvokeWorkflowExecutionWorkflowInput,
+  RelaySignalPayload,
+} from "../workflow-input.js";
+
+// ─── Signals (byte-pinned names; see names.ts) ──────────────────────────
+
+const pauseSignal = defineSignal<[string?]>(PAUSE_SIGNAL_NAME);
+const resumeSignal = defineSignal<[string?]>(RESUME_SIGNAL_NAME);
+const relaySignal = defineSignal<[RelaySignalPayload?]>(
+  RELAY_SIGNAL_CHANNEL_NAME,
+);
+
+// ─── Activity proxies (options are contract: 30s ScheduleToClose, 3 ─────
+// attempts, 2s initial interval — invoke_workflow_impl.go's uniform
+// policy for every orchestrator-side persist and the EC delete).
+
+interface StatusActivities {
+  [UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME]: (
+    executionId: string,
+    statusJson: JsonValue,
+  ) => Promise<void>;
+}
+
+interface CleanupActivities {
+  [UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME]: (
+    executionId: string,
+    statusJson: JsonValue,
+  ) => Promise<void>;
+  [DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME]: (
+    executionId: string,
+  ) => Promise<void>;
+}
+
+/**
+ * LOCAL-activity mode: the pause/resume signal handlers' persists (Go
+ * updateStatusToPaused/updateStatusToRunning use ExecuteLocalActivity).
+ */
+const signalPathActivities = proxyLocalActivities<StatusActivities>({
+  scheduleToCloseTimeout: "30s",
+  retry: { maximumAttempts: 3, initialInterval: "2s" },
+});
+
+/**
+ * REGULAR-activity mode on this workflow's own (stigmer) queue: the
+ * failure/cancellation persists and the EC delete (Go's v1
+ * "remote-cleanup-stubs" arm — local-activity RECORD_MARKER events in the
+ * same workflow task as a child-workflow failure trigger a Go-SDK state
+ * machine bug; the history shape is preserved as contract).
+ */
+const cleanupActivities = proxyActivities<CleanupActivities>({
+  scheduleToCloseTimeout: "30s",
+  retry: { maximumAttempts: 3, initialInterval: "2s" },
+});
+
+// ─── The workflow ───────────────────────────────────────────────────────
+
+export async function invokeWorkflowExecution(
+  input: InvokeWorkflowExecutionWorkflowInput,
+): Promise<void> {
+  const executionId = input.execution_id;
+  log.info("Starting workflow for execution", { executionId });
+
+  // Go reads ctx.Err() to distinguish external workflow cancellation from
+  // ordinary failures; the TS equivalent observes the root scope's
+  // cancellation request (the dangling rejection is the designed API
+  // shape — cancelRequested is a Promise<never>).
+  let workflowCancelled = false;
+  CancellationScope.current().cancelRequested.catch(() => {
+    workflowCancelled = true;
+  });
+
+  startSignalForwarders(executionId);
+
+  let childError: unknown;
+  try {
+    await executeChildWorkflow(input);
+  } catch (error) {
+    childError = error;
+  }
+
+  if (childError !== undefined) {
+    // Cancellation path — keyed on the WORKFLOW's cancel state alone
+    // (Go temporal.IsCanceledError(ctx.Err())): cleanup runs on a
+    // non-cancellable scope and the workflow must end CANCELLED, not
+    // FAILED, so the underlying CancelledFailure is what propagates.
+    if (workflowCancelled) {
+      log.info("Workflow cancelled, running cancellation cleanup", {
+        executionId,
+      });
+      await handleCancellation(executionId);
+      throw (
+        findInCauseChain(childError, CancelledFailure) ??
+        new CancelledFailure("Workflow cancelled")
+      );
+    }
+
+    log.error("Workflow execution failed", {
+      executionId,
+      error: errorMessage(childError),
+    });
+
+    try {
+      await updateStatusOnFailure(executionId, childError);
+    } catch (error) {
+      // Go logs and proceeds — the EC delete and the workflow's own
+      // failure must not be lost to a status-persist failure.
+      log.error("Failed to update execution status", {
+        error: errorMessage(error),
+      });
+    }
+
+    await deleteExecutionContext(executionId);
+
+    // Only a TemporalFailure fails a TS workflow — a plain throw fails
+    // the workflow TASK, which the server retries forever (the #18 panel
+    // finding). Go: temporal.NewApplicationError("Workflow execution
+    // failed", "", err).
+    throw ApplicationFailure.create({
+      message: "Workflow execution failed",
+      cause:
+        childError instanceof Error
+          ? childError
+          : new Error(String(childError)),
+    });
+  }
+
+  log.info(
+    "Workflow completed for execution (status updates were sent progressively via gRPC)",
+    { executionId },
+  );
+
+  await deleteExecutionContext(executionId);
+}
+
+// ─── Signal forwarders (Go startSignalHandlers) ─────────────────────────
+
+/**
+ * Installs the three signal handlers and starts the two forwarding loops.
+ * The loops are fire-and-forget workflow "goroutines": they emit no
+ * commands until a signal is actually processed, so the common case (no
+ * signal ever received) leaves history untouched. On external workflow
+ * cancellation their `condition` waits reject in the cancel activation
+ * itself — caught and treated as loop exit, because an uncaught rejection
+ * would fail the workflow task at the activation boundary and the server
+ * would retry it forever (the #18 monitor lesson; Go's goroutines get
+ * this leniency from their SDK for free).
+ */
+function startSignalForwarders(executionId: string): void {
+  // Buffered-channel semantics (Go GetSignalChannel): signals delivered
+  // before a handler runs — or while the loop is busy processing an
+  // earlier one — queue losslessly.
+  const pauseQueue: string[] = [];
+  let resumePending = 0;
+  const relayQueue: RelaySignalPayload[] = [];
+
+  setHandler(pauseSignal, (reason?: string) => {
+    pauseQueue.push(reason ?? "");
+  });
+  setHandler(resumeSignal, () => {
+    resumePending++;
+  });
+  setHandler(relaySignal, (payload?: RelaySignalPayload) => {
+    if (payload === undefined || (payload.signalName ?? "") === "") {
+      // Go zero-values a malformed envelope and the empty signal name
+      // then fails inside SignalExternalWorkflow's relay (warn-only).
+      // Refusing it here reaches the same non-fatal outcome without
+      // burning a relay command on a signal that cannot deliver.
+      log.warn("Relay signal with empty envelope ignored", { executionId });
+      return;
+    }
+    relayQueue.push(payload);
+  });
+
+  // ONE serialized pause/resume loop — the ordering guarantee (see the
+  // module header). Pause is checked first each iteration: Go's Selector
+  // registers pause first, so it wins ties when both are buffered.
+  void (async () => {
+    for (;;) {
+      try {
+        await condition(() => pauseQueue.length > 0 || resumePending > 0);
+      } catch {
+        return; // External cancellation — stand down.
+      }
+      if (pauseQueue.length > 0) {
+        const reason = pauseQueue.shift() ?? "";
+        log.info("Pause signal received", { executionId, reason });
+        await persistPhase(
+          executionId,
+          ExecutionPhase.EXECUTION_PAUSED,
+          "Failed to update execution status to PAUSED",
+        );
+        await relaySignalToChild(executionId, PAUSE_SIGNAL_NAME, reason);
+      } else {
+        resumePending--;
+        log.info("Resume signal received", { executionId });
+        await persistPhase(
+          executionId,
+          ExecutionPhase.EXECUTION_IN_PROGRESS,
+          "Failed to update execution status to IN_PROGRESS",
+        );
+        await relaySignalToChild(executionId, RESUME_SIGNAL_NAME, null);
+      }
+    }
+  })();
+
+  // Generic relay loop (LISTEN / human_input tasks): the API layer
+  // signals this orchestrator via SignalWithStart; task-specific signal
+  // channels are registered in the child.
+  void (async () => {
+    for (;;) {
+      try {
+        await condition(() => relayQueue.length > 0);
+      } catch {
+        return; // External cancellation — stand down.
+      }
+      const payload = relayQueue.shift();
+      if (payload === undefined) {
+        continue;
+      }
+      log.info("Relay signal received", {
+        executionId,
+        signal: payload.signalName,
+      });
+      await relaySignalToChild(
+        executionId,
+        payload.signalName,
+        payload.payload,
+      );
+    }
+  })();
+}
+
+/**
+ * Forwards a signal to the TS child workflow via SignalExternalWorkflow
+ * (Go relaySignalToChild). Best-effort: a missing/completed child is a
+ * warning, never a workflow failure. The payload is always sent as one
+ * argument — Go sends exactly one (nil for resume), and the child's
+ * handlers read the first argument or ignore it.
+ */
+async function relaySignalToChild(
+  executionId: string,
+  signalName: string,
+  payload: unknown,
+): Promise<void> {
+  const childId = childWorkflowId(executionId);
+  try {
+    await getExternalWorkflowHandle(childId).signal(signalName, payload);
+  } catch (error) {
+    log.warn("Failed to relay signal to child workflow", {
+      executionId,
+      signal: signalName,
+      childWorkflowId: childId,
+      error: errorMessage(error),
+    });
+  }
+}
+
+// ─── The child workflow (Go executeChildWorkflow) ───────────────────────
+
+/**
+ * Starts the TS unified runner's engine as a Temporal child workflow and
+ * awaits its result. The child handles the actual CNCF Serverless
+ * Workflow execution and reports progressive status via gRPC.
+ */
+async function executeChildWorkflow(
+  input: InvokeWorkflowExecutionWorkflowInput,
+): Promise<void> {
+  const executionId = input.execution_id;
+  const childId = childWorkflowId(executionId);
+  const taskQueue = getRunnerTaskQueue();
+
+  log.info("Starting child workflow", {
+    executionId,
+    childWorkflowId: childId,
+    taskQueue,
+  });
+
+  await executeChild(CHILD_WORKFLOW_TYPE, {
+    workflowId: childId,
+    taskQueue,
+    // The parent's close requests cancellation rather than killing the
+    // child mid-write; recover's terminate-existing step is the hard
+    // stop when an operator needs one.
+    parentClosePolicy: ParentClosePolicy.REQUEST_CANCEL,
+    // ALL retry semantics live above the child (recover is
+    // terminate-and-start-fresh, stigmer#200) — a blind engine re-run
+    // would replay side effects the runner already streamed.
+    retry: { maximumAttempts: 1 },
+    args: [input],
+  });
+}
+
+/**
+ * The dispatch-resolved runner queue, pinned in the workflow memo at
+ * creation (workflow_creator.go). The fallback "should never happen if
+ * the workflow is created properly" (Go getRunnerTaskQueue). Go's legacy
+ * "activityTaskQueue" memo fallback is deliberately not ported — no
+ * pre-migration history can replay on this server (OD-6; names.ts).
+ */
+function getRunnerTaskQueue(): string {
+  const memoValue = workflowInfo().memo?.[MEMO_RUNNER_TASK_QUEUE];
+  if (typeof memoValue === "string" && memoValue !== "") {
+    return memoValue;
+  }
+  return DEFAULT_RUNNER_TASK_QUEUE;
+}
+
+// ─── Status persists ────────────────────────────────────────────────────
+
+/**
+ * Phase-only status persist for the pause/resume handlers (Go
+ * updateStatusToPaused/updateStatusToRunning): LOCAL activity,
+ * best-effort — logs on error, never propagates.
+ */
+async function persistPhase(
+  executionId: string,
+  phase: ExecutionPhase,
+  warnMessage: string,
+): Promise<void> {
+  const status = create(WorkflowExecutionStatusSchema, { phase });
+  try {
+    await signalPathActivities[UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME](
+      executionId,
+      statusToJson(status),
+    );
+    log.info("Updated execution status", {
+      executionId,
+      phase: ExecutionPhase[phase],
+    });
+  } catch (error) {
+    log.warn(warnMessage, { executionId, error: errorMessage(error) });
+  }
+}
+
+/**
+ * FAILED persist on the system-error path (Go updateStatusOnFailure):
+ * REGULAR activity. Recognized worker-shutdown shapes persist the honest
+ * platform-failure copy instead of raw Temporal drain internals (#776) —
+ * the raw text stays in the workflow log (the caller already logged it).
+ * Unlike the other persists this one PROPAGATES its error (Go returns it
+ * for the caller's log line).
+ */
+async function updateStatusOnFailure(
+  executionId: string,
+  originalError: unknown,
+): Promise<void> {
+  log.info("Updating execution status to FAILED", { executionId });
+
+  // The child's real error hides in the failure's CAUSE chain (the TS
+  // SDK's ChildWorkflowFailure.message is the generic "Child Workflow
+  // execution failed"); Go's %s renders the whole chain, so the persisted
+  // copy joins it too — status.error is the operator's only view of WHY.
+  const statusError = isWorkerShutdown(originalError)
+    ? WORKER_SHUTDOWN_STATUS_ERROR
+    : `Workflow execution failed: ${errorChainMessage(originalError)}`;
+
+  const failedStatus = create(WorkflowExecutionStatusSchema, {
+    phase: ExecutionPhase.EXECUTION_FAILED,
+    error: statusError,
+  });
+
+  await cleanupActivities[UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME](
+    executionId,
+    statusToJson(failedStatus),
+  );
+  log.info("Updated execution status to FAILED", { executionId });
+}
+
+/**
+ * Cancellation cleanup on a non-cancellable scope (Go's disconnected
+ * context): both operations are best-effort and independent — the
+ * execution must reach CANCELLED and the ExecutionContext (secrets) must
+ * be cleaned up regardless.
+ */
+async function handleCancellation(executionId: string): Promise<void> {
+  await CancellationScope.nonCancellable(async () => {
+    await updateStatusOnCancellation(executionId);
+    await deleteExecutionContext(executionId);
+  });
+}
+
+/**
+ * CANCELLED persist (Go updateStatusOnCancellation): REGULAR activity,
+ * best-effort. Deliberately sets NO status.error — a user-initiated
+ * cancel is a quiet terminal state, not a failure (stigmer#282); display
+ * layers key error styling on status.error, so a sentinel here would
+ * render the stop as a failure. The CANCELLED phase alone carries the
+ * state.
+ */
+async function updateStatusOnCancellation(executionId: string): Promise<void> {
+  const cancelledStatus = create(WorkflowExecutionStatusSchema, {
+    phase: ExecutionPhase.EXECUTION_CANCELLED,
+  });
+  try {
+    await cleanupActivities[UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME](
+      executionId,
+      statusToJson(cancelledStatus),
+    );
+    log.info("Updated execution status to CANCELLED", { executionId });
+  } catch (error) {
+    log.warn("Failed to update execution status to CANCELLED", {
+      executionId,
+      error: errorMessage(error),
+    });
+  }
+}
+
+/**
+ * Deletes the ephemeral ExecutionContext (the fully-merged environment,
+ * including secrets) on a non-cancellable scope so cleanup runs on every
+ * exit path, cancellation included (Go's disconnected context). REGULAR
+ * activity (Go's v1 arm — agentexecution's Go uses a local activity here;
+ * this domain's Go does not, and the port follows ITS source). Errors are
+ * logged, never propagated.
+ */
+async function deleteExecutionContext(executionId: string): Promise<void> {
+  await CancellationScope.nonCancellable(async () => {
+    try {
+      await cleanupActivities[DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME](
+        executionId,
+      );
+      log.info("ExecutionContext cleaned up", { executionId });
+    } catch (error) {
+      log.warn("ExecutionContext cleanup failed (will rely on TTL backup)", {
+        executionId,
+        error: errorMessage(error),
+      });
+    }
+  });
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Statuses cross the activity payload boundary as proto-JSON — the TS
+ * default payload converter cannot serialize typed messages' bigint
+ * int64 fields (sub-project 20260824.03 design rule). Server-internal:
+ * this worker's workflow is the only caller.
+ */
+function statusToJson(status: WorkflowExecutionStatus): JsonValue {
+  return toJson(WorkflowExecutionStatusSchema, status);
+}
+
+function findInCauseChain<T extends Error>(
+  error: unknown,
+  ctor: new (...args: never[]) => T,
+): T | undefined {
+  for (
+    let e: unknown = error;
+    e instanceof Error;
+    e = (e as { cause?: unknown }).cause
+  ) {
+    if (e instanceof ctor) {
+      return e;
+    }
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Joins the failure's message chain (Go's `%s` on a wrapped error renders
+ * every layer): "Child Workflow execution failed: child engine boom".
+ * Used for the persisted user-facing copy; logs keep the top message.
+ */
+function errorChainMessage(error: unknown): string {
+  const messages: string[] = [];
+  for (
+    let e: unknown = error;
+    e instanceof Error;
+    e = (e as { cause?: unknown }).cause
+  ) {
+    if (e.message !== "") {
+      messages.push(e.message);
+    }
+  }
+  return messages.length > 0 ? messages.join(": ") : String(error);
+}

--- a/test/conformance/src/targets/local-ts-execution.ts
+++ b/test/conformance/src/targets/local-ts-execution.ts
@@ -50,6 +50,11 @@ export class LocalTsExecutionTarget implements TargetProfile {
     // provisions is the agent/workflow execution engine, not a channel
     // delivery runtime — the refusal posture is identical to local-ts.
     channelMessaging: false,
+    // The org BYOA lane is UNIMPLEMENTED on OSS by design (stigmer#558) —
+    // the suite pins the three refusals here. This line was CW-1's (#11)
+    // merge-coordination ask of whichever execution PR merged second; #18
+    // merged second and missed it — restored by D4 #21's pre-flight.
+    orgOAuthAppConfiguration: false,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/vitest.local-ts-execution.config.ts
+++ b/test/conformance/vitest.local-ts-execution.config.ts
@@ -21,17 +21,25 @@
 //   DD-002, owner-ratified): agentexecution-approval (the HITL matrix),
 //   mcp.harness.smoke, and mcp-caller-identity register McpServer
 //   resources as their tool surface — a domain this server serves only
-//   once #9 ports it. #9's PR rosters them and carries the "HITL matrix
-//   green" acceptance.
+//   once #9 ports it.
+//
+//   #21 (2026-08-25): the DD-002 deferral's carrier corrected — #9 merged
+//   BEFORE this roster file existed, so its PR could not roster the three
+//   MCP-dependent suites; they enter in #21's pre-flight, proven green
+//   against the TS engine (the "HITL matrix green" acceptance transfers
+//   to #21's PR).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     include: [
       "src/suites-execution/agentexecution.conformance.test.ts",
+      "src/suites-execution/agentexecution-approval.conformance.test.ts",
       "src/suites-execution/agentexecution-recover.conformance.test.ts",
       "src/suites-execution/agentexecution-memory-retrieval.conformance.test.ts",
       "src/suites-execution/agent.harness.smoke.test.ts",
+      "src/suites-execution/mcp.harness.smoke.test.ts",
+      "src/suites-execution/mcp-caller-identity.conformance.test.ts",
       "src/suites-execution/open-computer-use.conformance.test.ts",
       "src/suites-execution/session-immutability.conformance.test.ts",
       "src/suites-execution/envmerge-agent.conformance.test.ts",

--- a/test/conformance/vitest.local-ts-execution.config.ts
+++ b/test/conformance/vitest.local-ts-execution.config.ts
@@ -27,7 +27,10 @@
 //   BEFORE this roster file existed, so its PR could not roster the three
 //   MCP-dependent suites; they enter in #21's pre-flight, proven green
 //   against the TS engine (the "HITL matrix green" acceptance transfers
-//   to #21's PR).
+//   to #21's PR). The workflowexecution slice: the four workflowexecution
+//   suites + the envmerge workflow half (split at #18 for exactly this
+//   moment). Still out: workflowexecution-child-approval (the #23 flag
+//   flip) and schedule-firing (#22).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -43,6 +46,11 @@ export default defineConfig({
       "src/suites-execution/open-computer-use.conformance.test.ts",
       "src/suites-execution/session-immutability.conformance.test.ts",
       "src/suites-execution/envmerge-agent.conformance.test.ts",
+      "src/suites-execution/envmerge-workflow.conformance.test.ts",
+      "src/suites-execution/workflowexecution.conformance.test.ts",
+      "src/suites-execution/workflowexecution-approval.conformance.test.ts",
+      "src/suites-execution/workflowexecution-signal.conformance.test.ts",
+      "src/suites-execution/workflowexecution-recover.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts-execution.ts"],
     env: {


### PR DESCRIPTION
## Summary

The second TS execution-engine slice (stigmer-cloud program 20260822.01, D4 entry #21): workflow runs execute end-to-end on the TS server. Ports `pkg/domain/workflowexecution/temporal/` onto #18's shared worker infrastructure and fills the `ConnectedWorkflowExecutionEngine` seam #20 left disconnected.

## Changes

- **Orchestrator workflow** `stigmer/workflow-execution/invoke` (`src/temporal/workflowexecution/workflows/`): ONE serialized pause/resume loop preserving Go's FIFO relay ordering (pause wins buffered ties), generic `relaySignal` forwarding (June DD-013), child start `workflow-exec-{id}` on the memo-resolved runner queue (ParentClosePolicy REQUEST_CANCEL, MaximumAttempts 1), failure path (worker-shutdown mapping #776 → FAILED persist → EC delete → ApplicationFailure), cancellation cleanup on a non-cancellable scope (quiet CANCELLED, stigmer#282), EC delete on every exit. **v1 semantics only (OD-6)**: Go's two version gates and the legacy activity path are not ported.
- **Dispatch** (`dispatch.ts`): `ResolveWorkflowTaskQueue` — global → runner queue; execution → `wfexec:{id}`; UNSPECIFIED-target resolution through the config's single rule.
- **Worker factory** on the shared `TemporalManager` (queue `workflow_execution_stigmer`, decode-only codecs); registers `UpdateWorkflowExecutionStatus` + the #15 `DeleteExecutionContext` seam.
- **Engine client** (`engine-client.ts`): the five seam operations (start with slim omitempty input, SignalWithStart on the relay lane, raw signal/cancel/terminate with `WorkflowNotFoundError` mapping) + the memoized engine-state provider replacing compose's disconnected lambda.
- **Activity** (`activities.ts`): the ACTIVITY's merge (unconditional statusAudit bump, no event writes — deliberately NOT the RPC merge; they differ wire-visibly) on the store's atomic `updateResource` (#20 DD-001 posture), broadcasting through the domain broker.
- **Pre-flight roster debt**: the `orgOAuthAppConfiguration: false` flag that fell through the #11/#18 merge coordination, and the three MCP-dependent suites #18's DD-002 assigned to #9's PR (which merged before the roster file existed) — proven 17/17 on the TS engine before rostering. The "HITL matrix green on local-ts-execution" acceptance lands here.
- **Roster**: the five workflowexecution Class B suites enter `local-ts-execution`. Still out: `workflowexecution-child-approval` (#23's flag flip) and schedule-firing (#22).

## Parity register (disclosed)

1. **Go's orchestrator status persists are DEAD in production** (Closes-adjacent: filed as #877): `worker_config.go` registers the activity via `RegisterActivity(method)` — derived name `UpdateExecutionStatus` — while the workflow invokes the constant `UpdateWorkflowExecutionStatus`; every persist fails lookup behind best-effort call sites (Go's tests mask it by registering stubs under the constant; proven with a live SDK probe). This port registers AND invokes under the one constant name — the lane WORKS here (a failed child with a dead runner reaches FAILED instead of dangling IN_PROGRESS). Safe-direction divergence, the #18/oss#861 posture.
2. The activity persist is atomic (`updateResource`) vs Go's load-then-save — the #20 DD-001 posture extended; merge CONTENT is Go's activity merge field-for-field.
3. The persisted FAILED copy renders the failure's CAUSE CHAIN ("Workflow execution failed: Child Workflow execution failed: <child error>") — the TS SDK's ChildWorkflowFailure.message is generic; and Go's copy is unpinnable (its lane never ran).
4. Go's legacy `activityTaskQueue` memo fallback not ported (OD-6 — no pre-migration history can replay here).
5. Test-coverage notes: the memo-absent defense arm is untested (matching Go's own posture); the pause/resume buffered-tie coverage is per-activation probabilistic (the deterministic pin is arrival-order preservation, Go's test shape).

## Test plan

- [x] Server units: **1304/1304** (1275 baseline + 29 new: dispatch, engine-client, activity merge, TestWorkflowEnvironment scenario matrix over a scriptable stub child, replay determinism gate over 3 committed histories via `scripts/capture-wfexec-replay-histories.ts`).
- [x] `local-ts-execution`: **15 files, 128 passed / 1 skipped** (the desktop opt-in gate) — the five workflowexecution suites first-run green.
- [x] `local-ts`: 414 passed / 1 skipped — main's exact baseline, regression-free.
- [x] `local-go-execution`: 159 passed / 2 skipped — the shared harness changes hold on the Go engine.
- [x] `verify:dist` + `build:slim` + `verify:slim`: both bundles boot, serve, and shut down cleanly.
- [x] In-session two-reviewer panel (subagents died to model limits — the #20 fallback): one test gap closed (recovery_mode forwarding), one strengthening (back-to-back pause/resume), one live mutation probe (audit-bump mutant caught).

Program: stigmer-cloud `_projects/2026-08/20260825.04.sp.workflowexecution-orchestration`. Unblocks D4 #23 (child-approval derivation); #24 packaging follows.

Made with [Cursor](https://cursor.com)